### PR TITLE
fix(web): gate existing-term definition composer on signedIn (#2211)

### DIFF
--- a/apps/web/src/pages/SozlukTermPage.test.tsx
+++ b/apps/web/src/pages/SozlukTermPage.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Anon-affordance regression for the existing-term definition composer (#2211): a
+ * logged-out visitor must see a sign-in prompt, never the live composer they can't
+ * submit — matching the sözlük new-term branch and pano. The fate read hooks are
+ * spied (the composer never mounts on the signed-out path, so its own deep wiring
+ * is out of scope); the gate is driven purely by the mocked session.
+ */
+import {render, screen} from "@testing-library/react";
+import type {ViewRef} from "react-fate";
+import {MemoryRouter} from "react-router";
+import {describe, expect, it, vi} from "vitest";
+import {DefinitionsList} from "./SozlukTermPage";
+
+vi.mock("react-fate", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-fate")>();
+	return {
+		...actual,
+		useFateClient: () => ({request: vi.fn(), store: {}}),
+		useView: () => ({definitions: {}}),
+		useLiveListView: () => [[], null],
+	};
+});
+
+vi.mock("../fate/useReadbackRefetch", () => ({
+	useReadbackRefetch: () => vi.fn(),
+	useConfirmGone: () => vi.fn(),
+}));
+
+// Composer leaf deps — stubbed so the signed-in branch mounts the composer without
+// its full fate/flag/draft wiring (the gate, not the composer internals, is under test).
+vi.mock("../flags/useFlag", () => ({useFlag: () => ({value: false, loading: false})}));
+vi.mock("../components/authorship/FirstContributionOnramp", () => ({
+	FirstContributionOnramp: () => null,
+}));
+vi.mock("../fate/useDraftSubmit", () => ({
+	useDraftSubmit: () => ({error: null, setError: vi.fn(), inFlight: false, run: vi.fn()}),
+}));
+vi.mock("../lib/useDraftAutosave", () => ({
+	useDraftAutosave: () => ({offered: null, accept: vi.fn(), dismiss: vi.fn(), clear: vi.fn()}),
+}));
+
+const sessionMock = vi.hoisted(() => ({data: null as {user: unknown} | null}));
+vi.mock("../auth/client", () => ({useSession: () => sessionMock}));
+
+function renderList() {
+	render(
+		<MemoryRouter>
+			<DefinitionsList term={{} as ViewRef<"Term">} slug="foo-bar" seedDefinitionId={null} />
+		</MemoryRouter>,
+	);
+}
+
+describe("DefinitionsList anon affordance (#2211)", () => {
+	it("logged-out: shows a sign-in prompt, not the live composer", () => {
+		sessionMock.data = null;
+		renderList();
+		expect(screen.queryByTestId("sozluk-composer-submit")).toBeNull();
+		const prompt = screen.getByTestId("sozluk-composer-signin");
+		const link = prompt.querySelector("a");
+		expect(link?.getAttribute("href")).toBe("/auth?returnTo=%2Fsozluk%2Ffoo-bar");
+	});
+
+	it("signed-in: renders the live composer, no sign-in prompt", () => {
+		sessionMock.data = {user: {id: "u1", name: "yazar"}};
+		renderList();
+		expect(screen.queryByTestId("sozluk-composer-signin")).toBeNull();
+		expect(screen.getByTestId("sozluk-composer-submit")).not.toBeNull();
+	});
+});

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -20,7 +20,7 @@ import {
 	type ViewRef,
 	view,
 } from "react-fate";
-import {useNavigate, useParams} from "react-router";
+import {Link, useNavigate, useParams} from "react-router";
 import type {Term} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
 import {FirstContributionOnramp} from "../components/authorship/FirstContributionOnramp";
@@ -251,8 +251,10 @@ interface DefinitionsListProps {
 	seedDefinitionId: string | null;
 }
 
-function DefinitionsList(props: DefinitionsListProps) {
+export function DefinitionsList(props: DefinitionsListProps) {
 	const fate = useFateClient();
+	const session = useSession();
+	const signedIn = !!session.data?.user;
 	const term = useView(TermView, props.term);
 	const [items, loadNext] = useLiveListView(DefinitionConnectionView, term.definitions);
 
@@ -308,8 +310,31 @@ function DefinitionsList(props: DefinitionsListProps) {
 					<LoadMoreButton loadNext={loadNext} />
 				</div>
 			) : null}
-			<Composer slug={props.slug} onConfirm={confirmDefinition} />
+			{signedIn ? (
+				<Composer slug={props.slug} onConfirm={confirmDefinition} />
+			) : (
+				<DefinitionSignInPrompt slug={props.slug} />
+			)}
 		</>
+	);
+}
+
+/**
+ * Anon affordance for an existing term: a logged-out visitor can't add a definition,
+ * so the live composer is replaced by a sign-in prompt — mirroring the new-term
+ * branch ({@link SozlukTermContent}) and pano, instead of inviting an action anon
+ * can't complete (#2211).
+ */
+function DefinitionSignInPrompt({slug}: {slug: string}) {
+	return (
+		<div className="kp-sozluk-composer" data-testid="sozluk-composer-signin">
+			<header className="kp-sozluk-composer__head">
+				<span className="kp-sozluk-composer__title">sen nasıl tanımlardın?</span>
+			</header>
+			<p style={{font: "var(--t-body)", color: "var(--text-muted)"}}>
+				tanım eklemek için <Link to={authRedirectPath(`/sozluk/${slug}`)}>giriş yap</Link>.
+			</p>
+		</div>
 	);
 }
 


### PR DESCRIPTION
Fixes #2211

## What changed
On an **existing** sözlük term, `DefinitionsList` rendered the definition `<Composer>` **ungated** to logged-out visitors — inviting an action anon can't complete. This gates that composer on `signedIn`, showing a sign-in prompt (`DefinitionSignInPrompt`) instead — mirroring the affordance the sözlük **new-term branch** and **pano** already use.

- `apps/web/src/pages/SozlukTermPage.tsx`: `DefinitionsList` now reads the session; renders `<Composer>` when signed in, a sign-in prompt (linking to `/auth?returnTo=/sozluk/<slug>`) when not.
- Sign-in prompt copy is lowercase Turkish, consistent with the new-term branch.

## Acceptance criteria
- [x] A logged-out visitor on an existing sözlük term sees no live composer — a sign-in prompt instead, matching pano and the sözlük new-term branch.
- [x] Signed-in behavior unchanged (composer still renders).

## Test
`apps/web/src/pages/SozlukTermPage.test.tsx` (client tier): signed-out renders the sign-in prompt with no composer submit + the correct `returnTo` link; signed-in renders the composer with no prompt.

Local gates green: typecheck, lint, client test.