### PR TITLE
feat(web): render the curated reaction palette as on-brand controlled assets (#2165)

### DIFF
--- a/apps/web/src/components/reaction/ReactionBar.css
+++ b/apps/web/src/components/reaction/ReactionBar.css
@@ -1,6 +1,9 @@
-/* ReactionBar — the curated-palette emoji tepki bar (#1867), reused across pano
+/* ReactionBar — the curated-palette tepki bar (#1867), reused across pano
    post/comment + sözlük definition cards. A horizontal row of palette buttons;
-   the viewer's current reaction is highlighted via [aria-pressed="true"]. */
+   each member renders as an on-brand monochrome line-icon (#2165), not a raw OS
+   emoji glyph, so the affordance renders identically across OSes and coheres with
+   the monochrome-plus-accent palette. The viewer's current reaction is highlighted
+   via [aria-pressed="true"] (accent color + border). */
 
 :root {
 	/* One row of --t-meta buttons: line-height 1.6×11px + 2×1px padding + 2×1px
@@ -9,6 +12,9 @@
 	   down when it appears (#2054). The reserved slot (.kp-reaction-slot) and the
 	   mounted bar share this one source of truth so the reservation is exact. */
 	--reaction-bar-height: 22px;
+	/* The on-brand line-icon glyph box (#2165) — sized to sit on the --t-meta
+	   text baseline, one source of truth for every palette member. */
+	--reaction-glyph-size: 14px;
 }
 
 /* Reserved height for the reaction slot, held while the phoenix-reactions gate
@@ -52,10 +58,18 @@
 .kp-reaction-bar__btn[aria-pressed="true"] {
 	border-color: var(--accent);
 	background: var(--accent-soft, var(--surface-sunken));
+	/* The glyph paints in currentColor, so tinting the active button accent tints
+	   the icon too — the viewer's own reaction reads as the accent, on-brand. */
+	color: var(--accent);
 }
 
-.kp-reaction-bar__emoji {
-	font-size: 1em;
+/* The on-brand line-icon: paints in currentColor (inherits the button's token —
+   text by default, accent when active) and sizes off the glyph token, so no color
+   or size literal lives on the glyph (#2165). */
+.kp-reaction-bar__glyph {
+	width: var(--reaction-glyph-size);
+	height: var(--reaction-glyph-size);
+	flex: none;
 }
 
 .kp-reaction-bar__count {

--- a/apps/web/src/components/reaction/ReactionBar.test.tsx
+++ b/apps/web/src/components/reaction/ReactionBar.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * The on-brand controlled-asset render pass (#2165, pillar cohesiveness): the bar
+ * paints each palette member as a monochrome inline-SVG line-icon instead of its
+ * raw OS emoji glyph (so it renders identically across OSes and coheres with the
+ * monochrome-plus-accent palette), and names each button by ADR 0139's Turkish
+ * gloss. These assert the render contract the later ReactionBar convergence passes
+ * (#2166 contrast/focus, #2169 systematic focus/ARIA) build on.
+ */
+import {render} from "@testing-library/react";
+import {describe, expect, it, vi} from "vitest";
+import {REACTION_EMOJI} from "../../../worker/db/reaction-emoji";
+import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
+import {ReactionBar} from "./ReactionBar";
+import {REACTION_GLOSS} from "./reactionModel";
+
+describe("ReactionBar — on-brand controlled-asset render (#2165)", () => {
+	it("renders one inline-SVG line-icon per palette member, not the raw emoji glyph", () => {
+		const {container} = render(
+			<ReactionBar aggregate={null} onReact={vi.fn()} testIdSuffix="t1" />,
+		);
+		// One controlled SVG glyph per palette member — the OS-invariant asset.
+		const glyphs = container.querySelectorAll("svg.kp-reaction-bar__glyph");
+		expect(glyphs).toHaveLength(REACTION_EMOJI.length);
+		// The raw emoji text is no longer painted as a glyph (it stays the key/label only).
+		expect(container.querySelector(".kp-reaction-bar__emoji")).toBeNull();
+	});
+
+	it("paints the glyph in currentColor so it inherits the button's token", () => {
+		const {container} = render(
+			<ReactionBar aggregate={null} onReact={vi.fn()} testIdSuffix="t2" />,
+		);
+		for (const svg of container.querySelectorAll("svg.kp-reaction-bar__glyph")) {
+			expect(svg.getAttribute("stroke")).toBe("currentColor");
+		}
+	});
+
+	it("names each button by ADR 0139's Turkish gloss (the accessible name)", () => {
+		const {getByTestId} = render(
+			<ReactionBar aggregate={null} onReact={vi.fn()} testIdSuffix="t3" />,
+		);
+		for (const emoji of REACTION_EMOJI) {
+			const btn = getByTestId(`reaction-${emoji}-t3`);
+			expect(btn.getAttribute("aria-label")).toBe(REACTION_GLOSS[emoji]);
+		}
+	});
+
+	it("folds the count into the gloss accessible name when a member has reactions", () => {
+		const aggregate: ReactionAggregate = {counts: [{emoji: "🔥", count: 3}], myReaction: null};
+		const {getByTestId} = render(
+			<ReactionBar aggregate={aggregate} onReact={vi.fn()} testIdSuffix="t4" />,
+		);
+		expect(getByTestId("reaction-🔥-t4").getAttribute("aria-label")).toBe(
+			`${REACTION_GLOSS["🔥"]} (3)`,
+		);
+	});
+
+	it("marks the glyph decorative (aria-hidden) — the name lives on the button", () => {
+		const {container} = render(
+			<ReactionBar aggregate={null} onReact={vi.fn()} testIdSuffix="t5" />,
+		);
+		for (const svg of container.querySelectorAll("svg.kp-reaction-bar__glyph")) {
+			expect(svg.getAttribute("aria-hidden")).toBe("true");
+		}
+	});
+});

--- a/apps/web/src/components/reaction/ReactionBar.tsx
+++ b/apps/web/src/components/reaction/ReactionBar.tsx
@@ -7,9 +7,16 @@
  * `aria-pressed`) when it is the viewer's current reaction. The parent owns the
  * mutation + auth gate ({@link useReactionBar}); this only renders the slots and
  * routes a tap to `onReact`.
+ *
+ * Each member renders as an on-brand monochrome line-icon ({@link ReactionGlyph}),
+ * not its raw OS emoji glyph (#2165): the icon paints in `currentColor` so it
+ * inherits the button's token (text, or accent when active) and renders identically
+ * across OSes — the palette SET is ADR 0139's, unchanged; only the rendering is
+ * controlled. The accessible name is ADR 0139's Turkish gloss (`slot.gloss`).
  */
 import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
 import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
+import {ReactionGlyph} from "./ReactionGlyph";
 import {reactionSlots} from "./reactionModel";
 import "./ReactionBar.css";
 
@@ -32,11 +39,11 @@ export function ReactionBar({aggregate, onReact, testIdSuffix}: ReactionBarProps
 					type="button"
 					className="kp-reaction-bar__btn"
 					aria-pressed={slot.active}
-					aria-label={`${slot.emoji} tepki${slot.count ? ` (${slot.count})` : ""}`}
+					aria-label={`${slot.gloss}${slot.count ? ` (${slot.count})` : ""}`}
 					data-testid={`reaction-${slot.emoji}-${testIdSuffix}`}
 					onClick={() => onReact(slot.emoji)}
 				>
-					<span className="kp-reaction-bar__emoji">{slot.emoji}</span>
+					<ReactionGlyph emoji={slot.emoji} />
 					{slot.count > 0 ? (
 						<span
 							className="kp-reaction-bar__count"

--- a/apps/web/src/components/reaction/ReactionGlyph.tsx
+++ b/apps/web/src/components/reaction/ReactionGlyph.tsx
@@ -1,0 +1,129 @@
+/**
+ * The on-brand, OS-invariant glyphs for the curated reaction palette (#2165,
+ * pillar cohesiveness; epic #2168). ADR 0139 fixes the reaction SET — the six
+ * `REACTION_EMOJI` members and their Turkish glosses — and that membership is
+ * SETTLED; this module does not re-open it. What it replaces is the *rendering*:
+ * the bar used to paint each member as its raw OS emoji glyph, which (a) renders
+ * differently on every OS and (b) drops a full-color glyph into the
+ * monochrome-plus-accent palette. Instead every member is drawn as a controlled
+ * inline SVG line-icon that strokes/fills in `currentColor`, so it inherits the
+ * button's own token (text by default, accent when the viewer's reaction is
+ * active) and looks identical everywhere.
+ *
+ * The icons are the same affective symbols ADR 0139 chose — 👍 beğendim,
+ * ❤️ sevdim, 😂 güldüm, 🤔 düşündürdü, 😢 üzüldüm, 🔥 efsane — redrawn as
+ * monochrome line-art, not a different reaction set. The palette emoji stays the
+ * canonical identity/key everywhere else (wire, storage, ARIA gloss); this is a
+ * presentation layer keyed BY that emoji.
+ *
+ * Kept a pure keyed lookup with no color/size literals of its own: the SVG uses
+ * `currentColor` and scales to the button's glyph box, so color + size are driven
+ * by ReactionBar.css tokens, never hardcoded here.
+ */
+import type {ReactNode} from "react";
+import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
+
+/**
+ * Shared per-icon SVG frame: a 24×24 viewBox line-icon that fills the button's
+ * glyph box and paints in `currentColor`. `aria-hidden` — the accessible name
+ * lives on the parent button's `aria-label` (the ADR-0139 gloss), so the glyph
+ * itself is decorative.
+ */
+function Glyph({children}: {children: ReactNode}) {
+	return (
+		<svg
+			className="kp-reaction-bar__glyph"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+			focusable="false"
+		>
+			{children}
+		</svg>
+	);
+}
+
+/** 👍 beğendim — thumbs-up. */
+function ThumbsUp() {
+	return (
+		<Glyph>
+			<path d="M7 10v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1h3Z" />
+			<path d="M7 10l4-6a2 2 0 0 1 3 1.7V9h4.5a2 2 0 0 1 2 2.4l-1.3 6a2 2 0 0 1-2 1.6H7" />
+		</Glyph>
+	);
+}
+
+/** ❤️ sevdim — heart. */
+function Heart() {
+	return (
+		<Glyph>
+			<path d="M12 20s-7-4.3-9-8.2C1.6 8.9 3 5.5 6.3 5.5c1.9 0 3.1 1 3.7 2 .6 1 1.4 1 2 0 .6-1 1.8-2 3.7-2 3.3 0 4.7 3.4 3.3 6.3C19 15.7 12 20 12 20Z" />
+		</Glyph>
+	);
+}
+
+/** 😂 güldüm — laughing face. */
+function Laughing() {
+	return (
+		<Glyph>
+			<circle cx="12" cy="12" r="9" />
+			<path d="M8 10l2 1.5M16 10l-2 1.5" />
+			<path d="M8 14a4 4 0 0 0 8 0Z" />
+			<path d="M8.5 17.5c1 .6 2.2 1 3.5 1s2.5-.4 3.5-1" />
+		</Glyph>
+	);
+}
+
+/** 🤔 düşündürdü — thinking face. */
+function Thinking() {
+	return (
+		<Glyph>
+			<path d="M20.5 12A8.5 8.5 0 1 1 14 3.8" />
+			<circle cx="9" cy="11" r="0.6" fill="currentColor" stroke="none" />
+			<circle cx="15" cy="11" r="0.6" fill="currentColor" stroke="none" />
+			<path d="M9.5 15.5c1.2-.7 3.8-.7 5 0" />
+			<path d="M17.5 4.5c1.4 0 2.5 1 2.5 2.3S18.9 9 17.5 9" />
+		</Glyph>
+	);
+}
+
+/** 😢 üzüldüm — crying face. */
+function Crying() {
+	return (
+		<Glyph>
+			<circle cx="12" cy="12" r="9" />
+			<circle cx="9" cy="10.5" r="0.6" fill="currentColor" stroke="none" />
+			<circle cx="15" cy="10.5" r="0.6" fill="currentColor" stroke="none" />
+			<path d="M9 17c.9-1 1.9-1.5 3-1.5s2.1.5 3 1.5" />
+			<path d="M9 13v2.5" />
+		</Glyph>
+	);
+}
+
+/** 🔥 efsane — flame. */
+function Flame() {
+	return (
+		<Glyph>
+			<path d="M12 3c1 3 4 4.5 4 8.5A4 4 0 0 1 8 12c0-1.6.7-2.6 1.4-3.4C10 9.4 11 9 11 10c1-1 1-4 1-7Z" />
+		</Glyph>
+	);
+}
+
+const GLYPHS: Record<ReactionEmoji, () => ReactNode> = {
+	"👍": ThumbsUp,
+	"❤️": Heart,
+	"😂": Laughing,
+	"🤔": Thinking,
+	"😢": Crying,
+	"🔥": Flame,
+};
+
+/** Render the on-brand monochrome line-icon for a palette emoji (keyed by the ADR-0139 member). */
+export function ReactionGlyph({emoji}: {emoji: ReactionEmoji}) {
+	const Icon = GLYPHS[emoji];
+	return <Icon />;
+}

--- a/apps/web/src/components/reaction/reactionModel.test.ts
+++ b/apps/web/src/components/reaction/reactionModel.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from "vitest";
 import {REACTION_EMOJI} from "../../../worker/db/reaction-emoji";
 import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
-import {nextReaction, reactionOptimistic, reactionSlots} from "./reactionModel";
+import {nextReaction, REACTION_GLOSS, reactionOptimistic, reactionSlots} from "./reactionModel";
 
 /**
  * The load-bearing reaction-bar core the three surfaces ship through
@@ -46,6 +46,15 @@ describe("reactionSlots — the full curated palette, in order", () => {
 		const active = reactionSlots(agg).filter((s) => s.active);
 		expect(active).toHaveLength(1);
 		expect(active[0]?.emoji).toBe("❤️");
+	});
+
+	it("carries each member's ADR-0139 Turkish gloss (the accessible name seed)", () => {
+		const byEmoji = new Map(reactionSlots(null).map((s) => [s.emoji, s.gloss]));
+		expect(byEmoji.get("👍")).toBe("beğendim");
+		expect(byEmoji.get("🤔")).toBe("düşündürdü");
+		expect(byEmoji.get("🔥")).toBe("efsane");
+		// The gloss map covers every palette member exactly (no drift from the palette).
+		expect(Object.keys(REACTION_GLOSS).sort()).toEqual([...REACTION_EMOJI].sort());
 	});
 });
 

--- a/apps/web/src/components/reaction/reactionModel.ts
+++ b/apps/web/src/components/reaction/reactionModel.ts
@@ -28,9 +28,26 @@ export interface OptimisticReactionAggregate {
 	myReaction: ReactionEmoji | null;
 }
 
-/** One palette slot as the bar renders it: the emoji, its aggregate count, and whether it is the viewer's current reaction. */
+/**
+ * The Turkish reaction glosses fixed by ADR 0139 — one per palette member, in the
+ * same affective order. This is the single in-code seed of the ADR's gloss table;
+ * the bar uses it as each reaction's accessible name (ARIA label) so a screen
+ * reader announces "beğendim" / "sevdim" / … rather than the raw glyph. Keyed by
+ * the canonical `REACTION_EMOJI` member so it can never drift from the palette.
+ */
+export const REACTION_GLOSS: Record<ReactionEmoji, string> = {
+	"👍": "beğendim",
+	"❤️": "sevdim",
+	"😂": "güldüm",
+	"🤔": "düşündürdü",
+	"😢": "üzüldüm",
+	"🔥": "efsane",
+};
+
+/** One palette slot as the bar renders it: the emoji, its Turkish gloss, its aggregate count, and whether it is the viewer's current reaction. */
 export interface ReactionSlot {
 	readonly emoji: ReactionEmoji;
+	readonly gloss: string;
 	readonly count: number;
 	readonly active: boolean;
 }
@@ -51,6 +68,7 @@ export function reactionSlots(aggregate: ReactionAggregate | undefined | null): 
 	const countOf = new Map<string, number>(agg.counts.map((c) => [c.emoji, c.count]));
 	return REACTION_EMOJI.map((emoji) => ({
 		emoji,
+		gloss: REACTION_GLOSS[emoji],
 		count: countOf.get(emoji) ?? 0,
 		active: agg.myReaction === emoji,
 	}));


### PR DESCRIPTION
Fixes #2165

## What

The reaction bar rendered each ADR-0139 palette member as its **raw OS emoji glyph** (`{slot.emoji}` painted as glyph text). The cohesiveness-pillar audit flagged this: those full-color system glyphs render differently on every OS and clash with kamp.us's monochrome-plus-accent palette.

This pass replaces the rendering with **controlled inline-SVG line-icons** — one per palette member (`ReactionGlyph`), painted in `currentColor` so each inherits the button's own token (text by default, **accent** when it is the viewer's current reaction) and renders **identically across OSes**.

## What this does NOT do (scope guards)

- **The reaction SET is unchanged.** ADR [0139](https://github.com/kamp-us/phoenix/blob/main/.decisions/0139-reaction-curated-palette.md) fixes the six members `["👍","❤️","😂","🤔","😢","🔥"]` and their canonical order; that membership is **settled and not re-opened** (epic #2168 non-goal). Each icon is the same affective symbol redrawn as monochrome line-art, keyed by the same `REACTION_EMOJI` member — the emoji stays the canonical identity/key on the wire, in storage, and as the ARIA gloss.
- **Always-shown behavior is preserved.** `reactionModel.ts`'s always-shown model is untouched: every member still renders, in palette order, with its aggregate count and the viewer's pick highlighted. Single-vote is dropped and hover-reveal is deferred (both out of scope).

## Details

- `ReactionGlyph.tsx` — a pure keyed lookup of six monochrome 24×24 line-icons; no color/size literal of its own (the SVG uses `currentColor` and sizes off `--reaction-glyph-size`).
- **ARIA labels reuse ADR 0139's Turkish glosses** (`REACTION_GLOSS`, seeded once in `reactionModel.ts`): a screen reader now announces "beğendim" / "düşündürdü" / … instead of the raw glyph. The decorative SVG is `aria-hidden`; the accessible name lives on the button.
- Token seam honored (ADR 0147): glyph size + active color flow through `--reaction-glyph-size` and `--accent` — no raw px/hex on the asset. The `data-testid` contract (`reaction-bar-*`, `reaction-<emoji>-*`) is preserved, so the dark-ship e2e (`28-reaction-bar-darkship.spec.ts`) and the CLS slot (`#2054`) are unaffected.

Structurally clean for the serial ReactionBar convergence passes that build on this control: **#2166** (contrast/focus) and **#2169** (systematic focus/ARIA).

## Verification

- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm vitest` (reaction suite, unit + client) — 26 passed, incl. new asserts that the bar renders one inline-SVG per member (not the raw glyph), paints in `currentColor`, and names each button by its ADR-0139 gloss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)