### PR TITLE
perf(web): extend the two-tier fate provider to /profile — decouple Katkıların first paint (#2188)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -131,7 +131,20 @@ vi.mock("./auth/useMe", () => ({
 vi.mock("./pages/useProfileStats", () => ({useProfileStats: () => ({status: "idle"})}));
 vi.mock("./components/divan/useDivanAccess", () => ({useDivanAccess: () => false}));
 vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: () => 0}));
-vi.mock("./flags/useFlag", () => ({useFlag: () => ({value: false, status: "ok"})}));
+
+// Controllable flag mock. The eager `/profile` Katkıların skeleton (#2188) is gated on
+// the authorship-loop flag, so its tests flip `flags.authorshipLoop`; every other read
+// (and other flag key) stays off, matching the default the shell rendered under before.
+const flags = vi.hoisted(() => ({authorshipLoop: false}));
+vi.mock("./flags/useFlag", async () => {
+	const {PHOENIX_AUTHORSHIP_LOOP} = await import("./flags/keys");
+	return {
+		useFlag: (key: string) => ({
+			value: key === PHOENIX_AUTHORSHIP_LOOP ? flags.authorshipLoop : false,
+			loading: false,
+		}),
+	};
+});
 
 // Render the real App at a chosen route. Invariant 2's tests settle the session, which
 // commits FateProvider and mounts the routed page BELOW it — so they route to a
@@ -286,6 +299,55 @@ describe("Two-tier fate provider — /pano public first paint (#2285)", () => {
 		expect(authed).toHaveLength(1);
 		expect(authed[0]?.key).toBe("user-7");
 		expect(authed.map((m) => m.key)).not.toContain("anon");
+	});
+});
+
+// The two-tier decoupling extended to /profile (ADR 0167 / #2188): the identity-scoped
+// Katkıların read can't paint anon data pre-session, so /profile's eager tier paints a
+// SKELETON above the gate while `get-session` resolves, then the authed read below the
+// gate fills it in. Unlike /pano's tier it mounts NO FateClient — which is exactly what
+// keeps #438 preserved (no client above the gate ⇒ nothing to re-key anon→id).
+describe("Two-tier fate provider — /profile eager Katkıların skeleton (#2188)", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		flags.authorshipLoop = true;
+	});
+	afterEach(() => {
+		flags.authorshipLoop = false;
+		vi.clearAllMocks();
+	});
+
+	it("paints the Katkıların skeleton on /profile while the session isPending — before the authed gate commits", () => {
+		renderApp("/profile");
+
+		expect(screen.getByTestId("signal-loading")).toBeTruthy();
+		// It painted ABOVE the gate with NO FateClient committed — the authed tier is
+		// still deferred (isPending → null), and the eager tier mounts no client at all.
+		expect(fateMounts).toHaveLength(0);
+	});
+
+	it("#438: the eager /profile skeleton mounts NO FateClient — nothing to re-key anon→id", () => {
+		renderApp("/profile");
+		// The proof the eager tier can't reintroduce the #438 remount: it commits zero
+		// fate clients above the gate, so there is no anon-keyed client to later re-key to
+		// the resolved id. The authed FateProvider below is untouched (its once-on-settle
+		// mount is pinned by the invariant-2 tests above).
+		expect(fateMounts).toHaveLength(0);
+		expect(screen.getByTestId("signal-loading")).toBeTruthy();
+	});
+
+	it("scoped: a non-profile route paints NO eager Katkıların skeleton", () => {
+		renderApp("/sozluk");
+		expect(screen.queryByTestId("signal-loading")).toBeNull();
+		expect(fateMounts).toHaveLength(0);
+	});
+
+	it("flag-off: /profile paints NO eager skeleton — no flash of a section the settled page won't render", () => {
+		flags.authorshipLoop = false;
+		renderApp("/profile");
+		expect(screen.queryByTestId("signal-loading")).toBeNull();
+		expect(fateMounts).toHaveLength(0);
 	});
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,6 +18,7 @@ import {AppShell, Main} from "./components/layout/AppShell";
 import {Footer} from "./components/layout/Footer";
 import {Topbar} from "./components/layout/Topbar";
 import {actorLabel} from "./components/moderation/actor-identity";
+import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
@@ -99,6 +100,13 @@ function Layout() {
 	const eagerPanoHost = panoSiteMatch?.params.host;
 	const showEagerPanoFeed = session.isPending && (panoMatch != null || panoSiteMatch != null);
 
+	// The same two-tier decoupling (ADR 0167) extended to `/profile` (#2188): paint the
+	// Katkıların skeleton above the gate while `get-session` resolves. Why it is a
+	// skeleton (not anon data) and how it stays #438-safe with no fate client lives on
+	// `EagerProfileContributionSkeleton`.
+	const profileMatch = useMatch("/profile");
+	const showEagerProfileSkeleton = session.isPending && profileMatch != null;
+
 	// Echo the active query in the header input, but only on the results page — off
 	// `/search` the box keeps its empty `ara…` placeholder (#2199).
 	const searchQuery =
@@ -157,6 +165,7 @@ function Layout() {
 								<PanoFeed {...(eagerPanoHost ? {host: eagerPanoHost} : {})} />
 							</PublicFateProvider>
 						) : null}
+						{showEagerProfileSkeleton ? <EagerProfileContributionSkeleton /> : null}
 						{/* The routed content + fate-dependent chips live below the session
 						    gate — FateProvider keeps its #438 remount guard (first & only key
 						    is the resolved identity), while the shell frame above already

--- a/apps/web/src/auth/client.ts
+++ b/apps/web/src/auth/client.ts
@@ -3,6 +3,7 @@
 // Mirrors worker/features/pasaport/better-auth-live.ts.
 import type {} from "@better-auth/core";
 import type {} from "better-auth/client";
+import {inferAdditionalFields} from "better-auth/client/plugins";
 import type {} from "better-auth/react";
 import {createAuthClient} from "better-auth/react";
 import type {} from "better-call";
@@ -11,6 +12,16 @@ import type {} from "zod/v4/core";
 const TOKEN_KEY = "phoenix.bearer_token";
 
 export const authClient = createAuthClient({
+	// Type the server-managed `username` additional field (worker
+	// `better-auth-live.ts` `additionalUserFields`, `input:false`, returned on the
+	// session user) onto the client session `user`, so a read of the settled owner
+	// identity can use `session.data.user.username` directly instead of paying a
+	// second canonical-`me` round-trip to learn it (#2188). The plugin is type-only
+	// (its factory returns no endpoints/hooks — no runtime behavior); the schema form
+	// keeps the worker auth instance out of the SPA bundle. `username` is immutable
+	// once set, so this session value equals `me.username` — see `useMe` for the one
+	// transient (right after a `setUsername` write) where the canonical row still wins.
+	plugins: [inferAdditionalFields({user: {username: {type: "string", required: false}}})],
 	fetchOptions: {
 		auth: {
 			type: "Bearer",

--- a/apps/web/src/components/profile/ProfileContributionSignal.tsx
+++ b/apps/web/src/components/profile/ProfileContributionSignal.tsx
@@ -22,6 +22,8 @@ import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {Profile} from "../../../worker/features/fate/views";
 import {Screen} from "../../fate/Screen";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
 import {EmptyState} from "../ui/EmptyState";
 import {ContributionRow, ContributionView} from "./ContributionRow";
 import {CONTRIBUTIONS_EMPTY, CONTRIBUTIONS_HEADING} from "./profileContributions";
@@ -60,16 +62,44 @@ function SignalShell({children}: {children: ReactNode}) {
 	);
 }
 
+/**
+ * The Katkıların loading skeleton — shared by the `<Screen>` fallback below and the
+ * eager pre-session paint above the gate (ADR 0167 / #2188), so the skeleton the
+ * always-anonymous first paint shows is byte-identical to the one the settled authed
+ * read shows: no visual jump as the eager tier hands off to the below-gate read.
+ */
+export function ProfileContributionSkeleton() {
+	return (
+		<SignalShell>
+			<p className="kp-signal__status" data-testid="signal-loading">
+				yükleniyor…
+			</p>
+		</SignalShell>
+	);
+}
+
+/**
+ * The eager Katkıların skeleton the `/profile` route paints ABOVE the session gate
+ * (mounted by `Layout` while `get-session` is still pending), the two-tier decoupling
+ * of ADR 0167 extended to `/profile` (#2188). Unlike `/pano`'s eager tier it carries
+ * NO fate client: the owner's own contributions are identity-scoped (the resolver
+ * shows the owner their still-sandboxed rows), so the real read must stay on the authed
+ * client below the gate — pre-session there is only a skeleton to paint, no anon data.
+ * Mounting no `FateClient` is also what makes it #438-safe by construction: with no
+ * client above the gate there is nothing to re-key anon→id.
+ *
+ * Gated on the authorship-loop flag so a flag-off (rollback) load never flashes a
+ * Katkıların section the settled page won't render.
+ */
+export function EagerProfileContributionSkeleton() {
+	const {value: authorshipLoop} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
+	return authorshipLoop ? <ProfileContributionSkeleton /> : null;
+}
+
 export function ProfileContributionSignal({username}: {username: string}) {
 	return (
 		<Screen
-			fallback={
-				<SignalShell>
-					<p className="kp-signal__status" data-testid="signal-loading">
-						yükleniyor…
-					</p>
-				</SignalShell>
-			}
+			fallback={<ProfileContributionSkeleton />}
 			error={({code}) => (
 				<SignalShell>
 					<p className="kp-signal__status kp-signal__status--error" role="alert">

--- a/apps/web/src/pages/ProfilePage.test.tsx
+++ b/apps/web/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Precedence pins for `ProfilePage`'s `readUsername` — the load-bearing me-hop removal
+ * of #2188 (ADR 0167's two-tier decoupling extended to `/profile`). The counts + Katkıların
+ * reads key on the SESSION username the instant `FateProvider` commits, dropping the third
+ * serial `me?.username` round-trip that made the reads land ~822ms late.
+ *
+ * `App.test.tsx` mocks both `useMe` and `useProfileStats` inert, so it never exercises
+ * `readUsername`'s precedence — a silent revert to `me?.username` (reintroducing the serial
+ * waterfall) would pass every test there. These render the REAL `ProfilePage` and read back
+ * which username the two identity-scoped reads actually receive: the counts read via the
+ * `useProfileStats` argument, and the contributions read via the `ProfileContributionSignal`
+ * `username` prop. The precedence test fails on that revert; the fallback test guards the
+ * `me` fallback for the brief post-`setUsername` window the session row lags.
+ */
+import {render, screen} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {ProfilePage} from "./ProfilePage";
+
+// Controllable session + `me` — the two identity sources `readUsername` chooses between.
+// `sessionUsername === undefined` models the absent session `username` (the post-setUsername
+// lag window); a string models the settled, present-and-correct value.
+let sessionUsername: string | null | undefined;
+let meUsername: string | null;
+
+vi.mock("../auth/client", () => ({
+	useSession: () => ({
+		data: {user: {id: "u-1", email: "owner@kamp.us", name: "Owner", username: sessionUsername}},
+		isPending: false,
+		refetch: vi.fn(async () => undefined),
+	}),
+	authClient: {signOut: vi.fn(), revokeSessions: vi.fn()},
+	clearBearerToken: vi.fn(),
+}));
+
+vi.mock("../auth/useMe", () => ({
+	useMe: () => ({
+		me: {
+			id: "me-1",
+			email: "owner@kamp.us",
+			name: "Owner",
+			image: null,
+			username: meUsername,
+			tier: null,
+			isModerator: false,
+		},
+		status: "ok",
+		loading: false,
+		refetch: vi.fn(async () => undefined),
+	}),
+}));
+
+// Capture the username the COUNTS read (`useProfileStats`) receives — the arg IS the
+// assertion. Stays `idle` so it touches no wire.
+const statsCalls: (string | null | undefined)[] = [];
+vi.mock("./useProfileStats", () => ({
+	useProfileStats: (username: string | null | undefined) => {
+		statsCalls.push(username);
+		return {status: "idle"};
+	},
+}));
+
+// Capture the username the CONTRIBUTIONS read receives via the real prop `ProfilePage`
+// passes; rendered inert (its own fate reads are pinned by ProfileContributionSignal's tests).
+vi.mock("../components/profile/ProfileContributionSignal", () => ({
+	ProfileContributionSignal: ({username}: {username: string}) => (
+		<div data-testid="contrib-username">{username}</div>
+	),
+}));
+
+// Inert stubs for the fate-touching / dialog children — not under test here.
+vi.mock("../components/profile/CaylakStatusBlock", () => ({CaylakStatusBlock: () => null}));
+vi.mock("../components/profile/DeleteAccountDialog", () => ({DeleteAccountDialog: () => null}));
+vi.mock("../components/profile/ProfileHeader", () => ({ProfileHeader: () => null}));
+
+// Flag ON so the Katkıların contribution signal renders and its `username` prop is observable;
+// the counts read fires regardless of the flag.
+vi.mock("../flags/useFlag", () => ({useFlag: () => ({value: true, loading: false})}));
+
+// Appearance controls need their providers; stub the hooks inert — irrelevant to `readUsername`.
+vi.mock("../lib/theme", () => ({useTheme: () => ({choice: "auto", setChoice: vi.fn()})}));
+vi.mock("../lib/density", () => ({useDensity: () => ({choice: "normal", setChoice: vi.fn()})}));
+
+// Keep react-fate's real `view` (used at module load for `SetDisplayNameView`); stub the
+// client hook so no transport is built. `fate.mutations` is only touched by onSaveName, never render.
+vi.mock("react-fate", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-fate")>();
+	return {...actual, useFateClient: () => ({mutations: {}}) as never};
+});
+
+function renderProfile() {
+	return render(
+		<MemoryRouter initialEntries={["/profile"]}>
+			<ProfilePage />
+		</MemoryRouter>,
+	);
+}
+
+describe("ProfilePage readUsername precedence (#2188 — the me-hop removal)", () => {
+	beforeEach(() => {
+		statsCalls.length = 0;
+	});
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("keys the counts + contributions reads on the SESSION username, not the round-tripped me row", () => {
+		// The session username and the canonical `me` row DIVERGE. The win is reading off the
+		// session value (available the instant FateProvider commits), never the later `me` hop.
+		sessionUsername = "session-uname";
+		meUsername = "stale-me-uname";
+
+		renderProfile();
+
+		// REGRESSION: a silent revert of `readUsername` to `me?.username` reintroduces the serial
+		// waterfall — the counts read would receive "stale-me-uname" and this fails.
+		expect(statsCalls.at(-1)).toBe("session-uname");
+		expect(screen.getByTestId("contrib-username").textContent).toBe("session-uname");
+	});
+
+	it("falls back to me.username when the session username is absent (the post-setUsername lag window)", () => {
+		// Right after a setUsername write the session row still lags the just-written username, so
+		// `session.data.user.username` is absent; the read falls back to the canonical `me` row.
+		sessionUsername = undefined;
+		meUsername = "canonical-me-uname";
+
+		renderProfile();
+
+		expect(statsCalls.at(-1)).toBe("canonical-me-uname");
+		expect(screen.getByTestId("contrib-username").textContent).toBe("canonical-me-uname");
+	});
+});

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -39,7 +39,16 @@ export function ProfilePage() {
 	const session = useSession();
 	const {me, status: meStatus, refetch: refetchMe} = useMe();
 	const fate = useFateClient();
-	const statsState = useProfileStats(me?.username);
+	const u = session.data?.user;
+	// The username the profile READS (counts + Katkıların contributions) key on. Prefer
+	// the settled session identity — available the instant `FateProvider` commits — so
+	// the read fires WITHOUT the extra canonical-`me` round-trip that used to gate it,
+	// the third serial hop that made Katkıların land ~1.8s late (#2188). `username` is
+	// server-managed + immutable once set (`better-auth-live.ts`), so the session value
+	// equals `me.username`; fall back to `me` only for the brief post-`setUsername`
+	// window where the session row still lags the just-written username (see `useMe`).
+	const readUsername = u?.username ?? me?.username ?? null;
+	const statsState = useProfileStats(readUsername);
 	// Reinforce the owner's own karma on their identity mirror, dark behind the
 	// authorship-loop flag (#1208). Flag off → no karma stat, profile as today.
 	const {value: authorshipLoop} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
@@ -53,12 +62,11 @@ export function ProfilePage() {
 	const [revokeAllError, setRevokeAllError] = useState<string | null>(null);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 
-	const u = session.data?.user;
 	// Route the identity mirror through the shared actor-label rule (#2126): the
 	// display name, falling back to the chosen @username, never the email-derived
 	// local-part the old code leaked. `me` (the canonical row) is the source for the
-	// username — the session user's `username` doesn't round-trip cleanly right after
-	// a setUsername write (see useMe); `me.name` is the display name.
+	// display username — the session user's `username` can briefly lag right after a
+	// setUsername write (see useMe); `me.name` is the display name.
 	const username = me?.username ?? null;
 	const name = actorLabel(me?.name ?? u?.name ?? null, username, "kullanıcı");
 	// The handle line is the chosen username; on the settings page the account is
@@ -177,8 +185,8 @@ export function ProfilePage() {
 				    dark behind the authorship-loop flag (#1204). Flag off → exactly
 				    today's profile. The owner sees their OWN sandboxed content here
 				    (the feed keys on authorId with no sandbox filter). */}
-				{authorshipLoop && me?.username ? (
-					<ProfileContributionSignal username={me.username} />
+				{authorshipLoop && readUsername ? (
+					<ProfileContributionSignal username={readUsername} />
 				) : null}
 
 				<section className="kp-profile__section">


### PR DESCRIPTION
Fixes #2188

Extends #2292 / ADR 0167's two-tier fate-provider decoupling to the `/profile` route. Per the live-prod Playwright trace on the issue ([diagnosis](https://github.com/kamp-us/phoenix/issues/2188#issuecomment-4899989436)), `/profile` "Katkıların" (contributions) painted ~1.8s after the rest of the page because first paint was a **3-stage serial, session-gated waterfall**: `session` (FateProvider gate, ~845ms) → `me` (~822ms) → `profile`+`contributions` (~1011ms, keyed on `me?.username`). #2292 fixed this class for `/pano` only.

## What changed

### 1. Drop the third `me?.username` hop (the measured win)
The Katkıların (`ProfileContributionSignal`) + counts (`useProfileStats`) reads keyed on the canonical `me` row's username — a **second authed round-trip**. They now key on `session.data.user.username`, available the instant `FateProvider` commits, so the profile+contributions query fires **~822ms earlier** (no longer waits behind `me`).

- `username` is server-managed and **immutable once set** (`better-auth-live.ts` `additionalUserFields`, `input:false`), so the session value equals `me.username`. `me` is kept only as the fallback for the brief post-`setUsername` window where the session row lags the just-written username (documented in `useMe`).
- Typed via the documented `inferAdditionalFields` client plugin — verified **runtime-inert** (its factory returns `{id, version, $InferServerPlugin:{}}`, no endpoints/hooks), schema form so the worker auth instance stays out of the SPA bundle.

### 2. Eager Katkıların skeleton above the gate (the perceived-paint win)
`Layout` now paints a Katkıların **skeleton above the session gate** while `get-session` resolves (scoped to `/profile`, flag-gated). Unlike `/pano`, the owner's contributions are **identity-scoped** (the resolver shows the owner their still-sandboxed rows), so there is no anon data to paint pre-session — only a skeleton; the real, sandbox-honest read stays on the authed client below the gate.

## How the #438 remount guard is preserved
`FateProvider` (its `if (session.isPending) return null` + `key={userId ?? "anon"}`) is **untouched**. The eager `/profile` tier carries **NO fate client at all** — so, by construction, there is nothing above the gate to re-key `anon → userId`. This is *stronger* than #2292's preservation (which mounts a distinct never-re-keyed public client): here there is no client to re-key. The authed router subtree still mounts exactly once, on the resolved identity. A new `App.test.tsx` pin asserts the eager `/profile` skeleton mounts **zero** `FateClient`s.

## Tests
- `apps/web/src/App.test.tsx` — 4 new `/profile` two-tier pins (eager skeleton paints while `isPending`; mounts zero FateClients / #438-safe; scoped to `/profile`; flag-off shows nothing). `pnpm exec vitest run --project client` → **109/109 pass** (incl. the preserved #2160/#438/#2285 pins).
- `pnpm typecheck` → clean (27/27) — confirms `session.data.user.username` is typed via the plugin.
- `pnpm exec biome check` → clean.

**e2e note:** `apps/web/tests/e2e/09-profile.spec.ts` covers `/profile` render (needs a deployed stage + CF creds, not runnable locally). No first-paint-timing e2e exists for `/profile`; the client-project mount pins are the mechanical guard for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)