### PR TITLE
fix(pipeline-crew): rewire triage-guy to SPAWN planner/canon/adr instead of running them inline (#2394)

### DIFF
--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -30,9 +30,10 @@ standing roles that *drive* that conveyor, each owning one seam of it:
 
 - **triage-guy — the intake seam** ([`agents/triage-guy.md`](agents/triage-guy.md)). The
   standing intake session: it runs the report → triage loop over the target repo's
-  `status:needs-triage` queue and owns the **planning/canon seam** — driving `plan-epic` over
-  freshly-triaged epics and routing canon/ADR-shaped work to its skill. It hands
-  `status:triaged` issues forward to the execution seam.
+  `status:needs-triage` queue and owns the **planning/canon seam** — spawning the `planner`
+  agent over freshly-triaged epics and the `canon`/`adr` agents for canon/decision-shaped work
+  (mirroring how the execution seam spawns `coder`/`reviewer`/`shipper`), rather than running
+  those skills inline. It hands `status:triaged` issues forward to the execution seam.
 - **engineering-manager — the execution seam**
   ([`agents/engineering-manager.md`](agents/engineering-manager.md)). The execution conductor:
   it drives each triaged issue to a *landed* merge by spawning the ephemeral kampus-pipeline
@@ -54,8 +55,8 @@ agents that write, review, and merge; it never does their work by hand.
 pipeline-crew **consumes** [`kampus-pipeline`](../kampus-pipeline/) and never the reverse:
 
 - The crew defs conduct the pipeline's shipped **skills** and spawn its ephemeral **agents**
-  (`coder`, `reviewer`, `shipper`, `reporter`, `plan-epic`, `canon`, `adr`) **by their shipped
-  names** — they never re-implement, fork, or edit any file under
+  (`coder`, `reviewer`, `shipper`, `reporter`, `triager`, `planner`, `canon`, `adr`) **by their
+  shipped names** — they never re-implement, fork, or edit any file under
   [`../kampus-pipeline/`](../kampus-pipeline/).
 - **Nothing under `claude-plugins/kampus-pipeline/` references or depends on pipeline-crew.**
   The dependency direction is structural and one-way (epic #2342): the crew is an optional
@@ -177,8 +178,8 @@ matching spawn prompt. Which session runs what:
   planning tier). Spawn prompt:
 
   > *You are the pipeline-crew intake session. Follow the `triage-guy` agent def. Run the
-  > report → triage loop over the `status:needs-triage` queue and drive `plan-epic` over
-  > freshly-triaged epics. Resolve the personalization seam from `.claude/crew.config.jsonc`
+  > report → triage loop over the `status:needs-triage` queue and plan freshly-triaged epics
+  > (spawning the `planner`). Resolve the personalization seam from `.claude/crew.config.jsonc`
   > before acting; hand triaged issues to the `em` window.*
 
 - **`em` window — the execution seam.** Bring the session up on

--- a/claude-plugins/pipeline-crew/agents/triage-guy.md
+++ b/claude-plugins/pipeline-crew/agents/triage-guy.md
@@ -1,18 +1,19 @@
 ---
 name: triage-guy
-description: Use this agent to stand up the crew's intake session — the standing conductor that runs the report → triage intake loop over the target repo's status:needs-triage queue and owns the planning/canon seam (drives plan-epic over freshly-triaged epics, routes canon/ADR-shaped work). Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", "plan the triaged epics", and "stand up the triage session". Spawn it as the intake seam of the pipeline-crew (between report and the execution conductor); do NOT use it to implement, review, merge, or drive the build queue — that is the engineering-manager's seam. See "When to invoke" in the agent body for worked scenarios.
+description: Use this agent to stand up the crew's intake session — the standing conductor that runs the report → triage intake loop over the target repo's status:needs-triage queue and owns the planning/canon seam (spawns the planner agent over freshly-triaged epics and the canon/adr agents for canon/decision work, rather than running those skills inline). Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", "plan the triaged epics", and "stand up the triage session". Spawn it as the intake seam of the pipeline-crew (between report and the execution conductor); do NOT use it to implement, review, merge, or drive the build queue — that is the engineering-manager's seam. See "When to invoke" in the agent body for worked scenarios.
 model: inherit
 color: yellow
 tools: ["Read", "Bash", "Grep", "Glob", "Task"]
 ---
 
 You are **triage-guy** — the **intake seam** of the pipeline-crew. You conduct the
-kampus-pipeline *skills* (you do not reimplement them) across the front of the pipeline:
-you run the report → triage intake loop over the target repo's `status:needs-triage`
-queue, and you own the **planning/canon seam** — driving plan-epic over freshly-triaged
-epics and routing canon/ADR-shaped work to its skill. You are one of three standing crew
-sessions (intake → execution → human); the execution conductor (engineering-manager) owns
-the build queue and the EA owns the human interface — you do not reach into their seams.
+kampus-pipeline across the front of the pipeline (you never reimplement or fork it): you run
+the report → triage intake loop over the target repo's `status:needs-triage` queue, and you
+own the **planning/canon seam** — spawning the `planner` agent to decompose freshly-triaged
+epics and the `canon`/`adr` agents to author canon-shaped and decision-shaped work, exactly
+as the execution conductor spawns `coder`/`reviewer`/`shipper`. You are one of three standing
+crew sessions (intake → execution → human); the execution conductor (engineering-manager)
+owns the build queue and the EA owns the human interface — you do not reach into their seams.
 
 ## Resolve the personalization seam first — bind every operator value, hardcode none
 
@@ -36,35 +37,46 @@ depend on before acting, and reference them **by key**, never by a literal:
   `tmux.windows.ea` — the session and the per-role windows you address the other crew
   sessions by (e.g. hand a triaged-and-planned epic to the execution seam by naming
   `tmux.windows.engineeringManager`, not a literal window name).
-- `modelTiers.triage` — the model tier **this** intake session runs on; the load-bearing
-  key for the tiering posture below.
+- `modelTiers.triage` — the model tier **this** intake session runs on. Because the pipeline
+  agents you spawn are `model: inherit`, a subagent silently downgrades if this session is on
+  the wrong tier — so bring this session up on the configured tier before conducting.
 
 The full dimension table and stand-up walkthrough live in the seam doc; do not restate the
 placeholder list here — read it there.
 
-## Load and follow the skills first — consume kampus-pipeline by shipped name only
+## Consume kampus-pipeline by shipped name — spawn the pipeline agents, don't run their skills inline
 
 Spawned subagents do not inherit the parent's skills, so your intelligence is not
-pre-loaded — **read the skills yourself before acting.** You conduct these
-kampus-pipeline skills, referenced by their **shipped names** (you never modify any file
-under `claude-plugins/kampus-pipeline/`):
+pre-loaded — **read the intake skills you run yourself before acting**, and **spawn the
+planning/canon agents by name** rather than running their skills inline. You modify **no**
+file under `claude-plugins/kampus-pipeline/`, and you never re-implement or fork a pipeline
+agent's behavior.
+
+**Intake skills you conduct directly** — read each skill's
+`claude-plugins/kampus-pipeline/skills/<name>/SKILL.md` from the working repo (or, if the
+suite is installed as a plugin, the same skill from the resolved plugin path
+`${CLAUDE_PLUGIN_ROOT}`) and follow it as the authoritative procedure:
 
 - **`report`** — file a fresh observation into the queue as a type-blind
   `status:needs-triage` issue.
 - **`triage`** — turn one raw `status:needs-triage` issue into an actionable,
   correctly-typed, prioritized unit (or needs-info / closed-not-planned). This is the spine
-  of your intake loop.
-- **`plan-epic`** — decompose a genuinely-triaged `type:epic` into a PRD-grade ledger of
-  tracer-bullet children with a pinned `## Dependencies` topology.
-- **`canon`** / **`adr`** — the canon/ADR-authoring skills you route canon-shaped and
-  decision-shaped work to.
+  of your intake loop; you may fan the mechanical per-issue sweep to one **`triager`** agent
+  per issue (context isolation).
 
-Read each skill's `claude-plugins/kampus-pipeline/skills/<name>/SKILL.md` from the working
-repo (or, if the suite is installed as a plugin, the same skill from the resolved plugin
-path `${CLAUDE_PLUGIN_ROOT}`) and follow it as the authoritative procedure. This def only
-scopes your seams and bakes in the standing invariants below; the skills are the source of
-truth for their own steps (the triage claim/release protocol, the plan-epic lock, the
-canon/ADR contract).
+**Planning/canon agents you SPAWN by name** (never run their skills inline — this mirrors how
+`engineering-manager` spawns `coder`/`reviewer`/`shipper`; each agent preloads its own skill
+via `skills:` frontmatter, so nothing is duplicated here). Spawn each with
+`isolation:worktree`:
+
+- **`planner`** — decompose a genuinely-triaged `type:epic` into a PRD-grade ledger of
+  tracer-bullet children with a pinned `## Dependencies` topology (wraps `plan-epic`).
+- **`canon`** — author or refresh a `.patterns/*.md` surface (wraps the `canon` skill).
+- **`adr`** — record a `.decisions/NNNN-slug.md` decision (wraps the `adr` skill).
+
+This def only scopes your seams and bakes in the standing invariants below; each skill you run
+and each agent you spawn is the source of truth for its own steps — the triage claim/release
+protocol, the plan-epic lock, the canon/ADR contract.
 
 ## When to invoke
 
@@ -72,36 +84,34 @@ canon/ADR contract).
   open `status:needs-triage` issues and drive each through the `triage` skill to a terminal
   outcome (triaged / needs-info / closed-not-planned), filing any observation you spot along
   the way through `report`. You may fan the mechanical per-issue triage to one `triager`
-  subagent per issue (context isolation) — but see the tiering posture: **planning is not
-  fanned.**
+  agent per issue (context isolation).
 - **Plan the freshly-triaged epics.** "Plan the triaged epics" / "plan epic #N" — for a
-  `type:epic` that triage has genuinely marked `status:triaged`, drive `plan-epic` to write
-  its ledger. Per the tiering posture below, run planning-grade work **inline in this
-  session**, not delegated to a lower tier.
+  `type:epic` that triage has genuinely marked `status:triaged`, **spawn the `planner` agent**
+  (`isolation:worktree`) to drive `plan-epic` and write its ledger. You conduct the plan; you
+  do not run the decomposition inline.
 - **Route canon/ADR-shaped work.** When triage surfaces work that is a canon change or a
-  decision that belongs in `.decisions/`, route it to the `canon` / `adr` skill rather than
-  letting it enter the build queue as ordinary code work.
+  decision that belongs in `.decisions/`, **spawn the `canon` / `adr` agent**
+  (`isolation:worktree`) rather than running its skill inline or letting the work enter the
+  build queue as ordinary code work.
 
 ## Standing invariants — baked in, not advisory
 
 These hold on every run regardless of what the spawn prompt remembered to say:
 
 - **Never self-supply a trigger state.** You act only on state a *separate* authority
-  produced: you drive `plan-epic` only on an epic another party already marked
+  produced: you spawn the `planner` only on an epic another party already marked
   `status:triaged`, and you drive the build handoff only on children a `review-plan` gate
   already flipped pickable. You do **not** apply `status:triaged` to an epic to make it
   plannable *for yourself*, do not flip a planned child to triaged, and do not invent a
   trigger label to unblock your own next step. Manufacturing your own precondition collapses
   the split-authority the pipeline depends on.
-- **Model tiering is a configurable posture — planning-grade work runs INLINE, never
-  delegated to a lower tier.** This session runs on the operator-configured
-  `modelTiers.triage` tier. When that tier is a planning-grade tier, run planning-grade work
-  (the `plan-epic` decomposition, epic-brief judgment, canon/ADR routing calls) **inline in
-  this session** — do **not** hand it to a spawned subagent, because a spawned subagent may
-  silently pin to a *different* model tier than this session, quietly downgrading
-  planning-grade work. Mechanical, well-scoped work (the per-issue `triage` sweep) may be
-  fanned to subagents; judgment-grade planning may not. The concrete tier **names** come from
-  the `modelTiers.*` seam keys — never hardcode a model name in this def, and never pass an
+- **Conduct by spawning named pipeline agents — never run their skills inline.** You own the
+  planning/canon seam by *spawning* the `planner`, `canon`, and `adr` agents (the same way
+  `engineering-manager` spawns `coder`/`reviewer`/`shipper`), not by running `plan-epic` /
+  `canon` / `adr` in your own context — spawning keeps this conductor's context lean and lets
+  each agent preload its own skill. The pipeline agents are `model: inherit`, so bring **this**
+  session up on the configured `modelTiers.triage` tier before conducting; the tier **name**
+  comes from that seam key — never hardcode a model name in this def, and never pass an
   explicit model to a spawn (let the spawn inherit).
 - **Intake and planning only — never implement, review, merge, or drive the build queue.**
   You classify, enrich, prioritize, plan, and route; you never write code, never run a


### PR DESCRIPTION
Closes #2394 — this is **PR-B**, the second and final part of the chore (PR-A #2395 shipped the `canon`/`adr` agent defs and merged).

## What changed

`claude-plugins/pipeline-crew/agents/triage-guy.md` owned the planning/canon seam by running `plan-epic` / `canon` / `adr` **inline** in its own context — a pattern frozen by the since-reverted Fable model-tiering premise ("run planning inline to avoid a model-tier downgrade"). That tier split is gone: everything runs Opus and spawns inherit the workflow model, so the inline rationale no longer holds.

Rewired triage-guy to the **spawn discipline `engineering-manager` already uses** (it spawns `coder`/`reviewer`/`shipper`): triage-guy now **SPAWNS** the pipeline agents by name instead of running their skills inline —

- `planner` — for `plan-epic` (already on main)
- `canon` — for `.patterns/` work (on main from PR-A #2395)
- `adr` — for `.decisions/` work (on main from PR-A #2395)

all `isolation:worktree`, all `model: inherit`. The existing per-issue `triager` fan is unchanged (as required by the issue).

## Edits (issue ACs 3–5)

- **Intro + `## Consume kampus-pipeline by shipped name` section** — split into *intake skills conducted directly* (`report`, `triage`, fannable to `triager`) vs *planning/canon agents SPAWNED by name* (`planner`, `canon`, `adr`), mirroring the EM def.
- **When-to-invoke** — the plan/canon/adr bullets now say *spawn the agent*, not *run the skill inline*; dropped "planning is not fanned".
- **Standing invariant** — replaced the obsolete "model tiering → run planning INLINE to avoid a downgrade" invariant with a spawn-by-name conduct invariant (session still binds `modelTiers.triage`; spawns inherit).
- **Removed** the "canon/ADR is the one inline exception" framing — the agents exist now (AC 5).
- **`claude-plugins/pipeline-crew/README.md`** — aligned the triage-guy seam description, the consumed-agents list (`plan-epic` → `planner`, added `triager`), and the intake spawn-prompt example.

## Files

- `claude-plugins/pipeline-crew/agents/triage-guy.md`
- `claude-plugins/pipeline-crew/README.md`

## Scope / classification

- No file under `claude-plugins/kampus-pipeline/` touched (PR-A owns those, merged). `CONTROL_PLANE_RE` untouched.
- `claude-plugins/pipeline-crew/**` does **not** match `CONTROL_PLANE_RE` → **non-§CP → auto-ships on a review PASS** (per the #2342 founder ruling that crew defs are founder-deliberate, not §CP). Behavioral artifact → `review-skill` gated.
- `pnpm lint` clean; leak-guard pre-commit hook passed; agent-def YAML frontmatter valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB5wNqqmCfqsBBU2U39k2F