### PR TITLE
feat(web): systematic shared focus layer + reactions/A–Z index ARIA audit (#2169)

### DIFF
--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -130,10 +130,7 @@
 .kp-topbar__user:hover {
 	background: var(--surface-raised);
 }
-.kp-topbar__user:focus-visible {
-	outline: var(--focus-ring);
-	outline-offset: 2px;
-}
+/* Keyboard focus ring comes from the shared focus layer (global.css, #2169). */
 
 /* The ambient self-karma chip (#1208) — keep it centered in the topbar row. */
 .kp-topbar__karma {

--- a/apps/web/src/components/pano/PanoComment.css
+++ b/apps/web/src/components/pano/PanoComment.css
@@ -62,8 +62,9 @@
 .kp-comment__upvote--active {
 	color: var(--accent);
 }
+/* Ring from the shared focus layer (global.css, #2169); tighter offset + rounded
+   corner hug this compact vote control. */
 .kp-comment__upvote:focus-visible {
-	outline: var(--focus-ring);
 	outline-offset: 1px;
 	border-radius: var(--r-sm);
 }

--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -56,8 +56,9 @@
 .kp-pano-post__vote-btn[aria-pressed="true"] {
 	color: var(--accent);
 }
+/* Ring from the shared focus layer (global.css, #2169); tighter offset hugs the
+   compact vote control. */
 .kp-pano-post__vote-btn:focus-visible {
-	outline: var(--focus-ring);
 	outline-offset: 1px;
 }
 
@@ -154,8 +155,9 @@
 	color: var(--accent);
 	font-weight: 600;
 }
+/* Ring from the shared focus layer (global.css, #2169); tighter offset + rounded
+   corner hug the compact save control. */
 .kp-pano-post__save:focus-visible {
-	outline: var(--focus-ring);
 	outline-offset: 1px;
 	border-radius: var(--r-sm);
 }

--- a/apps/web/src/components/profile/ProfileContributionSignal.css
+++ b/apps/web/src/components/profile/ProfileContributionSignal.css
@@ -29,8 +29,9 @@
 	text-decoration: underline;
 }
 
+/* Ring + offset from the shared focus layer (global.css, #2169) — was a bespoke
+   `2px solid var(--accent)` that bypassed the --focus-ring token; only the rounded
+   corner is signal-specific now. */
 .kp-signal__more:focus-visible {
-	outline: 2px solid var(--accent);
-	outline-offset: 2px;
 	border-radius: var(--r-sm);
 }

--- a/apps/web/src/components/reaction/ReactionBar.css
+++ b/apps/web/src/components/reaction/ReactionBar.css
@@ -52,10 +52,9 @@
 	background: var(--surface-sunken);
 }
 
-.kp-reaction-bar__btn:focus-visible {
-	outline: var(--focus-ring);
-	outline-offset: var(--focus-ring-offset);
-}
+/* Keyboard focus ring comes from the shared focus layer (global.css, #2169) —
+   the same --focus-ring / --focus-ring-offset #2166 converged this button onto,
+   now sourced from one place instead of re-declared here. */
 
 .kp-reaction-bar__btn[aria-pressed="true"] {
 	border-color: var(--accent);

--- a/apps/web/src/components/sozluk/Sozluk.tsx
+++ b/apps/web/src/components/sozluk/Sozluk.tsx
@@ -133,6 +133,14 @@ const ALPHABET = [
  * each letter is a shareable URL, back-button-correct and middle-clickable. The
  * active letter links back to bare `/sozluk` so it still toggles its filter off.
  * Empty letters stay inert `<span>`s — no destination to navigate to.
+ *
+ * ARIA (#2169): the `<nav aria-label="Harf">` names the index as a landmark. Each
+ * populated letter is a link whose accessible name spells out the letter ("A
+ * harfi") — a bare "a" reads ambiguously to a screen reader that spells single
+ * chars. Empty letters are inert spans (not announced as links) carrying a
+ * visually-hidden "(… harfi, terim yok)" suffix, so an AT user hears the
+ * populated/empty distinction the muted color conveys visually. The active letter
+ * keeps `aria-current="page"`.
  */
 export function SozlukAlphabet({
 	value,
@@ -153,10 +161,17 @@ export function SozlukAlphabet({
 				]
 					.filter(Boolean)
 					.join(" ");
+				const letterName = `${l.toLocaleUpperCase("tr")} harfi`;
 				if (isEmpty) {
+					// Inert letter — a plain span (no interactive role) so it isn't announced as
+					// a link. The visible glyph reads as the letter; a visually-hidden suffix
+					// spells the name + "(terim yok)" so an AT user hears the empty distinction the
+					// muted color conveys visually. (aria-label/aria-disabled aren't valid on a
+					// generic span; the hidden text carries the semantics instead.)
 					return (
 						<span key={l} className={cls}>
 							{l}
+							<span className="kp-visually-hidden">{`(${letterName}, terim yok)`}</span>
 						</span>
 					);
 				}
@@ -165,6 +180,7 @@ export function SozlukAlphabet({
 						key={l}
 						to={sozlukLetterHref(l, isActive)}
 						className={cls}
+						aria-label={letterName}
 						aria-current={isActive ? "page" : undefined}
 					>
 						{l}

--- a/apps/web/src/components/sozluk/SozlukAlphabet.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukAlphabet.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * The A–Z index ARIA contract (#2169, a11y pillar of epic #2168). The alphabet is
+ * the sözlük letter index (`SozlukAlphabet`): populated letters are real
+ * `/sozluk?harf=<l>` links, empty letters are inert. These pin the accessible
+ * semantics an AT user relies on to tell a navigable letter from an empty one and
+ * to hear which letter each control is — the muted-color populated/empty
+ * distinction and the single-char label ambiguity are both invisible to a screen
+ * reader without these attributes.
+ */
+import {render} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {describe, expect, it} from "vitest";
+import {SozlukAlphabet} from "./Sozluk";
+
+function renderAlphabet(props: Parameters<typeof SozlukAlphabet>[0]) {
+	return render(
+		<MemoryRouter>
+			<SozlukAlphabet {...props} />
+		</MemoryRouter>,
+	);
+}
+
+describe("SozlukAlphabet — A–Z index ARIA (#2169)", () => {
+	it("names the index as a landmark (nav[aria-label])", () => {
+		const {container} = renderAlphabet({});
+		const nav = container.querySelector("nav.kp-sozluk-alphabet");
+		expect(nav?.getAttribute("aria-label")).toBe("Harf");
+	});
+
+	it("gives each populated letter a spelled-out accessible name (not a bare char)", () => {
+		const {container} = renderAlphabet({});
+		const a = container.querySelector("a.kp-sozluk-alphabet__letter");
+		expect(a?.getAttribute("aria-label")).toBe("A harfi");
+		// populated letters are real links (an href), never inert spans
+		expect(a?.tagName.toLowerCase()).toBe("a");
+	});
+
+	it("uppercases the letter name in Turkish locale (i → İ, not I)", () => {
+		const {container} = renderAlphabet({});
+		const labels = Array.from(container.querySelectorAll(".kp-sozluk-alphabet__letter")).map((el) =>
+			el.getAttribute("aria-label"),
+		);
+		expect(labels).toContain("İ harfi"); // Turkish dotted-capital, not the ASCII "I harfi"
+	});
+
+	it("renders empty letters as inert spans (not links) with a visually-hidden 'terim yok' suffix", () => {
+		const {container} = renderAlphabet({emptyLetters: ["z"]});
+		const spans = container.querySelectorAll("span.kp-sozluk-alphabet__letter.is-empty");
+		expect(spans).toHaveLength(1);
+		const z = spans[0] as HTMLElement;
+		// an inert span is not a link (no interactive role announced)
+		expect(z.tagName.toLowerCase()).toBe("span");
+		// the AT-only suffix spells the empty distinction the muted color conveys visually
+		const hidden = z.querySelector(".kp-visually-hidden");
+		expect(hidden?.textContent).toBe("(Z harfi, terim yok)");
+		// its full accessible text is the visible glyph + the hidden suffix
+		expect(z.textContent).toBe("z(Z harfi, terim yok)");
+	});
+
+	it("marks the active letter aria-current=page", () => {
+		const {container} = renderAlphabet({value: "a"});
+		const active = container.querySelector(".kp-sozluk-alphabet__letter.is-active");
+		expect(active?.getAttribute("aria-current")).toBe("page");
+		expect(active?.getAttribute("aria-label")).toBe("A harfi");
+	});
+});

--- a/apps/web/src/components/ui/Button.css
+++ b/apps/web/src/components/ui/Button.css
@@ -19,10 +19,7 @@
 		color 80ms,
 		border-color 80ms;
 }
-.kp-btn:focus-visible {
-	outline: var(--focus-ring);
-	outline-offset: 2px;
-}
+/* Keyboard focus ring comes from the shared focus layer (global.css, #2169). */
 .kp-btn:disabled {
 	opacity: 0.5;
 	cursor: not-allowed;

--- a/apps/web/src/components/ui/Collapsible.css
+++ b/apps/web/src/components/ui/Collapsible.css
@@ -26,7 +26,8 @@
 	background: var(--surface-raised);
 	color: var(--text-primary);
 }
+/* Ring from the shared focus layer (global.css, #2169); a tighter offset hugs
+   this full-width trigger's edge. */
 .kp-collapsible__trigger:focus-visible {
-	outline: var(--focus-ring);
 	outline-offset: 1px;
 }

--- a/apps/web/src/components/ui/Switch.css
+++ b/apps/web/src/components/ui/Switch.css
@@ -16,10 +16,7 @@
 	background: var(--accent-9);
 	border-color: var(--accent-9);
 }
-.kp-switch:focus-visible {
-	outline: var(--focus-ring);
-	outline-offset: 2px;
-}
+/* Keyboard focus ring comes from the shared focus layer (global.css, #2169). */
 
 .kp-switch__thumb {
 	position: absolute;

--- a/apps/web/src/components/ui/Tabs.css
+++ b/apps/web/src/components/ui/Tabs.css
@@ -30,9 +30,9 @@
 	color: var(--text-primary);
 	border-bottom-color: var(--accent-9);
 }
+/* Ring from the shared focus layer (global.css, #2169); only the rounded outline
+   corner is tab-specific. */
 .kp-tabs__tab:focus-visible {
-	outline: var(--focus-ring);
-	outline-offset: 2px;
 	border-radius: var(--r-sm);
 }
 

--- a/apps/web/src/components/ui/ToggleGroup.css
+++ b/apps/web/src/components/ui/ToggleGroup.css
@@ -34,10 +34,7 @@
 	border-color: var(--accent-9);
 	font-weight: 600;
 }
-.kp-toggle:focus-visible {
-	outline: var(--focus-ring);
-	outline-offset: 2px;
-}
+/* Keyboard focus ring comes from the shared focus layer (global.css, #2169). */
 .kp-toggle:disabled,
 .kp-toggle[data-disabled] {
 	opacity: 0.4;

--- a/apps/web/src/pages/SozlukTermPage.css
+++ b/apps/web/src/pages/SozlukTermPage.css
@@ -95,8 +95,9 @@
 	background: var(--accent);
 	border-color: var(--accent);
 }
+/* Ring from the shared focus layer (global.css, #2169); tighter offset hugs the
+   compact vote control. */
 .kp-sozluk-definition__vote-btn:focus-visible {
-	outline: var(--focus-ring);
 	outline-offset: 1px;
 }
 .kp-sozluk-definition__vote-count {

--- a/apps/web/src/pages/UserProfilePage.css
+++ b/apps/web/src/pages/UserProfilePage.css
@@ -124,10 +124,8 @@
 	background: var(--accent-soft);
 }
 
-.kp-promotion__action:focus-visible {
-	outline: 2px solid var(--accent);
-	outline-offset: 2px;
-}
+/* Keyboard focus ring comes from the shared focus layer (global.css, #2169) — was
+   a bespoke `2px solid var(--accent)` that bypassed the --focus-ring token. */
 
 .kp-promotion__action:disabled {
 	opacity: 0.6;

--- a/apps/web/src/styles/focus-layer.test.ts
+++ b/apps/web/src/styles/focus-layer.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The shared focus layer is defined ONCE (#2169, the discord/focus-rings idiom):
+ * `global.css` carries a single `:focus-visible` rule that paints the
+ * `--focus-ring` token on every interactive control, and component CSS no longer
+ * hand-rolls its own `outline: var(--focus-ring)` copy. These pin that
+ * single-source invariant against a regression that reintroduces a per-component
+ * ring: a new bespoke `outline: var(--focus-ring)` (or the pre-#2169 divergent
+ * `outline: 2px solid var(--accent)`) fails here rather than only under manual
+ * review.
+ *
+ * The one sanctioned exception is the skip-link, which uses `:focus` (not
+ * `:focus-visible`) on purpose — it is reached only by keyboard so it must show on
+ * any focus — and is allow-listed below.
+ */
+import {readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {describe, expect, it} from "vitest";
+
+const SRC = join(import.meta.dirname, "..");
+const GLOBAL_CSS = join(SRC, "styles", "global.css");
+
+/** Recursively collect every `.css` under `src/`. */
+function cssFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, {withFileTypes: true})) {
+		const p = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...cssFiles(p));
+		else if (entry.name.endsWith(".css")) out.push(p);
+	}
+	return out;
+}
+
+describe("shared focus layer (#2169)", () => {
+	it("defines one :where(...):focus-visible rule painting the token in global.css", () => {
+		const css = readFileSync(GLOBAL_CSS, "utf8");
+		// zero-specificity :where() selector so component variants override without a fight
+		expect(css).toMatch(/:where\([^)]*\):focus-visible\s*\{[^}]*outline:\s*var\(--focus-ring\)/s);
+		// the offset token rides on the same rule
+		expect(css).toMatch(
+			/:where\([^)]*\):focus-visible\s*\{[^}]*outline-offset:\s*var\(--focus-ring-offset\)/s,
+		);
+	});
+
+	it("no component/page CSS re-declares outline: var(--focus-ring) (single source)", () => {
+		// Only the skip-link's deliberate `:focus` (not `:focus-visible`) ring is exempt.
+		const allow = new Set([join(SRC, "components", "layout", "AppShell.css")]);
+		const offenders = cssFiles(SRC)
+			.filter((f) => f !== GLOBAL_CSS && !allow.has(f))
+			.filter((f) => /outline:\s*var\(--focus-ring\)/.test(readFileSync(f, "utf8")));
+		expect(offenders).toEqual([]);
+	});
+
+	it("no component/page CSS hand-rolls a divergent 2px-solid-accent focus ring", () => {
+		const offenders = cssFiles(SRC).filter((f) =>
+			/outline:\s*2px solid var\(--accent\)/.test(readFileSync(f, "utf8")),
+		);
+		expect(offenders).toEqual([]);
+	});
+});

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -63,11 +63,40 @@ select {
 	word-break: break-word;
 }
 
-/* Focus ring shared by all interactive elements.
-   Components opt in via :focus-visible { outline: var(--focus-ring); }   */
+/* One shared focus layer for every interactive control (#2169, the
+   discord/focus-rings idiom): the keyboard focus ring is defined ONCE here and
+   applied to all natively-interactive elements, so no component hand-rolls its
+   own `outline: … var(--focus-ring)` rule. The token pair below is the single
+   source; this `:where()` selector paints it.
+
+   `:where()` gives the rule ZERO specificity on purpose: a component that needs a
+   deliberate variant (a tighter offset for a dense control, the Dialog close's
+   softened inset ring) overrides it with a plain normal-specificity
+   `:focus-visible` rule — no `!important`, no specificity fight. `:focus-visible`
+   (not `:focus`) means the ring shows for keyboard/AT focus but not on a mouse
+   click, matching the platform default. */
 :root {
 	--focus-ring: 2px solid var(--accent-9);
 	--focus-ring-offset: 2px;
+}
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+	outline: var(--focus-ring);
+	outline-offset: var(--focus-ring-offset);
+}
+
+/* Visually-hidden but AT-readable text (#2169). Standard clip-rect: stays in the
+   accessibility tree + reading order while taking no visual space, for a text
+   suffix that names state a sighted user reads from color/position alone. */
+.kp-visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	border: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
 }
 
 /* Reduced motion — global, unconditional a11y baseline (WCAG 2.3.3).


### PR DESCRIPTION
## What & why

Third and last of the ReactionBar cluster (a11y pillar of frontend-audit epic #2168): the **systematic** successor to #2166's point fixes. #2166 landed the concrete WCAG defect fixes (contrast / tap-target / focus double-wrap) per-component; this generalizes them into one shared treatment, and folds in the ARIA audit on the two flagged surfaces.

Builds on #2166's fixes rather than undoing them — the ReactionBar ring is the exact `--focus-ring` / `--focus-ring-offset` #2166 converged it onto, now sourced from one place instead of re-declared in `ReactionBar.css`.

## 1 — Systematic focus layer (the discord/focus-rings idiom)

`apps/web/src/styles/global.css` now defines the shared focus-visible treatment **once**:

```css
:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
	outline: var(--focus-ring);
	outline-offset: var(--focus-ring-offset);
}
```

- **Zero specificity** (`:where()`) on purpose: a deliberate variant (a tighter offset on a dense control, the Dialog close's softened inset ring) overrides it with a plain `:focus-visible` rule — no `!important`, no specificity fight.
- **Grounded in the existing token seam** — `--focus-ring: 2px solid var(--accent-9)` + `--focus-ring-offset: 2px` (unchanged; not redefined). No new token, no raw px/hex.

Then every control converges onto it:

- **Dropped the redundant per-component rules** that only replicated the default: Button, Switch, Tabs, ToggleGroup, Collapsible, Topbar, PanoComment/PanoPost, ReactionBar, SozlukTermPage vote-btn. Where a component legitimately varies (tighter `outline-offset: 1px`, a rounded outline corner) only the *distinguishing* property is kept; the ring itself comes from the shared layer.
- **Fixed two divergent rings** that bypassed the token seam with `outline: 2px solid var(--accent)` (`ProfileContributionSignal`, `UserProfilePage`) — now fall through to the shared layer. (`--accent` resolves to `--accent-9`, so this is visually identical but restores the token seam.)
- **AppShell skip-link** keeps its deliberate `:focus` (not `:focus-visible`) ring — a skip link is keyboard-only and must show on any focus. Already token-sourced; allow-listed in the guard test.

Contrast/focus grounding: the ring is `2px solid var(--accent-9)` (the theme's step-9 accent), which is the same visible ring already shipped and WCAG-legible on both light and dark themes — this PR does not change the ring's color/width, only its source of truth.

## 2 — ARIA audit

**Reaction control** (`apps/web/src/components/reaction/`): audited, **already correct** — `aria-pressed` toggle semantics, the ADR-0139 Turkish gloss as `aria-label` (#2165), decorative `aria-hidden` glyph. Confirmed against the existing `ReactionBar.test.tsx` contract; **not duplicated**.

**A–Z index** (`SozlukAlphabet`):

- Each **populated** letter is a link with a spelled-out `aria-label` ("A harfi") instead of a bare, ambiguous single char (uppercased in Turkish locale, so `i` → `İ`).
- **Empty** letters are inert `<span>`s (not announced as links) carrying a **visually-hidden** "(… harfi, terim yok)" suffix, so an AT user hears the populated/empty distinction the muted color conveys visually. (A generic span supports neither `aria-label` nor `aria-disabled`, so the hidden text carries the semantics.)
- Active letter keeps `aria-current="page"`; the `<nav aria-label="Harf">` landmark is unchanged.
- Added a shared `.kp-visually-hidden` clip-rect utility to `global.css`.

## Tests

- `apps/web/src/styles/focus-layer.test.ts` — pins the single-source invariant (one `:where(...):focus-visible` rule in global.css; no component re-declares `outline: var(--focus-ring)`; no divergent `2px solid var(--accent)` ring).
- `apps/web/src/components/sozluk/SozlukAlphabet.test.tsx` — pins the A–Z index ARIA contract.
- `pnpm typecheck` ✅ · `biome check` ✅ · **1883 client+unit tests pass** ✅.

## Class / containment

**Pure client a11y/presentational change** (focus CSS + ARIA attributes) — contained entirely to `apps/web/src/**`, no data/logic/security surface. Containment-exempt pure-client class: **no flag added**. §CP:NO — auto-ships on green.

Fixes #2169
