### PR TITLE
fix(web): Turkish inline validation on the auth form (noValidate) (#2202)

### DIFF
--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -130,6 +130,37 @@ describe("AuthPage — signup→setUsername (#1888)", () => {
 		await waitFor(() => expect(screen.getByTestId("gate").textContent).toBe("clear"));
 	});
 
+	it("an empty signup submit shows Turkish validation and never reaches signUp (no browser-locale bubble)", async () => {
+		const setUsername = vi.fn(async () => ({error: null}));
+		renderAuth(setUsername);
+		switchToSignUp();
+		// noValidate → the browser suppresses its English constraint bubble, so an empty
+		// submit reaches onSubmit and the Turkish field message surfaces instead.
+		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
+		await waitFor(() => screen.getByText("görünen ad gerekli"));
+		expect(signUpEmail).not.toHaveBeenCalled();
+	});
+
+	it("a malformed signup e-posta shows the Turkish format message, not an English bubble", async () => {
+		const setUsername = vi.fn(async () => ({error: null}));
+		renderAuth(setUsername);
+		switchToSignUp();
+		fireEvent.change(screen.getByLabelText("görünen ad"), {target: {value: "Elif Kaya"}});
+		fireEvent.change(screen.getByLabelText("e-posta"), {target: {value: "elif"}});
+		fireEvent.change(screen.getByLabelText("parola"), {target: {value: "hunter2hunter2"}});
+		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
+		await waitFor(() => screen.getByText("geçerli bir e-posta gir"));
+		expect(signUpEmail).not.toHaveBeenCalled();
+	});
+
+	it("an empty sign-in submit shows Turkish validation and never reaches signIn", async () => {
+		const setUsername = vi.fn(async () => ({error: null}));
+		renderAuth(setUsername);
+		fireEvent.submit(screen.getByRole("button", {name: "devam et"}).closest("form")!);
+		await waitFor(() => screen.getByText("e-posta gerekli"));
+		expect(signInEmail).not.toHaveBeenCalled();
+	});
+
 	it("a blank username field never touches setUsername and never holds the gate", async () => {
 		const setUsername = vi.fn(async () => ({error: null}));
 		renderAuth(setUsername);

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -3,6 +3,7 @@ import {useFateClient, view} from "react-fate";
 import type {User} from "../../worker/features/fate/views";
 import {authClient} from "../auth/client";
 import {codeOf} from "../fate/wire";
+import {validateEmail, validateName, validatePassword, validateSignIn} from "./authValidation";
 import {beginUsernameResolution, endUsernameResolution} from "./signupUsernameGate";
 import {localRuleMessage, messageForCode} from "./usernameMessages";
 import "./AuthPage.css";
@@ -85,12 +86,18 @@ export function AuthPage() {
 		setError(null);
 
 		if (isSignIn) {
+			const email = String(data.get("email") ?? "");
+			const password = String(data.get("password") ?? "");
+			// Form is `noValidate` — drive the required/format checks in Turkish through
+			// the `kp-auth__error` surface instead of the browser's locale-default bubble.
+			const fieldError = validateSignIn(email, password);
+			if (fieldError) {
+				setError(fieldError);
+				return;
+			}
 			setPending(true);
 			try {
-				const result = await authClient.signIn.email({
-					email: String(data.get("email") ?? ""),
-					password: String(data.get("password") ?? ""),
-				});
+				const result = await authClient.signIn.email({email, password});
 				if (result.error) setError(result.error.message ?? "giriş başarısız");
 			} finally {
 				setPending(false);
@@ -98,6 +105,9 @@ export function AuthPage() {
 			return;
 		}
 
+		const name = String(data.get("name") ?? "");
+		const email = String(data.get("email") ?? "");
+		const password = String(data.get("password") ?? "");
 		// Username is optional at signup; when present it must pass the same rule the
 		// server enforces (`assertUsername`). Pre-flight here so a bad handle never
 		// creates the account, then surfaces as a confusing post-signup failure.
@@ -105,21 +115,23 @@ export function AuthPage() {
 		const username = String(data.get("username") ?? "")
 			.trim()
 			.toLowerCase();
-		if (username) {
-			const ruleError = localRuleMessage(username);
-			if (ruleError) {
-				setError(ruleError);
-				return;
-			}
+
+		// Form is `noValidate` — validate the required/format constraints in Turkish
+		// through the `kp-auth__error` surface (no browser-locale bubble), in visual
+		// field order: görünen ad → e-posta → kullanıcı adı → parola.
+		const fieldError =
+			validateName(name) ??
+			validateEmail(email) ??
+			(username ? localRuleMessage(username) : null) ??
+			validatePassword(password, "sign-up");
+		if (fieldError) {
+			setError(fieldError);
+			return;
 		}
 
 		setPending(true);
 		try {
-			const result = await authClient.signUp.email({
-				name: String(data.get("name") ?? ""),
-				email: String(data.get("email") ?? ""),
-				password: String(data.get("password") ?? ""),
-			});
+			const result = await authClient.signUp.email({name, email, password});
 			if (result.error) {
 				setError(result.error.message ?? "kayıt başarısız");
 				return;
@@ -210,7 +222,7 @@ export function AuthPage() {
 						girer.
 					</p>
 				) : null}
-				<form className="kp-auth__form" onSubmit={onSubmit}>
+				<form className="kp-auth__form" onSubmit={onSubmit} noValidate>
 					{!isSignIn ? (
 						<div className="kp-auth__field">
 							<label htmlFor="auth-name">görünen ad</label>

--- a/apps/web/src/pages/authValidation.ts
+++ b/apps/web/src/pages/authValidation.ts
@@ -1,0 +1,49 @@
+/**
+ * Turkish client-side field validation for the auth form (`AuthPage`). The form
+ * carries `noValidate`, so the browser's locale-default constraint bubbles ("Please
+ * fill out this field.") never fire — these pure checks drive the same required/format
+ * constraints through the existing `kp-auth__error` surface in Turkish instead.
+ *
+ * Username is validated separately by `localRuleMessage` (`usernameMessages.ts`), the
+ * single-source `checkUsername` rule the server also enforces; these cover the plain
+ * credential fields (görünen ad · e-posta · parola).
+ */
+
+// A pragmatic HTML5-ish email shape: one `@`, a dot-bearing domain, no spaces. It is
+// a UX pre-flight, not the authority — the server still validates on signUp/signIn.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Minimum password length — mirrors better-auth's signup policy. */
+const PASSWORD_MIN = 8;
+
+export function validateName(value: string): string | null {
+	return value.trim() ? null : "görünen ad gerekli";
+}
+
+export function validateEmail(value: string): string | null {
+	const v = value.trim();
+	if (!v) return "e-posta gerekli";
+	if (!EMAIL_RE.test(v)) return "geçerli bir e-posta gir";
+	return null;
+}
+
+/**
+ * Sign-up enforces the length floor (a new password must clear the policy); sign-in
+ * only requires a non-empty value, since an existing password's length is the
+ * server's business and revealing the floor to a login attempt is pointless.
+ */
+export function validatePassword(value: string, mode: "sign-in" | "sign-up"): string | null {
+	if (!value) return "parola gerekli";
+	if (mode === "sign-up" && value.length < PASSWORD_MIN) return "parola en az 8 karakter olmalı";
+	return null;
+}
+
+/** First failing credential message in field order, or `null` when all pass. */
+export function validateSignIn(email: string, password: string): string | null {
+	return validateEmail(email) ?? validatePassword(password, "sign-in");
+}
+
+/** First failing message for the non-username signup fields, in visual field order. */
+export function validateSignUp(name: string, email: string, password: string): string | null {
+	return validateName(name) ?? validateEmail(email) ?? validatePassword(password, "sign-up");
+}

--- a/apps/web/src/pages/authValidation.unit.test.ts
+++ b/apps/web/src/pages/authValidation.unit.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from "vitest";
+import {
+	validateEmail,
+	validateName,
+	validatePassword,
+	validateSignIn,
+	validateSignUp,
+} from "./authValidation";
+
+describe("authValidation — Turkish field messages", () => {
+	it("görünen ad is required", () => {
+		expect(validateName("")).toBe("görünen ad gerekli");
+		expect(validateName("   ")).toBe("görünen ad gerekli");
+		expect(validateName("Elif Kaya")).toBeNull();
+	});
+
+	it("e-posta is required and format-checked", () => {
+		expect(validateEmail("")).toBe("e-posta gerekli");
+		expect(validateEmail("elif")).toBe("geçerli bir e-posta gir");
+		expect(validateEmail("elif@kamp")).toBe("geçerli bir e-posta gir");
+		expect(validateEmail("elif kaya@kamp.us")).toBe("geçerli bir e-posta gir");
+		expect(validateEmail("elif@kamp.us")).toBeNull();
+		expect(validateEmail("  elif@kamp.us  ")).toBeNull();
+	});
+
+	it("parola is required; the length floor is sign-up only", () => {
+		expect(validatePassword("", "sign-up")).toBe("parola gerekli");
+		expect(validatePassword("short", "sign-up")).toBe("parola en az 8 karakter olmalı");
+		expect(validatePassword("hunter2hunter2", "sign-up")).toBeNull();
+		// Sign-in requires only a non-empty value — the length floor is the server's business.
+		expect(validatePassword("", "sign-in")).toBe("parola gerekli");
+		expect(validatePassword("short", "sign-in")).toBeNull();
+	});
+
+	it("validateSignUp returns the first failure in visual field order", () => {
+		expect(validateSignUp("", "elif@kamp.us", "hunter2hunter2")).toBe("görünen ad gerekli");
+		expect(validateSignUp("Elif", "bad", "hunter2hunter2")).toBe("geçerli bir e-posta gir");
+		expect(validateSignUp("Elif", "elif@kamp.us", "short")).toBe("parola en az 8 karakter olmalı");
+		expect(validateSignUp("Elif", "elif@kamp.us", "hunter2hunter2")).toBeNull();
+	});
+
+	it("validateSignIn checks e-posta then a non-empty parola", () => {
+		expect(validateSignIn("", "hunter2")).toBe("e-posta gerekli");
+		expect(validateSignIn("elif@kamp.us", "")).toBe("parola gerekli");
+		expect(validateSignIn("elif@kamp.us", "x")).toBeNull();
+	});
+});


### PR DESCRIPTION
Fixes #2202

## What changed
The auth form (`apps/web/src/pages/AuthPage.tsx`) leaned entirely on native HTML5 constraint validation, so an empty or malformed submit surfaced the browser's **locale-default English bubble** ("Please fill out this field.") on an otherwise fully-Turkish surface — a language-consistency break on the first screen a new user meets.

- Set `noValidate` on the `<form>` so the browser suppresses its own constraint bubbles.
- Drive the required/format checks in **Turkish** through the existing `kp-auth__error` surface, in visual field order (görünen ad → e-posta → kullanıcı adı → parola), reusing the lowercase-Turkish tone of `usernameMessages`.
- New pure module `apps/web/src/pages/authValidation.ts` holds the field checks (görünen ad · e-posta · parola). Username still pre-flights through the single-source `localRuleMessage` (`assertUsername` rule), so the `#1888` stuck-username handling is preserved.
- Sign-in shares the form, so it gets the same Turkish treatment (e-posta required+format, parola required) — no English bubbles anywhere on `AuthPage`.

## Tests
- `apps/web/src/pages/authValidation.unit.test.ts` — unit-covers every message and the first-failure ordering.
- `apps/web/src/pages/AuthPage.test.tsx` — new cases: empty/malformed signup and empty sign-in surface the Turkish message and never reach `signUp`/`signIn`; existing #1888 cases unchanged.

Local gates green: typecheck, biome, and the auth unit + client tests (13 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)