### PR TITLE
test(integration): classify preview-deploy secret-probe AuthError as transient (#2156)

### DIFF
--- a/apps/web/tests/integration/_deploy-transient.ts
+++ b/apps/web/tests/integration/_deploy-transient.ts
@@ -38,9 +38,23 @@ const DEPLOY_TRANSIENT_TAGS = new Set([
 // This precise substring is the version-propagation race alone.
 const NO_VERSIONS_MESSAGE = "no versions";
 
+// The preview-deploy secret probe's eventually-consistent signature: the `AuthError` _tag with a
+// "Edge-preview secret read failed: Secret probe returned <code>" message (a non-2xx probe result,
+// e.g. `400: <!DOCTYPE html>` or a 5xx). ADR 0061 already documents this verbatim string as a
+// Cloudflare preview-deploy infra flake unrelated to a PR that adds no worker/deploy code; it fired
+// in merge-group CI and ejected an approved PR from the queue (#2156, #2148). Matched on the MESSAGE
+// substring, NOT the bare `AuthError` _tag: a blanket AuthError retry would mask a genuine auth
+// failure (bad/expired token, wrong account), which must still fail fast — only the secret-probe
+// propagation race rides the bounded backoff.
+const SECRET_PROBE_MESSAGE = "Secret probe returned";
+
 export const isTransientDeployError = (error: unknown): boolean => {
 	if (typeof error !== "object" || error === null || !("_tag" in error)) return false;
 	const {_tag: tag, message} = error as {_tag: unknown; message?: unknown};
 	if (typeof tag === "string" && DEPLOY_TRANSIENT_TAGS.has(tag)) return true;
-	return tag === "NotFound" && typeof message === "string" && message.includes(NO_VERSIONS_MESSAGE);
+	if (tag === "NotFound" && typeof message === "string" && message.includes(NO_VERSIONS_MESSAGE))
+		return true;
+	return (
+		tag === "AuthError" && typeof message === "string" && message.includes(SECRET_PROBE_MESSAGE)
+	);
 };

--- a/apps/web/tests/integration/_deploy-transient.unit.test.ts
+++ b/apps/web/tests/integration/_deploy-transient.unit.test.ts
@@ -32,8 +32,27 @@ describe("isTransientDeployError", () => {
 		).toBe(true);
 	});
 
+	// #2156: the preview-deploy secret-probe AuthError (a non-2xx probe result) — the merge-group
+	// flake that ejected approved PR #2148. Matched on the message, not the bare `AuthError` _tag,
+	// so a genuine auth failure (below) still fails fast.
+	it.each([
+		[
+			"a 400-HTML probe result",
+			"Edge-preview secret read failed: Secret probe returned 400: <!DOCTYPE html>",
+		],
+		["a 502 probe result", "Edge-preview secret read failed: Secret probe returned 502"],
+	])("retries the transient preview-deploy secret-probe AuthError (%s)", (_label, message) => {
+		expect(isTransientDeployError({_tag: "AuthError", message})).toBe(true);
+	});
+
 	it.each([
 		["a bare NotFound (a genuinely missing resource)", {_tag: "NotFound", message: "gone"}],
+		// A real auth failure carries `AuthError` WITHOUT the secret-probe message — it must fail
+		// fast, never be swallowed by the #2156 secret-probe retry.
+		[
+			"a genuine auth failure (AuthError without the secret-probe message)",
+			{_tag: "AuthError", message: "invalid API token"},
+		],
 		["an auth failure", {_tag: "Unauthorized", message: "bad token"}],
 		["a config error", {_tag: "ConfigError", message: "missing binding"}],
 		["a tagless object", {message: "no tag here"}],


### PR DESCRIPTION
The merge-group `integration tests` job hard-failed on a known-transient Cloudflare preview-deploy infra flake — `AuthError: Edge-preview secret read failed: Secret probe returned 400: <!DOCTYPE html>` (`_tag: 'AuthError'`) — and ejected fully-approved PR #2148 from the merge queue (ADR 0132). 32/33 integration files passed on that batch; only `fts-backfill.test.ts` hit the probe. The signature is nondeterministic, so it can serially eject batched approved PRs.

## Fix
The harness already has a bounded transient-retry seam — `isTransientDeployError` in `apps/web/tests/integration/_deploy-transient.ts`, wrapped by `deployTransientRetry` in `_integration.ts`. It self-heals `WorkerNotFound`/`InternalServerError`/`UnknownCloudflareError`/`BadRequest` tags and the `NotFound "no versions"` propagation race, but did not cover the preview secret-probe `AuthError`, so this signature failed fast.

This folds the secret-probe `AuthError` into that same classifier, matched on the `Secret probe returned` **message substring** — not the bare `AuthError` _tag — mirroring the existing `no versions` `NotFound` message-match idiom. So the secret-probe propagation transient (a non-2xx probe result: 400-HTML or 5xx) rides the same bounded `deployTransientRetry` backoff, while a **genuine** auth failure (an `AuthError` without that message — bad/expired token, wrong account) still fails fast and exhausts the cap.

## Scope / §CP
- Purely under `apps/web/tests/**` → **§CP:NO, auto-shippable**. No `.github/workflows/ci.yml` merge_group gating and no `packages/ci-required/**` touched.

## Tests
`apps/web/tests/integration/_deploy-transient.unit.test.ts` extended:
- The secret-probe `AuthError` (400-HTML and 502 probe results) is now classified transient.
- A genuine `AuthError` **without** the secret-probe message still fails fast (not swallowed) — the fail-fast contract is preserved.

14/14 unit tests pass; `pnpm typecheck` clean.

Fixes #2156