### PR TITLE
fix(ship-it): per-run mktemp bundle dir in Step 3.5 (concurrent shippers race on fixed /tmp)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -984,10 +984,13 @@ RUN_ID=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
 # the run-evidence artifact id, then the manifest bytes
 ART_ID=$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
   --jq '.artifacts[] | select(.name=="run-evidence") | .id' 2>/dev/null)
-rm -rf /tmp/ship-it-bundle && mkdir -p /tmp/ship-it-bundle
-gh api "repos/$REPO/actions/artifacts/$ART_ID/zip" > /tmp/ship-it-bundle/run-evidence.zip 2>/dev/null \
-  && unzip -oq /tmp/ship-it-bundle/run-evidence.zip -d /tmp/ship-it-bundle
-MANIFEST=/tmp/ship-it-bundle/manifest.json
+# per-run bundle dir (mktemp -d), NOT a fixed /tmp/ship-it-bundle: concurrent §CP shippers
+# fan out, and a shared path lets two racing runs read each other's bundle — merge-safety must
+# not rest on Step 3.5's commit==head assertion catching the swap after the fact (#2281).
+BUNDLE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ship-it-bundle.XXXXXX")
+gh api "repos/$REPO/actions/artifacts/$ART_ID/zip" > "$BUNDLE_DIR/run-evidence.zip" 2>/dev/null \
+  && unzip -oq "$BUNDLE_DIR/run-evidence.zip" -d "$BUNDLE_DIR"
+MANIFEST="$BUNDLE_DIR/manifest.json"
 ```
 
 Now assert the four things, **failing closed** on each — a missing bundle, an unreadable


### PR DESCRIPTION
Fixes #2281

## The bug

`ship-it` Step 3.5 (Assert the run-evidence bundle) downloaded the bundle into a **fixed shared path**: `rm -rf /tmp/ship-it-bundle && mkdir -p /tmp/ship-it-bundle`, wrote `run-evidence.zip` there, `unzip -d /tmp/ship-it-bundle`, and read `MANIFEST=/tmp/ship-it-bundle/manifest.json`. No per-PR / per-session isolation.

The pipeline fans §CP shippers out concurrently, so two runs racing on that path read each other's bundle. Observed live: a #2265 shipper (head `619fa9a2`) read a bundle stamped `7a873d61` (#2271's head). The `commit == head` assertion caught it (equality failed → correctly REFUSED `unverified (stale run-evidence bundle)`), so no wrong-ship — but the shared path is a latent race and merge-safety rested entirely on that one backstop.

## The fix

Replace the fixed `/tmp/ship-it-bundle` with a per-run `mktemp -d "${TMPDIR:-/tmp}/ship-it-bundle.XXXXXX"` (the skill already uses `mktemp` elsewhere, e.g. its Step-2b block), so concurrent shippers can't collide. All downstream references (`run-evidence.zip`, the `unzip -d`, `MANIFEST`) now point at `$BUNDLE_DIR`.

Preserved verbatim:
- the `commit == head` (`BUNDLE_COMMIT == HEAD_SHA`) staleness assertion — the correctness backstop — unchanged and un-reordered;
- all four distinct refusal reasons (`no run-evidence bundle` / `unsupported bundle schemaVersion` / `stale run-evidence bundle` / `run-evidence checks failed`).

Surgical 7-line change to the download block only; no other step touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)