### PR TITLE
feat(web): wire the density preference control (compact/normal/spacious) — #2183

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider} from "./fate/FateProvider";
 import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
+import {DensityProvider} from "./lib/density";
 import {safeReturnTo} from "./lib/returnTo";
 import {searchTarget} from "./lib/searchTarget";
 import {ThemeProvider, useTheme} from "./lib/theme";
@@ -229,32 +230,34 @@ function PanoSiteFeedRoute() {
 export function App() {
 	return (
 		<ThemeProvider>
-			<Routes>
-				<Route element={<Layout />}>
-					<Route path="/" element={<LandingPage />} />
-					<Route path="/pano" element={<PanoFeed />} />
-					<Route path="/pano/yeni" element={<PanoSubmitPage />} />
-					<Route path="/pano/site/:host" element={<PanoSiteFeedRoute />} />
-					<Route path="/pano/kaydedilenler" element={<SavedPostsPage />} />
-					<Route path="/pano/:id" element={<PanoPostDetail />} />
-					<Route path="/sozluk" element={<SozlukHome />} />
-					<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
-					<Route path="/search" element={<SearchPage />} />
-					<Route path="/auth" element={<AuthPage />} />
-					{/* The divan reviewer workspace (#1290) — the page self-gates on the
+			<DensityProvider>
+				<Routes>
+					<Route element={<Layout />}>
+						<Route path="/" element={<LandingPage />} />
+						<Route path="/pano" element={<PanoFeed />} />
+						<Route path="/pano/yeni" element={<PanoSubmitPage />} />
+						<Route path="/pano/site/:host" element={<PanoSiteFeedRoute />} />
+						<Route path="/pano/kaydedilenler" element={<SavedPostsPage />} />
+						<Route path="/pano/:id" element={<PanoPostDetail />} />
+						<Route path="/sozluk" element={<SozlukHome />} />
+						<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
+						<Route path="/search" element={<SearchPage />} />
+						<Route path="/auth" element={<AuthPage />} />
+						{/* The divan reviewer workspace (#1290) — the page self-gates on the
 					    authorship-loop flag (off ⇒ 404), so the route is dark by default. */}
-					<Route path="/divan" element={<DivanPage />} />
-					{/* The founder/mod conversion readout (#1589) — the page self-gates on
+						<Route path="/divan" element={<DivanPage />} />
+						{/* The founder/mod conversion readout (#1589) — the page self-gates on
 					    the funnel-readout flag (off ⇒ 404), so the route is dark by default. */}
-					<Route path="/funnel" element={<FunnelPage />} />
-					{/* The notification center (#1694) — the page self-gates on the
+						<Route path="/funnel" element={<FunnelPage />} />
+						{/* The notification center (#1694) — the page self-gates on the
 					    phoenix-bildirim flag (off ⇒ 404), so the route is dark by default. */}
-					<Route path="/bildirimler" element={<BildirimlerPage />} />
-					<Route path="/profile" element={<ProfilePage />} />
-					<Route path="/u/:username" element={<UserProfilePage />} />
-					<Route path="*" element={<NotFoundPage />} />
-				</Route>
-			</Routes>
+						<Route path="/bildirimler" element={<BildirimlerPage />} />
+						<Route path="/profile" element={<ProfilePage />} />
+						<Route path="/u/:username" element={<UserProfilePage />} />
+						<Route path="*" element={<NotFoundPage />} />
+					</Route>
+				</Routes>
+			</DensityProvider>
 		</ThemeProvider>
 	);
 }

--- a/apps/web/src/components/controls/Controls.tsx
+++ b/apps/web/src/components/controls/Controls.tsx
@@ -1,5 +1,8 @@
+import type {Density} from "../../lib/density";
 import {ToggleGroup} from "../ui/ToggleGroup";
 import "./Controls.css";
+
+export type {Density};
 
 export type ColorTheme =
 	| "ember"
@@ -14,7 +17,6 @@ export type ColorTheme =
 	| "mauve";
 
 export type Mode = "dark" | "light";
-export type Density = "compact" | "normal" | "spacious";
 
 const THEME_SWATCHES: Record<ColorTheme, string> = {
 	ember: "#e54d2e",

--- a/apps/web/src/lib/density.test.tsx
+++ b/apps/web/src/lib/density.test.tsx
@@ -1,0 +1,78 @@
+import {act, render} from "@testing-library/react";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {DensityProvider, useDensity} from "./density";
+import {DENSITY_STORAGE_KEY} from "./densityStorage";
+
+// jsdom in the `client` tier ships no localStorage (Node's is experimental/off), so the
+// provider's persistence seam has nothing to read/write against by default. Install a
+// fake Storage on `window` per test so the mount-read and the setChoice-write are
+// observable — the same fake-Storage shape themeStorage's unit test uses.
+function installFakeStorage(initial?: Record<string, string>): Storage {
+	const map = new Map<string, string>(Object.entries(initial ?? {}));
+	const storage: Storage = {
+		get length() {
+			return map.size;
+		},
+		clear: () => map.clear(),
+		getItem: (k) => map.get(k) ?? null,
+		key: (i) => [...map.keys()][i] ?? null,
+		removeItem: (k) => void map.delete(k),
+		setItem: (k, v) => void map.set(k, v),
+	};
+	vi.stubGlobal("localStorage", storage);
+	Object.defineProperty(window, "localStorage", {value: storage, configurable: true});
+	return storage;
+}
+
+function Probe() {
+	const {setChoice} = useDensity();
+	return (
+		<button type="button" onClick={() => setChoice("spacious")}>
+			set
+		</button>
+	);
+}
+
+describe("DensityProvider", () => {
+	beforeEach(() => {
+		delete document.documentElement.dataset.density;
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		delete document.documentElement.dataset.density;
+	});
+
+	it("sets [data-density] on the document root from the persisted choice on mount", () => {
+		installFakeStorage({[DENSITY_STORAGE_KEY]: "normal"});
+		render(
+			<DensityProvider>
+				<Probe />
+			</DensityProvider>,
+		);
+		expect(document.documentElement.dataset.density).toBe("normal");
+	});
+
+	it("defaults to compact when nothing is persisted", () => {
+		installFakeStorage();
+		render(
+			<DensityProvider>
+				<Probe />
+			</DensityProvider>,
+		);
+		expect(document.documentElement.dataset.density).toBe("compact");
+	});
+
+	it("updates [data-density] live and persists on setChoice", () => {
+		const storage = installFakeStorage();
+		const {getByText} = render(
+			<DensityProvider>
+				<Probe />
+			</DensityProvider>,
+		);
+		act(() => {
+			getByText("set").click();
+		});
+		expect(document.documentElement.dataset.density).toBe("spacious");
+		expect(storage.getItem(DENSITY_STORAGE_KEY)).toBe("spacious");
+	});
+});

--- a/apps/web/src/lib/density.tsx
+++ b/apps/web/src/lib/density.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import {readStoredDensity, writeStoredDensity} from "./densityStorage";
+
+export type Density = "compact" | "normal" | "spacious";
+
+// tokens.css treats the absence of a [data-density] value as compact (the base
+// --s-* ramp), so compact is the default choice.
+const DEFAULT_CHOICE: Density = "compact";
+
+function browserStorage(): Storage | undefined {
+	return typeof window === "undefined" ? undefined : window.localStorage;
+}
+
+interface DensityContextValue {
+	choice: Density;
+	setChoice: (choice: Density) => void;
+}
+
+const DensityContext = React.createContext<DensityContextValue | null>(null);
+
+export function DensityProvider({children}: {children: React.ReactNode}) {
+	const [choice, setChoiceState] = React.useState<Density>(() =>
+		readStoredDensity(browserStorage(), DEFAULT_CHOICE),
+	);
+
+	const setChoice = React.useCallback((next: Density) => {
+		writeStoredDensity(browserStorage(), next);
+		setChoiceState(next);
+	}, []);
+
+	// tokens.css keys the whole --s-* spacing ramp off [data-density], so the
+	// chosen value lands on the document root here (mirroring theme.tsx).
+	React.useEffect(() => {
+		document.documentElement.dataset.density = choice;
+	}, [choice]);
+
+	const value = React.useMemo<DensityContextValue>(
+		() => ({choice, setChoice}),
+		[choice, setChoice],
+	);
+
+	return <DensityContext.Provider value={value}>{children}</DensityContext.Provider>;
+}
+
+export function useDensity(): DensityContextValue {
+	const ctx = React.useContext(DensityContext);
+	if (!ctx) throw new Error("useDensity must be used within a DensityProvider");
+	return ctx;
+}

--- a/apps/web/src/lib/densityStorage.ts
+++ b/apps/web/src/lib/densityStorage.ts
@@ -1,0 +1,30 @@
+import type {Density} from "./density";
+
+export const DENSITY_STORAGE_KEY = "kampus.density";
+
+const VALID: ReadonlySet<string> = new Set<Density>(["compact", "normal", "spacious"]);
+
+function isDensity(value: string | null): value is Density {
+	return value !== null && VALID.has(value);
+}
+
+/** Read the persisted density, falling back to `fallback` for missing/garbage/unavailable storage. */
+export function readStoredDensity(storage: Storage | undefined, fallback: Density): Density {
+	if (!storage) return fallback;
+	try {
+		const raw = storage.getItem(DENSITY_STORAGE_KEY);
+		return isDensity(raw) ? raw : fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+/** Persist the density. A throwing/unavailable storage (private mode, quota) is swallowed. */
+export function writeStoredDensity(storage: Storage | undefined, density: Density): void {
+	if (!storage) return;
+	try {
+		storage.setItem(DENSITY_STORAGE_KEY, density);
+	} catch {
+		// A failed write only costs persistence, never the in-memory density.
+	}
+}

--- a/apps/web/src/lib/densityStorage.unit.test.ts
+++ b/apps/web/src/lib/densityStorage.unit.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from "vitest";
+import {DENSITY_STORAGE_KEY, readStoredDensity, writeStoredDensity} from "./densityStorage";
+
+function fakeStorage(initial?: Record<string, string>): Storage {
+	const map = new Map<string, string>(Object.entries(initial ?? {}));
+	return {
+		get length() {
+			return map.size;
+		},
+		clear: () => map.clear(),
+		getItem: (k) => map.get(k) ?? null,
+		key: (i) => [...map.keys()][i] ?? null,
+		removeItem: (k) => void map.delete(k),
+		setItem: (k, v) => void map.set(k, v),
+	};
+}
+
+describe("densityStorage", () => {
+	it("rehydrates a chosen density written earlier (the round-trip)", () => {
+		const storage = fakeStorage();
+		writeStoredDensity(storage, "spacious");
+		expect(storage.getItem(DENSITY_STORAGE_KEY)).toBe("spacious");
+		expect(readStoredDensity(storage, "compact")).toBe("spacious");
+	});
+
+	it("persists each of the three valid choices", () => {
+		const storage = fakeStorage();
+		for (const choice of ["compact", "normal", "spacious"] as const) {
+			writeStoredDensity(storage, choice);
+			expect(readStoredDensity(storage, "compact")).toBe(choice);
+		}
+	});
+
+	it("falls back to compact when nothing is stored", () => {
+		expect(readStoredDensity(fakeStorage(), "compact")).toBe("compact");
+	});
+
+	it("falls back when the stored value is not a valid choice", () => {
+		const storage = fakeStorage({[DENSITY_STORAGE_KEY]: "cozy"});
+		expect(readStoredDensity(storage, "compact")).toBe("compact");
+	});
+
+	it("falls back (never throws) when storage is unavailable", () => {
+		expect(readStoredDensity(undefined, "normal")).toBe("normal");
+		expect(() => writeStoredDensity(undefined, "spacious")).not.toThrow();
+	});
+
+	it("swallows a throwing storage rather than losing the in-memory density", () => {
+		const broken: Storage = {
+			...fakeStorage(),
+			getItem: () => {
+				throw new Error("blocked");
+			},
+			setItem: () => {
+				throw new Error("quota");
+			},
+		};
+		expect(readStoredDensity(broken, "compact")).toBe("compact");
+		expect(() => writeStoredDensity(broken, "spacious")).not.toThrow();
+	});
+});

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -11,6 +11,7 @@ import {ProfileContributionSignal} from "../components/profile/ProfileContributi
 import {profileStandingLabel} from "../components/profile/profileStanding";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
+import {type Density, useDensity} from "../lib/density";
 import {type ThemeChoice, useTheme} from "../lib/theme";
 import {useProfileStats} from "./useProfileStats";
 import "./ProfilePage.css";
@@ -35,6 +36,13 @@ function initialsOf(name: string) {
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
+// Mirrors the DENSITY_LABELS Turkish copy in components/controls/Controls.tsx.
+const DENSITY_LABELS: Record<Density, string> = {
+	compact: "sıkı",
+	normal: "normal",
+	spacious: "ferah",
+};
+
 export function ProfilePage() {
 	const session = useSession();
 	const {me, status: meStatus, refetch: refetchMe} = useMe();
@@ -48,6 +56,7 @@ export function ProfilePage() {
 	const statsFailed = statsState.status === "error" || meStatus === "error";
 	const stats = statsState.status === "ok" ? statsState.stats : null;
 	const {choice: themeChoice, setChoice: setThemeChoice} = useTheme();
+	const {choice: densityChoice, setChoice: setDensityChoice} = useDensity();
 	const [revokingAll, setRevokingAll] = useState(false);
 	const [revokeAllError, setRevokeAllError] = useState<string | null>(null);
 	const [deleteOpen, setDeleteOpen] = useState(false);
@@ -270,6 +279,24 @@ export function ProfilePage() {
 										onClick={() => setThemeChoice(t)}
 									>
 										{t === "light" ? "açık" : t === "dark" ? "koyu" : "otomatik"}
+									</button>
+								))}
+							</span>
+						</span>
+						<span />
+					</div>
+					<div className="kp-profile__row">
+						<span className="label">yoğunluk</span>
+						<span className="value">
+							<span className="kp-profile__theme-toggle">
+								{(["compact", "normal", "spacious"] as Density[]).map((d) => (
+									<button
+										key={d}
+										type="button"
+										aria-pressed={densityChoice === d}
+										onClick={() => setDensityChoice(d)}
+									>
+										{DENSITY_LABELS[d]}
 									</button>
 								))}
 							</span>


### PR DESCRIPTION
Wires the already-built-but-unreachable density preference to users by mirroring the theme seam. The spacing-ramp token infra (`tokens.css` `[data-density]`) and the presentational `DensityToggle` already existed; nothing read/wrote a persisted choice, nothing mounted the control, and nothing set `dataset.density`. This adds the wiring only.

## What changed
- `apps/web/src/lib/densityStorage.ts` — `localStorage` read/write of the `Density` union (key `kampus.density`, default `compact`), mirroring `themeStorage.ts`.
- `apps/web/src/lib/density.tsx` — `DensityProvider` + `useDensity` that reads storage, holds the choice, and sets `document.documentElement.dataset.density`, mirroring `theme.tsx`.
- `apps/web/src/App.tsx` — mount `DensityProvider` alongside `ThemeProvider`.
- `apps/web/src/pages/ProfilePage.tsx` — a `yoğunluk` (sıkı / normal / ferah) row in the profile `görünüm` (appearance) section, next to the existing `tema` control, wired to the provider so a selection persists and updates the ramp live. `/profile` is the reachable settings surface that already renders the theme control.
- `apps/web/src/components/controls/Controls.tsx` — source the `Density` union from the new lib (single home) instead of redefining it locally.
- Tests: `densityStorage.unit.test.ts` (storage round-trip / fallbacks) and `density.test.tsx` (client tier: `dataset.density` set-on-mount from persisted choice, default `compact`, live-update + persist on `setChoice`).

## Scope / class
- **No ramp VALUES touched.** `tokens.css` is unchanged — the three `[data-density]` ramps are #2173's founder-owned scope. This wires the control over whatever the ramps resolve to; when #2173 ratifies the 4px-base values the toggle keeps working unchanged.
- **Client-only, no flag.** The entire change is a `localStorage` read/write plus a `data-density` attribute on the document root — no worker, data, logic, auth, or security surface, and no D1 column / künye DO. This is the containment-exempt pure-client-polish class, so no feature flag is added.
- Turkish user-facing copy (`yoğunluk`, `sıkı`/`normal`/`ferah`) mirrors the existing `DensityToggle` labels.

`pnpm typecheck` (26/26) and `pnpm lint:worktree` clean; the density unit + client tests pass and the existing `App.test.tsx` first-paint pins still pass.

Fixes #2183