### PR TITLE
docs(patterns): retire D1Connection API refs in effect-context-service + effect-layer-composition (#2375)

### DIFF
--- a/.patterns/effect-context-service.md
+++ b/.patterns/effect-context-service.md
@@ -1,5 +1,7 @@
 # Context.Service pattern
 
+> Derived from `alchemy@2.0.0-beta.59` — re-verify on pin bump.
+
 How to define and wire services in phoenix's worker.
 
 > [!IMPORTANT]
@@ -89,7 +91,7 @@ export const layer = Layer.effect(UserRepo)(
 );
 ```
 
-Use when the service needs other services from the context (here, `Database`). The resulting layer carries `R = Database` until that's provided. `worker/db/Drizzle.ts`'s `makeDrizzleLayer` is the canonical phoenix example — the worker init builds the drizzle builder once from the bound D1 (via `Cloudflare.D1Connection.bind(PhoenixDb).raw`) and hands it to `makeDrizzleLayer(db)`, which returns a `DrizzleAccess` record.
+Use when the service needs other services from the context (here, `Database`). The resulting layer carries `R = Database` until that's provided. `worker/db/Drizzle.ts`'s `makeDrizzleLayer` is the canonical phoenix example — the worker init builds the drizzle builder once from the bound D1 (via `Cloudflare.D1.QueryDatabase(PhoenixDb)`, whose `connection.raw` is the underlying `D1Database` — as `worker/db/Database.ts` resolves it) and hands it to `makeDrizzleLayer(db)`, which returns a `DrizzleAccess` record.
 
 ### `Layer.effectContext` — providing multiple tags from one construction
 

--- a/.patterns/effect-layer-composition.md
+++ b/.patterns/effect-layer-composition.md
@@ -1,5 +1,7 @@
 # Layer composition and runtime wiring
 
+> Derived from `alchemy@2.0.0-beta.59` — re-verify on pin bump.
+
 How phoenix builds Effect runtimes from layers. Read [effect-context-service.md](./effect-context-service.md) first, then [fate-effect-worker-wiring.md](./fate-effect-worker-wiring.md) for *where* these layers get provided (worker scope vs per request).
 
 ## The three layer constructors
@@ -77,7 +79,7 @@ The temptation is to define `class FateLayer extends Context.Service<FateLayer, 
 
 The factory shape is for **pure composition over already-resolved values**. A `Context.Service` Layer (with `Layer.effect(...)`) is the right call when the Layer is genuinely doing scoped work:
 
-- **Async or fallible construction** — building the service requires a `yield*` of an effect that can fail (e.g. `BetterAuthLive` resolving `Random` + `D1Connection`).
+- **Async or fallible construction** — building the service requires a `yield*` of an effect that can fail (e.g. `BetterAuthLive` resolving `Random` + `Cloudflare.D1.QueryDatabase`).
 - **Scoped resources** — a service that needs `Layer.scoped` for finalizers (connection pools, file handles).
 - **A real domain shape** — the service has methods (`Pasaport.validateSession`, `Drizzle.run`), not just a composed Layer.
 
@@ -142,7 +144,7 @@ const result = await Effect.runPromiseExit(
 // If SomeLayer fails to construct, the Exit is a failure with that layer's error.
 ```
 
-Phoenix's feature Layers don't fail at construction today — `DrizzleLive` just wraps a constructed builder, no validation. `BetterAuthLive` can fail at the `Random`/`D1Connection` resolve step; that surfaces as a Layer error at the worker's outer `Effect.provide`, before any handler runs.
+Phoenix's feature Layers don't fail at construction today — `DrizzleLive` just wraps a constructed builder, no validation. `BetterAuthLive` can fail at the `Random`/`Cloudflare.D1.QueryDatabase` resolve step; that surfaces as a Layer error at the worker's outer `Effect.provide`, before any handler runs.
 
 ## See also
 


### PR DESCRIPTION
## What

Retire the last stale pre-beta.59 alchemy D1 API references in two `.patterns/` docs, retargeting them to the current namespaced surface `Cloudflare.D1.QueryDatabase`.

- `.patterns/effect-context-service.md` — the `makeDrizzleLayer` wiring description was a code-level `Cloudflare.D1Connection.bind(PhoenixDb).raw` reference; retargeted to `Cloudflare.D1.QueryDatabase(PhoenixDb)` whose `connection.raw` is the underlying `D1Database`, matching how `apps/web/worker/db/Database.ts` resolves it.
- `.patterns/effect-layer-composition.md` — two prose `D1Connection` mentions (the `BetterAuthLive` fallible resolve step) retargeted to `Cloudflare.D1.QueryDatabase`.
- Both docs version-stamped (`> Derived from alchemy@2.0.0-beta.59 — re-verify on pin bump.`) per the canon-batch convention (PR #2374).

## Grounding

`D1Connection` does not exist in the installed patched `alchemy@2.0.0-beta.59` — its D1 surface is `Cloudflare/D1/QueryDatabase.ts` + `QueryDatabaseBinding.ts` (verified: no `D1Connection` anywhere in that package's `src/`). The live worker `apps/web/worker/db/Database.ts` resolves via `Cloudflare.D1.QueryDatabase(PhoenixDb)` → `connection.raw`. Idiom matches the sibling better-auth fix (PR #2374).

## Scope

`.patterns/effect-context-service.md` + `.patterns/effect-layer-composition.md` ONLY — file-disjoint from all in-flight canon work. `.patterns/index.md` is untouched (neither doc's index row restates the retired API; a sibling #2376 index PR is in flight). Other `.patterns/` carriers of `D1Connection` (alchemy-bindings/-drizzle-d1/-worker/-overview, better-auth) are covered by the separate canon-batch PRs #2351/#2362/#2374 and are out of scope here.

## Coupling

Completes the canon-residual purge #2352's AC#4 grep (`grep -rn 'D1Connection\|D1ConnectionLive' .patterns/`) checks — that grep stays dirty until this plus #2352's residual land.

Fixes #2375