### PR TITLE
fix(pipeline): make the verdict read-back guard unconditional across all three review gates (#2268)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -859,10 +859,21 @@ verdict_readback_guard() {
     || printf '%s' "$got" | grep -Eiq "^[[:space:]]*\**[[:space:]]*${gate}:[[:space:]]*advisory" \
     || { echo "verdict_readback_guard FAILED: no canonical '${gate}:' marker (PASS/FAIL @ ${sha:0:7} or advisory) in comment $cid — the body is malformed; the PR is UNGATED." >&2; return 1; }
 
-  # (2) the anchored `Reviewed-head: @ <sha>` binding line is present (§6.6 / ADR 0151), SHA
-  #     prefix-matched to the head reviewed — the body line every §CP consumer resolves the head from.
-  printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:[[:space:]]*@?[[:space:]]*${sha:0:7}" \
-    || { echo "verdict_readback_guard FAILED: no anchored 'Reviewed-head: @ ${sha:0:7}' line in comment $cid — the §CP head binding is missing." >&2; return 1; }
+  # (2) Head binding — SHA-SOURCE-AWARE (#2272): do NOT require a `Reviewed-head:` line
+  #     unconditionally. A bindable first line (`<gate>: PASS|FAIL @ <sha>`) already carries the head
+  #     binding — (1) validated it against ${sha:0:7} — so a non-blocking binding PASS/FAIL (whose
+  #     template carries the SHA only on the first line, no separate line) needs NO `Reviewed-head:`.
+  #     A SHA-less advisory binds the head via `Reviewed-head: @ <sha>`: review-doc/review-skill carry
+  #     it (verified against head WHEN PRESENT); review-code's §CP advisory carries NONE by design
+  #     (ADR 0111 — SHA-less first line, no body binding) → accept its absence, never un-gate it. A
+  #     `Reviewed-head:` line present but bound to the WRONG sha is ALWAYS fatal (a stale/mis-bound
+  #     head must never read as verified).
+  if printf '%s' "$got" | grep -Eiq "^[[:space:]]*\**[[:space:]]*${gate}:[[:space:]]*(PASS|FAIL)[[:space:]]*@[[:space:]]*${sha:0:7}"; then
+    : # bindable first line: its `@ <sha>` IS the head binding (validated by (1)) — no line required
+  elif printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:"; then
+    printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:[[:space:]]*@?[[:space:]]*${sha:0:7}" \
+      || { echo "verdict_readback_guard FAILED: 'Reviewed-head:' line in comment $cid is bound to the wrong head (not @ ${sha:0:7}) — a stale/mis-bound §CP head binding." >&2; return 1; }
+  fi
 
   # (3) NO local filesystem path leaked into the public body (the #2148 leak). Reject a machine-local
   #     scratch/home path or a leading `@<path>` marker-as-path. Patterns are placeholders, not real
@@ -871,7 +882,7 @@ verdict_readback_guard() {
     echo "verdict_readback_guard FAILED: comment $cid leaks a local filesystem path in its body — a #2148 marker-as-path leak; refuse and re-post the real verdict." >&2; return 1
   fi
 
-  echo "verdict_readback_guard OK: ${gate} verdict @ ${sha:0:7} landed on comment $cid — marker + Reviewed-head present, no local-path leak."
+  echo "verdict_readback_guard OK: ${gate} verdict @ ${sha:0:7} landed on comment $cid — marker + head binding valid, no local-path leak."
 }
 ```
 
@@ -883,10 +894,16 @@ it as a silent success. A moved `HEAD_SHA` between the post and the read-back me
 *during* the review — re-resolve the head, re-verify against it (the gate is stateless), and re-post;
 never loosen the match to paper over a moved head.
 
-Two of the three assertions bind to a **head SHA** ((1) and (2)); the advisory blocking-set path
-carries no first-line `@ <sha>` by design (ADR 0111), which is why (1) accepts the `<gate>: advisory`
-first line as a posted verdict — but even the advisory MUST carry the body's `Reviewed-head: @ <sha>`
-line, so (2) and (3) still bind it. The bindable PASS/FAIL first line satisfies (1) via its `@ <sha>`.
+Check (2) is **SHA-source-aware** (#2272), which is why the read-back is unconditional without
+false-failing a legitimate non-blocking PASS or the review-code §CP advisory. The bindable PASS/FAIL
+first line satisfies (1) via its `@ <sha>` — that SHA **is** the head binding, so (2) requires no
+separate `Reviewed-head:` line (the non-blocking binding templates carry the SHA only on the first
+line). The advisory blocking-set path carries no first-line `@ <sha>` by design (ADR 0111), which is
+why (1) accepts the `<gate>: advisory` first line; it binds the head via a body `Reviewed-head: @ <sha>`
+line — review-doc/review-skill carry it and (2) verifies it against head when present, while
+review-code's §CP advisory carries none by design (ADR 0111) and (2) accepts its absence. A
+`Reviewed-head:` line present but bound to the wrong sha is always fatal. The leak check (3) is
+**unconditional** on every verdict type — the #2148/#2264 path-leak protection is never relaxed.
 
 ### Make the read-back UNCONDITIONAL — resolve the landed verdict from PR state, never a carried id (`verdict_post_verify`)
 

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -888,6 +888,103 @@ carries no first-line `@ <sha>` by design (ADR 0111), which is why (1) accepts t
 first line as a posted verdict — but even the advisory MUST carry the body's `Reviewed-head: @ <sha>`
 line, so (2) and (3) still bind it. The bindable PASS/FAIL first line satisfies (1) via its `@ <sha>`.
 
+### Make the read-back UNCONDITIONAL — resolve the landed verdict from PR state, never a carried id (`verdict_post_verify`)
+
+`verdict_readback_guard` above is correct but only fires **if it is reached with the right comment
+id**. The #2264 recurrence (after #2148/#2153 already "fixed" the leak) proves that condition is the
+real gap: the guard was invoked as `verdict_readback_guard "$MINE" …`, and `$MINE` is populated on
+**one** posting branch only (the APPROVE-failed comment-upsert `else` fallback). A verdict that lands
+by any **other** path — the native `APPROVE`, a first-verdict `POST` on a branch that didn't set
+`$MINE`, or an agent hand-rolling `gh api -f body=@file` — reaches the guard with an **empty** id, so
+the guard reads nothing and the broken/leaking marker sails through. A guard you can skip by taking a
+different post branch is not a guard.
+
+The fix is to **stop trusting a carried variable and re-derive the landed verdict from live PR
+state**, then run the read-back **unconditionally** on whatever landed. This is the single wrapper
+every gate calls after posting — it resolves the marker comment id by re-scanning, proves *a* verdict
+actually landed for the head, and **hard-fails (non-zero)** on absent / broken / leaking so a garbled
+or path-leaking marker is a **fatal** error the gate cannot silently pass:
+
+```bash
+# verdict_post_verify <PR> <gate> <head-sha>: the UNCONDITIONAL post-verification, run after ANY
+# verdict post/upsert (native APPROVE, comment PATCH-upsert, comment POST, advisory). It does NOT
+# rely on a $MINE/$CID captured on one posting branch — it RE-SCANS the PR's live state to resolve
+# whatever landed, then proves it well-formed + leak-free. Returns 0 ONLY on a proven-clean landed
+# verdict; non-zero (FATAL) on absent / malformed / leaking. <gate> ∈ review-code|review-doc|review-skill.
+verdict_post_verify() {
+  local PR="$1" gate="$2" sha="$3" me cid approved rbody
+  me="$(gh api user --jq .login)"
+  # (A) resolve MY landed marker COMMENT id for this gate — the SHA-bound `<gate>: PASS|FAIL @ <sha>`
+  #     first line OR the SHA-less `<gate>: advisory` line — re-scanned from PR state, NOT a carried id.
+  #     A whole-body-path leak (#2264) has NO `<gate>:` first line, so it resolves empty here → caught in (C).
+  cid=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+    | jq -r --arg me "$me" --arg g "$gate" --arg sha "${sha:0:7}" '
+        [ .[] | select(.user.login==$me)
+              | select((.body | test("^\\s*\\**\\s*" + $g + ":\\s*(PASS|FAIL)\\s*@\\s*" + $sha; "i"))
+                        or (.body | test("^\\s*\\**\\s*" + $g + ":\\s*advisory"; "i"))) ]
+        | sort_by(.created_at) | last | .id // empty')
+  # (B) or a native approving REVIEW GitHub bound to this exact head (commit_id == head; its own SHA anchor):
+  approved=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
+    --jq "[.[] | select(.user.login==\"$me\" and .commit_id==\"$sha\" and .state==\"APPROVED\")] | length")
+  rbody=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
+    --jq "[.[] | select(.user.login==\"$me\" and .commit_id==\"$sha\" and .state==\"APPROVED\")] | last | .body // empty")
+  echo "verdict_post_verify: PR #$PR ${gate} @ ${sha:0:7} -> comment=${cid:-none} native-approve=${approved:-0}"
+
+  # (C) FATAL: nothing bound to this head landed — the post no-opped, OR the body carries no marker
+  #     line at all (the #2264 whole-body-path leak leaves no `<gate>:` first line). The PR is UNGATED.
+  if [ -z "$cid" ] && [ "${approved:-0}" -eq 0 ]; then
+    echo "verdict_post_verify FAILED (fatal): no ${gate} verdict bound to head ${sha:0:7} landed on PR #$PR — the post no-opped or the marker's first line is absent (a whole-body local-path leak leaves no marker). Re-post the real by-value verdict; if it still cannot land, report a POSTING FAILURE — the PR is ungated." >&2
+    return 1
+  fi
+
+  # (D) UNCONDITIONAL shape + leak read-back on the landed COMMENT — covers PATCH-upsert, POST, and
+  #     advisory (every comment post path). $cid came from a re-scan, so this runs no matter which
+  #     branch posted; the guard asserts marker shape + `Reviewed-head:` + NO local-path leak.
+  if [ -n "$cid" ]; then
+    verdict_readback_guard "$cid" "$gate" "$sha" || {
+      echo "verdict_post_verify FAILED (fatal): landed ${gate} comment $cid on PR #$PR is malformed or leaks a local filesystem path — delete/re-post the real by-value verdict and re-verify; never leave a broken/leaking marker." >&2
+      return 1
+    }
+  fi
+
+  # (E) UNCONDITIONAL leak check on the native-APPROVE body too. The APPROVE body is by-value, but a
+  #     hand-assembled body could still carry a local path; its SHA binding is the commit_id, so ONLY
+  #     the leak check applies (no `Reviewed-head:` line is required of a native approve). LINEAR regex
+  #     (literal alternation + anchored `(^|[[:space:]])` — no nested quantifier, no ReDoS), the same
+  #     pattern verdict_readback_guard uses; paths are placeholders, keeping this doc leak-clean.
+  if [ "${approved:-0}" -gt 0 ] && [ -n "$rbody" ]; then
+    if printf '%s' "$rbody" | grep -Eq '(/var/folders/|/Users/|/tmp[/.]|/private/tmp/|(^|[[:space:]])~/|(^|[[:space:]])@/)'; then
+      echo "verdict_post_verify FAILED (fatal): native APPROVE review body on PR #$PR leaks a local filesystem path — dismiss/re-post a clean by-value verdict." >&2
+      return 1
+    fi
+  fi
+
+  echo "verdict_post_verify OK: ${gate} verdict @ ${sha:0:7} landed clean on PR #$PR (comment=${cid:-none} native-approve=${approved:-0}) — present, well-formed, leak-free."
+}
+```
+
+**Why this closes the #2264 recurrence — the post-path enumeration.** Every way a gate can land a
+verdict now routes through the same unconditional read-back, because `verdict_post_verify` resolves
+the landed surface from PR state instead of from a branch-local variable:
+
+- **native `APPROVE`** → resolved by (B); its body is leak-checked by (E); commit_id is its SHA anchor.
+- **comment `PATCH`-upsert** (the old `$MINE` branch) → resolved by (A); shape+leak by (D).
+- **comment `POST`** (first verdict, `$MINE` empty) → resolved by (A); shape+leak by (D). *This is the
+  branch the carried-`$MINE` call silently skipped.*
+- **advisory comment** (§CP blocking-set) → resolved by (A) via the `<gate>: advisory` arm; shape+leak by (D).
+- **hand-rolled `gh api -f body=@file`** (the literal path as the whole body) → has **no** `<gate>:`
+  first line, so (A) resolves empty and (B) is 0 ⇒ **(C) fatal** (`ungated`). A garbled marker is fatal.
+
+The single **fatal** exit on absent/broken/leaking is the load-bearing change: the prior Step-4c
+presence check merely *echoed* a warning and re-posted without a non-zero exit, so a garble read as
+green. Callers **must** propagate the non-zero — `verdict_post_verify … || exit 1` — so the gate
+cannot report itself done over an ungated PR.
+
+Gate it exactly like the by-value post it follows: right after the last of the Step-5/4a-4b upsert
+branches runs, call `verdict_post_verify "$PR" <gate> "$HEAD_SHA" || exit 1`. On a moved `HEAD_SHA`
+between post and verify the head advanced *during* review — re-resolve the head, re-verify against it
+(the gate is stateless), and re-post; never loosen the match to paper over a moved head.
+
 ---
 
 ## 3. Progress-comment format

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1371,50 +1371,32 @@ you reviewed (`$HEAD_SHA`), **or** the native approving review GitHub recorded a
 the **same SHA-binding contract** (§5 / ADR 0058) the consumers apply, so "landed" means landed *for
 this head*, not "some review-code comment exists":
 
+Do **not** re-implement this inline against a `$MINE` you captured on one 4a/4b branch — that carried
+id is exactly what the #2264 recurrence slipped through (`$MINE` is set only on the APPROVE-failed
+comment-upsert `else` fallback, so the native-APPROVE, first-`POST`, and hand-rolled paths reached the
+guard with an empty id and a broken/leaking marker sailed through). Instead call the **single
+unconditional wrapper** from the shared contract, which re-derives the landed verdict from live PR
+state (never a carried variable) and runs the read-back on whatever landed, on **every** post path —
+[`gh-issue-intake-formats.md` §Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../gh-issue-intake-formats.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
+
 ```bash
-# verdict-posting self-assertion: prove a current-head review-code verdict actually landed (§ZS).
-ME="$(gh api user --jq .login)"
-# (1) a marker comment from me, first line review-code:, carrying THIS head's @ <sha> (or the
-#     advisory line, which is intentionally SHA-less — it authorizes nothing but IS a posted verdict):
-LANDED_COMMENT=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-  | jq -r --arg me "$ME" --arg sha "$HEAD_SHA" '
-      [ .[] | select(.user.login==$me)
-            | select((.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*" + ($sha[0:7]); "i"))
-                      or (.body | test("^\\s*\\**\\s*review-code:\\s*advisory"; "i"))) ]
-      | length')
-# (2) or a native approving review GitHub attributed to this exact head (commit_id == HEAD_SHA):
-LANDED_REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
-  --jq "[.[] | select(.user.login==\"$ME\" and .commit_id==\"$HEAD_SHA\" and .state==\"APPROVED\")] | length")
-echo "verdict-posting self-check @ ${HEAD_SHA:0:7}: marker=$LANDED_COMMENT native-approve=$LANDED_REVIEW"
-if [ "$LANDED_COMMENT" -eq 0 ] && [ "$LANDED_REVIEW" -eq 0 ]; then
-  # the gate computed a verdict but NONE bound to the current head landed: the post silently no-opped.
-  # Fail LOUD — do NOT exit 0 as if gated. Re-post the verdict (re-run the 4a/4b upsert) and re-assert;
-  # if it still cannot land, surface it as a posting failure in the run ledger (the PR is genuinely
-  # ungated and a consumer must not read it as verified), never swallow it as a silent success.
-  echo "review-code verdict-posting FAILED (fail-loud): no review-code verdict bound to head ${HEAD_SHA:0:7} landed — the post no-opped. Re-posting; if it still fails, report posting failure (the PR is ungated)." >&2
-fi
+# UNCONDITIONAL post-verify: resolve the landed verdict from PR state (marker comment @ HEAD_SHA, the
+# advisory line, or the native APPROVE at commit_id==HEAD_SHA), then prove it present + well-formed +
+# leak-free. FATAL (non-zero) on absent / malformed / leaking — the #2264 whole-body-path leak, a
+# no-opped post, and a stale-head marker all fail here. Propagate the non-zero: never report the gate
+# done over an ungated PR. Runs no matter which 4a/4b branch posted — no $MINE, no skippable path.
+verdict_post_verify "$PR" review-code "$HEAD_SHA" || exit 1
 ```
 
-The `marker=N native-approve=M` line is the **load-bearing emit** (§ZS #1): the run output now states
-that the verdict reached the PR for this head, so a posting step that quietly stopped landing is
-visible immediately instead of reading green. A SHA-binding read is deliberate — a *stale* marker
-from an earlier head (a pre-rebase verdict, the head-moved-under-the-verdict race ADR 0058 closes)
-does **not** count as landed here, exactly as `ship-it` would refuse it; the self-check and the
-consumer apply one SHA contract. This makes verdict-posting an **enforced** gate, not a convention:
-the gate does not consider itself done until its own verdict is provably on the current head — closing
-the case where the posting step silently no-ops and a PR reads as ungated (#749 part b).
-
-**Then run the shared verdict read-back guard on the comment you just wrote (the #2148 leak class).**
-The presence check above proves *some* current-head `review-code:` verdict landed; it does not prove
-the comment **body** is well-formed and **leak-free** — the #2148 failure was a marker comment whose
-entire body was a local temp path (`@/var/folders/…`), a broken-marker + local-path-leak that a
-presence scan doesn't catch. When you posted via the **comment** upsert path (not the native APPROVE),
-re-read *that* comment and run the single canonical guard defined in the shared contract —
-[`gh-issue-intake-formats.md` §The verdict read-back guard](../gh-issue-intake-formats.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard).
-Do **not** re-derive a local copy — call the shared `verdict_readback_guard "$MINE" review-code "$HEAD_SHA"`
-(it asserts the canonical marker token, the anchored `Reviewed-head: @ <sha>` line, and **no local
-filesystem path**, failing loud on any miss). On non-zero, re-post the real verdict and re-assert;
-never swallow it as a silent success.
+`verdict_post_verify` is the load-bearing change over the old inline check: the prior presence scan
+merely *echoed* a warning on a miss and re-posted **without a non-zero exit**, so a garbled/absent
+marker read as green (the #2264 slip). The wrapper's single **fatal** exit — on nothing-landed *and*
+on a malformed/leaking marker resolved from PR state — makes verdict-posting an **enforced** gate: the
+gate does not consider itself done until a clean, current-head `review-code:` verdict is provably on
+the PR. The SHA-binding is deliberate: a *stale* marker from an earlier head (a pre-rebase verdict,
+the head-moved-under-the-verdict race ADR 0058 closes) does **not** count as landed, exactly as
+`ship-it` would refuse it. See the shared contract for the full post-path enumeration proving no path
+skips the guard.
 
 > A `HEAD_SHA` moved between the 4a/4b post and this read-back means the PR head advanced *during*
 > the review — the verdict you posted is already stale against the new head. Re-resolve

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -793,14 +793,26 @@ the #2148 failure was a marker comment whose entire body was a local temp path (
 a broken marker (no SHA-bound verdict for consumers) **and** a public local-path leak. Only a
 post-write read-back sees it.
 
-Run the **single canonical guard** defined in the shared contract —
-[`gh-issue-intake-formats.md` §The verdict read-back guard](../gh-issue-intake-formats.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard).
-Do **not** re-derive a local copy — capture the upsert's comment id and call
-`verdict_readback_guard "$MINE" review-doc "$HEAD_SHA"` (it asserts the canonical `review-doc:`
-marker token, the anchored `Reviewed-head: @ <sha>` line, and **no local filesystem path**, failing
-loud on any miss). On non-zero, re-post the real verdict and re-assert; if it still cannot land
-clean, surface it as a posting failure in the run ledger — the PR is genuinely ungated and a
-consumer must not read it as verified — never swallow it as a silent success (fail-closed, ADR 0092 §ZS).
+Do **not** re-implement this against a `$MINE` captured on one Step-5 branch — that carried id is what
+the #2264 recurrence slipped through (`$MINE` is set only on the comment-upsert branch, so a verdict
+landed by any other path reached the guard with an empty id and a broken/leaking marker sailed
+through). Call the **single unconditional wrapper** from the shared contract, which re-derives the
+landed verdict from live PR state (never a carried variable) and runs the read-back on whatever
+landed, on **every** post path —
+[`gh-issue-intake-formats.md` §Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../gh-issue-intake-formats.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
+
+```bash
+# UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed
+# + leak-free, FATAL (non-zero) on absent / malformed / leaking. Propagate the non-zero — never report
+# the gate done over an ungated PR. Runs no matter which Step-5 branch posted; no $MINE, no skippable path.
+verdict_post_verify "$PR" review-doc "$HEAD_SHA" || exit 1
+```
+
+The wrapper's single **fatal** exit — on nothing-landed *and* on a malformed/leaking marker resolved
+from PR state — makes verdict-posting an **enforced** gate (fail-closed, ADR 0092 §ZS): the gate is
+not done until a clean, current-head `review-doc:` verdict is provably on the PR. The prior
+`verdict_readback_guard "$MINE"` call could be reached with an empty id and silently no-op; this
+cannot. See the shared contract for the full post-path enumeration proving no path skips the guard.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -730,14 +730,26 @@ the #2148 failure was a marker comment whose entire body was a local temp path (
 a broken marker (no SHA-bound verdict for consumers) **and** a public local-path leak. Only a
 post-write read-back sees it.
 
-Run the **single canonical guard** defined in the shared contract —
-[`gh-issue-intake-formats.md` §The verdict read-back guard](../gh-issue-intake-formats.md#the-verdict-read-back-guard--after-posting-a-gate-marker-re-read-it-and-fail-loud-verdict_readback_guard).
-Do **not** re-derive a local copy — capture the upsert's comment id and call
-`verdict_readback_guard "$MINE" review-skill "$HEAD_SHA"` (it asserts the canonical `review-skill:`
-marker token, the anchored `Reviewed-head: @ <sha>` line, and **no local filesystem path**, failing
-loud on any miss). On non-zero, re-post the real verdict and re-assert; if it still cannot land
-clean, surface it as a posting failure in the run ledger — the PR is genuinely ungated and a
-consumer must not read it as verified — never swallow it as a silent success (fail-closed, ADR 0092 §ZS).
+Do **not** re-implement this against a `$MINE` captured on one Step-5 branch — that carried id is what
+the #2264 recurrence slipped through (`$MINE` is set only on the comment-upsert branch, so a verdict
+landed by any other path reached the guard with an empty id and a broken/leaking marker sailed
+through). Call the **single unconditional wrapper** from the shared contract, which re-derives the
+landed verdict from live PR state (never a carried variable) and runs the read-back on whatever
+landed, on **every** post path —
+[`gh-issue-intake-formats.md` §Make the read-back UNCONDITIONAL (`verdict_post_verify`)](../gh-issue-intake-formats.md#make-the-read-back-unconditional--resolve-the-landed-verdict-from-pr-state-never-a-carried-id-verdict_post_verify):
+
+```bash
+# UNCONDITIONAL post-verify: resolve the landed verdict from PR state, prove it present + well-formed
+# + leak-free, FATAL (non-zero) on absent / malformed / leaking. Propagate the non-zero — never report
+# the gate done over an ungated PR. Runs no matter which Step-5 branch posted; no $MINE, no skippable path.
+verdict_post_verify "$PR" review-skill "$HEAD_SHA" || exit 1
+```
+
+The wrapper's single **fatal** exit — on nothing-landed *and* on a malformed/leaking marker resolved
+from PR state — makes verdict-posting an **enforced** gate (fail-closed, ADR 0092 §ZS): the gate is
+not done until a clean, current-head `review-skill:` verdict is provably on the PR. The prior
+`verdict_readback_guard "$MINE"` call could be reached with an empty id and silently no-op; this
+cannot. See the shared contract for the full post-path enumeration proving no path skips the guard.
 
 ---
 


### PR DESCRIPTION
## What this fixes

`Fixes #2268` — a §CP gate-reliability fire. The #2149 marker-path-leak class (fixed by #2153) **slipped again on PR #2264**: a review verdict posted the tmpfile PATH instead of its contents, leaking a local path into a public PR **and** landing an empty/broken SHA-bound marker that made a verified PR read as unverified (blocked a real ship; forced a human hand-repost). Recurred after the fix ⇒ the guard was demonstrably insufficient.

## Root cause (grounded)

The safe by-value post form **and** the read-back guard both already existed. `verdict_readback_guard` (in `gh-issue-intake-formats.md`) already matched `/Users/`, `/var/folders/`, `/tmp`, `/private/tmp/`. The gap was **reachability**, not the check:

- The guard was invoked as `verdict_readback_guard "$MINE" …`, and `$MINE` is populated on **one** posting branch only — the APPROVE-failed comment-upsert `else` fallback.
- A verdict landed by the **native APPROVE**, a **first-verdict POST**, an **advisory comment**, or a **hand-rolled `-f body=@file`** reached the guard with an **empty id** → the guard read nothing → the broken/leaking marker sailed through.
- The Step-4c presence-check fail branch only **echoed** a warning and re-posted — it never **exited non-zero**, so a garble read as green.

## The fix — make the guard unconditional and un-skippable (root, not the #2264 instance)

1. **New shared wrapper `verdict_post_verify <PR> <gate> <head-sha>`** in `gh-issue-intake-formats.md`: it **re-derives the landed verdict from live PR state** (the marker comment bound to `HEAD_SHA`, the advisory line, or the native APPROVE at `commit_id==HEAD_SHA`) instead of trusting a carried `$MINE`, then runs the read-back on whatever landed — on **every** post path.
2. **Hard-fail (non-zero) on ANY miss** — nothing landed for the head, a malformed marker, or a leaked local path. A whole-body-path leak resolves **no** marker → fatal (`ungated`). A garbled/leaking/absent marker is now a **fatal** error the gate cannot silently pass.
3. **All three consumers wired** — `review-code` Step 4c, `review-doc` / `review-skill` Step 5b now call `verdict_post_verify "$PR" <gate> "$HEAD_SHA" || exit 1`, replacing the skippable `$MINE`-gated call and the non-fatal presence check.
4. **Leak-check regex kept linear** — literal alternation + anchored `(^|[[:space:]])` prefixes, no nested quantifier (no ReDoS), reused verbatim from the existing guard.

## Adversarial post-path enumeration (proves the guard is now unconditional)

Every way a gate lands a verdict routes through the same read-back, because the surface is resolved from PR state, not a branch-local variable:

| Post path | Resolved by | Guarded by |
|---|---|---|
| native `APPROVE` | (B) commit_id==head | (E) leak-check on review body |
| comment `PATCH`-upsert (old `$MINE` branch) | (A) marker @ head | (D) shape + leak |
| comment `POST` (first verdict, `$MINE` empty) | (A) marker @ head | (D) shape + leak |
| advisory comment (§CP blocking-set) | (A) `advisory` arm | (D) shape + leak |
| hand-rolled `-f body=@file` (whole-body path) | no `<gate>:` first line | (C) **fatal** (ungated) |

**Residual note:** the guard is live-correct once the verdict has been posted (it verifies the landed state); it does not intercept the post call itself. A stale-head marker (pre-rebase) also fails (C)/(D) exactly as `ship-it` would refuse it — intended.

## Validation

- `bash -n` on the new `verdict_post_verify` function: OK.
- jq expression (A) parses; leak regex detects `@/var/folders/…` and passes a clean body.
- `leak-guard` pre-commit hook: clean — no user-local paths in any scanned doc surface (regex patterns are placeholders).

## §CP — human merge

This edits the review-* skills + the shared `gh-issue-intake-formats.md` contract (gate-critical control plane). It will be verified by `review-skill` and **human-merged by cansirin** — not auto-shipped, not self-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)