### PR TITLE
feat(pipeline): unresolved inline review thread is a merge gate — ship-it routes back by default (ADR 0158)

### DIFF
--- a/.decisions/0158-unresolved-review-thread-is-a-merge-gate.md
+++ b/.decisions/0158-unresolved-review-thread-is-a-merge-gate.md
@@ -1,0 +1,176 @@
+---
+id: 0158
+title: An unresolved inline review thread (human or bot) is a merge gate — ship-it reads it and routes back by default, never auto-dismisses
+status: accepted
+date: 2026-07-05
+tags: [pipeline, ship-it, review-code, control-plane]
+---
+
+# 0158 — An unresolved inline review thread is a merge gate
+
+## Context
+
+The merge gate silently discards inline review comments before merge — and not just the
+bot's. A **human** inline `"fix this"` (left inline rather than as a formal
+Request-Changes) is merged past unread exactly as a bot's lint finding is. Neither
+[`review-code`](../claude-plugins/kampus-pipeline/skills/review-code/SKILL.md) nor
+[`ship-it`](../claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md) ingests any
+**unresolved inline thread** as a merge signal, so a reviewer's substantive objection is
+treated as noise and auto-shipped over. The failure is **silent** — nothing surfaces that
+a thread was dropped — which is the dangerous part. The grounded instance: the
+code-quality bot's unresolved unused-import thread on PR #2113 shipped past CI +
+`review-code` + `ship-it` (issue #2121 closed exactly that one biome special case; #2123
+is this broadened root-cause parent).
+
+Inline comments are where much of real human review happens. A pipeline that honors only a
+formal Request-Changes and ignores inline threads gives a human who leaves a real
+objection inline **no guarantee it blocks the merge** — which erodes trust in the gate the
+whole autonomous-merge pipeline rests on.
+
+The founder settled the **principle** this session (not open for re-litigation here):
+*resolving every conversation thread enforces the pipeline no matter what.* The
+**whether** is decided — require-conversation-resolution **plus** ship-it-reads-unresolved-threads,
+with the default erring toward **routing-back**. This ADR records that settled principle
+and works out the **mechanism**.
+
+### The load-bearing crux — route back by default, never auto-dismiss
+
+A shipper that "resolves" a human's real objection just re-creates the throw-away one layer
+down. So the default **must** err toward addressing / routing-back, **never** auto-dismiss.
+This is the constraint the mechanism honors, not an optimization to trade away.
+
+### Grounded finding — where "require conversation resolution" gates the merge queue
+
+phoenix merges via the merge queue (ADR
+[0132](0132-merge-queue-for-base-freshness.md)); §CP PRs enter it too after a
+control-plane-team approval (ADR
+[0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)). A
+verification pass (GitHub docs + phoenix's live ruleset state) established, at
+medium-high confidence:
+
+- GitHub's **"Require conversation resolution before merging"** is a **PR-level
+  branch-protection admission condition**. It gates the merge queue at **ENQUEUE /
+  admission** — evaluated *before* the queue adds the PR — **not** at the queue's final
+  batch merge (the queue re-runs only the required **status checks** against the
+  `gh-readonly-queue/...` batch ref, and conversation-resolution is not a status check).
+  So it *is* a real server-side gate on phoenix's queue path, complementing `ship-it`
+  rather than being superseded by it.
+- phoenix gates via ruleset `17377992`; conversation resolution is the `pull_request`
+  rule's `required_review_thread_resolution`, currently **`false` (OFF)**.
+- **Caveat (recorded, not resolved here):** phoenix enqueues via `gh pr merge --auto`, and
+  that admission path had a **2022 bypass bug** where `--auto` could enqueue past an
+  unresolved thread (GitHub reported it fixed). The **definitive live test** — enable the
+  setting, open a throwaway PR with one unresolved thread, confirm it cannot enqueue — is
+  **founder-gated** and must be run before the ruleset flag is trusted as the sole gate.
+
+### The read-mechanism tension — REST-only vs. thread resolution state
+
+`ship-it`/`review-code`/`report` mandate **REST-only** (`gh api` REST, never GraphQL — the
+org's legacy Projects-classic integration breaks GraphQL issue/PR queries; ADR
+[0062](0062-repo-as-config-plugin.md)). But inline-thread **resolution** state
+(`isResolved`) is natively a **GraphQL** field
+(`repository.pullRequest.reviewThreads[].isResolved`); REST's
+`GET /repos/{o}/{r}/pulls/{n}/comments` exposes the inline comments but has **no**
+`isResolved` field and no thread grouping, so it cannot distinguish resolved from
+unresolved. This is a real tension: the required read is not available over the REST
+surface the org otherwise mandates.
+
+**Grounded resolution (verified live, read-only, against real phoenix PRs):** the
+GraphQL `reviewThreads { isResolved }` query **works cleanly** on this org — it returned
+exit 0 with valid data on PRs #2113, #2122, #2107 (e.g. PR #2113 returned
+`isResolved: false` for the exact unresolved bot thread that shipped past the gate). The
+Projects-classic breakage is **scoped to Projects fields**, not to `reviewThreads`. So the
+REST-only rule needs a **documented, narrow exception for this one read**: reading review
+**thread resolution** state is the single sanctioned GraphQL read in the pipeline, because
+REST does not expose `isResolved` at all. This is grounded in a real observation against
+the live API (the "ground platform claims in source / a real test" rule), not intuition.
+
+## Decision
+
+1. **An unresolved inline review thread — human or bot — is a merge gate.** Two
+   independent mechanisms, defense in depth:
+
+   - **Platform-native (server-side):** enable the ruleset's
+     `required_review_thread_resolution` so GitHub blocks **enqueue** while any inline
+     thread is unresolved (ADR 0132 queue path; gates at admission). **This flag flip is
+     founder-gated and is NOT part of this ADR's implementation** — see Consequences.
+   - **Pipeline-native (`ship-it`):** before enqueue, `ship-it` **reads** the PR's
+     unresolved inline threads and acts on them, so the pipeline enforces the principle
+     even before the flag is flipped (and remains correct on any repo where the ruleset
+     lever is absent, ADR 0062).
+
+2. **The read mechanism is the GraphQL `reviewThreads { isResolved }` query — the one
+   sanctioned GraphQL read in the pipeline.** REST does not expose thread resolution
+   state, and GraphQL `reviewThreads` is verified to work on this org (the Projects-classic
+   breakage is scoped to Projects fields). This is a **narrow, documented exception** to
+   the REST-only rule, for **this read only**; every other pipeline read/write stays REST.
+
+3. **Default is route-back, never auto-dismiss (the crux).** `ship-it` classifies each
+   unresolved thread:
+
+   - **Substantive** (a real objection: "this is wrong", "handle this case", "don't do
+     X") → **refuse to ship, route back to a coder** — treated exactly like a FAIL. The
+     PR does not enqueue; the thread stays unresolved for `write-code` to address.
+   - **Genuine nit** (a trivial, already-satisfied, or obsolete note) → `ship-it` may
+     **resolve-with-explicit-rationale**: post a reply stating *why* it is a nit and
+     resolve the thread. **Never** a blanket auto-resolve to clear the gate.
+   - **When in doubt, treat the thread as substantive and route back.** The bias is
+     deliberately conservative: a false route-back costs one cycle; a false auto-resolve
+     silently discards a real objection — the exact failure this ADR closes.
+
+4. **`review-code` surfaces unresolved inline threads in its verdict.** At review time the
+   gate reads unresolved threads and lists them in the per-criterion verdict table so an
+   unresolved substantive thread is **visible as a `[FAIL]` row** — making the objection
+   surface *at the gate*, not silently at merge. This keeps the same conjunctive
+   verdict computation (one FAIL fails the gate).
+
+## Consequences
+
+- **Objections stop being silently discarded.** A human's inline "fix this" and a bot's
+  inline finding both now block the merge until addressed or explicitly dismissed as a
+  nit — the trust hole (#2123, parent of #2121) is closed at the root, not just for the
+  unused-import special case.
+
+- **Sequencing is load-bearing — the flag flip comes AFTER `ship-it` can resolve threads.**
+  Enabling `required_review_thread_resolution` *before* `ship-it` can resolve nits would
+  **deadlock the pipeline on every unresolved bot comment** (every lint nit would block
+  enqueue with nothing able to clear it). So this ADR + PR build the **capability**
+  (`ship-it` reads + routes/resolves; `review-code` surfaces); the **founder flips the
+  ruleset flag** as a separate, gated step, after confirming the capability is live. The
+  PR does **not** touch ruleset settings.
+
+- **The `--auto` bypass caveat must be live-tested before trusting the flag alone.** The
+  2022 `gh pr merge --auto` bypass (GitHub reported fixed) means the platform gate is not
+  trusted as the *sole* gate until the founder runs the definitive test (enable → throwaway
+  PR with an unresolved thread → confirm it cannot enqueue). Until then, `ship-it`'s
+  pipeline-native read is the load-bearing enforcement; the two are defense in depth.
+
+- **One narrow GraphQL exception is now sanctioned.** Reading review-thread `isResolved`
+  is the single pipeline read that uses GraphQL, documented at its use site with the
+  grounding (verified working on this org; REST exposes no `isResolved`). Everything else
+  stays REST-only. A future migration off Projects-classic does not change this — GraphQL
+  `reviewThreads` already works; the exception is about *why* GraphQL is used here despite
+  the REST-only default.
+
+- **`ship-it` gains a judgment call it did not have** (substantive vs. nit). This is a
+  *conservative* judgment — the default is route-back, so the failure mode is an extra
+  cycle, never a discarded objection. The nit-resolve path always leaves a written
+  rationale reply, so a human can audit every resolution.
+
+- **This is §CP.** The PR edits gate-critical skills
+  (`ship-it/SKILL.md`, `review-code/SKILL.md`), so it stops at reviewed-ready for a human
+  (control-plane-team) merge (ADR 0135) — it does **not** auto-ship, and it weakens no
+  existing gate invariant (the new read is an *additional* pre-enqueue refusal layered on
+  the existing guard sequence).
+
+## Vocabulary impact
+
+**Term coined: "unresolved review thread" as a merge gate signal** — an inline review
+thread (human or bot) whose `isResolved` is false, now a first-class merge-blocking signal
+alongside the formal `review-*: FAIL` verdict. And the **substantive-vs-nit** thread
+classification (`ship-it`'s route-back-vs-resolve-with-rationale disposition). These are
+narrow, self-defining pipeline mechanics recorded here at their coining site; they extend
+the existing gate vocabulary rather than introducing a new domain noun, so no
+`.glossary/TERMS.md` row is added in this PR — the definitions live in this ADR and at the
+skills' use sites. Recorded outcome: **no `.glossary/TERMS.md` change** (mechanic extension
+of the already-named gate/verdict vocabulary).

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1029,6 +1029,62 @@ This row is governed by the conjunctive rule (Step 3): a `[FAIL]` comment-discip
 PR until the diff is deslopped. The author is the *fixer*; you are the *judge* — the split-role
 firewall holds, and the author bias #1394 named is gone by construction.
 
+### Step 3e — Unresolved inline review threads: surface them in the verdict (ADR 0158)
+
+An inline review thread — human **or** bot — left **unresolved** on this PR is a real objection
+that the acceptance-criteria checklist above does not see (a human's inline "fix this", the
+code-quality bot's inline finding). Historically these were silently discarded before merge
+(#2123, the broadened root-cause parent of #2121: the bot's unused-import thread shipped past this
+gate on PR #2113). Read them here so the objection **surfaces at the gate**, visible in this
+verdict, rather than at a silent merge.
+
+Thread **resolution** state (`isResolved`) is a **GraphQL** field
+(`repository.pullRequest.reviewThreads[].isResolved`); the REST inline-comments endpoint exposes
+the comments but has **no** `isResolved` field, so it cannot tell resolved from unresolved. Reading
+review-thread resolution is therefore the **single, narrow, documented exception** to this skill's
+REST-only rule — verified working on this org (the Projects-classic breakage is scoped to Projects
+fields, not `reviewThreads`; ADR
+[0158](https://github.com/kamp-us/phoenix/blob/main/.decisions/0158-unresolved-review-thread-is-a-merge-gate.md)).
+Every other read/write in this skill stays REST.
+
+```bash
+ORG="${REPO%%/*}"; NAME="${REPO#*/}"
+# The ONE GraphQL read in review-code (ADR 0158): REST exposes no isResolved.
+gh api graphql -f query='
+  query($o:String!,$n:String!,$pr:Int!) {
+    repository(owner:$o, name:$n) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes { isResolved path line comments(first:1){ nodes { author { login } body } } }
+        }
+      }
+    }
+  }' -F o="$ORG" -F n="$NAME" -F pr="$PR" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)
+        | {path, line, author: .comments.nodes[0].author.login, body: (.comments.nodes[0].body[0:200])}'
+echo "unresolved-threads: scanned the PR's review threads (§ZS: this read ran)"
+```
+
+Fold the result into the conjunctive table exactly like Step 3b/3c/3d:
+
+- **A substantive unresolved thread ⇒ `[FAIL]` row.** A real objection (a requested change, a bot
+  finding naming a real defect) that is still unresolved is an unmet criterion — name the site and
+  the thread so `write-code`'s repair round addresses it. **When in doubt, treat it as substantive**
+  (a false FAIL costs a cycle; a false PASS discards a real objection — ADR 0158's crux).
+- **Only genuine nits unresolved, or none ⇒ not a FAIL for this facet.** Cite that the unresolved
+  threads (if any) are trivial/obsolete nits, or that there are no unresolved threads.
+- **No review threads at all ⇒ explicit not-applicable skip** — emit
+  `unresolved-threads: not applicable — no review threads on this PR` and omit the row.
+
+```
+- [FAIL] unresolved-threads — apps/web/worker/features/pano/mutations.ts:18 @github-code-quality: "Unused import PHOENIX_KARMA_GATES" is unresolved and substantive → address on the branch (ADR 0158)
+```
+
+Surfacing the thread here does **not** resolve it or merge past it — the split-role firewall holds
+(you judge, `write-code` fixes, `ship-it` merges). `ship-it`'s Step 3.6 is the terminal enforcement
+that refuses to enqueue on a substantive unresolved thread; this step makes the same objection
+**visible at review time**, so it never reaches merge unread.
+
 ---
 
 ## Step 4a — Pass path: signal merge-ready (do NOT merge)

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -112,6 +112,14 @@ pointless.
    entirely over `gh api` / `gh pr merge` (the merge happens **server-side**), so you have **no
    reason to touch the local working tree at all** — read PR state read-only over `gh api`; you
    never need a checkout to ship.
+5. **An unresolved inline review thread (human or bot) blocks the merge — and the default is
+   route-back, never auto-dismiss.** Before you enqueue, read the PR's unresolved inline threads
+   (Step 3.6): a **substantive** one refuses the ship like a FAIL (routed back to `write-code`); a
+   **genuine nit** may be resolved **only with an explicit written rationale**; **in doubt, treat
+   it as substantive and route back** (ADR
+   [0158](https://github.com/kamp-us/phoenix/blob/main/.decisions/0158-unresolved-review-thread-is-a-merge-gate.md)).
+   A shipper that "resolves" a real objection just re-creates the throw-away one layer down —
+   never blanket-resolve threads to clear the gate.
 
 ## The merge-ready signals
 
@@ -1034,11 +1042,99 @@ node ../../bin.ts crabbox-manifest --run-summary <(node -e 'console.log(JSON.str
 
 ---
 
+## Step 3.6 — Unresolved inline review threads gate: read them, route back by default (ADR 0158, guard 3)
+
+An inline review thread — human **or** bot — whose resolution state is **unresolved** is a
+merge-blocking signal, on the same footing as a `review-*: FAIL` verdict. Before you enqueue,
+read the PR's unresolved threads and act on them. The `review-*: PASS` verdicts (Step 2), the
+green CI (Step 3), and the run-evidence bundle (Step 3.5) attest the diff against the issue's
+acceptance criteria — they do **not** see an inline "fix this" a human (or the code-quality bot)
+left on a line. That objection was silently discarded before merge (#2123, the broadened
+root-cause parent of #2121: the bot's unused-import thread shipped past every gate on PR #2113).
+This step closes that hole in the pipeline-native path, independent of whether the ruleset's
+`required_review_thread_resolution` flag is enabled (that server-side lever is founder-gated and
+NOT flipped by this skill — ADR 0158 Consequences).
+
+**The load-bearing crux (ADR 0158 §Decision 3): the default errs toward routing-back, NEVER
+auto-dismiss.** A shipper that "resolves" a human's real objection just re-creates the throw-away
+one layer down. So a **substantive** unresolved thread refuses the ship exactly like a FAIL; a
+**genuine nit** may be resolved **only with an explicit written rationale**; and **when in doubt,
+treat the thread as substantive and route back**. Never blanket-resolve threads to clear the gate.
+
+### Reading thread resolution — the one sanctioned GraphQL read (ADR 0158 §Decision 2)
+
+Thread **resolution** state (`isResolved`) is a **GraphQL** field
+(`repository.pullRequest.reviewThreads[].isResolved`); the REST inline-comments endpoint
+(`GET /repos/{o}/{r}/pulls/{n}/comments`) exposes the comments but has **no** `isResolved` field
+and no thread grouping, so it cannot tell resolved from unresolved. Reading review-thread
+resolution is therefore the **single, narrow, documented exception** to this skill's REST-only
+rule — verified working on this org (the Projects-classic breakage is scoped to Projects fields,
+not `reviewThreads`; grounded live on PRs #2113/#2122/#2107, ADR 0158). Every other read/write in
+this skill stays REST.
+
+```bash
+ORG="${REPO%%/*}"; NAME="${REPO#*/}"
+# The ONE GraphQL read in ship-it (ADR 0158): REST exposes no isResolved. Read every review thread's
+# resolution state + its first author, so a substantive-vs-nit judgment has the thread text.
+gh api graphql -f query='
+  query($o:String!,$n:String!,$pr:Int!) {
+    repository(owner:$o, name:$n) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes {
+            isResolved
+            isOutdated
+            path
+            line
+            comments(first:1) { nodes { author { login } body } }
+          }
+        }
+      }
+    }
+  }' -F o="$ORG" -F n="$NAME" -F pr="$PR" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)
+        | {path, line, author: .comments.nodes[0].author.login, body: (.comments.nodes[0].body[0:200])}'
+```
+
+### Disposition — classify each unresolved thread, then branch
+
+For **each** unresolved thread the query returns:
+
+- **Substantive** — a real objection: a requested change ("fix this", "handle this case", "this
+  is wrong", "don't do X"), a bot finding that names a real defect (an unused import, a missing
+  guard), or anything you cannot confidently call trivial. → **REFUSE to enqueue.** Report
+  `unresolved substantive review thread (<path>:<line>, @<author>)` and stop — this is a FAIL-class
+  refusal, routed back to `write-code` to address the thread on the branch. Do **not** resolve it.
+- **Genuine nit** — a trivial, already-satisfied, or obsolete note (a style preference already
+  followed, a question already answered in the diff, a finding a later commit made moot). → you
+  **may** resolve it, but **only with an explicit written rationale**: reply on the thread stating
+  *why* it is a nit, then resolve it. Never a silent or blanket resolve.
+
+If **any** unresolved thread is substantive (or in-doubt), you refuse — the whole PR does not
+enqueue. Only when **every** unresolved thread has been either addressed on the branch (so it no
+longer shows unresolved) or resolved-with-rationale as a nit do you proceed to Step 4.
+
+```bash
+# Resolve a NIT thread — ONLY after posting the rationale reply. Requires the thread's node id
+# (from the same GraphQL read, add `id` to the reviewThreads.nodes selection). REST cannot resolve
+# a thread, so the resolve mutation is part of the same sanctioned GraphQL exception (ADR 0158).
+# gh api graphql -f query='mutation($t:ID!){ resolveReviewThread(input:{threadId:$t}){ thread { isResolved } } }' -F t="$THREAD_ID"
+```
+
+**Refuse in doubt.** A false route-back costs one cycle; a false auto-resolve silently discards a
+real objection — the exact failure ADR 0158 closes. The conservative bias is the point, not a
+rough edge. This guard is **additive**: it layers a new pre-enqueue refusal on the existing
+sequence (Step 0 §CP approval, Step 2/2b current-head PASS, Step 3 green CI, Step 3.5
+run-evidence) and weakens none of them.
+
+---
+
 ## Step 4 — Enqueue for squash-merge (auto-merge / merge queue)
 
-Every guard cleared: not a control-plane PR (Step 0), the required gates' latest verdicts
-are a current-head PASS (Step 2/2b), checks are green (Step 3), and the run-evidence bundle
-is present, commit-bound, and all-`pass` (Step 3.5). **Enqueue** it for a squash merge — the
+Every guard cleared: not a control-plane PR without a current-head team approval (Step 0), the
+required gates' latest verdicts are a current-head PASS (Step 2/2b), checks are green (Step 3),
+the run-evidence bundle is present, commit-bound, and all-`pass` (Step 3.5), and **no unresolved
+inline review thread is substantive** (Step 3.6, ADR 0158). **Enqueue** it for a squash merge — the
 merge queue owns the final merge, testing the prospective batched merge result against a fresh
 base before it lands (ADR
 [0132](https://github.com/kamp-us/phoenix/blob/main/.decisions/0132-merge-queue-for-base-freshness.md)):


### PR DESCRIPTION
## What this does

Closes the trust hole where the merge gate **silently discarded inline review comments** (human + bot) before merge: neither `review-code` nor `ship-it` read any unresolved inline thread, so real objections — a human's inline "fix this" or the code-quality bot's finding — auto-shipped past unread (#2123, the broadened root-cause parent of #2121; the bot's unused-import thread shipped past CI + `review-code` + `ship-it` on PR #2113).

This is a **DECIDED** decision (founder settled the principle this session): require-conversation-resolution **+** ship-it-reads-unresolved-threads, with the default erring toward **routing-back**. This PR records the settled principle in an ADR and builds the pipeline-native capability.

### Changes

- **ADR 0158** (`.decisions/0158-unresolved-review-thread-is-a-merge-gate.md`) — records the settled principle, the load-bearing route-back-not-dismiss crux, the verified queue-admission gating mechanism + the `--auto` caveat, and the grounded thread-read mechanism.
- **`ship-it/SKILL.md` Step 3.6** (new pre-enqueue guard) — before enqueue, read unresolved inline threads; **substantive → refuse (route back like a FAIL)**, **genuine nit → resolve-with-explicit-rationale**, **never blanket-dismiss**; in doubt → treat as substantive. Additive to the existing guard sequence (Steps 0–3.5); weakens no gate invariant. Also added as hard-guard #5.
- **`review-code/SKILL.md` Step 3e** — surface unresolved inline threads in the verdict table so a substantive one shows as a `[FAIL]` row, visible at review time (not silently at merge).

## The load-bearing crux (honored throughout)

A shipper that "resolves" a human's real objection just re-creates the throw-away one layer down. So the default **must** route substantive threads back to a coder (refuse to ship, like a FAIL); resolve-with-explicit-rationale is scoped to **genuine nits only**. Never blanket auto-resolve to clear the gate. **When in doubt, treat a thread as substantive and route back** — a false route-back costs one cycle; a false auto-resolve silently discards a real objection.

## Grounded thread-read mechanism finding (GraphQL works)

The critical spike: `ship-it`/`review-code` must read inline-thread **resolution** state, but the org mandates **REST-only** (Projects-classic breaks GraphQL issue/PR queries). Verified **read-only against live phoenix PRs**:

- **GraphQL `reviewThreads { isResolved }` works cleanly on this org** — exit 0 with valid data on PRs #2113, #2122, #2107. PR #2113 returned `isResolved: false` for the exact unresolved bot thread that shipped past the gate. **The Projects-classic breakage is scoped to Projects fields, not `reviewThreads`.**
- **REST `GET /pulls/{n}/comments` has NO `isResolved` field** and no thread grouping — it cannot distinguish resolved from unresolved.

So GraphQL `reviewThreads` is the correct read, requiring a **narrow, documented exception** to the REST-only rule for **this one read** (recorded in the ADR + a load-bearing comment at each use site). Every other pipeline read/write stays REST.

## Merge-queue gating finding (founder-requested report)

Verification pass (GitHub docs + phoenix live ruleset state, medium-high confidence):

- GitHub's **"Require conversation resolution before merging"** is a **PR-level branch-protection admission condition** that gates the merge queue at **ENQUEUE / admission** (evaluated *before* the queue adds the PR), **NOT** at the queue's final batch merge (the queue re-runs only required **status checks** on the `gh-readonly-queue/...` batch ref; conversation-resolution is not a status check). So it IS a real server-side gate on phoenix's queue path (ADR 0132) — it **complements** `ship-it`, is not superseded by it.
- phoenix gates via ruleset `17377992`; conversation resolution = the `pull_request` rule's `required_review_thread_resolution`, currently **`false` (OFF)**.
- **Caveat:** phoenix enqueues via `gh pr merge --auto`; that admission path had a 2022 bypass bug (GitHub reported fixed). The **definitive live test** (enable the setting → throwaway PR with an unresolved thread → confirm it can't enqueue) is **FOUNDER-GATED**.

## Hard constraint — this PR does NOT flip the ruleset flag

`required_review_thread_resolution` is **NOT** flipped here. That is a **founder-gated** action that must come **AFTER** `ship-it` can resolve nits — else the pipeline **deadlocks on every unresolved bot comment**. This PR builds the *capability*; the founder flips the *gate*. No ruleset settings are touched.

## §CP — human-merge-only

Edits gate-critical skills (`ship-it/SKILL.md`, `review-code/SKILL.md`) → the PR **stops at reviewed-ready for a human (control-plane-team) merge** (ADR 0135). Does **not** auto-ship. No existing gate invariant weakened — the new read is an *additional* pre-enqueue refusal layered on the existing sequence.

Fixes #2123