### PR TITLE
feat(web): two-tier fate provider — decouple /pano first paint from the session gate (#2285)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -20,6 +20,12 @@
  * through a mount-recording `FateClient` spy. A regression that reaches a fate/session
  * read back into the shell (invariant 1) or re-keys `FateClient` anon→id (invariant 2)
  * fails these — see the two `// REGRESSION:` notes on the assertions.
+ *
+ * The third block pins the two-tier fate provider (ADR 0167 / #2285): the /pano feed
+ * paints over the PUBLIC client above the gate while `get-session` is pending, then hands
+ * off to the authed tier once it commits — WITHOUT dragging the authed router subtree
+ * through the anon→id re-key remount invariant 2 forbids. The spy tags each mount
+ * public/authed so the two tiers are told apart.
  */
 import {act, render, screen} from "@testing-library/react";
 import type {ReactNode} from "react";
@@ -27,11 +33,16 @@ import {MemoryRouter} from "react-router";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {App} from "./App";
 
-// The mounts the FateProvider gate commits, in order. Each entry is one `FateClient`
-// mount, recording the `key` it committed under. Invariant 2 reads this back: one entry
-// keyed on the resolved identity is correct; a second entry (or a leading "anon" entry)
-// is the #438 anon→id remount.
-type FateMount = {key: string};
+// The two-tier public client (ADR 0167 / #2285): the eager public tier passes this
+// sentinel as its `FateClient` `client`, so the spy can tag a mount as `public` (the
+// always-anonymous tier above the gate) vs `authed` (the identity-keyed tier below it).
+const {PUBLIC_CLIENT} = vi.hoisted(() => ({PUBLIC_CLIENT: {__tier: "public"} as never}));
+
+// The mounts the two-tier fate provider commits, in order. Each entry is one `FateClient`
+// mount: its `key` (the identity it committed under) and its `tier` (public/authed).
+// Invariant 2 / #438 reads the AUTHED tier back: one entry keyed on the resolved identity
+// is correct; a second entry (or a leading "anon" entry) is the anon→id remount.
+type FateMount = {key: string; tier: "public" | "authed"};
 const fateMounts: FateMount[] = [];
 
 // Spy `FateClient` in place of react-fate's real one, driving the REAL `FateProvider`
@@ -41,23 +52,36 @@ const fateMounts: FateMount[] = [];
 // source the real FateProvider keys on — the mocked `useSession`. React remounts the spy
 // exactly when the committed `key` changes, so one recorded mount == one real key, and a
 // second recorded mount is exactly the anon→id remount invariant 2 forbids. Recording on
-// MOUNT (an empty-dep effect), not per render, is what makes a remount observable.
+// MOUNT (an empty-dep effect), not per render, is what makes a remount observable. The
+// `tier` is read off the `client` instance — the public tier passes `PUBLIC_CLIENT`.
 vi.mock("react-fate", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("react-fate")>();
 	const {useEffect} = await import("react");
 	const {useSession} = await import("./auth/client");
-	function FateClientSpy({children}: {children: ReactNode}) {
+	function FateClientSpy({children, client}: {children: ReactNode; client: unknown}) {
 		const session = useSession();
 		const key = session.data?.user.id ?? "anon";
+		const tier = client === PUBLIC_CLIENT ? "public" : "authed";
 		useEffect(() => {
 			// Empty deps: fires once per real mount. A re-key (anon→id) tears this instance
 			// down and mounts a fresh one, firing this again — the double-mount we're pinning.
-			fateMounts.push({key});
+			fateMounts.push({key, tier});
 		}, []);
 		return <>{children}</>;
 	}
 	return {...actual, FateClient: FateClientSpy};
 });
+
+// The eager public pano feed (ADR 0167) renders the REAL `PanoFeed` over the public
+// client; stub it inert here so the tree renders offline without a real fate context —
+// its PRESENCE above the gate (the `eager-pano-feed` marker) is what the two-tier tests
+// assert, not its internal fate reads.
+vi.mock("./pages/PanoFeed", () => ({
+	PanoFeed: ({host}: {host?: string}) => <div data-testid="eager-pano-feed">{host ?? "all"}</div>,
+}));
+
+// The public tier's client factory — return the sentinel the spy tags as `public`.
+vi.mock("./fate/publicClient", () => ({getPublicFateClient: () => PUBLIC_CLIENT}));
 
 // Controllable, REACTIVE session store. The whole first-paint story is "shell paints
 // while pending, FateProvider commits once settled", so the mock must actually trigger a
@@ -205,6 +229,63 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 
 		expect(fateMounts).toHaveLength(1);
 		expect(fateMounts[0]?.key).toBe("anon");
+	});
+});
+
+// The two-tier fate provider's public first paint (ADR 0167 / #2285): the anon-capable
+// /pano feed paints over the PUBLIC (always-anonymous) client ABOVE the session gate,
+// in parallel with `get-session`, then hands off to the authed feed once the gate
+// commits — WITHOUT an anon→id re-key remount of the authed router subtree (#438).
+describe("Two-tier fate provider — /pano public first paint (#2285)", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+	});
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("AC2/AC5: the /pano feed paints over the public client while the session is isPending — before the authed gate commits", () => {
+		// First frame on /pano: session still resolving. The authed FateProvider gate is
+		// null, yet the public feed paints — proof the first paint does NOT wait on
+		// get-session.
+		renderApp("/pano");
+
+		expect(screen.getByTestId("eager-pano-feed")).toBeTruthy();
+		// It painted over the PUBLIC tier (above the gate)…
+		expect(fateMounts.some((m) => m.tier === "public")).toBe(true);
+		// …while the AUTHED tier has NOT committed (still isPending → null below).
+		expect(fateMounts.some((m) => m.tier === "authed")).toBe(false);
+	});
+
+	it("scoped: a non-pano route paints NO public feed (the eager tier is /pano-only)", () => {
+		renderApp("/sozluk");
+		expect(screen.queryByTestId("eager-pano-feed")).toBeNull();
+		// No public client mounts off the pano routes — the shell stays fate-free there.
+		expect(fateMounts).toHaveLength(0);
+	});
+
+	it("AC4 (#438): after the public first paint, the authed subtree mounts ONCE on the resolved id — no anon→id remount", () => {
+		renderApp("/pano");
+		// Pending: only the public tier has painted; the authed gate is still deferred.
+		expect(fateMounts.filter((m) => m.tier === "authed")).toHaveLength(0);
+
+		// The session settles authenticated → the authed FateProvider commits for the
+		// FIRST time now, under the resolved id — the eager public tier unmounts.
+		act(() => {
+			setSession({
+				data: {user: {id: "user-7", name: "Deniz", email: "deniz@kamp.us"}},
+				isPending: false,
+			});
+		});
+
+		const authed = fateMounts.filter((m) => m.tier === "authed");
+		// Exactly ONE authed mount, keyed on the resolved id — never "anon" first. Had the
+		// public first paint dragged the authed tree through an anon→id re-key, we'd see a
+		// leading {key:"anon"} authed mount (the #438 form-wiping remount).
+		expect(authed).toHaveLength(1);
+		expect(authed[0]?.key).toBe("user-7");
+		expect(authed.map((m) => m.key)).not.toContain("anon");
 	});
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,14 @@
 import {createContext, useContext, useEffect, useMemo, useState} from "react";
-import {Navigate, Outlet, Route, Routes, useLocation, useNavigate, useParams} from "react-router";
+import {
+	Navigate,
+	Outlet,
+	Route,
+	Routes,
+	useLocation,
+	useMatch,
+	useNavigate,
+	useParams,
+} from "react-router";
 import {authClient, clearBearerToken, useSession} from "./auth/client";
 import {useMe} from "./auth/useMe";
 import {useBildirimUnread} from "./components/bildirim/useBildirimUnread";
@@ -11,7 +20,7 @@ import {Topbar} from "./components/layout/Topbar";
 import {actorLabel} from "./components/moderation/actor-identity";
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
-import {FateProvider} from "./fate/FateProvider";
+import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
 import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
@@ -75,6 +84,21 @@ function Layout() {
 	const {toggle: toggleTheme} = useTheme();
 	const [chips, setChips] = useState<TopbarChips | null>(null);
 
+	// The two-tier fate provider's public first paint (ADR 0167). While `get-session`
+	// is still in flight the authed `FateProvider` gate below returns null, so the
+	// routed `/pano` feed can't paint. So for the anon-capable pano feed routes ONLY,
+	// render an eager copy over the PUBLIC (always-anonymous) fate client above the gate
+	// — it paints in parallel with `get-session` instead of serialized behind it. The
+	// instant the session settles the gate commits, the authed feed (with live +
+	// mutations) takes over, and this eager tier unmounts. This preserves #438 verbatim:
+	// the router-bearing authed subtree still mounts only once, on the resolved identity
+	// — the public client is a distinct, never-re-keyed instance, so there is no
+	// anon→userId re-key remount of the authed tree.
+	const panoMatch = useMatch("/pano");
+	const panoSiteMatch = useMatch("/pano/site/:host");
+	const eagerPanoHost = panoSiteMatch?.params.host;
+	const showEagerPanoFeed = session.isPending && (panoMatch != null || panoSiteMatch != null);
+
 	// Echo the active query in the header input, but only on the results page — off
 	// `/search` the box keeps its empty `ara…` placeholder (#2199).
 	const searchQuery =
@@ -125,6 +149,14 @@ function Layout() {
 						}
 					/>
 					<Main>
+						{/* PUBLIC tier (ADR 0167): the anon-capable pano feed paints over the
+						    always-anonymous public client while `get-session` resolves, then
+						    hands off to the authed feed once the gate below commits. */}
+						{showEagerPanoFeed ? (
+							<PublicFateProvider>
+								<PanoFeed {...(eagerPanoHost ? {host: eagerPanoHost} : {})} />
+							</PublicFateProvider>
+						) : null}
 						{/* The routed content + fate-dependent chips live below the session
 						    gate — FateProvider keeps its #438 remount guard (first & only key
 						    is the resolved identity), while the shell frame above already

--- a/apps/web/src/fate/FateProvider.tsx
+++ b/apps/web/src/fate/FateProvider.tsx
@@ -11,7 +11,19 @@ import {FateClient} from "react-fate";
 import {useSession} from "../auth/client";
 import {createClient} from "./client";
 import {createLiveRetryController, type LiveRetryController} from "./liveRetry";
+import {getPublicFateClient} from "./publicClient";
 import {useGlobalLivePin} from "./useGlobalLivePin";
+
+/**
+ * The PUBLIC tier of the two-tier fate provider (ADR 0167): mounts the eager,
+ * always-anonymous public client ABOVE the session gate. Its subtree reads public
+ * views (the /pano feed list) that need no settled session, so they paint in parallel
+ * with `get-session`. The client never re-keys (always anon), so this commit never
+ * triggers the #438 re-key remount the authed `FateProvider` below defers to avoid.
+ */
+export function PublicFateProvider({children}: {children: React.ReactNode}) {
+	return <FateClient client={getPublicFateClient()}>{children}</FateClient>;
+}
 
 // Holds the app-lifetime live pin (#711) from inside the FateClient context,
 // where `useFateClient` resolves. Renders nothing.

--- a/apps/web/src/fate/publicClient.ts
+++ b/apps/web/src/fate/publicClient.ts
@@ -1,0 +1,26 @@
+/**
+ * The eager, always-anonymous PUBLIC fate client — the top tier of the two-tier fate
+ * provider (ADR 0167). One app-lifetime instance mounted ABOVE the session gate so
+ * anon-capable public read views (the /pano feed list) can paint in parallel with
+ * `/api/auth/get-session` instead of serialized behind it.
+ *
+ * It is a distinct, never-re-keyed instance (always `authenticated: false`), which is
+ * exactly why it can commit pre-session without reintroducing the #438 anon→id re-key
+ * remount that the identity-keyed authed client below the gate defers to avoid: this
+ * client never becomes authenticated, so it never re-keys. Live SSE is no-op here
+ * (an anon `/fate/live` `EventSource` 401-loops); live + mutations + viewer-scoped
+ * scalars stay on the authed client below the gate. See ADR 0167.
+ */
+import {createClient, type FateClientInstance} from "./client";
+
+let publicClient: FateClientInstance | null = null;
+
+// A module singleton, not a per-render `useMemo`: the client owns one normalized cache,
+// and a lazily-cached single instance keeps that cache stable across every mount/unmount
+// of the eager public tier (it is torn out of the tree once the session settles and the
+// authed feed takes over, but the instance — and its warm cache — persists for the app
+// lifetime).
+export function getPublicFateClient(): FateClientInstance {
+	if (publicClient == null) publicClient = createClient({authenticated: false});
+	return publicClient;
+}


### PR DESCRIPTION
Fixes #2285

Implements ADR 0167 (two-tier fate provider): decouples the `/pano` `PanoFeed` first paint from the session gate so the anon-capable feed paints in parallel with `get-session` instead of serialized behind it — **without** reintroducing the #438 remount.

## The two-tier structure

- **PUBLIC tier (new, above the gate).** `PublicFateProvider` mounts one eager, always-anonymous fate client (`createClient({authenticated: false})`, a lazy app-lifetime singleton in `apps/web/src/fate/publicClient.ts`). It never re-keys (always anon), so it can commit pre-session.
- **AUTHENTICATED tier (unchanged, below the gate).** `FateProvider` keeps `if (session.isPending) return null` + `key={userId ?? "anon"}` **verbatim** — viewer-scoped scalars (`myVote`/`isSaved`), mutations, and live SSE + the #711 app-lifetime pin all stay on this identity-keyed client.

## What moved above vs below the gate

In `Layout`'s `<Main>` (`apps/web/src/App.tsx`):

- **Above the gate (public tier):** while `session.isPending` **and** the route is a pano feed route (`/pano` or `/pano/site/:host`, matched via `useMatch`), an eager `<PanoFeed>` renders under `<PublicFateProvider>`. It reads the anon public client (cookie-aware `/fate`, no-op live), so it paints on its own data arrival — not gated on `get-session`.
- **Below the gate (authed tier):** the routed `<Outlet/>` + `LayoutContent` stay under `<FateProvider>`, exactly as before. The instant the session settles, the gate commits, the authed feed (with live + mutations) takes over, and the eager public tier unmounts.

Scoped to the pano feed routes only — **not** a big-bang split of every view (per the ADR's consequences). The `/glossary` "two-tier fate provider" term addition rides separately.

## How #438 is preserved (the key argument)

#438 forbids mounting the router-bearing subtree under `"anon"` and then re-keying to the real `userId` (that re-key remounts the router and wipes controlled forms). The public client is a **distinct, never-re-keyed instance** — it is *always* anon and never becomes authenticated, so keying it `"anon"` is harmless (it never transitions). The **authenticated** `FateProvider` is untouched: it still defers its first commit until `session.isPending` clears, so its first (and only) `key` is the resolved identity. The public first paint happens in a **separate sibling subtree** that unmounts on settle — it never drags the authed router subtree through an `anon → userId` re-key.

## Test (`apps/web/src/App.test.tsx`)

Extends the #2160/#438 first-paint pins with a two-tier block. The `FateClient` spy now tags each mount `public` vs `authed` (by the client instance), so the tiers are told apart:

- **AC2/AC5** — on `/pano` with the session `isPending`, the feed paints over the **public** tier while the **authed** tier has **not** committed (proves first paint doesn't wait on `get-session`).
- **Scoped** — a non-pano route mounts no public client (the eager tier is pano-only; the shell stays fate-free there).
- **AC4 (#438)** — after the public first paint, settling the session commits the **authed** subtree **exactly once**, keyed on the resolved id, never `"anon"` first (no anon→id re-key remount).

## Verification

- `pnpm exec vitest run --project client src/App.test.tsx` — 10/10 pass (incl. the 3 new + the 4 preserved #2160/#438 pins).
- `pnpm typecheck` — clean.
- `pnpm exec biome check` on all changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)