### PR TITLE
feat(pano,sozluk): owner-only "incelemede" in-review badge on post/definition detail (#2200)

### DIFF
--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -14,6 +14,7 @@ import {Tag, type TagKind} from "../ui/atoms";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
+import {ReviewBadge} from "../ui/ReviewBadge";
 import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 
 /**
@@ -49,6 +50,7 @@ export const PanoPostHeaderView = view<Post>()({
 	commentCount: true,
 	createdAt: true,
 	updatedAt: true,
+	sandboxed: true,
 	tags: true,
 });
 
@@ -66,7 +68,12 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 	const tags = post.tags ?? [];
 	return (
 		<div>
-			<h1 className="kp-pano-postpage__title kp-prose">{post.title}</h1>
+			<h1 className="kp-pano-postpage__title kp-prose">
+				{post.title}
+				{/* Owner-only in-review signal (#2200): `sandboxed` is owner-scoped server-side,
+				    re-gated on `isAuthor` so only the author sees their own pending post's state. */}
+				{props.isAuthor && post.sandboxed ? <ReviewBadge /> : null}
+			</h1>
 			{post.url ? (
 				<a
 					className="kp-pano-postpage__url"

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -28,6 +28,7 @@ import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {Dialog} from "../ui/Dialog";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
+import {ReviewBadge} from "../ui/ReviewBadge";
 
 export const DefinitionView = view<Definition>()({
 	id: true,
@@ -40,6 +41,7 @@ export const DefinitionView = view<Definition>()({
 	authorId: true,
 	authorUsername: true,
 	authorDisplayName: true,
+	sandboxed: true,
 	reactions: {counts: true, myReaction: true},
 });
 
@@ -299,6 +301,9 @@ export function DefinitionCard(props: DefinitionCardProps) {
 					<DefinitionBody text={definition.body} />
 				)}
 				<footer className="kp-sozluk-definition__foot">
+					{/* Owner-only in-review signal (#2200): `sandboxed` is owner-scoped server-side,
+					    re-gated on `isAuthor` so only the author sees their own pending definition's state. */}
+					{isAuthor && definition.sandboxed ? <ReviewBadge /> : null}
 					{/* Live author identity via `actorLabel` (#2139): CURRENT displayName → @username,
 					    falling back to the write-time `author` snapshot for an unstamped/legacy row. */}
 					<span className="author">

--- a/apps/web/src/components/ui/ReviewBadge.css
+++ b/apps/web/src/components/ui/ReviewBadge.css
@@ -1,0 +1,12 @@
+/* "incelemede" in-review badge (#2200) — matches the profile katkıların badge
+   (ContributionRow.css). State is carried by the word, not color alone; the role
+   tokens are AA-contrast. */
+.kp-review-badge {
+	font: var(--t-meta);
+	font-weight: 600;
+	padding: 2px 6px;
+	border-radius: 4px;
+	background: var(--warning-soft, var(--accent-soft));
+	color: var(--warning, var(--accent));
+	text-transform: lowercase;
+}

--- a/apps/web/src/components/ui/ReviewBadge.tsx
+++ b/apps/web/src/components/ui/ReviewBadge.tsx
@@ -1,0 +1,14 @@
+// The "incelemede" in-review badge a çaylak sees on their OWN sandboxed content
+// (#2200). The `sandboxed` wire flag is owner-scoped server-side, so a caller only
+// ever has it `true` for the author themselves — this is the shared render for the
+// post-detail + definition surfaces (the profile katkıların list has its own #1291
+// badge). State is carried by the word, not color alone (the AA-contrast tokens).
+import "./ReviewBadge.css";
+
+export function ReviewBadge() {
+	return (
+		<span className="kp-review-badge" data-testid="incelemede-badge">
+			incelemede
+		</span>
+	);
+}

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.ts
@@ -124,6 +124,25 @@ export interface PublicLiveColumns extends SandboxColumns {
 export const publicLiveWhere = (cols: PublicLiveColumns, viewer: SandboxViewer): SQL | undefined =>
 	and(isNull(cols.removedAt), sandboxVisibleWhere(cols, viewer));
 
+/** The two record fields the owner-scoped in-review flag reads. */
+export interface OwnerSandboxRecord {
+	readonly sandboxedAt: Date | null;
+	readonly authorId: string;
+}
+
+/**
+ * The in-memory owner-scoped in-review flag (#2200): `true` iff the row is still
+ * sandboxed (#1205) AND the viewer is its author — the `sandboxed` wire signal a
+ * çaylak sees on their OWN in-review content. Owner-only by construction: any other
+ * viewer (anonymous, another member, a moderator) reads `false`, so the flag never
+ * leaks review state beyond the author. The in-memory dual of {@link sandboxArm}'s
+ * `Sandboxed` author branch, for the read paths that have already fetched the record.
+ */
+export const ownSandboxed = (
+	record: OwnerSandboxRecord,
+	viewerId: string | null | undefined,
+): boolean => record.sandboxedAt != null && viewerId != null && record.authorId === viewerId;
+
 /** The lifecycle columns the moderator sandbox queue reads. */
 export interface SandboxBacklogColumns {
 	readonly sandboxedAt: SQLWrapper;

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
@@ -12,7 +12,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as L from "./EntityLifecycle.ts";
-import {publicLiveWhere, sandboxVisibleWhere} from "./SandboxVisibility.ts";
+import {ownSandboxed, publicLiveWhere, sandboxVisibleWhere} from "./SandboxVisibility.ts";
 
 const at = new Date("2026-06-25T00:00:00.000Z");
 const AUTHOR = "caylak-author";
@@ -97,6 +97,31 @@ describe("sandboxVisibleWhere — the SQL predicate mirrors the decision shape",
 
 	it("an anonymous viewer gets a restricting predicate (public only)", () => {
 		assert.isDefined(sandboxVisibleWhere(cols, viewers.anonymous));
+	});
+});
+
+describe("ownSandboxed — the owner-scoped in-review flag (never leaks review state)", () => {
+	const ownSandboxedRecord = {sandboxedAt: at, authorId: AUTHOR};
+	const ownLiveRecord = {sandboxedAt: null, authorId: AUTHOR};
+
+	it("the author of a still-sandboxed row reads true (their own in-review signal)", () => {
+		assert.isTrue(ownSandboxed(ownSandboxedRecord, AUTHOR));
+	});
+
+	it("the author of a live (not-sandboxed) row reads false — no signal on public content", () => {
+		assert.isFalse(ownSandboxed(ownLiveRecord, AUTHOR));
+	});
+
+	it("another member never reads the flag on someone's sandboxed row", () => {
+		assert.isFalse(ownSandboxed(ownSandboxedRecord, OTHER));
+	});
+
+	it("a moderator (non-author) never reads the flag — owner-only, not moderator-scoped", () => {
+		assert.isFalse(ownSandboxed(ownSandboxedRecord, viewers.moderator.viewerId));
+	});
+
+	it("an anonymous viewer (null id) never reads the flag", () => {
+		assert.isFalse(ownSandboxed(ownSandboxedRecord, null));
 	});
 });
 

--- a/apps/web/worker/features/pano/post-fields.ts
+++ b/apps/web/worker/features/pano/post-fields.ts
@@ -87,6 +87,13 @@ export interface PostSummaryRow extends Omit<IntrinsicRow, "updatedAt" | "isDraf
 	/** Viewer's bookmark presence; `undefined` (unset) for reads that don't request it. */
 	isSaved?: boolean | null;
 	/**
+	 * The owner-scoped in-review flag (#2200): `true` iff this post is still sandboxed
+	 * (#1205) AND the viewer is its author, stamped by the read paths via `ownSandboxed`.
+	 * Owner-only by construction, so it never leaks review state to another viewer; a
+	 * read that doesn't stamp it leaves it `undefined` → the shaper defaults `false`.
+	 */
+	sandboxed?: boolean;
+	/**
 	 * The author's LIVE handle (`user_profile.username` / `.displayName`), stamped by
 	 * `stampAuthorIdentity` after the batched `getProfileIdentitiesByIds` read (#2139)
 	 * so the client renders the CURRENT display name via `actorLabel`, not the write-time
@@ -133,6 +140,7 @@ export type PostFields = Omit<IntrinsicRow, "updatedAt" | "isDraft" | "tags"> & 
 	isDraft?: boolean | null;
 	myVote?: boolean | null;
 	isSaved?: boolean | null;
+	sandboxed?: boolean;
 	authorUsername?: string | null;
 	authorDisplayName?: string | null;
 	reactions?: ReactionAggregate;
@@ -165,6 +173,7 @@ export const postViewFields = {
 	myVote: true,
 	isSaved: true,
 	isDraft: true,
+	sandboxed: true,
 	authorUsername: true,
 	authorDisplayName: true,
 	reactions: true,

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -33,6 +33,7 @@ import {applyRemovalTransition} from "../lifecycle/apply-removal-transition.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
+	ownSandboxed,
 	resolveSandboxViewer,
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
@@ -698,7 +699,13 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		// draft/ownership gate is enforced in SQL by `postVisibleWhere` above — a draft
 		// the viewer doesn't own never reaches this batch — so a surviving `isDraft` row
 		// is the author's own: read-your-writes, now verified rather than assumed.
-		const intrinsic = fetched.map(toPostSummaryRow);
+		// `sandboxed` is the owner-scoped in-review flag (#2200): computed off the fetched
+		// record (`sandboxed_at` + `author_id`) against the viewer, so it lands `true` only
+		// for the author's own still-in-review post and never leaks to another viewer.
+		const intrinsic = fetched.map((p) => ({
+			...toPostSummaryRow(p),
+			sandboxed: ownSandboxed(p, viewerId),
+		}));
 		const scalared = yield* stampViewerScalars(intrinsic, viewerId, postViewerScalars);
 		const reacted = yield* stampReactionAggregate(reactionSvc, "post", scalared, viewerId);
 		return yield* stampAuthorIdentity(readProfileIdentities, reacted);

--- a/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
@@ -82,6 +82,7 @@ const KEYSET_WIRE_FIELDS = [
 	"createdAt",
 	"myVote",
 	"isSaved",
+	"sandboxed",
 	"reactions",
 	"tags",
 ] as const;
@@ -147,6 +148,7 @@ describe("Pano Post wire shaper — by-id and keyset summaries converge (#1161, 
 			"isSaved",
 			"myVote",
 			"reactions",
+			"sandboxed",
 			"score",
 			"slug",
 			"tags",
@@ -159,6 +161,9 @@ describe("Pano Post wire shaper — by-id and keyset summaries converge (#1161, 
 		assert.strictEqual(wire.myVote, null);
 		assert.strictEqual(wire.isSaved, null);
 		assert.strictEqual(wire.isDraft, null);
+		// The owner-scoped in-review flag is stamped only by the read path (#2200); a
+		// bare summary shape defaults it `false`, never leaking review state.
+		assert.strictEqual(wire.sandboxed, false);
 		// No reactions requested on a bare summary read → the empty aggregate.
 		assert.deepStrictEqual(wire.reactions, EMPTY_REACTION_AGGREGATE);
 	});

--- a/apps/web/worker/features/pano/queries.ts
+++ b/apps/web/worker/features/pano/queries.ts
@@ -51,6 +51,7 @@ export const queries = {
 					authorUsername: stamped?.authorUsername ?? null,
 					authorDisplayName: stamped?.authorDisplayName ?? null,
 				},
+				stamped?.sandboxed ?? false,
 			);
 
 			// The native path doesn't auto-invoke a nested relation's `connection`

--- a/apps/web/worker/features/pano/shapers.ts
+++ b/apps/web/worker/features/pano/shapers.ts
@@ -43,6 +43,7 @@ export const toPost = (r: PostFields): Post => ({
 	myVote: r.myVote ?? null,
 	isSaved: r.isSaved ?? null,
 	isDraft: r.isDraft ?? null,
+	sandboxed: r.sandboxed ?? false,
 	reactions: r.reactions ?? EMPTY_REACTION_AGGREGATE,
 	tags: [...r.tags],
 });
@@ -60,6 +61,7 @@ export const toPostFromPage = (
 	isSaved: boolean | null = null,
 	reactions: ReactionAggregate = EMPTY_REACTION_AGGREGATE,
 	identity: {authorUsername?: string | null; authorDisplayName?: string | null} = {},
+	sandboxed = false,
 ): Post =>
 	toPost({
 		id: page.id,
@@ -78,6 +80,7 @@ export const toPostFromPage = (
 		updatedAt: page.updatedAt,
 		myVote,
 		isSaved,
+		sandboxed,
 		reactions,
 		tags: page.tags,
 	});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -22,6 +22,7 @@ import {applyRemovalTransition} from "../lifecycle/apply-removal-transition.ts";
 import {anonymousViewer, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
+	ownSandboxed,
 	publicLiveWhere,
 	resolveSandboxViewer,
 	sandboxBacklogWhere,
@@ -686,7 +687,18 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.limit(first + 1),
 			);
 
-			const page = forwardPage(fetched, first, (r: DefinitionRow) => r.id, toDefinitionRow);
+			// `sandboxed` is the owner-scoped in-review flag (#2200): computed off the fetched
+			// record against the viewer, so a çaylak sees the "incelemede" signal on their OWN
+			// still-in-review definition and no other viewer ever receives it.
+			const page = forwardPage(
+				fetched,
+				first,
+				(r: DefinitionRow) => r.id,
+				(d) => ({
+					...toDefinitionRow(d),
+					sandboxed: ownSandboxed(d, viewerId),
+				}),
+			);
 			const scalared = yield* stampViewerScalars(page.rows, viewerId, [definitionVoteScalar]);
 			const reacted = yield* stampReactionAggregate(reactionSvc, "definition", scalared, viewerId);
 			const rows = yield* stampAuthorIdentity(pasaport.getProfileIdentitiesByIds, reacted);
@@ -719,9 +731,11 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						),
 					),
 			);
-			const scalared = yield* stampViewerScalars(fetched.map(toDefinitionRow), viewerId, [
-				definitionVoteScalar,
-			]);
+			const scalared = yield* stampViewerScalars(
+				fetched.map((d) => ({...toDefinitionRow(d), sandboxed: ownSandboxed(d, viewerId)})),
+				viewerId,
+				[definitionVoteScalar],
+			);
 			const reacted = yield* stampReactionAggregate(reactionSvc, "definition", scalared, viewerId);
 			return yield* stampAuthorIdentity(pasaport.getProfileIdentitiesByIds, reacted);
 		});

--- a/apps/web/worker/features/sozluk/definition-fields.ts
+++ b/apps/web/worker/features/sozluk/definition-fields.ts
@@ -47,6 +47,13 @@ type IntrinsicRow = {[K in keyof typeof intrinsicFields]: ReturnType<(typeof int
 export interface DefinitionRow extends IntrinsicRow {
 	myVote?: boolean | null;
 	/**
+	 * The owner-scoped in-review flag (#2200): `true` iff this definition is still
+	 * sandboxed (#1205) AND the viewer is its author, stamped by the read paths via
+	 * `ownSandboxed`. Owner-only by construction, so it never leaks review state to
+	 * another viewer; a read that doesn't stamp it leaves it `undefined` → default `false`.
+	 */
+	sandboxed?: boolean;
+	/**
 	 * The author's LIVE handle (`user_profile.username` / `.displayName`), stamped by
 	 * `stampAuthorIdentity` after the batched `getProfileIdentitiesByIds` read (#2139)
 	 * so the client renders the CURRENT display name via `actorLabel`, not the write-time
@@ -98,6 +105,7 @@ export const definitionViewFields = {
 	createdAt: true,
 	updatedAt: true,
 	myVote: true,
+	sandboxed: true,
 	authorUsername: true,
 	authorDisplayName: true,
 	reactions: true,

--- a/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
@@ -51,6 +51,9 @@ describe("Sözlük Definition wire shaper — derived from the one column→fiel
 			createdAt: new Date(1000),
 			updatedAt: new Date(2000),
 			myVote: null,
+			// Owner-scoped in-review flag (#2200): stamped only by the read path, so a bare
+			// row shape defaults it `false` and never leaks review state to another viewer.
+			sandboxed: false,
 			reactions: EMPTY_REACTION_AGGREGATE,
 		});
 	});
@@ -69,12 +72,15 @@ describe("Sözlük Definition wire shaper — derived from the one column→fiel
 			"id",
 			"myVote",
 			"reactions",
+			"sandboxed",
 			"score",
 			"updatedAt",
 		]);
 		assert.strictEqual(wire.__typename, "Definition");
 		// No viewer scalar stamped on a bare row read → defaulted to `null`.
 		assert.strictEqual(wire.myVote, null);
+		// Owner-scoped in-review flag defaults `false` on a bare row shape (#2200).
+		assert.strictEqual(wire.sandboxed, false);
 		// No reactions stamped on a bare row read → the empty aggregate.
 		assert.deepStrictEqual(wire.reactions, EMPTY_REACTION_AGGREGATE);
 	});

--- a/apps/web/worker/features/sozluk/shapers.ts
+++ b/apps/web/worker/features/sozluk/shapers.ts
@@ -79,5 +79,6 @@ export const toDefinition = (r: DefinitionRow): Definition => ({
 	createdAt: r.createdAt,
 	updatedAt: r.updatedAt,
 	myVote: r.myVote ?? null,
+	sandboxed: r.sandboxed ?? false,
 	reactions: r.reactions ?? EMPTY_REACTION_AGGREGATE,
 });


### PR DESCRIPTION
Fixes #2200

A çaylak viewing their own just-posted pano post or sözlük definition saw it rendered identically to public content — same styling, ranked, full action bar — with **no** "incelemede" signal, contradicting the composer's promise that çaylak content is reviewed before it goes public. The `Post`/`Definition` fate views never carried the sandbox review-state flag the profile katkıların surface already exposes (#1316/#1291).

## What changed

- **Owner-scoped `sandboxed` flag on `Post` + `Definition` views.** New pure helper `ownSandboxed(record, viewerId)` (in `apps/web/worker/features/lifecycle/SandboxVisibility.ts`) resolves `true` only when the row is still sandboxed (#1205) **AND** the viewer is its author. Stamped at the read paths (`getPostsByIds`, `listDefinitionsKeyset`, `getDefinitionsByIds`); threaded through the post-detail resolver. Owner-only **by construction** — any other viewer (anonymous, another member, a moderator) reads `false`, so review state never leaks. The wire shaper defaults the field `false`, so a read that never stamps it (feed keyset) is safe.
- **Render a shared `ReviewBadge` ("incelemede")** on the pano post-detail header (`PanoPostHeader`) and the sözlük definition (`DefinitionCard`), re-gated on `isAuthor` per the owner-only scope. The `/profile` katkıların badge (#1291) already exists and is **untouched**.

## Scope

OWNER-scoped only (gate `viewer==author && sandboxed==true`), on the owner's own post/definition detail. Not public, not moderator-only. The broader access-model decision (#2217) is separate.

## Acceptance criteria

- [x] `Post` and `Definition` fate views carry a `sandboxed` boolean, exposed to the author-self only (owner-scoped; never leaks to another viewer).
- [x] A çaylak viewing their own sandboxed pano post / sözlük definition detail sees a clear "incelemede" signal; a yazar's live content shows no such signal.
- [x] Non-author viewers never receive a `true` flag (owner-scoped by construction).

## Verification

Local gates green: `pnpm typecheck`, `pnpm lint`, and the pano + sözlük + profile unit/client suites (289 tests). The two wire-convergence tests (`post-wire-convergence`, `definition-wire-convergence`) are extended to pin the new field's `false` default so the shaper key-set stays in lockstep.

§CP: NO — product code, auto-ships on green.