### PR TITLE
chore(pano): derive comment-count delta once in a domain rule (#2014)

### DIFF
--- a/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
@@ -326,3 +326,23 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 			}),
 	);
 });
+
+// The author `restoreComment` +1 (live) branch — the last arithmetic branch not asserted
+// directly (its +0 sandboxed arm is covered by the cross-path test above, #1811). Pins the
+// non-sandboxed restore to +1 so the shared delta rule (`nextCommentCount`) stays honest on
+// the create-mirror arm for the author path too.
+describe("commentCount is sandbox-gated on the author restoreComment path (#1811)", () => {
+	it.effect("author-restoring a NON-sandboxed comment bumps the public count by one (+1)", () =>
+		Effect.gen(function* () {
+			const {db, captured} = fakeDb({comment: removedRow(null), startCount: 5});
+			const ops = makeCommentOperations(deps(runOverDb(db)));
+			const result = yield* ops.restoreComment({commentId: "comm_1", actorId: "u-author"});
+			assert.isTrue(result.deleted, "the author-restore un-removes the comment");
+			assert.strictEqual(
+				captured.postCommentCount,
+				6,
+				"a comment restored to Live was not counted while removed, so its restore bumps +1",
+			);
+		}),
+	);
+});

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -190,6 +190,26 @@ const validateCommentBody = Effect.fn("Pano.validateCommentBody")(function* (
 	return rawBody;
 });
 
+/**
+ * The single source of truth for a post's public `comment_count` after one
+ * comment lifecycle step — the delta rule every add / delete / restore /
+ * mod-remove / mod-restore path routes through, so the count is derived here
+ * once and never re-hand-written per method. A sandboxed çaylak comment (#1205)
+ * is never in the public count, so a sandboxed step moves it by 0 — the
+ * create-gate the delete path must mirror (#1831/#1811). The `Math.max(0, …)`
+ * floor keeps a raced double-remove from driving the public count negative
+ * (the #1831 class this rule makes unrepresentable). A create bumps the count
+ * the same +1 as a `restore`.
+ */
+export const nextCommentCount = (
+	current: number,
+	sandboxedAt: Date | null,
+	direction: "remove" | "restore",
+): number => {
+	const step = sandboxedAt != null ? 0 : direction === "remove" ? -1 : 1;
+	return Math.max(0, current + step);
+};
+
 /** The shared runtime deps `PanoLive` threads into the comments plane. */
 export interface CommentOperationsDeps {
 	readonly run: DrizzleAccessOrDie["run"];
@@ -206,11 +226,10 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 
 	// The parent post's PUBLIC `comment_count` bookkeeping every comment remove/restore
 	// shares — the plane-specific `afterCommit` the four transition methods run after the
-	// substrate write. A sandboxed çaylak comment (#1205) was never counted into the public
-	// count on create, so a sandboxed transition adjusts by 0 — the create-gate mirror
-	// (#1831/#1811). `sandboxedAt` is the round-tripped marker the transition stamped. Only
-	// the author `deleteComment` also refreshes `hotScore` (the activity bump), so it opts in
-	// via `recomputeHot`; the mod + restore arms leave `hotScore` untouched, as before.
+	// substrate write. The delta rule itself lives in `nextCommentCount`; this only loads
+	// the post, applies it, and persists. `hotScore` is an explicit opt-in: only the author
+	// `deleteComment` refreshes it (`recomputeHot`), so the mod + restore arms leave it
+	// untouched — a deliberate per-caller decision, not an incidental divergence.
 	const adjustPostCommentCount = (
 		postId: string,
 		sandboxedAt: Date | null,
@@ -221,8 +240,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		Effect.gen(function* () {
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: postId}}));
 			if (!post) return;
-			const step = sandboxedAt != null ? 0 : direction === "remove" ? -1 : 1;
-			const commentCount = Math.max(0, post.commentCount + step);
+			const commentCount = nextCommentCount(post.commentCount, sandboxedAt, direction);
 			const hotScore = opts.recomputeHot
 				? computeHotScore(post.score, (post.createdAt ?? now).getTime(), now.getTime())
 				: undefined;
@@ -469,9 +487,14 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			}),
 		);
 
-		// A sandboxed çaylak comment (#1205) is pending — it must not bump the
-		// post's PUBLIC `comment_count`. Promotion (#1206) recomputes it on flip.
-		const newCommentCount = post.commentCount + (input.sandboxedAt != null ? 0 : 1);
+		// A create bumps the public count the same +1 as a `restore`, gated on the
+		// sandbox by the shared delta rule (a sandboxed çaylak comment (#1205) stays
+		// pending and is recomputed into the count on promotion, #1206).
+		const newCommentCount = nextCommentCount(
+			post.commentCount,
+			input.sandboxedAt ?? null,
+			"restore",
+		);
 		const hotScore = computeHotScore(post.score, (post.createdAt ?? now).getTime(), now.getTime());
 
 		yield* run((db) =>


### PR DESCRIPTION
Fixes #2014

## What

The sandbox-gated public `commentCount` delta rule (the `sandboxedAt != null ? 0 : ±1` step + the `Math.max(0, …)` floor) was re-derived per comment-lifecycle method. `adjustPostCommentCount` already owned it for the four remove/restore transitions (`deleteComment`, `restoreComment`, `moderateRemoveComment`, `moderateRestoreComment`), but the create path in `addComment` still hand-wrote its own `post.commentCount + (input.sandboxedAt != null ? 0 : 1)`.

This extracts the delta rule into one exported domain function, `nextCommentCount(current, sandboxedAt, direction)`, and routes **all five** callers through it — the count is derived once, and the #1831 count-drift class stays unrepresentable.

## Changes

- `apps/web/worker/features/pano/comment-operations.ts`
  - Add `nextCommentCount` — the single source of truth for the sandbox-gated delta + floor; the *why* (sandbox gate #1205, #1831/#1811 create-mirror, negative-floor) now lives in one docblock instead of five.
  - `adjustPostCommentCount` routes through it; its docblock is trimmed to what it adds (load + persist + the explicit `recomputeHot` opt-in). `hotScore` stays an explicit parameter (only the author `deleteComment` opts in), not an incidental per-caller divergence.
  - `addComment` routes its create-path `+1` through `nextCommentCount` (`"restore"` direction) instead of re-deriving it inline.
- `apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts`
  - Add the last missing branch: `restoreComment`'s non-sandboxed `+1` asserted directly.

## Acceptance criteria

- [x] The five callers no longer each re-derive the `sandboxedAt`-gated delta + `Math.max(0, …)` floor; they route through one shared helper (`nextCommentCount`).
- [x] The `hotScore` bump is an explicit parameter (`recomputeHot`), not an incidental per-caller divergence; existing per-method `hotScore`/`lastActivityAt` behavior preserved.
- [x] `restoreComment`'s non-sandboxed `+1` branch is directly asserted (alongside the four already-covered branches) — 12/12 pass.
- [x] No observable behavior change: `nextCommentCount` for the create path is arithmetically identical (the floor is a no-op on a non-negative increment). Typecheck green; 189 pano unit tests green; fanout-guard green.

## Notes

Pure refactor, no behavior change and no new mutation — the fanned-mutation classification is untouched (`fanout-guard check` passes: 38 classified, 24 fanned). Scoped entirely to `apps/web/worker/features/pano/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)