### PR TITLE
fix(pipeline): forbid bare checkout at the review/ship head-inspection surface (#2270)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -77,24 +77,37 @@ read the matching SKILL from the resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) 
 
 These hold on every run regardless of what the spawn prompt remembered to say:
 
-- **Verify the PR HEAD, never the CWD (`review_head`).** You verdict the PR's actual
-  head commit, not whatever happens to be checked out. Resolve and pin the head SHA up
-  front, then bring that head into **your own worktree by ref** — never a bare
-  `git checkout <sha>`, which after a between-calls cwd reset lands in the shared primary
-  and detaches its `main` (#1103). Capture `WT="$(git rev-parse --show-toplevel)"` once and
-  fetch/check out the PR head explicitly against it:
+- **Verify the PR HEAD, never the CWD — via a per-run ref, never a checkout (`review_head`).**
+  You verdict the PR's actual head commit, not whatever happens to be checked out. Resolve and
+  pin the head SHA up front, then **materialize that head into a per-run ref and an isolated
+  throwaway worktree** — the §RO/§HEAD read-only mechanism the routed skill already runs — and
+  source every file under review from *there*:
   ```bash
-  git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD
+  HEAD_SHA="$(gh pr view <N> --repo "$REPO" --json headRefOid -q .headRefOid)"
+  PR_REF="refs/pr/<N>-$(uuidgen)"
+  git fetch origin "pull/<N>/head:$PR_REF"                  # fetch into your OWN ref — moves no working-tree HEAD
+  [ "$(git rev-parse "$PR_REF")" = "$HEAD_SHA" ] || exit 1  # assert the fetched ref IS the pinned head
+  git worktree add "$(mktemp -d)/review-head-<N>" "$PR_REF" # an isolated throwaway tree the gate owns
+  git show "$PR_REF:<path>"                                 # or read from the throwaway worktree — NEVER a checkout
   ```
-  Confirm `git -C "$WT" rev-parse HEAD` equals the pinned SHA, then bind your verdict to it
-  — a verdict against the wrong tree is a false PASS/FAIL.
-- **Worktree preflight before any git checkout (`wt_preflight`).** You run in an isolated
-  worktree (`isolation:worktree`). The harness resets your shell cwd back to the shared
-  **primary** checkout between Bash calls — so **confirm pwd + branch before every git
-  read/checkout**, and address git at your worktree explicitly (`git -C "$WT" …`,
-  capturing `WT` once after the opening preflight) — **never a bare `git checkout` /
-  `switch` / `fetch` into the primary**, which detaches the shared primary HEAD (the
-  #1103 detach class). You hold no Edit/Write tool: the only thing that mutates is the
+  **Never `git checkout` / `git switch` a head into a working tree — not even a `git -C "$WT"`-scoped
+  one.** The harness resets your shell cwd back to the shared **primary** checkout between Bash calls,
+  so a bare checkout lands *there* and detaches the human's `main` (the #1103/#2270 detach class); and
+  even a checkout in your *own* launched worktree is forbidden by §RO (a gate never mutates working-tree
+  HEAD). `git fetch` into a per-run ref, `git show "$PR_REF:<path>"`, and `git worktree add` move no
+  working tree — they are the only sanctioned way to reach the head. Bind your verdict to `$HEAD_SHA` —
+  a verdict against the wrong tree is a false PASS/FAIL.
+- **Read-only on git working state — never a checkout to inspect a head (`wt_preflight`).** You run in
+  an isolated worktree (`isolation:worktree`), but the harness resets your shell cwd back to the shared
+  **primary** checkout between Bash calls — so a bare `git checkout` / `switch` / `reset` / `stash`
+  issued after a reset runs against the human's **primary** tree and detaches or mutates its `main`
+  (the #1103/#2270 detach class). The gate therefore **never** switches a working tree to inspect a
+  PR: it reaches the head **read-only** via a per-run ref (`git show "$PR_REF:<path>"`) or an isolated
+  throwaway worktree (`git worktree add … "$PR_REF"`), per `review_head` above. `git fetch` into your
+  own per-run ref and `git update-ref -d` are fine — they move no working tree; a `git checkout` /
+  `switch` is not, bare **or** `git -C`-scoped. The full single source is
+  [`../skills/gh-issue-intake-formats.md`](../skills/gh-issue-intake-formats.md) §RO/§HEAD; cite it,
+  don't re-derive the prohibition. You hold no Edit/Write tool: the only thing that mutates is the
   verdict comment, posted via `gh api`.
 - **Post the SHA-bound verdict comment to the PR — the marker contract.** Your verdict's
   **first line is always** `review-<class>: PASS|FAIL @ <sha>` (e.g.

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -83,7 +83,7 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   You run in an isolated worktree (`isolation:worktree`). The harness resets your shell cwd back
   to the shared **primary** checkout between Bash calls — so a bare `git checkout` / `switch` /
   `rebase` / `reset` / `merge` / `stash` issued after a reset runs against the shared primary tree
-  and detaches or resets the owner's `main` (the #1103/#1494 detach class this exact ship side
+  and detaches or resets the owner's `main` (the #1103/#1494/#2270 detach class this exact ship side
   hit). But ship-it does its whole job **read-only over `gh api` and server-side** — verdict +
   checks reads via `gh api`, the enqueue via `gh pr merge <n> --auto` (no method flag — the queue
   owns the SQUASH method; no `--delete-branch` — the queue owns the final merge, ADR 0132) — so you

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -265,7 +265,9 @@ git fetch origin "$BASE_REF"
 # Fetch the PR head into a dedicated ref WITHOUT touching the session tree. pull/$PR/head
 # resolves for same-repo AND cross-fork PRs, so there is no separate cross-fork branch to
 # check out into your own tree (the trust inversion ADR 0052 closes — never run
-# `gh pr checkout`, which would materialize the head's config into the session checkout).
+# `gh pr checkout` / `git checkout` / `git switch`, which materialize the head into a working
+# tree: the harness resets this cwd to the shared PRIMARY between Bash calls, so a bare checkout
+# lands there and detaches the human's `main` (#2270/#1103 detach class) — §RO forbids it outright).
 # Per-run ref: the PR number alone is shared, so a second review of the same PR would
 # overwrite the ref mid-review and you'd verify the wrong SHA — uniquify it per invocation.
 PR_REF="refs/pr/$PR-$(uuidgen)"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -324,7 +324,9 @@ the hunk alone — and read it **read-only**, without ever switching the checkou
 
 ```bash
 # Land the head in a per-run ref WITHOUT touching the working tree (resolves for same-repo
-# AND cross-fork PRs — never `gh pr checkout` / `git checkout`, which switch your tree):
+# AND cross-fork PRs — never `gh pr checkout` / `git checkout` / `git switch`: the harness
+# resets this cwd to the shared PRIMARY between Bash calls, so a checkout lands there and
+# detaches the human's `main` (#2270/#1103), and §RO forbids switching your tree outright):
 PR_REF="refs/pr/$PR-$(uuidgen)"
 git fetch origin "pull/$PR/head:$PR_REF"
 
@@ -352,7 +354,9 @@ git worktree add "$REVIEW_WT" "$PR_REF"
 rm -rf "$REVIEW_WT" && git worktree prune   # tear it down after
 ```
 
-Never `git checkout` / `gh pr checkout` in the checkout you were launched in.
+Never `git checkout` / `git switch` / `gh pr checkout` in the checkout you were launched in —
+not even `git -C`-scoped to your own worktree (the harness cwd-reset would still land a bare one
+on the shared primary and detach the human's `main`, #2270/#1103; §RO is the single source).
 
 ### Fetch the base fresh before any "is-it-shipped on main" check
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -74,7 +74,9 @@ git fetch origin "$BASE_REF"
 HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
 
 # Fetch the PR head into a dedicated ref WITHOUT touching the session tree (same-repo AND
-# cross-fork; never `gh pr checkout`, which would materialize head config into the session).
+# cross-fork; never `gh pr checkout` / `git checkout` / `git switch`, which materialize the head
+# into a working tree — the harness resets this cwd to the shared PRIMARY between Bash calls, so a
+# bare checkout lands there and detaches the human's `main` (#2270/#1103), and §RO forbids it).
 PR_REF="refs/pr/$PR-$(uuidgen)"
 git fetch origin "pull/$PR/head:$PR_REF"
 # §HEAD #2: confirm the fetched ref IS the resolved head before reviewing — else you'd review a

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -146,6 +146,9 @@ HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
 PR_REF="refs/review-trivial/$PR"
 git fetch --no-tags origin "pull/$PR/head:$PR_REF" >/dev/null 2>&1 || git fetch origin "$HEAD_SHA" >/dev/null 2>&1
 # read a head file WITHOUT a checkout:  git show "$PR_REF:<path>"   (or "$HEAD_SHA:<path>")
+# NEVER `git checkout` / `git switch` to inspect the head — the harness resets this cwd to the
+# shared PRIMARY between Bash calls, so a checkout lands there and detaches the human's `main`
+# (#2270/#1103); §RO in gh-issue-intake-formats.md forbids switching any working tree outright.
 
 # the PR body carries Fixes #N; pin the linked issue and its acceptance criteria
 ISSUE=$(gh api repos/$REPO/pulls/$PR --jq '.body' | grep -ioE '(fix(es|ed)?|close[sd]?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' | head -n1)


### PR DESCRIPTION
Refs #2270 — this PR delivers AC3 (prose/pattern hardening) only. Mechanical AC1/2/4 tracked separately in #2415. #2270 stays OPEN until that lands.

## Problem

A worktree-isolated review/ship agent's Bash cwd **resets to the shared PRIMARY checkout between calls** (harness behavior). So any `git checkout` / `switch` not scoped as a per-run-ref read runs against the human's primary tree and **detaches its `main`** — disrupting the running dev server (the #1103/#2270 detach class).

Grounding against `origin/main` (per the triage note): the gate skills already use the safe mechanism — fetch the head into a per-run `$PR_REF`, then `git worktree add` a throwaway tree, reading via `git show "$PR_REF:<path>"` / `$REVIEW_WT`. But two residual **prose** gaps remained:

1. **`agents/reviewer.md`'s `review_head` standing invariant actively instructed `git -C "$WT" checkout FETCH_HEAD`** — a working-tree checkout, contradicting the skills and the canonical §RO/§HEAD. This was the one place in the review surface that still *told* an agent to check out a head; a copy that drops the `-C "$WT"` (or a cwd-reset) detaches the primary.
2. Several review skills only warned off `gh pr checkout`, not a bare `git checkout` / `switch`.

## What this PR does (acceptance criterion 3 — prose/pattern hardening)

Aligns the review/ship **agent + skill text** to the single source, `skills/gh-issue-intake-formats.md` §RO/§HEAD (never mutate the launched checkout's working-tree HEAD; reach a head read-only via a per-run ref or an isolated throwaway worktree — never a checkout, bare **or** `git -C`-scoped):

- **`agents/reviewer.md`** — rewrote `review_head` to the fetch-into-ref + throwaway-worktree pattern with **no checkout**; reframed `wt_preflight` as *read-only on git working state*, citing §RO/§HEAD as the single source.
- **`skills/review-code`, `review-doc`, `review-skill`, `review-trivial`** — broadened each `gh pr checkout` warn-off to forbid a bare `git checkout` / `git switch` too, with the reset-to-primary rationale + §RO pointer.
- **`agents/shipper.md`** — added #2270 to the detach-class citation (ship-it is already fully read-only over `gh api`).

`validate-skills.sh` passes (21 skills valid); pre-commit biome + leak-guard clean.

## Scope note (§CP)

This is the **skill/agent-text** half of #2270 (criterion 3). The **mechanical** enforcement — extending the ref-guard past the `refs/heads/main`-update scope to also refuse a HEAD-detaching checkout on the shared primary, plus its regression test (criteria 1/2/4) — lives in `packages/pipeline-cli/` and is **out of this lane** (a sibling pipeline-cli lane). This PR edits the review/ship gate skills → **§CP → human-merge** (never auto-ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

