### PR TITLE
feat(pipeline): extend the #2446 fail-closed isolation guard to review-code/review-trivial/ship-it (#2454)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1654,6 +1654,73 @@ keeps the head's *instructions* out of a reviewer's path; this keeps *the gate's
 of the owner's working tree. A gate that needs a materialized head has the per-run-ref +
 throwaway-worktree mechanism above; it never reaches for the launched checkout.
 
+### RO-iso. `iso_preflight` — refuse head-materialization from the PRIMARY checkout when isolation was expected (ADR 0172)
+
+The §RO throwaway-worktree/per-run-ref materialization is safe **only** when the gate's git
+ops land somewhere other than the shared **primary** checkout's working state. The
+[#2452](https://github.com/kamp-us/phoenix/issues/2452)/[#2453](https://github.com/kamp-us/phoenix/issues/2453)
+detach proved the residual hole: a review/ship gate spawned `isolation:worktree` but dropped —
+by the [#2440](https://github.com/kamp-us/phoenix/issues/2440) harness no-op — into the primary
+checkout with `$WORKTREE_ROOT` unset ran its head-materialization there. That no-op *also*
+disarms the entire `$WORKTREE_ROOT`-keyed repo-side `worktree-guard`
+(`packages/pipeline-cli/src/tools/worktree-guard/`), so nothing loudly refused.
+
+`iso_preflight <surface>` is the **single-sourced** reviewer/shipper sibling of `write-code`'s
+Step-4 `wt_preflight` (ADR [0172](https://github.com/kamp-us/phoenix/blob/main/.decisions/0172-write-code-fails-loud-when-expected-worktree-isolation-is-absent.md),
+#2443/#2446): the **same** `git-dir == common-dir` primary-checkout detection and the **same**
+isolation-expected fork, defined **once here** so the three head-materializing gates
+(`review-code`, `review-trivial`, `ship-it`) share one contract rather than drifting three
+copies apart. Each gate runs it — `iso_preflight <surface> || exit 1` — **before** its first
+head fetch / `git worktree add`:
+
+```bash
+# iso_preflight <surface>: the shared primary-checkout fail-closed guard every head-materializing
+# gate runs BEFORE its first head fetch / `git worktree add` (§RO). Reviewer/shipper sibling of
+# write-code's Step-4 wt_preflight (ADR 0172) — the SAME git-dir==common-dir detection, the SAME
+# isolation-expected fork. Read-only (git rev-parse only); safe to re-run.
+iso_preflight() {
+  local surface="$1" gitdir common iso=0
+  gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null)" || {
+    echo "$surface iso_preflight FAILED (fail-closed): not inside a git repository — refusing to materialize a PR head." >&2; return 1; }
+  common="$(git rev-parse --git-common-dir 2>/dev/null)"
+  case "$common" in /*) ;; *) common="$(pwd)/$common" ;; esac   # normalize a relative `.git` (older git)
+  common="$(cd "$common" && pwd)"
+  # Isolation was EXPECTED when the run is under an isolation-asserting pipeline agent-type —
+  # coder/reviewer/shipper all spawn isolation:worktree (agents/{coder,reviewer,shipper}.md) — read
+  # from the harness-set $CLAUDE_CODE_AGENT (stable across an agent's Bash calls, unlike a shell
+  # export), corroborated by a set $WORKTREE_ROOT. A genuine standalone run (a human /review-code,
+  # /ship-it) matches NEITHER. Critically the LOUD refusal fires on the AGENT-TYPE ALONE and does
+  # NOT key on $WORKTREE_ROOT being set — so the #2440 no-op (isolation requested, $WORKTREE_ROOT
+  # unset, which also disarms the $WORKTREE_ROOT-keyed worktree-guard) still trips this preflight;
+  # it is then the sole surviving layer, exactly as in write-code (ADR 0172).
+  case "$CLAUDE_CODE_AGENT" in coder|*coder*|reviewer|*reviewer*|shipper|*shipper*) iso=1 ;; esac
+  [ -n "$WORKTREE_ROOT" ] && iso=1
+  echo "$surface iso_preflight: git-dir=$gitdir common-dir=$common cwd=$(pwd) isolation-expected=$iso (agent=${CLAUDE_CODE_AGENT:-unset} worktree-root=${WORKTREE_ROOT:+set})"
+  if [ "$gitdir" = "$common" ]; then
+    if [ "$iso" = 1 ]; then
+      echo "$surface iso_preflight FAILED (fail-closed, LOUD): worktree isolation was EXPECTED (agent=${CLAUDE_CODE_AGENT:-?}, worktree-root=${WORKTREE_ROOT:+set}) but this run is on the PRIMARY checkout (git-dir == common-dir) and \$WORKTREE_ROOT is unset." >&2
+      echo "  Refusing to fetch / \`git worktree add\` the PR head here — the #2440 harness no-op left this $surface spawn in the shared primary checkout, and a head-materialization run there is the #2452/#2453 primary-checkout-detach surface. The \$WORKTREE_ROOT-keyed repo-side worktree-guard is disarmed by the same no-op, so THIS preflight is the only surviving layer." >&2
+      echo "  Do NOT self-provision a worktree to route around it — that hides the harness failure and leaves the primary-corruption defense collapsed to one, invisibly (#2270)." >&2
+      echo "  ROUTED BLOCKER — surface UP to the operator/EM: 'harness worktree provisioning no-op'd for a $surface spawn (isolation expected, \$WORKTREE_ROOT unset); the out-of-repo harness half (#2440) needs attention. Do NOT blindly retry the same spawn.'" >&2
+      return 1
+    fi
+    # isolation NOT expected ⇒ a genuine standalone run on the owner's primary checkout. This gate
+    # never mutates the launched tree (§RO): it materializes the head ONLY into a throwaway worktree
+    # / per-run ref, so operating from the primary checkout is safe here — proceed, no LOUD stop.
+    echo "$surface iso_preflight: standalone run on the primary checkout — proceeding read-only via the §RO throwaway-worktree / per-run-ref materialization (the launched tree is never mutated)." >&2
+  fi
+}
+```
+
+The fork is what keeps this **non-breaking for a legitimate standalone gate**: §RO explicitly
+runs a gate "in a checkout it does not own — often the owner's live checkout," and that
+standalone-on-primary mode stays allowed (the gate's materialization is throwaway-only). The
+LOUD stop fires **only** for an isolation-expected pipeline spawn that mis-landed on the primary
+checkout — the exact #2440/#2453 condition. `write-code`'s Step-4 `wt_preflight` is the stricter
+sibling (it *always* expects isolation and additionally must branch the session tree, so it also
+refuses the standalone-on-primary case via its Non-isolated fallback); it is a deliberate,
+documented specialization of this same contract, not a fourth drifting copy.
+
 ---
 
 ## HEAD. Review the PR head, never the launched checkout's working copy (#793)

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -250,6 +250,14 @@ make the isolation hold *by construction*, not by your remembering to behave:
 Your own session stays in *this* worktree (the trusted base config you were launched under).
 
 ```bash
+# Isolation preflight FIRST, before any head fetch / `git worktree add` below. If this
+# review-code spawn expected worktree isolation (reviewer agent-type) but the #2440 harness no-op
+# dropped it onto the shared PRIMARY checkout ($WORKTREE_ROOT unset), materializing the head here
+# is the #2452/#2453 primary-checkout-detach surface — fail closed LOUD and route up, never
+# materialize. Single-sourced in gh-issue-intake-formats.md §RO-iso (ADR 0172; the write-code
+# wt_preflight sibling). A genuine standalone run on the owner's checkout still proceeds.
+iso_preflight review-code || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
+
 # the trusted base — the PR's merge target at tip; your config already comes from here
 BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
 

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -142,6 +142,14 @@ split holds too (ADR 0052): the **head is the diff under test**, your **config/i
 come from the trusted base** — never load the head's `.claude/**` / `CLAUDE.md` / hooks.
 
 ```bash
+# Isolation preflight FIRST, before the head fetch below. If this review-trivial spawn expected
+# worktree isolation (reviewer agent-type) but the #2440 harness no-op dropped it onto the shared
+# PRIMARY checkout ($WORKTREE_ROOT unset), fetching the head here is the #2452/#2453
+# primary-checkout-detach surface — fail closed LOUD and route up. Single-sourced in
+# gh-issue-intake-formats.md §RO-iso (ADR 0172; the write-code wt_preflight sibling). A genuine
+# standalone run on the owner's checkout still proceeds (the head read is via `git show`, checkout-free).
+iso_preflight review-trivial || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
+
 HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
 PR_REF="refs/review-trivial/$PR"
 git fetch --no-tags origin "pull/$PR/head:$PR_REF" >/dev/null 2>&1 || git fetch origin "$HEAD_SHA" >/dev/null 2>&1

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -193,6 +193,14 @@ Before anything else, read the PR's changed files and split them by class. This 
 
 ```bash
 PR=<pr number>
+# Isolation preflight FIRST. ship-it is §RO — it ships entirely over `gh api` / `gh pr merge`
+# (server-side) and materializes NO head via local git — so it should never touch the primary
+# checkout's git state. This is the defense-in-depth belt: if this ship-it spawn expected worktree
+# isolation (shipper agent-type) but the #2440 harness no-op dropped it onto the shared PRIMARY
+# checkout ($WORKTREE_ROOT unset — the #2452/#2453 condition), fail closed LOUD and route up rather
+# than run any git op there. Single-sourced in gh-issue-intake-formats.md §RO-iso (ADR 0172; the
+# write-code wt_preflight sibling). A genuine standalone `/ship-it` on the owner's checkout still proceeds.
+iso_preflight ship-it || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
 gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
 ```
 

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
@@ -24,11 +24,13 @@
  * `git stash pop` + `reset --hard` on the owner's checkout, silently discarding its
  * uncommitted state — same shared-checkout hazard, same fail-closed refusal). The owner's
  * ruling on the arm-vs-refuse posture (issue #1571) is REFUSE, scoped to guarded
- * agents: the refusal fires only when `$WORKTREE_ROOT` names a managed worktree —
- * i.e. this hook is active for an `isolation:worktree` subagent. The orchestrator's
- * own shell runs no such hook and carries no `$WORKTREE_ROOT`, so its legitimate
- * `git checkout main` (the ff-pull/reattach flow) can never reach this refusal. See
- * `.patterns/worktree-agent-constraints.md` (the guard route, now enforced).
+ * agents: the refusal fires when `$WORKTREE_ROOT` names a managed worktree —
+ * i.e. this hook is active for an `isolation:worktree` subagent — OR, per ADR 0172, when
+ * isolation was EXPECTED (an isolation-asserting agent-type) yet `$WORKTREE_ROOT` is unset
+ * (the #2440 harness no-op that disarms the root-keyed branch and leaves this the sole layer).
+ * The orchestrator's own shell runs no such hook, carries no `$WORKTREE_ROOT`, and asserts no
+ * isolation, so its legitimate `git checkout main` (the ff-pull/reattach flow) can never reach
+ * either refusal. See `.patterns/worktree-agent-constraints.md` (the guard route, now enforced).
  */
 
 export type BashDecision =
@@ -129,11 +131,31 @@ const REFUSE_REASON =
 	'`git -C "$WT" <op> …`, or bring a PR head in by ref — ' +
 	'`git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD`.';
 
+// The #2452/#2453 detach: an isolation-expecting agent (coder/reviewer/shipper) whose harness
+// no-op'd worktree provisioning (#2440) has NO worktree, so `$WORKTREE_ROOT` is unset — which ALSO
+// disarms the whole $WORKTREE_ROOT-keyed refusal below, allowing everything. With no worktree, even
+// the `-C "$WT"` "safe" form the REFUSE_REASON above points agents to resolves `$WT`
+// (`git rev-parse --show-toplevel`) to the shared PRIMARY checkout and detaches its HEAD. So when
+// isolation was expected but no managed worktree exists, a head-moving git op is REFUSED regardless
+// of `-C` scoping — this preflight is then the surviving layer (ADR 0172).
+const REFUSE_REASON_ISOLATION_NO_ROOT =
+	"refused a working-state-mutating git op (checkout/switch/reset/rebase/stash/merge) for an " +
+	"isolation-expecting agent (coder/reviewer/shipper) with NO provisioned worktree ($WORKTREE_ROOT " +
+	'unset/non-managed — the #2440 harness no-op). With no worktree the `-C "$WT"` form resolves to ' +
+	"the shared PRIMARY checkout and would detach its HEAD (#2452/#2453). This is a harness " +
+	"provisioning failure: STOP and surface it up (do NOT retry the spawn), and do NOT self-provision " +
+	"to route around it — that hides the failure and collapses the primary-corruption defense (ADR 0172, #2270).";
+
 /**
  * Decide whether to pin/refuse a Bash command for a guarded worktree agent.
  *
- * - No `$WORKTREE_ROOT`, or a non-managed root → **allow** (not a guarded agent; this is
- *   also the orchestrator's own shell — its `git checkout main` is never reached here).
+ * - No managed `$WORKTREE_ROOT` **and isolation NOT expected** → **allow** (the orchestrator's own
+ *   shell / a standalone run — its `git checkout main` is never reached here).
+ * - No managed `$WORKTREE_ROOT` **but isolation WAS expected** (`isolationExpected`, from an
+ *   isolation-asserting `$CLAUDE_CODE_AGENT`) → a head-moving git op is **refused** even in its
+ *   `-C "$WT"` form: with no worktree provisioned `$WT` can only be the shared PRIMARY checkout (the
+ *   #2440 no-op / #2452 detach), and the $WORKTREE_ROOT-keyed branch below is disarmed, so this is
+ *   the surviving refusal (ADR 0172). A non-head-move command still allows (no over-refusal).
  * - An empty/whitespace-only command → **allow** (nothing to pin).
  * - A command with a leading `cd ` → **allow** (it sets its own cwd; don't fight it).
  * - A working-state-mutating git op (`checkout`/`switch`/`reset`/`rebase`/`stash`/`merge`) NOT
@@ -145,9 +167,22 @@ const REFUSE_REASON =
 export const pinBash = (args: {
 	readonly worktreeRoot: string;
 	readonly command: string;
+	readonly isolationExpected?: boolean;
 }): BashDecision => {
-	const {worktreeRoot, command} = args;
-	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) return {kind: "allow"};
+	const {worktreeRoot, command, isolationExpected = false} = args;
+	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) {
+		// No managed worktree. Normally a clean allow — but if isolation was expected, the harness
+		// no-op'd provisioning (#2440) and a head-moving git op here hits the PRIMARY checkout (#2453).
+		if (
+			isolationExpected &&
+			command.trim() !== "" &&
+			!hasLeadingCd(command) &&
+			inspectGitHeadMove(command, worktreeRoot).isHeadMove
+		) {
+			return {kind: "refuse", reason: REFUSE_REASON_ISOLATION_NO_ROOT};
+		}
+		return {kind: "allow"};
+	}
 	if (command.trim() === "") return {kind: "allow"};
 	if (hasLeadingCd(command)) return {kind: "allow"};
 

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
@@ -133,6 +133,78 @@ describe("pinBash — refuse a bare HEAD-moving git op in a guarded worktree (#1
 	});
 });
 
+// ADR 0172 / #2454: when isolation was EXPECTED (coder/reviewer/shipper) but the harness no-op'd
+// provisioning (#2440), $WORKTREE_ROOT is unset — which used to disarm the guard entirely and let
+// the #2452/#2453 `git -C "$WT" checkout` primary-checkout detach through. isolationExpected closes it.
+describe("pinBash — isolation expected but NO provisioned worktree (ADR 0172, #2453)", () => {
+	it('refuses `git -C "$WT" checkout FETCH_HEAD` (the #2453 form) when root unset + isolation expected', () => {
+		const d = pinBash({
+			worktreeRoot: "",
+			command: 'git -C "$WT" checkout FETCH_HEAD',
+			isolationExpected: true,
+		});
+		assert.strictEqual(d.kind, "refuse");
+		if (d.kind === "refuse") assert.match(d.reason, /NO provisioned worktree/);
+	});
+	it("refuses a bare `git checkout main` when root unset + isolation expected", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: "", command: "git checkout main", isolationExpected: true}).kind,
+			"refuse",
+		);
+	});
+	it("refuses `git switch`/`reset`/`stash`/`merge` too (all HEAD-moving) when root unset + isolation expected", () => {
+		for (const cmd of [
+			"git switch main",
+			"git reset --hard FETCH_HEAD",
+			"git stash pop",
+			"git merge origin/main",
+			'git -C "$WORKTREE_ROOT" reset --hard FETCH_HEAD',
+		]) {
+			assert.strictEqual(
+				pinBash({worktreeRoot: "", command: cmd, isolationExpected: true}).kind,
+				"refuse",
+				`${cmd} should refuse`,
+			);
+		}
+	});
+	it("does NOT over-refuse a non-head-move (git status / fetch / worktree add) when root unset + isolation expected", () => {
+		// worktree add is the sanctioned self-provision op (not HEAD-moving) — never refuse it
+		for (const cmd of [
+			"git status",
+			"git fetch origin main",
+			"git worktree add -b br /tmp/wt FETCH_HEAD",
+			"ls -la",
+		]) {
+			assert.strictEqual(
+				pinBash({worktreeRoot: "", command: cmd, isolationExpected: true}).kind,
+				"allow",
+				`${cmd} should allow`,
+			);
+		}
+	});
+	it("still allows a bare HEAD-move when isolation was NOT expected (orchestrator/standalone — unchanged)", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: "", command: 'git -C "$WT" checkout FETCH_HEAD'}).kind,
+			"allow",
+		);
+		assert.strictEqual(
+			pinBash({worktreeRoot: "", command: "git checkout main", isolationExpected: false}).kind,
+			"allow",
+		);
+	});
+	it('is unchanged for a genuinely provisioned (managed) worktree — `-C "$WT"` still allowed', () => {
+		// isolation expected AND a real managed root: the safe scoped form is genuinely safe
+		assert.strictEqual(
+			pinBash({
+				worktreeRoot: WT,
+				command: 'git -C "$WT" checkout FETCH_HEAD',
+				isolationExpected: true,
+			}).kind,
+			"allow",
+		);
+	});
+});
+
 describe("inspectGitHeadMove — the pure parse (branch-by-branch)", () => {
 	it("flags a bare head-move as head-move + unscoped", () => {
 		assert.deepStrictEqual(inspectGitHeadMove("git checkout 1a2b", WT), {

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -7,7 +7,10 @@
  * and emitting the matching hook output. All read `$WORKTREE_ROOT` from the process
  * env (injected at spawn for an `isolation:worktree` subagent); an UNSET root makes
  * every subcommand a clean allow/skip no-op, so a non-worktree session is never
- * affected.
+ * affected — with ONE exception (ADR 0172): `pre-bash` still refuses a head-moving git
+ * op when isolation was EXPECTED (`$CLAUDE_CODE_AGENT` is coder/reviewer/shipper) yet the
+ * root is unset, because that unset root is itself the #2440 harness no-op that would
+ * otherwise let the #2452/#2453 primary-checkout detach through.
  *
  *   PreToolUse:
  *     pre-file  (matcher Read|Edit|Write) — rewrite/block a main-checkout path
@@ -31,6 +34,13 @@ import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
 import {decideReap} from "./reap.ts";
 
 const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
+
+// Was worktree isolation EXPECTED for this run? The coder/reviewer/shipper agent-types all spawn
+// `isolation:worktree` (agents/{coder,reviewer,shipper}.md), read from the harness-set
+// $CLAUDE_CODE_AGENT. This lets pre-bash refuse a head-moving git op even when $WORKTREE_ROOT is
+// unset — the #2440 no-op that disarms every $WORKTREE_ROOT-keyed subcommand — instead of the old
+// silent allow that let the #2452/#2453 primary-checkout detach through (ADR 0172).
+const ISOLATION_EXPECTED = /coder|reviewer|shipper/.test(process.env.CLAUDE_CODE_AGENT ?? "");
 
 // A non-force `git worktree remove` that errors means git judged the tree unsafe to
 // remove — we KEEP it (never escalate to --force). Tagged so the error channel stays typed.
@@ -125,7 +135,11 @@ const preBash = Command.make(
 		const input = yield* readStdin();
 		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
 		const command = str(toolInput.command);
-		const decision = pinBash({worktreeRoot: WORKTREE_ROOT, command});
+		const decision = pinBash({
+			worktreeRoot: WORKTREE_ROOT,
+			command,
+			isolationExpected: ISOLATION_EXPECTED,
+		});
 		if (decision.kind === "allow") return yield* allow();
 		if (decision.kind === "refuse") return yield* deny(`worktree-guard: ${decision.reason}`);
 		return yield* allow(


### PR DESCRIPTION
Fixes #2454

## What this does

Extends the #2446 / ADR 0172 fail-closed **isolation-expected** guard (primary-checkout
detection via `git-dir == common-dir`, forked on whether isolation was expected) from
`write-code` to every other head-materializing gate — `review-code`, `review-trivial`,
`ship-it` — closing the coverage gap that let the #2452/#2453 primary-checkout detach land.

### Single-sourced guard (AC 3)

- New `iso_preflight <surface>` in `gh-issue-intake-formats.md` **§RO-iso** — the reviewer/shipper
  sibling of `write-code`'s Step-4 `wt_preflight`: the **same** `git-dir == common-dir` detection
  and the **same** isolation-expected fork, defined **once** so the three gates share one contract
  instead of drifting three copies apart. `write-code`'s inline `wt_preflight` is a documented,
  intentionally-stricter specialization (it also branches the session tree), cited as the sibling —
  left untouched so no existing gate is weakened.

### Wired into each gate (ACs 1, 2)

- `review-code` — `iso_preflight review-code || exit 1` **before** the `git fetch` / `git worktree add`.
- `review-trivial` — before the `git fetch pull/$PR/head`.
- `ship-it` — at Step 0 entry (ship-it is §RO / `gh api`-only, so this is a defense-in-depth belt).

Each fails **closed + LOUD** with a ROUTED BLOCKER when isolation was expected (reviewer/shipper
agent-type) but the run is on the primary checkout with `$WORKTREE_ROOT` unset — the #2440 harness
no-op that also disarms the `$WORKTREE_ROOT`-keyed repo-side `worktree-guard`, leaving the preflight
the sole surviving layer. **Non-breaking:** a genuine standalone run on the owner's checkout
(`$CLAUDE_CODE_AGENT` unset) still proceeds — §RO already runs gates read-only in the owner's
checkout with throwaway-only materialization.

## ⚠️ Scope beyond #2454's stated ACs (flagged per coordinator)

#2454's ACs are skill-only. Per the coordinator's #2453-root-cause sharpening, this PR **also**
closes the two guard holes that let the detach through *regardless of skill-text freshness*, in the
`worktree-guard` TS package (`packages/pipeline-cli/src/tools/worktree-guard/`):

- **`bash-pin.ts` + `command.ts`:** the head-move refusal now fires even when `$WORKTREE_ROOT` is
  **unset**, if isolation was expected (`$CLAUDE_CODE_AGENT` ∈ coder/reviewer/shipper). Previously
  the whole guard no-op'd on unset root **and** the `git -C "$WT" checkout` form was trusted as safe —
  but with no provisioned worktree `$WT` resolves to the **primary** checkout. This refuses that exact
  bare-git form (the #2453 detach command), routing the harness failure up instead.
- Unit-tested in `bash-pin.unit.test.ts`: refuse the #2453 `git -C "$WT" checkout FETCH_HEAD` form and
  all HEAD-moving ops on unset-root + isolation-expected; **no over-refusal** of non-head-moves
  (`git worktree add`, `git status`, `git fetch`); unchanged for a genuinely managed worktree and for
  standalone / orchestrator runs.

This combination would have caught all 5 detach events. **@coordinator — flagging the widened diff.**

## Verification

- `pnpm typecheck` (full workspace) — green
- `vitest` bash-pin + command-hook — 39 passing (6 new)
- `pnpm lint:worktree` — clean; `validate-skills` / `validate-gate-path-drift` — OK

## Control-plane

§CP (gate-critical skills `review-code` / `review-trivial` / `ship-it` + `gh-issue-intake-formats.md`,
and the `worktree-guard` guard package per ADR 0100). Stops at **reviewed-ready** for human
control-plane merge; cites ADR 0172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
