### PR TITLE
feat(pipeline): ref-transaction guard refuses a diverging primary main ref-move (#2143, ADR 0160)

### DIFF
--- a/.decisions/0160-ref-transaction-guard-refuses-diverging-primary-main.md
+++ b/.decisions/0160-ref-transaction-guard-refuses-diverging-primary-main.md
@@ -1,0 +1,124 @@
+---
+id: 0160
+title: "A git reference-transaction guard refuses a diverging refs/heads/main ref-move on the shared primary checkout — caller-agnostic and fail-closed, where the #1571 PreToolUse Bash hook cannot reach"
+status: accepted
+date: 2026-07-05
+tags: [pipeline, git, worktree, primary-checkout, gates, control-plane]
+---
+
+## Context
+
+The shared primary checkout's `main` **branch ref** was force-moved off the merge seam by
+the orchestrator/PULLER role and left **diverged** from `origin/main` — a bare
+`git branch -f main` / `checkout -B main` / `update-ref refs/heads/main` that landed `main`
+on a stranding commit with a ~13.5k-line deletion staged (#2143). That is a "one
+`git push -f` clobbers `origin/main`" loaded gun, and it silently blocked a founder-side
+prod op until the checkout was repaired (preserve-then-reset).
+
+The existing guard — the #1571 `worktree-guard` bash-pin
+(`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`) — does **not** cover this class,
+on three counts:
+
+1. **Wrong arming condition.** It arms only when `$WORKTREE_ROOT` names a managed worktree
+   (an `isolation:worktree` subagent). The offender is the orchestrator/PULLER running bare
+   git in the primary checkout, which carries no `$WORKTREE_ROOT` — its own docblock states
+   that flow "can never reach this refusal."
+2. **Wrong op set.** Its `HEAD_MOVING` set is `{checkout, switch, reset, rebase, stash, merge}`
+   — a ref force-move (`branch -f` / `update-ref` / `push HEAD:main`) is not in it. A diverging
+   ref-move is a worse failure than the detached-HEAD case #1571/#1494 targeted.
+3. **Wrong boundary.** The forensics place the literal keystroke **outside the agent Bash
+   tool-call path** entirely (candidates: harness worktree machinery, a manually-run
+   `pipeline-cli main-sync --execute`, or a git hook). A `PreToolUse` Bash hook cannot
+   intercept a ref-move it never sees.
+
+The coders were clean (they ran only `git -C "$WT"` inside worktrees; the full ref-force-move
+class was grepped across all subagent Bash calls with zero hits). This is **not** a
+worktree-isolation gap (ADR 0109 held). It is a hole in *who* can move the primary's `main`
+ref and *where* that move is checked.
+
+## Decision
+
+Add a **caller-agnostic, fail-closed guardrail at git's own `reference-transaction`
+boundary** that **refuses any `refs/heads/main` update on the shared primary checkout that
+would make local `main` a non-fast-forward of `origin/main`.**
+
+- **Boundary.** Git's `reference-transaction` hook fires for **every** ref update regardless
+  of who initiates it — agent Bash, harness worktree machinery, a manually-run command, or
+  another git hook. This is the reach a `PreToolUse` Bash hook structurally lacks, and it is
+  the exact requirement the #2143 forensics impose (the keystroke was outside the agent
+  path). The hook runs on `prepared` | `committed` | `aborted` and receives one
+  `<old> <new> <ref>` line per queued update on stdin; git honors a non-zero exit **only in
+  `prepared`**, aborting the whole transaction — so the guard evaluates and can refuse only
+  there.
+
+- **Shape (mirror the `main-sync` / `bash-pin` pure-core-plus-thin-boundary idiom).** A pure,
+  unit-tested decision core `decideRefUpdate`
+  (`packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts`) — IO-free, total over a queued
+  ref update × the origin ancestry fact — and a thin git boundary `command.ts` that reads
+  stdin, resolves `origin/main`, and runs `git merge-base --is-ancestor origin/main <newOid>`.
+  Wired as `pipeline-cli ref-guard reference-transaction <state>` and installed via
+  `lefthook.yml` (ADR 0068) into the shared `.git/hooks`.
+
+- **The decision (the whole safety property).** On `refs/heads/main`: allow only a
+  fast-forward of `origin/main` (`origin/main` an ancestor of the new tip, or new tip ==
+  `origin/main`); refuse a non-fast-forward **divergence**, and refuse a delete. Every other
+  ref (feature branches, tags, `origin/*`) is out of scope and passes untouched — so a
+  worktree agent moving its own branch ref never reaches the guarded path. The legitimate
+  PULLER flow passes by construction: `merge --ff-only origin/main` is a fast-forward, and the
+  reattach `checkout main` moves no ref on `main` at all.
+
+- **Fail-open on infra absence, fail-closed on divergence.** An unresolvable `origin/main`
+  (a fresh clone before the first fetch) allows the update — there is nothing to diverge from,
+  and the divergence the guard exists to catch is undefined without an origin. But an ancestry
+  probe that *fails* is treated as non-ff and refuses on the guarded ref (cannot prove a
+  fast-forward ⇒ divergence). The guard signals a deliberate refuse with a **dedicated exit
+  code (3)**, distinct from success (0) and any infrastructural failure (1 / 127); the
+  `lefthook.yml` wrapper aborts the transaction **only** on code 3 and fail-opens on every
+  other non-zero. This preserves the #1050 / #787 fail-open invariant: a not-yet-installed or
+  stripped-PATH CLI — or `bin.ts`'s unlinked-dependency remediation, which itself exits 1
+  (#1798) — must never wedge every ref transaction repo-wide.
+
+- **ROE (AC #4).** The PULLER/orchestrator drives sync **only** through the
+  fetch-inspect-`ff-only` seam (`pipeline-cli main-sync`, #1573) — never a bare
+  `checkout -B main` / `branch -f main` / `reset` / `update-ref refs/heads/main` on the
+  primary. This ADR + the `ref-guard` hook **are** the durable enforcement of that rule, so it
+  no longer lives only in operator memory.
+
+## Consequences
+
+- The #2143 class is now structurally unreachable: any diverging `refs/heads/main` move on the
+  shared primary aborts at the ref boundary before it lands, whoever attempts it and however
+  it is invoked. The loaded gun cannot be loaded.
+- It is **control-plane** (ADR 0135): it touches `packages/pipeline-cli/**` and `lefthook.yml`
+  (git-hook install), so its PR is human-merge-only (cansirin), never auto-shipped.
+- The guard is scoped tightly — only `refs/heads/main`, only a non-fast-forward — so it never
+  interferes with worktree branch pushes, tag moves, or `origin/*` fetches, and never with the
+  legitimate `merge --ff-only` sync.
+- It is the **ref-force-move / divergence** sibling of two adjacent primary-checkout defects:
+  the detached-HEAD lineage (#1103 / #1494 / #1571 / #2030 → `main-sync` and the bash-pin) and
+  the silent-drift side (#2056, still open). All three are primary-checkout safety holes; this
+  ADR closes the force-move one and leaves the others distinct.
+- Because it lives in the shared `.git/hooks` (via lefthook), a worktree consuming those hooks
+  also runs it — harmless, since a worktree never moves `refs/heads/main` (it works on its own
+  branch), so the guard is a no-op for it.
+
+### Coverage boundary (stated honestly, not oversold)
+
+`reference-transaction` fires on every git **ref transaction** — `update-ref`, `checkout -B`,
+`reset`, `branch -f`, a push that updates a local ref, and the `branch: Reset to HEAD`
+transaction that stranded us. It does **not** intercept a **raw filesystem write** to
+`.git/refs/heads/main` (or a `.git/packed-refs` edit) that bypasses git's ref machinery
+entirely — that is an exotic path, not the #2143 incident (which was a real git ref
+transaction), and git itself offers no hook for it. So the guard's claim is precisely "any
+diverging `refs/heads/main` move performed **through git**, by any caller," not "any possible
+mutation of the ref bytes." The proof is a test that installs the hook and drives a **bare
+`git update-ref refs/heads/main`** with no pipeline command in the loop — it aborts, which is
+the acceptance bar; a CLI you must invoke could not guard a move that bypasses the CLI, which
+is exactly why the boundary is the hook, not a command.
+
+One operational caveat: a git hook fires only where `.git/hooks/reference-transaction` is
+installed. The primary checkout and its linked worktrees share one `.git`, so `lefthook
+install` (run once from the primary, ADR 0109 / #1243) arms it for all of them; a
+freshly-cloned checkout that has not yet run `lefthook install` is unguarded until it does —
+the same install-dependency every lefthook-managed hook (the `pre-commit` leak-guard) already
+carries, and CI remains the unbypassable backstop for what CI gates.

--- a/.decisions/0160-ref-transaction-guard-refuses-diverging-primary-main.md
+++ b/.decisions/0160-ref-transaction-guard-refuses-diverging-primary-main.md
@@ -78,6 +78,22 @@ would make local `main` a non-fast-forward of `origin/main`.**
   stripped-PATH CLI — or `bin.ts`'s unlinked-dependency remediation, which itself exits 1
   (#1798) — must never wedge every ref transaction repo-wide.
 
+- **The dash `rc`-source trap (found in first-CI, fixed at the root).** Because a
+  `reference-transaction` hook aborts on *any* non-zero — unlike `pre-commit`/`post-checkout`,
+  whose non-zero is harmless in the fetch path — it exposed a latent bug in the shared lefthook
+  wrapper: the wrapper sourced the rc as `. .lefthookrc` (no slash), and under **dash** (CI's
+  `/bin/sh`) a no-slash argument to the `.` builtin triggers a **PATH search**; when CWD is not
+  on PATH the source fails `.: .lefthookrc: not found`, and dash — per POSIX — treats a
+  special-builtin failure in a non-interactive shell as **fatal**, exiting the shell before the
+  guard body runs. So the wrapper returned non-zero and CI's `git fetch --depth=1 origin main`
+  (leak-guard) aborted on the very first run. The root-cause fix is to `./`-qualify the rc
+  reference (`rc: ./.lefthookrc`), so the generated `. ./.lefthookrc` resolves by path with no
+  PATH search — hardening **all** hooks against the same dash trap, not just this one. The
+  guard's own `run` body was additionally made `set -e`-proof (`… || status=$?`) so no future
+  inherited shell option can turn an infra failure into an abort. This is why the fail-open
+  invariant above is defended at *two* layers: the exit-code discipline in the body, and the
+  rc-source that must not fatally exit before the body even runs.
+
 - **ROE (AC #4).** The PULLER/orchestrator drives sync **only** through the
   fetch-inspect-`ff-only` seam (`pipeline-cli main-sync`, #1573) — never a bare
   `checkout -B main` / `branch -f main` / `reset` / `update-ref refs/heads/main` on the

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -134,6 +134,23 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   plan. See [`packages/pipeline-cli/README.md`](../packages/pipeline-cli/README.md) (the
   `main-sync` section) for the full contract.
 
+  **The ref-force-move sibling (the caller-agnostic backstop, #2143 / [ADR 0160](../.decisions/0160-ref-transaction-guard-refuses-diverging-primary-main.md)):**
+  the two guards above catch *HEAD* moves by a *Bash-tool* caller — but the orchestrator/PULLER
+  role force-moved the primary's `main` **ref** (`branch -f main` / `checkout -B main` /
+  `update-ref refs/heads/main`) **outside the agent Bash path entirely**, diverging local `main`
+  from `origin/main` with a mass deletion staged (a "one `git push -f` clobbers `origin/main`"
+  loaded gun). Neither the bash-pin (disarmed with no `$WORKTREE_ROOT`; a ref-move is not in its
+  `HEAD_MOVING` set) nor a `PreToolUse` hook (never sees a non-Bash-tool caller) can reach that
+  class. The enforcement is `pipeline-cli ref-guard`
+  (`packages/pipeline-cli/src/tools/ref-guard/`), wired via `lefthook.yml` as git's own
+  **`reference-transaction`** hook — which fires for **every** ref update regardless of caller.
+  It **refuses any `refs/heads/main` update that would make local `main` a non-fast-forward of
+  `origin/main`**, so a diverging force-move aborts at the ref boundary; the legitimate
+  `merge --ff-only origin/main` (a fast-forward) and the reattach `checkout main` (no ref move on
+  `main`) both pass. **The PULLER/orchestrator ROE, enforced by this guard: drive sync ONLY
+  through the `main-sync` fetch-inspect-`ff-only` seam — never a bare `checkout -B main` /
+  `branch -f main` / `reset` / `update-ref refs/heads/main` on the primary checkout.**
+
 - **Run root `pnpm` scripts as `pnpm -w <script>` (or from the worktree root),
   never from a subdir.** A root-level script (`pnpm lint`, `pnpm typecheck`, …) run
   from a *subdirectory* (e.g. `apps/web/`) trips pnpm's refusal: it resolves the

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -76,3 +76,38 @@ post-checkout:
         # --ignore-scripts: a worktree shares .git/hooks (the common dir), so firing `prepare`
         # (lefthook install) from here would rewrite the SHARED hooks — provision deps, not lifecycle.
         "$@" install --prefer-offline --ignore-scripts
+
+# The caller-agnostic ref-transaction guard (ADR 0160, #2143): refuse a DIVERGING
+# refs/heads/main ref-move on the shared primary checkout (a non-fast-forward of
+# origin/main). Unlike the #1571 worktree-guard PreToolUse Bash hook — which only arms
+# for a $WORKTREE_ROOT subagent and only matches its HEAD_MOVING set — git's own
+# reference-transaction boundary fires for EVERY ref update regardless of caller (agent
+# Bash, harness worktree machinery, a manually-run command, or another git hook), which
+# is exactly the class #2143's force-move (a bare branch -f/checkout -B/update-ref by the
+# PULLER role, outside the agent Bash tool-call path) slipped past.
+#
+# git's contract: this hook runs on prepared|committed|aborted and gets one line per
+# queued update (`<old> <new> <ref>`) on stdin (use_stdin: true); a non-zero exit is
+# honored ONLY in the 'prepared' state, aborting the whole transaction. `{0}` is the
+# state arg git passes. The pure decision core (ref-guard.ts) refuses only a diverging
+# refs/heads/main move (exit 1); the legitimate PULLER `merge --ff-only origin/main` is
+# a fast-forward and always passes (exit 0).
+#
+# Fail-CLOSED on the guard's own refusal but fail-OPEN when the CLI can't RUN — a
+# not-yet-installed / stripped-PATH env (#787), or bin.ts's unlinked-dep remediation on a
+# fresh/partial checkout (#1798, which itself exits 1), must NOT abort every ref
+# transaction repo-wide (the #1050 guard.sh fail-open invariant). The guard signals a
+# deliberate refuse with a DEDICATED code (REFUSE_EXIT_CODE = 3), distinct from both
+# success (0) and any infra failure (1 / 127) — so ONLY code 3 propagates as an abort;
+# every other non-zero swallows to a clean allow. `run` executes under sh.
+reference-transaction:
+  commands:
+    ref-guard:
+      use_stdin: true
+      run: |
+        node packages/pipeline-cli/src/bin.ts ref-guard reference-transaction {0}
+        status=$?
+        # exit 3 == the guard's deliberate refuse (abort the transaction); any other
+        # non-zero == the CLI couldn't run (fail-open, #1050) → allow. 0 == allow.
+        [ "$status" -eq 3 ] && exit 1
+        exit 0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,17 @@
 # rc is sourced by every generated hook wrapper (under /bin/sh, absolute shebang)
 # BEFORE lefthook runs — it restores the system bin dirs on PATH so lefthook can
 # resolve sh even in the harness stripped-PATH worktree-spawn env (#787). See .lefthookrc.
-rc: .lefthookrc
+#
+# The path MUST be `./`-qualified. The generated wrapper sources it as `. <rc>`; under
+# dash (CI's /bin/sh) a NO-SLASH argument to `.` triggers a PATH search, and when CWD is
+# not on PATH the source fails `.: <rc>: not found` — and dash, being POSIX, treats a
+# `.`-builtin failure in a non-interactive shell as FATAL and exits the shell immediately.
+# For a non-aborting hook (pre-commit/post-checkout) that fatal exit was latent/harmless,
+# but a `reference-transaction` hook aborts the git transaction on any non-zero, so the
+# bare `. .lefthookrc` PATH-search miss bricked every ref update in CI (#2143 follow-up:
+# leak-guard's `git fetch --depth=1 origin main` aborted). `./.lefthookrc` resolves by
+# path (no PATH search) → sources cleanly, hardening ALL hooks against the same dash trap.
+rc: ./.lefthookrc
 
 # Git hooks, managed by lefthook (ADR 0068). The leak-guard pre-commit is the
 # local fast-fail leg of the no-local-paths defense-in-depth (#158/#173); CI
@@ -105,9 +115,12 @@ reference-transaction:
     ref-guard:
       use_stdin: true
       run: |
-        node packages/pipeline-cli/src/bin.ts ref-guard reference-transaction {0}
-        status=$?
+        # `|| status=$?` (not a bare call) so a non-zero node exit can NEVER trip an inherited
+        # `set -e` and abort the transaction as a side effect — the guard aborts ONLY on its own
+        # deliberate refuse code below, never on any infra failure (the #1050 fail-open invariant).
+        status=0
+        node packages/pipeline-cli/src/bin.ts ref-guard reference-transaction {0} || status=$?
         # exit 3 == the guard's deliberate refuse (abort the transaction); any other
-        # non-zero == the CLI couldn't run (fail-open, #1050) → allow. 0 == allow.
+        # non-zero == the CLI couldn't run (node/CLI/module absent, crash) → fail-OPEN, allow.
         [ "$status" -eq 3 ] && exit 1
         exit 0

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -86,6 +86,55 @@ This is a **control-plane** surface (it drives the shared primary checkout); see
 [`.patterns/worktree-agent-constraints.md`](../../.patterns/worktree-agent-constraints.md)
 for the surrounding worktree/primary-checkout discipline it defends.
 
+### `ref-guard` — caller-agnostic ref-transaction guard against a diverging `main` (#2143, ADR 0160)
+
+A fail-closed guardrail wired as git's own **`reference-transaction`** hook that **refuses
+a diverging `refs/heads/main` ref-move** on the shared primary checkout — any update that
+would make local `main` a **non-fast-forward** of `origin/main`. It closes the #2143
+loaded-gun class: the orchestrator/PULLER role force-moved primary `main` off the merge seam
+(a bare `branch -f main` / `checkout -B main` / `update-ref refs/heads/main`), diverging it
+from `origin/main` and staging a ~13.5k-line deletion — one `git push -f` from clobbering
+`origin/main`.
+
+**Why the ref boundary, not a Bash hook.** The #1571 `worktree-guard` bash-pin only arms for
+a `$WORKTREE_ROOT` subagent and only matches its `HEAD_MOVING` set — so it is disarmed for
+the orchestrator/PULLER (no `$WORKTREE_ROOT`), a ref force-move is not in its set, and the
+#2143 keystroke was outside the agent Bash tool-call path entirely. Git's
+`reference-transaction` boundary fires for **every** ref update regardless of caller (agent
+Bash, harness worktree machinery, a manually-run command, or another git hook), which is
+exactly the reach a `PreToolUse` Bash hook lacks.
+
+Safe by construction (the pure core `ref-guard.ts` decides, `command.ts` runs it):
+
+- The pure `decideRefUpdate` allows every non-`refs/heads/main` update untouched, and on
+  `refs/heads/main` allows **only a fast-forward** of `origin/main` (`origin/main` an
+  ancestor of the new tip, or the new tip == `origin/main`); a non-ff divergence — or a
+  delete — **refuses**. The legitimate PULLER `merge --ff-only origin/main` is a fast-forward,
+  so it always passes; the reattach `checkout main` moves no ref on `main` at all.
+- **Fail-open on infra absence, fail-closed on divergence.** An unresolvable `origin/main`
+  (a fresh clone before the first fetch) allows the update (nothing to diverge from); an
+  ancestry probe that *fails* is treated as non-ff and refuses on the guarded ref (cannot
+  prove a fast-forward ⇒ divergence). The `lefthook.yml` wrapper aborts the transaction only
+  on the guard's **dedicated refuse exit code (3)** and fail-opens on any other non-zero, so a
+  not-yet-installed / stripped-PATH CLI (#787) or `bin.ts`'s unlinked-dep remediation (which
+  exits 1) can never wedge every ref transaction repo-wide (the #1050 fail-open invariant).
+
+Installed via `lefthook.yml` (ADR 0068), so it lands in the shared `.git/hooks` and fires for
+the primary checkout and every worktree that shares that `.git`. Git honors the exit status
+only in the `prepared` state, so the guard evaluates + can refuse only there; `committed` /
+`aborted` drain stdin and no-op.
+
+```bash
+# git invokes this itself as the reference-transaction hook; the manual shape (for a test):
+printf '%s %s refs/heads/main\n' "$OLD" "$NEW" \
+  | node packages/pipeline-cli/src/bin.ts ref-guard reference-transaction prepared
+# exit 0 = allow · exit 3 = REFUSE (a diverging main move) · other non-zero = CLI couldn't run (fail-open)
+```
+
+This is a **control-plane** surface (it guards the shared primary checkout's `main`); see
+[`.patterns/worktree-agent-constraints.md`](../../.patterns/worktree-agent-constraints.md)
+for the surrounding primary-checkout discipline it completes.
+
 ### `ship-digest` — the merged-since founder projection (#1595)
 
 Renders a **founder-facing** ship digest for a `--since` window from a pre-gathered

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -30,6 +30,7 @@ import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {readGuardCommand} from "./tools/read-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
+import {refGuardCommand} from "./tools/ref-guard/command.ts";
 import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
 import {shipDigestCommand} from "./tools/ship-digest/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
@@ -102,4 +103,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	resumePolicyCommand,
 	evalHarnessCommand,
 	mainSyncCommand,
+	refGuardCommand,
 ];

--- a/packages/pipeline-cli/src/tools/ref-guard/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/command.hook.test.ts
@@ -1,0 +1,230 @@
+import {execFile, execFileSync} from "node:child_process";
+import {mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {REFUSE_EXIT_CODE} from "./command.ts";
+
+// `pipeline-cli ref-guard reference-transaction <state>` reads git's ref-update lines
+// off stdin. These tests drive the real command against real git ref transactions —
+// grounding the guard's behavior in actual git `reference-transaction` semantics, not a
+// modeled stub (CLAUDE.md: ground platform-behavior claims in the real platform).
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stderr: string;
+}
+
+/** Run the guard with a given transaction state + stdin body, in a given cwd (a git repo). */
+const runGuard = (state: string, stdin: string, cwd: string): Promise<RunResult> =>
+	new Promise((resolve) => {
+		const child = execFile(
+			"node",
+			[BIN, "ref-guard", "reference-transaction", state],
+			{cwd},
+			(error, _stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stderr});
+			},
+		);
+		child.stdin?.end(stdin);
+	});
+
+const git = (cwd: string, ...args: string[]): string =>
+	execFileSync("git", args, {cwd, encoding: "utf8"}).trim();
+
+const ZERO = "0000000000000000000000000000000000000000";
+
+/**
+ * A local repo with an `origin` remote whose `main` sits one commit AHEAD of the local
+ * `main`, so we can craft both a fast-forward update (local main → origin/main, allow)
+ * and a diverging update (local main → a sibling commit off the shared base, refuse).
+ */
+interface Fixture {
+	readonly dir: string;
+	readonly base: string; // shared base commit both origin/main and the divergent commit descend from
+	readonly originTip: string; // origin/main's tip (a fast-forward of base)
+	readonly divergent: string; // a commit off base that is NOT an ancestor of origin/main
+}
+
+let fx: Fixture;
+
+const commitEmpty = (dir: string, msg: string): string => {
+	git(dir, "commit", "--allow-empty", "-q", "-m", msg);
+	return git(dir, "rev-parse", "HEAD");
+};
+
+beforeAll(() => {
+	const root = mkdtempSync(join(tmpdir(), "ref-guard-"));
+	const originDir = join(root, "origin.git");
+	const dir = join(root, "clone");
+
+	// A bare origin with main = base → originTip.
+	execFileSync("git", ["init", "-q", "--bare", "-b", "main", originDir]);
+	const seed = join(root, "seed");
+	execFileSync("git", ["init", "-q", "-b", "main", seed]);
+	git(seed, "config", "user.email", "t@t");
+	git(seed, "config", "user.name", "t");
+	const base = commitEmpty(seed, "base");
+	const originTip = commitEmpty(seed, "origin-ahead");
+	execFileSync("git", ["remote", "add", "origin", originDir], {cwd: seed});
+	execFileSync("git", ["push", "-q", "origin", "main"], {cwd: seed});
+
+	// The working clone: main at base, origin/main fetched at originTip.
+	execFileSync("git", ["clone", "-q", "-b", "main", originDir, dir]);
+	git(dir, "config", "user.email", "t@t");
+	git(dir, "config", "user.name", "t");
+	// Reset local main back to base so a move to originTip is a real fast-forward.
+	git(dir, "reset", "-q", "--hard", base);
+	// A divergent commit off base (a sibling of origin-ahead) — NOT an ancestor of origin/main.
+	const divergent = commitEmpty(dir, "divergent-off-base");
+	git(dir, "reset", "-q", "--hard", base);
+
+	fx = {dir, base, originTip, divergent};
+	// stash the root for cleanup
+	(fx as {cleanupRoot?: string}).cleanupRoot = root;
+});
+
+afterAll(() => {
+	const root = (fx as {cleanupRoot?: string}).cleanupRoot;
+	if (root) rmSync(root, {recursive: true, force: true});
+});
+
+describe("ref-guard reference-transaction — real git facts", () => {
+	it("REFUSES a diverging refs/heads/main move (non-fast-forward of origin/main) in 'prepared'", async () => {
+		const stdin = `${fx.base} ${fx.divergent} refs/heads/main\n`;
+		const {code, stderr} = await runGuard("prepared", stdin, fx.dir);
+		assert.strictEqual(code, REFUSE_EXIT_CODE);
+		assert.include(stderr, "DIVERGING");
+	});
+
+	it("ALLOWS a fast-forward refs/heads/main move (→ origin/main tip)", async () => {
+		const stdin = `${fx.base} ${fx.originTip} refs/heads/main\n`;
+		const {code} = await runGuard("prepared", stdin, fx.dir);
+		assert.strictEqual(code, 0);
+	});
+
+	it("ALLOWS a move whose new tip == origin/main (in sync)", async () => {
+		const stdin = `${fx.divergent} ${fx.originTip} refs/heads/main\n`;
+		const {code} = await runGuard("prepared", stdin, fx.dir);
+		assert.strictEqual(code, 0);
+	});
+
+	it("ALLOWS an off-main ref update regardless of divergence (out of scope)", async () => {
+		const stdin = `${fx.base} ${fx.divergent} refs/heads/feature\n`;
+		const {code} = await runGuard("prepared", stdin, fx.dir);
+		assert.strictEqual(code, 0);
+	});
+
+	it("REFUSES deleting refs/heads/main (new all-zeroes)", async () => {
+		const stdin = `${fx.originTip} ${ZERO} refs/heads/main\n`;
+		const {code, stderr} = await runGuard("prepared", stdin, fx.dir);
+		assert.strictEqual(code, REFUSE_EXIT_CODE);
+		assert.include(stderr, "DELETE");
+	});
+
+	it("does NOT refuse in 'committed' state even for a divergence (exit honored only in prepared)", async () => {
+		const stdin = `${fx.base} ${fx.divergent} refs/heads/main\n`;
+		const {code} = await runGuard("committed", stdin, fx.dir);
+		assert.strictEqual(code, 0);
+	});
+
+	it("does NOT refuse in 'aborted' state", async () => {
+		const stdin = `${fx.base} ${fx.divergent} refs/heads/main\n`;
+		const {code} = await runGuard("aborted", stdin, fx.dir);
+		assert.strictEqual(code, 0);
+	});
+
+	it("allows an empty transaction (no queued updates)", async () => {
+		const {code} = await runGuard("prepared", "", fx.dir);
+		assert.strictEqual(code, 0);
+	});
+});
+
+// The decisive end-to-end test the acceptance criteria demand: install the
+// reference-transaction hook (wired EXACTLY as lefthook.yml does — exit 3 → abort) into a
+// real repo, then perform a BARE git ref-move that goes through NO pipeline command. If the
+// guard only fired on CLI-invoked moves it would be theater with the #1571 hole; this proves
+// git's own ref boundary fires the hook and the guard aborts the transaction. We drive
+// `git update-ref refs/heads/main` (a bare ref-transaction) rather than `git branch -f main`
+// because git refuses a `-f` on the CURRENTLY-checked-out branch before any hook runs — the
+// incident's `branch: Reset to HEAD` was a checkout-B/reset on the checked-out branch, of
+// which update-ref is the minimal ref-transaction form.
+describe("ref-guard — installed reference-transaction hook fires on a BARE git ref-move (no pipeline command)", () => {
+	const hookBody = (bin: string): string =>
+		[
+			"#!/bin/sh",
+			`node "${bin}" ref-guard reference-transaction "$1"`,
+			"s=$?",
+			// mirror lefthook.yml: only the guard's dedicated refuse code (3) aborts; any other
+			// non-zero fail-opens (the CLI couldn't run) — never wedge every ref transaction.
+			'[ "$s" -eq 3 ] && exit 1',
+			"exit 0",
+			"",
+		].join("\n");
+
+	const installHook = (repoDir: string): void => {
+		const hookPath = join(repoDir, ".git", "hooks", "reference-transaction");
+		writeFileSync(hookPath, hookBody(BIN), {mode: 0o755});
+	};
+
+	it("aborts a bare `git update-ref refs/heads/main <divergent>` — main is held at its old tip", () => {
+		installHook(fx.dir);
+		let aborted = false;
+		try {
+			execFileSync("git", ["update-ref", "refs/heads/main", fx.divergent], {
+				cwd: fx.dir,
+				stdio: "pipe",
+			});
+		} catch {
+			aborted = true; // git exits non-zero: "ref updates aborted by hook"
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		assert.isTrue(aborted, "the bare update-ref should be aborted by the hook");
+		assert.strictEqual(
+			git(fx.dir, "rev-parse", "refs/heads/main"),
+			fx.base,
+			"main must still point at its pre-move tip (the force-move was refused)",
+		);
+	});
+
+	it("allows a bare `git update-ref refs/heads/main <origin-tip>` (a fast-forward)", () => {
+		// reset main to base, then fast-forward it to origin/main via a bare update-ref.
+		git(fx.dir, "update-ref", "refs/heads/main", fx.base);
+		installHook(fx.dir);
+		let ok = true;
+		try {
+			execFileSync("git", ["update-ref", "refs/heads/main", fx.originTip], {
+				cwd: fx.dir,
+				stdio: "pipe",
+			});
+		} catch {
+			ok = false;
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		assert.isTrue(ok, "a fast-forward update-ref should be allowed");
+		assert.strictEqual(git(fx.dir, "rev-parse", "refs/heads/main"), fx.originTip);
+		git(fx.dir, "update-ref", "refs/heads/main", fx.base); // restore fixture
+	});
+
+	it("does NOT block a bare ref-move of an off-main (worktree feature) branch", () => {
+		installHook(fx.dir);
+		let ok = true;
+		try {
+			execFileSync("git", ["update-ref", "refs/heads/umut/feature", fx.divergent], {
+				cwd: fx.dir,
+				stdio: "pipe",
+			});
+		} catch {
+			ok = false;
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		assert.isTrue(ok, "an off-main branch ref-move must not be blocked (no false-positive on coders)");
+		assert.strictEqual(git(fx.dir, "rev-parse", "refs/heads/umut/feature"), fx.divergent);
+	});
+});

--- a/packages/pipeline-cli/src/tools/ref-guard/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/command.hook.test.ts
@@ -156,21 +156,25 @@ describe("ref-guard reference-transaction — real git facts", () => {
 // incident's `branch: Reset to HEAD` was a checkout-B/reset on the checked-out branch, of
 // which update-ref is the minimal ref-transaction form.
 describe("ref-guard — installed reference-transaction hook fires on a BARE git ref-move (no pipeline command)", () => {
-	const hookBody = (bin: string): string =>
+	// Mirror the lefthook.yml wiring EXACTLY: `|| status=$?` (never a bare call, so an
+	// inherited `set -e` can't abort as a side effect) + abort ONLY on the dedicated refuse
+	// code 3; every other non-zero (CLI absent / crash) fail-opens. `cmd` is the guard
+	// invocation — parameterized so the CLI-unavailable test can point it at a missing bin.
+	const hookBody = (cmd: string): string =>
 		[
 			"#!/bin/sh",
-			`node "${bin}" ref-guard reference-transaction "$1"`,
-			"s=$?",
-			// mirror lefthook.yml: only the guard's dedicated refuse code (3) aborts; any other
-			// non-zero fail-opens (the CLI couldn't run) — never wedge every ref transaction.
-			'[ "$s" -eq 3 ] && exit 1',
+			"status=0",
+			`${cmd} || status=$?`,
+			'[ "$status" -eq 3 ] && exit 1',
 			"exit 0",
 			"",
 		].join("\n");
 
-	const installHook = (repoDir: string): void => {
+	const guardCmd = (bin: string): string => `node "${bin}" ref-guard reference-transaction "$1"`;
+
+	const installHook = (repoDir: string, cmd: string = guardCmd(BIN)): void => {
 		const hookPath = join(repoDir, ".git", "hooks", "reference-transaction");
-		writeFileSync(hookPath, hookBody(BIN), {mode: 0o755});
+		writeFileSync(hookPath, hookBody(cmd), {mode: 0o755});
 	};
 
 	it("aborts a bare `git update-ref refs/heads/main <divergent>` — main is held at its old tip", () => {
@@ -224,7 +228,75 @@ describe("ref-guard — installed reference-transaction hook fires on a BARE git
 			ok = false;
 		}
 		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
-		assert.isTrue(ok, "an off-main branch ref-move must not be blocked (no false-positive on coders)");
+		assert.isTrue(
+			ok,
+			"an off-main branch ref-move must not be blocked (no false-positive on coders)",
+		);
 		assert.strictEqual(git(fx.dir, "rev-parse", "refs/heads/umut/feature"), fx.divergent);
+	});
+
+	// Regression for Defect 2 (#2143 follow-up): a `git fetch` updates refs/remotes/origin/* +
+	// FETCH_HEAD, NOT refs/heads/main — the guard MUST allow it. The CI breaker was leak-guard's
+	// `git fetch --depth=1 origin main` aborting; this proves the fetch's ref-transaction passes.
+	it("ALLOWS a real `git fetch origin main` (updates refs/remotes/origin/main + FETCH_HEAD, not refs/heads/main)", () => {
+		// advance origin so the fetch actually transacts a remote-tracking update
+		const originClone = join(fx.dir, "..", "origin-advance");
+		execFileSync("git", ["clone", "-q", join(fx.dir, "..", "origin.git"), originClone]);
+		git(originClone, "config", "user.email", "t@t");
+		git(originClone, "config", "user.name", "t");
+		const advanced = commitEmpty(originClone, "origin-advance-2");
+		execFileSync("git", ["push", "-q", "origin", "main"], {cwd: originClone});
+
+		installHook(fx.dir);
+		let ok = true;
+		try {
+			execFileSync("git", ["fetch", "--no-tags", "origin", "main"], {cwd: fx.dir, stdio: "pipe"});
+		} catch {
+			ok = false;
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		rmSync(originClone, {recursive: true, force: true});
+		assert.isTrue(
+			ok,
+			"a `git fetch origin main` must not be aborted — it never touches refs/heads/main",
+		);
+		assert.strictEqual(
+			git(fx.dir, "rev-parse", "refs/remotes/origin/main"),
+			advanced,
+			"the remote-tracking ref must have advanced (the fetch's ref-transaction was allowed)",
+		);
+	});
+
+	// Regression for Defect 1 (#1050/#787 fail-open): when the CLI can't RUN (missing bin /
+	// node module), the hook must FAIL OPEN — allow the ref-move, never abort. Only a positive
+	// refuse (exit 3) aborts. We point the hook at a non-existent bin to simulate the
+	// not-yet-installed / stripped-PATH env, then attempt the very divergence that would abort
+	// if the guard were live — and assert it is ALLOWED (the guard couldn't run ⇒ fail-open).
+	it("FAILS OPEN (allows) when the CLI is unavailable — a missing bin never aborts a ref transaction", () => {
+		const missingBin = join(fx.dir, "does-not-exist", "bin.ts");
+		installHook(fx.dir, guardCmd(missingBin));
+		git(fx.dir, "update-ref", "refs/heads/main", fx.base); // ensure a known start
+		let ok = true;
+		try {
+			// This is a DIVERGENCE that a live guard would abort — but the CLI can't run, so fail-open.
+			execFileSync("git", ["update-ref", "refs/heads/main", fx.divergent], {
+				cwd: fx.dir,
+				stdio: "pipe",
+			});
+		} catch {
+			ok = false;
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		const landed = git(fx.dir, "rev-parse", "refs/heads/main");
+		git(fx.dir, "update-ref", "refs/heads/main", fx.base); // restore fixture
+		assert.isTrue(
+			ok,
+			"a missing-CLI hook must fail OPEN (allow), never abort the transaction (#1050/#787)",
+		);
+		assert.strictEqual(
+			landed,
+			fx.divergent,
+			"the move was allowed because the guard could not run",
+		);
 	});
 });

--- a/packages/pipeline-cli/src/tools/ref-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/command.ts
@@ -1,0 +1,184 @@
+/**
+ * The `ref-guard` tool — `pipeline-cli ref-guard reference-transaction <state>`.
+ *
+ * The caller-agnostic, fail-closed guardrail that refuses a DIVERGING ref-move on the
+ * shared primary checkout's `refs/heads/main` (issue #2143). Wired as git's own
+ * `reference-transaction` hook (via `lefthook.yml`), so it fires for EVERY ref update
+ * regardless of caller — agent Bash, harness worktree machinery, a manually-run
+ * command, or another git hook. This is the boundary a `PreToolUse` Bash hook (the
+ * #1571 `worktree-guard` bash-pin) structurally cannot reach: that guard only arms for
+ * a `$WORKTREE_ROOT` subagent and only matches its `HEAD_MOVING` set, while the #2143
+ * force-move was a bare ref-move by the orchestrator/PULLER role outside the agent
+ * Bash tool-call path entirely.
+ *
+ * The `reference-transaction` hook contract (git): it takes exactly one argument — the
+ * transaction state (`prepared` | `committed` | `aborted`) — and reads on stdin one line
+ * per queued update, `<old-oid> SP <new-oid> SP <ref-name>`. The exit status is honored
+ * ONLY in the `prepared` state: a non-zero exit there aborts the whole transaction. So
+ * this command evaluates + can refuse only in `prepared`; `committed`/`aborted` (and any
+ * other state) drain stdin and no-op (exit 0), since a refusal there is ignored anyway.
+ *
+ * Safe by construction (the pure core `ref-guard.ts` is the first enforcement line, this
+ * command's flow is the second):
+ *   1. The pure `decideRefUpdate` allows every non-`refs/heads/main` update untouched, and
+ *      on `refs/heads/main` allows only a fast-forward of `origin/main`; a non-ff divergence
+ *      (or a delete) REFUSES. The legitimate PULLER `merge --ff-only origin/main` is a
+ *      fast-forward, so it always passes.
+ *   2. The origin facts are gathered read-only (`git rev-parse origin/main` +
+ *      `git merge-base --is-ancestor origin/main <newOid>`) with `execFileSync` (mirrors
+ *      `main-sync` / the `worktree-guard` reaper) — no mutation, so evaluating the guard
+ *      never itself moves a ref.
+ *
+ * Fail-open on infrastructure absence (the git boundary can't gather facts), fail-CLOSED on
+ * a guarded-ref divergence: an unresolvable `origin/main` allows the update (nothing to
+ * diverge from — a fresh clone before the first fetch), but an ancestry probe that FAILS is
+ * passed as `originIsAncestorOfNew=false`, which on `refs/heads/main` refuses (cannot prove a
+ * fast-forward ⇒ treat as divergence).
+ */
+import {execFileSync} from "node:child_process";
+import {Console, Effect} from "effect";
+import {Argument, Command} from "effect/unstable/cli";
+import {
+	decideRefUpdate,
+	decideTransaction,
+	GUARDED_REF,
+	type OriginFacts,
+	type RefUpdate,
+	ZERO_OID,
+} from "./ref-guard.ts";
+
+/**
+ * The DEDICATED refuse exit code — deliberately NOT 1. The `lefthook.yml`
+ * reference-transaction wrapper aborts the git transaction ONLY on this exact code, and
+ * fail-OPENs (allows) on every other non-zero. This disambiguates a real guard refusal
+ * from an infrastructural CLI failure that also exits 1 — `bin.ts`'s unlinked-dependency
+ * remediation exits 1 on a fresh/partial checkout (#1798), and a fail-closed-on-1 hook
+ * would then abort every ref transaction repo-wide, exactly the #1050/#787 fail-open
+ * invariant this must not break. A unique code keeps refuse fail-CLOSED and every other
+ * failure fail-OPEN.
+ */
+export const REFUSE_EXIT_CODE = 3;
+
+/** Read the whole hook stdin (may be empty) synchronously. */
+const readStdin = (): Effect.Effect<string> =>
+	Effect.promise(async () => {
+		const chunks: Buffer[] = [];
+		for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+		return Buffer.concat(chunks).toString("utf8");
+	});
+
+/**
+ * Parse git's `reference-transaction` stdin — one `<old-oid> SP <new-oid> SP <ref-name>`
+ * line per queued update. Blank lines and malformed lines (not exactly three
+ * whitespace-separated fields) are skipped; the guard evaluates only well-formed updates.
+ */
+const parseUpdates = (stdin: string): ReadonlyArray<RefUpdate> => {
+	const updates: RefUpdate[] = [];
+	for (const line of stdin.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed === "") continue;
+		const parts = trimmed.split(/\s+/);
+		if (parts.length !== 3) continue;
+		const [oldOid, newOid, refName] = parts as [string, string, string];
+		updates.push({oldOid, newOid, refName});
+	}
+	return updates;
+};
+
+const runGit = (args: ReadonlyArray<string>): {ok: boolean; stdout: string} => {
+	try {
+		const stdout = execFileSync("git", [...args], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		return {ok: true, stdout};
+	} catch {
+		return {ok: false, stdout: ""};
+	}
+};
+
+/**
+ * Resolve `origin/main` to an OID, or `null` when the remote-tracking ref is absent (a
+ * fresh clone before the first fetch). `null` is the fail-OPEN sentinel the core reads as
+ * "nothing to diverge from".
+ */
+const resolveOriginMain = (): string | null => {
+	const r = runGit(["rev-parse", "--verify", "--quiet", "origin/main"]);
+	if (!r.ok) return null;
+	const oid = r.stdout.trim();
+	return oid === "" ? null : oid;
+};
+
+/**
+ * `true` iff `origin/main` is an ancestor of (or equal to) `newOid` — a fast-forward.
+ * `git merge-base --is-ancestor A B` exits 0 when A is an ancestor of B, 1 when not; any
+ * OTHER failure (bad OID, git error) is indeterminate and returns `false` (fail-safe: on
+ * the guarded ref the core refuses when a fast-forward can't be proven).
+ */
+const originIsAncestorOf = (newOid: string): boolean => {
+	try {
+		execFileSync("git", ["merge-base", "--is-ancestor", "origin/main", newOid], {
+			stdio: "ignore",
+		});
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const stateArg = Argument.string("state").pipe(
+	Argument.withDescription(
+		"the reference-transaction state: prepared | committed | aborted (git passes this). Only 'prepared' can refuse.",
+	),
+);
+
+const referenceTransaction = Command.make(
+	"reference-transaction",
+	{state: stateArg},
+	Effect.fn(function* ({state}) {
+		const stdin = yield* readStdin();
+		const updates = parseUpdates(stdin);
+
+		// Exit status is honored ONLY in 'prepared' (git contract) — a refuse in any other
+		// state is ignored, so drain and no-op. This also means the guard never blocks a
+		// 'committed'/'aborted' notification.
+		if (state !== "prepared") return;
+
+		// Evaluate only guarded-ref updates against origin facts; every other update is an
+		// out-of-scope allow the core returns without consulting origin (no needless git IO).
+		const guardsMain = updates.some((u) => u.refName === GUARDED_REF && u.newOid !== ZERO_OID);
+		const originMainOid = guardsMain ? resolveOriginMain() : null;
+
+		const facts = (update: RefUpdate): OriginFacts => {
+			if (update.refName !== GUARDED_REF || update.newOid === ZERO_OID) {
+				return {originMainOid: null, originIsAncestorOfNew: false};
+			}
+			return {
+				originMainOid,
+				originIsAncestorOfNew: originMainOid !== null && originIsAncestorOf(update.newOid),
+			};
+		};
+
+		const verdict = decideTransaction(updates.map((u) => decideRefUpdate(u, facts(u))));
+
+		if (verdict.kind === "refuse") {
+			// ADR 0092 "emit what you scanned": name the guarded ref + why before aborting.
+			yield* Console.error(`ref-guard: ${verdict.reason}`);
+			// The dedicated refuse code (not 1) — see REFUSE_EXIT_CODE: the hook aborts the
+			// transaction only on this code, fail-opening on an infra CLI failure that exits 1.
+			return yield* Effect.sync(() => process.exit(REFUSE_EXIT_CODE));
+		}
+		// allow: silent success (a hook that exits 0 with no stdout is a clean allow).
+	}),
+).pipe(
+	Command.withDescription(
+		"git reference-transaction hook: refuse a DIVERGING refs/heads/main ref-move on the shared primary checkout (non-fast-forward of origin/main) — caller-agnostic, fail-closed (#2143)",
+	),
+);
+
+export const refGuardCommand = Command.make("ref-guard").pipe(
+	Command.withSubcommands([referenceTransaction]),
+	Command.withDescription(
+		"Caller-agnostic ref-transaction guard — refuse a diverging refs/heads/main move on the shared primary checkout (#2143)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts
@@ -1,0 +1,154 @@
+/**
+ * `ref-guard` pure core — decide whether a `reference-transaction` update to the
+ * shared primary checkout's `refs/heads/main` is safe, given the already-gathered
+ * git facts. IO-free and total: a deterministic transform over a queued ref update
+ * plus the ancestry fact the git boundary computed. The git boundary (read stdin,
+ * resolve `origin/main`, run `merge-base --is-ancestor`) lives in `command.ts`; this
+ * module never runs a command.
+ *
+ * The problem it codifies (#2143 root cause): the orchestrator/PULLER role force-moved
+ * the shared primary checkout's `main` ref off the merge seam — a bare
+ * `branch -f main` / `checkout -B main` / `update-ref refs/heads/main` / `push HEAD:main`
+ * that landed `main` on a stranding commit DIVERGED from `origin/main` (not a
+ * fast-forward), with a ~13.5k-line deletion staged — a "one `git push -f` clobbers
+ * `origin/main`" loaded gun. The #1571 `worktree-guard` bash-pin can't reach this
+ * class on three counts (the offender has no `$WORKTREE_ROOT`; a ref force-move is not
+ * in its `HEAD_MOVING` set; the keystroke is outside the agent Bash tool-call path).
+ * A `reference-transaction` hook sits at git's OWN ref boundary, so it catches ANY
+ * caller — agent Bash, harness worktree machinery, a manually-run command, or another
+ * git hook — which a `PreToolUse` Bash hook cannot.
+ *
+ * The safety property (#2143 AC): a `refs/heads/main` update that would make local
+ * `main` a NON-fast-forward of `origin/main` (a divergence) is REFUSED; the legitimate
+ * PULLER flow — `checkout main` reattach (no ref move on `main`) + `merge --ff-only
+ * origin/main` (a fast-forward ⇒ `origin/main` is an ancestor of the new tip) — is
+ * ALLOWED. The core refuses only the diverging move, never the sync.
+ *
+ * Fail-safe posture (fail-closed on the guarded ref, fail-open off it): every
+ * indeterminate fact the git boundary can't resolve is passed as a discriminated flag
+ * so the decision is explicit, never a silent allow of a `main` divergence.
+ */
+
+/** The full ref name the guard protects. Other refs (feature branches, tags, `origin/*`) are out of scope. */
+export const GUARDED_REF = "refs/heads/main";
+
+/** Git's all-zeroes object name — the sentinel for a ref being created anew (old) or deleted (new). */
+export const ZERO_OID = "0000000000000000000000000000000000000000";
+
+/**
+ * A single queued reference update, as the `reference-transaction` hook receives it on
+ * stdin — `<old-value> SP <new-value> SP <ref-name>`. `oldOid`/`newOid` are the raw
+ * object names (either may be `ZERO_OID`: an all-zeroes `newOid` is a delete, an
+ * all-zeroes `oldOid` is a create/force).
+ */
+export interface RefUpdate {
+	readonly oldOid: string;
+	readonly newOid: string;
+	readonly refName: string;
+}
+
+/**
+ * The ancestry fact the git boundary resolves for a guarded update, reduced to exactly
+ * what the decision needs. Every field fails safe toward REFUSE on the guarded ref: an
+ * unresolvable `origin/main` or an indeterminate ancestry probe reads as "cannot prove a
+ * fast-forward", which — for `refs/heads/main` — is a refusal, never a silent allow.
+ */
+export interface OriginFacts {
+	/**
+	 * `origin/main` resolved to a concrete OID, or `null` when the remote-tracking ref is
+	 * absent/unresolvable. `null` ⇒ there is nothing to diverge FROM — see `decideRefUpdate`
+	 * for why that is an ALLOW (a fresh clone with no `origin/main` yet has no divergence to
+	 * guard), not a refuse.
+	 */
+	readonly originMainOid: string | null;
+	/**
+	 * `true` iff `origin/main` is an ancestor of (or equal to) the update's `newOid` —
+	 * i.e. the new `main` tip is a fast-forward of `origin/main`. Resolved by the boundary
+	 * with `git merge-base --is-ancestor origin/main <newOid>`. An indeterminate probe
+	 * (command failed) MUST be passed as `false` (fail-safe: cannot prove ff ⇒ treat as
+	 * divergence on the guarded ref).
+	 */
+	readonly originIsAncestorOfNew: boolean;
+}
+
+/**
+ * The verdict for one queued ref update. `allow` proceeds; `refuse` (only ever on
+ * `GUARDED_REF`) aborts the whole `reference-transaction` in the `prepared` state.
+ */
+export type RefDecision =
+	| {readonly kind: "allow"; readonly reason: string}
+	| {readonly kind: "refuse"; readonly reason: string};
+
+/**
+ * Decide whether a queued `reference-transaction` update is safe:
+ *
+ *   1. NOT `refs/heads/main` → `allow`. The guard is scoped to the one shared-primary ref;
+ *      every feature branch, tag, and `origin/*` update passes untouched. (Worktree agents
+ *      only ever move their OWN branch refs, so they never reach the guarded path.)
+ *   2. `refs/heads/main` DELETE (`newOid` all-zeroes) → `refuse`. Deleting the primary's
+ *      `main` is never a legitimate PULLER op and is a divergence in the extreme.
+ *   3. `refs/heads/main`, `origin/main` unresolvable → `allow`. With no `origin/main` there
+ *      is nothing to diverge from (a fresh clone before the first fetch); refusing here would
+ *      wedge legitimate setup. This is the ONE fail-OPEN on the guarded ref, safe precisely
+ *      because the divergence the guard exists to catch is undefined without an origin.
+ *   4. `refs/heads/main`, new tip == `origin/main` → `allow`. In-sync (e.g. a reset/reattach
+ *      landing exactly on `origin/main`); trivially a fast-forward.
+ *   5. `refs/heads/main`, `origin/main` IS an ancestor of the new tip → `allow`. A
+ *      fast-forward-ahead: the legitimate `merge --ff-only origin/main` and any `main` advance
+ *      that carries `origin/main`'s history forward.
+ *   6. `refs/heads/main`, `origin/main` is NOT an ancestor of the new tip → `refuse`. The
+ *      #2143 non-fast-forward divergence: `main` would leave `origin/main`'s history, the exact
+ *      loaded-gun state. Fail-closed.
+ *
+ * Total over every `RefUpdate` × `OriginFacts`. The order above is the policy: the ref-scope
+ * check gates first (off-`main` never touches origin facts), then delete, then the origin-absent
+ * fail-open, then the two fast-forward allows, then the divergence refuse.
+ */
+export const decideRefUpdate = (update: RefUpdate, facts: OriginFacts): RefDecision => {
+	if (update.refName !== GUARDED_REF) {
+		return {kind: "allow", reason: `${update.refName} is not the guarded ref (${GUARDED_REF})`};
+	}
+	if (update.newOid === ZERO_OID) {
+		return {
+			kind: "refuse",
+			reason: `refusing to DELETE ${GUARDED_REF} on the shared primary checkout — never a legitimate sync op (#2143)`,
+		};
+	}
+	if (facts.originMainOid === null) {
+		return {
+			kind: "allow",
+			reason: `origin/main is unresolvable — no origin to diverge from, allowing ${GUARDED_REF} update`,
+		};
+	}
+	if (update.newOid === facts.originMainOid) {
+		return {kind: "allow", reason: `${GUARDED_REF} new tip == origin/main (in sync)`};
+	}
+	if (facts.originIsAncestorOfNew) {
+		return {
+			kind: "allow",
+			reason: `${GUARDED_REF} update is a fast-forward of origin/main (origin/main is an ancestor of the new tip)`,
+		};
+	}
+	return {
+		kind: "refuse",
+		reason:
+			`refusing a DIVERGING ${GUARDED_REF} update on the shared primary checkout: the new tip ${update.newOid.slice(0, 12)} ` +
+			`is NOT a fast-forward of origin/main (${facts.originMainOid.slice(0, 12)}) — this is the #2143 loaded-gun state ` +
+			`(local main diverged from origin/main; one \`git push -f\` would clobber origin/main). Drive sync through ` +
+			`\`git merge --ff-only origin/main\`, never a bare \`branch -f main\` / \`checkout -B main\` / \`update-ref refs/heads/main\`.`,
+	};
+};
+
+/**
+ * Reduce a batch of queued updates to a single transaction verdict: the transaction is
+ * REFUSED iff ANY update in it is refused (a `reference-transaction` is all-or-nothing —
+ * a non-zero exit in the `prepared` state aborts the WHOLE transaction, not one ref). The
+ * refuse reason surfaced is the first refused update's, so the operator sees the guarded-ref
+ * divergence that triggered the abort. An empty batch (no updates queued) is a clean allow.
+ */
+export const decideTransaction = (decisions: ReadonlyArray<RefDecision>): RefDecision => {
+	for (const d of decisions) {
+		if (d.kind === "refuse") return d;
+	}
+	return {kind: "allow", reason: "no guarded-ref divergence in the transaction"};
+};

--- a/packages/pipeline-cli/src/tools/ref-guard/ref-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/ref-guard.unit.test.ts
@@ -1,0 +1,162 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	decideRefUpdate,
+	decideTransaction,
+	GUARDED_REF,
+	type OriginFacts,
+	type RefUpdate,
+	ZERO_OID,
+} from "./ref-guard.ts";
+
+const OID_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OID_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const OID_ORIGIN = "cccccccccccccccccccccccccccccccccccccccc";
+
+const update = (over: Partial<RefUpdate> = {}): RefUpdate => ({
+	oldOid: OID_A,
+	newOid: OID_B,
+	refName: GUARDED_REF,
+	...over,
+});
+
+const facts = (over: Partial<OriginFacts> = {}): OriginFacts => ({
+	originMainOid: OID_ORIGIN,
+	originIsAncestorOfNew: false,
+	...over,
+});
+
+describe("decideRefUpdate — off the guarded ref (out of scope, always allow)", () => {
+	it("a feature branch update is allowed regardless of origin facts", () => {
+		const d = decideRefUpdate(update({refName: "refs/heads/umut/some-branch"}), facts());
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a tag update is allowed", () => {
+		const d = decideRefUpdate(update({refName: "refs/tags/v1"}), facts());
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a remote-tracking origin/main update is allowed (not refs/heads/main)", () => {
+		const d = decideRefUpdate(update({refName: "refs/remotes/origin/main"}), facts());
+		assert.strictEqual(d.kind, "allow");
+	});
+});
+
+describe("decideRefUpdate — refs/heads/main fast-forward cases (allow)", () => {
+	it("already in sync: new tip == origin/main → allow", () => {
+		const d = decideRefUpdate(
+			update({newOid: OID_ORIGIN}),
+			facts({originMainOid: OID_ORIGIN, originIsAncestorOfNew: true}),
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("fast-forward-ahead: origin/main is an ancestor of the new tip → allow (the merge --ff-only flow)", () => {
+		const d = decideRefUpdate(
+			update({newOid: OID_B}),
+			facts({originMainOid: OID_ORIGIN, originIsAncestorOfNew: true}),
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a create (old all-zeroes) that is a fast-forward of origin/main → allow", () => {
+		const d = decideRefUpdate(
+			update({oldOid: ZERO_OID, newOid: OID_B}),
+			facts({originMainOid: OID_ORIGIN, originIsAncestorOfNew: true}),
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+});
+
+describe("decideRefUpdate — refs/heads/main divergence (the #2143 refuse)", () => {
+	it("non-fast-forward: origin/main is NOT an ancestor of the new tip → refuse", () => {
+		const d = decideRefUpdate(
+			update({newOid: OID_B}),
+			facts({originMainOid: OID_ORIGIN, originIsAncestorOfNew: false}),
+		);
+		assert.strictEqual(d.kind, "refuse");
+		assert.include(d.reason, "DIVERGING");
+	});
+
+	it("a force-move create (old all-zeroes) onto a diverged commit → refuse", () => {
+		const d = decideRefUpdate(
+			update({oldOid: ZERO_OID, newOid: OID_B}),
+			facts({originMainOid: OID_ORIGIN, originIsAncestorOfNew: false}),
+		);
+		assert.strictEqual(d.kind, "refuse");
+	});
+
+	it("an indeterminate ancestry probe is passed as false → refuse (fail-closed: cannot prove ff)", () => {
+		// The boundary passes originIsAncestorOfNew=false when the merge-base probe failed;
+		// on the guarded ref that must refuse rather than silently allow a possible divergence.
+		const d = decideRefUpdate(update({newOid: OID_B}), facts({originIsAncestorOfNew: false}));
+		assert.strictEqual(d.kind, "refuse");
+	});
+});
+
+describe("decideRefUpdate — refs/heads/main delete (refuse)", () => {
+	it("deleting main (new all-zeroes) → refuse, regardless of origin facts", () => {
+		const d = decideRefUpdate(update({newOid: ZERO_OID}), facts({originIsAncestorOfNew: true}));
+		assert.strictEqual(d.kind, "refuse");
+		assert.include(d.reason, "DELETE");
+	});
+});
+
+describe("decideRefUpdate — origin/main unresolvable (the one fail-open on the guarded ref)", () => {
+	it("no origin/main (fresh clone before fetch) → allow (nothing to diverge from)", () => {
+		const d = decideRefUpdate(update({newOid: OID_B}), facts({originMainOid: null}));
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a delete still refuses even when origin/main is unresolvable (delete gates before origin-absent)", () => {
+		const d = decideRefUpdate(update({newOid: ZERO_OID}), facts({originMainOid: null}));
+		assert.strictEqual(d.kind, "refuse");
+	});
+});
+
+describe("decideRefUpdate — totality", () => {
+	it("every (ref-scope × delete × origin-present × ancestry) combination maps to a kind", () => {
+		const refNames = [GUARDED_REF, "refs/heads/feature"];
+		const newOids = [OID_B, ZERO_OID];
+		const origins: Array<string | null> = [OID_ORIGIN, null];
+		const ancestry = [true, false];
+		const kinds = new Set(["allow", "refuse"]);
+		for (const refName of refNames) {
+			for (const newOid of newOids) {
+				for (const originMainOid of origins) {
+					for (const originIsAncestorOfNew of ancestry) {
+						const d = decideRefUpdate(update({refName, newOid}), {
+							originMainOid,
+							originIsAncestorOfNew,
+						});
+						assert.isTrue(kinds.has(d.kind));
+					}
+				}
+			}
+		}
+	});
+});
+
+describe("decideTransaction — all-or-nothing over a batch", () => {
+	it("empty batch → allow", () => {
+		assert.strictEqual(decideTransaction([]).kind, "allow");
+	});
+
+	it("all-allow batch → allow", () => {
+		const d = decideTransaction([
+			{kind: "allow", reason: "a"},
+			{kind: "allow", reason: "b"},
+		]);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("any refuse in the batch → refuse the whole transaction, surfacing the first refuse reason", () => {
+		const d = decideTransaction([
+			{kind: "allow", reason: "a"},
+			{kind: "refuse", reason: "the guarded divergence"},
+			{kind: "refuse", reason: "second"},
+		]);
+		assert.strictEqual(d.kind, "refuse");
+		assert.strictEqual(d.reason, "the guarded divergence");
+	});
+});


### PR DESCRIPTION
## What & why

The shared primary checkout's `main` **branch ref** was force-moved off the merge seam by the orchestrator/PULLER role and left **diverged** from `origin/main` — a stranding commit with a ~13.5k-line deletion staged (a "one `git push -f` clobbers `origin/main`" loaded gun) that silently blocked a founder-side prod op until the checkout was repaired (#2143).

This adds a **caller-agnostic, fail-closed guardrail at git's own `reference-transaction` boundary** that **refuses any `refs/heads/main` update on the shared primary checkout that would make local `main` a non-fast-forward of `origin/main`**.

**Why the ref boundary, not a Bash hook.** The #1571 `worktree-guard` bash-pin can't reach this class on three counts: it only arms for a `$WORKTREE_ROOT` subagent (the PULLER has none), a ref force-move (`branch -f` / `checkout -B` / `update-ref`) is not in its `HEAD_MOVING` set, and the #2143 keystroke was outside the agent Bash tool-call path entirely. Git's `reference-transaction` hook fires for **every** ref transaction regardless of caller — which is the reach a `PreToolUse` Bash hook lacks. Wired via `lefthook.yml` (ADR 0068), mirroring the existing `pre-commit → leak-guard → pipeline-cli leak-guard scan` idiom.

## Shape (mirrors main-sync / bash-pin: pure core + thin boundary)

- **Pure decision core** — `packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts` (`decideRefUpdate`): IO-free, total. Off-`main` → allow; `refs/heads/main` fast-forward of `origin/main` (or new tip == origin/main) → allow; non-ff divergence or a `main` delete → refuse. Unit-tested (fast-forward-ahead / non-ff divergence / already-in-sync / delete / origin-absent / totality).
- **Thin git boundary** — `command.ts`: reads git's stdin ref-update lines, resolves `origin/main` + `git merge-base --is-ancestor`; refuses only in the `prepared` state (git honors the exit status only there) with a **dedicated exit code (3)**.
- **Hook wiring** — `lefthook.yml` `reference-transaction` command; the wrapper aborts the transaction **only** on exit 3 and **fail-opens on any other non-zero** (a not-yet-installed / stripped-PATH CLI, or `bin.ts`'s unlinked-dep remediation which exits 1), preserving the #1050/#787 fail-open invariant.
- Registered in `pipeline-cli` registry; ADR 0160 + `.patterns/worktree-agent-constraints.md` + README document the PULLER ROE (drive sync ONLY through the `main-sync` ff-only seam).

## Acceptance — proven end-to-end against real git

`command.hook.test.ts` installs the actual `reference-transaction` hook (wired exactly as `lefthook.yml`) into a real repo and drives a **bare `git update-ref refs/heads/main <divergent>` with no pipeline command in the loop**:

- diverging bare ref-move → **transaction aborted** ("ref updates aborted by hook"), `main` held at its old tip
- fast-forward bare ref-move → allowed
- off-main (worktree feature) bare ref-move → allowed (no false-positive on coders)

(`git branch -f main` on a checked-out branch is refused by git before any hook; `update-ref` is the minimal ref-transaction form of the incident's `branch: Reset to HEAD`.) 27 tests pass; `pnpm typecheck` + `pnpm lint:worktree` clean.

## Honest coverage boundary

`reference-transaction` catches every diverging `refs/heads/main` move performed **through git**, by any caller — but **not** a raw filesystem write to `.git/refs` (exotic, not the #2143 incident, and git offers no hook for it). A hook fires only where `lefthook install` has armed it (the primary + its shared-`.git` worktrees); a fresh clone is unguarded until it installs, the same install-dependency the `pre-commit` leak-guard already carries.

## §CP — control-plane

Touches `packages/pipeline-cli/**` and `lefthook.yml` → control-plane per ADR 0135 → **human-merge only (cansirin), never auto-ship**.

Fixes #2143