### PR TITLE
feat(web): reload→feed-paint instrumentation for the three /pano paths (#2326)

### DIFF
--- a/apps/web/src/fate/FateProvider.tsx
+++ b/apps/web/src/fate/FateProvider.tsx
@@ -9,6 +9,7 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {FateClient} from "react-fate";
 import {useSession} from "../auth/client";
+import {noteSnapshotHydrated} from "../lib/feedPerf";
 import {createClient} from "./client";
 import {createLiveRetryController, type LiveRetryController} from "./liveRetry";
 import {getPublicFateClient} from "./publicClient";
@@ -86,7 +87,9 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 		// hydrate-before-render contract. The anon (userId null) client is the pending/signed-out
 		// tier and owns no authed snapshot, so it is skipped: the authed snapshot is strictly
 		// identity-scoped. No-op when the flag is off. See `snapshot.ts`.
-		if (userId != null) hydrateAuthedClient(created, userId);
+		// Note a hydrated snapshot so the reload→paint instrument classifies this paint as
+		// the snapshot path (#2326). No-op when the snapshot flag is off (returns false).
+		if (userId != null && hydrateAuthedClient(created, userId)) noteSnapshotHydrated();
 		return created;
 	}, [userId, scheduleRetry]);
 

--- a/apps/web/src/fate/publicClient.ts
+++ b/apps/web/src/fate/publicClient.ts
@@ -11,6 +11,7 @@
  * (an anon `/fate/live` `EventSource` 401-loops); live + mutations + viewer-scoped
  * scalars stay on the authed client below the gate. See ADR 0167.
  */
+import {noteSnapshotHydrated} from "../lib/feedPerf";
 import {createClient, type FateClientInstance} from "./client";
 import {hydrateAnonPublicClient, installAnonSnapshotPersistence} from "./snapshot";
 
@@ -31,7 +32,9 @@ export function getPublicFateClient(): FateClientInstance {
 		// uninstaller is intentionally discarded). Both no-op when the containment flag
 		// is off (flag-off ⇒ no storage reads/writes), so this is byte-identical to today
 		// until #2326 flips it. See `snapshot.ts`.
-		hydrateAnonPublicClient(publicClient);
+		// Note a hydrated snapshot so the reload→paint instrument classifies this paint as
+		// the snapshot path (#2326). No-op when the snapshot flag is off (returns false).
+		if (hydrateAnonPublicClient(publicClient)) noteSnapshotHydrated();
 		installAnonSnapshotPersistence(publicClient);
 	}
 	return publicClient;

--- a/apps/web/src/fate/snapshot.ts
+++ b/apps/web/src/fate/snapshot.ts
@@ -278,12 +278,14 @@ export function browserPersistenceBindings(): PersistenceBindings {
 }
 
 /** Boot-time hydrate for the always-anonymous public client. No-op when the flag is off
- *  or `localStorage` is unavailable, so the flag-off path performs no storage reads. */
-export function hydrateAnonPublicClient(client: SnapshotClient): void {
-	if (!FEED_SNAPSHOT_ENABLED) return;
+ *  or `localStorage` is unavailable, so the flag-off path performs no storage reads.
+ *  Returns whether a snapshot was applied (the reload→paint instrument reads this to
+ *  classify the paint as the snapshot path, #2326). */
+export function hydrateAnonPublicClient(client: SnapshotClient): boolean {
+	if (!FEED_SNAPSHOT_ENABLED) return false;
 	const storage = browserSnapshotStorage();
-	if (storage == null) return;
-	hydrateFromSnapshot(client, storage, {identity: ANON_IDENTITY});
+	if (storage == null) return false;
+	return hydrateFromSnapshot(client, storage, {identity: ANON_IDENTITY});
 }
 
 /** Install anon persistence for the public client's lifetime. No-op (an inert
@@ -303,12 +305,13 @@ export function installAnonSnapshotPersistence(client: SnapshotClient): () => vo
  *  resolves, keyed on the resolved `userId`, so a signed-in reload paints the viewer's own
  *  last-seen feed (base feed + private `myVote`/`isSaved`) synchronously before the first
  *  `useRequest`. Keyed per user, so one identity's snapshot never hydrates under another.
- *  No-op when the flag is off or `localStorage` is unavailable. */
-export function hydrateAuthedClient(client: SnapshotClient, userId: string): void {
-	if (!FEED_SNAPSHOT_ENABLED) return;
+ *  No-op when the flag is off or `localStorage` is unavailable. Returns whether a snapshot
+ *  was applied (the reload→paint instrument reads this to classify the paint, #2326). */
+export function hydrateAuthedClient(client: SnapshotClient, userId: string): boolean {
+	if (!FEED_SNAPSHOT_ENABLED) return false;
 	const storage = browserSnapshotStorage();
-	if (storage == null) return;
-	hydrateFromSnapshot(client, storage, {identity: authedIdentity(userId)});
+	if (storage == null) return false;
+	return hydrateFromSnapshot(client, storage, {identity: authedIdentity(userId)});
 }
 
 /** Install authed persistence for the identity-keyed client's lifetime, keyed per user id

--- a/apps/web/src/lib/feedPerf.ts
+++ b/apps/web/src/lib/feedPerf.ts
@@ -1,0 +1,142 @@
+/**
+ * Reload→first-feed-paint instrumentation (#2326, epic #2316 "instant /pano reload").
+ *
+ * Emits User Timing marks/measures around the pano feed's first paint so the epic's
+ * founding floor ("reload → feed on screen") is measurable in a DevTools/Performance
+ * trace with NO analytics dependency. The epic's three legs create three paths:
+ *   - `snapshot` — leg A hydrated the last-seen feed from `localStorage` at boot, so it
+ *     paints at ~JS-boot time (the residual floor the epic names), before any network.
+ *   - `edge`     — leg B's viewer-invariant base feed served from the CF edge cache
+ *     (fresh-device anon), no session/D1. The SPA does not fetch that GET, so this path
+ *     is classified from an injected `cf-cache-status` signal (network-layer measured on
+ *     `GET /fate/pano/feed`), never from a client render.
+ *   - `cold`     — today's path: the full worker→D1 read, gated behind the session.
+ *
+ * The measure spans navigation start → paint. `performance.timeOrigin` IS the reload's
+ * navigation start for the top document, so `performance.now()` at paint is the
+ * reload→paint duration — the measure runs from `start: 0` (i.e. `timeOrigin`) to it.
+ *
+ * Cost/containment (AC#3): a one-shot mark+measure is negligible, but per the epic's
+ * dark-ship ethos it is gated behind `FEED_PERF_ENABLED` — dev builds, plus an opt-in
+ * `VITE_FEED_PERF` measurement/stage build — so a production bundle pays nothing by
+ * default. Every call is best-effort: an absent or throwing `performance` (SSR, a
+ * legacy engine that rejects the L3 options object) degrades to a no-op, never a
+ * user-visible effect.
+ */
+
+/** Instrument gate: on in dev, or in a build that opts in via `VITE_FEED_PERF=on`
+ *  (a measurement/stage bundle). Off in a default production build ⇒ zero cost. A
+ *  build-time env flag, like `VITE_FEED_SNAPSHOT` — see `vite-env.d.ts`. */
+export const FEED_PERF_ENABLED = import.meta.env.DEV || import.meta.env.VITE_FEED_PERF === "on";
+
+/** Which path produced the first feed paint. */
+export type FeedPaintPath = "snapshot" | "edge" | "cold";
+
+/** The CF edge-cache status of the base-feed GET (leg B), read from its `cf-cache-status`
+ *  response header; `null` when unknown/not applicable (the SPA does not fetch that GET). */
+export type CacheStatus = "HIT" | "MISS" | null;
+
+export interface FeedPathSignals {
+	readonly snapshotHydrated: boolean;
+	readonly cacheStatus?: CacheStatus;
+}
+
+/**
+ * Classify which path produced the first paint. Snapshot wins whenever a snapshot
+ * hydrated — that IS the first paint the user sees (leg A paints before any network),
+ * so the edge/cold distinction only applies to the no-snapshot case. Among those, an
+ * edge cache HIT on the base feed outranks the cold worker→D1 path; everything else is
+ * cold. This is the rule the epic's flag-flip evidence rests on.
+ */
+export function classifyFeedPath({snapshotHydrated, cacheStatus}: FeedPathSignals): FeedPaintPath {
+	if (snapshotHydrated) return "snapshot";
+	if (cacheStatus === "HIT") return "edge";
+	return "cold";
+}
+
+/** Latched at boot when a feed snapshot hydrated (leg A) — read at first paint to
+ *  classify the path. A one-way latch: once a snapshot is applied it defined the paint. */
+let snapshotHydrated = false;
+
+/** Record that a feed snapshot hydrated at boot (leg A). Called from the public/authed
+ *  client wiring only when `hydrateFromSnapshot` actually applied a snapshot. */
+export function noteSnapshotHydrated(): void {
+	snapshotHydrated = true;
+}
+
+export function wasSnapshotHydrated(): boolean {
+	return snapshotHydrated;
+}
+
+/** The one paint-mark name (path-suffixed so each path is a distinct trace entry). */
+export const FEED_PAINT_MARK = "pano:feed-paint";
+
+/** The navigation-start→paint measure name for a path (rendered in the DevTools
+ *  Performance/User Timing lane). */
+export function feedPaintMeasureName(path: FeedPaintPath): string {
+	return `pano:reload->feed-paint:${path}`;
+}
+
+/** The `performance` slice this module drives, injected so the recorder is testable
+ *  without a real `performance` (and so a partial jsdom impl can be faked precisely). */
+export interface PerformanceLike {
+	now(): number;
+	mark(name: string, options?: {detail?: unknown}): unknown;
+	measure(name: string, options: {start?: number; end?: number; detail?: unknown}): unknown;
+}
+
+/**
+ * Emit the paint mark + a navigation-start→paint measure for `path`, returning the
+ * reload→paint duration in ms (or `null` when `performance` threw / was unusable).
+ * Best-effort: wrapped so a legacy `performance` that rejects the User Timing L3 options
+ * object never throws into the render.
+ */
+export function recordFeedPaint(
+	perf: PerformanceLike,
+	path: FeedPaintPath,
+	now: number = perf.now(),
+): number | null {
+	try {
+		const detail = {path, reloadToPaintMs: now};
+		perf.mark(`${FEED_PAINT_MARK}:${path}`, {detail});
+		perf.measure(feedPaintMeasureName(path), {start: 0, end: now, detail});
+		return now;
+	} catch {
+		return null;
+	}
+}
+
+/** `globalThis.performance` when it exposes the User Timing surface, else `null`
+ *  (SSR / a test env without it) so callers degrade cleanly. */
+export function globalPerformance(): PerformanceLike | null {
+	const perf = (globalThis as {performance?: Partial<PerformanceLike>}).performance;
+	return perf && typeof perf.mark === "function" && typeof perf.measure === "function"
+		? (perf as PerformanceLike)
+		: null;
+}
+
+/** Latched once the first paint is recorded — later feed re-renders (sort swaps,
+ *  pagination) must not re-mark; the epic measures the FIRST paint after reload. */
+let recorded = false;
+
+/**
+ * Record the first feed paint exactly once for the tab's lifetime. No-op when the
+ * instrument is disabled, already recorded, or `performance` is unavailable. `cacheStatus`
+ * refines the no-snapshot case to edge vs cold when a caller can observe the base-feed
+ * `cf-cache-status`; it defaults to `null` (the SPA render can't see it → the network-layer
+ * methodology distinguishes edge from cold on the GET itself).
+ */
+export function markFeedPaintOnce(
+	perf: PerformanceLike | null = globalPerformance(),
+	cacheStatus: CacheStatus = null,
+): number | null {
+	if (!FEED_PERF_ENABLED || recorded || perf == null) return null;
+	recorded = true;
+	return recordFeedPaint(perf, classifyFeedPath({snapshotHydrated, cacheStatus}));
+}
+
+/** Test seam: clear the module-level latches so each test starts from a clean instrument. */
+export function resetFeedPaintInstrumentation(): void {
+	recorded = false;
+	snapshotHydrated = false;
+}

--- a/apps/web/src/lib/feedPerf.unit.test.ts
+++ b/apps/web/src/lib/feedPerf.unit.test.ts
@@ -1,0 +1,133 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {
+	classifyFeedPath,
+	FEED_PAINT_MARK,
+	type FeedPaintPath,
+	feedPaintMeasureName,
+	markFeedPaintOnce,
+	noteSnapshotHydrated,
+	type PerformanceLike,
+	recordFeedPaint,
+	resetFeedPaintInstrumentation,
+	wasSnapshotHydrated,
+} from "./feedPerf";
+
+/** A recording fake of the `performance` slice this module drives. */
+function fakePerformance(now = 812): PerformanceLike & {
+	marks: Array<{name: string; detail: unknown}>;
+	measures: Array<{name: string; start?: number; end?: number; detail: unknown}>;
+} {
+	const marks: Array<{name: string; detail: unknown}> = [];
+	const measures: Array<{name: string; start?: number; end?: number; detail: unknown}> = [];
+	return {
+		marks,
+		measures,
+		now: () => now,
+		mark: (name, options) => void marks.push({name, detail: options?.detail}),
+		measure: (name, options) =>
+			void measures.push({name, start: options.start, end: options.end, detail: options.detail}),
+	};
+}
+
+beforeEach(() => resetFeedPaintInstrumentation());
+
+describe("classifyFeedPath", () => {
+	it("classifies a hydrated snapshot as the snapshot path — it is the first paint", () => {
+		expect(classifyFeedPath({snapshotHydrated: true})).toBe("snapshot");
+	});
+
+	it("snapshot outranks an edge cache HIT — leg A paints before any network", () => {
+		expect(classifyFeedPath({snapshotHydrated: true, cacheStatus: "HIT"})).toBe("snapshot");
+	});
+
+	it("classifies a no-snapshot base-feed cache HIT as the edge path", () => {
+		expect(classifyFeedPath({snapshotHydrated: false, cacheStatus: "HIT"})).toBe("edge");
+	});
+
+	it("classifies a MISS or unknown cache status (no snapshot) as the cold path", () => {
+		expect(classifyFeedPath({snapshotHydrated: false, cacheStatus: "MISS"})).toBe("cold");
+		expect(classifyFeedPath({snapshotHydrated: false, cacheStatus: null})).toBe("cold");
+		expect(classifyFeedPath({snapshotHydrated: false})).toBe("cold");
+	});
+});
+
+describe("the snapshot-hydrated latch", () => {
+	it("starts false and latches true once noted", () => {
+		expect(wasSnapshotHydrated()).toBe(false);
+		noteSnapshotHydrated();
+		expect(wasSnapshotHydrated()).toBe(true);
+	});
+});
+
+describe("recordFeedPaint", () => {
+	it("emits a path-suffixed mark and a navigation-start→paint measure with detail", () => {
+		const perf = fakePerformance(750);
+		const duration = recordFeedPaint(perf, "snapshot");
+
+		expect(duration).toBe(750);
+		expect(perf.marks).toEqual([
+			{name: `${FEED_PAINT_MARK}:snapshot`, detail: {path: "snapshot", reloadToPaintMs: 750}},
+		]);
+		expect(perf.measures).toEqual([
+			{
+				name: feedPaintMeasureName("snapshot"),
+				start: 0,
+				end: 750,
+				detail: {path: "snapshot", reloadToPaintMs: 750},
+			},
+		]);
+	});
+
+	it("names the measure per path so each path is a distinct trace entry", () => {
+		const paths: FeedPaintPath[] = ["snapshot", "edge", "cold"];
+		const names = paths.map(feedPaintMeasureName);
+		expect(new Set(names).size).toBe(3);
+		for (const name of names) expect(name).toMatch(/^pano:reload->feed-paint:/);
+	});
+
+	it("degrades to null (never throws) when performance rejects the call", () => {
+		const throwing: PerformanceLike = {
+			now: () => 10,
+			mark: () => {
+				throw new Error("legacy performance");
+			},
+			measure: () => undefined,
+		};
+		expect(() => recordFeedPaint(throwing, "cold")).not.toThrow();
+		expect(recordFeedPaint(throwing, "cold")).toBeNull();
+	});
+});
+
+describe("markFeedPaintOnce", () => {
+	it("records the first paint once and no-ops on every later call (a re-render)", () => {
+		const perf = fakePerformance(500);
+		expect(markFeedPaintOnce(perf)).toBe(500);
+		expect(markFeedPaintOnce(perf)).toBeNull();
+		expect(markFeedPaintOnce(perf)).toBeNull();
+		expect(perf.marks).toHaveLength(1);
+		expect(perf.measures).toHaveLength(1);
+	});
+
+	it("tags the paint with the snapshot path when a snapshot hydrated at boot", () => {
+		noteSnapshotHydrated();
+		const perf = fakePerformance();
+		markFeedPaintOnce(perf);
+		expect(perf.marks[0]?.name).toBe(`${FEED_PAINT_MARK}:snapshot`);
+	});
+
+	it("tags cold by default (no snapshot, no observed cache status)", () => {
+		const perf = fakePerformance();
+		markFeedPaintOnce(perf);
+		expect(perf.marks[0]?.name).toBe(`${FEED_PAINT_MARK}:cold`);
+	});
+
+	it("refines to the edge path when a base-feed cache HIT is observed", () => {
+		const perf = fakePerformance();
+		markFeedPaintOnce(perf, "HIT");
+		expect(perf.marks[0]?.name).toBe(`${FEED_PAINT_MARK}:edge`);
+	});
+
+	it("no-ops when no performance is available", () => {
+		expect(markFeedPaintOnce(null)).toBeNull();
+	});
+});

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -24,6 +24,7 @@ import {FEED_SNAPSHOT_ENABLED} from "../fate/snapshot";
 import {LoadMoreButton} from "../fate/wire";
 import {PANO_BASE_FEED} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
+import {markFeedPaintOnce} from "../lib/feedPerf";
 import {
 	PANO_FEED_PAGE_SIZE,
 	PANO_FILTERS,
@@ -186,6 +187,14 @@ function FeedRows({
 	compose: boolean;
 }) {
 	const [items, loadNext] = useLiveListView(PostConnectionView, connection);
+
+	// Reload→first-feed-paint instrumentation (#2326, epic #2316): mark the first committed
+	// feed rows so the epic's founding floor is readable in a DevTools/Performance trace.
+	// Fires once per tab (the module latches) and classifies the path (snapshot/edge/cold)
+	// from the boot-time snapshot signal; no-op when the instrument is off. See `feedPerf.ts`.
+	React.useEffect(() => {
+		if (items.length > 0) markFeedPaintOnce();
+	}, [items.length]);
 
 	const meta = host ? `${items.length} başlık · ${host}` : `${items.length} başlık`;
 

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -15,6 +15,14 @@ interface ImportMetaEnv {
 	 * round-trip — see `src/fate/snapshot.ts`. #2326 flips it on measured evidence.
 	 */
 	readonly VITE_FEED_SNAPSHOT?: string;
+	/**
+	 * Reload→feed-paint instrumentation flag (epic #2316, verification #2326). `"on"`
+	 * emits the User Timing marks/measures in a measurement/stage build; the instrument
+	 * is also on automatically in dev. Absent/anything else keeps it off in a production
+	 * build (zero cost). A build-time flag, like `VITE_FEED_SNAPSHOT` — see
+	 * `src/lib/feedPerf.ts`.
+	 */
+	readonly VITE_FEED_PERF?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## What

Verification / evidence leg (Phase 4) of the **instant /pano reload** epic (#2316, milestone #19). The earlier legs are merged: snapshot (leg A, #2319/#2321), the server base/overlay split (#2322), the client compose (#2323), and edge-cache + fanned purge (#2324). This child closes the loop on the epic's founding measurement by making **reload → first-feed-paint** measurable for the three paths the legs create, and delivers the flag-flip evidence on the epic.

## The three paths

- **`snapshot`** (leg A) — the last-seen feed hydrated from `localStorage` at boot, so it paints at ~JS-boot time (the residual floor the epic names), before any network.
- **`edge`** (leg B) — the viewer-invariant base feed served from the CF edge cache for a fresh-device anon. The SPA does not fetch that GET, so this path is classified from an injected `cf-cache-status` signal and measured at the network layer on `GET /fate/pano/feed` (per the methodology on the epic).
- **`cold`** — today's path: the full worker→D1 read, gated behind the session.

## Changes

- **`src/lib/feedPerf.ts`** (new) — the pure instrument: a path classifier (`snapshot > edge > cold`), a boot-time snapshot-hydrated latch, and a once-per-tab `markFeedPaintOnce` that emits a User Timing mark + a navigation-start→paint measure (`timeOrigin` is the reload's navigation start). Every call is best-effort (an absent/throwing `performance` degrades to a no-op) and gated behind `FEED_PERF_ENABLED` — dev builds plus an opt-in `VITE_FEED_PERF` measurement/stage build — so a **default production bundle pays nothing** (AC#3).
- **`src/pages/PanoFeed.tsx`** — marks the first committed feed rows.
- **`src/fate/publicClient.ts` / `src/fate/FateProvider.tsx`** — note a hydrated snapshot so the paint is classified as the snapshot path; `hydrateAnonPublicClient` / `hydrateAuthedClient` now return whether a snapshot applied.
- **`src/vite-env.d.ts`** — documents the `VITE_FEED_PERF` measurement flag.

## Acceptance criteria

- [x] Reload→first-feed-paint is measurable for all three paths — User Timing marks (`pano:feed-paint:<path>`) + measures (`pano:reload->feed-paint:<path>`) visible in the DevTools Performance / User Timing lane, **no analytics dependency**.
- [x] Measured floors + methodology (device/network/conditions) posted on the epic (#2316) as flag-flip evidence.
- [x] The instrumentation adds no user-facing behavior and is safe to leave in place — gated to dev/measurement contexts (`FEED_PERF_ENABLED`), best-effort, zero cost in a default prod build.

## Testing

Unit coverage of the classifier (all three paths + snapshot precedence), the latch, the recorder (mark/measure shape + detail + no-throw degrade), and the once-only paint mark (`src/lib/feedPerf.unit.test.ts`, 13 cases). Existing `snapshot.test.ts` and `App.test.tsx` wiring suites stay green. `pnpm typecheck` + biome clean.

**has-ui:** touches `apps/web/src/**` (incl. `PanoFeed.tsx`) — reviewer should run review-code + review-design (no visual surface added; the change is instrumentation only).

Fixes #2326

🤖 Generated with [Claude Code](https://claude.com/claude-code)