### PR TITLE
fix(pipeline): verdict read-back guard — fail loud on a broken/leaked review marker (#2149)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -785,6 +785,71 @@ silently leaks a local path into a **public** comment:
   route around this with `-F body=@file`: the `$BODY`-by-value form is the single idiom every
   skill here uses — reach for it, not a second mechanism.)
 
+### The verdict read-back guard — after posting a gate marker, re-read it and FAIL LOUD (`verdict_readback_guard`)
+
+The by-value form above (`-f body="$BODY"`) is the *source* idiom; it prevents a `body=@<path>`
+leak **at the call site**. But a source idiom cannot catch a **runtime deviation** — an agent that
+hand-assembles the wrong `$BODY` (the literal temp path as the marker body, a body missing its
+`Reviewed-head:` anchor, or a silently no-opped post) still lands a broken marker the by-value form
+happily transmits. That is the #2148 class: the posted verdict comment's entire body was a local
+temp path (`@/var/folders/…`), so no SHA-bound verdict existed for `ship-it` / the §CP merger to
+bind to (a **missing** gate verdict), **and** it leaked a machine-local path into a public comment.
+The source idiom alone can't see it; only a **post-write read-back** can.
+
+So every gate that posts a verdict marker — `review-code`, `review-doc`, `review-skill` — closes the
+loop with **one** canonical read-back guard: after the post/upsert lands, **re-read the comment you
+just wrote** and assert three invariants, failing **loud** (fail-closed, ADR
+[0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md) §ZS)
+on any miss — never a silent pass. This is the single source; each review skill **references it**
+(it does not re-derive its own copy — the three-copy drift is exactly what this contract exists to
+prevent):
+
+```bash
+# verdict_readback_guard <comment-id> <gate> <head-sha>: re-read the just-posted verdict comment
+# and PROVE it is a well-formed, leak-free, current-head-bound marker. FAIL LOUD (non-zero) on any
+# miss — a broken marker reads to consumers as "no verdict", or worse a human skims it as posted.
+# <gate> is one of: review-code | review-doc | review-skill.
+verdict_readback_guard() {
+  local cid="$1" gate="$2" sha="$3"
+  local got; got="$(gh api "repos/$REPO/issues/comments/$cid" --jq .body)" || {
+    echo "verdict_readback_guard FAILED: cannot re-read comment $cid — treat the verdict as UNLANDED." >&2; return 1; }
+
+  # (1) the canonical gate marker token is present: either the bindable first-line
+  #     `<gate>: PASS|FAIL @ <sha>` (SHA prefix-matched, ADR 0058), OR the SHA-less `<gate>: advisory`
+  #     first line (blocking-set path — authorizes nothing but IS a posted verdict).
+  printf '%s' "$got" | grep -Eiq "^[[:space:]]*\**[[:space:]]*${gate}:[[:space:]]*(PASS|FAIL)[[:space:]]*@[[:space:]]*${sha:0:7}" \
+    || printf '%s' "$got" | grep -Eiq "^[[:space:]]*\**[[:space:]]*${gate}:[[:space:]]*advisory" \
+    || { echo "verdict_readback_guard FAILED: no canonical '${gate}:' marker (PASS/FAIL @ ${sha:0:7} or advisory) in comment $cid — the body is malformed; the PR is UNGATED." >&2; return 1; }
+
+  # (2) the anchored `Reviewed-head: @ <sha>` binding line is present (§6.6 / ADR 0151), SHA
+  #     prefix-matched to the head reviewed — the body line every §CP consumer resolves the head from.
+  printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:[[:space:]]*@?[[:space:]]*${sha:0:7}" \
+    || { echo "verdict_readback_guard FAILED: no anchored 'Reviewed-head: @ ${sha:0:7}' line in comment $cid — the §CP head binding is missing." >&2; return 1; }
+
+  # (3) NO local filesystem path leaked into the public body (the #2148 leak). Reject a machine-local
+  #     scratch/home path or a leading `@<path>` marker-as-path. Patterns are placeholders, not real
+  #     paths — this doc stays leak-clean.
+  if printf '%s' "$got" | grep -Eq '(/var/folders/|/Users/|/tmp[/.]|/private/tmp/|(^|[[:space:]])~/|(^|[[:space:]])@/)'; then
+    echo "verdict_readback_guard FAILED: comment $cid leaks a local filesystem path in its body — a #2148 marker-as-path leak; refuse and re-post the real verdict." >&2; return 1
+  fi
+
+  echo "verdict_readback_guard OK: ${gate} verdict @ ${sha:0:7} landed on comment $cid — marker + Reviewed-head present, no local-path leak."
+}
+```
+
+Gate it exactly like the by-value post it follows: right after the `PATCH`/`POST` upsert returns the
+comment id, call `verdict_readback_guard "$CID" <gate> "$HEAD_SHA"` and, on non-zero, **re-post the
+real verdict and re-assert** — if it still cannot land clean, surface it as a **posting failure** in
+the run ledger (the PR is genuinely ungated; a consumer must not read it as verified), never swallow
+it as a silent success. A moved `HEAD_SHA` between the post and the read-back means the head advanced
+*during* the review — re-resolve the head, re-verify against it (the gate is stateless), and re-post;
+never loosen the match to paper over a moved head.
+
+Two of the three assertions bind to a **head SHA** ((1) and (2)); the advisory blocking-set path
+carries no first-line `@ <sha>` by design (ADR 0111), which is why (1) accepts the `<gate>: advisory`
+first line as a posted verdict — but even the advisory MUST carry the body's `Reviewed-head: @ <sha>`
+line, so (2) and (3) still bind it. The bindable PASS/FAIL first line satisfies (1) via its `@ <sha>`.
+
 ---
 
 ## 3. Progress-comment format

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1401,6 +1401,18 @@ consumer apply one SHA contract. This makes verdict-posting an **enforced** gate
 the gate does not consider itself done until its own verdict is provably on the current head — closing
 the case where the posting step silently no-ops and a PR reads as ungated (#749 part b).
 
+**Then run the shared verdict read-back guard on the comment you just wrote (the #2148 leak class).**
+The presence check above proves *some* current-head `review-code:` verdict landed; it does not prove
+the comment **body** is well-formed and **leak-free** — the #2148 failure was a marker comment whose
+entire body was a local temp path (`@/var/folders/…`), a broken-marker + local-path-leak that a
+presence scan doesn't catch. When you posted via the **comment** upsert path (not the native APPROVE),
+re-read *that* comment and run the single canonical guard defined in the shared contract —
+[`gh-issue-intake-formats.md` §The verdict read-back guard](../gh-issue-intake-formats.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard).
+Do **not** re-derive a local copy — call the shared `verdict_readback_guard "$MINE" review-code "$HEAD_SHA"`
+(it asserts the canonical marker token, the anchored `Reviewed-head: @ <sha>` line, and **no local
+filesystem path**, failing loud on any miss). On non-zero, re-post the real verdict and re-assert;
+never swallow it as a silent success.
+
 > A `HEAD_SHA` moved between the 4a/4b post and this read-back means the PR head advanced *during*
 > the review — the verdict you posted is already stale against the new head. Re-resolve
 > `HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"`, **re-verify against the new head**

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -783,6 +783,27 @@ comment.
 
 ---
 
+## Step 5b — Confirm the verdict landed clean (the shared read-back guard, #2148)
+
+After **any** of the three Step-5 upserts (PASS non-blocking, advisory, or FAIL) returns its
+comment id, close the loop: **re-read the comment you just wrote and prove its body is a
+well-formed, leak-free, current-head-bound marker.** The by-value `-f body="$BODY"` post prevents
+the `body=@<path>` leak at the call site, but a source idiom cannot catch a **runtime deviation** —
+the #2148 failure was a marker comment whose entire body was a local temp path (`@/var/folders/…`):
+a broken marker (no SHA-bound verdict for consumers) **and** a public local-path leak. Only a
+post-write read-back sees it.
+
+Run the **single canonical guard** defined in the shared contract —
+[`gh-issue-intake-formats.md` §The verdict read-back guard](../gh-issue-intake-formats.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard).
+Do **not** re-derive a local copy — capture the upsert's comment id and call
+`verdict_readback_guard "$MINE" review-doc "$HEAD_SHA"` (it asserts the canonical `review-doc:`
+marker token, the anchored `Reviewed-head: @ <sha>` line, and **no local filesystem path**, failing
+loud on any miss). On non-zero, re-post the real verdict and re-assert; if it still cannot land
+clean, surface it as a posting failure in the run ledger — the PR is genuinely ungated and a
+consumer must not read it as verified — never swallow it as a silent success (fail-closed, ADR 0092 §ZS).
+
+---
+
 ## Running it
 
 A single invocation gates one doc PR end to end: classify blocking vs non-blocking

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -720,6 +720,27 @@ a comment.
 
 ---
 
+## Step 5b — Confirm the verdict landed clean (the shared read-back guard, #2148)
+
+After **any** of the three Step-5 upserts (PASS non-blocking, advisory, or FAIL) returns its
+comment id, close the loop: **re-read the comment you just wrote and prove its body is a
+well-formed, leak-free, current-head-bound marker.** The by-value `-f body="$BODY"` post prevents
+the `body=@<path>` leak at the call site, but a source idiom cannot catch a **runtime deviation** —
+the #2148 failure was a marker comment whose entire body was a local temp path (`@/var/folders/…`):
+a broken marker (no SHA-bound verdict for consumers) **and** a public local-path leak. Only a
+post-write read-back sees it.
+
+Run the **single canonical guard** defined in the shared contract —
+[`gh-issue-intake-formats.md` §The verdict read-back guard](../gh-issue-intake-formats.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard).
+Do **not** re-derive a local copy — capture the upsert's comment id and call
+`verdict_readback_guard "$MINE" review-skill "$HEAD_SHA"` (it asserts the canonical `review-skill:`
+marker token, the anchored `Reviewed-head: @ <sha>` line, and **no local filesystem path**, failing
+loud on any miss). On non-zero, re-post the real verdict and re-assert; if it still cannot land
+clean, surface it as a posting failure in the run ledger — the PR is genuinely ungated and a
+consumer must not read it as verified — never swallow it as a silent success (fail-closed, ADR 0092 §ZS).
+
+---
+
 ## Running it
 
 A single invocation gates one skill PR end to end: config-pin yourself to the base (mandatory,


### PR DESCRIPTION
Fixes #2149

## What changed

Adds a single canonical **verdict read-back guard** to the shared pipeline contract and wires all three review gates to reference it.

**Premise correction (per triage's re-grounding):** the original title — "review skills post the marker via `body=@<file>`" — is falsified vs `main`. All three review skills already use the safe by-value idiom (`BODY="$(cat "$VERDICT_FILE")"` → `-f body="$BODY"`, 0 occurrences of `body=@`), and the contract already forbids `body=@file` (PR #1567). That fix is a no-op, so this PR does **not** hunt for `body=@`.

**What actually happened (#2148):** a *runtime* deviation — a reviewer posted the literal temp path as the marker body (`@/var/folders/…`). The result was a broken marker (no SHA-bound verdict for `ship-it`/the §CP merger to bind to — an effectively **missing** gate verdict) **and** a local-path leak in a public comment. A source-level idiom cannot catch a runtime deviation; only a post-write read-back can.

## The fix — one shared idiom, three references

- **New law in the shared contract** — `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, section **"The verdict read-back guard"** (added directly under §"Posting a comment body", where the safe-post idiom lives). After a gate posts/upserts its verdict comment, it re-reads that comment and asserts, failing **loud** (fail-closed, ADR 0092 §ZS) on any miss:
  1. the canonical `<gate>:` marker token is present — `PASS|FAIL @ <sha>` (SHA prefix-matched, ADR 0058) **or** the SHA-less `<gate>: advisory` first line;
  2. the anchored `Reviewed-head: @ <sha>` binding line is present (§6.6 / ADR 0151);
  3. **no** local filesystem path leaked into the body (the #2148 leak).
- **The three review skills now REFERENCE that one idiom** (they do not triplicate it — the drift the contract exists to prevent):
  - `review-code/SKILL.md` — Step 4c extended to call `verdict_readback_guard "$MINE" review-code "$HEAD_SHA"` after its existing presence check.
  - `review-doc/SKILL.md` — new **Step 5b** referencing the guard.
  - `review-skill/SKILL.md` — new **Step 5b** referencing the guard.

## Verification

- The guard function is syntactically valid and functionally correct: smoke-tested clean-PASS + advisory pass; the #2148 temp-path body, a missing `Reviewed-head:`, and a `/Users/…` leak all fail loud.
- **Leak-clean:** the guard's reject patterns are written as placeholders — `leak-guard scan` reports clean on all four files, and the pre-commit hook passed.
- The definition appears exactly once (in the contract); all three skills cite it via the anchored `../gh-issue-intake-formats.md#…` link.

## §CP — control plane

This edits gate-critical skills (`review-code`/`review-doc`/`review-skill`) + the shared `gh-issue-intake-formats.md` contract → §CP blocking set (ADR 0135). **Human-merge only** (cansirin @head); this PR is not self-shipped.
