### PR TITLE
test(pipeline-cli): refresh §CP CONTROL_PLANE_RE unit fixtures + put them under lockstep (#2343)

### DIFF
--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -1,3 +1,5 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {
 	type CpPath,
@@ -13,8 +15,10 @@ import {
 
 // The live CONTROL_PLANE_RE (gh-issue-intake-formats.md §CP) — kept here only as a
 // fixture for the parser; the gate reads it from disk, never from a hardcoded copy.
+// The lockstep test at the bottom of this file asserts this fixture still equals the
+// canonical §CP line on disk, so it can't silently drift again (#2343).
 const LIVE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
 
 describe("extractControlPlaneRe", () => {
 	it("pulls the regex from the canonical CONTROL_PLANE_RE='…' assignment line", () => {
@@ -33,7 +37,8 @@ describe("splitTopLevelBranches", () => {
 		const branches = splitTopLevelBranches(LIVE_RE);
 		expect(branches).toEqual([
 			"(\\.claude|\\.github)/",
-			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/",
+			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/",
+			"claude-plugins/kampus-pipeline/agents/",
 			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$",
 			"claude-plugins/kampus-pipeline/hooks(/|\\.json$)",
 			"packages/ci-required/",
@@ -50,18 +55,25 @@ describe("expandBranch", () => {
 		]);
 	});
 
-	it("expands the five skill dirs", () => {
+	it("expands the six skill dirs", () => {
 		const out = expandBranch(
-			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/",
+			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/",
 		);
 		expect(out.map((p) => p.path)).toEqual([
 			"claude-plugins/kampus-pipeline/skills/ship-it/",
 			"claude-plugins/kampus-pipeline/skills/review-code/",
 			"claude-plugins/kampus-pipeline/skills/review-doc/",
 			"claude-plugins/kampus-pipeline/skills/review-skill/",
+			"claude-plugins/kampus-pipeline/skills/review-design/",
 			"claude-plugins/kampus-pipeline/skills/review-plan/",
 		]);
 		expect(out.every((p) => p.kind === "dir")).toBe(true);
+	});
+
+	it("passes the group-free agents dir branch through as a single dir (ADR 0150)", () => {
+		expect(expandBranch("claude-plugins/kampus-pipeline/agents/")).toEqual([
+			{path: "claude-plugins/kampus-pipeline/agents/", kind: "dir"},
+		]);
 	});
 
 	it("strips the $ end-anchor and unescapes a single exact-file branch", () => {
@@ -87,7 +99,7 @@ describe("expandBranch", () => {
 });
 
 describe("cpPaths over the live regex", () => {
-	it("resolves the full §CP path set (8 paths: dirs + the two exact files)", () => {
+	it("resolves the full §CP path set (14 paths: dirs + the two exact files)", () => {
 		expect(cpPaths(LIVE_RE).map((p) => p.path)).toEqual([
 			".claude/",
 			".github/",
@@ -95,7 +107,9 @@ describe("cpPaths over the live regex", () => {
 			"claude-plugins/kampus-pipeline/skills/review-code/",
 			"claude-plugins/kampus-pipeline/skills/review-doc/",
 			"claude-plugins/kampus-pipeline/skills/review-skill/",
+			"claude-plugins/kampus-pipeline/skills/review-design/",
 			"claude-plugins/kampus-pipeline/skills/review-plan/",
+			"claude-plugins/kampus-pipeline/agents/",
 			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
 			"claude-plugins/kampus-pipeline/hooks/",
 			"claude-plugins/kampus-pipeline/hooks.json",
@@ -167,7 +181,9 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-skill/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-design/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-plan/ @usirin",
+			"/claude-plugins/kampus-pipeline/agents/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 			"/claude-plugins/kampus-pipeline/hooks/ @usirin",
 			"/claude-plugins/kampus-pipeline/hooks.json @usirin",
@@ -186,7 +202,9 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-skill/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-design/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-plan/ @usirin",
+			"/claude-plugins/kampus-pipeline/agents/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 			"/packages/ci-required/ @usirin",
 		].join("\n");
@@ -204,5 +222,25 @@ describe("renderReport", () => {
 		const out = renderReport([{path: "packages/pipeline-cli/", kind: "dir"} satisfies CpPath]);
 		expect(out).toContain("packages/pipeline-cli/  (dir)");
 		expect(out).toContain("1 §CP control-plane path");
+	});
+});
+
+// Lockstep: eat our own dogfood — extract the canonical §CP line from the real
+// gh-issue-intake-formats.md on disk and assert the LIVE_RE fixture still equals it.
+// Without this, the fixture drifts silently from §CP (the review-design/agents/ gap of
+// #2343), because validate-gate-path-drift.sh's consumer set never included these unit
+// fixtures. This assertion is the drift check the fixtures were missing.
+describe("LIVE_RE fixture stays in lockstep with §CP on disk", () => {
+	const FORMATS_PATH = fileURLToPath(
+		new URL(
+			"../../../../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+			import.meta.url,
+		),
+	);
+
+	it("equals the canonical CONTROL_PLANE_RE extracted from the formats doc", () => {
+		const canonical = extractControlPlaneRe(readFileSync(FORMATS_PATH, "utf8"));
+		expect(canonical).not.toBeNull();
+		expect(LIVE_RE).toBe(canonical);
 	});
 });

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -6,7 +6,7 @@ import {Effect, Exit} from "effect";
 import {type CheckFailed, CODEOWNERS_PATH, checkCodeownersCp, FORMATS_PATH} from "./gate.ts";
 
 const LIVE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
 
 const FULL_CODEOWNERS = [
 	"/.claude/ @usirin",
@@ -15,7 +15,9 @@ const FULL_CODEOWNERS = [
 	"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/review-skill/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/review-design/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/review-plan/ @usirin",
+	"/claude-plugins/kampus-pipeline/agents/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 	"/claude-plugins/kampus-pipeline/hooks/ @usirin",
 	"/claude-plugins/kampus-pipeline/hooks.json @usirin",

--- a/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.unit.test.ts
@@ -1,10 +1,15 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
+import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
 import {type ClassifyOptions, classify, parseUnifiedDiff} from "./trivial-diff.ts";
 
 // The live CONTROL_PLANE_RE (gh-issue-intake-formats.md §CP) — a fixture only. The bin
 // re-resolves this from origin/main at run time; the core takes it as a string input.
+// The lockstep test at the bottom of this file asserts this fixture still equals the
+// canonical §CP line on disk, so it can't silently drift again (#2343).
 const LIVE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
 
 const opts = (over: Partial<ClassifyOptions> = {}): ClassifyOptions => ({
 	controlPlaneRe: LIVE_RE,
@@ -118,6 +123,15 @@ describe("classify — §CP forces non-trivial (live boundary, checked first)", 
 		);
 	});
 
+	it("a pipeline agent-definition path (claude-plugins/…/agents/) → non-trivial (ADR 0150)", () => {
+		const c = classify(
+			fileDiff("claude-plugins/kampus-pipeline/agents/coder.md", ["a tweak"]),
+			opts(),
+		);
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/control-plane/);
+	});
+
 	it("the gate-critical formats doc → non-trivial (control-plane checked before doc bound)", () => {
 		const c = classify(
 			fileDiff("claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md", ["a tweak"]),
@@ -151,5 +165,23 @@ describe("classify — unreadable / unparseable boundary forces non-trivial (fai
 describe("classify — unparseable / empty diff forces non-trivial (fail-closed)", () => {
 	it("non-diff input → non-trivial", () => {
 		expect(classify("not a diff at all", opts()).verdict).toBe("non-trivial");
+	});
+});
+
+// Lockstep: extract the canonical §CP line from the real gh-issue-intake-formats.md on
+// disk (via the single-sourced extractControlPlaneRe) and assert LIVE_RE still equals it,
+// so this fixture can't silently drift from §CP again (#2343).
+describe("LIVE_RE fixture stays in lockstep with §CP on disk", () => {
+	const FORMATS_PATH = fileURLToPath(
+		new URL(
+			"../../../../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+			import.meta.url,
+		),
+	);
+
+	it("equals the canonical CONTROL_PLANE_RE extracted from the formats doc", () => {
+		const canonical = extractControlPlaneRe(readFileSync(FORMATS_PATH, "utf8"));
+		expect(canonical).not.toBeNull();
+		expect(LIVE_RE).toBe(canonical);
 	});
 });


### PR DESCRIPTION
## What

Refresh the two §CP `CONTROL_PLANE_RE` unit fixtures that had drifted from the canonical regex single-sourced in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (§CP), and put the fixtures under a lockstep check so they can't silently drift again.

Both `LIVE_RE` fixtures lacked two clauses the live regex carries:
- `^claude-plugins/kampus-pipeline/agents/` (added by ADR 0150), and
- `review-design` in the skills alternation.

They also carried stale count expectations ("8 paths"). No live gate hole — the bins re-resolve the live regex at runtime (`codeowners-cp`'s `extractControlPlaneRe`; `trivial-diff`'s `controlPlaneRe` option resolved from `origin/main`) — this was a unit-coverage gap.

Grounded against the live §CP line on `origin/main` (verified byte-equal to the refreshed fixtures): 7 top-level branches, 14 resolved §CP paths.

## Changes (all inside `packages/pipeline-cli/**`)

- `trivial-diff.unit.test.ts` — refresh `LIVE_RE`; add a classification case: a `claude-plugins/kampus-pipeline/agents/…` path → control-plane (non-trivial).
- `codeowners-cp.unit.test.ts` — refresh `LIVE_RE`; update `splitTopLevelBranches` (7 branches), `expandBranch` (six skill dirs + a new agents/ dir case), `cpPaths` (14 paths), and the `findUncovered` CODEOWNERS fixtures (add `review-design/` + `agents/` rows).
- `gate.test.ts` — align its self-contained `LIVE_RE` + `FULL_CODEOWNERS` fixtures too, so no stale §CP copy is left in the package.

## Lockstep mechanism (AC4)

Chose the **in-test assertion** (not `validate-gate-path-drift.sh`), keeping the entire change inside `packages/pipeline-cli/**` and avoiding collision with the in-flight §CP gate-machinery work. Both unit files now read the real `gh-issue-intake-formats.md` from disk (via the single-sourced `extractControlPlaneRe` — eating its own dogfood) and assert `LIVE_RE` equals the extracted canonical line. A future §CP regex change that doesn't update the fixtures now fails these tests.

**`validate-gate-path-drift.sh` was NOT touched.**

## Scope

Stayed inside `packages/pipeline-cli/**` per the triage note. Did **not** touch `ship-it/SKILL.md` or `agents/reviewer.md` (owned by #2341).

## Tests

`pnpm exec vitest run src/tools/codeowners-cp src/tools/trivial-diff` → 53 passed. `pnpm typecheck` clean, biome clean.

Note: `packages/pipeline-cli/**` is §CP (control-plane) — this PR banks for a human (cansirin) merge after review; it will not auto-ship.

Fixes #2343