### PR TITLE
feat(pipeline-cli): guard ci.yml/deploy.yml path-filter sync mechanically (#2372)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,10 @@ jobs:
             # this e2e RUN-set, or a PR that trips e2e but skips its deploy makes e2e's
             # 10-min preview-comment poll time out and wedge `ci-required`. An edit to
             # THIS list MUST be mirrored into deploy.yml's `deploy:` filter (and vice
-            # versa) — keep the two path sets identical.
+            # versa) — keep the two path sets identical. ENFORCED MECHANICALLY (issue
+            # #2372) by `pipeline-cli path-filter-guard check` (the path-filter-guard.yml
+            # job), which fails the build if this `e2e:` set and deploy.yml's `deploy:`
+            # set drift apart — this comment documents the invariant; the guard defends it.
             e2e:
               - 'apps/**/src/**'
               - 'apps/**/index.html'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,9 @@ jobs:
             # Keep this list byte-for-byte in sync with the `e2e:` block in
             # .github/workflows/ci.yml — the queue-safe invariant above (deploy-run ⊇
             # e2e-run) requires equal path sets, so an edit to one MUST edit the other.
+            # ENFORCED MECHANICALLY (issue #2372) by `pipeline-cli path-filter-guard check`
+            # (the path-filter-guard.yml job): it fails the build if this `deploy:` set and
+            # ci.yml's `e2e:` set drift apart — this comment documents it, the guard defends it.
             deploy:
               - 'apps/**/src/**'
               - 'apps/**/index.html'

--- a/.github/workflows/path-filter-guard.yml
+++ b/.github/workflows/path-filter-guard.yml
@@ -1,0 +1,45 @@
+name: path-filter-guard
+
+# CI gate for #2372 (the sync invariant of #2366 / PR #2371): deploy.yml's
+# `changes.deploy` dorny/paths-filter list and ci.yml's `changes.e2e` dorny/paths-filter
+# list must be the SAME set of globs. That pins the load-bearing invariant deploy's
+# RUN-set ⊇ e2e's RUN-set (deploy skips only where e2e also skips). ci.yml's `e2e` job
+# polls deploy.yml's sticky `<!-- preview-deploy -->` comment on a 10-minute deadline, so
+# a PR that trips e2e but skips its deploy times the poll out and wedges `ci-required`.
+# The two lists were guarded ONLY by a reciprocal human comment; this runs
+# `pipeline-cli path-filter-guard check` so a drifting edit to either list cannot merge.
+# It fails closed on zero scope — a missing file/job/step/key or an empty list (ADR 0092).
+# The scan lives once in the tool.
+on:
+  pull_request:
+
+# Least-privilege GITHUB_TOKEN: the job only checks out + reads the repo and runs the
+# guard, which fails via exit code — it posts no check-run/status/PR comment — so
+# contents:read is all it needs; default-deny every other scope (CodeQL least-privilege).
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: check ci.yml changes.e2e and deploy.yml changes.deploy stay in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 when the two path-filter sets drift apart, or zero scope (a missing
+      # file/job/step/key or an empty list, fail-closed). Report on stderr. See #2372.
+      - name: Check the ci.yml/deploy.yml path-filter sync invariant
+        run: node packages/pipeline-cli/src/bin.ts path-filter-guard check

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -206,6 +206,28 @@ of scope. Fails closed on zero CLAUDE.md in scope (ADR 0092).
 node packages/pipeline-cli/src/bin.ts pointer-guard check
 ```
 
+### `path-filter-guard` — fail-closed ci.yml/deploy.yml path-filter sync gate (#2372)
+
+Mechanizes the ci.yml/deploy.yml path-filter **sync invariant** (issue
+[#2372](https://github.com/kamp-us/phoenix/issues/2372); the invariant landed in #2366 / PR
+#2371). `deploy.yml`'s `changes.deploy` dorny/paths-filter list and `ci.yml`'s `changes.e2e`
+dorny/paths-filter list must be the **same set** of globs — pinning **deploy's RUN-set ⊇
+e2e's RUN-set** (deploy skips a preview only where e2e also skips). `ci.yml`'s `e2e` job
+polls `deploy.yml`'s sticky `<!-- preview-deploy -->` comment on a 10-minute deadline, so a
+PR that trips e2e but skips its deploy times the poll out and wedges `ci-required`. The two
+lists were guarded ONLY by a reciprocal human comment; this makes the invariant mechanical.
+
+Set **equality** is the checkable form (equality ⇒ superset, and equality is what the
+comments pin). The pure core parses each workflow YAML, reads the `changes` job's
+`dorny/paths-filter` `with.filters` string (parsed as YAML — the inline `#` comments are
+inert), and diffs the `e2e:` / `deploy:` lists as sets. Fails closed on zero scope — a
+missing file/job/step/key or an empty list (ADR 0092). See the tool README:
+[`src/tools/path-filter-guard/README.md`](src/tools/path-filter-guard/README.md).
+
+```bash
+node packages/pipeline-cli/src/bin.ts path-filter-guard check
+```
+
 ### `trivial-diff` — deterministic fail-closed trivial-diff classifier (ADR 0120 §1, #1557)
 
 Classifies a unified diff as `trivial` / `non-trivial` for the right-sized fan-out

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -27,6 +27,7 @@ import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {mainSyncCommand} from "./tools/main-sync/command.ts";
 import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
+import {pathFilterGuardCommand} from "./tools/path-filter-guard/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {refGuardCommand} from "./tools/ref-guard/command.ts";
@@ -82,6 +83,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	spawnGuardCommand,
 	leakGuardCommand,
 	mergeQueueClassifyCommand,
+	pathFilterGuardCommand,
 	pointerGuardCommand,
 	ciRequiredCommand,
 	ghPhoenixCommand,

--- a/packages/pipeline-cli/src/tools/path-filter-guard/README.md
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/README.md
@@ -1,0 +1,48 @@
+# path-filter-guard
+
+`pipeline-cli path-filter-guard check` — the mechanical enforcement of the
+ci.yml/deploy.yml path-filter **sync invariant** (issue
+[#2372](https://github.com/kamp-us/phoenix/issues/2372); the invariant landed in issue
+[#2366](https://github.com/kamp-us/phoenix/issues/2366) / PR
+[#2371](https://github.com/kamp-us/phoenix/pull/2371)).
+
+## What it enforces
+
+`deploy.yml`'s `changes.deploy` dorny/paths-filter list and `ci.yml`'s `changes.e2e`
+dorny/paths-filter list must be the **same set** of glob entries. This pins the
+load-bearing invariant **deploy's RUN-set ⊇ e2e's RUN-set** — deploy skips a preview
+only where e2e also skips. `ci.yml`'s `e2e` job polls `deploy.yml`'s sticky
+`<!-- preview-deploy -->` comment on a 10-minute deadline, so a PR that trips e2e but
+skips its deploy makes the poll time out and wedge the required `ci-required` check.
+
+Set **equality** is the checkable form: equality ⇒ superset, and equality is exactly what
+both files' reciprocal comments already pin (a general superset check would let deploy
+grow entries e2e lacks, which the comments forbid). The two lists were guarded **only** by
+those human comments — nothing mechanical stopped a future edit to one from silently
+drifting the other. This guard closes that gap.
+
+The core (`path-filter-guard.ts`) parses each workflow YAML, finds the `changes` job's
+`dorny/paths-filter` step, parses its `with.filters` string as YAML (as dorny does — so
+the inline `#` comments are inert), reads the `e2e:` / `deploy:` key, and diffs the two
+as sets (order-independent).
+
+Fail-closed on zero scope (ADR
+[0092](../../../../../.decisions/0092-gates-fail-closed-on-zero-scope.md)): a missing
+file, missing `changes` job or paths-filter step, a missing `e2e:`/`deploy:` key, or an
+empty list is a FAILURE — a guard that extracted nothing is broken, never a vacuous pass.
+
+## Usage
+
+```bash
+pipeline-cli path-filter-guard check              # the CI gate (exit non-zero on drift / zero scope)
+pipeline-cli path-filter-guard check --root <dir> # read the two workflow files under a specific root (default: walk up for one)
+```
+
+Wired as the always-on `.github/workflows/path-filter-guard.yml` gate (the `readme-guard`
+/ `fanout-guard` idiom). The pure core + IO seam live in `path-filter-guard.ts` /
+`gate.ts`; the pure verdict + extractor are unit-tested in
+`path-filter-guard.unit.test.ts`, the filesystem gate in `gate.unit.test.ts`.
+
+```bash
+pnpm --filter @kampus/pipeline-cli test    # vitest over the core + gate
+```

--- a/packages/pipeline-cli/src/tools/path-filter-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/command.ts
@@ -1,0 +1,80 @@
+/**
+ * The `path-filter-guard` tool — `pipeline-cli path-filter-guard check [--root <d>]`
+ * (issue #2372).
+ *
+ * The CI surface for "ci.yml's `changes.e2e` path-filter and deploy.yml's `changes.deploy`
+ * path-filter must stay the same set". The two lists pin the deploy⊇e2e sync invariant
+ * (deploy skips only where e2e also skips); it held only by a reciprocal human comment,
+ * so a future edit to one could silently drift the other and wedge `ci-required` via
+ * e2e's timed-out preview-comment poll. This guard makes the invariant mechanical:
+ *
+ *   pipeline-cli path-filter-guard check            # CI gate: exit non-zero on drift / zero scope
+ *   pipeline-cli path-filter-guard check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * The scan/IO lives in `gate.ts`; this file wires it to the CLI (mirrors `readme-guard`/
+ * `fanout-guard`).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — a gate failure (report on
+ * stderr) and an IO failure exit non-zero, undistinguished. `CheckFailed` is caught
+ * inside the handler (not at the bin's run boundary) so the contract survives folding
+ * into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../../find-root-dir.ts";
+import {type CheckFailed, checkPathFilters} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repo root to read the two workflow files under (default: walk up for one)",
+	),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
+// error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkPathFilters(resolveRoot(rootOpt)).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the build if ci.yml's changes.e2e and deploy.yml's changes.deploy path-filter sets drift apart",
+	),
+);
+
+export const pathFilterGuardCommand = Command.make("path-filter-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: ci.yml changes.e2e and deploy.yml changes.deploy stay the same path set (#2372)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/path-filter-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/gate.ts
@@ -1,0 +1,48 @@
+/**
+ * The `path-filter-guard` filesystem gate (issue #2372) — the IO seam behind the
+ * ci.yml/deploy.yml path-filter sync check, split from `command.ts` so it is crossable in
+ * unit tests over a fake repo dir rather than only by spawning the bin (the
+ * core-in-its-own-file idiom; #855).
+ *
+ * `checkPathFilters` is the CI gate: it reads the two workflow files and delegates the
+ * verdict to the pure core (`path-filter-guard.ts`). It fails `CheckFailed` (exit
+ * non-zero) on drift (the two path sets differ) or zero scope (a missing file/job/step/
+ * key or an empty list — fail-closed, ADR 0092). A file that cannot be read is an
+ * `IoError` (also non-zero — both failures, undistinguished, per the bin's contract).
+ */
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {CI_E2E_SOURCE, DEPLOY_SOURCE, judge, renderReport} from "./path-filter-guard.ts";
+
+/** A file IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+const readWorkflow = (root: string, relPath: string): Effect.Effect<string, IoError> =>
+	Effect.try({
+		try: () => readFileSync(join(root, relPath), "utf8"),
+		catch: (cause) => new IoError({path: join(root, relPath), cause}),
+	});
+
+/**
+ * The CI gate: succeed when ci.yml's `changes.e2e` and deploy.yml's `changes.deploy`
+ * dorny/paths-filter lists are the same set, else `CheckFailed`. Fails closed on any
+ * zero-scope gap (ADR 0092).
+ */
+export const checkPathFilters = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const ciText = yield* readWorkflow(root, CI_E2E_SOURCE.file);
+		const deployText = yield* readWorkflow(root, DEPLOY_SOURCE.file);
+		const verdict = judge({ciText, deployText});
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/path-filter-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/gate.unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `checkPathFilters` over a fake repo dir — the filesystem-seam test (issue #2372). The
+ * pure verdict is covered in `path-filter-guard.unit.test.ts`; this crosses the IO gate
+ * over a real temp dir, asserting the exit-code contract from observable outcomes — never
+ * by spawning the bin.
+ */
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import {CheckFailed, checkPathFilters} from "./gate.ts";
+
+let root: string;
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "path-filter-guard-gate-"));
+});
+afterEach(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+
+const mkWorkflow = (key: string, globs: ReadonlyArray<string>): string => {
+	const items = globs.map((g) => `              - '${g}'`);
+	return [
+		"name: T",
+		"on:",
+		"  pull_request:",
+		"jobs:",
+		"  changes:",
+		"    runs-on: ubuntu-latest",
+		"    steps:",
+		"      - uses: dorny/paths-filter@v3.0.2",
+		"        id: filter",
+		"        with:",
+		"          filters: |",
+		`            ${key}:`,
+		...items,
+		"",
+	].join("\n");
+};
+
+const writeWorkflows = (ci: string | null, deploy: string | null) => {
+	const dir = join(root, ".github", "workflows");
+	mkdirSync(dir, {recursive: true});
+	if (ci !== null) writeFileSync(join(dir, "ci.yml"), ci, "utf8");
+	if (deploy !== null) writeFileSync(join(dir, "deploy.yml"), deploy, "utf8");
+};
+
+const SAMPLE = ["apps/**/src/**", "apps/**/worker/**"];
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
+	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
+
+describe("checkPathFilters — the CI exit-code gate over a fake repo dir", () => {
+	it("SUCCEEDS when the two filter sets are identical (the proof)", async () => {
+		writeWorkflows(mkWorkflow("e2e", SAMPLE), mkWorkflow("deploy", SAMPLE));
+		const exit = await run(checkPathFilters(root));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed) when the two filter sets drift apart (the falsification)", async () => {
+		writeWorkflows(
+			mkWorkflow("e2e", [...SAMPLE, "apps/**/index.html"]),
+			mkWorkflow("deploy", SAMPLE),
+		);
+		const exit = await run(checkPathFilters(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (fail-closed) when a workflow file is missing (IoError)", async () => {
+		writeWorkflows(mkWorkflow("e2e", SAMPLE), null);
+		const exit = await run(checkPathFilters(root));
+		expect(Exit.isFailure(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed, fail-closed) on zero scope (empty deploy list)", async () => {
+		writeWorkflows(mkWorkflow("e2e", SAMPLE), mkWorkflow("deploy", []));
+		const exit = await run(checkPathFilters(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+});

--- a/packages/pipeline-cli/src/tools/path-filter-guard/path-filter-guard.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/path-filter-guard.ts
@@ -1,0 +1,209 @@
+/**
+ * `path-filter-guard` pure core (issue #2372) — decide whether ci.yml's `changes.e2e`
+ * dorny/paths-filter list and deploy.yml's `changes.deploy` dorny/paths-filter list are
+ * the SAME set of glob entries. IO-free and total: every decision is a deterministic
+ * transform over the two workflow-file texts. The filesystem boundary (read the two
+ * files) lives in `gate.ts`; this module never touches disk.
+ *
+ * The load-bearing invariant it mechanizes: deploy's RUN-set must be a SUPERSET of e2e's
+ * RUN-set (deploy skips only where e2e also skips). ci.yml's `e2e` job polls deploy.yml's
+ * sticky `<!-- preview-deploy -->` comment on a 10-minute deadline, so a PR that trips
+ * e2e but skips its deploy makes the poll time out and wedge the required `ci-required`
+ * check. Both files pin the invariant today with identical lists guarded ONLY by a
+ * reciprocal human comment — nothing mechanical stops a future edit to one from drifting
+ * the other. Set EQUALITY is the checkable form: equality ⇒ superset, and equality is
+ * exactly what the two comments already pin (a general superset check would let deploy
+ * grow entries e2e lacks, which the comments forbid). See ci.yml's `e2e:` block and
+ * deploy.yml's `deploy:` block.
+ *
+ * Fail-closed on zero scope (ADR 0092): a missing file/job/paths-filter step, a missing
+ * `e2e:`/`deploy:` key, or an empty list is a FAILURE — a guard that extracted nothing
+ * is broken, never a vacuous pass.
+ */
+import {parse} from "yaml";
+
+/** The source of one filter list — which workflow file, `changes` job, and filter key. */
+export interface FilterSource {
+	readonly file: string;
+	readonly job: string;
+	readonly key: string;
+}
+
+/** ci.yml's `changes` job → `dorny/paths-filter` step → `e2e:` filter list. */
+export const CI_E2E_SOURCE: FilterSource = {
+	file: ".github/workflows/ci.yml",
+	job: "changes",
+	key: "e2e",
+};
+
+/** deploy.yml's `changes` job → `dorny/paths-filter` step → `deploy:` filter list. */
+export const DEPLOY_SOURCE: FilterSource = {
+	file: ".github/workflows/deploy.yml",
+	job: "changes",
+	key: "deploy",
+};
+
+/** The two workflow-file texts the verdict is computed over — read at the IO boundary. */
+export interface PathFilterFacts {
+	readonly ciText: string;
+	readonly deployText: string;
+}
+
+/**
+ * Extracting one filter list either yields its entries or the reason it couldn't — every
+ * `ok: false` arm is a zero-scope failure (ADR 0092), never treated as an empty pass.
+ */
+export type FilterExtraction =
+	| {readonly ok: true; readonly entries: ReadonlyArray<string>}
+	| {readonly ok: false; readonly detail: string};
+
+/**
+ * The guard verdict — a discriminated union so an invalid state is unrepresentable: a
+ * pass never carries a drift list, and each failure shape carries exactly its evidence.
+ */
+export type PathFilterVerdict =
+	| {readonly pass: true; readonly count: number}
+	/** A file/job/step/key was missing or a list was empty — fail closed (ADR 0092). */
+	| {readonly pass: false; readonly reason: "zero-scope"; readonly detail: string}
+	/** The two path sets differ — the sync invariant has drifted. */
+	| {
+			readonly pass: false;
+			readonly reason: "drift";
+			/** Entries in ci.yml's `e2e` list absent from deploy.yml's `deploy` list. */
+			readonly onlyInE2e: ReadonlyArray<string>;
+			/** Entries in deploy.yml's `deploy` list absent from ci.yml's `e2e` list. */
+			readonly onlyInDeploy: ReadonlyArray<string>;
+	  };
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+	typeof v === "object" && v !== null && !Array.isArray(v);
+
+/**
+ * Normalize a dorny filter value (a YAML list of globs, or a lone scalar) to a trimmed
+ * string array. dorny parses the `filters:` block as YAML, so the inline `#` comments are
+ * already stripped by the parse — no comment handling is needed here.
+ */
+const toGlobList = (value: unknown): ReadonlyArray<string> | undefined => {
+	if (typeof value === "string") return [value.trim()];
+	if (Array.isArray(value)) {
+		const out: Array<string> = [];
+		for (const entry of value) {
+			if (typeof entry !== "string") return undefined;
+			out.push(entry.trim());
+		}
+		return out;
+	}
+	return undefined;
+};
+
+/**
+ * Extract the `<job>` dorny/paths-filter step's `<key>` glob list from a workflow YAML.
+ * Pure over the text: parses the workflow, finds the first `uses: dorny/paths-filter@…`
+ * step under `jobs.<job>.steps`, parses its `with.filters` string as YAML (as dorny
+ * does), and reads the `<key>` list. Any structural gap — unparseable YAML, no such job,
+ * no paths-filter step, no `filters`, no `<key>`, or an empty list — is `ok: false`.
+ */
+export const extractFilterList = (workflowText: string, source: FilterSource): FilterExtraction => {
+	let doc: unknown;
+	try {
+		doc = parse(workflowText);
+	} catch (cause) {
+		return {ok: false, detail: `${source.file}: could not parse workflow YAML (${String(cause)})`};
+	}
+	if (!isRecord(doc) || !isRecord(doc.jobs)) {
+		return {ok: false, detail: `${source.file}: no top-level 'jobs:' mapping`};
+	}
+	const job = doc.jobs[source.job];
+	if (!isRecord(job) || !Array.isArray(job.steps)) {
+		return {ok: false, detail: `${source.file}: no '${source.job}' job with a 'steps:' list`};
+	}
+	const filterStep = job.steps.find(
+		(s) => isRecord(s) && typeof s.uses === "string" && s.uses.startsWith("dorny/paths-filter"),
+	);
+	if (!isRecord(filterStep) || !isRecord(filterStep.with)) {
+		return {
+			ok: false,
+			detail: `${source.file}: '${source.job}' job has no dorny/paths-filter step with a 'with:' block`,
+		};
+	}
+	const filtersText = filterStep.with.filters;
+	if (typeof filtersText !== "string") {
+		return {ok: false, detail: `${source.file}: the paths-filter step has no string 'filters:'`};
+	}
+	let filters: unknown;
+	try {
+		filters = parse(filtersText);
+	} catch (cause) {
+		return {ok: false, detail: `${source.file}: 'filters:' is not valid YAML (${String(cause)})`};
+	}
+	if (!isRecord(filters) || !(source.key in filters)) {
+		return {ok: false, detail: `${source.file}: 'filters:' has no '${source.key}:' key`};
+	}
+	const entries = toGlobList(filters[source.key]);
+	if (entries === undefined) {
+		return {ok: false, detail: `${source.file}: '${source.key}:' is not a list of glob strings`};
+	}
+	if (entries.length === 0) {
+		return {ok: false, detail: `${source.file}: '${source.key}:' is an empty list`};
+	}
+	return {ok: true, entries};
+};
+
+/**
+ * Decide the verdict over the two workflow texts. Order: extract each list (fail closed
+ * on any zero-scope gap), then compare as SETS (order-independent). Set inequality —
+ * an entry in one list absent from the other, in either direction — is drift.
+ */
+export const judge = (facts: PathFilterFacts): PathFilterVerdict => {
+	const e2e = extractFilterList(facts.ciText, CI_E2E_SOURCE);
+	if (!e2e.ok) return {pass: false, reason: "zero-scope", detail: e2e.detail};
+	const deploy = extractFilterList(facts.deployText, DEPLOY_SOURCE);
+	if (!deploy.ok) return {pass: false, reason: "zero-scope", detail: deploy.detail};
+
+	const e2eSet = new Set(e2e.entries);
+	const deploySet = new Set(deploy.entries);
+	const onlyInE2e = [...e2eSet].filter((g) => !deploySet.has(g)).sort();
+	const onlyInDeploy = [...deploySet].filter((g) => !e2eSet.has(g)).sort();
+	if (onlyInE2e.length > 0 || onlyInDeploy.length > 0) {
+		return {pass: false, reason: "drift", onlyInE2e, onlyInDeploy};
+	}
+	return {pass: true, count: e2eSet.size};
+};
+
+/** Render the human-readable report (ADR 0092 §1 "emit what you scanned"). */
+export const renderReport = (verdict: PathFilterVerdict): string => {
+	if (verdict.pass) {
+		return (
+			`path-filter-guard: ci.yml changes.e2e and deploy.yml changes.deploy are identical ` +
+			`(${verdict.count} glob entries) — the deploy⊇e2e sync invariant holds`
+		);
+	}
+	if (verdict.reason === "zero-scope") {
+		return (
+			`path-filter-guard: ${verdict.detail} — fail-closed (ADR 0092). Could not extract both ` +
+			"the ci.yml changes.e2e and deploy.yml changes.deploy filter lists, so the sync invariant " +
+			"is unverifiable. Is the repo root correct, or did a workflow's paths-filter shape change?"
+		);
+	}
+	const lines: Array<string> = [];
+	if (verdict.onlyInE2e.length > 0) {
+		lines.push(
+			`  ONLY in ci.yml changes.e2e (${verdict.onlyInE2e.length}) — missing from deploy.yml changes.deploy:`,
+		);
+		for (const g of verdict.onlyInE2e) lines.push(`    ${g}`);
+	}
+	if (verdict.onlyInDeploy.length > 0) {
+		lines.push(
+			`  ONLY in deploy.yml changes.deploy (${verdict.onlyInDeploy.length}) — missing from ci.yml changes.e2e:`,
+		);
+		for (const g of verdict.onlyInDeploy) lines.push(`    ${g}`);
+	}
+	return (
+		"path-filter-guard: ci.yml's changes.e2e filter and deploy.yml's changes.deploy filter " +
+		`have DRIFTED — the two path sets are not equal:\n${lines.join("\n")}\n\n` +
+		"The deploy job's RUN-set must equal e2e's RUN-set (deploy skips only where e2e also skips). " +
+		"A PR that trips e2e but skips its deploy makes e2e's 10-min preview-comment poll time out and " +
+		"wedge ci-required (#2372). Restore the two lists to the SAME set of globs — edit whichever " +
+		"drifted so the `e2e:` block in ci.yml and the `deploy:` block in deploy.yml match."
+	);
+};

--- a/packages/pipeline-cli/src/tools/path-filter-guard/path-filter-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/path-filter-guard.unit.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The pure `path-filter-guard` verdict + extractor (issue #2372), over crafted workflow
+ * YAML — no disk. The IO exit-code gate is crossed in `gate.unit.test.ts`; here the
+ * decision itself is proven: set equality passes, any one-entry drift (either direction)
+ * fails, a reorder passes (set comparison), and every zero-scope arm fails closed.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {CI_E2E_SOURCE, DEPLOY_SOURCE, extractFilterList, judge} from "./path-filter-guard.ts";
+
+/**
+ * Build a workflow YAML with a `changes` job whose dorny/paths-filter step carries a
+ * single `<key>:` filter list. `extraLines` inject raw block-scalar lines (e.g. an inline
+ * `#` comment) to prove dorny-comment inertness. Indentation is exact: `filters: |` at 10
+ * spaces, block content at 12, list items at 14.
+ */
+const mkWorkflow = (
+	key: string,
+	globs: ReadonlyArray<string>,
+	extraLines: ReadonlyArray<string> = [],
+): string => {
+	const items = globs.map((g) => `              - '${g}'`);
+	const block = [`            ${key}:`, ...extraLines.map((l) => `            ${l}`), ...items];
+	return [
+		"name: T",
+		"on:",
+		"  pull_request:",
+		"jobs:",
+		"  changes:",
+		"    runs-on: ubuntu-latest",
+		"    steps:",
+		"      - uses: actions/checkout@v4.2.2",
+		"      - uses: dorny/paths-filter@v3.0.2",
+		"        id: filter",
+		"        with:",
+		"          filters: |",
+		...block,
+		"",
+	].join("\n");
+};
+
+const SAMPLE = ["apps/**/src/**", "apps/**/worker/**", ".github/workflows/deploy.yml"];
+
+describe("extractFilterList — the pure extractor", () => {
+	it("extracts the e2e glob list from a well-formed ci.yml changes job", () => {
+		const res = extractFilterList(mkWorkflow("e2e", SAMPLE), CI_E2E_SOURCE);
+		expect(res).toEqual({ok: true, entries: SAMPLE});
+	});
+
+	it("extracts the deploy glob list from a well-formed deploy.yml changes job", () => {
+		const res = extractFilterList(mkWorkflow("deploy", SAMPLE), DEPLOY_SOURCE);
+		expect(res).toEqual({ok: true, entries: SAMPLE});
+	});
+
+	it("ignores inline # comments in the filters block (dorny parses it as YAML)", () => {
+		const res = extractFilterList(
+			mkWorkflow("e2e", SAMPLE, ["# SYNC INVARIANT: keep in lockstep with deploy.yml"]),
+			CI_E2E_SOURCE,
+		);
+		expect(res).toEqual({ok: true, entries: SAMPLE});
+	});
+
+	it("fails closed on unparseable workflow YAML", () => {
+		const res = extractFilterList("name: [unterminated\n", CI_E2E_SOURCE);
+		expect(res.ok).toBe(false);
+	});
+
+	it("fails closed when the changes job is missing", () => {
+		const noJob = mkWorkflow("e2e", SAMPLE).replace("  changes:", "  other:");
+		const res = extractFilterList(noJob, CI_E2E_SOURCE);
+		expect(res.ok).toBe(false);
+	});
+
+	it("fails closed when there is no dorny/paths-filter step", () => {
+		const noStep = mkWorkflow("e2e", SAMPLE).replace(
+			"      - uses: dorny/paths-filter@v3.0.2",
+			"      - uses: some/other-action@v1",
+		);
+		const res = extractFilterList(noStep, CI_E2E_SOURCE);
+		expect(res.ok).toBe(false);
+	});
+
+	it("fails closed when the target filter key is missing", () => {
+		// A filters block that declares `code:` but not the requested `e2e:` key.
+		const res = extractFilterList(mkWorkflow("code", SAMPLE), CI_E2E_SOURCE);
+		expect(res.ok).toBe(false);
+	});
+
+	it("fails closed on an empty filter list", () => {
+		const res = extractFilterList(mkWorkflow("e2e", []), CI_E2E_SOURCE);
+		expect(res.ok).toBe(false);
+	});
+});
+
+describe("judge — set equality over the two filter lists", () => {
+	it("PASSES when the two lists are identical", () => {
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", SAMPLE),
+			deployText: mkWorkflow("deploy", SAMPLE),
+		});
+		expect(verdict).toEqual({pass: true, count: SAMPLE.length});
+	});
+
+	it("PASSES when the two lists are equal but reordered (set comparison)", () => {
+		const reversed = [...SAMPLE].reverse();
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", SAMPLE),
+			deployText: mkWorkflow("deploy", reversed),
+		});
+		expect(verdict.pass).toBe(true);
+	});
+
+	it("FAILS (drift) when ci.yml's e2e list has an entry deploy lacks", () => {
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", [...SAMPLE, "apps/**/index.html"]),
+			deployText: mkWorkflow("deploy", SAMPLE),
+		});
+		expect(verdict).toMatchObject({
+			pass: false,
+			reason: "drift",
+			onlyInE2e: ["apps/**/index.html"],
+			onlyInDeploy: [],
+		});
+	});
+
+	it("FAILS (drift) when deploy.yml's deploy list has an entry e2e lacks", () => {
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", SAMPLE),
+			deployText: mkWorkflow("deploy", [...SAMPLE, "packages/preview-seed/**"]),
+		});
+		expect(verdict).toMatchObject({
+			pass: false,
+			reason: "drift",
+			onlyInE2e: [],
+			onlyInDeploy: ["packages/preview-seed/**"],
+		});
+	});
+
+	it("FAILS (zero-scope) when the ci.yml e2e list can't be extracted", () => {
+		const verdict = judge({
+			ciText: mkWorkflow("code", SAMPLE),
+			deployText: mkWorkflow("deploy", SAMPLE),
+		});
+		expect(verdict).toMatchObject({pass: false, reason: "zero-scope"});
+	});
+
+	it("FAILS (zero-scope) when the deploy.yml deploy list is empty", () => {
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", SAMPLE),
+			deployText: mkWorkflow("deploy", []),
+		});
+		expect(verdict).toMatchObject({pass: false, reason: "zero-scope"});
+	});
+});


### PR DESCRIPTION
Fixes #2372

## What

Adds `pipeline-cli path-filter-guard check` — a fail-closed CI gate (readme-guard/fanout-guard idiom, ADR 0092/0155) that makes the **ci.yml/deploy.yml path-filter sync invariant** mechanical, replacing the comment-only defense.

`deploy.yml`'s `changes.deploy` dorny/paths-filter list and `ci.yml`'s `changes.e2e` dorny/paths-filter list must be the **same set** of globs — pinning **deploy's RUN-set ⊇ e2e's RUN-set** (deploy skips a preview only where e2e also skips). `ci.yml`'s `e2e` job polls `deploy.yml`'s sticky `<!-- preview-deploy -->` comment on a 10-minute deadline, so a PR that trips e2e but skips its deploy times the poll out and wedges `ci-required`. The two lists were guarded ONLY by a reciprocal human comment; nothing mechanical stopped a future edit to one from drifting the other.

## Core logic

Pure, IO-free core (`path-filter-guard.ts`) + thin Effect bin over an IO seam (`gate.ts`):

- Parse each workflow YAML, find the `changes` job's `dorny/paths-filter` step, parse its `with.filters` string as YAML (as dorny does — so the inline `#` comments are inert), read the `e2e:` / `deploy:` key.
- Compare the two lists as **SETS — exact set equality** (order-independent; equality ⇒ the deploy⊇e2e superset the comments pin — a general superset check would let deploy grow entries e2e lacks).
- **Fail closed on zero scope** (ADR 0092): a missing file, missing `changes` job / paths-filter step, missing `e2e:`/`deploy:` key, or an empty list ⇒ FAILURE, never a vacuous pass.

## Wiring

- Registered in `packages/pipeline-cli/src/registry.ts`.
- New required-lane job `.github/workflows/path-filter-guard.yml` (mirrors `fanout-guard.yml` / `design-token-guard.yml`, least-privilege `contents: read`).
- Both workflows' reciprocal sync comments now point at the guard as the enforcement (comment documents; guard defends).
- Package + tool `README.md` updated; deps `catalog:`-sourced (`yaml` already catalogued at 2.9.0).

## Tests (18, all AC arms)

Pure verdict (`path-filter-guard.unit.test.ts`) + IO gate over a temp dir (`gate.unit.test.ts`):
- identical lists → pass
- reordered-but-equal lists → pass (set comparison)
- one-entry drift, ci-side extra → fail (`onlyInE2e`)
- one-entry drift, deploy-side extra → fail (`onlyInDeploy`)
- every zero-scope arm → fail: unparseable YAML, missing job, no paths-filter step, missing key, empty list, missing file (IoError)
- inline `#` comment in the filters block ignored

## Verification

- `pnpm typecheck` — 27/27 tasks pass
- `pnpm lint` — clean
- `pnpm --filter @kampus/pipeline-cli test` — 877 pass (incl. 18 new)
- Guard against the real repo files: `path-filter-guard: ci.yml changes.e2e and deploy.yml changes.deploy are identical (12 glob entries)` exit 0 — matches the issue's grounded 12-entry shape.

Routing: touches `packages/pipeline-cli/**` + `.github/workflows/**` → §CP. Banks at reviewed-ready for a human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)