### PR TITLE
feat(web): extract the composite primitive layer (Surface/Card, MetaRow, CountToggle) + widen Button

### DIFF
--- a/apps/web/src/components/divan/ActorDrawer.tsx
+++ b/apps/web/src/components/divan/ActorDrawer.tsx
@@ -12,6 +12,7 @@
  * hop decisions live DOM-free in `actor-drawer.ts` (unit-tested); this is the thin shell.
  */
 import type {OpenReport} from "../../../worker/features/report/views";
+import {Surface} from "../ui/Card";
 import {
 	type ActorStanding,
 	actorIdentityLabel,
@@ -60,7 +61,16 @@ export function ActorDrawer({
 	const recordVerdicts = modRecordVerdicts(chamber);
 
 	return (
-		<aside className="kp-actor" aria-label="aktör künyesi" data-testid="actor-drawer">
+		<Surface
+			as="aside"
+			tone="raised"
+			radius="sm"
+			padding="lg"
+			border
+			className="kp-actor"
+			aria-label="aktör künyesi"
+			data-testid="actor-drawer"
+		>
 			<header className="kp-actor__head">
 				<span className="kp-actor__identity" data-testid="actor-identity">
 					{identity ?? "aktör bilinmiyor"}
@@ -139,6 +149,6 @@ export function ActorDrawer({
 					moderasyon (M)
 				</button>
 			</div>
-		</aside>
+		</Surface>
 	);
 }

--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -445,14 +445,12 @@
 	text-transform: lowercase;
 }
 
+/* Shell (surface-raised · border · r-sm · pad-lg) is the shared Surface primitive
+   (ui/Card.css, #2163); only the card's own column layout stays here. */
 .kp-triage__card {
 	display: flex;
 	flex-direction: column;
 	gap: var(--s-3);
-	padding: var(--s-4);
-	border: 1px solid var(--border);
-	border-radius: var(--r-sm);
-	background: var(--surface-raised);
 }
 
 .kp-triage__card-head {
@@ -595,14 +593,11 @@
 	}
 }
 
+/* Shell is the shared Surface primitive (ui/Card.css, #2163); layout stays here. */
 .kp-actor {
 	display: flex;
 	flex-direction: column;
 	gap: var(--s-3);
-	padding: var(--s-4);
-	border: 1px solid var(--border);
-	border-radius: var(--r-sm);
-	background: var(--surface-raised);
 }
 
 .kp-actor__identity {
@@ -669,14 +664,11 @@
 
 /* remove-the-wave (#1855): the same-author batch manifest, docked over the loop when
    the mod grabs a flood with Shift-X. */
+/* Shell is the shared Surface primitive (ui/Card.css, #2163); layout stays here. */
 .kp-wave {
 	display: flex;
 	flex-direction: column;
 	gap: var(--s-3);
-	padding: var(--s-4);
-	border: 1px solid var(--border);
-	border-radius: var(--r-sm);
-	background: var(--surface-raised);
 }
 
 .kp-wave__head {

--- a/apps/web/src/components/divan/TriageLoop.tsx
+++ b/apps/web/src/components/divan/TriageLoop.tsx
@@ -17,6 +17,7 @@
 import {useCallback, useEffect, useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {OpenReport, ResolveReceipt} from "../../../worker/features/report/views";
+import {Surface} from "../ui/Card";
 import {ActorDrawer} from "./ActorDrawer";
 import {type Chamber, drawerDefaultOpen, drawerKeyToAction, hopTarget} from "./actor-drawer";
 import {itemKindLabel, parseBacklogItemId} from "./divanGating";
@@ -594,7 +595,16 @@ function WaveManifest({
 	}, [busy, pending, manifest, index, selected, apply, onClose]);
 
 	return (
-		<div className="kp-wave" role="dialog" aria-label="dalgayı kaldır" data-testid="wave-manifest">
+		<Surface
+			tone="raised"
+			radius="sm"
+			padding="lg"
+			border
+			className="kp-wave"
+			role="dialog"
+			aria-label="dalgayı kaldır"
+			data-testid="wave-manifest"
+		>
 			<header className="kp-wave__head">
 				<span className="kp-wave__title" data-testid="wave-title">
 					{waveManifestLabel(manifest.length)}
@@ -664,7 +674,7 @@ function WaveManifest({
 			{rows.map(({node}) => (
 				<WaveProbe key={String(node.id)} node={node} onData={onProbe} />
 			))}
-		</div>
+		</Surface>
 	);
 }
 
@@ -734,7 +744,12 @@ function TriageCard({
 	);
 
 	return (
-		<article
+		<Surface
+			as="article"
+			tone="raised"
+			radius="sm"
+			padding="lg"
+			border
 			className="kp-triage__card"
 			data-testid={`triage-card-${data.targetKind}-${data.targetId}`}
 		>
@@ -769,6 +784,6 @@ function TriageCard({
 				)}
 				<span className="kp-triage__reason">{reasonLabel(data.reason)}</span>
 			</footer>
-		</article>
+		</Surface>
 	);
 }

--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -116,39 +116,14 @@
 	gap: 4px;
 }
 
-.kp-pano-post__meta {
-	font: var(--t-body-sm);
-	color: var(--text-muted);
-	display: flex;
+/* The row shell + shared child treatment is the MetaRow primitive (ui/MetaRow.css,
+   #2163); only this feed row's own tuning stays here (its 6px gap outranks the
+   primitive's default by specificity, so the fold is order-independent). */
+.kp-meta-row.kp-pano-post__meta {
 	gap: 6px;
-	align-items: center;
-	flex-wrap: wrap;
 }
 .kp-pano-post__meta .author {
-	color: var(--text-secondary);
-	font-weight: 600;
 	letter-spacing: -0.01em;
-}
-.kp-pano-post__meta a {
-	color: var(--text-secondary);
-}
-.kp-pano-post__meta a:hover {
-	color: var(--accent);
-	text-decoration: none;
-}
-.kp-pano-post__meta .dot {
-	color: var(--text-faint);
-}
-.kp-pano-post__meta button {
-	background: none;
-	border: 0;
-	padding: 0;
-	font: inherit;
-	color: inherit;
-	cursor: pointer;
-}
-.kp-pano-post__meta button:hover {
-	color: var(--accent);
 }
 
 /* Bookmark toggle — `aria-pressed` is the pressed state; the accent carries it

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -13,6 +13,7 @@ import {formatAgoTR} from "../../lib/datetime";
 import {tagClass} from "../../lib/panoTags";
 import {actorLabel} from "../moderation/actor-identity";
 import {Tag, type TagKind} from "../ui/atoms";
+import {MetaRow} from "../ui/MetaRow";
 import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 import "./PanoPost.css";
 
@@ -84,27 +85,27 @@ export function PanoPostCard({
 						<span className="kp-pano-post__site">{siteLabel}</span>
 					) : null}
 				</div>
-				<div className="kp-pano-post__meta">
+				<MetaRow className="kp-pano-post__meta">
 					{/* Live author identity via `actorLabel` (#2139): current displayName → @username,
 					    falling back to the write-time `author` snapshot for an unstamped/legacy row. */}
 					<span className="author">
 						{actorLabel(data.authorDisplayName ?? null, data.authorUsername ?? null, data.author)}
 					</span>
-					<span className="dot">·</span>
+					<MetaRow.Dot />
 					<span>{agoLabel}</span>
-					<span className="dot">·</span>
+					<MetaRow.Dot />
 					<a href={`${href}#comments`}>{data.commentCount} yorum</a>
-					<span className="dot">·</span>
+					<MetaRow.Dot />
 					<PostSaveButton postId={data.id} isSaved={data.isSaved ?? null} />
 					{onHide ? (
 						<>
-							<span className="dot">·</span>
+							<MetaRow.Dot />
 							<button type="button" onClick={() => onHide(data.id)}>
 								gizle
 							</button>
 						</>
 					) : null}
-				</div>
+				</MetaRow>
 			</div>
 		</article>
 	);

--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -15,6 +15,7 @@ import {ReactionBarSlot} from "../reaction/ReactionBarSlot";
 import {Tag, type TagKind} from "../ui/atoms";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
+import {MetaRow} from "../ui/MetaRow";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
 import {ReviewBadge} from "../ui/ReviewBadge";
 import {PostSaveButton, PostVoteWidget} from "./PanoPost";
@@ -87,7 +88,7 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 					{post.host ?? post.url} ↗
 				</a>
 			) : null}
-			<div className="kp-pano-postpage__meta">
+			<MetaRow className="kp-pano-postpage__meta">
 				{tags.map((t, i) => (
 					<Tag key={i} kind={tagClass(t.kind) as TagKind}>
 						{t.label}
@@ -117,7 +118,7 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 						</button>
 					</>
 				) : null}
-			</div>
+			</MetaRow>
 			{post.body ? (
 				<div className="kp-pano-postpage__body kp-prose">
 					{post.body.split(/\n{2,}/).map((para, i) => (

--- a/apps/web/src/components/reaction/ReactionBar.css
+++ b/apps/web/src/components/reaction/ReactionBar.css
@@ -32,37 +32,9 @@
 	min-height: var(--reaction-bar-height);
 }
 
-.kp-reaction-bar__btn {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	gap: 4px;
-	min-height: var(--reaction-bar-height); /* WCAG 2.5.8 24px min target (#2166) */
-	padding: 1px 6px;
-	border: 1px solid var(--border-faint);
-	border-radius: 999px;
-	background: var(--surface);
-	color: var(--text-primary);
-	font: var(--t-meta);
-	line-height: 1.6;
-	cursor: pointer;
-}
-
-.kp-reaction-bar__btn:hover {
-	background: var(--surface-sunken);
-}
-
-/* Keyboard focus ring comes from the shared focus layer (global.css, #2169) —
-   the same --focus-ring / --focus-ring-offset #2166 converged this button onto,
-   now sourced from one place instead of re-declared here. */
-
-.kp-reaction-bar__btn[aria-pressed="true"] {
-	border-color: var(--accent);
-	background: var(--accent-soft, var(--surface-sunken));
-	/* The glyph paints in currentColor, so tinting the active button accent tints
-	   the icon too — the viewer's own reaction reads as the accent, on-brand. */
-	color: var(--accent);
-}
+/* Each palette button is the shared CountToggle count-pill (ui/CountToggle.css,
+   #2163) — the pill shell, hover, [aria-pressed] accent tint, and count styling
+   live there now, so the bar owns only its own layout + the on-brand glyph. */
 
 /* The on-brand line-icon: paints in currentColor (inherits the button's token —
    text by default, accent when active) and sizes off the glyph token, so no color
@@ -71,11 +43,4 @@
 	width: var(--reaction-glyph-size);
 	height: var(--reaction-glyph-size);
 	flex: none;
-}
-
-.kp-reaction-bar__count {
-	font-variant-numeric: tabular-nums;
-	/* Meaning-carrying metadata → --text-muted (AA-safe ≥4.5:1); --text-faint is
-	   decorative-only and bottoms out at ~3:1 (#2166, tokens.css role layer). */
-	color: var(--text-muted);
 }

--- a/apps/web/src/components/reaction/ReactionBar.tsx
+++ b/apps/web/src/components/reaction/ReactionBar.tsx
@@ -16,6 +16,7 @@
  */
 import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
 import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
+import {CountToggle} from "../ui/CountToggle";
 import {ReactionGlyph} from "./ReactionGlyph";
 import {reactionSlots} from "./reactionModel";
 import "./ReactionBar.css";
@@ -34,25 +35,16 @@ export function ReactionBar({aggregate, onReact, testIdSuffix}: ReactionBarProps
 	return (
 		<div className="kp-reaction-bar" data-testid={`reaction-bar-${testIdSuffix}`}>
 			{slots.map((slot) => (
-				<button
+				<CountToggle
 					key={slot.emoji}
-					type="button"
-					className="kp-reaction-bar__btn"
-					aria-pressed={slot.active}
+					pressed={slot.active}
+					count={slot.count}
+					countTestId={`reaction-count-${slot.emoji}-${testIdSuffix}`}
+					icon={<ReactionGlyph emoji={slot.emoji} />}
 					aria-label={`${slot.gloss}${slot.count ? ` (${slot.count})` : ""}`}
 					data-testid={`reaction-${slot.emoji}-${testIdSuffix}`}
 					onClick={() => onReact(slot.emoji)}
-				>
-					<ReactionGlyph emoji={slot.emoji} />
-					{slot.count > 0 ? (
-						<span
-							className="kp-reaction-bar__count"
-							data-testid={`reaction-count-${slot.emoji}-${testIdSuffix}`}
-						>
-							{slot.count}
-						</span>
-					) : null}
-				</button>
+				/>
 			))}
 		</div>
 	);

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -27,6 +27,7 @@ import "../vote-cue.css";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {Dialog} from "../ui/Dialog";
 import {EditedIndicator} from "../ui/EditedIndicator";
+import {MetaRow} from "../ui/MetaRow";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
 import {ReviewBadge} from "../ui/ReviewBadge";
 
@@ -305,7 +306,7 @@ export function DefinitionCard(props: DefinitionCardProps) {
 				) : (
 					<DefinitionBody text={definition.body} />
 				)}
-				<footer className="kp-sozluk-definition__foot">
+				<MetaRow as="footer" className="kp-sozluk-definition__foot">
 					{/* Owner-only in-review signal (#2200): `sandboxed` is owner-scoped server-side,
 					    re-gated on `isAuthor` so only the author sees their own pending definition's state. */}
 					{isAuthor && definition.sandboxed ? <ReviewBadge /> : null}
@@ -318,7 +319,7 @@ export function DefinitionCard(props: DefinitionCardProps) {
 							definition.author,
 						)}
 					</span>
-					<span className="dot">·</span>
+					<MetaRow.Dot />
 					<span>{formatAgoTR(toIso(definition.createdAt))}</span>
 					<EditedIndicator
 						createdAt={toIso(definition.createdAt)}
@@ -353,7 +354,7 @@ export function DefinitionCard(props: DefinitionCardProps) {
 							</>
 						) : null}
 					</span>
-				</footer>
+				</MetaRow>
 				{!editing ? (
 					<ReactionBarSlot>
 						<DefinitionReactionBar

--- a/apps/web/src/components/ui/Button.css
+++ b/apps/web/src/components/ui/Button.css
@@ -77,3 +77,43 @@
 .kp-btn--block {
 	width: 100%;
 }
+
+/* Pressed/toggle — the accent-tinted active state, carried on top of
+   [aria-pressed] so it is never color-alone (#2163). */
+.kp-btn--pressed {
+	border-color: var(--accent);
+	background: var(--accent-faint);
+	color: var(--accent);
+}
+
+/* Leading icon slot — sizes the glyph to the text box. */
+.kp-btn__icon {
+	display: inline-flex;
+	align-items: center;
+}
+.kp-btn__icon svg {
+	width: 1em;
+	height: 1em;
+}
+
+/* Loading — the in-flight spinner replaces the leading icon; the label stays,
+   the control disables. The disabled dim is overridden so a busy button reads
+   as active-but-waiting, not unavailable. */
+.kp-btn--loading:disabled {
+	opacity: 1;
+	cursor: progress;
+}
+.kp-btn__spinner {
+	width: 0.85em;
+	height: 0.85em;
+	border: 2px solid currentColor;
+	border-right-color: transparent;
+	border-radius: var(--r-pill);
+	/* Neutralized by the global prefers-reduced-motion reset (global.css). */
+	animation: kp-btn-spin var(--motion-slow) linear infinite;
+}
+@keyframes kp-btn-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/apps/web/src/components/ui/Button.test.tsx
+++ b/apps/web/src/components/ui/Button.test.tsx
@@ -1,0 +1,46 @@
+import {render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Button} from "./Button";
+
+describe("Button — the widened primitive (#2163)", () => {
+	it("keeps its baseline behavior when the new props are unset (no extra attrs/nodes)", () => {
+		const {container} = render(<Button variant="primary">tamam</Button>);
+		const btn = container.querySelector("button")!;
+		expect(btn.getAttribute("type")).toBe("button");
+		expect(btn.classList.contains("kp-btn")).toBe(true);
+		expect(btn.classList.contains("kp-btn--primary")).toBe(true);
+		// unset toggle/busy/icon add nothing
+		expect(btn.hasAttribute("aria-pressed")).toBe(false);
+		expect(btn.hasAttribute("aria-busy")).toBe(false);
+		expect(btn.hasAttribute("disabled")).toBe(false);
+		expect(container.querySelector(".kp-btn__icon")).toBeNull();
+		expect(container.querySelector(".kp-btn__spinner")).toBeNull();
+	});
+
+	it("pressed sets aria-pressed and the pressed class", () => {
+		const {container} = render(<Button pressed>x</Button>);
+		const btn = container.querySelector("button")!;
+		expect(btn.getAttribute("aria-pressed")).toBe("true");
+		expect(btn.classList.contains("kp-btn--pressed")).toBe(true);
+	});
+
+	it("icon renders in a leading decorative slot", () => {
+		const {container, getByTestId} = render(
+			<Button icon={<span data-testid="g">g</span>}>kaydet</Button>,
+		);
+		const slot = container.querySelector(".kp-btn__icon")!;
+		expect(slot).not.toBeNull();
+		expect(slot.getAttribute("aria-hidden")).toBe("true");
+		expect(getByTestId("g")).not.toBeNull();
+	});
+
+	it("loading disables, marks aria-busy, shows the spinner, and keeps the label", () => {
+		const {container} = render(<Button loading>kaydet</Button>);
+		const btn = container.querySelector("button")!;
+		expect(btn.getAttribute("aria-busy")).toBe("true");
+		expect(btn.hasAttribute("disabled")).toBe(true);
+		expect(container.querySelector(".kp-btn__spinner")).not.toBeNull();
+		expect(container.querySelector(".kp-btn__icon")).toBeNull(); // spinner replaces the icon
+		expect(btn.textContent).toContain("kaydet");
+	});
+});

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -10,9 +10,27 @@ export const Button = React.forwardRef<
 		variant?: ButtonVariant;
 		size?: ButtonSize;
 		block?: boolean;
+		/** Toggle/active state → `aria-pressed` + the accent-tinted pressed styling. */
+		pressed?: boolean;
+		/** Leading icon/glyph (decorative — the label is the button's own children). */
+		icon?: React.ReactNode;
+		/** In-flight: shows a spinner, marks `aria-busy`, and disables interaction. */
+		loading?: boolean;
 	}
 >(function Button(
-	{variant = "secondary", size = "md", block, className = "", children, type = "button", ...rest},
+	{
+		variant = "secondary",
+		size = "md",
+		block,
+		pressed,
+		icon,
+		loading = false,
+		disabled,
+		className = "",
+		children,
+		type = "button",
+		...rest
+	},
 	ref,
 ) {
 	const cls = [
@@ -20,12 +38,29 @@ export const Button = React.forwardRef<
 		`kp-btn--${variant}`,
 		size !== "md" ? `kp-btn--${size}` : "",
 		block ? "kp-btn--block" : "",
+		pressed ? "kp-btn--pressed" : "",
+		loading ? "kp-btn--loading" : "",
 		className,
 	]
 		.filter(Boolean)
 		.join(" ");
 	return (
-		<button ref={ref} type={type} className={cls} {...rest}>
+		<button
+			ref={ref}
+			type={type}
+			className={cls}
+			aria-pressed={pressed}
+			aria-busy={loading || undefined}
+			disabled={disabled || loading}
+			{...rest}
+		>
+			{loading ? (
+				<span className="kp-btn__spinner" aria-hidden="true" />
+			) : icon ? (
+				<span className="kp-btn__icon" aria-hidden="true">
+					{icon}
+				</span>
+			) : null}
 			{children}
 		</button>
 	);

--- a/apps/web/src/components/ui/Card.css
+++ b/apps/web/src/components/ui/Card.css
@@ -1,0 +1,66 @@
+/* Surface / Card — the composite shell primitive (#2163). Role tokens only:
+   background from a tone, lift from the ADR 0162 elevation ramp, border/radius/
+   padding from the token scales. No color/spacing/shadow literal lives here. */
+
+.kp-surface {
+	box-sizing: border-box;
+}
+
+/* tone — background role */
+.kp-surface--tone-default {
+	background: var(--surface);
+}
+.kp-surface--tone-raised {
+	background: var(--surface-raised);
+}
+.kp-surface--tone-sunken {
+	background: var(--surface-sunken);
+}
+
+/* elevation — the four-level ramp (ADR 0162); flat carries no class */
+.kp-surface--elev-raised {
+	box-shadow: var(--shadow-raised);
+}
+.kp-surface--elev-dropdown {
+	box-shadow: var(--shadow-dropdown);
+}
+.kp-surface--elev-overlay {
+	box-shadow: var(--shadow-overlay);
+}
+
+/* radius */
+.kp-surface--radius-sm {
+	border-radius: var(--r-sm);
+}
+.kp-surface--radius-md {
+	border-radius: var(--r-md);
+}
+.kp-surface--radius-lg {
+	border-radius: var(--r-lg);
+}
+
+/* padding */
+.kp-surface--pad-sm {
+	padding: var(--s-2);
+}
+.kp-surface--pad-md {
+	padding: var(--s-3);
+}
+.kp-surface--pad-lg {
+	padding: var(--s-4);
+}
+
+.kp-surface--border {
+	border: 1px solid var(--border);
+}
+
+.kp-card--interactive {
+	cursor: pointer;
+	transition:
+		background var(--motion-fast) var(--ease-standard),
+		border-color var(--motion-fast) var(--ease-standard);
+}
+.kp-card--interactive:hover {
+	background: var(--surface-raised);
+	border-color: var(--border-strong);
+}

--- a/apps/web/src/components/ui/Card.test.tsx
+++ b/apps/web/src/components/ui/Card.test.tsx
@@ -1,0 +1,57 @@
+import {render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Card, Surface} from "./Card";
+
+describe("Surface / Card — the composite shell primitive (#2163)", () => {
+	it("emits only the role-token classes for the props it is given (flat default)", () => {
+		const {container} = render(<Surface>x</Surface>);
+		const el = container.firstElementChild!;
+		expect(el.classList.contains("kp-surface")).toBe(true);
+		expect(el.classList.contains("kp-surface--tone-default")).toBe(true);
+		// flat / no-radius / no-pad / no-border carry no class
+		expect(el.className).not.toMatch(/kp-surface--elev-/);
+		expect(el.className).not.toMatch(/kp-surface--radius-/);
+		expect(el.className).not.toMatch(/kp-surface--pad-/);
+		expect(el.classList.contains("kp-surface--border")).toBe(false);
+	});
+
+	it("maps tone / elevation / radius / padding / border onto their token classes", () => {
+		const {container} = render(
+			<Surface tone="raised" elevation="dropdown" radius="sm" padding="lg" border />,
+		);
+		const el = container.firstElementChild!;
+		expect(el.classList.contains("kp-surface--tone-raised")).toBe(true);
+		expect(el.classList.contains("kp-surface--elev-dropdown")).toBe(true);
+		expect(el.classList.contains("kp-surface--radius-sm")).toBe(true);
+		expect(el.classList.contains("kp-surface--pad-lg")).toBe(true);
+		expect(el.classList.contains("kp-surface--border")).toBe(true);
+	});
+
+	it("renders as the requested element and passes through attributes + className", () => {
+		const {container} = render(
+			<Surface as="article" className="kp-feature" data-testid="s" aria-label="k" />,
+		);
+		const el = container.querySelector("article")!;
+		expect(el).not.toBeNull();
+		expect(el.getAttribute("data-testid")).toBe("s");
+		expect(el.getAttribute("aria-label")).toBe("k");
+		expect(el.classList.contains("kp-feature")).toBe(true);
+	});
+
+	it("Card is the opinionated bordered/raised/padded default, overridable by props", () => {
+		const {container} = render(<Card interactive>c</Card>);
+		const el = container.firstElementChild!;
+		expect(el.classList.contains("kp-card")).toBe(true);
+		expect(el.classList.contains("kp-card--interactive")).toBe(true);
+		expect(el.classList.contains("kp-surface--border")).toBe(true);
+		expect(el.classList.contains("kp-surface--radius-md")).toBe(true);
+		expect(el.classList.contains("kp-surface--elev-raised")).toBe(true);
+	});
+
+	it("Card lets a prop override a default (radius)", () => {
+		const {container} = render(<Card radius="sm">c</Card>);
+		const el = container.firstElementChild!;
+		expect(el.classList.contains("kp-surface--radius-sm")).toBe(true);
+		expect(el.classList.contains("kp-surface--radius-md")).toBe(false);
+	});
+});

--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -1,0 +1,90 @@
+import type * as React from "react";
+import "./Card.css";
+
+/**
+ * The composite surface primitive (#2163, pillar cohesiveness; epic #2168). Every
+ * page used to hand-assemble its own bordered/tinted box shell — background,
+ * border, radius, padding, elevation — as a near-duplicate copy that drifted from
+ * the next. `Surface` is the one parameterized shell those copies collapse onto:
+ * it emits only role-token classes (no color/spacing/shadow literal lives here),
+ * so a shell reads its background from a `tone`, its lift from an `elevation`
+ * (the ADR 0162 four-level ramp), and its border/radius/padding from tokens.
+ *
+ * `Card` is the opinionated default for NEW surfaces — a bordered, subtly-raised,
+ * padded box — so a fresh card reaches for one cohesive shape instead of inventing
+ * another. A migration that must preserve an existing shell's exact look uses
+ * `Surface` with explicit props (moving the shell declarations off the feature CSS
+ * and onto props, leaving only the call-site's own layout behind).
+ */
+
+/** Background role of the surface — the role token, never a raw scale. */
+export type SurfaceTone = "default" | "raised" | "sunken";
+/** The ADR 0162 four-level elevation ramp (flat · raised · dropdown · overlay). */
+export type Elevation = "flat" | "raised" | "dropdown" | "overlay";
+/** Corner radius, off the `--r-*` token scale. */
+export type SurfaceRadius = "none" | "sm" | "md" | "lg";
+/** Inner padding, off the `--s-*` density scale. */
+export type SurfacePadding = "none" | "sm" | "md" | "lg";
+
+export interface SurfaceProps extends React.HTMLAttributes<HTMLElement> {
+	/** Render element (article/section/aside/li/…). Defaults to `div`. */
+	as?: React.ElementType;
+	tone?: SurfaceTone;
+	elevation?: Elevation;
+	radius?: SurfaceRadius;
+	padding?: SurfacePadding;
+	/** Draw the 1px role border. */
+	border?: boolean;
+}
+
+export function Surface({
+	as,
+	tone = "default",
+	elevation = "flat",
+	radius = "none",
+	padding = "none",
+	border = false,
+	className = "",
+	children,
+	...rest
+}: SurfaceProps) {
+	const Comp = as ?? "div";
+	const cls = [
+		"kp-surface",
+		`kp-surface--tone-${tone}`,
+		elevation !== "flat" ? `kp-surface--elev-${elevation}` : "",
+		radius !== "none" ? `kp-surface--radius-${radius}` : "",
+		padding !== "none" ? `kp-surface--pad-${padding}` : "",
+		border ? "kp-surface--border" : "",
+		className,
+	]
+		.filter(Boolean)
+		.join(" ");
+	return (
+		<Comp className={cls} {...rest}>
+			{children}
+		</Comp>
+	);
+}
+
+export interface CardProps extends SurfaceProps {
+	/** Add the hover affordance (background + border shift) for a clickable card. */
+	interactive?: boolean;
+}
+
+export function Card({interactive = false, className = "", ...props}: CardProps) {
+	const cls = ["kp-card", interactive ? "kp-card--interactive" : "", className]
+		.filter(Boolean)
+		.join(" ");
+	return (
+		<Surface
+			tone="default"
+			elevation="raised"
+			radius="md"
+			padding="md"
+			border
+			className={cls}
+			{...props}
+		/>
+	);
+}

--- a/apps/web/src/components/ui/CountToggle.css
+++ b/apps/web/src/components/ui/CountToggle.css
@@ -1,0 +1,41 @@
+/* CountToggle — the count-pill toggle primitive (#2163). The reaction bar's
+   per-emoji pill, extracted so the shape is built once. Pressed state is carried
+   by the accent tint (border + soft fill + accent text — which the icon inherits
+   via currentColor), on top of [aria-pressed]. Role tokens only. */
+
+.kp-count-toggle {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	/* WCAG 2.5.8 minimum target size (#2166) — a load-bearing a11y floor. */
+	min-height: 24px;
+	padding: 1px 6px;
+	border: 1px solid var(--border-faint);
+	border-radius: var(--r-pill);
+	background: var(--surface);
+	color: var(--text-primary);
+	font: var(--t-meta);
+	line-height: 1.6;
+	cursor: pointer;
+}
+
+.kp-count-toggle:hover {
+	background: var(--surface-sunken);
+}
+
+/* Keyboard focus ring comes from the shared focus layer (global.css, #2169). */
+
+.kp-count-toggle[aria-pressed="true"] {
+	border-color: var(--accent);
+	background: var(--accent-soft, var(--surface-sunken));
+	/* The icon paints in currentColor, so tinting the pressed pill accent tints
+	   the glyph too — the active state reads as the accent, on-brand. */
+	color: var(--accent);
+}
+
+.kp-count-toggle__count {
+	font-variant-numeric: tabular-nums;
+	/* Meaning-carrying metadata → --text-muted (AA-safe ≥4.5:1). */
+	color: var(--text-muted);
+}

--- a/apps/web/src/components/ui/CountToggle.test.tsx
+++ b/apps/web/src/components/ui/CountToggle.test.tsx
@@ -1,0 +1,40 @@
+import {fireEvent, render} from "@testing-library/react";
+import {describe, expect, it, vi} from "vitest";
+import {CountToggle} from "./CountToggle";
+
+describe("CountToggle — the count-pill toggle primitive (#2163)", () => {
+	it("carries on/off state via aria-pressed", () => {
+		const {rerender, container} = render(<CountToggle pressed={false} aria-label="beğen" />);
+		const btn = container.querySelector("button")!;
+		expect(btn.getAttribute("aria-pressed")).toBe("false");
+		rerender(<CountToggle pressed aria-label="beğen" />);
+		expect(btn.getAttribute("aria-pressed")).toBe("true");
+	});
+
+	it("hides a zero count by default, shows it with showZero", () => {
+		const {container, rerender} = render(<CountToggle count={0} aria-label="x" />);
+		expect(container.querySelector(".kp-count-toggle__count")).toBeNull();
+		rerender(<CountToggle count={0} showZero aria-label="x" />);
+		expect(container.querySelector(".kp-count-toggle__count")!.textContent).toBe("0");
+	});
+
+	it("renders a positive count with its test id", () => {
+		const {getByTestId} = render(<CountToggle count={3} countTestId="c" aria-label="x" />);
+		expect(getByTestId("c").textContent).toBe("3");
+	});
+
+	it("renders the icon and routes clicks", () => {
+		const onClick = vi.fn();
+		const {getByTestId, container} = render(
+			<CountToggle icon={<span data-testid="glyph">g</span>} onClick={onClick} aria-label="x" />,
+		);
+		expect(getByTestId("glyph")).not.toBeNull();
+		fireEvent.click(container.querySelector("button")!);
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it("defaults to type=button", () => {
+		const {container} = render(<CountToggle aria-label="x" />);
+		expect(container.querySelector("button")!.getAttribute("type")).toBe("button");
+	});
+});

--- a/apps/web/src/components/ui/CountToggle.tsx
+++ b/apps/web/src/components/ui/CountToggle.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import "./CountToggle.css";
+
+/**
+ * The count-pill toggle primitive (#2163, pillar cohesiveness; epic #2168). A
+ * pressable pill carrying an icon/label and an optional aggregate count, its
+ * on/off state exposed via `aria-pressed` and carried visually by the accent
+ * tint (never color alone — the pressed state is in the ARIA + the shape). The
+ * reaction bar's per-emoji buttons are the canonical instance; this extracts the
+ * pill so the shape is built once instead of re-assembled per surface. Role
+ * tokens only; the 24px floor is the WCAG 2.5.8 minimum target size (#2166).
+ */
+export interface CountToggleProps
+	extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+	/** On/off state → `aria-pressed` + the accent-tinted pressed styling. */
+	pressed?: boolean;
+	/** Aggregate count rendered after the icon/label. Hidden when 0 unless `showZero`. */
+	count?: number;
+	/** Render a `0` count instead of hiding it. */
+	showZero?: boolean;
+	/** Leading icon/glyph (decorative — name the control via `aria-label`). */
+	icon?: React.ReactNode;
+	children?: React.ReactNode;
+	/** Test id for the count element (the label lives on the button's own props). */
+	countTestId?: string;
+}
+
+export const CountToggle = React.forwardRef<HTMLButtonElement, CountToggleProps>(
+	function CountToggle(
+		{
+			pressed,
+			count,
+			showZero = false,
+			icon,
+			children,
+			countTestId,
+			className = "",
+			type = "button",
+			...rest
+		},
+		ref,
+	) {
+		const showCount = count != null && (showZero || count > 0);
+		return (
+			<button
+				ref={ref}
+				type={type}
+				className={`kp-count-toggle ${className}`.trim()}
+				aria-pressed={pressed}
+				{...rest}
+			>
+				{icon}
+				{children}
+				{showCount ? (
+					<span className="kp-count-toggle__count" data-testid={countTestId}>
+						{count}
+					</span>
+				) : null}
+			</button>
+		);
+	},
+);

--- a/apps/web/src/components/ui/MetaRow.css
+++ b/apps/web/src/components/ui/MetaRow.css
@@ -1,0 +1,43 @@
+/* MetaRow — the shared metadata-row primitive (#2163). Owns the inline row
+   layout and the shared child treatment; a migrating surface keeps only its own
+   diverging tuning (a bespoke gap, a top-margin) on a paired class that outranks
+   these defaults by specificity, so folding is order-independent. Role tokens
+   only — no color literal here. */
+
+.kp-meta-row {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: var(--s-2);
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+}
+
+.kp-meta-row .author {
+	color: var(--text-secondary);
+	font-weight: 600;
+}
+
+.kp-meta-row a {
+	color: var(--text-secondary);
+}
+.kp-meta-row a:hover {
+	color: var(--accent);
+	text-decoration: none;
+}
+
+.kp-meta-row button {
+	background: none;
+	border: 0;
+	padding: 0;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+}
+.kp-meta-row button:hover {
+	color: var(--accent);
+}
+
+.kp-meta-row__dot {
+	color: var(--text-faint);
+}

--- a/apps/web/src/components/ui/MetaRow.test.tsx
+++ b/apps/web/src/components/ui/MetaRow.test.tsx
@@ -1,0 +1,29 @@
+import {render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {MetaRow} from "./MetaRow";
+
+describe("MetaRow — the metadata-row primitive (#2163)", () => {
+	it("renders the shared row shell and passes through a feature className", () => {
+		const {container} = render(<MetaRow className="kp-pano-post__meta">x</MetaRow>);
+		const el = container.firstElementChild!;
+		expect(el.classList.contains("kp-meta-row")).toBe(true);
+		expect(el.classList.contains("kp-pano-post__meta")).toBe(true);
+	});
+
+	it("renders as the requested element (footer)", () => {
+		const {container} = render(<MetaRow as="footer">x</MetaRow>);
+		expect(container.querySelector("footer.kp-meta-row")).not.toBeNull();
+	});
+
+	it("Dot renders a decorative separator hidden from assistive tech", () => {
+		const {container} = render(
+			<MetaRow>
+				a<MetaRow.Dot />b
+			</MetaRow>,
+		);
+		const dot = container.querySelector(".kp-meta-row__dot")!;
+		expect(dot).not.toBeNull();
+		expect(dot.getAttribute("aria-hidden")).toBe("true");
+		expect(dot.textContent).toBe("·");
+	});
+});

--- a/apps/web/src/components/ui/MetaRow.tsx
+++ b/apps/web/src/components/ui/MetaRow.tsx
@@ -1,0 +1,40 @@
+import type * as React from "react";
+import "./MetaRow.css";
+
+/**
+ * The metadata-row primitive (#2163, pillar cohesiveness; epic #2168). Feed rows,
+ * post/definition headers, and comment footers each hand-rolled the same inline
+ * row — an align-baseline flex-wrap of muted metadata (author · time · a count ·
+ * an action or two, dot-separated) — as a near-duplicate copy. `MetaRow` is the
+ * one shell those collapse onto: it owns the row layout and the shared child
+ * treatment (a bold-secondary `.author`, secondary→accent links, reset inline
+ * `button`s), all off role tokens. `MetaRow.Dot` is the shared `·` separator so
+ * every surface's separators read identically.
+ *
+ * A migrating call-site keeps only its own genuine deltas (a bespoke gap, a
+ * top-margin) on its own class; the shared shape moves here.
+ */
+export interface MetaRowProps extends React.HTMLAttributes<HTMLElement> {
+	/** Render element (div/footer/header/…). Defaults to `div`. */
+	as?: React.ElementType;
+}
+
+export function MetaRow({as, className = "", children, ...rest}: MetaRowProps) {
+	const Comp = as ?? "div";
+	return (
+		<Comp className={`kp-meta-row ${className}`.trim()} {...rest}>
+			{children}
+		</Comp>
+	);
+}
+
+/** The shared dot separator (`·`), decorative — hidden from assistive tech. */
+export function MetaDot() {
+	return (
+		<span className="kp-meta-row__dot" aria-hidden="true">
+			·
+		</span>
+	);
+}
+
+MetaRow.Dot = MetaDot;

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -3,14 +3,27 @@ export type {TagKind} from "./atoms";
 export {Code, Kbd, Mark, Skeleton, Tag} from "./atoms";
 export type {ButtonSize, ButtonVariant} from "./Button";
 export {Button} from "./Button";
+export type {
+	CardProps,
+	Elevation,
+	SurfacePadding,
+	SurfaceProps,
+	SurfaceRadius,
+	SurfaceTone,
+} from "./Card";
+export {Card, Surface} from "./Card";
 export {Collapsible} from "./Collapsible";
 export type {CopyLinkButtonProps} from "./CopyLinkButton";
 export {CopyLinkButton} from "./CopyLinkButton";
+export type {CountToggleProps} from "./CountToggle";
+export {CountToggle} from "./CountToggle";
 export {Dialog} from "./Dialog";
 export {DraftRestoreBanner} from "./DraftRestoreBanner";
 export {EmptyState} from "./EmptyState";
 export {Field, FieldError, Form, Hint, Input, Label, Textarea} from "./Form";
 export {Menu} from "./Menu";
+export type {MetaRowProps} from "./MetaRow";
+export {MetaRow} from "./MetaRow";
 export type {ReportButtonProps, ReportOutcome} from "./ReportButton";
 export {ReportButton} from "./ReportButton";
 export {Switch} from "./Switch";

--- a/apps/web/src/pages/PanoPostDetail.css
+++ b/apps/web/src/pages/PanoPostDetail.css
@@ -44,28 +44,12 @@
 	text-decoration: underline;
 }
 
-.kp-pano-postpage__meta {
+/* Row shell + shared child treatment is the MetaRow primitive (ui/MetaRow.css,
+   #2163); only this header's own tuning (t-meta font, 8px gap) stays here, at a
+   specificity that outranks the primitive's defaults so the fold is order-free. */
+.kp-meta-row.kp-pano-postpage__meta {
 	font: var(--t-meta);
-	color: var(--text-muted);
-	display: flex;
 	gap: 8px;
-	align-items: center;
-	flex-wrap: wrap;
-}
-.kp-pano-postpage__meta .author {
-	color: var(--text-secondary);
-	font-weight: 600;
-}
-.kp-pano-postpage__meta button {
-	background: none;
-	border: 0;
-	padding: 0;
-	font: inherit;
-	color: inherit;
-	cursor: pointer;
-}
-.kp-pano-postpage__meta button:hover {
-	color: var(--accent);
 }
 
 /* Composer above the thread */

--- a/apps/web/src/pages/SozlukTermPage.css
+++ b/apps/web/src/pages/SozlukTermPage.css
@@ -148,36 +148,22 @@
 	color: var(--text-primary);
 	font-weight: 600;
 }
-.kp-sozluk-definition__foot {
-	display: flex;
+/* Row shell + shared child treatment is the MetaRow primitive (ui/MetaRow.css,
+   #2163). Only this footer's own tuning stays here, at a specificity that outranks
+   the primitive's defaults so the fold is order-free: its t-meta font + 10px gap +
+   top-margin, its right-aligned actions cluster, and its text-primary button hover
+   (the primitive hovers to accent; this surface hovers to text-primary). */
+.kp-meta-row.kp-sozluk-definition__foot {
 	gap: 10px;
-	align-items: center;
 	margin-top: 6px;
 	font: var(--t-meta);
-	color: var(--text-muted);
-	flex-wrap: wrap;
-}
-.kp-sozluk-definition__foot .author {
-	color: var(--text-secondary);
-	font-weight: 600;
-}
-.kp-sozluk-definition__foot .dot {
-	color: var(--text-faint);
 }
 .kp-sozluk-definition__foot .actions {
 	margin-left: auto;
 	display: flex;
 	gap: 10px;
 }
-.kp-sozluk-definition__foot button {
-	background: none;
-	border: 0;
-	padding: 0;
-	font: inherit;
-	color: inherit;
-	cursor: pointer;
-}
-.kp-sozluk-definition__foot button:hover {
+.kp-meta-row.kp-sozluk-definition__foot button:hover {
 	color: var(--text-primary);
 }
 


### PR DESCRIPTION
Fixes #2163

## What

Extracts the missing **composite-primitive layer** between the atoms in `apps/web/src/components/ui/` and the feature pages, and **widens `Button`** so hand-rolled variants can collapse onto the primitive. Internal extraction/refactor — no user-visible behavior change (`type:chore`).

### New primitives (`apps/web/src/components/ui/`, exported from `index.ts`)
- **`Surface` / `Card`** (`Card.tsx`, `Card.css`) — the parameterized shell. `Surface` emits only role-token classes: background from `tone` (default/raised/sunken), lift from `elevation` (the ADR 0162 four-level ramp), and `radius`/`padding`/`border` off the token scales. `Card` is the opinionated bordered/raised/padded default for new surfaces.
- **`MetaRow`** (`MetaRow.tsx`, `MetaRow.css`) — the metadata-row shell: inline flex-wrap layout + the shared child treatment (bold-secondary `.author`, secondary→accent links, reset inline `button`s), plus `MetaRow.Dot` (the shared `·` separator).
- **`CountToggle`** (`CountToggle.tsx`, `CountToggle.css`) — the count-pill toggle: an icon/label + optional count, pressed state via `aria-pressed` + the accent tint. Seeded from the reaction-bar pill.

### `Button` widened (`Button.tsx`, `Button.css`)
Adds `pressed` (→ `aria-pressed` + accent-tinted active), `icon` (leading decorative slot), and `loading` (spinner + `aria-busy` + disable, label preserved). Baseline behavior is unchanged when the new props are unset (asserted in `Button.test.tsx`).

### Migrations (behavior-preserving)
- **Count-pill:** `ReactionBar` now renders `CountToggle` (the pill shell/hover/pressed/count CSS moves to `CountToggle.css`; the bar keeps only its layout + the on-brand glyph). Testids/ARIA preserved.
- **Card shells:** the three identical Divan surface shells (`kp-triage__card`, `kp-actor`, `kp-wave`) migrate onto `Surface` — the shell declarations move entirely to props, leaving only each block's own column layout in `Divan.css` (no property declared in two sheets → order-independent).
- **Meta rows:** the pano feed row, the pano post-detail header, and the sözlük definition footer migrate onto `MetaRow`. Each keeps only its genuine deltas (a bespoke gap/font/margin, the definition footer's text-primary button hover) on a paired class that outranks the primitive's defaults by specificity, so the fold is byte-identical and order-free.

All visual values are grounded in the role tokens / 4-level elevation / type ramp in `apps/web/src/styles/tokens.css` (ADR 0162) — no raw hex/px introduced (the 24px WCAG 2.5.8 target-size floor is the one carried-over a11y constant).

## Verification
- `pnpm build` — clean
- `pnpm typecheck` — clean
- `pnpm lint` — clean (exit 0; 8 pre-existing repo-wide warnings, unchanged)
- `pnpm vitest run --project client --project unit` — **1979 passed** (incl. new `Card`/`MetaRow`/`CountToggle`/`Button` unit tests and the unchanged `ReactionBar` render contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)