### PR TITLE
feat(pipeline): gate guard-relaxing ADRs as §CP — content-inferred, fail-closed (#2191)

### DIFF
--- a/.decisions/0164-guard-relaxing-adr-cp-gate.md
+++ b/.decisions/0164-guard-relaxing-adr-cp-gate.md
@@ -1,0 +1,156 @@
+---
+id: 0164
+title: "A guard-relaxing ADR is control-plane (§CP) — the founder ratifies any ADR that cites or amends a documented guard; ship-it classifies a guard-touching .decisions/** file §CP by CONTENT (conservative, fail-closed), not by an author-declared tag"
+status: proposed
+date: 2026-07-06
+tags: [pipeline, ship-it, control-plane, governance, security, gates]
+---
+
+# 0164 — Guard-relaxing ADRs are §CP: the founder ratifies a guard amendment; ship-it holds a guard-touching ADR by a conservative, content-inferred predicate
+
+## Context
+
+An ADR under `.decisions/**` is **doc-class**: `review-doc` verifies it, and on a
+`review-doc: PASS` `ship-it` **auto-merges** it — `.decisions/**` is explicitly *non*-blocking
+in the control-plane set ([`gh-issue-intake-formats.md §CP`](../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md),
+"Everything else — … `.decisions/**` … — is non-blocking and auto-merges through its matching
+gate on a PASS"). The canonical §CP matcher is a **path** regex; it does not — and structurally
+cannot, by path alone — distinguish a guard-relaxing ADR from an ordinary one.
+
+**The hole (proven live).** When an ADR *relaxes, amends, or widens an exemption on* a documented
+guard, there is **no mechanical human-gate** holding it for ratification. The only thing that held
+the in-flight containment-exemption ADRs (0161/0162, which relax ADR 0083's containment guard) was **agent
+discipline** — the EM hand-holding the bank (a cansirin wait + a watcher). A stray shipper, or a
+mid-flight-on-green compaction that resumed at the enqueue step, would auto-merge a guard-weakening
+ADR past any founder ratification. That is a **fail-open in the control plane**: the pipeline
+auto-shipping a weakening of its own guardrails is exactly the class §CP exists to prevent (ADRs
+[0053](0053-control-plane-boundary.md)/[0065](0065-gate-critical-skills-are-blocking.md)), and
+guard/invariant relaxation is the **author ≠ approver** class that must keep a human in the loop
+(ADR [0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md); the
+invariant-removal-needs-adversarial-review rationale).
+
+This is engineering-led control-plane hardening (ADR
+[0078](0078-product-driven-decisions-by-default.md): the pipeline/gate substrate is the
+engineering lane), so there is **no founder prose-ratification gate on *this* ADR's authoring** —
+but its *subject* is precisely a founder-ratification gate on a future class of ADRs.
+
+## Decision
+
+### POLICY — the founder ratifies any guard-relaxing ADR
+
+An ADR that **relaxes, amends, widens an exemption on, or drops** a documented guard/invariant
+must be **ratified by the founder** before it merges. "Discipline holds the line" is fragile by
+construction — it holds until the first agent that lacks the norm, then silently ships a weakened
+gate. The gate must be **mechanical**, not a norm.
+
+### MECHANISM — conservative, content-inferred §CP classification (NOT an author-declared tag)
+
+The signal carrier is the load-bearing fork, and it is resolved **against** the tempting
+author-declared marker:
+
+- **Rejected: an author-declared frontmatter tag** (`relaxes:` / `guard-change` / `status:
+  needs-ratification`). It is **self-defeating**: the same agent that lacks the discipline to hold
+  a guard-relaxing ADR also lacks the discipline to *add the tag* — so the detection re-opens the
+  exact failure mode it closes. An author-declared signal is a norm wearing a mechanism's clothes.
+
+- **Chosen: a conservative, fail-closed CONTENT predicate.** `ship-it`'s Step-0 §CP classification
+  inspects the **content** of every touched `.decisions/**` file. If the ADR **cites or amends a
+  documented guard** — i.e. its prose names any guard/invariant/enforcement concept (or a
+  relaxation verb over one) — it classifies **§CP**: human-merge, held for founder ratification.
+  This is deliberately **over-inclusive**: an ADR that merely *cites* a guard without relaxing it
+  is still routed to a human approval, which is **cheap** (a fast approve), whereas a missed
+  guard-relaxer auto-ships a weakened gate, which is the bug. The design bias is flipped to
+  **"default §CP on any guard mention, auto-ship only on positive evidence the ADR is guard-free"**
+  — the same fail-closed stance as ADR
+  [0092](0092-gates-fail-closed-on-zero-scope.md). "You cannot relax a guard without naming it," so
+  a content probe over guard vocabulary catches the class that an author tag would let slip.
+
+**Why content-inference beats detecting "relaxes" precisely.** Whether an ADR *relaxes* a guard is
+a judgment call, not a mechanizable predicate — that is why this was filed `type:decision`. So the
+mechanism does **not** try to detect relaxation; it detects the strictly broader, mechanically
+decidable "**touches guard territory**" and routes the whole class to a human. Precision is traded
+for a fail-closed over-match, on purpose.
+
+### Enforcement seam — `ship-it` Step 0, single-sourced in §CP, drift-locked
+
+- The predicate lives as **one canonical definition** — `GUARD_ADR_RE`, the guard-vocabulary
+  regex — in [`gh-issue-intake-formats.md §CP`](../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md),
+  beside `CONTROL_PLANE_RE`. It is **not** a hard-coded copy: `ship-it` Step 0 carries only a
+  fail-closed reference literal and **re-resolves the live value from `origin/main` at run time**
+  (REST raw, `?ref=main`), exactly as it already does for `CONTROL_PLANE_RE` (#981) — so a stale
+  injected snapshot cannot mis-classify. `validate-gate-path-drift.sh` gains an invariant locking
+  `ship-it`'s copy byte-identical to the §CP canonical, mirroring the `CONTROL_PLANE_RE` lock (ADR
+  [0073](0073-review-skill-gate.md) §6). This respects the §CP single-source discipline (one
+  predicate, drift-locked; no reintroduced hard-coded copy).
+
+- The classification is **fail-closed end to end**: if the boundary read from `origin/main` fails,
+  the predicate degrades to "match everything" (every touched ADR is §CP); if any individual ADR's
+  content cannot be read at the PR head (a delete, a 404), that ADR is treated as §CP. The gate
+  never auto-ships an ADR it could not read and prove guard-free.
+
+- On a match, `ship-it` classifies the PR **§CP: APPROVAL-GATED** and **STOPS at `awaiting
+  control-plane approval`** absent a current-head `@kamp-us/control-plane` team approval — the
+  identical hold ADR 0135 already applies to path-§CP PRs. **No new approver system is
+  introduced**: the mechanical gate reuses the existing §CP control-plane approval. Per the POLICY,
+  the approving control-plane member for a guard-relaxer should be the **founder** (author ≠
+  approver, ADR 0135), not merely any control-plane merger.
+
+### Routing is unchanged — only merge-authority moves
+
+`review-doc` still **verifies** a guard-touching ADR (its verdict routing is orthogonal to
+merge-authority — the §CP set governs *who merges*, not *which gate verifies*; §CP). The content
+predicate adds the §CP **merge-authority hold** in `ship-it` only; `review-doc` is deliberately
+left unchanged. A guard-touching ADR therefore still earns a `review-doc` PASS, and `ship-it` then
+consumes that PASS **plus** the control-plane approval before enqueue.
+
+## Adversarial self-check (the classification boundary)
+
+- **(a) Author-tag evasion — closed by construction.** There is no author tag to omit; the signal
+  is inferred from prose. Evading it requires relaxing a guard while naming *no* guard/invariant/
+  enforcement concept — which is nearly impossible, since relaxing a guard requires citing it.
+  **Residual gap:** an ADR could reference a guard purely obliquely ("makes the check in ADR 0083
+  advisory") using no vocabulary in the regex. Mitigation: the regex is broad and **extensible**,
+  and the fail-closed default plus the path-§CP net (an ADR that also edits a §CP file is caught by
+  `CONTROL_PLANE_RE`) reduce the exposure; a missed synonym is a regex extension, not a redesign.
+
+- **(b) A guard-cite the pattern misses → default toward §CP.** The predicate over-matches on
+  purpose (guard-concept vocabulary *or* a relaxation verb), and the boundary/content reads are
+  fail-closed, so an unreadable or ambiguous ADR classifies §CP. The failure direction is toward
+  human approval, never toward auto-ship.
+
+- **(c) An exempt-class false-negative — none introduced.** The change only *adds* §CP coverage to
+  a subset of `.decisions/**`; it removes coverage from nothing. The path §CP set is untouched, so
+  no previously-blocking class is freed. A mixed PR that buries a guard-relaxing ADR among many
+  files is caught because the probe scans **every** touched `.decisions/**` file (paginated), and a
+  single match blocks the whole PR.
+
+## Consequences
+
+- A guard-relaxing ADR can no longer auto-ship on a `review-doc` PASS; it is held for a
+  control-plane (founder) approval — the guard now holds the guard-relaxation, not an agent's
+  memory.
+- Some guard-*mentioning* but non-relaxing ADRs will also require a control-plane approval. This is
+  an accepted, cheap over-match (a fast approve) traded for the fail-closed guarantee; it is not a
+  bug to "optimize away" by narrowing toward author-declared detection.
+- The predicate's vocabulary is a living list; extending it (per residual gap (a)) is itself a §CP
+  change to `gh-issue-intake-formats.md`.
+
+## Alternatives considered
+
+- **Author-declared frontmatter tag** — rejected as self-defeating (see MECHANISM).
+- **A new "founder-only" approver mechanism** — rejected as needless surface; the §CP control-plane
+  approval (ADR 0135) already provides the human hold, and the POLICY names the founder as the
+  expected approver within it.
+- **Teaching `review-doc` to detect guard-relaxation and withhold its PASS** — rejected: the
+  verdict axis is orthogonal to merge-authority (§CP), and putting the hold in the merge authority
+  (`ship-it`) keeps the single choke point where merge decisions already live (ADR
+  [0048](0048-ship-it-merge-actor.md)).
+
+## References
+
+- ADRs [0053](0053-control-plane-boundary.md)/[0065](0065-gate-critical-skills-are-blocking.md) — the control-plane boundary + gate-critical-skills widening.
+- ADR [0078](0078-product-driven-decisions-by-default.md) — engineering leads on platform/pipeline (this ADR's lane).
+- ADR [0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md) — approval-aware §CP enqueue (the reused hold) + author ≠ approver.
+- ADR [0073](0073-review-skill-gate.md) §6 — the §CP single-source + drift-lock discipline.
+- ADR [0092](0092-gates-fail-closed-on-zero-scope.md) — fail-closed on zero scope (the stance this predicate adopts).
+- ADR [0048](0048-ship-it-merge-actor.md) — ship-it as the single merge authority (where the hold belongs).

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1086,7 +1086,8 @@ through the consolidated `^packages/pipeline-cli/` package per ADR
 the **pipeline agent definitions** (`claude-plugins/kampus-pipeline/agents/**`) added by ADR
 [0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
 since a gate/merge agent's own instructions are a self-weakening surface). Everything else — `apps/**`,
-**non**-guard `packages/**`, `.decisions/**`, `.patterns/**`, every prose doc `*.md` (the
+**non**-guard `packages/**`, `.decisions/**` (**except a guard-touching ADR** — see the content
+clause below), `.patterns/**`, every prose doc `*.md` (the
 §DOC class), and every **non**-gate-critical `skills/**` — is **non-blocking** and
 auto-merges through its matching gate on a PASS. (This set governs *who merges*, not *which gate verifies* — a
 code-root `*.md` is non-blocking here yet rides `review-code`, not `review-doc`, per §DOC.)
@@ -1136,6 +1137,59 @@ The **0052 instruction-trust set** (root `CLAUDE.md`, `.claude/**`, `.decisions/
 `.patterns/**`) is a *different* set — what a reviewer must never *load*, an isolation
 concern, not a merge-blocking one. Keep them apart (review-code Step 2 spells out the
 distinction). This section governs **only** the merge-blocking / control-plane set above.
+
+### The guard-touching ADR predicate — a §CP membership test by CONTENT (ADR 0164)
+
+The path matcher above is **necessary but not sufficient**: a `.decisions/**` ADR that
+**relaxes, amends, or widens an exemption on a documented guard** is control-plane by *nature*
+(it weakens the pipeline's own guardrails — the exact class §CP exists to hold for human
+ratification), yet its **path** is indistinguishable from an ordinary ADR's. `.decisions/**` is
+otherwise non-blocking (it auto-merges on a `review-doc` PASS), so a guard-relaxing ADR would
+auto-ship past founder ratification with no mechanical hold — a control-plane fail-open (ADR
+[0164](https://github.com/kamp-us/phoenix/blob/main/.decisions/0164-guard-relaxing-adr-cp-gate.md),
+#2191).
+
+So §CP membership has a **second, content-inferred clause** for `.decisions/**` files, alongside
+the path `CONTROL_PLANE_RE`: a touched `.decisions/**` ADR whose **content cites or amends a
+documented guard** is §CP. The signal is **inferred from the ADR prose, never an author-declared
+tag** — an author-declared marker (`relaxes:` / `guard-change`) is self-defeating (the agent that
+lacks the discipline to hold the ADR also won't add the tag; ADR 0164 MECHANISM). The predicate is
+**deliberately conservative / fail-closed**: it over-matches on any guard-vocabulary mention
+(routing a merely-guard-*citing* ADR to a cheap human approval) rather than risk missing a
+guard-*relaxer* (which would auto-ship a weakened gate) — "you cannot relax a guard without naming
+it," so a content probe over guard vocabulary catches the class an author tag would let slip. This
+is the same fail-closed stance as §ZS / ADR 0092.
+
+The predicate is **single-sourced here** as one canonical regex — the same discipline that keeps
+`CONTROL_PLANE_RE` from drifting (ADR 0073 §6). Cite this line; do **not** re-hard-code the
+vocabulary. `validate-gate-path-drift.sh` locks `ship-it`'s copy byte-identical to this canonical.
+
+```
+GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|containment|control-plane|control plane|§cp|self-weakening|blocking set|adversarial review|must never|hard-gate|hard gate|enforcement|\bgat(e|es|ing|ed)\b|relax|loosen|weaken|soften|widen|broaden|waive|bypass|exempt|carve[ -]?out|opt[ -]?out'
+```
+
+```bash
+# §CP content clause (ADR 0164): a touched .decisions/** ADR whose CONTENT matches GUARD_ADR_RE is
+# §CP. Resolve GUARD_ADR_RE from origin/main at run time (like CONTROL_PLANE_RE, #981); read each
+# ADR's body at the PR head. FAIL CLOSED: an unreadable boundary ⇒ match-everything; an unreadable
+# ADR (delete/404) ⇒ §CP — never auto-ship an ADR that could not be read and proven guard-free.
+GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|containment|control-plane|control plane|§cp|self-weakening|blocking set|adversarial review|must never|hard-gate|hard gate|enforcement|\bgat(e|es|ing|ed)\b|relax|loosen|weaken|soften|widen|broaden|waive|bypass|exempt|carve[ -]?out|opt[ -]?out'
+GA_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^GUARD_ADR_RE=' | head -n1 || true)"
+if [ -n "$GA_LIVE" ]; then GUARD_ADR_RE="$(printf '%s' "$GA_LIVE" | sed "s/^GUARD_ADR_RE='//; s/'$//")"; else GUARD_ADR_RE='.'; fi   # FAIL CLOSED: '.' ⇒ every ADR word matches ⇒ every touched ADR is §CP
+HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+  [ -z "$adr" ] && continue
+  body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+  if [ -z "$body" ]; then echo "BLOCKING ($adr — unreadable at head ⇒ §CP, fail-closed)"
+  elif printf '%s' "$body" | grep -Eiq "$GUARD_ADR_RE"; then echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
+done
+```
+
+A guard-touching ADR classifies **§CP for merge-authority** exactly like a path-§CP file:
+`ship-it` STOPS at `awaiting control-plane approval` until a current-head `@kamp-us/control-plane`
+approval is present (per POLICY, the founder's; ADR 0135). Its **verdict routing is unchanged** —
+it is still doc-class, `review-doc`-verified (this set governs *who merges*, not *which gate
+verifies*); the content clause adds only the merge-authority hold.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -61,12 +61,18 @@ A PR is in one of two classes by the files it touches (ADR
   (blocking) is the *separate* axis 0065 owns, and 0065 stands verbatim until a later decision
   retires it against `review-skill`'s evidence (ADR 0073 §4).
 - **NON-BLOCKING — autonomous.** Everything else — `apps/**` (every app worker), `packages/**`,
-  `.decisions/**`, `.patterns/**`, and other prose docs. These are product or knowledge
+  `.decisions/**` (**except a guard-touching ADR** — see next paragraph), `.patterns/**`, and
+  other prose docs. These are product or knowledge
   artifacts; they are gated for quality, but a human at the merge adds no security value, so
   you ship them once the matching gate PASSes.
 
 Note `.decisions/**` and `.patterns/**` are **non-blocking** under 0053 — they auto-merge
-through `review-doc` (the boundary moved off "harness vs not" to "control plane vs not").
+through `review-doc` (the boundary moved off "harness vs not" to "control plane vs not"). **The
+one exception (ADR [0164](https://github.com/kamp-us/phoenix/blob/main/.decisions/0164-guard-relaxing-adr-cp-gate.md),
+#2191): a guard-touching `.decisions/**` ADR is §CP.** An ADR that relaxes/amends a documented
+guard is control-plane by nature, so Step 0 classifies a `.decisions/**` file §CP by its
+**content** (a conservative, fail-closed guard-vocabulary probe — not an author-declared tag) and
+holds it for a founder/control-plane approval rather than auto-shipping it on a `review-doc` PASS.
 
 ## All GitHub ops via `gh api` REST — never GraphQL
 
@@ -240,6 +246,24 @@ else
   CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ treat EVERY path as control-plane (refuse), never trust the possibly-stale snapshot
 fi
 echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065) + the enforcement-guard packages (ADR 0100/0103); other skills/** auto-merge on a review-skill PASS (ADR 0073)
+# §CP CONTENT clause (ADR 0164/#2191): a .decisions/** ADR is §CP by PATH only if it also matches
+# CONTROL_PLANE_RE (it doesn't) — but a guard-RELAXING ADR is control-plane by NATURE and path can't
+# tell it from an ordinary one. So classify a touched .decisions/** ADR §CP when its CONTENT cites or
+# amends a documented guard. GUARD_ADR_RE is single-sourced in gh-issue-intake-formats.md §CP — the
+# literal below is the fail-closed reference + validate-gate-path-drift lockstep target, NOT the live
+# decision source: re-resolve it from origin/main (like CONTROL_PLANE_RE, #981), and read each ADR's
+# body at the PR head. FAIL CLOSED throughout: unreadable boundary ⇒ match-everything; unreadable ADR
+# (delete/404) ⇒ §CP — never auto-ship an ADR that couldn't be read and proven guard-free.
+GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|containment|control-plane|control plane|§cp|self-weakening|blocking set|adversarial review|must never|hard-gate|hard gate|enforcement|\bgat(e|es|ing|ed)\b|relax|loosen|weaken|soften|widen|broaden|waive|bypass|exempt|carve[ -]?out|opt[ -]?out'   # §CP canonical (ADR 0164) — drift-locked to gh-issue-intake-formats.md
+GA_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^GUARD_ADR_RE=' | head -n1 || true)"
+if [ -n "$GA_LIVE" ]; then GUARD_ADR_RE="$(printf '%s' "$GA_LIVE" | sed "s/^GUARD_ADR_RE='//; s/'$//")"; else GUARD_ADR_RE='.'; fi   # FAIL CLOSED: '.' ⇒ every ADR word matches ⇒ every touched .decisions/** file is §CP
+HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+  [ -z "$adr" ] && continue
+  body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+  if [ -z "$body" ]; then echo "BLOCKING ($adr — unreadable at head ⇒ §CP, fail-closed)"
+  elif printf '%s' "$body" | grep -Eiq "$GUARD_ADR_RE"; then echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
+done
 echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/(skills|agents)/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063); agents/** are behavioral artifacts, skill-class for the verdict gate (ADR 0150/#2003) — §CP-blocking for merge via CONTROL_PLANE_RE above
 echo "$FILES" | grep -Eq '^(apps|packages|\.glossary|infra)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + infra/** standalone stacks (ADR 0057) + .glossary/** — agrees with the docs-probe exclusion below (#663/#919/#1987); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)
 # docs probe EXCLUDES the code roots, skills/**, AND .glossary/** first, so a code/app-internal README
@@ -251,7 +275,11 @@ echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary|infra)/' | g
 **Routing:**
 
 - If **any** file is control plane (the §CP set — `.claude/**`, `.github/**`, or a
-  gate-critical skill) → the PR is **§CP: APPROVAL-GATED** (not a blanket refuse — ADR
+  gate-critical skill) **OR any touched `.decisions/**` ADR matched the guard-touching content
+  probe above** (a guard-relaxing/amending ADR is control-plane by nature — ADR
+  [0164](https://github.com/kamp-us/phoenix/blob/main/.decisions/0164-guard-relaxing-adr-cp-gate.md),
+  #2191; its `review-doc` verdict routing is unchanged, only merge-authority moves) → the PR is
+  **§CP: APPROVAL-GATED** (not a blanket refuse — ADR
   [0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md),
   amending 0053's merge model). Check for a **current-head `@kamp-us/control-plane` team approval**
   (the [§CP approval gate](#step-0-cp-approval-gate) below):

--- a/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
@@ -100,6 +100,39 @@ for rel in $CONSUMERS; do
 	fi
 done
 
+# ── Invariant 1b: GUARD_ADR_RE copy matches §CP (ADR 0164) ──────────────────
+#
+# The guard-touching-ADR content predicate (ADR 0164, #2191) is single-sourced in §CP the
+# same way CONTROL_PLANE_RE is: one canonical GUARD_ADR_RE= line in gh-issue-intake-formats.md,
+# with ONE consumer copy in ship-it (its fail-closed reference literal). Lock the copy
+# byte-identical to §CP so the vocabulary can't drift between the source and ship-it.
+GA_CANONICAL=$(grep "^GUARD_ADR_RE=" "$FORMATS_MD" | head -n1 | sed 's/^GUARD_ADR_RE=//' || true)
+if [ -z "$GA_CANONICAL" ]; then
+	fail "§CP canonical GUARD_ADR_RE= not found in $FORMATS_MD — line must start with GUARD_ADR_RE= (ADR 0164)"
+else
+	ok "§CP canonical GUARD_ADR_RE extracted from gh-issue-intake-formats.md"
+	GA_MD="$skills_dir/ship-it/SKILL.md"
+	if [ ! -f "$GA_MD" ]; then
+		fail "ship-it/SKILL.md not found — cannot verify GUARD_ADR_RE copy"
+	else
+		GA_LINE=$(grep "GUARD_ADR_RE=" "$GA_MD" | head -n1 || true)
+		if [ -z "$GA_LINE" ]; then
+			fail "ship-it/SKILL.md: no GUARD_ADR_RE= line found — consumer must carry a copy matching §CP (ADR 0164)"
+		else
+			GA_STRIPPED="${GA_LINE#"${GA_LINE%%[![:space:]]*}"}"
+			GA_VAL="${GA_STRIPPED#GUARD_ADR_RE=}"
+			GA_VAL_CLEAN=$(printf '%s\n' "$GA_VAL" | sed "s/'[[:space:]]*#.*$/'/")
+			if [ "$GA_VAL_CLEAN" = "$GA_CANONICAL" ]; then
+				ok "ship-it/SKILL.md GUARD_ADR_RE matches §CP canonical"
+			else
+				fail "ship-it/SKILL.md GUARD_ADR_RE has drifted from §CP canonical
+  §CP:  $GA_CANONICAL
+  copy: $GA_VAL_CLEAN"
+			fi
+		fi
+	fi
+fi
+
 # ── Invariant 2: .claude/skills symlink agrees with marketplace source ───────
 #
 # .claude/skills -> ../claude-plugins/kampus-pipeline/skills


### PR DESCRIPTION
Fixes #2191

## What this closes

A `.decisions/**` ADR is doc-class and **auto-ships on a `review-doc: PASS`**, so an ADR that **relaxes/amends a documented guard** had **no mechanical human-gate** — only agent discipline held the line (the EM hand-holding in-flight ADRs 0161/0162, which relax ADR 0083's containment guard). A stray shipper, or a mid-flight-on-green compaction that resumed at enqueue, would auto-merge a guard-weakening ADR **past founder ratification** — a control-plane fail-open. This closes the hole.

## The build (two parts, one PR)

**1. ADR 0164** (`.decisions/0164-guard-relaxing-adr-cp-gate.md`, status: `proposed`)
- **POLICY** — the founder ratifies any guard-relaxing ADR.
- **MECHANISM** — a conservative, **fail-closed CONTENT predicate**, explicitly **rejecting** an author-declared tag (`relaxes:` / `guard-change`) as *self-defeating* (the agent that won't hold the ADR also won't add the tag). Any touched `.decisions/**` ADR whose content **cites or amends a documented guard** classifies §CP. Reuses the ADR 0135 §CP approval — **no new approver system**. Cites ADR 0053/0065 (control-plane boundary), 0078 (engineering-led), 0135 (approval-aware ship), 0073 §6 (single-source), 0092 (fail-closed).

**2. ship-it Step-0 §CP predicate**
- New single-source `GUARD_ADR_RE` in `gh-issue-intake-formats.md §CP` (the guard-vocabulary regex) + the content-clause definition.
- `ship-it` Step 0 runs a **content probe** over every touched `.decisions/**` file: `GUARD_ADR_RE` is **re-resolved from `origin/main` at run time** (like `CONTROL_PLANE_RE`, #981), each ADR body read at the PR head. **Fail-closed throughout**: an unreadable boundary ⇒ match-everything; an unreadable/deleted ADR at head ⇒ §CP. On a match → **§CP: APPROVAL-GATED**, `ship-it` **STOPS at `awaiting control-plane approval`**.
- **Verdict routing is unchanged** — the ADR is still `review-doc`-verified; only *merge-authority* moves (the §CP set governs *who merges*, not *which gate verifies*). `review-doc` deliberately untouched.
- `validate-gate-path-drift.sh` gains an invariant locking `ship-it`'s `GUARD_ADR_RE` copy byte-identical to the §CP canonical (respects AC3 — no reintroduced hard-coded copy). Drift-lock run: **9/9 checks OK**.

## Adversarial self-check (classification boundary)

- **(a) Author-tag evasion** — closed by construction (no tag to omit; signal inferred from prose). *Residual gap:* an ADR could cite a guard purely obliquely ("makes the check in ADR 0083 advisory") using no regex vocabulary; mitigated by a broad, **extensible** vocabulary + the fail-closed default + the path-§CP net. A missed synonym is a regex extension, not a redesign.
- **(b) A guard-cite the pattern misses → defaults toward §CP.** The predicate over-matches (guard vocabulary *or* a relaxation verb) and both the boundary and content reads are fail-closed, so ambiguity resolves to human approval, never auto-ship.
- **(c) Exempt-class false-negative — none introduced.** The change only *adds* §CP coverage to a subset of `.decisions/**`; it removes coverage from nothing. A guard-ADR buried in a large PR is caught because the probe scans **every** touched `.decisions/**` file (paginated); one match blocks the PR.

**Predicate sanity check:** matches this PR's own ADR 0164 (guard-touching), and does **not** match a synthetic pure-product ADR.

## §CP — human-merge

This PR **is §CP** (it touches `ship-it` + `gh-issue-intake-formats.md`, both gate-critical, plus `.decisions/**`). It is **not self-mergeable** — it needs a `@kamp-us/control-plane` approval and a human merge (cansirin). I have not merged or self-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)