### PR TITLE
feat(cf-utils): scrub-author-email verb — remove email-at-rest from author_name (#2137)

### DIFF
--- a/packages/cf-utils/README.md
+++ b/packages/cf-utils/README.md
@@ -1,8 +1,12 @@
 # @kampus/cf-utils
 
-A human-operated CLI for reading (and, in later slices, flipping) Cloudflare **Flagship**
-feature flags — one traceable command surface over the flags that gate phoenix, instead of
-an untraceable click in the Cloudflare dashboard.
+A human-operated CLI over Cloudflare + phoenix's D1: reading (and, in later slices, flipping)
+**Flagship** feature flags — one traceable command surface over the flags that gate phoenix,
+instead of an untraceable click in the Cloudflare dashboard — plus founder-side, direct-D1
+**data-scrub** verbs run with prod oversight (never a runtime worker route).
+
+> Naming: the cf-utils → anka-ops rename is tracked separately (#2089). Functionality grows
+> here now; the rename lands later.
 
 ## Why it exists
 
@@ -39,6 +43,44 @@ satisfies the guard by construction — a human runs the lever in a terminal and
 It is a **standalone ops tool**, not a worker route — the flag IaC itself (create/delete)
 stays in `apps/web/worker/features/flagship/resources.ts`; `cf-utils` only reads and
 releases a flag's serving state (targeting-rule and create/delete edits are out of scope).
+
+## `scrub-author-email` — remove email-at-rest from `author_name` (#2137)
+
+`scrub-author-email` is a founder-side, one-off data-scrub verb that removes leaked emails
+from the denormalized `author_name` column on the three record tables (`definition_record` /
+`post_record` / `comment_record`). It is the data-backfill remediation of the #2130 PII-at-rest
+leak: the old `authorName: user.name ?? user.email` write-fallback persisted a null-name
+account's **email** into a publicly-rendered column; #2136 stopped new email-bearing writes,
+and this verb scrubs the rows persisted *before* that fix. It is delivered as a **CLI verb over
+the D1 REST transport** (`@kampus/d1-rest`, credentialed by the same keychain seam) — **never** a
+runtime worker route: a public/`ENVIRONMENT`-gated admin/seeder endpoint is exactly the deleted
+fail-open hole (the removed `/api/admin/*` seeder routes).
+
+Two invariants are load-bearing:
+
+- **Destructive ceremony — dry-run by default.** The verb **scans and prints per-table affected
+  counts only** — never the email values (leak-clean output: the count is the signal a founder
+  needs to size the blast radius, the PII is what the output must never re-print). A write happens
+  **only** under an explicit confirm-and-name gate: **`--execute` AND `--confirm
+  scrub-author-email`**. No `--execute`, or a missing/wrong `--confirm` name, stays a dry-run —
+  there is no write-by-default and no single-flag write. A zero-count scan is a first-class
+  "nothing to scrub" (the #2137 close-as-done path).
+- **SQL grounded vs real D1 (ADR 0082).** D1 is SQLite-over-REST, so every clause is core SQLite:
+  the email-shaped predicate is `author_name LIKE '%_@_%_._%'` (a full `local@domain.tld` shape,
+  so a display name that merely contains an `@` is not over-scrubbed), and the replacement label
+  is recomputed **in SQL** by mirroring `authorDisplayLabel`
+  (`apps/web/worker/features/pasaport/author-label.ts`) —
+  `COALESCE(NULLIF(TRIM(name),''), '@'||NULLIF(TRIM(username),''), 'kullanıcı')` joined on
+  `author_id = user.id`. The BetterAuth `user` table lives on the **same** shared `PhoenixDb` D1
+  as the record tables (ADR 0009), so the identity JOIN resolves in one query. `LIKE`, `COALESCE`,
+  `NULLIF`, `TRIM`, and `||` are all core SQLite (present in D1). Because `author_name` is
+  `.notNull()`, the scrub **rewrites** the value to the recomputed label — it never nulls the
+  column and never deletes a row; and since the recomputed label is never email-shaped, re-running
+  is idempotent.
+
+Building the verb needs **no credentials** and ships through the normal pipeline; **running** it
+needs a token carrying D1:edit on the cf-utils keychain (a founder-side act against prod, with
+oversight and post-run verification — the CLI's build must not, and does not, run against prod).
 
 ## How it works
 
@@ -100,6 +142,13 @@ node src/bin.ts flag set authorship-loop --percent 50 --env prod --execute
 
 # Kill switch — clear the split AND set the default off (actually stops a split release):
 node src/bin.ts flag set authorship-loop off --env prod --execute
+
+# Scrub email-at-rest from author_name — DRY-RUN by default: scan + print per-table counts,
+# write nothing (the counts are leak-clean; no email value is ever printed):
+node src/bin.ts scrub-author-email --database-id <the target stage's D1 uuid>
+
+# Apply it — requires BOTH --execute AND the op name; anything less stays a dry-run:
+node src/bin.ts scrub-author-email --database-id <uuid> --execute --confirm scrub-author-email
 ```
 
 ## Tests

--- a/packages/cf-utils/package.json
+++ b/packages/cf-utils/package.json
@@ -11,14 +11,19 @@
 		"typecheck": "tsgo -p tsconfig.json",
 		"test": "vitest run --project unit",
 		"test:unit": "vitest run --project unit",
-		"flag": "node src/bin.ts flag"
+		"flag": "node src/bin.ts flag",
+		"scrub-author-email": "node src/bin.ts scrub-author-email"
 	},
 	"dependencies": {
 		"@distilled.cloud/cloudflare": "catalog:",
 		"@effect/platform-node": "catalog:",
+		"@kampus/d1-rest": "workspace:*",
+		"@kampus/db-schema": "workspace:*",
+		"drizzle-orm": "catalog:",
 		"effect": "catalog:"
 	},
 	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
 		"@effect/tsgo": "catalog:",
 		"@effect/vitest": "catalog:",
 		"@types/node": "catalog:",

--- a/packages/cf-utils/src/bin.ts
+++ b/packages/cf-utils/src/bin.ts
@@ -12,6 +12,8 @@
  *   node src/bin.ts flag set <key> … --env <env> --execute   apply it
  *   node src/bin.ts auth login                              paste an API token → keychain (#1730)
  *   node src/bin.ts auth status|logout                      inspect / clear stored credentials
+ *   node src/bin.ts scrub-author-email --database-id <uuid>            dry-run the email-at-rest scan (#2137)
+ *   node src/bin.ts scrub-author-email --database-id <uuid> --execute --confirm scrub-author-email   apply it
  *
  * Credentials resolve keychain-first (`auth login`, #1730), falling back to
  * $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID — the env-var path CI keeps using.
@@ -57,6 +59,7 @@ import {
 } from "./flag.ts";
 import {FlagshipRead, FlagshipReadLive, FlagshipWrite, FlagshipWriteLive} from "./flagship.ts";
 import {KeychainLive} from "./keychain.ts";
+import {makeScrubCommand} from "./scrub-command.ts";
 
 const list = Command.make(
 	"list",
@@ -246,9 +249,18 @@ const flag = Command.make("flag").pipe(
 	Command.withDescription("Read and flip Flagship flags across every env"),
 );
 
+// The D1 REST transport layer the scrub verb runs `makeD1Rest` on: the SAME keychain-first
+// `Credentials` seam (#1730) the flag surfaces use, plus a Fetch HTTP client — so a founder's
+// `auth login` credentials satisfy the D1 REST query API with zero extra wiring, and the
+// env-var fallback ($CLOUDFLARE_API_TOKEN) still works for a token-only run.
+const ScrubRestLayer = Layer.merge(
+	CredentialsKeychainFirst.pipe(Layer.provideMerge(KeychainLive)),
+	FetchHttpClient.layer,
+).pipe(Layer.provide(NodeServices.layer));
+
 const cli = Command.make("cf-utils").pipe(
-	Command.withSubcommands([flag, auth]),
-	Command.withDescription("Human-operated Cloudflare Flagship read/flip CLI"),
+	Command.withSubcommands([flag, auth, makeScrubCommand(ScrubRestLayer)]),
+	Command.withDescription("Human-operated Cloudflare Flagship read/flip + data-scrub CLI"),
 );
 
 // Credentials resolve keychain-first with the env-var fallback (#1730): the same ambient

--- a/packages/cf-utils/src/scrub-author-email.ts
+++ b/packages/cf-utils/src/scrub-author-email.ts
@@ -1,0 +1,236 @@
+/**
+ * The pure core of `cf-utils scrub-author-email` — the founder-side, one-off data-scrub verb
+ * that removes email-at-rest from the denormalized `author_name` column on the three record
+ * tables (`definition_record` / `post_record` / `comment_record`). It is the data-backfill
+ * remediation of #2130's PII-at-rest leak: #2136 stopped *new* email-bearing writes; this
+ * scrubs the rows persisted *before* that fix under the old `user.name ?? user.email`
+ * fallback, which still render an email publicly on the author surfaces (#2137).
+ *
+ * This is delivered as a `cf-utils` verb — a server-side direct-D1 CLI over the D1 REST
+ * transport (`@kampus/d1-rest`), reusing cf-utils' keychain credential seam — and NEVER as a
+ * runtime worker route: a public/`ENVIRONMENT`-gated admin/seeder endpoint is exactly the
+ * deleted fail-open hole (CLAUDE.md "Sözlük seed"; the removed `/api/admin/*` routes).
+ *
+ * Two invariants are load-bearing (both verified by `scrub-author-email.unit.test.ts`):
+ *
+ *   1. DESTRUCTIVE CEREMONY. The verb is DRY-RUN by default: it scans and prints the
+ *      per-table affected-row COUNT only — never the email values (leak-clean output: the
+ *      count is the signal, the PII is not). A write happens ONLY under an explicit
+ *      confirm-and-name gate: `--execute` AND `--confirm scrub-author-email`. No `--execute`,
+ *      or a wrong/absent `--confirm` name, is a refused write (a dry-run). There is no
+ *      write-by-default and no silent write.
+ *
+ *   2. SQL GROUNDED vs REAL D1 (ADR 0082 — D1 is SQLite-over-REST, no `node:sqlite` oracle).
+ *      The email-shaped predicate is core-SQLite `LIKE` (`author_name LIKE '%_@_%_._%'`), and
+ *      the replacement label is recomputed in SQL by MIRRORING `authorDisplayLabel`
+ *      (`apps/web/worker/features/pasaport/author-label.ts`) via core-SQLite scalar functions
+ *      — `COALESCE(NULLIF(TRIM(name),''), '@'||NULLIF(TRIM(username),''), 'kullanıcı')`,
+ *      joined on `author_id = user.id`. `LIKE`, `COALESCE`, `NULLIF`, `TRIM`, and `||` are all
+ *      core SQLite (present in D1); the pure `recomputeLabel` here is the same rule in TS, kept
+ *      in lockstep parity with `authorDisplayLabel` by the unit test.
+ *
+ * `author_name` is `.notNull()`, so the scrub REWRITES the value to the recomputed label — it
+ * never nulls the column and never deletes the row.
+ */
+import {commentRecord, definitionRecord, postRecord} from "@kampus/db-schema";
+import {like, sql} from "drizzle-orm";
+import {drizzle} from "drizzle-orm/d1";
+import {defineRelations} from "drizzle-orm/relations";
+import {AUTHOR_FALLBACK_LABEL, scrubUser} from "./scrub-schema.ts";
+
+/**
+ * The email-shaped `LIKE` heuristic, single-sourced so the count-scan and the UPDATE share the
+ * exact same predicate. `author_name` legitimately holds free-form display names that may
+ * contain a bare `@` (a name like `@ceyhun`), so a bare `%@%` match would over-scrub — the
+ * heuristic requires the full `local@domain.tld` shape: at least one char before the `@`, at
+ * least one after it before a `.`, and at least one char after the final `.`. In SQLite `LIKE`,
+ * `_` matches exactly one char and `%` matches any run — so `'%_@_%_._%'` reads as
+ * "(anything) _ @ _ (anything) _ . _ (anything)", i.e. a non-empty local part, a non-empty
+ * domain label, a dot, and a non-empty TLD. This is core SQLite, present in D1 (ADR 0082).
+ */
+export const EMAIL_SHAPED_LIKE = "%_@_%_._%";
+
+/** Does this persisted `author_name` look like an email (the {@link EMAIL_SHAPED_LIKE} shape)? */
+export const isEmailShaped = (value: string): boolean => {
+	// The TS mirror of the SQLite `LIKE` heuristic: a non-empty local part, `@`, a non-empty
+	// domain label, a `.`, and a non-empty TLD, with the dot AFTER the `@`. Deliberately close
+	// to the `LIKE` semantics (not a full RFC email validator) so the scan and the predicate
+	// agree on what "email-shaped" means.
+	const at = value.indexOf("@");
+	if (at <= 0) return false;
+	const domain = value.slice(at + 1);
+	const dot = domain.indexOf(".");
+	if (dot <= 0) return false;
+	const tld = domain.slice(dot + 1);
+	return tld.length > 0;
+};
+
+/**
+ * The TS mirror of the persisted replacement label — the SAME precedence as
+ * `authorDisplayLabel` (`apps/web/worker/features/pasaport/author-label.ts`): trimmed display
+ * name → `@username` → the fixed `kullanıcı` fallback, whitespace-only treated as absent, email
+ * structurally impossible (not an input). Kept in lockstep with `authorDisplayLabel` by the
+ * unit test; the SQL `recomputeLabelSql` below is the third co-parity expression.
+ */
+export const recomputeLabel = (identity: {
+	readonly name?: string | null | undefined;
+	readonly username?: string | null | undefined;
+}): string => {
+	if (identity.name?.trim()) return identity.name.trim();
+	if (identity.username?.trim()) return `@${identity.username.trim()}`;
+	return AUTHOR_FALLBACK_LABEL;
+};
+
+// RQB v2 (drizzle 1.0): drizzle() takes `relations`, not `schema`. No relational `.with`
+// traversal here (the recompute rides a correlated subquery in raw SQL), so an empty
+// `defineRelations` just registers the tables — mirrors `@kampus/moderator-grant`.
+const relations = defineRelations({
+	definitionRecord,
+	postRecord,
+	commentRecord,
+	user: scrubUser,
+});
+
+export type ScrubDb = ReturnType<typeof drizzle<typeof relations>>;
+
+export const makeScrubDb = (d1: D1Database): ScrubDb => drizzle(d1, {relations});
+
+/** The three denormalized read-model tables carrying an `author_name` / `author_id` pair. */
+export const SCRUB_TABLES = [
+	{name: "definition_record", table: definitionRecord},
+	{name: "post_record", table: postRecord},
+	{name: "comment_record", table: commentRecord},
+] as const;
+
+export type ScrubTableName = (typeof SCRUB_TABLES)[number]["name"];
+
+/** The count of email-shaped `author_name` rows in one table (the dry-run signal, never PII). */
+export interface TableAffected {
+	readonly table: ScrubTableName;
+	readonly count: number;
+}
+
+/**
+ * The recomputed-label SQL expression — the SQLite mirror of `recomputeLabel`, correlated to
+ * the matched record row's `author_id`. Core SQLite scalar functions only (ADR 0082):
+ * `COALESCE` / `NULLIF` / `TRIM` / `||`, resolving the current label from `user` by id:
+ *   COALESCE( NULLIF(TRIM(name),''), '@' || NULLIF(TRIM(username),''), 'kullanıcı' )
+ * A missing `user` row (no match) makes both NULLIFs NULL → the `kullanıcı` fallback, exactly
+ * as `authorDisplayLabel` returns the fallback for an empty identity — so a scrubbed row is
+ * never left email-shaped even when the author account is gone.
+ */
+const recomputeLabelSql = (authorIdCol: ReturnType<typeof sql>) => sql`
+	COALESCE(
+		(SELECT NULLIF(TRIM(u.name), '') FROM "user" u WHERE u.id = ${authorIdCol}),
+		(SELECT '@' || NULLIF(TRIM(u.username), '') FROM "user" u WHERE u.id = ${authorIdCol}),
+		${AUTHOR_FALLBACK_LABEL}
+	)
+`;
+
+/**
+ * Count the email-shaped `author_name` rows in each of the three tables — the dry-run scan.
+ * Returns per-table counts ONLY (leak-clean: it never selects or returns the email values).
+ */
+export const scanAffected = async (db: ScrubDb): Promise<ReadonlyArray<TableAffected>> => {
+	const out: Array<TableAffected> = [];
+	for (const {name, table} of SCRUB_TABLES) {
+		const rows = await db
+			.select({n: sql<number>`count(*)`})
+			.from(table)
+			.where(like(table.authorName, EMAIL_SHAPED_LIKE))
+			.all();
+		out.push({table: name, count: Number(rows[0]?.n ?? 0)});
+	}
+	return out;
+};
+
+/** The count of rows actually rewritten in one table under `--execute`. */
+export interface TableScrubbed {
+	readonly table: ScrubTableName;
+	readonly changed: number;
+}
+
+/**
+ * Rewrite every email-shaped `author_name` in each table to its recomputed label (name →
+ * `@username` → `kullanıcı`), joined on `author_id`. Idempotent: the recomputed label is never
+ * email-shaped, so re-running matches nothing. Never nulls the column, never deletes a row.
+ * Called ONLY after the confirm-and-name gate has authorized the write (see `decideWrite`).
+ */
+export const scrubEmails = async (db: ScrubDb): Promise<ReadonlyArray<TableScrubbed>> => {
+	const out: Array<TableScrubbed> = [];
+	for (const {name, table} of SCRUB_TABLES) {
+		const result = await db
+			.update(table)
+			.set({authorName: recomputeLabelSql(sql`${table.authorId}`)})
+			.where(like(table.authorName, EMAIL_SHAPED_LIKE))
+			.run();
+		out.push({table: name, changed: result.meta.changes});
+	}
+	return out;
+};
+
+/** The one op name the confirm gate demands be typed to authorize the destructive write. */
+export const CONFIRM_OP_NAME = "scrub-author-email";
+
+/**
+ * The pure confirm-and-name gate decision. A write is authorized ONLY when BOTH `--execute` is
+ * passed AND `--confirm` names the op exactly (`scrub-author-email`). Absent `--execute`, or a
+ * missing/wrong confirm name, is a refused write — the run stays a dry-run. This is the
+ * destructive-ceremony core: there is no write-by-default and no single-flag write.
+ */
+export type WriteDecision =
+	| {readonly _tag: "Write"}
+	| {readonly _tag: "DryRun"; readonly reason: string};
+
+export const decideWrite = (input: {
+	readonly execute: boolean;
+	readonly confirm: string | undefined;
+}): WriteDecision => {
+	if (!input.execute) {
+		return {_tag: "DryRun", reason: "no --execute (dry-run by default)"};
+	}
+	if (input.confirm === undefined) {
+		return {
+			_tag: "DryRun",
+			reason: `--execute given but --confirm is missing — name the op to authorize: --confirm ${CONFIRM_OP_NAME}`,
+		};
+	}
+	if (input.confirm !== CONFIRM_OP_NAME) {
+		return {
+			_tag: "DryRun",
+			reason: `--confirm "${input.confirm}" does not name the op — expected --confirm ${CONFIRM_OP_NAME}`,
+		};
+	}
+	return {_tag: "Write"};
+};
+
+/**
+ * Render the dry-run report — per-table counts and a total, and NOTHING ELSE. Deliberately
+ * emits only the affected-row COUNT, never an `author_name` value: the count is the signal a
+ * founder needs to size the blast radius, the email values are the PII the leak-clean output
+ * must never re-print. A zero total is a first-class "nothing to scrub" (the #2137
+ * close-as-done path).
+ */
+export const renderDryRun = (affected: ReadonlyArray<TableAffected>): string => {
+	const total = affected.reduce((sum, a) => sum + a.count, 0);
+	const lines = affected.map((a) => `  ${a.table}: ${a.count} email-shaped author_name row(s)`);
+	const header =
+		total === 0
+			? "scrub-author-email (dry-run): no email-shaped author_name rows found — nothing to scrub"
+			: `scrub-author-email (dry-run): ${total} email-shaped author_name row(s) would be rewritten`;
+	const footer =
+		total === 0
+			? "  (exposure is nil — #2137 closeable as done)"
+			: `  pass --execute --confirm ${CONFIRM_OP_NAME} to rewrite them to the author-label rule`;
+	return [header, ...lines, footer].join("\n");
+};
+
+/** Render the post-write summary — per-table rewritten counts + a total. Counts only, no PII. */
+export const renderScrubbed = (scrubbed: ReadonlyArray<TableScrubbed>): string => {
+	const total = scrubbed.reduce((sum, s) => sum + s.changed, 0);
+	const lines = scrubbed.map((s) => `  ${s.table}: ${s.changed} author_name row(s) rewritten`);
+	return [
+		`scrub-author-email: rewrote ${total} email-shaped author_name row(s) to the author-label rule`,
+		...lines,
+	].join("\n");
+};

--- a/packages/cf-utils/src/scrub-author-email.unit.test.ts
+++ b/packages/cf-utils/src/scrub-author-email.unit.test.ts
@@ -1,0 +1,269 @@
+/**
+ * The author-email scrub — pure core + statement-shape, asserted without a real DB (ADR 0082
+ * unit tier). The email-shaped heuristic, the label-recompute parity with `authorDisplayLabel`,
+ * the confirm-gate matrix, and the leak-clean render are pure and pinned directly; the
+ * `scanAffected` / `scrubEmails` DB paths resolve their SQL+params via drizzle's `.toSQL()` and
+ * a mock `D1Database` that records statements and returns fixture rows — so the `LIKE`
+ * predicate and the `COALESCE/NULLIF/TRIM` recompute are proven present without booting SQLite.
+ * Whether the UPDATE actually rewrites a real D1 row is only-wrong-if-D1-differs and belongs to
+ * a founder-run verification against prod (this CLI's run is founder-side; the build is
+ * creds-free).
+ */
+import {commentRecord, definitionRecord, postRecord} from "@kampus/db-schema";
+import {like, sql} from "drizzle-orm";
+import {assert, describe, it} from "vitest";
+import {
+	CONFIRM_OP_NAME,
+	decideWrite,
+	EMAIL_SHAPED_LIKE,
+	isEmailShaped,
+	makeScrubDb,
+	recomputeLabel,
+	renderDryRun,
+	renderScrubbed,
+	SCRUB_TABLES,
+	scanAffected,
+	scrubEmails,
+	type TableAffected,
+} from "./scrub-author-email.ts";
+import {AUTHOR_FALLBACK_LABEL} from "./scrub-schema.ts";
+
+describe("isEmailShaped — the email heuristic distinguishes a leak from a name with an @", () => {
+	it("matches full local@domain.tld emails (the leaked shape)", () => {
+		for (const email of ["umut@kamp.us", "a@b.co", "ceyhun.ozturk@gmail.com", "x@y.z.w"]) {
+			assert.isTrue(isEmailShaped(email), email);
+		}
+	});
+
+	it("does NOT match a free-form display name that merely contains an @", () => {
+		for (const name of [
+			"@ceyhun", // a leading-@ handle-style name — no domain.tld
+			"umut", // a plain name
+			"kullanıcı",
+			"a @ b", // spaces, no dotted domain
+			"@user.name", // no `@` after a local part (leads with @)
+			"first@last", // no dot in the domain
+			"", // empty
+			"foo@bar.", // dot but empty TLD
+		]) {
+			assert.isFalse(isEmailShaped(name), name);
+		}
+	});
+});
+
+describe("recomputeLabel — lockstep parity with authorDisplayLabel (name → @username → kullanıcı)", () => {
+	// The parity table restated inline: the worker module `author-label.ts` cannot be imported
+	// from a `packages/` CLI (no worker→packages edge), so the SAME precedence cases are pinned
+	// here — mirroring how `author-label.unit.test.ts` locks the SPA `actorLabel` parity.
+	it("prefers a trimmed display name", () => {
+		assert.strictEqual(recomputeLabel({name: "Umut Sirin", username: "umut"}), "Umut Sirin");
+		assert.strictEqual(recomputeLabel({name: "  Ceyhun  ", username: "cey"}), "Ceyhun");
+	});
+
+	it("falls to @username when name is absent/blank", () => {
+		assert.strictEqual(recomputeLabel({name: null, username: "umut"}), "@umut");
+		assert.strictEqual(recomputeLabel({name: "   ", username: "umut"}), "@umut");
+		assert.strictEqual(recomputeLabel({username: " cey "}), "@cey");
+	});
+
+	it("falls to the kullanıcı fallback when neither name nor username resolves", () => {
+		assert.strictEqual(recomputeLabel({}), AUTHOR_FALLBACK_LABEL);
+		assert.strictEqual(recomputeLabel({name: null, username: null}), AUTHOR_FALLBACK_LABEL);
+		assert.strictEqual(recomputeLabel({name: "  ", username: "  "}), AUTHOR_FALLBACK_LABEL);
+		assert.strictEqual(AUTHOR_FALLBACK_LABEL, "kullanıcı");
+	});
+
+	it("never returns an email — email is not an input (the leak is closed at the type)", () => {
+		// A recomputed label from ANY {name, username} snapshot is never email-shaped: the only
+		// values it can produce are a display name, `@username`, or the fixed fallback — an email
+		// is structurally excluded (it is never a field of the identity snapshot).
+		for (const label of [
+			recomputeLabel({name: "Umut", username: "u"}),
+			recomputeLabel({username: "u"}),
+			recomputeLabel({}),
+		]) {
+			assert.isFalse(isEmailShaped(label), label);
+		}
+	});
+});
+
+describe("decideWrite — the confirm-and-name gate blocks a write without --execute AND the op name", () => {
+	it("dry-runs by default (no --execute)", () => {
+		const d = decideWrite({execute: false, confirm: undefined});
+		assert.strictEqual(d._tag, "DryRun");
+	});
+
+	it("dry-runs when --execute is given but --confirm names nothing", () => {
+		const d = decideWrite({execute: true, confirm: undefined});
+		assert.strictEqual(d._tag, "DryRun");
+	});
+
+	it("dry-runs when --confirm names the WRONG op", () => {
+		const d = decideWrite({execute: true, confirm: "yes"});
+		assert.strictEqual(d._tag, "DryRun");
+		const d2 = decideWrite({execute: true, confirm: "scrub"});
+		assert.strictEqual(d2._tag, "DryRun");
+	});
+
+	it("authorizes a write ONLY with BOTH --execute AND --confirm scrub-author-email", () => {
+		const d = decideWrite({execute: true, confirm: CONFIRM_OP_NAME});
+		assert.strictEqual(d._tag, "Write");
+		assert.strictEqual(CONFIRM_OP_NAME, "scrub-author-email");
+	});
+
+	it("a confirm name alone (no --execute) never authorizes a write", () => {
+		const d = decideWrite({execute: false, confirm: CONFIRM_OP_NAME});
+		assert.strictEqual(d._tag, "DryRun");
+	});
+});
+
+describe("renderDryRun / renderScrubbed — leak-clean output: the count, never the PII", () => {
+	const affected: ReadonlyArray<TableAffected> = [
+		{table: "definition_record", count: 3},
+		{table: "post_record", count: 0},
+		{table: "comment_record", count: 2},
+	];
+
+	it("prints per-table counts and a total — and NO email value", () => {
+		const out = renderDryRun(affected);
+		assert.include(out, "definition_record: 3");
+		assert.include(out, "post_record: 0");
+		assert.include(out, "comment_record: 2");
+		assert.include(out, "5 email-shaped author_name row(s) would be rewritten");
+		// leak-clean: an `@`-bearing email string must never appear in the report.
+		assert.notMatch(out, /@[a-z0-9.-]+\.[a-z]{2,}/i);
+	});
+
+	it("a zero total is the first-class close-as-done path (nothing to scrub)", () => {
+		const out = renderDryRun([
+			{table: "definition_record", count: 0},
+			{table: "post_record", count: 0},
+			{table: "comment_record", count: 0},
+		]);
+		assert.include(out, "no email-shaped author_name rows found");
+		assert.include(out, "#2137 closeable as done");
+	});
+
+	it("renderScrubbed reports per-table rewritten counts + total, no PII", () => {
+		const out = renderScrubbed([
+			{table: "definition_record", changed: 3},
+			{table: "post_record", changed: 0},
+			{table: "comment_record", changed: 2},
+		]);
+		assert.include(out, "rewrote 5 email-shaped author_name row(s)");
+		assert.include(out, "definition_record: 3");
+		assert.notMatch(out, /@[a-z0-9.-]+\.[a-z]{2,}/i);
+	});
+});
+
+// A mock `D1Database` recording every prepared statement + returning fixture results. drizzle's
+// d1 driver calls `prepare(sql).bind(...params).all()` for selects and `.run()` for updates.
+interface Recorded {
+	sql: string;
+	params: unknown[];
+}
+const mockD1 = (
+	rowsFor: (sql: string) => Record<string, unknown>[],
+	changesFor: () => number,
+): {db: D1Database; statements: Recorded[]} => {
+	const statements: Recorded[] = [];
+	const bound = (sqlText: string) => ({
+		all: async () => ({results: rowsFor(sqlText)}),
+		run: async () => ({success: true as const, meta: {changes: changesFor()}, results: []}),
+		first: async () => rowsFor(sqlText)[0] ?? null,
+		raw: async () => rowsFor(sqlText).map((r) => Object.values(r)),
+	});
+	const prepare = (sqlText: string) => {
+		statements.push({sql: sqlText, params: []});
+		return {
+			...bound(sqlText),
+			bind: (...params: unknown[]) => {
+				statements[statements.length - 1]!.params = params;
+				return bound(sqlText);
+			},
+		};
+	};
+	// biome-ignore lint/plugin: a recording stand-in implements only the prepare slice drizzle-orm/d1 drives; the full D1Database surface can't be built honestly here.
+	return {db: {prepare} as unknown as D1Database, statements};
+};
+
+describe("SQL is grounded vs real D1 (ADR 0082): LIKE predicate + COALESCE/NULLIF/TRIM recompute", () => {
+	it("scanAffected issues a count(*) WHERE author_name LIKE the email heuristic, per table", async () => {
+		const {db, statements} = mockD1(
+			() => [{n: 4}],
+			() => 0,
+		);
+		const scrubDb = makeScrubDb(db);
+		const affected = await scanAffected(scrubDb);
+
+		// one scan per record table, each returning the mocked count
+		assert.deepStrictEqual(
+			affected.map((a) => a.table),
+			["definition_record", "post_record", "comment_record"],
+		);
+		assert.isTrue(affected.every((a) => a.count === 4));
+
+		// every scan is a count(*) with the email-shaped LIKE predicate + the heuristic param
+		const scans = statements.filter((s) => /count\(\*\)/i.test(s.sql));
+		assert.strictEqual(scans.length, 3);
+		for (const s of scans) {
+			assert.match(s.sql, /"[a-z_]+"\."author_name" like \?/i);
+			assert.include(s.params as unknown[], EMAIL_SHAPED_LIKE);
+		}
+	});
+
+	it("scrubEmails UPDATEs author_name to COALESCE(NULLIF(TRIM(name)), @username, kullanıcı) WHERE LIKE", () => {
+		// pin the UPDATE statement shape directly via .toSQL() (no engine): the recompute mirrors
+		// authorDisplayLabel in core-SQLite scalars, guarded by the email-shaped WHERE.
+		const db = makeScrubDb(
+			mockD1(
+				() => [],
+				() => 0,
+			).db,
+		);
+		for (const table of [definitionRecord, postRecord, commentRecord]) {
+			const {sql: text, params} = db
+				.update(table)
+				.set({
+					authorName: sql`
+						COALESCE(
+							(SELECT NULLIF(TRIM(u.name), '') FROM "user" u WHERE u.id = ${table.authorId}),
+							(SELECT '@' || NULLIF(TRIM(u.username), '') FROM "user" u WHERE u.id = ${table.authorId}),
+							${AUTHOR_FALLBACK_LABEL}
+						)
+					`,
+				})
+				.where(like(table.authorName, EMAIL_SHAPED_LIKE))
+				.toSQL();
+			assert.match(text, /update .*set "author_name" =/i);
+			assert.match(text, /coalesce\(/i);
+			assert.match(text, /nullif\(trim\(u\.name\)/i);
+			assert.match(text, /'@' \|\| nullif\(trim\(u\.username\)/i);
+			// the recompute is correlated to the matched row's author_id (drizzle qualifies the column)
+			assert.match(text, /from "user" u where u\.id = "[a-z_]+"\."author_id"/i);
+			assert.match(text, /where "[a-z_]+"\."author_name" like \?/i);
+			assert.include(params as unknown[], EMAIL_SHAPED_LIKE);
+			assert.include(params as unknown[], AUTHOR_FALLBACK_LABEL);
+		}
+	});
+
+	it("scrubEmails carries D1's real changed-row count per table (meta.changes plumbing)", async () => {
+		const {db} = mockD1(
+			() => [],
+			() => 7,
+		);
+		const scrubbed = await scrubEmails(makeScrubDb(db));
+		assert.deepStrictEqual(
+			scrubbed.map((s) => s.table),
+			["definition_record", "post_record", "comment_record"],
+		);
+		assert.isTrue(scrubbed.every((s) => s.changed === 7));
+	});
+
+	it("scans exactly the three record tables that carry author_name (no widening)", () => {
+		assert.deepStrictEqual(
+			SCRUB_TABLES.map((t) => t.name),
+			["definition_record", "post_record", "comment_record"],
+		);
+	});
+});

--- a/packages/cf-utils/src/scrub-command.ts
+++ b/packages/cf-utils/src/scrub-command.ts
@@ -1,0 +1,91 @@
+/**
+ * The `cf-utils scrub-author-email` IO shell — the thin Effect bin around the pure core
+ * (`scrub-author-email.ts`). It resolves the target D1 (an explicit `--database-id`, never a
+ * prod-hardcoded default, mirroring `@kampus/moderator-grant`; the account id from the
+ * keychain-first `CLOUDFLARE_ACCOUNT_ID` Config), builds the scrub db over the D1 REST
+ * transport (`@kampus/d1-rest`) credentialed by cf-utils' keychain seam, runs the dry-run scan,
+ * and — ONLY under the confirm-and-name gate (`--execute` AND `--confirm scrub-author-email`) —
+ * applies the rewrite. See `scrub-author-email.ts` for the destructive-ceremony + SQL-grounding
+ * invariants; this file only wires them to the CLI.
+ */
+
+import type {Credentials} from "@distilled.cloud/cloudflare/Credentials";
+import {makeD1Rest} from "@kampus/d1-rest";
+import {Config, Console, Effect, type Layer, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import type {HttpClient} from "effect/unstable/http/HttpClient";
+import {
+	CONFIRM_OP_NAME,
+	decideWrite,
+	makeScrubDb,
+	renderDryRun,
+	renderScrubbed,
+	scanAffected,
+	scrubEmails,
+} from "./scrub-author-email.ts";
+
+const databaseIdFlag = Flag.string("database-id").pipe(
+	Flag.withDescription("the target stage's D1 database UUID (never prod-hardcoded)"),
+);
+const accountIdFlag = Flag.string("account-id").pipe(
+	Flag.optional,
+	Flag.withDescription("Cloudflare account id (default: keychain / $CLOUDFLARE_ACCOUNT_ID)"),
+);
+const executeFlag = Flag.boolean("execute").pipe(
+	Flag.withDescription("actually rewrite (default: dry-run — scan + print counts, write nothing)"),
+);
+const confirmFlag = Flag.string("confirm").pipe(
+	Flag.optional,
+	Flag.withDescription(`name the op to authorize the write — must be "${CONFIRM_OP_NAME}"`),
+);
+
+const accountId = Config.string("CLOUDFLARE_ACCOUNT_ID");
+
+/**
+ * `scrub-author-email` — the one destructive verb. It runs the dry-run scan first ALWAYS (so a
+ * founder sees the per-table counts before any write), then consults the pure confirm-gate: a
+ * refused gate prints the dry-run report and stops; an authorized gate (`--execute` +
+ * `--confirm scrub-author-email`) applies the rewrite and prints the post-write summary. The
+ * scan/report never emits an email value — leak-clean output is the count, not the PII.
+ */
+export const makeScrubCommand = (restLayer: Layer.Layer<Credentials | HttpClient>) =>
+	Command.make(
+		"scrub-author-email",
+		{
+			databaseId: databaseIdFlag,
+			accountId: accountIdFlag,
+			execute: executeFlag,
+			confirm: confirmFlag,
+		},
+		Effect.fn(function* ({databaseId, accountId: accountIdOpt, execute, confirm}) {
+			const account = Option.isSome(accountIdOpt) ? accountIdOpt.value : yield* accountId;
+			const db = makeScrubDb(makeD1Rest({accountId: account, databaseId, layer: restLayer}));
+
+			// The dry-run scan runs ALWAYS — the count-only report a founder reads before any write.
+			const affected = yield* Effect.promise(() => scanAffected(db));
+			yield* Console.log(renderDryRun(affected));
+
+			const decision = decideWrite({
+				execute,
+				confirm: Option.isSome(confirm) ? confirm.value : undefined,
+			});
+			if (decision._tag === "DryRun") {
+				yield* Console.log(`  (write refused: ${decision.reason})`);
+				return;
+			}
+
+			const total = affected.reduce((sum, a) => sum + a.count, 0);
+			if (total === 0) {
+				yield* Console.log("  (nothing to rewrite — the scan found no email-shaped rows)");
+				return;
+			}
+
+			// Gate authorized (--execute + --confirm scrub-author-email) and there ARE rows: rewrite.
+			const scrubbed = yield* Effect.promise(() => scrubEmails(db));
+			yield* Console.log(renderScrubbed(scrubbed));
+		}),
+	).pipe(
+		Command.withDescription(
+			"Scrub email-at-rest from author_name (dry-run default; --execute --confirm scrub-author-email to apply) — #2137",
+		),
+	);

--- a/packages/cf-utils/src/scrub-schema.ts
+++ b/packages/cf-utils/src/scrub-schema.ts
@@ -1,0 +1,31 @@
+/**
+ * The minimal `user`-table drizzle slice the author-email scrub JOINs against — a local
+ * slice, NOT a `@kampus/web` import (the worker's auth `schema.ts` isn't an exported subpath,
+ * and pulling the whole worker graph into a `packages/` CLI is the anti-pattern
+ * `@kampus/moderator-grant` / `@kampus/preview-seed` avoid the same way). Only the identity
+ * columns the recompute reads: `id` (the `author_id` join key), and the nullable `name` /
+ * `username` the label rule flattens.
+ *
+ * These BetterAuth tables live on the SAME shared `PhoenixDb` D1 as the `_record` tables
+ * (ADR 0009; `apps/web/worker/features/pasaport/better-auth-live.ts` — "phoenix's better-auth
+ * tables live on the shared `PhoenixDb` D1"), so the scrub's `author_id = user.id` JOIN is
+ * resolvable in a single D1 query — the identity data is reachable, no DO / external store
+ * reach. The canonical `user` schema is `apps/web/worker/db/drizzle/schema.ts`.
+ */
+import {integer, sqliteTable, text} from "drizzle-orm/sqlite-core";
+
+export const scrubUser = sqliteTable("user", {
+	id: text("id").primaryKey(),
+	name: text("name"),
+	username: text("username").unique(),
+	createdAt: integer("created_at", {mode: "timestamp"}),
+	updatedAt: integer("updated_at", {mode: "timestamp"}),
+});
+
+/**
+ * The fixed fallback noun for an author with neither a display name nor a username — the SAME
+ * `kullanıcı` `authorDisplayLabel` (`apps/web/worker/features/pasaport/author-label.ts`)
+ * returns. Restated here (the worker module isn't importable from a `packages/` CLI); the
+ * parity is locked by `scrub-author-email.unit.test.ts`.
+ */
+export const AUTHOR_FALLBACK_LABEL = "kullanıcı";

--- a/packages/cf-utils/tsconfig.json
+++ b/packages/cf-utils/tsconfig.json
@@ -5,7 +5,7 @@
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
 		"noEmit": true,
 		"allowImportingTsExtensions": true,
-		"types": ["node"]
+		"types": ["node", "@cloudflare/workers-types"]
 	},
 	"include": ["src", "vitest.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,10 +567,22 @@ importers:
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      '@kampus/d1-rest':
+        specifier: workspace:*
+        version: link:../d1-rest
+      '@kampus/db-schema':
+        specifier: workspace:*
+        version: link:../db-schema
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260629.1
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2


### PR DESCRIPTION
Grows `@kampus/cf-utils` with a founder-side, direct-D1 **`scrub-author-email`** verb that removes the email-at-rest leaked into the denormalized `author_name` column on `definition_record` / `post_record` / `comment_record` before #2136 stopped the leaking write (the old `user.name ?? user.email` fallback). It is the data-backfill remediation of #2130 — #2136 stopped *new* email-bearing writes; this scrubs the pre-existing rows.

Delivered by **reusing the existing cf-utils substrate** (not a new package): the keychain credential seam, the `effect/unstable/cli` bin, and the D1-over-REST transport (`@kampus/d1-rest`) — and **never** a runtime worker route (the deleted `/api/admin/*` fail-open shape; CLAUDE.md "Sözlük seed"). Naming grows here now; the cf-utils → anka-ops rename is #2089's job.

## Identity-fields location (the resolved open design point)
`authorDisplayLabel` needs `{name, username}`. Grounded against the schema + `apps/web/worker/features/pasaport/better-auth-live.ts`: BetterAuth persists users into a `user` table (`id` PK, nullable `name` / `username`) that lives on the **same shared `PhoenixDb` D1** (ADR 0009) as the three record tables. So the scrub's `author_id = user.id` JOIN resolves **in one D1 query** — the identity data is D1-reachable, no DO / external-store reach problem.

## Ceremony (both unit-tested)
- **Destructive ceremony — dry-run by default.** Scans and prints **per-table affected counts only**, never the email values (leak-clean output). A write happens **only** under the confirm-and-name gate: **`--execute` AND `--confirm scrub-author-email`**. No `--execute`, or a missing/wrong confirm name, stays a dry-run — no write-by-default, no single-flag write. A zero-count scan is the first-class close-as-done path.
- **SQL grounded vs real D1 (ADR 0082).** D1 is SQLite-over-REST, so every clause is core SQLite: email-shaped predicate `author_name LIKE '%_@_%_._%'` (full `local@domain.tld` shape, so a name that merely contains `@` is not over-scrubbed), and the replacement label recomputed **in SQL** mirroring `authorDisplayLabel` — `COALESCE(NULLIF(TRIM(name),''), '@'||NULLIF(TRIM(username),''), 'kullanıcı')`. `LIKE`, `COALESCE`, `NULLIF`, `TRIM`, `||` are all core SQLite (present in D1). `author_name` is `.notNull()` → the value is **rewritten**, never nulled, never the row deleted; idempotent (a recomputed label is never email-shaped).

## Build/run split
Building the verb needs **no credentials** (ships through the pipeline); the pure core + dry-run + confirm-gate are unit-tested off a mock D1. **Running** it is founder-side — a token carrying D1:edit on the cf-utils keychain, against prod, with oversight and post-run verification. This build does not (and must not) run against prod.

## Verification
- `pnpm typecheck` — clean (full workspace, tsgo).
- `pnpm lint:worktree` — clean.
- `pnpm --filter @kampus/cf-utils test:unit` — 88 pass (incl. the new email-heuristic, label parity, confirm-gate matrix, leak-clean render, and the `LIKE` + `COALESCE/NULLIF/TRIM` SQL-shape assertions).

§CP self-assessment: **non-§CP** (`packages/cf-utils` matches nothing in CONTROL_PLANE_RE) — auto-ships on green.

Fixes #2137