### PR TITLE
fix(fate-live): register the savedPosts live topic so the saved-view subscribe decodes (#2214)

### DIFF
--- a/apps/web/worker/features/fate-live/fanned-mutations.ts
+++ b/apps/web/worker/features/fate-live/fanned-mutations.ts
@@ -75,12 +75,14 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 	{
 		key: "post.save",
 		fanned: false,
-		rationale: "writes the caller's private save relation — no subscribed connection",
+		rationale:
+			"writes the caller's private save relation; the `savedPosts` connection is per-viewer subscribe-only, so a publish onto its login-blind shared topic would leak viewer-private membership — no cross-client fan-out",
 	},
 	{
 		key: "post.unsave",
 		fanned: false,
-		rationale: "clears the caller's private save relation — no subscribed connection",
+		rationale:
+			"clears the caller's private save relation; the `savedPosts` connection is per-viewer subscribe-only, so a publish onto its login-blind shared topic would leak viewer-private membership — no cross-client fan-out",
 	},
 	{
 		key: "post.edit",

--- a/apps/web/worker/features/fate-live/protocol.ts
+++ b/apps/web/worker/features/fate-live/protocol.ts
@@ -35,6 +35,17 @@ export const LiveTopic = {
 	postComments: "Post.comments",
 	/** sözlük term → definitions (args: `{id: termSlug}`). */
 	termDefinitions: "Term.definitions",
+	/**
+	 * pano viewer's saved posts (per-viewer). Registered so the saved view's
+	 * connection-level subscribe DECODES instead of 400ing (`SavedConnectionView`
+	 * carries no `live:` config, so it wants no connection prepends — only a valid
+	 * subscribe). Deliberately has NO cross-client publish target: the saved list is
+	 * viewer-private, so a publish onto this login-blind shared topic would leak one
+	 * viewer's saved membership (and per-viewer `isSaved`) to every other subscriber.
+	 * Live save-state is carried per-row by the entity `Post` subscribe (`isSaved`)
+	 * + the client's local `savedReconcile`, not a connection fan-out.
+	 */
+	savedPosts: "savedPosts",
 } as const;
 
 /**

--- a/apps/web/worker/features/fate-live/protocol.unit.test.ts
+++ b/apps/web/worker/features/fate-live/protocol.unit.test.ts
@@ -1,0 +1,49 @@
+/**
+ * `parseLiveControlRequest` decode contract for the closed live-topic set. The
+ * one non-obvious guarantee under test: a `subscribeConnection` on a REGISTERED
+ * procedure (`savedPosts`, the per-viewer saved list) decodes instead of failing
+ * with the `BAD_REQUEST` the unregistered procedure returned (#2214), while an
+ * unknown procedure still fails closed.
+ *
+ * Unit tier (ADR 0082): pure decode, no storage, no platform fake.
+ */
+
+import {assert, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {LiveTopic, parseLiveControlRequest} from "./protocol.ts";
+
+const subscribeConnectionRequest = (procedure: string) => ({
+	version: 1,
+	connectionId: "c1",
+	operations: [
+		{
+			id: "op1",
+			kind: "subscribeConnection",
+			type: "Post",
+			procedure,
+			select: ["id"],
+		},
+	],
+});
+
+it.effect("decodes a subscribeConnection on the registered savedPosts topic", () =>
+	Effect.gen(function* () {
+		const decoded = yield* parseLiveControlRequest(
+			subscribeConnectionRequest(LiveTopic.savedPosts),
+		);
+		const op = decoded.operations[0];
+		if (op?.kind !== "subscribeConnection") {
+			return assert.fail(`expected a subscribeConnection op, got ${op?.kind}`);
+		}
+		assert.strictEqual(op.procedure, "savedPosts");
+	}),
+);
+
+it.effect("rejects a subscribeConnection on an unregistered procedure with BAD_REQUEST", () =>
+	Effect.gen(function* () {
+		const error = yield* Effect.flip(
+			parseLiveControlRequest(subscribeConnectionRequest("notATopic")),
+		);
+		assert.strictEqual(error.code, "BAD_REQUEST");
+	}),
+);


### PR DESCRIPTION
Fixes #2214

## Problem

The saved view (`/pano?sort=saved`) opens a connection-level fate-live subscribe on the `savedPosts` procedure via `useLiveListView`. `savedPosts` was **not** in the closed live-topic set (`LiveTopic` / `LiveTopicKeySchema` in `apps/web/worker/features/fate-live/protocol.ts`), so `parseLiveControlRequest` failed decode and mapped to `FateRequestError("BAD_REQUEST", "Invalid Fate live request.")` — the observed 400, fired twice per load. This is the protocol gap the report/triage identified; it survived PR #2197, which only moved client page structure.

## Fix

Register `savedPosts` in `LiveTopic` — the single source the union and the subscribe-side `LiveTopicKeySchema` both derive from — so the subscribe decodes instead of 400ing.

The topic is deliberately **subscribe-only with no cross-client publish target**: the saved list is viewer-private, so publishing onto this login-blind shared connection topic (`connection:savedPosts:*`) would leak one viewer's saved membership (and per-viewer `isSaved`) to every other subscriber. `SavedConnectionView` already carries no `live:` config, so the client wants no connection-level prepends — live save-state is carried per row by the entity `Post` subscribe (`isSaved`) plus the client's local `savedReconcile`, not a connection fan-out.

`post.save` / `post.unsave` stay `fanned: false`; their manifest rationale in `fanned-mutations.ts` is updated to name the now-registered per-viewer connection and why they must not fan (`fanout-guard check` passes — 38 classified, 24 fanned).

## Acceptance criteria

- [x] Loading the saved view issues no `subscribeConnection` the server rejects with 400 — `savedPosts` now decodes (new unit test).
- [x] The saved list stays live-correct for its rows — unchanged; per-row `useLiveView(isSaved)` + `savedReconcile` still drop an un-saved row.
- [x] Topic registered → added to `LiveTopic`'s closed set and `post.save`/`post.unsave` remain classified in `fanned-mutations.ts` (no live-list hook targets an unregistered procedure).

## Tests

New `apps/web/worker/features/fate-live/protocol.unit.test.ts`: `parseLiveControlRequest` decodes a `subscribeConnection` on `savedPosts`, and still rejects an unknown procedure with `BAD_REQUEST`.

Local gates green: web typecheck, biome, `fanout-guard check`, fate-live unit suite (46) + new protocol test (2).

§CP: NO (`apps/web/**` is product code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)