### PR TITLE
docs(patterns): /lab/* standing public prototype-route convention (#2469)

### DIFF
--- a/.patterns/frontend-routing.md
+++ b/.patterns/frontend-routing.md
@@ -1,0 +1,71 @@
+# Frontend routing
+
+How the SPA's route tree is shaped, and the standing `/lab/*` convention for
+in-product experiment/prototype routes.
+
+## The route tree
+
+`apps/web/src/App.tsx` owns the react-router `<Routes>`/`<Route>` tree. Every route
+mounts under one shared `<Route element={<Layout />}>` parent, so the AppShell frame
+(Topbar / `Main` / Footer) renders once and the routed page fills the `Outlet`. Page
+components live in `apps/web/src/pages/` — one file per screen (`PanoFeed`,
+`SozlukHome`, `SearchPage`, …). Paths are technical identifiers, so they are English
+and lowercase kebab-case even where the product noun they serve is Turkish
+(`/sozluk`, `/pano`, `/bildirimler`).
+
+Routes fall into two visibility classes:
+
+- **Public product routes** — mounted plainly, live for everyone (`/pano`, `/sozluk`,
+  `/search`, `/u/:username`).
+- **Dark feature routes** — mounted behind a flag the page self-gates on (off ⇒ 404):
+  `/divan`, `/funnel`, `/bildirimler`. These ship dark by default and a human flips
+  the flag to release them (the agents-deploy / humans-release contract, ADR 0083).
+
+`/lab/*` is a third, deliberately-public class — see below.
+
+## `/lab/*` — the standing prototype space
+
+`/lab/*` is a **durable, kept** home for in-product experiments and prototypes. It is
+**not** per-spike throwaway: every future spike gets a discoverable, felt place to live
+instead of being conjured and torn down each time. Mount a prototype as `/lab/<name>`
+under the same `<Layout />` parent as any other route.
+
+**Visibility: PUBLIC — the load-bearing rule.** `/lab/*` routes ship live to all users
+and are discoverable in production. There is **no `ENVIRONMENT` dev-gate and no
+`phoenix-*` dark-flag gate** on a lab route — this is the explicit inverse of the dark
+feature routes above. The convention is kampus spirit: open, transparent, dogfooded in
+the open. A lab route is reachable by anyone who navigates to it, the same as `/pano`.
+(This does not weaken per-*action* authorization — a prototype that writes still gates
+its writes on the actor the same way any surface does; it is the *route's reachability*
+that is public.)
+
+### Naming and nesting
+
+- **Flat `/lab/<name>`**, lowercase kebab-case, English (a technical path). One segment
+  names the prototype (`/lab/composer`).
+- A lab surface with its own sub-navigation nests under its segment
+  (`/lab/<name>/<sub>`), exactly as `/pano/:id` nests under `/pano` — the `/lab/`
+  prefix is the only added namespace.
+
+### Lifecycle
+
+A `/lab/<name>` route is **kept by default** once it lands. Two exits, both a
+product-owner call (product-driven, ADR
+[0078](../.decisions/0078-product-driven-decisions-by-default.md)):
+
+- **Graduate** — a prototype that earns a permanent home moves out of `/lab/` to a
+  first-class product path (its page component and route move; the `/lab/` alias is
+  dropped or redirected).
+- **Cull** — an abandoned prototype's route and page are deleted.
+
+Until one of those happens the route stays mounted and public under `/lab/`. The
+default is *keep*, not *delete* — the space exists precisely so a prototype can persist
+and be felt rather than vanish after one session.
+
+### First inhabitant
+
+**`/lab/composer` (#2465)** — the tiptap composer — is the first kept public route under
+this convention (opened as PR
+[#2472](https://github.com/kamp-us/phoenix/pull/2472)). It is a durable inhabitant of
+the standing space, not deletable scaffolding: publicly visible, kept, and prototyping
+toward the mecmua long-form publishing arc (#2467).

--- a/.patterns/index.md
+++ b/.patterns/index.md
@@ -75,6 +75,14 @@ live in `apps/web/src/components/ui/`.
 | [design-sync-authority.md](./design-sync-authority.md) | The **one-directional per-layer sync authority** contract every `/design-sync` (Claude Design) round-trip runs against (#2406): tokens/style → the visual tool is source; component logic + a11y (focus rings, aria wiring, keyboard order, reduced-motion) → the repo primitive is source. The behavioral spine is code-authoritative — a visual reskin consumes it read-only, never re-authors it. Enforced by the property-based a11y loop (generic) + the entry-row spine lock (`apps/web/src/components/entry-row-spine.test.tsx`, the composite tripwire) | Before any design round-trip, or when changing an entry-row primitive's behavior vs its paint ([ADR 0162](../.decisions/0162-four-pillars-design-law.md)) |
 | [moderation-admin-shared-components.md](./moderation-admin-shared-components.md) | The **one shared component layer** every moderation/admin surface consumes (`apps/web/src/components/moderation/`): the cross-surface primitives (actor/user row, action affordances, audit context), the shared-primitive + thin-per-surface-wrapper shape (divan's `CaylakIdentity` over `ActorIdentity`), how a new mod surface (the admin user-list #968) consumes it, the reuse-don't-fork rule, and the extract-on-the-second-consumer discipline | Building or extending any moderation/admin UI (divan, admin #873 children, future mod tooling) — before forking a user-list / action-row ([ADR 0147](../.decisions/0147-shared-moderation-admin-component-layer.md) / [0138](../.decisions/0138-divan-actor-centric-spine.md)) |
 
+## Index — frontend routing
+
+The SPA's route tree (`apps/web/src/App.tsx`) and the visibility classes a route can take.
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [frontend-routing.md](./frontend-routing.md) | How the react-router `<Routes>`/`<Route>` tree is shaped (one shared `<Layout />` parent, pages in `apps/web/src/pages/`); the two visibility classes (public product routes vs dark flag-gated feature routes that 404 when off); and the standing **`/lab/*` convention** — a durable, kept home for in-product prototypes with the load-bearing **PUBLIC** visibility rule (no `ENVIRONMENT` dev-gate, no `phoenix-*` dark flag), plus its naming/nesting and graduate-or-cull lifecycle; first inhabitant `/lab/composer` (#2465) | Adding a route, mounting a prototype under `/lab/*`, or deciding a route's production visibility |
+
 ## Index — alchemy infra layer
 
 The infra layer beneath the domain and fate layers. phoenix runs on [alchemy-effect](https://github.com/usirin/alchemy-effect) — one Effect program for infra + runtime, in place of `wrangler.jsonc`, a Hono entry, manual binding access, and hand-written DO classes. Read [alchemy-overview.md](./alchemy-overview.md) first; it maps how this layer sits under the unchanged `effect-*`/`fate-*` layers. phoenix and alchemy are both on effect v4.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,6 +89,7 @@ Run Biome through pnpm — `pnpm lint`, `pnpm format`, or `pnpm biome …` — w
 - **Make invalid states unrepresentable.** Domain logic lives in domain objects.
 - **No `export default`** (ADR [0001](./.decisions/0001-no-export-default.md)) except where the framework demands it (`alchemy.run.ts`, the worker entry, Vite config).
 - **Feature flags ship dark, default-off.** Gate a new path behind a flag and read it with the safe value as default — the read never throws, so an outage degrades to the old path. Declaring, reading (server or React), and flipping a flag are all in [.patterns/feature-flags.md](./.patterns/feature-flags.md) (ADR [0081](./.decisions/0081-feature-flag-substrate-cloudflare-flagship.md)).
+- **`/lab/*` is the standing prototype space, and it is PUBLIC.** In-product experiments/prototypes mount under `/lab/<name>` as a durable, kept home (not per-spike throwaway), shipped **live to all users with no dev-gate and no dark flag** — the explicit inverse of the flag-gated feature routes. The route-tree shape, the visibility classes, and the `/lab/*` naming/lifecycle convention are in [.patterns/frontend-routing.md](./.patterns/frontend-routing.md).
 - **pnpm, not npm.** Biome formatting: tabs, 100 col, no bracket spacing.
 
 Data tasks (seeding, backfills) are one-off direct-D1 scripts against the bound database, not worker routes.


### PR DESCRIPTION
Fixes #2469

Records the founder-ruled `/lab/*` standing convention as builder-facing docs. No runtime behavior change — this documents a current convention, grounded in the existing route tree (`apps/web/src/App.tsx`).

## What changed

- **New `.patterns/frontend-routing.md`** — the SPA route tree shape (one shared `<Layout />` parent, pages in `apps/web/src/pages/`), the two existing visibility classes (public product routes vs dark flag-gated feature routes that 404 when off), and the standing `/lab/*` convention.
- **Registered** the new doc as a row in `.patterns/index.md` (new "frontend routing" section), per the index's "when to add a pattern doc" criteria.
- **DEVELOPMENT.md §Conventions** — a short pointer to the pattern doc (canonical home stays `.patterns/`).

## Acceptance criteria

- [x] `/lab/*` documented as a **standing, kept** convention for in-product experiment/prototype routes in a new `.patterns/` frontend-routing doc.
- [x] Visibility rule stated **explicitly: `/lab/*` is PUBLIC** — live to all users, discoverable in production, with **no `ENVIRONMENT` dev-gate and no `phoenix-*` dark-flag gate** (framed as the explicit inverse of the dark feature routes).
- [x] Naming/nesting settled (flat `/lab/<name>`, lowercase kebab-case English path; sub-routes nest under the segment) and lifecycle settled (kept-by-default; graduate to a first-class route or cull, a product-owner call per ADR 0078).
- [x] Names `/lab/composer` (#2465) as the **first kept public route** under the convention (referencing PR #2472 as the inaugural inhabitant), with the kept-not-throwaway, publicly-visible framing.
- [x] New `.patterns/` doc registered in `.patterns/index.md`.

Ordinary repo docs (`.patterns/` + `DEVELOPMENT.md`), not a control-plane surface — standard review + merge. The `/lab/composer` route itself is owned by the sibling lane (#2465 / PR #2472); this PR documents the convention only, touching no app code.