### PR TITLE
fix(web): live token bugs — Toast light mode, --radius-md, ReactionBar --text

### DIFF
--- a/apps/web/src/components/funnel/Funnel.css
+++ b/apps/web/src/components/funnel/Funnel.css
@@ -32,7 +32,7 @@
 
 .kp-funnel__panel {
 	border: 1px solid var(--border-subtle);
-	border-radius: var(--radius-md);
+	border-radius: var(--r-md);
 	padding: var(--s-4);
 }
 

--- a/apps/web/src/components/reaction/ReactionBar.css
+++ b/apps/web/src/components/reaction/ReactionBar.css
@@ -34,7 +34,7 @@
 	border: 1px solid var(--border-faint);
 	border-radius: 999px;
 	background: var(--surface);
-	color: var(--text);
+	color: var(--text-primary);
 	font: var(--t-meta);
 	line-height: 1.6;
 	cursor: pointer;

--- a/apps/web/src/components/ui/Toast.css
+++ b/apps/web/src/components/ui/Toast.css
@@ -16,10 +16,10 @@
 	align-items: flex-start;
 	gap: 8px;
 	padding: 10px 12px;
-	border: 1px solid var(--border, #2a2a2a);
+	border: 1px solid var(--border);
 	border-radius: 8px;
-	background: var(--surface-1, #1a1a1a);
-	color: var(--text, #ededed);
+	background: var(--surface);
+	color: var(--text-primary);
 	font: var(--t-body, 13px / 1.4 system-ui);
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
 }
@@ -30,7 +30,7 @@
 }
 
 .kp-toast__body a {
-	color: var(--accent, #60a5fa);
+	color: var(--link);
 	text-decoration: underline;
 }
 
@@ -38,7 +38,7 @@
 	flex: 0 0 auto;
 	background: transparent;
 	border: none;
-	color: var(--text-muted, #888);
+	color: var(--text-muted);
 	font-size: 18px;
 	line-height: 1;
 	cursor: pointer;
@@ -46,5 +46,5 @@
 }
 
 .kp-toast__close:hover {
-	color: var(--text, #ededed);
+	color: var(--text-primary);
 }


### PR DESCRIPTION
Three live token defects where a CSS ref pointed at a non-existent role/radius token, so the ref resolved to nothing and either a hardcoded dark-hex fallback won (killing light mode) or the property fell to its initial value (square corners). All fixes point the refs at the real token layer — no new hardcoded hex.

- **Toast ignored light mode** (`apps/web/src/components/ui/Toast.css`) — referenced `--surface-1` / `--text` / `--accent`, none of which exist in the role layer, so the dark-hex fallbacks (`#1a1a1a` / `#ededed` / `#60a5fa`) won. Repointed to the real role tokens: `--surface`, `--text-primary`, `--link` (link text), `--text-muted` (close btn), and dropped every dark-hex fallback so the token/role layer wins in both themes.
- **Undefined `--radius-md`** (`apps/web/src/components/funnel/Funnel.css`) → square corners on the Funnel panel. Repointed to `--r-md` (4px), the medium rung of the defined `--r-sm`/`--r-md`/`--r-lg`/`--r-pill` radius ramp in `tokens.css`.
- **Undefined `--text`** (`apps/web/src/components/reaction/ReactionBar.css`) → repointed the button text color to `--text-primary`.

**`--focus-ring`: deferred, not touched.** It is already defined in `apps/web/src/styles/global.css`, so no token definition was needed. The ReactionBar `--focus-ring` component-focus defect belongs to the held focus/a11y cluster (#2166 / #2169) and is intentionally left alone here.

**Scope:** pure `apps/web/src/**` CSS value swaps (3 files) — non-§CP, no `.github/`, no lint tooling, no CI-required change. The role-token/px lint gate mentioned in the title is the separate §CP issue #2170 and is deliberately NOT built here.

Verified: `pnpm typecheck` clean (26/26), `pnpm lint:worktree` clean.

Fixes #2167