### PR TITLE
feat(web): add Smart Placement to apps/web worker (ADR 0168)

### DIFF
--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -140,6 +140,15 @@ const phoenixProps =
 				runWorkerFirst: [...workerFirstGlobs],
 			},
 			compatibility: {flags: ["nodejs_compat"]},
+			// Smart Placement (ADR 0168): run the worker near its heaviest upstream — the
+			// D1 primary in ENAM — so the authed `/fate` feed's ~11 sequential D1
+			// round-trips collapse from cross-region hops to in-region ones. Safe only
+			// because no worker code serves static assets via `env.ASSETS.fetch()` (the
+			// `assets` block above is edge-direct), so moving the worker toward ENAM does
+			// not pull asset serving off the edge. Read-replication (D1 Sessions API)
+			// stays deferred per ADR 0168; verify placement post-deploy via the
+			// `cf-placement` response header.
+			placement: {mode: "smart" as const},
 			// Workers Observability, declared explicitly rather than leaning on alchemy's
 			// default-on (Worker.ts `observability ?? {enabled, logs:{enabled,invocationLogs}}`)
 			// so the captured-exception behavior is legible in source. `headSamplingRate: 1`


### PR DESCRIPTION
## What

Add a `placement: {mode: "smart"}` block to the `apps/web` worker props so Cloudflare runs the worker near its heaviest upstream — the D1 primary in ENAM. This collapses the authed `/fate` feed's ~11 sequential cross-region D1 round-trips to in-region hops.

This implements the founder-accepted decision in **ADR 0168** (D1 region strategy: Smart Placement first).

## Where

The `placement` prop is a sibling to `assets`/`compatibility`/`observability` on the worker props object (`phoenixProps` in `apps/web/worker/index.ts`, the `.make()` props site — `alchemy.run.ts` only yields the `Phoenix` Tag). Config shape grounded against the alchemy source: `Worker.ts` exposes `placement?: WorkerPlacement`, whose union includes the `{mode: "smart"}` variant. `mode: "smart" as const` narrows the literal so it doesn't match the `"targeted"` variant (which requires a `target` field).

## Assets-direct-serve pre-check (build-time, re-run) — CLEAN

Smart Placement moves the whole worker toward ENAM, so if any worker code served static assets via `env.ASSETS.fetch()`, those assets would serve from ENAM instead of the edge and regress asset latency for all users. Re-ran the grep at build time: **zero `ASSETS.fetch` occurrences across `apps/web/worker/`**. The `assets` block is edge-direct (`directory ./dist/client` + SPA `notFoundHandling` + `runWorkerFirst` shadowing only `/fate`, `/api`, `/rss.xml`). Safe to place.

## Scope

Placement block only. Read-replication (D1 Sessions API / bookmarks / `read_replication`) stays **deferred** per ADR 0168 — not added here.

## Verification

`pnpm --filter @kampus/web typecheck` passes; biome clean.

**Post-deploy:** after merge + deploy, the placement takes effect and can be confirmed via the `cf-placement` response header on worker responses.

Fixes #2284