### PR TITLE
fix(pipeline-cli): main-sync --post-merge ff's through untracked-only dirt (#2455)

### DIFF
--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -23,8 +23,9 @@
  *     HEAD to `main` (clean tree only) before the merge, for the orchestrator's
  *     before/after-drain sync.
  *   - `--post-merge` (refresh, #2056): GENTLE — invoked by a pipeline step that knows a
- *     merge landed (ship-it / the orchestrator). It fast-forwards the primary ONLY when
- *     it is already on a clean `main`; on a non-`main` branch or a dirty tree it LEAVES
+ *     merge landed (ship-it / the orchestrator). It fast-forwards the primary when it is
+ *     on `main` and free of tracked modifications (ff'ing through untracked-only dirt,
+ *     #2455); on a non-`main` branch or a tree with tracked modifications it LEAVES
  *     THE CHECKOUT ALONE and exits 0 (never moves HEAD, never errors). This closes the
  *     silent-drift hazard under the merge queue (ADR 0132), where a PR lands GitHub-side
  *     with no local merge to advance the owner's checkout. See `decideMainRefresh`.
@@ -77,6 +78,19 @@ const treeIsDirty = (): boolean => {
 };
 
 /**
+ * `git status --porcelain -uno` non-empty ⇒ TRACKED modifications (staged/unstaged) — `-uno`
+ * excludes untracked files. Indeterminate (command failed) ⇒ true (fail-safe: treat an
+ * unreadable tree as tracked-dirty so the refresh leaves it alone). See #2455: the post-merge
+ * refresh ff's through untracked-only dirt but must still refuse on tracked modifications a
+ * fast-forward could clobber, so `decideMainRefresh` consults THIS, not `isDirty`.
+ */
+const treeHasTrackedModifications = (): boolean => {
+	const r = runGit(["status", "--porcelain", "-uno"]);
+	if (!r.ok) return true;
+	return r.stdout.trim() !== "";
+};
+
+/**
  * The gentle post-merge refresh (#2056) — the HEAD-preserving counterpart to the drain-sync
  * below. `decideMainRefresh` is the safety policy; this runs it. A `leave-alone` plan is a
  * clean exit-0 no-op (the whole point: a stale checkout is acceptable, disturbing the owner
@@ -87,13 +101,19 @@ const runPostMergeRefresh = Effect.fn(function* (head: HeadState, execute: boole
 	const plan = decideMainRefresh(head);
 
 	// ADR 0092 "emit what you scanned": the HEAD state + plan are observable before any action.
+	// Report the tracked/untracked distinction the refresh actually gates on (#2455), not bare dirt.
+	const treeLabel = head.hasTrackedModifications
+		? "tracked-modified"
+		: head.isDirty
+			? "untracked-only (ff-safe)"
+			: "clean";
 	yield* Console.log(
-		`main-sync --post-merge: HEAD ${head.branch ?? "(detached)"}, tree ${head.isDirty ? "DIRTY" : "clean"} — plan: ${plan.action}${execute ? " (EXECUTE)" : " (dry-run)"}`,
+		`main-sync --post-merge: HEAD ${head.branch ?? "(detached)"}, tree ${treeLabel} — plan: ${plan.action}${execute ? " (EXECUTE)" : " (dry-run)"}`,
 	);
 
 	if (plan.action === "leave-alone") {
 		yield* Console.log(
-			`  leaving the primary checkout ALONE (${plan.reason === "off-main" ? `on '${plan.branch}', not '${MAIN_BRANCH}'` : "tree is dirty"}) — a fast-forward would ${plan.reason === "off-main" ? "not advance a checked-out feature branch" : "risk uncommitted work"}. No-op (stale is acceptable; clobbering is not).`,
+			`  leaving the primary checkout ALONE (${plan.reason === "off-main" ? `on '${plan.branch}', not '${MAIN_BRANCH}'` : "tree has tracked modifications"}) — a fast-forward would ${plan.reason === "off-main" ? "not advance a checked-out feature branch" : "risk clobbering tracked work"}. No-op (stale is acceptable; clobbering is not).`,
 		);
 		return;
 	}
@@ -137,7 +157,7 @@ const executeFlag = Flag.boolean("execute").pipe(
 
 const postMergeFlag = Flag.boolean("post-merge").pipe(
 	Flag.withDescription(
-		"gentle post-merge refresh (#2056): fast-forward ONLY on a clean 'main'; on any other branch or a dirty tree, leave the checkout alone and exit 0 (never reattach, never error)",
+		"gentle post-merge refresh (#2056): fast-forward on 'main' when free of tracked modifications (ff's through untracked-only dirt, #2455); on any other branch or a tree with tracked modifications, leave the checkout alone and exit 0 (never reattach, never error)",
 	),
 );
 
@@ -145,7 +165,11 @@ const mainSync = Command.make(
 	"main-sync",
 	{execute: executeFlag, postMerge: postMergeFlag},
 	Effect.fn(function* ({execute, postMerge}) {
-		const head: HeadState = {branch: headBranch(), isDirty: treeIsDirty()};
+		const head: HeadState = {
+			branch: headBranch(),
+			isDirty: treeIsDirty(),
+			hasTrackedModifications: treeHasTrackedModifications(),
+		};
 
 		if (postMerge) {
 			return yield* runPostMergeRefresh(head, execute);
@@ -210,7 +234,7 @@ const mainSync = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Codified primary main-sync. Default (drain-sync): auto-reattach a detached primary HEAD to main, then fetch + merge --ff-only; refuses on a dirty tree (#1573 / #1494 Unit C). --post-merge (refresh): fast-forward ONLY on a clean main, else leave the checkout alone and exit 0 (#2056).",
+		"Codified primary main-sync. Default (drain-sync): auto-reattach a detached primary HEAD to main, then fetch + merge --ff-only; refuses on a dirty tree (#1573 / #1494 Unit C). --post-merge (refresh): fast-forward on main when free of tracked modifications (ff's through untracked-only dirt, #2455), else leave the checkout alone and exit 0 (#2056).",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
@@ -27,10 +27,11 @@
  * `origin/main` and any read of the local tree (next-free ADR number, "does X exist yet")
  * is made against stale state. The refresh is invoked by a pipeline step that KNOWS a merge
  * landed (ship-it / the orchestrator) and passively fast-forwards the primary — but, unlike
- * the drain-sync, it NEVER moves HEAD: on a non-`main` branch or a dirty tree it LEAVES THE
- * CHECKOUT ALONE and exits cleanly (a stale checkout is no worse than today; yanking the
- * owner off their feature branch or touching their uncommitted work is). Failing-to-refresh
- * is acceptable; failing-loudly or clobbering is not.
+ * the drain-sync, it NEVER moves HEAD: on a non-`main` branch or a tree with tracked
+ * modifications it LEAVES THE CHECKOUT ALONE and exits cleanly (a stale checkout is no worse
+ * than today; yanking the owner off their feature branch or clobbering their tracked work is).
+ * It ff's through untracked-only dirt, which a fast-forward never touches (see
+ * `decideMainRefresh`, #2455). Failing-to-refresh is acceptable; failing-loudly or clobbering is not.
  */
 
 /**
@@ -51,8 +52,19 @@ export interface HeadState {
 	 * The working tree has uncommitted/untracked changes (`git status --porcelain`
 	 * non-empty, or the probe was indeterminate). A dirty tree blocks a reattach —
 	 * a `git checkout main` from a detached HEAD with local changes could lose them.
+	 * This is the coarse dirty signal the drain-sync reattach consults; the post-merge
+	 * refresh consults the finer `hasTrackedModifications` instead (see #2455).
 	 */
 	readonly isDirty: boolean;
+	/**
+	 * The tree has TRACKED modifications — staged or unstaged changes to tracked files
+	 * (`git status --porcelain -uno` non-empty, or the probe was indeterminate),
+	 * EXCLUDING untracked files. This is the only dirt a `merge --ff-only` could clobber;
+	 * git fast-forwards straight through untracked files without touching them. The
+	 * post-merge refresh gates on THIS, not `isDirty`, so an untracked-only tree ff's
+	 * through (see #2455). Implies `isDirty` (tracked dirt is a subset of all dirt).
+	 */
+	readonly hasTrackedModifications: boolean;
 }
 
 /** The name of the branch the primary checkout must be attached to for a clean main-sync. */
@@ -125,18 +137,20 @@ export const decideMainSync = (head: HeadState): MainSyncPlan => {
  */
 export type MainRefreshPlan =
 	/**
-	 * HEAD is on `main` AND the tree is clean — the only state in which a `git merge
-	 * --ff-only origin/main` is both possible and non-destructive. The refresh runs
+	 * HEAD is on `main` AND free of tracked modifications — the state in which a `git merge
+	 * --ff-only origin/main` is both possible and non-destructive (untracked-only dirt is
+	 * fine; a fast-forward passes straight through it, #2455). The refresh runs
 	 * `fetch` + `merge --ff-only`; ff-only never creates a merge commit and aborts on any
 	 * divergence, so the worst case is a no-op, never a clobber.
 	 */
 	| {readonly action: "fast-forward"; readonly branch: string}
 	/**
-	 * The refresh is a deliberate NO-OP — HEAD is not on `main`, or the tree is dirty. It
-	 * exits cleanly (never an error): a fast-forward of `main` can't advance a checked-out
-	 * feature branch, and a dirty tree could have its uncommitted work disturbed, so the
+	 * The refresh is a deliberate NO-OP — HEAD is not on `main`, or the tree has tracked
+	 * modifications. It exits cleanly (never an error): a fast-forward of `main` can't advance
+	 * a checked-out feature branch, and tracked modifications could be clobbered, so the
 	 * refresh leaves the checkout untouched. `reason` records which condition held for the
-	 * report; `branch` is the current branch (or `detached-HEAD`).
+	 * report (`dirty` means tracked-modified, #2455); `branch` is the current branch (or
+	 * `detached-HEAD`).
 	 */
 	| {
 			readonly action: "leave-alone";
@@ -150,20 +164,28 @@ export type MainRefreshPlan =
  *   1. Not on `main` → `leave-alone` (reason `off-main`). The owner is on their own
  *      feature branch (or detached); a fast-forward of `main` cannot advance it, and
  *      yanking them onto `main` is exactly the disruption the refresh must avoid. No-op.
- *   2. On `main` but dirty → `leave-alone` (reason `dirty`). A fast-forward could disturb
- *      the owner's uncommitted work, and a stale-but-clean-of-clobber checkout is
- *      acceptable — failing-to-refresh beats touching uncommitted work. No-op.
- *   3. On `main` AND clean → `fast-forward`. The only state where the ff is safe: run it.
+ *   2. On `main` with TRACKED modifications → `leave-alone` (reason `dirty`). A fast-forward
+ *      could clobber the owner's uncommitted tracked work, and a stale-but-clobber-free
+ *      checkout is acceptable — failing-to-refresh beats touching tracked work. No-op.
+ *   3. On `main` AND free of tracked modifications → `fast-forward`. Safe to advance —
+ *      including when the tree carries untracked-only dirt (see the untracked note below).
  *
- * The branch check precedes the dirty check on purpose — off-`main` is reported even when
- * also dirty, because the branch is the binding reason the ff can't run (it can't advance
- * a checked-out feature branch regardless of tree state). Total over every `HeadState`.
+ * The branch check precedes the tracked-dirt check on purpose — off-`main` is reported even
+ * when also dirty, because the branch is the binding reason the ff can't run (it can't
+ * advance a checked-out feature branch regardless of tree state). Total over every `HeadState`.
+ *
+ * The tracked-vs-untracked distinction (#2455): the ff-blocking guard consults
+ * `hasTrackedModifications`, NOT `isDirty`. `merge --ff-only` fast-forwards straight through
+ * untracked files without touching them, so untracked-only dirt buys no safety by blocking —
+ * gating on `isDirty` instead pinned the primary STALE session-long (the #2453 detached-HEAD
+ * corruption root cause: stale on-disk skills). This matches the drain-sync path, which never
+ * consults dirt once already on `main`.
  */
 export const decideMainRefresh = (head: HeadState): MainRefreshPlan => {
 	if (head.branch !== MAIN_BRANCH) {
 		return {action: "leave-alone", reason: "off-main", branch: fromLabel(head.branch)};
 	}
-	if (head.isDirty) {
+	if (head.hasTrackedModifications) {
 		return {action: "leave-alone", reason: "dirty", branch: MAIN_BRANCH};
 	}
 	return {action: "fast-forward", branch: MAIN_BRANCH};

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts
@@ -12,6 +12,7 @@ import {
 const head = (over: Partial<HeadState> = {}): HeadState => ({
 	branch: "main",
 	isDirty: false,
+	hasTrackedModifications: false,
 	...over,
 });
 
@@ -54,8 +55,8 @@ describe("decideMainSync — blocked-dirty (detect-and-surface, never discard)",
 
 	it("dirty NEVER yields a reattach on the off-main path (safety invariant)", () => {
 		const plans: MainSyncPlan[] = [
-			decideMainSync({branch: null, isDirty: true}),
-			decideMainSync({branch: "x", isDirty: true}),
+			decideMainSync({branch: null, isDirty: true, hasTrackedModifications: true}),
+			decideMainSync({branch: "x", isDirty: true, hasTrackedModifications: true}),
 		];
 		for (const plan of plans) {
 			assert.notStrictEqual(plan.action, "reattach");
@@ -66,12 +67,12 @@ describe("decideMainSync — blocked-dirty (detect-and-surface, never discard)",
 describe("decideMainSync — totality", () => {
 	it("every HeadState maps to exactly one of the three actions", () => {
 		const cases: HeadState[] = [
-			{branch: "main", isDirty: false},
-			{branch: "main", isDirty: true},
-			{branch: null, isDirty: false},
-			{branch: null, isDirty: true},
-			{branch: "feature", isDirty: false},
-			{branch: "feature", isDirty: true},
+			{branch: "main", isDirty: false, hasTrackedModifications: false},
+			{branch: "main", isDirty: true, hasTrackedModifications: true},
+			{branch: null, isDirty: false, hasTrackedModifications: false},
+			{branch: null, isDirty: true, hasTrackedModifications: true},
+			{branch: "feature", isDirty: false, hasTrackedModifications: false},
+			{branch: "feature", isDirty: true, hasTrackedModifications: true},
 		];
 		const actions = new Set(["already-on-main", "reattach", "blocked-dirty"]);
 		for (const c of cases) {
@@ -85,11 +86,22 @@ describe("decideMainRefresh — fast-forward (the only safe-to-advance state)", 
 		const plan = decideMainRefresh(head({branch: "main", isDirty: false}));
 		assert.deepStrictEqual(plan, {action: "fast-forward", branch: MAIN_BRANCH});
 	});
+
+	it("on main + untracked-only dirt → fast-forward (#2455: ff passes straight through untracked files)", () => {
+		// The #2455 fix: a tree dirty ONLY with untracked files still fast-forwards. `merge --ff-only`
+		// never touches untracked files, so blocking on them bought no safety and pinned primary stale.
+		const plan = decideMainRefresh(
+			head({branch: "main", isDirty: true, hasTrackedModifications: false}),
+		);
+		assert.deepStrictEqual(plan, {action: "fast-forward", branch: MAIN_BRANCH});
+	});
 });
 
 describe("decideMainRefresh — leave-alone (never move HEAD, never error)", () => {
-	it("on main but dirty → leave-alone (reason dirty) — refuse to disturb uncommitted work", () => {
-		const plan = decideMainRefresh(head({branch: "main", isDirty: true}));
+	it("on main + tracked modifications → leave-alone (reason dirty) — a ff could clobber tracked work", () => {
+		const plan = decideMainRefresh(
+			head({branch: "main", isDirty: true, hasTrackedModifications: true}),
+		);
 		assert.deepStrictEqual(plan, {action: "leave-alone", reason: "dirty", branch: MAIN_BRANCH});
 	});
 
@@ -107,21 +119,25 @@ describe("decideMainRefresh — leave-alone (never move HEAD, never error)", () 
 		});
 	});
 
-	it("off-main takes precedence over dirty — the branch is the binding reason the ff can't run", () => {
-		// A dirty feature branch is reported off-main, not dirty: an ff of main can't advance a
-		// checked-out feature branch regardless of tree state, so the branch is the real blocker.
-		const plan = decideMainRefresh(head({branch: "umut/wip", isDirty: true}));
+	it("off-main takes precedence over tracked dirt — the branch is the binding reason the ff can't run", () => {
+		// A feature branch with tracked modifications is reported off-main, not dirty: an ff of main
+		// can't advance a checked-out feature branch regardless of tree state, so the branch is the
+		// real blocker (checked ahead of the tracked-dirt guard).
+		const plan = decideMainRefresh(
+			head({branch: "umut/wip", isDirty: true, hasTrackedModifications: true}),
+		);
 		assert.deepStrictEqual(plan, {action: "leave-alone", reason: "off-main", branch: "umut/wip"});
 	});
 
 	it("NEVER yields a HEAD-moving action — leave-alone or fast-forward only, no reattach/checkout", () => {
 		const cases: HeadState[] = [
-			{branch: "main", isDirty: false},
-			{branch: "main", isDirty: true},
-			{branch: null, isDirty: false},
-			{branch: null, isDirty: true},
-			{branch: "feature", isDirty: false},
-			{branch: "feature", isDirty: true},
+			{branch: "main", isDirty: false, hasTrackedModifications: false},
+			{branch: "main", isDirty: true, hasTrackedModifications: true},
+			{branch: "main", isDirty: true, hasTrackedModifications: false},
+			{branch: null, isDirty: false, hasTrackedModifications: false},
+			{branch: null, isDirty: true, hasTrackedModifications: true},
+			{branch: "feature", isDirty: false, hasTrackedModifications: false},
+			{branch: "feature", isDirty: true, hasTrackedModifications: true},
 		];
 		const actions = new Set<MainRefreshPlan["action"]>(["fast-forward", "leave-alone"]);
 		for (const c of cases) {


### PR DESCRIPTION
Fixes #2455

## Problem

`pipeline-cli main-sync --post-merge` treated an untracked-only working tree as "dirty" and left the primary checkout stale, even though `git merge --ff-only` fast-forwards straight through untracked files without touching them. This is the durable root cause behind the #2453 detached-HEAD incident: session-long staleness kept pre-#2414 skill copies on disk, and review agents in the primary loaded the old `reviewer.md` that still did a bare `git -C "$WT" checkout FETCH_HEAD`, detaching primary HEAD.

The asymmetry (source-verified): `decideMainRefresh` consulted the coarse `isDirty` (`git status --porcelain`, which reports untracked `??` entries) even when on `main`, returning `leave-alone`/`dirty` — a no-op — whereas plain `--execute`'s `decideMainSync` returns `already-on-main` *before* ever consulting dirt and ff's through untracked files.

## Fix

Distinguish untracked-only dirt from tracked-modified dirt at the git boundary and let `decideMainRefresh` fast-forward in the untracked-only case, keeping the conservative `leave-alone` no-op only for genuine tracked modifications a ff could clobber.

- New `HeadState.hasTrackedModifications` field, gathered in `command.ts` via `git status --porcelain -uno` (excludes untracked) and passed **into** the pure decider — mirroring the existing `isDirty` IO-boundary seam. The pure `decideMainRefresh` stays IO-free and total.
- `decideMainRefresh` now gates the ff-blocking guard on `hasTrackedModifications`, not `isDirty`.
- The off-`main` guard and the tracked-modified `leave-alone` guard are **unchanged**. `decideMainSync` (drain-sync) is untouched.

## Acceptance criteria

- [x] `--post-merge --execute` fast-forwards to `origin/main` when on a clean `main` whose only dirt is untracked files.
- [x] `--post-merge` still no-ops (`leave-alone`, reason `dirty`) on tracked modifications, and still no-ops off-`main` (reason `off-main`).
- [x] The untracked-vs-tracked distinction is gathered at the git boundary (`command.ts`) and passed as data into the pure core; `main-sync.ts` stays IO-free and total.
- [x] `main-sync.unit.test.ts` covers the new branch: on-`main` + untracked-only → fast-forward; on-`main` + tracked-modified → leave-alone; off-`main` and clean cases unchanged.

## Verification

- `main-sync.unit.test.ts`: 15/15 pass. Full `pipeline-cli` suite: 902/902 pass.
- `pnpm typecheck` (full workspace, 27 tasks): clean. `pnpm lint:worktree`: clean.

## Merge path

`packages/pipeline-cli/` is control-plane (§CP) — the shared primary-checkout sync mechanism, and this relaxes a safety guard on a HEAD/tree-touching tool. Warrants §CP merge handling (human approve/merge, not autonomous auto-ship).

Files:
- `packages/pipeline-cli/src/tools/main-sync/main-sync.ts` — `HeadState.hasTrackedModifications` + `decideMainRefresh` guard.
- `packages/pipeline-cli/src/tools/main-sync/command.ts` — `treeHasTrackedModifications()` probe + wiring + log labels.
- `packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts` — new decision-branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)