### PR TITLE
feat(web): compose pano base + overlay on the client, de-gate feed from the session (#2323)

### DIFF
--- a/apps/web/src/components/pano/PanoPostCard.compose.test.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.compose.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Base + overlay composition on the card (#2323, leg B). Pins the two client-composition
+ * ACs at the component level: (1) with compose on, the base row paints while the viewer
+ * scalars stay neutral until the overlay lands under the confirmed identity, then patch in
+ * place; (2) a signed-in viewer never sees another/stale identity's overlay during the
+ * compose window. The leaf vote/save widgets are stubbed to surface the scalars the card
+ * feeds them — the pure identity guard is covered separately in `panoFeedOverlay.test.ts`.
+ */
+import {render} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import type {useSession as useSessionType} from "../../auth/client";
+import {PanoPostCard} from "./PanoPostCard";
+
+type SessionResult = ReturnType<typeof useSessionType>;
+
+// The row `useLiveView` resolves for the post ref, and the session state, both swappable
+// per test through these holders (a live `Post` carrying identity A's own scalars).
+let rowData: Record<string, unknown>;
+let sessionState: SessionResult;
+
+vi.mock("react-fate", () => ({
+	useLiveView: () => rowData,
+	view: () => () => ({}),
+}));
+
+vi.mock("../../auth/client", () => ({
+	useSession: () => sessionState,
+}));
+
+// Stub the mutation-bearing leaf widgets to render the exact scalar the card feeds them,
+// so the assertion reads what the card composed — not the widget's own behavior.
+vi.mock("./PanoPost", () => ({
+	PostVoteWidget: ({myVote}: {myVote: boolean | null}) => (
+		<span data-testid="vote">{String(myVote)}</span>
+	),
+	PostSaveButton: ({isSaved}: {isSaved: boolean | null}) => (
+		<span data-testid="save">{String(isSaved)}</span>
+	),
+}));
+
+const POST_ID = "p1";
+
+function makeRow(myVote: boolean | null, isSaved: boolean | null): Record<string, unknown> {
+	return {
+		id: POST_ID,
+		title: "başlık",
+		url: "https://example.com",
+		host: "example.com",
+		score: 7,
+		myVote,
+		isSaved,
+		commentCount: 2,
+		createdAt: new Date("2026-07-01T00:00:00Z"),
+		author: "yazar",
+		authorId: "author-x",
+		authorUsername: "yazar",
+		authorDisplayName: "Yazar",
+		slug: "baslik",
+		tags: [],
+	};
+}
+
+const pending: SessionResult = {data: null, isPending: true} as SessionResult;
+const signedIn = (id: string): SessionResult =>
+	({data: {user: {id}}, isPending: false}) as SessionResult;
+const anon: SessionResult = {data: null, isPending: false} as SessionResult;
+
+const ref = {id: POST_ID} as never;
+
+function scalars(container: HTMLElement) {
+	return {
+		vote: container.querySelector('[data-testid="vote"]')?.textContent,
+		save: container.querySelector('[data-testid="save"]')?.textContent,
+	};
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("PanoPostCard — base + overlay composition (compose on)", () => {
+	it("paints base with NEUTRAL scalars while the session is still resolving (overlay pending)", () => {
+		rowData = makeRow(true, true);
+		sessionState = pending;
+		const {container} = render(
+			<MemoryRouter>
+				<PanoPostCard post={ref} compose />
+			</MemoryRouter>,
+		);
+		// The base row is on screen (title), but the viewer scalars are held neutral.
+		expect(container.textContent).toContain("başlık");
+		expect(scalars(container)).toEqual({vote: "null", save: "null"});
+	});
+
+	it("lands the viewer's own scalars once the session resolves under the matching identity", () => {
+		rowData = makeRow(true, true);
+		sessionState = signedIn("user-a");
+		const {container} = render(
+			<MemoryRouter>
+				<PanoPostCard post={ref} compose />
+			</MemoryRouter>,
+		);
+		expect(scalars(container)).toEqual({vote: "true", save: "true"});
+	});
+
+	it("renders the anon viewer's own null scalars (no vote/save)", () => {
+		rowData = makeRow(null, null);
+		sessionState = anon;
+		const {container} = render(
+			<MemoryRouter>
+				<PanoPostCard post={ref} compose />
+			</MemoryRouter>,
+		);
+		expect(scalars(container)).toEqual({vote: "null", save: "null"});
+	});
+});
+
+describe("PanoPostCard — compose off is byte-identical (reads scalars straight off the post)", () => {
+	it("feeds the post's own scalars to the controls regardless of session pending", () => {
+		rowData = makeRow(true, false);
+		sessionState = pending;
+		const {container} = render(
+			<MemoryRouter>
+				<PanoPostCard post={ref} />
+			</MemoryRouter>,
+		);
+		expect(scalars(container)).toEqual({vote: "true", save: "false"});
+	});
+});

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -11,6 +11,12 @@ import {useSession} from "../../auth/client";
 import {toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
 import {tagClass} from "../../lib/panoTags";
+import {
+	type OverlayState,
+	PENDING_OVERLAY,
+	resolveOverlay,
+	type ViewerOverlay,
+} from "../../pages/panoFeedOverlay";
 import {actorLabel} from "../moderation/actor-identity";
 import {Tag, type TagKind} from "../ui/atoms";
 import {MetaRow} from "../ui/MetaRow";
@@ -35,18 +41,56 @@ export const PanoPostCardView = view<Post>()({
 	tags: true,
 });
 
+/**
+ * The identity-guarded viewer scalars for one row's controls (leg B compose path). While
+ * the session is still resolving the overlay is `pending` → neutral (base painted, overlay
+ * not yet landed); once resolved it is a single-row batch tagged with the current identity,
+ * which `resolveOverlay` re-checks so a stale/foreign overlay reads neutral. See
+ * `panoFeedOverlay`.
+ */
+function composedScalars(
+	sessionPending: boolean,
+	viewerId: string | null,
+	row: {id: string; myVote?: boolean | null; isSaved?: boolean | null},
+): ViewerOverlay {
+	const state: OverlayState = sessionPending
+		? PENDING_OVERLAY
+		: {
+				status: "landed",
+				identity: viewerId,
+				byId: new Map([[row.id, {myVote: row.myVote ?? null, isSaved: row.isSaved ?? null}]]),
+			};
+	return resolveOverlay(state, viewerId, row.id);
+}
+
 export function PanoPostCard({
 	post,
 	rank,
 	onHide,
+	compose = false,
 }: {
 	post: ViewRef<"Post">;
 	rank?: number;
 	onHide?: (id: string) => void;
+	/**
+	 * Base + overlay composition (#2323, leg B, dark behind `pano-base-feed`). When set,
+	 * the viewer scalars (`myVote`/`isSaved`) render through the identity guard
+	 * (`panoFeedOverlay`): neutral while the session is still resolving (base painted,
+	 * overlay pending), then the viewer's own scalars once the session lands under a
+	 * matching identity — so a stale/foreign overlay (e.g. a snapshot's prior-identity
+	 * scalars) never paints. Off (the default / flag-off) ⇒ scalars read straight off the
+	 * post, byte-identical to today.
+	 */
+	compose?: boolean;
 }) {
 	const data = useLiveView(PanoPostCardView, post);
 	const session = useSession();
 	const isOwn = !!session.data?.user && session.data.user.id === data.authorId;
+	// The viewer scalars fed to the vote/save controls: flag-off reads them straight off the
+	// post (byte-identical to today); compose routes them through the identity guard below.
+	const {myVote, isSaved} = compose
+		? composedScalars(session.isPending, session.data?.user?.id ?? null, data)
+		: {myVote: data.myVote ?? null, isSaved: data.isSaved ?? null};
 	const href = `/pano/${data.slug ?? data.id}`;
 	const siteLabel = data.host ?? (data.url ? null : "yazı");
 	const agoLabel = formatAgoTR(toIso(data.createdAt));
@@ -57,12 +101,7 @@ export function PanoPostCard({
 			<span className="kp-pano-post__rank">
 				{rank != null ? String(rank).padStart(2, "0") : ""}
 			</span>
-			<PostVoteWidget
-				postId={data.id}
-				score={data.score}
-				myVote={data.myVote ?? null}
-				own={isOwn}
-			/>
+			<PostVoteWidget postId={data.id} score={data.score} myVote={myVote} own={isOwn} />
 			<div className="kp-pano-post__body">
 				<div className="kp-pano-post__title-row">
 					{tags.length ? (
@@ -96,7 +135,7 @@ export function PanoPostCard({
 					<MetaRow.Dot />
 					<a href={`${href}#comments`}>{data.commentCount} yorum</a>
 					<MetaRow.Dot />
-					<PostSaveButton postId={data.id} isSaved={data.isSaved ?? null} />
+					<PostSaveButton postId={data.id} isSaved={isSaved} />
 					{onHide ? (
 						<>
 							<MetaRow.Dot />

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -22,6 +22,8 @@ import {PanoFeedSkeleton} from "../components/pano/PanoSkeleton";
 import {Screen} from "../fate/Screen";
 import {FEED_SNAPSHOT_ENABLED} from "../fate/snapshot";
 import {LoadMoreButton} from "../fate/wire";
+import {PANO_BASE_FEED} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
 import {
 	PANO_FEED_PAGE_SIZE,
 	PANO_FILTERS,
@@ -134,6 +136,13 @@ function FeedContent({
 	pending: boolean;
 	chrome: Chrome;
 }) {
+	// Base + overlay composition (#2323, leg B), dark behind `pano-base-feed`. On ⇒ the
+	// rows compose the viewer scalars through the identity guard (`PanoPostCard compose`):
+	// base content paints de-gated from the session, `myVote`/`isSaved` stay neutral until
+	// the overlay lands under the confirmed identity. Off (default) ⇒ scalars read straight
+	// off the post, byte-identical to today. Sort feed only — `?sort=saved` is inherently
+	// per-viewer and stays on the authed path (`SavedContent`), out of the base/overlay split.
+	const {value: composeOverlay} = useFlag(PANO_BASE_FEED, false);
 	// Feed snapshot (leg A, #2319): under the containment flag, run the feed read
 	// stale-while-revalidate so a snapshot hydrated into the public client paints
 	// synchronously and the network patch lands in the background. Flag off ⇒ an
@@ -148,7 +157,15 @@ function FeedContent({
 		FEED_SNAPSHOT_ENABLED ? {mode: "stale-while-revalidate"} : undefined,
 	);
 
-	return <FeedRows connection={posts} host={host} pending={pending} chrome={chrome} />;
+	return (
+		<FeedRows
+			connection={posts}
+			host={host}
+			pending={pending}
+			chrome={chrome}
+			compose={composeOverlay}
+		/>
+	);
 }
 
 type PostConnection = ReturnType<
@@ -160,11 +177,13 @@ function FeedRows({
 	host,
 	pending,
 	chrome,
+	compose,
 }: {
 	connection: PostConnection;
 	host?: string;
 	pending: boolean;
 	chrome: Chrome;
+	compose: boolean;
 }) {
 	const [items, loadNext] = useLiveListView(PostConnectionView, connection);
 
@@ -186,7 +205,7 @@ function FeedRows({
 				}
 			>
 				{items.map(({node}, i) => (
-					<PanoPostCard key={node.id} post={node} rank={i + 1} />
+					<PanoPostCard key={node.id} post={node} rank={i + 1} compose={compose} />
 				))}
 			</div>
 			{loadNext ? (

--- a/apps/web/src/pages/panoFeedOverlay.test.ts
+++ b/apps/web/src/pages/panoFeedOverlay.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from "vitest";
+import {
+	NEUTRAL_OVERLAY,
+	type OverlayState,
+	PENDING_OVERLAY,
+	resolveOverlay,
+	type ViewerOverlay,
+} from "./panoFeedOverlay";
+
+const landed = (identity: string | null, entries: Record<string, ViewerOverlay>): OverlayState => ({
+	status: "landed",
+	identity,
+	byId: new Map(Object.entries(entries)),
+});
+
+describe("resolveOverlay", () => {
+	it("is neutral while the overlay is pending (base painted, scalars not yet landed)", () => {
+		expect(resolveOverlay(PENDING_OVERLAY, "user-a", "p1")).toEqual(NEUTRAL_OVERLAY);
+	});
+
+	it("returns the row's scalars once landed under the matching identity", () => {
+		const state = landed("user-a", {p1: {myVote: true, isSaved: false}});
+		expect(resolveOverlay(state, "user-a", "p1")).toEqual({myVote: true, isSaved: false});
+	});
+
+	it("stays neutral for a base row the landed batch does not cover", () => {
+		const state = landed("user-a", {p1: {myVote: true, isSaved: true}});
+		expect(resolveOverlay(state, "user-a", "p2")).toEqual(NEUTRAL_OVERLAY);
+	});
+
+	// The load-bearing invariant (#2323 AC): a viewer never sees another identity's overlay.
+	it("rejects an overlay landed under a DIFFERENT identity (never foreign state)", () => {
+		const stateForA = landed("user-a", {p1: {myVote: true, isSaved: true}});
+		expect(resolveOverlay(stateForA, "user-b", "p1")).toEqual(NEUTRAL_OVERLAY);
+	});
+
+	it("rejects a signed-in overlay for the anon viewer, and an anon overlay for a signed-in viewer", () => {
+		const anonBatch = landed(null, {p1: {myVote: false, isSaved: false}});
+		expect(resolveOverlay(anonBatch, "user-a", "p1")).toEqual(NEUTRAL_OVERLAY);
+		const authedBatch = landed("user-a", {p1: {myVote: true, isSaved: true}});
+		expect(resolveOverlay(authedBatch, null, "p1")).toEqual(NEUTRAL_OVERLAY);
+	});
+
+	it("resolves the anon viewer's own landed batch (identity null on both sides)", () => {
+		const anonBatch = landed(null, {p1: {myVote: null, isSaved: null}});
+		expect(resolveOverlay(anonBatch, null, "p1")).toEqual({myVote: null, isSaved: null});
+	});
+});

--- a/apps/web/src/pages/panoFeedOverlay.ts
+++ b/apps/web/src/pages/panoFeedOverlay.ts
@@ -1,0 +1,63 @@
+/**
+ * Client-side base+overlay composition for the pano feed (#2323, epic #2316 leg B).
+ *
+ * The feed splits into a viewer-invariant BASE (post content — title/score/host/…,
+ * identical for anon and every signed-in viewer) and a per-viewer OVERLAY (the
+ * `myVote`/`isSaved` scalars). The base paints as soon as it lands, de-gated from
+ * `get-session`; the overlay composes on top once the session resolves. This module
+ * is the pure composition rule — the identity guard that makes the load-bearing
+ * invariant structural: a viewer NEVER sees another (or a stale) identity's overlay
+ * during composition. An overlay whose landed identity ≠ the current viewer resolves
+ * to the neutral (null) state — the same read-path convention the server already
+ * degrades to for anon — never a wrong or foreign value.
+ */
+
+/** The per-viewer scalar slice composed on top of a base post row. `null` = the neutral,
+ *  overlay-pending state (also the anon read-path value): no vote, not saved-known-yet. */
+export interface ViewerOverlay {
+	readonly myVote: boolean | null;
+	readonly isSaved: boolean | null;
+}
+
+/** The overlay-pending / anon state: render controls neutral, reserving their landed
+ *  footprint so the later patch causes no layout shift. */
+export const NEUTRAL_OVERLAY: ViewerOverlay = {myVote: null, isSaved: null};
+
+/**
+ * A landed overlay batch, tagged with the identity it was read under. `identity` is the
+ * resolved viewer id (`null` for anon); `byId` maps each base row's post id to that
+ * viewer's scalars. Tagging the batch with its identity is what lets `resolveOverlay`
+ * reject a batch that belongs to a previous identity during a re-key/compose window.
+ */
+export interface OverlayBatch {
+	readonly identity: string | null;
+	readonly byId: ReadonlyMap<string, ViewerOverlay>;
+}
+
+/** The overlay's lifecycle: `pending` before the viewer's scalars land (base already
+ *  painted), then `landed` once they arrive under a known identity. */
+export type OverlayState =
+	| {readonly status: "pending"}
+	| ({readonly status: "landed"} & OverlayBatch);
+
+export const PENDING_OVERLAY: OverlayState = {status: "pending"};
+
+/**
+ * Resolve one base row's overlay against the current viewer — the identity guard.
+ *
+ * Returns the row's scalars ONLY when the overlay has landed AND was read under the
+ * SAME identity as the current viewer AND carries this id; otherwise the neutral state.
+ * The identity match is the guard: an overlay batch landed under identity A is inert for
+ * viewer B (and for anon), so a stale/foreign overlay can never paint — it reads neutral
+ * until B's own batch lands. A missing id (a base row the overlay batch didn't cover yet)
+ * likewise stays neutral, never borrowing a sibling row's scalars.
+ */
+export function resolveOverlay(
+	state: OverlayState,
+	viewerIdentity: string | null,
+	id: string,
+): ViewerOverlay {
+	if (state.status !== "landed") return NEUTRAL_OVERLAY;
+	if (state.identity !== viewerIdentity) return NEUTRAL_OVERLAY;
+	return state.byId.get(id) ?? NEUTRAL_OVERLAY;
+}


### PR DESCRIPTION
Leg B **client composition** for the "instant /pano reload" epic (#2316, Phase 3, `requires: #2322`). Dark behind `pano-base-feed` (default-off, the flag #2334 established — no new flag).

## What changed
The pano feed splits into a viewer-invariant **BASE** (post content — title/score/host/…, identical for anon and every signed-in viewer) and a per-viewer **OVERLAY** (the `myVote`/`isSaved` scalars). With the flag on, the base paints de-gated from `get-session`; the overlay composes on top once the session resolves — neutral (null) until it lands, then patched in place with no layout shift.

- `apps/web/src/pages/panoFeedOverlay.ts` — the pure composition primitive. `resolveOverlay` is the **identity guard**: a landed overlay batch is tagged with the identity it was read under, so a stale/foreign batch (e.g. a warm snapshot's prior-identity scalars) resolves to the neutral state rather than leaking into a different viewer. This makes "never sees another/stale identity's viewer state" structural.
- `apps/web/src/components/pano/PanoPostCard.tsx` — gains an opt-in `compose` prop that routes the viewer scalars through the guard (neutral while the session resolves, then the viewer's own scalars once landed under a matching identity). Flag-off reads the scalars straight off the post — byte-identical to today.
- `apps/web/src/pages/PanoFeed.tsx` — reads `pano-base-feed` via `useFlag` (default-off) and threads `compose` to the **sort-feed rows only**. `?sort=saved` stays authed-only on `SavedContent`, out of the base/overlay split.

The two-tier provider (ADR 0167) stays the frame: the eager public tier already paints base content above the session gate; this change makes the viewer scalars a composed overlay on top rather than reading them directly.

## Acceptance criteria
- Flag on: rows paint from the base without waiting on `get-session`; `myVote`/`isSaved` stay neutral until the overlay lands, then update in place (no layout shift — the controls' null footprint is the anon footprint, unchanged) — component-tested.
- A signed-in viewer never sees another/stale identity's overlay during composition — the pending compose window holds neutral (component-tested), and the pure identity guard rejects a foreign-identity batch (unit-tested).
- `?sort=saved` behavior unchanged — authed-only, live `isSaved` row-drop reconciliation untouched (`compose` never threaded there).
- Flag off ⇒ byte-identical (scalars read straight off the post; no extra work).

## Tests
- `apps/web/src/pages/panoFeedOverlay.test.ts` — the guard: pending → neutral, landed-under-matching-identity → scalars, uncovered id → neutral, **foreign identity → neutral**, anon batch semantics.
- `apps/web/src/components/pano/PanoPostCard.compose.test.tsx` — the compose window: base paints while warm scalars are held neutral (overlay pending), scalars land under the resolved identity, anon nulls, and compose-off byte-identical.

`pnpm typecheck` + `pnpm lint:worktree` clean; unit + client tests green (App two-tier tests unaffected).

Fixes #2323
Flag: pano-base-feed