### PR TITLE
fix(pano): toggle vote/comment button accessible name with vote state (#2215)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -130,7 +130,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 						type="button"
 						className={`kp-comment__upvote ${voted ? "kp-comment__upvote--active" : ""}`}
 						aria-pressed={voted}
-						aria-label="Yukarı oy"
+						aria-label={voted ? "Oyunu geri al" : "Yukarı oy"}
 						onClick={onUpvote}
 						data-testid={`comment-vote-${localId}`}
 					>

--- a/apps/web/src/components/pano/PanoPost.test.tsx
+++ b/apps/web/src/components/pano/PanoPost.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * a11y regression proof (#2215): the pano vote button's accessible name must
+ * TOGGLE with vote state — "Oyunu geri al" (undo) when the viewer's vote is
+ * active, "Yukarı oy" otherwise — mirroring the sözlük `DefinitionCard` control.
+ * A static aria-label leaves screen-reader users with stale toggle feedback.
+ */
+import {render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {VoteControl} from "./PanoPost";
+
+describe("VoteControl — vote button accessible name toggles with state (#2215)", () => {
+	it('reads "Yukarı oy" when the vote is not active', () => {
+		const {getByTestId} = render(<VoteControl count={3} pressed={false} testIdSuffix="p1" />);
+		expect(getByTestId("post-vote-p1").getAttribute("aria-label")).toBe("Yukarı oy");
+	});
+
+	it('reads "Oyunu geri al" (the undo affordance) when the vote is active', () => {
+		const {getByTestId} = render(<VoteControl count={4} pressed={true} testIdSuffix="p1" />);
+		expect(getByTestId("post-vote-p1").getAttribute("aria-label")).toBe("Oyunu geri al");
+	});
+});

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -32,7 +32,7 @@ export function VoteControl({
 					type="button"
 					className="kp-pano-post__vote-btn"
 					aria-pressed={pressed}
-					aria-label="Yukarı oy"
+					aria-label={pressed ? "Oyunu geri al" : "Yukarı oy"}
 					data-testid={testIdSuffix ? `post-vote-${testIdSuffix}` : undefined}
 					onClick={() => onToggle?.()}
 				>

--- a/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
+++ b/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
@@ -88,20 +88,25 @@ test.describe("Pano voteOnComment", () => {
 		await expect(voteBtn).toBeVisible({timeout: 5_000});
 		await expectScoreConsistent(page, score, "0");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "false");
+		// a11y: the accessible name toggles with vote state (#2215).
+		await expect(voteBtn).toHaveAttribute("aria-label", "Yukarı oy");
 
 		// Cast vote — optimistic flip lands first.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "1");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "true", {timeout: 5_000});
+		await expect(voteBtn).toHaveAttribute("aria-label", "Oyunu geri al");
 
 		// Retract.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "0");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "false");
+		await expect(voteBtn).toHaveAttribute("aria-label", "Yukarı oy");
 
 		// Re-vote.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "1");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "true");
+		await expect(voteBtn).toHaveAttribute("aria-label", "Oyunu geri al");
 	});
 });


### PR DESCRIPTION
## What

The pano post vote button (`PanoPost.tsx` `VoteControl`) and the comment vote control (`CommentTreeNode.tsx`) set a **static** `aria-label="Yukarı oy"` that never changed with vote state. Screen-reader users got stale toggle feedback — the sözlük `DefinitionCard` vote control already does this correctly (`voted ? "Oyunu geri al" : "Yukarı oy"`).

This mirrors that idiom onto both pano controls: the accessible name is now **derived from the active-vote state** (`pressed` / `voted`) rather than hand-set to one string, reusing sözlük's exact vocabulary so the two surfaces stay consistent. a11y-only — the visible control behavior is unchanged.

## Changes

- `apps/web/src/components/pano/PanoPost.tsx` — `VoteControl`'s button `aria-label={pressed ? "Oyunu geri al" : "Yukarı oy"}` (derived from the `pressed` prop that already carries vote state).
- `apps/web/src/components/pano/CommentTreeNode.tsx` — comment upvote button `aria-label={voted ? "Oyunu geri al" : "Yukarı oy"}`.

## Tests

- `apps/web/src/components/pano/PanoPost.test.tsx` (new) — `VoteControl — vote button accessible name toggles with state (#2215)`: asserts the button reads "Yukarı oy" when `pressed={false}` and "Oyunu geri al" when `pressed={true}`. The a11y regression proof. Passes (2/2).
- `apps/web/tests/e2e/18-pano-vote-comment.spec.ts` — extends the comment-vote round-trip with `aria-label` assertions coupled to the existing `aria-pressed` toggle (the e2e is `test.fixme`-quarantined on #1838, so the coverage arrives when it un-quarantines).

## Verification

- `pnpm typecheck` — green
- biome lint on changed files — clean
- new unit test — 2/2 pass

**§CP:** NO (`apps/web/**` is not control-plane).

Fixes #2215