### PR TITLE
feat(web): identity-scoped authed feed snapshot + sign-out teardown (#2321)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -122,6 +122,18 @@ vi.mock("./auth/client", async () => {
 vi.mock("./fate/client", () => ({createClient: () => ({}) as never}));
 vi.mock("./fate/useGlobalLivePin", () => ({useGlobalLivePin: () => undefined}));
 
+// Spy the authed-tier feed-snapshot seam (#2321) so the wiring is observable independent of
+// the (default-off, `window`-bound) flag: FateProvider hydrates at client creation on the
+// resolved id + installs persistence, and tears down the previous identity's snapshot on an
+// identity change / sign-out; App's `onSignOut` tears down eagerly. The pure storage contract
+// is proven in `snapshot.test.ts`; here we assert only that the seam CALLS teardown/hydrate.
+const snapshotSpies = vi.hoisted(() => ({
+	hydrateAuthedClient: vi.fn(),
+	installAuthedSnapshotPersistence: vi.fn(() => () => {}),
+	teardownAuthedSnapshot: vi.fn(),
+}));
+vi.mock("./fate/snapshot", () => snapshotSpies);
+
 // The fate-consuming hooks that live BELOW the gate in `LayoutContent`. Stub them inert
 // so `LayoutContent` renders offline once the gate commits — their PRESENCE below the
 // gate is invariant 1's point; here they must simply not touch the wire.
@@ -375,5 +387,87 @@ describe("Topbar search echo (#2199)", () => {
 	it("leaves the header input empty off the results page (unchanged behavior)", () => {
 		renderApp("/pano");
 		expect((screen.getByLabelText("Ara") as HTMLInputElement).value).toBe("");
+	});
+});
+
+// The authed-tier feed snapshot wiring (#2321): FateProvider hydrates the identity-keyed
+// client at creation on the RESOLVED id (never anon), installs per-identity persistence, and
+// tears down the previous identity's snapshot on an identity change / sign-out — all through
+// the REAL FateProvider gate the invariant-2 tests pin (#438-safe). The snapshot module is
+// spied (snapshotSpies), so these assert the SEAM fires, not the storage effect.
+describe("Authed feed snapshot wiring (#2321)", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		snapshotSpies.hydrateAuthedClient.mockClear();
+		snapshotSpies.installAuthedSnapshotPersistence.mockClear();
+		snapshotSpies.teardownAuthedSnapshot.mockClear();
+	});
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("AC1/AC4: hydrates the authed client ONCE on the resolved identity (never anon) + installs persistence", () => {
+		renderApp(FATE_FREE_ROUTE);
+		// Pending: the gate is deferred, so no authed client has been created/hydrated yet.
+		expect(snapshotSpies.hydrateAuthedClient).not.toHaveBeenCalled();
+
+		act(() => {
+			setSession({
+				data: {user: {id: "user-42", name: "Elif", email: "elif@kamp.us"}},
+				isPending: false,
+			});
+		});
+
+		// Hydrated exactly once, keyed on the resolved id — never a leading anon hydrate (the
+		// #438 re-key would have produced an anon-keyed pass first).
+		expect(snapshotSpies.hydrateAuthedClient).toHaveBeenCalledTimes(1);
+		expect(snapshotSpies.hydrateAuthedClient).toHaveBeenCalledWith(expect.anything(), "user-42");
+		expect(snapshotSpies.installAuthedSnapshotPersistence).toHaveBeenCalledWith(
+			expect.anything(),
+			"user-42",
+		);
+	});
+
+	it("AC3: an identity switch A→B tears down the PREVIOUS identity's snapshot", () => {
+		renderApp(FATE_FREE_ROUTE);
+		act(() => {
+			setSession({
+				data: {user: {id: "user-A", name: "Ada", email: "ada@kamp.us"}},
+				isPending: false,
+			});
+		});
+		expect(snapshotSpies.teardownAuthedSnapshot).not.toHaveBeenCalled(); // first identity, nothing prior
+
+		act(() => {
+			setSession({
+				data: {user: {id: "user-B", name: "Bora", email: "bora@kamp.us"}},
+				isPending: false,
+			});
+		});
+		expect(snapshotSpies.teardownAuthedSnapshot).toHaveBeenCalledWith("user-A");
+	});
+
+	it("AC3: sign-out / account deletion (A→signed-out) tears down A's snapshot", () => {
+		renderApp(FATE_FREE_ROUTE);
+		act(() => {
+			setSession({
+				data: {user: {id: "user-A", name: "Ada", email: "ada@kamp.us"}},
+				isPending: false,
+			});
+		});
+		act(() => {
+			setSession({data: null, isPending: false}); // session ends
+		});
+		expect(snapshotSpies.teardownAuthedSnapshot).toHaveBeenCalledWith("user-A");
+	});
+
+	it("identity-scoped: a signed-out settle hydrates NO authed snapshot (anon owns none)", () => {
+		renderApp(FATE_FREE_ROUTE);
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+		expect(snapshotSpies.hydrateAuthedClient).not.toHaveBeenCalled();
+		expect(snapshotSpies.installAuthedSnapshotPersistence).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import {EagerProfileContributionSkeleton} from "./components/profile/ProfileCont
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
+import {teardownAuthedSnapshot} from "./fate/snapshot";
 import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
@@ -113,6 +114,13 @@ function Layout() {
 		location.pathname === "/search" ? (new URLSearchParams(location.search).get("q") ?? "") : "";
 
 	async function onSignOut() {
+		// Drop this identity's persisted feed snapshot at the sign-out seam BEFORE the
+		// session clears — its private myVote/isSaved overlay must not outlive the session
+		// (#2321). Capture the id first: signOut() nulls the session. The FateProvider
+		// identity-change seam also tears down on the resulting A→anon transition; this
+		// eager call makes the removal immediate on click rather than after the async settle.
+		const signedOutUserId = session.data?.user.id;
+		if (signedOutUserId) teardownAuthedSnapshot(signedOutUserId);
 		await authClient.signOut();
 		clearBearerToken();
 	}

--- a/apps/web/src/fate/FateProvider.tsx
+++ b/apps/web/src/fate/FateProvider.tsx
@@ -12,6 +12,11 @@ import {useSession} from "../auth/client";
 import {createClient} from "./client";
 import {createLiveRetryController, type LiveRetryController} from "./liveRetry";
 import {getPublicFateClient} from "./publicClient";
+import {
+	hydrateAuthedClient,
+	installAuthedSnapshotPersistence,
+	teardownAuthedSnapshot,
+} from "./snapshot";
 import {useGlobalLivePin} from "./useGlobalLivePin";
 
 /**
@@ -57,12 +62,42 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 		return () => controller?.cancel();
 	}, [userId]);
 
+	// Identity-change teardown (#2321): when the resolved identity changes — a switch A→B
+	// or a sign-out/account-deletion A→anon (all reduce to the same transition) — drop the
+	// PREVIOUS identity's persisted snapshot, so its private myVote/isSaved overlay never
+	// survives the identity it belonged to. A content-cache eviction, not auth: the session
+	// cookie/validation is untouched.
+	const prevUserIdRef = useRef<string | null>(null);
+	useEffect(() => {
+		const prev = prevUserIdRef.current;
+		if (prev != null && prev !== userId) teardownAuthedSnapshot(prev);
+		prevUserIdRef.current = userId;
+	}, [userId]);
+
 	// Live SSE only opens for an authenticated client — `/fate/live` 401s for an
 	// anonymous viewer, so an anon client gets no-op live methods (no retry loop).
-	const client = useMemo(
-		() => createClient({authenticated: userId != null, onTransientLiveError: scheduleRetry}),
-		[userId, scheduleRetry],
-	);
+	const client = useMemo(() => {
+		const created = createClient({
+			authenticated: userId != null,
+			onTransientLiveError: scheduleRetry,
+		});
+		// Feed snapshot (leg A, #2321): restore this identity's persisted authed cache at
+		// client creation — BEFORE any `useRequest` renders under the FateClient below, fate's
+		// hydrate-before-render contract. The anon (userId null) client is the pending/signed-out
+		// tier and owns no authed snapshot, so it is skipped: the authed snapshot is strictly
+		// identity-scoped. No-op when the flag is off. See `snapshot.ts`.
+		if (userId != null) hydrateAuthedClient(created, userId);
+		return created;
+	}, [userId, scheduleRetry]);
+
+	// Persist this identity's authed cache on tab-hide for the committed client's lifetime
+	// (#2321). Tied to the client instance so a re-key uninstalls the old client's listeners
+	// before the next installs; anon owns no authed snapshot, so it is skipped. No-op when
+	// the flag is off.
+	useEffect(() => {
+		if (userId == null) return;
+		return installAuthedSnapshotPersistence(client, userId);
+	}, [client, userId]);
 
 	// `useSession` resolves async ({data:null, isPending:true} → user) with no
 	// synchronous hydration. Committing the keyed client before it settles mounts

--- a/apps/web/src/fate/snapshot.test.ts
+++ b/apps/web/src/fate/snapshot.test.ts
@@ -19,6 +19,8 @@ import {createClient, type FateDehydratedState} from "@nkzw/fate";
 import {describe, expect, it, vi} from "vitest";
 import {
 	ANON_IDENTITY,
+	authedIdentity,
+	clearSnapshot,
 	createLeadingThrottle,
 	hydrateFromSnapshot,
 	installSnapshotPersistence,
@@ -336,5 +338,111 @@ describe("real fate client round-trip", () => {
 		const restored = realClient("scope-B"); // schema rotated
 		expect(() => hydrateFromSnapshot(restored, storage)).not.toThrow();
 		expect(hydrateFromSnapshot(restored, storage)).toBe(false);
+	});
+});
+
+/**
+ * The identity-keyed authed tier (#2321): the authed snapshot embeds the viewer's private
+ * `myVote`/`isSaved` overlay, so its storage key must be scoped per user id — a snapshot
+ * written under user A must NEVER hydrate under user B or under anon (both directions), and
+ * an identity's snapshot must be torn down when its session ends (sign-out / identity switch
+ * / account deletion). These pin the pure key-scoping + teardown contract the browser-bound
+ * `hydrateAuthedClient` / `installAuthedSnapshotPersistence` / `teardownAuthedSnapshot`
+ * wrappers (flag-gated, `window`-bound — untested here, as the anon siblings are) delegate to.
+ */
+describe("authedIdentity — per-user key scoping, disjoint from anon", () => {
+	it("namespaces the identity under `user:` so it cannot collide with anon or another id", () => {
+		expect(authedIdentity("42")).toBe("user:42");
+		expect(authedIdentity("42")).not.toBe(ANON_IDENTITY);
+		expect(authedIdentity("A")).not.toBe(authedIdentity("B"));
+		// Even a user whose id were literally "anon" keys to a distinct segment.
+		expect(authedIdentity(ANON_IDENTITY)).not.toBe(ANON_IDENTITY);
+	});
+});
+
+describe("authed snapshot — cross-identity hydration is rejected (both directions, #2321 AC2)", () => {
+	it("a snapshot written under user A does NOT hydrate under user B", () => {
+		const storage = memoryStorage();
+		// A's snapshot carries A's private overlay.
+		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("A")});
+
+		const asB = fakeClient(sampleState);
+		expect(hydrateFromSnapshot(asB, storage, {identity: authedIdentity("B")})).toBe(false);
+		expect(asB.hydrated).toEqual([]); // B's client never saw A's overlay
+	});
+
+	it("a snapshot written under user A does NOT hydrate under anon", () => {
+		const storage = memoryStorage();
+		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("A")});
+
+		const asAnon = fakeClient(sampleState);
+		expect(hydrateFromSnapshot(asAnon, storage, {identity: ANON_IDENTITY})).toBe(false);
+		expect(asAnon.hydrated).toEqual([]);
+	});
+
+	it("the inverse: an anon snapshot does NOT hydrate under an authed identity", () => {
+		const storage = memoryStorage();
+		saveSnapshot(fakeClient(sampleState), storage, {identity: ANON_IDENTITY});
+
+		const asA = fakeClient(sampleState);
+		expect(hydrateFromSnapshot(asA, storage, {identity: authedIdentity("A")})).toBe(false);
+		expect(asA.hydrated).toEqual([]);
+	});
+
+	it("the same identity DOES hydrate its own snapshot (positive control)", () => {
+		const storage = memoryStorage();
+		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("A")});
+
+		const asA = fakeClient(sampleState);
+		expect(hydrateFromSnapshot(asA, storage, {identity: authedIdentity("A")})).toBe(true);
+		expect(asA.hydrated).toEqual([sampleState]);
+	});
+
+	it("restores the deep-linked subfeed (?sort/host connection state) for the authed tier (AC5)", () => {
+		// `sampleState.data` carries the `posts(sort:hot,host:example.com)` list identity — the
+		// `?sort=…` / `/pano/site/:host` subfeed. Through the authed key it round-trips intact,
+		// so a deep-linked subfeed restores instantly for a signed-in viewer too.
+		const storage = memoryStorage();
+		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("A")});
+		const restored = readSnapshot(storage, snapshotKey("v1", authedIdentity("A")));
+		expect(restored?.data).toEqual(sampleState.data);
+	});
+});
+
+describe("authed snapshot teardown — the sign-out / identity-change / deletion seam (#2321 AC3)", () => {
+	it("clearSnapshot removes exactly the target identity's snapshot, leaving siblings intact", () => {
+		const storage = memoryStorage();
+		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("A")});
+		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("B")});
+		saveSnapshot(fakeClient(sampleState), storage, {identity: ANON_IDENTITY});
+
+		// Tear down A (sign-out / switch away from A / A's account deletion).
+		clearSnapshot(storage, {identity: authedIdentity("A")});
+
+		// A is gone; B and anon survive — teardown is strictly identity-scoped.
+		expect(readSnapshot(storage, snapshotKey("v1", authedIdentity("A")))).toBeNull();
+		expect(readSnapshot(storage, snapshotKey("v1", authedIdentity("B")))).not.toBeNull();
+		expect(readSnapshot(storage, snapshotKey("v1", ANON_IDENTITY))).not.toBeNull();
+	});
+
+	it("after teardown, A's own re-hydration finds nothing (the overlay does not survive its session)", () => {
+		const storage = memoryStorage();
+		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("A")});
+		clearSnapshot(storage, {identity: authedIdentity("A")});
+
+		const asA = fakeClient(sampleState);
+		expect(hydrateFromSnapshot(asA, storage, {identity: authedIdentity("A")})).toBe(false);
+		expect(asA.hydrated).toEqual([]);
+	});
+
+	it("tolerates a throwing removeItem (Safari private mode) → clean no-op", () => {
+		const storage: KeyValueStorage = {
+			getItem: () => null,
+			setItem: () => undefined,
+			removeItem: () => {
+				throw new Error("access denied");
+			},
+		};
+		expect(() => clearSnapshot(storage, {identity: authedIdentity("A")})).not.toThrow();
 	});
 });

--- a/apps/web/src/fate/snapshot.ts
+++ b/apps/web/src/fate/snapshot.ts
@@ -39,6 +39,15 @@ export const FEED_SNAPSHOT_SCHEMA = "v1";
  *  per user-id and tears the snapshot down on identity change / sign-out. */
 export const ANON_IDENTITY = "anon";
 
+/** Identity segment for an authed viewer, keyed per user id (#2321). The `user:` prefix
+ *  keeps every authed key disjoint from the anon segment (`anon`) and from every other
+ *  user, so a snapshot written under user A lives at a distinct key from user B's and
+ *  from anon's — the primary guard that A's private `myVote`/`isSaved` overlay can never
+ *  hydrate under another identity (a mismatched key simply finds no snapshot). */
+export function authedIdentity(userId: string): string {
+	return `user:${userId}`;
+}
+
 /** Cap a persisted snapshot's serialized length. An oversized payload is neither
  *  written nor read back (dropped to a clean boot), bounding both `localStorage`
  *  pressure and the synchronous boot-time parse cost. */
@@ -176,6 +185,21 @@ export function saveSnapshot(
 	return writeSnapshot(storage, snapshotKey(schema, identity), state, maxChars);
 }
 
+/** Remove a persisted snapshot, tolerating a throwing `removeItem` (Safari private mode)
+ *  to a clean no-op. The identity teardown primitive: the snapshot is a content cache,
+ *  never an auth artifact, so an identity's persisted feed overlay is dropped the moment
+ *  its session ends (#2321). */
+export function clearSnapshot(
+	storage: KeyValueStorage,
+	{schema = FEED_SNAPSHOT_SCHEMA, identity = ANON_IDENTITY}: SnapshotScope = {},
+): void {
+	try {
+		storage.removeItem(snapshotKey(schema, identity));
+	} catch {
+		// storage unreachable ⇒ nothing to clean up; teardown stays best-effort like every other path
+	}
+}
+
 /** A leading-edge throttle gate: returns `true` at most once per `throttleMs`. Time is
  *  injected so the throttle is deterministically testable. */
 export function createLeadingThrottle(
@@ -272,4 +296,42 @@ export function installAnonSnapshotPersistence(client: SnapshotClient): () => vo
 	return installSnapshotPersistence(client, storage, browserPersistenceBindings(), {
 		identity: ANON_IDENTITY,
 	});
+}
+
+/** Boot-time hydrate for the identity-keyed authed client (#2321) — the authed sibling of
+ *  `hydrateAnonPublicClient`. Runs at client creation in `FateProvider` AFTER the session
+ *  resolves, keyed on the resolved `userId`, so a signed-in reload paints the viewer's own
+ *  last-seen feed (base feed + private `myVote`/`isSaved`) synchronously before the first
+ *  `useRequest`. Keyed per user, so one identity's snapshot never hydrates under another.
+ *  No-op when the flag is off or `localStorage` is unavailable. */
+export function hydrateAuthedClient(client: SnapshotClient, userId: string): void {
+	if (!FEED_SNAPSHOT_ENABLED) return;
+	const storage = browserSnapshotStorage();
+	if (storage == null) return;
+	hydrateFromSnapshot(client, storage, {identity: authedIdentity(userId)});
+}
+
+/** Install authed persistence for the identity-keyed client's lifetime, keyed per user id
+ *  (#2321). Inert uninstaller when the flag is off or `localStorage` is unavailable. */
+export function installAuthedSnapshotPersistence(
+	client: SnapshotClient,
+	userId: string,
+): () => void {
+	if (!FEED_SNAPSHOT_ENABLED) return () => {};
+	const storage = browserSnapshotStorage();
+	if (storage == null) return () => {};
+	return installSnapshotPersistence(client, storage, browserPersistenceBindings(), {
+		identity: authedIdentity(userId),
+	});
+}
+
+/** Tear down one authed identity's persisted snapshot (#2321). Wired at the sign-out path,
+ *  the identity-change seam, and account deletion so a viewer's private feed overlay never
+ *  outlives its session — session validation is untouched, this only drops a content cache.
+ *  No-op when the flag is off or `localStorage` is unavailable. */
+export function teardownAuthedSnapshot(userId: string): void {
+	if (!FEED_SNAPSHOT_ENABLED) return;
+	const storage = browserSnapshotStorage();
+	if (storage == null) return;
+	clearSnapshot(storage, {identity: authedIdentity(userId)});
 }


### PR DESCRIPTION
Fixes #2321

Extends the feed-snapshot persistence (from #2319/#2333) to the **identity-keyed authed client** with sign-out teardown (epic #2316 leg A, authed tier). Rides the same default-off flag as the public-client child — one staged rollout, no second flag.

## What it does
- `hydrate()` runs at client creation inside `FateProvider` **after** the session resolves — the provider still commits once on the resolved identity (#438 preserved: no anon→id re-key remount, no pre-session mount of the authed tree).
- Storage key is scoped **per user id** — the authed snapshot embeds that identity's private viewer scalars (`myVote`/`isSaved`), so a snapshot written under user A never hydrates under user B or under anon (rejected both directions).
- **Teardown** on sign-out, identity change, and account deletion removes that identity's persisted snapshot (wired into `App.tsx` `onSignOut` + the `FateProvider` identity-change seam). Per ADR 0169's immediate-teardown spirit: the snapshot is a content cache, never an auth artifact — session validation is untouched.

## Acceptance criteria
- [x] Flag on: signed-in `/pano` reload paints last-seen feed incl. the viewer's own `myVote`/`isSaved` from the snapshot, no pending, then revalidates.
- [x] Storage key embeds the user id; cross-identity / anon hydration rejected — unit-tested both directions.
- [x] Sign-out, identity switch, account deletion each remove the identity's snapshot — tested at the sign-out seam.
- [x] #438 preserved: authed subtree mounts exactly once on the resolved identity — asserted via the existing FateProvider test surface.
- [x] Deep-linked subfeed (`?sort=…`, `/pano/site/:host`) restores instantly for the authed tier.

## Files
`apps/web/src/fate/snapshot.ts` (+62, identity-keyed persist/teardown), `snapshot.test.ts` (+108), `FateProvider.tsx` (+43, post-session hydrate + identity-change teardown), `App.tsx` (+8, onSignOut teardown), `App.test.tsx` (+94).

<sub>Recovered from a stalled coder agent — the change was coded, tested, and committed in-worktree (commit 0972563); the agent's 600s watchdog fired at the push step, so the push + PR-create were completed by the engineering-manager. Verification is the review-code gate's.</sub>
