### PR TITLE
chore(web): set isolate:false on the integration vitest project (#958)

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -114,6 +114,8 @@ export default defineConfig({
 					// the harness holds no cross-file module-level mutable singleton (the
 					// shared stage handle arrives via `provide`, not a module global); a
 					// fully-green integration tier is the contamination proof.
+					// CI A/B (recorded on PR #958): integration-job wall-clock 251s median
+					// (isolate:true baseline, n=5 main runs) → 203s (isolate:false), ≈19% faster.
 					isolate: false,
 					// Per-file isolated stages (ADR 0082): each file deploys its own
 					// worker + D1, so files run in parallel — the inverse of the retired

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -103,6 +103,18 @@ export default defineConfig({
 					testTimeout: 120_000,
 					hookTimeout: 180_000,
 					pool: "forks",
+					// `isolate: false` shares one parsed JS module graph across the files
+					// that run in the same fork, so the phoenix worker barrel chain
+					// (`_integration.ts` → `alchemy.run.ts` → `worker/index.ts`, ~132 TS
+					// files, ~62% alchemy/CF SDK eval) is imported+transformed ONCE per fork
+					// instead of re-imported from scratch per file (#958, diagnosed in #682).
+					// This is Vitest's JS-module-registry isolation — DISTINCT from the
+					// per-file isolated D1 *stage* (ADR 0082/0104): it does NOT merge the
+					// real-D1 worker deploys, only the in-fork module cache. Safe here because
+					// the harness holds no cross-file module-level mutable singleton (the
+					// shared stage handle arrives via `provide`, not a module global); a
+					// fully-green integration tier is the contamination proof.
+					isolate: false,
 					// Per-file isolated stages (ADR 0082): each file deploys its own
 					// worker + D1, so files run in parallel — the inverse of the retired
 					// single-fork model. `disableConsoleIntercept` keeps the alchemy


### PR DESCRIPTION
## What

Sets `isolate: false` on the **integration** vitest project only (`apps/web/vitest.config.ts`), so files that run in the same fork share one parsed JS module graph — the phoenix worker barrel chain (`tests/integration/_integration.ts` → `alchemy.run.ts` → `worker/index.ts`, ~132 TS files, ~62% alchemy/CF-SDK eval) is imported+transformed **once per fork** instead of re-imported from scratch per file.

Amortizes the ~58s summed pre-`beforeAll` import cost diagnosed in #682 (per-file-linear, zero cross-fork reuse). Behavior-preserving test-infra tweak: tests run identically, just with a warm in-fork module cache.

## Distinct from the D1 stage isolation (not a conflation)

Vitest's `isolate` (shared JS module registry within a fork) is **distinct** from phoenix's per-file isolated D1 *stage* (the real-D1 worker deploy, ADR 0082/0104). `isolate: false` does **not** merge those D1 stages — it only shares the in-fork module cache. The shared stage handle arrives via `provide` (a run-scoped value), not a module-level global, so there is no cross-file module-level mutable singleton to bleed.

## Acceptance criteria

- [x] `isolate: false` set on the **integration** project only (not unit/client), in `apps/web/vitest.config.ts`, in a standalone PR.
- [x] CI before/after (A/B): the integration-job wall-clock delta is recorded on this PR. **Before (isolate:true, main baseline, n=5): 225–303s, median 251s. After (isolate:false, head `e8622c0`): 203s → ~48s / ≈19% faster vs baseline median, below every baseline run.** Full A/B table recorded in [this comment](https://github.com/kamp-us/phoenix/pull/2097#issuecomment-4885416449).
- [x] Full integration tier stays green under `isolate: false` (the contamination proof). CI on head `e8622c0` is that proof — integration tests = success, 1788/1788 passed, 0 failed, 0 skipped. If the win is not real OR any cross-file contamination appears, revert and record.

## Notes

- Local typecheck (`pnpm --filter @kampus/web typecheck`) and `biome check` pass.
- The A/B wall-clock delta and the green-tier contamination proof are properties of the CI run on this branch; both are now recorded above from the observed `integration tests` check-run wall-clock (before = recent `main` runs at isolate:true, after = this branch's head).

Fixes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)