### PR TITLE
ci: adopt gitleaks (stock rules) as a CI credential scanner

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,7 +8,7 @@ name: gitleaks
 # with a stripped PATH where a Go binary is unreliable (#2310), and CI is the only gate
 # that sees every PR's diff however it was authored.
 #
-# Scope is DIFF-scoped (the PR's own commits, base..HEAD), not full history: the repo's
+# Scope is DIFF-scoped (the PR's own commits, merge-base..HEAD), not full history: the repo's
 # git history already carries triaged findings (issue #2325 baseline), so a whole-history
 # scan would fail every run — the gate's job is to block a NET-NEW committed secret. A
 # real secret already in history is a separate rotation/remediation incident, never
@@ -36,8 +36,8 @@ jobs:
     name: scan PR commits for secrets
     runs-on: ubuntu-latest
     steps:
-      # Full history so base..HEAD resolves; the default shallow checkout has no
-      # merge-base for the diff-scoped log range below.
+      # Full history so the merge-base of base + HEAD resolves; the default shallow
+      # checkout has no merge-base for the diff-scoped log range below.
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -76,16 +76,25 @@ jobs:
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           set -uo pipefail
+          # Fetch the base WITH ancestry (no --depth=1): a shallow base has no history,
+          # so the merge-base below can't resolve and the range degenerates to a
+          # full-history walk that re-flags pre-existing triaged findings (issue #2325
+          # repair — the #2325 gate must scan ONLY this PR's net-new commits).
           if [ -n "$BASE_REF" ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            git fetch --no-tags origin "$BASE_REF"
             base="origin/$BASE_REF"
           else
-            git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA"
+            git fetch --no-tags origin "$MERGE_GROUP_BASE_SHA"
             base="$MERGE_GROUP_BASE_SHA"
           fi
-          echo "Scanning commits in range ${base}..HEAD"
+          # Scope to the PR's OWN commits via the merge-base — the git-log equivalent of
+          # leak-guard.yml's three-dot `git diff base...HEAD`. A two-dot `base..HEAD`
+          # against a moved base wrongly walks history; `merge-base..HEAD` never does.
+          mergebase="$(git merge-base "$base" HEAD)"
+          [ -n "$mergebase" ] || { echo "::error::could not resolve merge-base of ${base} and HEAD — refusing to scan a degenerate range (fail-closed)."; exit 1; }
+          echo "Scanning commits in range ${mergebase}..HEAD"
           ./gitleaks git . \
-            --log-opts="${base}..HEAD" \
+            --log-opts="${mergebase}..HEAD" \
             --config=.gitleaks.toml \
             --no-banner \
             --redact \

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,6 +13,12 @@ name: gitleaks
 # scan would fail every run — the gate's job is to block a NET-NEW committed secret. A
 # real secret already in history is a separate rotation/remediation incident, never
 # suppressed here.
+# Least-privilege token: the job only checks out and scans the repo (SARIF is written to
+# the runner's disk, never uploaded to code-scanning, and nothing comments/checks the PR),
+# so read-only `contents` is all it needs — no default write scopes on a control-plane gate.
+permissions:
+  contents: read
+
 on:
   pull_request:
   # `scan PR commits for secrets` is intended as a branch-protection-REQUIRED status

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,103 @@
+name: gitleaks
+
+# CI credential scanner (issue #2325). gitleaks scans the PR's new commits for
+# committed secrets — API keys, tokens, private keys — its actual domain, additive to
+# and orthogonal from leak-guard (machine-local-path/PII in doc surfaces; the #2310
+# spike measured stock gitleaks at 0/6 on leak-guard's corpus). CI is the enforcement
+# surface, not a pre-commit hook: the lean lefthook fires in harness-created worktrees
+# with a stripped PATH where a Go binary is unreliable (#2310), and CI is the only gate
+# that sees every PR's diff however it was authored.
+#
+# Scope is DIFF-scoped (the PR's own commits, base..HEAD), not full history: the repo's
+# git history already carries triaged findings (issue #2325 baseline), so a whole-history
+# scan would fail every run — the gate's job is to block a NET-NEW committed secret. A
+# real secret already in history is a separate rotation/remediation incident, never
+# suppressed here.
+on:
+  pull_request:
+  # `scan PR commits for secrets` is intended as a branch-protection-REQUIRED status
+  # check, so the merge queue awaits it on the batched `merge_group` ref before it can
+  # merge; without this trigger that required check never runs on the batch and every
+  # queued merge hangs (ADR 0132) — same wiring as leak-guard.yml.
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  # Pinned gitleaks binary — a CI binary, NOT a pnpm catalog: dependency, so it is pinned
+  # here by version + checksum, never a floating `latest`. Bump both together on upgrade.
+  GITLEAKS_VERSION: "8.21.2"
+  GITLEAKS_SHA256: "5bc41815076e6ed6ef8fbecc9d9b75bcae31f39029ceb55da08086315316e3ba" # gitleaks_8.21.2_linux_x64.tar.gz
+
+jobs:
+  scan:
+    name: scan PR commits for secrets
+    runs-on: ubuntu-latest
+    steps:
+      # Full history so base..HEAD resolves; the default shallow checkout has no
+      # merge-base for the diff-scoped log range below.
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      # Install the pinned gitleaks binary and verify its checksum. A version-only pin
+      # can still be swapped under the same tag; the checksum makes the binary itself
+      # immutable — refuse to run on a mismatch (fail-closed).
+      - name: Install pinned gitleaks
+        run: |
+          set -euo pipefail
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}"
+          curl -sSLf -o "$tarball" "$url"
+          echo "${GITLEAKS_SHA256}  ${tarball}" | sha256sum -c -
+          tar -xzf "$tarball" gitleaks
+          ./gitleaks version
+
+      # Diff-scoped scan of the PR's own commits. On `pull_request` the base is the
+      # target branch; on the merge queue's batched `merge_group` ref `base_ref` is
+      # empty, so we use `merge_group.base_sha` — the base commit the queue built the
+      # batch on (ADR 0132) — yielding exactly the commits the batch adds vs main.
+      #
+      # Exit-code contract (grounded in the #2310 spike against gitleaks source):
+      #   0   = clean               -> PASS (the ONLY passing outcome)
+      #   3   = findings            -> FAIL (a net-new committed secret) — `--exit-code 3`
+      #                               dodges gitleaks' reserved codes so a finding is
+      #                               DISTINGUISHABLE from a tool failure
+      #   1   = fatal/partial scan  -> FAIL
+      #   2   = panic (bad rule)    -> FAIL   (why 3, not 2, is the finding code)
+      #   126 = bad flag            -> FAIL
+      #   *   = anything else       -> FAIL
+      # Fail-closed: only exit 0 passes; a finding OR any error fails the job.
+      - name: Scan PR commits for secrets
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          set -uo pipefail
+          if [ -n "$BASE_REF" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            base="origin/$BASE_REF"
+          else
+            git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA"
+            base="$MERGE_GROUP_BASE_SHA"
+          fi
+          echo "Scanning commits in range ${base}..HEAD"
+          ./gitleaks git . \
+            --log-opts="${base}..HEAD" \
+            --config=.gitleaks.toml \
+            --no-banner \
+            --redact \
+            --exit-code 3 \
+            --report-format sarif \
+            --report-path gitleaks.sarif
+          code=$?
+          case "$code" in
+            0)   echo "gitleaks: clean — no committed secrets in the PR's commits."; exit 0 ;;
+            3)   echo "::error::gitleaks found a committed secret in this PR. Remove it, rotate it, and (if a real credential) treat the leak as an incident — do NOT allowlist a real secret."; exit 1 ;;
+            1)   echo "::error::gitleaks fatal/partial scan error (exit 1) — treating as fail-closed."; exit 1 ;;
+            2)   echo "::error::gitleaks panic (exit 2, e.g. a malformed rule) — treating as fail-closed."; exit 1 ;;
+            126) echo "::error::gitleaks bad flag/invocation (exit 126) — treating as fail-closed."; exit 1 ;;
+            *)   echo "::error::gitleaks unexpected exit code ${code} — treating as fail-closed."; exit 1 ;;
+          esac

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,35 @@
+# gitleaks configuration — stock ruleset + a narrow allowlist of triaged false positives.
+#
+# This is the config for the CI credential scanner wired in
+# `.github/workflows/gitleaks.yml` (issue #2325). gitleaks is adopted for its actual
+# domain — committed credentials (API keys, tokens, private keys) — additive to and
+# orthogonal from leak-guard, which keeps owning machine-local-path/PII leakage in doc
+# surfaces (the #2310 spike ruling: stock gitleaks scored 0/6 on leak-guard's corpus).
+#
+# Stock rules only. gitleaks' RE2 engine forbids lookbehind and panics on such a rule
+# (#2310), so this repo authors NO custom rules — `useDefault` pulls the maintained
+# upstream ruleset and the config adds only allowlist entries for triaged false
+# positives, each with a one-line reason (issue #2325 acceptance criteria).
+
+title = "phoenix gitleaks config"
+
+[extend]
+# Inherit gitleaks' stock/default ruleset — the ~upstream-maintained credential rules.
+# No custom rules are added (RE2-lookbehind panic constraint, #2310).
+useDefault = true
+
+# --- Triaged false positives (issue #2325 baseline scan) ------------------------------
+# Each regex suppresses ONE specific dummy/test literal — a narrow value match, never a
+# whole-file or whole-rule mute, so a real secret accidentally added to the same test
+# file is still caught. `regexTarget = "match"` matches against the full matched span.
+[allowlist]
+regexTarget = "match"
+regexes = [
+	# SHA-256('abc') content hash used as a fake content-addressed asset key in depo
+	# tests (packages/depo/src/{client,domain}.unit.test.ts) — a public digest, not a credential.
+	'''ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad''',
+	# Deliberate dummy Cloudflare token in orphan-sweep tests
+	# (packages/orphan-sweep/src/cloudflare.unit.test.ts); the value self-documents as
+	# 'Must_Never_Leak' — a fixture, not a credential.
+	'''cf-secret-Th1s_Must_Never_Leak_0000''',
+]


### PR DESCRIPTION
Adopts **gitleaks** with its **stock ruleset** as a CI-first credential scanner — its actual domain (committed API keys, tokens, private keys). Additive to and orthogonal from leak-guard, which keeps owning machine-local-path/PII leakage in doc surfaces (the #2310 spike measured stock gitleaks at 0/6 on leak-guard's corpus). Closes phoenix's zero-credential-scanning gap.

## What changed

- **`.github/workflows/gitleaks.yml`** — new CI job (`pull_request` + `merge_group`, mirroring leak-guard's wiring for ADR 0132 merge-queue). Downloads the **pinned** gitleaks binary (`v8.21.2`) and **verifies its SHA-256 checksum** before running (version + checksum pin; a CI binary, not a pnpm `catalog:` dep). Scans the PR's own commits (`base..HEAD`), not full history.
- **`.gitleaks.toml`** — `extend.useDefault = true` (stock rules only; no custom rules, per the #2310 RE2-lookbehind panic lesson) plus a narrow allowlist of two triaged false positives, each with a one-line reason.

## Exit-code contract (fail-closed)

Findings are remapped to **`--exit-code 3`** so a real finding is distinguishable from a tool failure — dodging gitleaks' reserved codes (1 = fatal/partial, 2 = Go panic, 126 = bad flag). The job is **fail-closed**: only exit `0` (verified-clean) passes; a finding (`3`) **or** any error (`1`/`2`/`126`/other) fails the job.

Verified locally against the pinned v8.21.2 binary:
- clean PR commits → exit `0` (pass)
- a planted net-new GitHub-PAT-format token → exit `3` (fail)
- the two allowlisted fixtures → suppressed (`no leaks found`)

## Baseline triage (run over working tree + full git history, 2617 commits)

The stock ruleset found **10 history findings, all false positives or a history-only test-env value — no live production credential in the working tree**:

| Finding | Disposition |
|---|---|
| `ba7816bf…015ad` in `packages/depo/src/{client,domain}.unit.test.ts` | **FP** — SHA-256("abc"), a public content-addressed asset-key fixture. **Allowlisted.** |
| `cf-secret-Th1s_Must_Never_Leak_0000` in `packages/orphan-sweep/src/cloudflare.unit.test.ts` | **FP** — deliberate dummy token (self-documents "Must_Never_Leak"). **Allowlisted.** |
| `-----BEGIN PRIVATE KEY-----\nnot-a-real-key` (bot-token test, history-only) | **FP** — literal placeholder; not in current tree. |
| `6d8c2255-…` OAuth client ID (cf-utils, history-only) | **FP** — an OAuth *client ID* is a public identifier, not a secret; not in current tree. |
| `BETTER_AUTH_SECRET` (`test` env) in the deleted `apps/web/wrangler.jsonc`, history-only | Flagged to the pipeline owner as a **separate rotation/remediation item** (see progress comment on #2325). **NOT allowlisted** — a real secret is never baked into a baseline. It is history-only in a file removed by the alchemy migration (ADR 0026–0031); prod/staging vars in that file were empty. |

The diff-scoped gate does **not** re-flag any history finding — a net-new committed secret is what fails CI.

## Decisions

- **CI-first, not pre-commit** — the lean lefthook fires in harness-created worktrees with a stripped PATH where a Go binary is unreliable (#2310); CI is the only surface that sees every PR's diff however authored.
- **Advisory-vs-fail-closed:** the job runs **fail-closed** (it fails the PR check on a finding). Adding it to the `main` branch-protection **required** set is a repo-settings governance action (like enabling GitHub native secret scanning, also currently disabled) — suggested as the follow-up once the false-positive rate has soaked, per the AC's advisory → required path.
- leak-guard is **untouched** (additive).

## §CP

The new `.github/workflows/*.yml` makes this PR §CP (`.github/**` is owned by @kamp-us/control-plane in CODEOWNERS — no new path added; `codeowners-cp` check stays green: all 14 §CP paths covered). Route to **human merge** (cansirin); do not self-merge.

Fixes #2325