### PR TITLE
perf(web): self-host IBM Plex Sans + JetBrains Mono, drop render-blocking Google Fonts hop

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -24,12 +24,6 @@
 				} catch {}
 			})();
 		</script>
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			rel="stylesheet"
-			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
-		/>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,8 @@
 		"@distilled.cloud/cloudflare": "catalog:",
 		"@effect/tsgo": "catalog:",
 		"@effect/vitest": "catalog:",
+		"@fontsource/ibm-plex-sans": "catalog:",
+		"@fontsource/jetbrains-mono": "catalog:",
 		"@kampus/admin-grant": "workspace:*",
 		"@kampus/d1-rest": "workspace:*",
 		"@kampus/founder-seed": "workspace:*",

--- a/apps/web/src/styles/fonts.css
+++ b/apps/web/src/styles/fonts.css
@@ -1,0 +1,184 @@
+/* First-party self-hosted faces — replaces the render-blocking fonts.googleapis.com
+   hop that gated first paint on the (known-slow) Turkey↔Google path, spiking LCP to
+   ~13s (#2252, ADR 0162 Performance pillar). The woff2 are catalog-sourced from
+   @fontsource/{ibm-plex-sans,jetbrains-mono}; Vite fingerprints them into dist/client
+   and the assets binding serves them first-party, so no external network hop remains.
+
+   Only the two families --font-body / --font-mono resolve (tokens.css) and only the
+   weights the app actually uses (Sans 400/500/600/700, Mono 400/500/600) are shipped,
+   subset to latin + latin-ext — latin-ext carries the Turkish glyphs (ğ ş İ ı, U+0100–),
+   load-bearing for the Turkish audience. `font-display: swap` paints text on the
+   fallback immediately, then swaps to the first-party face. unicode-range values are
+   Google's standard subset ranges (mirrored from @fontsource's per-weight CSS). */
+
+/* ──────────── IBM Plex Sans (--font-body) ──────────── */
+
+@font-face {
+	font-family: "IBM Plex Sans";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 400;
+	src: url("@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-400-normal.woff2") format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+@font-face {
+	font-family: "IBM Plex Sans";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 400;
+	src: url("@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-ext-400-normal.woff2")
+		format("woff2");
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+		U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+	font-family: "IBM Plex Sans";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 500;
+	src: url("@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-500-normal.woff2") format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+@font-face {
+	font-family: "IBM Plex Sans";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 500;
+	src: url("@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-ext-500-normal.woff2")
+		format("woff2");
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+		U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+	font-family: "IBM Plex Sans";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 600;
+	src: url("@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-600-normal.woff2") format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+@font-face {
+	font-family: "IBM Plex Sans";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 600;
+	src: url("@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-ext-600-normal.woff2")
+		format("woff2");
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+		U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+	font-family: "IBM Plex Sans";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 700;
+	src: url("@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-700-normal.woff2") format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+@font-face {
+	font-family: "IBM Plex Sans";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 700;
+	src: url("@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-ext-700-normal.woff2")
+		format("woff2");
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+		U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* ──────────── JetBrains Mono (--font-mono) ──────────── */
+
+@font-face {
+	font-family: "JetBrains Mono";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 400;
+	src: url("@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2") format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+@font-face {
+	font-family: "JetBrains Mono";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 400;
+	src: url("@fontsource/jetbrains-mono/files/jetbrains-mono-latin-ext-400-normal.woff2")
+		format("woff2");
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+		U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+	font-family: "JetBrains Mono";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 500;
+	src: url("@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-normal.woff2") format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+@font-face {
+	font-family: "JetBrains Mono";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 500;
+	src: url("@fontsource/jetbrains-mono/files/jetbrains-mono-latin-ext-500-normal.woff2")
+		format("woff2");
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+		U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+	font-family: "JetBrains Mono";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 600;
+	src: url("@fontsource/jetbrains-mono/files/jetbrains-mono-latin-600-normal.woff2") format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+@font-face {
+	font-family: "JetBrains Mono";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 600;
+	src: url("@fontsource/jetbrains-mono/files/jetbrains-mono-latin-ext-600-normal.woff2")
+		format("woff2");
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+		U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
+}

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,6 +1,7 @@
 /* Global reset + body defaults.
    Everything else lives in component CSS modules.            */
 
+@import "./fonts.css";
 @import "./tokens.css";
 
 *,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,12 @@ catalogs:
     '@effect/vitest':
       specifier: 4.0.0-beta.92
       version: 4.0.0-beta.92
+    '@fontsource/ibm-plex-sans':
+      specifier: 5.2.8
+      version: 5.2.8
+    '@fontsource/jetbrains-mono':
+      specifier: 5.2.8
+      version: 5.2.8
     '@nkzw/fate':
       specifier: 1.3.1
       version: 1.3.1
@@ -266,6 +272,12 @@ importers:
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@fontsource/ibm-plex-sans':
+        specifier: 'catalog:'
+        version: 5.2.8
+      '@fontsource/jetbrains-mono':
+        specifier: 'catalog:'
+        version: 5.2.8
       '@kampus/admin-grant':
         specifier: workspace:*
         version: link:../../packages/admin-grant
@@ -1962,6 +1974,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/ibm-plex-sans@5.2.8':
+    resolution: {integrity: sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==}
+
+  '@fontsource/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
@@ -4947,6 +4965,10 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/ibm-plex-sans@5.2.8': {}
+
+  '@fontsource/jetbrains-mono@5.2.8': {}
 
   '@ioredis/commands@1.5.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,8 @@ catalog:
   '@effect/sql-pg': 4.0.0-beta.92
   '@effect/tsgo': ^0.5.2
   '@effect/vitest': 4.0.0-beta.92
+  '@fontsource/ibm-plex-sans': 5.2.8
+  '@fontsource/jetbrains-mono': 5.2.8
   '@nkzw/fate': 1.3.1
   '@playwright/test': ^1.59.1
   '@sentry/cloudflare': 10.62.0


### PR DESCRIPTION
## What & why

The shared app-shell `<head>` (`apps/web/index.html`) loaded fonts via a **render-blocking** `fonts.googleapis.com` stylesheet `<link>` plus two `preconnect` hints. A stylesheet link in `<head>` blocks first paint until it resolves; on the **known-slow Turkey↔Google path** — phoenix's core audience — that gated all page paint for many seconds (founder-observed LCP ~13s, "poor"), on **every** page. It violates the ADR 0162 Performance pillar ("never block first paint on a deferrable resource").

## The fix — self-host exactly the two consumed families

`tokens.css` consumes only `--font-body: "IBM Plex Sans"` and `--font-mono: "JetBrains Mono"`. Those two are now first-party:

- **`apps/web/index.html`** — removed both `preconnect` hints and the `fonts.googleapis.com` stylesheet `<link>`. No external font hop remains.
- **`apps/web/src/styles/fonts.css`** (new) — first-party `@font-face` for only the weights the app actually uses (IBM Plex Sans 400/500/600/700, JetBrains Mono 400/500/600), subset to **latin + latin-ext**. latin-ext carries the Turkish glyphs (ğ ş İ ı, U+0100–), load-bearing for the Turkish audience. `font-display: swap` on every face paints on the fallback immediately, then swaps to the first-party face.
- **`apps/web/src/styles/global.css`** — `@import "./fonts.css"` ahead of `tokens.css`, so `--font-body` / `--font-mono` resolve to the self-hosted faces unchanged (rendered text identical).
- **`@fontsource/ibm-plex-sans` + `@fontsource/jetbrains-mono`** added via the workspace `catalog:` (`pnpm-workspace.yaml`) — the woff2 are catalog-sourced, and Vite fingerprints them into `dist/client/assets/*.woff2`, served first-party via the worker's `assets` binding. No woff2 is committed; the build emits them.

## Verification (local `pnpm build`)

- `dist/client/` contains **14 woff2** (7 weights × latin/latin-ext) and **14 `@font-face`** in the built CSS.
- **Zero** `fonts.googleapis.com` / `fonts.gstatic.com` references remain anywhere in `dist/client` (grep-clean), and none in the built `index.html`.
- `biome check` clean; frozen-lockfile install clean.

## Scope

Confined to `apps/web/**` (shell head + app CSS + new first-party font assets) + the two catalog entries. §CP: No — auto-ships on green. Distinct from #2188 (the fate `byId` data-seam waterfall) — no fate/data-seam code touched.

Fixes #2252

🤖 Generated with [Claude Code](https://claude.com/claude-code)