### PR TITLE
feat(web): recalibrate the type ramp to the 14px law + build the 4-level elevation system

### DIFF
--- a/apps/web/src/components/ui/Dialog.css
+++ b/apps/web/src/components/ui/Dialog.css
@@ -23,7 +23,7 @@
 	background: var(--surface);
 	border: 1px solid var(--border);
 	border-radius: var(--r-lg);
-	box-shadow: var(--shadow-md);
+	box-shadow: var(--shadow-overlay);
 	z-index: 61;
 	animation: kp-dialog-pop var(--motion-base) var(--ease-emphasized);
 }

--- a/apps/web/src/components/ui/Menu.css
+++ b/apps/web/src/components/ui/Menu.css
@@ -12,7 +12,7 @@
 	background: var(--surface-raised);
 	border: 1px solid var(--border);
 	border-radius: var(--r-md);
-	box-shadow: var(--shadow-md);
+	box-shadow: var(--shadow-dropdown);
 	padding: var(--s-1) 0;
 	animation: kp-menu-pop var(--motion-fast) var(--ease-standard);
 }

--- a/apps/web/src/components/ui/Tooltip.css
+++ b/apps/web/src/components/ui/Tooltip.css
@@ -15,7 +15,7 @@
 	border-radius: var(--r-sm);
 	padding: 4px var(--s-2);
 	font: var(--t-micro);
-	box-shadow: var(--shadow-md);
+	box-shadow: var(--shadow-dropdown);
 	max-width: 280px;
 	animation: kp-tooltip-pop var(--motion-fast) var(--ease-standard);
 }

--- a/apps/web/src/pages/PanoSubmitPage.css
+++ b/apps/web/src/pages/PanoSubmitPage.css
@@ -54,7 +54,7 @@
 .kp-pano-submit__toggle button[aria-pressed="true"] {
 	background: var(--surface-raised);
 	color: var(--text-primary);
-	box-shadow: var(--shadow-sm);
+	box-shadow: var(--shadow-raised);
 }
 
 .kp-pano-submit__form {

--- a/apps/web/src/pages/SozlukTermPage.css
+++ b/apps/web/src/pages/SozlukTermPage.css
@@ -55,8 +55,13 @@
 	padding: var(--s-3) 0;
 	border-bottom: 1px solid var(--border-faint);
 }
+/* Top definition — a highlighted, not an errored, card. A full --accent-faint
+   (maroon) fill read as destructive/error UI; the highlight is carried by a
+   neutral raised surface + an accent left-border marker instead (ADR 0162
+   cohesiveness; #2166). */
 .kp-sozluk-definition--top {
-	background: var(--accent-faint);
+	background: var(--surface-raised);
+	border-left: 2px solid var(--accent);
 	padding: var(--s-3);
 	margin: 0 -8px;
 	border-radius: var(--r-sm);

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -120,11 +120,22 @@
 	--plum-contrast: #fff;
 	--mauve-contrast: #fff;
 
-	/* misc raw */
+	/* misc raw — black/white alpha stops feeding the elevation ramp (§ ELEVATION).
+	   White stops are the dark-mode surface-tint highlights: a cast shadow reads
+	   poorly on a dark ground, so each dark level lifts the surface with a top-edge
+	   inset highlight instead of leaning on shadow alone (ADR 0162, Elevation). */
+	--black-a60: rgba(0, 0, 0, 0.6);
+	--black-a50: rgba(0, 0, 0, 0.5);
 	--black-a40: rgba(0, 0, 0, 0.4);
 	--black-a35: rgba(0, 0, 0, 0.35);
+	--black-a20: rgba(0, 0, 0, 0.2);
+	--black-a15: rgba(0, 0, 0, 0.15);
 	--black-a10: rgba(0, 0, 0, 0.1);
+	--black-a08: rgba(0, 0, 0, 0.08);
 	--black-a04: rgba(0, 0, 0, 0.04);
+	--white-a08: rgba(255, 255, 255, 0.08);
+	--white-a06: rgba(255, 255, 255, 0.06);
+	--white-a04: rgba(255, 255, 255, 0.04);
 }
 
 /* ──────────── 1. RAW SCALES (light) ──────────── */
@@ -451,8 +462,14 @@
 	--tag-news-bg: oklch(0.3 0.06 320);
 	--tag-news-fg: oklch(0.85 0.1 320);
 
-	--shadow-sm: 0 1px 0 0 var(--black-a40);
-	--shadow-md: 0 2px 4px 0 var(--black-a35);
+	/* Elevation — four levels (flat · raised · dropdown · overlay), ADR 0162.
+	   Dark: the cast shadow is near-invisible on the dark ground, so each level
+	   also lifts the surface with a top-edge inset highlight (the surface-tint
+	   bump) — the elevation reads even where the shadow does not. */
+	--shadow-flat: none;
+	--shadow-raised: inset 0 1px 0 0 var(--white-a04), 0 1px 3px 0 var(--black-a40);
+	--shadow-dropdown: inset 0 1px 0 0 var(--white-a06), 0 6px 16px -4px var(--black-a50);
+	--shadow-overlay: inset 0 1px 0 0 var(--white-a08), 0 16px 40px -8px var(--black-a60);
 }
 [data-theme="light"] {
 	--tag-discuss-bg: oklch(0.95 0.04 260);
@@ -468,8 +485,12 @@
 	--tag-news-bg: oklch(0.95 0.05 320);
 	--tag-news-fg: oklch(0.38 0.1 320);
 
-	--shadow-sm: 0 1px 0 0 var(--black-a04);
-	--shadow-md: 0 1px 3px 0 var(--black-a10);
+	/* Elevation — four levels (flat · raised · dropdown · overlay), ADR 0162.
+	   Light: real cast shadows carry the lift; no surface-tint bump needed. */
+	--shadow-flat: none;
+	--shadow-raised: 0 1px 2px 0 var(--black-a08), 0 1px 3px 0 var(--black-a04);
+	--shadow-dropdown: 0 4px 12px -2px var(--black-a15), 0 2px 6px -2px var(--black-a10);
+	--shadow-overlay: 0 12px 32px -8px var(--black-a20), 0 4px 12px -4px var(--black-a15);
 }
 
 /* ──────────── TYPE / SPACE / RADIUS / DENSITY ──────────── */
@@ -478,13 +499,16 @@
 		"IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
 	--font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
-	--t-body: 13px / 1.45 var(--font-body);
-	--t-body-sm: 12px / 1.45 var(--font-body);
-	--t-meta: 11px / 1.4 var(--font-body);
-	--t-micro: 10.5px / 1.4 var(--font-body);
-	--t-h-feed: 14px / 1.35 var(--font-body);
-	--t-h-page: 18px / 1.3 var(--font-body);
-	--t-mono: 12px / 1.45 var(--font-mono);
+	/* Type ramp — 14px body base (ADR 0162), a hand-tuned perceptual ladder that
+	   opens the body→heading range so headings read as hierarchy, not bold body.
+	   Sizes are a ladder (odd steps allowed), not rigid 4px multiples. */
+	--t-body: 14px / 1.5 var(--font-body);
+	--t-body-sm: 13px / 1.45 var(--font-body);
+	--t-meta: 12px / 1.4 var(--font-body);
+	--t-micro: 11px / 1.4 var(--font-body);
+	--t-h-feed: 16px / 1.35 var(--font-body);
+	--t-h-page: 22px / 1.25 var(--font-body);
+	--t-mono: 13px / 1.5 var(--font-mono);
 
 	--r-sm: 2px;
 	--r-md: 4px;

--- a/design-system-manifest.md
+++ b/design-system-manifest.md
@@ -27,10 +27,12 @@ pair is defined). Each value cites where it **actually lives** in source.
 > **Law vs live-value.** This manifest records the **law** — 0162's ratified target values —
 > which the token recalibration legs ([#2164](https://github.com/kamp-us/phoenix/issues/2164),
 > [#2163](https://github.com/kamp-us/phoenix/issues/2163)) then re-derive the live CSS to. Where
-> the live CSS currently differs from the law (body text is live `13px`, law is `14px`; the focus
-> ring is live a flush 2px ring, law adds the 2px gap; elevation is live two shadows, law is four
-> levels + dark-tint), the manifest states the **law** and annotates the **current → target
-> delta** so the recalibration leg knows its target and a reviewer knows what is not yet true.
+> the live CSS currently differs from the law (the focus ring is live a flush 2px ring, law adds
+> the 2px gap), the manifest states the **law** and annotates the **current → target delta** so
+> the recalibration leg knows its target and a reviewer knows what is not yet true; where a leg has
+> landed (body text is now `14px` and elevation is now the four named levels + dark-mode tint, both
+> per [#2164](https://github.com/kamp-us/phoenix/issues/2164)), the delta column records the
+> achieved state.
 > Encoding the law is not the same as the live CSS already satisfying it.
 
 ---
@@ -66,10 +68,10 @@ delta**.
 | # | Value | Law (0162) | Where it lives in source | Current → target delta |
 |---|---|---|---|---|
 | 1 | **Grid** | 4px base grid; sanctioned **1px & 2px** exceptions (hairline borders, optical nudges). Everything lands on the 4px lattice unless a sanctioned exception. | The 4px lattice is the discipline behind the spacing ramp (`--s-1..--s-8`) and radius scale (`--r-sm: 2px`, `--r-md: 4px`, `--r-lg: 6px`) in [`tokens.css`](apps/web/src/styles/tokens.css). | On-grid re-derivation of the ramps is [#2164](https://github.com/kamp-us/phoenix/issues/2164)/[#2163](https://github.com/kamp-us/phoenix/issues/2163)'s job (some live density steps are off-grid, e.g. `normal --s-1: 5px`). |
-| 2 | **Body text** | **14px** ratified body size. | `--t-body` in [`tokens.css`](apps/web/src/styles/tokens.css) (`:root` TYPE block). | **Live `--t-body` is `13px`** → the type recalibration [#2164](https://github.com/kamp-us/phoenix/issues/2164) moves it to 14px. |
+| 2 | **Body text** | **14px** ratified body size. | `--t-body` in [`tokens.css`](apps/web/src/styles/tokens.css) (`:root` TYPE block). | **Achieved** — `--t-body` is now `14px` and the full `--t-*` ramp opened to that base by [#2164](https://github.com/kamp-us/phoenix/issues/2164). |
 | 3 | **Spacing** | 4px-based ramp — hand-tuned but on-grid (Primer/Polaris perceptual ladder, not a rigid ×N multiplier); **all three density ramps re-derive to clean 4px multiples**. | `--s-1..--s-8` in [`tokens.css`](apps/web/src/styles/tokens.css), redefined per `[data-density="compact"\|normal\|spacious"]`. | Compact ramp is already 4px multiples (`4/8/12/16/20/24/32/40`); `normal`/`spacious` steps are re-derived to 4px multiples by [#2164](https://github.com/kamp-us/phoenix/issues/2164). |
 | 4 | **Tap target** | **36px minimum hit area** for every interactive control (the hit area, not necessarily the visible glyph). | Not a single token — enforced per interactive control (min-height / min-width or hit-area padding). | New floor; the concrete fixes land in [#2166](https://github.com/kamp-us/phoenix/issues/2166). |
-| 5 | **Elevation** | **Four levels — flat/resting · raised · dropdown · overlay** — plus a **dark-mode surface-tint bump** (each level lightens the surface, not shadow-only). | Today only `--shadow-sm` / `--shadow-md` exist in [`tokens.css`](apps/web/src/styles/tokens.css) (`[data-theme="dark"]` / `[data-theme="light"]` blocks). | **Live is two shadows** → the four-level ramp + dark-mode tint is built by [#2164](https://github.com/kamp-us/phoenix/issues/2164). |
+| 5 | **Elevation** | **Four levels — flat/resting · raised · dropdown · overlay** — plus a **dark-mode surface-tint bump** (each level lightens the surface, not shadow-only). | The four named levels `--shadow-flat` / `--shadow-raised` / `--shadow-dropdown` / `--shadow-overlay` in [`tokens.css`](apps/web/src/styles/tokens.css) (`[data-theme="dark"]` / `[data-theme="light"]` blocks). | **Achieved** — the four-level ramp + the dark-mode surface-tint bump are built by [#2164](https://github.com/kamp-us/phoenix/issues/2164); the old `--shadow-sm`/`--shadow-md` are retired and consumers rewired to the named levels. |
 | 6 | **Focus — the spacer ring** | **2px ring + 2px gap** (a ring separated from the control by a transparent spacer). The gap guarantees the ring clears **3:1 contrast even on same-family dark surfaces**. Extends the existing `--focus-ring` token — its *definition* gains the gap; the ~13 correct consumers keep consuming `--focus-ring` unchanged. | `--focus-ring: 2px solid var(--accent-9)` and `--focus-ring-offset: 2px`, defined in [`apps/web/src/styles/global.css`](apps/web/src/styles/global.css) (**NOT** `tokens.css`), painted by the single `:focus-visible` rule there. | **Live `--focus-ring` is a flush 2px ring** (`--focus-ring-offset: 2px` already exists as the outline offset) → 0162's spacer ring adds the **2px transparent gap** to the token's definition; [#2169](https://github.com/kamp-us/phoenix/issues/2169) builds the systematic focus layer, [#2166](https://github.com/kamp-us/phoenix/issues/2166) fixes the ReactionBar double-wrap misuse. |
 | 7 | **Contrast floors** | **AA 4.5:1** for body / any meaning-carrying text; **3:1** for large text and non-text UI (borders, icons, control affordances); **AAA where it comes for free** (`--text-primary` = `--gray-12` already clears AAA vs `--surface`). | The text-hierarchy ladder role tokens in [`tokens.css`](apps/web/src/styles/tokens.css) role block: `--text-primary` (`--gray-12`), `--text-secondary` (`mix(11,12)`), `--text-muted` (`--gray-11`, AA-safe floor for meaning), `--text-faint` (`--gray-10`, 3:1 only, decorative). | Law already holds for the ladder; the concrete WCAG-defect fixes (faint-for-meaning promotions, CTA-on-tomato) land in [#2166](https://github.com/kamp-us/phoenix/issues/2166). |
 | 8 | **Density** | Expose **all three ramps — compact · normal · spacious**. | The `[data-density="compact"\|normal\|spacious"]` ramp infra in [`tokens.css`](apps/web/src/styles/tokens.css). | Infra exists; the user-facing density control is wired by [#2183](https://github.com/kamp-us/phoenix/issues/2183). |
@@ -134,13 +136,13 @@ hand-roll a per-component `outline` — reach for `--focus-ring` (Pillar 4).
 
 | Role token | Value | Reach for it when |
 |---|---|---|
-| `--t-body` | `13px/1.45` (**law: 14px** — [#2164](https://github.com/kamp-us/phoenix/issues/2164)) | Default body copy. |
-| `--t-body-sm` | `12px/1.45` | Small body copy. |
-| `--t-meta` | `11px/1.4` | Meta rows (timestamps, counts, bylines). |
-| `--t-micro` | `10.5px/1.4` | The smallest micro-copy. |
-| `--t-h-feed` | `14px/1.35` | Feed-item headings. |
-| `--t-h-page` | `18px/1.3` | Page titles. |
-| `--t-mono` | `12px/1.45` (mono) | Code / monospace. |
+| `--t-body` | `14px/1.5` (law body base — [#2164](https://github.com/kamp-us/phoenix/issues/2164)) | Default body copy. |
+| `--t-body-sm` | `13px/1.45` | Small body copy. |
+| `--t-meta` | `12px/1.4` | Meta rows (timestamps, counts, bylines). |
+| `--t-micro` | `11px/1.4` | The smallest micro-copy. |
+| `--t-h-feed` | `16px/1.35` | Feed-item headings. |
+| `--t-h-page` | `22px/1.25` | Page titles. |
+| `--t-mono` | `13px/1.5` (mono) | Code / monospace. |
 
 ---
 


### PR DESCRIPTION
Fixes #2164

Cohesiveness pillar (ADR 0162 / `design-system-manifest.md`). Two token-value recalibrations on the existing `--t-*` / `--shadow-*` seams, plus the definition-card recolor flagged in the issue's design-lens tail.

## Type ramp — 14px body base
Anchored the ramp at the ratified **14px** body base (ADR 0162) and opened the body→heading range so headings read as hierarchy, not bold body. The whole ladder shifts up coherently on the perceptual-ladder discipline (odd steps allowed, not rigid 4px multiples):

| token | was | now |
|---|---|---|
| `--t-micro` | 10.5px | 11px |
| `--t-meta` | 11px | 12px |
| `--t-body-sm` | 12px | 13px |
| `--t-body` | 13px | **14px** (law) |
| `--t-mono` | 12px | 13px |
| `--t-h-feed` | 14px | 16px |
| `--t-h-page` | 18px | **22px** |

Body→page-title ratio widens 1.38× → 1.57×; total range ~1.7× → 2×.

## Elevation — four named levels + dark-mode surface-tint
Replaced the two near-adjacent shadows (`--shadow-sm`/`--shadow-md`) with the four named levels per ADR 0162: `--shadow-flat` · `--shadow-raised` · `--shadow-dropdown` · `--shadow-overlay`. In dark mode a cast shadow reads poorly on the dark ground, so each level also lifts the surface with a top-edge **inset highlight** (the surface-tint bump) — the elevation reads even where the shadow does not. Added the black/white alpha stops the ramp needs.

Rewired the four existing shadow consumers to the named levels; the old tokens are retired (no orphans):
- `Menu.css`, `Tooltip.css` → `--shadow-dropdown`
- `Dialog.css` (modal) → `--shadow-overlay`
- `PanoSubmitPage.css` (pressed toggle) → `--shadow-raised`

## Definition card — recolor off the error-maroon fill
`.kp-sozluk-definition--top` sat in a full `--accent-faint` (maroon) fill that reads as destructive/error UI. Recolored to a neutral `--surface-raised` + an `--accent` left-border marker so the highlight is carried by elevation + an accent meta, not a color that signals error (cross-ref #2166).

## Manifest delta reconcile
Updated the `design-system-manifest.md` current→target delta to **Achieved** for the two law values now met (body 14px, 4-level elevation) and refreshed the type-role + elevation-source annotations so the doc matches source. Law values unchanged.

## Icon idiom — surfaced, not done (out of scope here)
The issue's design-lens tail also flags "no unified icon system" (emoji vs thin-line glyphs vs wordmark dot). That is a large, forky change — a whole new icon idiom across every glyph — and the manifest notes it pairs with the reaction-control work in #2165. Per the task scoping, I kept this PR to type + elevation + the definition-card recolor and am surfacing the icon-idiom unification as a separate leg rather than half-doing it.

## Gates
- `pnpm lint` (biome) — clean
- Unit tests — green (incl. `styles/focus-layer.test.ts`, `DefinitionCard.test.ts`); full suite ran green on pre-push
- `pnpm typecheck` — green (CSS/MD-only change, no TS)
- pre-commit leak-guard clean (no local paths)

No component refactors; token-value change on existing seams + the four consumer rewires + the one definition-card recolor. Hard-coded per-site font sizes that don't consume `--t-*` are pre-existing and out of scope (the AC targets the token ramp; token consumers pick up the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)