### PR TITLE
test(pasaport): encode ADR 0169's two-axis session-freshness invariants + review-code gate (#2296)

### DIFF
--- a/apps/web/tests/integration/session-freshness-invariants.test.ts
+++ b/apps/web/tests/integration/session-freshness-invariants.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Session freshness is a TWO-AXIS invariant (ADR 0169) — black-box against the
+ * deployed worker on real remote D1 (ADR 0082 integration tier).
+ *
+ * ADR 0169 rejects session caching because a session-perf/caching review is a
+ * two-axis check, and the first #2263 `cookieCache` review scoped only axis (1) and
+ * missed axis (2) — the account-deletion integration test caught the teardown hole by
+ * luck, not by the review. This file encodes BOTH axes as REQUIRED, deterministic
+ * invariants so the catch lives in the suite, not in one incident:
+ *
+ *   1. **Capability staleness.** A gated decision (role/tier/karma/ban/kefil) must read
+ *      the capability FRESH from Künye on every request — never from a snapshot minted
+ *      into the session at login. Proven on the "earn to vote" tier gate (#1810): a
+ *      çaylak's cast is rejected, and an out-of-band promotion (no re-login, the SAME
+ *      cookie) is honored on the very next cast. A session-cache of the tier would keep
+ *      serving the stale çaylak snapshot and fail this. (Its `kunye-admin-seam` /
+ *      `kunye-moderate-seam` siblings prove the same fresh-per-call property for the
+ *      admin/moderator relation tuples.)
+ *   2. **Identity-continuity teardown.** A deleted / logged-out / revoked session must
+ *      stop authenticating IMMEDIATELY, never after a TTL. The DELETE path is the
+ *      `account-deletion.test` exemplar ADR 0169 keeps as-is; this file covers the
+ *      LOGOUT/REVOKE path — sign-out tears the session down so the very next request
+ *      under the same cookie is `UNAUTHORIZED`. A `cookieCache` window would keep the
+ *      torn-down identity alive for ≤TTL and fail this.
+ *
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7). Every email/username is `NS`-
+ * prefixed (this file's deterministic token) so its rows can't collide with a
+ * concurrent file's on the shared D1. The confirmation phrase is a product constant.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
+
+const h = sharedStack();
+
+const NS = nsToken(import.meta.url);
+let counter = 0;
+const uname = (label: string) => `${NS}-${label}-${counter++}`;
+
+const CONFIRMATION = "hesabımı kalıcı olarak sil";
+
+async function setUsername(cookie: string, value: string): Promise<void> {
+	const r = await h.fate(
+		{kind: "mutation", name: "user.setUsername", input: {value}, select: ["id"]},
+		{cookie},
+	);
+	expect(r.ok).toBe(true);
+}
+
+async function me(cookie: string) {
+	return h.fate({kind: "query", name: "me", select: ["id"]}, {cookie});
+}
+
+beforeAll(() => {
+	expect(typeof h.url()).toBe("string");
+});
+
+describe("ADR 0169 — session freshness is a two-axis invariant", () => {
+	// Axis 1: capability staleness. The tier that gates a vote is read fresh from Künye
+	// on EVERY cast, so a capability change AFTER the cookie was minted is honored under
+	// the SAME cookie — a login-time snapshot would keep the çaylak rejection.
+	it("axis 1 — a capability change (çaylak→yazar) is read FRESH under the same session, not from a login snapshot", async () => {
+		// An eligible author owns a definition the subject can vote on (a self-vote is a
+		// distinct rejection — `SELF_VOTE_NOT_ALLOWED` — so the target must be someone else's).
+		const author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "Author");
+		await setUsername(author.cookie, uname("author"));
+		await h.promoteToYazar(author.userId);
+		const termSlug = `${NS}-cap-term`;
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "definition.add",
+				input: {
+					termSlug,
+					termTitle: "Capability Term",
+					body: "a definition the subject can vote on",
+				},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const definitionId = (added.data as {id: string}).id;
+
+		// The subject signs up as a çaylak — THIS cookie is the "session snapshot" moment.
+		const subject = await h.signUp(`${NS}-subject@test.local`, "hunter2hunter2", "Subject");
+		await setUsername(subject.cookie, uname("subject"));
+
+		// çaylak cast is rejected by the live "earn to vote" tier gate (#1810).
+		const beforePromote = await h.fate(
+			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
+			{cookie: subject.cookie},
+		);
+		expect(beforePromote.ok).toBe(false);
+		if (!beforePromote.ok) expect(beforePromote.error.code).toBe("VOTE_REQUIRES_YAZAR");
+
+		// Promote out-of-band: the tier column flips WITHOUT a re-login, so the subject's
+		// cookie is byte-for-byte the same one minted while it was a çaylak.
+		await h.promoteToYazar(subject.userId);
+
+		// The very next cast under that SAME cookie is honored — the gate read the FRESH
+		// tier from Künye, never a login-time snapshot. (A session-cache of the capability
+		// would keep serving çaylak here and this assertion would fail — the axis-1 guard.)
+		const afterPromote = await h.fate(
+			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
+			{cookie: subject.cookie, retry: true},
+		);
+		expect(afterPromote.ok).toBe(true);
+		if (afterPromote.ok) expect((afterPromote.data as {score: number}).score).toBe(1);
+	});
+
+	// Axis 2 (logout/revoke): sign-out tears the session down at once. The DELETE path of
+	// this axis is `account-deletion.test`'s exemplar (ADR 0169 keeps it as-is); this is
+	// its logout/revoke sibling — the same immediate-teardown invariant, different trigger.
+	it("axis 2 — sign-out tears down the session immediately; the very next request is UNAUTHORIZED", async () => {
+		const user = await h.signUp(`${NS}-logout@test.local`, "hunter2hunter2", "Logout");
+		await setUsername(user.cookie, uname("logout"));
+
+		// The session authenticates before logout.
+		const before = await me(user.cookie);
+		expect(before.ok).toBe(true);
+
+		// Log out through the real better-auth endpoint — this revokes the session row.
+		const out = await h.json("/api/auth/sign-out", {}, user.cookie);
+		expect(out.ok).toBe(true);
+
+		// The SAME cookie no longer authenticates — teardown is immediate, not eventual.
+		// (A `cookieCache` TTL window would keep this torn-down identity alive for ≤TTL and
+		// return `ok` here — the exact identity-continuity hole ADR 0169 rejects.)
+		const after = await me(user.cookie);
+		expect(after.ok).toBe(false);
+		if (!after.ok) expect(after.error.code).toBe("UNAUTHORIZED");
+	});
+
+	// Axis 2 (delete): the invariant stated in its dedicated home, not as a side effect of
+	// the anonymize-semantics test — the "caught by luck" gap ADR 0169 closes. The rich
+	// re-attribution semantics stay owned by `account-deletion.test` (unrelaxed).
+	it("axis 2 — account deletion tears down the session immediately; the very next request is UNAUTHORIZED", async () => {
+		const user = await h.signUp(`${NS}-delete@test.local`, "hunter2hunter2", "Delete");
+		await setUsername(user.cookie, uname("delete"));
+
+		const before = await me(user.cookie);
+		expect(before.ok).toBe(true);
+
+		const del = await h.fate(
+			{
+				kind: "mutation",
+				name: "account.delete",
+				input: {confirmation: CONFIRMATION},
+				select: ["deleted"],
+			},
+			{cookie: user.cookie, retry: true},
+		);
+		expect(del.ok).toBe(true);
+		if (del.ok) expect((del.data as {deleted: boolean}).deleted).toBe(true);
+
+		const after = await me(user.cookie);
+		expect(after.ok).toBe(false);
+		if (!after.ok) expect(after.error.code).toBe("UNAUTHORIZED");
+	});
+});

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1088,6 +1088,72 @@ Surfacing the thread here does **not** resolve it or merge past it — the split
 that refuses to enqueue on a substantive unresolved thread; this step makes the same objection
 **visible at review time**, so it never reaches merge unread.
 
+### Step 3f — Session-caching two-axis staleness gate (ADR 0169)
+
+Session freshness is **security-load-bearing** and a session-perf/caching review is a **two-axis
+check** — the lesson ADR
+[0169](https://github.com/kamp-us/phoenix/blob/main/.decisions/0169-no-session-caching-immediate-teardown-invariant.md)
+records. The first #2263 `cookieCache` review scoped only axis (1) (all capability reads fresh from
+Künye) and **missed** axis (2) (a deleted account still authenticated for ≤TTL); the
+`account-deletion.test` integration test caught the hole by luck, not by the review. This step folds
+that catch into the gate so the **next** session-caching proposal can't pass by checking only one
+axis. It fires **only** when this PR **introduces a new session-caching path** — otherwise it is an
+explicit not-applicable skip.
+
+**What counts as a new session-caching path (the fire condition).** Any diff that lets an
+authenticated request be served **without** a fresh source-of-truth (D1 / Künye) session
+revalidation for some window: adopting better-auth `session.cookieCache` (or any signed-cookie
+session short-circuit), a TTL/in-memory/KV/DO cache of the validated session or of a gated
+capability (role / karma / ban / kefil), or any `maxAge`/staleness window on the session read.
+Detect it off the diff Step 2 already loaded — emit the scanned scope (§ZS #1) so a future drift
+that silently stops matching is visible in the run output rather than reading green:
+
+```bash
+# does this PR touch a session/caching seam? A hit ARMS the two-axis check below; it never
+# alone FAILs — the reviewer judges whether a hit is a genuine new caching path (per the fire
+# condition above) or an unrelated auth edit. Fail-closed on the security-load-bearing surface:
+# when in doubt that a hit is a caching path, run the check, don't skip it.
+CACHE_HITS="$(gh pr diff $PR \
+  | grep -inE 'cookieCache|session\.?cache|cacheSession|maxAge|staleness|ttl|revalidat' || true)"
+echo "session-caching gate: scanned the diff for session-caching seams — $(printf '%s\n' "$CACHE_HITS" | grep -c . || echo 0) candidate line(s)"
+```
+
+**When it fires, both axes MUST be verified as REQUIRED test coverage — not prose, not one axis.**
+Confirm the PR adds (or already has, exercising the new path) a deterministic integration test for
+**each**:
+
+1. **Capability staleness** — a gated decision (role / karma / ban / kefil) reads the capability
+   FRESH per request, never from a cached session snapshot. The canonical exemplars:
+   `apps/web/tests/integration/session-freshness-invariants.test.ts` (axis 1, the çaylak→yazar tier
+   gate read fresh under the same cookie) and its `kunye-admin-seam` / `kunye-moderate-seam` siblings
+   (a revoked tuple denies the very next discharge).
+2. **Identity-continuity teardown** — delete / logout / revoke stops authenticating **immediately**,
+   never after a TTL. The canonical exemplars: `apps/web/tests/integration/account-deletion.test.ts`
+   (the delete path) and `session-freshness-invariants.test.ts` (the logout/revoke path) — the very
+   next request under the torn-down cookie is `UNAUTHORIZED`.
+
+A caching PR that covers only axis (1) — the exact #2263 gap — is **incomplete on its face**; require
+the axis-(2) teardown test before PASS. Fold the result into the per-criterion table exactly like
+Step 3b–3e:
+
+- **New session-caching path, both axes covered by deterministic tests ⇒ PASS** for this facet —
+  cite the two test files/cases that exercise the new path on each axis.
+- **New session-caching path, an axis uncovered ⇒ `[FAIL]` row.** Name which axis is missing and the
+  test that must exist (a teardown test for the new window on axis 2, a fresh-read test on axis 1),
+  so `write-code`'s repair round adds it. **When in doubt, treat the path as caching and require both
+  axes** — a false FAIL costs a cycle; a false PASS ships an identity-continuity hole (ADR 0169's crux).
+- **No new session-caching path ⇒ explicit not-applicable skip** — emit
+  `session-caching gate: not applicable — no new session-caching path in this PR` and **omit the row**
+  from the conjunctive table, exactly as Step 3b–3e omit theirs.
+
+```
+- [FAIL] session-caching two-axis gate — PR adopts session.cookieCache (worker/features/pasaport/...:NN) with only a capability-staleness test; NO identity-continuity teardown test proves delete/logout/revoke stops authenticating within the window (ADR 0169 axis 2, the #2263 gap) → add a teardown integration test like session-freshness-invariants.test.ts before PASS
+```
+
+This row is governed by the conjunctive rule (Step 3): a `[FAIL]` fails the PR until both axes carry
+required test coverage. The firewall holds — you judge, `write-code` fixes, an independent re-review
+re-gates.
+
 ---
 
 ## Step 4a — Pass path: signal merge-ready (do NOT merge)


### PR DESCRIPTION
Fixes #2296

Folds the two-axis session-caching staleness check named in ADR 0169 into **enforceable** form — encoded as REQUIRED integration invariants **and** a review-code gate step — so the next session-perf/caching PR can't pass by checking only one axis (the exact #2263 gap, where the review scoped only capability-staleness and the `account-deletion.test` caught the teardown hole by luck).

## Where the two axes are encoded (both as REQUIRED, deterministic invariants)

New black-box integration file `apps/web/tests/integration/session-freshness-invariants.test.ts` (real remote D1, ADR 0082 integration tier), one `it` per axis wired to ADR 0169:

- **Axis 1 — capability staleness.** `axis 1 — a capability change (çaylak→yazar) is read FRESH under the same session, not from a login snapshot`. A çaylak's `definition.vote` is rejected `VOTE_REQUIRES_YAZAR`; an out-of-band promotion (D1 tier flip, **no re-login** — the SAME cookie) is honored on the very next cast. Proves the gated capability is read fresh from Künye per request, never from a login-time session snapshot. A session-cache of the capability would keep serving the stale çaylak and fail this. (Its `kunye-admin-seam` / `kunye-moderate-seam` siblings already prove the same fresh-per-call property for the admin/moderator relation tuples.)
- **Axis 2 — identity-continuity teardown.** Generalizes the account-deletion seed across **both** teardown triggers:
  - `axis 2 — sign-out tears down the session immediately …` (the **logout/revoke** path, the sibling that was missing) — sign-out revokes the session so the next `me` under the same cookie is `UNAUTHORIZED`.
  - `axis 2 — account deletion tears down the session immediately …` (the **delete** path, stated in its dedicated home rather than caught by luck).
  - A `cookieCache` TTL window would keep either torn-down identity alive for ≤TTL and fail these.

`apps/web/tests/integration/account-deletion.test.ts` is **left as-is** (ADR 0169 Consequences: "stays as-is, not relaxed") — it remains the rich anonymize-to-`silinen` exemplar; the new file is the dedicated two-axis invariant home.

## Backstop — the review-code gate step (§CP)

New `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md` **Step 3f — Session-caching two-axis staleness gate (ADR 0169)**. It fires **only** when a PR introduces a new session-caching path (detected off the loaded diff, §ZS scanned-scope emitted), and then requires deterministic test coverage on **both** axes (capability-staleness + identity-continuity teardown) before PASS — a caching PR covering only axis 1 is a `[FAIL]`. It folds into the conjunctive verdict exactly like Steps 3b–3e, with a graceful not-applicable skip when no caching path is present. References ADR 0169 and both exemplar test files.

## Routing — §CP → human-merge

The review-code skill edit is control-plane (gate-critical skill), so this PR is **§CP → human-merge** (cansirin; author ≠ approver) per the issue's §CP verdict and ADR 0135 — it does **not** auto-ship on review PASS. No new §CP path is introduced (an existing §CP file is edited + a test added under `apps/web/**`), so no CODEOWNERS row changes.

## Verification

- `pnpm typecheck` — clean (27/27, new test file compiles under the real project graph).
- `pnpm lint:worktree` — clean.
- The new invariants are **integration tier** (ADR 0082: real remote Cloudflare deploy, CI secrets), so they run in **CI**, not locally.

## Acceptance criteria

- [x] Home decided + rationale recorded: enforce (not just document) — REQUIRED integration invariants + a review-code enforced gate step, honoring "enforce, don't just document."
- [x] Both axes encoded explicitly as checks — capability staleness AND identity-continuity teardown — not optional prose.
- [x] References the invariant source (ADR 0169) and the axis-(2) exemplar (`account-deletion.test.ts`).
- [x] The review-code (§CP) home is routed for human-merge (cansirin), not auto-ship.
- [x] ADR 0169 (PR #2295) has landed on `main` (verified merged at pickup).
