### PR TITLE
feat(web): pano base feed / viewer-overlay server split + GET surface (#2322)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -50,6 +50,7 @@ import {
 	optimisticDefinitionAddFlag,
 	optimisticDefinitionDeleteFlag,
 	optimisticEditsFlag,
+	panoBaseFeedFlag,
 	panoDraftSaveFlag,
 	panoOptimisticCommentAddFlag,
 	panoOptimisticCommentDeleteFlag,
@@ -76,6 +77,10 @@ export default Alchemy.Stack(
 		yield* demoTargetingFlag(flagship.appId);
 		// The pano taslak (draft-save) dark-ship flag, default-off (#746).
 		yield* panoDraftSaveFlag(flagship.appId);
+		// The base-feed / viewer-overlay split dark-ship flag, default-off (#2322,
+		// epic #2316 leg B) — the single seam the GET-able base feed + PostOverlay read
+		// gate behind until a human release.
+		yield* panoBaseFeedFlag(flagship.appId);
 		// The optimistic post.submit (feed root-list insert) containment flag,
 		// default-off (#1676, epic #1637).
 		yield* panoOptimisticSubmitFlag(flagship.appId);

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -52,6 +52,18 @@ export const PANO_OPTIMISTIC_COMMENT_DELETE = "pano-optimistic-comment-delete";
 export const PANO_OPTIMISTIC_POST_DELETE = "pano-optimistic-post-delete";
 
 /**
+ * Base-feed / viewer-overlay split dark-ship flag (#2322, epic #2316 leg B). The
+ * SINGLE seam every leg-B surface gates behind — the server split (the GET-able
+ * viewer-invariant base feed + the authed `PostOverlay` read), the client
+ * composition (#2323), and the edge cache (#2324) reuse this one key. Default-off
+ * so the whole base/overlay path ships dark until a human flips it at release (ADR
+ * 0083): with it off the `GET /fate/pano/feed` route 404s, the `PostOverlay` source
+ * resolves inert (null scalars), and the existing per-viewer `posts` feed is the
+ * unchanged source of truth. Its own `pano-` key (the surface is pano-only).
+ */
+export const PANO_BASE_FEED = "pano-base-feed";
+
+/**
  * Earned-authorship loop (çaylak→yazar) dark-ship flag (#1204, epic #1202). The
  * single seam every authorship-loop surface gates behind: cross-cutting
  * (`phoenix`) because the loop touches sözlük/pano/pasaport, default-off so the

--- a/apps/web/tests/integration/pano-base-feed.test.ts
+++ b/apps/web/tests/integration/pano-base-feed.test.ts
@@ -1,0 +1,179 @@
+/**
+ * pano base feed / viewer overlay split (#2322, epic #2316 leg B) — black-box against
+ * the deployed worker (ADR 0026–0031, ADR 0082).
+ *
+ * Proves the leg-B server split:
+ *   1. The `GET /fate/pano/feed` base feed is served with `sort`/`host`/pagination in
+ *      the URL, carries NO viewer-scoped field, and is BYTE-IDENTICAL for an anonymous
+ *      request and a signed-in one — the whole point of a viewer-invariant, cacheable
+ *      base. An anon GET succeeds with no session (and the response sets no cookie), so
+ *      it does no session validation.
+ *   2. With the leg-B flag OFF (the default), the GET route 404s — the surface ships
+ *      dark. The existing per-viewer `posts` feed on `POST /fate` still stamps the
+ *      signed-in viewer's `myVote`/`isSaved` (the split changed nothing there).
+ *
+ * The base feed is dark behind `pano-base-feed` (default-off). Integration deploys run
+ * `ENVIRONMENT=development` (`_integration.ts` → `ensureIntegrationEnv`), so the dev-only
+ * override wrapper (`FlagsDevOverrideLive`, #622) is installed — this test flips the flag
+ * on for a single request by sending the `phoenix_flag_overrides` cookie. The default-off
+ * gate is the shipped state; the cookie only unlocks the flag-ON path for this test.
+ *
+ * Shared-stage NS isolation (ADR 0104): every seeded title/host carries the `${NS}-`
+ * prefix and the base feed is HOST-scoped to this file's `${NS}.example.com`, so the read
+ * returns exactly this file's seeded set on the shared D1.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
+
+const h = sharedStack();
+
+const NS = nsToken(import.meta.url);
+const FEED_HOST = `${NS}.example.com`;
+
+// The dev-override cookie that forces `pano-base-feed` on for a single request (#622 —
+// `phoenix_flag_overrides`, a URL-encoded JSON `{key: boolean}` map). Only takes effect
+// because integration deploys run with `ENVIRONMENT=development`.
+const BASE_FEED_ON_COOKIE = `phoenix_flag_overrides=${encodeURIComponent(
+	JSON.stringify({"pano-base-feed": true}),
+)}`;
+
+interface BaseNode {
+	__typename: string;
+	id: string;
+	title: string;
+	myVote?: unknown;
+	isSaved?: unknown;
+}
+type Connection<N> = {
+	items: Array<{cursor: string; node: N}>;
+	pagination: {hasNext: boolean; hasPrevious: boolean; nextCursor?: string};
+};
+
+let author: {userId: string; cookie: string};
+let viewer: {userId: string; cookie: string};
+const seeded: string[] = [];
+
+async function seedPost(title: string): Promise<string> {
+	const r = await h.fate(
+		{
+			kind: "mutation",
+			name: "post.submit",
+			input: {title, url: `https://${FEED_HOST}/${title}`, tags: [{kind: "tartışma"}]},
+			select: ["id"],
+		},
+		{cookie: author.cookie},
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error("seedPost failed");
+	return (r.data as {id: string}).id;
+}
+
+/** GET the base feed over the URL surface; returns the raw Response (caller asserts). */
+function getBaseFeed(query: string, cookie?: string): Promise<Response> {
+	return h.req(`/fate/pano/feed?${query}`, cookie ? {headers: {cookie}} : undefined);
+}
+
+beforeAll(async () => {
+	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "yazar");
+	viewer = await h.signUp(`${NS}-viewer@test.local`, "hunter2hunter2", "izleyen");
+	// A fresh account is a çaylak; promote so the author's posts are live (not sandboxed)
+	// and the viewer can cast a real vote (#1810 earn-to-vote gate).
+	await h.promoteToYazar(author.userId);
+	await h.promoteToYazar(viewer.userId);
+
+	for (const n of ["alpha", "bravo", "charlie"]) {
+		seeded.push(await seedPost(`${NS}-${n}`));
+	}
+});
+
+describe("pano base feed — GET surface + viewer-invariant base (#2322)", () => {
+	it("serves the base feed over GET with sort/host in the URL, no viewer-scoped field", async () => {
+		const res = await getBaseFeed(`sort=new&host=${FEED_HOST}&first=50`, BASE_FEED_ON_COOKIE);
+		// Name the flag in the failure so an ineffective override fails HERE with a clear
+		// cause, not as a confusing shape mismatch downstream.
+		expect(
+			res.status,
+			`GET base feed expected 200 with the flag ON, got ${res.status} — pano-base-feed override did not take effect`,
+		).toBe(200);
+		const conn = (await res.json()) as Connection<BaseNode>;
+		const titles = conn.items.map((e) => e.node.title).sort();
+		expect(titles).toEqual([`${NS}-alpha`, `${NS}-bravo`, `${NS}-charlie`]);
+		// The base carries NO viewer-scoped field.
+		for (const {node} of conn.items) {
+			expect(Object.hasOwn(node, "myVote")).toBe(false);
+			expect(Object.hasOwn(node, "isSaved")).toBe(false);
+		}
+	});
+
+	it("paginates via the URL cursor (first + nextCursor)", async () => {
+		const first = await getBaseFeed(`sort=new&host=${FEED_HOST}&first=2`, BASE_FEED_ON_COOKIE);
+		expect(first.status).toBe(200);
+		const page1 = (await first.json()) as Connection<BaseNode>;
+		expect(page1.items).toHaveLength(2);
+		expect(page1.pagination.hasNext).toBe(true);
+		const cursor = page1.pagination.nextCursor;
+		expect(cursor, "first page must expose a nextCursor").toBeTruthy();
+
+		const second = await getBaseFeed(
+			`sort=new&host=${FEED_HOST}&first=2&after=${encodeURIComponent(cursor!)}`,
+			BASE_FEED_ON_COOKIE,
+		);
+		expect(second.status).toBe(200);
+		const page2 = (await second.json()) as Connection<BaseNode>;
+		// The three seeded posts split 2 + 1 across the cursor with no overlap.
+		expect(page2.items).toHaveLength(1);
+		const ids1 = page1.items.map((e) => e.node.id);
+		expect(ids1).not.toContain(page2.items[0]!.node.id);
+	});
+
+	it("is byte-identical for an anonymous request and a signed-in one, and sets no cookie", async () => {
+		const query = `sort=new&host=${FEED_HOST}&first=50`;
+		const anon = await getBaseFeed(query, BASE_FEED_ON_COOKIE);
+		const authed = await getBaseFeed(query, `${viewer.cookie}; ${BASE_FEED_ON_COOKIE}`);
+		expect(anon.status).toBe(200);
+		expect(authed.status).toBe(200);
+		// No session validation: the base sets no cookie for either caller.
+		expect(anon.headers.get("set-cookie")).toBeNull();
+		expect(authed.headers.get("set-cookie")).toBeNull();
+		// Byte-identical bodies — the base is viewer-invariant by construction.
+		expect(await anon.text()).toBe(await authed.text());
+	});
+});
+
+describe("pano base feed — dark behind the leg-B flag (#2322)", () => {
+	it("404s the GET route when the flag is off (default dark state)", async () => {
+		const res = await getBaseFeed(`sort=new&host=${FEED_HOST}`);
+		expect(res.status).toBe(404);
+	});
+
+	it("leaves the existing POST /fate posts feed unchanged (still stamps myVote when off)", async () => {
+		// Vote a seeded post as the viewer, then read the existing `posts` feed WITHOUT any
+		// flag override: the per-viewer stamp is untouched by the split — myVote rides as
+		// before. (The author never self-votes; the viewer votes the author's post.)
+		const target = seeded[0]!;
+		const voted = await h.fate(
+			{kind: "mutation", name: "post.vote", input: {id: target}, select: ["id"]},
+			{cookie: viewer.cookie},
+		);
+		expect(voted.ok).toBe(true);
+
+		const feed = await h.fate(
+			{
+				kind: "list",
+				name: "posts",
+				args: {sort: "new", host: FEED_HOST, first: 50},
+				select: ["id", "myVote", "isSaved"],
+			},
+			{cookie: viewer.cookie},
+		);
+		expect(feed.ok).toBe(true);
+		if (!feed.ok) throw new Error("posts feed read failed");
+		const rows = new Map(
+			(
+				feed.data as Connection<{id: string; myVote: boolean | null; isSaved: boolean | null}>
+			).items.map((e) => [e.node.id, e.node]),
+		);
+		expect(rows.get(target)).toMatchObject({myVote: true});
+	});
+});

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -30,8 +30,13 @@ export {
 } from "../divan/views.ts";
 export type {FunnelSummary} from "../funnel/views.ts";
 export {funnelSummaryDataView} from "../funnel/views.ts";
-export type {Comment, Post, Tag} from "../pano/views.ts";
-export {commentDataView, postDataView, tagDataView} from "../pano/views.ts";
+export type {Comment, Post, PostOverlay, Tag} from "../pano/views.ts";
+export {
+	commentDataView,
+	postDataView,
+	postOverlayDataView,
+	tagDataView,
+} from "../pano/views.ts";
 export type {
 	AccountDeletionReceipt,
 	AuthorshipStanding,

--- a/apps/web/worker/features/flagship/pano-base-feed.invariant.test.ts
+++ b/apps/web/worker/features/flagship/pano-base-feed.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the base-feed / viewer-overlay
+ * split (#2322, epic #2316 leg B). Inspected off the exported `PANO_BASE_FEED_FLAG`
+ * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy
+ * resource is constructed — mirrors `funnel-readout.invariant.test.ts` (#1589).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PANO_BASE_FEED} from "../../../src/flags/keys.ts";
+import {PANO_BASE_FEED_FLAG, panoBaseFeedFlag} from "./resources.ts";
+
+describe("pano base feed — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(PANO_BASE_FEED_FLAG.defaultVariation, "off");
+		assert.strictEqual(PANO_BASE_FEED_FLAG.variations.off, false);
+		assert.strictEqual(PANO_BASE_FEED_FLAG.variations.on, true);
+		assert.strictEqual(PANO_BASE_FEED_FLAG.key, "pano-base-feed");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(PANO_BASE_FEED_FLAG.key, PANO_BASE_FEED);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof panoBaseFeedFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -11,6 +11,7 @@
 import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import {
+	PANO_BASE_FEED,
 	PANO_DRAFT_SAVE,
 	PANO_OPTIMISTIC_COMMENT_ADD,
 	PANO_OPTIMISTIC_COMMENT_DELETE,
@@ -85,6 +86,7 @@ export const demoTargetingFlag = (appId: Input<string>) =>
 	});
 
 export {
+	PANO_BASE_FEED,
 	PANO_DRAFT_SAVE,
 	PANO_OPTIMISTIC_COMMENT_ADD,
 	PANO_OPTIMISTIC_COMMENT_DELETE,
@@ -129,6 +131,40 @@ export const PANO_OPTIMISTIC_SUBMIT_FLAG = {
  */
 export const panoOptimisticSubmitFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("pano_optimistic_submit", {appId, ...PANO_OPTIMISTIC_SUBMIT_FLAG});
+
+/**
+ * The base-feed / viewer-overlay split dark-ship flag config (#2322, epic #2316 leg
+ * B). The SINGLE seam every leg-B surface gates behind (server split, client
+ * composition #2323, edge cache #2324). Default-OFF so the whole base/overlay path
+ * reaches production dark — with it off the `GET /fate/pano/feed` route 404s and the
+ * `PostOverlay` source resolves inert, so the per-viewer `posts` feed is unchanged;
+ * flipping it on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_DRAFT_SAVE_FLAG`, #746).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           pano (the feed read path)
+ *   - originating:     #2322 (epic: reload-to-feed-paint floor, #2316 leg B)
+ *   - removal trigger: once the base/overlay feed graduates to on at 100% and stable
+ *                      for one release, retire the flag and inline the split.
+ */
+export const PANO_BASE_FEED_FLAG = {
+	key: PANO_BASE_FEED,
+	description:
+		"base-feed / viewer-overlay split dark-ship (#2322, epic #2316 leg B). owner: pano. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const panoBaseFeedFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("pano_base_feed", {appId, ...PANO_BASE_FEED_FLAG});
 
 /**
  * The pano `taslak` (draft-save) dark-ship flag config (#746) — the feature-flag

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -169,6 +169,19 @@ export class Pano extends Context.Service<
 			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
 		) => Effect.Effect<ReadonlyArray<PostSummaryRow>>;
 
+		/**
+		 * The viewer overlay (#2322, epic #2316 leg B): the per-viewer `myVote`/`isSaved`
+		 * slice the GET-able base feed omits, keyed by the base feed's post ids. Reuses
+		 * the same batched `user_vote` / `post_bookmark` presence readers `getPostsByIds`
+		 * uses (one `IN (...)` per scalar, never per-row), reading no `post_record`.
+		 */
+		readonly readViewerOverlay: (
+			ids: ReadonlyArray<string>,
+			opts?: {viewerId?: string | null | undefined},
+		) => Effect.Effect<
+			ReadonlyArray<{id: string; myVote: boolean | null; isSaved: boolean | null}>
+		>;
+
 		/** Comment source `byIds` — batched read avoiding the relation N+1. */
 		readonly getCommentsByIds: (
 			ids: ReadonlyArray<string>,

--- a/apps/web/worker/features/pano/base-feed-route.ts
+++ b/apps/web/worker/features/pano/base-feed-route.ts
@@ -1,0 +1,91 @@
+/**
+ * `GET /fate/pano/feed?sort=…&host=…&first=…&after=…` (#2322, epic #2316 leg B) —
+ * the GET-able **base feed**: the pano feed connection served WITHOUT the per-viewer
+ * scalar stamp, so its bytes are identical for anon and every signed-in viewer and it
+ * can sit behind an edge cache (#2324). `sort` / `host` / pagination ride the URL (the
+ * cache key falls out of path+query, per the leg-B spike #2320), so each subfeed
+ * variant is its own entry. A raw `HttpRouter.add` route (like `rssRoute` /
+ * `linkMetadataRoute`) reaching `Pano` through the runtime-derived context layer. See
+ * `.patterns/alchemy-http-router.md`.
+ *
+ * Two load-bearing properties this route exists to hold:
+ *   - **No session validation, no per-viewer work.** It never validates a session and
+ *     never reads `CurrentUser`; it reads the ANONYMOUS sandbox viewer, so an anon GET
+ *     pays nothing for identity. The per-viewer `myVote`/`isSaved` arrive via the
+ *     separate authed `PostOverlay` read on `POST /fate` (ADR 0169 untouched — nothing
+ *     session-derived becomes cacheable).
+ *   - **Dark behind the leg-B flag.** With `PANO_BASE_FEED` off (the default / a
+ *     Flagship outage) the route 404s, so this whole surface ships dark until a human
+ *     flips the flag at release (ADR 0083). The flag is read under the anonymous flags
+ *     context (no identity), so the gate itself does no session work either.
+ *
+ * Cache headers / purge are the sibling cache child (#2324), NOT set here.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {PANO_BASE_FEED} from "../../../src/flags/keys.ts";
+import {toPostSort} from "../../../src/lib/panoFeedSort.ts";
+import {toConnection} from "../fate/connection.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {
+	anonymousFlagsContext,
+	FlagsContext,
+	makeRequestFlagsContext,
+} from "../flagship/FlagsContext.ts";
+import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
+import {Pano, type PostSummaryRow} from "./Pano.ts";
+import {type BasePost, toBasePost} from "./shapers.ts";
+
+/** The base-feed page size, matching the `posts` list resolver's default. */
+const DEFAULT_FIRST = 20;
+
+export const handleBaseFeed = Effect.gen(function* () {
+	const raw = yield* Cloudflare.Request;
+
+	// The dark-ship gate, evaluated under the ANONYMOUS flags context so it reads no
+	// session — an anon GET does zero identity work even to decide the flag. In every
+	// deployed stage this is the real Flagship read; in local dev the `phoenix_flag_overrides`
+	// cookie can force it on (#622), the same seam the integration suite drives.
+	const flags = yield* Flags;
+	const flagsContext = yield* makeRequestFlagsContext(
+		anonymousFlagsContext,
+		raw.headers.get("cookie"),
+	);
+	const on = yield* flags
+		.getBoolean(PANO_BASE_FEED, false)
+		.pipe(Effect.provideService(FlagsContext, flagsContext));
+	if (!on) {
+		return HttpServerResponse.empty({status: 404});
+	}
+
+	const params = new URL(raw.url).searchParams;
+	const host = params.get("host");
+	const after = params.get("after");
+	const firstRaw = params.get("first");
+	const first = firstRaw !== null ? Number.parseInt(firstRaw, 10) : DEFAULT_FIRST;
+
+	const pano = yield* Pano;
+	const page = yield* pano.listPostsConnection({
+		sort: toPostSort(params.get("sort") ?? undefined),
+		// `listPostsConnection` clamps `first` to [1,100]; a non-numeric `?first=` parses
+		// to `NaN`, so fall back to the default rather than pass `NaN` through the clamp.
+		first: Number.isNaN(first) ? DEFAULT_FIRST : first,
+		...(after !== null ? {after} : {}),
+		...(host !== null && host.length > 0 ? {host} : {}),
+		// The anonymous sandbox viewer: viewer-invariant + no moderator probe, so the
+		// base bytes never depend on who asked (a çaylak's sandboxed post is filtered out
+		// for everyone, exactly as the public `landingPosts` column already reads).
+		sandboxViewer: anonymousViewer,
+	});
+
+	const connection = toConnection<PostSummaryRow, BasePost>(
+		page,
+		(row) => row.id,
+		(row) => toBasePost(row),
+	);
+	return HttpServerResponse.jsonUnsafe(connection);
+});
+
+export const baseFeedRoute = HttpRouter.add("GET", "/fate/pano/feed", handleBaseFeed);

--- a/apps/web/worker/features/pano/base-post.unit.test.ts
+++ b/apps/web/worker/features/pano/base-post.unit.test.ts
@@ -1,0 +1,55 @@
+/**
+ * `toBasePost` — the viewer-invariant base projection (#2322, epic #2316 leg B): the
+ * wire `Post` MINUS the two viewer scalars (`myVote`/`isSaved`). Pure shaping, so it is
+ * unit-reachable (no DB). The load-bearing AC is byte-identity: because the base strips
+ * the only viewer-derived fields, its output is the SAME for any viewer-scalar input —
+ * which is exactly what makes the GET-able base feed cacheable and identical for anon vs
+ * signed-in. Proven here at the shaper (the route serializes this verbatim), with the
+ * anon-vs-authed round-trip left to the integration tier.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import type {PostFields} from "./post-fields.ts";
+import {toBasePost, toPost} from "./shapers.ts";
+
+const baseFields = (overrides: Partial<PostFields> = {}): PostFields => ({
+	id: "p1",
+	slug: "slug-1",
+	title: "başlık",
+	url: "https://example.com/a",
+	host: "example.com",
+	body: "gövde",
+	author: "yazar",
+	authorId: "u-author",
+	authorUsername: "yazar",
+	authorDisplayName: "Yazar",
+	score: 3,
+	commentCount: 2,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-02T00:00:00Z"),
+	tags: [{kind: "tartışma", label: "tartışma"}],
+	...overrides,
+});
+
+describe("toBasePost — viewer-invariant base projection (#2322)", () => {
+	it("omits the myVote/isSaved viewer scalars entirely", () => {
+		const base = toBasePost(baseFields({myVote: true, isSaved: true}));
+		assert.isFalse(Object.hasOwn(base, "myVote"), "base carries no myVote");
+		assert.isFalse(Object.hasOwn(base, "isSaved"), "base carries no isSaved");
+	});
+
+	it("keeps every non-viewer field identical to toPost", () => {
+		const fields = baseFields();
+		const {myVote: _mv, isSaved: _is, ...expected} = toPost(fields);
+		assert.deepStrictEqual(toBasePost(fields), expected);
+	});
+
+	it("is byte-identical regardless of the viewer scalar input (the cacheable-base guarantee)", () => {
+		// The same post as it would be stamped for a voter, for a non-voter, and unstamped:
+		// the base projection collapses all three to ONE serialization.
+		const voter = toBasePost(baseFields({myVote: true, isSaved: true}));
+		const nonVoter = toBasePost(baseFields({myVote: false, isSaved: false}));
+		const anon = toBasePost(baseFields({myVote: null, isSaved: null}));
+		assert.strictEqual(JSON.stringify(voter), JSON.stringify(nonVoter));
+		assert.strictEqual(JSON.stringify(voter), JSON.stringify(anon));
+	});
+});

--- a/apps/web/worker/features/pano/fate-module.ts
+++ b/apps/web/worker/features/pano/fate-module.ts
@@ -4,7 +4,7 @@ import type {FateModule, FateRootsRecord} from "../fate/module.ts";
 import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
 import {queries} from "./queries.ts";
-import {commentSource, postSource, tagSource} from "./sources.ts";
+import {commentSource, postOverlaySource, postSource, tagSource} from "./sources.ts";
 import {postDataView} from "./views.ts";
 
 const roots: FateRootsRecord = {
@@ -27,6 +27,6 @@ export const fateModule = {
 	queries,
 	lists,
 	mutations,
-	sources: [postSource, commentSource, tagSource],
+	sources: [postSource, postOverlaySource, commentSource, tagSource],
 	roots,
 } satisfies FateModule;

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -672,6 +672,29 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		return yield* stampAuthorIdentity(readProfileIdentities, reacted);
 	});
 
+	// The viewer overlay (#2322, epic #2316 leg B): given the base feed's post ids,
+	// return ONLY the per-viewer scalars (`myVote`/`isSaved`) — the exact slice the
+	// GET-able base projection omits so it can be viewer-invariant + cacheable. Reuses
+	// the SAME `postViewerScalars` batch readers as `getPostsByIds` (one `user_vote` +
+	// one `post_bookmark` `IN (...)` read for the whole id batch, never per-row), so the
+	// split adds no N+1. It reads no `post_record` at all — presence is a property of
+	// the viewer's own vote/bookmark rows, so an id the viewer never touched degrades to
+	// `false` (or `null` for an anonymous viewer, the read-path convention). Nothing here
+	// is viewer-cross-visible: a reader only ever learns its OWN vote/save state.
+	const readViewerOverlay = Effect.fn("Pano.readViewerOverlay")(function* (
+		ids: ReadonlyArray<string>,
+		opts: {viewerId?: string | null | undefined} = {},
+	) {
+		if (ids.length === 0) return [];
+		const viewerId = opts.viewerId ?? null;
+		const stamped = yield* stampViewerScalars(
+			ids.map((id) => ({id})),
+			viewerId,
+			postViewerScalars,
+		);
+		return stamped.map((row) => ({id: row.id, myVote: row.myVote, isSaved: row.isSaved}));
+	});
+
 	// The moderator sandbox-queue / promotion-backlog read model (#1205, the #1206
 	// seam): a çaylak's still-sandboxed, not-removed posts — scoped to one author when
 	// promotion flips their backlog. Authority is gated at the resolver; the service
@@ -1185,6 +1208,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		getPost,
 		listPostsConnection,
 		getPostsByIds,
+		readViewerOverlay,
 		listSandboxedPosts,
 		submitPost,
 		saveDraft,

--- a/apps/web/worker/features/pano/read-viewer-overlay.unit.test.ts
+++ b/apps/web/worker/features/pano/read-viewer-overlay.unit.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `Pano.readViewerOverlay` — the per-viewer overlay read (#2322, epic #2316 leg B):
+ * post ids in → `myVote`/`isSaved` out. Unit-reachable because the whole decision is
+ * "batch the presence readers once and stamp `viewerId ? set.has(id) : null`" — no SQL
+ * engine (ADR 0082 litmus: wrong-even-if-the-DB-behaved-perfectly → unit).
+ *
+ * The load-bearing AC is **no N+1**: each `ViewerScalarSpec` reader (`Vote.readMine` /
+ * `Bookmark.readMine`) must be called EXACTLY ONCE for the whole id batch, never per
+ * row. The doubles here record every call, so the test asserts the call count is 1 per
+ * spec with the full id set — the batched-read contract, proven structurally. A throwing
+ * `Drizzle` under `PanoLive` proves the overlay reads no `post_record` at all.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
+import {ReactionStub} from "../reaction/Reaction.testing.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Bookmark} from "./Bookmark.ts";
+import {Pano, PanoLive} from "./Pano.ts";
+
+// A `Drizzle` whose every `run`/`batch` dies — the overlay must reach NEITHER, so a
+// stray DB touch fails the test loudly (the no-`post_record`-read proof).
+const throwingAccess: DrizzleAccess = {
+	run: () => Effect.die(new Error("readViewerOverlay must not read the DB")),
+	batch: () => Effect.die(new Error("readViewerOverlay must not batch")),
+};
+
+interface VoteCall {
+	viewerId: string | null | undefined;
+	target: string;
+	ids: string[];
+}
+interface BookmarkCall {
+	viewerId: string | null | undefined;
+	ids: string[];
+}
+
+/** Build `PanoLive` over recording Vote/Bookmark doubles + the throwing Drizzle. */
+function overlayLayer(votedIds: string[], savedIds: string[]) {
+	const voteCalls: VoteCall[] = [];
+	const bookmarkCalls: BookmarkCall[] = [];
+
+	// biome-ignore lint/plugin: a service double — only `readMine` is on the overlay path; the other Vote methods die if reached.
+	const VoteRec = Layer.succeed(Vote, {
+		cast: () => Effect.die(new Error("overlay must not cast")),
+		readMine: (viewerId: string | null | undefined, target: string, ids: ReadonlyArray<string>) => {
+			voteCalls.push({viewerId, target, ids: [...ids]});
+			// The reader owns the anonymous short-circuit — no presence for a null viewer.
+			return Effect.succeed(viewerId ? new Set(votedIds) : new Set<string>());
+		},
+		clearTarget: () => Effect.void,
+	} as unknown as typeof Vote.Service);
+
+	// biome-ignore lint/plugin: a service double — only `readMine` is on the overlay path.
+	const BookmarkRec = Layer.succeed(Bookmark, {
+		toggle: () => Effect.die(new Error("overlay must not toggle")),
+		readMine: (viewerId: string | null | undefined, ids: ReadonlyArray<string>) => {
+			bookmarkCalls.push({viewerId, ids: [...ids]});
+			return Effect.succeed(viewerId ? new Set(savedIds) : new Set<string>());
+		},
+		listSavedConnection: () => Effect.die(new Error("not used")),
+	} as unknown as typeof Bookmark.Service);
+
+	const layer = PanoLive.pipe(
+		Layer.provide(VoteRec),
+		Layer.provide(BookmarkRec),
+		Layer.provide(ReactionStub),
+		Layer.provide(PasaportIdentityStub),
+		Layer.provide(Layer.succeed(Drizzle, throwingAccess)),
+	);
+	return {layer, voteCalls, bookmarkCalls};
+}
+
+describe("Pano.readViewerOverlay — batched per-viewer scalars, no N+1 (#2322)", () => {
+	it.effect(
+		"returns myVote/isSaved per id and reads each presence spec ONCE for the whole batch",
+		() => {
+			const {layer, voteCalls, bookmarkCalls} = overlayLayer(["p1"], ["p2"]);
+			return Effect.gen(function* () {
+				const pano = yield* Pano;
+				const overlay = yield* pano.readViewerOverlay(["p1", "p2", "p3"], {viewerId: "u1"});
+
+				assert.deepStrictEqual(overlay, [
+					{id: "p1", myVote: true, isSaved: false},
+					{id: "p2", myVote: false, isSaved: true},
+					{id: "p3", myVote: false, isSaved: false},
+				]);
+
+				// No N+1: ONE vote read + ONE bookmark read for the 3-id batch, each carrying
+				// the full id set (never one read per row).
+				assert.strictEqual(voteCalls.length, 1, "one batched user_vote read");
+				assert.strictEqual(bookmarkCalls.length, 1, "one batched post_bookmark read");
+				assert.deepStrictEqual(voteCalls[0], {
+					viewerId: "u1",
+					target: "post",
+					ids: ["p1", "p2", "p3"],
+				});
+				assert.deepStrictEqual(bookmarkCalls[0], {viewerId: "u1", ids: ["p1", "p2", "p3"]});
+			}).pipe(Effect.provide(layer));
+		},
+	);
+
+	it.effect("degrades every scalar to null for an anonymous viewer", () => {
+		const {layer} = overlayLayer(["p1"], ["p2"]);
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			const overlay = yield* pano.readViewerOverlay(["p1", "p2"], {viewerId: null});
+			assert.deepStrictEqual(overlay, [
+				{id: "p1", myVote: null, isSaved: null},
+				{id: "p2", myVote: null, isSaved: null},
+			]);
+		}).pipe(Effect.provide(layer));
+	});
+
+	it.effect("short-circuits an empty id batch with no presence read at all", () => {
+		const {layer, voteCalls, bookmarkCalls} = overlayLayer([], []);
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			const overlay = yield* pano.readViewerOverlay([], {viewerId: "u1"});
+			assert.deepStrictEqual(overlay, []);
+			assert.strictEqual(voteCalls.length, 0);
+			assert.strictEqual(bookmarkCalls.length, 0);
+		}).pipe(Effect.provide(layer));
+	});
+});

--- a/apps/web/worker/features/pano/shapers.ts
+++ b/apps/web/worker/features/pano/shapers.ts
@@ -48,6 +48,22 @@ export const toPost = (r: PostFields): Post => ({
 	tags: [...r.tags],
 });
 
+/**
+ * The viewer-invariant BASE post (#2322, epic #2316 leg B): `toPost` minus the two
+ * viewer scalars (`myVote`/`isSaved`). The GET-able base feed serves this so its bytes
+ * are identical for anon and every signed-in viewer — the per-viewer scalars ride the
+ * separate authed `PostOverlay` read instead. `sandboxed` stays but is structurally
+ * `false` on the base path (the route reads the ANONYMOUS sandbox viewer, and any
+ * sandboxed post is filtered out of the feed before it reaches here), so it carries no
+ * viewer-derived value.
+ */
+export type BasePost = Omit<Post, "myVote" | "isSaved">;
+
+export const toBasePost = (r: PostFields): BasePost => {
+	const {myVote: _myVote, isSaved: _isSaved, ...base} = toPost(r);
+	return base;
+};
+
 // The single `PostPage` → `Post` mapping shared by the read resolver
 // (`queries.post`) and the delete-refresh (`comment.delete`) so they can't drift.
 // `myVote`/`isSaved`/`reactions` and the live `authorUsername`/`authorDisplayName`

--- a/apps/web/worker/features/pano/sources.ts
+++ b/apps/web/worker/features/pano/sources.ts
@@ -6,10 +6,13 @@
  * `E = never` — infra failures die inside the domain service (the boundary rule
  * in `.patterns/feature-services.md`). See `.patterns/fate-effect-sources.md`.
  */
-import {Fate} from "@kampus/fate-effect";
+import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {PANO_BASE_FEED} from "../../../src/flags/keys.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Pano, tagLabel} from "./Pano.ts";
-import {CommentView, PostView, TagView} from "./views.ts";
+import {CommentView, PostOverlayView, PostView, TagView} from "./views.ts";
 
 export const postSource = Fate.source(
 	PostView,
@@ -19,6 +22,33 @@ export const postSource = Fate.source(
 			const pano = yield* Pano;
 			const sandboxViewer = yield* currentSandboxViewer;
 			return yield* pano.getPostsByIds(ids, {viewerId: sandboxViewer.viewerId, sandboxViewer});
+		},
+	},
+);
+
+/**
+ * The per-viewer overlay source (#2322, epic #2316 leg B): given the base feed's post
+ * ids, return each viewer's own `myVote`/`isSaved`. Session-gated by construction — it
+ * reads `CurrentUser` off the authed `POST /fate` edge (ADR 0169 untouched: nothing
+ * session-derived rides the cacheable base). Dark behind the leg-B flag: with it OFF
+ * (the default / a Flagship outage) it resolves INERT (`null` scalars for every id) so
+ * the new capability ships dark; flipping the flag on is the human release act (ADR
+ * 0083). An anonymous viewer likewise gets `null` scalars (the read-path convention).
+ */
+export const postOverlaySource = Fate.source(
+	PostOverlayView,
+	{id: "id"},
+	{
+		byIds: function* (ids) {
+			const {user} = yield* CurrentUser;
+			const viewerId = user?.id ?? null;
+			const flags = yield* Flags;
+			const on = yield* flags.getBoolean(PANO_BASE_FEED, false).pipe(provideRequestFlags);
+			if (!on || !viewerId) {
+				return ids.map((id) => ({id, myVote: null, isSaved: null}));
+			}
+			const pano = yield* Pano;
+			return yield* pano.readViewerOverlay(ids, {viewerId});
 		},
 	},
 );

--- a/apps/web/worker/features/pano/views.ts
+++ b/apps/web/worker/features/pano/views.ts
@@ -17,6 +17,20 @@ export type TagViewRow = ViewRow<PostTagRow>;
 export type CommentViewRow = ViewRow<CommentRow>;
 export type PostViewRow = ViewRow<PostSummaryRow>;
 
+/**
+ * `PostOverlay` — the per-viewer scalar slice (#2322, epic #2316 leg B), keyed by the
+ * post id. The GET-able base feed (`PostView` served without the viewer stamp) is
+ * viewer-invariant; the client fetches this overlay by the base feed's ids and composes
+ * `myVote`/`isSaved` on top (#2323). A distinct entity — not a `PostView` field set —
+ * so the base projection and the per-viewer read are separately cacheable/session-gated.
+ */
+export interface PostOverlayRow {
+	id: string;
+	myVote: boolean | null;
+	isSaved: boolean | null;
+}
+export type PostOverlayViewRow = ViewRow<PostOverlayRow>;
+
 // `Tag` is an embedded scalar on the post row (parsed from `post_record.tags`
 // CSV), not a standalone table; `kind` is the natural key.
 export class TagView extends FateDataView<TagViewRow>()("Tag")({
@@ -49,13 +63,23 @@ export class PostView extends FateDataView<PostViewRow>()("Post")({
 	comments: FateDataView.list(CommentView, {orderBy: viewOrderBy(COMMENT_ORDERING)}),
 }) {}
 
+// The per-viewer overlay view (#2322): three scalars, no relation. `myVote`/`isSaved`
+// are stamped by `Pano.readViewerOverlay` off the batched presence readers.
+export class PostOverlayView extends FateDataView<PostOverlayViewRow>()("PostOverlay")({
+	id: true,
+	myVote: true,
+	isSaved: true,
+}) {}
+
 // Kernel views for cross-feature surfaces that want fate's plain `dataView()`
 // value (the `fate/views.ts` `Root` map + barrel re-exports).
 export const tagDataView = TagView.view;
 export const commentDataView = CommentView.view;
 export const postDataView = PostView.view;
+export const postOverlayDataView = PostOverlayView.view;
 
 export type Tag = WorkerEntity<typeof TagView>;
+export type PostOverlay = WorkerEntity<typeof PostOverlayView>;
 // `deletedAt` is `Date | null` (the source row types it `deletedAt?: Date | null`, but
 // the corrected worker type drops the unset `undefined`) — an `Override`, not a `DateKeys`
 // member, which would preserve the optional and widen to `Date | null | undefined`.

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -22,6 +22,7 @@ import {fateRoute} from "../features/fate/route.ts";
 import {liveRoute} from "../features/fate-live/route.ts";
 import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
 import {flagsDevApplyRoute, flagsDevPageRoute} from "../features/flagship/route-dev.ts";
+import {baseFeedRoute} from "../features/pano/base-feed-route.ts";
 import {linkMetadataRoute} from "../features/pano/link-metadata-route.ts";
 import {authRoute} from "../features/pasaport/route.ts";
 import {rssRoute} from "../features/rss/route.ts";
@@ -60,6 +61,9 @@ export interface WorkerRoute {
 export const rawWorkerRoutes: readonly [WorkerRoute, ...WorkerRoute[]] = [
 	{path: "/fate", glob: "/fate", route: fateRoute},
 	{path: "/fate/live", glob: "/fate/*", route: liveRoute},
+	// The GET-able base feed (#2322, epic #2316 leg B); the `/fate/*` glob already
+	// shadows the SPA for it. Dark behind `PANO_BASE_FEED` (404 until flipped).
+	{path: "/fate/pano/feed", glob: "/fate/*", route: baseFeedRoute},
 	{path: "/api/auth/*", glob: "/api/*", route: authRoute},
 	{path: "/api/flags/probe", glob: "/api/*", route: flagsProbeRoute},
 	{path: "/api/flags/evaluate", glob: "/api/*", route: flagsEvaluateRoute},


### PR DESCRIPTION
Closes #2322 — epic #2316 (reload-to-feed-paint floor) **leg-B server split**. Lands the base/overlay seam dark behind the `pano-base-feed` flag (default-off); byte-identical behavior in production until a human flips it.

## What this lands

- **Base = viewer-invariant projection, over a GET surface.** New raw route `GET /fate/pano/feed?sort=&host=&first=&after=` (`worker/features/pano/base-feed-route.ts`), registered in the `worker-routes.ts` manifest like `rssRoute`/`linkMetadataRoute` (the `/fate/*` glob already shadows the SPA). It serves `listPostsConnection` shaped through the new `toBasePost` (the wire `Post` **minus** `myVote`/`isSaved`) under the **anonymous** sandbox viewer — so the bytes are identical for anon and every signed-in viewer, and an anon GET does **no session validation** and no per-viewer work. The flag gate is read under the anonymous flags context (no identity), so even the gate does no session work. Route 404s while the flag is off (dark).
- **Overlay = thin authed read.** `Pano.readViewerOverlay(ids, {viewerId})` reuses the existing `postViewerScalars` batch readers (one `IN (...)` per spec — **no N+1**), reading no `post_record`. Exposed as the new `PostOverlay` fate source on authed `POST /fate` (session-gated, ADR 0169 untouched). Inert (null scalars) while the flag is off.
- **Existing POST /fate `posts` feed path unchanged.**

The GET surface + the split seam at `stampViewerScalars` follow the leg-B spike decision (#2320). Cache headers/purge (#2324) and client composition (#2323) are the sibling children — **out of scope here**.

## Flag

`pano-base-feed` (`PANO_BASE_FEED`), default-off. IaC in `flagship/resources.ts` (`PANO_BASE_FEED_FLAG` + `panoBaseFeedFlag`), wired in `alchemy.run.ts`. The single leg-B seam #2323/#2324 reuse.

## Tests (TDD)

- **Unit** (offline, all green): `readViewerOverlay` batches one read per spec / no N+1 + anon→null + empty-batch short-circuit; `toBasePost` omits the viewer scalars and is byte-identical across any viewer-scalar input; the flag default-off invariant.
- **Integration** (CI-only, real remote D1): base GET surface with sort/host/pagination in the URL, no viewer-scoped field, **byte-identical anon vs signed-in** + no `set-cookie`; flag-off 404; existing POST /fate `posts` feed still stamps `myVote` when off.

Local: `pnpm lint`, `pnpm --filter @kampus/web typecheck`, and the full `unit` project (1900 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)