### PR TITLE
feat(pipeline-cli): eval-harness report — graded two-axis scorecard (#1853)

### DIFF
--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -94,8 +94,86 @@ Two modes, story-split:
 import {collectRuns, collectFromCapture, decodeCaptureManifest} from "./runner.ts";
 ```
 
-The runner is a pure library; presenting the collected rows (the two-axis scorecard) is the report
-slice ([#1853](https://github.com/kamp-us/phoenix/issues/1853)), not this core.
+Presenting the collected rows (the two-axis scorecard) is the report slice
+([#1853](https://github.com/kamp-us/phoenix/issues/1853)), documented next.
+
+## The report — graded two-axis scorecard ([#1853](https://github.com/kamp-us/phoenix/issues/1853))
+
+`report.ts` is the **top of the vertical slice** and the evidence artifact the model-tiering
+decision ([#1576](https://github.com/kamp-us/phoenix/issues/1576)) consumes. It aggregates the
+runner's graded `{entry, grade, spend}` rows into a per-(stage × model) **scorecard** on the ADR
+0112 §4 two-axis gate, now graded:
+
+- **Quality axis** — a **pass-rate** per (stage × model) over the corpus (`passedRuns / gradedRuns`),
+  the graded generalization of ADR 0112 §3's binary-per-run oracle.
+- **Token axis** — the mean **billed** + **ex-cache-read** spend per run (ADR 0112 §2), plus the
+  priced **repair-churn cost** (`repair-churn.ts`): the amortized true cost of one *accepted* run
+  once the extra cycles a lower pass-rate forces are amortized in.
+- **Net saving vs a baseline** — when a `baseline` (stage × model) is named, each other cell's
+  `netSaving = baseline.billedPerRun − candidate.amortizedBilledPerRun`. A **negative** net saving is
+  the epic's headline risk — a per-run token saving *eaten* by repair churn — rendered as
+  `NET-NEGATIVE` in the table and `netNegative: true` in the JSON, so the crossover the
+  binary-per-run gate cannot see is impossible to miss.
+
+The report is **measurement, not a recommendation**: it states pass-rate + net-token cost per cell
+and never selects or recommends a model — that call is #1576, a separate `type:decision`. Both
+rendered surfaces carry a framing line pointing at #1576, and the JSON has no
+`recommendation`/`selectedModel`/`winner` key by construction.
+
+Pure + total: a `TranscriptMissing` run still counts toward the pass-rate but is absent from the
+spend mean, and a cell with **no** reconstructed spend reports a `null` token axis rather than a
+fabricated zero. `buildScorecard`, `renderTable`, `toJson`, and `decodeReportInput` are the exports.
+
+### The CLI surface
+
+```bash
+# human table (default) — the founder reads this to decide #1576
+pipeline-cli eval-harness report <rows.json>
+
+# stable machine-readable JSON — a future gate / CI consumes this
+pipeline-cli eval-harness report <rows.json> --json
+
+# price net saving against a baseline (stage × model)
+pipeline-cli eval-harness report <rows.json> --baseline-stage write-code --baseline-model opus-4.8
+```
+
+`<rows.json>` is a serialized `RunRow[]` — the array `collectRuns` emits. `decodeReportInput` is
+total: a malformed body or a shape mismatch exits non-zero with a typed reason, never a throw.
+
+### The stable JSON shape (the contract a consumer decodes)
+
+```jsonc
+{
+  "decisionRef": 1576,                       // the decision this evidence feeds — never made here
+  "framing": "This scorecard is measurement feeding the model-tiering decision (#1576); …",
+  "baseline": { "stage": "write-code", "model": "opus-4.8" } | null,
+  "cells": [
+    {
+      "stage": "write-code",
+      "model": "opus-4.8" | null,            // reconstructed from the transcript; null when unattributable
+      "gradedRuns": 3,                        // pass-rate denominator (includes transcript-missing runs)
+      "passedRuns": 2,
+      "passRate": 0.6667,                     // the graded quality axis
+      "spend": {                              // the token axis — null when no run reconstructed
+        "billedPerRun": 200,
+        "exCacheReadPerRun": 180,
+        "reconstructedRuns": 3,
+        "transcriptMissingRuns": 0
+      } | null,
+      "churn": {                              // priced repair churn — null when no reconstructed spend
+        "expectedExtraCycles": 0.5,
+        "churnTokens": 100,                   // +Infinity when passRate === 0 (never adopt)
+        "amortizedBilledPerRun": 300
+      } | null,
+      "netSaving": -400 | null,               // vs baseline; null on the baseline cell / no spend
+      "netNegative": true                     // true iff netSaving is a finite number < 0
+    }
+  ]
+}
+```
+
+The shape is stable: field names + nesting are the contract, and `toJson` is a thin projection of
+the in-memory `Scorecard` so the JSON and the type never drift.
 
 ## Why it exists
 
@@ -108,11 +186,12 @@ This module is the shared format that graded slice is built on.
 ## How to use
 
 The core is a pure library — import `CorpusEntry`, `CorpusManifest`, `decodeManifest`,
-`encodeManifest`, and `STAGES` from `corpus.ts`. The one CLI surface validates a manifest
-file against the schema:
+`encodeManifest`, and `STAGES` from `corpus.ts`. The CLI has two surfaces — validate a manifest
+against the schema, and render the graded scorecard over runner rows:
 
 ```bash
-pipeline-cli eval-harness check <manifest>   # exit 0 if valid; non-zero on a bad manifest
+pipeline-cli eval-harness check <manifest>    # exit 0 if valid; non-zero on a bad manifest
+pipeline-cli eval-harness report <rows.json>  # the graded two-axis scorecard (see below)
 ```
 
 ## Repair-churn cost — net-token pricing of a model swap
@@ -224,7 +303,8 @@ triage corpus therefore covers the edge by spanning the classification space (a 
 `p2` `decision`, an urgent `p0` `bug`, a `p1` `chore`) rather than pinning an unstable
 `needs-info`.
 
-## Out of scope (later children)
+## Out of scope
 
-Running any stage (collecting the transcripts), grading an entry, and computing any metric
-(pass-rate, repair-churn cost) are separate slices under epic #1842 — not these cores.
+Running any stage (collecting the transcripts) is the operator's act, not this tool.
+**Making the tiering call** is [#1576](https://github.com/kamp-us/phoenix/issues/1576), a
+separate `type:decision` — the harness supplies the graded evidence, the human decides.

--- a/packages/pipeline-cli/src/tools/eval-harness/command.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/command.ts
@@ -1,22 +1,32 @@
 /**
- * The `eval-harness` tool — `pipeline-cli eval-harness check <manifest>`.
+ * The `eval-harness` tool — `pipeline-cli eval-harness check|report`.
  *
  * The graded-corpus apparatus for adjudicating a stochastic model swap per stage (epic
- * #1842). This first slice ships the FORMAT + its decode/encode core (issue #1848); it
- * does NOT populate real entries, run any stage, or compute any metric — those are later
- * children. The one live surface is a validator over the on-disk format:
+ * #1842). Two live surfaces:
  *
  *   pipeline-cli eval-harness check <manifest>   # decode a corpus manifest; exit non-zero on a bad one
+ *   pipeline-cli eval-harness report <rows>      # the graded two-axis scorecard over runner rows
  *
- * Thin IO shell over the pure `decodeManifest` core (the `token-spend` / `readme-guard`
- * idiom): read the file, decode, report. An unreadable path and a malformed/mismatched
- * manifest both exit non-zero — this is a named, explicit validation target, so a bad
- * input is an error, not a silent pass.
+ * `check` (issue #1848) validates the on-disk corpus format. `report` (issue #1853) is the
+ * top of the vertical slice: it reads the runner's graded `{entry, grade, spend}` rows and
+ * renders the per-(stage × model) scorecard — pass-rate + per-run token spend + repair-churn
+ * cost — as a human table (default) or stable JSON (`--json`), the evidence the model-tiering
+ * decision (#1576) consumes. It presents measurement, never a recommendation.
+ *
+ * Thin IO shell over the pure cores (the `token-spend` / `readme-guard` idiom): read the file,
+ * decode, render. An unreadable path and a malformed/mismatched input both exit non-zero.
  */
 import {readFileSync} from "node:fs";
 import {Console, Data, Effect, Result} from "effect";
-import {Argument, Command} from "effect/unstable/cli";
-import {decodeManifest} from "./corpus.ts";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {decodeManifest, STAGES} from "./corpus.ts";
+import {
+	type BaselineKey,
+	buildScorecard,
+	decodeReportInput,
+	renderTable,
+	toJson,
+} from "./report.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 
@@ -62,9 +72,97 @@ const check = Command.make(
 	),
 );
 
-export const evalHarnessCommand = Command.make("eval-harness").pipe(
-	Command.withSubcommands([check]),
+// A named report-input path that could not be read — a hard error (exit 1), not a skip.
+class RowsUnreadable extends Data.TaggedError("RowsUnreadable")<{
+	readonly path: string;
+}> {}
+
+const rowsArg = Argument.string("rows").pipe(
+	Argument.withDescription(
+		"path to a JSON file of the runner's graded rows (a serialized RunRow[])",
+	),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription(
+		"emit the stable machine-readable JSON scorecard instead of the human table",
+	),
+);
+
+const baselineStageFlag = Flag.string("baseline-stage").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		`the stage of the baseline cell net saving is measured against (one of: ${STAGES.join(", ")})`,
+	),
+);
+
+const baselineModelFlag = Flag.string("baseline-model").pipe(
+	Flag.optional,
+	Flag.withDescription("the model of the baseline cell (paired with --baseline-stage)"),
+);
+
+const isStage = (s: string): s is (typeof STAGES)[number] =>
+	(STAGES as ReadonlyArray<string>).includes(s);
+
+const report = Command.make(
+	"report",
+	{
+		rows: rowsArg,
+		json: jsonFlag,
+		baselineStage: baselineStageFlag,
+		baselineModel: baselineModelFlag,
+	},
+	Effect.fn(function* ({rows, json, baselineStage, baselineModel}) {
+		const run = Effect.gen(function* () {
+			const text = yield* Effect.try({
+				try: () => readFileSync(rows, "utf8"),
+				catch: () => new RowsUnreadable({path: rows}),
+			});
+			const decoded = decodeReportInput(text);
+			if (Result.isFailure(decoded)) {
+				yield* Console.error(
+					`eval-harness: ${rows} is not a valid runner-rows file (${decoded.failure.reason}): ${decoded.failure.message}`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+
+			// A --baseline-stage that isn't one of the known stages is a user error, not a silent
+			// no-baseline: fail loudly so a typo can't quietly drop the net-saving axis.
+			let baseline: BaselineKey | undefined;
+			if (baselineStage._tag === "Some") {
+				const stage = baselineStage.value;
+				if (!isStage(stage)) {
+					yield* Console.error(
+						`eval-harness: --baseline-stage '${stage}' is not a known stage (${STAGES.join(", ")})`,
+					);
+					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				}
+				baseline = {stage, model: baselineModel._tag === "Some" ? baselineModel.value : null};
+			}
+
+			const scorecard = buildScorecard(
+				baseline === undefined ? {rows: decoded.success} : {rows: decoded.success, baseline},
+			);
+			yield* Console.log(json ? toJson(scorecard) : renderTable(scorecard));
+		});
+		yield* run.pipe(
+			Effect.catchTag("RowsUnreadable", (e) =>
+				Effect.gen(function* () {
+					yield* Console.error(`eval-harness: cannot read runner-rows file ${e.path}`);
+					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				}),
+			),
+		);
+	}),
+).pipe(
 	Command.withDescription(
-		"Graded per-stage corpus: the labeled ground-truth format for model-tiering evaluation (#1848)",
+		"Render the graded two-axis scorecard (pass-rate + token spend + churn cost per stage×model) — evidence for #1576, not a recommendation",
+	),
+);
+
+export const evalHarnessCommand = Command.make("eval-harness").pipe(
+	Command.withSubcommands([check, report]),
+	Command.withDescription(
+		"Graded per-stage corpus + scorecard: the labeled ground-truth format and the model-tiering evidence report (#1848, #1853)",
 	),
 );

--- a/packages/pipeline-cli/src/tools/eval-harness/report.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/report.ts
@@ -1,0 +1,412 @@
+/**
+ * eval-harness report core — the graded two-axis scorecard (issue #1853, epic #1842).
+ *
+ * The top of the eval-harness vertical slice and the evidence artifact the model-tiering
+ * decision (#1576) consumes. It aggregates the runner's graded `{entry, grade, spend}` rows
+ * (`runner.ts`) into a per-(stage × model) scorecard on the ADR 0112 §4 two-axis gate, now
+ * GRADED: the token axis (billed + ex-cache-read spend per run, ADR 0112 §2) AND a graded
+ * quality axis (pass-rate over the corpus) with its net-token churn price (`repair-churn.ts`).
+ *
+ * The headline risk the epic exists to surface: a (stage × model) whose per-run token saving
+ * is EATEN by repair churn. Priced against a baseline (stage × model), such a cell reports a
+ * NEGATIVE `netSaving` — the saving that does not survive the extra churn a lower pass-rate
+ * forces — so the crossover the binary-per-run gate cannot see is legible at a glance.
+ *
+ * This is MEASUREMENT, not a recommendation. The report states pass-rate + net-token cost per
+ * cell; it never selects or recommends a model. That call is #1576, a separate `type:decision`
+ * — the harness supplies evidence, the human decides. `DECISION_POINTER` carries that framing
+ * into both the human table and the JSON.
+ *
+ * Pure + total, matching the corpus/oracle/runner discipline: rows with no reconstructed spend
+ * (a `TranscriptMissing` run) still COUNT toward the grade (pass-rate) and are reported as such
+ * — a cell's spend is the mean over its reconstructed runs, and a cell with zero reconstructed
+ * spends reports a null token axis rather than a fabricated zero.
+ */
+import {Data, Result} from "effect";
+import * as Schema from "effect/Schema";
+import {CorpusEntry} from "./corpus.ts";
+import {priceModelSwap, repairChurnCost} from "./repair-churn.ts";
+import type {RunRow} from "./runner.ts";
+
+/** The issue the report's evidence feeds — the tiering DECISION, which this report never makes. */
+export const DECISION_POINTER = 1576;
+
+/** The one-line framing carried into every rendered surface: evidence, not a recommendation. */
+export const DECISION_FRAMING =
+	`This scorecard is measurement feeding the model-tiering decision (#${DECISION_POINTER}); ` +
+	"it presents pass-rate + net-token cost and does not recommend or select a model.";
+
+/** A per-run token spend, averaged over a cell's reconstructed runs. Null when none reconstructed. */
+export interface CellSpend {
+	/** Mean billed tokens per run (the four-`usage`-component sum, ADR 0112 §2). */
+	readonly billedPerRun: number;
+	/** Mean ex-cache-read tokens per run (the cross-run comparator, ADR 0112 §2). */
+	readonly exCacheReadPerRun: number;
+	/** How many of the cell's runs had a reconstructed transcript (the mean's denominator). */
+	readonly reconstructedRuns: number;
+	/** How many of the cell's runs had NO transcript (counted for grade, absent from the mean). */
+	readonly transcriptMissingRuns: number;
+}
+
+/** The priced repair churn for a cell — the net-token price of a lower pass-rate. */
+export interface CellChurn {
+	readonly expectedExtraCycles: number;
+	readonly churnTokens: number;
+	readonly amortizedBilledPerRun: number;
+}
+
+/** One (stage × model) cell of the scorecard — the graded two-axis picture for that pair. */
+export interface ScorecardCell {
+	readonly stage: CorpusEntry["stage"];
+	/** The model the runs used, reconstructed from the transcript; `null` when unattributable. */
+	readonly model: string | null;
+	/** Total graded runs in the cell (the pass-rate denominator; includes transcript-missing). */
+	readonly gradedRuns: number;
+	/** Runs that graded `pass`. */
+	readonly passedRuns: number;
+	/** `passedRuns / gradedRuns` — the graded quality axis (ADR 0112 §4). */
+	readonly passRate: number;
+	/** The token axis: mean billed + ex-cache-read spend per run. Null when no run reconstructed. */
+	readonly spend: CellSpend | null;
+	/**
+	 * The priced repair churn: expected extra cycles × per-repair-cycle tokens, added to the
+	 * per-run spend to get the amortized true cost of one accepted run. Null when there is no
+	 * reconstructed spend to price against.
+	 */
+	readonly churn: CellChurn | null;
+	/**
+	 * The net saving of this cell against the scorecard's baseline cell, priced on
+	 * churn-amortized tokens. Null on the baseline cell itself, and when either this cell or the
+	 * baseline lacks a reconstructed spend. NEGATIVE ⇒ churn ate the saving — the epic's crossover.
+	 */
+	readonly netSaving: number | null;
+	/** True iff `netSaving` is a real number below zero — the unambiguous net-negative flag. */
+	readonly netNegative: boolean;
+}
+
+/** The whole scorecard: the framing pointer plus one cell per (stage × model). */
+export interface Scorecard {
+	/** The decision this evidence feeds (#1576) — the report never makes it. */
+	readonly decisionRef: number;
+	readonly framing: string;
+	/** The (stage × model) chosen as the per-run baseline saving is measured against, if any. */
+	readonly baseline: {readonly stage: string; readonly model: string | null} | null;
+	readonly cells: ReadonlyArray<ScorecardCell>;
+}
+
+/** Which (stage × model) to price the other cells' net saving against. */
+export interface BaselineKey {
+	readonly stage: CorpusEntry["stage"];
+	readonly model: string | null;
+}
+
+const cellKey = (stage: string, model: string | null): string => `${stage} ${model ?? ""}`;
+
+interface Bucket {
+	readonly stage: CorpusEntry["stage"];
+	readonly model: string | null;
+	graded: number;
+	passed: number;
+	billedSum: number;
+	exCacheReadSum: number;
+	reconstructed: number;
+	transcriptMissing: number;
+}
+
+const bucketize = (rows: ReadonlyArray<RunRow>): ReadonlyArray<Bucket> => {
+	const byKey = new Map<string, Bucket>();
+	for (const row of rows) {
+		const model = row.spend._tag === "Reconstructed" ? row.spend.spend.model : null;
+		const key = cellKey(row.entry.stage, model);
+		let bucket = byKey.get(key);
+		if (bucket === undefined) {
+			bucket = {
+				stage: row.entry.stage,
+				model,
+				graded: 0,
+				passed: 0,
+				billedSum: 0,
+				exCacheReadSum: 0,
+				reconstructed: 0,
+				transcriptMissing: 0,
+			};
+			byKey.set(key, bucket);
+		}
+		bucket.graded += 1;
+		if (row.grade.status === "pass") bucket.passed += 1;
+		if (row.spend._tag === "Reconstructed") {
+			bucket.reconstructed += 1;
+			bucket.billedSum += row.spend.spend.billed;
+			bucket.exCacheReadSum += row.spend.spend.exCacheRead;
+		} else {
+			bucket.transcriptMissing += 1;
+		}
+	}
+	return [...byKey.values()];
+};
+
+const spendOf = (bucket: Bucket): CellSpend | null =>
+	bucket.reconstructed === 0
+		? null
+		: {
+				billedPerRun: bucket.billedSum / bucket.reconstructed,
+				exCacheReadPerRun: bucket.exCacheReadSum / bucket.reconstructed,
+				reconstructedRuns: bucket.reconstructed,
+				transcriptMissingRuns: bucket.transcriptMissing,
+			};
+
+/**
+ * Aggregate the runner's graded rows into the two-axis scorecard. Rows are bucketed by
+ * (stage × reconstructed model); each cell gets its pass-rate, its mean per-run spend, its
+ * priced repair churn, and — when a `baseline` cell is named and both have a reconstructed
+ * spend — its net saving against that baseline. Pure + total: a cell with no reconstructed
+ * spend reports a null token axis / churn / net saving rather than fabricating a zero, and
+ * `passRate = 0` prices `+Infinity` churn (never adopt), the honest geometric limit.
+ *
+ * `tokensPerRepairCycle` defaults to the cell's own per-run billed spend — a repair cycle is
+ * another run of the same stage — matching `repair-churn.ts`'s model; a caller with a measured
+ * per-repair figure may override it.
+ */
+export const buildScorecard = (args: {
+	readonly rows: ReadonlyArray<RunRow>;
+	readonly baseline?: BaselineKey;
+	readonly tokensPerRepairCycle?: (cell: {stage: string; model: string | null}) => number;
+}): Scorecard => {
+	const buckets = bucketize(args.rows);
+	const baseline = args.baseline;
+	const baselineBucket =
+		baseline === undefined
+			? undefined
+			: buckets.find((b) => b.stage === baseline.stage && b.model === (baseline.model ?? null));
+	const baselineSpend = baselineBucket !== undefined ? spendOf(baselineBucket) : null;
+
+	const cells = buckets.map((bucket): ScorecardCell => {
+		const passRate = bucket.graded === 0 ? 0 : bucket.passed / bucket.graded;
+		const spend = spendOf(bucket);
+
+		let churn: CellChurn | null = null;
+		let netSaving: number | null = null;
+		let netNegative = false;
+
+		if (spend !== null) {
+			const repairCycle =
+				args.tokensPerRepairCycle?.({stage: bucket.stage, model: bucket.model}) ??
+				spend.billedPerRun;
+			const priced = repairChurnCost({
+				passRate,
+				tokensPerRun: spend.billedPerRun,
+				tokensPerRepairCycle: repairCycle,
+			});
+			// Inputs are already domain-valid (passRate ∈ [0,1], non-negative means), so this decode
+			// never fails here — but stay total: a failure leaves churn null, never throws.
+			if (Result.isSuccess(priced)) {
+				const c = priced.success;
+				churn = {
+					expectedExtraCycles: c.expectedExtraCycles,
+					churnTokens: c.churnTokens,
+					amortizedBilledPerRun: c.amortizedTokensPerRun,
+				};
+
+				const isBaselineCell =
+					baselineBucket !== undefined &&
+					bucket.stage === baselineBucket.stage &&
+					bucket.model === baselineBucket.model;
+				if (baselineSpend !== null && !isBaselineCell) {
+					const swap = priceModelSwap({
+						baselineTokensPerRun: baselineSpend.billedPerRun,
+						candidate: {
+							passRate,
+							tokensPerRun: spend.billedPerRun,
+							tokensPerRepairCycle: repairCycle,
+						},
+					});
+					if (Result.isSuccess(swap)) {
+						netSaving = swap.success.netSaving;
+						netNegative = Number.isFinite(netSaving) && netSaving < 0;
+					}
+				}
+			}
+		}
+
+		return {
+			stage: bucket.stage,
+			model: bucket.model,
+			gradedRuns: bucket.graded,
+			passedRuns: bucket.passed,
+			passRate,
+			spend,
+			churn,
+			netSaving,
+			netNegative,
+		};
+	});
+
+	return {
+		decisionRef: DECISION_POINTER,
+		framing: DECISION_FRAMING,
+		baseline:
+			baselineBucket !== undefined
+				? {stage: baselineBucket.stage, model: baselineBucket.model}
+				: null,
+		cells,
+	};
+};
+
+/**
+ * The stable, documented machine-readable form of a scorecard — the exact JSON a future gate
+ * or CI consumes. It is the `Scorecard` interface serialized as-is (field names + nesting are
+ * the contract, documented in README.md); a consumer decodes this shape. Kept as a thin
+ * projection so the JSON shape and the in-memory type never drift.
+ */
+export const toJson = (scorecard: Scorecard): string => `${JSON.stringify(scorecard, null, 2)}\n`;
+
+const num = (n: number): string =>
+	Number.isFinite(n) ? Math.round(n).toLocaleString("en-US") : n > 0 ? "+∞" : "-∞";
+
+const pct = (rate: number): string => `${(rate * 100).toFixed(1)}%`;
+
+const signedNum = (n: number | null): string => {
+	if (n === null) return "—";
+	if (!Number.isFinite(n)) return n > 0 ? "+∞" : "-∞";
+	const rounded = Math.round(n);
+	return rounded > 0 ? `+${rounded.toLocaleString("en-US")}` : rounded.toLocaleString("en-US");
+};
+
+/**
+ * Render the human-readable table the founder reads to decide #1576 (`token-spend`/`ship-digest`
+ * reporter idiom). One row per (stage × model): pass-rate, per-run billed + ex-cache-read spend,
+ * churn-amortized billed, and net saving vs the baseline. A net-negative cell is marked
+ * `NET-NEGATIVE` unambiguously — the epic's headline risk made impossible to miss. The framing
+ * line states this is evidence for #1576, never a recommendation.
+ */
+export const renderTable = (scorecard: Scorecard): string => {
+	const lines: Array<string> = [];
+	lines.push("eval-harness scorecard — graded two-axis gate (pass-rate × net-token cost)");
+	lines.push(scorecard.framing);
+	if (scorecard.baseline !== null) {
+		lines.push(
+			`baseline: ${scorecard.baseline.stage} × ${scorecard.baseline.model ?? "(unknown model)"} ` +
+				"— net saving is measured against this cell",
+		);
+	}
+	lines.push("");
+
+	const header = [
+		"stage",
+		"model",
+		"pass-rate",
+		"billed/run",
+		"ex-cache/run",
+		"amortized/run",
+		"net-saving",
+		"",
+	];
+	const rows = scorecard.cells.map((cell) => [
+		cell.stage,
+		cell.model ?? "(unknown)",
+		`${pct(cell.passRate)} (${cell.passedRuns}/${cell.gradedRuns})`,
+		cell.spend === null ? "—" : num(cell.spend.billedPerRun),
+		cell.spend === null ? "—" : num(cell.spend.exCacheReadPerRun),
+		cell.churn === null ? "—" : num(cell.churn.amortizedBilledPerRun),
+		signedNum(cell.netSaving),
+		cell.netNegative ? "NET-NEGATIVE (churn ate the saving)" : "",
+	]);
+
+	const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)));
+	const fmt = (cols: ReadonlyArray<string>): string =>
+		cols
+			.map((c, i) => c.padEnd(widths[i] ?? 0))
+			.join("  ")
+			.trimEnd();
+
+	lines.push(fmt(header));
+	lines.push(
+		widths
+			.map((w) => "-".repeat(w))
+			.join("  ")
+			.trimEnd(),
+	);
+	for (const r of rows) lines.push(fmt(r));
+
+	return lines.join("\n");
+};
+
+// --- The report's on-disk input: a serialized array of runner rows (`RunRow[]`) --------------
+//
+// The report command reads the runner's graded rows from a JSON file — the array `collectRuns`
+// produces, serialized. These schemas decode that file totally: a malformed body or a shape
+// mismatch returns a typed `Result` failure, never a throw (mirrors `decodeManifest`).
+
+const StageSpendSchema = Schema.Struct({
+	input: Schema.Finite,
+	cacheCreate: Schema.Finite,
+	cacheRead: Schema.Finite,
+	output: Schema.Finite,
+	billed: Schema.Finite,
+	exCacheRead: Schema.Finite,
+	assistantTurns: Schema.Finite,
+	model: Schema.NullOr(Schema.String),
+});
+
+const RunSpendSchema = Schema.Union([
+	Schema.Struct({_tag: Schema.Literal("Reconstructed"), spend: StageSpendSchema}),
+	Schema.Struct({_tag: Schema.Literal("TranscriptMissing")}),
+]);
+
+const FieldMismatchSchema = Schema.Struct({
+	field: Schema.String,
+	observed: Schema.String,
+	expected: Schema.String,
+});
+
+const MismatchSchema = Schema.Union([
+	Schema.Struct({_tag: Schema.Literal("MalformedArtifact"), reason: Schema.String}),
+	Schema.Struct({_tag: Schema.Literal("LabelMismatch"), fields: Schema.Array(FieldMismatchSchema)}),
+]);
+
+const GradeSchema = Schema.Union([
+	Schema.Struct({status: Schema.Literal("pass")}),
+	Schema.Struct({status: Schema.Literal("fail"), mismatch: MismatchSchema}),
+]);
+
+const RunRowSchema = Schema.Struct({
+	entry: CorpusEntry,
+	grade: GradeSchema,
+	spend: RunSpendSchema,
+});
+
+/** The report's input file: the array of graded rows `collectRuns` emits, serialized to JSON. */
+export const ReportInput = Schema.Array(RunRowSchema);
+
+export type ReportInput = typeof ReportInput.Type;
+
+/** A typed report-input decode failure — malformed JSON, or a shape that doesn't match the rows schema. */
+export class ReportInputError extends Data.TaggedError("ReportInputError")<{
+	readonly reason: "malformed-json" | "schema-mismatch";
+	readonly message: string;
+}> {}
+
+const decodeUnknownReportInput = Schema.decodeUnknownResult(ReportInput);
+
+/**
+ * Decode the report's input (a serialized `RunRow[]`) from its on-disk text. Total — a non-JSON
+ * body or a schema mismatch both return a typed `Result` failure, never a throw.
+ */
+export const decodeReportInput = (text: string): Result.Result<ReportInput, ReportInputError> => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (cause) {
+		return Result.fail(
+			new ReportInputError({
+				reason: "malformed-json",
+				message: cause instanceof Error ? cause.message : String(cause),
+			}),
+		);
+	}
+	return decodeUnknownReportInput(parsed).pipe(
+		Result.mapError(
+			(error) => new ReportInputError({reason: "schema-mismatch", message: error.message}),
+		),
+	);
+};

--- a/packages/pipeline-cli/src/tools/eval-harness/report.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/report.unit.test.ts
@@ -1,0 +1,188 @@
+import {assert, describe, it} from "@effect/vitest";
+import type {StageSpend} from "../token-spend/token-spend.ts";
+import type {CorpusEntry} from "./corpus.ts";
+import {
+	buildScorecard,
+	DECISION_POINTER,
+	renderTable,
+	type ScorecardCell,
+	toJson,
+} from "./report.ts";
+import type {RunRow} from "./runner.ts";
+
+// A triage corpus entry — the report only reads `entry.stage`, so any stage's entry serves.
+const triageEntry = (inputRef: number): CorpusEntry => ({
+	stage: "triage",
+	inputRef,
+	label: {type: "bug", priority: "p0", status: "triaged"},
+});
+
+// A reconstructed StageSpend fixture: `billed` and `exCacheRead` are the only fields the report
+// reads off the spend (plus `model` for bucketing).
+const spend = (billed: number, model: string): StageSpend => ({
+	input: billed,
+	cacheCreate: 0,
+	cacheRead: 0,
+	output: 0,
+	billed,
+	exCacheRead: billed,
+	assistantTurns: 1,
+	model,
+});
+
+// One graded run row: a pass/fail grade + a reconstructed spend at `billed` tokens on `model`.
+const row = (opts: {pass: boolean; billed: number; model: string; inputRef?: number}): RunRow => ({
+	entry: triageEntry(opts.inputRef ?? 1),
+	grade: opts.pass
+		? {status: "pass"}
+		: {status: "fail", mismatch: {_tag: "MalformedArtifact", reason: "x"}},
+	spend: {_tag: "Reconstructed", spend: spend(opts.billed, opts.model)},
+});
+
+const missingSpendRow = (opts: {pass: boolean; inputRef?: number}): RunRow => ({
+	entry: triageEntry(opts.inputRef ?? 1),
+	grade: opts.pass
+		? {status: "pass"}
+		: {status: "fail", mismatch: {_tag: "MalformedArtifact", reason: "x"}},
+	spend: {_tag: "TranscriptMissing"},
+});
+
+const cellFor = (cells: ReadonlyArray<ScorecardCell>, model: string | null): ScorecardCell => {
+	const found = cells.find((c) => c.model === model);
+	assert.isDefined(found, `expected a cell for model ${model}`);
+	return found as ScorecardCell;
+};
+
+describe("buildScorecard — single (stage × model)", () => {
+	it("computes pass-rate and mean per-run billed + ex-cache-read spend for one cell", () => {
+		// 3 runs, 2 pass ⇒ pass-rate 2/3; billed 100/200/300 ⇒ mean 200.
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 100, model: "opus"}),
+			row({pass: true, billed: 200, model: "opus"}),
+			row({pass: false, billed: 300, model: "opus"}),
+		];
+		const sc = buildScorecard({rows});
+		assert.strictEqual(sc.cells.length, 1);
+		const cell = cellFor(sc.cells, "opus");
+		assert.strictEqual(cell.stage, "triage");
+		assert.strictEqual(cell.gradedRuns, 3);
+		assert.strictEqual(cell.passedRuns, 2);
+		assert.approximately(cell.passRate, 2 / 3, 1e-9);
+		assert.isNotNull(cell.spend);
+		assert.strictEqual(cell.spend?.billedPerRun, 200);
+		assert.strictEqual(cell.spend?.exCacheReadPerRun, 200);
+		assert.isNotNull(cell.churn);
+		// No baseline named ⇒ no net saving computed on a lone cell.
+		assert.isNull(cell.netSaving);
+		assert.isFalse(cell.netNegative);
+	});
+
+	it("a transcript-missing run counts toward pass-rate but not toward the spend mean", () => {
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 100, model: "opus"}),
+			missingSpendRow({pass: true}),
+		];
+		const sc = buildScorecard({rows});
+		// Both runs land in the same (stage × model) cell — the missing-transcript run has model null,
+		// so it buckets separately. Assert the two are distinct and both counted.
+		const opusCell = cellFor(sc.cells, "opus");
+		assert.strictEqual(opusCell.gradedRuns, 1);
+		assert.strictEqual(opusCell.spend?.billedPerRun, 100);
+		const nullCell = cellFor(sc.cells, null);
+		assert.strictEqual(nullCell.gradedRuns, 1);
+		assert.strictEqual(nullCell.passedRuns, 1);
+		// A cell with no reconstructed spend reports a null token axis, not a fabricated zero.
+		assert.isNull(nullCell.spend);
+		assert.isNull(nullCell.churn);
+	});
+});
+
+describe("buildScorecard — multi-model comparison against a baseline", () => {
+	it("prices each candidate's net saving against the named baseline cell", () => {
+		// Baseline: opus, pass-rate 1.0, 1000 billed/run ⇒ zero churn, amortized 1000.
+		// Candidate: sonnet, pass-rate 1.0, 400 billed/run ⇒ zero churn, amortized 400.
+		// Net saving of sonnet = baseline 1000 − sonnet amortized 400 = +600.
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 1000, model: "opus", inputRef: 1}),
+			row({pass: true, billed: 400, model: "sonnet", inputRef: 2}),
+		];
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus"}});
+		assert.isNotNull(sc.baseline);
+		assert.strictEqual(sc.baseline?.model, "opus");
+
+		const opus = cellFor(sc.cells, "opus");
+		// The baseline cell measures no net saving against itself.
+		assert.isNull(opus.netSaving);
+		assert.isFalse(opus.netNegative);
+
+		const sonnet = cellFor(sc.cells, "sonnet");
+		assert.strictEqual(sonnet.churn?.churnTokens, 0);
+		assert.strictEqual(sonnet.netSaving, 600);
+		assert.isFalse(sonnet.netNegative);
+	});
+});
+
+describe("buildScorecard — the net-negative churn case (the epic's headline risk)", () => {
+	it("a cheaper-but-flakier model whose churn exceeds its per-run saving renders net-negative", () => {
+		// Baseline: opus, pass-rate 1.0, 1000 billed/run ⇒ amortized 1000.
+		// Candidate: sonnet, pass-rate 0.5, 700 billed/run (naive saving 300/run).
+		//   expected extra cycles = (1−0.5)/0.5 = 1; churn = 1 × 700 = 700; amortized = 700 + 700 = 1400.
+		//   net saving = 1000 − 1400 = −400 ⇒ NET-NEGATIVE: churn ate the saving.
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 1000, model: "opus", inputRef: 1}),
+			row({pass: true, billed: 700, model: "sonnet", inputRef: 2}),
+			row({pass: false, billed: 700, model: "sonnet", inputRef: 3}),
+		];
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus"}});
+		const sonnet = cellFor(sc.cells, "sonnet");
+		assert.approximately(sonnet.passRate, 0.5, 1e-9);
+		assert.strictEqual(sonnet.churn?.expectedExtraCycles, 1);
+		assert.strictEqual(sonnet.churn?.churnTokens, 700);
+		assert.strictEqual(sonnet.churn?.amortizedBilledPerRun, 1400);
+		assert.strictEqual(sonnet.netSaving, -400);
+		assert.isTrue(sonnet.netNegative);
+	});
+
+	it("a never-passing model (pass-rate 0) prices +Infinity churn and is net-negative", () => {
+		const rows: ReadonlyArray<RunRow> = [
+			row({pass: true, billed: 1000, model: "opus", inputRef: 1}),
+			row({pass: false, billed: 10, model: "flaky", inputRef: 2}),
+		];
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus"}});
+		const flaky = cellFor(sc.cells, "flaky");
+		assert.strictEqual(flaky.passRate, 0);
+		assert.strictEqual(flaky.churn?.churnTokens, Number.POSITIVE_INFINITY);
+		// netSaving = 1000 − Infinity = −Infinity: not a finite number, so not flagged net-negative,
+		// but the amortized cost is unbounded (rendered as -∞ saving) — never adopt.
+		assert.strictEqual(flaky.netSaving, Number.NEGATIVE_INFINITY);
+		assert.isFalse(flaky.netNegative);
+	});
+});
+
+describe("report — the output carries no model recommendation, only evidence for #1576", () => {
+	it("the scorecard and both rendered surfaces point at the decision and recommend nothing", () => {
+		const rows: ReadonlyArray<RunRow> = [row({pass: true, billed: 100, model: "opus"})];
+		const sc = buildScorecard({rows, baseline: {stage: "triage", model: "opus"}});
+		assert.strictEqual(sc.decisionRef, DECISION_POINTER);
+		assert.strictEqual(DECISION_POINTER, 1576);
+
+		const table = renderTable(sc);
+		assert.include(table, "#1576");
+		assert.include(table, "does not recommend or select a model");
+		// No verdict/recommendation vocabulary leaks into the rendered evidence.
+		assert.notMatch(
+			table.toLowerCase(),
+			/\brecommend(ed|s)?:\b|\buse (opus|sonnet)\b|\badopt (opus|sonnet)\b/,
+		);
+
+		const json = toJson(sc);
+		const parsed = JSON.parse(json);
+		assert.strictEqual(parsed.decisionRef, 1576);
+		assert.include(parsed.framing, "does not recommend or select a model");
+		// The JSON shape is stable + documented: no `recommendation`/`selected`/`winner` key.
+		assert.notProperty(parsed, "recommendation");
+		assert.notProperty(parsed, "selectedModel");
+		assert.notProperty(parsed, "winner");
+		assert.isArray(parsed.cells);
+	});
+});


### PR DESCRIPTION
The `pipeline-cli eval-harness report` command — the top of the eval-harness vertical slice (epic #1842) and the evidence artifact the model-tiering decision (#1576) consumes. It aggregates the runner's graded `{entry, grade, spend}` rows (`runner.ts`) into a per-(stage × model) scorecard on the ADR 0112 §4 two-axis gate, now graded.

## What changed

- `packages/pipeline-cli/src/tools/eval-harness/report.ts` — the pure `buildScorecard` core: buckets the runner rows by (stage × reconstructed model) and computes, per cell, the **pass-rate** (quality axis), the mean **billed + ex-cache-read** per-run spend (token axis, ADR 0112 §2), the priced **repair-churn** cost (`repair-churn.ts`), and the **net saving** vs a named baseline cell. `renderTable` (human) + `toJson` (stable machine-readable) render it; `decodeReportInput` totally decodes the on-disk serialized `RunRow[]`.
- `packages/pipeline-cli/src/tools/eval-harness/command.ts` — the `report <rows.json> [--json] [--baseline-stage S --baseline-model M]` subcommand, a thin IO shell over the core.
- `report.unit.test.ts` — unit tests: a single (stage × model), a multi-model comparison, the net-negative-churn case (plus the passRate=0 +Infinity limit and the no-recommendation contract on both surfaces).
- `README.md` — documents the command and the stable JSON shape.

## Acceptance criteria

- Emits pass-rate + per-run token spend (billed + ex-cache-read) + repair-churn cost per (stage × model).
- A (stage × model) whose churn cost exceeds its per-run saving renders **net-negative unambiguously** — `NET-NEGATIVE` in the table, `netNegative: true` in the JSON.
- Both a human table and machine-readable JSON are produced; the JSON shape is stable and documented in the README.
- The report carries **no model recommendation** — it presents evidence and points at #1576 (verified by a test asserting the framing on both surfaces and the absence of any `recommendation`/`selectedModel`/`winner` key).
- Unit tests cover the single-cell, multi-model, and net-negative-churn cases.

Measurement, not a recommendation: the report never selects a model — that call is #1576, a separate `type:decision`.

`pnpm typecheck` clean; `pnpm lint:worktree` clean; all 59 eval-harness tests pass.

Note: `packages/pipeline-cli/` is control-plane (§CP) — this ships to reviewed-ready and merges by a human, not auto-ship.

Fixes #1853