### PR TITLE
feat(pipeline-cli): extract the status:planning epic-lock into an epic-lock tool (#2098)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -132,65 +132,29 @@ means a caller keying on exit status alone cannot tell "planned" from "backed of
 the echo is the signal, so a wrapper must read it (or re-run) rather than treat `exit 0` as "the
 epic was planned".
 
+The whole protocol — the missing-session fail-closed, the coarse-label Rule-0 defer, the
+label `POST` (fail-closed on a 422 missing label), the claim-comment `POST`, the checkpoint-GET,
+and the earliest-authorized-claim resolution — lives in one deterministic, unit-tested tool,
+`pipeline-cli epic-lock` (ADR 0059/0115, #2098), so this skill **calls** it rather than
+re-implementing ~50 lines of `jq` inline. Resolve the tool in-repo first, published fallback
+(ADR 0064), then branch on its exit status:
+
 ```bash
-# 0. fail-closed on a missing session id: the claim is the ONLY agent-distinguishable signal under
-#    the shared `usirin` login — with no token a co-acquire is unresolvable, so we never mutate.
-if [ -z "$CLAUDE_CODE_SESSION_ID" ]; then
-  echo "no CLAUDE_CODE_SESSION_ID in env — cannot post an agent-distinguishable planning claim. BACK OFF, do not mutate."
-  exit 0
+# Resolve the epic-lock CLI once — in-repo first, published fallback (ADR 0064; epic #994).
+if [ -f packages/pipeline-cli/src/bin.ts ]; then
+  LOCK="node packages/pipeline-cli/src/bin.ts epic-lock"   # phoenix-local: the in-repo consolidated bin
+else
+  LOCK="pnpm dlx @kampus/pipeline-cli@0.1.0 epic-lock"     # foreign install: the published CLI
 fi
 
-# 1. coarse gate: defer to a label already held (Rule 0 — never evict a holder that was there first).
-HELD=$(gh api repos/$REPO/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
-# gh --jq prints "" (not "null") for a jq null, so test non-empty: index() is a numeric position when held, empty when absent.
-if [ -n "$HELD" ]; then
-  echo "epic #<EPIC> is being planned by another run (status:planning held) — BACK OFF, do not mutate."
-  exit 0   # the held lock is the holder's, not ours — do NOT release it.
+# Acquire the two-layer lock. `epic-lock acquire` runs the WHOLE ADR-0115 protocol over $CLAUDE_CODE_SESSION_ID
+# and exits 0 ONLY when the lock is ours; every fail-closed back-off — a held label, a 422 missing label, a
+# failed claim post, a lost co-acquire, a missing session id — prints its reason on stderr and exits NON-ZERO.
+# Branch on exit status — never mutate on a non-zero.
+if ! $LOCK acquire <EPIC>; then
+  exit 0   # backed off (held lock / setup gap / lost race is not a plan-epic failure) — re-run later.
 fi
-
-# 2. POST the coarse label — proceed ONLY if it lands (fails closed on a 422 missing label / IO fault).
-if ! gh api repos/$REPO/issues/<EPIC>/labels -f "labels[]=status:planning" >/dev/null; then
-  echo "could not acquire status:planning on epic #<EPIC> (422 missing label? transient gh fault?) — BACK OFF, do not mutate."
-  exit 0   # FAILS CLOSED: the POST didn't land, so we DON'T hold the lock — never mutate unlocked.
-fi
-
-# 3. post OUR agent-distinguishable claim ON THE EPIC (the §7 claim-comment primitive, ADR 0115 §1).
-NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-MYCLAIM=$(gh api repos/$REPO/issues/<EPIC>/comments -f "body=claim: $CLAUDE_CODE_SESSION_ID · $NOW" --jq .id)
-if [ -z "$MYCLAIM" ]; then
-  # FAILS CLOSED: we can't prove ownership, so we must not mutate. Leave the shared label (a co-racer
-  # may legitimately win on it) — never DELETE it here; a leaked label is human-cleared, a double-plan is not.
-  echo "failed to post the planning claim on epic #<EPIC> — BACK OFF, do not mutate (the status:planning label may be leaked; a human clears it)."
-  exit 0
-fi
-
-# 4. checkpoint GET — resolve co-acquirers to ONE holder: EARLIEST AUTHORIZED claim wins (ADR 0115 §2).
-cf=$(mktemp); gh api "repos/$REPO/issues/<EPIC>/comments?per_page=100" --paginate > "$cf"
-# authors of any claim marker on the epic
-claimAuthors=$(jq -r '[.[] | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*[0-9a-f-]{36}\\b")) | .user.login] | unique | .[]' "$cf")
-# keep only write+ collaborators (the ADR 0055 trust root) — a forged claim from a non-collaborator is ignored.
-authorized='[]'
-while IFS= read -r a; do
-  [ -z "$a" ] && continue
-  perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
-  case "$perm" in admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;; esac
-done <<<"$claimAuthors"
-# the EARLIEST authorized claim — min (created_at, comment id) — is the canonical winner; read its session.
-WINSID=$(jq -r --argjson authorized "$authorized" '
-  [.[] | select(.user.login | IN($authorized[]))
-       | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*[0-9a-f-]{36}\\b"))
-       | {sid: (.body | capture("(?i)^\\s*\\**\\s*claim:\\s*(?<s>[0-9a-f-]{36})").s), at: .created_at, id: .id}]
-  | sort_by([.at, .id]) | first | .sid // ""' "$cf")
-
-# 5. we win ONLY if the earliest authorized claim is ours. Else retract OUR claim and back off — NEVER the label.
-if [ "$WINSID" != "$CLAUDE_CODE_SESSION_ID" ]; then
-  echo "lost the status:planning co-acquire on epic #<EPIC> (earliest authorized claim is another run's) — BACK OFF, do not mutate."
-  gh api -X DELETE repos/$REPO/issues/comments/$MYCLAIM >/dev/null 2>&1 \
-    || echo "WARNING: failed to retract our planning claim $MYCLAIM on epic #<EPIC> — retract it by hand."
-  exit 0   # do NOT DELETE the shared status:planning label — the WINNER still holds it.
-fi
-# WON. WE hold the lock (label + earliest claim). WE must release BOTH our claim and the label
-# on EVERY terminal path (below).
+# WON. WE hold the lock (label + earliest claim). Release it on EVERY terminal path (below).
 ```
 
 **Release is an explicit agent step, not a shell `trap … EXIT`.** The acquire above runs in
@@ -203,25 +167,12 @@ the way out — run this exact `DELETE` once you reach **any** terminal state (P
 or a failure/abort mid-mutation):
 
 ```bash
-# release: run on EVERY exit path AFTER a WON acquire (done, park, or fault mid-mutation). Two parts.
-
-# (a) retract OUR own planning-claim comment(s). Re-find them by OUR session id — the acquire's
-#     $MYCLAIM was captured in a PRIOR bash process and is gone here (each call is its own shell).
-cf=$(mktemp); gh api "repos/$REPO/issues/<EPIC>/comments?per_page=100" --paginate > "$cf"
-for cid in $(jq -r --arg me "$CLAUDE_CODE_SESSION_ID" '.[] | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*" + $me + "\\b")) | .id' "$cf"); do
-  gh api -X DELETE repos/$REPO/issues/comments/$cid >/dev/null 2>&1 \
-    || echo "WARNING: failed to retract our planning claim $cid on epic #<EPIC> — clear it by hand."
-done
-
-# (b) release the coarse label. Do NOT fire-and-forget — a silently-failed DELETE LEAKS the lock and
-#     wedges the epic, the exact catastrophe this design prevents. A 404 is benign (label already gone —
-#     released, or never landed); ANY other failure means the lock may still be held, so surface it LOUDLY.
-if ! relerr=$(gh api -X DELETE repos/$REPO/issues/<EPIC>/labels/status:planning 2>&1); then
-  case "$relerr" in
-    *"HTTP 404"*|*"Label does not exist"*) : ;;  # already released / never acquired — nothing to free
-    *) echo "WARNING: failed to release status:planning on epic #<EPIC> — the epic-lock may be LEAKED (still held). Re-run this DELETE or clear the label by hand; until cleared, plan-epic/review-plan back off on this epic. ($relerr)" ;;
-  esac
-fi
+# release: run on EVERY exit path AFTER a WON acquire (done, park, or fault mid-mutation).
+# `epic-lock release` does BOTH parts: (a) retract OUR OWN claim comment(s) — re-found by session id,
+# since the acquire ran in a PRIOR process and its comment id is gone here; and (b) drop the coarse
+# label — a 404 is benign (already released), but ANY other DELETE failure is surfaced LOUDLY (a
+# silently-swallowed DELETE LEAKS the lock and wedges the epic, the exact ADR-0059 catastrophe).
+$LOCK release <EPIC>
 ```
 
 The release fires on **every** terminal path on purpose: you drive this as an LLM agent across

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -116,66 +116,29 @@ label, a flaky write, or a co-acquire loss never lets you flip/loop unlocked. **
 "gated" from "backed off, did nothing"; the echo is the signal, so a wrapper must read it (or
 re-run) rather than treat `exit 0` as "the epic was gated".
 
+The whole protocol — the missing-session fail-closed, the coarse-label Rule-0 defer, the
+label `POST` (fail-closed on a 422 missing label), the claim-comment `POST`, the checkpoint-GET,
+and the earliest-authorized-claim resolution — lives in one deterministic, unit-tested tool,
+`pipeline-cli epic-lock` (ADR 0059/0115, #2098), so this skill **calls** it rather than
+re-implementing ~50 lines of `jq` inline. Resolve the tool the same way `$GATE` is resolved —
+in-repo first, published fallback (ADR 0064) — then branch on its exit status:
+
 ```bash
-# 0. fail-closed on a missing session id: the claim is the ONLY agent-distinguishable signal under
-#    the shared `usirin` login — with no token a co-acquire is unresolvable, so we never flip/loop.
-if [ -z "$CLAUDE_CODE_SESSION_ID" ]; then
-  echo "no CLAUDE_CODE_SESSION_ID in env — cannot post an agent-distinguishable planning claim. DO NOT flip, DO NOT loop."
-  exit 0
+# Resolve the epic-lock CLI once — in-repo first, published fallback (ADR 0064; epic #994).
+if [ -f packages/pipeline-cli/src/bin.ts ]; then
+  LOCK="node packages/pipeline-cli/src/bin.ts epic-lock"   # phoenix-local: the in-repo consolidated bin
+else
+  LOCK="pnpm dlx @kampus/pipeline-cli@0.1.0 epic-lock"     # foreign install: the published CLI (same pin as $GATE)
 fi
 
-# 1. coarse gate: defer to a label already held (Rule 0 — never evict a holder that was there first).
-HELD=$(gh api repos/$REPO/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
-# gh --jq prints "" (not "null") for a jq null, so test non-empty: index() is a numeric position when held, empty when absent.
-if [ -n "$HELD" ]; then
-  echo "epic #<EPIC> is being planned by another run (status:planning held) — DO NOT flip, DO NOT loop."
-  exit 0   # the held lock is the holder's, not ours — do NOT release it. Re-run later.
+# Acquire the two-layer lock. `epic-lock acquire` runs the WHOLE ADR-0115 protocol over $CLAUDE_CODE_SESSION_ID
+# and exits 0 ONLY when the lock is ours; every fail-closed back-off — a held label, a 422 missing label, a
+# failed claim post, a lost co-acquire, a missing session id — prints its reason on stderr and exits NON-ZERO.
+# Branch on exit status — never flip/loop on a non-zero.
+if ! $LOCK acquire <EPIC>; then
+  exit 0   # backed off (held lock / setup gap / lost race is not a review-plan failure) — re-run later.
 fi
-
-# 2. POST the coarse label — proceed ONLY if it lands (fails closed on a 422 missing label / IO fault).
-if ! gh api repos/$REPO/issues/<EPIC>/labels -f "labels[]=status:planning" >/dev/null; then
-  echo "could not acquire status:planning on epic #<EPIC> (422 missing label? transient gh fault?) — DO NOT flip, DO NOT loop."
-  exit 0   # FAILS CLOSED: the POST didn't land, so we DON'T hold the lock — never flip/loop unlocked.
-fi
-
-# 3. post OUR agent-distinguishable claim ON THE EPIC (the §7 claim-comment primitive, ADR 0115 §1).
-NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-MYCLAIM=$(gh api repos/$REPO/issues/<EPIC>/comments -f "body=claim: $CLAUDE_CODE_SESSION_ID · $NOW" --jq .id)
-if [ -z "$MYCLAIM" ]; then
-  # FAILS CLOSED: we can't prove ownership, so we must not flip/loop. Leave the shared label (a co-racer
-  # may legitimately win on it) — never DELETE it here; a leaked label is human-cleared, a double-plan is not.
-  echo "failed to post the planning claim on epic #<EPIC> — DO NOT flip, DO NOT loop (the status:planning label may be leaked; a human clears it)."
-  exit 0
-fi
-
-# 4. checkpoint GET — resolve co-acquirers to ONE holder: EARLIEST AUTHORIZED claim wins (ADR 0115 §2).
-cf=$(mktemp); gh api "repos/$REPO/issues/<EPIC>/comments?per_page=100" --paginate > "$cf"
-# authors of any claim marker on the epic
-claimAuthors=$(jq -r '[.[] | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*[0-9a-f-]{36}\\b")) | .user.login] | unique | .[]' "$cf")
-# keep only write+ collaborators (the ADR 0055 trust root) — a forged claim from a non-collaborator is ignored.
-authorized='[]'
-while IFS= read -r a; do
-  [ -z "$a" ] && continue
-  perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
-  case "$perm" in admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;; esac
-done <<<"$claimAuthors"
-# the EARLIEST authorized claim — min (created_at, comment id) — is the canonical winner; read its session.
-WINSID=$(jq -r --argjson authorized "$authorized" '
-  [.[] | select(.user.login | IN($authorized[]))
-       | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*[0-9a-f-]{36}\\b"))
-       | {sid: (.body | capture("(?i)^\\s*\\**\\s*claim:\\s*(?<s>[0-9a-f-]{36})").s), at: .created_at, id: .id}]
-  | sort_by([.at, .id]) | first | .sid // ""' "$cf")
-
-# 5. we win ONLY if the earliest authorized claim is ours. Else retract OUR claim and back off — NEVER the label.
-if [ "$WINSID" != "$CLAUDE_CODE_SESSION_ID" ]; then
-  echo "lost the status:planning co-acquire on epic #<EPIC> (earliest authorized claim is another run's) — DO NOT flip, DO NOT loop."
-  # comment-scoped DELETE (no issue number) — the issue-scoped form 404s and LEAKS the claim (#1548).
-  gh api -X DELETE repos/$REPO/issues/comments/$MYCLAIM >/dev/null 2>&1 \
-    || echo "WARNING: failed to retract our planning claim $MYCLAIM on epic #<EPIC> — retract it by hand."
-  exit 0   # do NOT DELETE the shared status:planning label — the WINNER still holds it.
-fi
-# WON. WE hold the lock (label + earliest claim). WE must release BOTH our claim and the label
-# on EVERY terminal path (below).
+# WON. WE hold the lock (label + earliest claim). Release it on EVERY terminal path (below).
 ```
 
 **Release is an explicit agent step, not a shell `trap … EXIT`.** The acquire above runs in
@@ -187,26 +150,12 @@ snippet; it is an action **you** take, deliberately, on the way out — run this
 you reach **any** terminal state (PASS-and-flipped, parked, or a fault mid-flight):
 
 ```bash
-# release: run on EVERY exit path AFTER a WON acquire (PASS/flip, park, or fault mid-flight). Two parts.
-
-# (a) retract OUR own planning-claim comment(s). Re-find them by OUR session id — the acquire's
-#     $MYCLAIM was captured in a PRIOR bash process and is gone here (each call is its own shell).
-#     Use the comment-scoped DELETE (no issue number) — the issue-scoped form 404s and LEAKS it (#1548).
-cf=$(mktemp); gh api "repos/$REPO/issues/<EPIC>/comments?per_page=100" --paginate > "$cf"
-for cid in $(jq -r --arg me "$CLAUDE_CODE_SESSION_ID" '.[] | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*" + $me + "\\b")) | .id' "$cf"); do
-  gh api -X DELETE repos/$REPO/issues/comments/$cid >/dev/null 2>&1 \
-    || echo "WARNING: failed to retract our planning claim $cid on epic #<EPIC> — clear it by hand."
-done
-
-# (b) release the coarse label. Do NOT fire-and-forget — a silently-failed DELETE LEAKS the lock and
-#     wedges the epic, the exact catastrophe this design prevents. A 404 is benign (label already gone —
-#     released, or never landed); ANY other failure means the lock may still be held, so surface it LOUDLY.
-if ! relerr=$(gh api -X DELETE repos/$REPO/issues/<EPIC>/labels/status:planning 2>&1); then
-  case "$relerr" in
-    *"HTTP 404"*|*"Label does not exist"*) : ;;  # already released / never acquired — nothing to free
-    *) echo "WARNING: failed to release status:planning on epic #<EPIC> — the epic-lock may be LEAKED (still held). Re-run this DELETE or clear the label by hand; until cleared, plan-epic/review-plan back off on this epic. ($relerr)" ;;
-  esac
-fi
+# release: run on EVERY exit path AFTER a WON acquire (PASS/flip, park, or fault mid-flight).
+# `epic-lock release` does BOTH parts: (a) retract OUR OWN claim comment(s) — re-found by session id,
+# since the acquire ran in a PRIOR process and its comment id is gone here; and (b) drop the coarse
+# label — a 404 is benign (already released), but ANY other DELETE failure is surfaced LOUDLY (a
+# silently-swallowed DELETE LEAKS the lock and wedges the epic, the exact ADR-0059 catastrophe).
+$LOCK release <EPIC>
 ```
 
 The release fires on **every** terminal path on purpose: the gate and the convergence loop can

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -54,6 +54,35 @@ node packages/pipeline-cli/src/bin.ts version
 node packages/pipeline-cli/src/bin.ts <tool> …
 ```
 
+### `epic-lock` — the ADR-0059 `status:planning` epic-lock (#2098)
+
+The two-layer epic-plan lock the `plan-epic` / `review-plan` skills use to serialize
+concurrent mutation of one epic's children, extracted from the ~50-line inline `jq` glue
+each skill hand-rolled. It runs the ADR-0115 agent-distinguishable-claim protocol over the
+ADR-0059 `status:planning` lock-label:
+
+- **`epic-lock acquire <epic>`** — coarse-label Rule-0 defer → POST the label (fail-closed on
+  a 422 missing label) → POST the `claim: <session-id> · <ts>` comment → checkpoint-GET →
+  resolve the **earliest authorized claim** (write+ collaborators only, ADR 0055). **Exits 0
+  only when the lock is ours;** every fail-closed back-off (held label, 422 missing label,
+  failed claim post, lost co-acquire, missing `CLAUDE_CODE_SESSION_ID`) prints a reason on
+  stderr and exits **non-zero**, so a caller branches on exit status.
+- **`epic-lock release <epic>`** — retract our own claim comment(s) (re-found by session id)
+  and DELETE the label (404-benign, **loud** on any other DELETE failure — a swallowed DELETE
+  leaks the lock and wedges the epic).
+
+The session id is `$CLAUDE_CODE_SESSION_ID`; `--session` overrides it (the orchestrated
+delegated-token path, and tests). The pure claim-resolution decision (`claim-resolution.ts`)
+is IO-free and unit-tested table-driven; `github.ts` is the REST-only `gh api` boundary — the
+**template `github.ts` service pattern** the epic #994 Phase-2 families copy.
+
+```bash
+# acquire (exit 0 = held by us; non-zero = backed off, do not mutate)
+node packages/pipeline-cli/src/bin.ts epic-lock acquire 1234 && echo "hold the lock"
+# release on every terminal path
+node packages/pipeline-cli/src/bin.ts epic-lock release 1234
+```
+
 ### `leak-guard` — personal-data leak gate for shared artifacts (#173, #2357)
 
 Two modes, one deny-list-per-mode core:

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {designTokenGuardCommand} from "./tools/design-token-guard/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
+import {epicLockCommand} from "./tools/epic-lock/command.ts";
 import {evalHarnessCommand} from "./tools/eval-harness/command.ts";
 import {failureClassifierCommand} from "./tools/failure-classifier/command.ts";
 import {fanoutGuardCommand} from "./tools/fanout-guard/command.ts";
@@ -77,6 +78,7 @@ export type RegisteredTool = Command.Command<any, any, object, unknown, Platform
 export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	versionCommand,
 	epicLedgerCommand,
+	epicLockCommand,
 	decisionsIndexCommand,
 	readmeGuardCommand,
 	worktreeGuardCommand,

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.ts
@@ -1,0 +1,115 @@
+/**
+ * The pure claim-resolution core of `epic-lock` — IO-free, total, unit-testable.
+ *
+ * The single decision the `plan-epic` / `review-plan` / `write-code` skills each
+ * hand-rolled inline (~50 lines of jq apiece): given the raw claim comments on an
+ * epic, the write+ authorized-author set, and our own session id, decide the one
+ * lock holder. The holder is the **earliest authorized claim** — the minimum
+ * `(created_at, comment id)` (ADR 0115 §2) — among comments whose body matches the
+ * canonical `CLAIM_RE` and whose author holds write+ on the repo (the ADR 0055
+ * trust root). A forged claim from a non-collaborator is dropped before the
+ * tiebreak; an empty authorized set resolves NO winner (fail-closed, never a false
+ * win); a missing session id is its own fail-closed outcome. The contract — the
+ * marker grammar, the `CLAIM_RE`, and the tiebreak — is single-sourced in
+ * gh-issue-intake-formats.md §7 (see ADR 0115); this core is the deterministic
+ * decision the IO shell (`github.ts`) drives.
+ */
+
+/**
+ * The canonical claim marker (gh-issue-intake-formats.md §7): one anchored,
+ * emphasis-tolerant line; the embedded session id is captured in group 1. The
+ * `\**` absorbs any leading bold-marker, `[0-9a-f-]{36}` matches a session UUID.
+ */
+export const CLAIM_RE = /^\s*\**\s*claim:\s*([0-9a-f-]{36})\b/i;
+
+/** A claim comment as the issues/comments REST endpoint surfaces it (only these fields matter). */
+export interface ClaimComment {
+	/** Server-assigned, strictly-monotonic, globally-unique comment id (the tiebreak sub-key). */
+	readonly id: number;
+	/** The comment author's login (checked against the authorized set). */
+	readonly author: string;
+	/** ISO-8601 UTC creation time (the tiebreak primary key). */
+	readonly createdAt: string;
+	/** The raw comment body (matched against `CLAIM_RE`). */
+	readonly body: string;
+}
+
+/** Parse the embedded session id out of a claim-comment body, or `null` if it is not a claim. */
+export const parseClaimSession = (body: string): string | null => {
+	const session = CLAIM_RE.exec(body)?.[1];
+	return session ? session.toLowerCase() : null;
+};
+
+export interface ClaimResolutionInput {
+	readonly comments: ReadonlyArray<ClaimComment>;
+	/** The write+ collaborator logins — the ADR 0055 trust root (resolved by the IO shell). */
+	readonly authorizedAuthors: ReadonlyArray<string>;
+	/** Our own `CLAUDE_CODE_SESSION_ID`; absent/empty ⇒ fail-closed `no-session`. */
+	readonly sessionId: string | null | undefined;
+}
+
+/** The resolved lock holder — the earliest authorized claim. */
+export interface ClaimWinner {
+	readonly session: string;
+	readonly id: number;
+	readonly createdAt: string;
+}
+
+export type ClaimOutcome =
+	| {readonly _tag: "no-session"}
+	| {readonly _tag: "no-winner"}
+	| {readonly _tag: "won"; readonly winner: ClaimWinner}
+	| {readonly _tag: "lost"; readonly winner: ClaimWinner};
+
+/**
+ * The earliest authorized claim — min `(createdAt, id)` — among comments that both
+ * match `CLAIM_RE` and are authored by a write+ collaborator. Returns `null` when
+ * no such claim exists (empty authorized set, or only forged/non-claim comments):
+ * an empty result is the fail-closed "no owner", never a false win.
+ */
+export const resolveWinner = (
+	comments: ReadonlyArray<ClaimComment>,
+	authorizedAuthors: ReadonlyArray<string>,
+): ClaimWinner | null => {
+	const authorized = new Set(authorizedAuthors);
+	const claims: ClaimWinner[] = [];
+	for (const comment of comments) {
+		if (!authorized.has(comment.author)) continue;
+		const session = parseClaimSession(comment.body);
+		if (session === null) continue;
+		claims.push({session, id: comment.id, createdAt: comment.createdAt});
+	}
+	claims.sort((a, b) =>
+		a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
+	);
+	return claims[0] ?? null;
+};
+
+/**
+ * Decide our win/lose against canonical epic state. Fail-closed twice over: a
+ * missing session id is `no-session` (we have no agent-distinguishable identity to
+ * resolve under), and an empty authorized claim set is `no-winner` (nothing proven
+ * to hold). A real winner whose session equals ours is `won`; any other winner is
+ * `lost` — defer to the holder, never evict.
+ */
+export const resolveClaim = (input: ClaimResolutionInput): ClaimOutcome => {
+	if (!input.sessionId) return {_tag: "no-session"};
+	const winner = resolveWinner(input.comments, input.authorizedAuthors);
+	if (winner === null) return {_tag: "no-winner"};
+	return winner.session === input.sessionId.toLowerCase()
+		? {_tag: "won", winner}
+		: {_tag: "lost", winner};
+};
+
+/**
+ * The ids of our *own* claim comments (matched by session id) — the exact set
+ * `release` retracts. Our session may have posted more than one across retried
+ * acquires, so this returns all of them.
+ */
+export const ownClaimCommentIds = (
+	comments: ReadonlyArray<ClaimComment>,
+	sessionId: string,
+): ReadonlyArray<number> => {
+	const mine = sessionId.toLowerCase();
+	return comments.filter((comment) => parseClaimSession(comment.body) === mine).map((c) => c.id);
+};

--- a/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/claim-resolution.unit.test.ts
@@ -1,0 +1,162 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	CLAIM_RE,
+	type ClaimComment,
+	type ClaimOutcome,
+	ownClaimCommentIds,
+	parseClaimSession,
+	resolveClaim,
+	resolveWinner,
+} from "./claim-resolution.ts";
+
+const SID_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SID_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const SID_C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const claim = (session: string): string => `claim: ${session} · 2026-07-08T00:00:00Z`;
+
+const comment = (over: Partial<ClaimComment> & {readonly id: number}): ClaimComment => ({
+	author: "usirin",
+	createdAt: "2026-07-08T00:00:00Z",
+	body: claim(SID_A),
+	...over,
+});
+
+describe("parseClaimSession / CLAIM_RE — the canonical §7 marker", () => {
+	const cases: ReadonlyArray<{readonly body: string; readonly expected: string | null}> = [
+		{body: claim(SID_A), expected: SID_A},
+		{body: `**claim: ${SID_B} · 2026-07-08T00:00:00Z`, expected: SID_B}, // leading-bold emphasis-tolerant (§7 \**)
+		{body: `  claim:  ${SID_C}`, expected: SID_C}, // leading/inner whitespace
+		{body: `CLAIM: ${SID_A} · now`, expected: SID_A}, // case-insensitive keyword
+		{body: "just a normal comment", expected: null},
+		{body: "claim: not-a-uuid", expected: null},
+		{body: `prefix claim: ${SID_A}`, expected: null}, // must anchor at line start
+	];
+	for (const {body, expected} of cases) {
+		it(`${JSON.stringify(body)} → ${expected}`, () => {
+			assert.strictEqual(parseClaimSession(body), expected);
+			assert.strictEqual(CLAIM_RE.test(body), expected !== null);
+		});
+	}
+});
+
+describe("resolveClaim — the epic-lock win/lose decision (table-driven)", () => {
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly comments: ReadonlyArray<ClaimComment>;
+		readonly authorized: ReadonlyArray<string>;
+		readonly sessionId: string | null | undefined;
+		readonly expected: ClaimOutcome;
+	}> = [
+		{
+			name: "single acquirer wins",
+			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
+			authorized: ["usirin"],
+			sessionId: SID_A,
+			expected: {_tag: "won", winner: {session: SID_A, id: 1, createdAt: "2026-07-08T00:00:00Z"}},
+		},
+		{
+			name: "co-acquire tie broken by earliest created_at — earlier wins",
+			comments: [
+				comment({id: 20, author: "usirin", createdAt: "2026-07-08T00:00:02Z", body: claim(SID_B)}),
+				comment({id: 10, author: "usirin", createdAt: "2026-07-08T00:00:01Z", body: claim(SID_A)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_A,
+			expected: {_tag: "won", winner: {session: SID_A, id: 10, createdAt: "2026-07-08T00:00:01Z"}},
+		},
+		{
+			name: "co-acquire loser (our claim is not the earliest) → lost, defer to winner",
+			comments: [
+				comment({id: 10, author: "usirin", createdAt: "2026-07-08T00:00:01Z", body: claim(SID_A)}),
+				comment({id: 20, author: "usirin", createdAt: "2026-07-08T00:00:02Z", body: claim(SID_B)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_B,
+			expected: {_tag: "lost", winner: {session: SID_A, id: 10, createdAt: "2026-07-08T00:00:01Z"}},
+		},
+		{
+			name: "equal created_at → tie broken by the smaller comment id",
+			comments: [
+				comment({id: 30, author: "usirin", createdAt: "2026-07-08T00:00:00Z", body: claim(SID_B)}),
+				comment({id: 15, author: "usirin", createdAt: "2026-07-08T00:00:00Z", body: claim(SID_A)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_A,
+			expected: {_tag: "won", winner: {session: SID_A, id: 15, createdAt: "2026-07-08T00:00:00Z"}},
+		},
+		{
+			name: "a forged claim from a non-collaborator is ignored (dropped before the tiebreak)",
+			comments: [
+				// the earliest claim BUT from a non-authorized author — must not win
+				comment({id: 5, author: "attacker", createdAt: "2026-07-08T00:00:00Z", body: claim(SID_C)}),
+				comment({id: 9, author: "usirin", createdAt: "2026-07-08T00:00:05Z", body: claim(SID_A)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_A,
+			expected: {_tag: "won", winner: {session: SID_A, id: 9, createdAt: "2026-07-08T00:00:05Z"}},
+		},
+		{
+			name: "only a forged claim exists → no authorized winner (fail-closed)",
+			comments: [comment({id: 5, author: "attacker", body: claim(SID_C)})],
+			authorized: ["usirin"],
+			sessionId: SID_A,
+			expected: {_tag: "no-winner"},
+		},
+		{
+			name: "empty authorized set → no winner (fail-closed, never a false win)",
+			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
+			authorized: [],
+			sessionId: SID_A,
+			expected: {_tag: "no-winner"},
+		},
+		{
+			name: "missing session id fails closed (no-session) even with our own claim present",
+			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
+			authorized: ["usirin"],
+			sessionId: undefined,
+			expected: {_tag: "no-session"},
+		},
+		{
+			name: "empty-string session id also fails closed (no-session)",
+			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
+			authorized: ["usirin"],
+			sessionId: "",
+			expected: {_tag: "no-session"},
+		},
+	];
+
+	for (const {name, comments, authorized, sessionId, expected} of cases) {
+		it(name, () => {
+			assert.deepStrictEqual(
+				resolveClaim({comments, authorizedAuthors: authorized, sessionId}),
+				expected,
+			);
+		});
+	}
+});
+
+describe("resolveWinner — direct earliest-authorized-claim resolution", () => {
+	it("returns null on an empty comment set", () => {
+		assert.strictEqual(resolveWinner([], ["usirin"]), null);
+	});
+	it("ignores non-claim comments from authorized authors", () => {
+		const comments = [comment({id: 1, author: "usirin", body: "not a claim at all"})];
+		assert.strictEqual(resolveWinner(comments, ["usirin"]), null);
+	});
+});
+
+describe("ownClaimCommentIds — the release retraction set", () => {
+	it("selects exactly our own claim comments across a mixed set", () => {
+		const comments = [
+			comment({id: 1, author: "usirin", body: claim(SID_A)}), // mine
+			comment({id: 2, author: "usirin", body: claim(SID_B)}), // another session
+			comment({id: 3, author: "usirin", body: "chatter"}), // not a claim
+			comment({id: 4, author: "usirin", body: claim(SID_A)}), // mine (a retried acquire)
+		];
+		assert.deepStrictEqual(ownClaimCommentIds(comments, SID_A), [1, 4]);
+	});
+	it("is empty when we hold no claim", () => {
+		assert.deepStrictEqual(ownClaimCommentIds([comment({id: 1, body: claim(SID_B)})], SID_A), []);
+	});
+});

--- a/packages/pipeline-cli/src/tools/epic-lock/command.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/command.ts
@@ -77,10 +77,9 @@ const acquire = Command.make(
 	Effect.fn(function* ({epic, session}) {
 		const sessionId = resolveSession(session);
 		if (sessionId === "") {
-			yield* backOff(
+			return yield* backOff(
 				"no CLAUDE_CODE_SESSION_ID (and no --session) — cannot post an agent-distinguishable planning claim. BACK OFF, do not mutate.",
 			);
-			return;
 		}
 		const result = yield* (yield* Github).acquire(epic, sessionId);
 		yield* reportAcquire(epic, result);
@@ -99,10 +98,9 @@ const release = Command.make(
 		if (sessionId === "") {
 			// Release with no session id can only retract by session — nothing to do, but the label
 			// may still be held. Surface it loudly and exit non-zero rather than silently no-op.
-			yield* backOff(
+			return yield* backOff(
 				"no CLAUDE_CODE_SESSION_ID (and no --session) — cannot identify our own claim to retract. Clear status:planning by hand if leaked.",
 			);
-			return;
 		}
 		const result = yield* (yield* Github).release(epic, sessionId);
 		yield* Console.log(

--- a/packages/pipeline-cli/src/tools/epic-lock/command.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/command.ts
@@ -1,0 +1,127 @@
+/**
+ * The `epic-lock` tool — `pipeline-cli epic-lock acquire <epic>` /
+ * `pipeline-cli epic-lock release <epic>`.
+ *
+ * The ADR-0059 `status:planning` epic-lock, extracted from the ~50-line inline jq
+ * glue the `plan-epic` / `review-plan` / `write-code` skills each hand-rolled (#2098).
+ * `acquire` runs the two-layer coarse-label + agent-distinguishable-claim protocol
+ * (ADR 0115) and **exits 0 only when the lock is ours**; every fail-closed back-off —
+ * a held label, a 422 missing label, a failed claim post, a lost co-acquire, a missing
+ * session id — prints a reason on stderr and **exits non-zero**, so a caller branches
+ * on exit status (`epic-lock acquire N && <mutate>`) rather than parsing prose.
+ * `release` retracts our own claim comment(s) and drops the label (404-benign, loud on
+ * any other DELETE failure), exiting 0.
+ *
+ * The session id is our `CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable signal
+ * under the shared `usirin` login) — an absent value fails closed. `--session` overrides
+ * it for the orchestrated/delegated-token path and for tests.
+ *
+ * `GithubLive` is baked in with `Command.provide(...)` so the registered command's
+ * residual requirement is the Node platform union (the registry seam, epic #994).
+ */
+import {Console, Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {type AcquireResult, Github, GithubLive} from "./github.ts";
+
+const BACKOFF_EXIT_CODE = 1;
+
+const epicArg = Argument.integer("epic").pipe(
+	Argument.withDescription("the epic issue number to lock/unlock"),
+);
+
+const sessionFlag = Flag.string("session").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the claiming session id (default: $CLAUDE_CODE_SESSION_ID); the delegated token on the orchestrated path",
+	),
+);
+
+const resolveSession = (session: Option.Option<string>): string =>
+	Option.getOrElse(session, () => process.env.CLAUDE_CODE_SESSION_ID ?? "").trim();
+
+/** Print the back-off reason on stderr and exit non-zero — the "did not acquire" signal. */
+const backOff = (reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stderr.write(`epic-lock: ${reason}\n`);
+		process.exit(BACKOFF_EXIT_CODE);
+	});
+
+const reportAcquire = (epic: number, result: AcquireResult): Effect.Effect<void> => {
+	switch (result._tag) {
+		case "acquired":
+			return Console.log(
+				`epic-lock: acquired status:planning on epic #${epic} — proceed to mutate.`,
+			);
+		case "held-by-other":
+			return backOff(
+				`epic #${epic} is being planned by another run (status:planning held) — BACK OFF, do not mutate.`,
+			);
+		case "label-missing":
+			return backOff(
+				`could not acquire status:planning on epic #${epic} (422 missing label? transient gh fault?) — BACK OFF, do not mutate. (${result.stderr.trim()})`,
+			);
+		case "claim-post-failed":
+			return backOff(
+				`failed to post the planning claim on epic #${epic} — BACK OFF, do not mutate (the status:planning label may be leaked; a human clears it). (${result.stderr.trim()})`,
+			);
+		case "lost":
+			return backOff(
+				`lost the status:planning co-acquire on epic #${epic} (earliest authorized claim is ${result.winner}) — BACK OFF, do not mutate.`,
+			);
+	}
+};
+
+const acquire = Command.make(
+	"acquire",
+	{epic: epicArg, session: sessionFlag},
+	Effect.fn(function* ({epic, session}) {
+		const sessionId = resolveSession(session);
+		if (sessionId === "") {
+			yield* backOff(
+				"no CLAUDE_CODE_SESSION_ID (and no --session) — cannot post an agent-distinguishable planning claim. BACK OFF, do not mutate.",
+			);
+			return;
+		}
+		const result = yield* (yield* Github).acquire(epic, sessionId);
+		yield* reportAcquire(epic, result);
+	}),
+).pipe(
+	Command.withDescription(
+		"Acquire the status:planning epic-lock (exit 0 = held by us; non-zero = backed off, do not mutate)",
+	),
+);
+
+const release = Command.make(
+	"release",
+	{epic: epicArg, session: sessionFlag},
+	Effect.fn(function* ({epic, session}) {
+		const sessionId = resolveSession(session);
+		if (sessionId === "") {
+			// Release with no session id can only retract by session — nothing to do, but the label
+			// may still be held. Surface it loudly and exit non-zero rather than silently no-op.
+			yield* backOff(
+				"no CLAUDE_CODE_SESSION_ID (and no --session) — cannot identify our own claim to retract. Clear status:planning by hand if leaked.",
+			);
+			return;
+		}
+		const result = yield* (yield* Github).release(epic, sessionId);
+		yield* Console.log(
+			`epic-lock: released epic #${epic} — retracted ${result.retracted} claim comment(s), ` +
+				(result.labelRemoved
+					? "removed status:planning."
+					: "status:planning was already absent (404-benign)."),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Release the status:planning epic-lock: retract our claim comment(s) + drop the label (404-benign)",
+	),
+);
+
+export const epicLockCommand = Command.make("epic-lock").pipe(
+	Command.withSubcommands([acquire, release]),
+	Command.withDescription(
+		"Acquire/release the ADR-0059 status:planning epic-lock (ADR 0115 claim protocol)",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/epic-lock/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/github-service.unit.test.ts
@@ -1,0 +1,253 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {GhCommandError, Github, GithubLive, type RepoResolutionError} from "./github.ts";
+
+// The live layer resolves its repo lazily (ADR 0062 §1); pin the env override so the
+// fixtures keyed on `repos/kamp-us/phoenix/...` match without the ambient `gh repo view`.
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+const methodOf = (args: ReadonlyArray<string>): string => {
+	const i = args.indexOf("-X");
+	return i >= 0 ? (args[i + 1] ?? "GET") : "GET";
+};
+
+/**
+ * A `ChildProcessSpawner` answering `gh api` from a `${method} ${path}` fixture map
+ * (POST/GET/DELETE against the same REST path disambiguate by method). An unmapped
+ * key exits 1 (a not-found).
+ */
+const mockSpawner = (
+	responses: Record<string, Response>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				const path = rawPath.replace(/\?.*$/, "");
+				const key = `${methodOf(args)} ${path}`;
+				// key on PRESENCE, not truthiness: a DELETE fixture maps to "" (empty stdout),
+				// which is falsy — a truthiness check would mis-route it to the not-found branch.
+				const canned =
+					key in responses
+						? normalize(responses[key]!)
+						: {stdout: "", exitCode: 1, stderr: `not found: ${key}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	responses: Record<string, Response>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const EPIC = 900;
+const P = `repos/kamp-us/phoenix`;
+const SID_MINE = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SID_OTHER = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const SID_FORGED = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const claimComment = (over: {
+	readonly id: number;
+	readonly login: string;
+	readonly session: string;
+	readonly at?: string;
+}) =>
+	({
+		id: over.id,
+		created_at: over.at ?? "2026-07-08T00:00:00Z",
+		user: {login: over.login},
+		body: `claim: ${over.session} · ${over.at ?? "2026-07-08T00:00:00Z"}`,
+	}) as const;
+
+describe("Github.acquire — the two-layer lock over a mock gh spawner", () => {
+	it.effect("held label → held-by-other (Rule 0 defer, non-mutating)", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const result = yield* github.acquire(EPIC, SID_MINE);
+			assert.deepStrictEqual(result, {_tag: "held-by-other"});
+		}).pipe((effect) =>
+			provide(effect, {[`GET ${P}/issues/${EPIC}`]: JSON.stringify(["status:planning", "p1"])}),
+		),
+	);
+
+	it.effect(
+		"clean win: label posts, claim posts, our claim is the earliest authorized → acquired",
+		() =>
+			Effect.gen(function* () {
+				const github = yield* Github;
+				const result = yield* github.acquire(EPIC, SID_MINE);
+				assert.deepStrictEqual(result, {_tag: "acquired"});
+			}).pipe((effect) =>
+				provide(effect, {
+					[`GET ${P}/issues/${EPIC}`]: JSON.stringify([]),
+					[`POST ${P}/issues/${EPIC}/labels`]: "[]",
+					[`POST ${P}/issues/${EPIC}/comments`]: "700",
+					[`GET ${P}/issues/${EPIC}/comments`]: JSON.stringify([
+						claimComment({id: 700, login: "usirin", session: SID_MINE}),
+					]),
+					[`GET ${P}/collaborators/usirin/permission`]: "write",
+				}),
+			),
+	);
+
+	it.effect(
+		"422 missing label: the label POST fails → label-missing (fail-closed, non-mutating)",
+		() =>
+			Effect.gen(function* () {
+				const github = yield* Github;
+				const result = yield* github.acquire(EPIC, SID_MINE);
+				assert.strictEqual(result._tag, "label-missing");
+			}).pipe((effect) =>
+				provide(effect, {
+					[`GET ${P}/issues/${EPIC}`]: JSON.stringify([]),
+					[`POST ${P}/issues/${EPIC}/labels`]: {
+						stdout: "",
+						exitCode: 1,
+						stderr: "HTTP 422: Label does not exist",
+					},
+				}),
+			),
+	);
+
+	it.effect("lost co-acquire: an earlier authorized claim from another session → lost", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const result = yield* github.acquire(EPIC, SID_MINE);
+			assert.deepStrictEqual(result, {_tag: "lost", winner: SID_OTHER});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${EPIC}`]: JSON.stringify([]),
+				[`POST ${P}/issues/${EPIC}/labels`]: "[]",
+				[`POST ${P}/issues/${EPIC}/comments`]: "800",
+				[`GET ${P}/issues/${EPIC}/comments`]: JSON.stringify([
+					claimComment({id: 500, login: "usirin", session: SID_OTHER, at: "2026-07-08T00:00:01Z"}),
+					claimComment({id: 800, login: "usirin", session: SID_MINE, at: "2026-07-08T00:00:02Z"}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+				// the lost path retracts our own claim comment (ignored on failure)
+				[`DELETE ${P}/issues/comments/800`]: "",
+			}),
+		),
+	);
+
+	it.effect("a forged claim from a non-collaborator is ignored → our authorized claim wins", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const result = yield* github.acquire(EPIC, SID_MINE);
+			assert.deepStrictEqual(result, {_tag: "acquired"});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${EPIC}`]: JSON.stringify([]),
+				[`POST ${P}/issues/${EPIC}/labels`]: "[]",
+				[`POST ${P}/issues/${EPIC}/comments`]: "900",
+				[`GET ${P}/issues/${EPIC}/comments`]: JSON.stringify([
+					// earliest, but forged (non-collaborator) — must be dropped
+					claimComment({
+						id: 10,
+						login: "attacker",
+						session: SID_FORGED,
+						at: "2026-07-08T00:00:00Z",
+					}),
+					claimComment({id: 900, login: "usirin", session: SID_MINE, at: "2026-07-08T00:00:05Z"}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+				[`GET ${P}/collaborators/attacker/permission`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 404: Not Found",
+				},
+			}),
+		),
+	);
+});
+
+describe("Github.release — retract our claim + drop the label", () => {
+	it.effect("retracts our claim comment and removes the label → released", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const result = yield* github.release(EPIC, SID_MINE);
+			assert.deepStrictEqual(result, {_tag: "released", retracted: 1, labelRemoved: true});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${EPIC}/comments`]: JSON.stringify([
+					claimComment({id: 55, login: "usirin", session: SID_MINE}),
+					claimComment({id: 66, login: "usirin", session: SID_OTHER}),
+				]),
+				[`DELETE ${P}/issues/comments/55`]: "",
+				[`DELETE ${P}/issues/${EPIC}/labels/status:planning`]: "",
+			}),
+		),
+	);
+
+	it.effect("label DELETE 404 is benign → released with labelRemoved=false", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const result = yield* github.release(EPIC, SID_MINE);
+			assert.deepStrictEqual(result, {_tag: "released", retracted: 0, labelRemoved: false});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${EPIC}/comments`]: JSON.stringify([]),
+				[`DELETE ${P}/issues/${EPIC}/labels/status:planning`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 404: Label does not exist",
+				},
+			}),
+		),
+	);
+
+	it.effect("a non-404 label DELETE failure is LOUD (propagates GhCommandError)", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const error = yield* Effect.flip(github.release(EPIC, SID_MINE));
+			assert.isTrue(error instanceof GhCommandError);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${EPIC}/comments`]: JSON.stringify([]),
+				[`DELETE ${P}/issues/${EPIC}/labels/status:planning`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 500: server error",
+				},
+			}),
+		),
+	);
+});

--- a/packages/pipeline-cli/src/tools/epic-lock/github.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/github.ts
@@ -1,0 +1,425 @@
+/**
+ * The GitHub boundary for `epic-lock`: the live `Github` capability that acquires
+ * and releases the ADR-0059 `status:planning` epic-lock over `gh api` REST, driving
+ * the IO-free `claim-resolution.ts` core at the checkpoint.
+ *
+ * This is the **template child**'s `github.ts` service pattern the epic #994 Phase-2
+ * families copy: a `Context.Service` (`.patterns/effect-context-service.md`) on
+ * `ChildProcessSpawner` (`effect/unstable/process`), REST only (GraphQL is broken on
+ * the kamp-us org), with every infra failure a typed error in the `E` channel, never
+ * a throw (`.patterns/effect-errors.md`): a non-zero `gh` exit is `GhCommandError`,
+ * malformed `gh` output is `GhParseError`, an unresolvable target repo is
+ * `RepoResolutionError`. Schema decodes untrusted REST JSON at the boundary
+ * (`.patterns/effect-schema-validation.md`) into the domain `ClaimComment` the core
+ * resolves over.
+ *
+ * The lock is **two layers** (ADR 0115 / gh-issue-intake-formats.md §7): the coarse
+ * `status:planning` label (the "is this epic being planned at all?" gate) plus the
+ * agent-distinguishable claim comment that resolves the post-`/labels` TOCTOU under
+ * the shared login. `acquire`/`release` return a domain verdict (not a raw void), so
+ * every fail-closed back-off — a held label, a 422 missing label, a failed claim
+ * post, a lost co-acquire — is an observable outcome the command prints, never an
+ * exception. See ADR 0059 (the epic-plan lock) and ADR 0115 (the claim marker).
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {type ClaimComment, ownClaimCommentIds, resolveWinner} from "./claim-resolution.ts";
+
+/** The canonical epic-plan lock label (ADR 0059). */
+export const LOCK_LABEL = "status:planning";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, 422 missing label, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/epic-lock/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/epic-lock/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/epic-lock/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/** The `acquire` verdict — exactly one holder, or one of four fail-closed back-offs. */
+export type AcquireResult =
+	| {readonly _tag: "acquired"}
+	| {readonly _tag: "held-by-other"}
+	| {readonly _tag: "label-missing"; readonly stderr: string}
+	| {readonly _tag: "claim-post-failed"; readonly stderr: string}
+	| {readonly _tag: "lost"; readonly winner: string};
+
+/** The `release` verdict — how many of our claim comments were retracted, and whether the label was present. */
+export type ReleaseResult = {
+	readonly _tag: "released";
+	readonly retracted: number;
+	readonly labelRemoved: boolean;
+};
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit.
+ * `ChildProcessSpawner.string` surfaces only spawn/IO faults, not the process's own
+ * exit code — so the handle is spawned directly to read `exitCode` + `stderr` and
+ * lower a non-zero exit into a typed error. A spawn/IO `PlatformError` (e.g. `gh`
+ * not on PATH) folds into the same typed `GhCommandError` (exit code `-1`).
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
+ * defaults to a repo: with no env and no resolvable current repo it fails
+ * `RepoResolutionError`, so a foreign install can't accidentally operate on phoenix.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/epic-lock/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// --- REST arg builders (REST only, never GraphQL) --------------------------------
+
+const issueArgs = (repo: string, epic: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/${epic}`,
+	"--jq",
+	"[.labels[].name]",
+];
+
+const addLabelArgs = (repo: string, epic: number): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${epic}/labels`,
+	"-f",
+	`labels[]=${LOCK_LABEL}`,
+];
+
+const removeLabelArgs = (repo: string, epic: number): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"DELETE",
+	`repos/${repo}/issues/${epic}/labels/${LOCK_LABEL}`,
+];
+
+const postClaimArgs = (repo: string, epic: number, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${epic}/comments`,
+	"-f",
+	`body=${body}`,
+	"--jq",
+	".id",
+];
+
+const listCommentsArgs = (repo: string, epic: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${epic}/comments?per_page=100`,
+];
+
+const deleteCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"DELETE",
+	`repos/${repo}/issues/comments/${id}`,
+];
+
+const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/collaborators/${login}/permission`,
+	"--jq",
+	".permission",
+];
+
+// --- boundary decoders -----------------------------------------------------------
+
+/** The issue-label array `[.labels[].name]` returns. */
+const decodeLabels = Schema.decodeUnknownEffect(Schema.Array(Schema.String));
+
+/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
+const RawComment = Schema.Struct({
+	id: Schema.Number,
+	created_at: Schema.String,
+	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
+});
+const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+const toClaimComment = (raw: (typeof RawComment)["Type"]): ClaimComment => ({
+	id: raw.id,
+	author: raw.user?.login ?? "",
+	createdAt: raw.created_at,
+	body: raw.body ?? "",
+});
+
+/** A clean 404 — the only `gh` failure that means "already gone / not found". */
+const is404 = (stderr: string): boolean => /404|not found/i.test(stderr);
+
+// --- IO operations ---------------------------------------------------------------
+
+const labelHeld = Effect.fn("Github.labelHeld")(function* (repo: string, epic: number) {
+	const args = issueArgs(repo, epic);
+	const labels = yield* decodeLabels(yield* json(args));
+	return labels.includes(LOCK_LABEL);
+});
+
+const listClaimComments = Effect.fn("Github.listClaimComments")(function* (
+	repo: string,
+	epic: number,
+) {
+	const args = listCommentsArgs(repo, epic);
+	const raw = yield* decodeComments(yield* json(args));
+	return raw.map(toClaimComment);
+});
+
+/**
+ * The write+ collaborator subset of `logins` — the ADR 0055 trust root. Each login
+ * is probed with `collaborators/<login>/permission`; a non-`admin|maintain|write`
+ * permission, or any `gh` fault on the probe (a non-collaborator commonly 404s),
+ * drops the login. A forged claim from a non-collaborator therefore never enters the
+ * authorized set the core resolves over.
+ */
+const authorizedAuthors = Effect.fn("Github.authorizedAuthors")(function* (
+	repo: string,
+	logins: ReadonlyArray<string>,
+) {
+	const results = yield* Effect.forEach(
+		logins,
+		(login) =>
+			runGh(permissionArgs(repo, login)).pipe(
+				Effect.map((out) => ({login, permission: out.trim()})),
+				Effect.catchTag("@kampus/epic-lock/GhCommandError", () =>
+					Effect.succeed({login, permission: "none"}),
+				),
+			),
+		{concurrency: "unbounded"},
+	);
+	return results
+		.filter(
+			(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
+		)
+		.map((r) => r.login);
+});
+
+const resolveAuthorizedWinner = Effect.fn("Github.resolveAuthorizedWinner")(function* (
+	repo: string,
+	comments: ReadonlyArray<ClaimComment>,
+) {
+	const authors = [...new Set(comments.map((c) => c.author).filter((a) => a.length > 0))];
+	const authorized = yield* authorizedAuthors(repo, authors);
+	return resolveWinner(comments, authorized);
+});
+
+/**
+ * Acquire the two-layer lock, fail-closed at every step: defer if the label is
+ * already held (Rule 0 — never evict a pre-existing holder); POST the label and
+ * back off `label-missing` if it doesn't land (422 or IO); POST our claim comment
+ * and back off `claim-post-failed` if it doesn't land (leaving the label for a
+ * legitimate co-racer to win on — a human clears a leaked label, a double-plan is
+ * unrecoverable); then checkpoint-GET and resolve the earliest authorized claim. We
+ * hold the lock only if that winner is ours; otherwise retract our own claim comment
+ * and back off `lost` (never delete the shared label — the winner holds it).
+ */
+const acquire = Effect.fn("Github.acquire")(function* (
+	repo: string,
+	epic: number,
+	sessionId: string,
+) {
+	if (yield* labelHeld(repo, epic)) {
+		return {_tag: "held-by-other"} satisfies AcquireResult;
+	}
+	// "ok" is the label-landed sentinel; a GhCommandError lowers to the label-missing back-off.
+	const labelResult = yield* runGh(addLabelArgs(repo, epic)).pipe(
+		Effect.as<AcquireResult | "ok">("ok"),
+		Effect.catchTag("@kampus/epic-lock/GhCommandError", (error) =>
+			Effect.succeed<AcquireResult | "ok">({_tag: "label-missing", stderr: error.stderr}),
+		),
+	);
+	if (labelResult !== "ok") return labelResult;
+
+	const now = new Date().toISOString();
+	const claimResult = yield* json(postClaimArgs(repo, epic, `claim: ${sessionId} · ${now}`)).pipe(
+		Effect.map((v): number | AcquireResult =>
+			typeof v === "number"
+				? v
+				: {_tag: "claim-post-failed", stderr: "claim POST did not return a comment id"},
+		),
+		Effect.catchTag("@kampus/epic-lock/GhCommandError", (error) =>
+			Effect.succeed<number | AcquireResult>({_tag: "claim-post-failed", stderr: error.stderr}),
+		),
+	);
+	if (typeof claimResult !== "number") return claimResult;
+	const claimId = claimResult;
+
+	const comments = yield* listClaimComments(repo, epic);
+	const winner = yield* resolveAuthorizedWinner(repo, comments);
+	if (winner !== null && winner.session === sessionId.toLowerCase()) {
+		return {_tag: "acquired"} satisfies AcquireResult;
+	}
+	// Lost (or no authorized winner resolved): retract only OUR claim; never the shared label.
+	yield* runGh(deleteCommentArgs(repo, claimId)).pipe(Effect.ignore);
+	return {_tag: "lost", winner: winner?.session ?? "(none)"} satisfies AcquireResult;
+});
+
+/**
+ * Release a lock we won: retract *our own* claim comment(s) (re-found by session id,
+ * since the acquire's comment id lived in a prior process), then DELETE the coarse
+ * label. The label DELETE is 404-benign (already released / never landed) but LOUD on
+ * any other failure — a silently-swallowed DELETE leaks the lock and wedges the epic,
+ * the exact catastrophe ADR 0059 prevents — so a non-404 fault propagates as
+ * `GhCommandError`. Comment retraction is likewise loud on a non-404 fault.
+ */
+const release = Effect.fn("Github.release")(function* (
+	repo: string,
+	epic: number,
+	sessionId: string,
+) {
+	const comments = yield* listClaimComments(repo, epic);
+	const mine = ownClaimCommentIds(comments, sessionId);
+	yield* Effect.forEach(
+		mine,
+		(id) =>
+			runGh(deleteCommentArgs(repo, id)).pipe(
+				Effect.catchTag("@kampus/epic-lock/GhCommandError", (error) =>
+					is404(error.stderr) ? Effect.void : Effect.fail(error),
+				),
+			),
+		{concurrency: "unbounded", discard: true},
+	);
+	const labelRemoved = yield* runGh(removeLabelArgs(repo, epic)).pipe(
+		Effect.as(true),
+		Effect.catchTag("@kampus/epic-lock/GhCommandError", (error) =>
+			is404(error.stderr) ? Effect.succeed(false) : Effect.fail(error),
+		),
+	);
+	return {_tag: "released", retracted: mine.length, labelRemoved} satisfies ReleaseResult;
+});
+
+/**
+ * `Github` — the IO shell over `gh api` REST. `acquire` and `release` are the two
+ * verbs the epic-lock exposes; both take the epic number and the acquiring session
+ * id. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`: provide the platform
+ * spawner (`NodeServices.layer` in production); a test provides a mock spawner via
+ * `ChildProcessSpawner.make`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly acquire: (
+			epic: number,
+			sessionId: string,
+		) => Effect.Effect<
+			AcquireResult,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+		readonly release: (
+			epic: number,
+			sessionId: string,
+		) => Effect.Effect<
+			ReleaseResult,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/epic-lock/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at
+ * construction and provided *into* each method body, so the public methods carry
+ * `R = never`. Repo resolution is deferred to first use (`Effect.cached`, ADR 0062
+ * §1, #422): the layer build is side-effect-free, and `RepoResolutionError` lives in
+ * each method's `E` channel, raised only when a verb actually reads or mutates.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				acquire: (epic: number, sessionId: string) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(acquire(r, epic, sessionId)))),
+				release: (epic: number, sessionId: string) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(release(r, epic, sessionId)))),
+			};
+		}),
+	);


### PR DESCRIPTION
Extract the ADR-0059 `status:planning` epic-lock claim protocol — hand-rolled inline (~50 lines of `jq` apiece) in `plan-epic` and `review-plan` — into a deterministic, unit-tested `pipeline-cli` tool at `packages/pipeline-cli/src/tools/epic-lock/`, shaped like `epic-ledger` (pure IO-free core + `.unit.test.ts` + thin `command.ts` + a `github.ts` Effect REST service). This is the **template child** that establishes the `github.ts` service pattern the epic #994 Phase-2 families copy.

## What changed
- **`claim-resolution.ts`** — the pure ADR-0115 §2 decision: earliest authorized claim wins (min `(created_at, comment id)`); a forged claim from a non-collaborator is dropped before the tiebreak; an empty authorized set and a missing `CLAUDE_CODE_SESSION_ID` both fail closed. IO-free, table-driven unit-tested.
- **`github.ts`** — the REST-only `gh api` boundary exposing `acquire`/`release`. `acquire` fails closed (non-mutating back-off) on: held label, 422 missing label, failed claim post, lost co-acquire. `release` is 404-benign and **loud** on any other DELETE failure (a swallowed DELETE leaks the lock and wedges the epic).
- **`command.ts`** — `pipeline-cli epic-lock acquire|release <epic>`; `acquire` exits 0 **only** when the lock is ours, non-zero on every back-off, so a caller branches on exit status. Registered via a single append to `registry.ts`; `router.ts`/`bin.ts` unchanged.
- **Rewired `plan-epic` and `review-plan`** to call `pipeline-cli epic-lock` in place of their inline claim glue, preserving the in-repo/published-CLI fallback (ADR 0062/0064); ~70 lines of raw `jq` glue per skill collapse to a resolve + `acquire`/`release` call.

## Acceptance criteria
- [x] `epic-lock/` has a pure claim-resolution core, its `.unit.test.ts`, a `command.ts` exposing `acquire`/`release`, and a `github.ts` REST service.
- [x] The core is unit-tested table-driven: single acquirer wins; co-acquire tie broken by earliest authorized claim; forged non-collaborator claim ignored; missing session id fails closed.
- [x] `acquire` fails closed on held label / 422 missing label / failed claim post / lost co-acquire; `release` is 404-benign and loud otherwise (covered in `github-service.unit.test.ts`).
- [x] Registered via a single append to `registry.ts`; `router.ts`/`bin.ts` unchanged.
- [x] `plan-epic` **and** `review-plan` rewired to call the CLI with the in-repo/published fallback preserved; raw-glue line count drops measurably.
- [x] `pnpm typecheck` (full workspace) + the pipeline-cli unit tests pass (929 pass, incl. the 28 new epic-lock tests).

Note: `write-code`'s inline claim is the §7 **issue**-claim (a different primitive), not the `status:planning` epic-lock, so it carries no epic-lock call-site to rewire.

§CP: edits `packages/pipeline-cli/` (CODEOWNERS) — human-merge by cansirin (ADR 0135).

Fixes #2098

🤖 Generated with [Claude Code](https://claude.com/claude-code)