### PR TITLE
docs(pipeline): forbid `gh api -f body=@file` — stop the local-path comment leak (#1577)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -755,6 +755,38 @@ immutable; re-read it each round.
 
 ---
 
+## Posting a comment body — read it into `$BODY`, never `gh api -f body=@file` (the local-path leak)
+
+Formats 3 and 4 (and every claim/handoff comment below) are posted with `gh api … -f body=…`.
+There is **one** correct way to pass a body, and one form that is **forbidden** because it
+silently leaks a local path into a **public** comment:
+
+- **Required form — assemble the body into a shell var, then pass it by value.** Build the text
+  (a heredoc, or a scratchpad file you `cat`), read it into `$BODY`, and pass `-f body="$BODY"`:
+
+  ```bash
+  BODY="$(cat "$BODY_FILE")"                       # or: BODY=$(cat <<'EOF' … EOF)
+  gh api repos/$REPO/issues/<N>/comments -f body="$BODY"
+  ```
+
+- **Forbidden form — NEVER `gh api -f body=@<path>` (equivalently `--raw-field body=@<file>`).**
+  `gh api`'s `-f`/`--raw-field` adds a **static string** parameter: it takes the value *verbatim*
+  and, unlike `curl`, does **not** expand a leading `@` into the file's contents. So
+  `-f body=@/some/path` posts the raw text `@/some/path` as the comment body — two harms in one:
+  (1) the intended body never renders, and (2) the literal value is typically a machine-local
+  absolute path (a `mktemp`/scratchpad file), so a **local filesystem path leaks into a public
+  GitHub comment**, violating the no-local-paths-in-shared-artifacts invariant (`CLAUDE.md`). The
+  `leak-guard` CI gate scans **committed files**, not comment bodies posted at runtime, so nothing
+  catches this after the fact — the leak lives in the public comment until a human spots it (the
+  manually-patched comment on PR #1567). If you find yourself reaching for the curl-style `@file`
+  idiom, stop and use the `BODY="$(cat …)"` → `-f body="$BODY"` form above.
+
+  (Only `-F`/`--field` — the *typed* flag — reads a file via `@`, per `gh api --help`. Do not
+  route around this with `-F body=@file`: the `$BODY`-by-value form is the single idiom every
+  skill here uses — reach for it, not a second mechanism.)
+
+---
+
 ## 3. Progress-comment format
 
 While working an issue, an agent logs progress as **comments on that issue**.
@@ -786,6 +818,9 @@ otherwise have to reverse-engineer>
   buried in a diff is a decision the next agent will re-litigate.
 - This is the per-issue ledger. Cross-task context that the *epic* needs goes in
   a handoff note (format 4), not here.
+- Post the body the required way — read it into `$BODY` and pass `-f body="$BODY"`;
+  **never `gh api -f body=@file`**, which posts the literal path and leaks it publicly
+  (see [Posting a comment body](#posting-a-comment-body--read-it-into-body-never-gh-api--f-bodyfile-the-local-path-leak)).
 
 ---
 
@@ -823,6 +858,9 @@ assumption invalidated, a partial state left behind>
 - If a child completed in pure isolation with zero sibling impact, a one-line
   "Done" handoff is honest and complete. Don't manufacture cross-task context
   that isn't there.
+- Post the note the required way — read it into `$BODY` and pass `-f body="$BODY"`;
+  **never `gh api -f body=@file`**, which posts the literal path and leaks it publicly
+  (see [Posting a comment body](#posting-a-comment-body--read-it-into-body-never-gh-api--f-bodyfile-the-local-path-leak)).
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1203,6 +1203,15 @@ Assemble the comment from a temp file so multi-line markdown and backticks survi
 shell. Keep it scannable — bullets over paragraphs, omit a heading with nothing under
 it. Record decisions at the point you make them, not retroactively.
 
+> **Read the body into `$BODY` — NEVER `gh api -f body=@file`.** This applies to *every*
+> comment this skill posts — the progress comment here, the Step 7 handoff, and the repair
+> progress comment (Step R3). Unlike `curl`, `gh api -f`/`--raw-field` does **not** expand a
+> leading `@`: `-f body=@/some/path` posts the literal string `@/some/path` — the intended body
+> never renders *and* the local scratchpad path leaks into a public comment, which `leak-guard`
+> (committed-files only) does not catch (PR #1567). Always assemble the text into `$BODY` first
+> (`BODY="$(cat "$BODY_FILE")"`) and pass `-f body="$BODY"`, exactly as the snippets above do.
+> See [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) → **Posting a comment body**.
+
 ---
 
 ## Step 7 — Hand off to the parent epic (sub-issues only)


### PR DESCRIPTION
Fixes #1577

## What & why

`gh api`'s `-f`/`--raw-field` adds a **static string** parameter — it takes the value verbatim and, unlike `curl`, does **not** expand a leading `@` into the file's contents. So `gh api -f body=@<path>` posts the literal text `@<path>` as the comment body. Two harms: (1) the intended body never renders, and (2) the literal value is typically a machine-local scratchpad path, so a **local filesystem path leaks into a public GitHub comment** — violating the no-local-paths-in-shared-artifacts invariant. `leak-guard` scans committed files, not runtime comment bodies, so nothing catches it (the manually-patched comment on PR #1567).

None of the guidance forbade the `@file` form, so an agent pattern-matching to curl's `@file` expansion repeats the leak. This adds the doc-warning floor.

## Changes (docs only — control-plane skills)

- **`gh-issue-intake-formats.md`** — new **"Posting a comment body"** subsection ahead of formats 3/4: states the required form (`BODY="$(cat …)"` → `-f body="$BODY"`) and explicitly forbids `gh api -f body=@file`, explaining that `-f`/`--raw-field` does not expand `@` (only the typed `-F`/`--field` reads a file, per `gh api --help`) and that this leaks a local path publicly with no runtime gate to catch it. Cross-linked from the format-3 progress-comment and format-4 handoff-note field notes.
- **`write-code/SKILL.md`** — Step 6 (progress comment) now carries the same warning, scoped to cover the Step 7 handoff and Step R3 repair-progress comments too, pointing back at the contract's new subsection.

## Acceptance criteria

- [x] Shared comment-posting guidance in `gh-issue-intake-formats.md` warns against `gh api -f body=@file` / `--field body=@file` (does not expand; posts the literal path) and points at the `BODY="$(cat …)"` → `-f body="$BODY"` idiom as the required form.
- [x] The write-code progress/handoff-comment steps carry the same warning where an agent might reach for `@file`.
- [x] Repo-relative paths only in added text — no machine-local paths (`leak-guard` pre-commit hook passed clean).

Grounding: the `-f`/`--raw-field` vs `-F`/`--field` `@file` semantics are verified against `gh api --help` (raw-field = static string, no `@` expansion; typed field has magic `@file` conversion), not asserted from intuition.

Doc-only; no runtime guard added (the triage note left that as an optional in-scope hardening, and the doc-warning floor is the bounded always-correct fix).

## §CP

Touches gate-critical skills (`gh-issue-intake-formats.md`, `write-code/SKILL.md`) — matches `CONTROL_PLANE_RE`. Build-to-reviewed-ready; human merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)