### PR TITLE
fix(web): move rank numbers off decorative --text-faint to AA-safe --text-muted

### DIFF
--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -20,7 +20,9 @@
 
 .kp-pano-post__rank {
 	font: var(--t-meta);
-	color: var(--text-faint);
+	/* Rank number carries meaning → --text-muted (AA-safe ≥4.5:1); --text-faint is
+	   decorative-only and bottoms out at ~3:1 (#2166, tokens.css role layer). */
+	color: var(--text-muted);
 	text-align: right;
 	padding-top: 3px;
 }

--- a/apps/web/src/components/sozluk/Sozluk.css
+++ b/apps/web/src/components/sozluk/Sozluk.css
@@ -58,7 +58,9 @@
 }
 .kp-sozluk-popular__rank {
 	font: var(--t-meta);
-	color: var(--text-faint);
+	/* Rank number carries meaning → --text-muted (AA-safe ≥4.5:1); --text-faint is
+	   decorative-only and bottoms out at ~3:1 (#2166, tokens.css role layer). */
+	color: var(--text-muted);
 	text-align: right;
 }
 .kp-sozluk-popular__title {

--- a/apps/web/src/pages/LandingPage.css
+++ b/apps/web/src/pages/LandingPage.css
@@ -168,7 +168,9 @@
 }
 .kp-landing-row__rank {
 	font: var(--t-meta);
-	color: var(--text-faint);
+	/* Rank number carries meaning → --text-muted (AA-safe ≥4.5:1); --text-faint is
+	   decorative-only and bottoms out at ~3:1 (#2166, tokens.css role layer). */
+	color: var(--text-muted);
 	text-align: right;
 }
 .kp-landing-row__title {

--- a/apps/web/src/pages/SozlukTermPage.css
+++ b/apps/web/src/pages/SozlukTermPage.css
@@ -108,7 +108,9 @@
 }
 .kp-sozluk-definition__rank {
 	font: var(--t-micro);
-	color: var(--text-faint);
+	/* Rank number carries meaning → --text-muted (AA-safe ≥4.5:1); --text-faint is
+	   decorative-only and bottoms out at ~3:1 (#2166, tokens.css role layer). */
+	color: var(--text-muted);
 	margin-top: 2px;
 }
 .kp-sozluk-definition__body {


### PR DESCRIPTION
Fixes #2210

## What

Two rank numbers were rendered in `--text-faint`, a token documented in the tokens.css role layer as decorative-only ("clears the 3:1 large-text/UI bar but not 4.5:1, so it is never used for text that carries meaning"). A rank number is meaning-bearing content the user must read, so this was an AA contrast fail (type:bug).

Promoted both to `--text-muted` (AA-safe ≥4.5:1), extending the #2166 remediation precedent (`.kp-reaction-bar__count`) with the same rule captured in a code comment at each site:

- `.kp-pano-post__rank` — `apps/web/src/components/pano/PanoPost.css`
- `.kp-sozluk-definition__rank` — `apps/web/src/pages/SozlukTermPage.css`

Legitimately decorative `--text-faint` uses in the same files (`.dot` separators, vote-button icons) are left untouched, per the acceptance criteria.

## Gates

- `pnpm typecheck` green
- `pnpm lint` green (biome, 2 files)

CSS-only change; no runtime/test surface affected.