### PR TITLE
fix(pano): vote re-resolves the full post so isSaved + author identity survive (#2213)

### DIFF
--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -301,7 +301,16 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.voteOnPost({postId: input.id, voterId: user.id});
-			const post = shapePost(r);
+			// Re-resolve the affected post via the same batched read `post.save`/`post.unsave`
+			// use, so the returned AND published projection carries the real `isSaved` + live
+			// author identity. The write result (`VoteOnPostResult`) has neither, and its
+			// null-bearing shape clobbered the client cache — and the fanned live frame — of an
+			// already-saved post (#2213).
+			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
+			if (!row) {
+				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
+			}
+			const post = toPost(row);
 			yield* live.post.update(post.id, {changed: ["score"], data: post});
 			// Aggregated vote notification (#1698): a LANDED upvote (not an idempotent
 			// no-op) notifies the post author — rolled up per item, self-suppressed,
@@ -328,8 +337,14 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher);
-			const r = yield* pano.retractPostVote({postId: input.id, voterId: user.id});
-			const post = shapePost(r);
+			yield* pano.retractPostVote({postId: input.id, voterId: user.id});
+			// Re-resolve like `post.vote` above so the returned/published projection keeps the
+			// real `isSaved` + author identity instead of the null-bearing write shape (#2213).
+			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
+			if (!row) {
+				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
+			}
+			const post = toPost(row);
 			yield* live.post.update(post.id, {changed: ["score"], data: post});
 			return post;
 		}),

--- a/apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts
+++ b/apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts
@@ -1,0 +1,214 @@
+/**
+ * `post.vote` / `post.retractVote` wire-boundary regression coverage (#2213) —
+ * proof that voting an already-SAVED post no longer clobbers its saved state or
+ * author identity in the client cache (nor in the fanned `/fate/live` frame).
+ *
+ * The defect: both resolvers shaped their return from the write result
+ * (`VoteOnPostResult`), which carries NO `isSaved` and NO resolved author
+ * identity — so the returned/published `Post` reported `isSaved: null` +
+ * `authorUsername/authorDisplayName: null`, and the client cache-merge overwrote
+ * the true saved state (and identity) of a saved post. The fix re-resolves the
+ * post via the same batched `getPostsByIds` read `post.save`/`post.unsave` use, so
+ * BOTH the return value and the published live frame carry the real projection.
+ *
+ * Driven through the real external interface (`resolveWire`), with `Pano` +
+ * `LivePublisher` substituted directly (no DB): the recording publisher captures
+ * the published `/fate/live` frame so the fanned projection is asserted, not just
+ * the return.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import type {PublishMessage} from "../fate-live/protocol.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {mutations} from "./mutations.ts";
+import {Pano, type PostSummaryRow, type VoteOnPostResult} from "./Pano.ts";
+
+const VOTER = {id: "u-voter", email: "voter@example.com", name: "voter"};
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+// The write result `voteOnPost`/`retractPostVote` return — deliberately carries
+// NEITHER `isSaved` NOR resolved author identity, exactly the shape that used to
+// leak `null` into the cache. `authorName` is only the write-time snapshot.
+const writeResult = (overrides: Partial<VoteOnPostResult> = {}): VoteOnPostResult => ({
+	postId: "post_1",
+	title: "başlık",
+	url: null,
+	host: null,
+	body: "gövde",
+	authorId: "u-author",
+	authorName: "yaz-adı",
+	score: 1,
+	hotScore: 1,
+	commentCount: 0,
+	tags: [],
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	myVote: true,
+	changed: true,
+	...overrides,
+});
+
+// The re-resolved row `getPostsByIds` returns for the SAVED post: a real
+// `isSaved: true` plus the live-stamped author identity — the projection the fix
+// must echo back (return + publish) instead of the null-bearing write shape.
+const savedRow = (): PostSummaryRow => ({
+	id: "post_1",
+	slug: "post-1",
+	title: "başlık",
+	url: null,
+	host: null,
+	body: "gövde",
+	author: "yaz-adı",
+	authorId: "u-author",
+	authorUsername: "elif",
+	authorDisplayName: "Elif Yılmaz",
+	score: 1,
+	commentCount: 0,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	tags: [],
+	myVote: true,
+	isSaved: true,
+	isDraft: null,
+});
+
+// A `Pano` stub whose vote + re-resolve reads are scripted; every other method
+// dies loudly. The vote path only ever reaches `voteOnPost`/`retractPostVote`
+// then `getPostsByIds`.
+const panoStub = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
+	Layer.succeed(
+		Pano,
+		new Proxy(methods, {
+			get(target, prop) {
+				if (prop in target) return (target as Record<string, unknown>)[prop as string];
+				return () => Effect.die(`Pano.${String(prop)} not exercised in vote-preserves-saved-state`);
+			},
+		}) as typeof Pano.Service,
+	);
+
+// A recording `LivePublisher` — captures each published frame so the fanned
+// `/fate/live` projection is asserted, not just the return. Pushing in the
+// `publish` builder body captures synchronously (before `waitUntil` detaches it).
+const recordingLive = (frames: PublishMessage[]): Layer.Layer<LivePublisher> =>
+	Layer.succeed(LivePublisher)(
+		livePublisherFor({
+			publish: (_topicKey, message) => {
+				frames.push(message);
+				return Effect.void;
+			},
+			waitUntil: () => {},
+		}),
+	);
+
+const publishedData = (frames: PublishMessage[]): Record<string, unknown> | undefined => {
+	const entity = frames.find((m) => m.kind === "entity");
+	if (!entity || entity.kind !== "entity" || "delete" in entity.frame) return undefined;
+	return entity.frame.data as Record<string, unknown> | undefined;
+};
+
+// The vote path fires the flag-gated `notifyContentVote` emitter, so the resolver's
+// residual context carries `Flags` + `Notification`. Flag ON exercises the emit; the
+// recording stub swallows it — the notification wiring is proven elsewhere
+// (`bildirim/vote-emitters.unit.test.ts`), here it just discharges the context.
+const flagsOn: Layer.Layer<Flags> = Layer.succeed(Flags, {
+	getBoolean: () => Effect.succeed(true),
+	getString: () => Effect.die("getString not exercised"),
+	getNumber: () => Effect.die("getNumber not exercised"),
+	getObject: () => Effect.die("getObject not exercised"),
+} as typeof Flags.Service);
+
+const notificationStub = makeNotificationStub({
+	recordAggregate: () => Effect.succeed({aggregated: false}),
+});
+
+const drive = (
+	op: (typeof mutations)["post.vote" | "post.retractVote"],
+	pano: Layer.Layer<Pano>,
+	frames: PublishMessage[],
+) =>
+	resolveWire(op, {
+		input: {id: "post_1"},
+		select: ["id", "isSaved", "authorUsername", "authorDisplayName", "myVote", "score"],
+	}).pipe(
+		Effect.provide(Layer.mergeAll(pano, recordingLive(frames), flagsOn, notificationStub)),
+		Effect.provideService(CurrentUser, {user: VOTER}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+	);
+
+describe("post.vote — voting a saved post preserves isSaved + author identity (#2213)", () => {
+	it.effect("the returned projection carries isSaved:true and real identity, not null", () =>
+		Effect.gen(function* () {
+			const frames: PublishMessage[] = [];
+			const post = (yield* drive(
+				mutations["post.vote"],
+				panoStub({
+					voteOnPost: () => Effect.succeed(writeResult()),
+					getPostsByIds: () => Effect.succeed([savedRow()]),
+				}),
+				frames,
+			)) as Record<string, unknown>;
+			assert.strictEqual(post.isSaved, true, "returned isSaved is the real server state, not null");
+			assert.strictEqual(post.authorUsername, "elif", "returned authorUsername is resolved");
+			assert.strictEqual(
+				post.authorDisplayName,
+				"Elif Yılmaz",
+				"returned authorDisplayName is resolved",
+			);
+			assert.strictEqual(post.myVote, true);
+			assert.strictEqual(post.score, 1);
+		}),
+	);
+
+	it.effect(
+		"the published /fate/live frame carries the same resolved projection (no null leak)",
+		() =>
+			Effect.gen(function* () {
+				const frames: PublishMessage[] = [];
+				yield* drive(
+					mutations["post.vote"],
+					panoStub({
+						voteOnPost: () => Effect.succeed(writeResult()),
+						getPostsByIds: () => Effect.succeed([savedRow()]),
+					}),
+					frames,
+				);
+				const data = publishedData(frames);
+				assert.isDefined(data, "an entity update frame was published");
+				assert.strictEqual(data?.isSaved, true, "the fanned frame keeps isSaved, not null");
+				assert.strictEqual(data?.authorUsername, "elif", "the fanned frame keeps author identity");
+				assert.strictEqual(data?.authorDisplayName, "Elif Yılmaz");
+			}),
+	);
+});
+
+describe("post.retractVote — shares the fix (#2213)", () => {
+	it.effect("returned + published projection both keep isSaved:true and identity", () =>
+		Effect.gen(function* () {
+			const frames: PublishMessage[] = [];
+			const post = (yield* drive(
+				mutations["post.retractVote"],
+				panoStub({
+					retractPostVote: () => Effect.succeed(writeResult({myVote: false, score: 0})),
+					getPostsByIds: () => Effect.succeed([{...savedRow(), myVote: false, score: 0}]),
+				}),
+				frames,
+			)) as Record<string, unknown>;
+			assert.strictEqual(post.isSaved, true, "retractVote also preserves isSaved");
+			assert.strictEqual(post.authorUsername, "elif");
+			const data = publishedData(frames);
+			assert.strictEqual(data?.isSaved, true, "the fanned retract frame keeps isSaved too");
+			assert.strictEqual(data?.authorDisplayName, "Elif Yılmaz");
+		}),
+	);
+});


### PR DESCRIPTION
## What

`post.vote` / `post.retractVote` shaped their return from the write result (`VoteOnPostResult`), which carries **no `isSaved`** and **no resolved author identity** (only the write-time `authorName` snapshot). So the returned — and fanned `/fate/live` — `Post` reported `isSaved: null` + `authorUsername/authorDisplayName: null`, and the client cache-merge treated that partial projection as authoritative and **clobbered the true saved state (and author identity)** of an already-saved post the moment a user voted on it. The bookmark row was untouched server-side; this is a client-cache display-integrity bug.

## Fix

Mirror the correct sibling pattern in `post.save` / `post.unsave`: re-resolve the affected post via the same batched `getPostsByIds([id], {viewerId})` read, then `toPost(row)`. Applied to **both** `post.vote` and `post.retractVote`.

Both the **return value** and the **published `/fate/live` frame** now carry the fully-resolved projection (real `isSaved` + live-stamped `authorUsername`/`authorDisplayName` + `myVote`), so voting no longer fans `isSaved: null` out to other live subscribers either. A raced-away post surfaces as `POST_NOT_FOUND` (already in each resolver's error union), same as save/unsave.

The null-bearing local `shapePost` is no longer used on the vote path; it stays for `post.submit` / `post.saveDraft` / `post.edit`. Kept tightly scoped — no change to `applyPostVote`, `VoteOnPostResult`, or `vote/errors.ts`.

## Acceptance criteria

- [x] After `post.vote` on a saved post, the returned/merged `Post` reports `isSaved: true`, not `null`.
- [x] The returned `Post` carries resolved `authorUsername` / `authorDisplayName`, matching the `post.save`/`post.unsave` projection.
- [x] `post.retractVote` gets the same fix.
- [x] The `/fate/live` frame published by `post.vote` carries the corrected projection (no `isSaved:null` leak to subscribers).
- [x] Unit coverage: voting a saved post preserves `isSaved` in the returned projection.

## Verification

- `apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts` (new) — drives both resolvers through the real wire seam (`resolveWire`) with a recording live publisher; asserts a vote on a saved post **returns AND publishes** `isSaved: true` + resolved author identity, not null. 3/3 pass.
- `pnpm typecheck` green; `biome check` clean; full pano unit suite 172/172 pass; `fanout-guard check` green (both mutations stay classified fanned and publish).

Fixes #2213