### PR TITLE
perf(pano): parallelize the feed /fate count + keyset D1 reads (#2275)

### DIFF
--- a/apps/web/worker/features/pano/Pano.connection.unit.test.ts
+++ b/apps/web/worker/features/pano/Pano.connection.unit.test.ts
@@ -22,9 +22,11 @@ import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import type * as schema from "../../db/drizzle/schema.ts";
 import {makePasaportStub, PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import type {Pasaport, ProfileIdentityRow} from "../pasaport/Pasaport.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
+import {Reaction, type ReactionAggregate} from "../reaction/Reaction.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {Pano, PanoLive} from "./Pano.ts";
@@ -340,4 +342,127 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 			);
 		}).pipe(Effect.provide(panoLayer(access, LiveIdentityStub)));
 	});
+});
+
+describe("Pano — authed feed: parallelized listPostsConnection composes with the getPostsByIds re-hydrate (#2275)", () => {
+	// #2275 parallelizes the total-count and keyset-page reads inside
+	// `listPostsConnection`; the per-viewer scalars (`myVote`/`isSaved`) and the
+	// reaction aggregate are deliberately NOT read there — they come from the
+	// batched `getPostsByIds` re-hydrate the `posts` resolver runs for a signed-in
+	// viewer (lists.ts). This drives that exact composition end to end over the
+	// substituted seams and proves a viewer with a vote + a save + a reaction still
+	// sees all three after the parallelization — i.e. the re-hydrate stamps survive.
+	const VIEWER = "user-viewer";
+
+	// The keyset-page projection `listPostsConnection` returns (post-fields subset).
+	const keysetRow = {
+		id: "post-1",
+		slug: "baslik",
+		title: "başlık",
+		url: "https://kamp.us",
+		host: "kamp.us",
+		bodyExcerpt: "özet",
+		authorId: "user-1",
+		authorName: "eski-ad",
+		score: 3,
+		commentCount: 2,
+		createdAt: new Date(1000),
+		tags: "show",
+	};
+
+	// The full `post_record` the re-hydrate re-reads by id (getPostsByIds does a
+	// `select()` of the whole row, then stamps the viewer scalars + reactions onto it).
+	// biome-ignore lint/plugin: a row fixture standing in for a full `post_record` select; getPostsByIds reads the lifecycle/draft columns + the `toPostSummaryRow` field set off it, enumerating every column adds nothing.
+	const fullRecord = {
+		id: "post-1",
+		slug: "baslik",
+		title: "başlık",
+		url: "https://kamp.us",
+		host: "kamp.us",
+		body: "gövde",
+		bodyExcerpt: "özet",
+		authorId: "user-1",
+		authorName: "eski-ad",
+		tags: "show",
+		score: 3,
+		commentCount: 2,
+		hotScore: 5,
+		createdAt: new Date(1000),
+		updatedAt: new Date(1000),
+		lastActivityAt: new Date(1000),
+		removedAt: null,
+		removedBy: null,
+		removedReason: null,
+		sandboxedAt: null,
+		isDraft: null,
+	} as unknown as typeof schema.postRecord.$inferSelect;
+
+	const reactionAggregate: ReactionAggregate = {
+		counts: [{emoji: "🔥", count: 4}],
+		myReaction: "🔥",
+	};
+
+	// The viewer's state: a vote (Vote.readMine → the id), a save (Bookmark.readMine
+	// → the id), and a reaction (Reaction.readAggregate → the non-empty aggregate).
+	// biome-ignore lint/plugin: a service double — only `readMine` is on the re-hydrate path.
+	const VotedStub = Layer.succeed(Vote, {
+		cast: () => Effect.die(new Error("feed re-hydrate must not cast a vote")),
+		readMine: () => Effect.succeed(new Set<string>(["post-1"])),
+		clearTarget: () => Effect.void,
+	} as unknown as typeof Vote.Service);
+
+	// biome-ignore lint/plugin: a service double — only `readMine` is on the re-hydrate path.
+	const SavedStub = Layer.succeed(Bookmark, {
+		toggle: () => Effect.die(new Error("feed re-hydrate must not toggle a bookmark")),
+		readMine: () => Effect.succeed(new Set<string>(["post-1"])),
+		listSavedConnection: () => Effect.die(new Error("not used")),
+	} as unknown as typeof Bookmark.Service);
+
+	const ReactedStub = Layer.succeed(Reaction, {
+		react: () => Effect.die(new Error("feed re-hydrate must not react")),
+		readMine: () => Effect.die(new Error("readMine not on this path")),
+		readAggregate: () => Effect.succeed(new Map([["post-1", reactionAggregate]])),
+		clearTarget: () => Effect.void,
+	} satisfies typeof Reaction.Service);
+
+	const authedPanoLayer = (access: DrizzleAccess) =>
+		PanoLive.pipe(
+			Layer.provide(VotedStub),
+			Layer.provide(SavedStub),
+			Layer.provide(ReactedStub),
+			Layer.provide(PasaportIdentityStub),
+			Layer.provide(Layer.succeed(Drizzle, access)),
+		);
+
+	it.effect(
+		"a signed-in viewer with a vote + a save + a reaction sees all three on the composed feed row",
+		() => {
+			// The composed authed-feed read order: count + keyset fetch (the two now
+			// parallelized in listPostsConnection), then the getPostsByIds re-hydrate
+			// fetch — the scripted double replays these in call order.
+			const {access} = scriptedAccess([
+				1 /* count */,
+				[keysetRow] /* keyset page fetch */,
+				[fullRecord] /* getPostsByIds re-hydrate fetch */,
+			]);
+			return Effect.gen(function* () {
+				const pano = yield* Pano;
+				const page = yield* pano.listPostsConnection({sort: "new", first: 10});
+				assert.strictEqual(page.totalCount, 1, "parallelized count still lands on the page");
+				const ids = page.rows.map((row) => row.id);
+				assert.deepStrictEqual(ids, ["post-1"], "the keyset page carries the id to re-hydrate");
+
+				const hydrated = yield* pano.getPostsByIds(ids, {viewerId: VIEWER});
+				const row = hydrated[0];
+				assert.isDefined(row, "the re-hydrate returns the viewer-scoped row");
+				assert.strictEqual(row.myVote, true, "the viewer's vote survives the re-hydrate stamp");
+				assert.strictEqual(row.isSaved, true, "the viewer's save survives the re-hydrate stamp");
+				assert.deepStrictEqual(
+					row.reactions,
+					reactionAggregate,
+					"the reaction aggregate survives the re-hydrate stamp",
+				);
+			}).pipe(Effect.provide(authedPanoLayer(access)));
+		},
+	);
 });

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -572,7 +572,27 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		);
 		if (sandboxClause) baseConditions.push(sandboxClause);
 
-		const totalCount = yield* run((db) =>
+		type CursorRow = {
+			id: string;
+			score: number;
+			hotScore: number;
+			commentCount: number;
+			createdAt: Date | null;
+		};
+
+		// The total count and the keyset page are INDEPENDENT reads over the same
+		// base predicate — the page query never consumes the count — so they run
+		// concurrently instead of serially, collapsing two cross-region D1
+		// round-trips into one overlapped batch and cutting the feed's latency floor
+		// (#2275). The combinator is the repo's `Effect.all([...], {concurrency:
+		// "unbounded"})` parallel-reads idiom (Divan.collect). NOT folded into a
+		// single `count(*) OVER()` window: the keyset query's WHERE carries the
+		// cursor predicate (`id < cursor`), so a window count there would total only
+		// the post-cursor slice, not the whole feed — a different result the fold is
+		// forbidden to change. Per-viewer scalars (myVote/isSaved) + reaction
+		// aggregates are NOT read here; they come from the batched `getPostsByIds`
+		// re-hydrate in the resolver, left untouched.
+		const countEffect = run((db) =>
 			db
 				.select({n: sql<number>`count(*)`})
 				.from(schema.postRecord)
@@ -581,92 +601,102 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				.then((r) => r?.n ?? 0),
 		);
 
-		type CursorRow = {
-			id: string;
-			score: number;
-			hotScore: number;
-			commentCount: number;
-			createdAt: Date | null;
-		};
-		const resolvedRow = after
-			? ((yield* run((db) =>
-					db
-						.select({
-							id: schema.postRecord.id,
-							score: schema.postRecord.score,
-							hotScore: schema.postRecord.hotScore,
-							commentCount: schema.postRecord.commentCount,
-							createdAt: schema.postRecord.createdAt,
-						})
-						.from(schema.postRecord)
-						.where(eq(schema.postRecord.id, after))
-						.get(),
-				)) ?? null)
-			: null;
-		const cursor = resolveCursor<CursorRow>(after, resolvedRow);
-		if (cursor.kind === "miss") {
+		// The keyset page path: resolve the cursor (a DB read only when `after` is
+		// present), short-circuit to `null` on a cursor miss (the caller renders the
+		// empty page), else fetch the page and stamp the live author identity.
+		const pageEffect = Effect.gen(function* () {
+			const resolvedRow = after
+				? ((yield* run((db) =>
+						db
+							.select({
+								id: schema.postRecord.id,
+								score: schema.postRecord.score,
+								hotScore: schema.postRecord.hotScore,
+								commentCount: schema.postRecord.commentCount,
+								createdAt: schema.postRecord.createdAt,
+							})
+							.from(schema.postRecord)
+							.where(eq(schema.postRecord.id, after))
+							.get(),
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor<CursorRow>(after, resolvedRow);
+			if (cursor.kind === "miss") return null;
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
+
+			// Both the keyset cursor predicate and `orderBy` derive from the one
+			// `POST_SORT_LEAD_COLUMN` map: an optional lead column (descending) +
+			// `id` desc tiebreaker; `new` (no lead column) orders by `id` alone.
+			const leadKey = POST_SORT_LEAD_COLUMN[sort];
+			const leadColumn = leadKey
+				? {column: schema.postRecord[leadKey], value: cursorRow?.[leadKey]}
+				: null;
+
+			const cursorPredicate = keysetAfter([
+				...(leadColumn
+					? [{column: leadColumn.column, dir: "desc" as const, value: leadColumn.value ?? null}]
+					: []),
+				{column: schema.postRecord.id, dir: "desc", value: cursorRow?.id ?? null},
+			]);
+
+			const whereExpr = cursorPredicate
+				? and(...baseConditions, cursorPredicate)
+				: and(...baseConditions);
+
+			const orderBy = [
+				...(leadColumn ? [desc(leadColumn.column)] : []),
+				desc(schema.postRecord.id),
+			];
+
+			const fetched = yield* run((db) =>
+				db
+					.select({
+						id: schema.postRecord.id,
+						slug: schema.postRecord.slug,
+						title: schema.postRecord.title,
+						url: schema.postRecord.url,
+						host: schema.postRecord.host,
+						bodyExcerpt: schema.postRecord.bodyExcerpt,
+						authorId: schema.postRecord.authorId,
+						authorName: schema.postRecord.authorName,
+						score: schema.postRecord.score,
+						commentCount: schema.postRecord.commentCount,
+						createdAt: schema.postRecord.createdAt,
+						tags: schema.postRecord.tags,
+					})
+					.from(schema.postRecord)
+					.where(whereExpr)
+					.orderBy(...orderBy)
+					.limit(first + 1),
+			);
+
+			// Route the keyset projection through the same `post-fields.ts` column→field
+			// map the by-id path uses, so `body` collapses to `null` for an empty excerpt
+			// (not `""`) — the divergence is unrepresentable, not hand-synced (#1170).
+			const page = forwardPage(fetched, first, (r) => r.id, toPostSummaryKeysetRow);
+
+			// Stamp the LIVE author identity onto the page — one batched
+			// `getProfileIdentitiesByIds` read for the whole page (never per-row), the same
+			// idiom `getPostsByIds` uses. This is the feed's convergence point: the resolver
+			// paths that serve this page WITHOUT re-hydrating through `getPostsByIds` —
+			// `landingPosts` (always anon) and the signed-OUT `posts` feed — would otherwise
+			// render the write-time `authorName` snapshot and degrade to `@username` (#2151,
+			// the last unstamped pano read path from #2139's `stampAuthorIdentity` rollout).
+			const stampedRows = yield* stampAuthorIdentity(readProfileIdentities, page.rows);
+			return {...page, rows: stampedRows};
+		});
+
+		// `countEffect` is element 0 so its read is issued first — the parallelized
+		// reads are order-independent for correctness (each is fully consumed), but
+		// keeping count first preserves the deterministic call order the scripted
+		// unit doubles replay against (count, [cursor], fetch).
+		const [totalCount, pageResult] = yield* Effect.all([countEffect, pageEffect], {
+			concurrency: "unbounded",
+		});
+		if (pageResult === null) {
 			return {...emptyKeysetPage, totalCount} satisfies PostConnectionPage;
 		}
-		const cursorRow = cursor.kind === "hit" ? cursor.row : null;
-
-		// Both the keyset cursor predicate and `orderBy` derive from the one
-		// `POST_SORT_LEAD_COLUMN` map: an optional lead column (descending) +
-		// `id` desc tiebreaker; `new` (no lead column) orders by `id` alone.
-		const leadKey = POST_SORT_LEAD_COLUMN[sort];
-		const leadColumn = leadKey
-			? {column: schema.postRecord[leadKey], value: cursorRow?.[leadKey]}
-			: null;
-
-		const cursorPredicate = keysetAfter([
-			...(leadColumn
-				? [{column: leadColumn.column, dir: "desc" as const, value: leadColumn.value ?? null}]
-				: []),
-			{column: schema.postRecord.id, dir: "desc", value: cursorRow?.id ?? null},
-		]);
-
-		const whereExpr = cursorPredicate
-			? and(...baseConditions, cursorPredicate)
-			: and(...baseConditions);
-
-		const orderBy = [...(leadColumn ? [desc(leadColumn.column)] : []), desc(schema.postRecord.id)];
-
-		const fetched = yield* run((db) =>
-			db
-				.select({
-					id: schema.postRecord.id,
-					slug: schema.postRecord.slug,
-					title: schema.postRecord.title,
-					url: schema.postRecord.url,
-					host: schema.postRecord.host,
-					bodyExcerpt: schema.postRecord.bodyExcerpt,
-					authorId: schema.postRecord.authorId,
-					authorName: schema.postRecord.authorName,
-					score: schema.postRecord.score,
-					commentCount: schema.postRecord.commentCount,
-					createdAt: schema.postRecord.createdAt,
-					tags: schema.postRecord.tags,
-				})
-				.from(schema.postRecord)
-				.where(whereExpr)
-				.orderBy(...orderBy)
-				.limit(first + 1),
-		);
-
-		// Route the keyset projection through the same `post-fields.ts` column→field
-		// map the by-id path uses, so `body` collapses to `null` for an empty excerpt
-		// (not `""`) — the divergence is unrepresentable, not hand-synced (#1170).
-		const page = forwardPage(fetched, first, (r) => r.id, toPostSummaryKeysetRow);
-
-		// Stamp the LIVE author identity onto the page — one batched
-		// `getProfileIdentitiesByIds` read for the whole page (never per-row), the same
-		// idiom `getPostsByIds` uses. This is the feed's convergence point: the resolver
-		// paths that serve this page WITHOUT re-hydrating through `getPostsByIds` —
-		// `landingPosts` (always anon) and the signed-OUT `posts` feed — would otherwise
-		// render the write-time `authorName` snapshot and degrade to `@username` (#2151,
-		// the last unstamped pano read path from #2139's `stampAuthorIdentity` rollout).
-		const stampedRows = yield* stampAuthorIdentity(readProfileIdentities, page.rows);
-
-		return {...page, rows: stampedRows, totalCount} satisfies PostConnectionPage;
+		return {...pageResult, totalCount} satisfies PostConnectionPage;
 	});
 
 	const getPostsByIds = Effect.fn("Pano.getPostsByIds")(function* (


### PR DESCRIPTION
Fixes #2275

## What

The authed pano feed `/fate` load carried a ~1s latency floor from SERIAL cross-region D1 round-trips inside `listPostsConnection` (`apps/web/worker/features/pano/post-operations.ts`): the `totalCount` query and the keyset page query were issued back to back, each paying its own round-trip.

## The code lever (query parallelization only)

- **Parallelized the two INDEPENDENT reads.** `totalCount` and the keyset page path (cursor-resolve → fetch → author-identity stamp) do not depend on each other — the page query never consumes the count — so they now run concurrently via the repo's `Effect.all([...], {concurrency: "unbounded"})` parallel-reads idiom (the `Divan.collect` pattern), collapsing two serial round-trips into one overlapped batch. On the common head-page load (no cursor) this cuts `count + fetch` to `max(count, fetch)`; with a cursor it cuts `count + (cursorResolve + fetch)` to `max(count, cursorResolve + fetch)`.
- **Did NOT fold the count into a `count(*) OVER()` window.** The keyset query's WHERE carries the cursor predicate (`id < cursor`), so a window count there would total only the post-cursor slice, not the whole feed — a different result, which the issue's caveat forbids. The count stays its own query (over the base predicate only), just parallelized.
- **Grounding:** default `Effect.all` is sequential; `{concurrency: "unbounded"}` is the documented concurrent form (effect-smol `Effect.all` docs) and the established in-repo idiom for independent reads (`Divan.collect`). `countEffect` is element 0 so its read is still issued first, preserving the deterministic `run`-call order the scripted unit doubles replay against.

## Re-hydrate + viewer-scoped stamps: UNTOUCHED

The batched `getPostsByIds` re-hydrate is not collapsed. The keyset row does not carry `myVote` / `isSaved` nor the reaction aggregates — those come from the viewer-scoped re-hydrate the `posts` resolver runs for a signed-in viewer (`lists.ts`). Removing it would be a correctness bug, not an optimization; it is left exactly as-is. The parallelization lives entirely in the count/page split, which reads no viewer scalars.

The D1-replication / read-replica / placement half is out of scope (issue #2276, a platform decision) — untouched.

## Test

Added a composition test in `Pano.connection.unit.test.ts` driving the exact authed-feed path end to end over the substituted seams — parallelized `listPostsConnection` → `getPostsByIds` re-hydrate — and asserting a signed-in viewer with **a vote + a save + a reaction** sees all three (`myVote: true`, `isSaved: true`, the reaction aggregate) on the composed row. All pre-existing connection/keyset/cursor-miss/identity tests stay green (call-order preserved). Full pano unit suite: 176 passing. `pnpm typecheck` + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)