### PR TITLE
fix(bildirim): stop the NotificationChannel byId 500 on every authed page (#2206)

### DIFF
--- a/apps/web/src/components/bildirim/BildirimList.tsx
+++ b/apps/web/src/components/bildirim/BildirimList.tsx
@@ -55,8 +55,15 @@ const BildirimConnectionView = {
 	items: {node: BildirimRowView},
 } as const;
 
+// `bildirim.channel` rides the same request so `useLiveView(channelRef)` below reads a
+// HYDRATED cache instead of fetching a `byId` — `NotificationChannel` is a loader-less
+// `Fate.syntheticSource`, and a `byId` against it 500s through fate's capability-less arm
+// (#2206). `useRequest` suspends the component until this resolves, so the entity is in the
+// cache before `useLiveView`'s `readView` runs (a pure cache hit, no `byId`); the query
+// then reconciles live over `/fate/live` (seed-then-subscribe).
 const bildirimRequest = {
 	"bildirim.list": {list: BildirimConnectionView, args: {first: PAGE_SIZE}},
+	"bildirim.channel": {view: ChannelView},
 } as const;
 
 export function BildirimList() {

--- a/apps/web/src/components/bildirim/useBildirimUnread.test.tsx
+++ b/apps/web/src/components/bildirim/useBildirimUnread.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Regression pin for #2206: the topbar unread badge must NEVER issue a `byId` against
+ * the loader-less `NotificationChannel` synthetic source — a `byId` there 500s through
+ * fate's capability-less error arm, and this badge mounts on every authenticated page,
+ * so an ungated read was 500-spam on 100% of authed pageviews.
+ *
+ * `client.readView` is exactly the call that fetches a `byId` on a cache miss (fate's
+ * `readView` → `fetchByIdAndNormalize` when `missing.size > 0`). The fix gates the read
+ * behind the `bildirim.channel` query seed, so `readView` is only ever called once the
+ * channel is hydrated (a pure cache hit, no `byId`). The stub client below records every
+ * `readView`, and the load-bearing assertion is that it is NOT invoked before the seed
+ * resolves — pre-fix, `getSnapshot` called `readView` on the first synchronous render
+ * (empty cache → `byId` → 500).
+ */
+import {act, renderHook, waitFor} from "@testing-library/react";
+import type {ReactNode} from "react";
+import {FateClient} from "react-fate";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {useBildirimUnread} from "./useBildirimUnread";
+
+const USER = "user-1";
+const ENTITY = `NotificationChannel:${USER}`;
+
+// A fake fate client modeling the one behavior that matters for #2206: `readView` is the
+// call that fires a `byId` on a cache miss. Here it returns a PENDING thenable while the
+// channel is unhydrated (the real client's cache-miss branch that fetches the byId) and a
+// stable fulfilled snapshot once the `bildirim.channel` seed has resolved. A `readView`
+// call while unhydrated == the byId 500 path; the test asserts it never happens.
+function makeClient(unreadCount: number) {
+	let hydrated = false;
+	let resolveSeed!: () => void;
+	const seed = new Promise<void>((r) => {
+		resolveSeed = r;
+	});
+	// A single stable snapshot object — `useSyncExternalStore` requires getSnapshot to
+	// return a cached reference when nothing changed (the real client memoizes via its
+	// view-data cache); a fresh object each call would loop.
+	const snapshot = {
+		coverage: [[ENTITY, new Set(["unreadCount"])]] as ReadonlyArray<
+			readonly [string, ReadonlySet<string>]
+		>,
+		data: {unreadCount},
+	};
+	const fulfilled = {status: "fulfilled" as const, value: snapshot};
+	// Unhydrated → a bare pending thenable (fate's cache-miss branch, which fires the byId);
+	// hydrated → the stable fulfilled snapshot (a pure cache hit).
+	const readView = vi.fn(() => (hydrated ? fulfilled : Promise.resolve(null)));
+	const request = vi.fn(() =>
+		seed.then(() => {
+			hydrated = true;
+		}),
+	);
+	const client = {
+		request,
+		assertLiveViewSupport: vi.fn(),
+		subscribeLiveView: vi.fn(() => () => undefined),
+		ref: vi.fn((type: string, id: string) => ({__typename: type, id})),
+		readView,
+		store: {subscribe: vi.fn(() => () => undefined)},
+	};
+	return {client, readView, request, resolveSeed};
+}
+
+function wrapperFor(client: unknown) {
+	return function wrapper({children}: {children: ReactNode}) {
+		return <FateClient client={client as never}>{children}</FateClient>;
+	};
+}
+
+describe("useBildirimUnread — no byId against the loader-less NotificationChannel source (#2206)", () => {
+	beforeEach(() => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not read (and so never fetches a byId) until the query seed hydrates the cache", async () => {
+		const {client, readView, request, resolveSeed} = makeClient(3);
+		const {result} = renderHook(() => useBildirimUnread(true, USER), {
+			wrapper: wrapperFor(client),
+		});
+
+		// The seed request fired, but the reactive read did NOT — a readView on the empty
+		// cache is exactly the byId that 500s. This is the regression: pre-fix the first
+		// synchronous getSnapshot called readView before any hydration.
+		expect(request).toHaveBeenCalledWith({"bildirim.channel": {view: expect.anything()}});
+		expect(readView).not.toHaveBeenCalled();
+		expect(result.current).toBe(0);
+
+		// Resolve the seed → the cache hydrates → now the read is a pure cache hit and the
+		// badge reflects the live count. The read path still works: no regression to #1700.
+		await act(async () => {
+			resolveSeed();
+			await Promise.resolve();
+		});
+		await waitFor(() => expect(result.current).toBe(3));
+		expect(readView).toHaveBeenCalled();
+	});
+
+	it("stays at 0 and never touches the wire while disabled (signed-out / flag off)", () => {
+		const {client, readView, request} = makeClient(5);
+		const {result} = renderHook(() => useBildirimUnread(false, null), {
+			wrapper: wrapperFor(client),
+		});
+		expect(result.current).toBe(0);
+		expect(request).not.toHaveBeenCalled();
+		expect(readView).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/components/bildirim/useBildirimUnread.ts
+++ b/apps/web/src/components/bildirim/useBildirimUnread.ts
@@ -28,11 +28,24 @@ type ChannelSnapshot = {
 	data: {unreadCount?: number} | null;
 };
 
-/** Read the channel's merged snapshot from the cache, or `null` if not yet loaded. */
+/**
+ * Read the channel's merged snapshot from the cache, or `null` if not yet loaded.
+ *
+ * Reads ONLY once `seeded` — i.e. after the `bildirim.channel` query has hydrated the
+ * channel into the cache. `NotificationChannel` is a loader-less `Fate.syntheticSource`
+ * (no `byId`/`byIds`), and `client.readView` fetches a `byId` on a cache miss — which
+ * takes fate's capability-less error arm and 500s. This badge mounts on every
+ * authenticated page, so an ungated read is 500-spam on 100% of authed pageviews (#2206).
+ * Gating the read behind the seed keeps `readView` a pure cache hit (`missing.size === 0`),
+ * so the `byId` is never issued; the entity is delivered inline by the query and
+ * reconciled live over `/fate/live`.
+ */
 function readChannel(
 	client: ReturnType<typeof useFateClient>,
 	userId: string,
+	seeded: boolean,
 ): ChannelSnapshot | null {
+	if (!seeded) return null;
 	const ref = client.ref("NotificationChannel", userId, ChannelView);
 	const thenable = client.readView(ChannelView, ref);
 	return "status" in thenable && (thenable as {status?: unknown}).status === "fulfilled"
@@ -81,17 +94,16 @@ export function useBildirimUnread(enabled: boolean, userId: string | null): numb
 	// coverage-driven subscription, hoisted above Suspense (synchronous read; a
 	// not-yet-loaded ref reads 0).
 	const getSnapshot = useCallback(
-		() => (canRead && userId != null ? readChannel(client, userId) : null),
-		[client, canRead, userId],
+		() => (canRead && userId != null ? readChannel(client, userId, seeded > 0) : null),
+		[client, canRead, userId, seeded],
 	);
 
 	const subscribe = useCallback(
 		(onStoreChange: () => void) => {
-			void seeded; // re-establish the subscription once the seed populates coverage
 			if (!canRead || userId == null) return () => {};
 			const subscriptions = new Map<string, () => void>();
 			const sync = () => {
-				const snapshot = readChannel(client, userId);
+				const snapshot = readChannel(client, userId, seeded > 0);
 				const nextIds = new Set<string>();
 				for (const [entityId, paths] of snapshot?.coverage ?? []) {
 					nextIds.add(entityId);

--- a/apps/web/worker/features/bildirim/sources.ts
+++ b/apps/web/worker/features/bildirim/sources.ts
@@ -1,10 +1,18 @@
 /**
  * bildirim fate sources — every bildirim entity is delivered inline
  * (`Notification` by the `bildirim.list` resolver, `NotificationUnread` by the
- * `bildirim.unreadCount` query, `NotificationMarkReceipt` by the mark mutations)
- * and never read by id, so all are capability-less `Fate.syntheticSource`
- * entries — view-reachable, no fetch path (the `ReportReceipt` escape hatch,
- * `.patterns/fate-effect-sources.md`).
+ * `bildirim.unreadCount` query, `NotificationMarkReceipt` by the mark mutations,
+ * `NotificationChannel` by the `bildirim.channel` query + reconciled live over
+ * `/fate/live`) and never read by id, so all are capability-less
+ * `Fate.syntheticSource` entries — view-reachable, no fetch path (the `ReportReceipt`
+ * escape hatch, `.patterns/fate-effect-sources.md`).
+ *
+ * `NotificationChannel` stays loader-less on purpose: its id IS the recipient's user
+ * id, so a `byId(userId)` loader would be a cross-user read path bypassing the
+ * recipient-scoped `/fate/live` gate. The client must therefore NEVER issue a `byId`
+ * for it — it seeds the ref from the `bildirim.channel` query and subscribes live
+ * (`useBildirimUnread`, `BildirimList`); an ungated `readView` on a cache miss fetches a
+ * `byId` that 500s through the capability-less arm (#2206).
  */
 import {Fate} from "@kampus/fate-effect";
 import {


### PR DESCRIPTION
Fixes #2206

## Problem

`NotificationChannel` is a loader-less `Fate.syntheticSource` (no `byId`/`byIds`), but the client resolved it through a `byId` ref path: `client.readView` / `useLiveView` fetch a `byId` on a cache miss, and that `byId` takes fate's capability-less error arm → `INTERNAL_ERROR` → **500**. The unread badge (`useBildirimUnread`) mounts in the `Layout` shell on **every authenticated page**, so this was 500-spam on 100% of authed pageviews (masking real errors) — while the feature still functioned via the working inline `bildirim.channel` query. The notification center (`BildirimList`) hit the same 500 on `/bildirimler` via `useLiveView(channelRef)`.

Grounded against source: `readView` calls `fetchByIdAndNormalize` exactly when `missing.size > 0` (cache miss); `subscribeLiveView` itself never fetches. `useRequest` suspends via `use(...)`, so a request-seeded entity is hydrated before any later `readView` runs.

## Fix — option (b): make the invalid state unreachable, never issue the `byId`

Option (a) (adding a `byId` loader) was rejected: `NotificationChannel`'s id **is** the recipient's user id, so a `byId(userId)` loader would be a cross-user read path bypassing the recipient-scoped `/fate/live` gate — a data leak. The entity is self-scoped by construction, which is exactly why it's synthetic. So the fix removes the broken `byId` issuance instead:

- **`useBildirimUnread.ts`** — gate the reactive read behind the `bildirim.channel` seed, so `readView` is only ever a pure cache hit (`missing.size === 0`), never a `byId`. (Also drops a now-dead `void seeded` no-op, since `seeded` is genuinely read in the sync path.)
- **`BildirimList.tsx`** — seed `bildirim.channel` into the suspending `useRequest`, so `useLiveView(channelRef)` reads a hydrated cache instead of fetching a `byId` (seed-then-subscribe).
- **`sources.ts`** — document why `NotificationChannel` stays loader-less and must never be read by id.

The entity is delivered inline by the query and reconciled live over `/fate/live`. The recipient-scoped subscribe gate (`fate-live/route.ts`) and the live badge/center behavior (#1700) are unchanged.

## Acceptance criteria

- [x] No `byId`/`INTERNAL_ERROR` for a `{kind:"byId", type:"NotificationChannel"}` request on any authenticated route — the client never issues the `byId`.
- [x] The topbar badge and notification center still read the live unread count and reconcile over `/fate/live` (no #1700 regression).
- [x] The recipient-scoped subscribe authorization is preserved (untouched; option a was rejected precisely to keep it).
- [x] A test pins that the channel read path no longer hits fate's capability-less error arm.

## Test

`apps/web/src/components/bildirim/useBildirimUnread.test.tsx` — the read (and so the `byId`) never fires until the `bildirim.channel` seed hydrates the cache; once seeded, the badge reflects the live count. Pre-fix, `getSnapshot` called `readView` on the first synchronous render (empty cache → `byId` → 500), so the "not called before seed" assertion is a real regression pin.

## Gates (local)

- `pnpm typecheck` — 26/26 pass
- `biome check` (changed files) — clean
- client tier — 61/61 pass (incl. the new test + `App.test.tsx`)
- bildirim worker unit tier — 64/64 pass

§CP: NO (`apps/web/**` product code) — auto-ships on green.