### PR TITLE
chore(pipeline): milestone-governance convention + triage 100%-open flag sweep (#2093)

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -257,6 +257,16 @@ independently; the product simply comes home to **kamp.us**. Rebirth named in En
 English-for-technical rule (§3). `anka` is a **framework name**, not user-facing product
 copy, so it lives here in sense (3) rather than as a §3 Turkish-surface brand-noun row.
 
+### Milestone
+
+**A milestone is an *initiative*. An initiative has a Definition of Done.** A catch-all with
+no DoD is a **label, not a milestone**. A fixes-bucket like "Sözlük/Pano fixes" is an
+*oxymoron* to this definition — it has no DoD, so it can't be an initiative, so it isn't a
+milestone; its disposition is to **retire** (convert to a plain label if the grouping is
+still wanted), not "close as done." (ADR
+[0072](../.decisions/0072-milestones-encode-strategic-sequencing.md) — *milestones encode
+strategic sequencing*.)
+
 ---
 
 ## 3. Product / brand nouns (Turkish surface)

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -568,7 +568,7 @@ the human-filed-never-auto-closed rule (Step 5): the *disposition* of a complete
 is founder judgment, not a mechanical act. A 100%-open milestone may legitimately stay open
 (more issues genuinely planned), may be **done → close**, or may be a **bucket masquerading
 as a milestone → retire** (convert to a plain label). Per the glossary's **Milestone** term
-([`../../../.glossary/LANGUAGE.md`](../../../.glossary/LANGUAGE.md)) — *a milestone is an
+([`../../../../.glossary/LANGUAGE.md`](../../../../.glossary/LANGUAGE.md)) — *a milestone is an
 initiative; an initiative has a Definition of Done; a catch-all with no DoD is a label, not
 a milestone* — a fixes-bucket at 100% is retired, not closed-as-done. Deciding which of the
 three applies is out of triage's scope (ADR

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -555,6 +555,40 @@ sweeping:
    sibling-repo tree). The guarantee is a property of the agent, not of who dispatches it;
    a caller must never have to re-scrub the summary before relaying it.
 
+### Cadence hygiene sweep — flag 100%-open milestones (flag-only, NEVER auto-close)
+
+Once per sweep, run a **milestone-hygiene pass**: surface every open milestone that has hit
+**100% (`open_issues == 0`, `closed_issues > 0`)** to the EA for a close / keep / retire
+call. An open milestone is meant to signal *active work*; one sitting at 100% signals
+nothing, so the board's focus signal rots. This sweep is the natural home for that hygiene
+check — it costs one REST read and keeps the milestone list readable.
+
+**Flag-only — this sweep NEVER modifies or closes a milestone.** It is the exact mirror of
+the human-filed-never-auto-closed rule (Step 5): the *disposition* of a completed milestone
+is founder judgment, not a mechanical act. A 100%-open milestone may legitimately stay open
+(more issues genuinely planned), may be **done → close**, or may be a **bucket masquerading
+as a milestone → retire** (convert to a plain label). Per the glossary's **Milestone** term
+([`../../../.glossary/LANGUAGE.md`](../../../.glossary/LANGUAGE.md)) — *a milestone is an
+initiative; an initiative has a Definition of Done; a catch-all with no DoD is a label, not
+a milestone* — a fixes-bucket at 100% is retired, not closed-as-done. Deciding which of the
+three applies is out of triage's scope (ADR
+[0072](https://github.com/kamp-us/phoenix/blob/main/.decisions/0072-milestones-encode-strategic-sequencing.md)
+§3 — curating the milestone set is a roadmap, human act). Triage **flags**; the EA decides.
+
+```bash
+# open milestones at 100% — 0 open issues, at least one closed (an empty milestone is not "done")
+gh api "repos/$REPO/milestones?state=open&per_page=100" \
+  --jq '.[] | select(.open_issues == 0 and .closed_issues > 0)
+        | "#\(.number)\t\(.title)\t(\(.closed_issues) closed, 0 open)"'
+```
+
+Surface the matches in the sweep ledger (Step 5's report-back) as a **flag to the EA** — one
+line per 100%-open milestone with its number, title, and closed count, tagged for a
+close/keep/retire call. Do **not** `PATCH`/close a milestone, and do **not** file a follow-up
+issue per milestone — the flag in the ledger is the surfacing; the routed board-hygiene action
+is the EA's, downstream of this sweep. If the sweep finds no 100%-open milestone, note "none"
+and move on — the check is idempotent and read-only.
+
 ## Conventions
 
 This skill is one of a suite (`report` → **`triage`** → `plan-epic` → `review-plan` →


### PR DESCRIPTION
## What & why

Closes the process smell in #2093 — milestones hit 100% but never close — with two
right-sized, non-behavior-change deliverables. Cleanup of the 6 currently-100%-open
milestones (#3/#4/#8/#9/#11/#12) is **explicitly out of pipeline scope**: that is a
founder-routed board-hygiene call (done-vs-rolling-vs-retire), not this mechanical change.

## Deliverables

1. **Triage cadence hygiene sweep** — `claude-plugins/kampus-pipeline/skills/triage/SKILL.md`.
   A once-per-sweep pass that **flags** open milestones at 100% (`open_issues == 0 &&
   closed_issues > 0`) to the EA for a close/keep/retire call. **Flag-only — it never
   modifies or closes a milestone** (the exact mirror of the human-filed-never-auto-close
   rule); disposition is founder judgment (ADR 0072 §3), out of triage's scope.

2. **Milestone-governance convention** — `.glossary/LANGUAGE.md`, a new *Milestone*
   structural term (none existed): *a milestone is an initiative; an initiative has a
   Definition of Done; a catch-all with no DoD is a label, not a milestone.* A fixes-bucket
   is an oxymoron → **retire** (convert to a label), not close-as-done. (Founder-sharpened
   wording, taken verbatim from the #2093 issue thread.)

## §CP determination

**No §CP path is touched — this PR stays auto-shippable.** Per triage's own §CP grounding
(against `origin/main`): `skills/triage/SKILL.md` is **not** in `CONTROL_PLANE_RE` (which
covers the gate skills, `.claude/`, `.github/`, `gh-issue-intake-formats.md`, `*-guard`,
`ci-required`, `pipeline-cli`), and `.glossary/LANGUAGE.md` is a plain doc surface. The
issue's own pointer to the §Milestone section of `gh-issue-intake-formats.md` (which *is*
§CP) was deliberately **not** taken.

## Acceptance criteria

- [x] Triage's cadence loop gains a step that detects open milestones at 100% and surfaces
      them to the EA — flag-only, never auto-closes a milestone.
- [x] The milestone-governance convention is recorded on a Non-§CP surface (`.glossary/LANGUAGE.md`).
- [x] No milestone is closed or modified by this change.
- [x] Landing sites are Non-§CP (`.glossary/` + `skills/triage/`), not `gh-issue-intake-formats.md`.

Fixes #2093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
