### PR TITLE
fix(web): batch same-tick /fate/live subscribes into one control POST

### DIFF
--- a/apps/web/src/fate/liveSubscribeBatch.test.ts
+++ b/apps/web/src/fate/liveSubscribeBatch.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression for #2273: react-fate's HTTP transport (defined in `@nkzw/fate`, re-exported
+ * by `react-fate` — the import phoenix uses) must coalesce same-tick live subscribe control
+ * messages into ONE `POST /fate/live`. Unpatched 1.3.1 fired a separate `control([op])` per
+ * `add()` after the SSE `open`, so a feed load with N `useLiveView` mounts issued N
+ * single-operation POSTs, each re-running better-auth session validation (~22 on an authed
+ * /pano load). Fixed by `patches/@nkzw__fate@1.3.1.patch` (ADR 0038), which buffers adds and
+ * flushes them as one batched control POST — the same batching the reconnect path already
+ * did via `control(resubscribe)`. This drives the native live client through a mocked
+ * EventSource + fetch and asserts one POST carries every operation, and that a live frame
+ * still routes to each subscription afterward.
+ */
+
+import {createHTTPTransport} from "react-fate";
+import {describe, expect, it, vi} from "vitest";
+
+type ControlOperation = {
+	id: string;
+	kind: string;
+	entityId?: string;
+	type?: string;
+	procedure?: string;
+};
+type ControlBody = {
+	connectionId: string;
+	operations: ReadonlyArray<ControlOperation>;
+	version: number;
+};
+
+type Listener = (event: unknown) => void;
+
+// The shape createHTTPTransport's `eventSource` option expects (its EventSourceConstructor
+// type is not exported); MockEventSource is asserted to it once at the call site.
+type EventSourceCtor = new (
+	url: string,
+	options?: {withCredentials?: boolean},
+) => {
+	addEventListener(type: string, listener: (event: Event) => void): void;
+	close(): void;
+	removeEventListener(type: string, listener: (event: Event) => void): void;
+};
+
+// A synchronous EventSource stub: records listeners so the test can drive `open` and dispatch
+// live frames deterministically, without a real network stream.
+class MockEventSource {
+	static instances: MockEventSource[] = [];
+	readonly url: string;
+	closed = false;
+	private readonly listeners = new Map<string, Listener[]>();
+
+	constructor(url: string) {
+		this.url = url;
+		MockEventSource.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: Listener) {
+		const arr = this.listeners.get(type) ?? [];
+		arr.push(listener);
+		this.listeners.set(type, arr);
+	}
+
+	removeEventListener(type: string, listener: Listener) {
+		const arr = this.listeners.get(type);
+		if (arr) {
+			this.listeners.set(
+				type,
+				arr.filter((entry) => entry !== listener),
+			);
+		}
+	}
+
+	emit(type: string, event: unknown) {
+		for (const listener of [...(this.listeners.get(type) ?? [])]) listener(event);
+	}
+
+	close() {
+		this.closed = true;
+	}
+}
+
+// Drain the microtask + timer queue so the `open.then(flush)` batch flush and its awaited
+// fetch/json settle before we assert.
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function makeFetchMock() {
+	const calls: Array<{url: string; body: ControlBody}> = [];
+	const fetchMock = vi.fn(
+		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const raw = typeof init?.body === "string" ? init.body : "{}";
+			const body: ControlBody = JSON.parse(raw);
+			calls.push({body, url: String(input)});
+			const results = body.operations.map((op) => ({data: null, id: op.id, ok: true}));
+			return new Response(JSON.stringify({results, version: 1}), {
+				headers: {"content-type": "application/json"},
+				status: 200,
+			});
+		},
+	);
+	return {calls, fetchMock};
+}
+
+function makeTransport(fetchMock: ReturnType<typeof makeFetchMock>["fetchMock"]) {
+	MockEventSource.instances = [];
+	const transport = createHTTPTransport({
+		eventSource: MockEventSource as EventSourceCtor,
+		fetch: fetchMock,
+		live: true,
+		liveUrl: "/fate/live",
+		url: "/fate",
+	});
+	const subscribeById = transport.subscribeById;
+	if (!subscribeById) throw new Error("expected a live-capable transport with subscribeById");
+	return {subscribeById, transport};
+}
+
+describe("react-fate live transport — same-tick subscribe batching (#2273)", () => {
+	it("coalesces same-tick subscribeById calls into ONE /fate/live control POST", async () => {
+		const {calls, fetchMock} = makeFetchMock();
+		const {subscribeById} = makeTransport(fetchMock);
+		const handlers = {a: {onData: vi.fn()}, b: {onData: vi.fn()}, c: {onData: vi.fn()}};
+
+		// Three mounts subscribe in the same synchronous tick, as a feed of PanoPostCards does.
+		subscribeById("Post", "a", ["id", "body"], undefined, handlers.a);
+		subscribeById("Post", "b", ["id", "body"], undefined, handlers.b);
+		subscribeById("Post", "c", ["id", "body"], undefined, handlers.c);
+
+		// Exactly one SSE stream, and no control POST until the stream opens.
+		expect(MockEventSource.instances).toHaveLength(1);
+		expect(fetchMock).not.toHaveBeenCalled();
+
+		const source = MockEventSource.instances.at(-1);
+		expect(source).toBeDefined();
+		source?.emit("open", {});
+		await settle();
+
+		// The batching guarantee: one POST for all three subscribes, not three.
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const call = calls.at(0);
+		expect(call?.url).toBe("/fate/live");
+		expect(call?.body.operations).toHaveLength(3);
+		expect(call?.body.operations.every((op) => op.kind === "subscribe")).toBe(true);
+		expect([...(call?.body.operations ?? [])].map((op) => op.entityId).sort()).toEqual([
+			"a",
+			"b",
+			"c",
+		]);
+
+		// No subscription is lost: a live frame per entity still routes to its handler.
+		source?.emit("next", {
+			data: JSON.stringify({
+				event: {data: {__typename: "Post", body: "updated-a", id: "a"}, select: ["body"]},
+				id: "1",
+				kind: "next",
+			}),
+			lastEventId: "e1",
+		});
+		source?.emit("next", {
+			data: JSON.stringify({
+				event: {data: {__typename: "Post", body: "updated-c", id: "c"}, select: ["body"]},
+				id: "3",
+				kind: "next",
+			}),
+			lastEventId: "e2",
+		});
+
+		expect(handlers.a.onData).toHaveBeenCalledWith(
+			{__typename: "Post", body: "updated-a", id: "a"},
+			["body"],
+		);
+		expect(handlers.c.onData).toHaveBeenCalledWith(
+			{__typename: "Post", body: "updated-c", id: "c"},
+			["body"],
+		);
+		expect(handlers.b.onData).not.toHaveBeenCalled();
+	});
+
+	it("batches a mixed subscribeById + subscribeConnection tick into one POST", async () => {
+		const {calls, fetchMock} = makeFetchMock();
+		const {transport, subscribeById} = makeTransport(fetchMock);
+		const subscribeConnection = transport.subscribeConnection;
+		if (!subscribeConnection) throw new Error("expected subscribeConnection on a live transport");
+
+		subscribeById("Post", "a", ["id", "body"], undefined, {onData: vi.fn()});
+		subscribeConnection("posts", "Post", undefined, ["id"], undefined, {onEvent: vi.fn()});
+
+		const source = MockEventSource.instances.at(-1);
+		source?.emit("open", {});
+		await settle();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const kinds = [...(calls.at(0)?.body.operations ?? [])].map((op) => op.kind).sort();
+		expect(kinds).toEqual(["subscribe", "subscribeConnection"]);
+	});
+});

--- a/patches/@nkzw__fate@1.3.1.patch
+++ b/patches/@nkzw__fate@1.3.1.patch
@@ -1,0 +1,51 @@
+diff --git a/lib/index.mjs b/lib/index.mjs
+index c551f46050c0b41494a0360e7022a2e639bc5f10..bc41f30c59910cd9200b4c9c84db153a6bc4dacb 100644
+--- a/lib/index.mjs
++++ b/lib/index.mjs
+@@ -3731,14 +3731,41 @@ function createHTTPTransport({ eventSource, fetch: fetchImpl = defaultFetch, hea
+ 			source.addEventListener("message", handleLiveMessage);
+ 			source.addEventListener("next", handleLiveMessage);
+ 			source.addEventListener("connection", handleLiveMessage);
++			// phoenix #2273: coalesce same-tick subscribe ops into ONE /fate/live control
++			// POST. Upstream `add` fired its own `control([op])` after `open`, so a feed load
++			// with N useLiveView mounts issued N single-op POSTs, each re-validating the
++			// session. Buffer adds and flush once per tick across the `open` microtask
++			// boundary — the same batching the reconnect path already does via
++			// control(resubscribe) at the "open" listener above.
++			let pendingAdds = [];
++			let addScheduled = false;
++			const takePendingAdds = () => {
++				addScheduled = false;
++				const batch = pendingAdds;
++				pendingAdds = [];
++				return batch;
++			};
++			const discardAdds = (batch, error) => {
++				for (const operation of batch) {
++					operations.delete(operation.id);
++					liveSubscriptions.delete(operation.id);
++				}
++				reportError(error);
++			};
++			const flushAdds = () => {
++				const batch = takePendingAdds();
++				if (batch.length === 0) return;
++				control(batch.map(withLastEventId)).catch((error) => discardAdds(batch, error));
++			};
++			const failAdds = (error) => discardAdds(takePendingAdds(), error);
+ 			nativeLiveClient = {
+ 				add(operation) {
+ 					operations.set(operation.id, operation);
+-					open.then(() => control([withLastEventId(operation)])).catch((error) => {
+-						operations.delete(operation.id);
+-						liveSubscriptions.delete(operation.id);
+-						reportError(error);
+-					});
++					pendingAdds.push(operation);
++					if (!addScheduled) {
++						addScheduled = true;
++						open.then(flushAdds, failAdds);
++					}
+ 				},
+ 				remove(id) {
+ 					operations.delete(id);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ catalogs:
       version: 4.4.3
 
 patchedDependencies:
+  '@nkzw/fate@1.3.1':
+    hash: e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c
+    path: patches/@nkzw__fate@1.3.1.patch
   alchemy@2.0.0-beta.59:
     hash: f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d
     path: patches/alchemy@2.0.0-beta.59.patch
@@ -216,7 +219,7 @@ importers:
         version: link:../../packages/fate-effect
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@sentry/cloudflare':
         specifier: 'catalog:'
         version: 10.62.0(@cloudflare/workers-types@4.20260629.1)
@@ -785,7 +788,7 @@ importers:
     dependencies:
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92
@@ -5094,7 +5097,7 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@nkzw/fate@1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
       superjson: 2.2.6
@@ -6511,7 +6514,7 @@ snapshots:
 
   react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@nkzw/fate': 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,16 @@ onlyBuiltDependencies:
 #    record was deleted by an entity live frame (#1686 — the term-page crash on
 #    definition.delete). Regression test:
 #    apps/web/src/fate/useViewPendingSnapshot.test.tsx. Not upstreamed in 1.3.1.
+#
+# @nkzw/fate — ONE hunk on 1.3.1 (createHTTPTransport is defined here; react-fate only
+# re-exports it):
+# 1. lib/index.mjs — the native live client's `add` buffers same-tick subscribe ops and
+#    flushes them as ONE `/fate/live` control POST (mirroring the reconnect path's
+#    `control(resubscribe)`). Unpatched, each `add` fired its own `control([op])` after
+#    `open`, so a feed load with N `useLiveView` mounts issued N single-op POSTs, each
+#    re-validating the session (~22 on an authed /pano load — #2273). Regression test:
+#    apps/web/src/fate/liveSubscribeBatch.test.ts. Not upstreamed in 1.3.1.
 patchedDependencies:
+  '@nkzw/fate@1.3.1': patches/@nkzw__fate@1.3.1.patch
   alchemy@2.0.0-beta.59: patches/alchemy@2.0.0-beta.59.patch
   react-fate@1.3.1: patches/react-fate@1.3.1.patch


### PR DESCRIPTION
Coalesces same-tick live subscribe control messages into a **single** `POST /fate/live`, closing the ~22-unbatched-POST fan-out on an authed feed load.

## What changed
- **`patches/@nkzw__fate@1.3.1.patch` (new, ADR 0038):** the native live client's `add` now buffers same-tick subscribe operations and flushes them as ONE batched `control()` POST — mirroring the reconnect path, which already batched via `control(resubscribe)`, and the `/fate` read-batching scheduler. Error semantics are preserved: a failed batch discards exactly its own operations (from `operations` + `liveSubscriptions`) and reports the error.
- **`apps/web/src/fate/liveSubscribeBatch.test.ts` (new):** regression coverage — three same-tick `subscribeById` calls (plus a mixed `subscribeById + subscribeConnection` tick) coalesce into one POST carrying every operation, and a live frame per entity still routes to its handler afterward.
- **`pnpm-workspace.yaml`:** registers the patch and documents it in the patch-policy block.

## Grounding note — the transport lives in `@nkzw/fate`, not react-fate
The issue named `patches/react-fate@1.3.1.patch` as the locus, but grounding against the actual source shows `createHTTPTransport` (and its native live client `add`/`control` POST) is **defined in `@nkzw/fate`**; `react-fate` only re-exports it (phoenix imports it from `react-fate`, but the implementation is `@nkzw/fate`). The unbatched `control([op])` POST is a closure inside `@nkzw/fate`'s transport, unreachable from react-fate's public surface — so the batching patch targets `@nkzw/fate@1.3.1` (a direct, catalogued dependency). This still satisfies the acceptance intent: an in-repo pnpm patch per ADR 0038, no server/`protocol.ts` change (the wire already accepts `operations[]`).

## Acceptance criteria
- [x] A single authed feed view issues one batched `POST /fate/live` for the same-tick subscribe set, not ~22 single-op POSTs.
- [x] All subscriptions established by the pre-change fan-out are still established (same topics, same `lastEventId` catch-up via the unchanged reconnect/`withLastEventId` path) — asserted by the per-entity live-frame routing in the test.
- [x] The change is an in-repo pnpm patch (ADR 0038); the server handler and `protocol.ts` are unchanged.
- [x] Regression coverage that same-microtask subscribe operations coalesce into one control POST.

`pnpm typecheck`, `pnpm lint:worktree`, `pnpm install --frozen-lockfile`, and the new test all pass locally.

Fixes #2273