### PR TITLE
feat(pipeline): codify orchestrator main-sync with detached-HEAD auto-reattach (#1573)

### DIFF
--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -121,6 +121,19 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   rule above is now the **belt** to the guard's **braces**: the guard mechanically blocks the
   bare op, the prose tells you the shape to write instead.
 
+  **Defense-in-depth behind the guard (Unit C, #1573):** even with the guard preventing new
+  detaches, the orchestrator's main-sync is codified as a single runnable surface —
+  `pipeline-cli main-sync` (`packages/pipeline-cli/src/tools/main-sync/`) — that the driving
+  session runs **before/after a drain** instead of the hand-run
+  `git fetch origin main && git merge --ff-only origin/main`. If it finds the primary HEAD
+  already detached (a stray detach the guard didn't catch), it **auto-reattaches to `main`**
+  (`git checkout main`) before the merge, so a single stray detach can't wedge an unattended
+  overnight drain with a silent *"Not possible to fast-forward"*. The reattach is authorized
+  **only on a clean tree** — a dirty off-`main` HEAD is detect-and-surface (refuse, report the
+  dirt), never a blind `checkout` that discards work. Dry-run by default; `--execute` runs the
+  plan. See [`packages/pipeline-cli/README.md`](../packages/pipeline-cli/README.md) (the
+  `main-sync` section) for the full contract.
+
 - **Run root `pnpm` scripts as `pnpm -w <script>` (or from the worktree root),
   never from a subdir.** A root-level script (`pnpm lint`, `pnpm typecheck`, …) run
   from a *subdirectory* (e.g. `apps/web/`) trips pnpm's refusal: it resolves the

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -54,6 +54,38 @@ node packages/pipeline-cli/src/bin.ts version
 node packages/pipeline-cli/src/bin.ts <tool> …
 ```
 
+### `main-sync` — codified orchestrator main-sync with detached-HEAD auto-reattach (#1573)
+
+The single runnable surface for the orchestrator's **main-sync** — bringing the shared
+primary checkout up to `origin/main` before/after an unattended drain. It replaces the
+hand-run `git fetch origin main && git merge --ff-only origin/main` that lived only in
+operator memory (#1494 diagnosis, Unit C), and — the new capability — **auto-reattaches a
+detached primary HEAD to `main` first**, so a stray detach during a heavy parallel drain
+can't wedge the sync with a silent *"Not possible to fast-forward"* until a human notices.
+
+Safe by construction (the pure core `main-sync.ts` decides, `command.ts` runs it):
+
+- A reattach `git checkout main` is authorized **only when the working tree is clean**. A
+  dirty off-`main` HEAD is **detect-and-surface** (`blocked-dirty`): the tool refuses to
+  `checkout` and reports the dirt for a human, never blindly discarding uncommitted work —
+  consistent with the #1494 incidents, which were always clean.
+- The sync merge is `git merge --ff-only origin/main` — fast-forward only, so it never
+  creates a merge commit and fails loudly rather than diverging the primary.
+- **Dry-run by default:** with no flag it probes HEAD, prints the plan it *would* run, and
+  exits 0 without touching anything (not even a fetch). `--execute` runs the plan.
+
+```bash
+# before/after a drain: print what main-sync would do (dry-run, nothing touched)
+node packages/pipeline-cli/src/bin.ts main-sync
+
+# actually reattach (if detached+clean) then fetch + merge --ff-only origin/main
+node packages/pipeline-cli/src/bin.ts main-sync --execute
+```
+
+This is a **control-plane** surface (it drives the shared primary checkout); see
+[`.patterns/worktree-agent-constraints.md`](../../.patterns/worktree-agent-constraints.md)
+for the surrounding worktree/primary-checkout discipline it defends.
+
 ### `ship-digest` — the merged-since founder projection (#1595)
 
 Renders a **founder-facing** ship digest for a `--since` window from a pre-gathered

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -25,6 +25,7 @@ import {fanoutGuardCommand} from "./tools/fanout-guard/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
+import {mainSyncCommand} from "./tools/main-sync/command.ts";
 import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {readGuardCommand} from "./tools/read-guard/command.ts";
@@ -100,4 +101,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	fanoutGuardCommand,
 	resumePolicyCommand,
 	evalHarnessCommand,
+	mainSyncCommand,
 ];

--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -1,0 +1,142 @@
+/**
+ * The `main-sync` tool — `pipeline-cli main-sync [--execute]`.
+ *
+ * The codified, safe-by-default orchestrator main-sync for the shared primary
+ * checkout (issue #1573, Unit C of the #1494 diagnosis). Replaces the hand-run
+ * `git fetch origin main && git merge --ff-only origin/main` that lived only in
+ * operator memory — and, crucially, AUTO-REATTACHES a detached primary HEAD to
+ * `main` before the merge, so a stray detach during a heavy parallel drain can't
+ * wedge an unattended overnight sync. The orchestrator runs this before/after a
+ * drain instead of a human noticing the "Not possible to fast-forward" stall.
+ *
+ * Safe by construction (the pure core `main-sync.ts` is the first enforcement line,
+ * this command's flow is the second):
+ *   1. The pure `decideMainSync` authorizes a reattach `git checkout main` ONLY when
+ *      the tree is CLEAN. A dirty off-`main` HEAD is DETECT-AND-SURFACE (`blocked-dirty`):
+ *      the command refuses to `checkout` and surfaces the dirt, never discarding work —
+ *      consistent with the #1494 incidents, which were always clean.
+ *   2. The sync merge is `git merge --ff-only origin/main` — fast-forward only, so it
+ *      never creates a merge commit and fails loudly rather than diverging the primary.
+ *
+ * DRY-RUN by default: with no flag it probes HEAD, prints the plan it WOULD run, and
+ * exits 0 without touching anything (not even a fetch). `--execute` runs the plan:
+ * reattach if authorized, then `fetch` + `merge --ff-only`. The git IO uses
+ * `execFileSync` directly (mirrors `worktree-sweep` / the `worktree-guard` reaper),
+ * so the tool's requirement stays at the Node platform ceiling the registry provides.
+ */
+import {execFileSync} from "node:child_process";
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {decideMainSync, type HeadState, MAIN_BRANCH} from "./main-sync.ts";
+
+interface GitResult {
+	readonly ok: boolean;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const runGit = (args: ReadonlyArray<string>): GitResult => {
+	try {
+		const stdout = execFileSync("git", [...args], {encoding: "utf8"});
+		return {ok: true, stdout, stderr: ""};
+	} catch (cause) {
+		const e = cause as {stdout?: Buffer | string; stderr?: Buffer | string};
+		return {ok: false, stdout: String(e.stdout ?? ""), stderr: String(e.stderr ?? "")};
+	}
+};
+
+/**
+ * The short branch the primary HEAD points at, or `null` for a detached HEAD.
+ * `git rev-parse --abbrev-ref HEAD` prints the literal `HEAD` when detached; an
+ * indeterminate probe (command failed) also reads `null` — fail-safe toward
+ * "needs attention", never a false "on main".
+ */
+const headBranch = (): string | null => {
+	const r = runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
+	if (!r.ok) return null;
+	const name = r.stdout.trim();
+	return name === "" || name === "HEAD" ? null : name;
+};
+
+/** `git status --porcelain` non-empty ⇒ dirty. Indeterminate (command failed) ⇒ dirty (fail-safe: refuse reattach). */
+const treeIsDirty = (): boolean => {
+	const r = runGit(["status", "--porcelain"]);
+	if (!r.ok) return true;
+	return r.stdout.trim() !== "";
+};
+
+const executeFlag = Flag.boolean("execute").pipe(
+	Flag.withDescription(
+		"actually reattach (if detached+clean) and run fetch + merge --ff-only (default: dry-run, print the plan only)",
+	),
+);
+
+const mainSync = Command.make(
+	"main-sync",
+	{execute: executeFlag},
+	Effect.fn(function* ({execute}) {
+		const head: HeadState = {branch: headBranch(), isDirty: treeIsDirty()};
+		const plan = decideMainSync(head);
+
+		// ADR 0092 "emit what you scanned": the HEAD state + plan are observable before any action.
+		yield* Console.log(
+			`main-sync: HEAD ${head.branch ?? "(detached)"}, tree ${head.isDirty ? "DIRTY" : "clean"} — plan: ${plan.action}${execute ? " (EXECUTE)" : " (dry-run)"}`,
+		);
+
+		if (plan.action === "blocked-dirty") {
+			// Detect-and-surface, never discard: refuse the reattach on a dirty tree (#1494 AC #3).
+			yield* Console.error(
+				`main-sync: primary HEAD is off '${MAIN_BRANCH}' (from ${plan.from}) but the working tree is DIRTY — refusing to reattach (a checkout could discard uncommitted work). Resolve the tree by hand, then re-run.`,
+			);
+			return yield* Effect.sync(() => process.exit(1));
+		}
+
+		if (!execute) {
+			if (plan.action === "reattach") {
+				yield* Console.log(
+					`  would reattach: git checkout ${MAIN_BRANCH} (from ${plan.from}), then fetch + merge --ff-only origin/${MAIN_BRANCH}`,
+				);
+			} else {
+				yield* Console.log(
+					`  would sync: git fetch origin ${MAIN_BRANCH} && git merge --ff-only origin/${MAIN_BRANCH}`,
+				);
+			}
+			yield* Console.log("  (dry-run — pass --execute to run; nothing touched)");
+			return;
+		}
+
+		if (plan.action === "reattach") {
+			const co = runGit(["checkout", MAIN_BRANCH]);
+			if (!co.ok) {
+				yield* Console.error(
+					`main-sync: reattach \`git checkout ${MAIN_BRANCH}\` failed — ${co.stderr.trim() || "unknown error"}`,
+				);
+				return yield* Effect.sync(() => process.exit(1));
+			}
+			yield* Console.log(`  reattached: ${plan.from} → ${MAIN_BRANCH}`);
+		}
+
+		const fetched = runGit(["fetch", "origin", MAIN_BRANCH]);
+		if (!fetched.ok) {
+			yield* Console.error(
+				`main-sync: \`git fetch origin ${MAIN_BRANCH}\` failed — ${fetched.stderr.trim() || "network?"}`,
+			);
+			return yield* Effect.sync(() => process.exit(1));
+		}
+
+		const merged = runGit(["merge", "--ff-only", `origin/${MAIN_BRANCH}`]);
+		if (!merged.ok) {
+			yield* Console.error(
+				`main-sync: \`git merge --ff-only origin/${MAIN_BRANCH}\` failed — ${merged.stderr.trim() || "not fast-forwardable"}. The primary has diverged; resolve by hand.`,
+			);
+			return yield* Effect.sync(() => process.exit(1));
+		}
+		yield* Console.log(`main-sync: primary checkout synced to origin/${MAIN_BRANCH}.`);
+	}),
+).pipe(
+	Command.withDescription(
+		"Codified orchestrator main-sync — auto-reattach a detached primary HEAD to main, then fetch + merge --ff-only; refuses on a dirty tree (#1573 / #1494 Unit C)",
+	),
+);
+
+export const mainSyncCommand = mainSync;

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
@@ -1,0 +1,107 @@
+/**
+ * `main-sync` pure core — decide how the orchestrator should sync the shared
+ * primary checkout to `origin/main`, auto-reattaching a detached HEAD first
+ * (issue #1573, Unit C of the #1494 diagnosis). IO-free and total: every decision
+ * is a deterministic transform over already-gathered git facts. The git boundary
+ * (branch probe / dirty probe / fetch / checkout / merge) lives in `command.ts`;
+ * this module never runs a command.
+ *
+ * The problem it codifies (#1494 root cause): the hand-run orchestrator main-sync —
+ * `git fetch origin main && git merge --ff-only origin/main` on the primary checkout —
+ * lives only in operator memory. During a heavy parallel drain a primary-sharing
+ * process can detach that primary HEAD onto a non-`main` commit, and the next
+ * `merge --ff-only` then fails with "Not possible to fast-forward", silently wedging
+ * sync until a human runs `git checkout main && git merge --ff-only origin/main` by
+ * hand. This core encodes that recovery as a decision so the orchestrator runs it
+ * before/after a drain instead of a human noticing.
+ *
+ * The safety property (the whole point, #1494 AC #3): a reattach `git checkout main`
+ * is a HEAD-moving op, so it must never run when it could lose work. The #1494
+ * incidents all had a CLEAN tree — so a reattach is authorized ONLY on a clean tree;
+ * a dirty primary tree DETECTS-AND-SURFACES (refuse to reattach, report the dirt)
+ * rather than blindly `checkout`-ing and discarding the operator's changes.
+ */
+
+/**
+ * The primary checkout's HEAD state, reduced to exactly the facts the decision needs.
+ * Gathered at the git boundary (`command.ts`); both fields fail-safe toward refusing
+ * to mutate — an indeterminate branch probe reads detached, an indeterminate status
+ * probe reads dirty.
+ */
+export interface HeadState {
+	/**
+	 * The short branch name the primary HEAD points at, or `null` for a detached HEAD
+	 * (`git rev-parse --abbrev-ref HEAD` resolved to the literal `HEAD`, or the probe
+	 * was indeterminate). `"main"` is the healthy state; any other branch or `null`
+	 * needs attention.
+	 */
+	readonly branch: string | null;
+	/**
+	 * The working tree has uncommitted/untracked changes (`git status --porcelain`
+	 * non-empty, or the probe was indeterminate). A dirty tree blocks a reattach —
+	 * a `git checkout main` from a detached HEAD with local changes could lose them.
+	 */
+	readonly isDirty: boolean;
+}
+
+/** The name of the branch the primary checkout must be attached to for a clean main-sync. */
+export const MAIN_BRANCH = "main";
+
+/**
+ * What the orchestrator should do to bring the primary checkout to a state where
+ * `git merge --ff-only origin/main` can run. The order of the checks below IS the
+ * safety policy.
+ */
+export type MainSyncPlan =
+	/**
+	 * HEAD is already on `main` — no reattach needed. The orchestrator proceeds
+	 * straight to `fetch` + `merge --ff-only`. This is the healthy steady state.
+	 */
+	| {readonly action: "already-on-main"; readonly branch: string}
+	/**
+	 * HEAD is detached (or on a non-`main` branch) AND the tree is clean — the #1494
+	 * recoverable case. A reattach `git checkout main` is authorized; the
+	 * orchestrator runs it, then `fetch` + `merge --ff-only`.
+	 */
+	| {readonly action: "reattach"; readonly from: string}
+	/**
+	 * HEAD needs reattaching BUT the tree is dirty — DETECT-AND-SURFACE. A reattach
+	 * here could discard the operator's uncommitted work, so the tool refuses to
+	 * `checkout` and surfaces the dirt for a human, consistent with the #1494
+	 * incidents (which were always clean). The orchestrator must NOT force it.
+	 */
+	| {readonly action: "blocked-dirty"; readonly from: string};
+
+/**
+ * A `null` branch (detached HEAD) renders as this stable label in a plan's `from`
+ * field, so the report reads "reattach from detached-HEAD" rather than an empty string.
+ */
+export const DETACHED_LABEL = "detached-HEAD";
+
+const fromLabel = (branch: string | null): string => branch ?? DETACHED_LABEL;
+
+/**
+ * Decide the main-sync plan from the primary checkout's HEAD state:
+ *
+ *   1. On `main` → `already-on-main`. No HEAD move needed; sync can proceed. The
+ *      dirty flag is irrelevant here — `merge --ff-only` fails safe on its own if
+ *      the tree conflicts, and this tool never touches a tree that is already on the
+ *      right branch.
+ *   2. Not on `main` AND dirty → `blocked-dirty`. Detect-and-surface: a reattach
+ *      would risk the operator's uncommitted work, so refuse (never blindly discard).
+ *   3. Not on `main` AND clean → `reattach`. The #1494 recoverable case: authorize
+ *      `git checkout main` before the merge.
+ *
+ * Total over every `HeadState`; the dirty check is ONLY consulted on the off-`main`
+ * path, so a clean-but-detached HEAD reattaches and a dirty-but-detached HEAD is
+ * surfaced, never checked out.
+ */
+export const decideMainSync = (head: HeadState): MainSyncPlan => {
+	if (head.branch === MAIN_BRANCH) {
+		return {action: "already-on-main", branch: MAIN_BRANCH};
+	}
+	if (head.isDirty) {
+		return {action: "blocked-dirty", from: fromLabel(head.branch)};
+	}
+	return {action: "reattach", from: fromLabel(head.branch)};
+};

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts
@@ -1,0 +1,79 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	DETACHED_LABEL,
+	decideMainSync,
+	type HeadState,
+	MAIN_BRANCH,
+	type MainSyncPlan,
+} from "./main-sync.ts";
+
+const head = (over: Partial<HeadState> = {}): HeadState => ({
+	branch: "main",
+	isDirty: false,
+	...over,
+});
+
+describe("decideMainSync — already on main", () => {
+	it("clean HEAD on main → already-on-main (no reattach)", () => {
+		const plan = decideMainSync(head({branch: "main", isDirty: false}));
+		assert.deepStrictEqual(plan, {action: "already-on-main", branch: MAIN_BRANCH});
+	});
+
+	it("dirty tree on main is irrelevant — still already-on-main (merge --ff-only fails safe on its own)", () => {
+		// The tool never touches a tree already on the right branch; the dirty flag is
+		// only consulted on the off-main path, so an on-main dirty tree is NOT blocked here.
+		const plan = decideMainSync(head({branch: "main", isDirty: true}));
+		assert.deepStrictEqual(plan, {action: "already-on-main", branch: MAIN_BRANCH});
+	});
+});
+
+describe("decideMainSync — reattach (the #1494 recoverable case)", () => {
+	it("detached + clean → reattach from detached-HEAD", () => {
+		const plan = decideMainSync(head({branch: null, isDirty: false}));
+		assert.deepStrictEqual(plan, {action: "reattach", from: DETACHED_LABEL});
+	});
+
+	it("off-main branch + clean → reattach from that branch", () => {
+		const plan = decideMainSync(head({branch: "umut/some-branch", isDirty: false}));
+		assert.deepStrictEqual(plan, {action: "reattach", from: "umut/some-branch"});
+	});
+});
+
+describe("decideMainSync — blocked-dirty (detect-and-surface, never discard)", () => {
+	it("detached + dirty → blocked-dirty, NOT reattach (a checkout could lose work)", () => {
+		const plan = decideMainSync(head({branch: null, isDirty: true}));
+		assert.deepStrictEqual(plan, {action: "blocked-dirty", from: DETACHED_LABEL});
+	});
+
+	it("off-main branch + dirty → blocked-dirty from that branch", () => {
+		const plan = decideMainSync(head({branch: "umut/wip", isDirty: true}));
+		assert.deepStrictEqual(plan, {action: "blocked-dirty", from: "umut/wip"});
+	});
+
+	it("dirty NEVER yields a reattach on the off-main path (safety invariant)", () => {
+		const plans: MainSyncPlan[] = [
+			decideMainSync({branch: null, isDirty: true}),
+			decideMainSync({branch: "x", isDirty: true}),
+		];
+		for (const plan of plans) {
+			assert.notStrictEqual(plan.action, "reattach");
+		}
+	});
+});
+
+describe("decideMainSync — totality", () => {
+	it("every HeadState maps to exactly one of the three actions", () => {
+		const cases: HeadState[] = [
+			{branch: "main", isDirty: false},
+			{branch: "main", isDirty: true},
+			{branch: null, isDirty: false},
+			{branch: null, isDirty: true},
+			{branch: "feature", isDirty: false},
+			{branch: "feature", isDirty: true},
+		];
+		const actions = new Set(["already-on-main", "reattach", "blocked-dirty"]);
+		for (const c of cases) {
+			assert.isTrue(actions.has(decideMainSync(c).action));
+		}
+	});
+});


### PR DESCRIPTION
Fixes #1573

## What & why

Codifies the orchestrator's **main-sync** — bringing the shared primary checkout up to `origin/main` before/after an unattended drain — as a single runnable surface, `pipeline-cli main-sync`. It replaces the hand-run `git fetch origin main && git merge --ff-only origin/main` that lived **only in operator memory** (Unit C of the #1494 diagnosis), and adds the new capability: **auto-reattach a detached primary HEAD to `main`** before the merge, so a stray detach during a heavy parallel drain can't wedge an unattended overnight sync with a silent *"Not possible to fast-forward"* until a human notices. Kept as defense-in-depth **behind** the #1571 guard (Unit A), not instead of it.

## Design fork resolved

The issue left open whether this lands as a `pipeline-cli` subcommand or a documented convention. Resolved toward the **`pipeline-cli` subcommand** — it gives the detached-HEAD detect+reattach behavior a real, testable home (the Effect-CLI idiom: pure tested core + thin bin), which a pure-doc convention can't, while still being documented for operators.

## Shape

- `packages/pipeline-cli/src/tools/main-sync/main-sync.ts` — pure core `decideMainSync(HeadState) → MainSyncPlan` (`already-on-main` / `reattach` / `blocked-dirty`), IO-free and total.
- `packages/pipeline-cli/src/tools/main-sync/command.ts` — thin `effect/unstable/cli` command doing the git IO (`rev-parse --abbrev-ref HEAD`, `status --porcelain`, `checkout main`, `fetch`, `merge --ff-only`), registered in `registry.ts`.
- `packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts` — the decision matrix incl. the safety invariant (dirty never yields a reattach).

## Safety (the whole point — #1494 AC #3)

- A reattach `git checkout main` is authorized **only on a clean tree**. A dirty off-`main` HEAD is **detect-and-surface** (`blocked-dirty`): refuse to `checkout`, report the dirt, never blindly discard work — consistent with the always-clean #1494 incidents.
- The sync merge stays `git merge --ff-only origin/main`.
- **Dry-run by default** (prints the plan, touches nothing, not even a fetch); `--execute` runs it.

## Acceptance criteria

- [x] Main-sync codified as a single runnable surface (`pipeline-cli main-sync`).
- [x] Detects a detached primary HEAD and reattaches to `main` before `merge --ff-only`, instead of erroring out.
- [x] Reattach safe-by-construction: refuses on a dirty tree (detect-and-surface, no blind discard).
- [x] Documented where the driving loop is described (package README + `.patterns/worktree-agent-constraints.md`, where the #1494 detach is described).
- [x] Control-plane disposition honored: lands reviewed-ready for human hand-merge (ADR 0053/0065), not auto-merge.

## Verification

- `pnpm typecheck`, `pnpm test` (841 passing incl. the new decision matrix), `biome check`, `doc-links`, `readme-guard`, `leak-guard` all green.

## §CP note

Control-plane surface (drives the shared primary checkout; `packages/pipeline-cli/`). Routes reviewed-ready → human hand-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)