### PR TITLE
perf(web): cache the session on the data plane — kill the 2-query D1 session-validation tax on /fate + /fate/live (#2274)

### DIFF
--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -148,6 +148,22 @@ export const BetterAuthLive = Layer.effect(
 				database: drizzleAdapter(db, {provider: "sqlite", schema}),
 				secret: Redacted.value(secret),
 				...authUrlConfig,
+				// Take D1 off get-session's hot path (#2260). Authenticated
+				// `/api/auth/get-session` was 5–8s because it is the FIRST D1-touching
+				// request in a cold isolate and pays the cold first-D1-connection
+				// amplifier (the same session resolution runs in ~478ms on `/fate`
+				// once the isolate + D1 subrequest are warm — so it's cold-connection
+				// cost, not a slow query). `cookieCache` serves the session from a
+				// short-lived signed cookie (default `strategy: "compact"` =
+				// HMAC-SHA256), making get-session crypto-only with ZERO D1 on the hot
+				// path. Tradeoff: a revoked/logged-out session stays valid until the
+				// cookie expires, so `maxAge` is the session-revocation latency — kept
+				// SHORT at better-auth's own 5-minute default (300s) to bound it.
+				session: {cookieCache: {enabled: true, maxAge: 300}},
+				// Collapse the sequential session+user lookups into one relational
+				// query via the drizzle relations wired above (#2260). Complements
+				// cookieCache: cheap on the cache-miss / cold path that still hits D1.
+				experimental: {joins: true},
 				// Verify a new account's email via a delivered link (the `EmailSender`
 				// port; ADR 0101). Was unreachable before — no sender existed.
 				emailVerification: {

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -173,13 +173,19 @@ export const BetterAuthLive = Layer.effect(
 				// (treated as still-signed-in-as-self for ≤60s), never a stale
 				// capability — see the PR's Staleness-safety section.
 				session: {cookieCache: {enabled: true, maxAge: 60}},
-				// On the cache-miss / cold path that still hits D1, pass the
-				// session+user lookup to the drizzle adapter as ONE relational join
-				// (via the relations wired above) instead of better-auth's two-query
-				// fallback (@better-auth/core `db/adapter/factory.ts` gates the join on
-				// this flag). Part of killing the 2-query D1 session-validation tax
-				// (#2274); complements cookieCache on the path the cache doesn't serve.
-				experimental: {joins: true},
+				// NB: better-auth's `experimental.joins` (the cache-miss cold-path
+				// 2-query→1-join optimization) is NOT enabled — it's incompatible with
+				// this stack. Turning it on routes EVERY adapter read through drizzle's
+				// relational query builder (`db.query[model].findFirst`), and
+				// @better-auth/drizzle-adapter@1.6.10 passes a raw SQL `eq(...)`
+				// expression as the RQB `where` (RQB-v1 shape). drizzle-orm@1.0.0-rc.4
+				// is RQB-v2 (`defineRelations`), whose `where` must be a relational
+				// filter object — it iterates the SQL object's keys and rejects the
+				// internal `decoder` property (`Unknown relational filter field:
+				// "decoder"`), 500ing sign-up's create→read-back. cookieCache above
+				// already delivers #2274's primary win (zero D1 on the authenticated
+				// hot path via the signed cookie); joins was only the secondary
+				// cache-miss lever, so it's dropped rather than fought.
 				// Verify a new account's email via a delivered link (the `EmailSender`
 				// port; ADR 0101). Was unreachable before — no sender existed.
 				emailVerification: {

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -148,21 +148,37 @@ export const BetterAuthLive = Layer.effect(
 				database: drizzleAdapter(db, {provider: "sqlite", schema}),
 				secret: Redacted.value(secret),
 				...authUrlConfig,
-				// Take D1 off get-session's hot path (#2260). Authenticated
-				// `/api/auth/get-session` was 5–8s because it is the FIRST D1-touching
-				// request in a cold isolate and pays the cold first-D1-connection
-				// amplifier (the same session resolution runs in ~478ms on `/fate`
-				// once the isolate + D1 subrequest are warm — so it's cold-connection
-				// cost, not a slow query). `cookieCache` serves the session from a
-				// short-lived signed cookie (default `strategy: "compact"` =
-				// HMAC-SHA256), making get-session crypto-only with ZERO D1 on the hot
-				// path. Tradeoff: a revoked/logged-out session stays valid until the
-				// cookie expires, so `maxAge` is the session-revocation latency — kept
-				// SHORT at better-auth's own 5-minute default (300s) to bound it.
-				session: {cookieCache: {enabled: true, maxAge: 300}},
-				// Collapse the sequential session+user lookups into one relational
-				// query via the drizzle relations wired above (#2260). Complements
-				// cookieCache: cheap on the cache-miss / cold path that still hits D1.
+				// Take D1 off the session-validation hot path on the DATA plane
+				// (#2274). Every authenticated `/fate` + `/fate/live` request validated
+				// the session with a fresh 2-query D1 lookup (session, then user).
+				// `cookieCache` serves the session from a short-lived signed cookie
+				// (default `strategy: "compact"` = HMAC-SHA256), so the hot path is
+				// crypto-only with ZERO D1. (Distinct from #2260, the control-plane
+				// `/api/auth/get-session` endpoint — different route, different fix.)
+				//
+				// `maxAge` is the SESSION-REVOCATION LATENCY BOUND: within the window,
+				// `getSession` trusts the signed cookie and re-checks only its embedded
+				// expiry — it does NOT re-query D1 for a server-side revocation (verified
+				// against better-auth@1.6.10 `api/routes/session.mjs`), so a
+				// logged-out / admin-revoked / banned session stays valid until the
+				// cookie expires. 60s (not better-auth's 300s default, `|| 300` in
+				// `context/create-context.mjs`) bounds that lag 5× tighter. 60s is safe
+				// because NO authz decision reads the cached session: moderation
+				// authority is read fresh per call from the relation-tuple store
+				// (`kunye/moderate.ts`), karma gates read fresh from Künye
+				// (`kunye/privilege.ts`, "never trust a stale session value"), tier
+				// gates read fresh via `kunye.tierOf` (`fate/layers.ts`), and
+				// `CurrentActor` derives only `user.id` (`kunye/CurrentActorLive.ts`).
+				// The stale-session blast radius is thus identity-continuity only
+				// (treated as still-signed-in-as-self for ≤60s), never a stale
+				// capability — see the PR's Staleness-safety section.
+				session: {cookieCache: {enabled: true, maxAge: 60}},
+				// On the cache-miss / cold path that still hits D1, pass the
+				// session+user lookup to the drizzle adapter as ONE relational join
+				// (via the relations wired above) instead of better-auth's two-query
+				// fallback (@better-auth/core `db/adapter/factory.ts` gates the join on
+				// this flag). Part of killing the 2-query D1 session-validation tax
+				// (#2274); complements cookieCache on the path the cache doesn't serve.
 				experimental: {joins: true},
 				// Verify a new account's email via a delivered link (the `EmailSender`
 				// port; ADR 0101). Was unreachable before — no sender existed.


### PR DESCRIPTION
## What & why (data-plane cookieCache — #2274)

Every authenticated `/fate` + `/fate/live` request currently pays a **fresh 2-query D1 session validation** (session row, then user row) because `makeBetterAuth` set no `session.cookieCache`. This serves the session from a **short-lived signed cookie** (`strategy: "compact"` = HMAC-SHA256) — **crypto-only, zero D1 on the hot path**.

This kills the "2-query D1 session-validation tax" that #2274 names on the **data plane**.

### This is NOT #2260

#2260 is the **control-plane** `/api/auth/get-session` endpoint (a cold-isolate first-D1-connection latency investigation, still p0/open). This PR targets a **different path** — the per-request session validation on the `/fate` + `/fate/live` data plane. Same better-auth knob, different route and different problem; this PR must **not** auto-close #2260. It closes the data-plane issue only.

## TTL choice — `maxAge: 60s` (the session-revocation latency bound)

`maxAge` is the **session-revocation latency bound**. Verified against `better-auth@1.6.10` (`api/routes/session.mjs`): within the cache window, `getSession` trusts the signed cookie and re-checks **only its embedded expiry** — it does **not** re-query D1 for a server-side revocation. So a logged-out / admin-revoked / banned session stays valid until the cached cookie expires.

- better-auth's **default** `maxAge` is **300s / 5 min** (`|| 300` in `context/create-context.mjs`) — that is the default, **not** "short".
- Chosen **60s**, cutting the revocation lag **5× tighter** than the default.

Freshness ↔ speed tradeoff: a shorter `maxAge` bounds revocation lag tighter but yields more cache-miss (D1-touching) validations; 60s keeps revocation lag to one minute while still serving the overwhelming majority of hot-path requests crypto-only.

## `experimental.joins` was dropped (it 500'd sign-up — the fix in this revision)

The first revision of this PR also set `experimental: {joins: true}` to collapse the cache-miss cold-path lookup into one relational join. **It broke every sign-up with an HTTP 500** (integration suite red: 11 failing suites, all `sign-up failed: 500`). Root cause, reproduced locally against real SQLite with the exact pinned versions:

- Turning `joins` on routes **every** adapter read (not just the join) through drizzle's relational query builder — `db.query[model].findFirst({ where, with })` — including sign-up's create→read-back path (`findUserByEmail`).
- `@better-auth/drizzle-adapter@1.6.10` passes a **raw SQL `eq(...)` expression** as the RQB `where` (RQB-**v1** shape).
- `drizzle-orm@1.0.0-rc.4` is RQB-**v2** (`defineRelations`), whose `where` must be a **relational-filter object**. It iterates the SQL object's keys and rejects the internal `decoder` property → `DrizzleError: Unknown relational filter field: "decoder"`, surfaced as the 500.

This is a library-version mismatch (better-auth's join path is written for drizzle RQB v1; the repo pins RQB v2), not a relations-wiring bug — phoenix's own `db.query.user.findFirst({where: {id}})` works because it passes a v2 filter object. It can't be cleanly fixed from phoenix config, so `joins` is **dropped**.

cookieCache alone still delivers #2274's **primary** win — zero D1 on the authenticated hot path via the signed cookie. `joins` was only the **secondary** cache-miss lever (2 queries → 1 on the cold path), so dropping it still resolves #2274's core finding.

## Staleness-safety (what the reviewer will adversarially verify)

**No authz / moderation / karma / kefil decision reads the cached session** — every capability check reads fresh from D1 / Künye per request, so the 60s cache cannot serve a stale *capability*:

- **Moderation authority** — `kunye/moderate.ts`: `Moderate.over(platform)` discharges against the `relation_tuple` store, **checked fresh per call** (replaced the old `user.role` column read). A revoked moderator loses authority immediately.
- **Karma gates** — `kunye/privilege.ts`: `CanPost` / `CanFlag` read `Kunye.karmaOf` fresh — the code's own rule is *"never trust a stale session value."*
- **Tier gates** — `fate/layers.ts`: Vote's yazar gate and the çaylak sandbox read `kunye.tierOf(voterId)` fresh.
- **Kefil / standing** — vouch-revoke flows through Künye standing/karma, read fresh per request (not the session).
- **`CurrentActor`** — `kunye/CurrentActorLive.ts`: derives only `user.id` (authenticated vs anonymous); it carries no role/tier/karma off the session.

**Worst-case stale-session blast radius at 60s:** a session that has been logged out / administratively revoked / banned is treated as still-signed-in-**as-itself** for **≤ 60s**. Because no capability rides on the cached session, the blast radius is **identity-continuity only**, never a stale privilege. That is the safe window — no authz/moderation/karma/kefil decision may read a stale cached session past it, and none does.

## Grounding (source, not intuition)

- cookieCache trust + default — `better-auth@1.6.10` `api/routes/session.mjs` (cache-hit path checks embedded expiry only) and `context/create-context.mjs` (`maxAge || 300`).
- `experimental.joins` incompatibility — `@better-auth/core` `db/adapter/factory.mjs` (L545/593: joins-on keeps `passJoinToAdapter`), `@better-auth/drizzle-adapter@1.6.10` `dist/index.mjs` (`findOne`/`findMany` route through `db.query[model].findFirst` with a SQL `where`), vs `drizzle-orm@1.0.0-rc.4` RQB-v2 relational-filter `where`. Reproduced against real SQLite: joins-on 500s sign-up, joins-off + cookieCache@60s signs up cleanly.

## Checks

- `pnpm typecheck` — green
- `pnpm lint:worktree` — green
- sign-up path reproduced locally against real SQLite (`node:sqlite` + the pinned drizzle/better-auth) — passes with cookieCache@60s and joins dropped

Fixes #2274
