### PR TITLE
refactor(pipeline-cli): parse JUnit XML with fast-xml-parser, not regex (#2311)

### DIFF
--- a/packages/pipeline-cli/package.json
+++ b/packages/pipeline-cli/package.json
@@ -37,6 +37,7 @@
 	"dependencies": {
 		"@effect/platform-node": "catalog:",
 		"effect": "catalog:",
+		"fast-xml-parser": "catalog:",
 		"yaml": "catalog:"
 	},
 	"devDependencies": {

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.ts
@@ -19,6 +19,7 @@
  */
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {XMLParser} from "fast-xml-parser";
 import type {TestFailure, TestSummary} from "./Manifest.ts";
 
 /** One crabbox command within a run: the command line + its own `exitCode`. */
@@ -83,71 +84,117 @@ export class CrabboxParseError extends Schema.TaggedErrorClass<CrabboxParseError
 
 const ZERO_TESTS: TestSummary = {total: 0, passed: 0, failed: 0, skipped: 0, failures: []};
 
-const unescapeXml = (value: string): string =>
-	value
-		.replace(/&lt;/g, "<")
-		.replace(/&gt;/g, ">")
-		.replace(/&quot;/g, '"')
-		.replace(/&apos;/g, "'")
-		.replace(/&amp;/g, "&");
+const ATTR_PREFIX = "@_";
+const TEXT_KEY = "#text";
 
-const attr = (tag: string, name: string): string | undefined => {
-	const match = tag.match(new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`));
-	return match?.[1];
+// A real XML parser replaces the former hand-rolled regex extraction: fast-xml-parser
+// decodes entities, unwraps CDATA, and handles self-closing/single-quoted/whitespace
+// variants natively — the classes the regex silently misparsed (a raw `<![CDATA[…]]>`
+// wrapper leaking into the failure message; the lookbehind workaround for self-closing
+// `<testcase/>`). Numbers stay strings (`parseTagValue`/`parseAttributeValue` off) so we
+// keep this module's own integer coercion; `isArray` forces the counted/case tags into
+// arrays for uniform folding regardless of single-vs-multiple cardinality.
+const JUNIT_TAGS = new Set(["testsuites", "testsuite", "testcase", "failure", "error"]);
+const xmlParser = new XMLParser({
+	ignoreAttributes: false,
+	attributeNamePrefix: ATTR_PREFIX,
+	parseTagValue: false,
+	parseAttributeValue: false,
+	isArray: (name) => JUNIT_TAGS.has(name),
+});
+
+type XmlNode = Record<string, unknown>;
+
+const isNode = (v: unknown): v is XmlNode =>
+	typeof v === "object" && v !== null && !Array.isArray(v);
+
+const asArray = <T>(v: T | T[] | undefined): T[] =>
+	v === undefined ? [] : Array.isArray(v) ? v : [v];
+
+/** Depth-first collect every node reachable under `tag`, in document order. */
+const collect = (node: unknown, tag: string, out: XmlNode[]): void => {
+	if (Array.isArray(node)) {
+		for (const item of node) collect(item, tag, out);
+		return;
+	}
+	if (!isNode(node)) return;
+	for (const [key, value] of Object.entries(node)) {
+		if (key === tag) for (const item of asArray(value)) if (isNode(item)) out.push(item);
+		collect(value, tag, out);
+	}
 };
 
-const intAttr = (tag: string, name: string): number => {
-	const raw = attr(tag, name);
-	if (raw === undefined) return 0;
-	const n = Number.parseInt(raw, 10);
+const intAttr = (node: XmlNode, name: string): number => {
+	const raw = node[`${ATTR_PREFIX}${name}`];
+	if (raw === undefined || raw === null) return 0;
+	const n = Number.parseInt(String(raw), 10);
 	return Number.isNaN(n) ? 0 : n;
 };
 
+const stringAttr = (node: XmlNode, name: string): string | undefined => {
+	const raw = node[`${ATTR_PREFIX}${name}`];
+	return raw === undefined ? undefined : String(raw);
+};
+
+/** The `<failure>`/`<error>` payload — an attributed node, or a bare text child. */
+const failureMessage = (payload: unknown): string => {
+	if (isNode(payload)) {
+		const attrMessage = stringAttr(payload, "message");
+		if (attrMessage !== undefined) return attrMessage;
+		return String(payload[TEXT_KEY] ?? "").trim();
+	}
+	return String(payload ?? "").trim();
+};
+
 /**
- * Tolerantly parse JUnit XML into a `TestSummary`. Prefers the `<testsuites>` /
- * `<testsuite>` rollup attributes (`tests`/`failures`/`errors`/`skipped`); the
- * `passed` total is the derived remainder. Each failing `<testcase>` contributes
- * a `{suite, name, message}` failure. A `null`/empty/garbage input yields the
- * zeroed summary — the degrade path that keeps a no-JUnit run from crashing.
+ * Tolerantly parse JUnit XML into a `TestSummary`. Prefers the `<testsuites>` rollup
+ * attributes (`tests`/`failures`/`errors`/`skipped`) over summing the individual
+ * `<testsuite>`s; `passed` is the derived remainder. Each failing `<testcase>` (one
+ * carrying a `<failure>` or `<error>`) contributes a `{suite, name, message}`. A
+ * `null`/empty/unparseable input yields the zeroed summary — the degrade path (never a
+ * throw) that keeps a no-JUnit run from crashing (ADR 0054 §2).
  */
 export const parseJUnit = (xml: string | null | undefined): TestSummary => {
 	if (xml === null || xml === undefined) return {...ZERO_TESTS};
 	const text = xml.trim();
 	if (text.length === 0) return {...ZERO_TESTS};
 
-	const suiteTags = [...text.matchAll(/<testsuites?\b[^>]*>/g)].map((m) => m[0]);
-	if (suiteTags.length === 0) return {...ZERO_TESTS};
+	let root: unknown;
+	try {
+		root = xmlParser.parse(text);
+	} catch {
+		return {...ZERO_TESTS};
+	}
+
+	const suitesRollups: XmlNode[] = [];
+	const suites: XmlNode[] = [];
+	collect(root, "testsuites", suitesRollups);
+	collect(root, "testsuite", suites);
+	if (suitesRollups.length === 0 && suites.length === 0) return {...ZERO_TESTS};
 
 	let total = 0;
 	let failed = 0;
 	let skipped = 0;
 	// A `<testsuites>` rollup already sums its child `<testsuite>`s; counting both
 	// would double the totals. Prefer the rollup when present, else sum the suites.
-	const rollup = suiteTags.find((t) => /^<testsuites\b/.test(t));
-	const counted = rollup ? [rollup] : suiteTags;
-	for (const tag of counted) {
-		total += intAttr(tag, "tests");
-		failed += intAttr(tag, "failures") + intAttr(tag, "errors");
-		skipped += intAttr(tag, "skipped");
+	const counted = suitesRollups.length > 0 ? [suitesRollups[0] as XmlNode] : suites;
+	for (const node of counted) {
+		total += intAttr(node, "tests");
+		failed += intAttr(node, "failures") + intAttr(node, "errors");
+		skipped += intAttr(node, "skipped");
 	}
 
 	const failures: TestFailure[] = [];
-	// `[^>]*?(?<!\/)` keeps the container form from swallowing a self-closing
-	// `<testcase .../>`: without the lookbehind the greedy `[^>]*` eats the `/`,
-	// matches the next `</testcase>`, and mis-attributes one case's failure to a
-	// sibling. A self-closing case carries no `<failure>`, so it's skipped anyway.
-	const caseRe = /<testcase\b([^>]*?(?<!\/))>([\s\S]*?)<\/testcase>|<testcase\b([^>]*)\/>/g;
-	for (const m of text.matchAll(caseRe)) {
-		const openAttrs = m[1] ?? m[3] ?? "";
-		const inner = m[2] ?? "";
-		const failTag = inner.match(/<(failure|error)\b([^>]*)(?:\/>|>([\s\S]*?)<\/\1>)/);
-		if (!failTag) continue;
-		const suite = attr(openAttrs, "classname") ?? attr(openAttrs, "class") ?? "";
-		const name = attr(openAttrs, "name") ?? "";
-		const attrMessage = attr(failTag[2] ?? "", "message");
-		const message =
-			attrMessage !== undefined ? unescapeXml(attrMessage) : unescapeXml((failTag[3] ?? "").trim());
-		failures.push({suite, name, message});
+	const cases: XmlNode[] = [];
+	collect(root, "testcase", cases);
+	for (const tc of cases) {
+		const payload = asArray(tc.failure)[0] ?? asArray(tc.error)[0];
+		if (payload === undefined) continue;
+		failures.push({
+			suite: stringAttr(tc, "classname") ?? stringAttr(tc, "class") ?? "",
+			name: stringAttr(tc, "name") ?? "",
+			message: failureMessage(payload),
+		});
 	}
 
 	const passed = Math.max(0, total - failed - skipped);

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.unit.test.ts
@@ -1,7 +1,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {CrabboxParseError, parseJUnit, parseRunSummaryJson} from "./crabbox.ts";
-import {passingJUnit, passingRunSummary} from "./fixtures.ts";
+import {failingJUnit, passingJUnit, passingRunSummary} from "./fixtures.ts";
 
 describe("parseRunSummaryJson (crabbox trust boundary)", () => {
 	it.effect("decodes a well-formed run-summary", () =>
@@ -66,6 +66,52 @@ describe("parseJUnit (tolerant)", () => {
 		const t = parseJUnit(xml);
 		assert.strictEqual(t.failed, 1);
 		assert.strictEqual(t.failures[0]?.message, "kaboom");
+	});
+
+	it("skips self-closing <testcase/> siblings and only counts a real failure", () => {
+		// The self-closing `<testcase name="ok"/>` sits directly before the failing case;
+		// the former regex needed a `(?<!\/)` lookbehind to stop the container form from
+		// swallowing it and mis-attributing `bad`'s failure to `ok`. The real parser
+		// distinguishes them structurally, so no workaround is needed.
+		const xml = `<testsuites name="vitest" tests="2" failures="1" errors="0" skipped="0">
+  <testsuite name="s" tests="2" failures="1" skipped="0">
+    <testcase classname="s" name="ok"/>
+    <testcase classname="s" name="bad"><failure message="boom"/></testcase>
+  </testsuite>
+</testsuites>`;
+		const t = parseJUnit(xml);
+		assert.strictEqual(t.total, 2);
+		assert.strictEqual(t.failed, 1);
+		assert.strictEqual(t.passed, 1);
+		assert.strictEqual(t.failures.length, 1);
+		assert.strictEqual(t.failures[0]?.name, "bad");
+		assert.strictEqual(t.failures[0]?.message, "boom");
+	});
+
+	it("unwraps a CDATA failure message (the regex left the <![CDATA[…]]> wrapper in)", () => {
+		// A CDATA body carries raw `<`/`&` the regex path could not decode: it captured the
+		// literal `<![CDATA[…]]>` markers into the message. The real parser strips them and
+		// yields the raw content — the correctness win that justifies the swap.
+		const xml = `<testsuites tests="1" failures="1" errors="0" skipped="0">
+  <testsuite name="s" tests="1" failures="1" skipped="0">
+    <testcase classname="s" name="cdata"><failure><![CDATA[expected a < b && c > d]]></failure></testcase>
+  </testsuite>
+</testsuites>`;
+		const t = parseJUnit(xml);
+		assert.strictEqual(t.failed, 1);
+		assert.strictEqual(t.failures[0]?.suite, "s");
+		assert.strictEqual(t.failures[0]?.name, "cdata");
+		assert.strictEqual(t.failures[0]?.message, "expected a < b && c > d");
+	});
+
+	it("folds the failingJUnit fixture: entity-decoded attribute message, rollup totals", () => {
+		const t = parseJUnit(failingJUnit);
+		assert.strictEqual(t.total, 3);
+		assert.strictEqual(t.failed, 1);
+		assert.strictEqual(t.passed, 2);
+		assert.strictEqual(t.failures[0]?.suite, "adapter.buildManifest");
+		assert.strictEqual(t.failures[0]?.name, "stamps commit");
+		assert.strictEqual(t.failures[0]?.message, "expected 'abc123' to equal 'def456'");
 	});
 
 	it("degrades to zero on null / empty / garbage", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ catalogs:
     fast-check:
       specifier: ^3.23.2
       version: 3.23.2
+    fast-xml-parser:
+      specifier: 5.8.0
+      version: 5.8.0
     jsdom:
       specifier: ^26.1.0
       version: 26.1.0
@@ -1079,6 +1082,9 @@ importers:
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92
+      fast-xml-parser:
+        specifier: 'catalog:'
+        version: 5.8.0
       yaml:
         specifier: 'catalog:'
         version: 2.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,9 @@ catalog:
   drizzle-orm: 1.0.0-rc.4
   effect: 4.0.0-beta.92
   fast-check: ^3.23.2
+  # Pinned to the exact 5.8.0 an existing lockfile parent already links (@distilled.cloud/aws +
+  # alchemy) so no third version enters the tree — the PR #535 frozen-lockfile rule.
+  fast-xml-parser: 5.8.0
   jsdom: ^26.1.0
   lefthook: ^2.1.9
   react: 19.2.6


### PR DESCRIPTION
Fixes #2311

## What & why

`parseJUnit` in `packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.ts` hand-rolled JUnit XML parsing with regexes (attribute extractor, `<testsuites?>` open-tag `matchAll`, a lookbehind-guarded testcase regex, and a manual `unescapeXml`). Regex-XML is the fragile-reimplementation shape — it silently misparses valid-but-unanticipated XML — and this parser feeds the run-evidence manifest that `ship-it`/`review-code` trust-gate on (ADR 0054, `.github/workflows/run-evidence.yml`). This is the anti-NIH swap: use a real parser.

`parseJUnit` now decodes with **fast-xml-parser** behind the **same signature and semantics** — a mechanical swap, no behavior change:
- rollup-preferred totals (`<testsuites>` attrs over summing `<testsuite>`s), `<error>` counted as failure,
- one `{suite, name, message}` per failing `<testcase>`,
- degrade-to-zero on `null`/empty/garbage/unparseable — still **never throws** (the parse is wrapped; ADR 0054 §2).

## Fixture-equivalence (AC 1 + 2)

The existing `crabbox.unit.test.ts` assertions (rollup fold, per-suite sums, `<error>`-as-failure, degrade-to-zero) pass **unmodified** — the manifest output is identical over the existing corpus. The full `@kampus/pipeline-cli` suite is green (910 tests).

Corpus extended (AC 3) with:
- a **self-closing `<testcase/>`** sibling directly before a real failure — the case the old `(?<!\/)` lookbehind existed to disambiguate; the real parser distinguishes them structurally.
- a **CDATA failure body** — a case the regex got *wrong*: it captured the literal `<![CDATA[…]]>` markers into the message. The parser strips them and yields the raw content. This is the correctness win that justifies the swap.
- the `failingJUnit` fixture folded end-to-end (entity-decoded `&apos;` attribute message).

## Catalog discipline (AC 4 — PR #535 rule)

`fast-xml-parser` is already a transitive dep at **5.7.3** (via `@aws-sdk/xml-builder`) and **5.8.0** (via `@distilled.cloud/aws` + `alchemy`). Cataloged at **5.8.0** — the newer, more-linked existing parent version — and sourced via `catalog:` in `package.json`. **No third version enters the tree** (the lockfile still holds only 5.7.3 + 5.8.0); `pnpm install --frozen-lockfile` stays green.

## Untouched (AC 5)

`Manifest.ts` schema, SHA-stamping, `parseRunSummaryJson` trust-boundary decode, and the never-emit-half-formed contract are all out of scope and unchanged.

## Lane

`packages/pipeline-cli/` is control-plane (§CP), backing the run-evidence gate. Reviewed by `review-code`, then **human-merged** per ADR 0135 — stops at reviewed-ready. Do not self-merge.