### PR TITLE
fix(ci): enable --sweep-closed-previews in orphan-sweep (#2145)

### DIFF
--- a/.github/workflows/orphan-sweep.yml
+++ b/.github/workflows/orphan-sweep.yml
@@ -8,8 +8,10 @@ name: orphan-sweep
 #
 # Safety is the CLI's pure core (packages/orphan-sweep/src/orphan-sweep.ts):
 # allow-by-pattern + deny-by-protection. prod, named-dev (--protect), and OPEN-PR
-# pr-<n> previews are NEVER swept — only it-* orphans are. Closed-PR pr-<n> previews
-# are left to #813's lane (this job does NOT pass --sweep-closed-previews).
+# pr-<n> previews are NEVER swept. This job also passes --sweep-closed-previews, so it
+# is the backstop that reaps a MERGED/CLOSED PR's pr-<n> preview (open-PR previews stay
+# protected by construction — the core keeps any pr-<n> whose PR is in the open-PR list,
+# regardless of the flag); it-* orphans are swept as before (#2145).
 on:
   schedule:
     # Daily at 03:17 UTC — off-hours and off the top of the hour (the GitHub scheduler
@@ -60,9 +62,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.execute }}" = "true" ]; then
-            echo "Running sweep with --execute (deleting orphan it-* resources)."
-            node packages/orphan-sweep/src/bin.ts sweep --execute
+            echo "Running sweep with --execute (deleting orphan it-* and closed-PR pr-<n> resources)."
+            node packages/orphan-sweep/src/bin.ts sweep --execute --sweep-closed-previews
           else
             echo "Running sweep in dry-run mode (printing the plan only; no deletions)."
-            node packages/orphan-sweep/src/bin.ts sweep
+            node packages/orphan-sweep/src/bin.ts sweep --sweep-closed-previews
           fi


### PR DESCRIPTION
Fixes #2145

## What

Enable the already-built `--sweep-closed-previews` flag on the daily `orphan-sweep` workflow so it reaps merged/closed-PR `pr-<n>` preview workers. ~52 dead preview workers accumulated on the shared Cloudflare account because the scheduled sweep only swept `it-*` integration stages and deliberately omitted this flag ("left to #813's lane").

This is **workflow-only enablement** — the flag and its open-PR protection already exist in `@kampus/orphan-sweep`. No package behavior changed.

## Changes (`.github/workflows/orphan-sweep.yml`)

- Scheduled/`--execute` invocation: `node packages/orphan-sweep/src/bin.ts sweep --execute` → `... sweep --execute --sweep-closed-previews`.
- `workflow_dispatch` dry-run invocation: `... sweep` → `... sweep --sweep-closed-previews`, so a human eyeballing the plan sees exactly what the schedule will reap. Dry-run stays **print-only** — deletions are gated on `--execute` (absent here), not on this flag.
- Top-of-file docstring updated: no longer states closed-PR previews are "left to #813's lane"; it now describes this job as the backstop that reaps closed-PR `pr-<n>` previews, with open-PR previews still protected by construction.

## Open-PR protection (verified, unchanged)

- `packages/orphan-sweep/src/github.ts` reads only `repos/<repo>/pulls?state=open` (paginated), so an open PR's `pr-<n>` is always in `openPrNumbers`.
- `packages/orphan-sweep/src/orphan-sweep.ts` keeps any `pr-<n>` whose PR is in that open set (`open-pr`) **regardless of** `sweepClosedPreviews` — the flag only reaches CLOSED-PR previews. A live open PR's preview is never swept.

## Acceptance criteria

- [x] Daily scheduled run passes `--sweep-closed-previews` alongside `--execute`.
- [x] Open-PR previews remain protected (verified against the core's `open-pr` keep-rule).
- [x] Docstring no longer says closed-PR previews are "left to #813's lane"; it reflects the backstop.
- [x] `workflow_dispatch` dry-run stays print-only when `execute` is false.

## Scope

Strictly the scheduled/dry-run sweep lines + the docstring in `orphan-sweep.yml`. Does not touch the on-close teardown lane (#813) or #2146's credential-seam extraction — independent.

§CP: this edits `.github/workflows/**` (ADR 0135) — human-merge only (cansirin approves @head). Not self-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)