### PR TITLE
fix(vote): block self-voting on pano posts + sözlük definitions (#2216)

### DIFF
--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -5,31 +5,40 @@ import {currentLocationReturnTo, useGatedToggle, useVoteToggle} from "./useVoteT
 import "../vote-cue.css";
 import "./PanoPost.css";
 
-/** Presentational vote control; the parent owns the mutation + auth gate. */
+/**
+ * Presentational vote control; the parent owns the mutation + auth gate. `own`
+ * marks the viewer's own content: the vote button is dropped (self-voting is
+ * blocked, #2216) while the score still renders, so the affordance matches the
+ * rule — the server guard is the invariant, this is the matching UX.
+ */
 export function VoteControl({
 	count,
 	pressed = false,
 	onToggle,
 	testIdSuffix,
+	own = false,
 }: {
 	count: number;
 	pressed?: boolean;
 	onToggle?: () => void;
 	testIdSuffix?: string;
+	own?: boolean;
 }) {
 	const {flashing, endFlash} = useVoteFlash(count);
 	return (
 		<div className="kp-pano-post__vote">
-			<button
-				type="button"
-				className="kp-pano-post__vote-btn"
-				aria-pressed={pressed}
-				aria-label="Yukarı oy"
-				data-testid={testIdSuffix ? `post-vote-${testIdSuffix}` : undefined}
-				onClick={() => onToggle?.()}
-			>
-				<span className="triangle" />
-			</button>
+			{own ? null : (
+				<button
+					type="button"
+					className="kp-pano-post__vote-btn"
+					aria-pressed={pressed}
+					aria-label="Yukarı oy"
+					data-testid={testIdSuffix ? `post-vote-${testIdSuffix}` : undefined}
+					onClick={() => onToggle?.()}
+				>
+					<span className="triangle" />
+				</button>
+			)}
 			<span
 				className={`kp-pano-post__vote-count${flashing ? " kp-vote-flash" : ""}`}
 				onAnimationEnd={endFlash}
@@ -53,10 +62,13 @@ export function PostVoteWidget({
 	postId,
 	score,
 	myVote,
+	own = false,
 }: {
 	postId: string;
 	score: number;
 	myVote: boolean | null;
+	/** The viewer authored this post — drop the vote button (self-vote is blocked, #2216). */
+	own?: boolean;
 }) {
 	const fate = useFateClient();
 
@@ -74,7 +86,15 @@ export function PostVoteWidget({
 		},
 	});
 
-	return <VoteControl count={score} pressed={voted} onToggle={onToggle} testIdSuffix={postId} />;
+	return (
+		<VoteControl
+			count={score}
+			pressed={voted}
+			onToggle={onToggle}
+			testIdSuffix={postId}
+			own={own}
+		/>
+	);
 }
 
 /**

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -7,6 +7,7 @@
 import {useLiveView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {Post} from "../../../worker/features/fate/views";
+import {useSession} from "../../auth/client";
 import {toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
 import {tagClass} from "../../lib/panoTags";
@@ -46,6 +47,8 @@ export function PanoPostCard({
 	onHide?: (id: string) => void;
 }) {
 	const data = useLiveView(PanoPostCardView, post);
+	const session = useSession();
+	const isOwn = !!session.data?.user && session.data.user.id === data.authorId;
 	const href = `/pano/${data.slug ?? data.id}`;
 	const siteLabel = data.host ?? (data.url ? null : "yazı");
 	const agoLabel = formatAgoTR(toIso(data.createdAt));
@@ -56,7 +59,12 @@ export function PanoPostCard({
 			<span className="kp-pano-post__rank">
 				{rank != null ? String(rank).padStart(2, "0") : ""}
 			</span>
-			<PostVoteWidget postId={data.id} score={data.score} myVote={data.myVote ?? null} />
+			<PostVoteWidget
+				postId={data.id}
+				score={data.score}
+				myVote={data.myVote ?? null}
+				own={isOwn}
+			/>
 			<div className="kp-pano-post__body">
 				<div className="kp-pano-post__title-row">
 					{tags.length ? (

--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -119,7 +119,21 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 	);
 }
 
-export function PanoPostHeaderVote({post}: {post: ViewRef<"Post">}) {
+export function PanoPostHeaderVote({
+	post,
+	isAuthor = false,
+}: {
+	post: ViewRef<"Post">;
+	/** The viewer authored this post — drop the vote button (self-vote is blocked, #2216). */
+	isAuthor?: boolean;
+}) {
 	const data = useLiveView(PanoPostHeaderView, post);
-	return <PostVoteWidget postId={data.id} score={data.score} myVote={data.myVote ?? null} />;
+	return (
+		<PostVoteWidget
+			postId={data.id}
+			score={data.score}
+			myVote={data.myVote ?? null}
+			own={isAuthor}
+		/>
+	);
 }

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -229,16 +229,21 @@ export function DefinitionCard(props: DefinitionCardProps) {
 	return (
 		<article className={cls} data-testid={`definition-card-${definition.id}`}>
 			<div className="kp-sozluk-definition__vote">
-				<button
-					type="button"
-					className="kp-sozluk-definition__vote-btn"
-					aria-pressed={voted}
-					aria-label={voted ? "Oyunu geri al" : "Yukarı oy"}
-					data-testid={`definition-vote-${definition.id}`}
-					onClick={onVoteClick}
-				>
-					<span className="triangle" />
-				</button>
+				{/* Self-vote is blocked (#2216): drop the vote button on one's own definition
+				    while the score still renders. The server guard is the invariant, this is
+				    the matching affordance. */}
+				{isAuthor ? null : (
+					<button
+						type="button"
+						className="kp-sozluk-definition__vote-btn"
+						aria-pressed={voted}
+						aria-label={voted ? "Oyunu geri al" : "Yukarı oy"}
+						data-testid={`definition-vote-${definition.id}`}
+						onClick={onVoteClick}
+					>
+						<span className="triangle" />
+					</button>
+				)}
 				<span
 					className={`kp-sozluk-definition__vote-count${flashing ? " kp-vote-flash" : ""}`}
 					onAnimationEnd={endFlash}

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -27,6 +27,7 @@ export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	UNAUTHORIZED: "bu işlem için giriş yapmalısın",
 	FORBIDDEN: "bunu yapma yetkin yok",
 	VOTE_REQUIRES_YAZAR: "yazar olunca oy verebilirsin",
+	SELF_VOTE_NOT_ALLOWED: "kendi içeriğine oy veremezsin",
 	VOUCH_LIMIT_REACHED: "kefil olma sınırına ulaştın",
 	INSUFFICIENT_KARMA: "bunu yapmak için karman yetersiz",
 	DEFINITION_NOT_FOUND: "tanım bulunamadı",

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -29,6 +29,10 @@ export const FATE_WIRE_CODES = [
 	// overloaded `FORBIDDEN` (künye vouch denials) so the vote gate gets its own ladder
 	// copy without mislabelling other forbiddens (#1879): "yazar olunca oy verebilirsin".
 	"VOTE_REQUIRES_YAZAR",
+	// The self-vote denial — a voter cast on their OWN content (`vote/SelfVoteNotAllowed`,
+	// #2216, founder-ruled). The client hides the vote control on one's own content, so this
+	// is defense-in-depth: it reaches the wire only if that affordance is bypassed.
+	"SELF_VOTE_NOT_ALLOWED",
 	// The concurrent-vouch cap (D5) is reached — a yazar already holds the maximum
 	// active vouches (`kunye/VouchLimitReached`, #1289). Past the `FORBIDDEN` yazar
 	// floor: the actor IS a yazar, the act is just rationed.

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -346,7 +346,7 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 	return (
 		<>
 			<header className="kp-pano-postpage__head">
-				<PanoPostHeaderVote post={post} />
+				<PanoPostHeaderVote post={post} isAuthor={isAuthor} />
 				{editing ? (
 					<form className="kp-pano-edit-post" onSubmit={onEditSubmit}>
 						<input

--- a/apps/web/tests/e2e/22-pano-live.spec.ts
+++ b/apps/web/tests/e2e/22-pano-live.spec.ts
@@ -75,23 +75,29 @@ test.describe("Pano live (two clients)", () => {
 
 		try {
 			const {email: emailA} = await signUpAndBootstrap(pageA);
-			await signUpAndBootstrap(pageB);
-			// A casts a post-vote below; the anti-manipulation vote-gate (#1828/#1810)
-			// rejects a fresh çaylak's vote, so promote A to yazar first (ADR 0137).
+			const {email: emailB} = await signUpAndBootstrap(pageB);
+			// A casts a post-vote on B's post below. Self-voting is blocked (#2216), so the
+			// voter can't author the target: B creates the post, A votes it. Promote A past the
+			// anti-manipulation vote-gate (#1828/#1810, ADR 0137) and B so its post is live
+			// (not sandboxed) and thus votable.
 			await promoteToYazar(emailA);
+			await promoteToYazar(emailB);
 
-			// Client A creates the post all live action targets.
+			// Client B creates the post all live action targets and stays on its detail view —
+			// its live SSE connection + comments/header subscriptions are the observer.
 			const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`;
 			const title = `live target ${stamp}`;
-			const postPath = await submitPost(pageA, title);
-
-			// Client B opens the same post and waits for its detail view to settle
-			// (opens the live SSE connection + subscribes the comments list + header).
-			await pageB.goto(postPath);
-			await expect(pageB.getByRole("heading", {level: 1})).toContainText(title, {
+			const postPath = await submitPost(pageB, title);
+			await expect(pageB.locator(".kp-pano-postpage__thread-heading")).toHaveText("0 yorum", {
 				timeout: 10_000,
 			});
-			await expect(pageB.locator(".kp-pano-postpage__thread-heading")).toHaveText("0 yorum", {
+
+			// Client A opens the same post to act on it (comment + vote).
+			await pageA.goto(postPath);
+			await expect(pageA.getByRole("heading", {level: 1})).toContainText(title, {
+				timeout: 10_000,
+			});
+			await expect(pageA.locator('[data-testid="pano-comment-input"]')).toBeVisible({
 				timeout: 10_000,
 			});
 
@@ -134,17 +140,20 @@ test.describe("Pano live (two clients)", () => {
 
 		try {
 			const {email: emailA} = await signUpAndBootstrap(pageA);
-			await signUpAndBootstrap(pageB);
-			// A casts post-votes below; the anti-manipulation vote-gate (#1828/#1810)
-			// rejects a fresh çaylak's vote, so promote A to yazar first (ADR 0137).
+			const {email: emailB} = await signUpAndBootstrap(pageB);
+			// A casts post-votes on B's post below. Self-voting is blocked (#2216), so the
+			// voter can't author the target: B creates the post, A votes it. Promote A past the
+			// anti-manipulation vote-gate (#1828/#1810, ADR 0137) and B so its post is live/votable.
 			await promoteToYazar(emailA);
+			await promoteToYazar(emailB);
 
 			const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`;
 			const title = `reconnect target ${stamp}`;
-			const postPath = await submitPost(pageA, title);
+			const postPath = await submitPost(pageB, title);
 
-			await pageB.goto(postPath);
-			await expect(pageB.getByRole("heading", {level: 1})).toContainText(title, {timeout: 10_000});
+			// A opens B's post to cast the votes; B stays on its own detail view as the observer.
+			await pageA.goto(postPath);
+			await expect(pageA.getByRole("heading", {level: 1})).toContainText(title, {timeout: 10_000});
 
 			// A votes WHILE B is "away" (the reload below tears down B's SSE stream
 			// and rebuilds it). v1 resumes live-only — the event A sends during the

--- a/apps/web/tests/integration/pano-feed-viewer-state.test.ts
+++ b/apps/web/tests/integration/pano-feed-viewer-state.test.ts
@@ -51,7 +51,9 @@ let savedOnly = "";
 /** A post the viewer neither votes nor saves. */
 let neutral = "";
 
-/** Submit a post under the viewer cookie on the shared feed host; return its id. */
+// Posts are authored by `other`, not the `viewer`: since #2216 blocks self-voting, the
+// viewer's fixture votes below have to land on content it did not write.
+/** Submit a post under the author (`other`) cookie on the shared feed host; return its id. */
 async function seedPost(title: string): Promise<string> {
 	const r = await h.fate(
 		{
@@ -60,7 +62,7 @@ async function seedPost(title: string): Promise<string> {
 			input: {title, url: `https://${FEED_HOST}/${title}`, tags: [{kind: "tartışma"}]},
 			select: ["id"],
 		},
-		{cookie: viewer.cookie},
+		{cookie: other.cookie},
 	);
 	expect(r.ok).toBe(true);
 	if (!r.ok) throw new Error("seedPost failed");
@@ -86,9 +88,12 @@ async function feed(cookie?: string): Promise<Map<string, PostNode>> {
 beforeAll(async () => {
 	viewer = await h.signUp(`${NS}-viewer@test.local`, "hunter2hunter2", "izleyen");
 	other = await h.signUp(`${NS}-other@test.local`, "hunter2hunter2", "öteki");
-	// `viewer` casts real post votes below (voted/voted-saved fixtures). Since #1810's
-	// "earn to vote" gate a fresh çaylak is rejected at cast, so promote it to yazar.
+	// `viewer` casts real post votes below (voted/voted-saved fixtures) on posts `other`
+	// authored — self-voting is blocked (#2216), so the caster is never the author. Since
+	// #1810's "earn to vote" gate a fresh çaylak is rejected at cast, promote the voter; and
+	// promote `other` so its authored posts are live (not sandboxed) and thus votable/feed-visible.
 	await h.promoteToYazar(viewer.userId);
+	await h.promoteToYazar(other.userId);
 
 	votedSaved = await seedPost(`${NS}-voted-saved`);
 	votedOnly = await seedPost(`${NS}-voted-only`);

--- a/apps/web/tests/integration/pano-hot-score-backfill.test.ts
+++ b/apps/web/tests/integration/pano-hot-score-backfill.test.ts
@@ -64,6 +64,7 @@ const HOST = `hot-backfill-${Date.now().toString(36)}.example.com`;
 const HOUR_MS = 3_600_000;
 
 let author: {userId: string; cookie: string};
+let voter: {userId: string; cookie: string};
 
 async function seedPost(title: string): Promise<string> {
 	const r = await h.fate(
@@ -127,7 +128,11 @@ async function realOps() {
 
 beforeAll(async () => {
 	author = await h.signUp("hot-backfill-author@test.local", "hunter2hunter2", "hot-backfill-yazar");
+	// `voter` casts the fresher post's live vote below — self-voting is blocked (#2216), so the
+	// caster is never the author; both need yazar to clear the #1810 "earn to vote" gate.
+	voter = await h.signUp("hot-backfill-voter@test.local", "hunter2hunter2", "hot-backfill-oycu");
 	await h.promoteToYazar(author.userId);
+	await h.promoteToYazar(voter.userId);
 });
 
 describe("pano sıcak/hot one-time backfill (#2131) — the windowless recompute reaches rows OUTSIDE 72h", () => {
@@ -135,10 +140,11 @@ describe("pano sıcak/hot one-time backfill (#2131) — the windowless recompute
 		const staleId = await seedPost("stale-outside-window");
 		const fresherId = await seedPost("fresher-inside-window");
 
-		// The fresher post earns a young-high stored score via the live vote path.
+		// The fresher post earns a young-high stored score via the live vote path (cast by a
+		// non-author — self-voting is blocked, #2216).
 		const voted = await h.fate(
 			{kind: "mutation", name: "post.vote", input: {id: fresherId}, select: ["id", "score"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;

--- a/apps/web/tests/integration/pano-hot-score-decay.test.ts
+++ b/apps/web/tests/integration/pano-hot-score-decay.test.ts
@@ -67,6 +67,7 @@ const HOST = `hot-decay-${Date.now().toString(36)}.example.com`;
 const HOUR_MS = 3_600_000;
 
 let author: {userId: string; cookie: string};
+let voter: {userId: string; cookie: string};
 
 /** Submit a real post under `HOST` over `/fate`; return its id. */
 async function seedPost(title: string): Promise<string> {
@@ -131,9 +132,12 @@ async function realRefreshHotScores() {
 
 beforeAll(async () => {
 	author = await h.signUp("hot-decay-author@test.local", "hunter2hunter2", "hot-decay-yazar");
-	// A fresh account is a çaylak and is rejected at cast (#1810's "earn to vote" gate);
-	// the stale post is voted below to earn its young-high frozen score, so promote first.
+	// The fresher post is voted below by a non-author (`voter`) — self-voting is blocked
+	// (#2216) — to earn its young-high frozen score. A fresh account is a çaylak rejected at
+	// cast (#1810's "earn to vote" gate), so promote both.
+	voter = await h.signUp("hot-decay-voter@test.local", "hunter2hunter2", "hot-decay-oycu");
 	await h.promoteToYazar(author.userId);
+	await h.promoteToYazar(voter.userId);
 });
 
 describe("pano sıcak/hot decay-refresh (#2027 AC4) — the stored-column read → window → write-back", () => {
@@ -143,9 +147,10 @@ describe("pano sıcak/hot decay-refresh (#2027 AC4) — the stored-column read �
 
 		// The fresher post earns a young-high stored score by voting it while age≈0 — the
 		// live activity path, score 1 → `hot_score = computeHotScore(1, now, now)` = 287.
+		// Cast by a non-author (self-voting is blocked, #2216).
 		const voted = await h.fate(
 			{kind: "mutation", name: "post.vote", input: {id: fresherId}, select: ["id", "score"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;

--- a/apps/web/tests/integration/pano-mutations.test.ts
+++ b/apps/web/tests/integration/pano-mutations.test.ts
@@ -63,6 +63,7 @@ interface CommentNode {
 
 let author: {userId: string; cookie: string};
 let intruder: {userId: string; cookie: string};
+let voter: {userId: string; cookie: string};
 
 const POST_SELECT = [
 	"id",
@@ -100,11 +101,14 @@ async function seedPost(input: {
 beforeAll(async () => {
 	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", `${NS}-yazar`);
 	intruder = await h.signUp(`${NS}-intruder@test.local`, "hunter2hunter2", `${NS}-davetsiz`);
-	// `author` casts votes below (post.vote / comment.vote). A fresh account is a çaylak
-	// and, since #1810's "earn to vote" gate, is rejected at cast — so promote it to yazar
-	// (matching its `-yazar` name). `intruder` never votes (unauthorized-mutation cases),
-	// so it stays a çaylak.
+	voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", `${NS}-oycu`);
+	// `author` casts comment votes below (comment self-vote is not blocked). Post votes,
+	// however, must come from a non-author since #2216 blocks self-voting on posts — `voter`
+	// casts those. A fresh account is a çaylak and, since #1810's "earn to vote" gate, is
+	// rejected at cast, so promote both casters to yazar. `intruder` never votes
+	// (unauthorized-mutation cases), so it stays a çaylak.
 	await h.promoteToYazar(author.userId);
+	await h.promoteToYazar(voter.userId);
 });
 
 describe("pano mutations — post.submit", () => {
@@ -160,7 +164,7 @@ describe("pano mutations — post.vote / retractVote", () => {
 
 		const voted = await h.fate(
 			{kind: "mutation", name: "post.vote", input: {id}, select: ["id", "score", "myVote"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
@@ -169,7 +173,7 @@ describe("pano mutations — post.vote / retractVote", () => {
 
 		const retracted = await h.fate(
 			{kind: "mutation", name: "post.retractVote", input: {id}, select: ["id", "score", "myVote"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(retracted.ok).toBe(true);
 		if (!retracted.ok) return;

--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -61,15 +61,19 @@ type Connection<N> = {
 
 let author: {userId: string; cookie: string};
 let intruder: {userId: string; cookie: string};
+let voter: {userId: string; cookie: string};
 
 const DEF_SELECT = ["id", "body", "score", "author", "authorId", "myVote"];
 
 beforeAll(async () => {
 	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "yazar");
 	intruder = await h.signUp(`${NS}-intruder@test.local`, "hunter2hunter2", "davetsiz");
-	// `author` casts real definition votes below. Since #1810's "earn to vote" gate a fresh
-	// çaylak is rejected at cast, so promote it to yazar. `intruder` never votes.
+	voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", "oycu");
+	// `voter` casts every real definition vote below — self-voting is blocked since #2216, so
+	// the caster is never the definition's author. Since #1810's "earn to vote" gate a fresh
+	// çaylak is rejected at cast, so promote both. `intruder` never votes.
 	await h.promoteToYazar(author.userId);
+	await h.promoteToYazar(voter.userId);
 });
 
 describe("sozluk mutations — definition.add", () => {
@@ -180,7 +184,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 
 		const voted = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score", "myVote"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
@@ -194,7 +198,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 				input: {id},
 				select: ["score", "myVote"],
 			},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(retracted.ok).toBe(true);
 		if (!retracted.ok) return;
@@ -255,7 +259,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 
 		const voted = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score", "updatedAt"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
@@ -298,7 +302,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 
 		const first = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score", "myVote"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(first.ok).toBe(true);
 		if (!first.ok) return;
@@ -306,7 +310,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 
 		const second = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score", "myVote"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(second.ok).toBe(true);
 		if (!second.ok) return;
@@ -335,7 +339,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 				input: {id},
 				select: ["score", "myVote"],
 			},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
@@ -359,15 +363,15 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 
 		await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		await h.fate(
 			{kind: "mutation", name: "definition.retractVote", input: {id}, select: ["score"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		const final = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score", "myVote"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(final.ok).toBe(true);
 		if (!final.ok) return;
@@ -494,10 +498,11 @@ describe("sozluk mutations — definition.delete", () => {
 		if (!b.ok) return;
 		const survivorId = (b.data as DefNode).id;
 
-		// Vote the doomed definition so totalScore is observably 1 before delete.
+		// Vote the doomed definition (as a non-author — self-vote is blocked, #2216) so
+		// totalScore is observably 1 before delete.
 		await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id: aId}, select: ["score"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 
 		const before = await h.fate({

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -69,7 +69,7 @@ import {
 	DefinitionNotFound,
 	UnauthorizedDefinitionMutation,
 } from "../sozluk/errors.ts";
-import {VoterNotEligible} from "../vote/errors.ts";
+import {SelfVoteNotAllowed, VoterNotEligible} from "../vote/errors.ts";
 import {fateConfig} from "./config.ts";
 
 /**
@@ -126,6 +126,10 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	// (not the overloaded FORBIDDEN). Has extra required fields (`voterId`, `need`), so it
 	// is pinned here but NOT in ROUND_TRIP_CLASSES.
 	[VoterNotEligible, "VOTE_REQUIRES_YAZAR"],
+	// vote self-vote denial — reachable from fateConfig via the inline cast paths (pano
+	// post + sözlük definition), #2216. Its own distinct code. Has an extra required field
+	// (`voterId`), so pinned here but NOT in ROUND_TRIP_CLASSES.
+	[SelfVoteNotAllowed, "SELF_VOTE_NOT_ALLOWED"],
 	// künye karma-VALUE privilege floor (#150) — reachable from fateConfig via the
 	// content-creation mutations (`post.submit` / `comment.add` / `definition.add`) and
 	// `report.submit`. Its OWN code (not the tier-ladder FORBIDDEN). Has extra required

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -27,7 +27,7 @@ import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import type * as Removal from "../lifecycle/removal.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Reaction} from "../reaction/Reaction.ts";
-import type {VoterNotEligible} from "../vote/errors.ts";
+import type {SelfVoteNotAllowed, VoterNotEligible} from "../vote/errors.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
 import type {CommentConnectionPage, CommentRow} from "./comment-fields.ts";
@@ -238,11 +238,12 @@ export class Pano extends Context.Service<
 		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
 		// `VoterNotEligible` (#1810): a çaylak newcomer's cast is rejected — the "earn to vote"
-		// gate lives in `Vote.castImpl`, so it surfaces on the cast path only. Retraction never
-		// raises it (a newcomer holds no vote to retract), so `retractPostVote` keeps its channel.
+		// gate lives in `Vote.castImpl`. `SelfVoteNotAllowed` (#2216): a cast on one's own post
+		// is rejected at the cast site. Both surface on the cast path only — retraction raises
+		// neither (nothing to retract), so `retractPostVote` keeps its `PostNotFound` channel.
 		readonly voteOnPost: (
 			input: VoteOnPostInput,
-		) => Effect.Effect<VoteOnPostResult, PostNotFound | VoterNotEligible>;
+		) => Effect.Effect<VoteOnPostResult, PostNotFound | VoterNotEligible | SelfVoteNotAllowed>;
 
 		readonly retractPostVote: (
 			input: VoteOnPostInput,

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -28,7 +28,7 @@ import {InsufficientKarma} from "../kunye/errors.ts";
 import {gateContentOnKarma} from "../kunye/privilege.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {authorDisplayLabel} from "../pasaport/author-label.ts";
-import {VoterNotEligible} from "../vote/errors.ts";
+import {SelfVoteNotAllowed, VoterNotEligible} from "../vote/errors.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentNotFound,
@@ -292,9 +292,11 @@ export const mutations = {
 			input: PostIdInput,
 			type: PostView,
 			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate: a çaylak newcomer
-			// is rejected at cast, never a silent no-op (#1810). `retractVote` needs no such gate:
-			// a newcomer never cleared the cast, so there is nothing to retract.
-			error: Schema.Union([Unauthorized, PostNotFound, VoterNotEligible]),
+			// is rejected at cast, never a silent no-op (#1810). `SelfVoteNotAllowed` (wire
+			// `SELF_VOTE_NOT_ALLOWED`) — the founder-ruled self-vote block (#2216). Both are
+			// cast-only: `retractVote` needs neither (a newcomer never cleared the cast, and a
+			// blocked self-cast leaves nothing to retract).
+			error: Schema.Union([Unauthorized, PostNotFound, VoterNotEligible, SelfVoteNotAllowed]),
 		},
 		Effect.fn("post.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -40,6 +40,7 @@ import {
 import type {ReactionTargetNotFound} from "../reaction/errors.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
 import {syncPostSearch} from "../search/fts-sync.ts";
+import {SelfVoteNotAllowed} from "../vote/errors.ts";
 import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import type {Vote} from "../vote/Vote.ts";
 import type {Bookmark} from "./Bookmark.ts";
@@ -1101,6 +1102,17 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			});
 		}
 
+		// Self-vote guard (#2216, founder-ruled): a cast on one's OWN post is rejected
+		// at the domain, so an inflated self-score is unrepresentable rather than caught
+		// downstream. Cast-only (mirrors the `VoterNotEligible` tier gate) — a retraction
+		// is exempt because a blocked cast leaves nothing to retract.
+		if (isVote && meta.authorId === input.voterId) {
+			return yield* new SelfVoteNotAllowed({
+				voterId: input.voterId,
+				message: "kendi gönderine oy veremezsin",
+			});
+		}
+
 		const voteResult = yield* voteSvc
 			.cast({
 				userId: input.voterId,
@@ -1187,13 +1199,16 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 	});
 
 	const retractPostVote = Effect.fn("Pano.retractPostVote")(function* (input: VoteOnPostInput) {
-		// The shared body's channel carries `VoterNotEligible` because `Vote.cast`'s type
-		// does — but the tier gate fires on the CAST direction only (`value: true`), so a
-		// retraction (`value: false`) can never raise it. Die if it somehow does (a broken
-		// invariant, not a user-facing case), keeping this method's error channel to
-		// `PostNotFound`.
+		// The shared body's channel carries `VoterNotEligible` + `SelfVoteNotAllowed` because
+		// `applyPostVote`'s type does — but both fire on the CAST direction only (`isVote`/
+		// `value: true`), so a retraction (`value: false`) can never raise them. Die if one
+		// somehow does (a broken invariant, not a user-facing case), keeping this method's
+		// error channel to `PostNotFound`.
 		return yield* applyPostVote(input, false).pipe(
-			Effect.catchTag("vote/VoterNotEligible", (e) => Effect.die(e)),
+			Effect.catchTags({
+				"vote/VoterNotEligible": (e) => Effect.die(e),
+				"vote/SelfVoteNotAllowed": (e) => Effect.die(e),
+			}),
 		);
 	});
 

--- a/apps/web/worker/features/pano/self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/pano/self-vote-guard.unit.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `Pano.applyPostVote` self-vote guard (#2216, founder-ruled) — the cast-site domain
+ * guard proven over the real `makePostOperations` closures with a substituted `Drizzle`
+ * `run` (the post load) + a RECORDING `Vote`, so three things are wrong-or-right with no
+ * SQL engine:
+ *
+ *   1. self-cast rejected — `voteOnPost` where `voterId === post.authorId` fails
+ *      `SelfVoteNotAllowed` and NEVER reaches `Vote.cast` (no score/karma write).
+ *   2. other-author cast lands — a non-author vote reaches `Vote.cast` exactly as before.
+ *   3. self-retract exempt — `retractPostVote` on one's own post reaches `Vote.cast`
+ *      (the guard is cast-only; a blocked cast leaves nothing to retract).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
+import type {Vote, VoteInput, VoteResult} from "../vote/Vote.ts";
+import {makePostOperations, type PostOperationsDeps} from "./post-operations.ts";
+
+const AUTHOR = "u-author";
+const OTHER = "u-other";
+const POST_ID = "post_1";
+
+// The `post_record` the up-front load returns. Only `authorId` drives the guard; the
+// rest satisfy the row shape the return projection reads.
+const postRow = {
+	id: POST_ID,
+	slug: "post-1",
+	title: "başlık",
+	url: null,
+	host: null,
+	body: "gövde",
+	bodyExcerpt: "gövde",
+	authorId: AUTHOR,
+	authorName: "yazar",
+	score: 3,
+	hotScore: 3,
+	commentCount: 0,
+	tags: "",
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	removedAt: null,
+	sandboxedAt: null,
+	isDraft: null,
+};
+
+// A `Vote` double that RECORDS every cast and replays a no-op result — so "did the cast
+// path run" is observable with no engine. Only `cast` is on the vote path; every other
+// method dies on contact via the Proxy, so an off-path call is loud (the `reaction-mutation`
+// `panoStub` idiom).
+const recordingVote = (casts: VoteInput[]): typeof Vote.Service =>
+	new Proxy(
+		{
+			cast: (input: VoteInput) => {
+				casts.push(input);
+				return Effect.succeed({
+					targetKind: input.targetKind,
+					targetId: input.targetId,
+					authorId: AUTHOR,
+					score: postRow.score,
+					myVote: input.value,
+					changed: false,
+				} satisfies VoteResult);
+			},
+		} as Partial<typeof Vote.Service>,
+		{
+			get(target, prop) {
+				if (prop in target) return (target as Record<string, unknown>)[prop as string];
+				return () => Effect.die(`Vote.${String(prop)} not exercised in self-vote-guard`);
+			},
+		},
+	) as typeof Vote.Service;
+
+// Only `run` (the post load) + `voteSvc` are on the vote path; the other deps are captured
+// but never invoked, so they die on contact if the guard ever falls through to them.
+const deps = (voteSvc: typeof Vote.Service): PostOperationsDeps =>
+	({
+		run: (<A>(_fn: unknown) => Effect.succeed(postRow as A)) as DrizzleAccessOrDie["run"],
+		batch: (() =>
+			Effect.die("batch not exercised in self-vote-guard")) as DrizzleAccessOrDie["batch"],
+		voteSvc,
+		bookmarkSvc: {} as PostOperationsDeps["bookmarkSvc"],
+		reactionSvc: {} as PostOperationsDeps["reactionSvc"],
+		removalSeq: {} as PostOperationsDeps["removalSeq"],
+		persistPanoStats: (() => Effect.void) as PostOperationsDeps["persistPanoStats"],
+		readProfileIdentities: () => Effect.succeed([]),
+	}) satisfies PostOperationsDeps;
+
+describe("Pano.applyPostVote — the self-vote guard (#2216)", () => {
+	it.effect("(1) a self-cast fails SelfVoteNotAllowed and never reaches Vote.cast", () =>
+		Effect.gen(function* () {
+			const casts: VoteInput[] = [];
+			const ops = makePostOperations(deps(recordingVote(casts)));
+			const exit = yield* Effect.exit(ops.voteOnPost({postId: POST_ID, voterId: AUTHOR}));
+			assert.isTrue(Exit.isFailure(exit), "a self-cast is rejected");
+			if (Exit.isFailure(exit)) {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual((error.value as {_tag?: string})._tag, "vote/SelfVoteNotAllowed");
+				}
+			}
+			assert.deepStrictEqual(casts, [], "Vote.cast is never reached on a self-cast");
+		}),
+	);
+
+	it.effect("(2) a non-author cast reaches Vote.cast and lands", () =>
+		Effect.gen(function* () {
+			const casts: VoteInput[] = [];
+			const ops = makePostOperations(deps(recordingVote(casts)));
+			const result = yield* ops.voteOnPost({postId: POST_ID, voterId: OTHER});
+			assert.deepStrictEqual(casts, [
+				{userId: OTHER, targetKind: "post", targetId: POST_ID, value: true},
+			]);
+			assert.strictEqual(result.postId, POST_ID);
+		}),
+	);
+
+	it.effect("(3) a self-RETRACT is exempt — it reaches Vote.cast (cast-only guard)", () =>
+		Effect.gen(function* () {
+			const casts: VoteInput[] = [];
+			const ops = makePostOperations(deps(recordingVote(casts)));
+			yield* ops.retractPostVote({postId: POST_ID, voterId: AUTHOR});
+			assert.deepStrictEqual(casts, [
+				{userId: AUTHOR, targetKind: "post", targetId: POST_ID, value: false},
+			]);
+		}),
+	);
+});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -31,7 +31,7 @@ import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Reaction} from "../reaction/Reaction.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
-import type {VoterNotEligible} from "../vote/errors.ts";
+import {SelfVoteNotAllowed, type VoterNotEligible} from "../vote/errors.ts";
 import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import {Vote} from "../vote/Vote.ts";
 import {
@@ -381,10 +381,15 @@ export class Sozluk extends Context.Service<
 		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
 		// `VoterNotEligible` (#1810): a çaylak newcomer's cast is rejected by the "earn to
-		// vote" gate in `Vote.castImpl` — cast path only. Retraction never raises it.
+		// vote" gate in `Vote.castImpl`. `SelfVoteNotAllowed` (#2216): a cast on one's own
+		// definition is rejected at the cast site. Both cast path only — retraction raises
+		// neither, so `retractDefinitionVote` keeps its `DefinitionNotFound` channel.
 		readonly voteDefinition: (
 			input: VoteDefinitionInput,
-		) => Effect.Effect<VoteDefinitionResult, DefinitionNotFound | VoterNotEligible>;
+		) => Effect.Effect<
+			VoteDefinitionResult,
+			DefinitionNotFound | VoterNotEligible | SelfVoteNotAllowed
+		>;
 
 		readonly retractDefinitionVote: (
 			input: VoteDefinitionInput,
@@ -1145,6 +1150,17 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				});
 			}
 
+			// Self-vote guard (#2216, founder-ruled): a cast on one's OWN definition is
+			// rejected at the domain, so an inflated self-score is unrepresentable rather
+			// than caught downstream. Cast-only (mirrors the `VoterNotEligible` tier gate) —
+			// a retraction is exempt because a blocked cast leaves nothing to retract.
+			if (isVote && definition.authorId === input.voterId) {
+				return yield* new SelfVoteNotAllowed({
+					voterId: input.voterId,
+					message: "kendi tanımına oy veremezsin",
+				});
+			}
+
 			// A Vote miss (raced soft-delete or sandboxed) collapses to this
 			// surface's DefinitionNotFound — see translateVoteMiss.
 			const voteResult = yield* voteSvc
@@ -1196,11 +1212,14 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		const retractDefinitionVote = Effect.fn("Sozluk.retractDefinitionVote")(function* (
 			input: VoteDefinitionInput,
 		) {
-			// The tier gate fires on the cast direction only (`value: true`), so a retraction
-			// never raises `VoterNotEligible` — die if it somehow does, keeping this method's
-			// channel to `DefinitionNotFound`.
+			// `VoterNotEligible` + `SelfVoteNotAllowed` both fire on the cast direction only
+			// (`isVote`/`value: true`), so a retraction never raises either — die if one
+			// somehow does, keeping this method's channel to `DefinitionNotFound`.
 			return yield* applyVote(input, false).pipe(
-				Effect.catchTag("vote/VoterNotEligible", (e) => Effect.die(e)),
+				Effect.catchTags({
+					"vote/VoterNotEligible": (e) => Effect.die(e),
+					"vote/SelfVoteNotAllowed": (e) => Effect.die(e),
+				}),
 			);
 		});
 

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -24,7 +24,7 @@ import {InsufficientKarma} from "../kunye/errors.ts";
 import {gateContentOnKarma} from "../kunye/privilege.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {authorDisplayLabel} from "../pasaport/author-label.ts";
-import {VoterNotEligible} from "../vote/errors.ts";
+import {SelfVoteNotAllowed, VoterNotEligible} from "../vote/errors.ts";
 import {
 	BodyRequired,
 	BodyTooLong,
@@ -132,8 +132,9 @@ export const mutations = {
 			input: DefinitionIdInput,
 			type: DefinitionView,
 			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate (#1810): a çaylak
-			// newcomer is rejected at cast. Retraction is exempt (nothing cast to retract).
-			error: Schema.Union([Unauthorized, DefinitionNotFound, VoterNotEligible]),
+			// newcomer is rejected at cast. `SelfVoteNotAllowed` (wire `SELF_VOTE_NOT_ALLOWED`) — the
+			// founder-ruled self-vote block (#2216). Both cast-only; retraction is exempt for each.
+			error: Schema.Union([Unauthorized, DefinitionNotFound, VoterNotEligible, SelfVoteNotAllowed]),
 		},
 		Effect.fn("definition.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;

--- a/apps/web/worker/features/sozluk/self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/sozluk/self-vote-guard.unit.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `Sozluk.applyVote` self-vote guard (#2216, founder-ruled) — the cast-site domain guard
+ * proven over the REAL `SozlukLive` with a substituted `Drizzle` (the definition load) + a
+ * RECORDING `Vote`, so three things are wrong-or-right with no SQL engine:
+ *
+ *   1. self-cast rejected — `voteDefinition` where `voterId === definition.authorId` fails
+ *      `SelfVoteNotAllowed` and NEVER reaches `Vote.cast` (no score/karma write).
+ *   2. other-author cast lands — a non-author vote reaches `Vote.cast` exactly as before.
+ *   3. self-retract exempt — `retractDefinitionVote` on one's own definition reaches
+ *      `Vote.cast` (the guard is cast-only; a blocked cast leaves nothing to retract).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit, Layer} from "effect";
+import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
+import {Reaction} from "../reaction/Reaction.ts";
+import type {VoteInput, VoteResult} from "../vote/Vote.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Sozluk, SozlukLive} from "./Sozluk.ts";
+
+const AUTHOR = "u-author";
+const OTHER = "u-other";
+const DEF_ID = "def-1";
+
+// The `definition_record` the up-front load returns. Only `authorId` drives the guard; the
+// rest satisfy the row shape the return projection reads. `changed:false` from the Vote
+// double keeps `persistTermSummary` (and its DB writes) off the path, so one read is enough.
+const definitionRow = {
+	id: DEF_ID,
+	body: "bir tanım",
+	score: 3,
+	authorName: "yazar",
+	authorId: AUTHOR,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	removedAt: null,
+	sandboxedAt: null,
+	termSlug: "bir-terim",
+	termTitle: "bir terim",
+	bodyExcerpt: "bir tanım",
+};
+
+const definitionAccess = (row: unknown): DrizzleAccess => ({
+	run: () => Effect.succeed(row as never),
+	batch: () => Effect.die(new Error("the vote path takes no direct batch in self-vote-guard")),
+});
+
+// A `Vote` that RECORDS every cast and replays a no-op result — so "did the cast path run"
+// is observable with no engine. Only `cast` is on the vote WRITE path; every other method
+// dies on contact via the Proxy (the `reaction-mutation` `panoStub` idiom).
+const recordingVote = (casts: VoteInput[]): Layer.Layer<Vote> =>
+	Layer.succeed(
+		Vote,
+		new Proxy(
+			{
+				cast: (input: VoteInput) =>
+					Effect.sync(() => {
+						casts.push(input);
+						return {
+							targetKind: input.targetKind,
+							targetId: input.targetId,
+							authorId: AUTHOR,
+							score: definitionRow.score,
+							myVote: input.value,
+							changed: false,
+						} satisfies VoteResult;
+					}),
+			} as Partial<typeof Vote.Service>,
+			{
+				get(target, prop) {
+					if (prop in target) return (target as Record<string, unknown>)[prop as string];
+					return () => Effect.die(`Vote.${String(prop)} not exercised in self-vote-guard`);
+				},
+			},
+		) as typeof Vote.Service,
+	);
+
+// The vote path never reacts, so a fail-on-contact `Reaction` proves it — every method dies
+// on contact via the Proxy.
+const reactionStub = Layer.succeed(
+	Reaction,
+	new Proxy({} as Partial<typeof Reaction.Service>, {
+		get(_target, prop) {
+			return () => Effect.die(`Reaction.${String(prop)} not exercised in self-vote-guard`);
+		},
+	}) as typeof Reaction.Service,
+);
+
+const sozlukLayer = (casts: VoteInput[]) =>
+	SozlukLive.pipe(
+		Layer.provide(recordingVote(casts)),
+		Layer.provide(reactionStub),
+		Layer.provide(PasaportIdentityStub),
+		Layer.provide(Layer.succeed(Drizzle, definitionAccess(definitionRow))),
+	);
+
+describe("Sozluk.applyVote — the self-vote guard (#2216)", () => {
+	it.effect("(1) a self-cast fails SelfVoteNotAllowed and never reaches Vote.cast", () => {
+		const casts: VoteInput[] = [];
+		return Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			const exit = yield* sozluk
+				.voteDefinition({definitionId: DEF_ID, voterId: AUTHOR})
+				.pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit), "a self-cast is rejected");
+			if (Exit.isFailure(exit)) {
+				assert.match(String(exit.cause), /SelfVoteNotAllowed/);
+			}
+			assert.deepStrictEqual(casts, [], "Vote.cast is never reached on a self-cast");
+		}).pipe(Effect.provide(sozlukLayer(casts)));
+	});
+
+	it.effect("(2) a non-author cast reaches Vote.cast and lands", () => {
+		const casts: VoteInput[] = [];
+		return Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			const result = yield* sozluk.voteDefinition({definitionId: DEF_ID, voterId: OTHER});
+			assert.deepStrictEqual(casts, [
+				{userId: OTHER, targetKind: "definition", targetId: DEF_ID, value: true},
+			]);
+			assert.strictEqual(result.definitionId, DEF_ID);
+		}).pipe(Effect.provide(sozlukLayer(casts)));
+	});
+
+	it.effect("(3) a self-RETRACT is exempt — it reaches Vote.cast (cast-only guard)", () => {
+		const casts: VoteInput[] = [];
+		return Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			yield* sozluk.retractDefinitionVote({definitionId: DEF_ID, voterId: AUTHOR});
+			assert.deepStrictEqual(casts, [
+				{userId: AUTHOR, targetKind: "definition", targetId: DEF_ID, value: false},
+			]);
+		}).pipe(Effect.provide(sozlukLayer(casts)));
+	});
+});

--- a/apps/web/worker/features/vote/errors.ts
+++ b/apps/web/worker/features/vote/errors.ts
@@ -82,3 +82,23 @@ export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>(
 	},
 	{[FateWireCode]: VOTE_ELIGIBILITY_WIRE_CODE},
 ) {}
+
+/**
+ * A voter tried to cast on their **own** content (`voterId === authorId`), which the
+ * founder has ruled disallowed — a self-vote inflates the author's own score/karma and
+ * corrupts every ranking that reads it (#2216). Like {@link VoterNotEligible} this is a
+ * genuine *voter* rejection that reaches the wire (its own `SELF_VOTE_NOT_ALLOWED`
+ * {@link FateWireCode}, so the SPA can name it), never a target miss. Raised at the cast
+ * site (`Pano.applyPostVote` / `Sozluk.applyVote`), which already holds the target's
+ * `authorId` — and only on the CAST direction (`isVote === true`): a retraction is exempt,
+ * since once the cast is blocked there is no self-vote to retract (the same cast-only shape
+ * as {@link VoterNotEligible}).
+ */
+export class SelfVoteNotAllowed extends Schema.TaggedErrorClass<SelfVoteNotAllowed>()(
+	"vote/SelfVoteNotAllowed",
+	{
+		voterId: Schema.String,
+		message: Schema.String,
+	},
+	{[FateWireCode]: "SELF_VOTE_NOT_ALLOWED"},
+) {}


### PR DESCRIPTION
## What & why

Self-voting was **allowed** on both vote paths — a user could upvote their **own** content, inflating their own score/karma and corrupting every ranking that reads it (pano sıcak/oy, sözlük en çok oylananlar, profile karma). The founder has **ruled** self-voting must be blocked, so this is a forward-guard against a decided behavior (`type:bug`), **not** a reopened decision.

Confirmed against `origin/main`: neither `Pano.applyPostVote` nor `Sozluk.applyVote` guarded `voterId === authorId`, even though both fetch the target record (with its `authorId`) before casting.

## The fix

- **`SelfVoteNotAllowed`** tagged error in `apps/web/worker/features/vote/errors.ts` (wire `SELF_VOTE_NOT_ALLOWED`), modeled on the existing `VoterNotEligible` gate — a genuine *voter* rejection that reaches the wire, not a target miss.
- **Guard at BOTH cast sites**, right after the not-found check, where the target's `authorId` is already in hand:
  - `applyPostVote` (`apps/web/worker/features/pano/post-operations.ts`)
  - `applyVote` (`apps/web/worker/features/sozluk/Sozluk.ts`)
  - **Cast-only** (`isVote === true`), mirroring the `VoterNotEligible` tier gate — a retraction stays exempt (a blocked cast leaves nothing to retract), so `retractPostVote` / `retractDefinitionVote` catch+die the arm to keep their `*NotFound`-only channel.
- **Wired into** the `post.vote` / `definition.vote` mutation error unions (`pano/mutations.ts`, `sozluk/mutations.ts`) and the `Pano` / `Sozluk` service-tag signatures.
- **Registered** in the SPA wire-code vocabulary (`src/lib/fateWireCodes.ts`), the copy (`src/fate/wireMessages.ts` — "kendi içeriğine oy veremezsin"), and the per-class oracle (`wireCodes-per-class.unit.test.ts`).
- **Client:** hide the vote control on one's own post cards / detail header / own definition, so the affordance matches the rule. The server guard is the invariant; the client hide is the UX.

## Out of scope (triage-noted)

Historical self-vote karma backfill — this is a **forward guard only**.

## Tests

Service-level guards over the real cast bodies (substituted `Drizzle` + recording `Vote`):
- `apps/web/worker/features/pano/self-vote-guard.unit.test.ts`
- `apps/web/worker/features/sozluk/self-vote-guard.unit.test.ts`

Each proves: self-cast → `SelfVoteNotAllowed` (and `Vote.cast` is **never** reached), a non-author cast still lands, and a self-retract stays allowed.

Green locally: `pnpm typecheck`, `pnpm lint:worktree`, the new + wire-code guard tests, `fanout-guard check` (24 fanned mutations still publish; no fanned success projection changed).

Fixes #2216

🤖 Generated with [Claude Code](https://claude.com/claude-code)