### PR TITLE
fix(pasaport): case-insensitive /u/:username lookup (#2445)

### DIFF
--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -36,7 +36,7 @@ import {
 import {contributionOrdering} from "./ordering.ts";
 import type {ProfileRow} from "./profile-fields.ts";
 import {toUserRow, type UserRow} from "./user-fields.ts";
-import {checkUsername} from "./username-rule.ts";
+import {checkUsername, normalizeUsername} from "./username-rule.ts";
 
 // `UserRow`/`ProfileRow` are single-sourced in their field-map modules (#1545);
 // re-exported here so cross-feature callers keep their `./Pasaport.ts` import.
@@ -618,7 +618,7 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 					value: string;
 				}) {
 					const {userId} = input;
-					const normalized = input.value.trim().toLowerCase();
+					const normalized = normalizeUsername(input.value);
 					yield* assertUsername(normalized);
 
 					const existingUser = yield* run((db) => db.query.user.findFirst({where: {id: userId}}));
@@ -702,6 +702,11 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						sandboxViewer?: SandboxViewer | undefined;
 					},
 				) {
+					// Usernames are stored lowercased at write time (`setUsername`), so the
+					// read must normalize identically or a mixed-case `/u/Rasit` misses the
+					// stored `rasit` row and 404s (#2445). `normalizeUsername` is the one
+					// source read and write share, keeping every entry point case-insensitive.
+					const normalized = normalizeUsername(username);
 					const rows = yield* run((db) =>
 						db
 							.select({
@@ -712,7 +717,7 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 								totalKarma: schema.userProfile.totalKarma,
 							})
 							.from(schema.userProfile)
-							.where(eq(schema.userProfile.username, username))
+							.where(eq(schema.userProfile.username, normalized))
 							.limit(1),
 					);
 					const row = rows[0];

--- a/apps/web/worker/features/pasaport/lookup-profile-case-insensitive.unit.test.ts
+++ b/apps/web/worker/features/pasaport/lookup-profile-case-insensitive.unit.test.ts
@@ -1,0 +1,146 @@
+/**
+ * `Pasaport.lookupProfile` normalizes the incoming username the same way the write
+ * path does, so a mixed-case `/u/Rasit` resolves the lowercased stored `rasit` row
+ * instead of 404ing (#2445). Usernames are written lowercased (`setUsername` →
+ * `normalizeUsername`); the read must match that canonical form or the exact `eq`
+ * misses. This pins the profile-row SELECT to bind the lowercased handle regardless
+ * of the URL casing, and that a genuinely-absent handle still resolves to `null`.
+ *
+ * Unit-tier per ADR 0082: the query BUILDER is captured off `.toSQL()` (never
+ * executed), so `params` exposes the bound `where "username" = ?` value directly —
+ * that bound value IS the normalized lookup key, which is exactly what this asserts.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
+
+const inertAuth = {} as BetterAuthInstance;
+
+const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
+	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
+
+const isThenable = (v: unknown): v is PromiseLike<unknown> =>
+	typeof v === "object" && v !== null && typeof (v as {then?: unknown}).then === "function";
+
+// An inert D1 binding: the count reads (`countByAuthor`, a `.then()`) execute here and
+// resolve to empty; only SQL compilation is exercised, results are inert.
+function inertD1(): D1Database {
+	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only SQL compilation is exercised, results are inert.
+	return {
+		prepare() {
+			const stmt = {
+				bind: () => stmt,
+				all: async () => ({results: []}),
+				first: async () => null,
+				run: async () => ({}),
+				raw: async () => [],
+			};
+			return stmt;
+		},
+		batch: async () => [],
+	} as unknown as D1Database;
+}
+
+interface CapturedBuilder {
+	sql: string;
+	params: unknown[];
+}
+
+// Drives `lookupProfile` over scripted `run` results while CAPTURING each query
+// BUILDER's compiled SQL + bound params off `.toSQL()` (without executing it); a count
+// PROMISE is awaited so it resolves inertly. The first captured builder is the
+// profile-row SELECT — its bound param is the normalized lookup key under test.
+function capturingAccess(
+	binding: D1Database,
+	results: ReadonlyArray<unknown>,
+): {access: DrizzleAccess; builders: CapturedBuilder[]} {
+	const renderDb = drizzle(binding, {relations});
+	const builders: CapturedBuilder[] = [];
+	const state = {i: 0};
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) =>
+			Effect.promise(async () => {
+				const built = fn(renderDb) as unknown;
+				if (hasToSQL(built)) {
+					const compiled = built.toSQL();
+					builders.push({sql: compiled.sql, params: compiled.params});
+				} else if (isThenable(built)) {
+					await built;
+				}
+				return results[state.i++] as A;
+			}),
+		batch: () => Effect.die(new Error("lookupProfile must not batch")),
+	};
+	return {access, builders};
+}
+
+const pasaportOver = (access: DrizzleAccess) =>
+	makePasaportLive(inertAuth).pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+const STORED_ROW = {
+	userId: "user-rasit",
+	username: "rasit",
+	displayName: "Rasit",
+	image: null,
+	totalKarma: 0,
+};
+
+// A found profile: 1 profile-row SELECT (builder) then 3 `countByAuthor` reads.
+const foundResults = [[STORED_ROW], 0, 0, 0] as const;
+
+// Run `lookupProfile(arg)` over the found script; return the captured profile-row
+// SELECT builder (the first `run`) so its bound `where username = ?` param can be read.
+const runLookup = (arg: string) =>
+	Effect.gen(function* () {
+		const {access, builders} = capturingAccess(inertD1(), [...foundResults]);
+		yield* Effect.gen(function* () {
+			const pasaport = yield* Pasaport;
+			yield* pasaport.lookupProfile(arg);
+		}).pipe(Effect.provide(pasaportOver(access)));
+		const profileRow = builders[0];
+		if (!profileRow) throw new Error("expected the profile-row SELECT builder to be captured");
+		return profileRow;
+	});
+
+describe("Pasaport.lookupProfile — case-insensitive lookup (#2445)", () => {
+	for (const arg of ["Rasit", "RASIT", "rasit", "  Rasit  "]) {
+		it.effect(`\`${arg}\` binds the lowercased canonical handle \`rasit\``, () =>
+			Effect.gen(function* () {
+				const profileRow = yield* runLookup(arg);
+				assert.match(profileRow.sql.toLowerCase(), /"username" = \?/, "exact eq on username");
+				assert.include(
+					profileRow.params as unknown[],
+					"rasit",
+					"the lookup normalizes to the stored-lowercased handle before the eq",
+				);
+				// A non-canonical raw arg must never survive to the bound key; skip when the
+				// arg already IS the canonical form (nothing distinct to exclude).
+				if (arg.trim() !== "rasit") {
+					assert.notInclude(
+						profileRow.params as unknown[],
+						arg.trim(),
+						"the raw mixed-case arg is never the bound key",
+					);
+				}
+			}),
+		);
+	}
+
+	it.effect("a genuinely-absent handle still resolves to null (normalize ≠ match-any)", () =>
+		Effect.gen(function* () {
+			// Empty profile-row result ⇒ no row ⇒ null, and the counts never fire.
+			const {access} = capturingAccess(inertD1(), [[]]);
+			const row = yield* Effect.gen(function* () {
+				const pasaport = yield* Pasaport;
+				return yield* pasaport.lookupProfile("Nobody");
+			}).pipe(Effect.provide(pasaportOver(access)));
+			assert.strictEqual(
+				row,
+				null,
+				"an absent username 404s — casing normalization is not match-any",
+			);
+		}),
+	);
+});


### PR DESCRIPTION
Fixes #2445

## Problem

Usernames are stored **lowercased** at write time — `Pasaport.setUsername` normalizes with `.trim().toLowerCase()` before writing the `user` row and upserting the `userProfile` identity. But the **read path did not normalize**: `Pasaport.lookupProfile` ran an exact-match query (`.where(eq(schema.userProfile.username, username))`) against the raw route arg. So `/u/Rasit` looked up the literal `"Rasit"`, missed the lowercased stored `"rasit"` row, and the SPA rendered its 404 (`kullanıcı bulunamadı, @Rasit burada yok.`); only the manually-lowercased `/u/rasit` matched.

## Fix (root cause, single normalization site)

Mirror the write-side normalization on the read side, inside `lookupProfile`, using the existing `normalizeUsername` domain helper (`apps/web/worker/features/pasaport/username-rule.ts`) — the one source read and write now share. Normalizing at the lookup makes **every** entry point case-insensitive at the source (route param, a hand-typed or shared mixed-case URL), not just the pano comment link. `setUsername` now routes its inline `.trim().toLowerCase()` through the same helper too, so read and write agree on the canonical form by construction.

This targets the un-normalized lookup (the root cause), not the `CommentTreeNode` client fallback (a mitigation).

## Acceptance criteria

- [x] `/u/:username` resolves case-insensitively: `/u/Rasit`, `/u/RASIT`, `/u/rasit` all resolve the stored `rasit` row.
- [x] The lookup normalizes with the same rule the write path uses (`normalizeUsername` = `.trim().toLowerCase()`), so read and write agree on the canonical form.
- [x] A unit test covers the mixed-case lookup path — `lookup-profile-case-insensitive.unit.test.ts` asserts a mixed-case (and whitespace-padded) arg binds the lowercased `rasit` key before the `eq`.
- [x] Genuinely-absent usernames still 404 — a test asserts an absent handle resolves to `null` (normalization is not match-any).

## Verification

- `pnpm vitest run --project unit worker/features/pasaport` — 154 pass (5 new).
- `pnpm typecheck` — clean.
- `pnpm lint:worktree` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)