### PR TITLE
fix(web): a11y contrast + focus-ring + tap-target fixes on the reaction/vote cluster (#2166)

### DIFF
--- a/apps/web/src/components/pano/PanoComment.css
+++ b/apps/web/src/components/pano/PanoComment.css
@@ -44,6 +44,7 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 3px;
+	min-height: 24px; /* WCAG 2.5.8 24px min target (#2166) */
 	color: var(--text-muted);
 	background: none;
 	border: 0;

--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -33,8 +33,8 @@
 }
 
 .kp-pano-post__vote-btn {
-	width: 22px;
-	height: 22px;
+	width: 24px;
+	height: 24px; /* WCAG 2.5.8 24px min target (#2166) */
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;

--- a/apps/web/src/components/reaction/ReactionBar.css
+++ b/apps/web/src/components/reaction/ReactionBar.css
@@ -6,12 +6,12 @@
    via [aria-pressed="true"] (accent color + border). */
 
 :root {
-	/* One row of --t-meta buttons: line-height 1.6×11px + 2×1px padding + 2×1px
-	   border ≈ 21.6px. The phoenix-reactions gate resolves async, so the slot
-	   must reserve this height BEFORE the bar mounts or the whole feed reflows
-	   down when it appears (#2054). The reserved slot (.kp-reaction-slot) and the
-	   mounted bar share this one source of truth so the reservation is exact. */
-	--reaction-bar-height: 22px;
+	/* Each palette button is floored at the WCAG 2.5.8 24px minimum target size
+	   (#2166); the reserved slot must match that floor so the bar swaps into an
+	   already-sized slot instead of reflowing the feed when it mounts (#2054). The
+	   reserved slot (.kp-reaction-slot) and the mounted button share this one
+	   source of truth so the reservation is exact. */
+	--reaction-bar-height: 24px;
 	/* The on-brand line-icon glyph box (#2165) — sized to sit on the --t-meta
 	   text baseline, one source of truth for every palette member. */
 	--reaction-glyph-size: 14px;
@@ -35,7 +35,9 @@
 .kp-reaction-bar__btn {
 	display: inline-flex;
 	align-items: center;
+	justify-content: center;
 	gap: 4px;
+	min-height: var(--reaction-bar-height); /* WCAG 2.5.8 24px min target (#2166) */
 	padding: 1px 6px;
 	border: 1px solid var(--border-faint);
 	border-radius: 999px;
@@ -51,8 +53,8 @@
 }
 
 .kp-reaction-bar__btn:focus-visible {
-	outline: 2px solid var(--focus-ring);
-	outline-offset: 1px;
+	outline: var(--focus-ring);
+	outline-offset: var(--focus-ring-offset);
 }
 
 .kp-reaction-bar__btn[aria-pressed="true"] {
@@ -74,5 +76,7 @@
 
 .kp-reaction-bar__count {
 	font-variant-numeric: tabular-nums;
-	color: var(--text-faint);
+	/* Meaning-carrying metadata → --text-muted (AA-safe ≥4.5:1); --text-faint is
+	   decorative-only and bottoms out at ~3:1 (#2166, tokens.css role layer). */
+	color: var(--text-muted);
 }

--- a/apps/web/src/pages/AuthPage.css
+++ b/apps/web/src/pages/AuthPage.css
@@ -95,7 +95,10 @@
 	border: none;
 	border-radius: var(--r-sm);
 	padding: 10px 12px;
-	font: 600 14px var(--font-body);
+	/* White --accent-fg on the accent solid is Radix's accentContrast (3:1 UI/large-text
+	   pairing, not 4.5:1 small-text); the label qualifies as WCAG large text so the
+	   sanctioned pairing is AA-valid (#2166). */
+	font: 700 19px / 1.2 var(--font-body);
 	cursor: pointer;
 	margin-top: var(--s-2);
 }

--- a/apps/web/src/pages/LandingPage.css
+++ b/apps/web/src/pages/LandingPage.css
@@ -77,12 +77,16 @@
 	color: var(--accent-fg);
 	text-decoration: none;
 }
+/* On the tomato/accent solid the white --accent-fg is Radix's accentContrast — a
+   sanctioned 3:1 UI/large-text pairing, not 4.5:1 small-text (#2166). Both CTA lines
+   therefore qualify as WCAG large text (bold ≥18.66px → 3:1 bar) so the sanctioned
+   pairing is AA-valid; the sub also drops its opacity dilution (was ~3.1:1). The
+   label stays dominant via size; the sub is the smaller of the two large-text lines. */
 .kp-landing__join .label {
-	font: 600 15px / 1.2 var(--font-body);
+	font: 700 22px / 1.15 var(--font-body);
 }
 .kp-landing__join .sub {
-	font: 400 11px / 1.2 var(--font-body);
-	opacity: 0.85;
+	font: 700 19px / 1.25 var(--font-body);
 }
 .kp-landing__browse {
 	display: grid;


### PR DESCRIPTION
Fixes #2166

Concrete WCAG defect fixes from the frontend-audit **Accessibility** pillar (epic #2168) — the SECOND pass on the shared ReactionBar surface after #2165 (on-brand reaction glyphs). Scoped to the four named defects; the *systematic* focus layer + ARIA audit stay #2169's scope. Product UI only (`apps/web/src/**`) → §CP:NO.

## What changed

**1. Broken focus ring — un-break the double-wrap (`ReactionBar.css`).**
`.kp-reaction-bar__btn:focus-visible` used `outline: 2px solid var(--focus-ring)`, which expands to the invalid `outline: 2px solid 2px solid var(--accent-9)` — a malformed value the browser drops, so the ring silently vanished. Fixed to the repo convention `outline: var(--focus-ring)` + `outline-offset: var(--focus-ring-offset)` (global.css:69–70). The `--focus-ring` token already exists and ~13 other consumers use it correctly — this was the **only** double-wrap in the codebase, and no new token was defined.

**2. Contrast, faint→muted (`ReactionBar.css`).**
The reaction `count` is meaning-carrying metadata, so it moves off `--text-faint` (`--gray-10`, decorative-only, ~3:1) to `--text-muted` (`--gray-11`, AA ≥4.5:1) — the invariant stated in the `tokens.css` role-layer comment (faint is never used for text that carries meaning).

**3. Contrast, CTA text on the accent solid (`LandingPage.css`, `AuthPage.css`).**
White `--accent-fg` on the accent-9 solid is Radix's `accentContrast` — a **sanctioned 3:1 UI/large-text pairing, not 4.5:1 small-text**. Grounded in the raw scales: white on tomato-9 (#e54d2e) = 3.87:1, and the landing sub-label's `opacity: 0.85` pushed it to ~3.1:1 (matching the audit). The landing join CTA + auth submit labels now qualify as **WCAG large text** (bold ≥18.66px → 3:1 bar), so the sanctioned Radix pairing is AA-valid across every theme; the landing sub also drops its opacity dilution. No palette / token change — the token seam is honored.

**4. Tap targets — WCAG 2.5.8 24px minimum.**
- `.kp-reaction-bar__btn` was ~21.6px tall → floored at `min-height: 24px` (via `--reaction-bar-height`, bumped 22→24px in lockstep so the reserved slot still matches the mounted bar — no #2054 reflow).
- `.kp-pano-post__vote-btn` (the △ vote triangle) 22×22 → 24×24 (fits the `--vote-w` column).
- `.kp-comment__upvote` (comment △) → `min-height: 24px`.

## Acceptance criteria
- [x] Meaning-carrying metadata no longer uses `--text-faint`; contrast meets WCAG AA.
- [x] CTA text on the tomato/accent surface meets WCAG AA contrast.
- [x] Vote (△) and emoji controls meet the 24px minimum target size.
- [x] The broken focus ring renders a visible focus indicator again.

## Verification
- `pnpm typecheck` — pass (26/26).
- `pnpm lint` (biome) — pass (5 files, no fixes).
- vitest `--project client` (jsdom UI) — 45/45 pass, incl. `ReactionBarSlot.test.tsx` (the #2054 height-reservation pin holds with the 22→24 bump). The unit/integration projects' global setup requires a `@distilled.cloud/cloudflare` credential absent in this sandbox (pre-existing environmental, unrelated to these CSS-only changes); CI runs the full suite with credentials.

Cluster discipline: minimal correct fixes only — the double-wrap was **fixed** (not a new token), and the systematic focus-layer refactor + broad ARIA sweep were left to #2169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)