### PR TITLE
fix(web): converge per-item score copy to "oy" + shared relative time (#2204)

### DIFF
--- a/apps/web/src/components/profile/ContributionRow.tsx
+++ b/apps/web/src/components/profile/ContributionRow.tsx
@@ -5,6 +5,7 @@ import {useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {Contribution} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
+import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
 import "./ContributionRow.css";
 
@@ -26,17 +27,6 @@ export const ContributionView = view<Contribution>()({
 	postId: true,
 	postTitle: true,
 });
-
-function formatDate(value: Date | string | null | undefined): string {
-	const iso = toIso(value);
-	if (!iso) return "";
-	try {
-		const d = new Date(iso);
-		return d.toLocaleDateString("tr-TR", {day: "2-digit", month: "short", year: "numeric"});
-	} catch {
-		return iso;
-	}
-}
 
 export interface ContributionRowProps {
 	node: ViewRef<"Contribution">;
@@ -66,8 +56,8 @@ export function ContributionRow({node, sandboxBadge = false}: ContributionRowPro
 					<Link to={`/sozluk/${c.termSlug}`} className="kp-user-profile__row-title">
 						{c.termTitle}
 					</Link>
-					<span className="kp-user-profile__row-score">{c.score} puan</span>
-					<span className="kp-user-profile__row-date">{formatDate(c.createdAt)}</span>
+					<span className="kp-user-profile__row-score">{c.score} oy</span>
+					<span className="kp-user-profile__row-date">{formatAgoTR(toIso(c.createdAt))}</span>
 				</div>
 				<p className="kp-user-profile__row-body">{renderMarkdownInline(c.bodyExcerpt ?? "")}</p>
 			</li>
@@ -83,8 +73,8 @@ export function ContributionRow({node, sandboxBadge = false}: ContributionRowPro
 					<Link to={`/pano/${c.id}`} className="kp-user-profile__row-title">
 						{c.title}
 					</Link>
-					<span className="kp-user-profile__row-score">{c.score} puan</span>
-					<span className="kp-user-profile__row-date">{formatDate(c.createdAt)}</span>
+					<span className="kp-user-profile__row-score">{c.score} oy</span>
+					<span className="kp-user-profile__row-date">{formatAgoTR(toIso(c.createdAt))}</span>
 				</div>
 				{c.bodyExcerpt ? (
 					<p className="kp-user-profile__row-body">{renderMarkdownInline(c.bodyExcerpt)}</p>
@@ -102,8 +92,8 @@ export function ContributionRow({node, sandboxBadge = false}: ContributionRowPro
 					<Link to={`/pano/${c.postId}`} className="kp-user-profile__row-title">
 						{c.postTitle}
 					</Link>
-					<span className="kp-user-profile__row-score">{c.score} puan</span>
-					<span className="kp-user-profile__row-date">{formatDate(c.createdAt)}</span>
+					<span className="kp-user-profile__row-score">{c.score} oy</span>
+					<span className="kp-user-profile__row-date">{formatAgoTR(toIso(c.createdAt))}</span>
 				</div>
 				<p className="kp-user-profile__row-body">{renderMarkdownInline(c.bodyExcerpt ?? "")}</p>
 			</li>

--- a/apps/web/src/components/sozluk/Sozluk.tsx
+++ b/apps/web/src/components/sozluk/Sozluk.tsx
@@ -48,7 +48,7 @@ export function SozlukPopular({terms}: {terms: PopularTerm[]}) {
 					<Link className="kp-sozluk-popular__title" to={`/sozluk/${t.slug}`}>
 						{t.title}
 					</Link>
-					<span className="kp-sozluk-popular__meta">{t.totalScore} ↑</span>
+					<span className="kp-sozluk-popular__meta">{t.totalScore} oy</span>
 				</li>
 			))}
 		</ol>
@@ -80,7 +80,7 @@ export function SozlukDefinition({d}: {d: DefinitionData}) {
 				<span>·</span>
 				<span>{d.agoLabel}</span>
 				<span>·</span>
-				<span>{d.score} puan</span>
+				<span>{d.score} oy</span>
 			</div>
 		</article>
 	);

--- a/apps/web/src/components/sozluk/TermRow.tsx
+++ b/apps/web/src/components/sozluk/TermRow.tsx
@@ -30,7 +30,7 @@ export function TermRow({term, variant = "recent", rank}: TermRowProps) {
 				<Link className="kp-sozluk-popular__title" to={`/sozluk/${data.slug}`}>
 					{data.title}
 				</Link>
-				<span className="kp-sozluk-popular__meta">{data.totalScore} ↑</span>
+				<span className="kp-sozluk-popular__meta">{data.totalScore} oy</span>
 			</li>
 		);
 	}


### PR DESCRIPTION
Fixes #2204

## What changed

Copy-only convergence of the divergent per-item **score** vocabulary onto the already-canonical `.glossary/TERMS.md` terms (**score ≠ karma**). Grounded against live source; no ADR (triage classified this as `type:chore` alignment, not a naming decision).

**One Turkish noun `oy` for a per-item score** across the score-label surfaces:

- `components/sozluk/TermRow.tsx` — sözlük "en çok oylananlar" row: `↑` → `oy`
- `components/sozluk/Sozluk.tsx` — legacy `SozlukPopular` (`↑`) + `SozlukDefinition` (`puan`) → `oy` (kept the vocab uniform so a grep is clean)
- `components/profile/ContributionRow.tsx` — profile contributions: `puan` → `oy` (×3)
- The sözlük term header and pano/landing already said `oy` — unchanged.

`oy` is the right convergence target: it matches the vote vocabulary already in the aria-labels (`Yukarı oy`, `oy ver`) and the notification voice (`N oy aldı`), and keeps `karma` reserved for the **per-user** `Karma` atom (whose own default noun is `karma`). Per-item score copy therefore says `oy`, never `karma`.

**One shared time presentation:** profile contributions now use the shared relative `formatAgoTR` (the same formatter feeds already use), replacing an absolute `toLocaleDateString` local helper — so feeds and profile present time one way.

**Color token:** the score labels already share the `--text-muted` token (`.kp-sozluk-popular__meta`, `.kp-user-profile__row-score`, term-header/definition meta spans) — no change needed.

## Acceptance criteria

- [x] One Turkish surface noun (`oy`) for a per-item score across pano feed, sözlük term header, sözlük "en çok oylananlar", and vote controls — verified against `.glossary/TERMS.md` (score ≠ karma).
- [x] Per-item score copy no longer says "karma" (karma stays the per-user `Karma` atom).
- [x] One shared time-format presentation (relative `formatAgoTR`) across feeds and profile.
- [x] One pill/count color token (`--text-muted`) across the score surfaces.

## Verification

Local gates green: `biome check` clean on the 3 changed files, `@kampus/web typecheck` clean, `test:unit` 1841/1841 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)