### PR TITLE
test(integration): gate shared bootstrap on auth-route edge propagation (#2416)

### DIFF
--- a/apps/web/tests/integration/_edge-ready.unit.test.ts
+++ b/apps/web/tests/integration/_edge-ready.unit.test.ts
@@ -16,6 +16,7 @@
  * `_auth-signup-readiness.unit.test.ts` #1720) now that their logic is one primitive.
  */
 
+import * as Effect from "effect/Effect";
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {
 	awaitEdgeReady,
@@ -26,6 +27,7 @@ import {
 } from "./_edge-ready.ts";
 import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
 import {harness} from "./_harness.ts";
+import {awaitAuthRouteReady} from "./_integration.ts";
 
 // A tiny budget so the tests drive the readiness logic in milliseconds, not the real 60s.
 const BUDGET = {deadlineMs: 120, pollMs: 5} as const;
@@ -140,6 +142,51 @@ describe("awaitEdgeReady — the shared cold-start readiness primitive (ADR 0127
 		expect(res.status).toBe(401);
 		// Fast-fail: the terminal worker JSON 4xx was ready on the FIRST attempt, never re-polled.
 		expect(send).toHaveBeenCalledTimes(1);
+	});
+});
+
+// The shared bootstrap gates the run-scoped stage on the AUTH-provisioning route being past the CF
+// edge placeholder before releasing the URL — edge propagation is per-route, so `/api/health` can
+// ripen while `/api/auth/sign-up/email` still 404s and reds all 53 forked suites (#2416). This pins
+// that gate probes the auth route (POST) and rides ONLY the placeholder-404, not a real answer.
+describe("awaitAuthRouteReady — the bootstrap auth-route propagation gate (#2416)", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it("probes POST /api/auth/sign-up/email and resolves on the first real (non-placeholder) response", async () => {
+		// Typed impl params so `mock.calls` infers `[string, RequestInit?]` — assert the probed
+		// route + method off the recorded call without a type assertion.
+		const fetchMock = vi.fn(
+			async (_input: string, _init?: RequestInit) =>
+				new Response(JSON.stringify({code: "INVALID_EMAIL"}), {status: 400}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await Effect.runPromise(awaitAuthRouteReady("https://stage.example.workers.dev"));
+
+		// One call: a real worker 400 (the empty-body probe answer) is READY at once under
+		// `() => true` — a genuine auth 4xx is never swallowed into the readiness budget (invariant 2).
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [input, init] = fetchMock.mock.calls[0]!;
+		expect(input).toBe("https://stage.example.workers.dev/api/auth/sign-up/email");
+		expect(init?.method).toBe("POST");
+	});
+
+	it("rides out a cold-edge placeholder-404 on the auth route until it propagates, then resolves", async () => {
+		let call = 0;
+		const fetchMock = vi.fn(async () => {
+			call += 1;
+			// The auth route is not propagated on the first open (CF HTML placeholder 404 → edgeFetch
+			// throws the typed error the gate rides), then serves a structured 4xx (route propagated).
+			if (call === 1)
+				return new Response("<!DOCTYPE html>There is nothing here yet", {status: 404});
+			return new Response(JSON.stringify({code: "INVALID_EMAIL"}), {status: 400});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			Effect.runPromise(awaitAuthRouteReady("https://stage.example.workers.dev")),
+		).resolves.toBeUndefined();
+		expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
 	});
 });
 

--- a/apps/web/tests/integration/_global-setup.ts
+++ b/apps/web/tests/integration/_global-setup.ts
@@ -24,6 +24,7 @@ import * as Effect from "effect/Effect";
 import type {TestProject} from "vitest/node";
 import Stack from "../../alchemy.run.ts";
 import {
+	awaitAuthRouteReady,
 	awaitWorkerReady,
 	deployTransientRetry,
 	ensureIntegrationEnv,
@@ -70,6 +71,14 @@ export default async function setup(project: TestProject): Promise<() => Promise
 	// `deployTransientRetry`, then `awaitWorkerReady` + `warmLiveDO`. No scope: CI is non-dev,
 	// so there is no workerd sidecar to keep alive (the scope in `Test/Vitest.ts` exists only
 	// for `alchemy dev`).
+	//
+	// The readiness gate proves BOTH the health route AND the auth-provisioning route are past the
+	// CF edge placeholder before `project.provide` releases the URL: edge propagation is per-route,
+	// so `/api/health` (`awaitWorkerReady`) can ripen while `/api/auth/sign-up/email`
+	// (`awaitAuthRouteReady`) — the route every forked suite hits to provision users — still 404s.
+	// Gating on health alone released the URL early and reds all 53 suites with
+	// `CloudflarePlaceholder404Error` on a slow auth propagation (#2416); the auth gate pays that
+	// wait once, here, so no per-suite `signUp` rides the budget.
 	const {url, accountId, databaseId} = await Core.run(
 		Core.deploy(MAKE_OPTIONS, Stack, {stage}).pipe(
 			deployTransientRetry,
@@ -81,6 +90,7 @@ export default async function setup(project: TestProject): Promise<() => Promise
 					return Effect.die(new Error("shared deploy returned no D1 databaseId"));
 				}
 				return awaitWorkerReady(cleanUrl).pipe(
+					Effect.andThen(awaitAuthRouteReady(cleanUrl)),
 					Effect.andThen(warmLiveDO(cleanUrl)),
 					Effect.as({
 						url: cleanUrl,

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -322,6 +322,41 @@ export const awaitWorkerReady = (url: string): Effect.Effect<void, never, never>
 	});
 
 /**
+ * Probe a freshly-deployed worker's auth-provisioning route (`POST /api/auth/sign-up/email`, the
+ * route every suite hits at setup) until the CF edge stops serving the placeholder 404 for it.
+ *
+ * Edge propagation on Cloudflare is PER-ROUTE, not per-worker, so `/api/health` (`awaitWorkerReady`)
+ * can ripen while `/api/auth/*` still 404s at the edge for several more seconds (#2416). Without
+ * this gate the shared stage releases its URL on health alone; each forked suite's first `signUp`
+ * then rides its OWN `EDGE_READY_DEADLINE_MS` budget in-suite, and a slow auth propagation reds all
+ * of them with `CloudflarePlaceholder404Error`. Pay that wait ONCE here so the URL is released only
+ * after the auth route is serving.
+ *
+ * Reuses the shared `awaitEdgeReady`/`edgeFetch` primitive (ADR 0127) on its default
+ * `EDGE_READY_DEADLINE_MS` budget — at least as generous as the per-test one it front-loads. The
+ * probe body is deliberately empty: better-auth answers a structured 4xx (proof the route is
+ * serving) without provisioning a user, and the `() => true` predicate — the same shape the harness
+ * `postAuthReady` uses — rides ONLY the thrown placeholder-404 out; any real worker answer stops the
+ * poll AT ONCE, so a genuine auth 4xx/5xx is never swallowed into the budget (the `_edge-ready.ts`
+ * scoped-tolerance guarantee). If the route never propagates within the budget, `awaitEdgeReady`
+ * re-throws the typed placeholder-404 → an `Effect.promise` defect (die), failing the bootstrap
+ * loudly rather than releasing a URL whose auth route still 404s.
+ */
+export const awaitAuthRouteReady = (url: string): Effect.Effect<void, never, never> =>
+	Effect.promise(async () => {
+		await awaitEdgeReady(
+			() =>
+				edgeFetch(`${url}/api/auth/sign-up/email`, {
+					method: "POST",
+					headers: {"content-type": "application/json", origin: "http://localhost:3000"},
+					body: "{}",
+				}),
+			() => true,
+			{pollMs: WARM_POLL_MS},
+		);
+	});
+
+/**
  * Stand up this file's per-file `Test.make` lifecycle and return the black-box
  * `harness` bound to its deployed worker URL. Call once at module top level.
  *


### PR DESCRIPTION
Fixes #2416

## Problem

Edge propagation on Cloudflare is **per-route**, not per-worker. A freshly-deployed stage can have `/api/health` propagated while `/api/auth/sign-up/email` — the route every forked integration suite hits to provision users — still serves the CF placeholder 404 for several more seconds.

The run-scoped shared stage's bootstrap (`_global-setup.ts`) released its worker URL after gating on only `awaitWorkerReady` (`/api/health`) + `warmLiveDO` (`/fate/live`). Neither touches the auth route. So when `/api/health` ripens but `/api/auth/*` lags, the gate passes, the suites start, and each of the 53 forked suites' first `signUp` rides its **own** `EDGE_READY_DEADLINE_MS` budget in-suite. A slow auth propagation then reds the whole run with `CloudflarePlaceholder404Error` on green code (confirmed on PR #2407, frontend-only; rerun passes).

## Fix

Add `awaitAuthRouteReady(url)` in the shared deploy path (`_integration.ts`) and wire it into `_global-setup.ts` **before** `project.provide` releases the URL:

```
awaitWorkerReady(cleanUrl).pipe(
  Effect.andThen(awaitAuthRouteReady(cleanUrl)),   // ← auth-route propagation gate
  Effect.andThen(warmLiveDO(cleanUrl)),
  ...
)
```

- **Reuses the existing `awaitEdgeReady` / `edgeFetch` primitive** (ADR 0127) on its default `EDGE_READY_DEADLINE_MS` budget — at least as generous as the per-test one it front-loads. No new per-test retry.
- **Probes `POST /api/auth/sign-up/email` with a deliberately-empty body**: better-auth answers a structured 4xx (proof the route is serving) without provisioning a user.
- **Same `() => true` predicate the harness `postAuthReady` already uses**: rides ONLY the typed `CloudflarePlaceholder404Error` out; any real worker answer stops the poll at once, so a genuine auth 4xx/5xx is never swallowed into the budget (the `_edge-ready.ts` scoped-tolerance guarantee is preserved).
- If the auth route never propagates within the budget, `awaitEdgeReady` re-throws the typed placeholder-404 → an `Effect.promise` defect (die): the bootstrap fails **loudly** rather than releasing a URL whose auth route still 404s.

The wait is paid **once** at bootstrap instead of 53 times in-suite.

## Acceptance criteria

- [x] Bootstrap gate proves the auth-provisioning route (`/api/auth/sign-up/email`) is serving a non-placeholder response before releasing the URL — not just `/api/health`.
- [x] A slow `/api/auth/*` propagation results in a bounded startup wait (default `EDGE_READY_DEADLINE_MS`, ≥ the per-test budget), not 53 in-suite `CloudflarePlaceholder404Error` failures.
- [x] Fix lives in the shared bootstrap path (`_global-setup.ts` / the `awaitWorkerReady`-family in `_integration.ts`), reusing `awaitEdgeReady` rather than adding a per-test retry.
- [x] Genuine-failure escape hatch preserved: only the typed `CloudflarePlaceholder404Error` is ridden out; a real auth 4xx/5xx surfaces (`() => true` returns it at once).

## Verification

- `pnpm typecheck` clean (full workspace, tsgo).
- `pnpm lint:worktree` clean.
- `apps/web/tests/integration/_edge-ready.unit.test.ts` — added two focused tests pinning `awaitAuthRouteReady`: probes `POST /api/auth/sign-up/email` and resolves on the first real response; rides a cold-edge placeholder-404 until the auth route propagates. 25/25 pass.

Note: the 53-failure signature is a slow-edge-propagation **infra flake** reproducible only under a real cold Cloudflare deploy (the integration suite deploys real remote workers + D1 under CI credentials). The fix is unit-verified against the same `awaitEdgeReady` / `() => true` shape already proven for the per-test `signUp` path; the real end-to-end confirmation is the integration-tests job running green on this PR.

## Scope

Integration-test harness/bootstrap only. No `.github/workflows`, pipeline-cli, or review-skill changes (lanes kept disjoint per #2358).

🤖 Generated with [Claude Code](https://claude.com/claude-code)