### PR TITLE
feat(web): reusable EmptyState primitive for intentional empty/sparse surfaces (#2162)

### DIFF
--- a/apps/web/src/components/ui/EmptyState.css
+++ b/apps/web/src/components/ui/EmptyState.css
@@ -1,0 +1,35 @@
+/* The inline empty-state block — centered + vertically padded so a nearly-empty
+   region reads as composed, not a void with content jammed above it. Tokens only. */
+.kp-empty-state {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	gap: var(--s-2);
+	padding: var(--s-7) var(--s-4);
+	min-height: 30vh;
+}
+
+.kp-empty-state__icon {
+	font-size: var(--s-7);
+	line-height: 1;
+	color: var(--text-faint);
+}
+
+.kp-empty-state__title {
+	font: var(--t-body);
+	color: var(--text-secondary);
+	margin: 0;
+}
+
+.kp-empty-state__description {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+	margin: 0;
+	max-width: 42ch;
+}
+
+.kp-empty-state__action {
+	margin-top: var(--s-2);
+}

--- a/apps/web/src/components/ui/EmptyState.test.tsx
+++ b/apps/web/src/components/ui/EmptyState.test.tsx
@@ -1,0 +1,33 @@
+import {render, screen} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {EmptyState} from "./EmptyState";
+
+describe("EmptyState — the inline empty-state primitive (#2162)", () => {
+	it("renders the title, and only the slots it is given", () => {
+		const {container} = render(<EmptyState title="henüz yorum yok." />);
+		expect(screen.getByText("henüz yorum yok.")).not.toBeNull();
+		expect(container.querySelector(".kp-empty-state__description")).toBeNull();
+		expect(container.querySelector(".kp-empty-state__icon")).toBeNull();
+		expect(container.querySelector(".kp-empty-state__action")).toBeNull();
+	});
+
+	it("renders the description, icon, and action slots when provided", () => {
+		render(
+			<EmptyState
+				icon={<span data-testid="glyph">✦</span>}
+				title="henüz başlık yok."
+				description="ilk başlığı sen aç."
+				action={<button type="button">başlık aç</button>}
+			/>,
+		);
+		expect(screen.getByText("ilk başlığı sen aç.")).not.toBeNull();
+		expect(screen.getByTestId("glyph")).not.toBeNull();
+		expect(screen.getByRole("button", {name: "başlık aç"})).not.toBeNull();
+	});
+
+	it("hides the icon slot from assistive tech (decorative)", () => {
+		const {container} = render(<EmptyState icon={<span>✦</span>} title="boş" />);
+		const icon = container.querySelector(".kp-empty-state__icon");
+		expect(icon?.getAttribute("aria-hidden")).toBe("true");
+	});
+});

--- a/apps/web/src/components/ui/EmptyState.tsx
+++ b/apps/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,39 @@
+import type * as React from "react";
+import "./EmptyState.css";
+
+/**
+ * The inline empty-state primitive: a composed, centered block a sparse surface
+ * renders in place of a bare void (a "0 yorum" label, a feed with no posts, a
+ * profile with no contributions). `NotFoundPage` is its full-page 404 sibling —
+ * this one fills a region *within* a page so it reads as intentional, not truncated.
+ *
+ * Slots, not law: an `icon` glyph slot, a required `title`, an optional
+ * `description`, and an `action` CTA slot. Composed from existing spacing/text
+ * tokens only — it defines no new design-system primitive.
+ */
+export function EmptyState({
+	icon,
+	title,
+	description,
+	action,
+	className = "",
+}: {
+	icon?: React.ReactNode;
+	title: React.ReactNode;
+	description?: React.ReactNode;
+	action?: React.ReactNode;
+	className?: string;
+}) {
+	return (
+		<div className={`kp-empty-state ${className}`.trim()} data-testid="empty-state">
+			{icon ? (
+				<div className="kp-empty-state__icon" aria-hidden="true">
+					{icon}
+				</div>
+			) : null}
+			<p className="kp-empty-state__title">{title}</p>
+			{description ? <p className="kp-empty-state__description">{description}</p> : null}
+			{action ? <div className="kp-empty-state__action">{action}</div> : null}
+		</div>
+	);
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -8,6 +8,7 @@ export type {CopyLinkButtonProps} from "./CopyLinkButton";
 export {CopyLinkButton} from "./CopyLinkButton";
 export {Dialog} from "./Dialog";
 export {DraftRestoreBanner} from "./DraftRestoreBanner";
+export {EmptyState} from "./EmptyState";
 export {Field, FieldError, Form, Hint, Input, Label, Textarea} from "./Form";
 export {Menu} from "./Menu";
 export type {ReportButtonProps, ReportOutcome} from "./ReportButton";

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -13,6 +13,7 @@ import {Subnav} from "../components/layout/Subnav";
 import {PanoCrumb} from "../components/pano/index";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {PanoFeedSkeleton} from "../components/pano/PanoSkeleton";
+import {EmptyState} from "../components/ui/EmptyState";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
 import {
@@ -149,19 +150,26 @@ function FeedRows({
 			    go inert (`aria-busy`), so the swap reads as "loading the next sort" rather
 			    than a frozen screen — the `startTransition` in the parent keeps them here
 			    instead of unmounting to the skeleton (#2161). */}
-			<div
-				className="kp-pano-list"
-				aria-busy={pending}
-				style={
-					pending
-						? {opacity: 0.6, transition: "opacity var(--motion-base) var(--ease-standard)"}
-						: undefined
-				}
-			>
-				{items.map(({node}, i) => (
-					<PanoPostCard key={node.id} post={node} rank={i + 1} />
-				))}
-			</div>
+			{items.length === 0 && !pending ? (
+				<EmptyState
+					title={host ? `${host} için henüz başlık yok.` : "henüz başlık yok."}
+					description="ilk başlığı sen aç — pano seni bekliyor."
+				/>
+			) : (
+				<div
+					className="kp-pano-list"
+					aria-busy={pending}
+					style={
+						pending
+							? {opacity: 0.6, transition: "opacity var(--motion-base) var(--ease-standard)"}
+							: undefined
+					}
+				>
+					{items.map(({node}, i) => (
+						<PanoPostCard key={node.id} post={node} rank={i + 1} />
+					))}
+				</div>
+			)}
 			{loadNext ? (
 				<div style={{marginTop: "var(--s-3)", display: "flex", justifyContent: "center"}}>
 					<LoadMoreButton loadNext={loadNext} />

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -26,6 +26,7 @@ import {
 import {PanoPostSkeleton} from "../components/pano/PanoSkeleton";
 import {Button} from "../components/ui/Button";
 import {Dialog} from "../components/ui/Dialog";
+import {EmptyState} from "../components/ui/EmptyState";
 import type {ReportOutcome} from "../components/ui/ReportButton";
 import {
 	beginOptimisticCommentMembership,
@@ -719,6 +720,12 @@ function Comments(props: CommentsProps) {
 				optimistic={optimisticComment}
 			/>
 			<h2 className="kp-pano-postpage__thread-heading">{visibleCount} yorum</h2>
+			{visibleCount === 0 ? (
+				<EmptyState
+					title="henüz yorum yok."
+					description="ilk yorumu sen yaz — tartışmayı başlat."
+				/>
+			) : null}
 			<div className="kp-pano-thread">
 				{roots.map((r) => (
 					<CommentTreeNode

--- a/apps/web/src/pages/UserProfilePage.css
+++ b/apps/web/src/pages/UserProfilePage.css
@@ -71,11 +71,6 @@
 	margin: 0 0 var(--s-2);
 }
 
-.kp-user-profile__empty {
-	color: var(--text-muted);
-	font: var(--t-meta);
-}
-
 .kp-user-profile__list {
 	list-style: none;
 	padding: 0;

--- a/apps/web/src/pages/UserProfilePage.tsx
+++ b/apps/web/src/pages/UserProfilePage.tsx
@@ -12,6 +12,7 @@ import {shouldShowCaylakStatus} from "../components/profile/CaylakStatusBlock";
 import {ContributionRow, ContributionView} from "../components/profile/ContributionRow";
 import {PromotionActions, shouldShowPromotionActions} from "../components/profile/PromotionActions";
 import {UserProfileHeader, UserProfileHeaderView} from "../components/profile/UserProfileHeader";
+import {EmptyState} from "../components/ui/EmptyState";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
 import {FlagGate} from "../flags/FlagGate";
@@ -106,7 +107,10 @@ function ContributionsList({profile}: {profile: ViewRef<"Profile">}) {
 		<section className="kp-user-profile__feed" data-testid="user-profile-feed">
 			<h3>katkılar</h3>
 			{items.length === 0 ? (
-				<p className="kp-user-profile__empty">henüz katkı yok.</p>
+				<EmptyState
+					title="henüz katkı yok."
+					description="ilk tanımını ya da başlığını ekleyince burada görünür."
+				/>
 			) : (
 				<ul className="kp-user-profile__list">
 					{items.map(({cursor, node}) => (


### PR DESCRIPTION
Fixes #2162

## What
Sparse surfaces render a bare void — a "0 yorum" heading with nothing beneath it, a feed with no posts (`PanoFeed` had **no** empty branch at all), a profile with no contributions as a lone `<p>` label. This adds a reusable inline **`EmptyState`** primitive and adopts it at those bare surfaces so a nearly-empty page reads as composed, not broken.

## The primitive
- `apps/web/src/components/ui/EmptyState.tsx` (+ `.css`) — slots: `icon?`, `title`, `description?`, `action?`. Centered + vertically padded (`min-height: 30vh`) so a sparse region reads as intentional, not content-jammed-at-top. Exported from `components/ui/index.ts`.
- `NotFoundPage` stays its full-page 404 sibling; `EmptyState` fills a region *within* a page.

## Adopted at three bare surfaces
- **`PanoPostDetail`** — the "0 yorum" thread now renders an EmptyState under the composer instead of an empty void.
- **`PanoFeed`** — a feed with zero posts (`items.length === 0 && !pending`, distinguished from the chip-swap `pending` dim and the cold-load skeleton) now renders an EmptyState; host-scoped feeds get host-specific copy.
- **`UserProfilePage`** — the empty contributions list adopts EmptyState; the now-dead `.kp-user-profile__empty` class is removed.

The sözlük A–Z index empty-letter dimming (the "no state" finding) was **already shipped** (`SozlukAlphabet` `is-empty` on empty letters), so no change was needed there.

## Copy
All user-facing copy is Turkish per the language convention (`henüz yorum yok.` / `henüz başlık yok.` / `henüz katkı yok.` + inviting descriptions).

## Scope / class
- **§CP:NO — client-only presentational change.** Empty-state components + Turkish copy; no data/logic/security/API surface, no fate mutation. Containment-EXEMPT pure-client class (ADR 0161) — **no flag added**.
- **No new design-system law.** Composed from existing spacing/text **tokens** and primitives only — no new token, no new type scale/elevation, no composite Card/MetaRow primitive. Those are #2163/#2164, held behind the #2173 DS manifest.

## Verification
- `pnpm typecheck` — pass (26/26)
- `pnpm lint` (biome) — pass
- `vitest --project client` — new `EmptyState.test.tsx` (3 tests, slots + decorative-icon a11y) pass; touched `src/pages` client tests pass (12/12)