### PR TITLE
fix(pipeline): harden the verdict read-back leak guard — match by root + reject empty body (#2268)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -852,6 +852,13 @@ verdict_readback_guard() {
   local got; got="$(gh api "repos/$REPO/issues/comments/$cid" --jq .body)" || {
     echo "verdict_readback_guard FAILED: cannot re-read comment $cid — treat the verdict as UNLANDED." >&2; return 1; }
 
+  # (0) the body is non-empty. An empty/whitespace-only body carries no marker at all — the degenerate
+  #     case of a garbled post (#2268); reject it up front so the failure names the real cause rather
+  #     than falling through to (1)'s "no marker".
+  if [ -z "$(printf '%s' "$got" | tr -d '[:space:]')" ]; then
+    echo "verdict_readback_guard FAILED: comment $cid is empty/whitespace — no verdict landed; the PR is UNGATED." >&2; return 1
+  fi
+
   # (1) the canonical gate marker token is present: either the bindable first-line
   #     `<gate>: PASS|FAIL @ <sha>` (SHA prefix-matched, ADR 0058), OR the SHA-less `<gate>: advisory`
   #     first line (blocking-set path — authorizes nothing but IS a posted verdict).
@@ -875,11 +882,13 @@ verdict_readback_guard() {
       || { echo "verdict_readback_guard FAILED: 'Reviewed-head:' line in comment $cid is bound to the wrong head (not @ ${sha:0:7}) — a stale/mis-bound §CP head binding." >&2; return 1; }
   fi
 
-  # (3) NO local filesystem path leaked into the public body (the #2148 leak). Reject a machine-local
-  #     scratch/home path or a leading `@<path>` marker-as-path. Patterns are placeholders, not real
-  #     paths — this doc stays leak-clean.
-  if printf '%s' "$got" | grep -Eq '(/var/folders/|/Users/|/tmp[/.]|/private/tmp/|(^|[[:space:]])~/|(^|[[:space:]])@/)'; then
-    echo "verdict_readback_guard FAILED: comment $cid leaks a local filesystem path in its body — a #2148 marker-as-path leak; refuse and re-post the real verdict." >&2; return 1
+  # (3) NO local filesystem path leaked into the public body (the #2148/#2268 leak). Reject a
+  #     machine-local scratch/home path or a leading `@<path>` marker-as-path. Match by absolute ROOT
+  #     (`/Users`, `/var`, `/tmp`, `/private`) — the roots a `mktemp`/scratchpad path lands under —
+  #     not just `/var/folders/`, so a leaked path under any of them cannot read green (#2268). Patterns
+  #     are placeholders, not real paths — this doc stays leak-clean.
+  if printf '%s' "$got" | grep -Eq '(/var/|/Users/|/tmp[/.]|/private/|(^|[[:space:]])~/|(^|[[:space:]])@/)'; then
+    echo "verdict_readback_guard FAILED: comment $cid leaks a local filesystem path in its body — a #2148/#2268 marker-as-path leak; refuse and re-post the real verdict." >&2; return 1
   fi
 
   echo "verdict_readback_guard OK: ${gate} verdict @ ${sha:0:7} landed on comment $cid — marker + head binding valid, no local-path leak."
@@ -892,7 +901,9 @@ real verdict and re-assert** — if it still cannot land clean, surface it as a 
 the run ledger (the PR is genuinely ungated; a consumer must not read it as verified), never swallow
 it as a silent success. A moved `HEAD_SHA` between the post and the read-back means the head advanced
 *during* the review — re-resolve the head, re-verify against it (the gate is stateless), and re-post;
-never loosen the match to paper over a moved head.
+never loosen the match to paper over a moved head. (In practice a gate never calls this primitive with
+a hand-carried id — it calls the unconditional `verdict_post_verify` wrapper below, which resolves the
+landed comment id by re-scanning PR state and passes it here.)
 
 Check (2) is **SHA-source-aware** (#2272), which is why the read-back is unconditional without
 false-failing a legitimate non-blocking PASS or the review-code §CP advisory. The bindable PASS/FAIL
@@ -970,7 +981,7 @@ verdict_post_verify() {
   #     (literal alternation + anchored `(^|[[:space:]])` — no nested quantifier, no ReDoS), the same
   #     pattern verdict_readback_guard uses; paths are placeholders, keeping this doc leak-clean.
   if [ "${approved:-0}" -gt 0 ] && [ -n "$rbody" ]; then
-    if printf '%s' "$rbody" | grep -Eq '(/var/folders/|/Users/|/tmp[/.]|/private/tmp/|(^|[[:space:]])~/|(^|[[:space:]])@/)'; then
+    if printf '%s' "$rbody" | grep -Eq '(/var/|/Users/|/tmp[/.]|/private/|(^|[[:space:]])~/|(^|[[:space:]])@/)'; then
       echo "verdict_post_verify FAILED (fatal): native APPROVE review body on PR #$PR leaks a local filesystem path — dismiss/re-post a clean by-value verdict." >&2
       return 1
     fi


### PR DESCRIPTION
Fixes #2268.

## Root cause of the #2264 recurrence (as #2268 asks the PR to state)

The #2264 leak (a `review-code` verdict comment whose whole body was a `@/var/folders/…` tmpfile path → empty marker namespace + public local-path leak) was a **guard-reachability** gap, not a missing guard: the read-back was invoked as `verdict_readback_guard "$MINE" …`, and `$MINE` was populated on **one** post branch only (the APPROVE-failed comment-upsert `else` fallback). A verdict landing by any other route (native `APPROVE`, first-`POST`, or a hand-rolled `-f body=@file`) reached the guard with an empty id, so the broken/leaking marker sailed through.

## What already landed (do not re-do) — PR #2271

That reachability gap was **already closed** by the merged PR #2271 (`c4753c8c`), which introduced the unconditional `verdict_post_verify` wrapper. It re-scans **live PR state** (never a carried `$MINE`/`$CID`) to resolve whatever verdict landed — SHA-bound marker comment, `advisory` line, or native `APPROVE` at `commit_id==HEAD_SHA` — runs the read-back on it, and **hard-exits non-zero** on absent/malformed/leaking. All three gates (`review-code`, `review-doc`, `review-skill`) call it as `verdict_post_verify "$PR" <gate> "$HEAD_SHA" || exit 1` in their Step 4c/5b. So #2268's headline acceptance criteria (guard resolved by re-scan, not `$MINE`; fatal on non-canonical or path-leaking body) were **already met on `main`** — #2268 stayed open only because #2271 referenced it by `(#2268)` in the title rather than `Fixes`.

## What this PR adds — the two residual gaps in #2268's acceptance criteria

1. **Match the leaked local-path substring by absolute ROOT, not a specific subdir.** The regex matched `/var/folders/` and `/private/tmp/`; #2268's spec is `@?/(Users|var|tmp|private)/`. Broadened to `/var/` and `/private/` in **both** `verdict_readback_guard` (check 3) and `verdict_post_verify` (check E, the native-`APPROVE` body leak check), so a scratch path under any of `/Users` `/var` `/tmp` `/private` — not only `/var/folders/` — cannot read green.
2. **Reject an empty/whitespace-only body up front in `verdict_readback_guard` (check 0).** An empty body was already fatal via the wrapper's no-marker-resolved path (`verdict_post_verify` C), but the primitive now rejects it directly and names the real cause, so the guard is self-sufficient if ever called standalone.

## Regression lineage (auditable, per #2268)

#2149 → PR #2153 (original read-back guard) → #2264 recurrence → PR #2271 (unconditional `verdict_post_verify`) → **this residual hardening**.

## Leak scrub

Re-scanned PR #2264's comments via `gh api` REST: **zero** remaining bodies carry a local-path substring — the garbled comment was already deleted and re-posted clean (comment `4898302972`). No live public-comment scrub is outstanding.

## Classification — §CP, human-merge

Edits the shared `gh-issue-intake-formats.md` verdict read-back contract (gate-critical) → **§CP** (ADR 0053/0065): reviewed by `review-skill`, then **human-merged by cansirin** (ADR 0135). Not auto-shipped. No new §CP path is introduced (existing file), so no CODEOWNERS row is needed. `leak-guard scan` clean on the changed file; diff is markdown-only (no TS touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)