### PR TITLE
fix(pipeline): reviewer fans across every present artifact class, single-sourced class probes (#2383)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: Use this agent when the pipeline needs a PR (or a planned epic) verified against its linked issue's acceptance criteria before it advances — it is the single routing review gate, wrapping the five review skills. Typical triggers include "review this PR", "verify PR #N", "gate PR #N before merge", and "review the plan for epic #N". Spawn it (with isolation:worktree) as the verification stage of the issue pipeline; it routes by artifact class — code → review-code, docs → review-doc, skills/agents → review-skill, a UI-affecting PR → review-design (dispatched alongside its code/doc/skill gate), an epic plan → review-plan — and lands a SHA-bound verdict on the PR. It never edits a file, never merges, and never reviews its own work. See "When to invoke" in the agent body for worked scenarios.
+description: Use this agent when the pipeline needs a PR (or a planned epic) verified against its linked issue's acceptance criteria before it advances — it is the single routing review gate, wrapping the five review skills. Typical triggers include "review this PR", "verify PR #N", "gate PR #N before merge", and "review the plan for epic #N". Spawn it (with isolation:worktree) as the verification stage of the issue pipeline; it routes by artifact class and **fans across every class the diff spans** — code → review-code, docs → review-doc, skills/agents → review-skill (each present class gated in one pass), a UI-affecting PR → review-design (dispatched alongside), an epic plan → review-plan — landing one SHA-bound verdict per present class on the PR. It never edits a file, never merges, and never reviews its own work. See "When to invoke" in the agent body for worked scenarios.
 model: inherit
 color: purple
 tools: ["Read", "Grep", "Glob", "Bash"]
@@ -13,35 +13,52 @@ to this **fresh**, with no sunk-cost attachment to the work: you only know what 
 *asked for* and what the PR *actually does*. You are the gate, never the implementer —
 you verify and verdict, you never write code, edit a file, or merge.
 
-## Route by artifact class, then load and follow that skill first
+## Route by artifact class — fan across EVERY present class, then load and follow those skills first
 
 Spawned subagents do not inherit the parent's skills, so your intelligence is not
-pre-loaded — **read the right skill yourself before doing anything else.** First classify
-the artifact under review, then read the matching SKILL.md from the working repo and
-follow it as your authoritative procedure:
+pre-loaded — **read the right skill(s) yourself before doing anything else.** Classifying a
+PR is **not "pick one class and stop"** — a single PR routinely spans several artifact
+classes (an ADR + a `skills/README.md` + a `plugin.json` is docs **and** skills **and**
+code), and **each present class needs its own gate run in this one review pass**. This is
+the *routing-completeness rule* the three review skills' Step 0 already carry (`review-code`,
+`review-doc`, `review-skill`): *"run the matching gate for every non-blocking artifact class
+the diff spans."* If you gate only the PR's headline class, a sibling class reaches `ship-it`
+ungated and it fail-closes on the empty namespace — a late stall that bounces the PR back for
+a second review pass (#1460 / PR #1442; #2383 / PR #2378 reached `ship-it` with only
+`review-doc: PASS` on a docs+skills+code diff). So **probe the full changed-file set and
+dispatch the gate for every class present**, posting **one SHA-bound marker per present class**
+in the same pass:
 
-- **A code PR** (application/source changes) → read and follow
-  `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`.
-- **A doc/knowledge PR** (`.decisions/`, `.patterns/`, `.glossary/`, prose docs) → read
-  and follow `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md`.
-- **A skill or agent PR** (`skills/**`, `agents/**`, agent/skill definitions) → read and
-  follow `claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md`.
+- **has-code** (application/source under the code roots — `apps/**`, `packages/**`,
+  `infra/**`, `.glossary/**`) → read and follow
+  `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`, emit `review-code`.
+- **has-docs** (a prose/knowledge `*.md` on `review-doc`'s surface — `.decisions/`,
+  `.patterns/`, root docs — after the code-root/skills/`.glossary` carve-out) → read and
+  follow `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md`, emit `review-doc`.
+- **has-skills** (`skills/**`, `agents/**` — behavioral artifacts) → read and follow
+  `claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md`, emit `review-skill`.
+
+These three are **mutually inclusive** — dispatch **each** that the diff touches, not the
+first that matches. The class set is decided by the **canonical `HAS_*_RE=` probes**,
+re-resolved from live `main`, per the [fan across every present class](#fan-across-every-present-class-in-lockstep-with-ship-its-live-class-probes-class_reresolve)
+invariant below.
+
 - **A UI-affecting PR** (a changed file under `apps/web/src/`, any `*.tsx`, or a style
   surface — `*.css`/style modules) → **additionally** read and follow
-  `claude-plugins/kampus-pipeline/skills/review-design/SKILL.md`. Unlike the classes
-  above, this one is **not mutually exclusive**: a PR can be both code and UI, so when a
-  changed path matches the UI-affecting set, `review-design` is dispatched **alongside**
-  the PR's code/doc/skill gate — never instead of it. A PR with **no** UI-affecting path
+  `claude-plugins/kampus-pipeline/skills/review-design/SKILL.md`. `review-design` is
+  **additive** — dispatched **alongside** the present class gate(s) above when a changed path
+  matches the UI-affecting set, never instead of them. A PR with **no** UI-affecting path
   takes the mis-route off-ramp: `review-design` is not dispatched and emits no marker.
   **Resolve the UI-affecting set from live `main`, not this snapshot** — see the
   [UI dispatch in lockstep with ship-it](#dispatch-review-design-in-lockstep-with-ship-its-live-ui_re) invariant below.
 - **A planned epic** (a `plan-epic`-output ledger whose `status:planned` children need
   gating) → read and follow `claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md`.
+  This is a distinct **epic-plan mode**, not a PR class — it does not fan with the above.
 
 Each skill is the source of truth for its class — the criterion-by-criterion verification,
 the doc/skill-hygiene checklists, the BLOCKING-set advisory rule, and the exact verdict
-marker it emits. This definition only scopes your tools, picks the route, and bakes in the
-standing invariants below so they can't be skipped. The review skills already encode the
+marker it emits. This definition only scopes your tools, probes the class set, and bakes in
+the standing invariants below so they can't be skipped. The review skills already encode the
 class off-ramps (a mis-routed PR emits a plain note and stops, never a foreign marker);
 follow them.
 
@@ -83,11 +100,39 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   **first line is always** `review-<class>: PASS|FAIL @ <sha>` (e.g.
   `review-code: PASS @ <40-hex-sha>`), in the skill's exact namespace — `review-code` for
   code, `review-doc` for docs, `review-skill` for skills/agents, `review-design` for
-  UI-affecting PRs. Emit **only** your
-  class's marker, never another gate's (a foreign marker on the wrong PR class poisons
-  that namespace's scan). Upsert it one-per-PR per the skill. The verdict on the PR is the
-  whole output — a verdict returned only to the orchestrator and never posted is a dropped
-  gate.
+  UI-affecting PRs. Emit **one marker per present class** (the fan above) and **only** for
+  classes the diff actually spans — never a foreign marker for an absent class (a marker on the
+  wrong PR class poisons that namespace's scan). Upsert each one-per-PR per its skill. The
+  verdicts on the PR are the whole output — a verdict returned only to the orchestrator and
+  never posted is a dropped gate.
+<a id="fan-across-every-present-class-in-lockstep-with-ship-its-live-class-probes-class_reresolve"></a>
+- **Fan across EVERY present class in lockstep with ship-it's live class probes
+  (`class_reresolve`).** Decide the class set the *same* way `ship-it` Step 2 decides which
+  gates it requires: from the canonical `HAS_CODE_RE`/`HAS_SKILLS_RE`/`HAS_DOCS_*_RE` lines in
+  `gh-issue-intake-formats.md` §CLASS, **re-resolved from `origin/main`** — never the inline
+  literals in this snapshot (which can predate a probe amendment and mis-classify). This is the
+  `ui_reresolve` idiom (below) generalized from `review-design` to all three verdict classes:
+  because both sides read the one live source, `required-gate == dispatched-gate` holds by
+  construction, so a multi-class PR reaches `ship-it` with a current-head PASS already standing
+  in **every** present namespace — no late-stall bounce-back (#2383). **Fail-closed**: an
+  unreadable source ⇒ dispatch the gate (`.` for the match probes, a never-match sentinel for the
+  docs carve-out so every path reaches the doc test), consistent with `ui_reresolve` — never
+  fail-open to skip a class:
+  ```bash
+  HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'; HAS_SKILLS_RE='^claude-plugins/kampus-pipeline/(skills|agents)/'   # fail-closed reference; the live lines below are authoritative
+  HAS_DOCS_EXCLUDE_RE='^(claude-plugins|apps|packages|\.glossary|infra)/'; HAS_DOCS_RE='^(\.decisions|\.patterns)/|\.md$'
+  CLASS_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+  reresolve_re() { live="$(printf '%s\n' "$CLASS_RAW" | grep "^$1=" | head -n1 || true)"; if [ -n "$live" ]; then printf '%s' "$live" | sed "s/^$1='//; s/'\$//"; else printf '%s' "$2"; fi; }
+  HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"; HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
+  HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"; HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"   # unreadable ⇒ exclude nothing / every path a doc ⇒ dispatch review-doc
+  CHANGED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
+  echo "$CHANGED" | grep -Eq "$HAS_CODE_RE"   && echo "has-code → dispatch review-code"
+  echo "$CHANGED" | grep -Eq "$HAS_SKILLS_RE" && echo "has-skills → dispatch review-skill"
+  echo "$CHANGED" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs → dispatch review-doc"
+  ```
+  Dispatch each gate that fires and post its SHA-bound marker in this same pass; `review-design`
+  rides additively on top per `ui_reresolve`. A single-class PR simply fires one probe — the fan
+  degenerates to today's behavior, never a regression.
 <a id="dispatch-review-design-in-lockstep-with-ship-its-live-ui_re"></a>
 - **Dispatch `review-design` in lockstep with ship-it's LIVE `UI_RE` — resolve the
   UI-affecting set from `origin/main`, never this snapshot (`ui_reresolve`).** The prose set
@@ -136,7 +181,8 @@ defines the full resolution rule; follow it.
 
 ## Output
 
-Return what the routed skill produces: the artifact class you routed to, the PR (or epic)
-you verified, the pinned head SHA, the PASS/FAIL verdict and its posted-comment status,
-and any blocker — including a mis-route off-ramp or a SHA-staleness refusal surfaced
-fail-loud, never a silent drop. Stop at the posted verdict and leave the merge to `ship-it`.
+Return what the routed skill(s) produce: **every artifact class you fanned to** (one line
+per present class), the PR (or epic) you verified, the pinned head SHA, each class's
+PASS/FAIL verdict and its posted-comment status, and any blocker — including a mis-route
+off-ramp or a SHA-staleness refusal surfaced fail-loud, never a silent drop. Stop at the
+posted verdicts and leave the merge to `ship-it`.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1385,17 +1385,80 @@ has-code/docs-exclusion agreement invariant, extended to `.glossary/**` by #919 
 standalone stacks (ADR 0057) by #1987).
 
 The canonical probe both `ship-it` Step 0 and `review-doc` Step 0 run — carve out
-control-plane, then `skills/**`, then the code roots + `.glossary/**` + `infra/**`, *then* test for a doc path:
+control-plane, then `skills/**`, then the code roots + `.glossary/**` + `infra/**`, *then* test for a doc path.
+The two regexes it uses — the carve-out `HAS_DOCS_EXCLUDE_RE` and the doc-path `HAS_DOCS_RE` — are
+single-sourced as canonical named `_RE=` lines in [§CLASS](#class-the-artifact-class-probes--one-canonical-definition)
+below (alongside `HAS_CODE_RE`/`HAS_SKILLS_RE`), re-resolved from `origin/main`:
 
 ```bash
 # docs class = review-doc's surface: a .md/knowledge file outside control-plane, skills/**,
 # the code roots apps/**/packages/**/infra/**, AND .glossary/** (#542/#650/#663/#919/#1987). Cite this; don't re-derive it loosely.
-echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary|infra)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
+echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs"   # HAS_DOCS_* single-sourced in §CLASS
 ```
 
 A code-root `*.md` is **not** weakened by this carve-out — it is gated harder, by
 `review-code` over its whole tree, not skipped. Only the *class label* moves: from a
 phantom doc class with no reachable gate to the code class that already gates it.
+
+---
+
+## CLASS. The artifact-class probes — one canonical definition
+
+`ship-it` Step 0 (which gate(s) a PR needs before merge) and the `reviewer` agent (which
+gate(s) to dispatch in a review pass) both classify a PR's changed-file set into the
+**artifact classes** — **has-code / has-docs / has-skills**. Both must reach the *same*
+answer, or the review stage gates one class while `ship-it` demands another: the multi-class
+gap where a PR carrying one class's PASS reaches `ship-it` and fail-closes on an ungated
+sibling class, a late stall (#2383; PR #2378 touched docs+skills+code, reached `ship-it` with
+only `review-doc: PASS`).
+
+So these probes are **single-sourced here** as canonical named `_RE=` lines — the same
+discipline that single-sources `CONTROL_PLANE_RE`/`GUARD_ADR_RE` (§CP) and `UI_RE`
+(`ship-it/SKILL.md`). A third inline copy in `reviewer.md` is the exact drift `#375`/`#981`/`#2341`
+fought — the class probes were previously inline grep literals in `ship-it` Step 0 *only*, with
+no reusable line for the reviewer to consume:
+
+```bash
+HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'
+HAS_SKILLS_RE='^claude-plugins/kampus-pipeline/(skills|agents)/'
+HAS_DOCS_EXCLUDE_RE='^(claude-plugins|apps|packages|\.glossary|infra)/'
+HAS_DOCS_RE='^(\.decisions|\.patterns)/|\.md$'
+```
+
+The boundary each line draws is **not re-derived here** — it is §DOC's, above: `HAS_CODE_RE`
+names the code roots (`apps`/`packages`/`.glossary`/`infra`, the #663/#919/#1987 has-code set),
+`HAS_SKILLS_RE` the behavioral-artifact roots (`skills/**`/`agents/**`, ADR 0073/0150), and the
+two `HAS_DOCS_*` lines are the carve-then-test docs probe. `HAS_CODE_RE` and `HAS_DOCS_EXCLUDE_RE`
+name the **same** code roots (the has-code/docs-exclusion agreement invariant) and must move in
+lockstep — keep them adjacent so a root added to one is added to the other.
+
+**Both consumers re-resolve these lines from `origin/main` at run time** (REST raw, `?ref=main`
+— the #981 idiom, generalized from `CONTROL_PLANE_RE`/`UI_RE` to the class probes), never trusting
+the injected skill snapshot, which can lag `origin/main` even when the on-disk copy is current.
+The re-resolution is **fail-closed**: an unreadable source ⇒ **dispatch the gate** (never silently
+skip a class) — `HAS_CODE_RE`/`HAS_SKILLS_RE`/`HAS_DOCS_RE` default to `.` (every path matches),
+`HAS_DOCS_EXCLUDE_RE` defaults to a never-match sentinel (`$^`, so the carve-out excludes nothing
+and every path falls through to the doc test). This is the same stance as §CP's fail-closed
+`CONTROL_PLANE_RE='.'` and `UI_RE`'s fail-closed `has-ui`:
+
+```bash
+# Re-resolve a canonical _RE= line from gh-issue-intake-formats.md@main (#981 ?ref=main idiom).
+# Prints the live value, or the fail-closed default $2 when the line is unreadable.
+FORMATS_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+reresolve_re() {   # $1=var name, $2=fail-closed default
+  live="$(printf '%s\n' "$FORMATS_RAW" | grep "^$1=" | head -n1 || true)"
+  if [ -n "$live" ]; then printf '%s' "$live" | sed "s/^$1='//; s/'\$//"; else printf '%s' "$2"; fi
+}
+HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"
+HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
+HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"   # fail-closed: exclude NOTHING ⇒ every path reaches the doc test
+HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed: every path is a doc
+```
+
+`review-design`/`has-ui` is **additive** and stays single-sourced in `ship-it/SKILL.md`'s
+`UI_RE=` (dispatched alongside whatever class gate(s) fire, never as a class of its own — see the
+`ui_reresolve` invariant in `reviewer.md`); the `HAS_*` lines above cover the three mutually-inclusive
+verdict classes.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -278,12 +278,25 @@ echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
   if [ -z "$body" ]; then echo "BLOCKING ($adr — unreadable at head ⇒ §CP, fail-closed)"
   elif printf '%s' "$body" | grep -Eiq "$GUARD_ADR_RE"; then echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
 done
-echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/(skills|agents)/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063); agents/** are behavioral artifacts, skill-class for the verdict gate (ADR 0150/#2003) — §CP-blocking for merge via CONTROL_PLANE_RE above
-echo "$FILES" | grep -Eq '^(apps|packages|\.glossary|infra)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + infra/** standalone stacks (ADR 0057) + .glossary/** — agrees with the docs-probe exclusion below (#663/#919/#1987); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)
-# docs probe EXCLUDES the code roots, skills/**, AND .glossary/** first, so a code/app-internal README
-# (apps/**, packages/**, infra/**), a skills-only .md, or a .glossary/** touch is NOT classed docs — only a prose
-# .md on review-doc's own surface is (#542/#650/#919/#1987). The §DOC contract is the single source — cite, don't re-derive.
-echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary|infra)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
+# The has-code/has-docs/has-skills probes are single-sourced as canonical HAS_*_RE= lines in
+# gh-issue-intake-formats.md §CLASS and re-resolved from origin/main here (like CONTROL_PLANE_RE/
+# UI_RE, #981) so this snapshot can't mis-classify — and so the reviewer (which consumes the SAME
+# lines) fans across every present class in lockstep with what ship-it requires (#2383). FAIL CLOSED:
+# an unreadable source ⇒ dispatch/require the gate. The literals below are the fail-closed reference
+# + validate-gate-path-drift lockstep target, NOT the live decision source — §CLASS is the source.
+HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'
+HAS_SKILLS_RE='^claude-plugins/kampus-pipeline/(skills|agents)/'
+HAS_DOCS_EXCLUDE_RE='^(claude-plugins|apps|packages|\.glossary|infra)/'
+HAS_DOCS_RE='^(\.decisions|\.patterns)/|\.md$'
+CLASS_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+reresolve_re() { live="$(printf '%s\n' "$CLASS_RAW" | grep "^$1=" | head -n1 || true)"; if [ -n "$live" ]; then printf '%s' "$live" | sed "s/^$1='//; s/'\$//"; else printf '%s' "$2"; fi; }
+HAS_CODE_RE="$(reresolve_re HAS_CODE_RE '.')"
+HAS_SKILLS_RE="$(reresolve_re HAS_SKILLS_RE '.')"
+HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"   # fail-closed: exclude NOTHING ⇒ every path reaches the doc test
+HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed: every path is a doc
+echo "$FILES" | grep -Eq "$HAS_SKILLS_RE" && echo "has-skills"   # → review-skill (ADR 0073/0150); §CP-blocking for merge via CONTROL_PLANE_RE above
+echo "$FILES" | grep -Eq "$HAS_CODE_RE" && echo "has-code"       # → review-code; the has-code roots agree with the docs-exclusion below in lockstep (§CLASS/§DOC, #663/#919/#1987)
+echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs"   # → review-doc; carve out code roots/skills/.glossary first, then test for a doc path (§DOC contract)
 # UI probe → review-design (ADDITIVE, not a class): a changed path under apps/web/src, a *.tsx
 # file, or a style surface (*.css). Like CONTROL_PLANE_RE/GUARD_ADR_RE above, the literal below
 # is the fail-closed REFERENCE + the validate-gate-path-drift lockstep target, NOT the live


### PR DESCRIPTION
Fixes #2383

## Problem

The **reviewer** stage gated only a multi-class PR's headline class; sibling classes reached `ship-it` ungated and it fail-closed on the empty namespaces at the merge boundary — a **late stall + wasted ship cycle** (PR #2378: `.decisions/0171-*.md` + `skills/README.md` + `plugin.json` reached `ship-it` with only `review-doc: PASS`). `ship-it`'s per-present-class conjunction (Step 2) demands a PASS per present class, but the reviewer produced one marker for the headline class. The fix belongs upstream, in the review stage.

## The durable fix (single-sourced probes + fan, not a third inline copy)

1. **Single-sourced the class probes.** Added canonical `_RE=` lines to `gh-issue-intake-formats.md` in a new **§CLASS** section, mirroring how `CONTROL_PLANE_RE`/`GUARD_ADR_RE` (§CP) and `UI_RE` are single-sourced:
   - `HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'`
   - `HAS_SKILLS_RE='^claude-plugins/kampus-pipeline/(skills|agents)/'`
   - `HAS_DOCS_EXCLUDE_RE='^(claude-plugins|apps|packages|\.glossary|infra)/'`
   - `HAS_DOCS_RE='^(\.decisions|\.patterns)/|\.md$'`

   These were previously inline grep literals in `ship-it` Step 0 **only**, with no reusable line for the reviewer to consume — a third inline copy in `reviewer.md` is the drift trap (#375/#981/#2341).

2. **Both consumers re-resolve from the single live source.** `ship-it` Step 0 and `reviewer.md` now read the `HAS_*_RE` lines from `gh-issue-intake-formats.md@main` (the #981 `?ref=main` idiom), generalizing the #2341 `ui_reresolve` invariant from `review-design` to all three verdict classes. Fail-closed: an unreadable source ⇒ dispatch/require the gate (`.` for match probes; a never-match sentinel `$^` for the docs carve-out so every path reaches the doc test). The skill bodies and the `main`-resolved lines land atomically in this one PR, so re-resolution has no disruptive transition window (fail-closed only fires on a genuine transient API failure, exactly like `CONTROL_PLANE_RE`/`UI_RE`).

3. **Reviewer fans across every present class.** `reviewer.md`'s "Route by artifact class" section now probes the full changed-file set with the re-resolved probes and dispatches the matching gate for **every** present class (code→`review-code`, docs→`review-doc`, skills→`review-skill`; `review-design` stays additive on UI), posting **one SHA-bound marker per present class** in the same review pass. A single-class PR degenerates to today's one-marker behavior (no regression).

4. **Reconciled the prose.** `reviewer.md`'s routing prose now agrees with the routing-completeness rule already in the three review skills' Step 0 (no "pick one class" vs "fan across all" contradiction), citing the #1460/PR#1442 and #2341 lineage.

## Verification

- **Byte-equivalence:** the four extracted `_RE=` lines are byte-identical to the old inline `ship-it` literals (diff-checked), and classification is behavior-identical old-vs-new across the #2378 triple + edge samples (`apps/web/src/App.tsx`, `packages/foo/README.md`, `.glossary/TERMS.md`, `infra/depo/stack.ts`, `.patterns/index.md`, `CLAUDE.md`).
- **Fail-closed sentinel:** `grep -Ev '$^'` excludes nothing, so every path reaches the doc test ⇒ `review-doc` dispatched — confirmed.
- **Re-resolution resolves uniquely:** the canonical column-0 single-quoted lines precede the helper-assignment lines, so `grep '^HAS_..._RE=' | head -n1` picks the canonical value.
- `validate-gate-path-drift.sh` passes (10 checks); biome + leak-guard clean.

## ACs

- [x] `reviewer.md` fans across every present class, one SHA-bound marker per present class in one pass.
- [x] Probes re-resolved from a single live source (`gh-issue-intake-formats.md` §CLASS), consumed by both `ship-it` Step 0 and the reviewer — no third inline copy.
- [x] Fan is fail-closed (unreadable source ⇒ dispatch), consistent with `ui_reresolve`.
- [x] A multi-class PR like #2378 (docs+skills) reaches `ship-it` with a current-head PASS in every present namespace — no late-stall bounce-back.
- [x] The routing-completeness rule in the three review skills' Step 0 and the reviewer agent def agree.

## Control-plane

Touches gate-critical `ship-it/SKILL.md` + `gh-issue-intake-formats.md` + `agents/reviewer.md` → **§CP: approval-gated, banks for human (control-plane) merge**; does not auto-ship on gate PASS.

## Follow-up (out of scope, filing separately)

`.claude-plugin/plugin.json` classifies as **no** artifact class under the current probes (byte-preserved here) — a pre-existing #663-style neither-class path, independent of #2383's fan/single-source fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)