### PR TITLE
feat(write-code): fail closed LOUD when expected worktree isolation is absent (#2443)

### DIFF
--- a/.decisions/0172-write-code-fails-loud-when-expected-worktree-isolation-is-absent.md
+++ b/.decisions/0172-write-code-fails-loud-when-expected-worktree-isolation-is-absent.md
@@ -1,0 +1,80 @@
+---
+id: 0172
+title: write-code fails closed LOUD when worktree isolation was expected but the harness didn't provision it — self-provision is standalone-only
+status: accepted
+date: 2026-07-11
+tags: [pipeline, worktree, harness, safety, gates]
+---
+
+# 0172 — write-code fails closed LOUD when expected worktree isolation is absent
+
+## Context
+
+The defense against primary-checkout corruption (a coder run mutating the shared primary
+checkout's git state — the [#2270](https://github.com/kamp-us/phoenix/issues/2270) class) is
+meant to be **two layers**:
+
+1. The harness provisions a linked git worktree for an `isolation:worktree` coder spawn and
+   injects `$WORKTREE_ROOT` (the contract in `.patterns/worktree-agent-constraints.md`).
+2. `write-code`'s Step-4 preflight backstops it (`git-dir == common-dir` ⇒ primary checkout ⇒
+   refuse), and a **Non-isolated fallback** self-provisions a worktree from a primary-checkout
+   start.
+
+Investigation [#2440](https://github.com/kamp-us/phoenix/issues/2440) (root cause resolved)
+established that the **harness layer silently no-ops** for coder spawns nested under the crew
+Workflow — an out-of-repo harness condition, not a repo bug. When it no-ops, two things happen
+at once:
+
+- The entire repo-side `worktree-guard` suite disarms: every subcommand keys on `$WORKTREE_ROOT`
+  (`packages/pipeline-cli/src/tools/worktree-guard/command.ts`), so an unset root makes
+  path-pinning, cwd-pinning, and the bare-git refusal all clean no-ops.
+- The **only** surviving defense is `write-code`'s Step-4 preflight plus its Non-isolated
+  fallback — but that fallback **self-provisions silently in *both* the expected-isolation-failure
+  case and a legitimate standalone run**, because Step-4 consulted only `git-dir`/`common-dir`,
+  never whether isolation was *expected*.
+
+So a harness no-op collapsed the two-layer guarantee to one, *and did so invisibly*: the operator
+never learned provisioning was broken, and the underlying harness bug stayed hidden behind a
+self-provision that "just worked."
+
+## Decision
+
+`write-code` Step-4 now **distinguishes an expected-isolation failure from a genuine standalone
+run**, and forks the primary-checkout refusal accordingly:
+
+- **Isolation was EXPECTED** and the run is on the primary checkout with `$WORKTREE_ROOT` unset
+  ⇒ **fail closed LOUD and stop.** Emit a ROUTED BLOCKER surfacing the harness provisioning
+  failure up to the operator/EM. **Do not self-provision** — that would paper over the harness
+  no-op and leave the two-layer defense collapsed to one, invisibly.
+- **Isolation was NOT expected** (a standalone `write-code`, e.g. a human `/write-code`) ⇒ the
+  Non-isolated self-provision fallback stays, unchanged. The loud branch never fires here, so the
+  standalone path does not regress.
+
+The **"isolation expected" signal is machine-checkable and grounded in the coder agent-type's
+unconditional-isolation assertion** (`claude-plugins/kampus-pipeline/agents/coder.md`), read from
+the harness-set `$CLAUDE_CODE_AGENT` env (the agent-type name — stable across an agent's separate
+Bash calls, unlike a shell `export`), corroborated by a set `$WORKTREE_ROOT`. It is *not* a
+per-run guess.
+
+### Why the skill-internal signal, not a `.claude/workflows/drive-issue.js` spawn-env marker
+
+The mechanism is deliberately internal to the `write-code` skill + `coder.md` agent surface: it
+reads the already-existing `$CLAUDE_CODE_AGENT` signal rather than injecting a new env var at the
+`drive-issue.js` spawn site. This keeps the §CP spawn-orchestrator untouched and avoids a new
+spawn-to-skill contract. `coder.md` is itself §CP (control-plane owned), so the agent-type
+assertion the signal rests on is governed; the signal consumes it, it does not re-declare it.
+
+## Consequences
+
+- **The harness failure becomes observable and routed** instead of silently absorbed. The
+  out-of-repo harness half (why provisioning no-ops for a Workflow-nested spawn) can be fixed
+  because the operator now learns it happened, rather than the fallback masking it.
+- **The additive branch fails safe.** If the `$CLAUDE_CODE_AGENT` value ever differs from what the
+  match expects, the run degrades to `isolation-expected=0` — today's silent self-provision — never
+  to a dangerous primary-checkout mutation. The loud branch only *adds* a stop; the pre-existing
+  `git-dir == common-dir` refusal is preserved intact.
+- **The standalone path is unchanged.** A human running `write-code` directly still self-provisions
+  via the Non-isolated fallback.
+- **Scope note (§CP):** this decision changes `agents/coder.md` (control-plane owned) alongside the
+  non-§CP `skills/write-code/SKILL.md`, so the PR is §CP and merges by a human control-plane owner.
+  It does **not** touch `.claude/workflows/drive-issue.js`.

--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -41,7 +41,9 @@ the resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 These hold on every run regardless of what the spawn prompt remembered to say:
 
 - **Worktree preflight before any git mutation (`wt_preflight`).** You run in an isolated
-  worktree (`isolation:worktree`). The harness resets your shell cwd back to the shared
+  worktree (`isolation:worktree`) — the coder agent-type **asserts worktree isolation
+  unconditionally**, so a run under you *expects* the harness to have provisioned a linked
+  worktree and set `$WORKTREE_ROOT`. The harness resets your shell cwd back to the shared
   **primary** checkout between Bash calls — edits land in your worktree, but a fresh `git`
   invocation runs where the cwd points. So **confirm pwd + branch before every
   branch/commit/push**, and address git at your worktree explicitly (`git -C "$WT" …`,
@@ -49,6 +51,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   `switch` / `rebase` / `reset`**, which detaches or mis-branches the shared primary tree
   (the #832 / #1103 edit-bleed / detach class). Follow the skill's Step-4 fail-closed
   preflight and the per-mutation `wt_preflight` exactly.
+- **If isolation was expected but the harness didn't provision it → FAIL CLOSED LOUD, never
+  self-provision (ADR 0172, #2443).** Because you are the coder agent-type, isolation is
+  *expected*: if the Step-4 preflight finds you on the PRIMARY checkout with `$WORKTREE_ROOT`
+  unset, the harness's worktree provisioning silently no-op'd (#2440) — which also disarms the
+  `$WORKTREE_ROOT`-keyed repo-side worktree-guard, leaving the preflight the sole surviving
+  layer. **Do NOT take the skill's Non-isolated self-provision fallback in that case** — that
+  path is only for a genuine standalone (non-coder) run; self-provisioning here would paper over
+  the harness failure and collapse the two-layer primary-corruption defense to one, invisibly
+  (the #2270 class). Surface the preflight's ROUTED BLOCKER up to the operator/EM instead.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries; every read and write
   goes through `gh api`.

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -655,24 +655,77 @@ GITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || {
 COMMON="$(git rev-parse --git-common-dir 2>/dev/null)"
 case "$COMMON" in /*) ;; *) COMMON="$(pwd)/$COMMON" ;; esac   # normalize relative `.git` (older git)
 COMMON="$(cd "$COMMON" && pwd)"
-echo "write-code preflight: git-dir=$GITDIR common-dir=$COMMON cwd=$(pwd)"   # emit scanned scope (ADR 0092 §1)
+
+# Was worktree isolation EXPECTED for this run? The coder agent-type (agents/coder.md) asserts
+# isolation UNCONDITIONALLY, so any run under it expects the harness to have provisioned a linked
+# worktree + set $WORKTREE_ROOT. The signal is machine-checkable and harness-set — the agent-type
+# env var $CLAUDE_CODE_AGENT (stable across an agent's Bash calls, unlike a shell `export`),
+# corroborated by a set $WORKTREE_ROOT — NOT a per-run guess. A genuine standalone human run (a
+# direct `/write-code`) matches NEITHER. This is what lets the fail-closed branch below distinguish
+# "isolation expected but the harness no-op'd provisioning" (#2440) from a legitimate standalone
+# run, so it fires LOUD in the first case without regressing the second. See ADR 0172.
+ISOLATION_EXPECTED=0
+case "$CLAUDE_CODE_AGENT" in coder|*coder*) ISOLATION_EXPECTED=1 ;; esac   # ran AS the coder agent-type
+[ -n "$WORKTREE_ROOT" ] && ISOLATION_EXPECTED=1                            # harness signalled a provisioned root
+echo "write-code preflight: git-dir=$GITDIR common-dir=$COMMON cwd=$(pwd) isolation-expected=$ISOLATION_EXPECTED (agent=${CLAUDE_CODE_AGENT:-unset} worktree-root=${WORKTREE_ROOT:+set})"   # emit scanned scope (ADR 0092 §1)
 if [ "$GITDIR" = "$COMMON" ]; then
+  if [ "$ISOLATION_EXPECTED" = 1 ]; then
+    # FAIL-CLOSED LOUD (the #2443 branch): isolation was EXPECTED but this run is on the PRIMARY
+    # checkout with no linked worktree — the harness's `git worktree add` + $WORKTREE_ROOT injection
+    # silently didn't run for this coder spawn (#2440's harness no-op). Because the whole repo-side
+    # worktree-guard keys on $WORKTREE_ROOT, that no-op ALSO disarmed it, leaving this preflight the
+    # sole surviving layer. Do NOT self-provision here: doing so papers over the harness failure and
+    # leaves the two-layer primary-corruption defense collapsed to one, invisibly (#2270 class).
+    echo "write-code preflight FAILED (fail-closed, LOUD): worktree isolation was EXPECTED (agent=${CLAUDE_CODE_AGENT:-?}, worktree-root=${WORKTREE_ROOT:+set}) but this run is on the PRIMARY checkout (git-dir == common-dir) and \$WORKTREE_ROOT is unset." >&2
+    echo "  ROOT CAUSE: the harness's worktree provisioning (git worktree add + \$WORKTREE_ROOT injection) did NOT run for this coder spawn — the #2440 harness no-op. The repo-side worktree-guard also keys on \$WORKTREE_ROOT, so it is disarmed too; only this preflight is left." >&2
+    echo "  REFUSING to self-provision — that would hide the harness failure and leave the two-layer defense collapsed to one, invisibly (the primary-checkout-corruption class, #2270)." >&2
+    echo "  ROUTED BLOCKER — surface UP to the operator/EM: 'harness worktree provisioning no-op'd for a coder spawn (isolation expected, \$WORKTREE_ROOT unset); the out-of-repo harness half (#2440) needs attention. Do NOT blindly retry the same spawn.'" >&2
+    exit 1
+  fi
+  # isolation was NOT expected ⇒ a genuine standalone run: fall through to the Non-isolated fallback,
+  # which self-provisions a worktree (this path is unchanged, and the loud branch above never fires for it).
   echo "write-code preflight FAILED (fail-closed): git-dir == common-dir ⇒ this is the PRIMARY checkout, not an isolated worktree." >&2
   echo "  Refusing to branch/commit here — a spawn without isolation:worktree (or a cwd reset to the primary tree) would mis-branch the owner's checkout." >&2
-  echo "  Fix: re-spawn write-code with isolation:worktree, or take the Non-isolated fallback below to create a worktree before mutating." >&2
+  echo "  This run did NOT expect isolation (standalone) — take the Non-isolated fallback below to create a worktree before mutating." >&2
   exit 1
 fi
 ```
 
 The preflight is **fail-closed by construction**: it refuses on the primary checkout, on a
 not-a-repo cwd, *and* on the ambiguous default — only positive evidence of a linked worktree
-(git-dir ≠ common-dir) lets it through. It is **observable** (it prints the two dirs + cwd it
-compared, so "what did the preflight look at" is answerable from the run log) and **idempotent**
-(read-only `git rev-parse`, safe to re-run). The **one** sanctioned way to satisfy it from a
-non-worktree start is the [Non-isolated fallback](#non-isolated-fallback) below — which creates
-a real linked worktree and `cd`s into it, after which this same check passes. **Never** route
-around the preflight by deleting it or relaxing the comparison; a green preflight is the
-precondition every mutation in Steps 4–7 relies on.
+(git-dir ≠ common-dir) lets it through. It is **observable** (it prints the two dirs + cwd +
+`isolation-expected` it compared, so "what did the preflight look at" is answerable from the run
+log) and **idempotent** (read-only `git rev-parse`, safe to re-run). **Never** route around the
+preflight by deleting it or relaxing the comparison; a green preflight is the precondition every
+mutation in Steps 4–7 relies on.
+
+**The primary-checkout refusal forks on whether isolation was *expected* (ADR 0172, #2443).** The
+`git-dir == common-dir` refusal is a hard stop in both directions, but *how* you're meant to
+recover differs, and conflating the two is what let a harness failure hide:
+
+- **Isolation was EXPECTED** (`isolation-expected=1` — the run is under the coder agent-type, or
+  `$WORKTREE_ROOT` was set) yet you're on the primary checkout ⇒ **fail closed LOUD and STOP.**
+  This is the [#2440](https://github.com/kamp-us/phoenix/issues/2440) harness no-op: the harness
+  was supposed to provision a linked worktree and inject `$WORKTREE_ROOT` but silently didn't, which
+  *also* disarms the whole `$WORKTREE_ROOT`-keyed repo-side worktree-guard — so this preflight is
+  the only surviving layer. **Do NOT self-provision to route around it.** Self-provisioning here
+  would paper over the harness failure and leave the two-layer primary-corruption defense collapsed
+  to one, *invisibly* (the [#2270](https://github.com/kamp-us/phoenix/issues/2270)
+  primary-checkout-corruption class). Instead surface the printed **ROUTED BLOCKER** up to the
+  operator/EM so the out-of-repo harness half gets fixed rather than silently absorbed.
+- **Isolation was NOT expected** (`isolation-expected=0` — a genuine standalone `write-code`, e.g.
+  a human running `/write-code` directly) ⇒ take the [Non-isolated fallback](#non-isolated-fallback)
+  below, which creates a real linked worktree and `cd`s into it, after which this same check passes.
+  This is the **only** path where self-provisioning is sanctioned; the loud branch above never fires
+  for it, so the standalone flow is unchanged.
+
+The `isolation-expected` signal is **machine-checkable and grounded in the coder agent-type's
+unconditional-isolation assertion** ([`../../agents/coder.md`](../../agents/coder.md)), read from the
+harness-set `$CLAUDE_CODE_AGENT` env (stable across an agent's separate Bash calls) plus a set
+`$WORKTREE_ROOT` — never a per-run guess. It **fails safe**: if the agent-type value ever differs from
+what's matched, the run degrades to `isolation-expected=0` (today's silent self-provision), never to a
+dangerous primary-checkout mutation — the loud branch only *adds* a stop, it never removes the
+existing refusal.
 
 <a id="per-mutation-preflight"></a>
 > **The preflight runs once at Step-4 start AND re-asserts before EVERY git-mutating op.**
@@ -793,8 +846,12 @@ docblocks in a file (the `coder.md` standing invariant is the source; #2186).
 > then `cd "$WT"`. Branch off `FETCH_HEAD` (the just-fetched origin tip), **never** the possibly-stale
 > `origin/main` ref. When you're done, remove it with `git worktree remove "$WT"`. After the `cd "$WT"`, **re-run the Step 4 preflight** — the
 > fresh worktree's git-dir now differs from the common dir, so the check passes and you may
-> mutate. This is the *only* sanctioned route from a primary-checkout start; the preflight
-> stays fail-closed until a real worktree exists. Here too the branch name is **created once**
+> mutate. This fallback is **only for the standalone (`isolation-expected=0`) path** — a run where
+> isolation was *expected* must NOT reach it: the preflight's loud branch (ADR 0172, #2443) hard-stops
+> that case *before* here, because self-provisioning would silently absorb a harness provisioning
+> failure (#2440) and collapse the two-layer defense to one. For a standalone run this is the only
+> sanctioned route from a primary-checkout start; the preflight stays fail-closed until a real
+> worktree exists. Here too the branch name is **created once**
 > and thereafter **re-derived live** from the worktree (`git -C "$WT" branch
 > --show-current`) at each later git op — never carried across Bash calls in a shared file
 > (see [the live-derivation rule](#branch-name-is-re-derived-live) above; the same


### PR DESCRIPTION
Fixes #2443

## What & why

The primary-checkout-corruption defense is meant to be **two layers**: (1) the harness provisions a linked worktree for an `isolation:worktree` coder spawn and sets `$WORKTREE_ROOT`; (2) `write-code`'s Step-4 preflight backstops it. #2440 (resolved) found the harness layer **silently no-ops** for Workflow-nested coder spawns — which *also* disarms the whole `$WORKTREE_ROOT`-keyed repo-side worktree-guard, leaving Step-4 the sole surviving layer. But Step-4's Non-isolated fallback then **self-provisioned silently in both the expected-isolation-failure case and a legitimate standalone run**, so the two-layer guarantee collapsed to one, invisibly.

## The fix

Step-4 now distinguishes an **expected-isolation failure** from a **genuine standalone run** and forks the primary-checkout refusal:

- **Isolation EXPECTED** + primary checkout + `$WORKTREE_ROOT` unset ⇒ **fail closed LOUD**, emit a ROUTED BLOCKER up to the operator/EM. **No self-provision** — that would paper over the harness no-op (#2440) and leave the two-layer defense collapsed to one (#2270 class).
- **Isolation NOT expected** (standalone `/write-code`) ⇒ the Non-isolated self-provision fallback stays, unchanged.

The "isolation expected" signal is **machine-checkable and grounded in the coder agent-type's unconditional-isolation assertion** (`agents/coder.md`) via the harness-set `$CLAUDE_CODE_AGENT` env, corroborated by `$WORKTREE_ROOT`. It **fails safe**: an unexpected agent-type value degrades to today's silent self-provision, never a dangerous primary-checkout mutation. The pre-existing `git-dir == common-dir` refusal is preserved (additive branch).

## Acceptance criteria (#2443)

- [x] Coder run, isolation expected, `$WORKTREE_ROOT` unset ⇒ fails closed LOUD, routed blocker up, not silently self-provisioned.
- [x] "Isolation expected" signal machine-checkable, grounded in `agents/coder.md`'s unconditional-isolation assertion (`$CLAUDE_CODE_AGENT`), not guessed per-run.
- [x] Genuinely-standalone (marker-absent) run still self-provisions via the Non-isolated fallback — no regression.
- [x] Existing fail-closed `git-dir == common-dir` primary-checkout refusal preserved (additive).
- [x] §CP surface changed goes to human review/merge (see below).

## §CP + ADR

- **§CP:** this changes `claude-plugins/kampus-pipeline/agents/coder.md` (control-plane owned per CODEOWNERS) alongside the non-§CP `skills/write-code/SKILL.md` and the new ADR. So this PR is **§CP → human control-plane merge** (stops at reviewed-ready; the author does not merge).
- **Mechanism choice called out for the merger:** the chosen mechanism is **skill-internal** (reads the existing `$CLAUDE_CODE_AGENT` signal) and **does NOT touch the §CP spawn site `.claude/workflows/drive-issue.js`** — the triage-preferred path that avoids editing the orchestrator.
- **ADR authored:** [`0172`](.decisions/0172-write-code-fails-loud-when-expected-worktree-isolation-is-absent.md) records the fail-closed-vs-self-provision decision and the `$CLAUDE_CODE_AGENT` signal contract.

## Files
- `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` — Step-4 preflight fork + prose + fallback scoping
- `claude-plugins/kampus-pipeline/agents/coder.md` (§CP) — standing invariant for the loud-fail
- `.decisions/0172-*.md` — new ADR

## Note (dogfooding)
This PR was produced by a `write-code` run that itself had **no `$WORKTREE_ROOT`** — the exact harness no-op #2440/#2443 describe. Because the run was under the `engineering-manager` agent-type (not `coder`), the new guard correctly classified it `isolation-expected=0` and self-provisioned via the standalone fallback, as intended.