### PR TITLE
fix(pipeline-cli): ref-guard refuses a HEAD-detaching checkout on the shared primary (#2415)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -149,15 +149,28 @@ This is a **control-plane** surface (it drives the shared primary checkout); see
 [`.patterns/worktree-agent-constraints.md`](../../.patterns/worktree-agent-constraints.md)
 for the surrounding worktree/primary-checkout discipline it defends.
 
-### `ref-guard` — caller-agnostic ref-transaction guard against a diverging `main` (#2143, ADR 0160)
+### `ref-guard` — caller-agnostic ref-transaction guard for the shared primary (#2143 diverging `main`; #2270 HEAD detach)
 
-A fail-closed guardrail wired as git's own **`reference-transaction`** hook that **refuses
-a diverging `refs/heads/main` ref-move** on the shared primary checkout — any update that
-would make local `main` a **non-fast-forward** of `origin/main`. It closes the #2143
-loaded-gun class: the orchestrator/PULLER role force-moved primary `main` off the merge seam
-(a bare `branch -f main` / `checkout -B main` / `update-ref refs/heads/main`), diverging it
-from `origin/main` and staging a ~13.5k-line deletion — one `git push -f` from clobbering
-`origin/main`.
+A fail-closed guardrail wired as git's own **`reference-transaction`** hook that refuses two
+shared-primary hazards at git's own ref boundary:
+
+1. **A diverging `refs/heads/main` ref-move** (#2143, ADR 0160) — any update that would make
+   local `main` a **non-fast-forward** of `origin/main`. It closes the #2143 loaded-gun class:
+   the orchestrator/PULLER role force-moved primary `main` off the merge seam (a bare
+   `branch -f main` / `checkout -B main` / `update-ref refs/heads/main`), diverging it from
+   `origin/main` and staging a ~13.5k-line deletion — one `git push -f` from clobbering
+   `origin/main`.
+2. **A bare HEAD-detaching checkout on the shared primary** (#2270) — a `git checkout <sha>` /
+   `checkout FETCH_HEAD` / `switch --detach` that detaches the human's shared `HEAD` off its
+   branch. This is the exact corruption a worktree-isolated agent triggers when its cwd resets
+   to the primary between Bash calls. `decideHeadDetach` catches it via the same
+   `reference-transaction` boundary: a detach queues an update whose ref-name is exactly `HEAD`
+   to a concrete commit with **no paired `refs/heads/*` move to that same commit** (an attached
+   commit pairs them; an attached `switch <branch>` retargets the symref and queues no `HEAD`
+   update at all), and only on the **primary** checkout (git-dir == git-common-dir). A linked
+   worktree's own HEAD detach — and the PULLER `checkout main` reattach, which queues no `HEAD`
+   ref update — stay allowed. The signal is grounded in git's real `reference-transaction`
+   behavior (verified against git 2.40, not assumed).
 
 **Why the ref boundary, not a Bash hook.** The #1571 `worktree-guard` bash-pin only arms for
 a `$WORKTREE_ROOT` subagent and only matches its `HEAD_MOVING` set — so it is disarmed for
@@ -191,7 +204,7 @@ only in the `prepared` state, so the guard evaluates + can refuse only there; `c
 # git invokes this itself as the reference-transaction hook; the manual shape (for a test):
 printf '%s %s refs/heads/main\n' "$OLD" "$NEW" \
   | node packages/pipeline-cli/src/bin.ts ref-guard reference-transaction prepared
-# exit 0 = allow · exit 3 = REFUSE (a diverging main move) · other non-zero = CLI couldn't run (fail-open)
+# exit 0 = allow · exit 3 = REFUSE (a diverging main move OR a bare HEAD detach on the primary) · other non-zero = CLI couldn't run (fail-open)
 ```
 
 This is a **control-plane** surface (it guards the shared primary checkout's `main`); see

--- a/packages/pipeline-cli/src/tools/ref-guard/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/command.hook.test.ts
@@ -12,6 +12,13 @@ import {REFUSE_EXIT_CODE} from "./command.ts";
 // modeled stub (CLAUDE.md: ground platform-behavior claims in the real platform).
 const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
 
+// Every test here spawns `node bin.ts` through a REAL git ref-transaction, and git ≥ 2.45 (CI/prod
+// runs 2.55) fires the `reference-transaction` hook once per state (preparing/prepared/committed) AND
+// again for the AUTO_MERGE ref of a `checkout` — several node cold-starts per git op. On CI that blows
+// vitest's 5000ms default (the #2415 timeouts). A generous suite-level timeout keeps the real-git
+// tripwires green on the deployed git without weakening what they assert.
+const HOOK_TEST_TIMEOUT = 60_000;
+
 interface RunResult {
 	readonly code: number;
 	readonly stderr: string;
@@ -95,7 +102,7 @@ afterAll(() => {
 	if (root) rmSync(root, {recursive: true, force: true});
 });
 
-describe("ref-guard reference-transaction — real git facts", () => {
+describe("ref-guard reference-transaction — real git facts", {timeout: HOOK_TEST_TIMEOUT}, () => {
 	it("REFUSES a diverging refs/heads/main move (non-fast-forward of origin/main) in 'prepared'", async () => {
 		const stdin = `${fx.base} ${fx.divergent} refs/heads/main\n`;
 		const {code, stderr} = await runGuard("prepared", stdin, fx.dir);
@@ -155,7 +162,9 @@ describe("ref-guard reference-transaction — real git facts", () => {
 // because git refuses a `-f` on the CURRENTLY-checked-out branch before any hook runs — the
 // incident's `branch: Reset to HEAD` was a checkout-B/reset on the checked-out branch, of
 // which update-ref is the minimal ref-transaction form.
-describe("ref-guard — installed reference-transaction hook fires on a BARE git ref-move (no pipeline command)", () => {
+describe("ref-guard — installed reference-transaction hook fires on a BARE git ref-move (no pipeline command)", {
+	timeout: HOOK_TEST_TIMEOUT,
+}, () => {
 	// Mirror the lefthook.yml wiring EXACTLY: `|| status=$?` (never a bare call, so an
 	// inherited `set -e` can't abort as a side effect) + abort ONLY on the dedicated refuse
 	// code 3; every other non-zero (CLI absent / crash) fail-opens. `cmd` is the guard
@@ -355,7 +364,10 @@ describe("ref-guard — installed reference-transaction hook fires on a BARE git
 		);
 	});
 
-	it("does NOT abort a `git checkout main` reattach on the PRIMARY (a symref retarget, no HEAD ref update)", () => {
+	// The load-bearing PULLER flow (#2415): git ≥ 2.45 (CI/prod 2.55) queues this reattach as a HEAD
+	// update whose new value is the SYMREF `ref:refs/heads/main` (git 2.40 queues no HEAD line at all).
+	// Either way it is an ATTACH, never a detach — the guard must allow it on both versions.
+	it("does NOT abort a `git checkout main` reattach on the PRIMARY (HEAD → symref, git ≥ 2.45; no HEAD line, git 2.40)", () => {
 		git(fx.dir, "checkout", "-q", "--detach", fx.base); // detach BEFORE the hook is installed
 		installHook(fx.dir);
 		let ok = true;

--- a/packages/pipeline-cli/src/tools/ref-guard/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/command.hook.test.ts
@@ -299,4 +299,91 @@ describe("ref-guard — installed reference-transaction hook fires on a BARE git
 			"the move was allowed because the guard could not run",
 		);
 	});
+
+	// #2270 mechanical half (criteria 1/2/4): the SAME installed reference-transaction hook that
+	// catches a diverging refs/heads/main move must also refuse a bare HEAD-DETACHING checkout on
+	// the shared PRIMARY checkout — the operation that strands the human's shared HEAD off its
+	// branch when a worktree-isolated agent's cwd resets to the primary between Bash calls. These
+	// drive a REAL `git checkout` (not a synthetic update-ref) so the assertion is grounded in
+	// git's actual reference-transaction behavior for a detach: HEAD → a concrete commit, no
+	// paired refs/heads/* move.
+	const headRef = (repoDir: string): string =>
+		execFileSync("git", ["symbolic-ref", "-q", "HEAD"], {cwd: repoDir, encoding: "utf8"}).trim();
+
+	it("aborts a bare `git checkout <sha>` HEAD-detach on the PRIMARY — HEAD stays attached to its branch", () => {
+		git(fx.dir, "checkout", "-q", "main"); // known attached start
+		const before = headRef(fx.dir);
+		installHook(fx.dir);
+		let aborted = false;
+		try {
+			execFileSync("git", ["checkout", fx.divergent], {cwd: fx.dir, stdio: "pipe"});
+		} catch {
+			aborted = true; // git exits non-zero: "ref updates aborted by hook"
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		assert.isTrue(aborted, "the bare HEAD-detach on the primary should be aborted by the hook");
+		assert.strictEqual(
+			headRef(fx.dir),
+			before,
+			"HEAD must still be attached to its branch (the detach was refused)",
+		);
+	});
+
+	it("does NOT abort an attached commit on a feature branch on the PRIMARY (HEAD paired with its branch move)", () => {
+		// A feature branch, not main, so the pre-existing #2143 main-divergence guard is out of the
+		// picture — this isolates the HEAD-detach guard's pairing rule (HEAD moved WITH its branch).
+		git(fx.dir, "checkout", "-q", "-b", "attached-feature", fx.base);
+		installHook(fx.dir);
+		let ok = true;
+		try {
+			execFileSync("git", ["commit", "--allow-empty", "-q", "-m", "attached"], {
+				cwd: fx.dir,
+				stdio: "pipe",
+			});
+		} catch {
+			ok = false;
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		const stayed = headRef(fx.dir);
+		git(fx.dir, "checkout", "-q", "main"); // restore fixture: reattach main, drop the feature branch
+		git(fx.dir, "branch", "-qD", "attached-feature");
+		assert.isTrue(ok, "an attached commit (paired HEAD+branch move) must not be aborted");
+		assert.strictEqual(
+			stayed,
+			"refs/heads/attached-feature",
+			"HEAD stays attached to the feature branch after the commit",
+		);
+	});
+
+	it("does NOT abort a `git checkout main` reattach on the PRIMARY (a symref retarget, no HEAD ref update)", () => {
+		git(fx.dir, "checkout", "-q", "--detach", fx.base); // detach BEFORE the hook is installed
+		installHook(fx.dir);
+		let ok = true;
+		try {
+			execFileSync("git", ["checkout", "main"], {cwd: fx.dir, stdio: "pipe"});
+		} catch {
+			ok = false;
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		assert.isTrue(ok, "the PULLER `checkout main` reattach must not be aborted");
+		assert.strictEqual(headRef(fx.dir), "refs/heads/main", "HEAD is reattached to main");
+	});
+
+	it("does NOT abort a bare HEAD-detach inside a LINKED worktree (only the shared primary is guarded)", () => {
+		const wt = join(fx.dir, "..", "wt-head-detach");
+		execFileSync("git", ["worktree", "add", "-q", "--detach", wt, fx.base], {cwd: fx.dir});
+		installHook(fx.dir); // shared hook (common .git) — but the worktree's HEAD is not the primary's
+		let ok = true;
+		try {
+			execFileSync("git", ["checkout", fx.divergent], {cwd: wt, stdio: "pipe"});
+		} catch {
+			ok = false;
+		}
+		rmSync(join(fx.dir, ".git", "hooks", "reference-transaction"), {force: true});
+		execFileSync("git", ["worktree", "remove", "--force", wt], {cwd: fx.dir});
+		assert.isTrue(
+			ok,
+			"a worktree agent detaching its OWN HEAD must not be blocked (no false-positive on coders)",
+		);
+	});
 });

--- a/packages/pipeline-cli/src/tools/ref-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/command.ts
@@ -39,6 +39,8 @@ import {execFileSync} from "node:child_process";
 import {Console, Effect} from "effect";
 import {Argument, Command} from "effect/unstable/cli";
 import {
+	type CheckoutContext,
+	decideHeadDetach,
 	decideRefUpdate,
 	decideTransaction,
 	GUARDED_REF,
@@ -126,6 +128,25 @@ const originIsAncestorOf = (newOid: string): boolean => {
 	}
 };
 
+/**
+ * `true` iff this reference-transaction is firing against the shared PRIMARY checkout, resolved
+ * exactly as `write-code`'s worktree preflight does: the per-tree git-dir equals the shared
+ * git-common-dir on the primary, and differs in a linked worktree. Both are read with
+ * `--path-format=absolute` so the comparison is over identically-normalized absolute paths.
+ * An indeterminate resolution (either rev-parse fails/empty) returns `false` — fail-OPEN, so a
+ * HEAD detach we cannot prove is on the primary is allowed and a worktree agent is never
+ * false-refused (mirrors the guard's fail-open-on-infrastructure-absence posture).
+ */
+const resolvePrimaryCheckout = (): boolean => {
+	const gd = runGit(["rev-parse", "--path-format=absolute", "--git-dir"]);
+	const cd = runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+	if (!gd.ok || !cd.ok) return false;
+	const gitDir = gd.stdout.trim();
+	const commonDir = cd.stdout.trim();
+	if (gitDir === "" || commonDir === "") return false;
+	return gitDir === commonDir;
+};
+
 const stateArg = Argument.string("state").pipe(
 	Argument.withDescription(
 		"the reference-transaction state: prepared | committed | aborted (git passes this). Only 'prepared' can refuse.",
@@ -159,7 +180,15 @@ const referenceTransaction = Command.make(
 			};
 		};
 
-		const verdict = decideTransaction(updates.map((u) => decideRefUpdate(u, facts(u))));
+		// Two orthogonal concerns fold into one transaction verdict: the per-update
+		// refs/heads/main divergence guard (#2143), and the batch-level HEAD-detach guard on
+		// the primary checkout (#2270 — a detach moves HEAD, not refs/heads/main, so it is a
+		// separate decision over the whole batch). Any refuse aborts the transaction.
+		const checkout: CheckoutContext = {isPrimaryCheckout: resolvePrimaryCheckout()};
+		const verdict = decideTransaction([
+			decideHeadDetach(updates, checkout),
+			...updates.map((u) => decideRefUpdate(u, facts(u))),
+		]);
 
 		if (verdict.kind === "refuse") {
 			// ADR 0092 "emit what you scanned": name the guarded ref + why before aborting.

--- a/packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts
@@ -27,10 +27,22 @@
  * Fail-safe posture (fail-closed on the guarded ref, fail-open off it): every
  * indeterminate fact the git boundary can't resolve is passed as a discriminated flag
  * so the decision is explicit, never a silent allow of a `main` divergence.
+ *
+ * A second, orthogonal concern lives here too (#2270, the mechanical half): `decideHeadDetach`
+ * refuses a bare HEAD-detaching checkout on the shared PRIMARY checkout — a distinct hazard from
+ * the `refs/heads/main` force-move above, and one `decideRefUpdate` structurally cannot see (a
+ * detach moves `HEAD`, not `refs/heads/main`). See its docblock for the git-grounded signal.
  */
 
 /** The full ref name the guard protects. Other refs (feature branches, tags, `origin/*`) are out of scope. */
 export const GUARDED_REF = "refs/heads/main";
+
+/**
+ * Git's per-worktree symbolic `HEAD`, as it appears verbatim on the `reference-transaction`
+ * stdin (`<old> SP <new> SP HEAD`). A detaching checkout moves THIS ref to a concrete commit —
+ * the operation `decideHeadDetach` guards on the primary checkout.
+ */
+export const HEAD_REF = "HEAD";
 
 /** Git's all-zeroes object name — the sentinel for a ref being created anew (old) or deleted (new). */
 export const ZERO_OID = "0000000000000000000000000000000000000000";
@@ -137,6 +149,72 @@ export const decideRefUpdate = (update: RefUpdate, facts: OriginFacts): RefDecis
 			`(local main diverged from origin/main; one \`git push -f\` would clobber origin/main). Drive sync through ` +
 			`\`git merge --ff-only origin/main\`, never a bare \`branch -f main\` / \`checkout -B main\` / \`update-ref refs/heads/main\`.`,
 	};
+};
+
+/**
+ * The checkout a `reference-transaction` is firing against, reduced to the one fact the
+ * HEAD-detach decision needs: whether it is the shared PRIMARY checkout rather than a linked
+ * worktree. The git boundary resolves it by comparing the per-tree git-dir with the shared
+ * git-common-dir (equal ⇒ primary; differ ⇒ linked worktree — the same plumbing `write-code`'s
+ * worktree preflight uses). An indeterminate resolution passes `false` (fail-OPEN: a detach we
+ * can't prove is on the primary is allowed, so a worktree agent is never false-refused).
+ */
+export interface CheckoutContext {
+	readonly isPrimaryCheckout: boolean;
+}
+
+/**
+ * Refuse a bare HEAD-detaching checkout on the shared PRIMARY checkout — the #2270 hazard: a
+ * worktree-isolated agent whose cwd resets to the primary between Bash calls runs a bare
+ * `git checkout <sha>` / `checkout FETCH_HEAD` / `switch --detach`, detaching the human's shared
+ * `HEAD` off its branch and corrupting the checkout. `decideRefUpdate`'s `refs/heads/main` scope
+ * never sees this: a detach moves `HEAD`, not `refs/heads/main`, so it is a separate decision.
+ *
+ * The signal is grounded in git's real `reference-transaction` behavior (verified against git
+ * 2.40, not assumed — the AC's requirement): a detaching checkout queues an update whose ref-name
+ * is exactly `HEAD`, whose new value is a concrete commit, with NO sibling `refs/heads/*` update
+ * to that same commit in the transaction. An ATTACHED move — a commit/reset on the current branch,
+ * including the unborn-branch first commit — queues `HEAD` PAIRED with its `refs/heads/<branch>`
+ * update to the same new oid; an attached `switch <branch>` retargets the HEAD symref and queues
+ * no `HEAD` update at all. So "HEAD moved to a commit that no branch in this transaction is also
+ * moving to" isolates exactly a detach, and only a detach.
+ *
+ * Scoped to the PRIMARY checkout (`ctx.isPrimaryCheckout`). A worktree's own HEAD detach fires
+ * against its per-tree git-dir, so this allows it — worktree agents moving/detaching their OWN
+ * HEAD are untouched, as is the PULLER `checkout main` reattach (a symref retarget queues no HEAD
+ * ref update) and the human's normal attached work (paired HEAD+branch moves).
+ */
+export const decideHeadDetach = (
+	updates: ReadonlyArray<RefUpdate>,
+	ctx: CheckoutContext,
+): RefDecision => {
+	if (!ctx.isPrimaryCheckout) {
+		return {
+			kind: "allow",
+			reason:
+				"not the shared primary checkout (a linked worktree) — HEAD moves are the worktree's own",
+		};
+	}
+	const branchTargets = new Set(
+		updates
+			.filter((u) => u.refName.startsWith("refs/heads/") && u.newOid !== ZERO_OID)
+			.map((u) => u.newOid),
+	);
+	for (const u of updates) {
+		if (u.refName !== HEAD_REF) continue;
+		if (u.newOid === ZERO_OID) continue; // a HEAD delete / no concrete target is not a detach
+		if (branchTargets.has(u.newOid)) continue; // paired with a branch move ⇒ attached, allow
+		return {
+			kind: "refuse",
+			reason:
+				`refusing a HEAD-detaching checkout on the shared PRIMARY checkout: HEAD would move to ${u.newOid.slice(0, 12)} ` +
+				`with no branch tracking it (a detached HEAD). On the primary this strands the human's shared checkout off its ` +
+				`branch (#2270) — the exact corruption a worktree-isolated agent triggers when its cwd resets to the primary ` +
+				`between calls. Detach inside your OWN worktree, or reattach with \`git checkout <branch>\`, never a bare ` +
+				`\`git checkout <sha>\` / \`checkout FETCH_HEAD\` / \`switch --detach\` on the primary.`,
+		};
+	}
+	return {kind: "allow", reason: "no bare HEAD detach on the primary checkout"};
 };
 
 /**

--- a/packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts
@@ -44,6 +44,17 @@ export const GUARDED_REF = "refs/heads/main";
  */
 export const HEAD_REF = "HEAD";
 
+/**
+ * The prefix git ≥ 2.45 stamps on a SYMREF value in a `reference-transaction` line when the update
+ * retargets a symbolic ref rather than moving it to an object — e.g. reattaching HEAD queues
+ * `<old> SP ref:refs/heads/main SP HEAD`. Grounded by direct measurement on git 2.55 (below); it is
+ * the signal that a HEAD update is an ATTACH (reattach / branch switch), never a detach.
+ */
+export const SYMREF_VALUE_PREFIX = "ref:";
+
+/** A `reference-transaction` value naming a symbolic-ref target (`ref:refs/…`) rather than an object id. */
+const isSymrefValue = (value: string): boolean => value.startsWith(SYMREF_VALUE_PREFIX);
+
 /** Git's all-zeroes object name — the sentinel for a ref being created anew (old) or deleted (new). */
 export const ZERO_OID = "0000000000000000000000000000000000000000";
 
@@ -170,19 +181,27 @@ export interface CheckoutContext {
  * `HEAD` off its branch and corrupting the checkout. `decideRefUpdate`'s `refs/heads/main` scope
  * never sees this: a detach moves `HEAD`, not `refs/heads/main`, so it is a separate decision.
  *
- * The signal is grounded in git's real `reference-transaction` behavior (verified against git
- * 2.40, not assumed — the AC's requirement): a detaching checkout queues an update whose ref-name
- * is exactly `HEAD`, whose new value is a concrete commit, with NO sibling `refs/heads/*` update
- * to that same commit in the transaction. An ATTACHED move — a commit/reset on the current branch,
- * including the unborn-branch first commit — queues `HEAD` PAIRED with its `refs/heads/<branch>`
- * update to the same new oid; an attached `switch <branch>` retargets the HEAD symref and queues
- * no `HEAD` update at all. So "HEAD moved to a commit that no branch in this transaction is also
- * moving to" isolates exactly a detach, and only a detach.
+ * The signal is grounded in git's real `reference-transaction` behavior, measured directly on BOTH
+ * deployed git versions — local 2.40.1 AND CI/production 2.55.0 (git changed HEAD emission between
+ * them: the symref-in-transaction work of git 2.45; #2415/#2270 regrounding). A detaching checkout
+ * (`checkout <sha>` / `switch --detach`) queues, in the `prepared` state, an update whose ref-name
+ * is exactly `HEAD` and whose NEW VALUE is a CONCRETE object id — identical on 2.40 and 2.55. The
+ * two legitimate look-alikes differ by version, and BOTH must be allowed:
+ *   - a REATTACH / branch switch (`checkout main`, `switch <branch>`) queues, on git ≥ 2.45, a HEAD
+ *     update whose new value is the SYMREF `ref:refs/heads/<branch>` (not an object) — and on 2.40
+ *     queues no `HEAD` update at all. `isSymrefValue` catches the ≥2.45 form; the 2.40 form has no
+ *     line to catch. Either way: never a detach.
+ *   - an ATTACHED commit/reset on the current branch queues, on 2.40, `HEAD` PAIRED with its
+ *     `refs/heads/<branch>` update to the SAME new oid; on 2.55 the `prepared` batch carries only
+ *     the `refs/heads/<branch>` line (no HEAD). The `branchTargets` pairing catches the 2.40 form.
+ * So a detach is exactly: a HEAD update to a concrete oid that is NEITHER a symref value NOR paired
+ * with a same-oid branch move in the batch. This isolates a detach on both versions, and only a
+ * detach — never the reattach the shared-primary PULLER relies on.
  *
  * Scoped to the PRIMARY checkout (`ctx.isPrimaryCheckout`). A worktree's own HEAD detach fires
  * against its per-tree git-dir, so this allows it — worktree agents moving/detaching their OWN
- * HEAD are untouched, as is the PULLER `checkout main` reattach (a symref retarget queues no HEAD
- * ref update) and the human's normal attached work (paired HEAD+branch moves).
+ * HEAD are untouched, as are the PULLER `checkout main` reattach and the human's normal attached
+ * work.
  */
 export const decideHeadDetach = (
 	updates: ReadonlyArray<RefUpdate>,
@@ -203,7 +222,8 @@ export const decideHeadDetach = (
 	for (const u of updates) {
 		if (u.refName !== HEAD_REF) continue;
 		if (u.newOid === ZERO_OID) continue; // a HEAD delete / no concrete target is not a detach
-		if (branchTargets.has(u.newOid)) continue; // paired with a branch move ⇒ attached, allow
+		if (isSymrefValue(u.newOid)) continue; // HEAD retargeted to a branch (ref:refs/heads/*) ⇒ reattach/switch, allow (git ≥ 2.45)
+		if (branchTargets.has(u.newOid)) continue; // paired with a branch move ⇒ attached, allow (git 2.40)
 		return {
 			kind: "refuse",
 			reason:

--- a/packages/pipeline-cli/src/tools/ref-guard/ref-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/ref-guard.unit.test.ts
@@ -140,10 +140,11 @@ describe("decideRefUpdate — totality", () => {
 });
 
 // #2270 mechanical half: a bare HEAD-detaching checkout on the shared PRIMARY checkout is
-// refused. The signal (grounded in git's real reference-transaction behavior, see the
-// command.hook.test.ts end-to-end cases) is a HEAD update to a concrete commit with NO paired
-// refs/heads/* update to the same oid in the batch — an attached move pairs them, a detach does
-// not — and only on the primary (a linked worktree's own HEAD is its business).
+// refused. The signal (grounded in git's real reference-transaction behavior on BOTH 2.40 and
+// 2.55, see the command.hook.test.ts end-to-end cases) is a HEAD update to a CONCRETE oid that is
+// neither a symref value (`ref:refs/heads/*`, the git ≥ 2.45 reattach form) nor paired with a
+// same-oid refs/heads/* move in the batch (the git 2.40 attached-commit form) — and only on the
+// primary (a linked worktree's own HEAD is its business).
 describe("decideHeadDetach — bare HEAD detach on the primary (the #2270 refuse)", () => {
 	const headUpdate = (over: Partial<RefUpdate> = {}): RefUpdate => ({
 		oldOid: ZERO_OID,
@@ -224,6 +225,35 @@ describe("decideHeadDetach — bare HEAD detach on the primary (the #2270 refuse
 
 	it("an empty batch → allow", () => {
 		assert.strictEqual(decideHeadDetach([], {isPrimaryCheckout: true}).kind, "allow");
+	});
+
+	// git ≥ 2.45 (CI/prod runs 2.55) routes symref updates through the transaction: a `checkout main`
+	// reattach on the PRIMARY queues `HEAD` whose NEW VALUE is the symref `ref:refs/heads/main`, NOT a
+	// concrete oid. Measured on git 2.55.0. The pre-fix heuristic (any non-zero HEAD newOid with no
+	// paired branch ⇒ detach) false-refused this legitimate PULLER reattach — the #2415 regression.
+	it("a `checkout main` reattach on the primary (HEAD → ref:refs/heads/main symref, git ≥ 2.45) → allow", () => {
+		const d = decideHeadDetach(
+			[{oldOid: ZERO_OID, newOid: "ref:refs/heads/main", refName: HEAD_REF}],
+			{isPrimaryCheckout: true},
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a `switch <branch>` retarget on the primary (HEAD → ref:refs/heads/feature symref) → allow", () => {
+		const d = decideHeadDetach(
+			[{oldOid: ZERO_OID, newOid: "ref:refs/heads/feature", refName: HEAD_REF}],
+			{isPrimaryCheckout: true},
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	// The refuse path stays exact across versions: a concrete-oid HEAD move with no symref value and no
+	// paired branch is a real detach on both 2.40 and 2.55 (identical signature) — still refused.
+	it("a bare detach (concrete-oid HEAD, no symref, no paired branch) still refuses on the primary", () => {
+		const d = decideHeadDetach([{oldOid: ZERO_OID, newOid: OID_B, refName: HEAD_REF}], {
+			isPrimaryCheckout: true,
+		});
+		assert.strictEqual(d.kind, "refuse");
 	});
 });
 

--- a/packages/pipeline-cli/src/tools/ref-guard/ref-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/ref-guard.unit.test.ts
@@ -1,8 +1,10 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
+	decideHeadDetach,
 	decideRefUpdate,
 	decideTransaction,
 	GUARDED_REF,
+	HEAD_REF,
 	type OriginFacts,
 	type RefUpdate,
 	ZERO_OID,
@@ -134,6 +136,94 @@ describe("decideRefUpdate — totality", () => {
 				}
 			}
 		}
+	});
+});
+
+// #2270 mechanical half: a bare HEAD-detaching checkout on the shared PRIMARY checkout is
+// refused. The signal (grounded in git's real reference-transaction behavior, see the
+// command.hook.test.ts end-to-end cases) is a HEAD update to a concrete commit with NO paired
+// refs/heads/* update to the same oid in the batch — an attached move pairs them, a detach does
+// not — and only on the primary (a linked worktree's own HEAD is its business).
+describe("decideHeadDetach — bare HEAD detach on the primary (the #2270 refuse)", () => {
+	const headUpdate = (over: Partial<RefUpdate> = {}): RefUpdate => ({
+		oldOid: ZERO_OID,
+		newOid: OID_B,
+		refName: HEAD_REF,
+		...over,
+	});
+
+	it("a bare HEAD detach on the primary (HEAD → concrete, no paired branch) → refuse", () => {
+		const d = decideHeadDetach([headUpdate()], {isPrimaryCheckout: true});
+		assert.strictEqual(d.kind, "refuse");
+		assert.include(d.reason, "PRIMARY");
+	});
+
+	it("the same detach in a linked worktree (not primary) → allow", () => {
+		const d = decideHeadDetach([headUpdate()], {isPrimaryCheckout: false});
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("an attached commit on the primary (HEAD paired with refs/heads/main to the same oid) → allow", () => {
+		const d = decideHeadDetach(
+			[
+				{oldOid: OID_A, newOid: OID_B, refName: HEAD_REF},
+				{oldOid: OID_A, newOid: OID_B, refName: GUARDED_REF},
+			],
+			{isPrimaryCheckout: true},
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("the unborn-branch first commit (HEAD + refs/heads/main, both zero-old, same new) → allow", () => {
+		const d = decideHeadDetach(
+			[
+				{oldOid: ZERO_OID, newOid: OID_B, refName: HEAD_REF},
+				{oldOid: ZERO_OID, newOid: OID_B, refName: "refs/heads/main"},
+			],
+			{isPrimaryCheckout: true},
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a branch-only ref move on the primary (no HEAD update at all) → allow", () => {
+		const d = decideHeadDetach(
+			[{oldOid: ZERO_OID, newOid: OID_B, refName: "refs/heads/umut/feature"}],
+			{isPrimaryCheckout: true},
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a HEAD delete (new all-zeroes) on the primary is not a detach → allow", () => {
+		const d = decideHeadDetach([headUpdate({oldOid: OID_A, newOid: ZERO_OID})], {
+			isPrimaryCheckout: true,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a FETCH_HEAD / ORIG_HEAD update (not exactly HEAD) is out of scope → allow", () => {
+		const d = decideHeadDetach(
+			[
+				{oldOid: ZERO_OID, newOid: OID_B, refName: "FETCH_HEAD"},
+				{oldOid: ZERO_OID, newOid: OID_A, refName: "ORIG_HEAD"},
+			],
+			{isPrimaryCheckout: true},
+		);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("a detach paired with an UNRELATED branch move (different oid) still refuses", () => {
+		const d = decideHeadDetach(
+			[
+				{oldOid: ZERO_OID, newOid: OID_B, refName: HEAD_REF},
+				{oldOid: OID_A, newOid: OID_ORIGIN, refName: "refs/heads/other"},
+			],
+			{isPrimaryCheckout: true},
+		);
+		assert.strictEqual(d.kind, "refuse");
+	});
+
+	it("an empty batch → allow", () => {
+		assert.strictEqual(decideHeadDetach([], {isPrimaryCheckout: true}).kind, "allow");
 	});
 });
 


### PR DESCRIPTION
## What

Extend `ref-guard` past its `refs/heads/main`-update scope to also **refuse a bare HEAD-detaching checkout on the shared PRIMARY checkout** — the mechanical / root-cause half of bug #2270 (its acceptance criteria **1, 2, and 4**). The prose half (criterion 3) shipped separately in PR #2414.

Fixes #2415
Refs #2270 (completes the mechanical AC1/2/4)

## The gap

`decideRefUpdate` was scoped to `refs/heads/main` updates. A detaching `git checkout <sha>` / `checkout FETCH_HEAD` / `switch --detach` on the shared primary **moves `HEAD`** (symbolic-ref → detached) and does **not** update `refs/heads/main`, so it never reached the divergence check and was allowed — the exact operation that corrupts the human's shared checkout when a worktree-isolated agent's cwd resets to the primary between Bash calls (#2270's root mechanism).

## How it refuses a HEAD detach (grounded in git's real behavior, not assumed)

Per AC2, I verified against git 2.40 which mechanism actually observes a HEAD detach — the `reference-transaction` boundary **does** fire on a detach:

- A **detaching** checkout queues `<zero> <concrete-sha> HEAD` **alone** — no paired `refs/heads/*` update to that same commit.
- An **attached commit** (incl. the unborn-branch first commit) queues `HEAD` **paired** with its `refs/heads/<branch>` update to the *same* new oid.
- An **attached `switch <branch>`** retargets the HEAD symref and queues **no** `HEAD` update at all; the PULLER `checkout main` reattach likewise queues no `HEAD` ref update.

New pure-core `decideHeadDetach(updates, {isPrimaryCheckout})` refuses a queued update whose ref-name is exactly `HEAD` to a concrete commit **with no paired `refs/heads/*` move to that same commit** — the signal that isolates a detach from an attached move — and **only on the primary checkout**. The boundary (`command.ts`) resolves primary-vs-worktree by comparing `git rev-parse --git-dir` with `--git-common-dir` (equal ⇒ primary), the same plumbing `write-code`'s worktree preflight uses. Aborting the HEAD `reference-transaction` (exit 3, via the existing `lefthook.yml` wrapper) cleanly prevents the detach — HEAD stays attached to its branch.

## No false positives (AC3)

- **Worktree agents detaching their OWN HEAD** — fire against the per-tree git-dir (≠ common-dir) ⇒ `isPrimaryCheckout` false ⇒ allowed.
- **PULLER `checkout main` reattach + `merge --ff-only origin/main`** — reattach queues no HEAD ref update; the ff-merge is an attached `refs/heads/main` fast-forward (already allowed).
- **Human's normal attached work** — paired HEAD+branch moves are allowed.
- Fails **OPEN** when it can't prove the primary (indeterminate `rev-parse`), so a worktree agent is never false-refused.

## Tests (AC4)

- `ref-guard.unit.test.ts` — pure-core cases for `decideHeadDetach` (bare detach on primary → refuse; same detach in a worktree → allow; attached commit / unborn first commit / branch-only move / HEAD delete / FETCH_HEAD / unrelated-branch pairing / empty batch).
- `command.hook.test.ts` — end-to-end: install the real `reference-transaction` hook and drive a **real `git checkout`** detach on the primary (aborted, HEAD stays attached), an attached feature-branch commit (allowed), the `checkout main` reattach (allowed), and a detach inside a **linked worktree** (allowed).

Full `pipeline-cli` suite green (942 tests), typecheck + biome clean.

## §CP note

This is pipeline-cli code + tests only (no gate-skill edits), but it is control-plane-adjacent tooling — flagging for the §CP human-merge disposition per the triage note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)