### PR TITLE
feat(pipeline-cli): shift-left the two common CodeQL findings to author time (#2261)

### DIFF
--- a/.github/codeql-lint-baseline.json
+++ b/.github/codeql-lint-baseline.json
@@ -1,0 +1,18 @@
+{
+	"_comment": "codeql-lint grandfather baseline (issue #2261). Pre-existing CodeQL debt that default-setup already carries as unrelated alerts, so `pipeline-cli codeql-lint check` is GREEN on main and fails only on NEW violations. Do NOT add a NEW workflow here to dodge the gate — add an explicit least-privilege `permissions:` block instead. This list only shrinks (as legacy workflows get pinned).",
+	"grandfatheredWorkflows": [
+		".github/workflows/ci.yml",
+		".github/workflows/codeowners-cp.yml",
+		".github/workflows/decisions-index.yml",
+		".github/workflows/deploy.yml",
+		".github/workflows/doc-links.yml",
+		".github/workflows/fanout-guard.yml",
+		".github/workflows/leak-guard.yml",
+		".github/workflows/migrations-guard.yml",
+		".github/workflows/pointer-guard.yml",
+		".github/workflows/readme-guard.yml",
+		".github/workflows/skill-gh-lint.yml",
+		".github/workflows/workflow-contract.yml"
+	],
+	"grandfatheredRegexes": []
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -121,6 +121,35 @@ pre-push:
           exit 0
         }
         pnpm --filter './apps/**' exec vitest run --config vitest.config.ts --project unit --changed origin/main
+    codeql-lint:
+      # Shift-left the two COMMON CodeQL findings to author time (#2261): a net-new
+      # workflow missing a least-privilege `permissions:` block or a catastrophic-
+      # backtracking regex (ReDoS) fails the PUSH here, deterministically and locally
+      # (no network, NOT CodeQL) — instead of surfacing late as a CodeQL alert that
+      # refuses the PR at ship and costs a full repair → re-review → re-ship cycle. The
+      # grandfather baseline (`.github/codeql-lint-baseline.json`) keeps main green, so
+      # only NEW violations block. Runs via `node …/bin.ts` (not pnpm) like leak-guard —
+      # it needs only node + the installed effect deps.
+      #
+      # Fail-CLOSED on a real finding, fail-OPEN on an absent toolchain — the dedicated
+      # exit-code contract (bin.ts: 2 = finding → block; any OTHER non-zero = couldn't
+      # run, e.g. stripped-PATH worktree / unlinked deps #1798 → allow). CodeQL's own CI
+      # scan stays the unbypassable backstop; this is the local fast-fail.
+      run: |
+        command -v node >/dev/null 2>&1 || {
+          echo "codeql-lint: no node on PATH (stripped-PATH/lean worktree); skipping local pre-push check — CodeQL at CI is the backstop" >&2
+          exit 0
+        }
+        status=0
+        node packages/pipeline-cli/src/bin.ts codeql-lint check || status=$?
+        if [ "$status" -eq 2 ]; then
+          echo "blocked by codeql-lint (#2261); fix the finding above or \`git push --no-verify\` to bypass" >&2
+          exit 1
+        elif [ "$status" -ne 0 ]; then
+          echo "codeql-lint: check could not run (e.g. run 'pnpm install'); skipping local pre-push check — CodeQL at CI is the backstop" >&2
+          exit 0
+        fi
+        exit 0
 
 # `git worktree add` fires post-checkout, so this provisions a fresh worktree's deps —
 # node_modules is gitignored and per-checkout, so a worktree is otherwise dead-on-arrival

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -86,6 +86,28 @@ This is a **control-plane** surface (it drives the shared primary checkout); see
 [`.patterns/worktree-agent-constraints.md`](../../.patterns/worktree-agent-constraints.md)
 for the surrounding worktree/primary-checkout discipline it defends.
 
+### `codeql-lint` — author-time shift-left for the two common CodeQL findings (#2261)
+
+A deterministic, local (**no network, not CodeQL**) pre-push lint that catches the two
+COMMON CodeQL findings which keep blocking net-new-artifact PRs at ship — never at
+`review-code`, which does not run CodeQL: a workflow missing a least-privilege
+`permissions:` block (PR #2251) and a catastrophic-backtracking regex / ReDoS (PR #2258).
+It fails the **push** (deterministically, ~1s over the whole repo) instead of surfacing
+late as a CodeQL alert that refuses the PR at ship and costs a full repair → re-review →
+re-ship cycle.
+
+```bash
+# gate: exit 0 clean / 2 on a real finding / other non-zero = couldn't run
+node packages/pipeline-cli/src/bin.ts codeql-lint check
+node packages/pipeline-cli/src/bin.ts codeql-lint check --root <d>
+```
+
+A grandfather baseline (`.github/codeql-lint-baseline.json`) keeps `main` green so only
+NEW violations block; the `lefthook` pre-push leg keys off the dedicated exit code `2` to
+fail-closed on a finding but fail-open on an absent toolchain. Full detail — the two ReDoS
+shapes, the documented scan surface, the baseline model — in the
+[tool README](src/tools/codeql-lint/README.md).
+
 ### `ref-guard` — caller-agnostic ref-transaction guard against a diverging `main` (#2143, ADR 0160)
 
 A fail-closed guardrail wired as git's own **`reference-transaction`** hook that **refuses

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -15,6 +15,7 @@ import type {Command} from "effect/unstable/cli";
 import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
 import {ciRequiredCommand} from "./tools/ci-required/command.ts";
 import {codeownersCpCommand} from "./tools/codeowners-cp/command.ts";
+import {codeqlLintCommand} from "./tools/codeql-lint/command.ts";
 import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {designTokenGuardCommand} from "./tools/design-token-guard/command.ts";
@@ -106,4 +107,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	evalHarnessCommand,
 	mainSyncCommand,
 	refGuardCommand,
+	codeqlLintCommand,
 ];

--- a/packages/pipeline-cli/src/tools/codeql-lint/README.md
+++ b/packages/pipeline-cli/src/tools/codeql-lint/README.md
@@ -1,0 +1,92 @@
+# codeql-lint
+
+`pipeline-cli codeql-lint check [--root <d>]` — a deterministic, local, author-time
+approximation of the two **common** CodeQL findings that keep blocking net-new-artifact
+PRs at ship (issue #2261). It shifts those findings LEFT: they fail the push (or a manual
+run) instead of surfacing late as a CodeQL alert that refuses the PR at ship and costs a
+full repair → re-review → re-ship cycle.
+
+It is **not** CodeQL and makes **no network call** — it is a fast static check
+(~1s over the whole repo) for the two well-known *shapes*:
+
+1. **workflow-permissions** — CodeQL's *"Workflow does not contain permissions"* (PR
+   #2251). A GitHub Actions workflow whose `GITHUB_TOKEN` scope is not pinned
+   least-privilege. A workflow PASSES iff it declares an explicit `permissions:` block at
+   the **top level** or on **every job**; otherwise it FAILS. The fix is the merged
+   precedent — an explicit least-privilege block:
+
+   ```yaml
+   permissions:
+     contents: read
+   ```
+
+2. **redos** — CodeQL's *"Polynomial/exponential regular expression on uncontrolled data"*
+   (PR #2258). A regex whose structure admits catastrophic backtracking. Two textbook
+   shapes are flagged, chosen to be unambiguous and **low-false-positive**:
+   - **nested quantifier** — an unbounded-quantified group whose body is *exactly* a
+     single unbounded-quantified atom: `(a+)+`, `(a*)*`, `([a-z]+)*`, `(\d+){2,}`.
+   - **quantified/overlapping alternation** — an unbounded-quantified group whose body
+     has a top-level `|` where a branch is a single unbounded-quantified atom (`(a+|b)*`)
+     or two branches are identical (`(a|a)+`).
+
+   The *"single quantified atom"* condition is load-bearing: it is what makes the
+   catastrophe real (inner and outer quantifiers matching the same input ambiguously). A
+   group that merely *ends* in a quantifier but has a mandatory disambiguating prefix —
+   the standard kebab/slug `(-[a-z0-9]+)*`, each iteration forced to start with a literal
+   `-` — is **linear**, not catastrophic, and is deliberately **not** flagged (CodeQL does
+   not flag it either).
+
+## Scope (documented, no silent caps — the scan surface is logged to stderr)
+
+- **workflows:** `.github/workflows/*.{yml,yaml}`.
+- **source (regex scan):** `.ts/.tsx/.js/.jsx/.mjs/.cjs` under `apps/`, `packages/`,
+  `infra/`, skipping `node_modules`, `dist`, `build`, `coverage`, `.git`, `tests`/
+  `__tests__` dirs, and any `*.d.ts` / `*.test.*` / `*.spec.*` file. Test files are out
+  of scope on purpose: ReDoS-on-uncontrolled-data is a runtime-path concern, and a test
+  may legitimately carry an adversarial regex fixture (this tool's own tests do).
+  Template-literal `RegExp` args are out of scope (rare).
+
+## The grandfather baseline
+
+`.github/codeql-lint-baseline.json` grandfathers the **pre-existing** debt CodeQL
+default-setup already carries as unrelated alerts, so `check` is **green on `main`** and
+fails only on **new** violations — the whole point is to block net-new artifacts, not to
+boil the ocean on legacy workflows (the design-token-guard config model).
+
+```json
+{
+  "grandfatheredWorkflows": [".github/workflows/ci.yml", "…"],
+  "grandfatheredRegexes": [{"path": "…", "pattern": "…"}]
+}
+```
+
+Do **not** add a *new* workflow here to dodge the gate — add a `permissions:` block
+instead. The list only shrinks, as legacy workflows get pinned. A missing baseline is the
+strictest posture (nothing grandfathered); a present-but-malformed baseline **fails
+closed** (ADR 0092).
+
+## Exit-code contract
+
+A **dedicated** gate-fail code (the `leak-guard` = 2 / `ref-guard` = 3 idiom):
+
+- `0` — clean.
+- `2` — a real finding (a workflow missing permissions / a catastrophic regex).
+- any **other** non-zero (`1`, `127`, the #1798 unlinked-dep remediation) — the check
+  could not **run**.
+
+The `lefthook` pre-push leg keys off code `2` to **fail-closed on a finding** but
+**fail-open on an absent toolchain** — so a lean/stripped-PATH worktree is never bricked.
+CodeQL's own CI scan stays the backstop.
+
+## Design
+
+- `codeql-lint.ts` — the **pure, IO-free** core: the ReDoS shape detector (`detectRedos`),
+  the comment/string-aware regex extractor (`extractRegexes`), the workflow-permissions
+  parser/judge, and the top-level `judge` (+ grandfather filtering). Unit-tested over
+  strings/facts with no disk (`codeql-lint.unit.test.ts`).
+- `gate.ts` — the **filesystem seam**: walk the workflow + source roots, read the
+  baseline, delegate to the core. Crossed over a fake temp tree in `gate.unit.test.ts`.
+- `command.ts` — the thin `effect/unstable/cli` wiring (mirrors `design-token-guard`).
+
+Fails closed on zero scope (ADR 0092): zero workflows **and** zero source files is a wrong
+root, not a vacuous pass.

--- a/packages/pipeline-cli/src/tools/codeql-lint/codeql-lint.ts
+++ b/packages/pipeline-cli/src/tools/codeql-lint/codeql-lint.ts
@@ -1,0 +1,569 @@
+/**
+ * `codeql-lint` pure core (issue #2261) — a deterministic, IO-free author-time
+ * approximation of the two COMMON CodeQL findings that keep blocking net-new-artifact
+ * PRs at ship (never at `review-code`, which does not run CodeQL). It is NOT CodeQL and
+ * makes no network call: it catches the two well-known *shapes* cheaply at pre-push so
+ * the coder fixes them before CI, not after a full repair → re-review → re-ship cycle.
+ *
+ * The two classes it decides over already-gathered facts:
+ *
+ *   1. workflow-permissions — a GitHub Actions workflow whose `GITHUB_TOKEN` scope is
+ *      not pinned least-privilege. CodeQL's "Workflow does not contain permissions"
+ *      (PR #2251). A workflow PASSES iff it declares an explicit `permissions:` block
+ *      at the top level OR on every job; a workflow with no `permissions:` anywhere
+ *      (or a job missing one when there is no top-level block) FAILS. The fix is the
+ *      merged precedent: an explicit `permissions: { contents: read }`.
+ *   2. redos — a regex literal whose structure admits catastrophic backtracking
+ *      (CodeQL "Polynomial/exponential regular expression on uncontrolled data",
+ *      PR #2258). Two textbook shapes are flagged, chosen to be unambiguous and
+ *      low-false-positive (NOT the high-FP safe-regex star-height heuristic):
+ *        a. nested quantifier — an unbounded-quantified group whose body is EXACTLY a
+ *           single unbounded-quantified atom: `(a+)+`, `(a*)*`, `([a-z]+)*`, `(\d+){2,}`.
+ *        b. quantified/overlapping alternation — an unbounded-quantified group whose
+ *           body has a top-level `|` where a branch is itself a single unbounded-
+ *           quantified atom (`(a+|b)*`) or two branches are identical (`(a|a)+`).
+ *      The "single quantified atom" condition is load-bearing: it is what makes the
+ *      catastrophe real (inner and outer quantifiers matching the SAME input
+ *      ambiguously). A group that merely *ends* in a quantifier but has a mandatory
+ *      disambiguating prefix — the standard kebab/slug `(-[a-z0-9]+)*`, each iteration
+ *      forced to start with a literal `-` — is LINEAR, not catastrophic, and is
+ *      deliberately NOT flagged (CodeQL does not flag it either); flagging it would
+ *      false-fail the repo.
+ *
+ * IO-free and total: every decision is a deterministic transform over facts gathered at
+ * the filesystem boundary (`gate.ts`); this module never touches disk. Fail-closed on
+ * zero scope (ADR 0092): zero workflows AND zero source files discovered is a broken
+ * scope assumption (a wrong root), not a vacuous pass.
+ */
+import {parse as parseYaml} from "yaml";
+
+// ---------------------------------------------------------------------------
+// Facts (gathered at the IO boundary, judged here)
+// ---------------------------------------------------------------------------
+
+/** The permissions facts parsed out of one workflow YAML file. */
+export interface WorkflowFacts {
+	/** Repo-relative POSIX path (e.g. `.github/workflows/leak-guard.yml`). */
+	readonly path: string;
+	/** Does the workflow declare a top-level `permissions:` key? */
+	readonly hasTopLevelPermissions: boolean;
+	/** Each job's id + whether it declares its own `permissions:` key. */
+	readonly jobs: ReadonlyArray<{readonly name: string; readonly hasPermissions: boolean}>;
+}
+
+/** One regex literal (or `RegExp(...)` string arg) discovered in a source file. */
+export interface RegexLiteral {
+	readonly path: string;
+	readonly line: number;
+	/** The regex *source* (pattern body, without the delimiting slashes/flags). */
+	readonly pattern: string;
+}
+
+/** Everything the gate gathered, ready to judge. */
+export interface CodeqlLintFacts {
+	readonly workflows: ReadonlyArray<WorkflowFacts>;
+	readonly regexes: ReadonlyArray<RegexLiteral>;
+}
+
+/**
+ * The grandfather baseline (mirrors design-token-guard's config model): the pre-existing
+ * debt CodeQL default-setup already carries as unrelated alerts, so the gate is GREEN on
+ * `main` while still failing on any NEW violation — the whole shift-left point is to
+ * block net-new artifacts, not to boil the ocean on legacy workflows. Every entry is a
+ * bounded, documented allow-list; adding one is a deliberate act (see the tool README).
+ */
+export interface CodeqlLintBaseline {
+	/** Repo-relative workflow paths grandfathered as pre-existing permissions debt. */
+	readonly grandfatheredWorkflows: ReadonlyArray<string>;
+	/** Regex sources grandfathered as pre-existing (keyed by path + pattern, line-stable). */
+	readonly grandfatheredRegexes: ReadonlyArray<{readonly path: string; readonly pattern: string}>;
+}
+
+export const EMPTY_BASELINE: CodeqlLintBaseline = {
+	grandfatheredWorkflows: [],
+	grandfatheredRegexes: [],
+};
+
+// ---------------------------------------------------------------------------
+// Failures + verdict
+// ---------------------------------------------------------------------------
+
+/** A workflow whose GITHUB_TOKEN scope is not pinned least-privilege. */
+export interface WorkflowPermissionsFailure {
+	readonly path: string;
+	/**
+	 * The jobs missing a `permissions:` block (only when there is no top-level block).
+	 * Empty when the workflow declares no `permissions:` anywhere and has no parseable
+	 * jobs — i.e. nothing is pinned at all.
+	 */
+	readonly jobsMissing: ReadonlyArray<string>;
+}
+
+/** The two catastrophic-backtracking shapes. */
+export type RedosKind = "nested-quantifier" | "quantified-alternation";
+
+/** A regex literal whose structure admits catastrophic backtracking. */
+export interface RedosFailure {
+	readonly path: string;
+	readonly line: number;
+	readonly pattern: string;
+	readonly kind: RedosKind;
+}
+
+export type CodeqlLintVerdict =
+	| {readonly pass: true; readonly workflowsChecked: number; readonly regexesChecked: number}
+	/** No workflows AND no source files in scope — fail closed, never a vacuous pass (ADR 0092). */
+	| {readonly pass: false; readonly reason: "zero-scope"}
+	| {
+			readonly pass: false;
+			readonly reason: "violations";
+			readonly workflowPermissions: ReadonlyArray<WorkflowPermissionsFailure>;
+			readonly redos: ReadonlyArray<RedosFailure>;
+	  };
+
+// ---------------------------------------------------------------------------
+// Rule 1 — workflow permissions
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a workflow YAML file into its permissions facts. A top-level `permissions:`
+ * key pins the token for every job; otherwise each job must pin its own. A parse
+ * failure (or a non-mapping document) yields "no top-level, no jobs" — which fails
+ * the rule fail-closed (a workflow we cannot read is not a workflow we can clear).
+ */
+export const parseWorkflowFacts = (path: string, yamlText: string): WorkflowFacts => {
+	let doc: unknown;
+	try {
+		doc = parseYaml(yamlText);
+	} catch {
+		return {path, hasTopLevelPermissions: false, jobs: []};
+	}
+	if (doc === null || typeof doc !== "object") {
+		return {path, hasTopLevelPermissions: false, jobs: []};
+	}
+	const root = doc as Record<string, unknown>;
+	const hasTopLevelPermissions = Object.hasOwn(root, "permissions");
+	const jobsNode = root.jobs;
+	const jobs: Array<{name: string; hasPermissions: boolean}> = [];
+	if (jobsNode !== null && typeof jobsNode === "object") {
+		for (const [name, body] of Object.entries(jobsNode as Record<string, unknown>)) {
+			const hasPermissions =
+				body !== null && typeof body === "object" && Object.hasOwn(body, "permissions");
+			jobs.push({name, hasPermissions});
+		}
+	}
+	return {path, hasTopLevelPermissions, jobs};
+};
+
+/**
+ * A workflow clears the rule iff it declares a top-level `permissions:` block, or it
+ * has at least one job and every job declares its own. Returns the failure (naming the
+ * jobs missing a block) or `null` when the workflow is clear.
+ */
+export const judgeWorkflowPermissions = (w: WorkflowFacts): WorkflowPermissionsFailure | null => {
+	if (w.hasTopLevelPermissions) return null;
+	if (w.jobs.length > 0 && w.jobs.every((j) => j.hasPermissions)) return null;
+	return {path: w.path, jobsMissing: w.jobs.filter((j) => !j.hasPermissions).map((j) => j.name)};
+};
+
+// ---------------------------------------------------------------------------
+// Rule 2 — ReDoS (catastrophic backtracking)
+// ---------------------------------------------------------------------------
+
+/**
+ * The outer quantifier that makes a group repeat unbounded: `*`, `+`, or an open-ended
+ * `{n,}`. A bounded `{n,m}` / `{n}` does not blow up, so it is deliberately excluded.
+ * `at` points at the quantifier char just after a group's `)`.
+ */
+const outerUnboundedQuantifierAt = (pattern: string, at: number): boolean => {
+	const ch = pattern[at];
+	if (ch === "*" || ch === "+") return true;
+	if (ch === "{") {
+		const close = pattern.indexOf("}", at);
+		if (close === -1) return false;
+		const inner = pattern.slice(at + 1, close);
+		return /^\d*,\s*$/.test(inner); // e.g. "2," or "," — comma with no upper bound
+	}
+	return false;
+};
+
+/** Consume one atom from the start of `s`; return its length, or 0 if none. An atom is a
+ * single char, an escape `\x`, a char class `[...]`, or a group `(...)`. */
+const atomLength = (s: string): number => {
+	if (s.length === 0) return 0;
+	const c = s[0];
+	if (c === "\\") return s.length >= 2 ? 2 : 0;
+	if (c === "[") {
+		let i = 1;
+		if (s[i] === "^") i++;
+		if (s[i] === "]") i++; // a leading `]` is a literal member
+		while (i < s.length) {
+			if (s[i] === "\\") i += 2;
+			else if (s[i] === "]") return i + 1;
+			else i++;
+		}
+		return 0; // unterminated class — not a clean atom
+	}
+	if (c === "(") {
+		let depth = 0;
+		let inClass = false;
+		for (let i = 0; i < s.length; i++) {
+			if (s[i] === "\\") {
+				i++;
+				continue;
+			}
+			if (inClass) {
+				if (s[i] === "]") inClass = false;
+				continue;
+			}
+			if (s[i] === "[") inClass = true;
+			else if (s[i] === "(") depth++;
+			else if (s[i] === ")" && --depth === 0) return i + 1;
+		}
+		return 0;
+	}
+	if (c === ")" || c === "|" || c === "*" || c === "+" || c === "?") return 0; // not an atom start
+	return 1;
+};
+
+/**
+ * Is this branch EXACTLY one atom followed by an unbounded quantifier (`+`, `*`, or open
+ * `{n,}`), allowing a trailing lazy `?`? This — not "ends in a quantifier" — is the
+ * catastrophic shape: `a+`, `[a-z]+`, `\d*`, `(ab)+` all qualify; `-[a-z]+` (two atoms,
+ * the slug separator case) does NOT, because its mandatory `-` disambiguates iterations.
+ */
+const isSingleQuantifiedAtom = (branch: string): boolean => {
+	const s = branch.replace(/\?$/, ""); // a trailing lazy `?` still backtracks
+	const len = atomLength(s);
+	if (len === 0 || len >= s.length) return false; // no atom, or nothing left for a quantifier
+	const rest = s.slice(len);
+	if (rest === "*" || rest === "+") return true;
+	if (rest[0] === "{" && rest[rest.length - 1] === "}") {
+		return /^\d*,\s*$/.test(rest.slice(1, rest.length - 1)); // `{n,}` open upper bound
+	}
+	return false;
+};
+
+/** Split a group body on its TOP-LEVEL `|` (depth-0, not inside nested `()`/`[]`). */
+const splitTopLevelAlternation = (body: string): ReadonlyArray<string> => {
+	const parts: Array<string> = [];
+	let depth = 0;
+	let inClass = false;
+	let start = 0;
+	for (let i = 0; i < body.length; i++) {
+		const ch = body[i];
+		if (ch === "\\") {
+			i++; // skip the escaped char
+			continue;
+		}
+		if (inClass) {
+			if (ch === "]") inClass = false;
+			continue;
+		}
+		if (ch === "[") inClass = true;
+		else if (ch === "(") depth++;
+		else if (ch === ")") depth--;
+		else if (ch === "|" && depth === 0) {
+			parts.push(body.slice(start, i));
+			start = i + 1;
+		}
+	}
+	parts.push(body.slice(start));
+	return parts;
+};
+
+/**
+ * The core ReDoS shape detector: given a regex source, return the catastrophic-
+ * backtracking kind it matches, or `null` when none. Walks the pattern once, tracking
+ * group spans and char classes (parens inside `[...]` are literal), and — for each
+ * unbounded-quantified group — inspects its body's top-level structure:
+ *
+ *   - a body that is EXACTLY a single unbounded-quantified atom → nested-quantifier;
+ *   - a body with a top-level `|` where a branch is a single unbounded-quantified atom
+ *     OR two branches are identical → quantified-alternation.
+ *
+ * A capturing/non-capturing/named group's leading `(?:` / `(?<name>` marker is stripped
+ * before inspection; lookarounds are zero-width and never quantified, so they never
+ * reach the quantifier test.
+ */
+export const detectRedos = (pattern: string): RedosKind | null => {
+	const stack: Array<number> = []; // indices of unmatched `(`
+	let inClass = false;
+	for (let i = 0; i < pattern.length; i++) {
+		const ch = pattern[i];
+		if (ch === "\\") {
+			i++; // skip the escaped char
+			continue;
+		}
+		if (inClass) {
+			if (ch === "]") inClass = false;
+			continue;
+		}
+		if (ch === "[") {
+			inClass = true;
+		} else if (ch === "(") {
+			stack.push(i);
+		} else if (ch === ")") {
+			const open = stack.pop();
+			if (open === undefined) continue; // unbalanced source — ignore, don't throw
+			if (!outerUnboundedQuantifierAt(pattern, i + 1)) continue;
+			let body = pattern.slice(open + 1, i);
+			// strip a non-capturing / named / lookaround marker to get the raw body
+			body = body.replace(/^\?(:|<[^>]*>|=|!|<=|<!)/, "");
+			const branches = splitTopLevelAlternation(body);
+			if (branches.length > 1) {
+				if (branches.some(isSingleQuantifiedAtom)) return "quantified-alternation";
+				const seen = new Set<string>();
+				for (const b of branches) {
+					const key = b.trim();
+					if (key.length > 0 && seen.has(key)) return "quantified-alternation";
+					seen.add(key);
+				}
+			} else if (isSingleQuantifiedAtom(body)) {
+				return "nested-quantifier";
+			}
+		}
+	}
+	return null;
+};
+
+// ---------------------------------------------------------------------------
+// Regex extraction from TS/JS source (comment/string aware)
+// ---------------------------------------------------------------------------
+
+/**
+ * A `/` begins a regex literal (rather than division) when the previous significant
+ * token is an operator / opener / keyword — the standard lexer heuristic. Kept as a set
+ * of the last non-space char plus a small keyword set, which is deterministic and
+ * sufficient for source-scanning (a mis-classified division rarely forms a quantified
+ * group, and detectRedos would reject it anyway).
+ */
+const REGEX_PRECEDERS = new Set([
+	"(",
+	",",
+	"=",
+	":",
+	"[",
+	"!",
+	"&",
+	"|",
+	"?",
+	"{",
+	"}",
+	";",
+	"+",
+	"-",
+	"*",
+	"%",
+	"<",
+	">",
+	"~",
+	"^",
+]);
+const REGEX_PRECEDING_KEYWORDS = new Set(["return", "typeof", "case", "in", "of", "do", "else"]);
+
+/**
+ * Extract regex literals + `RegExp(...)` / `new RegExp(...)` string-arg patterns from a
+ * source file, comment- AND string-aware in a single pass. Returns `{line, pattern}` for
+ * each. Being string-aware is load-bearing: a `new RegExp("(a+)+")` that appears INSIDE a
+ * string literal (a test asserting on source text) must NOT be extracted — folding the
+ * constructor detection into the scanner (rather than a separate post-scan regex) is what
+ * gives that. Template-literal RegExp args are out of scope (rare; skipped) — see the tool
+ * README for the documented scan surface.
+ */
+export const extractRegexes = (src: string): ReadonlyArray<{line: number; pattern: string}> => {
+	const found: Array<{line: number; pattern: string}> = [];
+	let line = 1;
+	let prevSignificant = ""; // last non-space token char, for the regex/division call
+	let word = ""; // the in-progress identifier run
+	let lastWord = ""; // the most recently COMPLETED identifier (survives a whitespace boundary)
+	let expectRegExpArg = false; // a `RegExp(` was just seen — its first string arg is a pattern
+	const flushWord = () => {
+		if (word) {
+			lastWord = word;
+			word = "";
+		}
+	};
+
+	for (let i = 0; i < src.length; i++) {
+		const ch = src[i];
+		if (ch === undefined) break; // unreachable (i < length), but narrows `string | undefined`
+		const next = src[i + 1];
+		if (ch === "\n") {
+			line++;
+			continue;
+		}
+		if (ch === "/" && next === "/") {
+			while (i < src.length && src[i] !== "\n") i++;
+			i--; // let the loop see the newline
+			continue;
+		}
+		if (ch === "/" && next === "*") {
+			i += 2;
+			while (i < src.length && !(src[i] === "*" && src[i + 1] === "/")) {
+				if (src[i] === "\n") line++;
+				i++;
+			}
+			i++; // skip the closing `/`
+			continue;
+		}
+		// string / template literal — skipped, EXCEPT when it is the arg to `RegExp(`
+		if (ch === '"' || ch === "'" || ch === "`") {
+			const quote = ch;
+			const startLine = line;
+			let raw = "";
+			i++;
+			while (i < src.length && src[i] !== quote) {
+				if (src[i] === "\\") {
+					raw += src[i] + (src[i + 1] ?? "");
+					i += 2;
+					continue;
+				}
+				if (src[i] === "\n") line++;
+				raw += src[i];
+				i++;
+			}
+			if (expectRegExpArg && quote !== "`") {
+				// recover the regex source from the string literal (undo its `\` escapes)
+				found.push({line: startLine, pattern: raw.replace(/\\(.)/g, "$1")});
+			}
+			prevSignificant = quote;
+			word = "";
+			lastWord = "";
+			expectRegExpArg = false;
+			continue;
+		}
+		// regex literal
+		if (ch === "/") {
+			const wordBefore = word || lastWord;
+			const startsRegex =
+				prevSignificant === "" ||
+				REGEX_PRECEDERS.has(prevSignificant) ||
+				REGEX_PRECEDING_KEYWORDS.has(wordBefore);
+			if (startsRegex) {
+				let j = i + 1;
+				let cls = false;
+				let ok = false;
+				const startLine = line;
+				while (j < src.length) {
+					const c = src[j];
+					if (c === "\\") {
+						j += 2;
+						continue;
+					}
+					if (c === "\n") break; // unterminated on this line — not a regex
+					if (cls) {
+						if (c === "]") cls = false;
+					} else if (c === "[") {
+						cls = true;
+					} else if (c === "/") {
+						ok = true;
+						break;
+					}
+					j++;
+				}
+				if (ok) {
+					found.push({line: startLine, pattern: src.slice(i + 1, j)});
+					i = j; // resume after the closing slash
+					prevSignificant = "/";
+					word = "";
+					lastWord = "";
+					expectRegExpArg = false;
+					continue;
+				}
+			}
+		}
+		if (/\s/.test(ch)) {
+			flushWord(); // whitespace ends an identifier but preserves prevSignificant
+			continue;
+		}
+		if (/[A-Za-z_$0-9]/.test(ch)) {
+			word += ch;
+			expectRegExpArg = false;
+		} else if (ch === "(") {
+			flushWord();
+			expectRegExpArg = lastWord === "RegExp"; // `RegExp(` / `new RegExp(`
+		} else {
+			flushWord();
+			expectRegExpArg = false; // only an IMMEDIATE string arg counts
+		}
+		prevSignificant = ch;
+	}
+	return found;
+};
+
+// ---------------------------------------------------------------------------
+// Verdict + report
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide the verdict over the gathered facts: fail-closed on zero scope, then gather
+ * both violation classes and fail if either is non-empty. The two checks are independent
+ * so one run surfaces every finding.
+ */
+export const judge = (
+	facts: CodeqlLintFacts,
+	baseline: CodeqlLintBaseline = EMPTY_BASELINE,
+): CodeqlLintVerdict => {
+	if (facts.workflows.length === 0 && facts.regexes.length === 0) {
+		return {pass: false, reason: "zero-scope"};
+	}
+	const grandfatheredWorkflows = new Set(baseline.grandfatheredWorkflows);
+	const grandfatheredRegexes = new Set(
+		baseline.grandfatheredRegexes.map((g) => `${g.path} ${g.pattern}`),
+	);
+	const workflowPermissions = facts.workflows
+		.map(judgeWorkflowPermissions)
+		.filter((f): f is WorkflowPermissionsFailure => f !== null)
+		.filter((f) => !grandfatheredWorkflows.has(f.path));
+	const redos: Array<RedosFailure> = [];
+	for (const r of facts.regexes) {
+		if (grandfatheredRegexes.has(`${r.path} ${r.pattern}`)) continue;
+		const kind = detectRedos(r.pattern);
+		if (kind !== null) redos.push({path: r.path, line: r.line, pattern: r.pattern, kind});
+	}
+	if (workflowPermissions.length === 0 && redos.length === 0) {
+		return {
+			pass: true,
+			workflowsChecked: facts.workflows.length,
+			regexesChecked: facts.regexes.length,
+		};
+	}
+	return {pass: false, reason: "violations", workflowPermissions, redos};
+};
+
+/** Render a human-readable report for either verdict polarity. */
+export const renderReport = (verdict: CodeqlLintVerdict): string => {
+	if (verdict.pass) {
+		return `codeql-lint: PASS — ${verdict.workflowsChecked} workflow(s) pin least-privilege permissions, ${verdict.regexesChecked} regex(es) clear of catastrophic backtracking.`;
+	}
+	if (verdict.reason === "zero-scope") {
+		return "codeql-lint: FAIL (fail-closed) — zero workflows AND zero source files in scope; the scan root is wrong (ADR 0092).";
+	}
+	const lines: Array<string> = [
+		"codeql-lint: FAIL — author-time CodeQL shapes found (fix before push):",
+	];
+	if (verdict.workflowPermissions.length > 0) {
+		lines.push(
+			"",
+			"  workflow-permissions (add an explicit least-privilege `permissions:` block, e.g. `permissions: { contents: read }`):",
+		);
+		for (const f of verdict.workflowPermissions) {
+			const where =
+				f.jobsMissing.length > 0
+					? ` — no top-level block and jobs missing one: ${f.jobsMissing.join(", ")}`
+					: " — no `permissions:` declared anywhere";
+			lines.push(`    ${f.path}${where}`);
+		}
+	}
+	if (verdict.redos.length > 0) {
+		lines.push(
+			"",
+			"  redos (catastrophic backtracking — restructure to linear/bounded, clamp input length):",
+		);
+		for (const f of verdict.redos) {
+			lines.push(`    ${f.path}:${f.line} [${f.kind}] /${f.pattern}/`);
+		}
+	}
+	return lines.join("\n");
+};

--- a/packages/pipeline-cli/src/tools/codeql-lint/codeql-lint.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeql-lint/codeql-lint.unit.test.ts
@@ -1,0 +1,223 @@
+/**
+ * The pure `codeql-lint` core — the ReDoS shape detector, the regex extractor, the
+ * workflow-permissions parser/judge, and the top-level `judge` (issue #2261).
+ * Deterministic transforms over strings / gathered facts, tested with no IO. The
+ * filesystem seam (`checkCodeqlLint` over a fake tree) is covered in `gate.unit.test.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	type CodeqlLintBaseline,
+	detectRedos,
+	extractRegexes,
+	judge,
+	judgeWorkflowPermissions,
+	parseWorkflowFacts,
+	type WorkflowFacts,
+} from "./codeql-lint.ts";
+
+describe("detectRedos — the two catastrophic-backtracking shapes", () => {
+	it.each([
+		"(a+)+",
+		"(a*)*",
+		"(a+)*",
+		"(a*)+",
+		"([a-z]+)+",
+		"([a-z0-9]+)*",
+		"(\\d+)+",
+		"(\\w*)*",
+		"(a+){2,}",
+		"((ab)+)+",
+		"^(x+)+$",
+		"(?:a+)+",
+		"(?<g>a+)+",
+	])("flags nested quantifier %s", (p) => {
+		expect(detectRedos(p)).toBe("nested-quantifier");
+	});
+
+	it.each([
+		"(a+|b)*",
+		"(a|a+)+",
+		"(\\d+|\\w+)*",
+		"(a|a)+",
+		"(ab|ab)*",
+	])("flags quantified/overlapping alternation %s", (p) => {
+		expect(detectRedos(p)).toBe("quantified-alternation");
+	});
+
+	it.each([
+		"(-[a-z0-9]+)*", // the standard kebab/slug — LINEAR (mandatory `-` separator disambiguates)
+		"^[a-z0-9]+(-[a-z0-9]+)*$", // the real repo _stage-name regex — must NOT flag
+		"(ab*c)+", // fixed prefix/suffix anchor the iterations
+		"(a+b)+", // trailing literal `b` disambiguates
+		"(a|b)+", // plain alternation, no overlap
+		"(a|b|c)*",
+		"(abc)+", // no inner quantifier
+		"(a+)", // inner quantifier but the group itself is NOT quantified
+		"a+b+c+", // sequential quantifiers, no nesting
+		"([a-z]+)", // quantified atom, un-quantified group
+		"(a{2,3})+", // bounded inner quantifier
+		"(a+){2}", // bounded OUTER quantifier
+		"https?://\\S+", // a URL pattern — no dangerous nesting
+	])("does not flag the linear/anchored pattern %s", (p) => {
+		expect(detectRedos(p)).toBeNull();
+	});
+
+	it("does not throw on unbalanced or empty input", () => {
+		expect(detectRedos("")).toBeNull();
+		expect(detectRedos("(a+")).toBeNull();
+		expect(detectRedos("a+)")).toBeNull();
+		expect(detectRedos("[(]+")).toBeNull(); // `(` inside a class is a literal
+	});
+});
+
+describe("extractRegexes — comment/string-aware", () => {
+	it("extracts a regex literal and its line", () => {
+		const src = "const re = /(a+)+/;\n";
+		expect(extractRegexes(src)).toEqual([{line: 1, pattern: "(a+)+"}]);
+	});
+
+	it("ignores a regex-looking sequence inside a string or comment", () => {
+		const src = ['const s = "/(a+)+/";', "// const c = /(b+)+/;", "/* /(c+)+/ */", ""].join("\n");
+		expect(extractRegexes(src)).toEqual([]);
+	});
+
+	it("does not misread division as a regex", () => {
+		const src = "const x = a / b / c;\n";
+		expect(extractRegexes(src)).toEqual([]);
+	});
+
+	it("extracts a new RegExp(string) pattern, unescaping the source string", () => {
+		const src = 'const re = new RegExp("(a+)+");\n';
+		expect(extractRegexes(src)).toContainEqual({line: 1, pattern: "(a+)+"});
+	});
+
+	it("keeps a `/` inside a char class from terminating the literal early", () => {
+		const src = "const re = /[/]+x/;\n";
+		expect(extractRegexes(src)).toEqual([{line: 1, pattern: "[/]+x"}]);
+	});
+});
+
+describe("workflow permissions", () => {
+	const wf = (over: Partial<WorkflowFacts>): WorkflowFacts => ({
+		path: ".github/workflows/x.yml",
+		hasTopLevelPermissions: false,
+		jobs: [],
+		...over,
+	});
+
+	it("passes a workflow with a top-level permissions block", () => {
+		expect(judgeWorkflowPermissions(wf({hasTopLevelPermissions: true}))).toBeNull();
+	});
+
+	it("passes a workflow where every job pins its own permissions", () => {
+		expect(
+			judgeWorkflowPermissions(
+				wf({
+					jobs: [
+						{name: "a", hasPermissions: true},
+						{name: "b", hasPermissions: true},
+					],
+				}),
+			),
+		).toBeNull();
+	});
+
+	it("fails and names the jobs missing a block", () => {
+		const f = judgeWorkflowPermissions(
+			wf({
+				jobs: [
+					{name: "a", hasPermissions: true},
+					{name: "b", hasPermissions: false},
+				],
+			}),
+		);
+		expect(f).not.toBeNull();
+		expect(f?.jobsMissing).toEqual(["b"]);
+	});
+
+	it("fails with an empty jobsMissing when nothing is pinned anywhere", () => {
+		expect(judgeWorkflowPermissions(wf({}))?.jobsMissing).toEqual([]);
+	});
+
+	it("parseWorkflowFacts reads top-level + per-job permissions", () => {
+		const yaml = [
+			"name: x",
+			"permissions:",
+			"  contents: read",
+			"jobs:",
+			"  build:",
+			"    permissions:",
+			"      contents: read",
+			"  test:",
+			"    runs-on: ubuntu-latest",
+		].join("\n");
+		const facts = parseWorkflowFacts(".github/workflows/x.yml", yaml);
+		expect(facts.hasTopLevelPermissions).toBe(true);
+		expect(facts.jobs).toEqual([
+			{name: "build", hasPermissions: true},
+			{name: "test", hasPermissions: false},
+		]);
+	});
+
+	it("parseWorkflowFacts fails closed on unparseable YAML", () => {
+		const facts = parseWorkflowFacts(".github/workflows/x.yml", "\t: : broken\n  - [");
+		expect(facts.hasTopLevelPermissions).toBe(false);
+		expect(facts.jobs).toEqual([]);
+	});
+});
+
+describe("judge — verdict + baseline grandfathering", () => {
+	it("fails closed on zero scope", () => {
+		expect(judge({workflows: [], regexes: []})).toEqual({pass: false, reason: "zero-scope"});
+	});
+
+	it("passes clean facts", () => {
+		const v = judge({
+			workflows: [{path: "w.yml", hasTopLevelPermissions: true, jobs: []}],
+			regexes: [{path: "a.ts", line: 1, pattern: "(a|b)+"}],
+		});
+		expect(v.pass).toBe(true);
+	});
+
+	it("fails on a net-new workflow + a catastrophic regex", () => {
+		const v = judge({
+			workflows: [{path: "new.yml", hasTopLevelPermissions: false, jobs: []}],
+			regexes: [{path: "a.ts", line: 3, pattern: "(x+)+"}],
+		});
+		expect(v.pass).toBe(false);
+		if (v.pass || v.reason !== "violations") throw new Error("expected violations");
+		expect(v.workflowPermissions.map((f) => f.path)).toEqual(["new.yml"]);
+		expect(v.redos.map((f) => f.kind)).toEqual(["nested-quantifier"]);
+	});
+
+	it("grandfathers a baselined workflow + regex (green despite pre-existing debt)", () => {
+		const baseline: CodeqlLintBaseline = {
+			grandfatheredWorkflows: ["legacy.yml"],
+			grandfatheredRegexes: [{path: "old.ts", pattern: "(x+)+"}],
+		};
+		const v = judge(
+			{
+				workflows: [{path: "legacy.yml", hasTopLevelPermissions: false, jobs: []}],
+				regexes: [{path: "old.ts", line: 9, pattern: "(x+)+"}],
+			},
+			baseline,
+		);
+		expect(v.pass).toBe(true);
+	});
+
+	it("still fails a NEW violation while a baselined one is grandfathered", () => {
+		const v = judge(
+			{
+				workflows: [
+					{path: "legacy.yml", hasTopLevelPermissions: false, jobs: []},
+					{path: "new.yml", hasTopLevelPermissions: false, jobs: []},
+				],
+				regexes: [],
+			},
+			{grandfatheredWorkflows: ["legacy.yml"], grandfatheredRegexes: []},
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass || v.reason !== "violations") throw new Error("expected violations");
+		expect(v.workflowPermissions.map((f) => f.path)).toEqual(["new.yml"]);
+	});
+});

--- a/packages/pipeline-cli/src/tools/codeql-lint/command.ts
+++ b/packages/pipeline-cli/src/tools/codeql-lint/command.ts
@@ -1,0 +1,86 @@
+/**
+ * The `codeql-lint` tool — `pipeline-cli codeql-lint check [--root <d>]` (issue #2261).
+ *
+ * The author-time (pre-push) shift-left for the two COMMON CodeQL findings that keep
+ * blocking net-new-artifact PRs at ship — never at `review-code`, which does not run
+ * CodeQL: a workflow missing a least-privilege `permissions:` block (PR #2251) and a
+ * regex with catastrophic backtracking (ReDoS, PR #2258). It is a deterministic local
+ * static check — NO network, NO CodeQL — that catches the common shapes cheaply so the
+ * fix lands before CI, not after a full repair → re-review → re-ship cycle.
+ *
+ *   pipeline-cli codeql-lint check              # gate: exit non-zero on any finding / zero scope
+ *   pipeline-cli codeql-lint check --root <d>   # point at a specific repo root (else: walk up for one)
+ *
+ * The scan/IO lives in `gate.ts` and the decision in the pure core `codeql-lint.ts`;
+ * this file wires them to the CLI (mirrors `design-token-guard` / `fanout-guard`). With
+ * no --root the repo root is resolved by walking UP from cwd for a workspace marker (so
+ * `pnpm --filter <pkg> …`, whose cwd is the package dir, scans the whole repo).
+ *
+ * Exit-code contract (a DEDICATED gate-fail code, like `leak-guard` = 2 / `ref-guard` = 3):
+ *   0 = clean; 2 = a real finding (a workflow missing permissions / a catastrophic regex);
+ *   any OTHER non-zero (1, 127, the #1798 unlinked-dep remediation) = the check could not
+ *   RUN. The pre-push hook keys off code 2 to fail-CLOSED on a finding but fail-OPEN on an
+ *   absent toolchain — so a lean/stripped-PATH worktree is never bricked (CodeQL at CI/ship
+ *   remains the backstop). `CheckFailed` is caught inside the handler (not at the bin's run
+ *   boundary) so the contract survives folding into the shared `pipeline-cli` bin, which
+ *   provides only `NodeServices.layer`.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../doc-links/doc-links.ts";
+import {type CheckFailed, checkCodeqlLint} from "./gate.ts";
+
+// Dedicated gate-fail code (distinct from an infra/IO failure) so the pre-push hook can
+// fail-closed on a finding yet fail-open when the check can't run — see the exit-code
+// contract above (the leak-guard=2 / ref-guard=3 idiom).
+const GATE_FAIL_EXIT_CODE = 2;
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root to scan (default: walk up for a workspace marker)"),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
+// error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		const root = resolveRoot(rootOpt);
+		yield* checkCodeqlLint(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail on a workflow missing least-privilege permissions or a catastrophic-backtracking regex (the two common CodeQL shapes, author-time)",
+	),
+);
+
+export const codeqlLintCommand = Command.make("codeql-lint").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed pre-push gate: shift-left the two common CodeQL findings (workflow-permissions + ReDoS) to author time (issue #2261)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/codeql-lint/gate.ts
+++ b/packages/pipeline-cli/src/tools/codeql-lint/gate.ts
@@ -1,0 +1,180 @@
+/**
+ * The `codeql-lint` filesystem gate (issue #2261) — the IO seam behind the two
+ * author-time CodeQL-shape checks, split from `command.ts` so the pure core is crossable
+ * in unit tests over a fake repo dir rather than only by spawning the bin (the
+ * core-in-its-own-file idiom; #855).
+ *
+ * `checkCodeqlLint` is the pre-push / CI gate: it walks `.github/workflows/*.{yml,yaml}`
+ * for permissions facts and the documented TS/JS source roots for regex literals, then
+ * delegates the verdict to the pure core (`codeql-lint.ts`). It fails `CheckFailed`
+ * (exit non-zero) on any workflow missing a least-privilege `permissions:` block or any
+ * catastrophic-backtracking regex, or on zero scope (fail-closed, ADR 0092). A directory/
+ * file IO failure is an `IoError` (also non-zero — both failures, undistinguished, per
+ * the bin's contract).
+ *
+ * SCOPE (documented, no silent caps — skipped dirs are logged to stderr):
+ *   - workflows: `.github/workflows/*.{yml,yaml}` (case-insensitive suffix).
+ *   - source: `.ts/.tsx/.js/.jsx/.mjs/.cjs` under `apps/`, `packages/`, `infra/`,
+ *     skipping `node_modules`, `dist`, `build`, `coverage`, `.git`, `tests`/`__tests__`
+ *     dirs, and any `*.d.ts` / `*.test.*` / `*.spec.*` file. Test files are out of scope
+ *     on purpose: ReDoS-on-uncontrolled-data is a runtime-path concern, and a test may
+ *     legitimately carry an adversarial regex fixture (e.g. this tool's own tests).
+ */
+import {existsSync, readdirSync, readFileSync} from "node:fs";
+import {join, relative, sep} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {
+	type CodeqlLintBaseline,
+	type CodeqlLintFacts,
+	EMPTY_BASELINE,
+	extractRegexes,
+	judge,
+	parseWorkflowFacts,
+	type RegexLiteral,
+	renderReport,
+	type WorkflowFacts,
+} from "./codeql-lint.ts";
+
+/** A directory/file IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+const WORKFLOWS_DIR = join(".github", "workflows");
+const BASELINE_PATH = join(".github", "codeql-lint-baseline.json");
+/** The TS/JS roots the regex scan descends (documented; skips logged, no silent caps). */
+const SOURCE_ROOTS = ["apps", "packages", "infra"] as const;
+const SKIP_DIRS = new Set([
+	"node_modules",
+	"dist",
+	"build",
+	"coverage",
+	".git",
+	"tests",
+	"__tests__",
+]);
+const SOURCE_EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"] as const;
+
+/** Repo-relative POSIX path — the key reports use. */
+const toRel = (root: string, abs: string): string => relative(root, abs).split(sep).join("/");
+
+const isWorkflowFile = (name: string): boolean => {
+	const lower = name.toLowerCase();
+	return lower.endsWith(".yml") || lower.endsWith(".yaml");
+};
+
+const isSourceFile = (name: string): boolean =>
+	!name.endsWith(".d.ts") &&
+	!/\.(test|spec)\.[cm]?[jt]sx?$/.test(name) &&
+	SOURCE_EXTS.some((ext) => name.endsWith(ext));
+
+/** Gather every workflow file's permissions facts. Missing dir ⇒ no workflows (not an error). */
+const gatherWorkflowFacts = (root: string): Effect.Effect<ReadonlyArray<WorkflowFacts>, IoError> =>
+	Effect.try({
+		try: () => {
+			const dir = join(root, WORKFLOWS_DIR);
+			if (!existsSync(dir)) return [];
+			const out: Array<WorkflowFacts> = [];
+			for (const entry of readdirSync(dir, {withFileTypes: true})) {
+				if (!entry.isFile() || !isWorkflowFile(entry.name)) continue;
+				const abs = join(dir, entry.name);
+				out.push(parseWorkflowFacts(toRel(root, abs), readFileSync(abs, "utf8")));
+			}
+			return out;
+		},
+		catch: (cause) => new IoError({path: join(root, WORKFLOWS_DIR), cause}),
+	});
+
+/**
+ * Walk a source root, collecting regex literals from every in-scope TS/JS file. Logs
+ * each skipped directory name-class to stderr (no silent caps, ADR 0092) via `skipped`.
+ */
+const walkSource = (dir: string, root: string, acc: Array<RegexLiteral>): void => {
+	for (const entry of readdirSync(dir, {withFileTypes: true})) {
+		const abs = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (SKIP_DIRS.has(entry.name)) continue;
+			walkSource(abs, root, acc);
+		} else if (entry.isFile() && isSourceFile(entry.name)) {
+			const path = toRel(root, abs);
+			for (const r of extractRegexes(readFileSync(abs, "utf8"))) {
+				acc.push({path, line: r.line, pattern: r.pattern});
+			}
+		}
+	}
+};
+
+/**
+ * Read the grandfather baseline (`.github/codeql-lint-baseline.json`). A MISSING file is
+ * the empty baseline — strictest posture, nothing grandfathered (a fresh repo pins every
+ * new workflow); a PRESENT-but-malformed file fails closed (a broken allow-list is a
+ * broken scope assumption, not a vacuous pass — ADR 0092).
+ */
+const readBaseline = (root: string): Effect.Effect<CodeqlLintBaseline, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const path = join(root, BASELINE_PATH);
+		if (!existsSync(path)) return EMPTY_BASELINE;
+		const text = yield* Effect.try({
+			try: () => readFileSync(path, "utf8"),
+			catch: (cause) => new IoError({path, cause}),
+		});
+		const parsed = yield* Effect.try({
+			try: () => JSON.parse(text) as Partial<CodeqlLintBaseline>,
+			catch: (cause) => new IoError({path, cause}),
+		});
+		if (
+			!Array.isArray(parsed.grandfatheredWorkflows) ||
+			!Array.isArray(parsed.grandfatheredRegexes)
+		) {
+			return yield* Effect.fail(
+				new CheckFailed({
+					reason: `codeql-lint: ${BASELINE_PATH} is missing grandfatheredWorkflows / grandfatheredRegexes — the allow-list is broken, fail-closed (ADR 0092).`,
+				}),
+			);
+		}
+		return {
+			grandfatheredWorkflows: parsed.grandfatheredWorkflows,
+			grandfatheredRegexes: parsed.grandfatheredRegexes,
+		};
+	});
+
+const gatherRegexes = (root: string): Effect.Effect<ReadonlyArray<RegexLiteral>, IoError> =>
+	Effect.try({
+		try: () => {
+			const acc: Array<RegexLiteral> = [];
+			for (const r of SOURCE_ROOTS) {
+				const base = join(root, r);
+				if (!existsSync(base)) continue;
+				walkSource(base, root, acc);
+			}
+			return acc;
+		},
+		catch: (cause) => new IoError({path: root, cause}),
+	});
+
+/**
+ * The pre-push / CI gate: succeed when every workflow pins least-privilege permissions
+ * and no regex admits catastrophic backtracking, else `CheckFailed`. Fails closed on
+ * zero scope (ADR 0092). The scanned scope (workflow + source-root skip set) is emitted
+ * so "what did the gate look at" is answerable from the run log.
+ */
+export const checkCodeqlLint = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		yield* Console.error(
+			`codeql-lint: scanning ${WORKFLOWS_DIR}/*.{yml,yaml} + ${SOURCE_ROOTS.join("/")} for *.{${SOURCE_EXTS.map((e) => e.slice(1)).join(",")}} (skipping ${[...SKIP_DIRS].join(", ")}, *.d.ts, *.test.*, *.spec.*).`,
+		);
+		const baseline = yield* readBaseline(root);
+		const workflows = yield* gatherWorkflowFacts(root);
+		const regexes = yield* gatherRegexes(root);
+		const facts: CodeqlLintFacts = {workflows, regexes};
+		const verdict = judge(facts, baseline);
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/codeql-lint/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeql-lint/gate.unit.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `checkCodeqlLint` over a fake repo dir — the filesystem-seam test (#855, issue #2261).
+ * The pure verdict is covered in `codeql-lint.unit.test.ts`; this crosses the IO gate
+ * over a real temp tree, asserting the exit-code contract from observable outcomes —
+ * never by spawning the bin.
+ */
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {dirname, join} from "node:path";
+import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import {CheckFailed, checkCodeqlLint} from "./gate.ts";
+
+/** The gate-fail reason, or "" for a non-CheckFailed failure. */
+const failReason = (exit: Exit.Exit<void, unknown>): string => {
+	if (!Exit.isFailure(exit)) return "";
+	const err = Cause.squash(exit.cause);
+	return err instanceof CheckFailed ? err.reason : "";
+};
+
+let root: string;
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "codeql-lint-"));
+});
+afterEach(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+
+const write = (rel: string, contents: string) => {
+	const abs = join(root, rel);
+	mkdirSync(dirname(abs), {recursive: true});
+	writeFileSync(abs, contents, "utf8");
+};
+
+const WORKFLOW_OK = [
+	"name: x",
+	"permissions:",
+	"  contents: read",
+	"jobs:",
+	"  a:",
+	"    runs-on: x",
+].join("\n");
+const WORKFLOW_BAD = ["name: y", "jobs:", "  a:", "    runs-on: x"].join("\n");
+
+const run = (baseline?: object) => {
+	if (baseline) write(".github/codeql-lint-baseline.json", JSON.stringify(baseline));
+	return Effect.runPromiseExit(checkCodeqlLint(root));
+};
+
+describe("checkCodeqlLint", () => {
+	it("fails closed on zero scope (no workflows, no source)", async () => {
+		const exit = await run();
+		expect(Exit.isFailure(exit)).toBe(true);
+	});
+
+	it("passes a clean tree (pinned workflow + linear regex)", async () => {
+		write(".github/workflows/x.yml", WORKFLOW_OK);
+		write("packages/p/a.ts", "export const re = /^[a-z]+(-[a-z]+)*$/;\n");
+		const exit = await run();
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("fails on a workflow missing permissions", async () => {
+		write(".github/workflows/y.yml", WORKFLOW_BAD);
+		const exit = await run();
+		expect(Exit.isFailure(exit)).toBe(true);
+		expect(failReason(exit)).toContain("workflow-permissions");
+	});
+
+	it("fails on a catastrophic regex in source", async () => {
+		write(".github/workflows/x.yml", WORKFLOW_OK);
+		write("apps/web/src/bad.ts", "export const re = /(\\w+)+$/;\n");
+		const exit = await run();
+		expect(Exit.isFailure(exit)).toBe(true);
+	});
+
+	it("grandfathers a baselined workflow", async () => {
+		write(".github/workflows/y.yml", WORKFLOW_BAD);
+		write("packages/p/a.ts", "export const ok = /(a|b)+/;\n");
+		const exit = await run({
+			grandfatheredWorkflows: [".github/workflows/y.yml"],
+			grandfatheredRegexes: [],
+		});
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("fails closed on a malformed baseline file", async () => {
+		write(".github/workflows/x.yml", WORKFLOW_OK);
+		const exit = await run({grandfatheredWorkflows: "not-an-array"});
+		expect(Exit.isFailure(exit)).toBe(true);
+	});
+
+	it("skips node_modules / dist / *.d.ts when walking source", async () => {
+		write(".github/workflows/x.yml", WORKFLOW_OK);
+		write("packages/p/node_modules/dep/bad.ts", "export const re = /(a+)+/;\n");
+		write("packages/p/dist/bad.js", "export const re = /(a+)+/;\n");
+		write("packages/p/types.d.ts", "export const re: RegExp;\n");
+		const exit = await run();
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #2261.

## What

A new deterministic, local (**no network, not CodeQL**) `pipeline-cli codeql-lint check` that catches at **pre-push** the two COMMON CodeQL findings that keep blocking net-new-artifact PRs at ship — never at `review-code`, which does not run CodeQL — plus the `lefthook` pre-push leg that runs it. Shifts those findings left so the fix lands before CI, not after a full repair → re-review → re-ship cycle.

The two shapes (grounded in the two evidence PRs the issue cites):

1. **workflow-permissions** — CodeQL *"Workflow does not contain permissions"* (PR #2251). A GitHub Actions workflow whose `GITHUB_TOKEN` scope is not pinned least-privilege. Passes iff a `permissions:` block is declared at the top level **or** on every job.
2. **redos** — CodeQL *"Polynomial/exponential regular expression on uncontrolled data"* (PR #2258). Two textbook, **low-false-positive** shapes:
   - nested quantifier whose group body is *exactly* a single unbounded-quantified atom: `(a+)+`, `([a-z]+)*`, `(\d+){2,}`;
   - quantified / overlapping alternation: `(a+|b)*`, `(a|a)+`.
   The standard kebab/slug `(-[a-z0-9]+)*` is **linear** (each iteration forced to start with a literal `-`) and is deliberately **not** flagged — CodeQL does not flag it either. This is what keeps the repo green.

## How (design — the `design-token-guard` idiom)

- `codeql-lint.ts` — pure, IO-free core: the ReDoS shape detector (`detectRedos`), a comment/string-aware regex extractor (`extractRegexes`, which folds `RegExp(...)` detection into the scanner so a `new RegExp(...)` inside a *string literal* is not falsely extracted), the workflow-permissions parser/judge, and the top-level `judge` with grandfather filtering.
- `gate.ts` — the filesystem seam: walk `.github/workflows/*.{yml,yaml}` + the TS/JS source roots (`apps`/`packages`/`infra`, skipping `node_modules`/`dist`/`build`/`coverage`/tests/`*.d.ts`/`*.test.*`), read the baseline, delegate to the core. Emits its scan surface (no silent caps, ADR 0092).
- `command.ts` — thin `effect/unstable/cli` wiring.
- `.github/codeql-lint-baseline.json` — grandfathers the 12 pre-existing workflows lacking a `permissions:` block (CodeQL debt default-setup already carries as unrelated alerts), so `check` is **green on main** and fails only on NEW violations. A missing baseline is the strictest posture; a malformed one fails closed.
- **Dedicated gate-fail exit code 2** (the `leak-guard`=2 / `ref-guard`=3 idiom) lets the `lefthook` pre-push leg fail-**closed** on a real finding but fail-**open** on an absent toolchain (lean/stripped-PATH worktree), with CodeQL at CI as the backstop.

## Verification

- `pipeline-cli` unit suite green: **965 passed** (55 new across `codeql-lint.unit.test.ts` + `gate.unit.test.ts`).
- `pnpm typecheck` + `pnpm lint` clean.
- `codeql-lint check` run against the repo: **PASS** — 20 workflows pin least-privilege permissions (12 grandfathered), 271 non-test regexes clear of catastrophic backtracking. **No real existing violations** (the 4 `_stage-name` slug regexes are correctly recognized as linear, not flagged).

## Routing

§CP — touches `packages/pipeline-cli/` (control-plane) + `lefthook.yml`. No new §CP path (pipeline-cli is already control-plane-owned), so no CODEOWNERS change. → reviewed, then **human-merged**; not self-merged or enqueued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)