### PR TITLE
docs(glossary): axis:* is a label not a milestone; axis does not anchor p1 (#2127)

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -267,6 +267,21 @@ still wanted), not "close as done." (ADR
 [0072](../.decisions/0072-milestones-encode-strategic-sequencing.md) — *milestones encode
 strategic sequencing*.)
 
+A **standing cross-cutting axis** — a perpetual concern with no terminal DoD (token
+efficiency, test/CI health, pipeline hardening) — is likewise **a label, not a milestone**,
+by the same DoD test. Its label is `axis:*`, distinct from `area:*`: **`area:*` = product
+area, `axis:*` = cross-cutting concern** (e.g. `axis:token-efficiency`, `axis:test-ci-health`,
+`axis:pipeline-hardening` vs `area:sozluk-pano-ui`). Tag **go-forward only** — open issues get
+the axis label; closed issues are not retro-tagged (the `area:sozluk-pano-ui` precedent).
+
+An `axis:*` label **does not anchor p1** — only a **live fire** or an **active bounded
+milestone** does. A standing axis is **p2-by-default**; an individual item rises to p1 only
+when it is a genuine fire (a broken gate, a false-verdict trust bug). This keeps a lane's
+sustained importance out of the priority spine, so it can't rebuild the p1-inflation backdoor
+the milestone-relative p1 rule closed (#1936 / #2078). *Founder-override-open* — the founder
+may later designate an `axis:*` (e.g. `axis:pipeline-hardening`) a p1-anchor; until relayed,
+this rule stands. (Extends the #2093 → #2095 milestone-governance convention.)
+
 ---
 
 ## 3. Product / brand nouns (Turkish surface)


### PR DESCRIPTION
Extends the **Milestone** structural term in [`.glossary/LANGUAGE.md`](.glossary/LANGUAGE.md) with two settled rules from the #2093 → #2095 milestone-governance convention (encode-only; no system-behavior change).

**Rule 1 — axis vs milestone.** A standing cross-cutting axis (a perpetual concern with no terminal DoD — token efficiency, test/CI health, pipeline hardening) is a **label, not a milestone**, by the same DoD test the entry already applies. Its label is `axis:*`, distinct from `area:*`: `area:*` = product area, `axis:*` = cross-cutting concern. Go-forward tagging only (open issues get the label; closed issues are not retro-tagged — the `area:sozluk-pano-ui` precedent). Cites the existing precedent labels (`axis:token-efficiency`, `axis:test-ci-health`, `axis:pipeline-hardening`, `area:sozluk-pano-ui`); no new labels introduced.

**Rule 2 — p1-anchor.** An `axis:*` label does **not** anchor p1 — only a live fire or an active bounded milestone does. A standing axis is p2-by-default; an item rises to p1 only when it is a genuine fire. This keeps a lane's sustained importance out of the priority spine so it can't rebuild the p1-inflation backdoor #1936/#2078 closed. Marked founder-override-open per the 2026-07-05 EA ruling on the issue.

Landed in-place in the existing Milestone term (still citing ADR 0072); `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` is deliberately untouched (§CP — #2095 kept this convention off it).

Non-§CP doc extend — `.glossary/**` is routed to review-code (Step 3c glossary contract), auto-ships on a PASS + green CI.

Fixes #2127