### PR TITLE
fix(web): never persist user email as authorName — flatten identity through authorDisplayLabel

### DIFF
--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -27,6 +27,7 @@ import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
 import {InsufficientKarma} from "../kunye/errors.ts";
 import {gateContentOnKarma} from "../kunye/privilege.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {authorDisplayLabel} from "../pasaport/author-label.ts";
 import {VoterNotEligible} from "../vote/errors.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {
@@ -201,7 +202,7 @@ export const mutations = {
 					...(input.body ? {body: input.body} : {}),
 					tags: input.tags.map((t) => ({kind: t.kind, ...(t.label ? {label: t.label} : {})})),
 					authorId: user.id,
-					authorName: user.name ?? user.email,
+					authorName: authorDisplayLabel(user),
 					sandboxedAt,
 				});
 				const post = shapePost({...r, myVote: null});
@@ -248,7 +249,7 @@ export const mutations = {
 			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.saveDraft({
 				authorId: user.id,
-				authorName: user.name ?? user.email,
+				authorName: authorDisplayLabel(user),
 				...(input.title != null ? {title: input.title} : {}),
 				...(input.url != null ? {url: input.url} : {}),
 				...(input.body != null ? {body: input.body} : {}),
@@ -518,7 +519,7 @@ export const mutations = {
 				const r = yield* pano.addComment({
 					postId: input.postId,
 					authorId: user.id,
-					authorName: user.name ?? user.email,
+					authorName: authorDisplayLabel(user),
 					body: input.body,
 					sandboxedAt,
 					...(input.parentId ? {parentId: input.parentId} : {}),

--- a/apps/web/worker/features/pasaport/author-label.ts
+++ b/apps/web/worker/features/pasaport/author-label.ts
@@ -1,0 +1,47 @@
+/**
+ * The write-boundary author-label rule: the ONE place a signed-in user's identity
+ * is flattened into the denormalized `authorName` column persisted on
+ * `definition_record` / `post_record` / `comment_record`.
+ *
+ * It exists to make an invalid state unrepresentable — an email in a public
+ * display column (the #2130 PII-at-rest leak, where the old
+ * `authorName: user.name ?? user.email` persisted a null-name account's EMAIL and
+ * served it on the public author surfaces). The input is a typed
+ * {@link AuthorIdentity} snapshot of `{name, username}` ONLY; `email` is not a
+ * field, so no write path can pass it as a fallback here — the leak is closed at
+ * the type, not by a spot check at each call site.
+ *
+ * The precedence mirrors the SPA read surface's `actorLabel`
+ * (`apps/web/src/components/moderation/actor-identity.ts`) exactly — display name →
+ * `@username` → the fixed `kullanıcı` fallback noun — so the persisted string and
+ * the optimistic client author (#2129, `actorLabel(user.name, …, "kullanıcı")`)
+ * agree by construction. The two rules are kept in parity by
+ * `author-label.unit.test.ts`; the worker cannot import the SPA module (no
+ * worker→src dependency), so the pure rule is restated here with that test as the
+ * lockstep guard. Threading the full `{username, displayName}` snapshot through the
+ * fate views so the READ surfaces call `actorLabel` on live identity (finishing
+ * #2126 for the denormalized surfaces) is the separately-tracked follow-up.
+ */
+
+/** The fixed fallback noun for an actor with neither a display name nor a username. */
+export const AUTHOR_FALLBACK_LABEL = "kullanıcı";
+
+/**
+ * The non-PII identity snapshot a write path flattens into `authorName`. Deliberately
+ * carries no `email` field: email is structurally excluded from the display label.
+ */
+export interface AuthorIdentity {
+	readonly name?: string | null | undefined;
+	readonly username?: string | null | undefined;
+}
+
+/**
+ * Resolve the persisted author display label from a `{name, username}` snapshot:
+ * trimmed display name → `@username` → the fixed `kullanıcı` fallback. Whitespace-only
+ * is treated as absent. Never returns an email — email is not an input.
+ */
+export function authorDisplayLabel(actor: AuthorIdentity): string {
+	if (actor.name?.trim()) return actor.name.trim();
+	if (actor.username?.trim()) return `@${actor.username.trim()}`;
+	return AUTHOR_FALLBACK_LABEL;
+}

--- a/apps/web/worker/features/pasaport/author-label.unit.test.ts
+++ b/apps/web/worker/features/pasaport/author-label.unit.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, it} from "vitest";
+import {AUTHOR_FALLBACK_LABEL, authorDisplayLabel} from "./author-label.ts";
+
+describe("authorDisplayLabel — the write-boundary author label (no email at rest, #2130)", () => {
+	it("prefers a trimmed display name", () => {
+		expect(authorDisplayLabel({name: "Ada Lovelace", username: "ada"})).toBe("Ada Lovelace");
+		expect(authorDisplayLabel({name: "  Ada Lovelace  ", username: "ada"})).toBe("Ada Lovelace");
+	});
+
+	it("falls back to @username when the name is blank/absent", () => {
+		expect(authorDisplayLabel({name: null, username: "ada"})).toBe("@ada");
+		expect(authorDisplayLabel({name: "   ", username: "ada"})).toBe("@ada");
+		expect(authorDisplayLabel({name: undefined, username: " ada "})).toBe("@ada");
+	});
+
+	it("degrades to the fixed kullanıcı fallback when both are blank/absent", () => {
+		expect(authorDisplayLabel({name: null, username: null})).toBe(AUTHOR_FALLBACK_LABEL);
+		expect(authorDisplayLabel({name: "", username: "  "})).toBe(AUTHOR_FALLBACK_LABEL);
+		expect(authorDisplayLabel({})).toBe(AUTHOR_FALLBACK_LABEL);
+		expect(AUTHOR_FALLBACK_LABEL).toBe("kullanıcı");
+	});
+
+	// The regression this helper exists to prevent (#2130): a null-name account must
+	// NEVER have its email persisted as authorName. Email is not an input to the rule —
+	// a caller with only {email} in scope resolves to the fallback, not the email.
+	it("never emits an email — a null-name actor resolves to @username or the fallback, never PII", () => {
+		expect(authorDisplayLabel({name: null, username: "handle"})).toBe("@handle");
+		const nullNameNoUsername = authorDisplayLabel({name: null, username: null});
+		expect(nullNameNoUsername).toBe(AUTHOR_FALLBACK_LABEL);
+		expect(nullNameNoUsername).not.toContain("@");
+		expect(nullNameNoUsername).not.toMatch(/@.+\./);
+	});
+});

--- a/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
@@ -77,16 +77,29 @@ const relationStoreStub = Layer.succeed(RelationStore, {
 
 // A `Sozluk` stub whose `addDefinition` is scripted; every other method dies on
 // contact, so a passing test proves `definition.add` reached only the write it
-// routes around. Mirrors `draft-save.invariant.test.ts`'s `panoStub`.
-const sozlukStub = (result: AddDefinitionResult): Layer.Layer<Sozluk> =>
+// routes around. Mirrors `draft-save.invariant.test.ts`'s `panoStub`. `capture`
+// (when passed) records the write input so a test can assert the persisted
+// `authorName` the resolver chose (#2130 — never the user's email).
+const sozlukStub = (
+	result: AddDefinitionResult,
+	capture?: (input: {authorName: string}) => void,
+): Layer.Layer<Sozluk> =>
 	Layer.succeed(
 		Sozluk,
-		new Proxy({addDefinition: () => Effect.succeed(result)} as Partial<typeof Sozluk.Service>, {
-			get(target, prop) {
-				if (prop in target) return (target as Record<string, unknown>)[prop as string];
-				return () => Effect.die(`Sozluk.${String(prop)} not exercised in definition-mutation`);
+		new Proxy(
+			{
+				addDefinition: (input: {authorName: string}) => {
+					capture?.(input);
+					return Effect.succeed(result);
+				},
+			} as Partial<typeof Sozluk.Service>,
+			{
+				get(target, prop) {
+					if (prop in target) return (target as Record<string, unknown>)[prop as string];
+					return () => Effect.die(`Sozluk.${String(prop)} not exercised in definition-mutation`);
+				},
 			},
-		}) as typeof Sozluk.Service,
+		) as typeof Sozluk.Service,
 	);
 
 const ADD_RESULT: AddDefinitionResult = {
@@ -154,4 +167,50 @@ it.effect(
 			// `Term.definitions` subscriber across all slugs). That topic must be absent.
 			assert.isFalse(recorded.includes(liveGlobalConnectionTopic("Term.definitions")));
 		}),
+);
+
+// #2130 (PII-at-rest): a null-name account must NEVER have its EMAIL persisted as the
+// denormalized `authorName` — the old `user.name ?? user.email` fallback did exactly
+// that, and the flattened string renders publicly on the author surfaces. The resolver
+// now flattens identity through `authorDisplayLabel` (name → @username → fallback), so a
+// null-name / no-username actor persists the fixed fallback noun, never the email.
+it.effect("definition.add never persists a null-name author's email as authorName", () =>
+	Effect.gen(function* () {
+		const nullNameUser = {id: "u-nameless", email: "leak@example.com", name: null, username: null};
+		let captured: {authorName: string} | undefined;
+
+		const liveStub = Layer.succeed(LivePublisher)(
+			livePublisherFor({
+				publish: () => Effect.void,
+				waitUntil: () => {},
+			}),
+		);
+
+		yield* mutations["definition.add"]
+			.handler({input: {termSlug: "gizli", body: ADD_RESULT.body}, select: ["id"]})
+			.pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						sozlukStub(ADD_RESULT, (input) => {
+							captured = input;
+						}),
+						liveStub,
+						flagsOffStub,
+						kunyeStub,
+						notificationStub,
+						divanStub,
+						relationStoreStub,
+						noRequestFlagOverrides,
+					),
+				),
+				Effect.provideService(CurrentUser, {user: nullNameUser}),
+				Effect.provideService(CurrentActor, {actor: human(nullNameUser.id)}),
+				Effect.provideService(RuntimeContext, runtimeContextStub),
+			);
+
+		assert.isDefined(captured);
+		assert.strictEqual(captured?.authorName, "kullanıcı");
+		assert.notStrictEqual(captured?.authorName, nullNameUser.email);
+		assert.notInclude(captured?.authorName ?? "", "@");
+	}),
 );

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -23,6 +23,7 @@ import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {InsufficientKarma} from "../kunye/errors.ts";
 import {gateContentOnKarma} from "../kunye/privilege.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {authorDisplayLabel} from "../pasaport/author-label.ts";
 import {VoterNotEligible} from "../vote/errors.ts";
 import {
 	BodyRequired,
@@ -101,7 +102,7 @@ export const mutations = {
 				const result = yield* sozluk.addDefinition({
 					termSlug: input.termSlug,
 					authorId: user.id,
-					authorName: user.name ?? user.email,
+					authorName: authorDisplayLabel(user),
 					body: input.body,
 					sandboxedAt,
 					...(input.termTitle ? {termTitle: input.termTitle} : {}),

--- a/packages/fate-effect/src/CurrentUser.ts
+++ b/packages/fate-effect/src/CurrentUser.ts
@@ -15,10 +15,12 @@
  * The shape is deliberately minimal: `user` is `undefined` for anonymous
  * traffic (mirroring the worker's `Auth`), and {@link CurrentUserInfo} carries
  * exactly the identity fields phoenix resolvers consume (`id`/`email`/`name`/
- * `image`) — a structural subset of the better-auth session user, so the
- * worker provides it from the session value directly. Anything richer
- * (username, karma) is a database read behind a domain service, not session
- * state.
+ * `image`/`username`) — a structural subset of the better-auth session user, so
+ * the worker provides it from the session value directly. `username` is the
+ * public handle (a better-auth `additionalFields.username`, nullable until an
+ * account bootstraps it) — it rides on the session so a write path can persist a
+ * non-PII display label without a second DB read. Anything richer (karma) is a
+ * database read behind a domain service, not session state.
  */
 import {Context, Effect} from "effect";
 import * as Schema from "effect/Schema";
@@ -31,8 +33,22 @@ import {FateWireCode} from "./WireError.ts";
 export interface CurrentUserInfo {
 	readonly id: string;
 	readonly email: string;
-	readonly name: string;
+	/**
+	 * Display name — NULLABLE: the `user.name` column is nullable and the magic-link
+	 * signup mints nameless accounts (only email/password signup supplies a name). The
+	 * type must reflect that (the old non-null `string` lie is what made the
+	 * `name ?? email` PII fallback look safe, #2130); a null-name write flattens through
+	 * `authorDisplayLabel`, never email.
+	 */
+	readonly name: string | null;
 	readonly image?: string | null | undefined;
+	/**
+	 * Public handle (better-auth `additionalFields.username`), `null` until the
+	 * account bootstraps one. Carried on the session so a write path can resolve a
+	 * non-PII author label (name → `@username` → fallback) without a DB read — the
+	 * `email` field is NEVER a display fallback (a null name must not leak email).
+	 */
+	readonly username?: string | null | undefined;
 }
 
 /**


### PR DESCRIPTION
## The leak (PII-at-rest)

The sozluk + pano write-sites persisted `authorName: user.name ?? user.email`, so a **null-name account's EMAIL** was written into the denormalized `author_name` column and served publicly on the definition/post/comment author surfaces (`@{author}` / `/u/{author}`, including the unauthenticated landing page). Null-name is reachable — the magic-link plugin mints nameless accounts (only email/password signup supplies a name). #2129 fixed the SPA optimistic sites but could not reach these surfaces, which render the flattened string the worker baked in.

## The fix — invalid state made unrepresentable at the write boundary

- New `apps/web/worker/features/pasaport/author-label.ts` — `authorDisplayLabel({name, username})` resolves the persisted label as **display name → `@username` → `kullanıcı` fallback**. Its input snapshot carries **no `email` field**, so no write path can pass email as a fallback — the leak is closed at the type, not by a per-site check. The precedence mirrors the SPA read surface's `actorLabel` exactly; `author-label.unit.test.ts` pins the parity (the worker cannot import the SPA module).
- Threaded the (nullable) `username` onto `CurrentUserInfo` in `@kampus/fate-effect` (a better-auth session `additionalFields.username`), so the label resolves without a DB read.
- Corrected `CurrentUserInfo.name` to `string | null` — the old non-null `string` type is precisely what made the `?? email` fallback look safe.
- All four write-sites now flatten through the helper: `definition.add` (sozluk), `post.submit` / `post.saveDraft` / `comment.add` (pano).

## Tests

- `author-label.unit.test.ts` — the rule (name → @username → fallback) + an explicit **no-email** assertion.
- `definition-mutation.unit.test.ts` — a new resolver-level case: a null-name / no-username user's `definition.add` persists `kullanıcı`, **never** the email.

`pnpm typecheck` (25/25) and `pnpm lint:worktree` clean; worker unit suite for the touched features + the full `@kampus/fate-effect` suite green. Grep confirms no path emits `user.email` into a display column after this change.

## Scope boundary — READ-path threading deferred (finishing #2126)

This closes the **write** leak fully. Threading the full `{username, displayName}` snapshot through the fate views + wire fields so the READ surfaces call `actorLabel` on live identity (the cross-package change #2126/#2129 deferred, which finishes #2126 for the denormalized surfaces) is the separately-tracked larger follow-up.

## Unit 2 — DATA BACKFILL (flagged, NOT attempted)

This code fix does **not** scrub already-persisted rows. Any `author_name` value written before this PR for a null-name account still holds that account's email at rest. I **cannot** verify or scrub prod D1 — agents have no deploy/DB creds (#2061). A safe backfill is non-trivial: `author_name` legitimately holds free-form display names, so distinguishing an email leak from a name that merely contains `@` is a heuristic, and the correct replacement (the author's current `@username` or fallback) requires a JOIN to the `user` table by `author_id`. **A data-backfill/scrub unit is needed for existing rows and likely requires founder-side D1 access (#2061)** — filed as a follow-up for the EA to route rather than ballooning this PR with a migration that assumes prod access.

Fixes #2130