### PR TITLE
docs(pipeline): allow a <details> wrap-in-place for the triaged epic brief (#2344)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -25,10 +25,12 @@ product judgment; you do not ask the user questions (the human already approved 
 triage). When a user story hinges on a genuine product decision you can't ground from the
 codebase, carve it as a `type:decision` child — never handwave it. Plan, split, link, done.
 
-The epic body is **append-down**: the triaged original brief stays untouched at the top, and you
-write *below* it. You never rewrite-on-top an epic — its original content is the brief that
-grounds your plan, not noise to bury. (This is exactly the exception triage carves out for
-epics; the formats doc spells out why.)
+The epic body is **append-down**: the triaged original brief stays untouched at the top — triage
+may collapse it into a `<details>` wrap-in-place, but it is preserved byte-for-byte and is still
+your input — and you write *below* it. You never rewrite-on-top an epic: its original content is
+the brief that grounds your plan, and your surgical splice preserves it verbatim whether or not
+it's wrapped. (This is exactly the exception triage carves out for epics; the formats doc spells
+out why.)
 
 ## All GitHub ops via `gh api` REST — never GraphQL
 

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -317,13 +317,34 @@ BODY="$(cat /tmp/triage-body-<N>.md)"
 gh api -X PATCH "repos/$REPO/issues/<N>" -f body="$BODY"
 ```
 
-**Epics are the exception — do not rewrite-on-top.** An epic's original content is
-the *brief*, not superseded noise; the `plan-epic` skill appends its plan *below* the
-untouched original (append-down, not rewrite-on-top — see the formats doc). For an
-epic, classify and prioritize it, optionally add a short triage note as a comment,
-but leave the body's original brief intact at the top. Do not bury it in a
-`<details>`. (If an epic was filed truly threadbare, prefer `status:needs-info` over
-mangling it.)
+**Epics are the exception — wrap-in-place, never rewrite-on-top.** An epic's original
+content is the *brief*, not superseded noise, and it is `plan-epic`'s input: the plan is
+appended *below* it (append-down, not rewrite-on-top — see the formats doc), and
+`plan-epic`'s surgical splice preserves it byte-for-byte. So for an epic you **do not**
+write an enriched, actionable version on top — that would fork the brief `plan-epic`
+reads. What you *may* do (and now should, so a post-triage epic body isn't the one type
+that leads with flat, un-collapsed intake prose) is **wrap the preserved original in a
+`<details>` in place** — byte-for-byte, with nothing enriched above it. Classify and
+prioritize, optionally add a short triage note as a comment, then shape the body as:
+
+```markdown
+**Epic — awaiting plan.** `plan-epic` appends `## Plan (plan-epic)` and `## Dependencies` below.
+
+<details>
+<summary>Original brief (verbatim)</summary>
+
+<the original body, byte-for-byte unchanged>
+
+</details>
+```
+
+This is a *collapse in place*, not the Step-4 rewrite-on-top: nothing sits above the
+`<details>` but the one-line typed header (so a pre-plan epic body leads with the epic,
+not a bare collapsed element), and the brief inside is verbatim — so the exact bytes
+`plan-epic` splices are unchanged. The `<summary>` is the epic variant of the other
+types' `Original report (verbatim)` — `Original brief` names an epic's original as its
+*brief* (Step 2's tell), the same verbatim-provenance guarantee. (If an epic was filed
+truly threadbare, prefer `status:needs-info` over mangling it.)
 
 **Re-typing an issue? Reconcile the BODY, not just a comment.** When you change an
 already-typed issue's type (a `decision` re-scoped to `feature`, a `bug` recut as a


### PR DESCRIPTION
Fixes #2344

## What changed

Amends the triage skill's Step-4 epic-exception rule so a triaged epic body no longer leads with flat, un-collapsed intake prose — the one type that skipped the `<details>` wrap every other type gets.

**`claude-plugins/kampus-pipeline/skills/triage/SKILL.md` (Step 4).** Replaces the `Do not bury it in a <details>` prohibition with a **wrap-in-place**: the byte-preserved original brief collapsed under `<details><summary>Original brief (verbatim)</summary>…</details>`, with a one-line typed header (`**Epic — awaiting plan.** …`) above it and **nothing enriched**. The load-bearing **no-rewrite-on-top** invariant is kept intact — nothing actionable is written on top of the brief, so the exact bytes `plan-epic`'s surgical splice reads are unchanged (append-down still lands `## Plan (plan-epic)` / `## Dependencies` below).

**`claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md` (append-down intro).** Reconciles the "original brief stays untouched at the top" wording to name the now-possibly-`<details>`-wrapped brief: triage may collapse it, but it is preserved byte-for-byte and remains plan-epic's verbatim input — the surgical splice preserves it whether or not it's wrapped. This removes the stale "not noise to bury" phrasing that echoed the deleted prohibition.

## Acceptance criteria

- [x] Step 4's epic-exception paragraph updated: no-rewrite-on-top kept, `Do not bury it in a <details>` replaced with the wrap-in-place (original preserved byte-for-byte inside the details block).
- [x] plan-epic append-down confirmed compatible + wording adjusted (appends land below the wrapped brief; surgical splice untouched).
- [x] The epic `<details>` treatment uses a deliberately chosen epic variant summary — `Original brief (verbatim)` vs the other types' `Original report (verbatim)` — stated in the diff (an epic's original is its *brief*, same verbatim-provenance guarantee).

## Design micro-decisions

- **Pre-plan header line:** `**Epic — awaiting plan.** \`plan-epic\` appends \`## Plan (plan-epic)\` and \`## Dependencies\` below.` — so a pre-plan epic body leads with the epic, not a bare collapsed element.
- **`<summary>` wording:** `Original brief (verbatim)` — the epic variant, chosen deliberately over `Original report`.

## Notes

- Docs-only change to two pipeline skills (`triage`, `plan-epic`). Neither is a gate-critical skill (`ship-it` / `review-*` / `gh-issue-intake-formats.md`) — `ship-it` decides §CP routing at ship time against live main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)