### PR TITLE
feat(bildirim): mod-queue emitters — report filed + çaylak awaiting review (Fixes #1699)

### DIFF
--- a/apps/web/src/components/bildirim/bildirim.ts
+++ b/apps/web/src/components/bildirim/bildirim.ts
@@ -70,6 +70,10 @@ const KIND_COPY = {
 	// The aggregated live-content vote voice (#1698): the anti-hype "N yeni oy",
 	// one rolled-up line per item — never one-per-vote, never a per-voter identity drip.
 	vote: (count) => (count > 1 ? `içeriğin ${count} yeni oy aldı` : "içeriğin 1 yeni oy aldı"),
+	// The mod-queue heartbeat (#1699): mod-facing lines, not member-facing.
+	"report-filed": (count) =>
+		count > 1 ? `${count} yeni içerik bildirildi` : "yeni bir içerik bildirildi",
+	"caylak-pending": () => "yeni bir çaylak divanda incelenmeyi bekliyor",
 } satisfies Record<NotificationKind, (count: number) => string>;
 
 /**

--- a/apps/web/worker/features/bildirim/kind.ts
+++ b/apps/web/worker/features/bildirim/kind.ts
@@ -1,23 +1,34 @@
 /**
  * The bildirim **notification kind** — the closed discriminant naming what kind of
- * moment a notification is (`divan-vote` | `kefil` | `terfi` | `reply` | `vote`), the
- * `TARGET_KINDS` / `NOTIFICATION_TARGET_KINDS` idiom (`target-kind.ts` / `target.ts`).
+ * moment a notification is (`divan-vote` | `kefil` | `terfi` | `reply` | `vote` |
+ * `report-filed` | `caylak-pending`), the `TARGET_KINDS` /
+ * `NOTIFICATION_TARGET_KINDS` idiom (`target-kind.ts` / `target.ts`).
  *
  * `NOTIFICATION_KINDS` is the one runtime tuple every emitter const and the client
  * copy map source from, so the kind can no longer be independent string literals
  * that silently drift: the emitters (`REPLY_KIND`, `DIVAN_VOTE_KIND`, `KEFIL_KIND`,
- * `PROMOTION_KIND`, `VOTE_KIND`) type against this union, and the client `KIND_COPY`
- * map is `satisfies Record<NotificationKind, …>` — so shipping a new kind without its
+ * `PROMOTION_KIND`, `VOTE_KIND`, `REPORT_FILED_KIND`, `CAYLAK_PENDING_KIND`) type
+ * against this union, and the client `KIND_COPY` map is
+ * `satisfies Record<NotificationKind, …>` — so shipping a new kind without its
  * Turkish copy is a compile error, not a raw wire identifier rendered to a reader
  * (the `reply` drift, #2016).
  *
  * `vote` (#1698) is the aggregated live-content vote moment — a vote on a member's
  * pano post/comment or sözlük definition — kept DISTINCT from divan's sandboxed
  * `divan-vote` so the two surfaces carry their own product voice ("N yeni oy" vs
- * "divandaki içeriğin oy aldı").
+ * "divandaki içeriğin oy aldı"). The mod-facing kinds (`report-filed` /
+ * `caylak-pending`, #1699) are the moderator queue's heartbeat.
  */
 
 /** The closed notification-kind set, as the one runtime tuple emitters + copy source from. */
-export const NOTIFICATION_KINDS = ["divan-vote", "kefil", "terfi", "reply", "vote"] as const;
+export const NOTIFICATION_KINDS = [
+	"divan-vote",
+	"kefil",
+	"terfi",
+	"reply",
+	"vote",
+	"report-filed",
+	"caylak-pending",
+] as const;
 
 export type NotificationKind = (typeof NOTIFICATION_KINDS)[number];

--- a/apps/web/worker/features/bildirim/mod-emitters.ts
+++ b/apps/web/worker/features/bildirim/mod-emitters.ts
@@ -1,0 +1,122 @@
+/**
+ * Mod-queue emitters (#1699, epic #1666) — the moderator team's pager, through the
+ * spine's {@link Notification} write surface (stories 9/10/12):
+ *
+ *  - **report-filed** — a freshly-filed content report notifies EVERY moderator, so
+ *    the two-person team learns of a new item in the queue without polling it. The
+ *    target is the reported content, so the row links a moderator straight to it.
+ *  - **caylak-pending** — a new çaylak entering the divan review queue notifies every
+ *    moderator. Fired by the content-create path only on the çaylak's FIRST currently
+ *    pending item (the 0→1 transition — see the divan-side gate), so it is the
+ *    "a new çaylak is awaiting review" signal, not one ping per sandboxed item.
+ *
+ * The recipient set is resolved from the authority model, never a hardcoded list:
+ * {@link allModerators} enumerates every subject holding `(moderates, platform)` —
+ * the SAME tuple `Moderate.over(platform)` discharges against (ADR 0107). The acting
+ * moderator is self-suppressed ({@link modRecipients}): a moderator who files a report
+ * is never paged about their own action (story 12). Fan-out is a simple per-recipient
+ * loop for the two-person team — no subscription system (the brief).
+ *
+ * Each moment is discrete, so both use {@link Notification.record} (one row per
+ * recipient) — NOT the vote path's aggregate-upsert.
+ *
+ * The emits ride AFTER the committed report/create mutation and can never fail it: the
+ * whole effect — flag read AND the moderator enumeration included — is swallowed-with-log
+ * (`catchCause`, the ADR 0039 fire-and-forget posture; the rite-emitters idiom), which
+ * also absorbs the `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors.
+ * Writes are gated on the spine's `phoenix-bildirim` flag (dark by default).
+ */
+import {Effect} from "effect";
+import type {TargetKind} from "../../db/target-kind.ts";
+import {Divan} from "../divan/Divan.ts";
+import {allModerators} from "../kunye/moderate.ts";
+import {bildirimOn} from "./gate.ts";
+import type {NotificationKind} from "./kind.ts";
+import {Notification} from "./Notification.ts";
+
+export const REPORT_FILED_KIND: NotificationKind = "report-filed";
+export const CAYLAK_PENDING_KIND: NotificationKind = "caylak-pending";
+
+/**
+ * The self-suppressed moderator recipient set for one mod-queue moment (pure): every
+ * moderator except the actor. A moderator who triggered the event (e.g. filed the
+ * report) is never paged about their own action; a `null` actor (a system moment with
+ * no acting user) suppresses no one. Deterministic order for a stable fan-out.
+ */
+export const modRecipients = (
+	moderators: ReadonlySet<string>,
+	actorId: string | null,
+): ReadonlyArray<string> => [...moderators].filter((id) => id !== actorId).sort();
+
+const swallow = (label: string) =>
+	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
+
+/**
+ * Notify every moderator that a content report was filed. The target is the reported
+ * content (so the row links to it); the actor is the reporter, who is self-suppressed
+ * if they are themselves a moderator. `targetKind` is a report {@link TargetKind}
+ * (`definition`/`post`/`comment`), a subset of the notification target taxonomy.
+ */
+export const notifyReportFiled = (input: {
+	reporterId: string;
+	targetKind: TargetKind;
+	targetId: string;
+}) =>
+	Effect.gen(function* () {
+		if (!(yield* bildirimOn)) return;
+		const recipients = modRecipients(yield* allModerators(), input.reporterId);
+		if (recipients.length === 0) return;
+		const bildirim = yield* Notification;
+		for (const recipientId of recipients) {
+			yield* bildirim.record({
+				recipientId,
+				kind: REPORT_FILED_KIND,
+				targetKind: input.targetKind,
+				targetId: input.targetId,
+				actorId: input.reporterId,
+			});
+		}
+	}).pipe(swallow(REPORT_FILED_KIND));
+
+/**
+ * Notify every moderator that a new çaylak entered the divan review queue. The target
+ * is the çaylak's own account (the roster's unit is the person, not the item); the
+ * moment is a system event with no acting user, so `actorId` is null and no moderator
+ * is self-suppressed. The çaylak itself is never a recipient (they hold no `moderates`
+ * tuple), so the moderator set already excludes them.
+ */
+export const notifyCaylakPending = (input: {caylakId: string}) =>
+	Effect.gen(function* () {
+		if (!(yield* bildirimOn)) return;
+		const recipients = modRecipients(yield* allModerators(), null);
+		if (recipients.length === 0) return;
+		const bildirim = yield* Notification;
+		for (const recipientId of recipients) {
+			yield* bildirim.record({
+				recipientId,
+				kind: CAYLAK_PENDING_KIND,
+				targetKind: "user",
+				targetId: input.caylakId,
+				actorId: null,
+			});
+		}
+	}).pipe(swallow(CAYLAK_PENDING_KIND));
+
+/**
+ * The content-create wiring for {@link notifyCaylakPending}: page the moderators only
+ * when a çaylak's item lands sandboxed AND it is their FIRST currently-pending item —
+ * the 0→1 roster entry (`Divan.pendingCountOf === 1` right after the item committed).
+ * A live item (`sandboxedAt === null` — flag-off or a yazar) is never a divan entry, so
+ * it short-circuits with no read; a çaylak's second+ item leaves the count > 1 and
+ * pages nobody. The whole effect (the count read included) is swallowed by
+ * {@link notifyCaylakPending}, so it can never fail the committed create.
+ */
+export const notifyCaylakEntersDivan = (input: {authorId: string; sandboxedAt: Date | null}) =>
+	Effect.gen(function* () {
+		if (input.sandboxedAt === null) return;
+		if (!(yield* bildirimOn)) return;
+		const divan = yield* Divan;
+		const pending = yield* divan.pendingCountOf(input.authorId);
+		if (pending !== 1) return;
+		yield* notifyCaylakPending({caylakId: input.authorId});
+	}).pipe(swallow(CAYLAK_PENDING_KIND));

--- a/apps/web/worker/features/bildirim/mod-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/mod-emitters.unit.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Mod-queue emitter coverage (#1699) — the decisions wrong-or-right with no database
+ * (ADR 0082 T1/T2; `.patterns/effect-testing.md`): moderator resolution + actor
+ * self-suppression, the flag containment (dark by default), the çaylak-entry 0→1
+ * transition gate, and the swallow-at-the-seam guarantee — a DYING dependency (the
+ * `orDieAccess` defect shape) cannot fail the caller. The `Notification` / `Divan` /
+ * `RelationStore` seams are fail-on-contact stubs with only the exercised method
+ * overridden, so "touched the wrong surface" is a test failure.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {RelationStore} from "@kampus/authz";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {Divan} from "../divan/Divan.ts";
+import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {
+	CAYLAK_PENDING_KIND,
+	modRecipients,
+	notifyCaylakEntersDivan,
+	notifyReportFiled,
+	REPORT_FILED_KIND,
+} from "./mod-emitters.ts";
+import {makeNotificationStub} from "./Notification.testing.ts";
+import type {NotificationRecordInput} from "./Notification.ts";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "mod-emitters-test",
+	id: "mod-emitters-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(on),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service);
+
+// A no-op `LivePublisher`: `Notification.record` yields the per-request publisher for
+// the fire-and-forget live fan-out (#2076). The stub `record` never touches it, so a
+// do-nothing publisher satisfies the requirement without asserting on it.
+const noopLivePublisher = Layer.succeed(LivePublisher)({
+	update: () => Effect.void,
+	delete: () => Effect.void,
+	topic: () => {
+		throw new Error("noopLivePublisher.topic unused");
+	},
+} as typeof LivePublisher.Service);
+
+const requestContext = (on: boolean) =>
+	Layer.mergeAll(
+		flagsStub(on),
+		Layer.succeed(CurrentUser, {user: undefined}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+		noRequestFlagOverrides,
+		noopLivePublisher,
+	);
+
+// A `RelationStore` where exactly `mods` hold the `(moderates, platform)` tuple — the
+// authority model the recipient set is resolved from (never a hardcoded list).
+const relationStoreOf = (mods: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
+	Layer.succeed(RelationStore, {
+		has: () => Effect.die(new Error("mod-emitters resolve via subjectsOf, not has")),
+		hasSubjects: () =>
+			Effect.die(new Error("mod-emitters resolve via subjectsOf, not hasSubjects")),
+		subjectsOf: ({relation, object}) =>
+			Effect.succeed(new Set(relation === "moderates" && object.type === "platform" ? mods : [])),
+	});
+
+// A `Divan` whose `pendingCountOf` answers a scripted count; the other reads die.
+const divanPending = (count: number): Layer.Layer<Divan> =>
+	Layer.succeed(Divan, {
+		roster: () => Effect.die(new Error("Divan.roster not exercised")),
+		backlogOf: () => Effect.die(new Error("Divan.backlogOf not exercised")),
+		pendingCountOf: () => Effect.succeed(count),
+	});
+
+const divanDies: Layer.Layer<Divan> = Layer.succeed(Divan, {
+	roster: () => Effect.die(new Error("Divan.roster not exercised")),
+	backlogOf: () => Effect.die(new Error("Divan.backlogOf not exercised")),
+	pendingCountOf: () => Effect.die(new Error("Divan.pendingCountOf must not be read")),
+});
+
+describe("modRecipients — moderator resolution + actor self-suppression, pure", () => {
+	it("returns every moderator, deterministically ordered, when the actor is not one", () => {
+		assert.deepStrictEqual(modRecipients(new Set(["u-mod-b", "u-mod-a"]), "u-reporter"), [
+			"u-mod-a",
+			"u-mod-b",
+		]);
+	});
+	it("suppresses the acting moderator — no self-notification for their own action", () => {
+		assert.deepStrictEqual(modRecipients(new Set(["u-mod-a", "u-mod-b"]), "u-mod-a"), ["u-mod-b"]);
+	});
+	it("a null actor (a system moment) suppresses no one", () => {
+		assert.deepStrictEqual(modRecipients(new Set(["u-mod-a"]), null), ["u-mod-a"]);
+	});
+	it("an empty moderator set resolves to nobody", () => {
+		assert.deepStrictEqual(modRecipients(new Set(), "u-reporter"), []);
+	});
+});
+
+describe("notifyReportFiled — the report-filed mod page", () => {
+	it.effect(
+		"records one report-filed notification per moderator, targeting the reported content",
+		() =>
+			Effect.gen(function* () {
+				const calls: NotificationRecordInput[] = [];
+				yield* notifyReportFiled({
+					reporterId: "u-reporter",
+					targetKind: "post",
+					targetId: "p1",
+				}).pipe(
+					Effect.provide(
+						Layer.mergeAll(
+							makeNotificationStub({
+								record: (input) => {
+									calls.push(input);
+									return Effect.succeed({id: "n1"});
+								},
+							}),
+							relationStoreOf(["u-mod-a", "u-mod-b"]),
+							requestContext(true),
+						),
+					),
+				);
+				assert.strictEqual(calls.length, 2);
+				assert.deepStrictEqual(calls[0], {
+					recipientId: "u-mod-a",
+					kind: REPORT_FILED_KIND,
+					targetKind: "post",
+					targetId: "p1",
+					actorId: "u-reporter",
+				});
+				assert.deepStrictEqual(calls[1]?.recipientId, "u-mod-b");
+			}),
+	);
+
+	it.effect(
+		"a moderator who files a report is NOT paged about their own report (self-suppression)",
+		() =>
+			Effect.gen(function* () {
+				const calls: NotificationRecordInput[] = [];
+				yield* notifyReportFiled({
+					reporterId: "u-mod-a",
+					targetKind: "comment",
+					targetId: "c1",
+				}).pipe(
+					Effect.provide(
+						Layer.mergeAll(
+							makeNotificationStub({
+								record: (input) => {
+									calls.push(input);
+									return Effect.succeed({id: "n1"});
+								},
+							}),
+							relationStoreOf(["u-mod-a", "u-mod-b"]),
+							requestContext(true),
+						),
+					),
+				);
+				assert.deepStrictEqual(
+					calls.map((c) => c.recipientId),
+					["u-mod-b"],
+				);
+			}),
+	);
+
+	it.effect("no moderators ⇒ the fail-on-contact Notification stub is never touched", () =>
+		notifyReportFiled({reporterId: "u-reporter", targetKind: "post", targetId: "p1"}).pipe(
+			Effect.provide(
+				Layer.mergeAll(makeNotificationStub(), relationStoreOf([]), requestContext(true)),
+			),
+		),
+	);
+
+	it.effect("with the bildirim flag OFF nothing is read or written (dark by default)", () =>
+		notifyReportFiled({reporterId: "u-reporter", targetKind: "post", targetId: "p1"}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeNotificationStub(),
+					// RelationStore dies on contact: flag-off must not even resolve moderators.
+					Layer.succeed(RelationStore, {
+						has: () => Effect.die(new Error("flag OFF must not read authority")),
+						hasSubjects: () => Effect.die(new Error("flag OFF must not read authority")),
+						subjectsOf: () => Effect.die(new Error("flag OFF must not read authority")),
+					}),
+					requestContext(false),
+				),
+			),
+		),
+	);
+
+	it.effect(
+		"a DYING notification write is swallowed — the report caller still succeeds (the seam AC)",
+		() =>
+			Effect.gen(function* () {
+				const exit = yield* notifyReportFiled({
+					reporterId: "u-reporter",
+					targetKind: "post",
+					targetId: "p1",
+				}).pipe(
+					Effect.provide(
+						Layer.mergeAll(
+							makeNotificationStub(),
+							relationStoreOf(["u-mod-a"]),
+							requestContext(true),
+						),
+					),
+					Effect.exit,
+				);
+				assert.strictEqual(exit._tag, "Success");
+			}),
+	);
+});
+
+describe("notifyCaylakEntersDivan — the çaylak-awaiting-review page, 0→1 transition-gated", () => {
+	it.effect(
+		"a live item (sandboxedAt null) is not a divan entry — nothing is read or written",
+		() =>
+			notifyCaylakEntersDivan({authorId: "u-caylak", sandboxedAt: null}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub(),
+						relationStoreOf(["u-mod-a"]),
+						divanDies,
+						requestContext(true),
+					),
+				),
+			),
+	);
+
+	it.effect("the çaylak's FIRST pending item (count 1) pages every moderator", () =>
+		Effect.gen(function* () {
+			const calls: NotificationRecordInput[] = [];
+			yield* notifyCaylakEntersDivan({
+				authorId: "u-caylak",
+				sandboxedAt: new Date("2026-01-01T00:00:00Z"),
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub({
+							record: (input) => {
+								calls.push(input);
+								return Effect.succeed({id: "n1"});
+							},
+						}),
+						relationStoreOf(["u-mod-a", "u-mod-b"]),
+						divanPending(1),
+						requestContext(true),
+					),
+				),
+			);
+			assert.strictEqual(calls.length, 2);
+			assert.deepStrictEqual(calls[0], {
+				recipientId: "u-mod-a",
+				kind: CAYLAK_PENDING_KIND,
+				targetKind: "user",
+				targetId: "u-caylak",
+				actorId: null,
+			});
+		}),
+	);
+
+	it.effect("a çaylak's SECOND+ pending item (count > 1) pages nobody — no re-notify", () =>
+		notifyCaylakEntersDivan({
+			authorId: "u-caylak",
+			sandboxedAt: new Date("2026-01-01T00:00:00Z"),
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeNotificationStub(),
+					relationStoreOf(["u-mod-a"]),
+					divanPending(3),
+					requestContext(true),
+				),
+			),
+		),
+	);
+
+	it.effect("with the bildirim flag OFF nothing is read or written (dark by default)", () =>
+		notifyCaylakEntersDivan({
+			authorId: "u-caylak",
+			sandboxedAt: new Date("2026-01-01T00:00:00Z"),
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeNotificationStub(),
+					relationStoreOf(["u-mod-a"]),
+					divanDies,
+					requestContext(false),
+				),
+			),
+		),
+	);
+
+	it.effect("a DYING count read is swallowed — the create caller still succeeds", () =>
+		Effect.gen(function* () {
+			const exit = yield* notifyCaylakEntersDivan({
+				authorId: "u-caylak",
+				sandboxedAt: new Date("2026-01-01T00:00:00Z"),
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub(),
+						relationStoreOf(["u-mod-a"]),
+						divanDies,
+						requestContext(true),
+					),
+				),
+				Effect.exit,
+			);
+			assert.strictEqual(exit._tag, "Success");
+		}),
+	);
+});

--- a/apps/web/worker/features/divan/Divan.ts
+++ b/apps/web/worker/features/divan/Divan.ts
@@ -35,6 +35,14 @@ export class Divan extends Context.Service<
 		readonly roster: () => Effect.Effect<ReadonlyArray<DivanRosterRow>>;
 		/** One çaylak's sandboxed backlog (newest first) — the detail-view items. */
 		readonly backlogOf: (authorId: string) => Effect.Effect<ReadonlyArray<DivanItem>>;
+		/**
+		 * How many still-pending (sandboxed, not-removed) items one author has across
+		 * all three kinds — the mod-notification transition gate (#1699): a create path
+		 * fires the "new çaylak awaiting review" page only when this count is exactly 1
+		 * right after a çaylak's item committed (their 0→1 entry onto the roster), so a
+		 * çaylak's second and later items don't re-page the team.
+		 */
+		readonly pendingCountOf: (authorId: string) => Effect.Effect<number>;
 	}
 >()("divan/Divan") {}
 
@@ -115,6 +123,7 @@ export const DivanLive = Layer.effect(Divan)(
 				Effect.map(collect({authorId}), (items) =>
 					[...items].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),
 				),
+			pendingCountOf: (authorId) => Effect.map(collect({authorId}), (items) => items.length),
 		};
 	}),
 );

--- a/apps/web/worker/features/divan/Divan.unit.test.ts
+++ b/apps/web/worker/features/divan/Divan.unit.test.ts
@@ -283,3 +283,14 @@ describe("Divan.backlogOf — one çaylak's sandboxed backlog, newest first", ()
 		);
 	});
 });
+
+describe("Divan.pendingCountOf — the mod-notification 0→1 transition gate (#1699)", () => {
+	it("counts a çaylak's still-pending items across all kinds (removed & live excluded)", () => {
+		// cyl-a: d1 (sandboxed) + p1 (sandboxed) = 2; d2 (removed) and the yazar's live d4 excluded.
+		assert.strictEqual(run(Effect.flatMap(Divan, (d) => d.pendingCountOf("cyl-a"))), 2);
+	});
+
+	it("is 0 for an author with no pending items", () => {
+		assert.strictEqual(run(Effect.flatMap(Divan, (d) => d.pendingCountOf("yzr"))), 0);
+	});
+});

--- a/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
+++ b/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
@@ -70,6 +70,7 @@ const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationSt
 			Effect.succeed(
 				new Set(relation === "moderates" ? subjects.filter((s) => holders.includes(s)) : []),
 			),
+		subjectsOf: ({relation}) => Effect.succeed(new Set(relation === "moderates" ? holders : [])),
 	});
 
 const kunyeOf = (
@@ -341,6 +342,7 @@ describe("divan.vote — gated sandboxed vote", () => {
 					Layer.succeed(RelationStore, {
 						has: () => Effect.die(new Error("flag OFF must not check authority")),
 						hasSubjects: () => Effect.die(new Error("flag OFF must not check authority")),
+						subjectsOf: () => Effect.die(new Error("flag OFF must not check authority")),
 					}),
 					kunyeOf({"u-yazar": "yazar"}),
 					agentAuthorityStub,

--- a/apps/web/worker/features/divan/gate.unit.test.ts
+++ b/apps/web/worker/features/divan/gate.unit.test.ts
@@ -55,6 +55,12 @@ const access = (
 								: [],
 						),
 					),
+				subjectsOf: ({relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "moderates" && object.type === "platform" ? (opts.mods ?? []) : [],
+						),
+					),
 			}),
 		),
 	);
@@ -114,6 +120,7 @@ describe("divan gate — yazar OR mod, collapse-to-allow", () => {
 				Effect.provideService(RelationStore, {
 					has: () => Effect.succeed(false),
 					hasSubjects: () => Effect.succeed(new Set<string>()),
+					subjectsOf: () => Effect.succeed(new Set<string>()),
 				}),
 			),
 		);

--- a/apps/web/worker/features/funnel/gate.unit.test.ts
+++ b/apps/web/worker/features/funnel/gate.unit.test.ts
@@ -46,6 +46,12 @@ const access = (
 								: [],
 						),
 					),
+				subjectsOf: ({relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "moderates" && object.type === "platform" ? (opts.mods ?? []) : [],
+						),
+					),
 			}),
 		),
 	);
@@ -84,6 +90,7 @@ describe("funnel gate — platform-moderation only", () => {
 				Effect.provideService(RelationStore, {
 					has: () => Effect.succeed(true),
 					hasSubjects: ({subjects}) => Effect.succeed(new Set(subjects)),
+					subjectsOf: () => Effect.succeed(new Set<string>()),
 				}),
 			),
 		);

--- a/apps/web/worker/features/kunye/RelationStore.ts
+++ b/apps/web/worker/features/kunye/RelationStore.ts
@@ -57,6 +57,22 @@ export const RelationStoreLive = Layer.effect(RelationStore)(
 				);
 				return new Set(rows.map((row) => row.subject));
 			}),
+
+			subjectsOf: Effect.fn("RelationStore.subjectsOf")(function* ({relation, object}) {
+				const rows = yield* run((db) =>
+					db
+						.select({subject: schema.relationTuple.subject})
+						.from(schema.relationTuple)
+						.where(
+							and(
+								eq(schema.relationTuple.relation, relation),
+								eq(schema.relationTuple.object, objectKey(object)),
+							),
+						)
+						.all(),
+				);
+				return new Set(rows.map((row) => row.subject));
+			}),
 		};
 	}),
 );

--- a/apps/web/worker/features/kunye/RelationStore.unit.test.ts
+++ b/apps/web/worker/features/kunye/RelationStore.unit.test.ts
@@ -134,6 +134,49 @@ describe("RelationStore.hasSubjects — batched membership over a subject set (#
 	});
 });
 
+describe("RelationStore.subjectsOf — the open-set enumeration for one (relation, object) (#1699)", () => {
+	it.effect("returns every subject the read rows carry", () =>
+		Effect.gen(function* () {
+			const store = yield* RelationStore;
+			const mods = yield* store.subjectsOf({relation: "moderates", object: platform});
+			assert.deepStrictEqual([...mods].sort(), ["u-mod-a", "u-mod-b"]);
+		}).pipe(
+			Effect.provide(
+				storeLayer(countingAccess([{subject: "u-mod-a"}, {subject: "u-mod-b"}]).access),
+			),
+		),
+	);
+
+	it.effect("is empty when no tuple matches (no moderators)", () =>
+		Effect.gen(function* () {
+			const store = yield* RelationStore;
+			const mods = yield* store.subjectsOf({relation: "moderates", object: platform});
+			assert.strictEqual(mods.size, 0);
+		}).pipe(Effect.provide(storeLayer(countingAccess([]).access))),
+	);
+
+	it("compiles to a relation/object-filtered read over relation_tuple (statement pin, no engine)", () => {
+		const db: DrizzleDb = createDrizzle({} as D1Database);
+		const {sql, params} = db
+			.select({subject: schema.relationTuple.subject})
+			.from(schema.relationTuple)
+			.where(
+				and(
+					eq(schema.relationTuple.relation, "moderates"),
+					eq(schema.relationTuple.object, objectKey(platform)),
+				),
+			)
+			.toSQL();
+		assert.match(sql, /from "relation_tuple"/i);
+		assert.match(sql, /"relation" = \?/i);
+		assert.match(sql, /"object" = \?/i);
+		// No subject predicate — the enumeration is the whole set for this (relation, object).
+		assert.notMatch(sql, /"subject" (=|in)/i);
+		assert.include(params as unknown[], "moderates");
+		assert.include(params as unknown[], "platform:kampus");
+	});
+});
+
 describe("RelationStore.has — query shape (statement pin, no engine)", () => {
 	// The production lookup compiles to an existence read over `relation_tuple`,
 	// filtered by the three tuple columns with the `objectKey` serialization. The real

--- a/apps/web/worker/features/kunye/admin.unit.test.ts
+++ b/apps/web/worker/features/kunye/admin.unit.test.ts
@@ -46,6 +46,10 @@ const discharge = (actor: Actor, holders: ReadonlyArray<string>): Exit.Exit<Gran
 								: [],
 						),
 					),
+				subjectsOf: ({relation, object}) =>
+					Effect.succeed(
+						new Set(relation === "admin" && object.type === "platform" ? holders : []),
+					),
 			}),
 		),
 	);

--- a/apps/web/worker/features/kunye/moderate.ts
+++ b/apps/web/worker/features/kunye/moderate.ts
@@ -57,6 +57,21 @@ export const moderatorsAmong = (
 	});
 
 /**
+ * EVERY platform moderator's account id — the mod-fan-out recipient set (#1699):
+ * every subject holding `(subject, "moderates", platform)`, read off the same
+ * direct tuple {@link isModerator} / {@link moderatorsAmong} key. Where those two
+ * ANSWER membership for a known candidate, this ENUMERATES the open set a `notify
+ * every moderator` emit needs — a recipient set with no candidate ids up front, so
+ * neither `has` nor `hasSubjects` can produce it. The tuple key lives here next to
+ * {@link Moderate} so the enumeration key can't drift from the discharge key.
+ */
+export const allModerators = (): Effect.Effect<ReadonlySet<string>, never, RelationStore> =>
+	Effect.gen(function* () {
+		const store = yield* RelationStore;
+		return yield* store.subjectsOf({relation: "moderates", object: platform});
+	});
+
+/**
  * Gate `body` behind platform-moderation authority: discharge
  * `Moderate.over(platform)` (the invisible {@link Denied} on failure) and thread
  * the resulting `Grant` into `body`'s R-channel via `Grant.provide`. So `body`

--- a/apps/web/worker/features/kunye/moderate.unit.test.ts
+++ b/apps/web/worker/features/kunye/moderate.unit.test.ts
@@ -23,7 +23,7 @@ import {
 } from "@kampus/authz";
 import {Effect, Exit} from "effect";
 import {Denied} from "./errors.ts";
-import {Moderate, moderatorOf, moderatorsAmong} from "./moderate.ts";
+import {allModerators, Moderate, moderatorOf, moderatorsAmong} from "./moderate.ts";
 
 // Provide the three ports off a fixture (the holder set the `moderates` tuple
 // proves membership against) and run `Moderate.over(platform)` to an Exit.
@@ -49,6 +49,10 @@ const discharge = (
 								? subjects.filter((subject) => holders.includes(subject))
 								: [],
 						),
+					),
+				subjectsOf: ({relation, object}) =>
+					Effect.succeed(
+						new Set(relation === "moderates" && object.type === "platform" ? holders : []),
 					),
 			}),
 		),
@@ -115,6 +119,10 @@ describe("moderatorsAmong", () => {
 							: [],
 					),
 				),
+			subjectsOf: ({relation, object}) =>
+				Effect.succeed(
+					new Set(relation === "moderates" && object.type === "platform" ? holders : []),
+				),
 		});
 
 	it("returns exactly the subjects that hold the moderates tuple", () => {
@@ -129,6 +137,33 @@ describe("moderatorsAmong", () => {
 
 	it("is empty for an empty subject set", () => {
 		const mods = Effect.runSync(moderatorsAmong([]).pipe(storeOf(["u1"])));
+		assert.strictEqual(mods.size, 0);
+	});
+});
+
+// `allModerators` is the OPEN-set enumeration (#1699) the membership pair can't
+// answer: the whole `(moderates, platform)` subject set with no candidates up front —
+// the mod fan-out recipient set. The fixture returns exactly the holders for the
+// moderates/platform tuple, so the enumeration reads off the same key `has` proves.
+describe("allModerators", () => {
+	const storeOf = (holders: ReadonlyArray<string>) =>
+		Effect.provideService(RelationStore, {
+			has: () => Effect.die(new Error("allModerators enumerates via subjectsOf, not has")),
+			hasSubjects: () =>
+				Effect.die(new Error("allModerators enumerates via subjectsOf, not hasSubjects")),
+			subjectsOf: ({relation, object}) =>
+				Effect.succeed(
+					new Set(relation === "moderates" && object.type === "platform" ? holders : []),
+				),
+		});
+
+	it("enumerates every subject holding the moderates tuple", () => {
+		const mods = Effect.runSync(allModerators().pipe(storeOf(["u-mod1", "u-mod2"])));
+		assert.deepStrictEqual([...mods].sort(), ["u-mod1", "u-mod2"]);
+	});
+
+	it("is empty when no one moderates", () => {
+		const mods = Effect.runSync(allModerators().pipe(storeOf([])));
 		assert.strictEqual(mods.size, 0);
 	});
 });

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -18,6 +18,7 @@ import * as Schema from "effect/Schema";
 import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
 import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
 import {notifyCommentReply} from "../bildirim/conversation-emitters.ts";
+import {notifyCaylakEntersDivan} from "../bildirim/mod-emitters.ts";
 import {notifyContentVote} from "../bildirim/vote-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
@@ -206,6 +207,10 @@ export const mutations = {
 			// but only when the post is live: the feed topic is viewer-blind, so a
 			// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
 			yield* live.post.feed.prependNode(post.id, {node: post}, decidePublish(sandboxedAt));
+			// Mod-queue heartbeat (#1699): if this sandboxed post is the çaylak's FIRST
+			// pending item, page the moderators that a new çaylak awaits review. Gated,
+			// transition-guarded and swallowed inside the emitter — never fails the post.
+			yield* notifyCaylakEntersDivan({authorId: user.id, sandboxedAt});
 			return post;
 		}),
 	),
@@ -517,6 +522,9 @@ export const mutations = {
 				parentAuthorId: r.parentAuthorId,
 				actorId: user.id,
 			});
+			// Mod-queue heartbeat (#1699): a sandboxed comment that is the çaylak's FIRST
+			// pending item pages the moderators — same transition gate as post.submit.
+			yield* notifyCaylakEntersDivan({authorId: user.id, sandboxedAt});
 			return comment;
 		}),
 	),

--- a/apps/web/worker/features/pasaport/promote-live.testing.ts
+++ b/apps/web/worker/features/pasaport/promote-live.testing.ts
@@ -35,6 +35,7 @@ export const noopLive: Layer.Layer<LivePublisher> = Layer.succeed(LivePublisher)
 export const relationStoreNoModerators: Layer.Layer<RelationStore> = Layer.succeed(RelationStore, {
 	has: () => Effect.die(new Error("moderatorsAmong reads hasSubjects, not has")),
 	hasSubjects: () => Effect.succeed(new Set<string>()),
+	subjectsOf: () => Effect.succeed(new Set<string>()),
 });
 
 /**

--- a/apps/web/worker/features/pasaport/promote-live.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promote-live.unit.test.ts
@@ -32,6 +32,7 @@ import {publishPromotion} from "./promote-live.ts";
 const relationStoreEmpty: Layer.Layer<RelationStore> = Layer.succeed(RelationStore, {
 	has: () => Effect.succeed(false),
 	hasSubjects: () => Effect.succeed(new Set<string>()),
+	subjectsOf: () => Effect.succeed(new Set<string>()),
 });
 
 // One `user` record the re-resolve reads back — the promoted member, now `yazar`.

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -77,6 +77,7 @@ const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationSt
 			Effect.succeed(
 				new Set(relation === "moderates" ? subjects.filter((s) => holders.includes(s)) : []),
 			),
+		subjectsOf: ({relation}) => Effect.succeed(new Set(relation === "moderates" ? holders : [])),
 	});
 
 // A `Kunye` whose standing/karma answer by id.
@@ -178,6 +179,7 @@ describe("user.promote — direct moderator promotion", () => {
 					Layer.succeed(RelationStore, {
 						has: () => Effect.die(new Error("flag OFF must not check authority")),
 						hasSubjects: () => Effect.die(new Error("flag OFF must not check authority")),
+						subjectsOf: () => Effect.die(new Error("flag OFF must not check authority")),
 					}),
 					agentAuthorityStub,
 					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),

--- a/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
@@ -50,6 +50,7 @@ const relationStoreOf = (mods: ReadonlyArray<string>): Layer.Layer<RelationStore
 			Effect.succeed(
 				new Set(relation === "moderates" ? subjects.filter((s) => mods.includes(s)) : []),
 			),
+		subjectsOf: ({relation}) => Effect.succeed(new Set(relation === "moderates" ? mods : [])),
 	});
 
 describe("toTrustedUser — the SELF trusted User shape", () => {

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -24,6 +24,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {type TargetKind, TargetKindSchema, targetKey} from "../../db/target-kind.ts";
+import {notifyReportFiled} from "../bildirim/mod-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Denied} from "../kunye/errors.ts";
 import {Moderate, moderatorOf, requireModeration} from "../kunye/moderate.ts";
@@ -105,6 +106,17 @@ export const mutations = {
 				.pipe(
 					Effect.catchTag("report/ReportTargetNotFound", (e) => Effect.fail(toFeatureNotFound(e))),
 				);
+			// Mod-queue heartbeat (#1699): page every moderator that a report was filed —
+			// but only on a GENUINELY new report (`created`), never an idempotent re-report.
+			// Flag-gated, moderator-resolved and swallowed inside the emitter, so it can
+			// never fail this committed report.
+			if (result.created) {
+				yield* notifyReportFiled({
+					reporterId: user.id,
+					targetKind: input.targetKind,
+					targetId: input.targetId,
+				});
+			}
 			return toReportReceipt(result);
 		}),
 	),

--- a/apps/web/worker/features/report/report-live-fanout.unit.test.ts
+++ b/apps/web/worker/features/report/report-live-fanout.unit.test.ts
@@ -21,8 +21,12 @@ import {assert, describe, it} from "@effect/vitest";
 import {type Actor, AgentAuthority, CurrentActor, human, RelationStore} from "@kampus/authz";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveEntityTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, Effect, Layer} from "effect";
+import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
+import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {Flags} from "../flagship/Flags.ts";
 import {Pano} from "../pano/Pano.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
 import {mutations} from "./mutations.ts";
@@ -38,9 +42,32 @@ const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationSt
 			Effect.succeed(
 				new Set(relation === "moderates" ? subjects.filter((s) => holders.includes(s)) : []),
 			),
+		subjectsOf: ({relation}) => Effect.succeed(new Set(relation === "moderates" ? holders : [])),
 	});
 
 const agentAuthorityStub = Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)});
+
+// The mod-emitter deps `report.submit` gained (#1699): `Flags` OFF ⇒ `bildirimOn` is
+// false ⇒ the report-filed page no-ops before the moderator read / notification write.
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "report-live-fanout-test",
+	id: "report-live-fanout-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+const bildirimOffStub = Layer.mergeAll(
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(false),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service),
+	Layer.succeed(RuntimeContext, runtimeContextStub),
+	noRequestFlagOverrides,
+	makeNotificationStub(),
+	relationStoreOf([]),
+);
 
 const actorContext = (actor: Actor) => Layer.succeed(CurrentActor, {actor});
 
@@ -590,27 +617,36 @@ describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () =
 	});
 });
 
-describe("report.submit — the audit refuted submit; it fans out nothing", () => {
+describe("report.submit — the audit refuted submit; the CONTENT path fans out nothing", () => {
 	it.effect(
-		"submit acquires NO publisher (a private report row changes no subscribed content)",
+		"submit never publishes to a CONTENT topic (a private report row changes no subscribed content)",
 		() =>
-			// The submit handler never reaches `WorkerLivePublisher` — a fail-on-contact
-			// publisher would DIE if it did. That it lands with no `LivePublisher` provided
-			// at all is the strongest proof: submit's R-channel carries no live dependency.
+			// The submit handler never touches `WorkerLivePublisher` on the content path — a
+			// report is private moderation state. Its ONLY live dependency is the bildirim
+			// spine's per-recipient `Notification.record` delivery (#2076/#1699), gated OFF
+			// here (`bildirimOffStub`), so the recording publisher captures NOTHING.
 			Effect.gen(function* () {
+				const {recorded, scheduled, layer} = recordingPublisher();
 				const receipt = yield* mutations["report.submit"]
 					.handler({
 						input: {targetKind: "post", targetId: "p1"},
 						select: ["id", "created"],
 					})
-					.pipe(Effect.provideService(CurrentUser, {user: {id: "u-reporter"} as never}));
+					.pipe(
+						Effect.provideService(CurrentUser, {user: {id: "u-reporter"} as never}),
+						Effect.provide(
+							Layer.mergeAll(
+								makeReportStub({
+									submit: () => Effect.succeed({targetKind: "post", targetId: "p1", created: true}),
+								}),
+								layer,
+								bildirimOffStub,
+							),
+						),
+					);
+				yield* flush(scheduled);
 				assert.strictEqual((receipt as {created: boolean}).created, true);
-			}).pipe(
-				Effect.provide(
-					makeReportStub({
-						submit: () => Effect.succeed({targetKind: "post", targetId: "p1", created: true}),
-					}),
-				),
-			),
+				assert.deepStrictEqual(recorded, [], "submit published to no topic (content or bildirim)");
+			}),
 	);
 });

--- a/apps/web/worker/features/report/report-mutation.unit.test.ts
+++ b/apps/web/worker/features/report/report-mutation.unit.test.ts
@@ -13,15 +13,53 @@
  */
 
 import {assert, describe, it} from "@effect/vitest";
-import {CurrentUser} from "@kampus/fate-effect";
-import {Cause, Effect, type Layer} from "effect";
-import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {RelationStore} from "@kampus/authz";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Cause, Effect, Layer} from "effect";
+import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
+import {noRequestFlagOverrides, resolveWire} from "../fate/resolve-wire.testing.ts";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {Flags} from "../flagship/Flags.ts";
 import {ReportTargetNotFound} from "./errors.ts";
 import {mutations} from "./mutations.ts";
 import {makeReportStub} from "./Report.testing.ts";
 import type {Report, ReportInput, ReportResult} from "./Report.ts";
 
 const REPORTER = {id: "u-reporter", email: "elif@example.com", name: "elif"};
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "report-mutation-test",
+	id: "report-mutation-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+// The mod-emitter deps `report.submit` gained (#1699): the report-filed page rides
+// AFTER the committed submit. `Flags` OFF ⇒ `bildirimOn` is false ⇒ the emit no-ops
+// before the moderator read or any notification write, so the Notification /
+// RelationStore stubs exist only to satisfy the type and die if ever reached.
+const bildirimOffStub = Layer.mergeAll(
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(false),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service),
+	Layer.succeed(RuntimeContext, runtimeContextStub),
+	noRequestFlagOverrides,
+	makeNotificationStub(),
+	// `Notification.record` rides `LivePublisher` (the per-recipient live delivery seam,
+	// #2076) — a static requirement of the mod emit even though the flag-off path never
+	// records. A no-op publisher satisfies it; it is never reached.
+	Layer.succeed(LivePublisher)(livePublisherFor({publish: () => Effect.void, waitUntil: () => {}})),
+	Layer.succeed(RelationStore, {
+		has: () => Effect.die("RelationStore.has not exercised in report-mutation"),
+		hasSubjects: () => Effect.die("RelationStore.hasSubjects not exercised in report-mutation"),
+		subjectsOf: () => Effect.die("RelationStore.subjectsOf not exercised in report-mutation"),
+	}),
+);
 
 // Drive the op through its real external interface (`resolveWire`: `resolve`
 // decode + the `encodeWireError` class→wire-code seam), not `.handler` — so the
@@ -35,7 +73,7 @@ const submit = (
 	resolveWire(mutations["report.submit"], {
 		input,
 		select: ["id", "targetKind", "targetId", "created"],
-	}).pipe(Effect.provideService(CurrentUser, {user}));
+	}).pipe(Effect.provideService(CurrentUser, {user}), Effect.provide(bildirimOffStub));
 
 // The wire `code` carried by a `resolveWire` failure `Cause` (the `FateRequestError`
 // `encodeWireError` produced), or `undefined` if the cause holds no error / on success.

--- a/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
@@ -19,10 +19,13 @@
  */
 
 import {assert, it} from "@effect/vitest";
+import {RelationStore} from "@kampus/authz";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
+import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
+import {Divan} from "../divan/Divan.ts";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {Flags} from "../flagship/Flags.ts";
@@ -56,6 +59,21 @@ const kunyeStub = Layer.succeed(Kunye, {
 	karmaOf: () => Effect.succeed(0),
 	rootOf: (id: string) => Effect.succeed(id),
 } as typeof Kunye.Service);
+
+// The mod-emitter deps the resolver gained (#1699). `Flags` OFF ⇒ `sandboxedAtForAuthor`
+// returns null ⇒ `notifyCaylakEntersDivan` short-circuits before touching any of these,
+// so they exist only to satisfy the type and die on contact if ever reached.
+const notificationStub = makeNotificationStub();
+const divanStub = Layer.succeed(Divan, {
+	roster: () => Effect.die("Divan.roster not exercised in definition-mutation"),
+	backlogOf: () => Effect.die("Divan.backlogOf not exercised in definition-mutation"),
+	pendingCountOf: () => Effect.die("Divan.pendingCountOf not exercised in definition-mutation"),
+});
+const relationStoreStub = Layer.succeed(RelationStore, {
+	has: () => Effect.die("RelationStore.has not exercised in definition-mutation"),
+	hasSubjects: () => Effect.die("RelationStore.hasSubjects not exercised in definition-mutation"),
+	subjectsOf: () => Effect.die("RelationStore.subjectsOf not exercised in definition-mutation"),
+});
 
 // A `Sozluk` stub whose `addDefinition` is scripted; every other method dies on
 // contact, so a passing test proves `definition.add` reached only the write it
@@ -114,6 +132,9 @@ it.effect(
 							liveStub,
 							flagsOffStub,
 							kunyeStub,
+							notificationStub,
+							divanStub,
+							relationStoreStub,
 							noRequestFlagOverrides,
 						),
 					),

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -15,6 +15,7 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
 import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
+import {notifyCaylakEntersDivan} from "../bildirim/mod-emitters.ts";
 import {notifyContentVote} from "../bildirim/vote-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
@@ -111,6 +112,9 @@ export const mutations = {
 			yield* live.definition
 				.term(input.termSlug)
 				.appendNode(definition.id, {node: definition}, decidePublish(sandboxedAt));
+			// Mod-queue heartbeat (#1699): a sandboxed definition that is the çaylak's
+			// FIRST pending item pages the moderators — same transition gate as pano.
+			yield* notifyCaylakEntersDivan({authorId: user.id, sandboxedAt});
 			return definition;
 		}),
 	),

--- a/packages/authz/src/Capability.unit.test.ts
+++ b/packages/authz/src/Capability.unit.test.ts
@@ -84,6 +84,14 @@ const run = <A, E>(
 							),
 						),
 					),
+				subjectsOf: ({object}) =>
+					Effect.succeed(
+						new Set(
+							(env.tuples ?? [])
+								.filter((t) => t.type === object.type && t.id === object.id)
+								.map((t) => t.subject),
+						),
+					),
 			}),
 		),
 	);

--- a/packages/authz/src/Relation.ts
+++ b/packages/authz/src/Relation.ts
@@ -37,5 +37,15 @@ export class RelationStore extends Context.Service<
 			readonly relation: string;
 			readonly object: Resource;
 		}) => Effect.Effect<ReadonlySet<string>>;
+
+		// Enumerate EVERY subject holding `(relation, object)` — the open-set read the
+		// membership pair (`has`/`hasSubjects`) can't answer, because both need the
+		// candidate ids up front. A mod fan-out (`notify every moderator`, #1699) has no
+		// candidate set: the recipient set IS "who holds `(moderates, platform)`". Same
+		// direct-tuple semantics as `has` (no ancestry walk); one read returns the whole set.
+		readonly subjectsOf: (query: {
+			readonly relation: string;
+			readonly object: Resource;
+		}) => Effect.Effect<ReadonlySet<string>>;
 	}
 >()("authz/RelationStore") {}


### PR DESCRIPTION
Fixes #1699. Part of the bildirim epic #1666.

## What

The moderator team's pager, through the bildirim spine's `Notification` write surface (stories 9/10/12). Two mod-facing emitters, both fire-and-forget after the committed mutation, dark behind the existing default-off `phoenix-bildirim` flag.

- **report-filed** — a genuinely-new content report (`report.submit`, gated on `result.created`, never an idempotent re-report) pages every moderator. Target is the reported content (the row links straight to it); actor is the reporter.
- **caylak-pending** — a çaylak entering the divan review queue pages every moderator. Wired into the three content-create paths (pano `post.submit` / `comment.add`, sözlük `definition.add`) behind a `Divan.pendingCountOf(author) === 1` **0→1 transition gate**, so it fires only on the çaylak's **first** currently-pending item — "a new çaylak is awaiting review", not one ping per sandboxed item.

## How the recipient set is grounded (not a hardcoded list)

Moderators are resolved from the authority model (ADR 0107): a new `RelationStore.subjectsOf` port primitive enumerates every subject holding `(moderates, platform)` — the **same tuple** `Moderate.over(platform)` discharges against — surfaced as `moderate.ts`'s `allModerators()`. The membership pair (`has`/`hasSubjects`) can't answer this: a `notify every moderator` fan-out has no candidate ids up front. The acting moderator is self-suppressed (a moderator who files a report is never paged about their own action).

## Safety

Both emits ride AFTER the committed report/create mutation and are swallowed-with-log (`catchCause`, ADR 0039 posture), absorbing the `orDieAccess` **defect** a D1 hiccup raises, not just typed errors — a failed notification write can never fail the underlying mutation (tested at the seam). Live delivery is free via the per-recipient `Notification.record` seam (#2076); no live-wiring code. The two new kinds (`report-filed` / `caylak-pending`) carry Turkish copy, `satisfies Record<NotificationKind, …>` (exhaustive — a kind without copy is a compile error).

## Acceptance criteria

- [x] Filing a report produces a notification for every moderator, moderators resolved from the authority model (`RelationStore.subjectsOf` / `allModerators`).
- [x] A new çaylak entering pending review produces a notification for every moderator (0→1 transition gate).
- [x] An acting moderator receives no self-notification for their own action (`modRecipients` self-suppression).
- [x] A failed notification write cannot fail the underlying mutation (tested at the seam — dying `Notification`/`Divan` swallowed).
- [x] Fan-out and recipient resolution are unit-tested (`mod-emitters.unit.test.ts`, `moderate.unit.test.ts` `allModerators`, `RelationStore.unit.test.ts` `subjectsOf`, `Divan.unit.test.ts` `pendingCountOf`).

## Tests / checks

`pnpm typecheck` clean, `pnpm lint` clean, all affected unit suites green (440 passed across the touched feature dirs). The `RelationStore.subjectsOf` addition rippled a `subjectsOf` method into the existing inline `RelationStore` test doubles (mechanical, additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)