### PR TITLE
fix(web): consume the spacing seam in CountToggle.css (heal design-token-guard RED on main from #2259)

### DIFF
--- a/apps/web/src/components/ui/CountToggle.css
+++ b/apps/web/src/components/ui/CountToggle.css
@@ -7,10 +7,11 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	gap: 4px;
-	/* WCAG 2.5.8 minimum target size (#2166) — a load-bearing a11y floor. */
-	min-height: 24px;
-	padding: 1px 6px;
+	gap: var(--s-1);
+	/* WCAG 2.5.8 minimum target size (#2166) — a load-bearing a11y floor.
+	   --s-6 is 24px at the compact default and only grows with density. */
+	min-height: var(--s-6);
+	padding: 1px var(--s-2);
 	border: 1px solid var(--border-faint);
 	border-radius: var(--r-pill);
 	background: var(--surface);


### PR DESCRIPTION
Part of #2170 (design-token-guard enforcement — CI-health heal of #2259's CountToggle.css raw-px regression).

## CI-health heal — `design-token-guard` RED on `main` from #2259's `CountToggle.css`

`apps/web/src/components/ui/CountToggle.css` (landed by #2259, composite primitives)
carried three raw-px values above the 1px/2px grid ceiling. The newly-merged
`design-token-guard` (#2170, ADR 0162 spacing seam) flags them, so the guard job is
**FAIL on `main`** and every PR cut from `main` inherits the red. This heal makes the
primitive consume the spacing seam — no baseline/allow-list entry (CountToggle is a
*new* primitive; it should consume the seam, not be grandfathered).

### Token substitutions (grounded in `apps/web/src/styles/tokens.css`)

| line | before | after | px @ compact | note |
|------|--------|-------|--------------|------|
| L10 | `gap: 4px` | `gap: var(--s-1)` | 4px | pure no-op (`--s-1` = 4px @ compact) |
| L12 | `min-height: 24px` | `min-height: var(--s-6)` | 24px | pure no-op @ compact; the WCAG 2.5.8 tap-target floor only *grows* with density |
| L13 | `padding: 1px 6px` | `padding: 1px var(--s-2)` | 8px | `1px` is sanctioned (≤2px); `6px` is **off the 4px grid** → mapped to the nearest grid token that matches the sibling convention |

The `1px 6px` horizontal padding is the only visual change: `6px → 8px` (**+2px**).
`6px` is not a multiple of 4 and not a sanctioned 1/2px hairline, so it cannot stay.
`var(--s-2)` (8px) over `var(--s-1)` (4px) — equidistant on the grid — is chosen to
match the established small-pill convention: `ToggleGroup.css` (`3px var(--s-2)`) and
`Button.css` small (`3px var(--s-2)`) both use `var(--s-2)` for horizontal padding.
The `gap` and `min-height` swaps are exact px no-ops at the compact default.

### Verification (all green in the worktree)
- `node packages/pipeline-cli/src/bin.ts design-token-guard check` → PASS (51 CSS files, 1452 refs, no raw-px regression)
- `pnpm typecheck` · `pnpm lint` · `pnpm build` → all pass

§CP:NO (apps/web CSS only). Relates to #2259, #2170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)