### PR TITLE
chore(pipeline): sweep orphaned agent worktrees on SessionStart cadence (#2238)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,6 +77,10 @@
 					{
 						"type": "command",
 						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" spawn-guard freshness"
+					},
+					{
+						"type": "command",
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" worktree-sweep --execute"
 					}
 				]
 			}

--- a/claude-plugins/kampus-pipeline/hooks.json
+++ b/claude-plugins/kampus-pipeline/hooks.json
@@ -1,5 +1,5 @@
 {
-	"description": "kampus-pipeline portable guard surface: SessionStart-installs @kampus/pipeline-cli into ${CLAUDE_PLUGIN_DATA} (version-aware, idempotent, network-resilient) and wires the read/worktree/spawn guards through a fail-open dispatch wrapper. Mirrors the matchers in phoenix's .claude/settings.json (ADR 0103, #1001). Inert until the plugin is enabled (#1003).",
+	"description": "kampus-pipeline portable guard surface: SessionStart-installs @kampus/pipeline-cli into ${CLAUDE_PLUGIN_DATA} (version-aware, idempotent, network-resilient), sweeps orphaned agent worktrees left by aborted/hard-stopped lanes via the safe `worktree-sweep --execute` classifier (#2238), and wires the read/worktree/spawn guards through a fail-open dispatch wrapper. Mirrors the matchers in phoenix's .claude/settings.json (ADR 0103, #1001). Inert until the plugin is enabled (#1003).",
 	"hooks": {
 		"SessionStart": [
 			{
@@ -13,6 +13,10 @@
 					{
 						"type": "command",
 						"command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/guard.sh spawn-guard freshness"
+					},
+					{
+						"type": "command",
+						"command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/guard.sh worktree-sweep --execute"
 					}
 				]
 			}

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
@@ -1,0 +1,86 @@
+/**
+ * End-to-end guard for the SessionStart cadence (#2238): the wiring runs
+ * `pipeline-cli worktree-sweep --execute`, so this drives that exact command
+ * against a REAL git repo and asserts the safe-prune invariant holds through the
+ * command boundary — a clean, merged worktree is removed WITHOUT `--force`, and a
+ * dirty (unpushed) worktree is KEPT. The pure classifier is unit-tested in
+ * `worktree-sweep.unit.test.ts`; this proves the executable the cadence invokes
+ * honors that classification and never force-discards work.
+ */
+import {execFile, execFileSync} from "node:child_process";
+import {existsSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+// Run `pipeline-cli worktree-sweep [--execute]` with the process cwd inside `mainRepo`
+// (the sweep enumerates the current repo's worktrees), exactly as the SessionStart hook does.
+const runSweep = (cwd: string, flags: ReadonlyArray<string>): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile("node", [BIN, "worktree-sweep", ...flags], {cwd}, (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+	});
+
+describe("worktree-sweep --execute — SessionStart cadence against a REAL git repo (#2238)", () => {
+	let mainRepo: string;
+	const git = (cwd: string, ...args: string[]) =>
+		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
+
+	beforeAll(() => {
+		mainRepo = mkdtempSync(join(tmpdir(), "wts-main-"));
+		git(mainRepo, "init", "-q", "-b", "main");
+		git(mainRepo, "config", "user.email", "t@t.t");
+		git(mainRepo, "config", "user.name", "t");
+		writeFileSync(join(mainRepo, "README.md"), "x");
+		git(mainRepo, "add", ".");
+		git(mainRepo, "commit", "-q", "-m", "init");
+		// `origin/main` is the reachability oracle the classifier consults — point it at self.
+		git(mainRepo, "remote", "add", "origin", mainRepo);
+		git(mainRepo, "fetch", "-q", "origin");
+	});
+
+	afterAll(() => {
+		rmSync(mainRepo, {recursive: true, force: true});
+	});
+
+	it("removes a CLEAN worktree reachable from origin/main, and KEEPS a DIRTY one (never --force)", async () => {
+		// Clean + reachable (detached at a commit already on origin/main) → removable.
+		const cleanWt = join(mainRepo, ".claude", "worktrees", "wf_clean");
+		git(mainRepo, "worktree", "add", "-q", "--detach", cleanWt, "HEAD");
+		// Dirty → must be KEPT with its unpushed file intact.
+		const dirtyWt = join(mainRepo, ".claude", "worktrees", "wf_dirty");
+		git(mainRepo, "worktree", "add", "-q", "--detach", dirtyWt, "HEAD");
+		writeFileSync(join(dirtyWt, "uncommitted.txt"), "unpushed work");
+
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"]);
+		assert.strictEqual(code, 0, stdout);
+		assert.isFalse(existsSync(cleanWt), "clean+merged worktree must be removed");
+		assert.isTrue(existsSync(dirtyWt), "dirty worktree must be kept");
+		assert.isTrue(
+			existsSync(join(dirtyWt, "uncommitted.txt")),
+			"unpushed file must survive — the classifier KEEPS dirty, and remove runs without --force",
+		);
+	}, 30_000);
+
+	it("dry-run (no --execute) touches nothing — the default cadence-free behavior stays safe", async () => {
+		const keepWt = join(mainRepo, ".claude", "worktrees", "wf_dryrun");
+		git(mainRepo, "worktree", "add", "-q", "--detach", keepWt, "HEAD");
+		const {code} = await runSweep(mainRepo, []);
+		assert.strictEqual(code, 0);
+		assert.isTrue(existsSync(keepWt), "dry-run must never remove a worktree");
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
@@ -2,13 +2,19 @@
  * End-to-end guard for the SessionStart cadence (#2238): the wiring runs
  * `pipeline-cli worktree-sweep --execute`, so this drives that exact command
  * against a REAL git repo and asserts the safe-prune invariant holds through the
- * command boundary — a clean, merged worktree is removed WITHOUT `--force`, and a
- * dirty (unpushed) worktree is KEPT. The pure classifier is unit-tested in
- * `worktree-sweep.unit.test.ts`; this proves the executable the cadence invokes
- * honors that classification and never force-discards work.
+ * command boundary — a clean, merged, IDLE, unlocked worktree is removed WITHOUT
+ * `--force`, while a dirty (unpushed), a recently-active, or a locked worktree is
+ * KEPT (the #2240 liveness guard — a live sibling lane must never be swept). The
+ * pure classifier is unit-tested in `worktree-sweep.unit.test.ts`; this proves the
+ * executable the cadence invokes honors that classification.
+ *
+ * The tmp repo's `origin` is a local path, not github.com, so the network open-PR
+ * signal is N/A here and the mtime-idle + locked guards carry liveness (the open-PR
+ * KEEP is proven at the pure-classifier level). Idleness is simulated by backdating
+ * the worktree dir + its per-tree `HEAD`/`logs/HEAD` mtimes past the 30-min threshold.
  */
 import {execFile, execFileSync} from "node:child_process";
-import {existsSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
@@ -35,10 +41,20 @@ const runSweep = (cwd: string, flags: ReadonlyArray<string>): Promise<RunResult>
 		});
 	});
 
-describe("worktree-sweep --execute — SessionStart cadence against a REAL git repo (#2238)", () => {
+describe("worktree-sweep --execute — SessionStart cadence against a REAL git repo (#2238/#2240)", () => {
 	let mainRepo: string;
 	const git = (cwd: string, ...args: string[]) =>
 		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
+
+	// Push a managed worktree's dir + per-tree HEAD/logs mtimes ~2h into the past so it reads
+	// idle (well past the 30-min threshold) — simulating an orphaned tree a live lane would not be.
+	const backdate = (wtPath: string) => {
+		const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		const gitdir = git(mainRepo, "-C", wtPath, "rev-parse", "--absolute-git-dir").trim();
+		for (const p of [wtPath, join(gitdir, "HEAD"), join(gitdir, "logs", "HEAD")]) {
+			if (existsSync(p)) utimesSync(p, old, old);
+		}
+	};
 
 	beforeAll(() => {
 		mainRepo = mkdtempSync(join(tmpdir(), "wts-main-"));
@@ -57,28 +73,47 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		rmSync(mainRepo, {recursive: true, force: true});
 	});
 
-	it("removes a CLEAN worktree reachable from origin/main, and KEEPS a DIRTY one (never --force)", async () => {
-		// Clean + reachable (detached at a commit already on origin/main) → removable.
-		const cleanWt = join(mainRepo, ".claude", "worktrees", "wf_clean");
-		git(mainRepo, "worktree", "add", "-q", "--detach", cleanWt, "HEAD");
-		// Dirty → must be KEPT with its unpushed file intact.
+	it("removes a CLEAN + IDLE + unlocked orphan, but KEEPS dirty / recently-active / locked (never --force)", async () => {
+		// Clean + reachable + IDLE (backdated) + unlocked → the only genuinely-orphaned tree → removed.
+		const orphanWt = join(mainRepo, ".claude", "worktrees", "wf_orphan");
+		git(mainRepo, "worktree", "add", "-q", "--detach", orphanWt, "HEAD");
+		backdate(orphanWt);
+
+		// Clean + reachable but RECENTLY-ACTIVE (fresh mtime, not backdated) → live lane → KEPT.
+		const liveWt = join(mainRepo, ".claude", "worktrees", "wf_live");
+		git(mainRepo, "worktree", "add", "-q", "--detach", liveWt, "HEAD");
+
+		// Clean + reachable + idle but LOCKED → pinned in-use → KEPT.
+		const lockedWt = join(mainRepo, ".claude", "worktrees", "wf_locked");
+		git(mainRepo, "worktree", "add", "-q", "--detach", lockedWt, "HEAD");
+		git(mainRepo, "worktree", "lock", lockedWt);
+		backdate(lockedWt);
+
+		// Dirty → must be KEPT with its unpushed file intact (proves no --force).
 		const dirtyWt = join(mainRepo, ".claude", "worktrees", "wf_dirty");
 		git(mainRepo, "worktree", "add", "-q", "--detach", dirtyWt, "HEAD");
 		writeFileSync(join(dirtyWt, "uncommitted.txt"), "unpushed work");
+		backdate(dirtyWt);
 
 		const {stdout, code} = await runSweep(mainRepo, ["--execute"]);
 		assert.strictEqual(code, 0, stdout);
-		assert.isFalse(existsSync(cleanWt), "clean+merged worktree must be removed");
+		assert.isFalse(existsSync(orphanWt), "clean+idle+unlocked orphan must be removed");
+		assert.isTrue(existsSync(liveWt), "recently-active worktree must be kept (live sibling lane)");
+		assert.isTrue(existsSync(lockedWt), "locked worktree must be kept");
 		assert.isTrue(existsSync(dirtyWt), "dirty worktree must be kept");
 		assert.isTrue(
 			existsSync(join(dirtyWt, "uncommitted.txt")),
 			"unpushed file must survive — the classifier KEEPS dirty, and remove runs without --force",
 		);
+
+		// unlock so afterAll's rmSync can tear the tree down cleanly.
+		git(mainRepo, "worktree", "unlock", lockedWt);
 	}, 30_000);
 
-	it("dry-run (no --execute) touches nothing — the default cadence-free behavior stays safe", async () => {
+	it("dry-run (no --execute) touches nothing — even a clean+idle+unlocked orphan", async () => {
 		const keepWt = join(mainRepo, ".claude", "worktrees", "wf_dryrun");
 		git(mainRepo, "worktree", "add", "-q", "--detach", keepWt, "HEAD");
+		backdate(keepWt);
 		const {code} = await runSweep(mainRepo, []);
 		assert.strictEqual(code, 0);
 		assert.isTrue(existsSync(keepWt), "dry-run must never remove a worktree");

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -8,13 +8,16 @@
  * prints the plan, and — ONLY with `--execute` — runs `git worktree remove` (NEVER
  * `--force`) on the removable set.
  *
- * Safe by construction (two enforcement lines):
- *   1. The pure classifier only marks a worktree removable when it is CLEAN AND its
- *      HEAD is reachable from `origin/main`; dirty / unmerged trees are KEPT, so a
- *      live agent's in-flight branch is never swept.
+ * Safe by construction (enforcement lines):
+ *   1. The pure classifier only marks a worktree removable when it is CLEAN, reachable
+ *      from `origin/main`, AND provably not-in-use — unlocked, mtime-idle past a
+ *      threshold, and with no open PR (the #2240 liveness guard). Dirty / unmerged /
+ *      live trees are KEPT, so a running sibling lane is never swept.
  *   2. `git worktree remove` runs WITHOUT `--force` — git itself refuses a tree it
  *      judges unsafe (dirty/locked/current), and that refusal is caught and reported
- *      as KEPT, never escalated.
+ *      as KEPT, never escalated. This is a dirty-work guard, orthogonal to liveness
+ *      (git does NOT refuse a clean tree a *sibling* holds as CWD — #2240) — the
+ *      classifier's liveness gate is what covers the concurrent-sibling case.
  *
  * DRY-RUN by default: with no flag it prints what it WOULD remove and exits 0
  * without touching anything. The git IO uses `execFileSync` directly (mirrors the
@@ -22,10 +25,13 @@
  * ceiling the registry provides.
  */
 import {execFileSync} from "node:child_process";
+import {statSync} from "node:fs";
+import {join} from "node:path";
 import {Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {
 	computeWorktreeSweepPlan,
+	isManagedWorktree,
 	parseWorktreeList,
 	type WorktreeRecord,
 } from "./worktree-sweep.ts";
@@ -92,6 +98,85 @@ const squashMergedToOriginMain = (head: string | null): boolean => {
 	return cherry.stdout.trimStart().startsWith("-");
 };
 
+/** A managed worktree untouched this long is presumed orphaned, not a live lane (#2240). */
+const IDLE_THRESHOLD_MS = 30 * 60 * 1000;
+
+/** Newest mtime (ms) among the given paths, or `null` when none can be stat'd. */
+const newestMtimeMs = (paths: ReadonlyArray<string>): number | null => {
+	let newest: number | null = null;
+	for (const p of paths) {
+		try {
+			const m = statSync(p).mtimeMs;
+			if (newest === null || m > newest) newest = m;
+		} catch {
+			// path absent/unreadable — skip; a wholly unresolvable set falls to the null fail-safe below.
+		}
+	}
+	return newest;
+};
+
+/**
+ * Is a managed worktree still LIVE by recency (#2240)? Probes the worktree dir + its
+ * per-tree `HEAD` and `logs/HEAD` — a commit/checkout bumps HEAD and appends the reflog,
+ * a new file bumps the dir; a still-editing lane is caught earlier as `dirty`. The index
+ * is deliberately NOT probed: `git status` (the dirty check) can rewrite it, which would
+ * mask idleness. Any unresolvable mtime ⇒ presumed active (fail-safe KEEP).
+ */
+const worktreeRecentlyActive = (path: string): boolean => {
+	const gitdir = runGit(["-C", path, "rev-parse", "--absolute-git-dir"]);
+	const probes = [path];
+	if (gitdir.ok) {
+		const g = gitdir.stdout.trim();
+		probes.push(join(g, "HEAD"), join(g, "logs", "HEAD"));
+	}
+	const newest = newestMtimeMs(probes);
+	if (newest === null) return true;
+	return Date.now() - newest < IDLE_THRESHOLD_MS;
+};
+
+const runGh = (args: ReadonlyArray<string>): GitResult => {
+	try {
+		const stdout = execFileSync("gh", [...args], {encoding: "utf8"});
+		return {ok: true, stdout, stderr: ""};
+	} catch (cause) {
+		const e = cause as {stdout?: Buffer | string; stderr?: Buffer | string};
+		return {ok: false, stdout: String(e.stdout ?? ""), stderr: String(e.stderr ?? "")};
+	}
+};
+
+/** `owner/repo` from a github.com remote URL (ssh or https), or `null` for a non-GitHub remote. */
+const githubSlug = (url: string): string | null => {
+	const m = url.match(/github\.com[/:]([^/]+)\/(.+?)(?:\.git)?\/?$/i);
+	return m ? `${m[1]}/${m[2]}` : null;
+};
+
+/**
+ * Does `branch` have an OPEN PR on the GitHub origin (#2240)? An open PR marks an
+ * in-flight lane → KEEP. Meaningful only for a GitHub origin: a non-GitHub / absent
+ * origin (a local test repo) has no PR concept, so this signal is N/A there and the
+ * mtime-idle + locked guards carry liveness. When origin IS GitHub, ANY resolution or
+ * query failure is fail-safe toward KEEP (returns `true`). Queried per REST (never
+ * GraphQL — the org's Projects-classic integration errors GraphQL PR queries).
+ */
+const branchHasOpenPr = (branch: string | null): boolean => {
+	if (branch === null) return false;
+	const remote = runGit(["remote", "get-url", "origin"]);
+	if (!remote.ok) return false;
+	const slug = githubSlug(remote.stdout.trim());
+	if (slug === null) return false;
+	const owner = slug.split("/")[0];
+	const r = runGh([
+		"api",
+		`repos/${slug}/pulls?head=${owner}:${branch}&state=open&per_page=1`,
+		"--jq",
+		"length",
+	]);
+	if (!r.ok) return true;
+	const n = Number.parseInt(r.stdout.trim(), 10);
+	if (!Number.isFinite(n)) return true;
+	return n > 0;
+};
+
 const executeFlag = Flag.boolean("execute").pipe(
 	Flag.withDescription("actually remove the removable worktrees (default: dry-run, print only)"),
 );
@@ -114,14 +199,27 @@ const worktreeSweep = Command.make(
 		const records: ReadonlyArray<WorktreeRecord> = parsed
 			.filter((p) => !p.bare)
 			.map((p) => {
+				const managed = isManagedWorktree(p.path);
+				const isDirty = worktreeIsDirty(p.path);
 				const reachable = reachableFromOriginMain(p.head);
+				// Only probe the costlier squash signal when ancestry already missed.
+				const squashMerged = reachable ? false : squashMergedToOriginMain(p.head);
+				const recentlyActive = managed ? worktreeRecentlyActive(p.path) : false;
+				// The network open-PR probe fires ONLY for a tree that would otherwise be swept —
+				// managed, clean, unlocked, idle, and content-merged — so SessionStart makes at most
+				// one gh call per reap candidate (usually zero), never one per worktree.
+				const wouldRemove =
+					managed && !isDirty && !p.locked && !recentlyActive && (reachable || squashMerged);
+				const hasOpenPr = wouldRemove ? branchHasOpenPr(p.branch) : false;
 				return {
 					path: p.path,
 					branch: p.branch,
-					isDirty: worktreeIsDirty(p.path),
+					isDirty,
 					reachableFromOriginMain: reachable,
-					// Only probe the costlier squash signal when ancestry already missed.
-					squashMergedToOriginMain: reachable ? false : squashMergedToOriginMain(p.head),
+					squashMergedToOriginMain: squashMerged,
+					locked: p.locked,
+					recentlyActive,
+					hasOpenPr,
 				};
 			});
 

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
@@ -17,6 +17,16 @@
  * agent's live PR branch) is never silently discarded. `git worktree remove` *without*
  * `--force` is the second enforcement line in `command.ts`; this core only chooses
  * WHETHER to attempt the remove, and never escalates to a forced one.
+ *
+ * Liveness guard (#2240 FAIL): clean-AND-merged is NOT sufficient to remove. On the
+ * SessionStart cadence, sibling agents run concurrently and a LIVE lane is routinely
+ * momentarily clean-and-on-main — right after it commits+pushes, or once its PR
+ * squash-merges to `origin/main` while it finishes a repair round. `git worktree remove`
+ * WITHOUT `--force` does NOT protect that case: it refuses only dirty/locked/current
+ * trees, not a clean tree a *sibling* process holds as its CWD (the no-`--force` line is
+ * a dirty-work guard, orthogonal to liveness). So a clean+merged tree is removed only
+ * when it is also provably NOT in use: unlocked AND idle past a threshold (mtime) AND
+ * with no open PR for its branch. Every liveness signal fails safe toward KEEP.
  */
 
 /** The segment that marks a harness-managed agent worktree: `<main>/.claude/worktrees/<id>`. */
@@ -46,6 +56,17 @@ export interface WorktreeRecord {
 	 * `reachableFromOriginMain` misses (ADR 0048, #1328).
 	 */
 	readonly squashMergedToOriginMain: boolean;
+	/**
+	 * The three liveness facts (#2240) — each fail-safe toward KEEP, gathered at the git
+	 * boundary. `locked`: `git worktree lock` was set (an operator/agent pinned it).
+	 * `recentlyActive`: the worktree was touched within the idle threshold (an unresolvable
+	 * mtime reads active). `hasOpenPr`: the branch has an open PR on the GitHub origin (a
+	 * failed/indeterminate query on a GitHub origin reads true). A clean+merged tree is
+	 * removed only when all three are false.
+	 */
+	readonly locked: boolean;
+	readonly recentlyActive: boolean;
+	readonly hasOpenPr: boolean;
 }
 
 /** Why a worktree is KEPT — the audit trail, so the plan is never an opaque list. */
@@ -54,6 +75,12 @@ export type KeepReason =
 	| "not-managed"
 	/** Uncommitted/untracked changes present — keep, never `--force` (unpushed work is sacred). */
 	| "dirty"
+	/** `git worktree lock` is set — an operator/agent pinned it as in-use (#2240). */
+	| "locked"
+	/** Touched within the idle threshold — presumed a live lane, never swept (#2240). */
+	| "recently-active"
+	/** The branch has an open PR — an in-flight lane, kept until it merges + goes idle (#2240). */
+	| "open-pr"
 	/** Branch not merged into `origin/main` (or detached HEAD not reachable) — live/unmerged work. */
 	| "unmerged";
 
@@ -92,14 +119,17 @@ export interface WorktreeSweepPlan {
  *      foreign tree are never candidates, regardless of their other facts.
  *   2. Dirty → KEEP (`dirty`). Wins over every merge signal: a worktree with
  *      working-tree changes is never removed, even when its branch has merged.
- *   3. Ancestor-reachable from `origin/main` → REMOVE. `merged-clean` on a branch,
+ *   3. Liveness gates (#2240) — locked / recently-active / open-PR → KEEP. A clean+merged
+ *      tree may still belong to a LIVE sibling lane (just committed+pushed, or PR just
+ *      squash-merged mid-repair). These gates run BEFORE the remove branches, so each is a
+ *      necessary condition on REMOVE: a tree is swept only when it clears all three.
+ *   4. Ancestor-reachable from `origin/main` → REMOVE. `merged-clean` on a branch,
  *      `detached-reachable` when detached at a merged commit. Ancestry wins over the
  *      squash signal (a non-squash merge is the simpler, stronger fact).
- *   4. Else squash-merged to `origin/main` → REMOVE (`squash-merged-clean`). The
+ *   5. Else squash-merged to `origin/main` → REMOVE (`squash-merged-clean`). The
  *      #1328 case: a squash merge (ADR 0048) leaves the tip un-ancestored but lands
  *      the branch's content, so the worktree is done.
- *   5. Otherwise → KEEP (`unmerged`). Protects a live agent's in-flight branch (an
- *      open PR's worktree, or one with no PR yet) from being swept.
+ *   6. Otherwise → KEEP (`unmerged`). Genuinely unmerged work.
  */
 export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
 	if (!isManagedWorktree(wt.path)) {
@@ -107,6 +137,15 @@ export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
 	}
 	if (wt.isDirty) {
 		return {kind: "keep", reason: "dirty"};
+	}
+	if (wt.locked) {
+		return {kind: "keep", reason: "locked"};
+	}
+	if (wt.recentlyActive) {
+		return {kind: "keep", reason: "recently-active"};
+	}
+	if (wt.hasOpenPr) {
+		return {kind: "keep", reason: "open-pr"};
 	}
 	if (wt.reachableFromOriginMain) {
 		return wt.branch === null

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
@@ -16,6 +16,9 @@ const record = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	isDirty: false,
 	reachableFromOriginMain: true,
 	squashMergedToOriginMain: false,
+	locked: false,
+	recentlyActive: false,
+	hasOpenPr: false,
 	...over,
 });
 
@@ -77,6 +80,39 @@ describe("classifyWorktree — KEEP branches (the safety cases)", () => {
 			record({branch: null, isDirty: false, reachableFromOriginMain: false}),
 		);
 		assert.deepStrictEqual(d, {kind: "keep", reason: "unmerged"});
+	});
+
+	// The #2240 liveness guard: clean+merged is NOT sufficient — a live sibling lane is
+	// routinely momentarily clean-and-on-main, so each liveness signal must veto the remove.
+	it("keeps a LOCKED clean+merged worktree (an operator/agent pinned it)", () => {
+		const d = classifyWorktree(record({locked: true, reachableFromOriginMain: true}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "locked"});
+	});
+
+	it("keeps a RECENTLY-ACTIVE clean+merged worktree (presumed a live lane)", () => {
+		const d = classifyWorktree(record({recentlyActive: true, reachableFromOriginMain: true}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "recently-active"});
+	});
+
+	it("keeps a clean+merged worktree WITH an OPEN PR (an in-flight lane)", () => {
+		const d = classifyWorktree(record({hasOpenPr: true, reachableFromOriginMain: true}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "open-pr"});
+	});
+
+	it("keeps a clean, squash-merged worktree that is still recently-active (live post-merge round)", () => {
+		const d = classifyWorktree(
+			record({
+				recentlyActive: true,
+				reachableFromOriginMain: false,
+				squashMergedToOriginMain: true,
+			}),
+		);
+		assert.deepStrictEqual(d, {kind: "keep", reason: "recently-active"});
+	});
+
+	it("dirty wins over a liveness signal (still kept, reported as dirty)", () => {
+		const d = classifyWorktree(record({isDirty: true, locked: true, hasOpenPr: true}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "dirty"});
 	});
 });
 


### PR DESCRIPTION
## What

Wires the existing safe `worktree-sweep` classifier on a **SessionStart cadence** so orphaned agent worktrees under `.claude/worktrees/` get reaped regardless of how they leaked — closing the coverage gap the `SubagentStop` reaper cannot.

Added the same `guard.sh worktree-sweep --execute` SessionStart entry to **both** hook surfaces:
- `.claude/settings.json`
- `claude-plugins/kampus-pipeline/hooks.json` (the portable plugin mirror)

## Why — root cause, and why the reaper can't cover it

Aborted/interrupted lanes leak worktrees. The chief case is a **weekly-limit hard-stop / process-kill mid-run**: a SIGKILL/process-death by definition runs **no cleanup**, so the `SubagentStop` "worktree-guard reap" hook **never fires** and those trees accumulate without bound (the reported residue).

Extending the reaper to fire on a kill is **infeasible** — you cannot hook a kill. So the robust, root-cause fix is a **cadence**: invoke the existing safe `worktree-sweep` classifier at each session start, and every new session reaps orphans left by prior aborted/killed lanes no matter how they leaked. The cadence sweep **is** the coverage for the reaper's hard-stop gap; a reviewer/reader should not expect a hook that can't exist.

## Reuse, not new logic

No new prune-decision logic. The cadence dispatches `pipeline-cli worktree-sweep --execute` through the existing fail-open `guard.sh` wrapper (same dispatch as the `worktree-guard reap` hook), reusing the untouched sweep core:
- `packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts` (pure classifier)
- `packages/pipeline-cli/src/tools/worktree-sweep/command.ts` (git boundary)

## Safe-prune invariant (load-bearing) holds

Removal is **only** for a tree that is CLEAN **and** whose content is already on `origin/main`, via `git worktree remove` **WITHOUT `--force`**. A dirty/unmerged tree **errors out and is KEPT** — unpushed work is never silently discarded, and the primary checkout / any foreign tree is never a candidate (`not-managed`).

## Test

New `packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts` drives `worktree-sweep --execute` against a **real git repo** and asserts through the command boundary:
- a CLEAN, `origin/main`-reachable worktree is **removed**,
- a DIRTY worktree is **KEPT** with its unpushed file intact (proving no `--force`),
- dry-run (no `--execute`) touches nothing.

Gates: `pipeline-cli` typecheck + biome clean; the full `worktree-sweep/` suite (23 tests) passes.

## Acceptance criteria

- [x] Bounded ceiling that survives a hard-stop mid-run — the SessionStart cadence, not only a clean `SubagentStop`.
- [x] Reuses the existing safe classifier — no divergent prune logic.
- [x] Every remove uses `git worktree remove` WITHOUT `--force`; dirty/unmerged KEPT (existing + new tests).
- [x] No worktree outside `.claude/worktrees/` is ever a candidate.

Fixes #2238