### PR TITLE
feat(pipeline): review-design skill — capture→judge→marker gate vs the ADR-0162 four-pillars law (#2246)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 /claude-plugins/kampus-pipeline/skills/review-code/                @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/review-doc/                 @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/review-skill/               @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/review-design/              @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/review-plan/                @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md  @kamp-us/control-plane
 # Control-plane: the pipeline agent definitions — the behavior of the very agents that run the

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1103,13 +1103,13 @@ Every consumer matches the set with this **one** anchored regex (POSIX ERE; the 
 form below). Cite this regex; do **not** re-hard-code the path list:
 
 ```
-^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/
+^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/
 ```
 
 ```bash
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — one definition, no fourth copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -491,7 +491,7 @@ snapshot once mis-classified a now-control-plane PR (#981); reading §CP freshly
 # is current — a pre-amendment snapshot once mis-classified a now-control-plane PR (#981). So the
 # literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
 # live decision source: the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -1,0 +1,547 @@
+---
+name: review-design
+description: Verify a UI-affecting PR against the four-pillars design law (ADR 0162) by driving Playwright over the PR's preview deploy, capturing the changed UI surfaces, and judging the rendered screenshots multimodally — the 4th reviewer skill alongside review-code / review-doc / review-skill in the configured target repo's pipeline. It hard-FAILs ONLY on the six enumerable, objective ADR-0162 prohibitions (faint-for-meaning, missing focus ring, off-grid spacing/type, void empty state, sub-36px tap target, colour-alone meaning); all holistic/taste judgment rides as advisory (non-blocking) notes in the same verdict comment, and it is calibrated to FAIL conservatively — a borderline call is downgraded to advisory, never a hard block. Trigger on "review the design of PR #N", "review-design #N", "run the design gate on #N", "gate the UI PR against the pillars", "does this UI PR meet the design law", "run review-design", or whenever you're asked to confirm a UI PR's rendered surfaces obey ADR 0162 before merge. This is the design-class verification stage of the issue-intake pipeline: it consumes the UI PRs write-code opens, renders and looks at them over the preview deploy, and emits a namespaced, SHA-bound `review-design: PASS @ <sha> — merge-ready` / `review-design: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted to one-per-PR, embedding the GitHub-hosted screenshot evidence; on a FAIL it feeds the existing write-code repair loop. It never merges; it never emits a review-code / review-doc / review-skill marker.
+---
+
+# review-design
+
+You are the **design-class gate** — the agent vision-gate ADR
+[0165](https://github.com/kamp-us/phoenix/blob/main/.decisions/0165-review-design-gate.md) records.
+`write-code` already picked a triaged issue, implemented it on a branch, and opened a PR with
+`Fixes #N` — but where `review-code` reads product code, `review-doc` reads prose, and
+`review-skill` reads a behavioral artifact, **you look at the rendered screen**. Your job is to
+drive the PR's **preview deploy** with Playwright, **capture the changed UI surfaces**, and judge
+those screenshots against the **four-pillars design law** (ADR
+[0162](https://github.com/kamp-us/phoenix/blob/main/.decisions/0162-four-pillars-design-law.md))
+and its machine-readable transcription in
+[`design-system-manifest.md`](https://github.com/kamp-us/phoenix/blob/main/design-system-manifest.md).
+
+**Claude — you, multimodal — are the vision model.** There is no exotic vision service and no human
+in the capture loop (ADR 0165, "Fork ruled — agent vision-gate, not human-eyeball"): the reviewer
+agent that already runs the other gates simply *sees* the captured images and emits a machine
+verdict. Screenshots are still hosted so a human *can* look, but the human look is not the gate — the
+agent verdict is.
+
+You are the fourth sibling in the suite: `report` → `triage` → `plan-epic` → `review-plan` →
+`write-code` → **`review-code` / `review-doc` / `review-skill` / `review-design`** → `ship-it`.
+`review-code` gates code PRs, `review-doc` gates doc PRs, `review-skill` gates skill PRs, **you gate
+the rendered UI** of UI-affecting PRs; `ship-it` routes to whichever produced the matching verdict.
+This gate is the review surface ADR 0162's Consequences named ("checks every UI PR against these four
+pillars … the way review-code checks acceptance criteria"), now specified.
+
+You come to this **fresh**, with no sunk-cost attachment to the change: the agent that built the UI
+is the worst judge of whether it obeys the pillars, because it knows what it *meant* the pixels to
+look like. You only know what ADR 0162 forbids and what the preview *actually renders*. Judge the
+second against the first, from the outside.
+
+## The judged source is the LOCAL captured bytes; the upload is evidence-only (ADR 0165)
+
+**You judge the locally captured screenshot bytes** — the PNGs the capture helper writes to disk,
+which you read as multimodal input. The GitHub-hosted upload is **display-only and out of the
+decision path**: it merely *shows* the evidence to a human reading the PR. If the upload failed, your
+verdict still stands (you judged the local bytes). Never make the verdict depend on the hosted URL —
+embed it as evidence, but decide on what you saw locally.
+
+## The blocking surface is narrow — hard-FAIL only on the six objective prohibitions, everything else is advisory
+
+The gate is **blocking**, but its hard-FAIL surface is deliberately narrow (ADR 0165, "Blocking
+scope — calibrated, fail-conservative"). You hard-FAIL **only** on the six enumerable, objective
+ADR-0162 prohibitions — the "never" rules that are **visual facts** a reviewer can point at without
+taste entering the judgment. Everything holistic or taste-based ("this feels cramped", "the
+hierarchy is muddy") rides as **advisory, non-blocking notes in the same verdict comment**, never as
+a FAIL.
+
+You are **calibrated to fail conservatively**: only a *clear, objective* violation trips a FAIL;
+**anything borderline is downgraded to an advisory note.** When you are unsure whether a rendered
+surface violates a prohibition, it is advisory, not a FAIL. A FAIL blocks a merge and costs a repair
+round — reserve it for a violation you can point at in the screenshot and name against the exact
+prohibition below.
+
+### The six hard-FAIL prohibitions (enumerated from ADR 0162 §Prohibitions)
+
+A PR hard-FAILs if a captured surface **objectively** exhibits any of these. Cite the surface + the
+specific prohibition in the verdict:
+
+1. **Faint-for-meaning.** Meaning-carrying text rendered on `--text-faint` (`--gray-10`, 3:1 only)
+   or any token/colour below the **AA 4.5:1** floor. Meaning-carrying text bottoms out at
+   `--text-muted` (`--gray-11`, AA-safe); anything fainter used for real content (not a placeholder,
+   disabled, or decorative hint) is a FAIL. (Pillar 4; Pillar 2's role-token rule.)
+2. **Missing focus ring.** An interactive control (button, link, toggle, input, reaction, A–Z index
+   letter) that shows **no visible focus ring** when focused, or that hand-rolls its own `outline`
+   in place of the shared spacer-ring (`--focus-ring`, a 2px ring + 2px gap). Verify by capturing the
+   control in its `:focus-visible` state. (Pillar 4.)
+3. **Off-grid spacing / type.** Layout that visibly lands **off the 4px lattice** — spacing, padding,
+   or a type step that isn't a clean 4px multiple, outside the **sanctioned 1px/2px exceptions**
+   (hairline borders, optical nudges). (Pillar 1 grid / Pillar 2 one-type-ramp.) *Conservative note:*
+   only FAIL on a clear, measurable off-grid break, not a suspected sub-pixel — borderline → advisory.
+4. **Void empty state.** A list/detail surface rendered **empty with no designed empty treatment** —
+   a blank void, or a bare `0 yorum`-style label as the entire empty state, or content jammed at the
+   top of a void. Capture the surface in its empty/sparse state where the diff can produce one.
+   (Pillar 3.)
+5. **Sub-36px tap target.** An interactive control whose **hit area** is below the **36px minimum**
+   (the hit area, not necessarily the visible glyph). (Pillar 4 / value 4.)
+6. **Colour-alone meaning.** State or meaning signalled by **colour alone** — a selected/active/error
+   state distinguished only by hue, with no second channel (icon, text, shape, weight). (Pillar 4.)
+
+**Holistic / taste** — cohesiveness drift, muddy hierarchy, cramped rhythm, an off-brand
+composition, a primitive that *could* have been reached for but wasn't yet renders acceptably — is
+**advisory**, surfaced in the same comment under an **Advisory (non-blocking)** heading. Advisory
+notes never flip the verdict to FAIL.
+
+**#2174 is folded in here (ADR 0165 Consequences).** The earlier framing — bolting a "design + a11y
+dimension" onto `review-code` / `review-doc` — is **subsumed** by this gate. Design review is its own
+gate with its own SHA-bound marker, not a rider on the code/doc gates; the design + a11y check
+dimension #2174 named **is** this skill's rubric (the six prohibitions above + the advisory pass).
+
+## Authority limit: you never merge
+
+**You do not merge. Not on a pass, not ever, not on your own authority.** Your output is a *verdict*
+— a merge-ready signal (non-blocking) or advice (blocking) plus a fail comment naming the violated
+prohibition. Merging is the deliberate act of **`ship-it`** (the one stage granted merge authority),
+or, for the blocking set, a human. You signal merge-ready; `ship-it` asserts your PASS, confirms CI
+is green, and squash-merges. Conflating "verified" with "merged" is the self-grading collapse this
+stage exists to prevent — the same invariant the sibling gates hold.
+
+## You emit a `review-design` marker, NEVER a `review-code`/`review-doc`/`review-skill` one
+
+`ship-it` matches the gate markers in **separate namespaces** (anchored, emphasis-tolerant,
+SHA-capturing regexes that never cross-match — the matcher contract in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §5 / §6.5), latest-verdict-wins per
+namespace, then a SHA-staleness refusal (ADR 0058). Your verdict's first line is **always**
+`review-design: … @ <sha>` — never another gate's token. Emitting another gate's marker on a UI PR
+would let that namespace's scan match your verdict, collapsing the gates into one. Keep the namespace
+clean: `review-design:` for the design gate, full stop.
+
+## All GitHub ops via `gh api` REST — never GraphQL
+
+The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue and PR queries.
+Every issue/PR/comment read and write goes through `gh api` REST — not a style preference, GraphQL
+calls error out on this org. **Resolve the target repo once, up front** (this skill is
+repo-agnostic — every `gh api` call targets `$REPO`, not a hardcoded repo) per the shared contract's
+**Target repo resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), ADR
+0062 §1); in phoenix this defaults to `kamp-us/phoenix` with no config.
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
+
+## Read-only on git working state
+
+**You never mutate the git working tree of the checkout you run in** — the single canonical rule
+lives in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §RO; cite it, don't restate
+the prohibition. You do not need to check out the PR head to run: you drive the **deployed preview**
+over the network and read the **diff** via `gh api` / `gh pr diff` for surface selection. There is no
+head-config-load hazard here (you render the preview, you don't load the PR's instructions), so no
+config-pin worktree is needed — but you still **read all working state read-only** and never branch,
+reset, or check out in your session tree.
+
+## The formats contract
+
+Your inputs and output live in the shared contract — read it before you start:
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md).
+
+- **§CP** — the canonical control-plane / blocking-set definition (Step 0 classification). Cite it;
+  don't re-hard-code the path list.
+- **§5 / §6.5** — the SHA-bound verdict-marker matcher contract. Your `review-design` marker lives in
+  its own namespace, distinct from `review-code` (§5), `review-doc` (§6), and `review-skill` (§6.5);
+  emit the same SHA-bound `PASS @ <sha> — merge-ready` / `FAIL @ <sha> — changes-requested` shape and
+  token order, under the `review-design:` token.
+- **The verdict read-back guard** (`verdict_readback_guard`) — the single canonical post-write
+  read-back you call after your upsert (Step 5). It is **gate-parameterized** — call it with the
+  `review-design` gate token; do not re-derive a local copy.
+
+The design contract you verify against is **ADR 0162 + the design-system-manifest**, not an issue's
+acceptance-criteria checklist. The issue's ACs are the *feature* contract `review-code` checks; your
+contract is the *design law*. You still read the linked issue and the PR body for context (what the
+UI change is *for*, which surfaces it touches) — context, not the rubric.
+
+---
+
+## Step 0 — Classify: is this a UI-affecting PR? (mis-route off-ramp) + §CP
+
+Pull the file list first. This gate applies to a PR that **changes rendered UI** — the frontend
+under `apps/web/src/**` (React components, styles, tokens, routes). If the diff touches **no**
+UI-affecting path at all, this is the wrong gate.
+
+```bash
+PR=<pr number>
+# UI-affecting = the rendered frontend surface (components, styles, tokens, routes)
+UI_RE='^apps/web/src/'
+UI_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+  --jq '.[].filename' | grep -E "$UI_RE" || true)"
+```
+
+- **Empty** (the diff changes no `apps/web/src/**` surface — a pure backend / infra / docs / skill
+  PR) → **mis-route off-ramp.** Post a **plain note** (no `review-design:` marker — there is no
+  rendered UI to verdict) saying `not a UI-affecting PR — no rendered surface to gate; route to
+  review-code / review-doc / review-skill by class` and **stop**. Never emit a `review-design` marker
+  on a non-UI PR, and never emit a foreign gate's marker — routing to the right gate is the sibling's
+  Step 0, not yours to stamp.
+- **Non-empty** → this is a UI PR; proceed. (A **mixed** PR — UI *and* code/docs — is gated by the
+  matching gate per class: you verdict the design surface and emit `review-design`; `review-code` /
+  `review-doc` verdict their classes. `ship-it` requires the latest PASS in **each** namespace
+  present before it merges.)
+
+**Then classify blocking vs non-blocking via the canonical §CP set** — the same probe the sibling
+gates run, read **freshly from `origin/main`** (the embedded literal is the fail-closed reference +
+drift-lockstep target, not the live decision source; a stale injected snapshot once mis-flagged a
+now-control-plane PR, #981):
+
+```bash
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
+if [ -n "$CP_LIVE" ]; then
+  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"
+else
+  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ treat as blocking (advisory)
+fi
+CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+  --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
+```
+
+- **Empty** (an ordinary product-UI PR — the common case for this gate) → **non-blocking**: your
+  PASS marker binds `ship-it`.
+- **Non-empty** (the UI PR also touches a `.claude`/`.github` path or a gate-critical skill) →
+  **blocking** (§CP): you review it and post your findings, but **advisory only** — a maintainer
+  merges by hand. Say so in the verdict (Step 5, advisory path).
+
+---
+
+## Step 1 — Resolve the PR, its head SHA, the preview URL, and the changed surfaces
+
+```bash
+gh api repos/$REPO/pulls/$PR \
+  --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head your verdict binds to (ADR 0058)
+```
+
+Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `write-code` writes) —
+cross-check via the timeline if it's not obvious — for context on *what* the UI change is and which
+surfaces it targets:
+
+```bash
+gh api "repos/$REPO/issues/$PR/timeline?per_page=100" \
+  --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
+```
+
+### Resolve the preview URL from the sticky preview-deploy comment
+
+The pipeline already produces a **per-PR preview deploy** (ADR
+[0088](https://github.com/kamp-us/phoenix/blob/main/.decisions/0088-preview-deploy-environment.md)):
+CI posts a **sticky comment keyed by `<!-- preview-deploy -->`**, with a per-app sub-line
+`- **web** — Stage \`pr-<n>\` → <url>`. Resolve the `web` preview URL from it — **do not stand up
+your own app server**:
+
+```bash
+PREVIEW_COMMENT="$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+  --jq '[.[] | select(.body | test("<!-- preview-deploy -->"))] | last | .body // ""')"
+# parse the `web` sub-line: `- **web** — Stage `pr-<n>` → <url>`
+PREVIEW_URL="$(printf '%s' "$PREVIEW_COMMENT" | grep -oE 'https://[^ )]*workers\.dev' | head -n1)"
+```
+
+If **no preview URL** can be resolved (the preview-deploy comment is absent or the deploy failed),
+you **cannot render the change** — do not guess and do not FAIL on a rendering gap you couldn't
+observe. Post a **plain note** that the preview deploy is unavailable so the gate can't run yet
+(re-run once the preview lands), and stop. This is a *can't-gate-yet*, not a design FAIL.
+
+### Select the changed UI surfaces (routes) to capture
+
+Derive the **routes/surfaces** the diff affects from the changed frontend files — a changed component
+maps to the page(s) that render it. Read the diff for surface selection:
+
+```bash
+gh pr diff $PR || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
+```
+
+Map each changed `apps/web/src/**` surface to the route(s) that render it (a changed
+`sozluk/TermPage` component → the term route; a changed reaction/vote component → every feed + detail
+route that shows it; a changed empty-state primitive → a route in its **empty** state). Include the
+**state variants** a prohibition needs — an interactive control's `:focus-visible` state (prohibition
+2), a list's **empty** state (prohibition 4). This route+state list is the input to the capture
+helper.
+
+---
+
+## Step 2 — Capture over the preview deploy, then read the LOCAL bytes (the #2247 helper seam)
+
+The Playwright capture + GitHub-attachment-upload mechanics are the **sibling helper's** job
+(issue [#2247](https://github.com/kamp-us/phoenix/issues/2247)), **not re-implemented here**. This
+skill *drives* that helper: it is a `packages/*` mechanical-tooling member (pure core + thin Effect
+bin, the `epic-ledger` / `leak-guard` idiom), invoked as a thin bin.
+
+**The seam this skill codes against** (the expected contract — see the PR body's "helper seam" note;
+if #2247 lands a different package name/flags, this reference updates in lockstep, ADR 0165's four
+implementation legs land to match):
+
+- **Module:** `@kampus/design-capture` at `packages/design-capture/`, run as `node
+  packages/design-capture/src/bin.ts capture …` (the `pipeline-cli` / `node src/bin.ts` idiom).
+- **Input:** the preview URL, the route+state surface list (Step 1), an output dir for the PNG bytes,
+  and the target `repository_id` (for the upload).
+- **Output (stdout JSON):** one record per captured surface —
+  `{ surface, route, state, localPath, hostedUrl, uploadError }`. `localPath` is the on-disk PNG the
+  gate judges; `hostedUrl` is the GitHub user-attachments URL for evidence (or `null` with
+  `uploadError` set when the undocumented upload endpoint fails — a **tolerated** degradation: the
+  gate still judges `localPath`).
+
+```bash
+# Drive the helper (the seam; #2247 owns the Playwright + upload mechanics):
+OUT="$(mktemp -d)"
+CAPTURES="$(node packages/design-capture/src/bin.ts capture \
+  --preview-url "$PREVIEW_URL" \
+  --surface "<route>[:state]" [--surface "<route>[:state]" ...] \
+  --out "$OUT" \
+  --repo-id "$(gh api repos/$REPO --jq .id)")"
+# CAPTURES is the stdout JSON array of { surface, route, state, localPath, hostedUrl, uploadError }
+```
+
+**Now judge the LOCAL bytes.** For each captured surface, **read the local PNG** (`localPath`) as
+multimodal input — you look at the actual rendered pixels. The `hostedUrl` is **not** what you judge;
+it is embedded in the verdict as evidence only (ADR 0165). If a capture's `hostedUrl` is `null` (an
+upload failure), that does **not** affect the verdict — you judged the local bytes; note the upload
+degradation in the evidence section and proceed.
+
+---
+
+## Step 3 — Judge the rendered surfaces against the six prohibitions + advisory taste
+
+For **each** captured surface, look at the image and reach a per-prohibition verdict. Walk the six
+**hard-FAIL** prohibitions (the enumerated list above) one at a time, then collect **advisory** taste
+notes separately.
+
+For each of the six, decide:
+
+- **PASS** — the surface does not exhibit the prohibition. Evidence is concrete: the surface + what
+  you see (the focus ring is visibly present on the focused control; the meaning-carrying text reads
+  at `--text-muted` or stronger; the empty state renders a designed treatment).
+- **FAIL** — the surface **objectively** exhibits the prohibition. Evidence is the surface + the
+  visual fact (the reaction count renders on `--text-faint` while carrying meaning; the toggle shows
+  no focus ring when focused; the list is a blank void). Name the exact prohibition.
+- **N/A** — the changed surfaces don't reach this prohibition (no interactive control changed → the
+  focus-ring / tap-target checks are N/A; no list/detail surface changed → the empty-state check is
+  N/A). Record N/A with that reason; it is not a FAIL.
+
+**Calibrate to FAIL conservatively.** A clear, pointable-at violation is a FAIL. **Anything
+borderline — a *suspected* sub-pixel off-grid, a *maybe* too-faint token, a contrast you can't
+confidently call below 4.5:1 from the capture — is downgraded to an advisory note, not a FAIL** (ADR
+0165). When in doubt, advisory.
+
+Collect **advisory (non-blocking)** notes for everything holistic — cohesiveness drift, muddy
+hierarchy, cramped rhythm, a primitive that could have been reached for, an off-brand composition —
+plus every borderline call you downgraded. These ride in the same comment and **never** flip the
+verdict.
+
+**The design verdict is conjunctive over the six hard-FAIL prohibitions:** every applicable
+prohibition must PASS (or be N/A). One objective FAIL → the PR fails the gate. Advisory notes do not
+count against the verdict.
+
+---
+
+## Step 4 — Land the verdict (SHA-bound, upserted, evidence embedded)
+
+**Re-resolve the head SHA** and confirm it hasn't moved since you captured — the gate is stateless;
+if the head advanced *during* review, the preview you captured is stale, so re-capture against the
+new head before posting (never bind a verdict to a head whose UI you didn't see):
+
+```bash
+HEAD_NOW="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
+[ "$HEAD_NOW" = "$HEAD_SHA" ] || { echo "head moved ($HEAD_SHA → $HEAD_NOW) during review — re-capture against $HEAD_NOW before posting"; HEAD_SHA="$HEAD_NOW"; }
+```
+
+Write the verdict to a per-run temp file so multi-line markdown + backticks survive the shell, then
+**upsert** it: scan the PR for *your own* prior `review-design:` marker comment and `PATCH` it with
+the fresh verdict, else `POST` a new one — exactly **one** `review-design` verdict comment per PR
+(ADR 0058 rule 2). The `mktemp` handle must be run-unique (the PR number alone isn't — two concurrent
+reviews of the same PR would collide on a fixed path). Post it **as a comment, never a native
+review** (ADR 0058 rule 4): a native review can't carry the `@ <sha>` in the shape this contract
+controls, so the comment is the single carrier.
+
+The SHA in the first line is **load-bearing**: `ship-it` refuses any verdict not bound to the PR's
+current head (ADR 0058). **Token order is fixed** (§5): `@ <HEAD_SHA>` comes **immediately after**
+`PASS`/`FAIL`, **before** `— merge-ready`/`— changes-requested` — never a trailing `@ <sha>` (that
+captures `sha=null` and `ship-it` refuses a correct PASS as `unverified`, #625).
+
+Every verdict body carries the canonical **`Reviewed-head: @ <HEAD_SHA>`** anchor line (§6.6 / ADR
+0151) — the read-back guard asserts it on every path, and `ship-it`'s §CP enqueue resolves the head
+from exactly that line. Every body also carries an **Evidence** section embedding the helper's
+GitHub-hosted screenshot URLs so a human can see what you judged.
+
+```bash
+ME="$(gh api user --jq .login)"
+find_mine() {   # the namespace-anchored find filter — matches PASS/FAIL/advisory, never a foreign gate
+  gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+    | jq -r --arg me "$ME" 'map(select(.user.login==$me
+        and (.body | test("^\\s*\\**\\s*review-design:"; "i")))) | last | .id // empty'
+}
+upsert() {   # $1 = path to the composed verdict body
+  local BODY; BODY="$(cat "$1")"; local MINE; MINE="$(find_mine)"
+  if [ -n "$MINE" ]; then gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY" --jq .id
+  else gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$BODY" --jq .id; fi
+}
+```
+
+### Pass path — non-blocking PR (the binding signal)
+
+Every applicable prohibition passed (or was N/A) and Step 0 classified the PR **non-blocking**. Land
+the namespaced, SHA-bound marker so `ship-it` can merge on it:
+
+```markdown
+review-design: PASS @ <HEAD_SHA> — merge-ready
+
+Rendered PR #<PR> over the preview deploy and judged the changed UI surfaces against the ADR-0162
+four-pillars design law. Judged the **local captured bytes**; the hosted screenshots below are
+evidence only.
+
+Reviewed-head: @ <HEAD_SHA>
+
+**Hard-FAIL prohibitions (ADR 0162)**
+- [PASS] Faint-for-meaning — <surface>: meaning-carrying text reads at --text-muted+ (AA)
+- [PASS] Missing focus ring — <surface>: focused control shows the spacer ring
+- [PASS] Off-grid spacing/type — <surface>: on the 4px lattice
+- [N/A]  Void empty state — no list/detail empty state in the changed surfaces
+- [PASS] Sub-36px tap target — <surface>: hit area ≥ 36px
+- [PASS] Colour-alone meaning — <surface>: state carries a second channel
+
+**Advisory (non-blocking)**
+- <holistic/taste note, or "none">
+
+**Evidence**
+- <surface>[:state] — ![<surface>](<hostedUrl>)
+
+All objective prohibitions pass. This PR is design-merge-ready. **review-design does not merge** —
+`ship-it` is the authorized merge step.
+```
+
+### Pass path — blocking-set PR (advisory only)
+
+Every check passed but Step 0 classified the PR **blocking** (§CP). Post the **same evidence**, but
+the first line is the **canonical advisory line** — **not** a merge-ready go-ahead. The advisory line
+carries **no first-line `@ <sha>`** by design (ADR 0111 — it authorizes nothing, so it stays out of
+`ship-it`'s PASS namespace); the reviewed head is recorded once, in the body's canonical
+`Reviewed-head:` line (ADR 0151), which `ship-it`'s §CP enqueue reads. `ship-it` refuses this PR
+regardless; a human merges it.
+
+```markdown
+review-design: advisory — blocking-set PR (manual merge)
+
+PR #<PR> touches the control plane (§CP) — the agent control plane / pipeline gates (ADR
+0053/0065/0165). My verdict is **advisory only**: it does **not** authorize a merge. A maintainer
+merges this by hand.
+
+Reviewed-head: @ <HEAD_SHA>
+
+Judged the changed UI surfaces against the ADR-0162 four-pillars law (local captured bytes; hosted
+screenshots are evidence only) — all objective prohibitions pass:
+
+**Hard-FAIL prohibitions (ADR 0162)**
+- [PASS/N/A] <the six, as above>
+
+**Advisory (non-blocking)**
+- <note, or "none">
+
+**Evidence**
+- <surface>[:state] — ![<surface>](<hostedUrl>)
+```
+
+### Fail path — an objective prohibition violated
+
+One or more of the six hard-FAIL prohibitions is **objectively** violated. **Nothing merges. The PR
+stays open; the linked issue stays open and assigned** — don't unassign, relabel, or close. Post the
+SHA-bound FAIL marker (the seam `write-code`'s fix round-trip keys on) with the full per-prohibition
+table — the passing rows too, so the author sees how close they are — and the **specific prohibition
+citation** on each FAIL so the repair round knows exactly what to fix:
+
+```markdown
+review-design: FAIL @ <HEAD_SHA> — changes-requested
+
+Rendered PR #<PR> over the preview deploy and judged the changed UI surfaces against the ADR-0162
+four-pillars law (local captured bytes; hosted screenshots are evidence only).
+
+Reviewed-head: @ <HEAD_SHA>
+
+**Hard-FAIL prohibitions (ADR 0162)**
+- [PASS] <prohibition> — <surface>: <what you saw>
+- [FAIL] Missing focus ring — <surface>: the <control> shows no focus ring in :focus-visible
+  (ADR 0162 Pillar 4 — "never ship an interactive control with no focus ring")
+- [PASS/N/A] <the rest>
+
+**Advisory (non-blocking)**
+- <note, or "none">
+
+**Evidence**
+- <surface>[:state] — ![<surface>](<hostedUrl>)
+
+The FAILed prohibition(s) above must be fixed before this PR can merge. The PR stays open and
+unmerged; #<ISSUE> stays open and assigned. `write-code` repair mode consumes this FAIL — fix on the
+same branch and re-request review.
+```
+
+Do **not** post a native `REQUEST_CHANGES` review — `review-design` is comment-only (ADR 0058 rule
+4), so the SHA-bound marker comment is the sole verdict artifact. Do **not** touch the issue's
+labels, assignee, or state on a fail — a failed gate is a no-op on the work state plus a comment.
+
+### Confirm the verdict landed clean (the shared read-back guard, #2148)
+
+After **any** of the three upserts returns its comment id, close the loop: call the **single
+canonical** [`verdict_readback_guard`](../gh-issue-intake-formats.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard)
+from the shared contract with the **`review-design`** gate token — it re-reads the comment you just
+wrote and asserts the canonical `review-design:` marker, the anchored `Reviewed-head: @ <sha>` line,
+and **no leaked local filesystem path** (the #2148 marker-as-path leak). Do **not** re-derive a local
+copy:
+
+```bash
+CID="$(upsert "$VERDICT_FILE")"
+verdict_readback_guard "$CID" review-design "$HEAD_SHA" \
+  || { echo "read-back failed — re-post the real verdict and re-assert; if it still can't land clean, surface a posting failure (the PR is genuinely ungated) — never swallow it (fail-closed, ADR 0092 §ZS)"; }
+```
+
+On non-zero, re-post the real verdict and re-assert; if it still cannot land clean, surface it as a
+**posting failure** in the run ledger — the PR is genuinely ungated and a consumer must not read it
+as verified. A moved `HEAD_SHA` between the post and the read-back means the head advanced *during*
+review — re-resolve, re-capture against it (the gate is stateless), and re-post; never loosen the
+match to paper over a moved head.
+
+---
+
+## Running it
+
+A single invocation gates one UI PR end to end: classify UI-affecting + blocking/non-blocking via the
+canonical §CP set (Step 0, mis-route off-ramp if not a UI PR), resolve the PR / head SHA / preview
+URL / changed surfaces (Step 1), drive the #2247 helper to capture over the preview deploy and read
+the **local bytes** (Step 2), judge each surface against the six objective ADR-0162 prohibitions with
+advisory taste alongside — calibrated to FAIL conservatively (Step 3), then land the SHA-bound
+`review-design` verdict — PASS (non-blocking) / advisory (blocking) on a full pass, or FAIL on an
+objective violation — with the hosted screenshots embedded as evidence, and close with the read-back
+guard (Step 4). **You never merge, and you never emit a `review-code`/`review-doc`/`review-skill`
+marker.**
+
+Report back a short ledger: the PR, its class (UI / mixed; blocking/non-blocking), the preview URL,
+the surfaces captured, the per-prohibition verdict (N pass / M fail / K N/A), the advisory notes, the
+overall result, and the link to the comment you posted. Don't narrate every REST call — the posted
+verdict is the durable record.
+
+The gate is **stateless**: a re-review re-captures the (possibly updated) preview and re-runs every
+prohibition check against the current head, so it naturally picks up both the fixes and any surface
+that changed underneath — exactly the property `ship-it`'s latest-verdict-wins relies on.
+
+## Conventions
+
+This skill is one of a suite (`report` → `triage` → `plan-epic` → `review-plan` → `write-code` →
+**`review-code` / `review-doc` / `review-skill` / `review-design`** → `ship-it`) that turns GitHub
+issues into an agent-operable pipeline. The shared label semantics and the
+body/comment/dependency/marker formats live in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md); the control-plane boundary that
+decides whether your marker binds `ship-it` or merely advises is ADR
+[0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md)
+(widened to the gate-critical skills by ADR
+[0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md)).
+Your input is a `write-code`-produced UI PR whose diff renders a changed screen, linked by
+`Fixes #N`; your output is the verdict that decides whether that PR's **rendered UI** obeys the
+four-pillars design law. You are the design-class sibling of
+[`review-code`](../review-code/SKILL.md) / [`review-doc`](../review-doc/SKILL.md) /
+[`review-skill`](../review-skill/SKILL.md): the four gates split on artifact class — code →
+`review-code`, docs → `review-doc`, skills → `review-skill`, rendered UI → you — and none merges on
+its own authority (`ship-it` does that) nor strays into another's namespace. You realize ADR
+[0165](https://github.com/kamp-us/phoenix/blob/main/.decisions/0165-review-design-gate.md), the review
+surface ADR [0162](https://github.com/kamp-us/phoenix/blob/main/.decisions/0162-four-pillars-design-law.md)
+named; `review-design` is itself a **gate-critical skill** (§CP), governed by the same control-plane
+approval discipline it embodies.

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -168,7 +168,7 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   # is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981). So the
   # literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
   # live decision source: the regex actually classified is re-resolved from origin/main right after it.
-  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
+  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
   # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
   # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
   # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -205,7 +205,7 @@ PR=<pr number>
 # once mis-flagged a now-control-plane PR as auto-mergeable (#981). So the literal below is the
 # fail-closed reference + the validate-gate-path-drift lockstep target, NOT the live decision source:
 # the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -229,7 +229,7 @@ FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].f
 # is current — a pre-amendment snapshot once auto-merged a now-control-plane PR (#981). So the
 # literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
 # live decision source: the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-classify a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL, top-of-skill rule). origin/main's line wins over the snapshot.

--- a/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
@@ -2,11 +2,11 @@
 # Mechanical drift guard for the §CP canonical regex and the .claude/skills symlink
 # (issue #720). Two invariants, both runnable in CI/locally:
 #
-#   1. REGEX COPIES — the five CONTROL_PLANE_RE= copies in ship-it, review-code,
-#      review-doc, review-skill, and gh-issue-intake-formats (§CP, the source)
-#      must be byte-identical to the §CP canonical line. A rename of the plugin
-#      path string currently requires ~11 lockstep edits with no guard; this
-#      fails CI on any copy that drifts from §CP.
+#   1. REGEX COPIES — the CONTROL_PLANE_RE= copies in ship-it, review-code,
+#      review-doc, review-skill, review-design, and gh-issue-intake-formats
+#      (§CP, the source) must be byte-identical to the §CP canonical line. A
+#      rename of the plugin path string currently requires ~11 lockstep edits
+#      with no guard; this fails CI on any copy that drifts from §CP.
 #
 #   2. SYMLINK ↔ MARKETPLACE — .claude/skills must resolve to the same directory
 #      as marketplace.json's `source` field + /skills. Both express the same plugin
@@ -67,6 +67,7 @@ ship-it/SKILL.md
 review-code/SKILL.md
 review-doc/SKILL.md
 review-skill/SKILL.md
+review-design/SKILL.md
 "
 
 for rel in $CONSUMERS; do


### PR DESCRIPTION
## What this is

The 4th reviewer skill, `review-design`, per ADR 0165 — an **agent vision-gate** that drives Playwright over a UI PR's **preview deploy**, captures the changed UI surfaces, and judges the **local captured bytes** multimodally against the ADR-0162 four-pillars design law + `design-system-manifest.md`. Mirrors the review-* skill shape (fresh-eyes gate, SHA-bound namespaced marker, upsert one-per-PR, mis-route off-ramp, never-merge, config-isolation-equivalent read-only stance).

`Fixes #2246` — Phase-1 foundation leg of epic #1966.

## How it behaves

- **Blocking, but hard-FAILs only on the six enumerable ADR-0162 prohibitions**: faint-for-meaning, missing focus ring, off-grid spacing/type, void empty state, sub-36px tap target, colour-alone meaning. All enumerated explicitly in the skill.
- **All holistic/taste judgment is advisory (non-blocking)** in the same verdict comment; **calibrated to FAIL conservatively** — a borderline call is downgraded to advisory, never a hard block.
- Marker: `review-design: PASS @ <sha> — merge-ready` / `review-design: FAIL @ <sha> — changes-requested`, SHA-bound (ADR 0058), comment-only (never a native review), upserted one-per-PR, embedding the helper's GitHub-hosted screenshot **evidence URLs**. A FAIL feeds the existing `write-code` repair loop.
- **The judged source is the LOCAL captured bytes**; the upload is evidence-only and out of the decision path (ADR 0165). Upload failure degrades the evidence embed, never the verdict.
- **Mis-route off-ramp**: a non-UI PR gets a plain note routing it to review-code/review-doc/review-skill — **no `review-design` marker, no foreign marker**.
- **#2174 folded in** — the design + a11y check dimension is this skill's rubric, not a rider on the code/doc gates.
- Reuses the existing per-PR preview-deploy URL (the sticky `<!-- preview-deploy -->` comment's `web` sub-line) — does not stand up its own app server.

## The #2247 helper seam I assumed

`review-design` **consumes**, does not re-implement, the Playwright capture + GitHub-attachment-upload helper (issue #2247). The seam I coded against:

- **Module:** `@kampus/design-capture` at `packages/design-capture/`, invoked as `node packages/design-capture/src/bin.ts capture …` (the `pipeline-cli` / `node src/bin.ts` mechanical-tooling idiom).
- **Input:** preview URL + a route+state surface list + an output dir for the PNG bytes + the target `repository_id`.
- **Output (stdout JSON):** one record per captured surface — `{ surface, route, state, localPath, hostedUrl, uploadError }`. `localPath` is the on-disk PNG the gate **judges**; `hostedUrl` is the user-attachments URL embedded as **evidence** (or `null` + `uploadError` on the tolerated undocumented-endpoint failure).

If #2247 lands a different package name/flags, this reference updates in lockstep (ADR 0165's four implementation legs land to match). Flagging it here so #2247 can settle to this shape or propose a different one.

## §CP self-consistency lockstep (path-classification only)

ADR 0165 §Self-consistency: `review-design` is itself a gate-critical skill → **§CP**. For that to be *mechanically* true — and for this very PR to correctly stop for cansirin's human merge instead of auto-shipping — `review-design` must be in the canonical §CP set. This PR therefore adds `review-design` to `CONTROL_PLANE_RE` in `gh-issue-intake-formats.md` and lockstep-updates the four sibling copies (ship-it/review-code/review-doc/review-skill) + the `validate-gate-path-drift.sh` consumer list. `validate-gate-path-drift` and `validate-skills` both pass.

**This is the path-classification lockstep only** — NOT the ship-it required-`review-design`-PASS gate-routing (#2250) or the reviewer.md dispatch (#2249), both explicitly out of scope and left untouched.

## §CP — human merge

This PR touches `claude-plugins/kampus-pipeline/skills/**` (and now is §CP-classified as a gate-critical skill), so it **stops at reviewed-ready for cansirin's control-plane human-merge** — no auto-ship. Verified by `review-skill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)