### PR TITLE
chore(pano): drop unused PHOENIX_KARMA_GATES import (post-#2113 cleanup)

### DIFF
--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -15,7 +15,7 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
-import {PHOENIX_KARMA_GATES, PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
+import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
 import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
 import {notifyCommentReply} from "../bildirim/conversation-emitters.ts";
 import {notifyCaylakEntersDivan} from "../bildirim/mod-emitters.ts";


### PR DESCRIPTION
## What

Removes the unused `PHOENIX_KARMA_GATES` named import from `apps/web/worker/features/pano/mutations.ts` (line 18). Only `PHOENIX_REACTIONS` is actually used in this file (the reaction feature gate, at ~lines 357 and 624).

## Why

`#2113` landed `PHOENIX_KARMA_GATES` in this import but never referenced it. `github-code-quality[bot]` flagged it inline on that PR and the founder confirmed. CI passed it because biome runs `organizeImports` (sort/group) but does not treat unused named imports as an error, and `review-code` missed it. This is an immediate post-merge cleanup — no separate issue.

## Scope

- One file, one line: dead-import removal only.
- Confirmed `PHOENIX_KARMA_GATES` has zero remaining occurrences in the file (was import-only).
- `pnpm lint:worktree` (biome) clean; `pnpm typecheck` clean (24/24).
- NON-§CP: `apps/web` product code, no control-plane surface touched.