### PR TITLE
test(integration): uniquify seeded author identity per run + rename fixtures off `umut` (#2116)

### DIFF
--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -208,6 +208,20 @@ const liveControlReady = (res: Response): boolean => res.status !== 503;
 // prior run left behind.
 const STAMP_SEED = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
+// The seed-id counter MUST live at module scope, the SAME scope as STAMP_SEED — NOT inside
+// `harness()`. Every test file builds its own `harness()` (each `const h = sharedStack()`), so a
+// per-instance counter resets to 0 in every file and each file's first seed user requests the
+// IDENTICAL email `seed-<STAMP>-0@seed.local`. On that collision `signUp`'s 422 fallback signs in
+// as whichever file created the user first — adopting a FOREIGN author (e.g. `yazar-<stamp>`) while
+// the caller records its own base — the cross-file identity bleed behind #2116 (`expected
+// 'yazar-<stamp>' to be 'anka-<stamp>'`, identical stamps). A process-global counter makes
+// `seed-<STAMP>-<n>` unique across ALL harness instances, so `signUp` always creates a fresh user
+// and stored authorName == recorded authorName. The NO_DESTROY re-run path stays correct: STAMP_SEED
+// is stable across a re-run, so the email sequence is stable within a run and the sign-in fallback
+// still adopts the same prior-run users.
+let seedCounter = 0;
+const nextSeedId = () => `seed-${STAMP_SEED}-${seedCounter++}`;
+
 const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
 
 // The CF REST bearer token — the SAME one the integration deploy uses
@@ -495,9 +509,9 @@ export function harness(
 	// (author = session user) and scores are vote-derived, so seeding drives the
 	// same public surface the app does: one cached session per distinct
 	// `authorName`, and a shared, lazily-grown pool of throwaway voters that each
-	// cast a single up-vote to realize a definition's `score`.
-	let seedCounter = 0;
-	const nextSeedId = () => `seed-${STAMP_SEED}-${seedCounter++}`;
+	// cast a single up-vote to realize a definition's `score`. The seed-id counter
+	// (`nextSeedId`) is process-global (module scope, above) — never re-declared here,
+	// so emails stay unique across every file's harness instance (#2116).
 
 	// The seeded author identity is uniquified PER RUN at this source: the stored `author_name`
 	// (`user.name ?? user.email`) is the requested base + the per-process `STAMP_SEED`, so no two

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -81,6 +81,11 @@ export interface Harness {
 	 * the REAL `id`/`authorId` the worker assigned — assert against those, not a
 	 * caller-chosen id.
 	 *
+	 * The input `authorName` is a BASE — the stored `author_name` is uniquified per
+	 * run (`<base>-<run-stamp>`) so a fixed handle can't collide with a pre-existing
+	 * actor on the shared stage (#2116). The returned rows carry that REAL stored
+	 * `authorName`; assert `author` against `definitions[i].authorName`, never the base.
+	 *
 	 * Re-seeding the same `(slug, body)` is idempotent: the body is skipped (not
 	 * re-added), mirroring the old admin upsert's dedup. `created` is true only the
 	 * first time a slug is seeded in this process.
@@ -494,13 +499,22 @@ export function harness(
 	let seedCounter = 0;
 	const nextSeedId = () => `seed-${STAMP_SEED}-${seedCounter++}`;
 
+	// The seeded author identity is uniquified PER RUN at this source: the stored `author_name`
+	// (`user.name ?? user.email`) is the requested base + the per-process `STAMP_SEED`, so no two
+	// runs — and no actor already present on the run-scoped SHARED stage (ADR 0104) — can collide
+	// on it. Fixed identity + a shared mutable stage was the nondeterministic-read root cause
+	// (#2116: `expected 'yazar' to be 'umut'` — a fixed `umut` handle colliding with a pre-existing
+	// stage actor). Callers assert against the RETURNED `authorName` (threaded through `seedTerm`),
+	// never the requested base literal, since the two now differ.
+	const runAuthorName = (base: string): string => `${base}-${STAMP_SEED}`;
 	const authorCookies = new Map<string, string>();
-	const authorCookie = async (authorName: string): Promise<string> => {
+	const authorCookie = async (base: string): Promise<{cookie: string; authorName: string}> => {
+		const authorName = runAuthorName(base);
 		const existing = authorCookies.get(authorName);
-		if (existing) return existing;
+		if (existing) return {cookie: existing, authorName};
 		const {cookie} = await signUp(`${nextSeedId()}@seed.local`, "seedpass-seedpass", authorName);
 		authorCookies.set(authorName, cookie);
-		return cookie;
+		return {cookie, authorName};
 	};
 
 	// Grow-only pool of voter cookies, sized on demand. Each voter is a distinct
@@ -607,7 +621,7 @@ export function harness(
 			}
 			seededBodies.add(key);
 
-			const cookie = await authorCookie(def.authorName);
+			const {cookie, authorName} = await authorCookie(def.authorName);
 			const node = await addDefinition(cookie, input.slug, input.title, def.body);
 			insertedDefinitions++;
 
@@ -631,7 +645,10 @@ export function harness(
 			definitions.push({
 				id: node.id,
 				authorId: node.authorId,
-				authorName: def.authorName,
+				// The REAL stored `author_name` (uniquified per run), not the requested base —
+				// the deployed row carries this, so an id-pinned read asserting `author` must
+				// compare against it, never the base literal (#2116).
+				authorName,
 				score,
 			});
 		}

--- a/apps/web/tests/integration/pano-read.test.ts
+++ b/apps/web/tests/integration/pano-read.test.ts
@@ -82,7 +82,7 @@ let postId = "";
 const commentIds: string[] = [];
 
 beforeAll(async () => {
-	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "umut");
+	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "anka");
 	for (let i = 0; i < 5; i++) {
 		commenters.push(await h.signUp(`${NS}-c${i}@test.local`, "hunter2hunter2", `commenter ${i}`));
 	}
@@ -139,7 +139,7 @@ describe("pano reads — /fate", () => {
 		expect(seeded!.cursor).toBe(postId); // cursor is the post id keyset
 		expect(seeded!.node.title).toBe("Fate Pano Read");
 		expect(seeded!.node.commentCount).toBe(5);
-		expect(seeded!.node.author).toBe("umut");
+		expect(seeded!.node.author).toBe("anka");
 		expect(data.pagination.hasPrevious).toBe(false);
 	});
 
@@ -300,7 +300,7 @@ describe("pano reads — /fate", () => {
 		expect(post.title).toContain("phoenix");
 		expect(post.url).toBe(`https://${host}/phoenix`);
 		expect(post.host).toBe(host);
-		expect(post.author).toBe("umut");
+		expect(post.author).toBe("anka");
 		expect(post.score).toBe(0);
 		expect(post.commentCount).toBe(0);
 		expect(post.tags).toHaveLength(1);

--- a/apps/web/tests/integration/sozluk-keyset.test.ts
+++ b/apps/web/tests/integration/sozluk-keyset.test.ts
@@ -117,15 +117,15 @@ beforeAll(async () => {
 		await h.seedTerm({
 			slug,
 			title: slug.toUpperCase(),
-			definitions: [{authorName: "umut", body: `body ${slug}`, score}],
+			definitions: [{authorName: "anka", body: `body ${slug}`, score}],
 		});
 	}
 	await h.seedTerm({
 		slug: DEFS_SLUG,
 		title: "Keyset Defs",
 		definitions: [
-			{authorName: "umut", body: "high", score: 5},
-			{authorName: "elif", body: "mid", score: 3},
+			{authorName: "anka", body: "high", score: 5},
+			{authorName: "zumrud", body: "mid", score: 3},
 			{authorName: "ada", body: "low", score: 1},
 		],
 	});
@@ -137,7 +137,7 @@ beforeAll(async () => {
 		await h.seedTerm({
 			slug,
 			title: slug.toUpperCase(),
-			definitions: [{authorName: "umut", body: `body ${slug}`}],
+			definitions: [{authorName: "anka", body: `body ${slug}`}],
 		});
 	}
 	for (const slug of REC_SLUGS) {

--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -622,7 +622,7 @@ describe("sozluk mutations — seed idempotency / emptying a term", () => {
 	it("seedTerm is idempotent: re-seeding the same definition skips it", async () => {
 		const slug = `${NS}-outbox`;
 		const def = {
-			authorName: "umut",
+			authorName: "anka",
 			body: "Atomic durability primitive in the producer-consumer outbox pattern.",
 		};
 

--- a/apps/web/tests/integration/sozluk-read.test.ts
+++ b/apps/web/tests/integration/sozluk-read.test.ts
@@ -62,8 +62,8 @@ beforeAll(async () => {
 		slug: SLUG,
 		title: "Fate Read",
 		definitions: [
-			{authorName: "umut", body: "alpha definition", score: 2},
-			{authorName: "elif", body: "beta definition", score: 1},
+			{authorName: "anka", body: "alpha definition", score: 2},
+			{authorName: "zumrud", body: "beta definition", score: 1},
 		],
 	});
 	seeded = result.definitions;
@@ -136,16 +136,17 @@ describe("sozluk reads — deployed worker /fate (system smoke)", () => {
 		expect(conn.items.length).toBe(2);
 		// Scope the scalar-surface assertion to the EXACT row this file seeded, found by
 		// the real id the worker assigned (captured from the seed) — never the positional
-		// `items[0]` + a hardcoded handle. The connection is `termSlug`-scoped so only
-		// this NS term's rows appear, but pinning by seeded id keeps the assertion
-		// deterministic on the run-scoped SHARED stage (ADR 0104): it verifies the
-		// session-derived surface of the definition we know we authored, whatever the
-		// stage's actor population — instead of `expected 'yazar' to be 'umut'`, the
-		// fixture-pinned read of another shared-stage file's author (#2116).
+		// `items[0]`. Determinism on the run-scoped SHARED stage (ADR 0104) rests on TWO
+		// facts: the connection is `termSlug`-scoped so only this NS term's rows appear, AND
+		// the seed's author identity is uniquified per run at the harness source, so the
+		// stored `author_name` can't collide with a pre-existing stage actor. Asserting
+		// against the seed's RETURNED `authorName` (never a base/handle literal) is what
+		// closes the fixed-identity-on-a-shared-stage flake (#2116: `expected 'yazar' to
+		// be 'umut'` — a fixed handle read back as another actor's).
 		const alpha = conn.items.find((e) => e.node.id === seeded[0]!.id)?.node;
 		expect(alpha).toBeDefined();
-		// `author` round-trips the seed's own username (`author_name`, snapshotted from
-		// `user.name` at add-time) — a straight scalar passthrough (`definition-fields.ts`:
+		// `author` round-trips the seed's own (uniquified) username (`author_name`, snapshotted
+		// from `user.name` at add-time) — a straight scalar passthrough (`definition-fields.ts`:
 		// `author: d => d.authorName`), NOT the `yazar` authorship-tier noun (ADR 0107).
 		expect(alpha!.author).toBe(seeded[0]!.authorName);
 		expect(alpha!.authorId).toBe(seeded[0]!.authorId);


### PR DESCRIPTION
## What this fixes

The deployed-worker integration smoke `apps/web/tests/integration/sozluk-read.test.ts` failed **intermittently** on the shared deployed stage (ADR 0104) with `expected 'yazar' to be 'umut'`. It is a fail-closed `ci-required` gate (ADR 0092), so its flakiness evicted unrelated approved PRs from the merge queue.

#2117 scoped the READ to the seeded row by id — necessary but **insufficient**. This PR closes the residual root cause at the **seed/identity layer**.

## Root cause (identity, not read-scoping)

The harness (`_harness.ts`) `seedTerm` signs a user up via `definition.add`, and the stored `author_name` derives from `user.name ?? user.email`. It signed up a **FIXED** author handle (`umut`) on a **SHARED, persistent** deployed stage — so it could collide with pre-existing stage state (e.g. an actor whose displayed authorName is the tier-noun `yazar`, seeded by another file). Fixed identity + a shared mutable stage = nondeterministic reads.

## The fix (two combined requirements)

1. **Unique-per-run seeded identity at the SOURCE.** `authorCookie` now derives the stored `author_name` as `<base>-<STAMP_SEED>` (the per-process run stamp already used for seed emails), and `seedTerm` **threads the real stored name back** through its returned `definitions[i].authorName`. No two runs — and no persistent stage actor — can collide on the seeded author. Uniqueness at the harness source **propagates** to every `seedTerm` consumer.
2. **Fixtures renamed off `umut`** (the real founder handle) to `anka`. The `sozluk-read` scalar assertion already reads the seed's **returned** `authorName` dynamically (`seeded[0].authorName`, from #2117) — which now resolves to the uniquified stored name, so it is deterministic against the exact row this file authored, never a literal. The pano-read direct-signup fixture (literal name + literal assertion) is renamed on both sides consistently.

Grounded in source: `definition-fields.ts` (`author: d => d.authorName`) confirms `author` is a straight scalar passthrough of the snapshotted `author_name`, not a read-path derivation of the `yazar` tier noun — so the fix is purely test-side identity determinism.

## Scope / §CP self-assessment

**§CP: NO.** The change is confined to `apps/web/tests/integration/**` (the harness + five test files). No gate rewiring, no `packages/ci-required`, no `.github/**`, no `.claude/**`. The smoke is **not** de-gated, skipped, or weakened — it is made deterministic. Whether a deployed-worker smoke should gate at all is the separate §CP follow-up #2118, deliberately not in this PR.

## Follow-up (unbundled)

Several other integration files still seed/sign up with the literal `yazar` tier-noun as a fixture base (`report.test.ts`, `report-moderation.test.ts`, the search/fts files). These no longer flake (the harness now uniquifies the stored name for the `seedTerm` path, and none assert the author scalar against the literal), so renaming them off the tier-noun is cosmetic and left as a follow-up rather than ballooning this PR.

## Verification

`pnpm typecheck` (24/24) and `pnpm lint:worktree` clean. The test is a deployed-worker smoke (needs CF creds) — not locally runnable; correctness is by construction + branch CI.

Fixes #2116