### PR TITLE
feat(health): typed 503 degraded readiness body when Flagship unreachable, not orDie→500 (ADR 0156, #1991)

### DIFF
--- a/.decisions/0156-health-probe-flagship-unreachable-is-typed-503.md
+++ b/.decisions/0156-health-probe-flagship-unreachable-is-typed-503.md
@@ -1,0 +1,120 @@
+---
+id: 0156
+title: The health probe returns a typed 503 degraded body when Flagship is unreachable, not orDie→500
+status: accepted
+date: 2026-07-05
+tags: [health, readiness, http, flagship, worker, observability, product-development-framework]
+---
+
+# 0156 — Health-probe Flagship-unreachable is a typed 503, not an orDie→500 defect
+
+## Context
+
+`GET /api/health` (`apps/web/worker/http/health.ts`) is the worker's readiness
+probe. It drives one Flagship evaluation purely to assert binding reachability
+(epic #488, #507): the read completing at all proves the `FlagshipClient` resolved
+end-to-end through the worker, so the returned `HealthStatus.flagshipReachable` is
+`true`. Before this decision the handler did:
+
+```ts
+yield* flagship.getBooleanValue("phoenix-health-probe", false).pipe(Effect.orDie);
+return new HealthStatus({status: "ok", environment, flagshipReachable: true});
+```
+
+Two grounded facts about the seam (both verified in source, per the CLAUDE.md
+"ground falsifiable claims" rule):
+
+- **`FlagshipError` is a promise-reject-only channel.** In the alchemy source
+  (`Cloudflare/Flagship/ReadFlags.ts` `ReadFlagsClient` docblock):
+  "Flagship evaluation never throws — it falls back to the provided `defaultValue`
+  — so the `FlagshipError` channel only surfaces unexpected runtime failures (e.g.
+  a misconfigured binding)." So the only way `getBooleanValue` fails is an
+  unreachable/misconfigured binding, never a normal evaluation.
+- **Flags fail-closed.** The feature-facing evaluator (`features/flagship/Flags.ts`
+  `buildRealFlags`) `catch`es any `FlagshipError` to the caller's supplied default,
+  so a Flagship outage degrades safe — the worker keeps serving with flags at their
+  defaults. `Flags.getBoolean`'s public error channel is therefore `never`.
+
+Given those two facts, the pre-decision `orDie` had two defects:
+
+1. It turned `FlagshipError` into an Effect **defect → HTTP 500**, indistinguishable
+   from any other handler crash. An operator or the integration harness
+   (`tests/integration/_integration.ts` `healthReady`) could not tell
+   "Flagship binding unreachable" from a generic worker crash.
+2. It made `HealthStatus.flagshipReachable` **dead** — the field could never be
+   `false`, because the failure path never reached the `HealthStatus` return. The
+   schema carried a readiness signal the code could never emit.
+
+`ConfigError` (a malformed `ENVIRONMENT`/`AppConfig` value) is a different animal:
+that is a genuine handler defect — the env is broken — not a representable degraded
+state. It stays `orDie`→500.
+
+## Decision
+
+Split the two error channels by what they mean:
+
+- **`ConfigError` (malformed env / `AppConfig`) → keep `orDie`→500.** A real handler
+  defect; the narrow-error-channel discipline holds.
+- **`FlagshipError` (Flagship unreachable) → return a typed 503 degraded body.**
+  Catch the `FlagshipError` and return a `HealthDegraded` body
+  (`status:"degraded"`, `flagshipReachable:false`) at HTTP **503**
+  (not-ready-but-alive). The reachable path is unchanged: 200
+  `{status:"ok", flagshipReachable:true}`.
+
+`HealthDegraded` is a `Schema.TaggedErrorClass` whose `status` and
+`flagshipReachable` fields are pinned to `Schema.Literal("degraded")` /
+`Schema.Literal(false)` — the only values a degraded body can hold, so an
+"ok-looking" degraded response is unrepresentable. The 503 status is carried by the
+schema's `httpApiStatus: 503` annotation; `HttpApiSchema.getStatusError` reads it
+(an unannotated error would encode as 500). The endpoint declares it via
+`error: HealthDegraded`, so the typed non-200 is part of the route's HTTP contract,
+not an ad-hoc response.
+
+**Deciding rationale.** Because flags fail-closed, Flagship-unreachable is a
+**known, representable degraded-readiness state**, not an unhandled defect. `orDie`→500
+wrongly conflates dependency-degradation with a handler crash and defeats the body's
+own `flagshipReachable` field. A typed 503 makes the state legible to
+orchestration/alerting under standard readiness semantics: **200 ready · 503
+not-ready-but-alive · 500 only for real defects.**
+
+### What `flagshipReachable: false` means, and how `healthReady` reads it
+
+`flagshipReachable: false` means the `FlagshipClient` binding did not resolve
+end-to-end for this request (an unreachable/misconfigured binding) — the worker is
+degraded but alive. It does **not** report the value of any flag.
+
+The integration harness readiness predicate (`_integration.ts` `healthReady`) already
+requires **a 200 whose JSON `status === "ok"`**; a 503 degraded body is therefore not
+ready → the deploy-warm poll keeps retrying, which is correct: a degraded worker is
+not a ready worker. No harness change is required by this decision — the existing
+predicate already reads the readiness signal the right way; ADR 0156 only makes the
+degraded case a typed 503 instead of an opaque 500, so `healthReady` distinguishing
+it is now a semantic contract, not an accident.
+
+## Alternatives weighed
+
+- **(a) Keep `orDie`→500 (status quo) — rejected.** Simplest and already live, but
+  the readiness signal is opaque: an unreachable dependency is indistinguishable from
+  a generic handler crash, and `flagshipReachable: false` is unreachable dead code.
+  It conflates dependency-degradation with a defect.
+- **(b) Typed 503 readiness body — CHOSEN.** See Decision. Widens the handler's error
+  channel by exactly one typed, HTTP-annotated error, which is the cost; the payoff is
+  a legible readiness contract and a live `flagshipReachable` field.
+- **(c) 200 + degraded body — rejected.** Returning `{status:"degraded"}` at HTTP
+  200 keeps the field alive but breaks readiness semantics: a readiness probe must
+  signal degraded via a **non-200** so orchestration/load-balancers can act on the
+  status code without parsing the body. A 200 that says "degraded" is a trap for any
+  probe that only inspects the status line.
+
+## Consequences
+
+- `HealthStatus.flagshipReachable` is now a live signal — `true` on the 200 path,
+  and the `false` reading is its own typed body, `HealthDegraded` (503).
+- The health endpoint's HTTP contract gains one declared error response (503); the
+  route is unit-covered at the local tier (`http/health.unit.test.ts`: reachable →
+  200, `FlagshipError` → typed 503) and black-box over HTTP in the CI-only
+  integration tier (`flagship-binding.test.ts`, ADR 0154).
+- The `ConfigError`→500 discipline is unchanged; only the Flagship channel moved.
+- Future changes to the health route now have a recorded contract to respect:
+  Flagship-unreachable is 503-degraded, malformed-env is 500-defect, reachable is
+  200-ok.

--- a/apps/web/worker/http/health.ts
+++ b/apps/web/worker/http/health.ts
@@ -1,9 +1,15 @@
 /**
- * The liveness probe — `GET /api/health` (ADR 0027,
- * `.patterns/alchemy-http-router.md`). The only typed-JSON `HttpApi` group;
- * returns `{status, environment}`. The handler reads the deploy environment via
- * `yield* AppConfig`, so the route's only upstream requirement is the
- * `ConfigProvider` alchemy auto-wires at worker scope.
+ * The readiness probe — `GET /api/health` (ADR 0027,
+ * `.patterns/alchemy-http-router.md`). The only typed-JSON `HttpApi` group.
+ *
+ * Two readiness outcomes, both TYPED (ADR 0156): a **200** `HealthStatus`
+ * (`status:"ok"`, `flagshipReachable:true`) when the Flagship binding is
+ * reachable, and a **503** `HealthDegraded` (`status:"degraded"`,
+ * `flagshipReachable:false`) when a `FlagshipError` proves it unreachable. Flags
+ * fail-closed (a Flagship outage → flag defaults, the worker still serves), so
+ * Flagship-unreachable is a representable degraded-readiness state, not a handler
+ * defect — 503 (not-ready-but-alive) makes it legible to orchestration/alerting.
+ * A `ConfigError` (malformed env) STAYS `orDie`→500 — that IS a real defect.
  */
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -22,16 +28,38 @@ import {Flagship} from "../features/flagship/Flagship.ts";
 export class HealthStatus extends Schema.Class<HealthStatus>("@kampus/HealthStatus")({
 	status: Schema.String,
 	environment: Schema.NullOr(Schema.String),
-	// System-tier liveness: `true` once the `FlagshipClient` binding resolved
+	// System-tier readiness: `true` once the `FlagshipClient` binding resolved
 	// end-to-end through the worker (epic #488, #507). It asserts reachability of
 	// the binding, NOT the value of any feature flag — `true` on a healthy worker,
 	// independent of how any individual flag evaluates. Named `flagshipReachable`
 	// (not `…Bound`) so an operator can't misread it as a did-it-bind boolean whose
-	// `false` reads as "missing/unhealthy" (#864).
+	// `false` reads as "missing/unhealthy" (#864). The `false` (degraded) reading is
+	// its own typed body, `HealthDegraded` (ADR 0156).
 	flagshipReachable: Schema.Boolean,
 }) {}
 
-const health = HttpApiEndpoint.get("health", "/api/health", {success: HealthStatus});
+/**
+ * The typed not-ready-but-alive body (HTTP 503, ADR 0156): a `FlagshipError`
+ * proved the Flagship binding unreachable. The two fields are pinned to the only
+ * values this state can hold — `Literal`, so a degraded body can never claim
+ * `"ok"`/`flagshipReachable:true`. The `httpApiStatus: 503` annotation is what the
+ * framework encodes the error response as (`HttpApiSchema.getStatusError` reads it;
+ * an unannotated error is 500).
+ */
+export class HealthDegraded extends Schema.TaggedErrorClass<HealthDegraded>()(
+	"@kampus/HealthDegraded",
+	{
+		status: Schema.Literal("degraded"),
+		environment: Schema.NullOr(Schema.String),
+		flagshipReachable: Schema.Literal(false),
+	},
+	{httpApiStatus: 503},
+) {}
+
+const health = HttpApiEndpoint.get("health", "/api/health", {
+	success: HealthStatus,
+	error: HealthDegraded,
+});
 
 export class HealthGroup extends HttpApiGroup.make("health").add(health) {}
 
@@ -41,22 +69,36 @@ const healthGroup = HttpApiBuilder.group(HealthApi, "health", (h) =>
 	h.handle("health", () =>
 		Effect.gen(function* () {
 			// `orDie`: a `ConfigError` (value outside the two literals) means a
-			// malformed env; die rather than widen the handler's error channel.
+			// malformed env — a real handler defect, kept narrow at 500 (ADR 0156).
 			const {environment} = yield* AppConfig.pipe(Effect.orDie);
 			// Drive one evaluation through the resolved Flagship binding (epic #488):
 			// the read completing at all proves the `FlagshipClient` resolved
 			// end-to-end through the worker, so `flagshipReachable` is `true` once it
 			// returns — the probe asserts reachability, not the flag's value. Flagship
 			// evaluation never throws (it falls back to the default), so a misconfigured
-			// binding surfaces only on the `FlagshipError` channel; `orDie` keeps the
-			// handler's error channel narrow.
+			// binding surfaces only on the `FlagshipError` channel — which we catch to
+			// the typed 503 degraded body rather than `orDie`→500 (ADR 0156): flags
+			// fail-closed, so an unreachable Flagship is a representable degraded state,
+			// not a crash.
 			const flagship = yield* Flagship;
-			yield* flagship.getBooleanValue("phoenix-health-probe", false).pipe(Effect.orDie);
-			return new HealthStatus({
-				status: "ok",
-				environment,
-				flagshipReachable: true,
-			});
+			return yield* flagship.getBooleanValue("phoenix-health-probe", false).pipe(
+				Effect.as(
+					new HealthStatus({
+						status: "ok",
+						environment,
+						flagshipReachable: true,
+					}),
+				),
+				Effect.catchTag(
+					"FlagshipError",
+					() =>
+						new HealthDegraded({
+							status: "degraded",
+							environment,
+							flagshipReachable: false,
+						}),
+				),
+			);
 		}),
 	),
 );

--- a/apps/web/worker/http/health.unit.test.ts
+++ b/apps/web/worker/http/health.unit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit coverage for the `/api/health` readiness contract (ADR 0156). Drives the
+ * real `healthApiLayer` router over `HttpRouter.toWebHandler` — no workerd, no
+ * binding — with a stubbed `Flagship` client, and asserts the two typed outcomes:
+ *
+ *   - REACHABLE → 200 `{status:"ok", flagshipReachable:true}`;
+ *   - a `FlagshipError` (unreachable/misconfigured binding) → 503
+ *     `{status:"degraded", flagshipReachable:false}`, NOT an `orDie`→500.
+ *
+ * The 503 path is the ADR 0156 decision: flags fail-closed, so Flagship-unreachable
+ * is a representable degraded-readiness state (not-ready-but-alive), not a handler
+ * defect. The full black-box HTTP path is the CI-only integration tier
+ * (`flagship-binding.test.ts`, ADR 0154); this is the local-runnable unit tier.
+ */
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Flagship as CfFlagship} from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import {describe, expect, it} from "vitest";
+import {Flagship} from "../features/flagship/Flagship.ts";
+import {healthApiLayer} from "./health.ts";
+
+/**
+ * The health read the handler exercises: the boolean probe evaluation, either
+ * reachable (`succeed`) or a `FlagshipError` (unreachable/misconfigured binding).
+ */
+type ProbeRead = Effect.Effect<boolean, CfFlagship.FlagshipError>;
+
+// `RuntimeContext` is the alchemy binding's intrinsic ambient requirement
+// (discharged at worker scope in production, #507); the stub satisfies it here.
+const runtimeContext: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const unexercised = (method: string) => () =>
+	Effect.die(`Flagship.${method} not exercised in health.unit.test`);
+
+/**
+ * A `Flagship` stub whose `getBooleanValue` runs the supplied probe read; every
+ * other method dies so an accidental call is loud (the `Flags.unit.test` idiom).
+ */
+const stubFlagship = (probe: ProbeRead): Layer.Layer<Flagship> =>
+	Layer.succeed(Flagship)(
+		Flagship.of({
+			raw: Effect.die("Flagship.raw not exercised in health.unit.test"),
+			get: unexercised("get"),
+			getBooleanValue: () => probe,
+			getStringValue: unexercised("getStringValue"),
+			getNumberValue: unexercised("getNumberValue"),
+			getObjectValue: unexercised("getObjectValue"),
+			getBooleanDetails: unexercised("getBooleanDetails"),
+			getStringDetails: unexercised("getStringDetails"),
+			getNumberDetails: unexercised("getNumberDetails"),
+			getObjectDetails: unexercised("getObjectDetails"),
+		} as Flagship["Service"]),
+	);
+
+/**
+ * Compile the real health router over a stub client into a `Request → Response`.
+ * `provideRequest` discharges the group's per-request `Flagship` + `RuntimeContext`
+ * markers (plain `Layer.provide` does not lift them — same seam as `app.ts`).
+ */
+const healthHandler = (probe: ProbeRead) =>
+	HttpRouter.toWebHandler(
+		healthApiLayer.pipe(
+			HttpRouter.provideRequest(
+				Layer.mergeAll(stubFlagship(probe), Layer.succeed(RuntimeContext)(runtimeContext)),
+			),
+		),
+		{disableLogger: true},
+	);
+
+const GET = new Request("http://health.test/api/health");
+
+describe("/api/health readiness contract (ADR 0156)", () => {
+	it("a reachable Flagship binding returns 200 {status:ok, flagshipReachable:true}", async () => {
+		const {handler, dispose} = healthHandler(Effect.succeed(false));
+		try {
+			const res = await handler(GET);
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as {status: string; flagshipReachable: boolean};
+			expect(body.status).toBe("ok");
+			expect(body.flagshipReachable).toBe(true);
+		} finally {
+			await dispose();
+		}
+	});
+
+	it("a FlagshipError returns a typed 503 {status:degraded, flagshipReachable:false}", async () => {
+		const {handler, dispose} = healthHandler(
+			Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
+		);
+		try {
+			const res = await handler(GET);
+			// 503 (not-ready-but-alive), NOT the pre-ADR-0156 orDie→500 defect.
+			expect(res.status).toBe(503);
+			const body = (await res.json()) as {status: string; flagshipReachable: boolean};
+			expect(body.status).toBe("degraded");
+			expect(body.flagshipReachable).toBe(false);
+		} finally {
+			await dispose();
+		}
+	});
+});


### PR DESCRIPTION
Implements the settled `type:decision` on the `GET /api/health` failure contract (#1991): Flagship-unreachable becomes a **typed 503 degraded body**, not an `orDie`→500 defect. Records the choice as **ADR 0156** and wires the code.

## The problem

`apps/web/worker/http/health.ts` drove one Flagship eval and `orDie`d on `FlagshipError`, so:
- an unreachable/misconfigured binding surfaced as an **opaque HTTP 500 defect**, indistinguishable from any handler crash;
- `HealthStatus.flagshipReachable` was **dead** — the failure path never reached the return, so it could never be `false`.

## The decision (ADR 0156)

Split the two error channels by meaning:
- **`ConfigError` (malformed env) → keep `orDie`→500.** A real handler defect; narrow-channel discipline holds.
- **`FlagshipError` (binding unreachable) → typed 503.** Caught to a `HealthDegraded` body (`status:"degraded"`, `flagshipReachable:false`) at HTTP **503** (not-ready-but-alive). Reachable path unchanged: 200 `{status:"ok", flagshipReachable:true}`.

**Grounded rationale** (verified in source, per the CLAUDE.md ground-claims rule):
- `FlagshipError` is a promise-reject-only channel — the alchemy `ReadFlagsClient` docblock: "Flagship evaluation never throws … the `FlagshipError` channel only surfaces unexpected runtime failures (e.g. a misconfigured binding)."
- Flags fail-closed — `features/flagship/Flags.ts` `buildRealFlags` catches `FlagshipError` to the caller's default, so a Flagship outage degrades safe and the worker keeps serving.

So Flagship-unreachable is a **representable degraded-readiness state**, not a crash. A typed 503 makes it legible to orchestration/alerting under standard readiness semantics: **200 ready / 503 not-ready-but-alive / 500 real defect**.

`HealthDegraded`'s `status`/`flagshipReachable` fields are `Schema.Literal`-pinned so an "ok-looking" degraded body is unrepresentable; `httpApiStatus: 503` carries the status (`HttpApiSchema.getStatusError` reads it — an unannotated error would be 500).

## Alternatives weighed (in the ADR)

- **(a) `orDie`→500 status quo** — rejected: opaque signal, dead field, conflates degradation with a defect.
- **(b) typed 503** — chosen.
- **(c) 200 + degraded body** — rejected: a readiness probe must signal degraded via a **non-200** so orchestration can act on the status line.

## Acceptance criteria

- [x] ADR recorded in `.decisions/` stating the chosen contract + rationale (`0156-health-probe-flagship-unreachable-is-typed-503.md`).
- [x] ADR names what `flagshipReachable:false` means and how the integration harness `healthReady` predicate reads the signal (its existing `200 && status==="ok"` gate already treats a 503 as not-ready — no harness change needed).
- [x] The `health.ts:54` `orDie` seam left pointing at the recorded decision (the seam and its docblock now cite ADR 0156, and `ConfigError` stays `orDie`→500 by decision).

## Tests

- `apps/web/worker/http/health.unit.test.ts` — drives the real router over `HttpRouter.toWebHandler` (local unit tier): a `FlagshipError` → typed **503** `{status:"degraded", flagshipReachable:false}`, and the reachable path → **200** `{status:"ok", flagshipReachable:true}`. Both green; full flagship + http unit suite (126 tests) green; typecheck clean.
- The black-box HTTP path stays in the CI-only integration tier (`flagship-binding.test.ts`, ADR 0154).

## Notes

- **NON-§CP** (worker http + `.decisions/`; normal product paths).
- ADR number **0156** — allocated from fresh `origin/main` (last on main is 0155, which landed since the settled decision was written; 0156 was free).

Fixes #1991

🤖 Generated with [Claude Code](https://claude.com/claude-code)