### PR TITLE
refactor(web): dedupe /u and /profile into shared profile primitives (#2203)

### DIFF
--- a/apps/web/src/components/profile/ProfileContributionSignal.tsx
+++ b/apps/web/src/components/profile/ProfileContributionSignal.tsx
@@ -22,7 +22,9 @@ import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {Profile} from "../../../worker/features/fate/views";
 import {Screen} from "../../fate/Screen";
+import {EmptyState} from "../ui/EmptyState";
 import {ContributionRow, ContributionView} from "./ContributionRow";
+import {CONTRIBUTIONS_EMPTY, CONTRIBUTIONS_HEADING} from "./profileContributions";
 import "./ProfileContributionSignal.css";
 
 // Thin by design: just enough recent items to read as a track record, never a feed.
@@ -42,7 +44,7 @@ function SignalShell({children}: {children: ReactNode}) {
 			aria-labelledby="kp-signal-heading"
 			data-testid="contribution-signal"
 		>
-			<h3 id="kp-signal-heading">katkıların</h3>
+			<h3 id="kp-signal-heading">{CONTRIBUTIONS_HEADING.self}</h3>
 			{children}
 		</section>
 	);
@@ -96,9 +98,7 @@ function SignalContent({username}: {username: string}) {
 
 function EmptySignal() {
 	return (
-		<p className="kp-signal__status" data-testid="signal-empty">
-			henüz katkın yok — ilk tanımını ya da başlığını ekleyince burada görünür.
-		</p>
+		<EmptyState title={CONTRIBUTIONS_EMPTY.title} description={CONTRIBUTIONS_EMPTY.description} />
 	);
 }
 

--- a/apps/web/src/components/profile/ProfileHeader.css
+++ b/apps/web/src/components/profile/ProfileHeader.css
@@ -1,0 +1,77 @@
+/* ProfileHeader (#2203) — the one header shared by /profile and /u/:username.
+   Avatar + id + right-aligned activity tiles; wraps below 640px (the shared
+   narrow-viewport breakpoint for this cluster). */
+
+.kp-profile-header {
+	display: flex;
+	align-items: center;
+	gap: var(--s-4);
+	padding-bottom: var(--s-4);
+	border-bottom: 1px solid var(--border);
+}
+
+.kp-profile-header__avatar {
+	width: 56px;
+	height: 56px;
+	flex-shrink: 0;
+	border-radius: var(--r-sm);
+	background: var(--surface);
+	color: var(--accent-11);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font: 600 22px var(--font-body);
+	overflow: hidden;
+}
+.kp-profile-header__avatar img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.kp-profile-header__id {
+	display: grid;
+	gap: 4px;
+	min-width: 0;
+}
+.kp-profile-header__name {
+	font: 600 18px / 1.1 var(--font-body);
+	color: var(--text-primary);
+	letter-spacing: -0.01em;
+}
+.kp-profile-header__handle {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+}
+
+.kp-profile-header__stats {
+	display: flex;
+	gap: var(--s-5);
+	margin-left: auto;
+	align-items: flex-end;
+}
+.kp-profile-header__stat {
+	text-align: right;
+}
+.kp-profile-header__stat .n {
+	font: 600 15px var(--font-body);
+	color: var(--text-primary);
+}
+.kp-profile-header__stat .l {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+.kp-profile-header__stats--error {
+	align-items: center;
+	font: var(--t-meta);
+	color: var(--danger);
+}
+
+@media (max-width: 640px) {
+	.kp-profile-header {
+		flex-wrap: wrap;
+	}
+	.kp-profile-header__stats {
+		margin-left: 0;
+	}
+}

--- a/apps/web/src/components/profile/ProfileHeader.tsx
+++ b/apps/web/src/components/profile/ProfileHeader.tsx
@@ -1,0 +1,99 @@
+/**
+ * `ProfileHeader` — the shared, presentational profile-header primitive (#2203):
+ * avatar (image-or-initials) + display name + `@handle`{+ standing} + the canonical
+ * activity tiles. Consumed by BOTH the owner's self-service `/profile`
+ * (`ProfilePage`) and the public `/u/:username` (`UserProfileHeader`), which
+ * previously hand-derived two headers that drifted (two stat orders, a standing
+ * badge on one but not the other). This component owns the DOM; each surface only
+ * maps its own data source (imperative `useMe`/`useProfileStats` on `/profile`, the
+ * fate `Profile` view on `/u/`) into these plain props.
+ *
+ * The activity-tile order is the single source `profileStatTiles`; `karma` is the
+ * optional flag-gated tile (`showKarma`, the `PHOENIX_AUTHORSHIP_LOOP` seam),
+ * rendered via the shared `Karma` atom and kept structurally last. `standingLabel`
+ * is likewise optional (owner-only — the public view has no viewed-user tier), so a
+ * `null` renders handle-only, exactly as before.
+ */
+import {Karma} from "../karma/Karma";
+import {profileStatTiles} from "./profileStatTiles";
+import "./ProfileHeader.css";
+
+function initialsOf(name: string) {
+	return name
+		.split(/\s+|_|-/)
+		.filter(Boolean)
+		.slice(0, 2)
+		.map((p) => p[0]?.toUpperCase() ?? "")
+		.join("");
+}
+
+export interface ProfileHeaderStats {
+	readonly definitionCount: number;
+	readonly postCount: number;
+	readonly commentCount: number;
+	readonly totalKarma: number;
+}
+
+export interface ProfileHeaderProps {
+	readonly displayName: string;
+	readonly handle: string;
+	/** Owner-only trusted-tier subtitle; `null`/absent ⇒ handle-only. */
+	readonly standingLabel?: string | null;
+	/** Avatar image; falls back to display-name initials when absent. */
+	readonly image?: string | null;
+	/** Activity + karma counts. `null` renders the tiles as an error strip. */
+	readonly stats: ProfileHeaderStats | null;
+	/** A failed stats read — renders the error strip, never a misleading `0` (#448). */
+	readonly statsError?: boolean;
+	/** Emit the karma tile — gated by `PHOENIX_AUTHORSHIP_LOOP` on `/profile`. */
+	readonly showKarma?: boolean;
+}
+
+export function ProfileHeader({
+	displayName,
+	handle,
+	standingLabel = null,
+	image = null,
+	stats,
+	statsError = false,
+	showKarma = false,
+}: ProfileHeaderProps) {
+	const tiles = profileStatTiles(stats ?? {definitionCount: 0, postCount: 0, commentCount: 0});
+
+	return (
+		<header className="kp-profile-header">
+			<div className="kp-profile-header__avatar" aria-hidden>
+				{image ? <img src={image} alt="" /> : <span>{initialsOf(displayName)}</span>}
+			</div>
+			<div className="kp-profile-header__id">
+				<div className="kp-profile-header__name" data-testid="user-profile-display-name">
+					{displayName}
+				</div>
+				<div className="kp-profile-header__handle" data-testid="user-profile-handle">
+					{standingLabel ? `@${handle} · ${standingLabel}` : `@${handle}`}
+				</div>
+			</div>
+			{statsError ? (
+				<div
+					className="kp-profile-header__stats kp-profile-header__stats--error"
+					data-testid="stats-error"
+					role="alert"
+				>
+					istatistikler yüklenemedi
+				</div>
+			) : (
+				<div className="kp-profile-header__stats" data-testid="user-profile-stats">
+					{tiles.map((tile) => (
+						<div className="kp-profile-header__stat" data-testid={tile.testId} key={tile.key}>
+							<div className="n">{tile.value}</div>
+							<div className="l">{tile.label}</div>
+						</div>
+					))}
+					{showKarma ? (
+						<Karma variant="stat" value={stats?.totalKarma ?? 0} testId="stat-karma" />
+					) : null}
+				</div>
+			)}
+		</header>
+	);
+}

--- a/apps/web/src/components/profile/UserProfileHeader.tsx
+++ b/apps/web/src/components/profile/UserProfileHeader.tsx
@@ -2,6 +2,7 @@ import {useView, type ViewRef, view} from "react-fate";
 import type {Profile} from "../../../worker/features/fate/views";
 import {actorLabel} from "../moderation/actor-identity";
 import {CaylakStatusBlock} from "./CaylakStatusBlock";
+import {ProfileHeader} from "./ProfileHeader";
 
 export const UserProfileHeaderView = view<Profile>()({
 	userId: true,
@@ -13,15 +14,6 @@ export const UserProfileHeaderView = view<Profile>()({
 	postCount: true,
 	commentCount: true,
 });
-
-function initialsOf(name: string) {
-	return name
-		.split(/\s+|_|-/)
-		.filter(Boolean)
-		.slice(0, 2)
-		.map((p) => p[0]?.toUpperCase() ?? "")
-		.join("");
-}
 
 export interface UserProfileHeaderProps {
 	profile: ViewRef<"Profile">;
@@ -35,41 +27,18 @@ export function UserProfileHeader(props: UserProfileHeaderProps) {
 
 	return (
 		<>
-			<header className="kp-user-profile__head">
-				<div className="kp-user-profile__avatar" aria-hidden>
-					{profile.image ? (
-						<img src={profile.image} alt="" />
-					) : (
-						<span>{initialsOf(displayName)}</span>
-					)}
-				</div>
-				<div className="kp-user-profile__id">
-					<div className="kp-user-profile__name" data-testid="user-profile-display-name">
-						{displayName}
-					</div>
-					<div className="kp-user-profile__handle" data-testid="user-profile-handle">
-						@{handle}
-					</div>
-				</div>
-				<div className="kp-user-profile__stats" data-testid="user-profile-stats">
-					<div className="kp-user-profile__stat" data-testid="stat-definitions">
-						<div className="n">{profile.definitionCount}</div>
-						<div className="l">tanım</div>
-					</div>
-					<div className="kp-user-profile__stat" data-testid="stat-posts">
-						<div className="n">{profile.postCount}</div>
-						<div className="l">başlık</div>
-					</div>
-					<div className="kp-user-profile__stat" data-testid="stat-comments">
-						<div className="n">{profile.commentCount}</div>
-						<div className="l">yorum</div>
-					</div>
-					<div className="kp-user-profile__stat" data-testid="stat-karma">
-						<div className="n">{profile.totalKarma}</div>
-						<div className="l">karma</div>
-					</div>
-				</div>
-			</header>
+			<ProfileHeader
+				displayName={displayName}
+				handle={handle}
+				image={profile.image}
+				stats={{
+					definitionCount: profile.definitionCount,
+					postCount: profile.postCount,
+					commentCount: profile.commentCount,
+					totalKarma: profile.totalKarma,
+				}}
+				showKarma
+			/>
 			{/* The çaylak's own "yazarlığa giden yol" status block (#1291), dark behind
 			    the #1204 authorship-loop flag; renders only for a çaylak on their own
 			    profile, off an aggregate-only read (one-way glass). */}

--- a/apps/web/src/components/profile/profileContributions.ts
+++ b/apps/web/src/components/profile/profileContributions.ts
@@ -1,0 +1,22 @@
+/**
+ * The shared contributions copy for the two profile surfaces (#2203). Both `/u/`
+ * (public) and `/profile` (self) render the same `EmptyState` card and the same
+ * `ContributionRow` cards; the only intentional divergence is the section heading,
+ * which stays per-surface-intent: third-person `katkılar` on someone else's public
+ * profile, second-person `katkıların` on the owner's own self-service view. Naming
+ * them here makes the split intentional rather than the accidental drift #2203
+ * observed. Lowercase Turkish (user-facing copy).
+ */
+
+export const CONTRIBUTIONS_HEADING = {
+	/** `/u/:username` — a third party viewing someone's public contributions. */
+	public: "katkılar",
+	/** `/profile` — the owner viewing their own contributions. */
+	self: "katkıların",
+} as const;
+
+/** The one empty-state card both surfaces render (via the shared `EmptyState`). */
+export const CONTRIBUTIONS_EMPTY = {
+	title: "henüz katkı yok.",
+	description: "ilk tanımını ya da başlığını ekleyince burada görünür.",
+} as const;

--- a/apps/web/src/components/profile/profileStatTiles.test.ts
+++ b/apps/web/src/components/profile/profileStatTiles.test.ts
@@ -1,0 +1,35 @@
+/**
+ * The canonical profile activity-tile order (#2203), asserted DOM-free — the ONE
+ * ordering shared by `/profile` and `/u/:username` is factored to a pure function
+ * and pinned here (the pure-extraction idiom of `profileStandingLabel`). Before
+ * this the two hand-derived headers rendered the same scalars in two orders; the
+ * test is what keeps them from drifting apart again.
+ */
+import {describe, expect, it} from "vitest";
+import {profileStatTiles} from "./profileStatTiles";
+
+const counts = {definitionCount: 3, postCount: 5, commentCount: 7};
+
+describe("profileStatTiles — the shared canonical activity order (#2203)", () => {
+	it("orders the tiles tanım → başlık → yorum (sözlük is definition-first)", () => {
+		expect(profileStatTiles(counts).map((t) => t.label)).toEqual(["tanım", "başlık", "yorum"]);
+	});
+
+	it("maps each count to its tile with the preserved e2e testid", () => {
+		expect(profileStatTiles(counts)).toEqual([
+			{key: "definitions", testId: "stat-definitions", value: 3, label: "tanım"},
+			{key: "posts", testId: "stat-posts", value: 5, label: "başlık"},
+			{key: "comments", testId: "stat-comments", value: 7, label: "yorum"},
+		]);
+	});
+
+	it("never emits a karma tile — karma is appended by the flag-gated header, not this set", () => {
+		expect(profileStatTiles(counts).some((t) => t.label === "karma")).toBe(false);
+	});
+
+	it("emits only lowercase-Turkish labels (user-facing convention)", () => {
+		for (const tile of profileStatTiles(counts)) {
+			expect(tile.label).toBe(tile.label.toLocaleLowerCase("tr-TR"));
+		}
+	});
+});

--- a/apps/web/src/components/profile/profileStatTiles.ts
+++ b/apps/web/src/components/profile/profileStatTiles.ts
@@ -1,0 +1,38 @@
+/**
+ * The canonical profile activity-tile order (#2203) — factored DOM-free so the ONE
+ * ordering shared by both profile surfaces (`/profile` and `/u/:username`) is
+ * unit-testable without a DOM (the pure-extraction idiom of `profileStandingLabel`
+ * / `shouldShowCaylakStatus`). Before this the two hand-derived headers rendered
+ * the same activity scalars in two different orders (`ProfilePage` had
+ * `[başlık, yorum, tanım]`, `UserProfileHeader` had `[tanım, başlık, yorum]`); this
+ * is the single source they now share.
+ *
+ * Canonical order is `[tanım, başlık, yorum]` — sözlük is definition-first, so the
+ * tanım count leads. The flag-gated `karma` tile is appended by `ProfileHeader`
+ * (via the shared `Karma` atom, `PHOENIX_AUTHORSHIP_LOOP` seam), so it stays
+ * structurally last and never enters this reorderable set.
+ */
+
+export interface ProfileActivityCounts {
+	readonly definitionCount: number;
+	readonly postCount: number;
+	readonly commentCount: number;
+}
+
+export interface ProfileStatTile {
+	/** Stable React key + the tile's identity. */
+	readonly key: "definitions" | "posts" | "comments";
+	/** The `data-testid` the profile e2e keys on. */
+	readonly testId: string;
+	readonly value: number;
+	/** Lowercase-Turkish tile label. */
+	readonly label: string;
+}
+
+export function profileStatTiles(counts: ProfileActivityCounts): ProfileStatTile[] {
+	return [
+		{key: "definitions", testId: "stat-definitions", value: counts.definitionCount, label: "tanım"},
+		{key: "posts", testId: "stat-posts", value: counts.postCount, label: "başlık"},
+		{key: "comments", testId: "stat-comments", value: counts.commentCount, label: "yorum"},
+	];
+}

--- a/apps/web/src/pages/ProfilePage.css
+++ b/apps/web/src/pages/ProfilePage.css
@@ -13,58 +13,8 @@
 	gap: var(--s-6);
 }
 
-.kp-profile__head {
-	display: flex;
-	align-items: center;
-	gap: var(--s-4);
-	padding-bottom: var(--s-4);
-	border-bottom: 1px solid var(--border);
-}
-.kp-profile__avatar {
-	width: 56px;
-	height: 56px;
-	border-radius: var(--r-sm);
-	background: var(--surface);
-	color: var(--accent-11);
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	font: 600 22px var(--font-body);
-}
-.kp-profile__id {
-	display: grid;
-	gap: 4px;
-}
-.kp-profile__name {
-	font: 600 18px / 1.1 var(--font-body);
-	color: var(--text-primary);
-	letter-spacing: -0.01em;
-}
-.kp-profile__handle {
-	font: var(--t-body-sm);
-	color: var(--text-muted);
-}
-.kp-profile__stats-strip {
-	display: flex;
-	gap: var(--s-5);
-	margin-left: auto;
-}
-.kp-profile__stat {
-	text-align: right;
-}
-.kp-profile__stat .n {
-	font: 600 15px var(--font-body);
-	color: var(--text-primary);
-}
-.kp-profile__stat .l {
-	font: var(--t-meta);
-	color: var(--text-muted);
-}
-.kp-profile__stats-strip--error {
-	align-items: center;
-	font: var(--t-meta);
-	color: var(--danger);
-}
+/* The profile header now lives in the shared ProfileHeader primitive
+   (components/profile/ProfileHeader.css, #2203). */
 
 .kp-profile__section {
 	display: grid;
@@ -225,18 +175,10 @@
 }
 
 /* Phone account surface (~375–414px, content ≈ 327px): the fixed 140px label track
-   crushes the value cell, and the margin-left:auto stats strip overflows a non-wrapping
-   flex head. Stack the label above the value (1fr value + auto edit-btn) and let the head
-   wrap so the stats strip drops below the avatar/name. 640px is the shared narrow-viewport
-   breakpoint for this cluster (LandingPage #1249, SozlukHome #1250). */
+   crushes the value cell. Stack the label above the value (1fr value + auto edit-btn).
+   640px is the shared narrow-viewport breakpoint for this cluster (LandingPage #1249,
+   SozlukHome #1250); the header's own wrap lives in ProfileHeader.css. */
 @media (max-width: 640px) {
-	.kp-profile__head {
-		flex-wrap: wrap;
-	}
-	.kp-profile__stats-strip {
-		margin-left: 0;
-	}
-
 	.kp-profile__row {
 		grid-template-columns: 1fr auto;
 	}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -4,10 +4,11 @@ import {Navigate} from "react-router";
 import type {User} from "../../worker/features/fate/views";
 import {authClient, clearBearerToken, useSession} from "../auth/client";
 import {useMe} from "../auth/useMe";
-import {Karma} from "../components/karma/Karma";
 import {actorLabel} from "../components/moderation/actor-identity";
+import {CaylakStatusBlock} from "../components/profile/CaylakStatusBlock";
 import {DeleteAccountDialog} from "../components/profile/DeleteAccountDialog";
 import {ProfileContributionSignal} from "../components/profile/ProfileContributionSignal";
+import {ProfileHeader} from "../components/profile/ProfileHeader";
 import {profileStandingLabel} from "../components/profile/profileStanding";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
@@ -24,15 +25,6 @@ const SetDisplayNameView = view<User>()({
 	image: true,
 	username: true,
 });
-
-function initialsOf(name: string) {
-	return name
-		.split(/\s+|_|-/)
-		.filter(Boolean)
-		.slice(0, 2)
-		.map((p) => p[0]?.toUpperCase() ?? "")
-		.join("");
-}
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
@@ -165,42 +157,21 @@ export function ProfilePage() {
 	return (
 		<div className="kp-profile">
 			<div className="kp-profile__inner">
-				<header className="kp-profile__head">
-					<div className="kp-profile__avatar">{initialsOf(name)}</div>
-					<div className="kp-profile__id">
-						<div className="kp-profile__name">{name}</div>
-						<div className="kp-profile__handle">
-							{standingLabel ? `@${handle} · ${standingLabel}` : `@${handle}`}
-						</div>
-					</div>
-					{statsFailed ? (
-						<div
-							className="kp-profile__stats-strip kp-profile__stats-strip--error"
-							data-testid="stats-error"
-							role="alert"
-						>
-							istatistikler yüklenemedi
-						</div>
-					) : (
-						<div className="kp-profile__stats-strip">
-							<div className="kp-profile__stat" data-testid="stat-posts">
-								<div className="n">{stats?.postCount ?? 0}</div>
-								<div className="l">başlık</div>
-							</div>
-							<div className="kp-profile__stat" data-testid="stat-comments">
-								<div className="n">{stats?.commentCount ?? 0}</div>
-								<div className="l">yorum</div>
-							</div>
-							<div className="kp-profile__stat" data-testid="stat-definitions">
-								<div className="n">{stats?.definitionCount ?? 0}</div>
-								<div className="l">tanım</div>
-							</div>
-							{authorshipLoop ? (
-								<Karma variant="stat" value={stats?.totalKarma ?? 0} testId="stat-karma" />
-							) : null}
-						</div>
-					)}
-				</header>
+				<ProfileHeader
+					displayName={name}
+					handle={handle}
+					standingLabel={standingLabel}
+					image={me?.image ?? null}
+					stats={stats}
+					statsError={statsFailed}
+					showKarma={authorshipLoop}
+				/>
+
+				{/* The çaylak's own "yazarlığa giden yol" tracker (#1291), surfaced on the
+				    self-service profile too (#2203) so promotion progress is reachable from
+				    settings, not only the public /u/ page. Reuses the existing block, which
+				    self-gates on the #1204 authorship-loop flag + own-profile + çaylak. */}
+				{me?.id ? <CaylakStatusBlock profileUserId={me.id} /> : null}
 
 				{/* Thin contribution signal (#1209) — the owner's own track record,
 				    dark behind the authorship-loop flag (#1204). Flag off → exactly

--- a/apps/web/src/pages/UserProfilePage.css
+++ b/apps/web/src/pages/UserProfilePage.css
@@ -8,63 +8,8 @@
 	padding: 0 var(--s-3);
 }
 
-.kp-user-profile__head {
-	display: grid;
-	grid-template-columns: auto 1fr auto;
-	gap: var(--s-3);
-	align-items: center;
-	padding: var(--s-3) 0;
-	border-bottom: 1px solid var(--border-faint);
-	margin-bottom: var(--s-4);
-}
-
-.kp-user-profile__avatar {
-	width: 64px;
-	height: 64px;
-	border-radius: 50%;
-	background: var(--surface);
-	display: grid;
-	place-items: center;
-	font: 600 22px var(--font-body);
-	color: var(--accent-11);
-	overflow: hidden;
-}
-
-.kp-user-profile__avatar img {
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
-}
-
-.kp-user-profile__name {
-	font: var(--t-h-page);
-	color: var(--text-primary);
-}
-
-.kp-user-profile__handle {
-	font: var(--t-meta);
-	color: var(--text-muted);
-}
-
-.kp-user-profile__stats {
-	display: flex;
-	gap: var(--s-3);
-}
-
-.kp-user-profile__stat {
-	text-align: center;
-	min-width: 60px;
-}
-
-.kp-user-profile__stat .n {
-	font: var(--t-h-feed);
-	color: var(--text-primary);
-}
-
-.kp-user-profile__stat .l {
-	font: var(--t-meta);
-	color: var(--text-muted);
-}
+/* The profile header now lives in the shared ProfileHeader primitive
+   (components/profile/ProfileHeader.css, #2203). */
 
 .kp-user-profile__feed h3 {
 	font: var(--t-h-feed);

--- a/apps/web/src/pages/UserProfilePage.tsx
+++ b/apps/web/src/pages/UserProfilePage.tsx
@@ -11,6 +11,10 @@ import {useMe} from "../auth/useMe";
 import {shouldShowCaylakStatus} from "../components/profile/CaylakStatusBlock";
 import {ContributionRow, ContributionView} from "../components/profile/ContributionRow";
 import {PromotionActions, shouldShowPromotionActions} from "../components/profile/PromotionActions";
+import {
+	CONTRIBUTIONS_EMPTY,
+	CONTRIBUTIONS_HEADING,
+} from "../components/profile/profileContributions";
 import {UserProfileHeader, UserProfileHeaderView} from "../components/profile/UserProfileHeader";
 import {EmptyState} from "../components/ui/EmptyState";
 import {Screen} from "../fate/Screen";
@@ -105,11 +109,11 @@ function ContributionsList({profile}: {profile: ViewRef<"Profile">}) {
 
 	return (
 		<section className="kp-user-profile__feed" data-testid="user-profile-feed">
-			<h3>katkılar</h3>
+			<h3>{CONTRIBUTIONS_HEADING.public}</h3>
 			{items.length === 0 ? (
 				<EmptyState
-					title="henüz katkı yok."
-					description="ilk tanımını ya da başlığını ekleyince burada görünür."
+					title={CONTRIBUTIONS_EMPTY.title}
+					description={CONTRIBUTIONS_EMPTY.description}
 				/>
 			) : (
 				<ul className="kp-user-profile__list">

--- a/apps/web/tests/e2e/09-profile.spec.ts
+++ b/apps/web/tests/e2e/09-profile.spec.ts
@@ -25,10 +25,13 @@ test.describe("ProfilePage (/profile)", () => {
 		const creds = await signUp(page);
 		await bootstrapUsername(page);
 		await page.goto("/profile");
-		await expect(page.locator(".kp-profile__avatar")).toBeVisible();
-		await expect(page.locator(".kp-profile__name")).toContainText(creds.name);
-		await expect(page.locator(".kp-profile__handle")).toBeVisible();
-		await expect(page.locator(".kp-profile__stat")).toHaveCount(3);
+		// #2203: the header is now the shared `ProfileHeader` primitive
+		// (`kp-profile-header__*`), consumed by both /profile and /u/. Assert its
+		// stable testids / structure rather than the retired hand-derived classes.
+		await expect(page.locator(".kp-profile-header__avatar")).toBeVisible();
+		await expect(page.getByTestId("user-profile-display-name")).toContainText(creds.name);
+		await expect(page.getByTestId("user-profile-handle")).toBeVisible();
+		await expect(page.locator(".kp-profile-header__stat")).toHaveCount(3);
 		// email row should show the credential email
 		await expect(page.locator(".kp-profile__row.readonly .value")).toContainText(creds.email);
 


### PR DESCRIPTION
Fixes #2203

## What
`/u/:username` (public) and `/profile` (self-service) had drifted into two hand-derived headers plus per-surface contribution/empty-state markup. This dedupes them into shared primitives without collapsing the two audiences (they legitimately differ — this is drift-correction, not a which-surface-wins ruling).

## Changes
- **Shared `ProfileHeader` primitive** (`components/profile/ProfileHeader.tsx` + `.css`) — avatar (image-or-initials) + display name + `@handle`{+ standing} + activity tiles. Consumed by both `ProfilePage` and `UserProfileHeader`; each surface only maps its own data source into plain props.
- **One canonical activity-tile order** via the pure, unit-tested `profileStatTiles` (`profileStatTiles.ts` + `.test.ts`): `tanım → başlık → yorum` (sözlük is definition-first); the flag-gated `karma` tile is appended last via the shared `Karma` atom. Fixes the two-different-orders drift.
- **Shared contributions copy** (`profileContributions.ts`): both surfaces render the same `EmptyState` card; the section heading stays per-surface-intent — `katkılar` (public, third-person) vs `katkıların` (self, second-person), now named constants rather than accidental drift.
- **Çaylak promotion tracker on `/profile`**: `ProfilePage` now renders the existing `CaylakStatusBlock` ("yazarlığa giden yol"), self-gated on the existing `PHOENIX_AUTHORSHIP_LOOP` flag — no new flag, no new capability, just reachable from self-service settings as well as `/u/`.

## Split preserved (no regression)
Account / appearance / session / danger-zone stay `/profile`-only; the public page stays read-only. Public karma tile remains ungated (unchanged); the owner's karma stat + standing badge stay behind the authorship-loop flag.

## Tests
- New `profileStatTiles.test.ts` pins the canonical order + testids + no-karma-in-set.
- Full local gates green: typecheck (+ build), lint, `vitest --project unit` (1845 passed). Preserved the profile e2e testids (`stat-*`, `user-profile-handle`, `contribution-*`).

Coordinated with the shared-file cluster (#2209); did not touch the #2188 fate defer-on-nested-connection seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)