### PR TITLE
feat(marketplace): add pipeline-crew catalog entry (#2353)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,6 +20,24 @@
 			},
 			"license": "MIT",
 			"keywords": ["github", "issue-pipeline", "triage", "code-review", "agent-workflow"]
+		},
+		{
+			"name": "pipeline-crew",
+			"source": "./claude-plugins/pipeline-crew",
+			"description": "The kamp.us pipeline crew: three spawnable agent defs (EA / engineering-manager / triage-guy) that conduct the kampus-pipeline skills as a 3-session crew across the intake → execution → human-merge seams. Consumes kampus-pipeline's shipped agents; every operator-specific detail is supplied per install through the personalization seam, so the plugin carries zero operator data. Repo-agnostic (CLAUDE_PIPELINE_REPO override).",
+			"author": {
+				"name": "kamp-us",
+				"url": "https://github.com/kamp-us"
+			},
+			"license": "MIT",
+			"keywords": [
+				"agent-crew",
+				"pipeline-orchestration",
+				"tmux",
+				"agent-workflow",
+				"issue-pipeline",
+				"repo-agnostic"
+			]
 		}
 	]
 }


### PR DESCRIPTION
## What

Adds the `pipeline-crew` plugin to the repo-root `.claude-plugin/marketplace.json` catalog so it is installable by name via the `/plugin` flow — the "anyone can spawn them" end state (crew epic #2342).

The entry mirrors the existing `kampus-pipeline` shape:
- **Dedicated subdir `source`**: `./claude-plugins/pipeline-crew` — the ADR 0087 shape (a per-plugin subtree copy, not a repo-root `"./"` copy).
- **No `version` field** on the plugin entry — per ADR 0110 (continuous-ship, content-addressed by commit SHA; a pin froze the install cache in #945).
- Description + author + license + keywords consistent with the `kampus-pipeline` entry (keywords sourced from the plugin's own `plugin.json`).

The `kampus-pipeline` entry is **byte-untouched** — the diff is purely additive (one new array element), so its continuous-ship posture (ADR 0110) is unchanged.

## Verification

**Spec-valid against the declared schema.** `$schema` is `claude-code-marketplace.json` (draft-07). Fetched live (HTTP 200 after the schemastore 301 redirect) and validated with `ajv` + `ajv-formats`:
```
.claude-plugin/marketplace.json valid
```
Required keys satisfied — top-level `name`/`owner`/`plugins`; per-plugin-item `name`/`source`.

**Lint clean.** `biome check .claude-plugin/marketplace.json` → No fixes. Pre-commit `biome` + `leak-guard` hooks both green (`leak-guard: clean — no user-local paths`).

**Both `source` subdirs resolve.**
```
OK ./claude-plugins/kampus-pipeline -> plugin.json present
OK ./claude-plugins/pipeline-crew  -> plugin.json present
```

**No leaked operator data / local paths.** Grep for `/Users/`, `/home/`, `~/`, session/worktree paths, operator handles over the entry → empty.

### Fresh-install scoping — a by-name install receives ONLY its own subtree (no repo bleed)

Because `source` is a relative subdir (ADR 0087), a plugin install copies exactly that subtree. `installing pipeline-crew` copies only:
```
claude-plugins/pipeline-crew/.claude-plugin/plugin.json
claude-plugins/pipeline-crew/PERSONALIZATION.md
claude-plugins/pipeline-crew/README.md
claude-plugins/pipeline-crew/agents/.gitkeep
claude-plugins/pipeline-crew/agents/engineering-manager.md
claude-plugins/pipeline-crew/agents/exec-assistant.md
claude-plugins/pipeline-crew/agents/triage-guy.md
claude-plugins/pipeline-crew/crew.config.template.jsonc
```
- **No repo-root bleed:** the subtree contains no `apps/`, `packages/`, `infra/`, or repo `CLAUDE.md` — the exact bloat ADR 0087 removed.
- **Subtrees are disjoint:** `comm -12` of the two plugins' file lists is **empty** — installing either plugin cannot pull the other's tree.

Fixes #2353