### PR TITLE
docs(pipeline): footer is the never-auto-close signal, not GitHub authorship — ADR 0159 (Fixes #2135)

### DIFF
--- a/.decisions/0159-never-auto-close-signal-is-the-report-footer.md
+++ b/.decisions/0159-never-auto-close-signal-is-the-report-footer.md
@@ -1,0 +1,99 @@
+---
+id: 0159
+title: The never-auto-close signal is the report footer, not GitHub authorship
+status: accepted
+date: 2026-07-05
+tags: [pipeline, triage, control-plane]
+---
+
+# 0159 — The never-auto-close signal is the report footer, not GitHub authorship
+
+## Context
+
+Triage's Step 5 protects human-filed issues from being auto-closed: an autonomous
+agent (an audit or kill-sweep) must never silently close an issue a human owns. That
+protection needs a reliable **human-vs-agent-filed** signal — and GitHub issue
+authorship is **not** one.
+
+Every issue filed through the `report` → `triage` skills goes through the shared
+`usirin` gh token, so **all agent-filed issues show `author: usirin` — identical to a
+genuinely hand-typed issue** (the same shared-login degeneracy ADR
+[0115](0115-agent-distinguishable-claim-marker.md) removes for the claim marker). Any
+protection that keys off `author == usirin` classifies *everything* as human-filed and
+over-protects the whole board into un-closeable, defeating the sweep; keying off
+`author != usirin` silently bypasses the protection. Authorship is unusable either way.
+
+The reliable signal already exists: the `report` skill emits a
+`<sub>Filed by an agent · …</sub>` footer
+(`claude-plugins/kampus-pipeline/skills/report/footer.sh`). Its **presence** means the
+issue was filed via the report skill; its **absence** means it was hand-typed in the
+GitHub UI. This footer rule already held operationally as an interim convention — we're
+codifying it, not inventing new behavior.
+
+There is one load-bearing residual: a **human-invoked `/report` also emits the footer**.
+So the footer signals "filed via the report skill," *not* "agent intent." That leaves a
+fork the decision must settle — how to distinguish "a human wants this protected" from
+"an agent filed this" on the footer-present path:
+
+1. **Option 1 — a distinct human-invoked marker** (a separate footer token / env flag
+   set when a human runs `/report`), so the report-skill path carries the human-vs-agent
+   bit explicitly.
+2. **Option 2 — accept "footer present ⇒ auto-close-eligible after confirmation,"** and
+   rely on the confirmation step for the human-owned report case.
+
+## Decision
+
+**The never-auto-close signal is the report footer, with this semantic:**
+
+- **Footer ABSENT** (the issue was hand-typed in the GitHub UI) ⇒ **human-owned ⇒
+  PROTECTED**: never auto-close.
+- **Footer PRESENT** (filed via the report skill, *including* a human-invoked `/report`)
+  ⇒ **raw INTAKE ⇒ auto-close-ELIGIBLE after confirmation.**
+- **The confirmation step IS the guard** on the footer-present path.
+
+The literal **`Filed by an agent`** marker is the invariant tell; the footer's
+session/model/branch fields are best-effort and often absent, so a sparse footer is
+still a present footer.
+
+**We take Option 2 and reject Option 1.** A `/report` issue is intake *by nature* —
+meant to be triaged and, once handled, closed; a human tracking their own thing types it
+directly in the UI (where it has no footer and is therefore protected). Distinguishing
+human- from agent-invoked `/report` adds ceremony to separate two things that should be
+treated identically: both are raw intake, and the confirmation step already stands
+between "eligible" and "closed." Building a human-invoked marker would carry a
+human-vs-agent bit that no downstream consumer needs, because the confirmation guard
+already covers the human-owned-report case.
+
+This convention is encoded in two surfaces:
+
+- **The canonical convention** — footer present/absent semantic — lands in the shared
+  intake contract `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`.
+  That file is control-plane per §CP / ADR
+  [0053](0053-control-plane-boundary.md) / ADR
+  [0065](0065-gate-critical-skills-are-blocking.md), so the coordinated PR is §CP →
+  human-merge (ADR
+  [0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)).
+- **The behavior** — the close-eligibility path that keys on footer presence — lands in
+  `claude-plugins/kampus-pipeline/skills/triage/SKILL.md` Step 5 (non-§CP).
+
+## Consequences
+
+- **The protection has a reliable input.** An autonomous close/kill-sweep can safely key
+  off footer presence: footer-absent issues are structurally excluded from
+  auto-close-eligibility, so a human's hand-typed capture is never silently closed even
+  when an autonomous sweep runs. Authorship is never consulted for this judgment again.
+- **The confirmation step becomes load-bearing on the footer-present path.** "Eligible"
+  is not "closed" — a footer-present issue a human owns (their own `/report`) is still
+  caught at confirmation. This is a deliberate choice to keep the guard where it already
+  is rather than push it upstream into a new marker. A future move to a fully-autonomous,
+  confirmation-free close-sweep would re-open the residual this ADR left to confirmation,
+  and would need to revisit Option 1 — but that is out of scope here (the interim rule
+  holds operationally; no live incident is burning).
+- **No new marker, no new env flag, no `footer.sh` change.** Option 1's ceremony is not
+  built. The signal is the marker `footer.sh` already emits.
+- **Follow-on decisions cite this ADR** as the single source of the human-vs-agent-filed
+  signal (footer, not authorship); the interim operational rule is now recorded.
+
+*No vocabulary impact* — this ADR re-decides the mechanics of an existing protection
+(the never-auto-close rule) over already-named concepts (the report footer / the
+`Filed by an agent` marker); it coins no new term and redefines none.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -864,6 +864,53 @@ assumption invalidated, a partial state left behind>
 
 ---
 
+## 4.5. The filing-provenance signal — the report footer, not GitHub authorship (ADR 0159)
+
+This is the **single source** of the human-vs-agent-filed signal that triage's
+never-auto-close protection consumes (`triage/SKILL.md` Step 5). The protection exists so
+an autonomous agent — an audit or kill-sweep — never silently closes an issue a human
+owns; that judgment needs a reliable filing-provenance signal, and this section defines it
+(ADR [0159](https://github.com/kamp-us/phoenix/blob/main/.decisions/0159-never-auto-close-signal-is-the-report-footer.md)).
+
+**GitHub issue authorship is NOT the signal.** Every issue filed through the `report` →
+`triage` skills goes through the shared `usirin` gh token, so **an agent-filed issue and a
+hand-typed one both show `author: usirin`** — the same shared-login degeneracy §7 / ADR
+0115 removes for the claim marker. Keying off authorship over-protects the whole board
+(everything reads as `usirin`) or silently bypasses the protection; it is unusable either
+way. **Never consult authorship for this judgment.**
+
+**The signal is the report footer.** The `report` skill emits a
+`<sub>Filed by an agent · …</sub>` footer (`report/footer.sh`). The literal
+**`Filed by an agent`** marker is the invariant tell — the footer's session/model/branch
+fields are best-effort and often absent, so a **sparse footer is still a present footer**
+(do not read a missing session/branch as "no footer").
+
+**The canonical semantic:**
+
+- **Footer ABSENT** — the issue was **hand-typed in the GitHub UI** ⇒ **human-owned ⇒
+  PROTECTED**: never auto-close.
+- **Footer PRESENT** — filed via the report skill, **including a human-invoked `/report`**
+  ⇒ **raw INTAKE ⇒ auto-close-ELIGIBLE after confirmation.**
+- **The confirmation step IS the guard** on the footer-present path — "eligible" is not
+  "closed."
+
+The footer means "**filed via the report skill**," **not** "agent intent": a
+human-invoked `/report` also emits it. ADR 0159 settles the resulting fork by **taking
+the confirmation step as the guard** and **rejecting a distinct human-invoked marker** — a
+`/report` issue is intake by nature (meant to be triaged and closed), so human- and
+agent-invoked `/report` are treated identically, and a human tracking their own thing
+types it directly in the UI (no footer ⇒ protected). There is **no** separate
+human-invoked footer token or env flag, and `footer.sh` is unchanged.
+
+> **Provenance beyond the footer (unchanged).** A pipeline-made issue can carry the five
+> report sections but **no** footer — e.g. a triage split child (look for `split from #N`).
+> Such an issue is agent-made by provenance, not by footer; triage judges those by
+> provenance the same as before (`triage/SKILL.md` Step 5). This section governs the
+> footer signal itself; it does not narrow the "when in doubt, treat it as human" default
+> the never-auto-close protection keeps.
+
+---
+
 ## CP. The control-plane / blocking set — one canonical definition
 
 Three gates and the merge actor all need to answer the *same* question — **does this PR

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -338,6 +338,18 @@ you don't parse a flag.
 agents running under their own account. So never treat "who filed it" as settling
 the question; read the body.
 
+**The filing-provenance signal is the report footer, not authorship (ADR 0159).** The
+reliable input is defined once in
+[`gh-issue-intake-formats.md` §4.5](../gh-issue-intake-formats.md) — cite it, don't
+re-derive it. In short: authorship is unusable (every report-filed issue shows
+`author: usirin` via the shared token), so the signal is the `Filed by an agent` footer.
+**Footer ABSENT ⇒ hand-typed in the GitHub UI ⇒ human-owned ⇒ PROTECTED (never
+auto-close); footer PRESENT ⇒ filed via the report skill (including a human-invoked
+`/report`) ⇒ raw INTAKE ⇒ auto-close-ELIGIBLE after confirmation — the confirmation step
+IS the guard.** So an autonomous close/kill-sweep keys eligibility on footer presence: a
+footer-absent issue is structurally excluded from auto-close, and a footer-present issue
+is only closed once its confirmation step passes — never on footer presence alone.
+
 Tells that an issue is **agent-filed** (the only kind you may close):
 
 - **It carries the agent-report fingerprint.** The `report` skill files a


### PR DESCRIPTION
Fixes #2135

## What this does

Hardens triage's **never-auto-close** protection to key on the **report footer**, not GitHub authorship. Authorship is unusable: every issue filed via `report` → `triage` goes through the shared `usirin` gh token, so an agent-filed issue shows `author: usirin`, identical to a hand-typed one (the same shared-login degeneracy ADR 0115 removed for the claim marker).

This is a **decided decision** (EA ruled Option 2, engineering-led per ADR 0078). It **records + implements** the settled semantic — it does not re-decide.

## The settled semantic (ADR 0159)

The signal is the `Filed by an agent` footer (`report/footer.sh`):

- **Footer ABSENT** (hand-typed in the GitHub UI) ⇒ human-owned ⇒ **PROTECTED** (never auto-close).
- **Footer PRESENT** (filed via the report skill, *including* a human-invoked `/report`) ⇒ raw **INTAKE** ⇒ auto-close-**ELIGIBLE after confirmation**. **The confirmation step IS the guard.**

**Option 2 over the rejected Option 1** (a distinct human-invoked marker): a `/report` issue is intake by nature — meant to be triaged and closed; a human tracking their own thing types it directly in the UI (no footer ⇒ protected). No new footer token, no env flag, `footer.sh` unchanged.

## Deliverables (one coordinated PR)

1. **`.decisions/0159-never-auto-close-signal-is-the-report-footer.md`** — records the footer-as-signal semantic, why Option 2 over Option 1, and that the confirmation step is the guard.
2. **`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §4.5** (§CP) — the canonical footer present/absent convention, single-sourced.
3. **`claude-plugins/kampus-pipeline/skills/triage/SKILL.md` Step 5** (non-§CP) — footer-keyed close-eligibility behavior; cites §4.5, does not re-derive it.

## §CP — human-merge-only

This PR touches `gh-issue-intake-formats.md`, matched exactly by `CONTROL_PLANE_RE` in that file. Per §CP / ADR 0053 / 0065 / 0135, the **whole PR is control-plane → human-merge-only**. It **stops at reviewed-ready for cansirin**; it does **not** auto-ship.

## Validation

- `decisions-index validate` — clean (no duplicate/mismatched id).
- `doc-links check` — no dead internal doc links.
- `leak-guard scan` — no user-local paths.
- `lint:worktree` — clean skip (markdown-only changes).

The interim footer rule already held operationally — this codifies it, it does not invent new behavior.