### PR TITLE
docs(wayfinder): collapse unreachable fork-only sentence in WORK step-1 (#2450)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
@@ -225,8 +225,9 @@ shaped for and the durable seam between runs — WORK mutates the map only throu
    ticket. Otherwise pick the **next resolvable** ticket deterministically (oldest sub-issue
    first). A ticket already flagged **founder-decision-fork** and awaiting the founder is **not
    resolvable by the agent** — skip it (see the seam below) and take the next investigation ticket.
-   If the only remaining frontier is forks awaiting the founder, there is nothing for WORK to
-   resolve: surface that the map is blocked on the human and stop.
+   A fork-only map (no answerable ticket left) is already caught by the emission-readiness check
+   above, which routes it into emission's graceful-block-on-human handling — so it never reaches
+   this pick step.
 
 2. **Classify the picked ticket — investigation (AFK) or founder-decision-fork.** An investigation
    ticket (`type:investigation`, the AFK/Research + Prototype-spike rows of CHART's translation


### PR DESCRIPTION
WORK mode's step-1 in `claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md` checks emission-readiness first. Because the `wayfinder-map` CLI's `answerableFrontier`/`isGraduationReady` exclude founder-decision forks from the answerable frontier, a fork-only map returns "ready" and routes into emission's graceful-block-on-human handling — it never reaches the `Otherwise` pick branch. The trailing sentence there ("If the only remaining frontier is forks awaiting the founder … stop") was therefore unreachable dead doc.

This collapses that dead sentence into a one-line pointer to the emission-readiness check that actually governs fork-only maps, so step-1 reads with a single clear path. The fork-only-map behavior stays documented (it routes via the emission-readiness check into emission's graceful-block-on-human handling) and the safe fork-never-auto-resolved semantics remain enforced by the emission path.

No behavior/code change: `answerableFrontier` / `isGraduationReady` are untouched; docs-only.

Fixes #2450