### PR TITLE
fix(review-code): fail closed on test surface when run-evidence degrades (#1658)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -429,15 +429,17 @@ has repo-wide contract blast radius against `apps/web/worker/features/fate/wireC
 feature-scoped green while that contract test is red is the #1657-class false-green a trust
 gate exists to prevent. On the degrade path therefore:
 
-- **Run the full unit project, not a feature-scoped subset.** Use `pnpm -C "$REVIEW_WT" test:unit`
-  (repo script = `vitest run --config vitest.config.ts --project unit`, the whole unit
-  surface), never `--project unit <feature-path>`. This is the fail-closed fix: it verifies
-  the change's real blast radius, so a cross-cutting contract test cannot slip past a
-  degraded verification.
+- **Run the full unit project, not a feature-scoped subset.** Use `pnpm -C "$REVIEW_WT/apps/web" test:unit`
+  (the `apps/web` package script = `vitest run --config vitest.config.ts --project unit`, the
+  whole unit surface — `test:unit` lives in `apps/web/package.json`, NOT the repo root, since
+  `$REVIEW_WT` is the repo root a bare `pnpm -C "$REVIEW_WT" test:unit` hits
+  `ERR_PNPM_NO_SCRIPT`), never `--project unit <feature-path>`. This is the fail-closed fix:
+  it verifies the change's real blast radius, so a cross-cutting contract test cannot slip
+  past a degraded verification.
 
   ```bash
-  . "$WT_FILE"                        # re-source $REVIEW_WT/$PR_REF after a between-call reset (#1807)
-  pnpm -C "$REVIEW_WT" test:unit      # FULL unit project — never path-narrowed on the degrade path
+  . "$WT_FILE"                              # re-source $REVIEW_WT/$PR_REF after a between-call reset (#1807)
+  pnpm -C "$REVIEW_WT/apps/web" test:unit   # FULL unit project (the apps/web script) — never path-narrowed on the degrade path
   ```
 
 - **If — and only if — the full unit project genuinely cannot run** (an environment fault

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -328,6 +328,10 @@ pnpm -C "$REVIEW_WT" install   # the catalog/lockfile + patches/ are present, so
 # so it catches root + `.claude/**` violations a bare `biome check apps packages` would miss and
 # reliably predicts the CI lint job (#553/#559):
 pnpm -C "$REVIEW_WT" lint:worktree   # and/or the specific test the criterion names
+# Scoping a test to the criterion is fine when the SHA-bound run-evidence bundle (Step 2)
+# corroborates the full surface. But when the bundle is DEGRADED (absent/expired/stale-for-SHA),
+# a feature-scoped run under-verifies the change's blast radius — see the "fail closed on the
+# test surface" rule in the degrade block below: run the FULL unit project, never a subset.
 rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"   # tear the throwaway tree + ref down
 ```
 
@@ -414,6 +418,35 @@ bundle's absence in the verdict and fall back to the current behavior** — veri
 from the diff, the tests you run in the review worktree above, and the PR's checks the
 ordinary way. Do **not** fail the gate, refuse to review, or block on the bundle: it
 *strengthens* evidence when present; its absence costs only reproducibility, not the review.
+
+**But fail closed on the test surface (ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)) — a `PASS` must never be reachable on a strictly-narrower
+test surface than the change's blast radius.** When the bundle degrades and you fall back to
+running tests in the review worktree, the SHA-bound proof of *what CI ran* is gone, so a
+feature-scoped run (`--project unit <feature-path>`) can miss a **cross-cutting contract
+test** that lives outside the changed feature's cone — e.g. a new server-emittable wire code
+has repo-wide contract blast radius against `apps/web/worker/features/fate/wireCodes.unit.test.ts`
+(asserts every server code is in the SPA decode list), not feature-local blast radius. A
+feature-scoped green while that contract test is red is the #1657-class false-green a trust
+gate exists to prevent. On the degrade path therefore:
+
+- **Run the full unit project, not a feature-scoped subset.** Use `pnpm -C "$REVIEW_WT" test:unit`
+  (repo script = `vitest run --config vitest.config.ts --project unit`, the whole unit
+  surface), never `--project unit <feature-path>`. This is the fail-closed fix: it verifies
+  the change's real blast radius, so a cross-cutting contract test cannot slip past a
+  degraded verification.
+
+  ```bash
+  . "$WT_FILE"                        # re-source $REVIEW_WT/$PR_REF after a between-call reset (#1807)
+  pnpm -C "$REVIEW_WT" test:unit      # FULL unit project — never path-narrowed on the degrade path
+  ```
+
+- **If — and only if — the full unit project genuinely cannot run** (an environment fault
+  unrelated to the PR, not a slow/large suite), fence the verdict as partial rather than
+  emitting a full-trust `PASS`: `review-code: PASS (partial local verification — CI-authoritative) @ <sha>`,
+  and name in the body what was and was not run. A downstream human hand-merging a §CP PR
+  (ADRs [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md)/[0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md)) must not over-trust a narrow-surface PASS; the fence tells them (and
+  `ship-it`) that CI is the authority for the surface you could not cover. Fencing is the
+  fallback, not the default — prefer running the full unit project.
 
 ### Flag a control-plane PR (complementary signal, not the isolation)
 


### PR DESCRIPTION
Fixes #1658

## Problem

`review-code`'s local-verification **degrade path** (SHA-bound run-evidence bundle absent/expired/stale-for-SHA) fell back to a **feature-scoped** worktree test run (`vitest --project unit <feature-path>`). A **cross-cutting contract test** that lives outside the changed feature's cone is structurally unreachable by a feature-scoped run, so `review-code` could emit a full-trust `PASS` that CI then reddened — a false-green in a trust gate (the exact failure mode ADR 0092's fail-closed principle exists to prevent).

Observed on PR #1657 (fixes #1639): a new server-emittable wire code `POST_DELETE_FAILED` broke the cross-cutting contract `apps/web/worker/features/fate/wireCodes.unit.test.ts` (asserts every server code is in the SPA decode list). The degraded verification ran only the pano feature's unit project (85 green), missing the failing `fate/` contract test; `ship-it`'s independent CI re-check caught it, but the review verdict itself was misleading — and §CP PRs are hand-merged by a human who may trust the PASS (ADRs 0053/0073).

## Fix (fail-closed, ADR 0092)

Encode the invariant into `review-code`'s degrade block: **a `PASS` must not be reachable on a strictly-narrower test surface than the change's blast radius.**

- On the degrade path, run the **full unit project** (`pnpm -C "$REVIEW_WT" test:unit` = `vitest run --project unit`, no path filter), **never** a feature-scoped subset — so a cross-cutting contract test cannot slip past a degraded verification. This is the stronger, ADR-0092-aligned fix (Direction option 1).
- Only if the full unit project genuinely cannot run (an environment fault unrelated to the PR), **fence** the verdict: `review-code: PASS (partial local verification — CI-authoritative) @ <sha>`, naming what was/wasn't run, so a downstream human / `ship-it` does not over-trust a narrow-surface PASS (option 2, as the fallback — not the default).
- Corrected the earlier worktree-run note (L330 "the specific test the criterion names") so criterion-scoping is confined to the corroborated (non-degraded) path.

## Acceptance criteria

- [x] Degraded-verification path no longer emits a full-trust `PASS` reachable on a strictly-narrower surface than the change's blast radius.
- [x] For a new server-emittable wire code / repo-wide contract change, the degraded path runs the full unit project (covering `wireCodes.unit.test.ts`) — or fences as partial/CI-authoritative — so the #1657-class miss cannot yield an un-fenced `PASS`.
- [x] Behavior written into `review-code/SKILL.md`'s degrade block, citing ADR 0092.
- [x] Scoped to the review-code skill's verification procedure; no unrelated gate behavior altered.

## §CP — control plane

This edits a gate-critical skill (`claude-plugins/kampus-pipeline/skills/review-code/**`), which is **control-plane** per §CP. **Not auto-mergeable → routes to human merge.** `ship-it` will refuse auto-merge by design; expect the §CP flag. No gate invariant is weakened — this closes a false-green (tightens the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)