### PR TITLE
fix(ci): fail closed when prod deploy emits no URL to health-verify (#1617)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,12 +238,30 @@ jobs:
       # job (no false-green) — an unreachable prod, a non-200, or a body whose `status`
       # is not "ok" (the health handler returns `{status:"ok",…}`, see
       # apps/web/worker/http/health.ts) all red the deploy run.
+      #
+      # The URL-presence check lives INSIDE the step body, NOT in the `if:` guard (issue
+      # #1617). The guard is `github.event_name == 'push'` ALONE: an empty `outputs.url`
+      # after a "successful" deploy — an alchemy log-scrape miss or a genuinely URL-less
+      # deploy — must RED the job, not skip it green. A `&& steps.deploy.outputs.url != ''`
+      # clause in the `if:` would make an empty URL SKIP the step, which GitHub records as
+      # a passed job: a fail-OPEN corner in the very gate meant to be fail-closed against a
+      # broken prod (ADR 0092, gates fail closed on zero scope). So on a prod push the step
+      # always runs, and an empty URL exits non-zero with `::error::` — "no URL to check"
+      # is itself a deploy failure worth surfacing.
       - name: Verify prod serves — GET /api/health (${{ matrix.app }})
-        if: github.event_name == 'push' && steps.deploy.outputs.url != ''
+        if: github.event_name == 'push'
         env:
           PROD_URL: ${{ steps.deploy.outputs.url }}
         run: |
           set -uo pipefail
+          # Fail closed on an empty URL (issue #1617): `alchemy deploy` exited 0 but the
+          # scrape yielded no worker URL, so there is nothing to probe — red the deploy
+          # rather than pass silently, same fail-closed posture as the retry exhaustion below.
+          if [ -z "$PROD_URL" ]; then
+            echo "::error::prod health gate FAILED (issue #1617) — alchemy deploy exited 0 but emitted no scrapeable worker URL."
+            echo "An empty URL after a successful deploy is itself a deploy failure. Failing so it surfaces instead of skipping green (ADR 0092)."
+            exit 1
+          fi
           healthy=""
           last=""
           # Retry across CF's propagation window (same shape as the teardown-verify loop):


### PR DESCRIPTION
## What

The post-deploy prod health gate (`.github/workflows/deploy.yml`, added by #1616, closes #1436) had a fail-open corner: on a prod push where `alchemy deploy` exits 0 but the log-scrape yields no worker URL, the `Verify prod serves — GET /api/health` step was **skipped** rather than failed, because its guard was:

```yaml
if: github.event_name == 'push' && steps.deploy.outputs.url != ''
```

GitHub records a skipped step as a **passed job** — a false-green inside the very gate meant to be fail-closed against a broken prod (ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md), gates fail closed on zero scope).

## Fix

- Guard the step on `github.event_name == 'push'` **alone** (dropped the `&& steps.deploy.outputs.url != ''` clause).
- At the top of the step's `run:`, if `PROD_URL` (`steps.deploy.outputs.url`) is empty, emit `::error::` and `exit 1` — an empty URL after a "successful" deploy is itself a deploy failure worth surfacing.
- The bounded-retry health probe for a present URL is unchanged.

## Acceptance criteria

- [x] On a prod push where `steps.deploy.outputs.url` is empty, the step **fails the deploy job** (non-zero exit + `::error::`) instead of being skipped/green.
- [x] On a prod push where the URL is present, existing behavior is unchanged (bounded-retry probe of `GET /api/health`, red on non-healthy).
- [x] The step is not reachable on `pull_request` events (guard is `push`-only).
- [x] No fail-open path remains: no combination of `event_name == 'push'` + empty URL yields a passing job.

## Control-plane

Touches `.github/workflows/deploy.yml` (§CP) — human-merged, not auto-shipped, per the triage note.

Fixes #1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)