### PR TITLE
chore(pipeline): inject the docblock-collapse convention into the coder prompt (#2186)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -56,6 +56,13 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   progress comments, commit messages, and committed files cite repo-relative paths only —
   never a `~/`, `/Users/…`, vault, or sibling-clone path.
 - **Work from the repo root**, not a nested app directory.
+- **State a *why* ONCE — collapse duplicated docblocks to a pointer.** In the code you
+  generate, apply CLAUDE.md's "Comments earn their place or die" convention: state a
+  rationale at its single most load-bearing site, and collapse any docblock that
+  re-derives an ADR's *why* to a `// See ADR NNNN` (or `#NNNN`) pointer. Do NOT re-narrate
+  the same *why* across multiple docblocks in a file — no near-identical per-item
+  docblocks (one per glyph/case/component). Duplicated *why* rots in N places and reads as
+  a boilerplate wall (the #2179 reaction-surface duplication).
 - **Claim the issue first (self-assign).** Follow the skill's claim protocol before
   implementing, so a parallel coder steps over your issue.
 - **Implement only — never review, merge, or close a human-filed issue.** You own

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -775,6 +775,11 @@ per-run nonce so two concurrent runs on the same issue never push the same `orig
 and honor the `**TDD:**` flag — `yes` means write the failing test first, then make it
 pass; `no` means config/docs/scaffolding where test-first doesn't apply.
 
+As you write, apply CLAUDE.md's "Comments earn their place or die" collapse convention to
+the code you generate: state a *why* once at its most load-bearing site and point elsewhere
+with `// See ADR NNNN` / `#NNNN` — never re-derive the same ADR rationale across multiple
+docblocks in a file (the `coder.md` standing invariant is the source; #2186).
+
 <a id="non-isolated-fallback"></a>
 > **Non-isolated fallback.** For the rare invocation that isn't already in a worktree,
 > spin one up rather than checking out `main`. **Fetch first** — the local `origin/main`


### PR DESCRIPTION
## What

Inject the repo's own **docblock-collapse** convention into the `write-code` coder so it stops re-deriving the same ADR/pillar rationale at every docblock.

Root cause (per triage on #2186): neither `claude-plugins/kampus-pipeline/agents/coder.md` nor the `write-code` skill carried any comment/docblock instruction, so the coder relied on *ambient* CLAUDE.md — which was not being applied to the docblocks it **generates**. Result: duplicated-*why* comment explosion (e.g. the #2179 reaction surface re-narrated the ADR-0139 / monochrome / `currentColor` cohesion rationale ~4x across `ReactionGlyph.tsx` / `ReactionBar.tsx` and their tests).

## Changes

- **`claude-plugins/kampus-pipeline/agents/coder.md`** (§CP leg) — added a standing-invariant bullet: state a *why* once at its most load-bearing site, collapse any docblock that re-derives an ADR's *why* to a `// See ADR NNNN` / `#NNNN` pointer, and never re-narrate the same *why* across multiple docblocks in a file (no near-identical per-item docblocks). Mirrors CLAUDE.md's "Comments earn their place or die" convention, does not contradict it.
- **`claude-plugins/kampus-pipeline/skills/write-code/SKILL.md`** (optional non-§CP mirror) — one-line pointer to the same collapse rule at the Step-4 implement step, so it's discoverable there too. This leg is not a gate skill and not §CP.

The convention text itself obeys the rule it states (tight, load-bearing). Prompt/process-only — no net behavior change to shipped app code. Paths cited repo-relative only.

## §CP — human merge

`agents/coder.md` is in the §CP set (pipeline agent prompt, ADR 0135) → **§CP:YES, human-merge (cansirin)**, NOT auto-ship. The `write-code` SKILL mirror is a non-§CP leg included for discoverability. My job ends at PR-open + clean review; the merge is a human's.

## Acceptance criteria

- [x] Coder guidance explicitly instructs applying CLAUDE.md's collapse convention (one *why* per file, `// See ADR NNNN` / `#NNNN` pointers, no re-derivation across docblocks).
- [x] Instruction lands in `claude-plugins/kampus-pipeline/agents/coder.md`; the mirrored `write-code` SKILL leg stays consistent with it.
- [x] No net behavior change to shipped app code (prompt/process-only).
- [x] Paths cited repo-relative only; no machine-local paths.

Fixes #2186