### PR TITLE
fix(web): consistent displayName (→ @username, never email) via actorLabel across visible surfaces (#2126)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import {useDivanAccess} from "./components/divan/useDivanAccess";
 import {AppShell, Main} from "./components/layout/AppShell";
 import {Footer} from "./components/layout/Footer";
 import {Topbar} from "./components/layout/Topbar";
+import {actorLabel} from "./components/moderation/actor-identity";
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
@@ -81,14 +82,15 @@ function Layout() {
 	}
 
 	const sessionUser = session.data?.user;
-	const fallbackName = sessionUser
-		? (sessionUser.name ?? sessionUser.email.split("@")[0] ?? "user")
-		: "";
+	// The topbar identity, routed through the shared actor-label rule (#2126):
+	// display name, falling back to the @username, never the email local-part the
+	// old `email.split("@")[0]` leaked into the visible name.
+	const username = me?.username ?? null;
 	const userProps = sessionUser
 		? {
 				user: {
-					name: me?.name ?? fallbackName,
-					username: me?.username ?? null,
+					name: actorLabel(me?.name ?? sessionUser.name, username, "kullanıcı"),
+					username,
 				},
 			}
 		: {};

--- a/apps/web/src/components/moderation/actor-identity.test.ts
+++ b/apps/web/src/components/moderation/actor-identity.test.ts
@@ -25,4 +25,16 @@ describe("actorLabel — the shared actor-row display handle", () => {
 		// a different surface (e.g. the admin user-list) supplies its own fallback noun
 		expect(actorLabel(null, null, "kullanıcı")).toBe("kullanıcı");
 	});
+
+	// The PII-safety contract the #2126 fold-in rests on: routing every author/name
+	// surface through actorLabel means a missing display name falls back to the
+	// @username, or a fixed noun — NEVER the email the old `?? user.email` leaked.
+	// The helper simply has no email input; these lock that no username-less call
+	// yields anything but the fixed noun (the shape the optimistic author sites use).
+	it("returns only the fixed noun when username is absent — never an email leak", () => {
+		expect(actorLabel(null, null, "kullanıcı")).toBe("kullanıcı");
+		expect(actorLabel("  ", null, "kullanıcı")).toBe("kullanıcı");
+		// with a display name present, that name renders — the email is never consulted
+		expect(actorLabel("Ada Lovelace", null, "kullanıcı")).toBe("Ada Lovelace");
+	});
 });

--- a/apps/web/src/components/profile/UserProfileHeader.tsx
+++ b/apps/web/src/components/profile/UserProfileHeader.tsx
@@ -1,5 +1,6 @@
 import {useView, type ViewRef, view} from "react-fate";
 import type {Profile} from "../../../worker/features/fate/views";
+import {actorLabel} from "../moderation/actor-identity";
 import {CaylakStatusBlock} from "./CaylakStatusBlock";
 
 export const UserProfileHeaderView = view<Profile>()({
@@ -29,7 +30,7 @@ export interface UserProfileHeaderProps {
 
 export function UserProfileHeader(props: UserProfileHeaderProps) {
 	const profile = useView(UserProfileHeaderView, props.profile);
-	const displayName = profile.displayName ?? profile.username ?? "kullanıcı";
+	const displayName = actorLabel(profile.displayName, profile.username, "kullanıcı");
 	const handle = profile.username ?? props.fallbackHandle;
 
 	return (

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -15,6 +15,7 @@ import {useFateClient, useLiveListView, useRequest, useView, type ViewRef, view}
 import {Link, useLocation, useNavigate, useParams} from "react-router";
 import type {Post, ReportReceipt} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
+import {actorLabel} from "../components/moderation/actor-identity";
 import {CommentTreeNode, CommentTreeNodeView} from "../components/pano/CommentTreeNode";
 import {buildCommentTree, type CommentNode} from "../components/pano/commentTree";
 import {
@@ -445,7 +446,9 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 				postPath={`/pano/${data.slug ?? data.id}`}
 				signedIn={!!session.data?.user}
 				currentUserId={session.data?.user?.id ?? null}
-				currentUserName={session.data?.user?.name ?? session.data?.user?.email ?? null}
+				currentUserName={
+					session.data?.user ? actorLabel(session.data.user.name, null, "kullanıcı") : null
+				}
 			/>
 		</>
 	);
@@ -460,7 +463,7 @@ interface CommentsProps {
 	postPath: string;
 	signedIn: boolean;
 	currentUserId: string | null;
-	/** Author display name (`user.name ?? user.email`) for the optimistic comment node; null when signed out. */
+	/** Author label (`actorLabel`: display name → @username, never email) for the optimistic comment node; null when signed out. */
 	currentUserName: string | null;
 }
 

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -3,6 +3,7 @@ import {useFateClient} from "react-fate";
 import {Link, useNavigate} from "react-router";
 import {useSession} from "../auth/client";
 import {FirstContributionOnramp} from "../components/authorship/FirstContributionOnramp";
+import {actorLabel} from "../components/moderation/actor-identity";
 import {PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Button} from "../components/ui/Button";
 import {DraftRestoreBanner} from "../components/ui/DraftRestoreBanner";
@@ -197,7 +198,11 @@ export function PanoSubmitPage() {
 						url: linkUrl,
 						host: linkUrl ? hostOf(linkUrl) : null,
 						tags: Array.from(selectedTags),
-						author: user.name ?? user.email,
+						// Shared actor-label rule (#2126): display name → fixed noun, never the
+						// email the old `?? user.email` could leak into the optimistic author.
+						// The session user has no typed `username`; the server round-trip
+						// replaces this optimistic author with the stored value.
+						author: actorLabel(user.name, null, "kullanıcı"),
 						authorId: user.id,
 						now,
 					}),

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import {Navigate} from "react-router";
 import {authClient, clearBearerToken, useSession} from "../auth/client";
 import {useMe} from "../auth/useMe";
 import {Karma} from "../components/karma/Karma";
+import {actorLabel} from "../components/moderation/actor-identity";
 import {DeleteAccountDialog} from "../components/profile/DeleteAccountDialog";
 import {ProfileContributionSignal} from "../components/profile/ProfileContributionSignal";
 import {profileStandingLabel} from "../components/profile/profileStanding";
@@ -40,8 +41,17 @@ export function ProfilePage() {
 	const [deleteOpen, setDeleteOpen] = useState(false);
 
 	const u = session.data?.user;
-	const name = u?.name ?? u?.email.split("@")[0] ?? "user";
-	const handle = u?.email.split("@")[0] ?? "user";
+	// Route the identity mirror through the shared actor-label rule (#2126): the
+	// display name, falling back to the chosen @username, never the email-derived
+	// local-part the old code leaked. `me` (the canonical row) is the source for the
+	// username — the session user's `username` doesn't round-trip cleanly right after
+	// a setUsername write (see useMe); `me.name` is the display name.
+	const username = me?.username ?? null;
+	const name = actorLabel(me?.name ?? u?.name ?? null, username, "kullanıcı");
+	// The handle line is the chosen username; on the settings page the account is
+	// always booted, so `username` is set — the `kullanıcı` fallback is only the
+	// defensive not-yet-booted degenerate, never the email local-part.
+	const handle = username ?? "kullanıcı";
 	// The handle-line standing label, derived from the trusted tier (#1302) instead
 	// of the old hard-coded `· yeni üye` lie. `null` (flag off, or no honest tier) →
 	// handle-only, never a placeholder. Dark behind the same authorship-loop flag as

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -24,6 +24,7 @@ import {useNavigate, useParams} from "react-router";
 import type {Term} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
 import {FirstContributionOnramp} from "../components/authorship/FirstContributionOnramp";
+import {actorLabel} from "../components/moderation/actor-identity";
 import {DefinitionCard, DefinitionView} from "../components/sozluk/DefinitionCard";
 import {SozlukTermHeader, TermHeaderView} from "../components/sozluk/SozlukTermHeader";
 import {Skeleton} from "../components/ui/atoms";
@@ -384,7 +385,12 @@ function Composer({
 		// to and drives its own force-refetch + remount, left untouched.
 		const optimistic = buildOptimisticDefinition(optimisticAdd && !onTermCreated, {
 			body,
-			author: user.name ?? user.email,
+			// Route through the shared actor-label rule (#2126): display name, falling
+			// back to a fixed noun, NEVER the email — the old `?? user.email` could
+			// surface a user's email in the optimistic author line (a PII leak). The
+			// session user carries no typed `username`, so the middle @username tier is
+			// unreachable here; the server round-trip replaces this optimistic value.
+			author: actorLabel(user.name, null, "kullanıcı"),
 			authorId: user.id,
 		});
 		await run(


### PR DESCRIPTION
Fixes #2126

## Problem
A user's name rendered inconsistently across visible surfaces — profil/pano showed the `@username`, ayarlar/sözlük showed the display name. Each surface picked its own field, so the same person read as two different identities depending on where you looked. The founder principle: **every visible surface shows the display name, falling back to `@username` when displayName is NULL, and to a fixed noun only when both are absent.**

`displayName` (`schema.ts` `display_name`) is **nullable** and `username` is unique/non-null — confirmed against fresh origin/main. A naive "always show displayName" would render blank names; the `?? @username` fallback IS the fix.

## Approach — route every site through the ONE existing helper
Standardized on the canonical, already-tested `actorLabel(displayName, username, fallback)` (`apps/web/src/components/moderation/actor-identity.ts`, ADR 0147) rather than reinventing the fallback inline — so no surface can silently diverge again. It returns the trimmed display name, else `@username`, else the fixed noun (whitespace-only treated as absent).

Surfaces now routed through `actorLabel`:
- **App.tsx** — topbar identity (was `email.split("@")[0]`)
- **ProfilePage.tsx** — the identity mirror (was email-derived for BOTH name and handle; now the real chosen username via the canonical `me` row — also fixes the DESIGN-AUDIT "email-derived handle is often wrong vs `me.username`" bug)
- **UserProfileHeader.tsx** — inline fallback → the shared rule (consistent `@username` fallback)
- **SozlukTermPage.tsx** — optimistic definition author
- **PanoPostDetail.tsx** — optimistic comment author
- **PanoSubmitPage.tsx** — optimistic post author

## Fold-in — kills a PII leak (also resolves the separate SozlukTermPage email-leak privacy issue)
The three optimistic author sites previously fell back to `user.name ?? user.email`, which could **surface a user's email in the UI** — a PII leak. They now route through `actorLabel` and can **never** fall back to email. Verified: no visible author/name surface falls back to `.email` after this change. The only remaining `.email` reads are the user's **own** email under the settings "e-posta" label and the `UsernameBootstrap` form input — both intentional. (This PR also resolves the `SozlukTermPage.tsx:387` email-leak that is tracked as a separate privacy issue; triage will cross-link it — the fix lands here because a separate PR would conflict on the same surface.)

## Scope note (honest boundary)
The session/better-auth user carries **no typed `username`** client-side (only `name` + `email`; the server declares `username` as an `additionalField` but the client doesn't infer it — the reliable client source is the fate `me` row via `useMe`). The three optimistic sites don't call `useMe`, so they pass `null` for the username tier: **display name → fixed noun, never email**. The email leak is fully closed regardless; the middle `@username` tier just isn't reachable there without threading `username` onto the session/`CurrentUser`, and the server round-trip immediately replaces the optimistic author with the stored value.

Two **denormalized author-snapshot** sites (`DefinitionCard` `@{definition.author}`, `Sozluk.tsx`) render a single pre-flattened `author` string with no displayName/username split available client-side; the worker also stores `authorName: user.name ?? user.email` at the write sites (`sozluk/mutations.ts`, `pano/mutations.ts`) but `CurrentUserInfo` (`@kampus/fate-effect`) carries no `username`. Fixing those correctly means threading `username` through the fate views + `CurrentUserInfo` — a cross-package change beyond this issue's `apps/web/src` scope. **Flagging for a follow-up rather than ballooning scope here.**

## Tests
- Extended `actor-identity.test.ts` locking the PII-safety contract this fold-in rests on (username-absent yields only the fixed noun, never an email-shaped string).
- `pnpm typecheck` clean (25/25); `pnpm run lint:worktree` clean; full unit project green (196 files, 1807 tests).

§CP self-assessment: **non-§CP** (product UI under `apps/web/src`; one test).