### PR TITLE
docs(triage): reconcile the issue BODY on a re-type, not just a comment (#2180)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -325,6 +325,17 @@ but leave the body's original brief intact at the top. Do not bury it in a
 `<details>`. (If an epic was filed truly threadbare, prefer `status:needs-info` over
 mangling it.)
 
+**Re-typing an issue? Reconcile the BODY, not just a comment.** When you change an
+already-typed issue's type (a `decision` re-scoped to `feature`, a `bug` recut as a
+`chore`), the body's `## Acceptance criteria` are still written for the *old* type — and
+the body, not a comment, is the source of truth a `review-*` gate and a `write-code` agent
+read. A re-type that lands the new scope in a **comment** while leaving the stale
+criteria in the body ships a misleading spec: the coder builds against decision-era ACs
+("record an ADR", "file follow-ups") that no longer describe the work (#2165 →
+#2180). So on any re-type, **rewrite the body's acceptance criteria to the new type**
+(reusing Step 4's temp-file `PATCH` flow), then record the re-scope rationale in a
+comment — the comment explains *why*, the body carries *what to build*.
+
 ---
 
 ## Step 5 — The human-vs-agent judgment (who never gets auto-closed)


### PR DESCRIPTION
## What

Encode the root-cause rule that a **re-type must reconcile the issue BODY, not just add a comment** into the triage skill (`claude-plugins/kampus-pipeline/skills/triage/SKILL.md`, Step 4 — Enrich and rewrite).

## Why

#2165 was re-typed `decision` → `feature`. The re-scope landed in a **comment**, but the body's `## Acceptance criteria` still carried the decision-era checklist (record-an-ADR / keep-karma-free / file-follow-ups). The body — not a comment — is the source of truth a `review-*` gate and a `write-code` agent read, so a coder would build against acceptance criteria that no longer describe the work. That stale-body defect is what #2180 tracks.

The note tells a triager: on any re-type, rewrite the body's acceptance criteria to the new type (via Step 4's temp-file `PATCH` flow), then record the re-scope rationale in a comment — the comment explains *why*, the body carries *what to build*.

## Facets

This issue had two facets, one PR:

- **(a) Data fix — reconcile #2165's own stale body: SKIPPED.** #2165's PR #2179 was in the merge queue and auto-closed #2165 (at `2026-07-06T03:00:12Z`, PR merged `03:00:11Z`) before the reconciliation could land. Per triage's judgment, a closed issue's stale body no longer misleads a live gate or coder, so facet (a) has ~zero value once closed. The durable fix (b) carries the outcome.
- **(b) Convention note — the durable root-cause fix: DELIVERED (this PR).** One file touched.

## Notes

- §CP: NO. Skill-class change (triage is not a gate-critical skill) → `review-skill` gate, auto-ships on PASS.
- No control-plane files, no `.github/**`, no gate-critical skill touched.
- Edited the canonical plugin path (not a `.claude/` symlink). leak-guard + biome pre-commit hooks pass.

Fixes #2180

🤖 Generated with [Claude Code](https://claude.com/claude-code)