### PR TITLE
chore(pano): converge post.react flag-off onto the inert re-resolve shape (#1918)

### DIFF
--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -43,7 +43,6 @@ export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	TAGS_REQUIRED: "en az bir etiket seç",
 	TAG_INVALID: "geçersiz etiket",
 	DRAFTS_DISABLED: "taslaklar şu an devre dışı",
-	REACTIONS_DISABLED: "tepkiler şu an devre dışı",
 	PARENT_NOT_FOUND: "yanıtlanan içerik bulunamadı",
 	INVALID_FORMAT: "geçersiz biçim",
 	TOO_SHORT: "çok kısa",

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -64,9 +64,6 @@ export const FATE_WIRE_CODES = [
 	// Pano taslak (draft-save) is gated on the `pano-draft-save` flag; the server
 	// raises this when a draft mutation runs with the flag off (#746).
 	"DRAFTS_DISABLED",
-	// Reactions (emoji tepki) are gated on the `phoenix-reactions` flag; the server
-	// raises this when a react mutation runs with the flag off (#1863, epic #1840).
-	"REACTIONS_DISABLED",
 	"PARENT_NOT_FOUND",
 	"INVALID_FORMAT",
 	"TOO_SHORT",

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -45,7 +45,6 @@ import {
 	PostBodyTooLong,
 	PostDeleteFailed,
 	PostNotFound,
-	ReactionsDisabled,
 	TagInvalid,
 	TagsRequired,
 	TitleRequired,
@@ -99,7 +98,6 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	[UnauthorizedPostMutation, "UNAUTHORIZED"],
 	[UnauthorizedCommentMutation, "UNAUTHORIZED"],
 	[DraftsDisabled, "DRAFTS_DISABLED"],
-	[ReactionsDisabled, "REACTIONS_DISABLED"],
 	// sozluk
 	[BodyRequired, "BODY_REQUIRED"],
 	[BodyTooLong, "BODY_TOO_LONG"],
@@ -165,7 +163,6 @@ const ROUND_TRIP_CLASSES = [
 	ParentCommentNotFound,
 	PostDeleteFailed,
 	DraftsDisabled,
-	ReactionsDisabled,
 	BodyRequired,
 	UsernameInvalidFormat,
 	UsernameTooShort,

--- a/apps/web/worker/features/pano/errors.ts
+++ b/apps/web/worker/features/pano/errors.ts
@@ -149,15 +149,3 @@ export class DraftsDisabled extends Schema.TaggedErrorClass<DraftsDisabled>()(
 	{message: Schema.String},
 	{[FateWireCode]: "DRAFTS_DISABLED"},
 ) {}
-
-/**
- * Reactions (emoji tepki) are reachable only when the `phoenix-reactions` flag is
- * on. The server-side gate raises this when a react mutation runs with the flag
- * off, so the dark path is unreachable even if a client bypasses the (not-yet-
- * shipped) UI. See issue #1863, epic #1840 (dark-ship per ADR 0083).
- */
-export class ReactionsDisabled extends Schema.TaggedErrorClass<ReactionsDisabled>()(
-	"pano/ReactionsDisabled",
-	{message: Schema.String},
-	{[FateWireCode]: "REACTIONS_DISABLED"},
-) {}

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -37,7 +37,6 @@ import {
 	PostDeleteFailed,
 	PostNotFound,
 	PostValidationErrors,
-	ReactionsDisabled,
 	UnauthorizedCommentMutation,
 	UnauthorizedPostMutation,
 } from "./errors.ts";
@@ -359,25 +358,32 @@ export const mutations = {
 	// the service. A palette emoji sets/changes the viewer's single reaction; a
 	// `null` emoji retracts it (the cardinality-one change/retract contract). Unlike
 	// `post.vote` there is deliberately NO `VoterNotEligible` tier arm and NO karma
-	// path: any signed-in user — including a çaylak — may react. Ships DARK behind
-	// the default-off `phoenix-reactions` flag: with it off every react fails
-	// `ReactionsDisabled`, so the path is unreachable even if a client bypasses the
-	// (not-yet-shipped) UI. The re-resolved post carries the fresh `reactions`
-	// aggregate; `live.update` flips every open card's reaction bar.
+	// path: any signed-in user — including a çaylak — may react. The re-resolved post
+	// carries the fresh `reactions` aggregate; `live.update` flips every open card's
+	// reaction bar.
 	"post.react": Fate.mutation(
 		{
 			input: ReactToPostInput,
 			type: PostView,
-			error: Schema.Union([Unauthorized, ReactionsDisabled, PostNotFound]),
+			error: Schema.Union([Unauthorized, PostNotFound]),
 		},
 		Effect.fn("post.react")(function* ({input}) {
 			const user = yield* CurrentUser.required;
+			const pano = yield* Pano;
+			// Dark-ship gate (ADR 0083): default-off `phoenix-reactions`. Off ⇒ inert — the
+			// react never lands (the write is the new path, unreachable until release);
+			// re-resolve the post unchanged so the caller's cache stays consistent (the
+			// `comment.react` / `definition.react` dark-ship inert-receipt shape). On a
+			// Flagship outage the safe read default (`false`) keeps the path dark.
 			const flags = yield* Flags;
 			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
 			if (!on) {
-				return yield* new ReactionsDisabled({message: "tepki özelliği şu an kapalı"});
+				const [current] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
+				if (!current) {
+					return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
+				}
+				return toPost(current);
 			}
-			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const r = yield* pano.reactToPost({postId: input.id, userId: user.id, emoji: input.emoji});
 			const post = toPost(r.post);

--- a/apps/web/worker/features/pano/reaction-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-mutation.unit.test.ts
@@ -2,8 +2,8 @@
  * `post.react` wire-boundary unit coverage (#1863, epic #1840) — the pano-post
  * reaction mutation's four AC proofs, driven through its real external interface
  * (`resolveWire`: the `resolve` decode + the `encodeWireError` class→wire-code
- * seam), so a decode rejection surfaces as a WIRE `code` and a mis-annotated
- * `[FateWireCode]` on `ReactionsDisabled` is a unit failure. The `Pano` / `Flags` /
+ * seam), so a decode rejection surfaces as a WIRE `code` (an off-palette emoji →
+ * `VALIDATION_ERROR`). The `Pano` / `Flags` /
  * `LivePublisher` seams are substituted directly — no DB, no Flagship binding. The
  * react/change/retract write semantics themselves (probe-then-write, cardinality
  * one, NO karma, NO tier gate) are proven over the real service in
@@ -15,9 +15,11 @@
  *      emoji, a different palette emoji, `null`).
  *   2. non-palette rejection — an off-palette emoji FAILS to decode at the wire
  *      boundary (`ReactionEmojiSchema`), so the service is NEVER reached.
- *   3. flag gate — with `Flags` OFF the mutation fails the wire `REACTIONS_DISABLED`
- *      and never touches the service (dark-ship unreachable even past the UI); with
- *      it ON the delegation runs.
+ *   3. flag gate (dark ship, ADR 0083) — with `Flags` OFF the mutation is inert: no
+ *      react lands (`Pano.reactToPost` is never called), the post is re-resolved
+ *      unchanged via `getPostsByIds` and returned with no error — a merged-but-
+ *      unflipped feature is invisible, matching `comment.react` / `definition.react`;
+ *      with it ON the delegation runs.
  *   4. ungated — a çaylak/newcomer (any authenticated user) reacts with no tier
  *      gate: the mutation carries no `VOTE_REQUIRES_YAZAR` arm, so a plain user
  *      succeeds exactly like any other.
@@ -60,15 +62,16 @@ const liveStub = Layer.succeed(LivePublisher)(
 	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
 );
 
-// A `Pano` stub whose `reactToPost` is scripted; every other method dies. Cast to
-// the full service tag — the react path only ever reaches `reactToPost`.
-const panoStub = (reactToPost: (typeof Pano.Service)["reactToPost"]): Layer.Layer<Pano> =>
+// A `Pano` whose named methods are scripted; every OTHER method dies on contact, so
+// a passing test proves the resolver reached only the method its path routes to (the
+// flag-ON path routes to `reactToPost`, the inert flag-OFF path to `getPostsByIds`).
+const panoProxy = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
 	Layer.succeed(
 		Pano,
-		new Proxy({reactToPost} as Partial<typeof Pano.Service>, {
+		new Proxy(methods, {
 			get(target, prop) {
 				if (prop in target) return (target as Record<string, unknown>)[prop as string];
-				return () => Effect.die(`Pano.${String(prop)} not exercised in reaction-mutation`);
+				return () => Effect.die(`Pano.${String(prop)} not exercised in post.react`);
 			},
 		}) as typeof Pano.Service,
 	);
@@ -121,9 +124,11 @@ describe("post.react — (1) delegation threads the emoji and echoes the aggrega
 				changed: true,
 			};
 			const post = yield* react(
-				panoStub((i) => {
-					calls.push({postId: i.postId, userId: i.userId, emoji: i.emoji});
-					return Effect.succeed(result);
+				panoProxy({
+					reactToPost: (i) => {
+						calls.push({postId: i.postId, userId: i.userId, emoji: i.emoji});
+						return Effect.succeed(result);
+					},
 				}),
 				flagsStub(true),
 				{id: "post_1", emoji: "👍"},
@@ -140,12 +145,14 @@ describe("post.react — (1) delegation threads the emoji and echoes the aggrega
 		Effect.gen(function* () {
 			const calls: Array<string | null> = [];
 			const post = yield* react(
-				panoStub((i) => {
-					calls.push(i.emoji);
-					return Effect.succeed({
-						post: postRowWith({counts: [{emoji: "🔥", count: 1}], myReaction: "🔥"}),
-						changed: true,
-					});
+				panoProxy({
+					reactToPost: (i) => {
+						calls.push(i.emoji);
+						return Effect.succeed({
+							post: postRowWith({counts: [{emoji: "🔥", count: 1}], myReaction: "🔥"}),
+							changed: true,
+						});
+					},
 				}),
 				flagsStub(true),
 				{id: "post_1", emoji: "🔥"},
@@ -162,9 +169,11 @@ describe("post.react — (1) delegation threads the emoji and echoes the aggrega
 		Effect.gen(function* () {
 			const calls: Array<string | null> = [];
 			const post = yield* react(
-				panoStub((i) => {
-					calls.push(i.emoji);
-					return Effect.succeed({post: postRowWith(EMPTY_REACTION_AGGREGATE), changed: true});
+				panoProxy({
+					reactToPost: (i) => {
+						calls.push(i.emoji);
+						return Effect.succeed({post: postRowWith(EMPTY_REACTION_AGGREGATE), changed: true});
+					},
 				}),
 				flagsStub(true),
 				{id: "post_1", emoji: null},
@@ -180,7 +189,9 @@ describe("post.react — (2) a non-palette emoji is rejected at the wire boundar
 		Effect.gen(function* () {
 			const exit = yield* Effect.exit(
 				react(
-					panoStub(() => Effect.die("Pano.reactToPost ran on a non-palette emoji")),
+					panoProxy({
+						reactToPost: () => Effect.die("Pano.reactToPost ran on a non-palette emoji"),
+					}),
 					flagsStub(true),
 					{id: "post_1", emoji: "🚀"},
 				),
@@ -197,24 +208,21 @@ describe("post.react — (2) a non-palette emoji is rejected at the wire boundar
 	);
 });
 
-describe("post.react — (3) the flag gate is the safe default", () => {
-	it.effect("flag OFF → the wire REACTIONS_DISABLED, and Pano.reactToPost is never called", () =>
+describe("post.react — (3) flag OFF is inert (dark ship)", () => {
+	it.effect("inert: no react lands, the unchanged post is re-resolved and returned", () =>
 		Effect.gen(function* () {
-			const exit = yield* Effect.exit(
-				react(
-					panoStub(() => Effect.die("Pano.reactToPost ran with the flag off")),
-					flagsStub(false),
-					{id: "post_1", emoji: "👍"},
-				),
+			const post = yield* react(
+				// reactToPost fail-on-contact: the write must never land when dark; the inert
+				// path re-resolves the current post via `getPostsByIds`.
+				panoProxy({
+					getPostsByIds: () => Effect.succeed([postRowWith(EMPTY_REACTION_AGGREGATE)]),
+				}),
+				flagsStub(false),
+				{id: "post_1", emoji: "👍"},
 			);
-			assert.isTrue(exit._tag === "Failure", "off-path fails");
-			if (exit._tag === "Failure") {
-				const error = Cause.findErrorOption(exit.cause);
-				assert.isTrue(error._tag === "Some");
-				if (error._tag === "Some") {
-					assert.strictEqual((error.value as {code?: unknown}).code, "REACTIONS_DISABLED");
-				}
-			}
+			assert.strictEqual((post as {id: string}).id, "post_1");
+			// The current, unreacted aggregate — the react write never happened while dark.
+			assert.deepStrictEqual((post as {reactions?: unknown}).reactions, EMPTY_REACTION_AGGREGATE);
 		}),
 	);
 });
@@ -225,14 +233,16 @@ describe("post.react — (4) reactions are ungated (a çaylak reacts, no tier ga
 		() =>
 			Effect.gen(function* () {
 				const post = yield* react(
-					panoStub((i) => {
-						// The mutation carries no tier gate: a plain user's react reaches the
-						// service exactly like any other — the ungated/social-only model.
-						assert.strictEqual(i.userId, CAYLAK.id);
-						return Effect.succeed({
-							post: postRowWith({counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"}),
-							changed: true,
-						});
+					panoProxy({
+						reactToPost: (i) => {
+							// The mutation carries no tier gate: a plain user's react reaches the
+							// service exactly like any other — the ungated/social-only model.
+							assert.strictEqual(i.userId, CAYLAK.id);
+							return Effect.succeed({
+								post: postRowWith({counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"}),
+								changed: true,
+							});
+						},
 					}),
 					flagsStub(true),
 					{id: "post_1", emoji: "❤️"},


### PR DESCRIPTION
Converges the `post.react` flag-off branch onto the **inert re-resolve** shape that `comment.react` / `definition.react` already use, so all three reaction wirings dark-ship identically behind the default-off `phoenix-reactions` flag (ADR 0083). Mechanical harmonization onto a settled shape — no open decision (per the issue).

## What changed

- **`post.react` flag-off is now inert** (`apps/web/worker/features/pano/mutations.ts`): with the flag off it re-resolves the post via `getPostsByIds` and returns it unchanged (`PostNotFound` only if the row is missing), instead of raising `ReactionsDisabled`. Its error union drops `ReactionsDisabled` (now `Union([Unauthorized, PostNotFound])`); the docblock's flag-off narration moved to the inline dark-ship note (stated once, mirroring `comment.react`).
- **The `ReactionsDisabled` surface is fully removed** now that nothing emits it: the error class (`pano/errors.ts`), its `REACTIONS_DISABLED` wire code (`src/lib/fateWireCodes.ts`), and its message (`src/fate/wireMessages.ts`). No consumer remained (the exhaustive wire-code / message registry keeps a dangling entry from surviving).
- **Test converged**: the `post.react` flag-off unit test (`pano/reaction-mutation.unit.test.ts`) flips from asserting the `REACTIONS_DISABLED` wire error to asserting the inert re-resolved post with no error, mirroring the comment/definition flag-off tests; the Pano stub is generalized to the same partial-proxy shape the comment twin test uses. The `wireCodes-per-class` / `wireCodes` registry tests drop `ReactionsDisabled` and stay green (its code is no longer in `declaredWireCodes`).

Released behavior is unchanged — flag-on never takes this branch; this only affects direct API callers during the dark period.

## Acceptance criteria

- [x] `post.react` flag-off re-resolves the post inert (matching `comment.react` / `definition.react`) instead of returning `ReactionsDisabled`.
- [x] `post.react`'s error union no longer includes `ReactionsDisabled`; the docblock note updated to the inert shape.
- [x] `ReactionsDisabled` class + wire code + message removed (unused after the flip; no remaining consumer).
- [x] Unit coverage asserts flag-off `post.react` returns the re-resolved post with no error.
- [x] Depends on #1908 / #1916 / #1912 — all merged.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm vitest run --project unit` on `reaction-mutation.unit.test.ts`, `wireCodes-per-class.unit.test.ts`, `wireCodes.unit.test.ts` — all pass

Fixes #1918