### PR TITLE
fix(pipeline-cli): self-heal main-sync's unlinked-workspace-dep condition (#2459)

### DIFF
--- a/packages/pipeline-cli/src/bin.ts
+++ b/packages/pipeline-cli/src/bin.ts
@@ -9,17 +9,46 @@
  * The router itself lives in `run.ts` (`Command.withSubcommands(registeredTools)`);
  * this file is a thin bootstrap that loads it via a **dynamic** `import()` so an
  * unlinked `catalog:` dep — the in-repo-first path hit before `pnpm install` has
- * settled on a fresh/partial checkout — surfaces as an actionable remediation
- * instead of a raw `ERR_MODULE_NOT_FOUND` from deep in the static tool graph
- * (#1798). A static `import "./run.ts"` would link that graph before any code
- * here runs, so the throw could not be caught; the dynamic import is what makes
- * the module-not-found catchable. On the normal (installed) path this is a plain
- * pass-through — `run.ts` wires and runs the CLI exactly as before.
+ * settled on a fresh/partial checkout — is a *catchable* `ERR_MODULE_NOT_FOUND`
+ * (#1798) instead of a raw static-load throw. On catch, `loadWithSelfHeal` first
+ * tries a bounded one-shot `pnpm install` + retry (the #2459 self-heal — see its
+ * docblock in `module-load-guard.ts`); only if that still can't link the dep does
+ * the legible remediation print and the bin exit(1) (the #1798 fallback, preserved).
+ * On the normal (installed) path this is a plain pass-through.
  */
-import {isUnlinkedDependencyError, remediationMessage} from "./module-load-guard.ts";
+import {spawnSync} from "node:child_process";
+import {existsSync} from "node:fs";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {findRootDir} from "./find-root-dir.ts";
+import {
+	isUnlinkedDependencyError,
+	loadWithSelfHeal,
+	remediationMessage,
+	shouldSelfHeal,
+} from "./module-load-guard.ts";
+
+const load = () => import("./run.ts");
+
+/** One-shot workspace install at the repo root — the side-effecting half of the #2459 self-heal. */
+const install = async (): Promise<void> => {
+	const here = dirname(fileURLToPath(import.meta.url));
+	const rootDir =
+		findRootDir(here, (dir) => existsSync(join(dir, "pnpm-workspace.yaml")), dirname) ??
+		process.cwd();
+	console.error(
+		"pipeline-cli: an unlinked workspace dep — self-healing with a one-shot `pnpm install`…",
+	);
+	const result = spawnSync("pnpm", ["install"], {cwd: rootDir, stdio: "inherit"});
+	if (result.status !== 0) {
+		throw new Error(
+			`pipeline-cli self-heal: \`pnpm install\` failed (exit ${result.status ?? `signal ${result.signal}`}) — cannot link deps`,
+		);
+	}
+};
 
 try {
-	await import("./run.ts");
+	await loadWithSelfHeal({load, install, selfHealEnabled: shouldSelfHeal(process.env)});
 } catch (err) {
 	if (isUnlinkedDependencyError(err)) {
 		console.error(remediationMessage(err));

--- a/packages/pipeline-cli/src/module-load-guard.ts
+++ b/packages/pipeline-cli/src/module-load-guard.ts
@@ -61,3 +61,61 @@ export const remediationMessage = (err: Error & {code: string}): string => {
 		`  ${FILTER_INSTALL}   # just this package`,
 	].join("\n");
 };
+
+/** Opt-out env var: set it to disable the self-heal and drop straight to the #1798 fallback. */
+export const NO_SELF_HEAL_ENV = "PIPELINE_CLI_NO_SELF_HEAL";
+
+/**
+ * True unless the caller opted out via `PIPELINE_CLI_NO_SELF_HEAL`. The auto-install is
+ * desirable on the primary checkout (where `main-sync` must be runnable with zero manual
+ * install), but an environment that installs deps itself and forbids an implicit one — a
+ * frozen-lockfile CI runner, say — sets the var to skip the heal and fail fast instead.
+ * A falsey value (`""`, `"0"`, `"false"`) reads as unset so `VAR=0` doesn't accidentally arm it.
+ */
+export const shouldSelfHeal = (env: {[NO_SELF_HEAL_ENV]?: string}): boolean => {
+	const v = env[NO_SELF_HEAL_ENV];
+	return v === undefined || v === "" || v === "0" || v === "false";
+};
+
+export interface SelfHealOptions {
+	/** Load the tool graph — the bin's dynamic `import("./run.ts")`. */
+	load: () => Promise<unknown>;
+	/** The one-shot workspace install run to link the missing dep. */
+	install: () => Promise<void>;
+	/** Off ⇒ skip the heal and rethrow the unlinked-dep error to the #1798 fallback. Default on. */
+	selfHealEnabled?: boolean;
+	/** Observability hook fired just before the single install attempt (the healed package name). */
+	onHealAttempt?: (pkg: string | null) => void;
+}
+
+/**
+ * Bounded, idempotent self-heal for the unlinked-workspace-dep condition (#2459).
+ *
+ * `main-sync` (and every pipeline-cli tool) runs from source as `node src/bin.ts …`, so a
+ * `pipeline-cli` workspace-dep-graph change (PR #2447 switched `@kampus/ci-required` to a
+ * `workspace:*` import) leaves the primary checkout's `node_modules` stale and the dynamic
+ * `import("./run.ts")` throws the unlinked-dep `ERR_MODULE_NOT_FOUND` `isUnlinkedDependencyError`
+ * classifies. Rather than dead-ending at the legible remediation, we first try to heal the exact
+ * condition: run one workspace install, then retry the load. The install runs **at most once** per
+ * process (bounded — never a retry loop) and **only** for the classifier-accepted unlinked-dep case,
+ * so a genuine missing-source-file miss (or any unrelated throw) propagates untouched and still fails
+ * as the real bug it is. If the single retry still can't link the dep, that throw propagates too and
+ * the caller falls back to the #1798 fail-fast remediation — the legible message is preserved as the
+ * last resort, not replaced.
+ */
+export const loadWithSelfHeal = async ({
+	load,
+	install,
+	selfHealEnabled = true,
+	onHealAttempt,
+}: SelfHealOptions): Promise<void> => {
+	try {
+		await load();
+		return;
+	} catch (err) {
+		if (!selfHealEnabled || !isUnlinkedDependencyError(err)) throw err;
+		onHealAttempt?.(unlinkedPackageName(err.message));
+		await install();
+		await load();
+	}
+};

--- a/packages/pipeline-cli/src/module-load-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/module-load-guard.unit.test.ts
@@ -1,7 +1,9 @@
-import {describe, expect, it} from "vitest";
+import {describe, expect, it, vi} from "vitest";
 import {
 	isUnlinkedDependencyError,
+	loadWithSelfHeal,
 	remediationMessage,
+	shouldSelfHeal,
 	unlinkedPackageName,
 } from "./module-load-guard.ts";
 
@@ -75,5 +77,75 @@ describe("remediationMessage", () => {
 	it("degrades to a generic phrasing when the package name is unresolvable", () => {
 		const weird = Object.assign(new Error("Cannot find package"), {code: "ERR_MODULE_NOT_FOUND"});
 		expect(remediationMessage(weird)).toContain("a dependency");
+	});
+});
+
+describe("shouldSelfHeal", () => {
+	it("is on by default when the opt-out env var is unset", () => {
+		expect(shouldSelfHeal({})).toBe(true);
+	});
+
+	it("is off when the opt-out env var is set to a truthy value", () => {
+		expect(shouldSelfHeal({PIPELINE_CLI_NO_SELF_HEAL: "1"})).toBe(false);
+		expect(shouldSelfHeal({PIPELINE_CLI_NO_SELF_HEAL: "yes"})).toBe(false);
+	});
+
+	it("treats falsey values as unset so `VAR=0`/`VAR=` doesn't accidentally arm it", () => {
+		expect(shouldSelfHeal({PIPELINE_CLI_NO_SELF_HEAL: ""})).toBe(true);
+		expect(shouldSelfHeal({PIPELINE_CLI_NO_SELF_HEAL: "0"})).toBe(true);
+		expect(shouldSelfHeal({PIPELINE_CLI_NO_SELF_HEAL: "false"})).toBe(true);
+	});
+});
+
+describe("loadWithSelfHeal", () => {
+	it("passes through when the first load succeeds — no install", async () => {
+		const load = vi.fn().mockResolvedValue(undefined);
+		const install = vi.fn().mockResolvedValue(undefined);
+		await expect(loadWithSelfHeal({load, install})).resolves.toBeUndefined();
+		expect(load).toHaveBeenCalledTimes(1);
+		expect(install).not.toHaveBeenCalled();
+	});
+
+	it("self-heals the unlinked-dep case: one install, then the retry succeeds", async () => {
+		const load = vi
+			.fn()
+			.mockRejectedValueOnce(unlinkedPkgErr("@kampus/ci-required"))
+			.mockResolvedValueOnce(undefined);
+		const install = vi.fn().mockResolvedValue(undefined);
+		const onHealAttempt = vi.fn();
+		await expect(loadWithSelfHeal({load, install, onHealAttempt})).resolves.toBeUndefined();
+		// bounded: exactly one install, exactly one retry (two loads total) — never a loop
+		expect(install).toHaveBeenCalledTimes(1);
+		expect(load).toHaveBeenCalledTimes(2);
+		expect(onHealAttempt).toHaveBeenCalledWith("@kampus/ci-required");
+	});
+
+	it("falls back to the #1798 remediation when the retry still can't link the dep", async () => {
+		const stillUnlinked = unlinkedPkgErr("@kampus/ci-required");
+		const load = vi.fn().mockRejectedValue(stillUnlinked);
+		const install = vi.fn().mockResolvedValue(undefined);
+		// the second unlinked throw propagates so the bin prints remediation + exit(1)
+		await expect(loadWithSelfHeal({load, install})).rejects.toBe(stillUnlinked);
+		expect(install).toHaveBeenCalledTimes(1); // still bounded — one install, no loop
+		expect(load).toHaveBeenCalledTimes(2);
+		expect(isUnlinkedDependencyError(stillUnlinked)).toBe(true);
+	});
+
+	it("does NOT self-heal a genuine missing-source-file miss — rethrows the real bug untouched", async () => {
+		const realBug = missingRelativeFileErr();
+		const load = vi.fn().mockRejectedValue(realBug);
+		const install = vi.fn().mockResolvedValue(undefined);
+		await expect(loadWithSelfHeal({load, install})).rejects.toBe(realBug);
+		expect(install).not.toHaveBeenCalled();
+		expect(load).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips the heal entirely when disabled — the unlinked error drops straight to the fallback", async () => {
+		const unlinked = unlinkedPkgErr("yaml");
+		const load = vi.fn().mockRejectedValue(unlinked);
+		const install = vi.fn().mockResolvedValue(undefined);
+		await expect(loadWithSelfHeal({load, install, selfHealEnabled: false})).rejects.toBe(unlinked);
+		expect(install).not.toHaveBeenCalled();
+		expect(load).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
Fixes #2459

## Problem

`main-sync` — the crew's only sanctioned way to advance the primary checkout's `main` — runs from source as `node packages/pipeline-cli/src/bin.ts main-sync …`. When a `pipeline-cli` **workspace-dep-graph** change lands on `main` (PR #2447 switched `@kampus/ci-required` to a `workspace:*` import), the primary checkout's `node_modules` no longer satisfies the bin's import graph. The dynamic `import("./run.ts")` then throws the unlinked-dep `ERR_MODULE_NOT_FOUND` that `module-load-guard.ts` (#1798) classifies, and the tool refuses to start until a human runs `pnpm install`. In that window the safe-sync tool is unrunnable and the primary drifts.

This is **not** a silent failure — #1798's fail-fast legible remediation is working as designed. The gap is purely additive: there is no self-heal / install-free path, so the post-merge freshness discipline can't run unattended right after such a merge.

## Fix (option (b) from the issue — self-heal, bounded)

On catching the classifier-accepted unlinked-dep throw, the bin bootstrap now runs **one** workspace `pnpm install` at the repo root, then retries the load — **at most one install + one retry, never a loop** (bounded, idempotent). If the single retry still can't link the dep, that throw propagates and the **existing #1798 legible remediation prints as the last-resort fallback** — preserved, not replaced.

- A genuine missing-source-file miss (or any unrelated throw) is **not** self-healed — it propagates untouched and still fails as the real bug it is (the guard's bare-specifier-only scoping stays intact).
- `PIPELINE_CLI_NO_SELF_HEAL` opts out (e.g. a frozen-lockfile CI runner that forbids an implicit install) and drops straight to the fallback.
- The **decision + orchestration are a pure, unit-tested core** in `module-load-guard.ts` (`shouldSelfHeal`, `loadWithSelfHeal` with injected `load`/`install`); `bin.ts` holds only the thin `spawnSync("pnpm", ["install"])` side effect at the repo root (found via the existing `findRootDir` primitive).

## Acceptance criteria

- [x] After a `pipeline-cli` workspace-dep-graph change, `main-sync` is runnable from the primary checkout with **zero manual `pnpm install`** — the bin self-heals the unlinked-dep condition.
- [x] The #1798 legible-remediation behavior is **preserved as the fallback** for the genuinely-uninstalled case; the guard's bare-specifier-only scoping is untouched, so a real missing-source-file bug is never masked.
- [x] `pipeline-cli`'s tests cover the new branch: unlinked-dep → install → retry succeeds; retry-still-fails → falls back; genuine code-miss still throws; opt-out skips the heal; the install is bounded to exactly one call.

## Verification

- `pnpm test` (pipeline-cli): 916 passed (73 files) — 8 new tests in `module-load-guard.unit.test.ts`.
- `pnpm typecheck` (exact CI command): clean.
- `biome check` on the three touched files: clean.
- Bin normal pass-through smoke: `node packages/pipeline-cli/src/bin.ts version` → `pipeline-cli 0.1.0`.

## Merge path

`pipeline-cli` / `main-sync` is control-plane (§CP) infra (the shared primary-checkout sync mechanism), and this touches the bin bootstrap — **§CP: stops at reviewed-ready for human approve/merge (cansirin), not autonomous auto-ship.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)