### PR TITLE
fix(web): drop redundant CTA from the çaylak onramp above live composers (#2208)

### DIFF
--- a/apps/web/src/components/authorship/FirstContributionOnramp.css
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.css
@@ -27,9 +27,3 @@
 	font: var(--t-body-sm);
 	color: var(--text-secondary);
 }
-
-.kp-onramp__actions {
-	display: flex;
-	gap: var(--s-2);
-	margin-top: var(--s-1);
-}

--- a/apps/web/src/components/authorship/FirstContributionOnramp.test.ts
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.test.ts
@@ -39,20 +39,17 @@ describe("onrampCopy — per-surface lowercase-Turkish copy", () => {
 	it("uses the tanım noun on the sözlük surface", () => {
 		const copy = onrampCopy("sozluk");
 		expect(copy.heading).toBe("ilk tanımını yazmaya hazırsın");
-		expect(copy.cta).toBe("ilk tanımını yaz");
 	});
 
 	it("uses the gönderi noun on the pano surface", () => {
 		const copy = onrampCopy("pano");
 		expect(copy.heading).toBe("ilk gönderini paylaşmaya hazırsın");
-		expect(copy.cta).toBe("ilk gönderini yaz");
 	});
 
-	it("keeps all copy lowercase (Turkish user-facing convention)", () => {
+	it("keeps the heading lowercase (Turkish user-facing convention)", () => {
 		for (const surface of ["sozluk", "pano"] as const) {
-			const {heading, cta} = onrampCopy(surface);
+			const {heading} = onrampCopy(surface);
 			expect(heading).toBe(heading.toLocaleLowerCase("tr-TR"));
-			expect(cta).toBe(cta.toLocaleLowerCase("tr-TR"));
 		}
 	});
 });

--- a/apps/web/src/components/authorship/FirstContributionOnramp.tsx
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.tsx
@@ -13,23 +13,22 @@
  * view, never the untrusted better-auth session field.
  *
  * It does NOT touch the surface's draft autosave (#1214) — the on-ramp only
- * nudges + focuses the composer, so in-progress writing survives the auth
- * round-trip exactly as before.
+ * frames the composer sitting right below it, so in-progress writing survives the
+ * auth round-trip exactly as before. It carries no CTA: the composer it would
+ * "lead" to is already rendered and interactive, so a button that merely focused
+ * it was a doubled affordance (#2208) — the honest-framing header is the whole job.
  *
- * a11y: a labelled `<section>` region (`aria-labelledby` → its own heading), a
- * real `<h2>` (not div-soup), an optional native `<Button>` (full keyboard path +
- * visible focus + AA contrast from the shared button styles); meaning is carried
- * by text, never color alone; copy is lowercase Turkish (çaylak/yazar/karma are
- * brand nouns); no animation — reduced-motion-safe by default, and the global
- * `prefers-reduced-motion` reset (styles/global.css) neutralizes any inherited
- * transition.
+ * a11y: a labelled `<section>` region (`aria-labelledby` → its own heading) and a
+ * real `<h2>` (not div-soup); meaning is carried by text, never color alone; copy
+ * is lowercase Turkish (çaylak/yazar/karma are brand nouns); no animation —
+ * reduced-motion-safe by default, and the global `prefers-reduced-motion` reset
+ * (styles/global.css) neutralizes any inherited transition.
  */
 import {useId} from "react";
 import type {Tier} from "../../../worker/features/kunye/standing";
 import {useMe} from "../../auth/useMe";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../flags/keys";
 import {useFlag} from "../../flags/useFlag";
-import {Button} from "../ui/Button";
 import "./FirstContributionOnramp.css";
 
 /** The write surface the on-ramp sits on — selects the per-surface copy noun. */
@@ -46,25 +45,19 @@ export function shouldShowOnramp(flagOn: boolean, tier: Tier | undefined): boole
 	return flagOn && tier === "çaylak";
 }
 
-/** Per-surface lowercase-Turkish heading + CTA label. The body copy is shared. */
-export function onrampCopy(surface: OnrampSurface): {heading: string; cta: string} {
+/** Per-surface lowercase-Turkish heading. The body copy is shared. */
+export function onrampCopy(surface: OnrampSurface): {heading: string} {
 	return surface === "sozluk"
-		? {heading: "ilk tanımını yazmaya hazırsın", cta: "ilk tanımını yaz"}
-		: {heading: "ilk gönderini paylaşmaya hazırsın", cta: "ilk gönderini yaz"};
+		? {heading: "ilk tanımını yazmaya hazırsın"}
+		: {heading: "ilk gönderini paylaşmaya hazırsın"};
 }
 
 export interface FirstContributionOnrampProps {
 	/** The write surface — picks the copy noun. */
 	readonly surface: OnrampSurface;
-	/**
-	 * Optional "start writing" handler — the page wires it to focus its composer
-	 * field, so the CTA actually guides to the first contribution. Omitted ⇒ no
-	 * CTA button (the honest framing still renders).
-	 */
-	readonly onStart?: () => void;
 }
 
-export function FirstContributionOnramp({surface, onStart}: FirstContributionOnrampProps) {
+export function FirstContributionOnramp({surface}: FirstContributionOnrampProps) {
 	// Fail-closed default `false`: every flag failure mode (loading/error/undeclared)
 	// degrades to today's behavior.
 	const {value: flagOn} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
@@ -88,19 +81,6 @@ export function FirstContributionOnramp({surface, onStart}: FirstContributionOnr
 				incelenir — hemen herkese görünmez. yazıp katkı verdikçe karma toplar, bir yazarın
 				desteğiyle yazar olursun; o zaman yazdıkların doğrudan yayına girer.
 			</p>
-			{onStart ? (
-				<div className="kp-onramp__actions">
-					<Button
-						type="button"
-						variant="secondary"
-						size="sm"
-						onClick={onStart}
-						data-testid="first-contribution-onramp-start"
-					>
-						{copy.cta}
-					</Button>
-				</div>
-			) : null}
 		</section>
 	);
 }

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -111,8 +111,6 @@ export function PanoSubmitPage() {
 	}
 	const urlRef = React.useRef<HTMLInputElement>(null);
 	const titleRef = React.useRef<HTMLInputElement>(null);
-	// CTA focus target: the URL field leads in link mode, the title field otherwise.
-	const focusFirstField = () => (mode === "link" ? urlRef : titleRef).current?.focus();
 
 	const draftValue = React.useMemo<PanoDraft>(
 		() => ({mode, url, title, body, tags: Array.from(selectedTags)}),
@@ -265,7 +263,7 @@ export function PanoSubmitPage() {
 						<DraftRestoreBanner onRestore={restoreDraft} onDismiss={draft.dismiss} />
 					) : null}
 
-					<FirstContributionOnramp surface="pano" onStart={focusFirstField} />
+					<FirstContributionOnramp surface="pano" />
 
 					<form className="kp-pano-submit__form" onSubmit={onSubmit}>
 						{mode === "link" ? (

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -450,7 +450,7 @@ function Composer({
 
 	return (
 		<form className="kp-sozluk-composer" onSubmit={onSubmit}>
-			<FirstContributionOnramp surface="sozluk" onStart={() => bodyRef.current?.focus()} />
+			<FirstContributionOnramp surface="sozluk" />
 			<header className="kp-sozluk-composer__head">
 				<span className="kp-sozluk-composer__title">sen nasıl tanımlardın?</span>
 			</header>


### PR DESCRIPTION
## What

Drop the redundant CTA from the çaylak `FirstContributionOnramp` so it renders as a pure honest-framing header above the composer — resolving the doubled affordance where a CTA button ("ilk gönderini yaz" / "ilk tanımını yaz") pointed at an already-live, interactive form directly below it.

## Shape chosen

Option (a) from the triage note — **drop the CTA** (smaller, lower-risk than gating/replacing the composer, and it preserves the honest-framing copy the onramp exists for, #1210). Applied consistently on **both** surfaces:

- `apps/web/src/components/authorship/FirstContributionOnramp.tsx` — removed the `onStart` prop, the `Button`/`kp-onramp__actions` block, and the `cta` from `onrampCopy`; the component now renders only the labelled `<section>` + `<h2>` heading + body copy.
- `apps/web/src/components/authorship/FirstContributionOnramp.css` — removed the now-dead `.kp-onramp__actions` rule.
- `apps/web/src/pages/PanoSubmitPage.tsx` — `<FirstContributionOnramp surface="pano" />`; removed the now-unused `focusFirstField`.
- `apps/web/src/pages/SozlukTermPage.tsx` — `<FirstContributionOnramp surface="sozluk" />`.
- `apps/web/src/components/authorship/FirstContributionOnramp.test.ts` — dropped the `cta` assertions (the intended copy change); the gate tests are untouched.

## Invariants preserved

- The `phoenix-authorship-loop` flag gate and the çaylak-tier gate (`shouldShowOnramp`) remain the sole render condition — a yazar/visitor/flag-off render stays a clean no-op.
- Draft autosave (#1214) is untouched (the onramp never touched it).

## Gates (local, green)

- `pnpm typecheck` — pass
- `pnpm lint` — pass (5 changed files clean)
- `pnpm test:unit` — 1841 passed, incl. the updated `FirstContributionOnramp` gate/copy tests

Fixes #2208