### PR TITLE
ci(web): wire VITE_FEED_SNAPSHOT into the production SPA build env (#2379)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -267,6 +267,10 @@ jobs:
           # only: an empty DSN leaves the SPA wiring inert (sentry.ts `sentryEnabled`
           # gate), so per-PR previews neither init Sentry nor burn the free-tier quota.
           VITE_SENTRY_DSN: ${{ env.ENVIRONMENT == 'production' && vars.VITE_SENTRY_DSN || '' }}
+          # Snapshot-hydration containment flag (#2319/#2333) — same build-time repo-variable
+          # gate as the Sentry DSN above: prod reads the variable (its value IS the release
+          # state), previews build flag-dark (empty ≠ "on"). The variable's absence = flag off.
+          VITE_FEED_SNAPSHOT: ${{ env.ENVIRONMENT == 'production' && vars.VITE_FEED_SNAPSHOT || '' }}
         run: pnpm --filter ${{ matrix.pnpm-name }} build
 
       # `exec alchemy` forwards `--stage`/`--yes` to the alchemy CLI. A bare


### PR DESCRIPTION
Fixes #2379

## What

One line in `deploy.yml`'s "Build SPA" step `env:` block maps `VITE_FEED_SNAPSHOT` from the repo Actions variable, production-gated exactly like the `VITE_SENTRY_DSN` precedent beside it (ADR 0118):

```yaml
VITE_FEED_SNAPSHOT: ${{ env.ENVIRONMENT == 'production' && vars.VITE_FEED_SNAPSHOT || '' }}
```

## Why

`apps/web/src/fate/snapshot.ts:30` reads `import.meta.env.VITE_FEED_SNAPSHOT === "on"` at **build time** (Vite bakes the flag into the SPA bundle — boot hydration must resolve synchronously, by design). But the Build SPA step never mapped `VITE_FEED_SNAPSHOT` into the build env, so `import.meta.env.VITE_FEED_SNAPSHOT` was `undefined` in every deployed bundle and `FEED_SNAPSHOT_ENABLED` was permanently `false` in prod — the snapshot-hydration containment flag (#2319/#2333) was dark with no release path. This is the containment design's own contract violated: the flag was built to be releasable and had no release path.

Production-gated like Sentry: previews build with the flag dark (empty string ≠ `"on"`), prod reads the repo variable. The variable's value then **is** the release state — future flips are a variable edit, no PR.

## Half 2 — the flip (deliberately OUT of this PR's scope)

Creating the repo Actions variable is a founder/EA action (it requires `actions:write`, and creating it **is** the release act). This PR wires the plumbing only; the variable being absent means the flag stays off — the safe default.

**Runbook one-liner** (founder/EA, after this PR merges):

```bash
gh api -X POST repos/kamp-us/phoenix/actions/variables -f name=VITE_FEED_SNAPSHOT -f value=on
```

The next prod deploy after both halves lands releases the snapshot leg. To flip it back off later, edit or delete the variable — no PR needed.

## Interaction with the #2366/#2371 deploy.yml rework

None. The env mapping lives on the Build SPA step inside the `deploy` job; the new `changes` job only gates whether `deploy` runs on PRs. On `push` (prod), `deploy=true` is forced, so the docs-only skip path cannot affect the prod build env. Written against current post-#2366/#2371 `main`.

`.github/workflows/deploy.yml` is itself in the `changes` deploy filter, so this PR deploys a preview + runs e2e. Previews build flag-dark by the production gate (intentional, matches Sentry gating) — preview e2e never exercises the snapshot leg; noted, not in scope here.

## Control-plane note

`.github/workflows/**` is §CP → this PR **banks for human merge** after review-code. It will not auto-ship. Expected.

## Validation

- `actionlint .github/workflows/deploy.yml` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
