### PR TITLE
docs(patterns): retire D1Connection.bind → D1.QueryDatabase in better-auth-on-d1 (#2352)

### DIFF
--- a/.patterns/better-auth-with-plugins-on-d1.md
+++ b/.patterns/better-auth-with-plugins-on-d1.md
@@ -1,5 +1,7 @@
 # better-auth on Cloudflare D1 with plugins — the forked CloudflareD1 Layer
 
+> Derived from `alchemy@2.0.0-beta.59` — re-verify on pin bump.
+
 Phoenix runs better-auth on `@alchemy.run/better-auth`'s `BetterAuth`
 Context.Service tag, but provides its own Layer implementation rather than
 the upstream `CloudflareD1` reference Layer. The reasons are concrete: the
@@ -36,7 +38,7 @@ export const BetterAuthLive = Layer.effect(
   BetterAuth.BetterAuth,
   Effect.gen(function* () {
     // Reuse phoenix's existing D1 — no separate BetterAuth DB.
-    const connection = yield* Cloudflare.D1Connection.bind(PhoenixDb);
+    const connection = yield* Cloudflare.D1.QueryDatabase(PhoenixDb);
     const env = yield* Cloudflare.WorkerEnvironment;
 
     // Mint (or recover from state) the session-signing secret. `Random`
@@ -74,7 +76,7 @@ export const BetterAuthLive = Layer.effect(
       fetch: /* request handler that calls auth.handler(...) */,
     };
   }),
-).pipe(Layer.provide(Cloudflare.D1ConnectionLive));
+).pipe(Layer.provide(Cloudflare.D1.QueryDatabaseBinding));
 ```
 
 The Layer satisfies `BetterAuth.BetterAuth` (the Context tag from
@@ -92,8 +94,8 @@ Three load-bearing differences from the reference Layer:
   pre-constructed `Auth` instance, so the construction itself has to
   carry them.
 - **Database reuse.** The reference Layer declares its own
-  `Cloudflare.D1Database("BetterAuth")` — a second D1 alongside the
-  canonical `PhoenixDb` defined in `apps/web/work../db/resources.ts`.
+  `Cloudflare.D1.Database("BetterAuth")` — a second D1 alongside the
+  canonical `PhoenixDb` defined in `apps/web/worker/db/resources.ts`.
   The better-auth tables (user, session, account, verification) live on
   the same D1 as the rest of the product data (post, term,
   definition, user_profile) — schema is in
@@ -108,7 +110,7 @@ Three load-bearing differences from the reference Layer:
 
 The fork is ~40 lines and is the smallest delta that keeps the three
 above. Tracking upstream is straightforward — the structure (Random for
-secret, `D1Connection.bind`, `Effect.cached` for the
+secret, `D1.QueryDatabase`, `Effect.cached` for the
 `makeBetterAuth` call) mirrors the reference Layer; only the
 `makeBetterAuth` body diverges.
 
@@ -186,8 +188,8 @@ parameter is the seam.
 
 ## Reuse the existing phoenix D1
 
-`yield* Cloudflare.D1Connection.bind(PhoenixDb)` is how the Layer binds
-to the canonical D1 (declared in `apps/web/work../db/resources.ts`).
+`yield* Cloudflare.D1.QueryDatabase(PhoenixDb)` is how the Layer binds
+to the canonical D1 (declared in `apps/web/worker/db/resources.ts`).
 The drizzle adapter then takes `connection.raw` (the underlying
 `D1Database` handle) plus the shared schema:
 
@@ -231,13 +233,13 @@ unchanged.
   factory that takes the resolved instance.
 - `apps/web/worker/index.ts` — the worker init that yields `betterAuth.auth`
   once and threads `authInstance` into the fate Layer.
-- `apps/web/work../db/resources.ts` — `PhoenixDb` (the shared D1).
+- `apps/web/worker/db/resources.ts` — `PhoenixDb` (the shared D1).
 - `apps/web/worker/db/drizzle/schema.ts` — the shared schema (product
   tables + better-auth tables).
 
 ## See also
 
-- [alchemy-drizzle-d1.md](./alchemy-drizzle-d1.md) — `D1Connection.bind`,
+- [alchemy-drizzle-d1.md](./alchemy-drizzle-d1.md) — `D1.QueryDatabase`,
   drizzle wiring.
 - [effect-layer-composition.md](./effect-layer-composition.md) — the
   `RuntimeContext`-escape: why a service whose method yields


### PR DESCRIPTION
## What

Retires the pre-beta.59 flat alchemy D1 API (`Cloudflare.D1Connection.bind(PhoenixDb)` / `Cloudflare.D1ConnectionLive`) from `.patterns/better-auth-with-plugins-on-d1.md`, the last `.patterns/` doc still teaching it after canon batches A/B/C merged. Swaps to the namespaced `Cloudflare.D1.QueryDatabase(PhoenixDb)` capability backed by the `Cloudflare.D1.QueryDatabaseBinding` layer — the surface that actually exists in the pinned `alchemy@2.0.0-beta.59` and that the worker uses (`apps/web/worker/db/Database.ts`).

Grounded against the installed patched `alchemy@2.0.0-beta.59` package (`src/Cloudflare/D1/QueryDatabase.ts`, `QueryDatabaseBinding.ts`, `index.ts`), the live `apps/web/worker/db/Database.ts` + `apps/web/worker/index.ts` wiring, and the refreshed `.patterns/alchemy-bindings.md` / `.patterns/alchemy-drizzle-d1.md`.

## Changes (`.patterns/better-auth-with-plugins-on-d1.md` only)

- `Cloudflare.D1Connection.bind(PhoenixDb)` → `Cloudflare.D1.QueryDatabase(PhoenixDb)` (shape example + "Reuse the existing phoenix D1" section).
- `Layer.provide(Cloudflare.D1ConnectionLive)` → `Layer.provide(Cloudflare.D1.QueryDatabaseBinding)`.
- Prose/see-also references to `D1Connection.bind` → `D1.QueryDatabase`.
- Upstream reference-layer mention `Cloudflare.D1Database("BetterAuth")` → `Cloudflare.D1.Database("BetterAuth")` (the namespaced resource constructor, matching `apps/web/worker/db/resources.ts`).
- Fixed the broken `apps/web/work../db/resources.ts` path → `apps/web/worker/db/resources.ts` (3 occurrences).
- Added the `> Derived from alchemy@2.0.0-beta.59 — re-verify on pin bump.` version stamp, matching the sibling canon docs.

## Scope notes (at-pickup coverage re-check, AC#1)

- Re-verified on fresh `origin/main`: all canon batches merged (#2363, #2351, #2362), no open PR touches `.patterns/`. The only residual in the named issue scope was this doc.
- The `.patterns/index.md` better-auth row was **already clean** (no `D1Connection` reference) — no index edit needed, so this PR does not touch the hot `index.md` serialization file (leaving sibling #2359 unblocked).
- **Out of this issue's named scope (flagged, not fixed here):** `.patterns/effect-context-service.md` (`Cloudflare.D1Connection.bind(PhoenixDb).raw`) and `.patterns/effect-layer-composition.md` (two `D1Connection` mentions) still carry stray `D1Connection` references. They were not among the issue's enumerated surfaces, so a repo-wide `grep -rn 'D1Connection' .patterns/` (AC#4) will still match those two. Filed as a follow-up report for triage.

Fixes #2352