### PR TITLE
ci(web): gate the client vitest project so *.test.tsx fail CI (#2266)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       - run: pnpm typecheck
 
   unit:
-    name: unit tests
+    name: unit + client tests
     needs: changes
     # Same gate as `check`: skip (→ green, non-blocking) on a docs/skills-only PR.
     #
@@ -319,6 +319,17 @@ jobs:
       # 0057): runs each app's `test:unit`, so a second app is gated with no edit here.
       # Recursive `run` skips an app without the script — same posture as packages-tests.
       - run: pnpm --filter './apps/**' test:unit
+
+      # The `client` vitest project (#1419, ADR 0082): the SPA component/DOM tier —
+      # jsdom, renders the real React shells and queries the DOM for the `src/**/*.test.tsx`
+      # suites (ui primitives, ReactionBar, PanoPost, Screen, the pages latches). It's a
+      # sibling of `unit` (never `.tsx`), authored but ungated until now — CI ran only
+      # `--project unit`, so a client-tier regression reached main on a green CI (#2266).
+      # Folded into this same `code`-gated job: no worker deploy, no creds, and its fork
+      # heap is already CI-capped (`--max-old-space-size=512`, vitest.config.ts). A
+      # failing `.test.tsx` fails this job → UNIT_RESULT ≠ success → `ci-required` fails
+      # closed, exactly as a `test:unit` failure does.
+      - run: pnpm --filter './apps/**' test:client
 
   # The `packages/**` vitest suites (#760). Every workspace tooling/guard package
   # ships a `test` script (pipeline-cli — now the single home for the consolidated

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
 		"typecheck": "pnpm fate:generate && tsgo -b tsconfig.worker.json tsconfig.node.json && tsgo -p tsconfig.app.json --composite false",
 		"test": "vitest run --config vitest.config.ts",
 		"test:unit": "vitest run --config vitest.config.ts --project unit",
+		"test:client": "vitest run --config vitest.config.ts --project client",
 		"test:integration": "vitest run --config vitest.config.ts --project integration",
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",


### PR DESCRIPTION
## What & why

CI's `unit` job ran only `pnpm --filter './apps/**' test:unit` → the `unit` vitest project, whose `include` is `.test.ts` **only**. The `client` project (`apps/web/vitest.config.ts`: jsdom, `src/**/*.test.tsx`) was authored (#1419) but wired into **no** CI job and had **no** `test:client` script — so ~24 client-tier component/DOM suites (ui primitives, `ReactionBar`, `PanoPost`, `Screen`, the pages latches) passed locally but gated nothing. A client-tier regression could reach `main` on a green CI: false coverage.

## The fix

Fold the `client` tier into the existing `code`-gated `unit` job — the clean, minimal wiring:

- Add a `test:client` script to `apps/web/package.json` (`vitest run --config vitest.config.ts --project client`), mirroring `test:unit`.
- Run `pnpm --filter './apps/**' test:client` as a **second step** of the `unit` job in `.github/workflows/ci.yml` (renamed `unit + client tests`).

**Why extend `unit` rather than add a job:** the `unit` job already reads the single-sourced `check_required` predicate (skips → green on a docs/skills-only PR, satisfying the AC's shared `code`-gate) and is **already required** via `ci-required` (`needs: [… unit …]`, `UNIT_RESULT`). A failing `.test.tsx` now fails the job → `UNIT_RESULT ≠ success` → `ci-required` fails **closed**, exactly as a `test:unit` failure does. No new job, no new `GITHUB_TOKEN` permissions (the `unit` job carries none — matches existing posture, no over-broad token introduced), and no change to the unit-tested `ci-required` core.

The `client` tier's fork heap is already CI-tuned (`--max-old-space-size=512`, vitest.config.ts), so no infra change was needed.

## Green-on-main confirmed BEFORE wiring required

Ran the exact CI invocation on the branch (off fresh `main`):

```
pnpm --filter './apps/**' test:client
 Test Files  25 passed (25)
      Tests  88 passed (88)
```

`unit` / `integration` / e2e gates unchanged; no product behavior change.

## Acceptance criteria

- [x] The CI test gate runs the `client` vitest project (`--project client`) — a failing `src/**/*.test.tsx` now fails CI.
- [x] Shares the same `code`-gated predicate as `unit` (reads `check_required`; skips → green on docs/skills-only) and is required via `ci-required` (`UNIT_RESULT`).
- [x] Confirmed green on `main` first (25 files / 88 tests) before making it required.
- [x] No product-behavior change; `unit` / `integration` / e2e gates unchanged.

## §CP — human merge

This edits `.github/workflows/ci.yml` (a control-plane path) → **§CP**: reviewed-ready, human-merged by cansirin, **not** auto-shipped.

Fixes #2266

🤖 Generated with [Claude Code](https://claude.com/claude-code)