### PR TITLE
fix(pano): name the silent tag-required gate on the submit composer (#2201)

### DIFF
--- a/apps/web/src/lib/panoSubmitGate.test.ts
+++ b/apps/web/src/lib/panoSubmitGate.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from "vitest";
+import {type PanoSubmitFields, panoSubmitGate} from "./panoSubmitGate";
+
+const valid: PanoSubmitFields = {
+	inFlight: false,
+	titleInvalid: false,
+	titleTooLong: false,
+	bodyTooLong: false,
+	noTags: false,
+	linkModeUrlEmpty: false,
+};
+
+describe("panoSubmitGate", () => {
+	it("enables submit when every field is valid and a tag is selected (#2201 no-regression)", () => {
+		expect(panoSubmitGate(valid)).toEqual({submitDisabled: false, tagsAreSoleBlocker: false});
+	});
+
+	it("flags the missing tag as the sole blocker when nothing else is wrong (#2201)", () => {
+		const g = panoSubmitGate({...valid, noTags: true});
+		expect(g.submitDisabled).toBe(true);
+		expect(g.tagsAreSoleBlocker).toBe(true);
+	});
+
+	it("does not name tags the sole blocker while another field also blocks", () => {
+		for (const other of [
+			"titleInvalid",
+			"titleTooLong",
+			"bodyTooLong",
+			"linkModeUrlEmpty",
+			"inFlight",
+		] as const) {
+			const g = panoSubmitGate({...valid, noTags: true, [other]: true});
+			expect(g.submitDisabled).toBe(true);
+			expect(g.tagsAreSoleBlocker).toBe(false);
+		}
+	});
+
+	it("keeps submit disabled with no inline tag reason when only another field blocks", () => {
+		const g = panoSubmitGate({...valid, titleInvalid: true});
+		expect(g.submitDisabled).toBe(true);
+		expect(g.tagsAreSoleBlocker).toBe(false);
+	});
+});

--- a/apps/web/src/lib/panoSubmitGate.ts
+++ b/apps/web/src/lib/panoSubmitGate.ts
@@ -1,0 +1,30 @@
+/**
+ * The pano submit gate: whether "paylaş" is disabled, and — the reason #2201 fixed —
+ * whether the missing tag is the *sole* remaining blocker, so the composer can name that
+ * silent requirement inline instead of leaving the button dead with no explanation.
+ */
+
+/** Field-validity inputs. `titleInvalid` folds empty + below-min into one blocker. */
+export interface PanoSubmitFields {
+	inFlight: boolean;
+	titleInvalid: boolean;
+	titleTooLong: boolean;
+	bodyTooLong: boolean;
+	noTags: boolean;
+	linkModeUrlEmpty: boolean;
+}
+
+export interface PanoSubmitGate {
+	submitDisabled: boolean;
+	/** True iff no tag is selected AND every other field is valid — the reason to surface inline. */
+	tagsAreSoleBlocker: boolean;
+}
+
+export function panoSubmitGate(f: PanoSubmitFields): PanoSubmitGate {
+	const otherFieldsBlock =
+		f.inFlight || f.titleInvalid || f.titleTooLong || f.bodyTooLong || f.linkModeUrlEmpty;
+	return {
+		submitDisabled: otherFieldsBlock || f.noTags,
+		tagsAreSoleBlocker: f.noTags && !otherFieldsBlock,
+	};
+}

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -12,6 +12,7 @@ import type {WireMessageOverrides} from "../fate/wireMessages";
 import {FlagGate} from "../flags/FlagGate";
 import {PANO_DRAFT_SAVE, PANO_OPTIMISTIC_SUBMIT} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
+import {panoSubmitGate} from "../lib/panoSubmitGate";
 import {POST_TAG_KINDS, tagClass, tagLabel} from "../lib/panoTags";
 import {authRedirectPath} from "../lib/returnTo";
 import {useDraftAutosave} from "../lib/useDraftAutosave";
@@ -155,13 +156,14 @@ export function PanoSubmitPage() {
 	const noTags = selectedTags.size === 0;
 	const linkModeUrlEmpty = mode === "link" && url.trim().length === 0;
 
-	const submitDisabled =
-		isInFlight ||
-		trimmedTitle.length < TITLE_MIN ||
-		titleTooLong ||
-		bodyTooLong ||
-		noTags ||
-		linkModeUrlEmpty;
+	const {submitDisabled, tagsAreSoleBlocker} = panoSubmitGate({
+		inFlight: isInFlight,
+		titleInvalid: trimmedTitle.length < TITLE_MIN,
+		titleTooLong,
+		bodyTooLong,
+		noTags,
+		linkModeUrlEmpty,
+	});
 
 	async function onSubmit(e: React.SyntheticEvent) {
 		e.preventDefault();
@@ -347,7 +349,9 @@ export function PanoSubmitPage() {
 						)}
 
 						<fieldset className="kp-pano-submit__field kp-pano-submit__fieldset">
-							<legend className="kp-pano-submit__field-label">etiketler · en fazla 3</legend>
+							<legend className="kp-pano-submit__field-label">
+								etiketler · en az 1, en fazla 3
+							</legend>
 							<div className="kp-pano-submit__tagrow">
 								{TAGS.map((t) => {
 									const on = selectedTags.has(t.kind);
@@ -365,6 +369,15 @@ export function PanoSubmitPage() {
 									);
 								})}
 							</div>
+							{tagsAreSoleBlocker ? (
+								<span
+									className="kp-pano-submit__hint"
+									data-testid="pano-submit-tags-required"
+									style={{color: "var(--text-faint)"}}
+								>
+									{PANO_SUBMIT_OVERRIDES.TAGS_REQUIRED}
+								</span>
+							) : null}
 						</fieldset>
 
 						{error ? (


### PR DESCRIPTION
Fixes #2201

## Problem

The pano composer (`/pano/yeni`) left **paylaş** disabled until ≥1 tag was selected, but never communicated that requirement. The tag legend advertised only the max (`etiketler · en fazla 3`), and the existing `TAGS_REQUIRED` copy (`en az bir etiket seç`) was reachable **only** through the submit round-trip's error state — `onSubmit` early-returns on `if (submitDisabled) return;` before any round-trip, so that copy never surfaced for the disabled state. A fully-filled form (url + valid title) sat behind a greyed-out button with no explanation.

## Fix

- **Extract the gate into a pure `panoSubmitGate()`** (`apps/web/src/lib/panoSubmitGate.ts`) that returns both `submitDisabled` and `tagsAreSoleBlocker` — true iff no tag is selected *and* every other field is valid.
- **Legend now marks the field required:** `etiketler · en az 1, en fazla 3` (communicates the min, not only the max).
- **Inline reason surfaces when the tag is the sole blocker:** the existing `en az bir etiket seç` copy renders near the tag field, so the disabled reason is visible *before* the user gives up — not only after a round-trip.

## Acceptance criteria

- [x] The tag field communicates that at least one tag is required (legend copy `en az 1`), not only the max-3.
- [x] When submit is blocked solely because no tag is selected, the inline `en az bir etiket seç` reason shows near the tag field.
- [x] A url + valid title with a tag selected still enables paylaş (no regression) — pinned by unit test.

## Tests

`apps/web/src/lib/panoSubmitGate.test.ts` — 4 cases pinning: valid+tagged enables submit (no regression), missing tag is the sole blocker when nothing else is wrong, another concurrent blocker suppresses the tag hint, and a non-tag blocker keeps submit disabled with no tag reason. Green locally (`vitest --project unit`), plus `pnpm --filter @kampus/web typecheck` and biome lint clean.

§CP: NO — product UI, auto-ships on green.