### PR TITLE
chore(web): lowercase dropdown + pano composer copy to house style

### DIFF
--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -148,16 +148,16 @@ export function Topbar({
 							data-testid="topbar-profile-link"
 							onClick={() => navigate(user.username ? `/u/${user.username}` : "/profile")}
 						>
-							Profil
+							profil
 						</Menu.Item>
 						{bildirim ? (
 							<Menu.Item data-testid="topbar-bildirim-link" onClick={() => navigate(bildirim.to)}>
-								Bildirimler
+								bildirimler
 							</Menu.Item>
 						) : null}
-						<Menu.Item onClick={() => navigate("/profile")}>Ayarlar</Menu.Item>
+						<Menu.Item onClick={() => navigate("/profile")}>ayarlar</Menu.Item>
 						<Menu.Separator />
-						<Menu.Item onClick={onLogout}>Çıkış</Menu.Item>
+						<Menu.Item onClick={onLogout}>çıkış</Menu.Item>
 					</Menu.Popup>
 				</Menu.Root>
 			) : null}

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -247,9 +247,9 @@ export function PanoSubmitPage() {
 					<Link to="/pano" className="kp-pano-submit__back">
 						← akışa dön
 					</Link>
-					<h1 className="kp-pano-submit__title">Bir şey paylaş</h1>
+					<h1 className="kp-pano-submit__title">bir şey paylaş</h1>
 					<p className="kp-pano-submit__lede">
-						Bağlantı, yazı, soru. Self-promo da olur — bir kere açıkla niye paylaşıyorsun.
+						bağlantı, yazı, soru. self-promo da olur — bir kere açıkla niye paylaşıyorsun.
 					</p>
 
 					<div className="kp-pano-submit__toggle">


### PR DESCRIPTION
Applies the strict-lowercase house style consistently across the avatar dropdown and the pano composer.

## Changes
- **Avatar dropdown** (`apps/web/src/components/layout/Topbar.tsx`): `Profil`/`Bildirimler`/`Ayarlar`/`Çıkış` → `profil`/`bildirimler`/`ayarlar`/`çıkış`.
- **Pano composer** (`apps/web/src/pages/PanoSubmitPage.tsx`): heading `Bir şey paylaş` → `bir şey paylaş`; lede sentence-case → lowercase (`bağlantı, yazı, soru. self-promo da olur — …`).

The dropdown item `bildirimler` now matches its destination page H1 (`BildirimlerPage.tsx` renders lowercase `bildirimler`) — resolving the within-feature Title/lowercase contradiction.

Copy-only, no behavior change. Composer copy confirmed live in source before editing (the audit's reported string had not shifted).

Local gates green: typecheck, lint (biome), relevant client vitest (Topbar/pages/Menu) all pass.

Fixes #2207