### PR TITLE
test(integration): rename yazar tier-noun fixture authors to anka (#2120)

### DIFF
--- a/apps/web/tests/integration/fts-backfill.test.ts
+++ b/apps/web/tests/integration/fts-backfill.test.ts
@@ -50,13 +50,13 @@ const TITLE = "Şişli Büyük Buluşma";
 const FOLDED_QUERY = "sisli";
 
 beforeAll(async () => {
-	await h.signUp(`${SLUG}-author@test.local`, "hunter2hunter2", "yazar");
+	await h.signUp(`${SLUG}-author@test.local`, "hunter2hunter2", "anka");
 	// Seed through the public dual-write: a real term_record row + its term_search
 	// FTS row land together.
 	await h.seedTerm({
 		slug: SLUG,
 		title: TITLE,
-		definitions: [{authorName: "yazar", body: "Şişli gövde"}],
+		definitions: [{authorName: "anka", body: "Şişli gövde"}],
 	});
 	// Drop ONLY this term's FTS row, off the worker binding — reconstructing the
 	// pre-backfill state (#534): the summary row exists, the FTS index does not.

--- a/apps/web/tests/integration/report-moderation.test.ts
+++ b/apps/web/tests/integration/report-moderation.test.ts
@@ -98,7 +98,7 @@ beforeAll(async () => {
 	moderator = await h.signUp(`${NS}-mod@test.local`, "hunter2hunter2", "mod");
 	reporterA = await h.signUp(`${NS}-ra@test.local`, "hunter2hunter2", "ra");
 	reporterB = await h.signUp(`${NS}-rb@test.local`, "hunter2hunter2", "rb");
-	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "yazar");
+	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "anka");
 
 	// The grant path: mint the moderator's `moderates` tuple directly in D1 (the
 	// offline mint, no runtime endpoint), keyed by canonical `key(platform)`.

--- a/apps/web/tests/integration/report.test.ts
+++ b/apps/web/tests/integration/report.test.ts
@@ -53,7 +53,7 @@ async function submitReport(
 
 beforeAll(async () => {
 	reporter = await h.signUp(`${NS}-reporter@test.local`, "hunter2hunter2", "muhbir");
-	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "yazar");
+	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "anka");
 
 	const post = await h.fate(
 		{
@@ -84,7 +84,7 @@ beforeAll(async () => {
 	const seeded = await h.seedTerm({
 		slug: `${NS}-term`,
 		title: `${NS} term`,
-		definitions: [{authorName: "yazar", body: "report target definition body"}],
+		definitions: [{authorName: "anka", body: "report target definition body"}],
 	});
 	definitionId = seeded.definitions[0]!.id;
 });

--- a/apps/web/tests/integration/search-error-vs-empty.test.ts
+++ b/apps/web/tests/integration/search-error-vs-empty.test.ts
@@ -32,11 +32,11 @@ beforeAll(async () => {
 	// A real seeded term gives the control query a populated, well-formed index to read
 	// a legitimate zero-match against — so the empty-vs-error contrast below is genuine,
 	// not an artifact of an empty database.
-	await h.signUp(`search549-${STAMP}-author@test.local`, "hunter2hunter2", "yazar");
+	await h.signUp(`search549-${STAMP}-author@test.local`, "hunter2hunter2", "anka");
 	await h.seedTerm({
 		slug: `search549-${STAMP}-istanbul`,
 		title: "İstanbul",
-		definitions: [{authorName: "yazar", body: "İstanbul gövde"}],
+		definitions: [{authorName: "anka", body: "İstanbul gövde"}],
 	});
 });
 

--- a/apps/web/tests/integration/search.test.ts
+++ b/apps/web/tests/integration/search.test.ts
@@ -90,7 +90,7 @@ async function searchPosts(
 let author: {userId: string; cookie: string};
 
 beforeAll(async () => {
-	author = await h.signUp(`${NS}-${STAMP}-author@test.local`, "hunter2hunter2", "yazar");
+	author = await h.signUp(`${NS}-${STAMP}-author@test.local`, "hunter2hunter2", "anka");
 });
 
 /** Submit a post under the author cookie; assert success; return its id. */
@@ -121,17 +121,17 @@ describe("searchTerms — real FTS5 over the deployed worker", () => {
 		await h.seedTerm({
 			slug: istanbulSlug,
 			title: `${NS} İstanbul`,
-			definitions: [{authorName: "yazar", body: "İstanbul gövde"}],
+			definitions: [{authorName: "anka", body: "İstanbul gövde"}],
 		});
 		await h.seedTerm({
 			slug: sisliSlug,
 			title: `${NS} Şişli`,
-			definitions: [{authorName: "yazar", body: "Şişli gövde"}],
+			definitions: [{authorName: "anka", body: "Şişli gövde"}],
 		});
 		await h.seedTerm({
 			slug: ankaraSlug,
 			title: `${NS} Ankara`,
-			definitions: [{authorName: "yazar", body: "Ankara gövde"}],
+			definitions: [{authorName: "anka", body: "Ankara gövde"}],
 		});
 	});
 
@@ -182,17 +182,17 @@ describe("searchTerms — bm25-ranked keyset pagination over real FTS5", () => {
 		await h.seedTerm({
 			slug: projectSlugs[0]!,
 			title: `${NS} ortak proje a`,
-			definitions: [{authorName: "yazar", body: "ortak proje a gövde"}],
+			definitions: [{authorName: "anka", body: "ortak proje a gövde"}],
 		});
 		await h.seedTerm({
 			slug: projectSlugs[1]!,
 			title: `${NS} ortak proje b`,
-			definitions: [{authorName: "yazar", body: "ortak proje b gövde"}],
+			definitions: [{authorName: "anka", body: "ortak proje b gövde"}],
 		});
 		await h.seedTerm({
 			slug: projectSlugs[2]!,
 			title: `${NS} ortak proje c`,
-			definitions: [{authorName: "yazar", body: "ortak proje c gövde"}],
+			definitions: [{authorName: "anka", body: "ortak proje c gövde"}],
 		});
 	});
 
@@ -265,7 +265,7 @@ describe("searchTerms — title-only scope (guards against scope creep)", () => 
 		await h.seedTerm({
 			slug: `${NS}-${STAMP}-kavram`,
 			title: `${NS} Kavram`,
-			definitions: [{authorName: "yazar", body: "Kavram gövde"}],
+			definitions: [{authorName: "anka", body: "Kavram gövde"}],
 		});
 		const c = await searchTerms({query: `${NS} govde`});
 		expect(c.items).toEqual([]);

--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -66,7 +66,7 @@ let voter: {userId: string; cookie: string};
 const DEF_SELECT = ["id", "body", "score", "author", "authorId", "myVote"];
 
 beforeAll(async () => {
-	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "yazar");
+	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "anka");
 	intruder = await h.signUp(`${NS}-intruder@test.local`, "hunter2hunter2", "davetsiz");
 	voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", "oycu");
 	// `voter` casts every real definition vote below — self-voting is blocked since #2216, so
@@ -94,7 +94,7 @@ describe("sozluk mutations — definition.add", () => {
 		expect(def.__typename).toBe("Definition");
 		expect(def.id).toBeTruthy();
 		expect(def.body).toBe("an added definition");
-		expect(def.author).toBe("yazar");
+		expect(def.author).toBe("anka");
 		expect(def.authorId).toBe(author.userId);
 		expect(def.score).toBe(0);
 		expect(def.myVote).toBeNull();


### PR DESCRIPTION
Six integration-test fixtures signed up their author identity as the literal `yazar` — the authorship-**tier** noun (`visitor < çaylak < yazar`, ADR 0107), not a person handle. Naming a fixture user after a ladder rung is what made the original shared-stage flake read as `expected 'yazar' to be 'umut'` (context in #2116 / PR #2119).

This renames the fixture author base off the tier-noun to `anka` (a neutral, non-tier handle that matches the sibling role-handle convention already in these files — `muhbir`, `davetsiz`, `oycu`, `mod`), keeping each signUp name consistent with its `seedTerm` `authorName` and, in `sozluk-mutations`, its `expect(def.author).toBe(...)` assertion.

Scope is integration-test fixtures only (`apps/web/tests/integration/`):
- `report.test.ts`, `report-moderation.test.ts`, `search.test.ts`, `search-error-vs-empty.test.ts`, `fts-backfill.test.ts`, `sozluk-mutations.test.ts`

Untouched by design: legitimate tier references (`promoteToYazar`, the `// … promoted yazar` comment in `sozluk-mutations`), product source, unit tests, and the pano fixtures (a pano PR is mid-flight). `anka` is checked against `.glossary/TERMS.md` / `LANGUAGE.md` — it is not a tier-noun or any reserved vocabulary term. `pnpm typecheck` (27/27) and `pnpm lint:worktree` pass.

Fixes #2120