### PR TITLE
fix(pano): stamp live author identity on the feed read path (Fixes #2151)

### DIFF
--- a/apps/web/worker/features/pano/Pano.connection.unit.test.ts
+++ b/apps/web/worker/features/pano/Pano.connection.unit.test.ts
@@ -22,7 +22,8 @@ import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
-import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
+import {makePasaportStub, PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
+import type {Pasaport, ProfileIdentityRow} from "../pasaport/Pasaport.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
@@ -98,12 +99,12 @@ const BookmarkStub = Layer.succeed(Bookmark, {
 	listSavedConnection: () => Effect.die(new Error("not used")),
 } as unknown as typeof Bookmark.Service);
 
-const panoLayer = (access: DrizzleAccess) =>
+const panoLayer = (access: DrizzleAccess, pasaport: Layer.Layer<Pasaport> = PasaportIdentityStub) =>
 	PanoLive.pipe(
 		Layer.provide(VoteStub),
 		Layer.provide(BookmarkStub),
 		Layer.provide(ReactionStub),
-		Layer.provide(PasaportIdentityStub),
+		Layer.provide(pasaport),
 		Layer.provide(Layer.succeed(Drizzle, access)),
 	);
 
@@ -244,5 +245,99 @@ describe("Pano.listPostsConnection — cursor-miss → empty page, NO second DB 
 			const page = yield* pano.listPostsConnection({first: 10});
 			assert.strictEqual(page.totalCount, 0);
 		}).pipe(Effect.provide(panoLayer(access)));
+	});
+});
+
+describe("Pano.listPostsConnection — stamps the LIVE author identity on the page (#2151)", () => {
+	// The keyset fetch projects exactly `PostKeysetRow` (post-fields.ts): the resolver
+	// reads only these columns, so a scripted fetch row must carry the same subset.
+	const fetchRow = {
+		id: "post-1",
+		slug: "baslik",
+		title: "başlık",
+		url: "https://kamp.us",
+		host: "kamp.us",
+		bodyExcerpt: "özet",
+		authorId: "user-1",
+		// The write-time snapshot — the STALE handle the pre-fix feed rendered.
+		authorName: "eski-ad",
+		score: 3,
+		commentCount: 2,
+		createdAt: new Date(1000),
+		tags: "show",
+	};
+
+	// The LIVE `user_profile` identity for `user-1` — deliberately DIVERGENT from the
+	// write-time `authorName` snapshot above, so a stamped row proves the feed read the
+	// current handle rather than echoing the snapshot.
+	const liveIdentity: ProfileIdentityRow = {
+		userId: "user-1",
+		username: "umut",
+		displayName: "Umut Şirin",
+		totalKarma: 42,
+	};
+
+	const readSpy: {ids: ReadonlyArray<string> | null} = {ids: null};
+	const LiveIdentityStub = makePasaportStub({
+		getProfileIdentitiesByIds: (ids: ReadonlyArray<string>) => {
+			readSpy.ids = ids;
+			return Effect.succeed([liveIdentity]);
+		},
+	});
+
+	it.effect(
+		"landingPosts / signed-out feed path: the page row carries the LIVE username + displayName, not the write-time snapshot",
+		() => {
+			readSpy.ids = null;
+			// count + fetch (head page, no cursor). The fetch returns the one live row.
+			const {access} = scriptedAccess([1 /* count */, [fetchRow] /* fetch */]);
+			return Effect.gen(function* () {
+				const pano = yield* Pano;
+				const page = yield* pano.listPostsConnection({sort: "new", first: 10});
+				assert.strictEqual(page.rows.length, 1, "head page returns the one row");
+				const row = page.rows[0];
+				assert.isDefined(row, "head page returns the one row");
+				// The stamp — the fix's whole point: the resolver paths that DON'T re-hydrate
+				// through `getPostsByIds` (landingPosts, signed-out posts) now get the live
+				// identity here, so `actorLabel` renders the current display name.
+				assert.strictEqual(
+					row.authorDisplayName,
+					"Umut Şirin",
+					"the live displayName is stamped onto the feed row",
+				);
+				assert.strictEqual(
+					row.authorUsername,
+					"umut",
+					"the live username is stamped onto the feed row",
+				);
+				// The write-time `authorName` snapshot still rides as `author` (the intrinsic
+				// field) — the stamp ADDS the live identity, it does not overwrite the snapshot.
+				assert.strictEqual(
+					row.author,
+					"eski-ad",
+					"the write-time snapshot is preserved as `author`",
+				);
+			}).pipe(Effect.provide(panoLayer(access, LiveIdentityStub)));
+		},
+	);
+
+	it.effect("the identity read is ONE batched query keyed by the page's authorIds — no N+1", () => {
+		readSpy.ids = null;
+		const rows = [
+			{...fetchRow, id: "post-1", authorId: "user-1"},
+			{...fetchRow, id: "post-2", authorId: "user-2"},
+			// Two posts by the same author collapse to one id in the batch.
+			{...fetchRow, id: "post-3", authorId: "user-1"},
+		];
+		const {access} = scriptedAccess([3 /* count */, rows /* fetch */]);
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.listPostsConnection({sort: "new", first: 10});
+			assert.deepStrictEqual(
+				[...(readSpy.ids ?? [])].sort(),
+				["user-1", "user-2"],
+				"one identity read over the page's DISTINCT authorIds — never per-row",
+			);
+		}).pipe(Effect.provide(panoLayer(access, LiveIdentityStub)));
 	});
 });

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -655,7 +655,16 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		// (not `""`) — the divergence is unrepresentable, not hand-synced (#1170).
 		const page = forwardPage(fetched, first, (r) => r.id, toPostSummaryKeysetRow);
 
-		return {...page, totalCount} satisfies PostConnectionPage;
+		// Stamp the LIVE author identity onto the page — one batched
+		// `getProfileIdentitiesByIds` read for the whole page (never per-row), the same
+		// idiom `getPostsByIds` uses. This is the feed's convergence point: the resolver
+		// paths that serve this page WITHOUT re-hydrating through `getPostsByIds` —
+		// `landingPosts` (always anon) and the signed-OUT `posts` feed — would otherwise
+		// render the write-time `authorName` snapshot and degrade to `@username` (#2151,
+		// the last unstamped pano read path from #2139's `stampAuthorIdentity` rollout).
+		const stampedRows = yield* stampAuthorIdentity(readProfileIdentities, page.rows);
+
+		return {...page, rows: stampedRows, totalCount} satisfies PostConnectionPage;
 	});
 
 	const getPostsByIds = Effect.fn("Pano.getPostsByIds")(function* (


### PR DESCRIPTION
Fixes #2151.

## What this is

Brings the **last unstamped pano read path** to stamp parity with the rest of the #2139 `stampAuthorIdentity` rollout. `listPostsConnection` served its keyset page straight through `toPost` **without** calling `stampAuthorIdentity`, so the two resolver paths that do **not** re-hydrate through `getPostsByIds` degraded to the write-time `authorName` snapshot (→ `@username` via `actorLabel`):

- `landingPosts` (the public "panoda son 24 saat" column — always anon), and
- the **signed-OUT** `posts` feed branch in `lists.ts`.

(The signed-IN `posts` feed already re-hydrates via `getPostsByIds`, which stamps — it was already correct and is untouched.)

## The fix

Stamp at the service `listPostsConnection` convergence point — the single place both unstamped resolver paths flow through — mirroring the existing idiom on `getPostsByIds`: **one** batched `Pasaport.getProfileIdentitiesByIds` read over the page's **distinct** authorIds. One query per page, **no N+1**. The signed-in path's subsequent `getPostsByIds` re-stamp is a harmless re-write of the same live values, not a regression.

## Scope: coverage parity, NOT an end-to-end symptom fix

This closes the pano-feed **coverage gap** only — the feed now stamps like every other read path. It is **not** claimed to fix the founder-visible display-name report end-to-end.

There is a **separate, distinct** bug behind the same symptom: `user_profile.displayName` is written in only one place (`upsertProfileIdentity`, reached only from `setUsername`, copying `user.name` at that instant) — there is **no `setDisplayName` propagation**, and seeded/early rows can have null identity fields entirely. So a null/stale `user_profile` row still degrades to `@username` even with the feed stamping correctly. That `user_profile.displayName` one-shot-sync gap is a **separate lane** (being filed via report→triage by the EA); this PR does **not** address it, and the symptom persists for null/stale rows until that lands. The public-profile loader is deliberately **not** touched here (out of scope, and triage verified it threads `displayName` end-to-end structurally).

## Test

Adds a wire-convergence test to `Pano.connection.unit.test.ts` proving:
1. the resolver now **returns the stamped live identity** (`authorUsername`/`authorDisplayName`) when the `user_profile` row IS populated — while preserving the write-time snapshot as `author`, and
2. the identity read is **one batched query keyed by the page's distinct authorIds** (no N+1).

Both assertions **fail without the stamp** (verified by reverting the service change: `expected undefined to equal 'Umut Şirin'` / `expected [] to deeply equal [ 'user-1', 'user-2' ]`), so the test genuinely catches the regression. The test asserts wire-convergence only — a null `user_profile` row still degrades by design (the separate bug's territory).

`pnpm typecheck` clean; the full `worker/features/pano/` unit suite (19 files) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)