### PR TITLE
docs(infra): note the better-auth RQB-v1 vs drizzle-orm RQB-v2 incompatibility at its blast sites (#2286)

### DIFF
--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -145,6 +145,12 @@ export const BetterAuthLive = Layer.effect(
 			const db = drizzle(raw, {relations: defineRelations(schema)});
 			return makeBetterAuth({
 				emailAndPassword: {enabled: true},
+				// `experimental.joins` MUST stay off: the adapter emits an RQB-v1 raw-SQL `eq()`
+				// where-shape, but our drizzle-orm is RQB-v2 (`defineRelations`), which feeds
+				// `where` into `relationsFilterToSQL` with no SQL pass-through → any better-auth
+				// read on the joins path (not just sign-up) 500s. Re-enabling (to collapse the
+				// 2-query session read) needs the pre-scoped pnpm patch or an RQB-v2 adapter —
+				// tracked in #2291; blast-site context in #2286.
 				database: drizzleAdapter(db, {provider: "sqlite", schema}),
 				secret: Redacted.value(secret),
 				...authUrlConfig,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,11 @@ catalog:
   '@vitejs/plugin-react': ^6.0.2
   alchemy: 2.0.0-beta.59
   axe-core: ^4.10.3
+  # better-auth's drizzle-adapter speaks RQB v1 (raw-SQL `eq()` where-shape); drizzle-orm 1.x
+  # is RQB v2 (`defineRelations`). The two do NOT interoperate through RQB: routing a better-auth
+  # read via `experimental.joins` 500s ("Unknown relational filter field"). These pins are coupled
+  # by that incompatibility — don't assume a bump makes them join-compatible (no RQB-v2 adapter
+  # release exists yet). See #2286 (guard) / #2291 (re-enable joins via pnpm patch).
   better-auth: ^1.6.10
   better-call: 1.3.5
   drizzle-kit: 1.0.0-rc.4


### PR DESCRIPTION
Fixes #2286

## What

Facet A of #2286 (re-scoped): add **discoverability notes** at the two blast sites of the better-auth ↔ drizzle-orm RQB incompatibility, so nobody re-enables `experimental.joins` or routes a better-auth read through RQB blind. **Comments only — no config/pin/behavior change.**

## The incompatibility (grounded in the #2286 investigation)

better-auth's drizzle-adapter (`better-auth@^1.6.10`) emits an RQB **v1** `where`-shape — a raw SQL `eq()` — but phoenix pins `drizzle-orm@1.0.0-rc.4` = RQB **v2** (`defineRelations`), whose dialect feeds `where` into `relationsFilterToSQL` with no SQL pass-through guard. So any better-auth read routed through `experimental.joins` (not just sign-up) 500s with `Unknown relational filter field`. No RQB-v2-supporting adapter release exists yet (verified vs 1.6.23 / 1.7.0-rc.1 / next-HEAD). Mitigation: keep `experimental.joins` OFF.

## The two annotated sites

1. **`pnpm-workspace.yaml`** — a comment above the coupled `better-auth` / `drizzle-orm` catalog pins noting the RQB-v1-vs-v2 incompatibility and that the pins are coupled by it (don't assume a bump makes them join-compatible). Points to #2286 / #2291.
2. **`apps/web/worker/features/pasaport/better-auth-live.ts`** — a load-bearing comment at the `drizzleAdapter(...)` call site (where `experimental.joins` would go) that it must stay OFF because the adapter's RQB-v1 where-shape 500s against the RQB-v2 pin, and that re-enabling is tracked as #2291.

No prior `joins`-off comment existed on `main` (base `origin/main@e6b0892a`; #2263 is an open PR, not merged), so both notes are freshly added — nothing to reconcile.

## Out of scope

Facet B (re-enabling `experimental.joins` via the pre-scoped pnpm patch) is tracked separately as #2291 — untouched here. No CI guard/enforcement was built (over-scope for size S).

## Verification

- `pnpm typecheck` — green (27/27)
- `pnpm lint` — green
- §CP:NO — `pnpm-workspace.yaml` + worker code are not control-plane paths.