### PR TITLE
feat(web): feed snapshot — persist + hydrate the public anon fate cache (#2319)

### DIFF
--- a/apps/web/src/fate/publicClient.ts
+++ b/apps/web/src/fate/publicClient.ts
@@ -12,6 +12,7 @@
  * scalars stay on the authed client below the gate. See ADR 0167.
  */
 import {createClient, type FateClientInstance} from "./client";
+import {hydrateAnonPublicClient, installAnonSnapshotPersistence} from "./snapshot";
 
 let publicClient: FateClientInstance | null = null;
 
@@ -21,6 +22,17 @@ let publicClient: FateClientInstance | null = null;
 // authed feed takes over, but the instance — and its warm cache — persists for the app
 // lifetime).
 export function getPublicFateClient(): FateClientInstance {
-	if (publicClient == null) publicClient = createClient({authenticated: false});
+	if (publicClient == null) {
+		publicClient = createClient({authenticated: false});
+		// Feed snapshot (leg A, #2319): restore the persisted anon cache into this
+		// singleton at creation — BEFORE any `useRequest` renders under
+		// `PublicFateProvider`, fate's hydrate-before-render contract — then persist it
+		// on tab-hide for the app's lifetime (the singleton never tears down, so its
+		// uninstaller is intentionally discarded). Both no-op when the containment flag
+		// is off (flag-off ⇒ no storage reads/writes), so this is byte-identical to today
+		// until #2326 flips it. See `snapshot.ts`.
+		hydrateAnonPublicClient(publicClient);
+		installAnonSnapshotPersistence(publicClient);
+	}
 	return publicClient;
 }

--- a/apps/web/src/fate/snapshot.test.ts
+++ b/apps/web/src/fate/snapshot.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Feed-snapshot module contract (#2319, epic #2316). Two tiers of coverage:
+ *
+ *   1. The pure persistence layer (read/write/hydrate/save + throttle/installer) against
+ *      a fake client + in-memory storage — round-trip fidelity and the four tolerance
+ *      paths (corrupt, quota, oversized, scope/version mismatch), each degrading to a
+ *      clean no-snapshot boot with no throw.
+ *   2. A REAL `@nkzw/fate` client round-trip (the `optimisticCommentAdd.realstore`
+ *      idiom): populate a client's store, dehydrate → persist → hydrate into a fresh
+ *      client, and assert the fresh client re-dehydrates to an equal state — proving the
+ *      persist layer carries fate's dehydrated cache (records + list/pagination state)
+ *      without loss, and that fate rejects a scope-mismatched snapshot (which we catch).
+ *
+ * The "paints without a skeleton" experience is a flag-on behavior the verification
+ * child (#2326) measures on a deployed stage — the unit tier proves the module contract
+ * the epic's testing strategy scopes here.
+ */
+import {createClient, type FateDehydratedState} from "@nkzw/fate";
+import {describe, expect, it, vi} from "vitest";
+import {
+	ANON_IDENTITY,
+	createLeadingThrottle,
+	hydrateFromSnapshot,
+	installSnapshotPersistence,
+	type KeyValueStorage,
+	type PersistenceBindings,
+	readSnapshot,
+	type SnapshotClient,
+	saveSnapshot,
+	snapshotKey,
+	writeSnapshot,
+} from "./snapshot";
+
+/** In-memory `localStorage` stand-in; optionally throws on `setItem`/`getItem` to model
+ *  quota-exceeded and access-denied (Safari private mode). */
+function memoryStorage(
+	opts: {throwOnSet?: boolean; throwOnGet?: boolean} = {},
+): KeyValueStorage & {map: Map<string, string>} {
+	const map = new Map<string, string>();
+	return {
+		map,
+		getItem: (k) => {
+			if (opts.throwOnGet) throw new Error("access denied");
+			return map.get(k) ?? null;
+		},
+		setItem: (k, v) => {
+			if (opts.throwOnSet) throw new DOMException("quota", "QuotaExceededError");
+			map.set(k, v);
+		},
+		removeItem: (k) => {
+			map.delete(k);
+		},
+	};
+}
+
+const KEY = snapshotKey("v1", ANON_IDENTITY);
+
+/** A fake client returning a fixed dehydrated state and recording hydrate calls. */
+function fakeClient(
+	state: FateDehydratedState,
+): SnapshotClient & {hydrated: FateDehydratedState[]} {
+	const hydrated: FateDehydratedState[] = [];
+	return {
+		hydrated,
+		dehydrate: () => state,
+		hydrate: (s) => {
+			hydrated.push(s);
+		},
+	};
+}
+
+const sampleState: FateDehydratedState = {
+	// A representative payload carrying list/pagination + connection-identity shaped
+	// fields (the `?sort`/`host` connection args live inside `data`) — the round-trip
+	// must preserve them byte-for-byte.
+	data: {
+		rootLists: [["posts", ["Post:1", "Post:2"]]],
+		lists: {
+			"posts(sort:hot,host:example.com)": {ids: ["Post:1", "Post:2"], pagination: {hasNext: true}},
+		},
+	},
+	scope: "schema-abc",
+	version: 1,
+};
+
+describe("readSnapshot / writeSnapshot round-trip", () => {
+	it("persists and reads back a structurally-valid snapshot unchanged", () => {
+		const storage = memoryStorage();
+		expect(writeSnapshot(storage, KEY, sampleState)).toBe(true);
+		expect(readSnapshot(storage, KEY)).toEqual(sampleState);
+	});
+
+	it("preserves nested list + pagination + connection-identity fields through JSON", () => {
+		const storage = memoryStorage();
+		writeSnapshot(storage, KEY, sampleState);
+		const restored = readSnapshot(storage, KEY);
+		expect(restored?.data).toEqual(sampleState.data);
+	});
+
+	it("reads back null for an absent key", () => {
+		expect(readSnapshot(memoryStorage(), KEY)).toBeNull();
+	});
+});
+
+describe("readSnapshot tolerance — every bad state degrades to a clean no-snapshot boot", () => {
+	it("returns null on a corrupt (non-JSON) payload, no throw", () => {
+		const storage = memoryStorage();
+		storage.map.set(KEY, "{not valid json");
+		expect(() => readSnapshot(storage, KEY)).not.toThrow();
+		expect(readSnapshot(storage, KEY)).toBeNull();
+	});
+
+	it("returns null on a structurally-wrong payload (wrong version / missing fields)", () => {
+		const storage = memoryStorage();
+		storage.map.set(KEY, JSON.stringify({data: {}, scope: "x", version: 2}));
+		expect(readSnapshot(storage, KEY)).toBeNull();
+		storage.map.set(KEY, JSON.stringify({nope: true}));
+		expect(readSnapshot(storage, KEY)).toBeNull();
+	});
+
+	it("returns null on an oversized payload without parsing it", () => {
+		const storage = memoryStorage();
+		storage.map.set(KEY, JSON.stringify(sampleState));
+		expect(readSnapshot(storage, KEY, 10)).toBeNull();
+	});
+
+	it("returns null (no throw) when getItem itself throws (access denied)", () => {
+		const storage = memoryStorage({throwOnGet: true});
+		expect(() => readSnapshot(storage, KEY)).not.toThrow();
+		expect(readSnapshot(storage, KEY)).toBeNull();
+	});
+});
+
+describe("writeSnapshot tolerance", () => {
+	it("returns false (no throw) on a quota-exceeded setItem", () => {
+		const storage = memoryStorage({throwOnSet: true});
+		expect(() => writeSnapshot(storage, KEY, sampleState)).not.toThrow();
+		expect(writeSnapshot(storage, KEY, sampleState)).toBe(false);
+	});
+
+	it("refuses to persist an oversized snapshot", () => {
+		const storage = memoryStorage();
+		expect(writeSnapshot(storage, KEY, sampleState, 10)).toBe(false);
+		expect(storage.map.has(KEY)).toBe(false);
+	});
+});
+
+describe("hydrateFromSnapshot", () => {
+	it("hydrates the client from a persisted snapshot and reports true", () => {
+		const storage = memoryStorage();
+		writeSnapshot(storage, KEY, sampleState);
+		const client = fakeClient(sampleState);
+		expect(hydrateFromSnapshot(client, storage)).toBe(true);
+		expect(client.hydrated).toEqual([sampleState]);
+	});
+
+	it("is a no-op returning false when there is no snapshot", () => {
+		const client = fakeClient(sampleState);
+		expect(hydrateFromSnapshot(client, memoryStorage())).toBe(false);
+		expect(client.hydrated).toEqual([]);
+	});
+
+	it("swallows a client.hydrate throw (scope/version mismatch, pending requests) → false", () => {
+		const storage = memoryStorage();
+		writeSnapshot(storage, KEY, sampleState);
+		const throwing: SnapshotClient = {
+			dehydrate: () => sampleState,
+			hydrate: () => {
+				throw new Error("fate: Hydration state scope does not match this client.");
+			},
+		};
+		expect(() => hydrateFromSnapshot(throwing, storage)).not.toThrow();
+		expect(hydrateFromSnapshot(throwing, storage)).toBe(false);
+	});
+});
+
+describe("saveSnapshot", () => {
+	it("dehydrates and persists, reporting true", () => {
+		const storage = memoryStorage();
+		const client = fakeClient(sampleState);
+		expect(saveSnapshot(client, storage)).toBe(true);
+		expect(readSnapshot(storage, KEY)).toEqual(sampleState);
+	});
+
+	it("swallows a client.dehydrate throw (requests in flight) → false, nothing written", () => {
+		const storage = memoryStorage();
+		const throwing: SnapshotClient = {
+			dehydrate: () => {
+				throw new Error("fate: Cannot dehydrate while requests are pending.");
+			},
+			hydrate: () => undefined,
+		};
+		expect(() => saveSnapshot(throwing, storage)).not.toThrow();
+		expect(saveSnapshot(throwing, storage)).toBe(false);
+		expect(storage.map.size).toBe(0);
+	});
+});
+
+describe("createLeadingThrottle", () => {
+	it("allows the first call and blocks until the window elapses", () => {
+		let t = 1000;
+		const allow = createLeadingThrottle(2000, () => t);
+		expect(allow()).toBe(true); // leading edge
+		t = 1500;
+		expect(allow()).toBe(false); // within window
+		t = 3000;
+		expect(allow()).toBe(true); // window elapsed
+	});
+});
+
+describe("installSnapshotPersistence — event-driven, throttled, not per-render", () => {
+	function fakeBindings(): PersistenceBindings & {
+		fire: (type: string) => void;
+		hidden: boolean;
+		listeners: Map<string, Set<() => void>>;
+	} {
+		const listeners = new Map<string, Set<() => void>>();
+		return {
+			listeners,
+			hidden: false,
+			addEventListener(type, handler) {
+				(listeners.get(type) ?? listeners.set(type, new Set()).get(type)!).add(handler);
+			},
+			removeEventListener(type, handler) {
+				listeners.get(type)?.delete(handler);
+			},
+			isHidden() {
+				return this.hidden;
+			},
+			fire(type) {
+				for (const h of listeners.get(type) ?? []) h();
+			},
+		};
+	}
+
+	it("persists on pagehide", () => {
+		const storage = memoryStorage();
+		const client = fakeClient(sampleState);
+		const bindings = fakeBindings();
+		installSnapshotPersistence(client, storage, bindings, {now: () => 0});
+		bindings.fire("pagehide");
+		expect(readSnapshot(storage, KEY)).toEqual(sampleState);
+	});
+
+	it("persists on visibilitychange only when hidden", () => {
+		const storage = memoryStorage();
+		const client = fakeClient(sampleState);
+		const bindings = fakeBindings();
+		installSnapshotPersistence(client, storage, bindings, {now: () => 0});
+		bindings.hidden = false;
+		bindings.fire("visibilitychange");
+		expect(storage.map.size).toBe(0); // visible → no write
+		bindings.hidden = true;
+		bindings.fire("visibilitychange");
+		expect(readSnapshot(storage, KEY)).toEqual(sampleState);
+	});
+
+	it("throttles back-to-back events into a single write", () => {
+		const storage = memoryStorage();
+		const save = vi.fn(() => sampleState);
+		const client: SnapshotClient = {dehydrate: save, hydrate: () => undefined};
+		const bindings = fakeBindings();
+		bindings.hidden = true;
+		let t = 0;
+		installSnapshotPersistence(client, storage, bindings, {now: () => t, throttleMs: 2000});
+		bindings.fire("visibilitychange"); // t=0 → save
+		bindings.fire("pagehide"); // t=0, within window → throttled
+		expect(save).toHaveBeenCalledTimes(1);
+		t = 3000;
+		bindings.fire("pagehide"); // window elapsed → save again
+		expect(save).toHaveBeenCalledTimes(2);
+	});
+
+	it("uninstall removes both listeners", () => {
+		const storage = memoryStorage();
+		const client = fakeClient(sampleState);
+		const bindings = fakeBindings();
+		const uninstall = installSnapshotPersistence(client, storage, bindings, {now: () => 0});
+		uninstall();
+		bindings.fire("pagehide");
+		bindings.fire("visibilitychange");
+		expect(storage.map.size).toBe(0);
+	});
+});
+
+/**
+ * Real `@nkzw/fate` client round-trip — the `optimisticCommentAdd.realstore` idiom: a
+ * minimal client with a never-invoked transport, driven through the REAL dehydrate /
+ * hydrate the persistence layer wraps.
+ */
+function realClient(hydrationScope = "test-scope") {
+	return createClient({
+		hydrationScope,
+		roots: {},
+		types: [{type: "Post"}],
+		transport: {
+			fetchById: () => {
+				throw new Error("transport unused");
+			},
+			fetchList: () => {
+				throw new Error("transport unused");
+			},
+			fetchQuery: () => {
+				throw new Error("transport unused");
+			},
+			mutate: () => {
+				throw new Error("transport unused");
+			},
+		},
+	});
+}
+
+describe("real fate client round-trip", () => {
+	it("carries the dehydrated cache through persist → hydrate without loss", () => {
+		const source = realClient();
+		source.write("Post", {id: "1", title: "merhaba"}, new Set(["id", "title"]));
+		source.write("Post", {id: "2", title: "dünya"}, new Set(["id", "title"]));
+
+		const storage = memoryStorage();
+		expect(saveSnapshot(source, storage)).toBe(true);
+
+		const restored = realClient();
+		expect(hydrateFromSnapshot(restored, storage)).toBe(true);
+
+		// A fresh client that re-dehydrates to the same state proves the persist layer
+		// lost nothing fate had encoded (records, lists, coverage, root lists).
+		expect(restored.dehydrate()).toEqual(source.dehydrate());
+	});
+
+	it("rejects a scope-mismatched snapshot (fate throws; we catch) → clean no-snapshot boot", () => {
+		const source = realClient("scope-A");
+		source.write("Post", {id: "1", title: "x"}, new Set(["id", "title"]));
+		const storage = memoryStorage();
+		saveSnapshot(source, storage);
+
+		const restored = realClient("scope-B"); // schema rotated
+		expect(() => hydrateFromSnapshot(restored, storage)).not.toThrow();
+		expect(hydrateFromSnapshot(restored, storage)).toBe(false);
+	});
+});

--- a/apps/web/src/fate/snapshot.ts
+++ b/apps/web/src/fate/snapshot.ts
@@ -1,0 +1,275 @@
+/**
+ * Feed snapshot — leg A of the "instant /pano reload" epic (#2316, child #2319).
+ *
+ * Persist the public (always-anonymous) fate cache to `localStorage` and restore it
+ * at boot, so a reload paints the last-seen feed synchronously — before the network
+ * revalidate lands — instead of a skeleton. Terms: a *feed snapshot* is the persisted,
+ * versioned dehydrated fate cache; the *base feed* it carries is viewer-invariant
+ * (leg B); the *viewer overlay* (`myVote`/`isSaved`) is composed on top after the
+ * session resolves (the authed tier, #2321 — out of scope here).
+ *
+ * Uses fate's native `FateClient.dehydrate()`/`hydrate()` (versioned, JSON-safe
+ * `FateDehydratedState` with a schema-derived `hydrationScope`) — never a hand-rolled
+ * serializer. `localStorage`, not IndexedDB, on purpose: the restore must be
+ * synchronous so `hydrate()` runs *before* the first `useRequest` (fate's documented
+ * hydrate-before-render contract; `hydrate()` also throws if the client already has
+ * requests pending). Every failure mode — quota, corrupt/oversized payload,
+ * scope/version mismatch, a client with in-flight requests — degrades to a clean
+ * no-snapshot boot: a feed snapshot is a best-effort content cache, never load-bearing.
+ *
+ * Containment: the whole feature is dark behind `VITE_FEED_SNAPSHOT` (default-off);
+ * #2326 flips it on measured evidence. A build-time env flag, NOT the server-evaluated
+ * Flagship flag, because boot hydration must resolve synchronously before any async
+ * `/api/flags/evaluate` round-trip could return — the `VITE_SENTRY_DSN` precedent
+ * (`vite-env.d.ts`). Flag off ⇒ no storage reads or writes, byte-identical to today.
+ */
+import type {FateDehydratedState, HydrateOptions} from "react-fate";
+
+/** Build-time containment flag (default-off). See the module docblock for why it is a
+ *  Vite env var rather than the Flagship server flag. */
+export const FEED_SNAPSHOT_ENABLED = import.meta.env.VITE_FEED_SNAPSHOT === "on";
+
+/** Storage-key schema segment. fate's payload-embedded `scope` guards the fate schema
+ *  itself (an incompatible dehydrated shape is rejected by `hydrate()`); this segment
+ *  guards *our* keying/format — bump it to force-invalidate every persisted snapshot on
+ *  an incompatible change to this module. */
+export const FEED_SNAPSHOT_SCHEMA = "v1";
+
+/** Identity segment for the always-anonymous public tier. The authed tier (#2321) keys
+ *  per user-id and tears the snapshot down on identity change / sign-out. */
+export const ANON_IDENTITY = "anon";
+
+/** Cap a persisted snapshot's serialized length. An oversized payload is neither
+ *  written nor read back (dropped to a clean boot), bounding both `localStorage`
+ *  pressure and the synchronous boot-time parse cost. */
+export const DEFAULT_MAX_SNAPSHOT_CHARS = 2_000_000;
+
+/** Minimum gap between two persists. The save is event-driven (`pagehide` /
+ *  `visibilitychange`), and both can fire back-to-back on the same tab-hide — the
+ *  throttle collapses that into one write. */
+export const DEFAULT_SAVE_THROTTLE_MS = 2_000;
+
+/** The one storage-key shape: `fate-snapshot:<schema>:<identity>`. */
+export function snapshotKey(schema: string, identity: string): string {
+	return `fate-snapshot:${schema}:${identity}`;
+}
+
+/** The slice of a fate client this module drives — just the two persistence primitives,
+ *  so the pure functions are testable with a fake and decoupled from the generated
+ *  client type. */
+export interface SnapshotClient {
+	dehydrate(): FateDehydratedState;
+	hydrate(state: FateDehydratedState, options?: HydrateOptions): void;
+}
+
+/** The `localStorage`-shaped subset this module needs, injected so the pure functions
+ *  run without a DOM. */
+export interface KeyValueStorage {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+	removeItem(key: string): void;
+}
+
+interface SnapshotScope {
+	schema?: string;
+	identity?: string;
+	maxChars?: number;
+}
+
+/** A structurally-valid dehydrated snapshot is `{data, scope: string, version: 1}`.
+ *  Anything else read from storage is treated as absent — fate's own `hydrate()` would
+ *  reject it, but we screen here so a malformed blob never reaches the client. */
+function isDehydratedState(value: unknown): value is FateDehydratedState {
+	if (typeof value !== "object" || value === null) return false;
+	const candidate = value as {version?: unknown; scope?: unknown};
+	return candidate.version === 1 && typeof candidate.scope === "string" && "data" in candidate;
+}
+
+/** Read + parse a persisted snapshot, tolerating every failure to `null` (no throw):
+ *  a `getItem` that throws, an absent key, an oversized blob, invalid JSON, or a
+ *  structurally-wrong payload all degrade to "no snapshot". */
+export function readSnapshot(
+	storage: KeyValueStorage,
+	key: string,
+	maxChars: number = DEFAULT_MAX_SNAPSHOT_CHARS,
+): FateDehydratedState | null {
+	let raw: string | null;
+	try {
+		raw = storage.getItem(key);
+	} catch {
+		return null;
+	}
+	if (raw == null || raw.length > maxChars) return null;
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		return isDehydratedState(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Serialize + persist a snapshot, tolerating every failure to `false` (no throw): a
+ *  non-serializable state, an oversized payload (not written), or a quota-exceeded
+ *  `setItem`. Returns whether the write landed. */
+export function writeSnapshot(
+	storage: KeyValueStorage,
+	key: string,
+	state: FateDehydratedState,
+	maxChars: number = DEFAULT_MAX_SNAPSHOT_CHARS,
+): boolean {
+	let serialized: string;
+	try {
+		serialized = JSON.stringify(state);
+	} catch {
+		return false;
+	}
+	if (serialized.length > maxChars) return false;
+	try {
+		storage.setItem(key, serialized);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Restore a snapshot into the client. `hydrate()` throws on a version/scope mismatch,
+ *  a payload that fails fate's decode limits, or a client with pending requests — all
+ *  caught here so a bad snapshot degrades to a clean no-snapshot boot. Returns whether
+ *  a snapshot was applied. */
+export function hydrateFromSnapshot(
+	client: SnapshotClient,
+	storage: KeyValueStorage,
+	{
+		schema = FEED_SNAPSHOT_SCHEMA,
+		identity = ANON_IDENTITY,
+		maxChars = DEFAULT_MAX_SNAPSHOT_CHARS,
+	}: SnapshotScope = {},
+): boolean {
+	const state = readSnapshot(storage, snapshotKey(schema, identity), maxChars);
+	if (state == null) return false;
+	try {
+		client.hydrate(state, {merge: "preserve-existing"});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Dehydrate the client and persist the snapshot. `dehydrate()` throws while a request
+ *  or optimistic update is in flight (fate's contract) — caught here so a save is
+ *  always best-effort. Returns whether the write landed. */
+export function saveSnapshot(
+	client: SnapshotClient,
+	storage: KeyValueStorage,
+	{
+		schema = FEED_SNAPSHOT_SCHEMA,
+		identity = ANON_IDENTITY,
+		maxChars = DEFAULT_MAX_SNAPSHOT_CHARS,
+	}: SnapshotScope = {},
+): boolean {
+	let state: FateDehydratedState;
+	try {
+		state = client.dehydrate();
+	} catch {
+		return false;
+	}
+	return writeSnapshot(storage, snapshotKey(schema, identity), state, maxChars);
+}
+
+/** A leading-edge throttle gate: returns `true` at most once per `throttleMs`. Time is
+ *  injected so the throttle is deterministically testable. */
+export function createLeadingThrottle(
+	throttleMs: number,
+	now: () => number = Date.now,
+): () => boolean {
+	let last = Number.NEGATIVE_INFINITY;
+	return () => {
+		const t = now();
+		if (t - last < throttleMs) return false;
+		last = t;
+		return true;
+	};
+}
+
+/** The DOM bindings the persistence installer needs, injected so it is testable without
+ *  a real `window`/`document`. */
+export interface PersistenceBindings {
+	addEventListener(type: string, handler: () => void): void;
+	removeEventListener(type: string, handler: () => void): void;
+	/** Whether the document is currently hidden (`visibilityState === "hidden"`). */
+	isHidden(): boolean;
+}
+
+interface InstallOptions extends SnapshotScope {
+	throttleMs?: number;
+	now?: () => number;
+}
+
+/** Wire throttled snapshot persistence to `pagehide` and `visibilitychange` (on hide) —
+ *  never per-render — and return an uninstaller. These two events fire as the tab is
+ *  backgrounded or torn down, the last moment the cache is worth capturing. */
+export function installSnapshotPersistence(
+	client: SnapshotClient,
+	storage: KeyValueStorage,
+	bindings: PersistenceBindings,
+	{schema, identity, maxChars, throttleMs = DEFAULT_SAVE_THROTTLE_MS, now}: InstallOptions = {},
+): () => void {
+	const allow = createLeadingThrottle(throttleMs, now);
+	const persist = () => {
+		if (allow()) saveSnapshot(client, storage, {schema, identity, maxChars});
+	};
+	const onPageHide = () => persist();
+	const onVisibility = () => {
+		if (bindings.isHidden()) persist();
+	};
+	bindings.addEventListener("pagehide", onPageHide);
+	bindings.addEventListener("visibilitychange", onVisibility);
+	return () => {
+		bindings.removeEventListener("pagehide", onPageHide);
+		bindings.removeEventListener("visibilitychange", onVisibility);
+	};
+}
+
+/** `localStorage`, or `null` if it is unavailable (Safari private mode throws on access,
+ *  SSR/tests without a DOM have no `window`). A `null` storage disables persistence
+ *  cleanly. */
+export function browserSnapshotStorage(): KeyValueStorage | null {
+	try {
+		return typeof window === "undefined" ? null : window.localStorage;
+	} catch {
+		return null;
+	}
+}
+
+/** Bind persistence to the real DOM: `pagehide` on `window`, `visibilitychange` on
+ *  `document`. */
+export function browserPersistenceBindings(): PersistenceBindings {
+	const targetFor = (type: string): EventTarget =>
+		type === "visibilitychange" ? document : window;
+	return {
+		addEventListener: (type, handler) => targetFor(type).addEventListener(type, handler),
+		removeEventListener: (type, handler) => targetFor(type).removeEventListener(type, handler),
+		isHidden: () => document.visibilityState === "hidden",
+	};
+}
+
+/** Boot-time hydrate for the always-anonymous public client. No-op when the flag is off
+ *  or `localStorage` is unavailable, so the flag-off path performs no storage reads. */
+export function hydrateAnonPublicClient(client: SnapshotClient): void {
+	if (!FEED_SNAPSHOT_ENABLED) return;
+	const storage = browserSnapshotStorage();
+	if (storage == null) return;
+	hydrateFromSnapshot(client, storage, {identity: ANON_IDENTITY});
+}
+
+/** Install anon persistence for the public client's lifetime. No-op (an inert
+ *  uninstaller) when the flag is off or `localStorage` is unavailable, so the flag-off
+ *  path performs no storage writes. */
+export function installAnonSnapshotPersistence(client: SnapshotClient): () => void {
+	if (!FEED_SNAPSHOT_ENABLED) return () => {};
+	const storage = browserSnapshotStorage();
+	if (storage == null) return () => {};
+	return installSnapshotPersistence(client, storage, browserPersistenceBindings(), {
+		identity: ANON_IDENTITY,
+	});
+}

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -20,6 +20,7 @@ import {PanoCrumb} from "../components/pano/index";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {PanoFeedSkeleton} from "../components/pano/PanoSkeleton";
 import {Screen} from "../fate/Screen";
+import {FEED_SNAPSHOT_ENABLED} from "../fate/snapshot";
 import {LoadMoreButton} from "../fate/wire";
 import {
 	PANO_FEED_PAGE_SIZE,
@@ -133,12 +134,19 @@ function FeedContent({
 	pending: boolean;
 	chrome: Chrome;
 }) {
-	const {posts} = useRequest({
-		posts: {
-			list: PostConnectionView,
-			args: {sort, first: PANO_FEED_PAGE_SIZE, ...(host ? {host} : {})},
+	// Feed snapshot (leg A, #2319): under the containment flag, run the feed read
+	// stale-while-revalidate so a snapshot hydrated into the public client paints
+	// synchronously and the network patch lands in the background. Flag off ⇒ an
+	// `undefined` options arg, behaviorally identical to today's cache-first default.
+	const {posts} = useRequest(
+		{
+			posts: {
+				list: PostConnectionView,
+				args: {sort, first: PANO_FEED_PAGE_SIZE, ...(host ? {host} : {})},
+			},
 		},
-	});
+		FEED_SNAPSHOT_ENABLED ? {mode: "stale-while-revalidate"} : undefined,
+	);
 
 	return <FeedRows connection={posts} host={host} pending={pending} chrome={chrome} />;
 }

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -7,6 +7,14 @@
  */
 interface ImportMetaEnv {
 	readonly VITE_SENTRY_DSN?: string;
+	/**
+	 * Feed-snapshot containment flag (epic #2316, leg A). `"on"` enables the
+	 * boot-time persist+hydrate of the public fate cache; absent/anything else keeps
+	 * it dark (default-off). A build-time flag, not the server-evaluated Flagship
+	 * flag, because boot hydration resolves synchronously before any `/api/flags`
+	 * round-trip — see `src/fate/snapshot.ts`. #2326 flips it on measured evidence.
+	 */
+	readonly VITE_FEED_SNAPSHOT?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## What & why

Leg A of the "instant /pano reload" epic (#2316). Today a `/pano` reload rebuilds from zero: fate's normalized cache is in-memory only, so nothing can paint until a fresh fetch returns. This adds the **feed snapshot** — persist the public (always-anonymous) fate cache to `localStorage` on tab-hide and re-hydrate it at boot, so a warm reload paints the **last-seen feed synchronously** (before the network revalidate) instead of a skeleton.

Fixes #2319.

## Approach

- **`apps/web/src/fate/snapshot.ts`** — the persistence module. Uses fate's native `FateClient.dehydrate()` / `hydrate()` (versioned, JSON-safe `FateDehydratedState`, schema-derived `hydrationScope`) — **never** a hand-rolled serializer. `localStorage`, not IndexedDB, because the restore must be **synchronous** so `hydrate()` runs *before* the first `useRequest` (fate's documented hydrate-before-render contract; grounded against `@nkzw/fate@1.3.1` — `hydrate()` throws on version/scope mismatch, on a payload past its decode limits, and on a client with pending requests). Every failure mode — quota, corrupt/oversized payload, scope/version mismatch, in-flight requests — degrades to a **clean no-snapshot boot** (no throw, no wedged cache).
- **Wired into `getPublicFateClient()`** (the anon singleton, ADR 0167) — hydrate at instance creation, throttled persist installed on `pagehide` / `visibilitychange` for the app lifetime.
- **`PanoFeed`** runs the feed read `stale-while-revalidate` under the flag, so a hydrated snapshot paints synchronously and the network patch lands in the background (fate restores list pagination state, so the `?sort`/`host` connection identity comes back with it, #2072).

## Vocabulary (epic-coined; #2327 transcribes to `.glossary/TERMS.md`)

**feed snapshot** — the persisted, versioned dehydrated fate cache restored at boot. **base feed** / **viewer overlay** — leg B / the authed tier (out of scope here).

## Containment — FLAG-DARK

Behind the build-time **`VITE_FEED_SNAPSHOT`** flag (default-off / absent ⇒ off). A **Vite env flag, not the server-evaluated Flagship flag**, because boot hydration must resolve synchronously before any async `/api/flags/evaluate` round-trip could return — the `VITE_SENTRY_DSN` precedent (`vite-env.d.ts`). **Flag off ⇒ no storage reads or writes, byte-identical to today.** #2326 flips it on measured evidence, so this auto-ships safely dark.

## Adaptation note (for the reviewer)

The child's "What to build" named a not-yet-merged `publicClient.ts`/`getPublicFateClient()` — those **do** exist on current `main` (ADR 0167 two-tier provider landed), so the wiring lands in exactly the seam the child specified. The hydrate goes on the **public singleton only**, not the transient below-gate anon client, so it can't touch the #438 re-key path.

## Tests (TDD, per the child AC)

21 unit tests in `snapshot.test.ts` (`unit` tier): the pure persistence layer round-trip incl. nested list/pagination/connection-identity fields; the four tolerance paths (corrupt, quota, oversized, scope/version mismatch); the event-driven throttled installer (pagehide / visibilitychange-when-hidden / throttle-collapse / uninstall); and a **real `@nkzw/fate` client round-trip** proving dehydrate → persist → hydrate carries the cache without loss and that fate rejects a scope-mismatched snapshot (which we catch). `pnpm typecheck` + biome clean; the existing two-tier first-paint DOM tests (`App.test.tsx`) still green (flag-off unchanged).

## Scope boundary

Out of scope (sibling children): the authed tier + identity teardown (#2321), the base/overlay server split (#2322), client composition (#2323), edge cache + purge (#2324). No fate mutation touched (fanout-guard N/A); no CSS (design-token-guard N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)