### PR TITLE
fix(telemetry): contain defects at the TelemetryLive.emit seam, not per call-site (#2085)

### DIFF
--- a/.patterns/telemetry.md
+++ b/.patterns/telemetry.md
@@ -36,19 +36,27 @@ binding is resolved **once per isolate in worker init** and carried on a depende
 Emitting is **fire-and-forget best-effort, never a source of truth** (ADR 0153). Internalize
 this before anything else: a telemetry failure — an AE write error *or* a defect — must never
 fail, unwind, or slow the mutation it observes. `emit`'s type is `Effect<void>` precisely
-because both channels are discharged inside `TelemetryLive`, so a call-site can't accidentally
-route a telemetry error into its own error union.
+because **both a typed failure and a defect are contained inside `TelemetryLive`**, so a
+call-site can neither route a telemetry error into its own error union nor be unwound by a
+telemetry defect. **S4 is a property of the seam, not of each call-site** — instruments emit
+BARE and inherit containment by construction (#2085).
 
 Two discharges live in the layer (`Telemetry.ts`), so the call-site gets a clean `Effect<void>`:
 
 - **The `RuntimeContext` requirement** `writeDataPoint` needs is captured once in the layer
   closure and `provideService`'d — the same pattern `LiveTopics.publish` uses in the worker.
-- **The `DatasetError` error channel** is swallowed with a log (`Effect.ignore({log: "Warn"})`)
-  — the same best-effort boundary `LivePublisher` uses. The failure is logged; `emit` still
-  succeeds.
+- **The whole failure `Cause`** is swallowed with a log (`Effect.ignoreCause({log: "Warn"})`).
+  This is the load-bearing choice: `Effect.ignoreCause` discards the **whole Cause — a typed
+  `DatasetError` AND a defect (a `die`, a sync throw in `writeDataPoint`, a `toDataPoint` bug)
+  and interruptions** — whereas `Effect.ignore` would discard only the typed `E` channel and let
+  a defect propagate out. Containing the whole Cause **at the seam** is what makes `emit` a
+  genuine `Effect<void>` that cannot fail OR die for every caller, so no instrument has to
+  remember a call-site wrap. Grounded in effect-smol `Effect.ts` (`ignoreCause`: "Ignores the
+  effect's failure cause, including defects and interruptions"; `ignore`: discards only the
+  failure value).
 
 ```ts
-// features/telemetry/Telemetry.ts — the layer discharges both channels
+// features/telemetry/Telemetry.ts — the seam contains the WHOLE Cause (defects included)
 export const TelemetryLive = Layer.effect(
 	Telemetry,
 	Effect.gen(function* () {
@@ -58,16 +66,20 @@ export const TelemetryLive = Layer.effect(
 			emit: (event) =>
 				client.writeDataPoint(toDataPoint(event)).pipe(
 					Effect.provideService(RuntimeContext, runtimeContext),
-					// best-effort: log the DatasetError, return void — never fail the caller (ADR 0153)
-					Effect.ignore({log: "Warn"}),
+					// best-effort: log the whole Cause (error OR defect), return void — never fail
+					// or die out of the caller (ADR 0153 S4). ignoreCause, not ignore: a defect must
+					// be contained at the seam so every instrument gets S4 by construction (#2085).
+					Effect.ignoreCause({log: "Warn"}),
 				),
 		});
 	}),
 );
 ```
 
-The invariant is pinned by a test: `Telemetry.unit.test.ts` substitutes a `failingClient` whose
-`writeDataPoint` always fails with a `DatasetError`, and asserts `emit` still exits **success**.
+The invariant is pinned by two tests in `Telemetry.unit.test.ts`: a `failingClient` whose
+`writeDataPoint` fails with a `DatasetError` (the typed-failure case) **and** a `dyingClient`
+whose `writeDataPoint` **dies** (the defect case) — both assert `emit` still exits **success**,
+proving the seam contains error *and* defect.
 
 ## The fixed positional event-schema (one owner, `schema.ts`)
 
@@ -155,23 +167,29 @@ yield* telemetry.emit({
 });
 ```
 
-**4. Wrap the emit for defect-containment where the instrument is on a hot mutation path.**
-`Vote.cast` wraps its emit in `Effect.ignoreCause` — and this is the load-bearing distinction:
+**4. Emit BARE — no call-site containment wrap.** Both reference instruments (`Vote.cast`,
+`Reaction.react`) emit bare; the seam already contains the whole failure `Cause` (error **and**
+defect), so a call-site `Effect.ignoreCause` would be pure redundancy:
 
 ```ts
-// features/vote/Vote.ts — emit after the atomic batch commits, defect-contained
-yield* telemetry
-	.emit({feature: "vote", action: isCast ? "cast" : "retract", surface: input.targetKind, userId: input.userId})
-	.pipe(Effect.ignoreCause({log: "Warn"}));
+// features/vote/Vote.ts — emit after the atomic batch commits; bare, seam-contained
+yield* telemetry.emit({
+	feature: "vote",
+	action: isCast ? "cast" : "retract",
+	surface: input.targetKind,
+	userId: input.userId,
+});
 ```
 
-> **Why `Effect.ignoreCause`, not `Effect.ignore`.** `Effect.ignore` discards only the **error
-> (`E`) channel** — a *defect* (a `die`, a thrown bug in the emit path) still propagates and
-> would unwind the mutation. `Effect.ignoreCause` discards the **whole `Cause`** — error **and**
-> defect — so even a broken emit can never fail or slow the cast it observes. `TelemetryLive`
-> already swallows the `DatasetError` (the `E` channel), so this is belt-and-suspenders: it
-> contains a *defect* that slipped past the layer, keeping telemetry fully off the mutation's
-> critical path. Use it on any instrument where a telemetry defect must not touch the mutation.
+> **The seam uses `ignoreCause` so callers don't have to.** The `ignore` vs `ignoreCause`
+> distinction still matters — it's just resolved **once, at the seam**, not at every call-site.
+> `Effect.ignore` discards only the **error (`E`) channel**, so a *defect* (a `die`, a thrown
+> bug in the emit path) would propagate and unwind the mutation; `Effect.ignoreCause` discards
+> the **whole `Cause`** — error **and** defect — so even a broken emit can never fail or slow the
+> mutation. `TelemetryLive` uses `Effect.ignoreCause` internally (see [The one invariant](#the-one-invariant-telemetry-can-never-fail-the-mutation-it-observes-s4)),
+> which makes `emit: Effect<void>` genuinely unfailable-and-undyable for **every** instrument by
+> construction — so a per-call-site wrap is redundant and instruments emit bare (#2085). Don't
+> re-add a call-site `ignoreCause`: it duplicates a guarantee the seam already gives.
 
 **5. Discharge the `Telemetry` layer requirement at `makeFateLayer`.** Emitting gives the
 feature's `*Live` a build-time `Telemetry` requirement. Discharge it with `Layer.provide` at the
@@ -206,13 +224,18 @@ Substitute the `Telemetry` tag directly (the unit-tier seam substitution,
 - **`recordingTelemetry(sink)`** — records every emitted event so a test asserts the exact
   `{feature, action, surface, emoji?}` shape it emitted, or that it emitted **nothing** on a
   no-op (an empty `sink`).
-- **`dyingTelemetry`** — makes `emit` **die**, so a test proves the instrument's write already
-  committed **before** the (best-effort) emit — i.e. the emit is off the commit path and a
-  blown-up emit can't unwind the mutation.
+- **`dyingTelemetry`** — makes `emit` **die**, so an instrument test proves the write already
+  committed **before** the (best-effort) emit — the emit is off the commit path. Note this double
+  substitutes the `Telemetry` *tag*, so it **bypasses the real seam** and its assertion is
+  commit-ordering only (the write is in `batches` even as the emit blows up); it does **not** run
+  the defect through the real containment. The seam-level defect containment itself is pinned in
+  `Telemetry.unit.test.ts`, below.
 
-The production fail-safe (the `DatasetError` swallow inside `TelemetryLive`) is pinned separately
-by the `failingClient` case in `Telemetry.unit.test.ts` — that substitutes the AE client at the
-`TelemetryClient` tag and asserts `emit` still succeeds.
+The production fail-safe is pinned by **two** cases in `Telemetry.unit.test.ts`, both substituting
+the AE client at the `TelemetryClient` tag and running through the real `TelemetryLive`: a
+`failingClient` whose `writeDataPoint` fails with a `DatasetError` (typed-failure containment) and
+a `dyingClient` whose `writeDataPoint` **dies** (defect containment) — both assert `emit` still
+succeeds, proving `Effect.ignoreCause` at the seam swallows error *and* defect (#2085).
 
 ## The read contract — reads are sampling-correct, and never from the Worker
 
@@ -249,8 +272,12 @@ GROUP BY day ORDER BY day
   one silently misaligns columns.
 - **Emitting before the commit, or on a no-op.** Emit after the mutation commits, on the
   state-change tail only, so a rolled-back or idempotent-no-op mutation emits nothing.
-- **`Effect.ignore` where a defect must not touch the mutation.** Use `Effect.ignoreCause` on hot
-  instrument paths — `ignore` leaves defects on the critical path.
+- **`Effect.ignore` at the seam.** The seam (`TelemetryLive`) must use `Effect.ignoreCause`, not
+  `Effect.ignore` — `ignore` leaves defects on the mutation's critical path; only `ignoreCause`
+  contains the whole Cause so S4 holds by construction for every caller (#2085).
+- **A call-site containment wrap on `emit`.** Instruments emit **bare** — the seam already
+  contains error *and* defect, so a call-site `Effect.ignoreCause`/`Effect.ignore` is redundant
+  and drifts the pattern; don't re-add one.
 - **Routing telemetry into a call-site's error union.** `emit` is `Effect<void>`; never widen it.
 - **`count()` in a read query, or reading from the Worker.** Weight by `SUM(_sample_interval)`
   and read only through the external SQL API.

--- a/apps/web/worker/features/telemetry/Telemetry.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.ts
@@ -13,9 +13,13 @@
  * discharged inside the layer so call-sites get a clean `Effect<void>`:
  *   - `writeDataPoint`'s ambient `RuntimeContext` requirement — captured once and
  *     `provideService`'d, the same pattern `LiveTopics.publish` uses (`index.ts`).
- *   - the `DatasetError` error channel — swallowed with a log (fire-and-forget
- *     best-effort). A telemetry failure can NEVER fail the mutation it observes
- *     (ADR 0153 fail-safe invariant).
+ *   - the WHOLE failure `Cause` — swallowed with a log (fire-and-forget
+ *     best-effort). A telemetry failure — a typed `DatasetError` OR a *defect* —
+ *     can NEVER fail the mutation it observes (ADR 0153 fail-safe invariant, S4).
+ *     `Effect.ignoreCause` (not `Effect.ignore`) is what makes this a SEAM property:
+ *     it discards defects and interruptions too, so `emit: Effect<void>` genuinely
+ *     cannot fail OR die and every caller gets S4 by construction — no per-call-site
+ *     `ignoreCause` an instrument must remember.
  *
  * The `Context.Service` + `Layer.effect` idiom is grounded in effect-smol
  * `LLMS.md` §"Writing Effect services" → "Context.Service" and
@@ -68,12 +72,14 @@ export const TelemetryLive = Layer.effect(
 			emit: (event) =>
 				client.writeDataPoint(toDataPoint(event)).pipe(
 					Effect.provideService(RuntimeContext, runtimeContext),
-					// Swallow-with-log: telemetry is best-effort, never a source of truth,
-					// and must not fail the mutation it observes (ADR 0153 fail-safe). The
-					// same `Effect.ignore({log})` boundary `LivePublisher` uses
-					// (`fate-live/live-publisher.ts`) — the failure is logged, `emit` is
-					// `Effect<void>`, and the caller never sees the `DatasetError`.
-					Effect.ignore({log: "Warn"}),
+					// Swallow-with-log the WHOLE Cause: telemetry is best-effort, never a
+					// source of truth, and must not fail the mutation it observes (ADR 0153
+					// S4). `ignoreCause` (not `ignore`) discards defects/interruptions too,
+					// so a DEFECT thrown inside emit — a sync throw in `writeDataPoint`, an
+					// `orDie`, a `toDataPoint` bug — is contained AT THE SEAM. That makes S4
+					// a property of the seam for every instrument, so callers emit BARE and
+					// never repeat a call-site `ignoreCause` (ADR 0153, #2085).
+					Effect.ignoreCause({log: "Warn"}),
 				),
 		});
 	}),

--- a/apps/web/worker/features/telemetry/Telemetry.unit.test.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.unit.test.ts
@@ -61,6 +61,17 @@ const failingClient = Layer.succeed(TelemetryClient)(
 	}),
 );
 
+// A `TelemetryClient` whose `writeDataPoint` DIES (a defect, not a typed error) —
+// drives the seam-contains-a-defect proof (#2085): `emit` must still succeed even
+// though a defect slipped into the emit path, because the seam swallows the whole
+// Cause (`Effect.ignoreCause`), not just the typed `E` (`Effect.ignore`).
+const dyingClient = Layer.succeed(TelemetryClient)(
+	TelemetryClient.of({
+		raw: Effect.die(new Error("raw unused")),
+		writeDataPoint: () => Effect.die(new Error("writeDataPoint blew up")),
+	}),
+);
+
 describe("toDataPoint — fixed positional AE schema (ADR 0153)", () => {
 	it("maps a vote event to the fixed slot order (index=feature, blobs, doubles=[1])", () => {
 		assert.deepStrictEqual(
@@ -143,6 +154,22 @@ describe("Telemetry.emit", () => {
 		}).pipe(
 			Effect.provide(
 				TelemetryLive.pipe(Layer.provide(Layer.mergeAll(failingClient, inertRuntimeContext))),
+			),
+		));
+
+	it("contains a DEFECT in the write path — emit still succeeds (seam-level S4, #2085)", () =>
+		// The whole point of moving containment into the seam: a defect (a die, a sync
+		// throw) inside emit must NOT propagate to the caller. `Effect.ignore` would let
+		// this exit die; `Effect.ignoreCause` swallows the whole Cause, so emit succeeds.
+		Effect.gen(function* () {
+			const telemetry = yield* Telemetry;
+			const exit = yield* Effect.exit(
+				telemetry.emit({feature: "reaction", action: "react", surface: "sozluk"}),
+			);
+			assert.strictEqual(Exit.isSuccess(exit), true);
+		}).pipe(
+			Effect.provide(
+				TelemetryLive.pipe(Layer.provide(Layer.mergeAll(dyingClient, inertRuntimeContext))),
 			),
 		));
 });

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -289,19 +289,16 @@ export const VoteLive = Layer.effect(Vote)(
 			// commits, so a rolled-back cast — and every idempotent no-op above, which
 			// returns before reaching here — emits nothing. `surface` is the vote's
 			// `targetKind` (definition|post|comment), `userId` the caster (a
-			// deliberately-approximate blob, ADR 0153). `Telemetry.emit` already discharges
-			// its error channel inside `TelemetryLive` (`Effect<void>`, ADR 0153 fail-safe);
-			// `Effect.ignoreCause` is the belt-and-suspenders that keeps even a *defect* off
-			// the vote path (the `live-publisher`/`email-sender` best-effort idiom) — telemetry
-			// is best-effort and can NEVER fail or slow the cast it observes.
-			yield* telemetry
-				.emit({
-					feature: "vote",
-					action: isCast ? "cast" : "retract",
-					surface: input.targetKind,
-					userId: input.userId,
-				})
-				.pipe(Effect.ignoreCause({log: "Warn"}));
+			// deliberately-approximate blob, ADR 0153). Emitted BARE: `TelemetryLive`
+			// contains the whole failure Cause — a `DatasetError` OR a defect — inside the
+			// seam (`Effect.ignoreCause`, ADR 0153 S4 / #2085), so `emit: Effect<void>`
+			// cannot fail or die and a call-site wrap would be redundant.
+			yield* telemetry.emit({
+				feature: "vote",
+				action: isCast ? "cast" : "retract",
+				surface: input.targetKind,
+				userId: input.userId,
+			});
 
 			const newScore = yield* readCachedScore(input.targetKind, input.targetId);
 

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -13,7 +13,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {wireCodeOfClass} from "@kampus/fate-effect";
-import {Effect, Exit, Layer} from "effect";
+import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {TARGET_KINDS} from "../../db/target-kind.ts";
 import type {TelemetryEvent} from "../telemetry/schema.ts";
@@ -33,12 +33,13 @@ const recordingTelemetry = (sink: TelemetryEvent[]) =>
 			}),
 	});
 
-// A `Telemetry` whose `emit` returns a FAILING effect — the S4 fail-safe double. The
-// real `TelemetryLive` discharges its error channel internally so `emit` is `Effect<void>`,
-// but this double proves the invariant from Vote's side: even if `emit` itself failed, the
-// vote's success/failure contract is unchanged (a telemetry hiccup can never fail the cast).
+// A `Telemetry` whose `emit` DIES — the commit-ordering double. The real `TelemetryLive`
+// discharges the WHOLE Cause internally (`Effect.ignoreCause`, #2085) so `emit` is `Effect<void>`
+// and a defect can never surface; substituting the tag with this dying double bypasses that
+// seam, so it can only prove the cast is committed BEFORE the emit runs (the seam-level S4 proof
+// itself lives in `Telemetry.unit.test.ts`), never fed through the real containment.
 const failingTelemetry = Layer.succeed(Telemetry, {
-	emit: () => Effect.die(new Error("telemetry emit blew up — must NOT surface to the vote")),
+	emit: () => Effect.die(new Error("telemetry emit blew up — off the commit path")),
 });
 
 // A `Drizzle` whose every call throws — provided so that any path which actually
@@ -571,29 +572,26 @@ describe("Vote.cast — telemetry instrument (ADR 0153, #2068, mocked Drizzle + 
 		);
 	});
 
-	it.effect(
-		"a Telemetry failure NEVER fails the vote — the cast still commits (S4 fail-safe)",
-		() => {
-			// The failing double's `emit` DIES; `Vote.cast`'s `Effect.ignoreCause` contains it, so
-			// the vote's success contract is unchanged — `changed:true` with the committed score.
-			const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
-			return Effect.gen(function* () {
-				const vote = yield* Vote;
-				const exit = yield* Effect.exit(
-					vote.cast({
-						userId: "voter-1",
-						targetKind: "definition",
-						targetId: "def-live",
-						value: true,
-					}),
-				);
-				assert.isTrue(Exit.isSuccess(exit), "a telemetry blow-up leaves the vote succeeding");
-				if (Exit.isSuccess(exit)) {
-					assert.isTrue(exit.value.changed, "the cast is committed");
-					assert.strictEqual(exit.value.score, 1);
-				}
-				assert.strictEqual(batches.length, 1, "the vote batch committed before the failing emit");
-			}).pipe(Effect.provide(instrumentLayer(access, failingTelemetry)));
-		},
-	);
+	it.effect("the emit is off the commit path — the cast commits before the emit runs", () => {
+		// The `Telemetry` double's `emit` DIES. The vote batch is sequenced BEFORE the emit,
+		// so its statement is already in `batches` (the cast committed) even as the emit blows
+		// up — proving the emit is downstream of the commit, never a gate on it. Since #2085
+		// the vote emits BARE (no call-site wrap): the production fail-safe that turns a defect
+		// into a swallowed no-op lives in `TelemetryLive` (`Effect.ignoreCause`) and is pinned
+		// seam-side in `Telemetry.unit.test.ts`; this double substitutes the `Telemetry` tag so
+		// it never reaches that seam, and here we only assert the commit-before-emit ordering.
+		const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			yield* Effect.exit(
+				vote.cast({
+					userId: "voter-1",
+					targetKind: "definition",
+					targetId: "def-live",
+					value: true,
+				}),
+			);
+			assert.strictEqual(batches.length, 1, "the vote batch committed before the emit");
+		}).pipe(Effect.provide(instrumentLayer(access, failingTelemetry)));
+	});
 });


### PR DESCRIPTION
Fixes #2085

## What

Move S4 defect-containment (ADR 0153: "telemetry must never fail the observed mutation") **into the `TelemetryLive.emit` seam** so the invariant is a property of the seam for every instrument — not a per-call-site `ignoreCause` each instrument must remember.

## The bug

`TelemetryLive.emit` discharged only the typed `DatasetError` E-channel with `Effect.ignore` — which does **not** catch a *defect*. `Vote.cast` compensated with a call-site `Effect.ignoreCause` (correct), but `Reaction.react` emitted **bare**, relying only on the seam's `Effect.ignore`. So a real defect inside emit (a sync throw in `writeDataPoint`, an `orDie`, a `toDataPoint` bug) propagated out of `Reaction.react` **after** the reaction already committed — a user-visible partial failure.

## The fix

- **`Telemetry.ts`** — `Effect.ignore` → `Effect.ignoreCause` at the seam. `ignoreCause` discards the whole `Cause` (defects and interruptions too — grounded in effect-smol `Effect.ts`: *"Ignores the effect's failure cause, including defects and interruptions"*), so `emit: Effect<void>` genuinely cannot fail **or** die for any caller. S4 holds by construction.
- **`Reaction.ts`** — now safe by construction with its existing bare emit; no change needed.
- **`Vote.ts`** — the call-site `Effect.ignoreCause` is now redundant; simplified to a bare emit so both reference instruments are consistent and future instruments copy the bare pattern.
- **`Telemetry.unit.test.ts`** — added a `dyingClient` (a *defect*, not a typed error) case proving the seam contains a defect and `emit` still exits **Success**, alongside the existing `failingClient` (typed-error) case.
- **`Vote.unit.test.ts`** — reworked the dying-emit test to assert commit-ordering only; the seam (not the tag-substituted double, which bypasses `TelemetryLive`) now owns defect containment.
- **`.patterns/telemetry.md`** — updated in lockstep: S4 is a **seam** property, instruments emit **bare**, the add-an-instrument recipe drops the call-site wrap, and the `ignore` vs `ignoreCause` teaching is reframed as "the seam uses `ignoreCause` so callers don't have to."

Hardens epic #2065's S4 invariant.

## Verification

- `pnpm typecheck` — clean
- `pnpm biome check` on changed files — clean
- telemetry + vote + reaction unit tests — 60 passed (incl. the new seam defect case)

## Class

Mixed-class: code (`apps/web/worker/**`) + doc (`.patterns/telemetry.md`) — non-§CP, needs both `review-code` + `review-doc` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)