### PR TITLE
feat(orphan-sweep): opt-in dev/test stale-D1 sweep category, dev-* protected (#2340)

### DIFF
--- a/packages/orphan-sweep/README.md
+++ b/packages/orphan-sweep/README.md
@@ -20,18 +20,50 @@ and irreversible (ADR 0032: these are real remote D1s, never emulated). So the p
 1. An **unrecognized** resource (not `phoenix-phoenix-…`) is NEVER swept.
 2. A **protected** stage (`prod`, plus any `--protect` named-dev) is NEVER swept — this
    wins even over an `it-`/`pr-` allow-match.
-3. An **`it-*`** integration stage is deleted (`orphan-integration`).
-4. A **`pr-<n>`** preview is kept for an OPEN PR; a CLOSED PR's preview is deleted only
+3. A **`dev`/`dev-*`** named-dev stage (e.g. `dev-usirin`) is **NEVER** swept — a new
+   protected category (`named-dev`), deny-by-protection regardless of any opt-in ([#2340](https://github.com/kamp-us/phoenix/issues/2340)).
+4. An **`it-*`** integration stage is deleted (`orphan-integration`).
+5. A **`pr-<n>`** preview is kept for an OPEN PR; a CLOSED PR's preview is deleted only
    with `--sweep-closed-previews` (off by default — #690's mandate is the `it-*` leak).
+6. A **`test`/`test-*`** ephemeral dev/test stage is deleted (`stale-dev-test`) only with
+   `--sweep-dev-test-stages` (off by default; [#2340](https://github.com/kamp-us/phoenix/issues/2340)).
 
 This holds **identically across every resource kind** — Worker scripts, D1 databases, and
 **Flagship apps + flags** (#1505/#1506). A leaked preview Flagship app and its flags decode
 their stage the same way and flow through the same deny-by-default protection, so an OPEN
 PR's preview flags are **never** swept and a closed PR's are reclaimed only behind the gate.
 
-The match anchors are exact (`it-` start, not substring; `^pr-\d+$`), and the protection
-ordering is exhaustively unit-tested in `src/orphan-sweep.unit.test.ts` — the load-bearing
-test is that prod / named-dev / open-PR can never enter the delete set, in any kind.
+The match anchors are exact (`it-` start, not substring; `^pr-\d+$`; `dev`/`dev-` and
+`test`/`test-` starts, never a substring), and the protection ordering is exhaustively
+unit-tested in `src/orphan-sweep.unit.test.ts` — the load-bearing test is that prod /
+named-dev / open-PR can never enter the delete set, in any kind.
+
+## The dev/test staleness policy (`--sweep-dev-test-stages`, #2340)
+
+Per-stage `dev-*` and `test-*` D1s used to fall through the classifier to `unrecognized`
+and accumulate forever ([#2340](https://github.com/kamp-us/phoenix/issues/2340)). The
+dev/test stage family now classifies **explicitly**, split into a sweepable and a protected
+half — and the design tension the issue names (a `dev-usirin` stage is named-dev-shaped, so
+sweeping it relaxes the guard the core exists to enforce) is settled by making that split
+the policy, not by relaxing the guard:
+
+- **Sweepable** — `test` / `test-*` stages. These are **machine-owned, run-unique** (each
+  test spin-up gets a fresh physical suffix), exactly the `it-*` accumulation pattern but
+  outside #690's `it-*` mandate — so they reclaim behind their **own** opt-in flag,
+  `--sweep-dev-test-stages`, dry-run by default (mirroring `--sweep-closed-previews`). Their
+  delete reason is `stale-dev-test`.
+- **Protected (NEVER swept, flag or not)** — `dev` / `dev-*` stages (`dev-usirin` is exactly
+  this shape). A dev stage belongs to a **human**, and the pure core carries **no signal**
+  — no age, no live-worker match — that can safely distinguish a dead named-dev stage from
+  an active one. So the whole `dev-*` family is **deny-by-protection** (kept reason
+  `named-dev`), and no flag reaches it. A unit test pins that `dev-usirin` is kept even with
+  the sweep ON. Draining any genuinely-dead `dev-usirin` D1 is a founder-side judgement call
+  (they hold the credentials), not an automated sweep target.
+
+This is **code + tests + CLI flag only** — no scheduled-workflow change and no actual drain
+of the current stale cohort. Arming the daily `orphan-sweep.yml` with the new flag is a
+control-plane follow-up (it banks for a human merge), and the one-shot drain of the existing
+`test-*` cohort runs founder-side (agents hold no Cloudflare credentials).
 
 ## Physical name shape
 
@@ -95,6 +127,9 @@ node packages/orphan-sweep/src/bin.ts sweep --execute
 
 # Also reap closed PRs' pr-<n> previews.
 node packages/orphan-sweep/src/bin.ts sweep --execute --sweep-closed-previews
+
+# Also reap stale test/test-* stages (dev/dev-* named-dev stages are NEVER swept).
+node packages/orphan-sweep/src/bin.ts sweep --execute --sweep-dev-test-stages
 ```
 
 `sweep` resolves the target repo for the open-PR lookup per ADR

--- a/packages/orphan-sweep/src/bin.ts
+++ b/packages/orphan-sweep/src/bin.ts
@@ -9,9 +9,10 @@
  * delete and exits 0 without touching the account.
  *
  * The catastrophe guard lives in the pure core (`orphan-sweep.ts`): prod, named-dev
- * (`--protect`), and open-PR resources are NEVER in the plan, so `--execute` can only
- * ever delete an orphan `it-*` (and, with `--sweep-closed-previews`, a closed PR's
- * `pr-<n>`) — across all resource kinds, the Flagship apps/flags included. Credentials
+ * (`--protect` AND the `dev`/`dev-*` shape), and open-PR resources are NEVER in the plan,
+ * so `--execute` can only ever delete an orphan `it-*` (with `--sweep-closed-previews`, a
+ * closed PR's `pr-<n>`; with `--sweep-dev-test-stages`, a stale `test`/`test-*` stage —
+ * #2340) — across all resource kinds, the Flagship apps/flags included. Credentials
  * come from the environment at runtime (`$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID`),
  * never from source.
  *
@@ -43,14 +44,21 @@ const sweepClosedPreviewsFlag = Flag.boolean("sweep-closed-previews").pipe(
 	),
 );
 
+const sweepDevTestStagesFlag = Flag.boolean("sweep-dev-test-stages").pipe(
+	Flag.withDescription(
+		"also delete stale test/test-* stage resources (off by default; dev/dev-* named-dev stages are NEVER swept — #2340)",
+	),
+);
+
 const sweep = Command.make(
 	"sweep",
 	{
 		execute: executeFlag,
 		protect: protectFlag,
 		sweepClosedPreviews: sweepClosedPreviewsFlag,
+		sweepDevTestStages: sweepDevTestStagesFlag,
 	},
-	Effect.fn(function* ({execute, protect, sweepClosedPreviews}) {
+	Effect.fn(function* ({execute, protect, sweepClosedPreviews, sweepDevTestStages}) {
 		const cloudflare = yield* Cloudflare;
 		const github = yield* Github;
 
@@ -62,6 +70,7 @@ const sweep = Command.make(
 			protectedStages: ["prod", ...protect],
 			openPrNumbers,
 			sweepClosedPreviews,
+			sweepDevTestStages,
 		};
 		const plan = computeSweepPlan(resources, protection);
 

--- a/packages/orphan-sweep/src/orphan-sweep.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.ts
@@ -10,8 +10,10 @@
  * `afterAll(destroy(...))`. A partial `beforeAll` deploy can orphan its remote D1; the
  * #689 run-unique stage names mean a later run never overwrites it, so orphans
  * ACCUMULATE on the one shared account. This sweep is the bound: it deletes the
- * ephemeral integration (`it-*`) resources and the preview (`pr-<n>`) resources of
- * CLOSED PRs, and protects everything else.
+ * ephemeral integration (`it-*`) resources, the preview (`pr-<n>`) resources of
+ * CLOSED PRs, and — behind a separate opt-in — the stale `test`/`test-*` dev/test
+ * stage resources (#2340), and protects everything else. The `dev`/`dev-*` named-dev
+ * stages are deny-by-protection and never swept, flag or not.
  *
  * The safety property is the whole point. A sweep that deletes a prod, named-dev, or
  * open-PR resource is catastrophic and irreversible (ADR 0032: these are REAL remote
@@ -75,12 +77,34 @@ export interface Protection {
 	 * minimal.
 	 */
 	readonly sweepClosedPreviews: boolean;
+	/**
+	 * Sweep stale dev/test per-stage resources (#2340). The dev/test family splits into
+	 * a *sweepable* and a *protected* half, and this flag governs ONLY the sweepable half:
+	 *
+	 * - **Sweepable** — ephemeral `test`/`test-*` stages: machine-owned, run-unique per
+	 *   spin-up (like `it-*`, but outside #690's `it-*` mandate — hence a separate opt-in).
+	 * - **Protected (NEVER swept, flag or not)** — `dev`/`dev-*` named-dev stages
+	 *   (`dev-usirin` is exactly this shape). A dev stage belongs to a human, and the pure
+	 *   core carries no signal — no age, no live-worker match — to distinguish a dead
+	 *   named-dev stage from an active one, so the whole `dev-*` family stays
+	 *   deny-by-protection. This is the load-bearing carve-out the #2340 design tension names.
+	 *
+	 * Off by default, mirroring `sweepClosedPreviews`: it widens the delete set, so it is
+	 * opt-in and dry-run-safe.
+	 */
+	readonly sweepDevTestStages: boolean;
 }
 
 /** Why a resource is in the plan — the audit trail, so the plan is never an opaque list. */
-export type DeleteReason = "orphan-integration" | "closed-preview";
+export type DeleteReason = "orphan-integration" | "closed-preview" | "stale-dev-test";
 
-export type KeepReason = "protected-stage" | "open-pr" | "unrecognized" | "preview-sweep-disabled";
+export type KeepReason =
+	| "protected-stage"
+	| "open-pr"
+	| "unrecognized"
+	| "preview-sweep-disabled"
+	| "named-dev"
+	| "dev-test-sweep-disabled";
 
 export interface PlannedDelete {
 	readonly resource: CfResource;
@@ -161,16 +185,29 @@ const previewPrNumber = (stage: string): number | undefined => {
 };
 
 /**
+ * The two halves of the dev/test stage family (#2340), both anchored (a match on the
+ * exact stage or a `<fam>-` prefix, never a substring — `development`/`testing` match
+ * neither). See the `sweepDevTestStages` docblock for why the split is where it is.
+ */
+const isNamedDevStage = (stage: string): boolean => stage === "dev" || stage.startsWith("dev-");
+const isEphemeralTestStage = (stage: string): boolean =>
+	stage === "test" || stage.startsWith("test-");
+
+/**
  * Compute the deletion plan. The order of checks IS the safety policy:
  *
  *   1. Unrecognized (not one of our resources) → KEPT. Nothing foreign is ever swept.
- *   2. The decoded stage is in `protectedStages` (prod, named-dev) → KEPT. This wins
- *      even over an `it-`/`pr-` allow-match, so a stage someone deliberately protected
- *      can never be swept regardless of its name shape.
- *   3. `it-*` integration stage → DELETE (`orphan-integration`).
- *   4. `pr-<n>` preview: open PR → KEPT (`open-pr`). Closed PR → DELETE only if
+ *   2. The decoded stage is in `protectedStages` (prod, `--protect`-ed) → KEPT. This wins
+ *      even over an `it-`/`pr-`/`test-` allow-match, so a stage someone deliberately
+ *      protected can never be swept regardless of its name shape.
+ *   3. `dev`/`dev-*` named-dev stage → KEPT (`named-dev`). A protection that wins before
+ *      any sweep: `dev-usirin`-shaped stages are NEVER deleted, flag or not (#2340).
+ *   4. `it-*` integration stage → DELETE (`orphan-integration`).
+ *   5. `pr-<n>` preview: open PR → KEPT (`open-pr`). Closed PR → DELETE only if
  *      `sweepClosedPreviews`, else KEPT (`preview-sweep-disabled`).
- *   5. Anything else recognized but not matched → KEPT (`unrecognized`).
+ *   6. `test`/`test-*` ephemeral stage → DELETE (`stale-dev-test`) only if
+ *      `sweepDevTestStages`, else KEPT (`dev-test-sweep-disabled`) (#2340).
+ *   7. Anything else recognized but not matched → KEPT (`unrecognized`).
  */
 export const computeSweepPlan = (
 	resources: ReadonlyArray<CfResource>,
@@ -191,6 +228,12 @@ export const computeSweepPlan = (
 			kept.push({resource, reason: "protected-stage"});
 			continue;
 		}
+		// Named-dev (`dev-usirin`-shaped) is a protection: it must win before ANY sweep
+		// branch below, so a dev stage is never deleted regardless of the opt-in (#2340).
+		if (isNamedDevStage(stage)) {
+			kept.push({resource, reason: "named-dev"});
+			continue;
+		}
 		if (isIntegrationStage(stage)) {
 			toDelete.push({resource, reason: "orphan-integration", stage});
 			continue;
@@ -203,6 +246,14 @@ export const computeSweepPlan = (
 				toDelete.push({resource, reason: "closed-preview", stage});
 			} else {
 				kept.push({resource, reason: "preview-sweep-disabled"});
+			}
+			continue;
+		}
+		if (isEphemeralTestStage(stage)) {
+			if (protection.sweepDevTestStages) {
+				toDelete.push({resource, reason: "stale-dev-test", stage});
+			} else {
+				kept.push({resource, reason: "dev-test-sweep-disabled"});
 			}
 			continue;
 		}

--- a/packages/orphan-sweep/src/orphan-sweep.unit.test.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.unit.test.ts
@@ -43,6 +43,7 @@ const protection = (over: Partial<Protection> = {}): Protection => ({
 	protectedStages: ["prod"],
 	openPrNumbers: [],
 	sweepClosedPreviews: false,
+	sweepDevTestStages: false,
 	...over,
 });
 
@@ -145,6 +146,99 @@ describe("computeSweepPlan — open PR previews are protected", () => {
 			protection({sweepClosedPreviews: true}),
 		);
 		assert.strictEqual(plan.toDelete.length, 0);
+	});
+});
+
+describe("computeSweepPlan — named-dev (dev-*) stages are a protected category (#2340)", () => {
+	// The load-bearing carve-out: dev-usirin-* is named-dev-shaped, so the dev/test opt-in
+	// must NEVER reach it. A dev stage belongs to a human; the pure core has no signal
+	// (no age, no live-worker match) to tell a dead named-dev stage from an active one, so
+	// the whole dev-* family is deny-by-protection.
+	it("keeps a dev-usirin stage as named-dev, even with the dev/test sweep ON", () => {
+		const w = worker("dev-usirin");
+		const db = d1("dev-usirin");
+		const plan = computeSweepPlan([w, db], protection({sweepDevTestStages: true}));
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "named-dev");
+		assert.strictEqual(keptReasonFor(plan, db.name), "named-dev");
+	});
+
+	it("keeps any dev-* stage (dev-cansirin) as named-dev with the sweep ON", () => {
+		const db = d1("dev-cansirin");
+		const plan = computeSweepPlan([db], protection({sweepDevTestStages: true}));
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, db.name), "named-dev");
+	});
+
+	it("keeps a bare `dev` stage as named-dev (no name segment still means a dev stage)", () => {
+		const w = worker("dev");
+		const plan = computeSweepPlan([w], protection({sweepDevTestStages: true}));
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "named-dev");
+	});
+
+	it("never matches `dev` via a substring — `development` is not a dev stage", () => {
+		// A stage merely CONTAINING dev is unrecognized, never named-dev, never swept.
+		const w = worker("development");
+		const plan = computeSweepPlan([w], protection({sweepDevTestStages: true}));
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "unrecognized");
+	});
+});
+
+describe("computeSweepPlan — stale test-* stages sweep only under the opt-in (#2340)", () => {
+	// `phoenix-phoenix-db-test-<hash>` decodes to stage `test`; a namespaced test stage to
+	// `test-<slug>`. These are machine-owned, run-unique ephemeral stages — like it-* but
+	// outside #690's mandate — so they reclaim only behind the explicit opt-in flag.
+	it("deletes a bare `test` stage D1 (stale-dev-test) only when the flag is ON", () => {
+		const db = d1("test");
+		const on = computeSweepPlan([db], protection({sweepDevTestStages: true}));
+		assert.deepStrictEqual(deletedNames(on), [db.name]);
+		assert.strictEqual(on.toDelete[0]?.reason, "stale-dev-test");
+		assert.strictEqual(on.toDelete[0]?.stage, "test");
+
+		const off = computeSweepPlan([db], protection({sweepDevTestStages: false}));
+		assert.strictEqual(off.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(off, db.name), "dev-test-sweep-disabled");
+	});
+
+	it("deletes a namespaced test-<slug> stage when the flag is ON", () => {
+		const w = worker("test-report");
+		const on = computeSweepPlan([w], protection({sweepDevTestStages: true}));
+		assert.deepStrictEqual(deletedNames(on), [w.name]);
+		assert.strictEqual(on.toDelete[0]?.reason, "stale-dev-test");
+		assert.strictEqual(on.toDelete[0]?.stage, "test-report");
+	});
+
+	it("keeps a test stage that is ALSO explicitly --protect-ed (protection wins first)", () => {
+		const w = worker("test-keepme");
+		const plan = computeSweepPlan(
+			[w],
+			protection({protectedStages: ["prod", "test-keepme"], sweepDevTestStages: true}),
+		);
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "protected-stage");
+	});
+
+	it("never matches `test` via a substring — `testing` is not a test stage", () => {
+		const w = worker("testing");
+		const plan = computeSweepPlan([w], protection({sweepDevTestStages: true}));
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "unrecognized");
+	});
+
+	it("the dev/test opt-in NEVER reaches prod, it-*, or pr-<n> — those keep their own reasons", () => {
+		// The new flag widens coverage to test-* ONLY; it must not perturb the existing
+		// classifications. it-* still deletes (its own mandate), prod stays protected.
+		const resources = [worker("prod"), worker("it-report-aaaa"), worker("pr-5")];
+		const plan = computeSweepPlan(
+			[...resources],
+			protection({openPrNumbers: [5], sweepDevTestStages: true}),
+		);
+		assert.deepStrictEqual(deletedNames(plan), [worker("it-report-aaaa").name]);
+		assert.strictEqual(plan.toDelete[0]?.reason, "orphan-integration");
+		assert.strictEqual(keptReasonFor(plan, worker("prod").name), "protected-stage");
+		assert.strictEqual(keptReasonFor(plan, worker("pr-5").name), "open-pr");
 	});
 });
 
@@ -274,6 +368,20 @@ describe("computeSweepPlan — Flagship apps/flags flow through the SAME protect
 		assert.strictEqual(plan.toDelete.length, 0);
 		assert.strictEqual(keptReasonFor(plan, foreignApp.name), "unrecognized");
 		assert.strictEqual(keptReasonFor(plan, foreignFlag.name), "unrecognized");
+	});
+
+	it("dev/test classification flows through flagship kinds too (#2340)", () => {
+		// A leaked test-stage flagship app + flag sweep under the opt-in; a named-dev one never does.
+		const testApp = flagshipApp("test");
+		const testFlag = flagshipFlag("test");
+		const devApp = flagshipApp("dev-usirin");
+		const on = computeSweepPlan(
+			[testFlag, testApp, devApp],
+			protection({sweepDevTestStages: true}),
+		);
+		assert.deepStrictEqual(new Set(deletedNames(on)), new Set([testFlag.name, testApp.name]));
+		for (const d of on.toDelete) assert.strictEqual(d.reason, "stale-dev-test");
+		assert.strictEqual(keptReasonFor(on, devApp.name), "named-dev");
 	});
 
 	it("a flag named `prod-…` (open pr) is kept even though its KEY looks prod-ish", () => {

--- a/packages/orphan-sweep/src/report.ts
+++ b/packages/orphan-sweep/src/report.ts
@@ -14,7 +14,7 @@ export const renderSummary = (plan: SweepPlan, execute: boolean): string => {
 /** The delete set, one `kind name (reason, stage)` per line — empty plan renders a clear note. */
 export const renderPlan = (plan: SweepPlan): string => {
 	if (plan.toDelete.length === 0) {
-		return "  (nothing to delete — no orphan it-* or closed-preview resources found)";
+		return "  (nothing to delete — no orphan it-*, closed-preview, or stale dev/test resources found)";
 	}
 	return plan.toDelete
 		.map((d) => `  - ${d.resource.kind} ${d.resource.name} (${d.reason}, stage ${d.stage})`)


### PR DESCRIPTION
Extends the `@kampus/orphan-sweep` pure core with an explicit **dev/test stage classification**, replacing the blanket `kept: unrecognized` fall-through for `dev-*`/`test-*` per-stage resources.

## The staleness policy (the #2340 design tension, settled)

The dev/test family splits into a sweepable and a protected half, and **that split IS the policy** — settled without relaxing the guard the core exists to enforce:

- **Sweepable** — `test`/`test-*` stages: machine-owned, run-unique ephemeral stages (the `it-*` accumulation pattern, but outside #690's mandate). Deleted with reason `stale-dev-test` behind a **new opt-in flag `--sweep-dev-test-stages`**, dry-run by default, mirroring `--sweep-closed-previews`.
- **Protected (NEVER swept, flag or not)** — `dev`/`dev-*` named-dev stages (`dev-usirin` is exactly this shape): a **new protected category** (`named-dev`), deny-by-protection. The pure core has no age / live-worker signal to distinguish a dead dev stage from an active one, so the whole `dev-*` family stays protected. Draining a genuinely-dead `dev-usirin` D1 is a founder-side call.

Protection is ordered **before** any sweep branch; matches are anchored (never substring — `development`/`testing` match neither). Flows through Worker / D1 / Flagship kinds identically.

## Test coverage (TDD)

New unit tests in `src/orphan-sweep.unit.test.ts` (42 total pass): `dev-usirin`/`dev-cansirin`/bare-`dev` kept as `named-dev` **with the flag ON**; `development` stays `unrecognized`; `test`/`test-*` deleted only under the opt-in, else `dev-test-sweep-disabled`; a `--protect`-ed test stage wins first; `testing` stays `unrecognized`; the opt-in never perturbs prod / `it-*` / `pr-<n>`; and the classification flows through Flagship kinds.

## Scope — code + tests + CLI + README only

Per the issue's cred-routing: **no `.github/workflows` change** (arming `orphan-sweep.yml` with the flag is a control-plane follow-up that banks for human merge) and **no actual drain** of the current stale cohort (a one-shot founder-side run — agents hold no Cloudflare credentials). This keeps the PR non-§CP and auto-shippable; the workflow-arming and drain are deliberately split out per AC #4/#5.

Fixes #2340