### PR TITLE
fix(web): relocate pano reaction bar from the feed card to the post detail (#2212)

### DIFF
--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -12,8 +12,6 @@ import {toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
 import {tagClass} from "../../lib/panoTags";
 import {actorLabel} from "../moderation/actor-identity";
-import {PostReactionBar} from "../reaction/PostReactionBar";
-import {ReactionBarSlot} from "../reaction/ReactionBarSlot";
 import {Tag, type TagKind} from "../ui/atoms";
 import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 import "./PanoPost.css";
@@ -34,7 +32,6 @@ export const PanoPostCardView = view<Post>()({
 	authorDisplayName: true,
 	slug: true,
 	tags: true,
-	reactions: {counts: true, myReaction: true},
 });
 
 export function PanoPostCard({
@@ -108,9 +105,6 @@ export function PanoPostCard({
 						</>
 					) : null}
 				</div>
-				<ReactionBarSlot>
-					<PostReactionBar postId={data.id} reactions={data.reactions} />
-				</ReactionBarSlot>
 			</div>
 		</article>
 	);

--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -10,6 +10,8 @@ import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
 import {tagClass} from "../../lib/panoTags";
 import {actorLabel} from "../moderation/actor-identity";
+import {PostReactionBar} from "../reaction/PostReactionBar";
+import {ReactionBarSlot} from "../reaction/ReactionBarSlot";
 import {Tag, type TagKind} from "../ui/atoms";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
@@ -52,6 +54,7 @@ export const PanoPostHeaderView = view<Post>()({
 	updatedAt: true,
 	sandboxed: true,
 	tags: true,
+	reactions: {counts: true, myReaction: true},
 });
 
 export interface PanoPostHeaderProps {
@@ -122,6 +125,11 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 					))}
 				</div>
 			) : null}
+			{/* Reactions are scoped to the post detail, not the feed row (#2212) — mirroring
+			    how sözlük scopes them to the definition detail, not the term list. */}
+			<ReactionBarSlot>
+				<PostReactionBar postId={post.id} reactions={post.reactions} />
+			</ReactionBarSlot>
 		</div>
 	);
 }

--- a/apps/web/src/components/pano/reactionBarPlacement.test.ts
+++ b/apps/web/src/components/pano/reactionBarPlacement.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Pins the reaction-bar placement decision (#2212, founder ruled option (b)
+ * keep-but-relocate): pano reactions live on the post DETAIL surface, not the
+ * feed row — mirroring how sözlük scopes reactions to the definition detail
+ * (`DefinitionCard`), never the term list. The upvote (△) stays the feed-level
+ * signal, so `PostVoteWidget` must remain on the card.
+ *
+ * A static source assertion (like `styles/focus-layer.test.ts`) rather than a
+ * render: the contract is *which surface wires the bar*, which the imports +
+ * JSX tag encode directly and stably — no fate client/session harness, and it
+ * won't churn when unrelated card work lands.
+ */
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+const feedCard = read("./PanoPostCard.tsx");
+const detailHeader = read("./PanoPostHeader.tsx");
+
+describe("reaction-bar placement — detail surface, not the feed (#2212)", () => {
+	it("the feed card does NOT render the reaction bar", () => {
+		expect(feedCard).not.toContain("PostReactionBar");
+		expect(feedCard).not.toContain("ReactionBarSlot");
+	});
+
+	it("the feed card keeps the upvote signal", () => {
+		expect(feedCard).toContain("PostVoteWidget");
+	});
+
+	it("the post-detail header renders the reaction bar (mirroring sözlük's definition detail)", () => {
+		expect(detailHeader).toContain("ReactionBarSlot");
+		expect(detailHeader).toContain("PostReactionBar");
+	});
+});


### PR DESCRIPTION
Relocates the pano reaction bar from the feed card to the post-detail surface — the founder-ruled option (b) keep-but-relocate for #2212.

## What changed
- **`PanoPostCard.tsx` (feed row) loses the emoji bar.** Removed `ReactionBarSlot` + `PostReactionBar` and the now-unused `reactions` field from `PanoPostCardView`. This same card is the /pano feed row *and* the search-results row, so the bar leaves both surfaces at once.
- **`PanoPostHeader.tsx` (post detail) gains the emoji bar.** Added `reactions` to `PanoPostHeaderView` and rendered `<ReactionBarSlot><PostReactionBar …/></ReactionBarSlot>` after the post body — mirroring how sözlük scopes the bar to the definition **detail** (`DefinitionCard`), never the term list. `PanoPostHeader` is rendered by `PanoPostDetail`, so the bar now appears once per post, on its own page.
- **The upvote (△) stays the feed-level signal.** `PostVoteWidget` on the feed card is untouched, as is the #2230 self-vote hide logic.

The `post.react` mutation and its `/fate/live` publish are unchanged — only the render surface moves. `fanout-guard check` stays green (38 classified, 24 fanned, all publish).

## Grounding
- Sözlük mirror: `apps/web/src/components/sozluk/DefinitionCard.tsx` wires the bar on the definition detail, not `TermRow`/the list — the exact pattern followed here.
- ADR 0139 ("reactions span posts, comments, definitions") and the shipped `PostReactionBar` (#1867) are preserved — the feature moves surfaces, it doesn't die.

## Test
`apps/web/src/components/pano/reactionBarPlacement.test.ts` — a static source assertion (like `styles/focus-layer.test.ts`) pinning the placement contract: the feed card renders neither `PostReactionBar` nor `ReactionBarSlot` but keeps `PostVoteWidget`; the detail header renders both. 3 new cases, all green; the full reaction suite (29 tests) passes.

`pnpm typecheck`, biome, fanout-guard: all green.

Fixes #2212

🤖 Generated with [Claude Code](https://claude.com/claude-code)