### PR TITLE
fix(pano): one-time full hot_score backfill for pre-#2033 frozen posts (#2131)

### DIFF
--- a/apps/web/tests/integration/pano-hot-score-backfill.test.ts
+++ b/apps/web/tests/integration/pano-hot-score-backfill.test.ts
@@ -1,0 +1,203 @@
+/**
+ * pano sıcak/hot one-time full backfill → the end-to-end guard for #2131.
+ *
+ * The bug (#2131): the go-forward decay cron (#2033) re-decays `post_record.hot_score`
+ * only over a 72h recency window (`decayWindowMs`, `db/hotScoreDecay.ts`) — its query
+ * filters `gte(created_at, now - decayWindowMs)`. So a post that froze high BEFORE that
+ * fix shipped and now sits OUTSIDE the window is never selected by `refreshHotScores` and
+ * keeps its stale young-high stored score forever, pinned #1 on the sıcak feed (the live
+ * 17-day-old squatter the founder observed). There is no backfill path.
+ *
+ * The fix is `Pano.backfillHotScores` (`post-operations.ts`): a ONE-TIME windowless
+ * recompute over ALL live non-draft rows, reusing the SAME pure core (`decayHotScores`)
+ * MINUS the window clause, guarded run-once by the `hot_score_backfill` marker row.
+ *
+ * This is the integration tier (ADR 0082 §irreducible-integration): the stored-column
+ * read → windowless recompute → write-back → keyset feed re-ordering that the pure
+ * `decayHotScores` unit test and the query-shape unit test can't reach. It proves the
+ * exact pre-fix-frozen case — a post OUTSIDE the 72h window — by:
+ *   1. seeding two real posts over `/fate` under one per-file host;
+ *   2. constructing the #2131 bug state on the stale post via a setup-only D1 write: a
+ *      higher score, a `hot_score` FROZEN at the young value, and a `created_at` aged 17
+ *      DAYS into the past — far OUTSIDE the 72h decay window the cron scans;
+ *   3. asserting the WINDOWED `refreshHotScores` does NOT re-decay it (the bug: the row is
+ *      outside the window, so it is never selected — it stays pinned above the fresher
+ *      post);
+ *   4. running the REAL `Pano.backfillHotScores(now)` against this stage's REAL remote D1
+ *      (the shipped code path over `@kampus/d1-rest`, no re-implementation of the query);
+ *   5. asserting the stale post's rank drops BELOW the fresher post through the `/fate`
+ *      hot feed — driven purely by the stored column the backfill rewrote;
+ *   6. asserting a SECOND backfill is a run-once no-op (`ran === false`), and that no
+ *      activity write was needed (the stale post's `score`/`commentCount` are unchanged).
+ *
+ * Like `pano-hot-score-decay`, there is no HTTP route to trigger the scheduled handler on
+ * demand, so the test drives the real method directly against this stage's real D1 REST
+ * target — the fts-backfill precedent (#645). Per-file `integrationStack`: this file owns
+ * its own worker + D1, so the direct-D1 backfill and the feed reads see one isolated table.
+ */
+import {makeD1RestFromEnv} from "@kampus/d1-rest";
+import {Effect} from "effect";
+import {beforeAll, describe, expect, it} from "vitest";
+import {createDrizzle, makeDrizzleAccess, orDieAccess} from "../../worker/db/Drizzle.ts";
+import {computeHotScore} from "../../worker/db/hotScore.ts";
+import {
+	makeBackfillHotScores,
+	makeRefreshHotScores,
+} from "../../worker/features/pano/post-operations.ts";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+interface PostNode {
+	id: string;
+	title: string;
+	host: string | null;
+	score: number;
+	commentCount: number;
+}
+type Connection<N> = {
+	items: Array<{cursor: string; node: N}>;
+	pagination: {hasNext: boolean; hasPrevious: boolean; nextCursor?: string};
+};
+
+const HOST = `hot-backfill-${Date.now().toString(36)}.example.com`;
+const HOUR_MS = 3_600_000;
+
+let author: {userId: string; cookie: string};
+
+async function seedPost(title: string): Promise<string> {
+	const r = await h.fate(
+		{
+			kind: "mutation",
+			name: "post.submit",
+			input: {
+				title,
+				url: `https://${HOST}/${title.replace(/\s+/g, "-")}`,
+				tags: [{kind: "tartışma"}],
+			},
+			select: ["id"],
+		},
+		{cookie: author.cookie},
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error(`seedPost(${title}) failed`);
+	return (r.data as PostNode).id;
+}
+
+async function hotFeedIds(): Promise<string[]> {
+	const feed = await h.fate({
+		kind: "list",
+		name: "posts",
+		args: {sort: "hot", host: HOST, first: 50},
+		select: ["id", "host", "score", "commentCount"],
+	});
+	expect(feed.ok).toBe(true);
+	if (!feed.ok) throw new Error("hot feed read failed");
+	return (feed.data as Connection<PostNode>).items.map((e) => e.node.id);
+}
+
+async function readPost(id: string): Promise<{score: number; commentCount: number}> {
+	const r = await h.fate({
+		kind: "query",
+		name: "post",
+		args: {idOrSlug: id},
+		select: ["id", "score", "commentCount"],
+	});
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error(`readPost(${id}) failed`);
+	const node = r.data as PostNode;
+	return {score: node.score, commentCount: node.commentCount};
+}
+
+/**
+ * Build the REAL `Pano.refreshHotScores` / `Pano.backfillHotScores` bound to this stage's
+ * REAL remote D1 over `@kampus/d1-rest` — the shipped worker code path
+ * (`createDrizzle` → `makeDrizzleAccess` → `orDieAccess` → the factory), never a
+ * re-implementation of the query. Both methods read only `run`, so they build standalone.
+ */
+async function realOps() {
+	const target = await h.d1Target();
+	const db = createDrizzle(makeD1RestFromEnv(target));
+	const access = orDieAccess(makeDrizzleAccess(db));
+	return {
+		refreshHotScores: makeRefreshHotScores(access.run),
+		backfillHotScores: makeBackfillHotScores(access.run),
+	};
+}
+
+beforeAll(async () => {
+	author = await h.signUp("hot-backfill-author@test.local", "hunter2hunter2", "hot-backfill-yazar");
+	await h.promoteToYazar(author.userId);
+});
+
+describe("pano sıcak/hot one-time backfill (#2131) — the windowless recompute reaches rows OUTSIDE 72h", () => {
+	it("un-freezes a post OUTSIDE the 72h window that the windowed refresh never touches", async () => {
+		const staleId = await seedPost("stale-outside-window");
+		const fresherId = await seedPost("fresher-inside-window");
+
+		// The fresher post earns a young-high stored score via the live vote path.
+		const voted = await h.fate(
+			{kind: "mutation", name: "post.vote", input: {id: fresherId}, select: ["id", "score"]},
+			{cookie: author.cookie},
+		);
+		expect(voted.ok).toBe(true);
+		if (!voted.ok) return;
+		expect((voted.data as PostNode).score).toBe(1);
+
+		// The exact #2131 bug state on the stale post: a higher score (5), a `hot_score`
+		// FROZEN at the young age≈0 value, and a `created_at` aged 17 DAYS into the past —
+		// far OUTSIDE the 72h window (`decayWindowMs`). `created_at` is
+		// `integer(mode:"timestamp")`, stored as whole epoch SECONDS.
+		const nowMs = Date.now();
+		const staleCreatedSec = Math.floor((nowMs - 17 * 24 * HOUR_MS) / 1000);
+		const staleFrozenHot = computeHotScore(5, nowMs, nowMs); // young-high, frozen at age≈0
+		const changed = await h.execD1(
+			"UPDATE post_record SET score = ?, hot_score = ?, created_at = ? WHERE id = ?",
+			[5, staleFrozenHot, staleCreatedSec, staleId],
+		);
+		expect(changed).toBe(1);
+
+		// Pre-fix: the frozen-while-young stale score keeps the OLD post ranked #1.
+		const before = await hotFeedIds();
+		expect(before.indexOf(staleId)).toBeLessThan(before.indexOf(fresherId));
+
+		// Grounding (the same formula the backfill applies): re-decayed at 17 days the stale
+		// score collapses far below the fresher post's young score, so a windowless recompute
+		// MUST flip the order.
+		const staleDecayed = computeHotScore(5, staleCreatedSec * 1000, nowMs);
+		const fresherYoung = computeHotScore(1, nowMs, nowMs);
+		expect(staleDecayed).toBeLessThan(fresherYoung);
+
+		const {refreshHotScores, backfillHotScores} = await realOps();
+
+		// The WINDOWED refresh does NOT reach the 17-day post — it is outside the 72h window,
+		// so `refreshHotScores` never selects it and the bug persists (this is why a backfill
+		// is needed). The stale post is still pinned above the fresher one.
+		await Effect.runPromise(refreshHotScores(new Date(nowMs)));
+		const afterRefresh = await hotFeedIds();
+		expect(afterRefresh.indexOf(staleId)).toBeLessThan(afterRefresh.indexOf(fresherId));
+
+		// The ONE-TIME windowless backfill DOES reach it: it recomputes every row regardless
+		// of age and rewrites the stale post's collapsed stored score.
+		const result = await Effect.runPromise(backfillHotScores(new Date(nowMs)));
+		expect(result.ran).toBe(true);
+		expect(result.scanned).toBeGreaterThanOrEqual(2);
+		expect(result.updated).toBeGreaterThanOrEqual(1);
+
+		// Post-backfill: the aged stale post's re-decayed stored score has collapsed, so the
+		// fresher post now outranks it in the SAME keyset feed.
+		const after = await hotFeedIds();
+		expect(after.indexOf(fresherId)).toBeLessThan(after.indexOf(staleId));
+
+		// Run-once: a second backfill is a no-op guarded by the `hot_score_backfill` marker.
+		const second = await Effect.runPromise(backfillHotScores(new Date(nowMs)));
+		expect(second.ran).toBe(false);
+		expect(second.updated).toBe(0);
+
+		// No activity write was needed: decay rewrote `hot_score` alone. The stale post's
+		// activity-bearing scalars are untouched.
+		const stalePost = await readPost(staleId);
+		expect(stalePost.score).toBe(5);
+		expect(stalePost.commentCount).toBe(0);
+	});
+});

--- a/apps/web/worker/db/drizzle/migrations/0021_hot_score_backfill.sql
+++ b/apps/web/worker/db/drizzle/migrations/0021_hot_score_backfill.sql
@@ -1,0 +1,14 @@
+-- #2131 — run-once completion marker for the one-time full `hot_score` backfill.
+-- #2033's decay cron is window-scoped to 72h, so a post that froze high before that
+-- fix and now sits outside the window never re-decays — it stays pinned #1 on the
+-- sıcak feed. The one-time fix is a WINDOWLESS recompute over all rows. The formula
+-- uses `POW` (`^1.8`, `db/hotScore.ts`), which SQLite/D1 lacks, so the backfill can't
+-- be pure SQL here — it reuses the worker-side pure core (`decayHotScores`). This table
+-- is the persisted "already ran" signal: the guarded run-once path inserts the `id = 1`
+-- row on completion and no-ops thereafter (idempotent). Singleton, `pano_stats` idiom.
+CREATE TABLE `hot_score_backfill` (
+	`id` integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	`completed_at` integer NOT NULL,
+	`scanned` integer DEFAULT 0 NOT NULL,
+	`updated` integer DEFAULT 0 NOT NULL
+);

--- a/apps/web/worker/db/drizzle/migrations/meta/0021_hot_score_backfill_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0021_hot_score_backfill_snapshot.json
@@ -1,0 +1,2019 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f0296e79-f5e5-4777-9e9a-444dba08e85d",
+  "prevId": "23976255-60d4-4079-a953-53959d8022fd",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        },
+        "post_record_sandboxed": {
+          "name": "post_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\u00e7aylak'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wave_id": {
+          "name": "wave_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "content_report_wave": {
+          "name": "content_report_wave",
+          "columns": [
+            "wave_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        },
+        "definition_record_sandboxed": {
+          "name": "definition_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_sandboxed": {
+          "name": "comment_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authorship_vouch": {
+      "name": "authorship_vouch",
+      "columns": {
+        "voucher_id": {
+          "name": "voucher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authorship_vouch_candidate": {
+          "name": "authorship_vouch_candidate",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "authorship_vouch_voucher_id_candidate_id_pk": {
+          "name": "authorship_vouch_voucher_id_candidate_id_pk",
+          "columns": [
+            "voucher_id",
+            "candidate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_recipient_read": {
+          "name": "notification_recipient_read",
+          "columns": [
+            "recipient_id",
+            "read_at"
+          ],
+          "isUnique": false
+        },
+        "notification_recipient_created": {
+          "name": "notification_recipient_created",
+          "columns": [
+            "recipient_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_reaction": {
+      "name": "user_reaction",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_reaction_target": {
+          "name": "user_reaction_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_reaction_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_reaction_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hot_score_backfill": {
+      "name": "hot_score_backfill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated": {
+          "name": "updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1792000000000,
       "tag": "0020_drop_imge_object",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1792500000000,
+      "tag": "0021_hot_score_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -235,6 +235,24 @@ export const panoStats = sqliteTable("pano_stats", {
 });
 
 /**
+ * Run-once completion marker for the one-time full `hot_score` backfill (#2131).
+ * The go-forward decay cron (#2033) is window-scoped to 72h, so a post that froze high
+ * BEFORE that fix and now sits outside the window never re-decays — a stale post stays
+ * pinned to the sıcak feed. The fix is a single windowless recompute over ALL rows, and
+ * the `hot_score` formula uses `POW` (`^1.8`, `db/hotScore.ts`) which SQLite lacks, so it
+ * can't be a pure-SQL data migration — it must reuse the worker-side pure core. This
+ * table IS the persisted "already ran" signal: presence of the `id = 1` row means the
+ * backfill completed, so the guarded run-once path (`backfillHotScores`) no-ops
+ * thereafter. Singleton row (`id` default 1), matching the `pano_stats` idiom.
+ */
+export const hotScoreBackfill = sqliteTable("hot_score_backfill", {
+	id: integer("id").primaryKey().default(1),
+	completedAt: timestamp("completed_at").notNull(),
+	scanned: integer("scanned").notNull().default(0),
+	updated: integer("updated").notNull().default(0),
+});
+
+/**
  * Per-user-per-target vote presence table powering the `myVote` view field.
  * Up-only in the MVP — presence of a row means voted, absence means not; there
  * is no `value` column. Maintained inline by `Vote.cast`'s atomic batch (insert

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -326,6 +326,20 @@ export class Pano extends Context.Service<
 		readonly refreshHotScores: (
 			now: Date,
 		) => Effect.Effect<{readonly scanned: number; readonly updated: number}>;
+
+		/**
+		 * One-time FULL `hot_score` backfill (#2131): a single windowless recompute over
+		 * ALL live, non-draft posts, reusing the same pure decay core as
+		 * `refreshHotScores` but MINUS the 72h window clause — so it re-decays the pre-fix
+		 * frozen rows outside the window that the cron can never reach. Run-once +
+		 * idempotent via the `hot_score_backfill` marker row: `ran: false` once it has
+		 * completed. Driven by a guarded run-once cron subscriber (`index.ts`).
+		 */
+		readonly backfillHotScores: (now: Date) => Effect.Effect<{
+			readonly ran: boolean;
+			readonly scanned: number;
+			readonly updated: number;
+		}>;
 	}
 >()("@kampus/pano/Pano") {}
 

--- a/apps/web/worker/features/pano/hot-score-backfill.unit.test.ts
+++ b/apps/web/worker/features/pano/hot-score-backfill.unit.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Off-DB coverage for `makeBackfillHotScores` (#2131) — the one-time full `hot_score`
+ * backfill: a windowless recompute + a run-once marker guard.
+ *
+ * The pure decay decision (`decayHotScores`) is proven in `db/hotScoreDecay.unit.test.ts`;
+ * the stored-column → feed re-ordering over real remote D1 is the integration tier
+ * (`tests/integration/pano-hot-score-backfill.test.ts`). What THIS file proves, off-DB
+ * with a scripted `run`, is the two things the backfill adds over `refreshHotScores`:
+ *
+ *   1. WINDOWLESS — it recomputes an ANCIENT row (created 17 days ago, far outside the
+ *      72h decay window `refreshHotScores` scopes to). A windowed query would never hand
+ *      that row to the backfill, so it would produce no update; here it DOES, proving the
+ *      selection reaches rows outside the window. The `run` replays the ancient row, and
+ *      the assertion is that the backfill emits the collapsed `hot_score` UPDATE for it.
+ *   2. RUN-ONCE — the marker read (`hot_score_backfill.findFirst`) short-circuits a second
+ *      pass to a `ran: false` no-op with no select and no writes.
+ *
+ * No engine, no `node:sqlite` (ADR 0082/0104/0105): `run` is scripted by call order, and
+ * the per-row UPDATE + the marker INSERT are captured via a builder-shaped capturing
+ * `DrizzleDb`, never executed against a binding.
+ */
+import {describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {assert} from "vitest";
+import type {DrizzleAccessOrDie, DrizzleDb} from "../../db/Drizzle.ts";
+import {computeHotScore} from "../../db/hotScore.ts";
+import {makeBackfillHotScores} from "./post-operations.ts";
+
+interface Row {
+	id: string;
+	score: number;
+	hotScore: number;
+	createdAt: Date;
+}
+
+interface CapturedUpdate {
+	set: Record<string, unknown>;
+}
+
+// The two unavoidable stub casts, each isolated behind a single suppressed helper (the
+// persist-pano-stats.unit.test idiom): `asDb` shapes a partial capturing object as the
+// `DrizzleDb` the closure receives, and `asRun` types the scripted closure as the
+// `run` port. Nothing executes against a binding — no engine, ADR 0082/0104/0105.
+
+// biome-ignore lint/plugin: a capturing DrizzleDb stub — only the methods the backfill invokes are present; no query runs against a binding.
+const asDb = (o: object): DrizzleDb => o as unknown as DrizzleDb;
+
+const asRun = (fn: <A>(build: (db: DrizzleDb) => Promise<A>) => Effect.Effect<A>) =>
+	// biome-ignore lint/plugin: a scripted `run` port stub — replays canned reads / records write-builder calls; no binding is touched.
+	fn as unknown as DrizzleAccessOrDie["run"];
+
+/**
+ * Script `run` for a backfill that has NOT run yet: call 0 is the marker read (no row),
+ * call 1 is the row select (replays `rows`), the middle calls are the per-changed-row
+ * UPDATEs (captured via the builder chain), and the last call is the marker INSERT
+ * (captured). The capturing db mimics only the builder methods the backfill invokes —
+ * `.update().set().where()` and `.insert().values()` — as thenables the drizzle
+ * `await`/`yield*` resolves; nothing runs against a binding.
+ */
+function scriptedRun(rows: readonly Row[]): {
+	run: DrizzleAccessOrDie["run"];
+	updates: () => CapturedUpdate[];
+	markerInserted: () => boolean;
+} {
+	const state = {i: 0};
+	const updates: CapturedUpdate[] = [];
+	let markerInserted = false;
+	const resolved = () => Promise.resolve({results: []});
+	const run = asRun(<A>(build: (db: DrizzleDb) => Promise<A>) => {
+		const idx = state.i++;
+		if (idx === 0) {
+			const markerDb = asDb({
+				query: {hotScoreBackfill: {findFirst: () => Promise.resolve(undefined)}},
+			});
+			return Effect.promise(() => build(markerDb));
+		}
+		if (idx === 1) return Effect.succeed(rows) as Effect.Effect<A>;
+		const captureDb = asDb({
+			update: () => ({
+				set: (set: Record<string, unknown>) => ({
+					where: () => {
+						updates.push({set});
+						return resolved();
+					},
+				}),
+			}),
+			insert: () => ({
+				values: () => {
+					markerInserted = true;
+					return resolved();
+				},
+			}),
+		});
+		return Effect.promise(() => build(captureDb));
+	});
+	return {run, updates: () => updates, markerInserted: () => markerInserted};
+}
+
+describe("makeBackfillHotScores (#2131) — the windowless run-once hot_score backfill", () => {
+	it.effect("recomputes a row 17 days OLD (outside the 72h window the cron scans)", () =>
+		Effect.gen(function* () {
+			const now = new Date("2026-07-05T12:00:00.000Z");
+			const nowMs = now.getTime();
+			// The exact pre-fix-frozen case: created 17 days ago, `hot_score` FROZEN at the
+			// young age≈0 value — the row the windowed `refreshHotScores` never selects.
+			const createdAt = new Date(nowMs - 17 * 24 * 3_600_000);
+			const frozenYoung = computeHotScore(5, nowMs, nowMs);
+			const scripted = scriptedRun([{id: "post_old", score: 5, hotScore: frozenYoung, createdAt}]);
+
+			const result = yield* makeBackfillHotScores(scripted.run)(now);
+
+			assert.strictEqual(result.ran, true, "the first pass runs");
+			assert.strictEqual(result.scanned, 1, "the ancient row was scanned (not window-filtered)");
+			assert.strictEqual(result.updated, 1, "its frozen score was re-decayed");
+
+			// The emitted UPDATE carries the row's collapsed 17-day score — far below the
+			// frozen young value, so the feed re-orders it down.
+			const decayed = computeHotScore(5, createdAt.getTime(), nowMs);
+			assert.isBelow(decayed, frozenYoung, "17-day decay collapses the frozen young score");
+			const [update] = scripted.updates();
+			assert.isDefined(update, "a hot_score UPDATE was issued for the ancient row");
+			assert.strictEqual(
+				update.set.hotScore,
+				decayed,
+				"the UPDATE writes the re-decayed hot_score",
+			);
+
+			// The run-once marker is stamped after the write-back.
+			assert.isTrue(
+				scripted.markerInserted(),
+				"the hot_score_backfill marker row is inserted on completion",
+			);
+		}),
+	);
+
+	it.effect("is a run-once no-op once the marker row exists", () =>
+		Effect.gen(function* () {
+			const now = new Date("2026-07-05T12:00:00.000Z");
+			let calls = 0;
+			const run = asRun(<A>(build: (db: DrizzleDb) => Promise<A>) => {
+				const idx = calls++;
+				// The marker read returns a row ⇒ the backfill must short-circuit before any
+				// select or write. A call past the marker read means the guard failed.
+				if (idx === 0) {
+					const markerDb = asDb({
+						query: {hotScoreBackfill: {findFirst: () => Promise.resolve({id: 1})}},
+					});
+					return Effect.promise(() => build(markerDb));
+				}
+				return Effect.succeed([]) as Effect.Effect<A>;
+			});
+
+			const result = yield* makeBackfillHotScores(run)(now);
+
+			assert.strictEqual(result.ran, false, "the marker present ⇒ no re-run");
+			assert.strictEqual(result.scanned, 0, "no rows scanned on the no-op path");
+			assert.strictEqual(result.updated, 0, "no writes on the no-op path");
+			assert.strictEqual(
+				calls,
+				1,
+				"only the marker read ran — no select/write after the short-circuit",
+			);
+		}),
+	);
+});

--- a/apps/web/worker/features/pano/hot-score-decay-cron.ts
+++ b/apps/web/worker/features/pano/hot-score-decay-cron.ts
@@ -40,3 +40,23 @@ export const subscribeHotScoreDecay = (fateLayer: Layer.Layer<Pano>) =>
 			yield* pano.refreshHotScores(new Date(controller.scheduledTime));
 		}).pipe(Effect.provide(fateLayer)),
 	);
+
+/**
+ * The one-time full `hot_score` backfill trigger (#2131). The go-forward cron above is
+ * window-scoped to 72h, so a post that froze high before #2033 shipped and now sits
+ * outside the window never re-decays — it stays pinned to the sıcak feed. This subscriber
+ * drives `Pano.backfillHotScores`, a single windowless recompute over ALL rows, guarded
+ * run-once by the `hot_score_backfill` marker: the first scheduled pass after deploy does
+ * the recompute and stamps the marker; every later pass reads the marker and no-ops
+ * cheaply. It rides the SAME 15-minute cron trigger — no new schedule, no route, no creds
+ * — so the backfill fires purely on the normal deploy + scheduled-worker path. This is the
+ * route-free one-shot the security guard requires: NOT a public or `ENVIRONMENT`-gated
+ * admin/seeder endpoint (the deleted fail-open hole), just a marker-guarded scheduled pass.
+ */
+export const subscribeHotScoreBackfill = (fateLayer: Layer.Layer<Pano>) =>
+	Cloudflare.cron(HOT_SCORE_DECAY_CRON, (controller) =>
+		Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.backfillHotScores(new Date(controller.scheduledTime));
+		}).pipe(Effect.provide(fateLayer)),
+	);

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -407,6 +407,78 @@ export const makeRefreshHotScores = (run: DrizzleAccessOrDie["run"]) =>
 		return {scanned: rows.length, updated: updates.length};
 	});
 
+/**
+ * The one-time FULL `hot_score` backfill (#2131). {@link makeRefreshHotScores} decays
+ * only the 72h recency window (`decayWindowMs`), so a post that froze high BEFORE the
+ * #2033 cron shipped and now sits OUTSIDE that window is never re-selected and stays
+ * pinned to the sıcak feed. This drops the window clause and recomputes EVERY live,
+ * non-draft row once, reusing the SAME pure core (`decayHotScores`) and the same
+ * changed-only write-back — the go-forward cron is left untouched.
+ *
+ * Run-once + idempotent by construction: the `hot_score_backfill` singleton row is the
+ * persisted marker. If it already exists the pass no-ops (`ran: false`); otherwise it
+ * recomputes, then inserts the marker so it never runs again. A recompute is naturally
+ * idempotent anyway (same rows + same clock ⇒ same result), so the marker only avoids a
+ * redundant table-wide scan on later invocations — a re-run before the marker lands is
+ * harmless. Factored to the one dep it reads (`run`) so it builds standalone, exactly
+ * like {@link makeRefreshHotScores}, and can be driven by an integration test.
+ */
+export const makeBackfillHotScores = (run: DrizzleAccessOrDie["run"]) =>
+	Effect.fn("Pano.backfillHotScores")(function* (now: Date) {
+		const alreadyRan = yield* run((db) =>
+			db.query.hotScoreBackfill.findFirst({columns: {id: true}}),
+		);
+		if (alreadyRan) {
+			return {ran: false as const, scanned: 0, updated: 0};
+		}
+
+		const nowMs = now.getTime();
+		// The windowless twin of refreshHotScores' query: SAME live/non-draft predicate,
+		// MINUS the `gte(createdAt, cutoff)` recency clause — so it reaches the pre-fix
+		// frozen rows outside the 72h window that the cron can never select.
+		const rows = yield* run((db) =>
+			db
+				.select({
+					id: schema.postRecord.id,
+					score: schema.postRecord.score,
+					hotScore: schema.postRecord.hotScore,
+					createdAt: schema.postRecord.createdAt,
+				})
+				.from(schema.postRecord)
+				.where(
+					and(isNull(schema.postRecord.removedAt), sql`${schema.postRecord.isDraft} is not 1`),
+				),
+		);
+		const updates = decayHotScores(
+			rows.map((r) => ({
+				id: r.id,
+				score: r.score,
+				hotScore: r.hotScore,
+				createdAtMs: (r.createdAt ?? now).getTime(),
+			})),
+			nowMs,
+		);
+		yield* Effect.forEach(
+			updates,
+			(u) =>
+				run((db) =>
+					db
+						.update(schema.postRecord)
+						.set({hotScore: u.hotScore})
+						.where(eq(schema.postRecord.id, u.id)),
+				),
+			{discard: true},
+		);
+		// Stamp the run-once marker LAST so a mid-pass failure leaves it unset and a later
+		// invocation retries the (idempotent) recompute rather than skipping a partial run.
+		yield* run((db) =>
+			db
+				.insert(schema.hotScoreBackfill)
+				.values({id: 1, completedAt: now, scanned: rows.length, updated: updates.length}),
+		);
+		return {ran: true as const, scanned: rows.length, updated: updates.length};
+	});
+
 export const makePostOperations = (deps: PostOperationsDeps) => {
 	const {run, batch, voteSvc, bookmarkSvc, reactionSvc, removalSeq, persistPanoStats} = deps;
 
@@ -1104,6 +1176,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 	});
 
 	const refreshHotScores = makeRefreshHotScores(run);
+	const backfillHotScores = makeBackfillHotScores(run);
 
 	return {
 		getPost,
@@ -1122,5 +1195,6 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		retractPostVote,
 		reactToPost,
 		refreshHotScores,
+		backfillHotScores,
 	};
 };

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -32,7 +32,10 @@ import type {DeliverFrame, PublishMessage} from "./features/fate-live/protocol.t
 import {LiveConnections, LiveTopics} from "./features/fate-live/topics.ts";
 import {Flagship, FlagshipLive} from "./features/flagship/Flagship.ts";
 import {Flagship as FlagshipResource} from "./features/flagship/resources.ts";
-import {subscribeHotScoreDecay} from "./features/pano/hot-score-decay-cron.ts";
+import {
+	subscribeHotScoreBackfill,
+	subscribeHotScoreDecay,
+} from "./features/pano/hot-score-decay-cron.ts";
 import {BetterAuthLive} from "./features/pasaport/better-auth-live.ts";
 import {EmailSenderLive} from "./features/pasaport/email-sender.ts";
 import {Events as TelemetryEvents} from "./features/telemetry/resources.ts";
@@ -260,6 +263,14 @@ export default Phoenix.make(
 		// built `fateLayer` so it resolves `Pano` at dispatch. `subscribe` only
 		// registers a listener (no async/timer work), so it is init-safe.
 		yield* subscribeHotScoreDecay(fateLayer);
+
+		// The one-time full `hot_score` backfill (#2131): a marker-guarded run-once
+		// windowless recompute that un-freezes pre-#2033 posts stranded outside the 72h
+		// decay window. Rides the same 15-min cron trigger; the first scheduled pass after
+		// deploy runs it and stamps the `hot_score_backfill` marker, later passes no-op.
+		// Route-free by design (NOT a public/ENVIRONMENT-gated seeder route — the deleted
+		// fail-open hole). `subscribe` only registers a listener, so it stays init-safe.
+		yield* subscribeHotScoreBackfill(fateLayer);
 
 		// The live path (ADR 0028/0029): the unified `LiveDO` namespace resolved
 		// once above, wrapped as worker-level services. One namespace plays both


### PR DESCRIPTION
## What & why

`#2033`'s decay cron (`Pano.refreshHotScores`) re-decays `post_record.hot_score` only over a **72h recency window** (`decayWindowMs`, `db/hotScoreDecay.ts` — its query filters `gte(created_at, now - decayWindowMs)`). So a post that froze high **before** that fix shipped and now sits **outside** the window is never re-selected — it keeps its stale young-high stored score forever and stays pinned #1 on the sıcak feed (the live 17-day-old squatter the founder observed). There was no backfill path.

This adds **`Pano.backfillHotScores`**: a **one-time windowless recompute** over ALL live, non-draft rows, reusing the **same pure core** (`decayHotScores`) **minus** the window clause. The go-forward windowed cron (the 15-min sweep) is left untouched — this is additive.

## Delivery mechanism — route-free one-shot (security guard honored)

Per the CLAUDE.md load-bearing guard, this is **NOT** a public or `ENVIRONMENT`-gated admin/seeder route (the deleted fail-open hole). The `hot_score` formula uses `POW` (`^1.8`, `db/hotScore.ts`), which SQLite/D1 **lacks**, so it is **not SQL-expressible** — a pure-SQL data-migration backfill is impossible, and the recompute **must** reuse the worker-side core.

It is delivered as a **marker-guarded run-once pass on the existing 15-min cron seam** (`subscribeHotScoreBackfill`, `index.ts`):
- The first scheduled pass after deploy runs the recompute and stamps the `hot_score_backfill` **singleton marker row** (added by migration `0021`).
- Every later pass reads the marker and no-ops cheaply.
- **Idempotent by construction** (a recompute is naturally idempotent; the marker only avoids a redundant table-wide scan).

No new schedule, no route, no creds — it fires purely on the normal deploy + scheduled-worker path.

## Founder-side invocation (#2061)

The backfill fires automatically on the **next scheduled cron pass after deploy** — no manual invocation needed. The only founder-side action is the normal **deploy** (which applies migration `0021` and ships the new subscriber); the sandbox has no deploy creds (#2061), so the deploy itself is the trigger. This PR delivers the code + the route-free one-shot mechanism.

## Scope discipline

Unit 1 only. **Not** touched: Unit 2 (verify the cron fires in prod — #2061, founder-side ops) or Unit 3 (widen the 72h window — separate p2). The windowed `refreshHotScores` (the ongoing sweep) is unchanged.

## Tests

- **Integration** (`tests/integration/pano-hot-score-backfill.test.ts`): seeds a post aged **17 days** (outside the 72h window), proves the windowed `refreshHotScores` does **not** re-decay it (the bug persists), then proves `backfillHotScores` **does** re-decay it and flips the `/fate` hot feed order — plus the run-once no-op and no activity write. Real remote D1 over `@kampus/d1-rest` (the fts-backfill precedent), the shipped code path.
- **Unit** (`worker/features/pano/hot-score-backfill.unit.test.ts`): off-DB, proves the windowless selection reaches an ancient row (emits the collapsed `hot_score` UPDATE) and the marker short-circuit.

`pnpm typecheck` + `lint` clean; 180 pano/hotScore unit tests pass.

§CP self-assessment: **non-§CP** (worker + migration only; no control-plane/pipeline/infra surface).

Fixes #2131