### PR TITLE
fix(web): style /lab/composer prose + comprehensive render-test seed (#2477)

### DIFF
--- a/apps/web/src/pages/LabComposerPage.css
+++ b/apps/web/src/pages/LabComposerPage.css
@@ -111,6 +111,159 @@
 	outline: none;
 }
 
+/* Element-level prose rules for the rendered markdown (#2477). Without these every
+   block fell back to a bare browser default (the reported unstyled blockquote); each
+   supported element now gets a real treatment. Role tokens only (ADR 0162): sizes come
+   from the type ramp, spacing/radius/color from role tokens — no raw hex, no raw px. */
+.kp-lab__editor .tiptap > :first-child {
+	margin-top: 0;
+}
+
+.kp-lab__editor .tiptap > :last-child {
+	margin-bottom: 0;
+}
+
+.kp-lab__editor .tiptap p {
+	margin: var(--s-3) 0;
+}
+
+/* Six heading levels off a two-size type ramp: h1/h2 take the dedicated heading
+   sizes; h3–h6 lean on weight, caps, and color to stay distinct without a raw size. */
+.kp-lab__editor .tiptap :is(h1, h2, h3, h4, h5, h6) {
+	color: var(--text-primary);
+	font-weight: 700;
+	margin: var(--s-4) 0 var(--s-2);
+}
+
+.kp-lab__editor .tiptap h1 {
+	font: var(--t-h-page);
+	font-weight: 700;
+}
+
+.kp-lab__editor .tiptap h2 {
+	font: var(--t-h-feed);
+	font-weight: 700;
+}
+
+.kp-lab__editor .tiptap h3 {
+	font: var(--t-body);
+	font-weight: 700;
+}
+
+.kp-lab__editor .tiptap h4 {
+	font: var(--t-body);
+	font-weight: 600;
+	color: var(--text-secondary);
+}
+
+.kp-lab__editor .tiptap h5 {
+	font: var(--t-meta);
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--text-secondary);
+}
+
+.kp-lab__editor .tiptap h6 {
+	font: var(--t-micro);
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--text-muted);
+}
+
+.kp-lab__editor .tiptap strong {
+	font-weight: 700;
+	color: var(--text-primary);
+}
+
+.kp-lab__editor .tiptap em {
+	font-style: italic;
+}
+
+.kp-lab__editor .tiptap s,
+.kp-lab__editor .tiptap del {
+	text-decoration: line-through;
+	color: var(--text-muted);
+}
+
+.kp-lab__editor .tiptap a {
+	color: var(--link);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+/* Inline code gets a chip; a code block resets that chip back to a plain slab. */
+.kp-lab__editor .tiptap code {
+	font: var(--t-mono);
+	background: var(--surface-sunken);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	padding: 0 var(--s-1);
+}
+
+.kp-lab__editor .tiptap pre {
+	font: var(--t-mono);
+	color: var(--text-primary);
+	background: var(--surface-sunken);
+	border: 1px solid var(--border);
+	border-radius: var(--r-lg);
+	padding: var(--s-3);
+	margin: var(--s-3) 0;
+	overflow-x: auto;
+}
+
+.kp-lab__editor .tiptap pre code {
+	background: none;
+	border: none;
+	border-radius: 0;
+	padding: 0;
+	font: inherit;
+	color: inherit;
+}
+
+.kp-lab__editor .tiptap ul,
+.kp-lab__editor .tiptap ol {
+	margin: var(--s-3) 0;
+	padding-left: var(--s-5);
+}
+
+.kp-lab__editor .tiptap ul {
+	list-style: disc;
+}
+
+.kp-lab__editor .tiptap ol {
+	list-style: decimal;
+}
+
+.kp-lab__editor .tiptap li {
+	margin: var(--s-1) 0;
+}
+
+/* A nested list tightens and sheds the outer block's vertical margin. */
+.kp-lab__editor .tiptap li > ul,
+.kp-lab__editor .tiptap li > ol {
+	margin: var(--s-1) 0;
+}
+
+.kp-lab__editor .tiptap blockquote {
+	margin: var(--s-3) 0;
+	padding: var(--s-1) 0 var(--s-1) var(--s-3);
+	border-left: 2px solid var(--border-strong);
+	color: var(--text-secondary);
+}
+
+.kp-lab__editor .tiptap blockquote blockquote {
+	margin: var(--s-2) 0 0;
+	color: var(--text-muted);
+}
+
+.kp-lab__editor .tiptap hr {
+	border: none;
+	border-top: 1px solid var(--border);
+	margin: var(--s-4) 0;
+}
+
 .kp-lab__out {
 	font: var(--t-mono);
 	color: var(--text-primary);

--- a/apps/web/src/pages/LabComposerPage.tsx
+++ b/apps/web/src/pages/LabComposerPage.tsx
@@ -18,16 +18,64 @@ import StarterKit from "@tiptap/starter-kit";
 import {useState} from "react";
 import "./LabComposerPage.css";
 
-const SEED_MARKDOWN = `# merhaba
+// Canonical render-test content (#2477): every block + inline element the
+// StarterKit + `@tiptap/markdown` set actually round-trips, so the panels below
+// double as a render checklist now and a reusable fixture for the shared
+// `@kampus/composer` base (#2476). Verified idempotent — `getMarkdown()` echoes
+// this verbatim. NOT included: tables and task-lists — this route is StarterKit-only,
+// which ships no table/taskList node, so both are dropped by the markdown parser
+// (tables vanish, `- [ ]` degrades to a plain bullet) rather than shipped broken.
+const SEED_MARKDOWN = `# Composer render testi
 
-tiptap **kalın**, *italik* ve \`satır içi kod\` destekliyor.
+Bu örnek, StarterKit + \`@tiptap/markdown\` setinin **round-trip** ile işlediği her blok ve satır-içi öğeyi gösterir — hem şimdi bir render kontrol listesi, hem #2476'daki paylaşılan \`@kampus/composer\` tabanına taşınacak kanonik test içeriği.
+
+## Satır içi biçimler
+
+Paragraf içinde **kalın**, *italik*, ~~üstü çizili~~ ve \`satır içi kod\` bir arada. Bir de [kamp.us bağlantısı](https://kamp.us) burada.
+
+### Üçüncü seviye başlık
+
+#### Dördüncü seviye başlık
+
+##### Beşinci seviye başlık
+
+###### Altıncı seviye başlık
+
+## Listeler
 
 - birinci madde
 - ikinci madde
+  - iç içe madde
+  - ikinci iç madde
+- üçüncü madde
 
-> bir alıntı
+1. birinci adım
+2. ikinci adım
+  1. iç içe numaralı
+  2. ikinci iç numaralı
+3. üçüncü adım
 
-[kamp.us](https://kamp.us)`;
+## Alıntılar
+
+> Bir alıntı bloğu — kenar çizgisi ve soluk renkle ayrışır.
+>
+> > İç içe alıntı ayrı bir tonda görünür.
+
+## Kod bloğu
+
+\`\`\`ts
+export function selam(ad: string): string {
+	return "merhaba, " + ad;
+}
+\`\`\`
+
+## Yatay çizgi
+
+Aşağıda bir ayraç var:
+
+---
+
+Ayracın altındaki paragraf.`;
 
 export function LabComposerPage() {
 	const [pasted, setPasted] = useState(SEED_MARKDOWN);


### PR DESCRIPTION
Fixes #2477

## Problem

`apps/web/src/pages/LabComposerPage.css` styled only the `.tiptap` container (font/color/min-height/outline) — it carried **zero** block-element prose rules. Every rendered markdown block (blockquote, `h1`–`h6`, inline `code`/fenced `pre`, `ul`/`ol`, `hr`) fell back to bare browser defaults; the reported unstyled `> bir alıntı` blockquote is the visible symptom of that gap. The thin `SEED_MARKDOWN` didn't exercise most of those elements, so the gaps went unnoticed.

## Change

- **Prose CSS** — author element-level rules inside the `.kp-lab__editor .tiptap` scope for blockquote (visible left-rule + muted color, incl. a distinct nested tone), `h1`–`h6` (a real six-level hierarchy off the type ramp), inline `code` chip + fenced `pre` slab (chip reset inside blocks), ordered/unordered/nested lists, `hr`, strikethrough, and links. **Role tokens only** (ADR 0162) — sizes from the type ramp (`--t-*`), spacing/radius/color from role tokens; no raw hex, no raw px > 2px. `design-token-guard check` passes.
- **`SEED_MARKDOWN`** — replaced with a comprehensive example exercising every block + inline element the extension set supports, authored to be **reusable as the canonical render-test carried into the `@kampus/composer` base (#2476)**.

## Round-trip verification (grounded, not assumed)

Ran the exact seed through a headless `StarterKit + @tiptap/markdown` editor (the same v3.27.3 pins this route uses). `getMarkdown()` echoes the seed **verbatim** (idempotent round-trip), and the parsed doc contains every intended node type: `heading`, `bold`, `italic`, `strike`, `code`, `codeBlock`, `bulletList`, `orderedList`, `listItem`, `blockquote` (incl. nested), `horizontalRule`, `link`.

**Elements the example exercises:** `h1`–`h6`; bold, italic, strikethrough, inline code; fenced code block (with language); unordered + ordered lists (both with a nested level); blockquote incl. a nested blockquote; horizontal rule; links.

**Omitted with a note (AC #5):** **tables** and **task-lists**. This route is StarterKit-only, which ships no `table`/`taskList` node — verified: tables vanish entirely from the parse and `- [ ]` degrades to a plain bullet. Both are dropped rather than shipped broken (noted inline at `SEED_MARKDOWN`).

## Checks

- `design-token-guard check` — pass (53 CSS files, all refs resolve, no raw hex/px)
- `biome check` — clean
- `apps/web` typecheck — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)