### PR TITLE
fix(write-code): cut the initial branch from a freshly-fetched origin, not a stale ref (#1920)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -714,7 +714,13 @@ isolated worktree (`fatal: 'main' is already checked out at <primary>`). Branch 
 latest origin `main` **without checking it out**:
 
 ```bash
-git fetch origin main
+# Fetch the base fresh, and FAIL-LOUD if it doesn't run: FETCH_HEAD is what the branch below is
+# cut from, so a silently-failed fetch (network blip, a harness worktree whose exec env stripped
+# PATH) leaves FETCH_HEAD at a STALE prior tip, and the branch misses a base file merged just
+# before branch-cut → the SHA-bound run-evidence check false-fails on a file the head never
+# carried (#1920; the same stale-base class #1837 fixed at the repair step). Never proceed on an
+# unverified fetch — assert it succeeded before branching off FETCH_HEAD.
+git fetch origin main || { echo "write-code: 'git fetch origin main' failed — refusing to branch off a stale FETCH_HEAD (would cut a head missing a just-merged base file; #1920)." >&2; exit 1; }
 # Derive the prefix from THIS checkout's git identity — never a hardcoded literal. A copied
 # literal namespaces every agent's branch under one person's handle regardless of who runs.
 PREFIX="$(git config user.name | tr '[:upper:] ' '[:lower:]-')"   # e.g. "Umut Sirin" → "umut-sirin"
@@ -771,11 +777,16 @@ pass; `no` means config/docs/scaffolding where test-first doesn't apply.
 
 <a id="non-isolated-fallback"></a>
 > **Non-isolated fallback.** For the rare invocation that isn't already in a worktree,
-> spin one up rather than checking out `main`. Create the worktree on the per-run `$BRANCH`
-> (nonce and all) at a per-run worktree path so two concurrent fallback runs collide on
-> neither the branch nor the dir: `WT="../wt-issue-<N>-$(uuidgen | head -c 8)"; git worktree
-> add -b "$BRANCH" "$WT" origin/main`, then `cd "$WT"`. When you're done, remove it with
-> `git worktree remove "$WT"`. After the `cd "$WT"`, **re-run the Step 4 preflight** — the
+> spin one up rather than checking out `main`. **Fetch first** — the local `origin/main`
+> remote-tracking ref can predate a just-merged base commit (e.g. a run-evidence-referenced
+> tooling file added seconds before branch-cut), so `git worktree add … origin/main` off a
+> stale ref cuts a head that misses that file and false-fails the SHA-bound CI (#1920; the same
+> stale-base class #1837 fixed at the repair step). Create the worktree on the per-run
+> `$BRANCH` (nonce and all) at a per-run worktree path off the **freshly-fetched** tip, so two
+> concurrent fallback runs collide on neither the branch nor the dir: `git fetch origin main;
+> WT="../wt-issue-<N>-$(uuidgen | head -c 8)"; git worktree add -b "$BRANCH" "$WT" FETCH_HEAD`,
+> then `cd "$WT"`. Branch off `FETCH_HEAD` (the just-fetched origin tip), **never** the possibly-stale
+> `origin/main` ref. When you're done, remove it with `git worktree remove "$WT"`. After the `cd "$WT"`, **re-run the Step 4 preflight** — the
 > fresh worktree's git-dir now differs from the common dir, so the check passes and you may
 > mutate. This is the *only* sanctioned route from a primary-checkout start; the preflight
 > stays fail-closed until a real worktree exists. Here too the branch name is **created once**


### PR DESCRIPTION
## What & why

Fixes #1920. The `write-code` skill's Step-4 **initial branch** step could cut a PR head off a **stale base**, so a PR whose base gained a run-evidence-referenced tooling file just before branch-cut (the #1839 → #1914/#1909 case) permanently misses that file and **false-fails** the SHA-bound `produce run-evidence bundle` job (`MODULE_NOT_FOUND` → synthesized `bundle-node-core-free: fail` → ship-it guard-2 refuses to enqueue). This mirrors, at the **initial** step, the base-freshness fix #1837 landed at the **repair** step for the same stale-base class.

## Fix locus (grounded against skill source)

Two stale-base surfaces in `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md`, Step 4:

1. **Mainline isolated-worktree path** — already did `git fetch origin main` → `git switch -c "$BRANCH" FETCH_HEAD` (branches off the fresh tip). The gap: the fetch was **unchecked**, so a silently-failed fetch (network blip, or a PATH-stripped harness worktree per the known harness-exec-env behavior) leaves `FETCH_HEAD` at a **stale prior tip** and reproduces the bug. Now the fetch is **fail-loud** — the branch refuses to cut on an unverified fetch.

2. **Non-isolated fallback** — branched a new worktree off `origin/main` with **no preceding `git fetch`**, so it used the possibly-stale remote-tracking ref. Now it `git fetch origin main` first and branches off **`FETCH_HEAD`**, never the stale `origin/main`.

## Acceptance criteria

- [x] Identified the actual stale-base steps against source (mainline unchecked fetch + fetch-less fallback), not a blanket patch.
- [x] Both steps now cut the initial branch from a **freshly-fetched** `origin/main` (FETCH_HEAD), carrying any base file merged just before branch-cut.
- [x] Mirrors the #1837 base-freshness approach (fetch against origin before the branch), applied at the initial step.
- [x] A PR whose base gained a run-evidence tooling file just before branch-cut no longer cuts a head missing it → no HEAD_SHA false-fail.
- [x] No GraphQL, no local paths introduced; leak-guard clean.

The out-of-scope `type:decision` (source CI tooling scripts from base vs HEAD) is deliberately **not** folded in, per the issue.

## Lane

The fix is confined to the `write-code` **skill** (`claude-plugins/kampus-pipeline/skills/write-code/SKILL.md`), which is **not** in the §CP CODEOWNERS set (only `ship-it`/`review-*`/`gh-issue-intake-formats.md` under that dir are). It touches **no** `.claude/`, `.github/`, `packages/ci-required/`, or `drive-issue.js`. Per the issue's routing, a skill-only fix is **non-control-plane**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)