### PR TITLE
chore(biome): make noUnusedImports + noUnusedVariables error-level (#2121)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -56,6 +56,10 @@
 		"enabled": true,
 		"rules": {
 			"recommended": true,
+			"correctness": {
+				"noUnusedImports": "error",
+				"noUnusedVariables": "error"
+			},
 			"suspicious": {
 				"noExplicitAny": "off"
 			}


### PR DESCRIPTION
## What

Set `correctness.noUnusedImports` **and** `correctness.noUnusedVariables` to `"error"` in the root `biome.jsonc` (Unit A of #2121). Under `recommended: true` these were warn-level, so `biome check` passed dead imports/vars — the exact gate hole that let a dead import merge past CI + review-code + ship-it in #2113.

## Why

`.github/workflows/ci.yml`'s check job runs `pnpm lint` → `biome check .`. With the rules at error-level, a dead import/var now **fails CI automatically** and never reaches review. No `ci.yml` edit is needed (and none was made) — the workflow starts failing at error-level on its own.

## Repo-wide sweep

Ran `biome check` at the new error-level across the full lintable surface (apps, packages, infra, claude-plugins, scripts, tests, .decisions, .glossary, .patterns, biome-plugins — 1121 files). It surfaced **zero** existing `noUnused*` violations: the codebase was already free of dead imports/vars (the #2113 instance at `apps/web/worker/features/pano/mutations.ts:18` was already cleaned fix-forward). So this PR is the config flip alone — no code removals were required. The 8 pre-existing warnings biome reports are unrelated categories (`noBannedTypes`, `noDescendingSpecificity`, `noTemplateCurlyInString`) that remain warnings and do not fail the check.

## Scope

- **Unit A only.** Unit B (whether review-code should ingest `github-code-quality[bot]` inline findings) is the separate §CP issue #2123 — not touched here.
- **Non-§CP.** `biome.jsonc` at root is not in `CONTROL_PLANE_RE` (it matches none of `.github/`, `.claude/`, the gate skills, `packages/ci-required/`, or `packages/pipeline-cli/`).

## Verification

- `biome check` (full lintable surface): exit 0, 0 `noUnused*` errors
- `pnpm lint:worktree`: clean
- `pnpm typecheck`: 25/25 pass

Fixes #2121