### PR TITLE
fix(pipeline-cli): re-key worktree-guard isolation detector onto git-dir == common-dir (#2462)

### DIFF
--- a/.decisions/0172-write-code-fails-loud-when-expected-worktree-isolation-is-absent.md
+++ b/.decisions/0172-write-code-fails-loud-when-expected-worktree-isolation-is-absent.md
@@ -78,3 +78,34 @@ assertion the signal rests on is governed; the signal consumes it, it does not r
 - **Scope note (§CP):** this decision changes `agents/coder.md` (control-plane owned) alongside the
   non-§CP `skills/write-code/SKILL.md`, so the PR is §CP and merges by a human control-plane owner.
   It does **not** touch `.claude/workflows/drive-issue.js`.
+
+## Amendment (2026-07-11, [#2462](https://github.com/kamp-us/phoenix/issues/2462)) — the isolation gate is re-keyed onto `git-dir == git-common-dir`; the `$CLAUDE_CODE_AGENT` signal is not reliable across a nested crew spawn
+
+The Decision above called `$CLAUDE_CODE_AGENT` "stable across an agent's separate Bash calls." That
+holds for a **direct** coder spawn but **not across a nested crew spawn**: a coder spawned under the
+crew Workflow inherits the *parent's* agent-type (`engineering-manager`), not `coder`. So the
+`/coder|reviewer|shipper/` match returned `isolation-expected=0` for exactly the #2440 spawn shape
+this ADR set out to fence — the loud-fail went **inert** for the nested coder, and the guard's
+`ISOLATION_EXPECTED` in `packages/pipeline-cli/src/tools/worktree-guard/command.ts` was disarmed the
+same way. The env signal is not the reliable machine-check the Decision assumed.
+
+**Correction.** The "isolation expected" detection is **re-keyed** off `$CLAUDE_CODE_AGENT` alone
+onto the **env-independent primary-checkout signal** `git-dir == git-common-dir` — the same signal
+`write-code` Step-4 already uses (`git rev-parse --absolute-git-dir` vs the cwd-resolved
+`--git-common-dir`; equal ⇒ primary checkout, differ ⇒ linked worktree). The gate now arms when the
+agent-type names itself directly **OR** when the run is in an agent context (`$CLAUDE_CODE_AGENT`
+set to any value) sitting on the primary checkout. A genuine standalone (`$CLAUDE_CODE_AGENT` unset —
+a human `/write-code`) matches neither clause, so the standalone path is unchanged and does not
+over-refuse. The repo-side gate lives in
+`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts` (`isIsolationExpected`), pinned by unit
+tests for the nested-coder shape; the identical fix in the `write-code` Step-4 preflight follows the
+same signal.
+
+**Coverage-limit note (carried from #2462, demonstrated by the #2459 near-miss).** The
+`worktree-guard` belt intercepts **git head-materialization only** — a head-moving git op that would
+land on the primary checkout. Raw `Edit`/`Write` file-writes into the primary checkout are **not**
+guarded by this belt (they are not git operations), so a cwd-reset bleed that writes absolute
+primary-checkout paths can still slip past it; the only durable cover for that vector is the harness
+actually provisioning the worktree (#2440's out-of-repo half). #2459 was a near-miss of exactly this
+Edit/Write vector — caught pre-commit by the coder's own vigilance, not by the belt. Do not
+over-trust the belt as covering both vectors.

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
@@ -26,8 +26,10 @@
  * ruling on the arm-vs-refuse posture (issue #1571) is REFUSE, scoped to guarded
  * agents: the refusal fires when `$WORKTREE_ROOT` names a managed worktree —
  * i.e. this hook is active for an `isolation:worktree` subagent — OR, per ADR 0172, when
- * isolation was EXPECTED (an isolation-asserting agent-type) yet `$WORKTREE_ROOT` is unset
- * (the #2440 harness no-op that disarms the root-keyed branch and leaves this the sole layer).
+ * isolation was EXPECTED (a direct isolation-asserting agent-type, OR a nested crew spawn whose
+ * inherited agent-type masks that — detected via `git-dir == git-common-dir`; #2462) yet
+ * `$WORKTREE_ROOT` is unset (the #2440 harness no-op that disarms the root-keyed branch and leaves
+ * this the sole layer).
  * The orchestrator's own shell runs no such hook, carries no `$WORKTREE_ROOT`, and asserts no
  * isolation, so its legitimate `git checkout main` (the ff-pull/reattach flow) can never reach
  * either refusal. See `.patterns/worktree-agent-constraints.md` (the guard route, now enforced).
@@ -145,6 +147,26 @@ const REFUSE_REASON_ISOLATION_NO_ROOT =
 	"the shared PRIMARY checkout and would detach its HEAD (#2452/#2453). This is a harness " +
 	"provisioning failure: STOP and surface it up (do NOT retry the spawn), and do NOT self-provision " +
 	"to route around it — that hides the failure and collapses the primary-corruption defense (ADR 0172, #2270).";
+
+/**
+ * Was worktree isolation EXPECTED for this run — the gate that arms the {@link pinBash}
+ * no-worktree refusal (ADR 0172)?
+ *
+ * A **direct** guarded spawn names itself: `$CLAUDE_CODE_AGENT` is coder/reviewer/shipper. But a
+ * **nested crew spawn** inherits the *parent's* agent-type (a coder spawned under the crew reads
+ * `engineering-manager`), so the agent-type regex alone goes inert for it and ADR 0172's loud-fail
+ * never arms (#2462). So we corroborate with an **env-independent** signal — `onPrimaryCheckout`
+ * (`git-dir == git-common-dir`, the same primary-checkout signal write-code Step-4 uses): an
+ * agent-context run (`$CLAUDE_CODE_AGENT` set) sitting on the primary checkout is a broken/absent
+ * worktree, whatever its inherited agent-type. A genuine standalone (`$CLAUDE_CODE_AGENT` unset — a
+ * human `/write-code`) matches neither clause, so it never over-refuses (ADR 0172's standalone path).
+ */
+export const isIsolationExpected = (args: {
+	readonly agentType: string;
+	readonly onPrimaryCheckout: boolean;
+}): boolean =>
+	/coder|reviewer|shipper/.test(args.agentType) ||
+	(args.agentType.trim() !== "" && args.onPrimaryCheckout);
 
 /**
  * Decide whether to pin/refuse a Bash command for a guarded worktree agent.

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
@@ -1,5 +1,5 @@
 import {assert, describe, it} from "@effect/vitest";
-import {hasLeadingCd, inspectGitHeadMove, pinBash} from "./bash-pin.ts";
+import {hasLeadingCd, inspectGitHeadMove, isIsolationExpected, pinBash} from "./bash-pin.ts";
 
 const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
 
@@ -202,6 +202,39 @@ describe("pinBash — isolation expected but NO provisioned worktree (ADR 0172, 
 			}).kind,
 			"allow",
 		);
+	});
+});
+
+// ADR 0172 amendment / #2462: re-key the isolation gate off $CLAUDE_CODE_AGENT alone onto the
+// env-independent primary-checkout signal (git-dir == common-dir) so the loud-fail arms for a
+// NESTED crew-spawned coder, whose inherited $CLAUDE_CODE_AGENT (engineering-manager) masks the
+// direct agent-type regex and used to leave the guard inert.
+describe("isIsolationExpected — the ADR-0172 gate, re-keyed onto git-dir == common-dir (#2462)", () => {
+	it("arms for a DIRECT guarded agent-type (coder/reviewer/shipper), regardless of checkout", () => {
+		for (const agentType of ["coder", "reviewer", "shipper"]) {
+			assert.isTrue(isIsolationExpected({agentType, onPrimaryCheckout: true}), agentType);
+			assert.isTrue(isIsolationExpected({agentType, onPrimaryCheckout: false}), agentType);
+		}
+	});
+
+	// The load-bearing AC2 case: a nested coder inherits CLAUDE_CODE_AGENT=engineering-manager with
+	// $WORKTREE_ROOT unset; on the primary checkout the loud-fail must now arm (it did not before).
+	it("arms for a NESTED crew spawn (engineering-manager) sitting on the primary checkout", () => {
+		assert.isTrue(isIsolationExpected({agentType: "engineering-manager", onPrimaryCheckout: true}));
+	});
+
+	it("does NOT arm for a nested spawn that IS in a linked worktree (not on primary)", () => {
+		assert.isFalse(
+			isIsolationExpected({agentType: "engineering-manager", onPrimaryCheckout: false}),
+		);
+	});
+
+	// AC3: a genuine standalone (no CLAUDE_CODE_AGENT) never arms — no over-refusal regression, even
+	// though a human /write-code also sits on the primary checkout.
+	it("does NOT arm for a genuine standalone (empty agent-type) even on the primary checkout", () => {
+		assert.isFalse(isIsolationExpected({agentType: "", onPrimaryCheckout: true}));
+		assert.isFalse(isIsolationExpected({agentType: "   ", onPrimaryCheckout: true}));
+		assert.isFalse(isIsolationExpected({agentType: "", onPrimaryCheckout: false}));
 	});
 });
 

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -8,9 +8,10 @@
  * env (injected at spawn for an `isolation:worktree` subagent); an UNSET root makes
  * every subcommand a clean allow/skip no-op, so a non-worktree session is never
  * affected — with ONE exception (ADR 0172): `pre-bash` still refuses a head-moving git
- * op when isolation was EXPECTED (`$CLAUDE_CODE_AGENT` is coder/reviewer/shipper) yet the
- * root is unset, because that unset root is itself the #2440 harness no-op that would
- * otherwise let the #2452/#2453 primary-checkout detach through.
+ * op when isolation was EXPECTED (a direct coder/reviewer/shipper agent-type, or a nested
+ * crew spawn detected via `git-dir == git-common-dir`; #2462) yet the root is unset, because
+ * that unset root is itself the #2440 harness no-op that would otherwise let the #2452/#2453
+ * primary-checkout detach through.
  *
  *   PreToolUse:
  *     pre-file  (matcher Read|Edit|Write) — rewrite/block a main-checkout path
@@ -26,21 +27,40 @@
  */
 import {execFileSync} from "node:child_process";
 import {existsSync, statSync} from "node:fs";
+import {resolve} from "node:path";
 import {Console, Data, Effect} from "effect";
 import {Command} from "effect/unstable/cli";
-import {pinBash} from "./bash-pin.ts";
+import {isIsolationExpected, pinBash} from "./bash-pin.ts";
 import {guardEnterWorktree} from "./enter-guard.ts";
 import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
 import {decideReap} from "./reap.ts";
 
 const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
 
-// Was worktree isolation EXPECTED for this run? The coder/reviewer/shipper agent-types all spawn
-// `isolation:worktree` (agents/{coder,reviewer,shipper}.md), read from the harness-set
-// $CLAUDE_CODE_AGENT. This lets pre-bash refuse a head-moving git op even when $WORKTREE_ROOT is
-// unset — the #2440 no-op that disarms every $WORKTREE_ROOT-keyed subcommand — instead of the old
-// silent allow that let the #2452/#2453 primary-checkout detach through (ADR 0172).
-const ISOLATION_EXPECTED = /coder|reviewer|shipper/.test(process.env.CLAUDE_CODE_AGENT ?? "");
+// Is this run sitting on the PRIMARY checkout? Env-independent signal (see ADR 0172 amendment,
+// #2462): `git rev-parse --absolute-git-dir` equals the (cwd-resolved) `--git-common-dir` on the
+// primary checkout, but differs in a linked worktree (whose per-tree git dir is
+// `.git/worktrees/<id>`) — the same signal write-code Step-4 uses. This corroborates the isolation
+// gate for a NESTED crew spawn whose inherited $CLAUDE_CODE_AGENT (engineering-manager) masks the
+// direct agent-type regex. Resolved against the hook's reported cwd; unknowable ⇒ false (degrade to
+// today's allow, never a spurious refusal).
+const onPrimaryCheckout = (cwd: string): boolean => {
+	const base = cwd || process.cwd();
+	try {
+		const opts = {cwd: base, encoding: "utf8" as const};
+		const gitDir = resolve(
+			base,
+			execFileSync("git", ["rev-parse", "--absolute-git-dir"], opts).trim(),
+		);
+		const commonDir = resolve(
+			base,
+			execFileSync("git", ["rev-parse", "--git-common-dir"], opts).trim(),
+		);
+		return gitDir === commonDir;
+	} catch {
+		return false;
+	}
+};
 
 // A non-force `git worktree remove` that errors means git judged the tree unsafe to
 // remove — we KEEP it (never escalate to --force). Tagged so the error channel stays typed.
@@ -135,10 +155,14 @@ const preBash = Command.make(
 		const input = yield* readStdin();
 		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
 		const command = str(toolInput.command);
+		const cwd = str(field(input, "cwd"));
 		const decision = pinBash({
 			worktreeRoot: WORKTREE_ROOT,
 			command,
-			isolationExpected: ISOLATION_EXPECTED,
+			isolationExpected: isIsolationExpected({
+				agentType: process.env.CLAUDE_CODE_AGENT ?? "",
+				onPrimaryCheckout: onPrimaryCheckout(cwd),
+			}),
 		});
 		if (decision.kind === "allow") return yield* allow();
 		if (decision.kind === "refuse") return yield* deny(`worktree-guard: ${decision.reason}`);


### PR DESCRIPTION
Fixes #2462

## Problem

ADR 0172's fail-loud-when-expected-isolation-absent guard is **inert for a nested crew-spawned coder**. The isolation detector keyed `ISOLATION_EXPECTED` off `$CLAUDE_CODE_AGENT` (matching `coder|reviewer|shipper`), but a coder spawned under the crew Workflow inherits the *parent's* agent-type (`engineering-manager`), so the regex missed it → `ISOLATION_EXPECTED=0` → the #2440 primary-checkout loud-fail never armed for exactly the spawn shape it was built to fence.

## Fix

Re-key the isolation detector off `$CLAUDE_CODE_AGENT` alone onto the **env-independent primary-checkout signal** `git-dir == git-common-dir` — the same signal `write-code` Step-4 already uses (`git rev-parse --absolute-git-dir` vs the cwd-resolved `--git-common-dir`; equal ⇒ primary checkout).

- New pure `isIsolationExpected({agentType, onPrimaryCheckout})` in `packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`: arms when the agent-type names itself directly **OR** when an agent-context run (`$CLAUDE_CODE_AGENT` set to any value) sits on the primary checkout. A genuine standalone (`$CLAUDE_CODE_AGENT` unset — a human `/write-code`) matches neither clause → no over-refusal regression.
- `command.ts` derives the primary-checkout signal per-invocation from the hook's reported `cwd` (unknowable ⇒ `false`, degrade to today's allow) and feeds it into `pinBash`.
- ADR 0172 amended (§Amendment) to correct the "stable env signal" claim and record the re-key + the belt's git-op-only coverage limit (the #2459 Edit/Write near-miss).

## Acceptance criteria

- [x] Detector no longer relies solely on `$CLAUDE_CODE_AGENT`; detects the primary checkout via `git-dir == git-common-dir`.
- [x] Loud-fail proven to fire for the nested-coder shape (`CLAUDE_CODE_AGENT=engineering-manager` on the primary checkout) — unit-pinned in `bash-pin.unit.test.ts`.
- [x] Standalone / non-isolated run (empty agent-type) unaffected — no over-refusal regression (unit-pinned).
- [x] ADR 0172's "reliable/stable env signal" claim amended.
- [x] Durable note that the belt intercepts git head-materialization only; raw Edit/Write bleed into primary is unguarded (#2459 as the demonstrating incident) — recorded in the ADR 0172 amendment.

## Verification

- `vitest` worktree-guard suite: 34 passed (incl. the new `isIsolationExpected` cases).
- `pnpm typecheck` (tsgo) clean; `biome check` clean; pre-commit leak-guard/ref-guard clean.

## Scope

§CP by path (worktree-guard code + ADR 0172) → routes to a human control-plane owner (cansirin) for approval + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)