### PR TITLE
fix(pipeline): reconcile the canonical Reviewed-head contract across the §CP verdict seam (#2272, #2329)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -859,20 +859,30 @@ verdict_readback_guard() {
     || printf '%s' "$got" | grep -Eiq "^[[:space:]]*\**[[:space:]]*${gate}:[[:space:]]*advisory" \
     || { echo "verdict_readback_guard FAILED: no canonical '${gate}:' marker (PASS/FAIL @ ${sha:0:7} or advisory) in comment $cid — the body is malformed; the PR is UNGATED." >&2; return 1; }
 
-  # (2) Head binding — SHA-SOURCE-AWARE (#2272): do NOT require a `Reviewed-head:` line
-  #     unconditionally. A bindable first line (`<gate>: PASS|FAIL @ <sha>`) already carries the head
-  #     binding — (1) validated it against ${sha:0:7} — so a non-blocking binding PASS/FAIL (whose
-  #     template carries the SHA only on the first line, no separate line) needs NO `Reviewed-head:`.
-  #     A SHA-less advisory binds the head via `Reviewed-head: @ <sha>`: review-doc/review-skill carry
-  #     it (verified against head WHEN PRESENT); review-code's §CP advisory carries NONE by design
-  #     (ADR 0111 — SHA-less first line, no body binding) → accept its absence, never un-gate it. A
-  #     `Reviewed-head:` line present but bound to the WRONG sha is ALWAYS fatal (a stale/mis-bound
-  #     head must never read as verified).
+  # (2) Head binding — SHA-SOURCE-AWARE (#2272), and every verdict body binds the reviewed head:
+  #     - a bindable first line (`<gate>: PASS|FAIL @ <sha>`) carries the binding inline — (1) already
+  #       validated it against ${sha:0:7}, so a non-blocking binding PASS/FAIL needs no separate line
+  #       (this is the branch that keeps a legitimate non-blocking PASS from false-failing; #2272).
+  #     - a SHA-less advisory first line (`<gate>: advisory`, ALL FOUR gates INCL review-code) MUST
+  #       carry the canonical body `Reviewed-head: @ <sha>` line (§6.6 / ADR 0151) — absence is FATAL.
+  #       (#2329: the prior "review-code's §CP advisory carries NONE by design → accept its absence"
+  #       carve-out contradicted §6.6's own MUST and blinded the read-back to a drifted
+  #       `**Reviewed head:**` variant — bold, space-not-hyphen, backticked SHA — that does NOT match
+  #       `^Reviewed-head:` and that ship-it's §6.6 enqueue matcher then rejects, leaving a genuinely
+  #       -approved §CP PASS silently unshippable until a human hand-re-posts. Requiring the canonical
+  #       line on every advisory makes a drifted line read as absent → FATAL here → forces a canonical
+  #       re-post at EMISSION time, never a ship-it refusal on an approved PR.)
+  #     - ANY `Reviewed-head:` line present (advisory, or a belt-and-suspenders non-blocking PASS) must
+  #       bind ${sha:0:7} — a mis-bound/stale one is ALWAYS fatal (a wrong head must never read verified).
   if printf '%s' "$got" | grep -Eiq "^[[:space:]]*\**[[:space:]]*${gate}:[[:space:]]*(PASS|FAIL)[[:space:]]*@[[:space:]]*${sha:0:7}"; then
-    : # bindable first line: its `@ <sha>` IS the head binding (validated by (1)) — no line required
-  elif printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:"; then
+    : # bindable first line: its `@ <sha>` IS the head binding (validated by (1))
+  elif ! printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:"; then
+    echo "verdict_readback_guard FAILED: SHA-less advisory in comment $cid carries no canonical 'Reviewed-head: @ ${sha:0:7}' line — §6.6/ADR 0151 requires it on ALL four gates' advisories (incl review-code); a drifted '**Reviewed head:**' variant reads as absent. Re-post the canonical 'Reviewed-head: @ <sha>' line (hyphen, no bold, no backticks around the SHA)." >&2; return 1
+  fi
+  # a present `Reviewed-head:` line (advisory OR a non-blocking PASS that also carries it) must bind head:
+  if printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:"; then
     printf '%s' "$got" | grep -Eiq "^[[:space:]]*Reviewed-head:[[:space:]]*@?[[:space:]]*${sha:0:7}" \
-      || { echo "verdict_readback_guard FAILED: 'Reviewed-head:' line in comment $cid is bound to the wrong head (not @ ${sha:0:7}) — a stale/mis-bound §CP head binding." >&2; return 1; }
+      || { echo "verdict_readback_guard FAILED: 'Reviewed-head:' line in comment $cid is bound to the wrong head (not @ ${sha:0:7}) — a stale/mis-bound head binding." >&2; return 1; }
   fi
 
   # (3) NO local filesystem path leaked into the public body (the #2148 leak). Reject a machine-local
@@ -894,16 +904,21 @@ it as a silent success. A moved `HEAD_SHA` between the post and the read-back me
 *during* the review — re-resolve the head, re-verify against it (the gate is stateless), and re-post;
 never loosen the match to paper over a moved head.
 
-Check (2) is **SHA-source-aware** (#2272), which is why the read-back is unconditional without
-false-failing a legitimate non-blocking PASS or the review-code §CP advisory. The bindable PASS/FAIL
-first line satisfies (1) via its `@ <sha>` — that SHA **is** the head binding, so (2) requires no
-separate `Reviewed-head:` line (the non-blocking binding templates carry the SHA only on the first
-line). The advisory blocking-set path carries no first-line `@ <sha>` by design (ADR 0111), which is
-why (1) accepts the `<gate>: advisory` first line; it binds the head via a body `Reviewed-head: @ <sha>`
-line — review-doc/review-skill carry it and (2) verifies it against head when present, while
-review-code's §CP advisory carries none by design (ADR 0111) and (2) accepts its absence. A
-`Reviewed-head:` line present but bound to the wrong sha is always fatal. The leak check (3) is
-**unconditional** on every verdict type — the #2148/#2264 path-leak protection is never relaxed.
+Check (2) is **SHA-source-aware** (#2272): the read-back fires on every verdict type without
+false-failing a legitimate non-blocking PASS. The bindable PASS/FAIL first line satisfies (1) via its
+`@ <sha>` — that SHA **is** the head binding, so (2) requires no separate `Reviewed-head:` line (the
+non-blocking binding templates carry the SHA only on the first line; this is the branch that keeps a
+clean non-blocking doc/skill PASS from false-failing under the unconditional `verdict_post_verify …
+|| exit 1`). The advisory blocking-set path carries no first-line `@ <sha>` by design (ADR 0111),
+which is why (1) accepts the `<gate>: advisory` first line; it binds the head **in the body** via the
+canonical `Reviewed-head: @ <sha>` line, which §6.6/ADR 0151 mandates on **all four gates'** advisories
+— **review-code included** (#2329: the earlier "review-code's §CP advisory carries NONE by design →
+accept its absence" carve-out contradicted §6.6's MUST and blinded (2) to a drifted `**Reviewed head:**`
+variant, which ship-it's §6.6 enqueue matcher then rejects; the carve-out is removed, so a missing or
+drifted advisory head-binding fails **loud at emission** rather than surfacing as a ship-it refusal on
+an approved PR). Any `Reviewed-head:` line present but bound to the wrong sha is always fatal. The
+canonical-marker check (1) and the leak check (3) are **unconditional** on every verdict type — the
+#2148/#2264 path-leak protection is never relaxed.
 
 ### Make the read-back UNCONDITIONAL — resolve the landed verdict from PR state, never a carried id (`verdict_post_verify`)
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1165,9 +1165,11 @@ gets the **canonical advisory line** instead — `review-code: advisory — bloc
 merge)`, no `@ <sha>` — the one advisory shape all three gates converge on (ADR
 [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §5;
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §6.6). It carries the same
-per-criterion evidence table, but it authorizes nothing — it stays *out* of `ship-it`'s PASS
-namespace (there is nothing to bind, so no `@ <sha>`), `ship-it` refuses the blocking-set PR
-regardless (its Step 0), and a human merges it. Skip to **the blocking-set advisory path** below.
+per-criterion evidence table, but it authorizes nothing on its first line — it stays *out* of
+`ship-it`'s auto-merge PASS namespace (no first-line `@ <sha>`), and it binds the reviewed head in
+the body's canonical `Reviewed-head: @ <sha>` line instead (ADR 0151). Under ADR 0135's
+approve-then-enqueue, a human merges the §CP PR by hand, **or** `ship-it` enqueues it once a
+`@kamp-us/control-plane` approval is present at head. Skip to **the blocking-set advisory path** below.
 
 > **Why the advisory line, not "binding PASS + a caveat"?** The old shape — a real
 > `PASS @ <sha> — merge-ready` plus a control-plane warning — put a *binding* marker into
@@ -1314,19 +1316,36 @@ same forbidden forms — differing only in polarity (`FAIL @ <sha> — not merge
 
 Every criterion passed but `CONTROL_PLANE_TOUCHED` (Step 2) is non-empty — the PR touches the
 control plane (§CP). Post the **same evidence**, but the first line is the **canonical advisory
-line** (§6.6), **not** a binding merge-ready marker. It carries **no `@ <sha>`** by design (it
-authorizes nothing, so there is nothing to bind), keeping the verdict out of `ship-it`'s PASS
-namespace; `ship-it` refuses the PR regardless (Step 0) and a human merges it (ADR 0053/0065).
-Upsert it exactly as the PASS path (one `review-code:` marker per PR), and — like the PASS
+line** (§6.6), **not** a binding merge-ready marker. Its **first line** carries **no `@ <sha>`** by
+design (it authorizes nothing on its first line, so it never enters `ship-it`'s auto-merge PASS
+namespace — ADR 0111); under ADR 0135's approve-then-enqueue a human merges it by hand, **or**
+`ship-it` enqueues it once a `@kamp-us/control-plane` approval is present at head (ADR 0135, amending
+0053). Upsert it exactly as the PASS path (one `review-code:` marker per PR), and — like the PASS
 fallback — post it as a **comment**, not a native `APPROVE` (a native APPROVE would re-enter the
-code review namespace via its `commit_id`, defeating the advisory's purpose):
+code review namespace via its `commit_id`, defeating the advisory's purpose).
+
+> **The body's `Reviewed-head:` line is canonical and load-bearing — emit it verbatim (ADR 0151).**
+> The advisory's first line is SHA-less by design (ADR 0111), so the reviewed head is bound **in the
+> body**, on the canonical `Reviewed-head: @ <HEAD_SHA>` line below — the one form all four gates
+> converge on (§6.6). `ship-it`'s ADR-0135 approval-aware §CP enqueue reads the reviewed head from
+> **exactly** that line via the anchored matcher `^\s*Reviewed-head:\s*@?\s*([0-9a-f]{7,40})`, gated
+> on the control-plane approval — that is what makes a §CP code PR's enqueue **deterministic**
+> (#1932/#2022; free-prose "reviewed head" phrasings resolved nondeterministically and are retired).
+> Emit it as its own line with the **exact** `Reviewed-head:` prefix — **hyphen, not a space; no bold
+> `**`; no backticks around the SHA** (the drift on PR #2318 — `**Reviewed head:** \`<sha>\`` — did
+> not match the matcher and blocked a genuinely-approved §CP PASS until it was hand-re-posted; #2329).
+> Do **not** paraphrase it, and do **not** promote it to a first-line `PASS @ <sha>` marker (that
+> would drop the §CP verdict into `ship-it`'s auto-merge namespace, the ADR 0111 hazard).
 
 ```markdown
 review-code: advisory — blocking-set PR (manual merge)
 
 PR #<PR> touches the control plane (`.claude/**`, `.github/**`, or a gate-critical skill — §CP):
 the agent control plane / pipeline gates (ADR 0053/0065). My verdict is **advisory only**: it
-does **not** authorize a merge. A maintainer merges this by hand.
+does **not** authorize a merge. A maintainer merges this by hand, or `ship-it` enqueues it once a
+`@kamp-us/control-plane` approval is present at head (ADR 0135).
+
+Reviewed-head: @ <HEAD_SHA>
 
 Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time — all pass:
 

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -623,6 +623,8 @@ so a trailing `@ <sha>` captures `sha=null` and refuses a correct PASS as `unver
 ```markdown
 review-doc: PASS @ <HEAD_SHA> — merge-ready
 
+Reviewed-head: @ <HEAD_SHA>
+
 Verified PR #<PR> against the acceptance criteria of #<ISSUE> + the doc-hygiene checklist:
 
 **Acceptance criteria**
@@ -643,6 +645,12 @@ Read the PR head (§HEAD): all files under review sourced from `<HEAD_SHA>` via
 All checks pass. This PR is merge-ready. **review-doc does not merge** — `ship-it` is the
 authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
 ```
+
+The body carries the canonical `Reviewed-head: @ <HEAD_SHA>` line here too, so **every** verdict body
+this gate emits — non-blocking PASS, advisory, FAIL — binds the reviewed head in one uniform form
+(#2272). The non-blocking PASS is still bound primarily by its first-line `@ <sha>`; the body line is
+the same canonical token the read-back guard (§6.6) validates, so a clean non-blocking PASS never
+false-fails the unconditional `verdict_post_verify … || exit 1`.
 
 ### Pass path — blocking-set PR (advisory only)
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -563,6 +563,8 @@ order, so a trailing `@ <sha>` captures `sha=null` and refuses a correct PASS as
 ```markdown
 review-skill: PASS @ <HEAD_SHA> — merge-ready
 
+Reviewed-head: @ <HEAD_SHA>
+
 Verified PR #<PR> against the acceptance criteria of #<ISSUE> + the skill-rigor checklist:
 
 **Acceptance criteria**
@@ -581,6 +583,12 @@ Read the PR head (§HEAD): all skill text under review sourced from `<HEAD_SHA>`
 All checks pass. This PR is merge-ready. **review-skill does not merge** — `ship-it` is the
 authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
 ```
+
+The body carries the canonical `Reviewed-head: @ <HEAD_SHA>` line here too, so **every** verdict body
+this gate emits — non-blocking PASS, advisory, FAIL — binds the reviewed head in one uniform form
+(#2272). The non-blocking PASS is still bound primarily by its first-line `@ <sha>`; the body line is
+the same canonical token the read-back guard (§6.6) validates, so a clean non-blocking PASS never
+false-fails the unconditional `verdict_post_verify … || exit 1`.
 
 ### Pass path — blocking-set PR (advisory only, the canonical advisory form)
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -658,7 +658,14 @@ Now resolve **per namespace**, latest-wins by timestamp:
   `CHANGES_REQUESTED` review or a `review-code: FAIL` marker is FAIL. The verdict's bound SHA
   is the marker's `@ <sha>` (or, for a native review, its `commit_id`). (The native
   approving-review path stays; it interleaves only with the review-code markers, never with
-  review-doc.)
+  review-doc.) A **§CP** code PR's verdict is likewise the SHA-less-first-line advisory
+  (`review-code: advisory — blocking-set PR …`) — §6.6/ADR 0151 converges **all four** gates on
+  the one advisory form, so a §CP review-code advisory is resolved from the body's canonical
+  `Reviewed-head` line via the
+  **[§CP advisory resolution](#step-2cp--cp-advisory-namespace-resolution-adr-01350151)** below
+  (ADR 0111/0151), gated on Step 0's control-plane approval — **never** from a bindable first-line
+  marker (that would drop the §CP verdict into the auto-merge namespace, the ADR 0111 hazard). This
+  is the written resolution path a canonical review-code §CP advisory previously lacked (#2329).
 - **review-doc namespace** — the verdict is the **latest `review-doc` marker comment** by
   `created_at`; its bound SHA is the marker's `@ <sha>`. `review-doc: PASS … merge-ready` is
   PASS; `review-doc: FAIL … changes-requested` is FAIL. (review-doc lands no native review —
@@ -752,12 +759,16 @@ ADR 0053/0065/0111 hazard; the hand-posted-marker forge on #2005 is the workarou
 forbids).
 
 For each §CP namespace whose latest verdict is a **current-head advisory** (first line matches
-`^\s*\**\s*review-(skill|doc|design):\s*advisory\b`), resolve it as an **enqueue-eligible
+`^\s*\**\s*review-(code|skill|doc|design):\s*advisory\b`), resolve it as an **enqueue-eligible
 current-head PASS-equivalent** iff **all three** hold, else **refuse deterministically with the
-named reason**:
+named reason**. `review-code` is in this set: a §CP code PR's approved verdict is the same SHA-less
+advisory (§6.6/ADR 0151 converges **all four** gates on one advisory form), so its body
+`Reviewed-head` line resolves the enqueue exactly like the doc/skill/design namespaces — without it,
+a canonical review-code §CP advisory had no written resolution path and read as `sha: null` → refused
+on a legitimately-approved PR (#2329):
 
 ```bash
-# $ADV_BODY = the latest §CP advisory comment body for this namespace (review-skill or review-doc),
+# $ADV_BODY = the latest §CP advisory comment body for this namespace (review-code/skill/doc/design),
 # author-gated (write+, ADR 0055) and latest-wins exactly like the markers above.
 # (a) body's canonical Reviewed-head SHA (ADR 0151 §6.6) must prefix-match the PR's current head.
 #     Anchored to the `Reviewed-head:` line — a DISTINCT token from the first-line advisory marker,
@@ -775,8 +786,8 @@ fi
 ```
 
 A §CP namespace with **no** advisory comment at all (nor any PASS/FAIL marker) is still
-`unverified (no review-<skill|doc> PASS)` — the resolution needs a current-head advisory to read.
-A §CP namespace whose latest verdict is a `review-<skill|doc>: FAIL` marker is a **FAIL** (the
+`unverified (no review-<code|skill|doc> PASS)` — the resolution needs a current-head advisory to read.
+A §CP namespace whose latest verdict is a `review-<code|skill|doc>: FAIL` marker is a **FAIL** (the
 reviewer found a miss), refused exactly as a non-§CP FAIL — the §CP advisory path is entered only
 when the latest verdict is an *advisory*, never to mask a FAIL.
 


### PR DESCRIPTION
## What this does

Resolves **both** #2272 and #2329 in one PR — they are opposite-polarity fixes on the **same** `verdict_readback_guard()` **check (2)** clause, so building them apart re-breaks the other (triage's coordination flag on both issues).

The reconciling direction: **the canonical `Reviewed-head: @ <sha>` line is present on every verdict body the guard runs against, and check (2) fires on every path** — while the leak check (3) and canonical-marker check (1) stay unconditional (#2148 protection intact).

## Grounding — is #2271 on main?

**Yes.** PR #2271 ("make the read-back unconditional", #2268) is **merged** onto `main` (merge commit `c4753c8`, its open head was `7a873d61`). `verdict_post_verify` and the three `… || exit 1` call sites are live in `gh-issue-intake-formats.md` + the three review skills.

This changes the picture the two issues were filed against:

- **#2272's fatal-abort is no longer active on main.** #2271 already made check (2) **SHA-source-aware** — a non-blocking PASS binds via its first-line `<gate>: PASS @ <sha>`, so it satisfies check (2) without a `Reviewed-head:` line and does **not** fatally abort. The core defect #2272 reported was folded into #2271.
- **But #2271 codified the exact carve-out #2329 is about.** Its check (2) comment reads *"review-code's §CP advisory carries NONE by design (ADR 0111) → accept its absence"* — which contradicts §6.6's MUST (*"The advisory body MUST carry the canonical `Reviewed-head` line"* for the one form **all four gates** converge on) and blinds the read-back to the drifted `**Reviewed head:**` variant that ship-it's §6.6 matcher then rejects (the PR #2318 incident).

So this PR keeps #2271's bindable-first-line branch (protecting the non-blocking PASS — the #2272 direction) and closes the remaining #2329 seam, plus adds the `Reviewed-head` line to the non-blocking PASS bodies so every verdict body is uniform.

## Exact loci changed

**`gh-issue-intake-formats.md` — `verdict_readback_guard` check (2)**
- Removed the `review-code advisory carries NONE by design → accept its absence` carve-out.
- A SHA-less advisory (all four gates, incl `review-code`) now **REQUIRES** a canonical `Reviewed-head: @ <sha>` bound to head — absence, a wrong SHA, or a drifted `**Reviewed head:**` variant is **fatal at emission** (matcher `^\s*Reviewed-head:\s*@?\s*<sha>`).
- The bindable-first-line branch stays, so a non-blocking PASS never false-fails; leak (3) + marker (1) unchanged. Prose paragraph updated to match.

**`review-code/SKILL.md` — Step 4a §CP advisory template (#2329a)**
- Emits the canonical `Reviewed-head: @ <HEAD_SHA>` line, with an anti-drift note (**hyphen not space, no bold, no backticks around the SHA**) and the ADR 0111/0151 body-binding blockquote the other gates carry.
- Stripped the stale pre-0135 *"ship-it refuses the PR regardless / a human merges it"* prose → ADR 0135 approve-then-enqueue model (here and in the Step 4a intro).

**`review-doc/SKILL.md` + `review-skill/SKILL.md` — non-blocking PASS bodies (#2272)**
- Each non-blocking PASS body now also carries the canonical `Reviewed-head: @ <HEAD_SHA>` line, so every verdict body binds the head in one uniform form (validated-when-present by check (2)).

**`ship-it/SKILL.md` — Step 2.§CP (#2329c)**
- Advisory-namespace matcher is now `^\s*\**\s*review-(code|skill|doc|design):\s*advisory\b` (was `review-(skill|doc|design)` — `review-code` was missing).
- The review-code namespace bullet now documents the §CP advisory resolution it previously lacked; the `$ADV_BODY` comment and the `no review-<…> PASS` / `FAIL` messages include `review-code`.

## Verification (mechanical)

- (a) Every non-blocking PASS body + every advisory body carries `Reviewed-head:` — verified across all three review skills.
- (b) ship-it's advisory matcher now includes `review-code`.
- (c) check (2) has no live review-code exemption (the only remaining mentions are past-tense rationale referencing the removed carve-out).
- (d) Execute-tested the check (2) branch against 7 verdict-body shapes: non-blocking PASS (first-line-only and +Reviewed-head) → OK; advisory + canonical → OK; advisory drifted / absent / wrong-sha → **FATAL**. No template contradicts check (2).

`biome`, `leak-guard`, `ref-guard` pass in pre-commit.

## §CP — do not auto-merge

All five files are in the §CP set (`review-code/`, `review-doc/`, `review-skill/`, `ship-it/`, `gh-issue-intake-formats.md` per CONTROL_PLANE_RE). This is advisory-reviewed and **human-merged (cansirin, ADR 0135)** — never auto-shipped/enqueued.

Fixes #2272
Fixes #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)