### PR TITLE
perf(web): short-circuit guaranteed-unauthorized divan.roster probe + dedupe subsumed profile read (#2209)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -164,7 +164,9 @@ function LayoutContent() {
 	// The yazar/mod-only divan entry (#1290), dark behind the same authorship-loop
 	// flag. `useDivanAccess` probes the server's gated read (yazar OR mod), so the
 	// entry is server-authoritative — invisible to çaylak/visitor, absent when off.
-	const divanAccess = useDivanAccess();
+	// `me` feeds the #2209 client short-circuit: a provably-denied çaylak/non-mod
+	// skips the guaranteed-`UNAUTHORIZED` probe; the ambiguous case still probes.
+	const divanAccess = useDivanAccess(me);
 	const showDivan = shouldShowDivanEntry(authorshipLoop, divanAccess);
 	// The bildirim entry + unread chip (#1694), dark behind the `phoenix-bildirim`
 	// flag. Gating the fetch on flag+session keeps the flag-off path exactly as

--- a/apps/web/src/components/divan/divanGating.test.ts
+++ b/apps/web/src/components/divan/divanGating.test.ts
@@ -9,11 +9,13 @@ import {describe, expect, it} from "vitest";
 import {
 	canVouch,
 	caylakLabel,
+	divanAccessDefinitelyDenied,
 	itemKindLabel,
 	parseBacklogItemId,
 	promoteOutcome,
 	promoteOutcomeMessage,
 	promoteVisible,
+	shouldProbeDivanRoster,
 	shouldRenderDivanPage,
 	shouldShowDivanEntry,
 	vouchOutcome,
@@ -48,6 +50,54 @@ describe("shouldShowDivanEntry — the yazar/mod-only topbar entry", () => {
 
 	it("hides the entry when both are false", () => {
 		expect(shouldShowDivanEntry(false, false)).toBe(false);
+	});
+});
+
+describe("divanAccessDefinitelyDenied — the #2209 client short-circuit for the roster probe", () => {
+	it("is TRUE for a loaded çaylak non-moderator (the guaranteed-UNAUTHORIZED case → skip the probe)", () => {
+		expect(divanAccessDefinitelyDenied("çaylak", false)).toBe(true);
+	});
+
+	it("is TRUE for a loaded visitor non-moderator", () => {
+		expect(divanAccessDefinitelyDenied("visitor", false)).toBe(true);
+	});
+
+	it("is FALSE for a yazar — the server grants, so it must still probe (never short-circuit a grant)", () => {
+		expect(divanAccessDefinitelyDenied("yazar", false)).toBe(false);
+	});
+
+	it("is FALSE for a çaylak who IS a moderator — the mod arm grants, so it must still probe", () => {
+		expect(divanAccessDefinitelyDenied("çaylak", true)).toBe(false);
+	});
+
+	it("is FALSE for the AMBIGUOUS not-yet-loaded case (undefined tier and/or undefined isModerator) → still probe", () => {
+		expect(divanAccessDefinitelyDenied(undefined, undefined)).toBe(false);
+		expect(divanAccessDefinitelyDenied(undefined, false)).toBe(false);
+		expect(divanAccessDefinitelyDenied("çaylak", undefined)).toBe(false);
+	});
+});
+
+describe("shouldProbeDivanRoster — fire the wire probe iff not client-provably denied (#2209)", () => {
+	it("does NOT fire the roster probe for a signed-in çaylak non-moderator (guaranteed UNAUTHORIZED)", () => {
+		expect(shouldProbeDivanRoster(true, true, "çaylak", false)).toBe(false);
+	});
+
+	it("does NOT fire for a signed-in visitor non-moderator", () => {
+		expect(shouldProbeDivanRoster(true, true, "visitor", false)).toBe(false);
+	});
+
+	it("DOES fire for the ambiguous not-yet-loaded viewer (undefined signals)", () => {
+		expect(shouldProbeDivanRoster(true, true, undefined, undefined)).toBe(true);
+	});
+
+	it("DOES fire for a yazar and for a çaylak moderator — the server is the authority for the grant", () => {
+		expect(shouldProbeDivanRoster(true, true, "yazar", false)).toBe(true);
+		expect(shouldProbeDivanRoster(true, true, "çaylak", true)).toBe(true);
+	});
+
+	it("never fires with the flag off or while signed out, regardless of tier", () => {
+		expect(shouldProbeDivanRoster(false, true, "yazar", true)).toBe(false);
+		expect(shouldProbeDivanRoster(true, false, "yazar", true)).toBe(false);
 	});
 });
 

--- a/apps/web/src/components/divan/divanGating.ts
+++ b/apps/web/src/components/divan/divanGating.ts
@@ -49,6 +49,44 @@ export function shouldShowDivanEntry(flagOn: boolean, accessGranted: boolean): b
 }
 
 /**
+ * Can the CLIENT prove — from its trusted signals alone — that `divan.roster`
+ * would deny this viewer, so the guaranteed-`UNAUTHORIZED` probe need never be
+ * fired (#2209)? The server grant is the disjunction yazar OR moderator
+ * (`requireDivanAccess`, divan/gate.ts), so denial is provable iff BOTH arms are
+ * KNOWN-false: the tier is loaded and below yazar (`visitor`/`çaylak`) AND the
+ * `isModerator` signal is loaded and false. An `undefined` tier (`me` not yet
+ * read) is the AMBIGUOUS case — the client cannot prove anything, so this returns
+ * `false` and the server probe still runs, keeping the server the sole authority
+ * for the yazar/mod case. The short-circuit is layered ON the server gate, never a
+ * replacement: a viewer this returns `false` for is still probed.
+ */
+export function divanAccessDefinitelyDenied(
+	tier: Tier | undefined,
+	isModerator: boolean | undefined,
+): boolean {
+	return tier !== undefined && tier !== "yazar" && isModerator === false;
+}
+
+/**
+ * Should `useDivanAccess` fire the server-side `divan.roster` wire probe (#2209)?
+ * TRUE only when the flag is on, the viewer is signed in, and access is NOT
+ * client-provably denied. A provably-denied çaylak/non-mod ({@link
+ * divanAccessDefinitelyDenied}) returns `false` — the guaranteed-`UNAUTHORIZED`
+ * request is never issued — while the AMBIGUOUS case (a not-yet-loaded `me`, a
+ * yazar, or a moderator) returns `true`, so the server stays the sole authority for
+ * the yazar/mod grant. Factored DOM-free so "the probe fires iff …" is asserted
+ * without a React runtime (`apps/web/src` has no jsdom).
+ */
+export function shouldProbeDivanRoster(
+	flagOn: boolean,
+	signedIn: boolean,
+	tier: Tier | undefined,
+	isModerator: boolean | undefined,
+): boolean {
+	return flagOn && signedIn && !divanAccessDefinitelyDenied(tier, isModerator);
+}
+
+/**
  * Show the yazar **"kefil ol"** (vouch) affordance iff the viewer is a yazar — the
  * trusted account tier (`requireVouch` is the yazar floor server-side). A mod who
  * is not a yazar cannot vouch, so the affordance is yazar-tier only.

--- a/apps/web/src/components/divan/useDivanAccess.ts
+++ b/apps/web/src/components/divan/useDivanAccess.ts
@@ -1,10 +1,18 @@
 /**
  * `useDivanAccess` — the server-authoritative answer to "may THIS user see the
  * divan?" (#1290). The divan is reached by yazar OR mod (the disjunctive
- * `requireDivanAccess` gate, divan/gate.ts), and the frontend carries no mod
- * signal (`role` is not on the `User` view) — so rather than guess authority
- * client-side, this probes the gated `divan.roster` read and reports whether it
+ * `requireDivanAccess` gate, divan/gate.ts), so rather than guess authority for the
+ * ambiguous case, this probes the gated `divan.roster` read and reports whether it
  * resolved (granted) or denied (the invisible `UNAUTHORIZED`).
+ *
+ * Client short-circuit (#2209): the `me` row carries the trusted `tier` +
+ * `isModerator` signals, so for a viewer whose disjunction is PROVABLY false
+ * (`divanAccessDefinitelyDenied` — a loaded non-yazar tier AND a loaded
+ * `isModerator: false`, i.e. a çaylak/visitor non-mod) the probe is skipped: it
+ * would return `UNAUTHORIZED` on every authed load. The server probe still runs for
+ * the AMBIGUOUS case (`me` not yet loaded, a yazar, or a moderator) — the gate stays
+ * server-authoritative; the short-circuit only elides a request the client can PROVE
+ * is wasted.
  *
  * Imperative (`request` in an effect, not the suspending `useRequest`), for the
  * same reason as `useMe` / `useProfileStats`: it drives the topbar entry, which
@@ -24,21 +32,27 @@ import {useCallback, useEffect, useState} from "react";
 import {useFateClient, view} from "react-fate";
 import type {DivanCaylak} from "../../../worker/features/fate/views";
 import {useSession} from "../../auth/client";
+import type {MeUser} from "../../auth/useMe";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../flags/keys";
 import {useFlag} from "../../flags/useFlag";
+import {shouldProbeDivanRoster} from "./divanGating";
 
 const DivanAccessProbeView = view<DivanCaylak>()({id: true});
 const DivanRosterProbeConnection = {items: {node: DivanAccessProbeView}} as const;
 
-export function useDivanAccess(): boolean {
+export function useDivanAccess(me: MeUser | null): boolean {
 	const {value: flagOn} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
 	const session = useSession();
 	const fate = useFateClient();
 	const [granted, setGranted] = useState(false);
 	const signedIn = !!session.data;
+	// Fire the wire probe only when the flag+session are on AND access isn't
+	// client-provably denied (#2209): a çaylak/non-mod short-circuits off the wire; a
+	// not-yet-loaded `me`, a yazar, or a moderator is ambiguous ⇒ still probed.
+	const probeWire = shouldProbeDivanRoster(flagOn, signedIn, me?.tier, me?.isModerator);
 
 	const probe = useCallback(async () => {
-		if (!flagOn || !signedIn) {
+		if (!probeWire) {
 			setGranted(false);
 			return;
 		}
@@ -52,7 +66,7 @@ export function useDivanAccess(): boolean {
 			// failure ⇒ no access. Fail-closed: the entry stays hidden.
 			setGranted(false);
 		}
-	}, [flagOn, signedIn, fate]);
+	}, [probeWire, fate]);
 
 	useEffect(() => {
 		void probe();

--- a/apps/web/src/components/profile/ProfileContributionSignal.tsx
+++ b/apps/web/src/components/profile/ProfileContributionSignal.tsx
@@ -32,8 +32,18 @@ const SIGNAL_SIZE = 5;
 
 const ContributionsConnectionView = {items: {node: ContributionView}} as const;
 
+// Selects the count scalars alongside `contributions` so this read is a SUPERSET
+// of `useProfileStats`'s counts-only `profile` read (#2209): the two share a
+// `profile` root queryKey (root-path args `{username}`), so once this superset
+// populates the record, the sibling counts-only read on `/profile` resolves those
+// scalars from the normalized store instead of a second wire round-trip — the
+// counts read deduped onto this fuller one. The scalars aren't rendered here.
 const SignalView = view<Profile>()({
 	userId: true,
+	postCount: true,
+	commentCount: true,
+	definitionCount: true,
+	totalKarma: true,
 	contributions: ContributionsConnectionView,
 });
 


### PR DESCRIPTION
## What

Two client-side over-fetches on the profile surfaces, both grounded against the worker query source. No user-visible behavior change (topbar entries, stats) — round-trip reduction only.

### 1 — `divan.roster` probe skipped for a client-provably-denied viewer
`useDivanAccess` fired the yazar/moderator-gated `divan.roster` read on every authed layout mount, which is guaranteed to return `UNAUTHORIZED` ("Divanı görmek için yazar ya da moderatör olmalısın") for a çaylak/non-mod. The `me` row already carries the trusted `tier` + `isModerator` signals, so a new pure predicate `shouldProbeDivanRoster` short-circuits the wire probe when access is client-**provably** denied — a loaded non-yazar tier **and** `isModerator: false`.

The server probe still runs for the **ambiguous** case (`me` not yet loaded → `undefined` signals, a yazar, or a moderator): the disjunctive `requireDivanAccess` gate (`apps/web/worker/features/divan/gate.ts`, yazar **OR** mod) stays the sole authority. The short-circuit is an optimization layered **on** the server gate, never a replacement — it only elides a request the client can prove is wasted.

### 2 — subsumed counts-only `profile` read deduped onto the fuller read
`ProfileContributionSignal`'s `SignalView` now selects the count scalars, making its `/profile` read a **superset** of `useProfileStats`'s counts-only `profile` read. Both share the `profile` root queryKey (root-path args `{username}` — the nested `contributions` arg does not enter the root descriptor key), so once the superset populates the normalized record, the counts-only read resolves those scalars from the store instead of a second wire round-trip — deduped onto the existing fuller read (AC #1).

Grounded in `@nkzw/fate` source: `getRootDescriptorKey` keys the query on root-path args only; `executeRequest` skips the wire fetch for a query item when `missingForSelection` is empty for an already-resolved queryKey.

## Scope
Data/fetch layer only. Stays out of the `ProfileHeader`/`ProfilePage` header markup that #2203/#2231 just restructured (the added `SignalView` scalars are fetched, never rendered).

## Tests
`apps/web/src/components/divan/divanGating.test.ts`:
- `shouldProbeDivanRoster` — proves the roster probe is **NOT** issued for a signed-in çaylak/visitor non-mod, and **IS** issued for the ambiguous (not-yet-loaded), yazar, and moderator cases; never fires flag-off or signed-out.
- `divanAccessDefinitelyDenied` — the underlying provable-denial predicate.

`pnpm typecheck`, `biome check`, and the divan + `App.test.tsx` suites are green.

Fixes #2209