### PR TITLE
test(vote): assert self-vote rejection end-to-end at the integration tier

### DIFF
--- a/apps/web/tests/integration/pano-mutations.test.ts
+++ b/apps/web/tests/integration/pano-mutations.test.ts
@@ -210,7 +210,11 @@ describe("pano mutations — post.vote / retractVote", () => {
 		if (result.ok) return;
 		expect(result.error.code).toBe("SELF_VOTE_NOT_ALLOWED");
 
-		// The rejected cast wrote nothing: the post is still at score 0 with no vote stamped.
+		// The rejected cast wrote nothing: the post is still at score 0, and the author's
+		// re-resolve stamps `myVote: false` — the authenticated-but-unvoted default. In
+		// stampViewerScalars the scalar is `viewerId ? set.has(id) : null`; the author IS the
+		// viewer here (non-null viewerId), so an unvoted post is `false`, not the anonymous-only
+		// `null`. Matches the retractVote sibling below and the sözlük counterpart.
 		const detail = await h.fate(
 			{kind: "query", name: "post", args: {idOrSlug: id}, select: ["id", "score", "myVote"]},
 			{cookie: author.cookie},
@@ -218,7 +222,7 @@ describe("pano mutations — post.vote / retractVote", () => {
 		expect(detail.ok).toBe(true);
 		if (!detail.ok) return;
 		expect((detail.data as PostNode).score).toBe(0);
-		expect((detail.data as PostNode).myVote).toBeNull();
+		expect((detail.data as PostNode).myVote).toBe(false);
 	});
 
 	// The guard is cast-only (#2216): the author retracting a vote on its own post is exempt —

--- a/apps/web/tests/integration/pano-mutations.test.ts
+++ b/apps/web/tests/integration/pano-mutations.test.ts
@@ -195,6 +195,45 @@ describe("pano mutations — post.vote / retractVote", () => {
 		if (result.ok) return;
 		expect(result.error.code).toBe("POST_NOT_FOUND");
 	});
+
+	// The self-vote block (#2216) proven end-to-end through the real mutation, not just the
+	// domain unit (self-vote-guard.unit.test.ts): `author` is a promoted yazar, so it clears
+	// the earn-to-vote gate (#1810) and it is the self-vote guard specifically that rejects a
+	// cast on its own post with the `SELF_VOTE_NOT_ALLOWED` wire code the client receives.
+	it("post.vote by the post's own author is rejected with SELF_VOTE_NOT_ALLOWED", async () => {
+		const id = await seedPost({title: `${NS} self-vote target`, tags: [{kind: "soru"}]});
+		const result = await h.fate(
+			{kind: "mutation", name: "post.vote", input: {id}, select: ["id", "score", "myVote"]},
+			{cookie: author.cookie},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.code).toBe("SELF_VOTE_NOT_ALLOWED");
+
+		// The rejected cast wrote nothing: the post is still at score 0 with no vote stamped.
+		const detail = await h.fate(
+			{kind: "query", name: "post", args: {idOrSlug: id}, select: ["id", "score", "myVote"]},
+			{cookie: author.cookie},
+		);
+		expect(detail.ok).toBe(true);
+		if (!detail.ok) return;
+		expect((detail.data as PostNode).score).toBe(0);
+		expect((detail.data as PostNode).myVote).toBeNull();
+	});
+
+	// The guard is cast-only (#2216): the author retracting a vote on its own post is exempt —
+	// a retract by the owner is not rejected (here a no-op, since no vote was cast).
+	it("post.retractVote by the post's own author is NOT rejected (cast-only guard)", async () => {
+		const id = await seedPost({title: `${NS} self-retract exempt`, tags: [{kind: "soru"}]});
+		const result = await h.fate(
+			{kind: "mutation", name: "post.retractVote", input: {id}, select: ["id", "score", "myVote"]},
+			{cookie: author.cookie},
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect((result.data as PostNode).score).toBe(0);
+		expect((result.data as PostNode).myVote).toBe(false);
+	});
 });
 
 describe("pano mutations — post.edit / post.delete", () => {

--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -393,6 +393,71 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		if (result.ok) return;
 		expect(result.error.code).toBe("DEFINITION_NOT_FOUND");
 	});
+
+	// The self-vote block (#2216) proven end-to-end through the real mutation, not just the
+	// domain unit (self-vote-guard.unit.test.ts): `author` is a promoted yazar, so it clears
+	// the earn-to-vote gate (#1810) and it is the self-vote guard specifically that rejects a
+	// cast on its own definition with the `SELF_VOTE_NOT_ALLOWED` wire code the client receives.
+	it("definition.vote by the definition's own author is rejected with SELF_VOTE_NOT_ALLOWED", async () => {
+		const slug = `${NS}-self-vote`;
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "definition.add",
+				input: {termSlug: slug, body: "a self-vote target"},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const id = (added.data as DefNode).id;
+
+		const result = await h.fate(
+			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score", "myVote"]},
+			{cookie: author.cookie},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.code).toBe("SELF_VOTE_NOT_ALLOWED");
+
+		// The rejected cast wrote nothing: the definition is still at score 0 with no vote stamped.
+		const detail = await h.fate(
+			{kind: "mutation", name: "definition.retractVote", input: {id}, select: ["score", "myVote"]},
+			{cookie: author.cookie},
+		);
+		expect(detail.ok).toBe(true);
+		if (!detail.ok) return;
+		expect((detail.data as DefNode).score).toBe(0);
+		expect((detail.data as DefNode).myVote).toBe(false);
+	});
+
+	// The guard is cast-only (#2216): the author retracting a vote on its own definition is
+	// exempt — a retract by the owner is not rejected (here a no-op, since no vote was cast).
+	it("definition.retractVote by the definition's own author is NOT rejected (cast-only guard)", async () => {
+		const slug = `${NS}-self-retract-exempt`;
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "definition.add",
+				input: {termSlug: slug, body: "a self-retract exempt target"},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const id = (added.data as DefNode).id;
+
+		const result = await h.fate(
+			{kind: "mutation", name: "definition.retractVote", input: {id}, select: ["score", "myVote"]},
+			{cookie: author.cookie},
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect((result.data as DefNode).score).toBe(0);
+		expect((result.data as DefNode).myVote).toBe(false);
+	});
 });
 
 describe("sozluk mutations — definition.edit", () => {


### PR DESCRIPTION
The self-vote block (`vote/SelfVoteNotAllowed` → wire `SELF_VOTE_NOT_ALLOWED`, #2216) is a karma-integrity invariant. It was proven **only at the unit tier** (`self-vote-guard.unit.test.ts` for pano + sözlük). The integration mutation suites exercised only the non-author happy path — nothing asserted a self-vote is rejected end-to-end through the real mutation wire (`post.vote` / `definition.vote`). This closes that gap.

## What changed (test files only — no product code)

`apps/web/tests/integration/pano-mutations.test.ts`:
- `post.vote` by the post's own author (a promoted yazar, so it clears the earn-to-vote gate #1810 and it is the self-vote guard specifically that fires) is rejected with `SELF_VOTE_NOT_ALLOWED`; the rejected cast wrote nothing (re-resolved post is `score 0`, `myVote null`).
- `post.retractVote` by the author is **not** rejected — the guard is cast-only.

`apps/web/tests/integration/sozluk-mutations.test.ts`:
- `definition.vote` by the definition's own author is rejected with `SELF_VOTE_NOT_ALLOWED`; the rejected cast wrote nothing (`score 0`, `myVote false`).
- `definition.retractVote` by the author is **not** rejected — cast-only guard.

The assertions mirror the suites' existing idiom (`expect(result.ok).toBe(false); expect(result.error.code).toBe(...)`), reusing the same `author` fixture (already promoted to yazar) so the earn-to-vote gate is cleared and the self-vote guard is the sole rejection cause.

## Verification

- `pnpm typecheck` (tsgo, full workspace incl. new test lines): clean.
- `pnpm lint:worktree`: clean.
- Full unit tier (`209 files / 1878 tests`) green locally, including the `self-vote-guard` unit suites and `wireCodes-per-class` (`SelfVoteNotAllowed` → `SELF_VOTE_NOT_ALLOWED`).
- The integration tier deploys to real remote Cloudflare (needs `CLOUDFLARE_*`/`ALCHEMY_PASSWORD`) — not runnable locally without creds; it runs on the deployed-stage tier in CI.

Fixes #2233