### PR TITLE
fix(pipeline): class .claude-plugin/** + any-plugin defs as has-skills (#2387)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1420,17 +1420,31 @@ no reusable line for the reviewer to consume:
 
 ```bash
 HAS_CODE_RE='^(apps|packages|\.glossary|infra)/'
-HAS_SKILLS_RE='^claude-plugins/kampus-pipeline/(skills|agents)/'
+HAS_SKILLS_RE='^claude-plugins/[^/]+/(skills|agents)/|^\.claude-plugin/'
 HAS_DOCS_EXCLUDE_RE='^(claude-plugins|apps|packages|\.glossary|infra)/'
 HAS_DOCS_RE='^(\.decisions|\.patterns)/|\.md$'
 ```
 
 The boundary each line draws is **not re-derived here** — it is §DOC's, above: `HAS_CODE_RE`
 names the code roots (`apps`/`packages`/`.glossary`/`infra`, the #663/#919/#1987 has-code set),
-`HAS_SKILLS_RE` the behavioral-artifact roots (`skills/**`/`agents/**`, ADR 0073/0150), and the
+`HAS_SKILLS_RE` the plugin behavioral-artifact surface — **any** plugin's `skills/**`/`agents/**`
+(the plugin-name is `[^/]+`, not the `kampus-pipeline` literal) **plus the `.claude-plugin/**`
+plugin/marketplace manifest** that declares that surface (ADR 0073/0150; #2387) — and the
 two `HAS_DOCS_*` lines are the carve-then-test docs probe. `HAS_CODE_RE` and `HAS_DOCS_EXCLUDE_RE`
 name the **same** code roots (the has-code/docs-exclusion agreement invariant) and must move in
 lockstep — keep them adjacent so a root added to one is added to the other.
+
+`HAS_SKILLS_RE`'s two additions close the **#663 neither-class gap** for the plugin surface (#2387):
+a PR touching only a **non-`kampus-pipeline`** plugin's `agents/**`/`skills/**` (e.g. the
+`pipeline-crew` crew defs) or only the `.claude-plugin/**` manifest (`plugin.json`,
+`marketplace.json`) previously matched **no** class — so `ship-it` Step 0 demanded no gate and it
+reached merge un-reviewed. Both now class **has-skills** and ride the `review-skill` gate: the
+manifest surface *declares* the plugin's skill/agent artifacts (and is the drift-check `source`
+`validate-gate-path-drift.sh` locks), so it belongs to the same behavioral-artifact class and gate
+as the artifacts it manifests — no new class or gate is invented. This is **only** the review-class
+axis: `CONTROL_PLANE_RE` (§CP, who-merges) is a **separate** regex and is **untouched**, so a crew
+plugin's `agents/**` gains a `review-skill` gate yet still **auto-ships** on PASS (the founder #2342
+ruling — extras don't block — is preserved; the class fix and the §CP ruling compose).
 
 **Both consumers re-resolve these lines from `origin/main` at run time** (REST raw, `?ref=main`
 — the #981 idiom, generalized from `CONTROL_PLANE_RE`/`UI_RE` to the class probes), never trusting


### PR DESCRIPTION
## What

Closes the #663-style **neither-class merge gap** on the plugin surface (#2387). A one-place edit to the single-sourced artifact-class probes in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §CLASS:

```diff
-HAS_SKILLS_RE='^claude-plugins/kampus-pipeline/(skills|agents)/'
+HAS_SKILLS_RE='^claude-plugins/[^/]+/(skills|agents)/|^\.claude-plugin/'
```

Two additions, both fixing paths that previously matched **no** artifact class and so reached `ship-it` Step 0 with **no gate demanded** (ungated merge):

1. **Any-plugin generalization** — the plugin name is now `[^/]+`, not the `kampus-pipeline` literal. A non-`kampus-pipeline` plugin's `skills/**`/`agents/**` (e.g. the `pipeline-crew` crew defs from epic #2342) now classes **has-skills**.
2. **`.claude-plugin/**` manifest surface** (`plugin.json`, `marketplace.json`) now classes **has-skills**.

## Class chosen for `.claude-plugin/**` and why: `has-skills` (→ `review-skill`)

The manifest surface **declares** the plugin's skill/agent behavioral artifacts (and its `source` field is the drift-check target `validate-gate-path-drift.sh` locks). It belongs to the **same behavioral-artifact class and gate** as the artifacts it manifests — so it rides `review-skill`, the gate that understands plugin structure. This avoids inventing a new class or a new gate that doesn't exist, and folds into `HAS_SKILLS_RE` in one regex alongside the any-plugin generalization. (It is `.json`, so it never interacted with `HAS_DOCS_RE`'s `.md$` test; `HAS_DOCS_EXCLUDE_RE` stays a pure code-root lockstep partner of `HAS_CODE_RE` and is untouched.)

## Review-class only — §CP untouched (the ruling composes)

`CONTROL_PLANE_RE` (§CP, the *who-merges* axis) is a **separate regex** and is **not edited**. Verified behavior:

| path | class | §CP |
|---|---|---|
| `.claude-plugin/marketplace.json` | has-skills | — |
| `claude-plugins/pipeline-crew/agents/em.md` | has-skills | — (auto-ships) |
| `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` | has-skills | CP (human-merge) |

So a crew plugin's `agents/**` gains a `review-skill` gate yet still **auto-ships** on PASS — the founder #2342 "extras don't block" ruling is preserved. The class fix and the §CP ruling compose.

## Single-source discipline

One-place edit in `gh-issue-intake-formats.md` §CLASS. `ship-it` Step 0 and `reviewer` re-resolve `HAS_SKILLS_RE` from `origin/main` at run time (the #981 `?ref=main` idiom); their embedded literals are non-locked fail-closed references (`validate-gate-path-drift.sh` locks only `CONTROL_PLANE_RE`/`GUARD_ADR_RE`, not `HAS_SKILLS_RE`). **No edit to `ship-it/SKILL.md` (in-flight PR #2417) or `reviewer.md`** — the fix lands entirely at the single source.

## Built on #2386

Branched off `origin/main` after PR #2386 merged (single-sourced the `HAS_*_RE` variables). Edits the exact `HAS_SKILLS_RE=` line #2386 created.

Fixes #2387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
