### PR TITLE
feat(web): migrate the Unicode functional glyphs to the ruled Lucide icon idiom (#2257)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
 		"better-call": "catalog:",
 		"drizzle-orm": "catalog:",
 		"effect": "catalog:",
+		"lucide-react": "catalog:",
 		"react": "catalog:",
 		"react-dom": "catalog:",
 		"react-fate": "catalog:",

--- a/apps/web/src/components/Icon.tsx
+++ b/apps/web/src/components/Icon.tsx
@@ -1,0 +1,28 @@
+import type {LucideIcon} from "lucide-react";
+import "./icon.css";
+
+// See ADR 0166 — the one canonical icon idiom. This wrapper pins every functional
+// icon to the ruled delivery so call-sites can't drift: drawn Lucide glyphs on the
+// 16/20/24 size scale, Lucide's native per-size optical stroke (never a pinned
+// absoluteStrokeWidth), and monochrome stroke:currentColor driven by role tokens
+// only (icon.css). Pass `label` for a meaningful icon; omit it for a decorative one.
+export type IconSize = 16 | 20 | 24;
+
+export interface IconProps {
+	icon: LucideIcon;
+	size?: IconSize;
+	className?: string;
+	label?: string;
+}
+
+export function Icon({icon: Glyph, size = 20, className, label}: IconProps) {
+	return (
+		<Glyph
+			className={className ? `kp-icon ${className}` : "kp-icon"}
+			size={size}
+			aria-hidden={label ? undefined : true}
+			aria-label={label}
+			role={label ? "img" : undefined}
+		/>
+	);
+}

--- a/apps/web/src/components/VoteTriangle.tsx
+++ b/apps/web/src/components/VoteTriangle.tsx
@@ -1,0 +1,12 @@
+import {Triangle} from "lucide-react";
+import "./vote-cue.css";
+
+// See ADR 0166 §6 — the vote affordance is a DRAWN triangle (the HN / lobste.rs
+// lineage), not a Unicode △. Shape carries the redundant non-color cue (WCAG 1.4.1):
+// outline when not voted, filled when the ancestor button is aria-pressed — the toggle
+// lives in vote-cue.css so every vote site shares one cue. Stroke is currentColor, so
+// the glyph takes each button's own role-token color (accent on cast). `dir` supplies
+// the up/down symmetry §6 requires.
+export function VoteTriangle({dir = "up"}: {dir?: "up" | "down"}) {
+	return <Triangle className={`triangle triangle--${dir}`} size={16} aria-hidden="true" />;
+}

--- a/apps/web/src/components/divan/CaylakDetail.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.tsx
@@ -30,6 +30,7 @@ import {Screen} from "../../fate/Screen";
 import {codeOf} from "../../fate/wire";
 import {Button} from "../ui/Button";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
+import {VoteTriangle} from "../VoteTriangle";
 import {CaylakIdentityById, IdentityFallback} from "./CaylakIdentity";
 import {
 	itemKindLabel,
@@ -262,7 +263,7 @@ function BacklogItemRow({node}: {readonly node: ViewRef<"DivanBacklogItem">}) {
 					aria-label={mine ? "oyu geri çek" : "oy ver"}
 					data-testid={`divan-upvote-${data.id}`}
 				>
-					<span aria-hidden="true">▲</span>
+					<VoteTriangle />
 				</button>
 				{score !== null ? (
 					<span className="kp-divan__score" data-testid={`divan-score-${data.id}`}>

--- a/apps/web/src/components/icon.css
+++ b/apps/web/src/components/icon.css
@@ -1,0 +1,9 @@
+/* See ADR 0166 §5 — functional icons are monochrome, painted via stroke:currentColor
+   and driven by role tokens only (never a hardcoded color). The default role is
+   --text-secondary; a call-site raises it to --text-primary (hover), --accent
+   (active), or --text-muted (disabled) by setting `color` on the icon or its control. */
+.kp-icon {
+	flex: none;
+	vertical-align: middle;
+	color: var(--text-secondary);
+}

--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -17,8 +17,8 @@ import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
 import {useVoteFlash} from "../useVoteFlash";
+import {VoteTriangle} from "../VoteTriangle";
 import {currentLocationReturnTo, useVoteToggle} from "./useVoteToggle";
-import "../vote-cue.css";
 import "./PanoComment.css";
 
 export const CommentTreeNodeView = view<Comment>()({
@@ -134,7 +134,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 						onClick={onUpvote}
 						data-testid={`comment-vote-${localId}`}
 					>
-						<span className="triangle" />{" "}
+						<VoteTriangle />{" "}
 						<span
 							className={flashing ? "kp-vote-flash" : undefined}
 							onAnimationEnd={endFlash}

--- a/apps/web/src/components/pano/PanoComment.css
+++ b/apps/web/src/components/pano/PanoComment.css
@@ -68,9 +68,6 @@
 	outline-offset: 1px;
 	border-radius: var(--r-sm);
 }
-.kp-comment__upvote .triangle {
-	font-size: 10px;
-}
 
 .kp-comment__collapser {
 	margin-left: auto;

--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -64,10 +64,6 @@
 	outline-offset: 1px;
 }
 
-.kp-pano-post__vote-btn .triangle {
-	font-size: 13px;
-}
-
 .kp-pano-post__vote-count {
 	font: var(--t-micro);
 	color: var(--text-muted);

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -1,8 +1,8 @@
 import {useFateClient} from "react-fate";
 import {useVoteFlash} from "../useVoteFlash";
+import {VoteTriangle} from "../VoteTriangle";
 import {PostSaveView, PostVoteView} from "./PanoPostHeader";
 import {currentLocationReturnTo, useGatedToggle, useVoteToggle} from "./useVoteToggle";
-import "../vote-cue.css";
 import "./PanoPost.css";
 
 /**
@@ -36,7 +36,7 @@ export function VoteControl({
 					data-testid={testIdSuffix ? `post-vote-${testIdSuffix}` : undefined}
 					onClick={() => onToggle?.()}
 				>
-					<span className="triangle" />
+					<VoteTriangle />
 				</button>
 			)}
 			<span

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -22,14 +22,14 @@ import {useVoteToggle} from "../pano/useVoteToggle";
 import {DefinitionReactionBar} from "../reaction/DefinitionReactionBar";
 import {ReactionBarSlot} from "../reaction/ReactionBarSlot";
 import {Button} from "../ui/Button";
-import {useVoteFlash} from "../useVoteFlash";
-import "../vote-cue.css";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {Dialog} from "../ui/Dialog";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {MetaRow} from "../ui/MetaRow";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
 import {ReviewBadge} from "../ui/ReviewBadge";
+import {useVoteFlash} from "../useVoteFlash";
+import {VoteTriangle} from "../VoteTriangle";
 
 export const DefinitionView = view<Definition>()({
 	id: true,
@@ -244,7 +244,7 @@ export function DefinitionCard(props: DefinitionCardProps) {
 						data-testid={`definition-vote-${definition.id}`}
 						onClick={onVoteClick}
 					>
-						<span className="triangle" />
+						<VoteTriangle />
 					</button>
 				)}
 				<span

--- a/apps/web/src/components/vote-cue.css
+++ b/apps/web/src/components/vote-cue.css
@@ -1,20 +1,21 @@
-/* Shared vote-state cue — the cross-site half of issue #1213.
-   The vote-state channel must not be color alone (WCAG 1.4.1): the triangle's
-   FILL is the redundant non-color signal — hollow (△) when not voted, filled
-   (▲) when `aria-pressed` is true. Landed once here so all three vote sites
-   (pano post, pano comment, sözlük definition) inherit the same cue; each site's
-   own CSS only sizes the glyph and owns its button's press/focus. */
+/* Shared vote-state cue — the cross-site half of issue #1213, migrated to the drawn
+   Lucide triangle (ADR 0166 §6). The vote-state channel must not be color alone
+   (WCAG 1.4.1): the triangle's FILL is the redundant non-color signal — outline when
+   not voted, filled when the ancestor button is aria-pressed. Stroke is currentColor,
+   so each site's button drives the glyph color; this file owns only the fill toggle,
+   alignment, and up/down symmetry. All three vote sites (pano post, pano comment,
+   sözlük definition) plus the divan çaylak list inherit the same cue. */
 
 .triangle {
 	display: inline-block;
-	line-height: 1;
 	vertical-align: middle;
+	fill: none;
 }
-.triangle::before {
-	content: "\25B3"; /* △ hollow — not voted */
+[aria-pressed="true"] .triangle {
+	fill: currentColor;
 }
-[aria-pressed="true"] .triangle::before {
-	content: "\25B2"; /* ▲ filled — voted; the non-color (1.4.1) cue, color merely reinforces */
+.triangle--down {
+	transform: rotate(180deg);
 }
 
 /* Count flash on cast — re-armed per cast by the `useVoteFlash` hook toggling

--- a/apps/web/src/pages/LandingPage.css
+++ b/apps/web/src/pages/LandingPage.css
@@ -152,6 +152,14 @@
 	color: var(--accent);
 }
 
+/* The inline directional arrow (ADR 0166 — the retired `→` glyph, now Lucide
+   ArrowRight) follows its link's own role-token color + hover instead of the icon
+   default, so it reads as part of the link rather than a detached secondary mark. */
+.kp-icon.kp-inline-arrow {
+	color: inherit;
+	margin-inline-start: 0.15em;
+}
+
 .kp-landing__col ul {
 	list-style: none;
 	padding: 0;

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -5,11 +5,13 @@
  * `Screen` (ADR 0021). Server types are the source of truth (ADR 0022) — the rows
  * read the `Post`/`Term` views directly, no hand-written shadow shapes.
  */
+import {ArrowRight} from "lucide-react";
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {LandingStats, Post, Term} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
 import {useMe} from "../auth/useMe";
+import {Icon} from "../components/Icon";
 import {Screen} from "../fate/Screen";
 import {toIso} from "../fate/wire";
 import {formatAgoTR} from "../lib/datetime";
@@ -102,17 +104,23 @@ export function LandingPage() {
 				<div className="kp-landing__cta">
 					{joinVisible ? (
 						<Link className="kp-landing__join" to="/auth" data-testid="landing-join-cta">
-							<span className="label">hesap aç →</span>
+							<span className="label">
+								hesap aç <Icon icon={ArrowRight} size={16} className="kp-inline-arrow" />
+							</span>
 							<span className="sub">kapı açık · söz hakkı kazanılır</span>
 						</Link>
 					) : null}
 					<div className="kp-landing__browse">
 						<Link to="/pano">
-							<span className="label">pano →</span>
+							<span className="label">
+								pano <Icon icon={ArrowRight} size={16} className="kp-inline-arrow" />
+							</span>
 							<span className="sub">başlıklar · tartışmalar</span>
 						</Link>
 						<Link to="/sozluk">
-							<span className="label">sözlük →</span>
+							<span className="label">
+								sözlük <Icon icon={ArrowRight} size={16} className="kp-inline-arrow" />
+							</span>
 							<span className="sub">terimler · tanımlar</span>
 						</Link>
 					</div>
@@ -138,7 +146,9 @@ function LandingBody() {
 				<section className="kp-landing__col">
 					<header className="kp-landing__col-head">
 						<h3>panoda son 24 saat</h3>
-						<Link to="/pano">hepsini gör →</Link>
+						<Link to="/pano">
+							hepsini gör <Icon icon={ArrowRight} size={16} className="kp-inline-arrow" />
+						</Link>
 					</header>
 					<ul>
 						{postItems.length === 0 ? (
@@ -159,7 +169,9 @@ function LandingBody() {
 				<section className="kp-landing__col">
 					<header className="kp-landing__col-head">
 						<h3>sözlüğe son eklenenler</h3>
-						<Link to="/sozluk">hepsini gör →</Link>
+						<Link to="/sozluk">
+							hepsini gör <Icon icon={ArrowRight} size={16} className="kp-inline-arrow" />
+						</Link>
 					</header>
 					<ul>
 						{termItems.length === 0 ? (
@@ -248,7 +260,9 @@ function LandingColsSkeleton({status}: {status: "loading" | "error"}) {
 			<section className="kp-landing__col">
 				<header className="kp-landing__col-head">
 					<h3>panoda son 24 saat</h3>
-					<Link to="/pano">hepsini gör →</Link>
+					<Link to="/pano">
+						hepsini gör <Icon icon={ArrowRight} size={16} className="kp-inline-arrow" />
+					</Link>
 				</header>
 				<ul>
 					<li className="kp-landing-row">
@@ -262,7 +276,9 @@ function LandingColsSkeleton({status}: {status: "loading" | "error"}) {
 			<section className="kp-landing__col">
 				<header className="kp-landing__col-head">
 					<h3>sözlüğe son eklenenler</h3>
-					<Link to="/sozluk">hepsini gör →</Link>
+					<Link to="/sozluk">
+						hepsini gör <Icon icon={ArrowRight} size={16} className="kp-inline-arrow" />
+					</Link>
 				</header>
 				<ul>
 					<li className="kp-landing-row">

--- a/apps/web/src/pages/SozlukTermPage.css
+++ b/apps/web/src/pages/SozlukTermPage.css
@@ -88,9 +88,6 @@
 .kp-sozluk-definition__vote-btn:active {
 	transform: scale(0.92);
 }
-.kp-sozluk-definition__vote-btn .triangle {
-	font-size: 13px;
-}
 .kp-sozluk-definition__vote-btn:hover {
 	color: var(--accent);
 	border-color: var(--accent);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ catalogs:
     lefthook:
       specifier: ^2.1.9
       version: 2.1.9
+    lucide-react:
+      specifier: 1.23.0
+      version: 1.23.0
     react:
       specifier: 19.2.6
       version: 19.2.6
@@ -256,6 +259,9 @@ importers:
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92
+      lucide-react:
+        specifier: 'catalog:'
+        version: 1.23.0(react@19.2.6)
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -1458,28 +1464,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.15':
     resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.15':
     resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.15':
     resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.15':
     resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
@@ -2373,84 +2375,72 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.1':
     resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
@@ -3588,28 +3578,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3642,6 +3628,11 @@ packages:
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  lucide-react@1.23.0:
+    resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -6425,6 +6416,10 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru.min@1.1.4: {}
+
+  lucide-react@1.23.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   lz-string@1.5.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,7 @@ catalog:
   fast-xml-parser: 5.8.0
   jsdom: ^26.1.0
   lefthook: ^2.1.9
+  lucide-react: 1.23.0
   react: 19.2.6
   react-dom: 19.2.6
   react-fate: 1.3.1


### PR DESCRIPTION
Executes ADR [0166](.decisions/0166-canonical-icon-idiom.md) across `apps/web/src`: retires the Unicode functional glyphs used as icons and delivers their semantics as drawn Lucide glyphs on the one ruled idiom. This is the deferred code-migration half of the ADR (the ADR itself changed no component code). Scoped to `apps/web/src` UI only.

## The five glyph → Lucide mappings

| Glyph | Semantics | Delivery on the ruled idiom |
|---|---|---|
| `△` / `▲` | vote | **Drawn Lucide `Triangle`** (new `VoteTriangle`, ADR 0166 §6) at all four vote sites — pano post, pano comment, sözlük definition, divan çaylak. |
| `→` | forward / next | **Lucide `ArrowRight`** via the new `Icon` wrapper — the LandingPage CTA + browse + "hepsini gör" links. |
| `⌘` | command keycap | **No change** — already renders inside a `<kbd>` chip (Topbar, composer footers). Per §7 keycaps are legal *only* inside `<kbd>`, so these were already compliant. |
| `↵` | enter keycap | **No change** — already inside `<kbd>` chips (composer footers). §7-compliant as-is. |
| `↑` | up | **No live render site.** The character appears only in comments/tests, never rendered as an icon — nothing to migrate. |

## How it follows the ruled idiom (ADR 0166 / `design-system-manifest.md`)

- **Set = Lucide, drawn glyphs** (`lucide-react`, added via `catalog:` — one shared version per CLAUDE.md), never hand-inlined SVG.
- **Native per-size optical stroke** — no `absoluteStrokeWidth` pinned; the wrapper passes only `size`.
- **Size scale 16/20/24** — the `Icon` wrapper's `IconSize` union pins it; the vote glyph uses the floor **16** (§4 "dense rows · vote"), replacing the old sub-16 Unicode sizing (10/13px `font-size`, now removed).
- **Monochrome, `stroke: currentColor`, role tokens only** (§5) — `icon.css` defaults `.kp-icon` to `--text-secondary`; no icon hardcodes a color.
- **Vote glyph (§6, the one component that is real design, not a substitution)** — a drawn triangle (HN/lobste.rs lineage, not a chevron). Stroke is `currentColor` so each vote button's existing role-token color drives the glyph (this deliberately preserves the sözlük "accent-fill button → `--accent-fg` glyph" active treatment, which a forced `--accent` fill would render invisible on the accent background). **Fill toggles** `none` → `currentColor` on the ancestor button's `aria-pressed` — the WCAG-1.4.1 redundant non-color cue (outline when not voted, filled when voted). `VoteTriangle` takes a `dir` prop and `vote-cue.css` supplies the `rotate(180deg)` down variant for the §6 up/down symmetry (no downvote site exists today).

## Notes / deferrals

- **Hit-area ≥36px** (§4 / §6) is explicitly deferred to #2166 (the manifest's Pillar-4 tap-target fixes), not done here — this PR is the glyph-idiom swap, not the tap-target campaign.
- Two of the five glyph families (`⌘`, `↵`) were already delivered correctly as `<kbd>` keycaps; `↑` has no render site. So the live migration is the vote triangle and the forward arrow.

## Verification

- `pnpm typecheck` — clean (27/27).
- `pnpm lint:worktree` — clean.
- `pnpm test:client` — 119 passed (incl. the vote-button a11y-name tests); `pnpm test:a11y` — 14 passed.

Fixes #2257