### PR TITLE
feat(pipeline-cli): gentle --post-merge refresh for the primary checkout (#2056)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -145,6 +145,38 @@ node packages/pipeline-cli/src/bin.ts main-sync
 node packages/pipeline-cli/src/bin.ts main-sync --execute
 ```
 
+#### `--post-merge` — the gentle post-merge refresh (#2056)
+
+Every pipeline agent works in an isolated `git worktree` (correctly — ADR 0109), so
+*nobody ever pulls the primary checkout*. Under the merge queue (ADR 0132) a PR lands
+GitHub-side with **no local `git merge` on the primary** to advance it, so the owner's
+checkout **silently drifts behind `origin/main`** — and any read of the local tree (the
+next-free ADR number, "does file X exist yet", "is this already on main") is then made
+against stale state. A local `post-merge` lefthook can't fix this (the triggering local
+merge never happens under the queue); the refresh must be driven by a pipeline step that
+*knows* a PR merged (`ship-it` / the orchestrator), which invokes:
+
+```bash
+# after a PR lands: fast-forward the primary IF it's on a clean 'main', else no-op (exit 0)
+node packages/pipeline-cli/src/bin.ts main-sync --post-merge --execute
+```
+
+`--post-merge` is the **HEAD-preserving** counterpart to the default drain-sync — it is
+gentle where the default is aggressive:
+
+- It **only** fast-forwards when the primary is already on a **clean `main`** — the one
+  state where `merge --ff-only` is both possible and non-destructive.
+- On a **non-`main` branch** (the owner is on their own feature branch, or detached) **or a
+  dirty tree**, it **leaves the checkout alone and exits 0** — it never reattaches, never
+  moves HEAD, never touches uncommitted work. Failing-to-refresh is acceptable (a stale
+  checkout is no worse than today); clobbering the owner or yanking them off their branch
+  is not.
+- It still `--ff-only`, so even on the fast-forward path it aborts on any divergence and
+  never force-updates.
+
+The refresh **wiring** into `ship-it`'s post-landed step is tracked separately (#2417); this
+tool ships the safe refresh *mechanism* those steps invoke.
+
 This is a **control-plane** surface (it drives the shared primary checkout); see
 [`.patterns/worktree-agent-constraints.md`](../../.patterns/worktree-agent-constraints.md)
 for the surrounding worktree/primary-checkout discipline it defends.

--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -18,16 +18,27 @@
  *   2. The sync merge is `git merge --ff-only origin/main` — fast-forward only, so it
  *      never creates a merge commit and fails loudly rather than diverging the primary.
  *
+ * TWO policies, one runnable surface:
+ *   - default (drain-sync, #1494/#1573): AGGRESSIVE — reattaches a detached/off-`main`
+ *     HEAD to `main` (clean tree only) before the merge, for the orchestrator's
+ *     before/after-drain sync.
+ *   - `--post-merge` (refresh, #2056): GENTLE — invoked by a pipeline step that knows a
+ *     merge landed (ship-it / the orchestrator). It fast-forwards the primary ONLY when
+ *     it is already on a clean `main`; on a non-`main` branch or a dirty tree it LEAVES
+ *     THE CHECKOUT ALONE and exits 0 (never moves HEAD, never errors). This closes the
+ *     silent-drift hazard under the merge queue (ADR 0132), where a PR lands GitHub-side
+ *     with no local merge to advance the owner's checkout. See `decideMainRefresh`.
+ *
  * DRY-RUN by default: with no flag it probes HEAD, prints the plan it WOULD run, and
- * exits 0 without touching anything (not even a fetch). `--execute` runs the plan:
- * reattach if authorized, then `fetch` + `merge --ff-only`. The git IO uses
- * `execFileSync` directly (mirrors `worktree-sweep` / the `worktree-guard` reaper),
- * so the tool's requirement stays at the Node platform ceiling the registry provides.
+ * exits 0 without touching anything (not even a fetch). `--execute` runs the plan. The
+ * git IO uses `execFileSync` directly (mirrors `worktree-sweep` / the `worktree-guard`
+ * reaper), so the tool's requirement stays at the Node platform ceiling the registry
+ * provides.
  */
 import {execFileSync} from "node:child_process";
 import {Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {decideMainSync, type HeadState, MAIN_BRANCH} from "./main-sync.ts";
+import {decideMainRefresh, decideMainSync, type HeadState, MAIN_BRANCH} from "./main-sync.ts";
 
 interface GitResult {
 	readonly ok: boolean;
@@ -65,17 +76,81 @@ const treeIsDirty = (): boolean => {
 	return r.stdout.trim() !== "";
 };
 
+/**
+ * The gentle post-merge refresh (#2056) — the HEAD-preserving counterpart to the drain-sync
+ * below. `decideMainRefresh` is the safety policy; this runs it. A `leave-alone` plan is a
+ * clean exit-0 no-op (the whole point: a stale checkout is acceptable, disturbing the owner
+ * is not), so it NEVER errors — only a genuine fetch/merge failure on the fast-forward path
+ * exits non-zero.
+ */
+const runPostMergeRefresh = Effect.fn(function* (head: HeadState, execute: boolean) {
+	const plan = decideMainRefresh(head);
+
+	// ADR 0092 "emit what you scanned": the HEAD state + plan are observable before any action.
+	yield* Console.log(
+		`main-sync --post-merge: HEAD ${head.branch ?? "(detached)"}, tree ${head.isDirty ? "DIRTY" : "clean"} — plan: ${plan.action}${execute ? " (EXECUTE)" : " (dry-run)"}`,
+	);
+
+	if (plan.action === "leave-alone") {
+		yield* Console.log(
+			`  leaving the primary checkout ALONE (${plan.reason === "off-main" ? `on '${plan.branch}', not '${MAIN_BRANCH}'` : "tree is dirty"}) — a fast-forward would ${plan.reason === "off-main" ? "not advance a checked-out feature branch" : "risk uncommitted work"}. No-op (stale is acceptable; clobbering is not).`,
+		);
+		return;
+	}
+
+	if (!execute) {
+		yield* Console.log(
+			`  would refresh: git fetch origin ${MAIN_BRANCH} && git merge --ff-only origin/${MAIN_BRANCH}`,
+		);
+		yield* Console.log("  (dry-run — pass --execute to run; nothing touched)");
+		return;
+	}
+
+	const fetched = runGit(["fetch", "origin", MAIN_BRANCH]);
+	if (!fetched.ok) {
+		yield* Console.error(
+			`main-sync --post-merge: \`git fetch origin ${MAIN_BRANCH}\` failed — ${fetched.stderr.trim() || "network?"}`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+
+	// --ff-only is the invariant that makes the refresh safe: it advances main to origin/main
+	// when it's a strict fast-forward and ABORTS on any divergence — never a merge commit,
+	// never a force. On a clean 'main' the worst case is a no-op, never a clobber (#2056).
+	const merged = runGit(["merge", "--ff-only", `origin/${MAIN_BRANCH}`]);
+	if (!merged.ok) {
+		yield* Console.error(
+			`main-sync --post-merge: \`git merge --ff-only origin/${MAIN_BRANCH}\` failed — ${merged.stderr.trim() || "not fast-forwardable"}. The primary has diverged; resolve by hand.`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+	yield* Console.log(
+		`main-sync --post-merge: primary checkout fast-forwarded to origin/${MAIN_BRANCH}.`,
+	);
+});
+
 const executeFlag = Flag.boolean("execute").pipe(
 	Flag.withDescription(
 		"actually reattach (if detached+clean) and run fetch + merge --ff-only (default: dry-run, print the plan only)",
 	),
 );
 
+const postMergeFlag = Flag.boolean("post-merge").pipe(
+	Flag.withDescription(
+		"gentle post-merge refresh (#2056): fast-forward ONLY on a clean 'main'; on any other branch or a dirty tree, leave the checkout alone and exit 0 (never reattach, never error)",
+	),
+);
+
 const mainSync = Command.make(
 	"main-sync",
-	{execute: executeFlag},
-	Effect.fn(function* ({execute}) {
+	{execute: executeFlag, postMerge: postMergeFlag},
+	Effect.fn(function* ({execute, postMerge}) {
 		const head: HeadState = {branch: headBranch(), isDirty: treeIsDirty()};
+
+		if (postMerge) {
+			return yield* runPostMergeRefresh(head, execute);
+		}
+
 		const plan = decideMainSync(head);
 
 		// ADR 0092 "emit what you scanned": the HEAD state + plan are observable before any action.
@@ -135,7 +210,7 @@ const mainSync = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Codified orchestrator main-sync — auto-reattach a detached primary HEAD to main, then fetch + merge --ff-only; refuses on a dirty tree (#1573 / #1494 Unit C)",
+		"Codified primary main-sync. Default (drain-sync): auto-reattach a detached primary HEAD to main, then fetch + merge --ff-only; refuses on a dirty tree (#1573 / #1494 Unit C). --post-merge (refresh): fast-forward ONLY on a clean main, else leave the checkout alone and exit 0 (#2056).",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
@@ -20,6 +20,17 @@
  * incidents all had a CLEAN tree — so a reattach is authorized ONLY on a clean tree;
  * a dirty primary tree DETECTS-AND-SURFACES (refuse to reattach, report the dirt)
  * rather than blindly `checkout`-ing and discarding the operator's changes.
+ *
+ * A SECOND, gentler policy lives beside the drain-sync above: `decideMainRefresh`, the
+ * post-merge refresh (#2056). Under the merge queue (ADR 0132) a PR lands GitHub-side with
+ * no local `git merge` on the primary, so the owner's checkout silently drifts behind
+ * `origin/main` and any read of the local tree (next-free ADR number, "does X exist yet")
+ * is made against stale state. The refresh is invoked by a pipeline step that KNOWS a merge
+ * landed (ship-it / the orchestrator) and passively fast-forwards the primary — but, unlike
+ * the drain-sync, it NEVER moves HEAD: on a non-`main` branch or a dirty tree it LEAVES THE
+ * CHECKOUT ALONE and exits cleanly (a stale checkout is no worse than today; yanking the
+ * owner off their feature branch or touching their uncommitted work is). Failing-to-refresh
+ * is acceptable; failing-loudly or clobbering is not.
  */
 
 /**
@@ -104,4 +115,56 @@ export const decideMainSync = (head: HeadState): MainSyncPlan => {
 		return {action: "blocked-dirty", from: fromLabel(head.branch)};
 	}
 	return {action: "reattach", from: fromLabel(head.branch)};
+};
+
+/**
+ * What the post-merge refresh should do to bring the primary checkout up to
+ * `origin/main` — the gentle, HEAD-preserving counterpart to `MainSyncPlan`. It has
+ * exactly two outcomes because the refresh never moves HEAD (see the module docblock,
+ * #2056): either a fast-forward is safe, or the checkout is left exactly as it is.
+ */
+export type MainRefreshPlan =
+	/**
+	 * HEAD is on `main` AND the tree is clean — the only state in which a `git merge
+	 * --ff-only origin/main` is both possible and non-destructive. The refresh runs
+	 * `fetch` + `merge --ff-only`; ff-only never creates a merge commit and aborts on any
+	 * divergence, so the worst case is a no-op, never a clobber.
+	 */
+	| {readonly action: "fast-forward"; readonly branch: string}
+	/**
+	 * The refresh is a deliberate NO-OP — HEAD is not on `main`, or the tree is dirty. It
+	 * exits cleanly (never an error): a fast-forward of `main` can't advance a checked-out
+	 * feature branch, and a dirty tree could have its uncommitted work disturbed, so the
+	 * refresh leaves the checkout untouched. `reason` records which condition held for the
+	 * report; `branch` is the current branch (or `detached-HEAD`).
+	 */
+	| {
+			readonly action: "leave-alone";
+			readonly reason: "off-main" | "dirty";
+			readonly branch: string;
+	  };
+
+/**
+ * Decide the post-merge refresh plan from the primary checkout's HEAD state (#2056):
+ *
+ *   1. Not on `main` → `leave-alone` (reason `off-main`). The owner is on their own
+ *      feature branch (or detached); a fast-forward of `main` cannot advance it, and
+ *      yanking them onto `main` is exactly the disruption the refresh must avoid. No-op.
+ *   2. On `main` but dirty → `leave-alone` (reason `dirty`). A fast-forward could disturb
+ *      the owner's uncommitted work, and a stale-but-clean-of-clobber checkout is
+ *      acceptable — failing-to-refresh beats touching uncommitted work. No-op.
+ *   3. On `main` AND clean → `fast-forward`. The only state where the ff is safe: run it.
+ *
+ * The branch check precedes the dirty check on purpose — off-`main` is reported even when
+ * also dirty, because the branch is the binding reason the ff can't run (it can't advance
+ * a checked-out feature branch regardless of tree state). Total over every `HeadState`.
+ */
+export const decideMainRefresh = (head: HeadState): MainRefreshPlan => {
+	if (head.branch !== MAIN_BRANCH) {
+		return {action: "leave-alone", reason: "off-main", branch: fromLabel(head.branch)};
+	}
+	if (head.isDirty) {
+		return {action: "leave-alone", reason: "dirty", branch: MAIN_BRANCH};
+	}
+	return {action: "fast-forward", branch: MAIN_BRANCH};
 };

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts
@@ -1,9 +1,11 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
 	DETACHED_LABEL,
+	decideMainRefresh,
 	decideMainSync,
 	type HeadState,
 	MAIN_BRANCH,
+	type MainRefreshPlan,
 	type MainSyncPlan,
 } from "./main-sync.ts";
 
@@ -74,6 +76,56 @@ describe("decideMainSync — totality", () => {
 		const actions = new Set(["already-on-main", "reattach", "blocked-dirty"]);
 		for (const c of cases) {
 			assert.isTrue(actions.has(decideMainSync(c).action));
+		}
+	});
+});
+
+describe("decideMainRefresh — fast-forward (the only safe-to-advance state)", () => {
+	it("clean HEAD on main → fast-forward", () => {
+		const plan = decideMainRefresh(head({branch: "main", isDirty: false}));
+		assert.deepStrictEqual(plan, {action: "fast-forward", branch: MAIN_BRANCH});
+	});
+});
+
+describe("decideMainRefresh — leave-alone (never move HEAD, never error)", () => {
+	it("on main but dirty → leave-alone (reason dirty) — refuse to disturb uncommitted work", () => {
+		const plan = decideMainRefresh(head({branch: "main", isDirty: true}));
+		assert.deepStrictEqual(plan, {action: "leave-alone", reason: "dirty", branch: MAIN_BRANCH});
+	});
+
+	it("clean feature branch → leave-alone (reason off-main) — never yank the owner onto main", () => {
+		const plan = decideMainRefresh(head({branch: "umut/wip", isDirty: false}));
+		assert.deepStrictEqual(plan, {action: "leave-alone", reason: "off-main", branch: "umut/wip"});
+	});
+
+	it("detached HEAD → leave-alone (reason off-main) from detached-HEAD", () => {
+		const plan = decideMainRefresh(head({branch: null, isDirty: false}));
+		assert.deepStrictEqual(plan, {
+			action: "leave-alone",
+			reason: "off-main",
+			branch: DETACHED_LABEL,
+		});
+	});
+
+	it("off-main takes precedence over dirty — the branch is the binding reason the ff can't run", () => {
+		// A dirty feature branch is reported off-main, not dirty: an ff of main can't advance a
+		// checked-out feature branch regardless of tree state, so the branch is the real blocker.
+		const plan = decideMainRefresh(head({branch: "umut/wip", isDirty: true}));
+		assert.deepStrictEqual(plan, {action: "leave-alone", reason: "off-main", branch: "umut/wip"});
+	});
+
+	it("NEVER yields a HEAD-moving action — leave-alone or fast-forward only, no reattach/checkout", () => {
+		const cases: HeadState[] = [
+			{branch: "main", isDirty: false},
+			{branch: "main", isDirty: true},
+			{branch: null, isDirty: false},
+			{branch: null, isDirty: true},
+			{branch: "feature", isDirty: false},
+			{branch: "feature", isDirty: true},
+		];
+		const actions = new Set<MainRefreshPlan["action"]>(["fast-forward", "leave-alone"]);
+		for (const c of cases) {
+			assert.isTrue(actions.has(decideMainRefresh(c).action));
 		}
 	});
 });


### PR DESCRIPTION
Refs #2056 (mechanism-only building block — the primary-refresh CALLER is deferred; #2056 stays open for that design decision)

## What & why

Under the merge queue (ADR 0132) a PR lands GitHub-side with **no local `git merge` on the primary checkout**, so the owner's `main` silently drifts behind `origin/main`. Every pipeline agent works in an isolated worktree (ADR 0109), so nobody ever pulls the primary — any read of the local tree (next-free ADR number, "does file X exist yet", "is this already on main") is then made against stale state. This already caused a near-miss: an agent read the local `.decisions/` max as `0150` while `origin/main` was already at `0151`.

A local `post-merge` lefthook can't fix this — the triggering local merge never happens under the queue. So this adds a **gentle, HEAD-preserving refresh** to `pipeline-cli main-sync`, driven by a pipeline step that *knows* a merge landed.

## Change

New `main-sync --post-merge` policy (`decideMainRefresh`), beside the existing aggressive drain-sync (`decideMainSync`, #1494/#1573) — unchanged:

- **On a clean `main`** → `git fetch origin main && git merge --ff-only origin/main`.
- **On a non-`main` branch (or detached), or a dirty tree** → **leave the checkout alone and exit 0**. Never reattach, never move HEAD, never touch uncommitted work.

## How the refresh stays safe (never force-primary; ADR 0160 invariant preserved)

- **ff-only**: the advance is `git merge --ff-only origin/main` — advances only on a strict fast-forward, aborts on any divergence, never creates a merge commit, never force-updates.
- **refuse-on-dirty**: a dirty tree yields `leave-alone` (reason `dirty`) — a no-op, so uncommitted work is never disturbed.
- **leave-alone off-main**: unlike the drain-sync, the refresh **never** does a reattach `git checkout main`; an off-`main` checkout is a no-op (reason `off-main`) because an ff of `main` can't advance a checked-out feature branch and yanking the owner off their branch is the disruption to avoid.
- **exit 0 on no-op**: failing-to-refresh is acceptable (stale is no worse than today); only a genuine `fetch`/`merge` failure on the fast-forward path exits non-zero.

Acceptance criteria mapping:

- [x] After a PR merges, the primary is fast-forwarded automatically, driven by a pipeline step that knows a merge landed (this tool; not a local git hook that can't fire under the queue).
- [x] `--ff-only` semantics — never clobbers, never force-updates on divergence.
- [x] No-ops safely (exit 0, no partial state) on a non-`main` branch or dirty tree.
- [x] §CP surface (`packages/pipeline-cli/`) → human-merge (cansirin approval @head, ADR 0135).

## Scope note

This ships the safe refresh **mechanism**. The **wiring** into `ship-it`'s post-landed step is tracked in #2417 (which owns `ship-it/SKILL.md`) and left untouched here.

## Tests

`decideMainRefresh` covered in `main-sync.unit.test.ts` (fast-forward on clean main; leave-alone on dirty-main / feature-branch / detached; off-main precedence over dirty; the never-move-HEAD invariant across all six HeadStates). `pnpm --filter @kampus/pipeline-cli typecheck` + biome clean.
