### PR TITLE
fix(pipeline): re-resolve UI_RE from origin/main so review-design can't slip on a stale snapshot (#2341)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -33,6 +33,8 @@ follow it as your authoritative procedure:
   changed path matches the UI-affecting set, `review-design` is dispatched **alongside**
   the PR's code/doc/skill gate — never instead of it. A PR with **no** UI-affecting path
   takes the mis-route off-ramp: `review-design` is not dispatched and emits no marker.
+  **Resolve the UI-affecting set from live `main`, not this snapshot** — see the
+  [UI dispatch in lockstep with ship-it](#dispatch-review-design-in-lockstep-with-ship-its-live-ui_re) invariant below.
 - **A planned epic** (a `plan-epic`-output ledger whose `status:planned` children need
   gating) → read and follow `claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md`.
 
@@ -86,6 +88,27 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   that namespace's scan). Upsert it one-per-PR per the skill. The verdict on the PR is the
   whole output — a verdict returned only to the orchestrator and never posted is a dropped
   gate.
+<a id="dispatch-review-design-in-lockstep-with-ship-its-live-ui_re"></a>
+- **Dispatch `review-design` in lockstep with ship-it's LIVE `UI_RE` — resolve the
+  UI-affecting set from `origin/main`, never this snapshot (`ui_reresolve`).** The prose set
+  above (`apps/web/src/`, `*.tsx`, style surfaces) is the fail-closed **reference**, not the
+  live decision source: a reviewer whose worktree/injected snapshot predates the review-design
+  merge would otherwise silently omit the dispatch on a UI PR, while ship-it — grounding against
+  live main — still *requires* the gate, so the PR deadlocks (`unverified — no review-design
+  PASS`). ship-it and this agent therefore read the **same one live source**: the `UI_RE=` line
+  in `ship-it/SKILL.md` on `origin/main`. Re-resolve it before deciding to dispatch, fail-closed
+  to **has-ui** (dispatch `review-design`) if that line is unreadable — never fail-open to skip
+  it (#2341, the #981 `?ref=main` idiom):
+  ```bash
+  UI_RE='^apps/web/src/|\.tsx$|\.css$'   # fail-closed reference; the live line below is authoritative
+  UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
+  if [ -n "$UI_LIVE" ]; then UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"; else UI_RE='.'; fi   # unreadable ⇒ '.' ⇒ every path is UI-affecting ⇒ dispatch review-design (never silently drop it)
+  CHANGED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
+  echo "$CHANGED" | grep -Eq "$UI_RE" && echo "UI-affecting → dispatch review-design alongside the class gate"
+  ```
+  Because both sides resolve the identical live `UI_RE`, `required-gate == dispatched-gate` holds
+  by construction, not by hand-syncing two aging copies — the exact staleness that let UI PRs slip
+  the gate non-deterministically (PR #2333 merged un-design-reviewed).
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries; every read and write
   goes through `gh api`.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -285,12 +285,22 @@ echo "$FILES" | grep -Eq '^(apps|packages|\.glossary|infra)/' && echo "has-code"
 # .md on review-doc's own surface is (#542/#650/#919/#1987). The §DOC contract is the single source — cite, don't re-derive.
 echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary|infra)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
 # UI probe → review-design (ADDITIVE, not a class): a changed path under apps/web/src, a *.tsx
-# file, or a style surface (*.css). This UI_RE MUST stay identical to the reviewer agent's
-# UI-affecting dispatch rule (reviewer.md, #2249: "apps/web/src, *.tsx, and style surfaces") —
-# required-gate == dispatched-gate, else a UI PR routes to review-design at review time but
-# ship-it doesn't require it (or vice versa). When a second app worker is added, generalize BOTH
-# this UI_RE and reviewer.md's rule to apps/**/src in lockstep. See the note after the routing.
+# file, or a style surface (*.css). Like CONTROL_PLANE_RE/GUARD_ADR_RE above, the literal below
+# is the fail-closed REFERENCE + the validate-gate-path-drift lockstep target, NOT the live
+# decision source: it is re-resolved from origin/main right after, so an injected skill snapshot
+# that predates the review-design gate can't silently DROP the UI probe and slip a UI PR past the
+# gate (#2341 — the #981 idiom, previously only on §CP/GUARD, now extended to UI_RE). ship-it/
+# SKILL.md@main's `UI_RE=` line is the ONE live source; reviewer.md re-resolves the SAME line from
+# the same ref (reviewer.md, #2249/#2341), so required-gate == dispatched-gate holds by
+# construction — both sides read live main, not two independently-aging snapshots. When a second
+# app worker is added, generalize this one live UI_RE to apps/**/src and both sides track it.
 UI_RE='^apps/web/src/|\.tsx$|\.css$'
+UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
+if [ -n "$UI_LIVE" ]; then
+  UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"   # UI-gating tracks origin/main, not the snapshot's age (#2341)
+else
+  UI_RE='.'   # FAIL CLOSED: can't read origin/main's UI_RE ⇒ treat EVERY path as UI-affecting ⇒ REQUIRE review-design, never silently skip the gate (the safe default is demand-the-gate)
+fi
 echo "$FILES" | grep -Eq "$UI_RE" && echo "has-ui"   # UI-affecting → require review-design ALONGSIDE the class gate(s)
 ```
 
@@ -377,9 +387,16 @@ files under `apps/web/src`, `*.tsx`, and style surfaces"). This is the
 same **required-gate == dispatched-gate** invariant that binds the has-code probe to review-code's
 scope: if ship-it required `review-design` on a diff the reviewer never routed to `review-design`,
 that PR would demand a `review-design: PASS` **no gate ever produces** → every UI PR **deadlocks**
-(`unverified — no review-design PASS`). Keep the two definitions in **lockstep** — when the
-reviewer's UI-affecting rule changes (e.g. a new app worker, a new style surface), this `UI_RE`
-changes with it, never one without the other.
+(`unverified — no review-design PASS`). Lockstep here is **not two hand-synced copies that drift as
+each side's checkout ages** — that staleness was the enforcement hole (#2341: a shipper/reviewer on
+a snapshot predating the review-design merge silently omitted the gate; PR #2333 merged
+un-design-reviewed). Both sides instead resolve `UI_RE` from **one live source — `UI_RE=` in
+`ship-it/SKILL.md` on `origin/main`**, read via `?ref=main` at run time (the `#981` idiom the §CP
+`CONTROL_PLANE_RE`/`GUARD_ADR_RE` already use): ship-it re-resolves it in the probe above, and
+`reviewer.md` re-resolves the **same line from the same ref** before deciding to dispatch
+`review-design`. Both fail closed to *require*/`dispatch` the gate if that line is unreadable —
+never to skip it. So the two agree by construction, not by manual sync: change the one live `UI_RE`
+(e.g. a new app worker → `apps/**/src`) and both sides track it on their next run.
 
 **The docs class must equal `review-doc`'s verification scope, or the gate it demands is
 unreachable.** ship-it requires a class's gate PASS *because that gate runs on that class* —


### PR DESCRIPTION
Fixes #2341

## Problem
The `has-ui` → require-`review-design` gate was enforced **non-deterministically**. ship-it's `UI_RE` (~L293) and `reviewer.md`'s UI-affecting dispatch rule were **snapshot-only** — read from each agent's local worktree checkout, which can predate the `review-design` merge. An agent on a stale snapshot silently omitted the gate, so UI-affecting PRs slipped it depending on how fresh a given checkout happened to be. PR #2333 (all files under `apps/web/src/`, incl. a rendered `PanoFeed.tsx`) merged un-design-reviewed; #2334 confirmed the hole mechanically.

This is the same stale-snapshot class ship-it already immunized `CONTROL_PLANE_RE`/`GUARD_ADR_RE` against with the `?ref=main` re-resolve idiom (#981) — the idiom was just never extended to `UI_RE`, and `reviewer.md` had no live re-resolve at all. A two-layer drop.

## Fix — extend the existing `?ref=main` fail-closed idiom to `UI_RE`
**Layer 1 — `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`:** re-resolve `UI_RE` from `ship-it/SKILL.md?ref=main` at run time, exactly mirroring the `CONTROL_PLANE_RE`/`GUARD_ADR_RE` blocks above it. **Fail-closed:** if the live `UI_RE=` line is unreadable, `UI_RE='.'` ⇒ every path is treated as `has-ui` ⇒ `review-design` is **required**, never silently skipped. The literal `UI_RE='^apps/web/src/|\.tsx$|\.css$'` stays as the fail-closed reference + drift-lockstep target (same role the `CONTROL_PLANE_RE` literal plays), not the live decision source.

**Layer 2 — `claude-plugins/kampus-pipeline/agents/reviewer.md`:** add the equivalent live re-resolve of `UI_RE` from `ship-it/SKILL.md?ref=main` before deciding to dispatch `review-design`, fail-closed to **dispatch** if unreadable. The reviewer's UI-affecting detection now tracks ship-it's live `UI_RE` rather than an aging prose snapshot.

## Lockstep
Both sides read **one live source** — the `UI_RE=` line in `ship-it/SKILL.md` on `origin/main`. So `required-gate == dispatched-gate` holds **by construction**, not by hand-syncing two independently-aging copies (which was the whole bug). ship-it's lockstep comment (~L381) is updated to name the shared live source instead of "two hand-synced copies". `grep '^UI_RE='` matches exactly the one col-0 canonical line, so the self-re-resolve is a fixed point (verified: it extracts the identical pattern).

## Acceptance criteria
- [x] ship-it resolves `UI_RE` from `origin/main` at run time, fail-closed (unreadable ⇒ `has-ui`), matching the `CONTROL_PLANE_RE`/`GUARD_ADR_RE` idiom already in the skill.
- [x] The reviewer agent's UI-affecting dispatch rule is re-resolved from `origin/main` (single-sourced with ship-it's `UI_RE`) so a stale checkout cannot silently omit the `review-design` dispatch.
- [x] The lockstep comment in ship-it names the shared live source, not two hand-synced copies.

## Scope
Stays in `ship-it/SKILL.md` + `agents/reviewer.md` only. Does **not** touch `packages/pipeline-cli/**` (#2343's PR #2364 owns those fixtures) or other skills.

## §CP — expected to bank for human merge
This touches gate-critical `ship-it/SKILL.md` + `agents/` → §CP. It will **not** auto-ship; it awaits a `@kamp-us/control-plane` approval + the machine gates (incl. a current-head `review-skill` PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)