### PR TITLE
fix(web): reframe /lab/composer masthead as kept + public (#2490)

### DIFF
--- a/apps/web/src/pages/LabComposerPage.tsx
+++ b/apps/web/src/pages/LabComposerPage.tsx
@@ -96,11 +96,12 @@ export function LabComposerPage() {
 			<div className="kp-lab__inner">
 				<header className="kp-lab__masthead">
 					<h1 className="kp-lab__title">
-						lab · composer <span className="kp-lab__badge">spike</span>
+						lab · composer <span className="kp-lab__badge">kalıcı</span>
 					</h1>
 					<p className="kp-lab__lead">
 						tiptap StarterKit + native v3 markdown. paste markdown, düzenle, ve JSON → markdown
-						gidiş-dönüşünü canlı gör. atılabilir bir deneme — kalıcı bir özellik değil.
+						gidiş-dönüşünü canlı gör. paylaşılan @kampus/composer tabanının ilk canlı yüzü — herkese
+						açık, kalıcı bir ürün parçası.
 					</p>
 				</header>
 


### PR DESCRIPTION
Fixes #2490

## What changed
The `/lab/composer` masthead framed the public route as a throwaway experiment, contradicting the #2465 KEPT+CANONICAL founder ruling and the #2469 `/lab/*`-is-PUBLIC convention. Copy-only fix in one file — `apps/web/src/pages/LabComposerPage.tsx`:

- **Badge** (`kp-lab__badge`): `spike` → `kalıcı` — no longer signals disposable.
- **Lead**: dropped `atılabilir bir deneme — kalıcı bir özellik değil` ("a throwaway experiment — not a permanent feature"); replaced with kept+public Turkish framing — `paylaşılan @kampus/composer tabanının ilk canlı yüzü — herkese açık, kalıcı bir ürün parçası` (the first live surface of the shared `@kampus/composer` base, a public, permanent product part).

## Constraints honored
- **Turkish stays Turkish** (CLAUDE.md): replacement copy is Turkish, no Anglicized badge/lead.
- **No behavior/logic change** beyond copy + the badge's text content. The `SEED_MARKDOWN` constant, editor wiring, and `renderTestMarkdown` region owned by sibling #2482 are untouched — lanes stay disjoint.
- Docblock (already kept+canonical, #2479's scope) left as-is.

## Acceptance criteria
- [x] `spike` badge reworded so it no longer signals throwaway/disposable.
- [x] Lead copy no longer says `atılabilir bir deneme — kalıcı bir özellik değil`; reflects kept + public.
- [x] All replacement strings are Turkish.
- [x] No behavior/logic change beyond copy + badge markup.

## Gates
- `pnpm --filter @kampus/web typecheck` — clean
- `biome check` — clean
- `pipeline-cli design-token-guard check` — clean (no CSS/token change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)