### PR TITLE
fix(pipeline): reviewer emits one comment per namespace on a multi-namespace fan (#2458)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -115,7 +115,13 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   code, `review-doc` for docs, `review-skill` for skills/agents, `review-design` for
   UI-affecting PRs. Emit **one marker per present class** (the fan above) and **only** for
   classes the diff actually spans — never a foreign marker for an absent class (a marker on the
-  wrong PR class poisons that namespace's scan). Upsert each one-per-PR per its skill. The
+  wrong PR class poisons that namespace's scan). **When the fan spans more than one class, emit
+  each namespace's marker as its OWN separate PR comment — one comment per namespace, marker on
+  that comment's literal first line, never two markers stacked in one comment.** Each namespace's
+  `^` anchor pins its marker to the first line of *its own* comment, so a second namespace stacked
+  on line 2 is un-anchored, resolves empty, and fail-closes a substantively-PASS PR (the PR #2456
+  stall; the forbidden "stacked" emit form in `gh-issue-intake-formats.md` §5 — cited, not
+  re-derived here). Upsert each one-per-PR per its skill. The
   verdicts on the PR are the whole output — a verdict returned only to the orchestrator and
   never posted is a dropped gate.
 <a id="fan-across-every-present-class-in-lockstep-with-ship-its-live-class-probes-class_reresolve"></a>

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1870,10 +1870,22 @@ and stalled every code-lane merge — #219), this contract pins **one** rule bot
   - **Marker not on the literal first line** — the `^` anchor pins the marker to the **start of
     the comment body**; a marker buried after a preamble paragraph never matches. It leads the
     body.
+  - **Two namespace markers stacked in one comment (the multi-namespace fan)** — on a
+    mixed-class diff the reviewer fans several verdict namespaces (e.g. `review-code` +
+    `review-skill` for a skill+code PR, `review-design` for a UI PR). Each namespace's `^`
+    anchor pins its marker to the first line of **its own comment**, so stacking a second
+    namespace's marker on line 2 of the first's comment leaves that second marker un-anchored:
+    it never matches, its namespace resolves **empty**, and `ship-it` fail-closes a
+    substantively-PASS PR (the live PR #2456 stall — both reviews PASSed, but the stacked
+    `review-skill` marker was unmatchable and recovery needed a manual re-emit). **Emit each
+    fanned namespace's verdict as its OWN separate PR comment, its `<namespace>: PASS|FAIL @
+    <sha>` marker on that comment's literal first line — one comment per namespace, never two
+    markers stacked.** The upsert is still one-comment-per-`(PR, namespace)`; the fan writes
+    N such comments (one each), not one comment carrying N markers.
   These are emitter bugs, not matcher gaps — the fix is always to **emit the canonical shape**,
   never to loosen the anchored matcher to chase a malformed marker (ADR 0058 forbids weakening
-  the SHA-binding). §6/§6.5 inherit this forbidden-forms list for `review-doc` / `review-skill`
-  via the same matcher contract.
+  the SHA-binding). §6/§6.5/§6.7 inherit this forbidden-forms list for `review-doc` /
+  `review-skill` / `review-design` via the same matcher contract.
 
 ### Field notes
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -202,9 +202,13 @@ when you finish the code class on a mixed PR, **ensure the gate for every other 
 also run against this same head before the review is reported complete** — load and follow the
 sibling gate(s) (`review-doc` for the docs class, `review-skill` for the skills class) in this
 pass, or have the routing dispatch fan out to them, so each present namespace carries a
-current-head verdict. `ship-it`'s per-present-class requirement (its Step 2) is unchanged — it
-remains the **fail-closed late catch**, the safety net for a genuinely-missing namespace, not the
-*first* place the second namespace is discovered.
+current-head verdict. **Emit each namespace's verdict as its OWN separate PR comment — one
+comment per namespace, marker on that comment's literal first line — never two markers stacked
+in one comment** (the second would be un-anchored, resolve empty, and fail-close a
+substantively-PASS PR — the PR #2456 stall; the forbidden "stacked" emit form in
+`../gh-issue-intake-formats.md` §5). `ship-it`'s per-present-class requirement (its Step 2) is
+unchanged — it remains the **fail-closed late catch**, the safety net for a genuinely-missing
+namespace, not the *first* place the second namespace is discovered.
 
 ### The trust split: head = code under test, base = the reviewer's instructions (ADR 0052)
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -262,6 +262,10 @@ stop." So after you verify the skills and emit `review-skill`, **ensure `review-
 `review-doc` (docs) are also run against this same head before the review is reported complete**
 — load and follow the sibling gate(s) in this pass, or have the routing dispatch fan out to them,
 so the PR reaches `ship-it` with a current-head PASS standing in each present namespace.
+**Emit each namespace's verdict as its OWN separate PR comment — one comment per namespace, marker
+on that comment's literal first line — never two markers stacked in one comment** (the second
+would be un-anchored, resolve empty, and fail-close a substantively-PASS PR — the PR #2456 stall;
+the forbidden "stacked" emit form in `../gh-issue-intake-formats.md` §5).
 `ship-it`'s per-present-class requirement (its Step 2) is unchanged — it remains the
 **fail-closed late catch** for a genuinely-missing namespace, not the *first* place the second
 namespace is discovered.


### PR DESCRIPTION
## What

Fixes #2458 — emitter-side fix for the reviewer stacking multiple namespace verdict markers into one PR comment on a mixed-class diff.

On a mixed-class diff the reviewer fans several verdict namespaces (e.g. `review-code` + `review-skill` for a skill+code PR, `review-design` for a UI PR). Each namespace's marker is `^`-anchored to the **first line of its own comment**. When the reviewer stacked two markers in **one** comment (`review-code` on line 1, `review-skill` on line 2), the line-2 marker was un-anchored, never matched, and its namespace resolved **empty** — so `ship-it` correctly fail-closed a substantively-PASS §CP PR. Live instance: PR #2456 (both reviews genuinely PASSed; recovery needed a manual re-emit of the `review-skill` marker as its own comment).

## Fix — emitter-side only

Per ADR 0058 the matcher is correct and must not be loosened; the fix makes the **one-comment-per-namespace** rule explicit and enforced at the emit sites:

- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §5 — new **forbidden emit form**: "Two namespace markers stacked in one comment (the multi-namespace fan)", with the positive rule (emit each fanned namespace as its own comment, marker on the literal first line). §6/§6.5/§6.7 inherit it (extended the inheritance line to `review-doc` / `review-skill` / `review-design`).
- `claude-plugins/kampus-pipeline/agents/reviewer.md` — the verdict-post bullet now mandates one comment per namespace on a fan, citing the §5 contract (not re-deriving it).
- `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md` and `.../review-skill/SKILL.md` — the mixed-class fan step (where a skill following its sibling gate posts both markers) carries a concise one-comment-per-namespace pointer to §5.

The `^`-anchored, SHA-bound matcher regex and ADR 0058's SHA-binding are **unchanged** (verified: no matcher/regex/ADR-binding line added). Each namespace retains its own first-line anchor + `@ <sha>` binding.

## Acceptance criteria

- [x] Multi-namespace fan emits one comment per namespace, marker on the literal first line — never stacked.
- [x] A mixed skill+code diff produces a matchable `review-skill` AND `review-code` marker, each per-namespace resolvable.
- [x] Emitter-side only; anchored SHA-bound matcher + ADR 0058 binding left unchanged.
- [x] Cross-references PR #2456 (live instance) at every fix site.

## Class

§CP — edits gate-critical review skills / reviewer agent / intake-formats contract under `claude-plugins/kampus-pipeline/**`. Stops at reviewed-ready; human-merge (cansirin). Docs/skills-markdown only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)