### PR TITLE
fix(web): clamp long pano feed titles to one line (#2303)

### DIFF
--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -94,6 +94,15 @@
 	font-weight: 500;
 	color: var(--text-primary);
 	text-decoration: none;
+	/* Clamp a long feed title to one line so the row stays uniform and the feed
+	   scans (#2303); the full title lives on the detail-page h1 + this link's
+	   `title`. `min-width: 0` lets the anchor shrink below its content — without it
+	   the `flex-wrap` title-row grows it full-width instead of ellipsizing. */
+	min-width: 0;
+	display: -webkit-box;
+	-webkit-line-clamp: 1;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
 }
 .kp-pano-post__title:hover {
 	color: var(--accent);

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -74,7 +74,7 @@ export function PanoPostCard({
 							))}
 						</span>
 					) : null}
-					<a className="kp-pano-post__title kp-prose" href={data.url ?? href}>
+					<a className="kp-pano-post__title kp-prose" href={data.url ?? href} title={data.title}>
 						{data.title}
 					</a>
 					{data.host ? (


### PR DESCRIPTION
Fixes #2303

## What

Long pano post titles rendered full-width in the feed, wrapping across the whole row and dominating the scan rhythm (founder-observed). This clamps the feed title to a single line with an ellipsis.

## Changes

- **`apps/web/src/components/pano/PanoPost.css`** — `.kp-pano-post__title` now clamps to one line via the existing `-webkit-line-clamp` idiom (`display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical; overflow: hidden`), reused verbatim from `.kp-sozluk-term-row__excerpt` (Pillar 2 — one system, no second treatment). The `--t-h-feed` type role is unchanged. Added `min-width: 0` so the anchor shrinks below its content instead of growing the `flex-wrap` `.kp-pano-post__title-row` full-width (the flex-item shrink gotcha).
- **`apps/web/src/components/pano/PanoPostCard.tsx`** — added a `title={data.title}` attribute on the feed-title anchor so the full title stays available on hover / to assistive tech.

## Full title stays available

- The detail-page `<h1>` in `PanoPostHeader.tsx` is **untouched** — the full title still renders there.
- The truncated feed link exposes the full title via the new `title` attribute.

## Acceptance criteria

- [x] Long feed title truncates with an ellipsis (single-line clamp, matching the sözlük 1-line precedent).
- [x] Full title available: untruncated on the detail page + `title` attr on the feed link.
- [x] Tags + site label in `.kp-pano-post__title-row` still render next to the truncated title (single-line clamp keeps the anchor inline; `align-items: baseline` + `flex-wrap` place the trailing site label as before).
- [x] CSS-only truncation, `--t-h-feed` unchanged, existing clamp idiom reused (no second treatment).
- [x] Short titles visually unchanged.

## Checks (local, green)

- `pnpm typecheck` — 27/27 pass
- `pnpm lint` (biome) — clean
- `pipeline-cli design-token-guard check` — 51 CSS files / 1452 refs resolve, no raw-px regression

## Design-law

Truncation is an overflow treatment, not a type change (`--t-h-feed` kept). Reuses the single in-repo clamp idiom (Pillar 2). CSS-only, no JS measurement (Pillar 1) — `PanoSkeleton` row height is unaffected (a clamped title makes real row height *more* uniform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
