### PR TITLE
feat(composer): export renderTestMarkdown fixture + render round-trip coverage (#2482)

### DIFF
--- a/apps/web/src/pages/LabComposerPage.tsx
+++ b/apps/web/src/pages/LabComposerPage.tsx
@@ -8,68 +8,14 @@
  * imports tiptap directly.
  */
 
-import {Composer, useComposerEditor} from "@kampus/composer";
+import {Composer, renderTestMarkdown, useComposerEditor} from "@kampus/composer";
 import {useState} from "react";
 import "./LabComposerPage.css";
 
-// Canonical render-test content (#2477): every block + inline element the
-// StarterKit + `@tiptap/markdown` set actually round-trips, so the panels below
-// double as a render checklist now and a reusable fixture for the shared
-// `@kampus/composer` base (#2476). Verified idempotent — `getMarkdown()` echoes
-// this verbatim. NOT included: tables and task-lists — this route is StarterKit-only,
-// which ships no table/taskList node, so both are dropped by the markdown parser
-// (tables vanish, `- [ ]` degrades to a plain bullet) rather than shipped broken.
-const SEED_MARKDOWN = `# Composer render testi
-
-Bu örnek, StarterKit + \`@tiptap/markdown\` setinin **round-trip** ile işlediği her blok ve satır-içi öğeyi gösterir — hem şimdi bir render kontrol listesi, hem #2476'daki paylaşılan \`@kampus/composer\` tabanına taşınacak kanonik test içeriği.
-
-## Satır içi biçimler
-
-Paragraf içinde **kalın**, *italik*, ~~üstü çizili~~ ve \`satır içi kod\` bir arada. Bir de [kamp.us bağlantısı](https://kamp.us) burada.
-
-### Üçüncü seviye başlık
-
-#### Dördüncü seviye başlık
-
-##### Beşinci seviye başlık
-
-###### Altıncı seviye başlık
-
-## Listeler
-
-- birinci madde
-- ikinci madde
-  - iç içe madde
-  - ikinci iç madde
-- üçüncü madde
-
-1. birinci adım
-2. ikinci adım
-  1. iç içe numaralı
-  2. ikinci iç numaralı
-3. üçüncü adım
-
-## Alıntılar
-
-> Bir alıntı bloğu — kenar çizgisi ve soluk renkle ayrışır.
->
-> > İç içe alıntı ayrı bir tonda görünür.
-
-## Kod bloğu
-
-\`\`\`ts
-export function selam(ad: string): string {
-	return "merhaba, " + ad;
-}
-\`\`\`
-
-## Yatay çizgi
-
-Aşağıda bir ayraç var:
-
----
-
-Ayracın altındaki paragraf.`;
+// The canonical render-test content is the shared `renderTestMarkdown` fixture the base
+// exports (#2482) — the single source, so this playground and `@kampus/composer`'s
+// round-trip test can never drift. The panels below double as its live render checklist.
+const SEED_MARKDOWN = renderTestMarkdown;
 
 export function LabComposerPage() {
 	const [pasted, setPasted] = useState(SEED_MARKDOWN);

--- a/packages/composer/README.md
+++ b/packages/composer/README.md
@@ -70,6 +70,7 @@ function MyComposer() {
 | `ComposerContentType` | `"markdown"` — the only content type v1 accepts (see below)          |
 | `ComposerJSON`        | the ProseMirror JSON doc type `toJSON()` returns                     |
 | `SetContentOptions`   | `setContent()`'s options (`{contentType?}`)                          |
+| `renderTestMarkdown`  | the canonical render-test fixture (see below)                        |
 
 `useComposerEditor` returns `null` until the editor mounts (SSR / first render) — guard
 it, as the example does.
@@ -125,6 +126,20 @@ consumer needs one (rule of three), it slots in as a **new named kit** alongside
 (e.g. a `mentionKit()` returning its own `Extensions`), composed by that consumer's own
 `useEditor` wiring — never by widening `baseKit()` itself. Until then, the surface stays
 emergent.
+
+## Render-test fixture — `renderTestMarkdown`
+
+`renderTestMarkdown` is a shared markdown document exercising every block + inline element
+`baseKit()` round-trips — headings h1–h6, bold/italic/strikethrough, inline + fenced code,
+ordered/unordered/nested lists, plain + nested blockquotes, horizontal rule, and links. It is
+the **single source** for that content: [`/lab/composer`](../../apps/web/src/pages/LabComposerPage.tsx)
+seeds its playground from it and the base's round-trip test drives it, so the public render
+checklist and the base fixture can never drift. A downstream consumer (mecmua / sözlük / pano)
+reuses it to prove the base round-trips before depending on it.
+
+Task-lists and tables are **not** in the fixture — the v1 set is StarterKit-only, which ships
+no such node, so they'd be dropped by the markdown parser rather than round-trip; they land here
+only when a kit that round-trips them does (the emergent discipline above).
 
 ## First consumer
 

--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -24,6 +24,8 @@
 	},
 	"devDependencies": {
 		"@effect/tsgo": "catalog:",
+		"@testing-library/dom": "catalog:",
+		"@testing-library/react": "catalog:",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",

--- a/packages/composer/src/index.ts
+++ b/packages/composer/src/index.ts
@@ -1,4 +1,5 @@
 export {type BaseKitOptions, baseKit, type ComposerContentType} from "./baseKit.ts";
 export {Composer, type ComposerProps} from "./Composer.tsx";
 export type {ComposerHandle, ComposerJSON, SetContentOptions} from "./handle.ts";
+export {renderTestMarkdown} from "./renderTestMarkdown.ts";
 export {type UseComposerEditorOptions, useComposerEditor} from "./useComposerEditor.ts";

--- a/packages/composer/src/renderTestMarkdown.render.test.tsx
+++ b/packages/composer/src/renderTestMarkdown.render.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * T1 (issue #2482 AC) — the canonical render / round-trip checklist over the base. Unlike
+ * the no-render handle test (`public-surface.unit.test.ts`, #2480), this drives the fixture
+ * through the React render path — `useComposerEditor` via `renderHook` — so it exercises the
+ * same wiring `/lab/composer` and every product consumer use, not a bare `new Editor(...)`.
+ *
+ * Two properties are pinned: the markdown round-trips (`setContent(renderTestMarkdown)` →
+ * `getMarkdown()` is idempotent, the load-bearing "equivalent in, equivalent out"), and every
+ * block node type the fixture claims to cover actually appears in `toJSON()` — a real render
+ * checklist that would catch a regression in the base before mecmua/sözlük/pano depend on it.
+ */
+import {act, renderHook, waitFor} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import type {ComposerJSON} from "./handle.ts";
+import {renderTestMarkdown} from "./renderTestMarkdown.ts";
+import {useComposerEditor} from "./useComposerEditor.ts";
+
+/** Every node `type` in the ProseMirror doc, walked depth-first — the checklist's evidence. */
+function collectNodeTypes(node: ComposerJSON, acc: Set<string> = new Set()): Set<string> {
+	if (node.type) acc.add(node.type);
+	for (const child of node.content ?? []) collectNodeTypes(child, acc);
+	return acc;
+}
+
+// The block nodes baseKit() (StarterKit + @tiptap/markdown) round-trips and the fixture
+// exercises. Task-list / table are intentionally absent from both fixture and this list —
+// the v1 set ships no such node (see renderTestMarkdown's drop note).
+const EXPECTED_BLOCK_NODES = [
+	"heading",
+	"paragraph",
+	"bulletList",
+	"orderedList",
+	"listItem",
+	"blockquote",
+	"codeBlock",
+	"horizontalRule",
+];
+
+describe("renderTestMarkdown through useComposerEditor (render path)", () => {
+	it("round-trips the fixture: setContent → getMarkdown is idempotent and preserves every element", async () => {
+		const {result} = renderHook(() => useComposerEditor());
+		await waitFor(() => expect(result.current).not.toBeNull());
+		const handle = result.current;
+		if (!handle) throw new Error("editor did not mount");
+
+		act(() => handle.setContent(renderTestMarkdown));
+		const out = handle.getMarkdown();
+
+		// Every block + inline element the fixture claims survives the round-trip.
+		expect(out).toContain("# Composer render testi");
+		expect(out).toContain("###### Altıncı seviye başlık");
+		expect(out).toContain("**kalın**");
+		expect(out).toContain("*italik*");
+		expect(out).toContain("~~üstü çizili~~");
+		expect(out).toContain("`satır içi kod`");
+		expect(out).toContain("[kamp.us bağlantısı](https://kamp.us)");
+		expect(out).toContain("- birinci madde");
+		expect(out).toContain("1. birinci adım");
+		expect(out).toContain("> Bir alıntı bloğu");
+		expect(out).toContain("```ts");
+		expect(out).toContain("---");
+
+		// The load-bearing property: re-seeding the serialized output yields byte-identical
+		// markdown (equivalent in → equivalent out). tiptap's serializer may normalize the
+		// first pass, so idempotency — not equality to the raw input — is what round-trip means.
+		act(() => handle.setContent(out));
+		expect(handle.getMarkdown()).toBe(out);
+	});
+
+	it("renders every expected block node type into toJSON()", async () => {
+		const {result} = renderHook(() => useComposerEditor({content: renderTestMarkdown}));
+		await waitFor(() => expect(result.current).not.toBeNull());
+		const handle = result.current;
+		if (!handle) throw new Error("editor did not mount");
+
+		const json = handle.toJSON();
+		expect(json).toMatchObject({type: "doc"});
+		const nodeTypes = collectNodeTypes(json);
+		for (const type of EXPECTED_BLOCK_NODES) {
+			expect(nodeTypes).toContain(type);
+		}
+	});
+});

--- a/packages/composer/src/renderTestMarkdown.ts
+++ b/packages/composer/src/renderTestMarkdown.ts
@@ -1,0 +1,68 @@
+/**
+ * The canonical render-test fixture (#2477 → carried into the base, #2482): a single
+ * markdown document exercising every block + inline element `baseKit()` (StarterKit +
+ * `@tiptap/markdown`) actually round-trips — headings h1–h6, bold/italic/strikethrough,
+ * inline + fenced code, ordered/unordered/nested lists, plain + nested blockquotes,
+ * horizontal rule, and links.
+ *
+ * This is the SINGLE SOURCE for that content: `/lab/composer` seeds its playground from
+ * this export and the base's round-trip test drives it, so the public render checklist
+ * and the base fixture can never drift. A downstream consumer (mecmua / sözlük / pano)
+ * reuses it to prove the base round-trips before depending on it.
+ *
+ * NOT included — tables and task-lists: the v1 set is StarterKit-only, which ships no
+ * table/taskList node, so both are dropped by the markdown parser (tables vanish,
+ * `- [ ]` degrades to a plain bullet) rather than shipped broken. Add them here only
+ * when a kit that round-trips them lands (the emergent discipline, #2464).
+ */
+export const renderTestMarkdown = `# Composer render testi
+
+Bu örnek, StarterKit + \`@tiptap/markdown\` setinin **round-trip** ile işlediği her blok ve satır-içi öğeyi gösterir — hem şimdi bir render kontrol listesi, hem #2476'daki paylaşılan \`@kampus/composer\` tabanına taşınacak kanonik test içeriği.
+
+## Satır içi biçimler
+
+Paragraf içinde **kalın**, *italik*, ~~üstü çizili~~ ve \`satır içi kod\` bir arada. Bir de [kamp.us bağlantısı](https://kamp.us) burada.
+
+### Üçüncü seviye başlık
+
+#### Dördüncü seviye başlık
+
+##### Beşinci seviye başlık
+
+###### Altıncı seviye başlık
+
+## Listeler
+
+- birinci madde
+- ikinci madde
+  - iç içe madde
+  - ikinci iç madde
+- üçüncü madde
+
+1. birinci adım
+2. ikinci adım
+  1. iç içe numaralı
+  2. ikinci iç numaralı
+3. üçüncü adım
+
+## Alıntılar
+
+> Bir alıntı bloğu — kenar çizgisi ve soluk renkle ayrışır.
+>
+> > İç içe alıntı ayrı bir tonda görünür.
+
+## Kod bloğu
+
+\`\`\`ts
+export function selam(ad: string): string {
+	return "merhaba, " + ad;
+}
+\`\`\`
+
+## Yatay çizgi
+
+Aşağıda bir ayraç var:
+
+---
+
+Ayracın altındaki paragraf.`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,6 +732,12 @@ importers:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2


### PR DESCRIPTION
## What

Carries the canonical render-test markdown (authored on `/lab/composer` in #2477) **into** `@kampus/composer` as a reusable, exported fixture — `renderTestMarkdown` — the single source of truth every consumer imports. Phase 2 of epic #2476 (requires #2479 + #2480, both landed).

## Changes

- **`packages/composer/src/renderTestMarkdown.ts`** — new exported fixture covering every element `baseKit()` (StarterKit + `@tiptap/markdown`) round-trips: headings h1–h6, bold/italic/strikethrough, inline + fenced code, ordered/unordered/nested lists, plain + nested blockquotes, horizontal rule, links. Task-lists and tables are omitted with a one-line note (StarterKit ships no such node — they'd drop rather than round-trip).
- **`index.ts`** — exports `renderTestMarkdown` from the root.
- **`apps/web/src/pages/LabComposerPage.tsx`** — now imports `renderTestMarkdown` instead of defining `SEED_MARKDOWN` inline, so the public playground and the base fixture are literally one source (no drift).
- **`renderTestMarkdown.render.test.tsx`** — a T1 render/round-trip test driving the fixture through `useComposerEditor` via `renderHook` (the real React render path, not a bare `new Editor`): `setContent(renderTestMarkdown)` → `getMarkdown()` idempotency, and every expected `baseKit()` block node type present in `toJSON()`.
- **README** — documents the `renderTestMarkdown` export.
- **package.json** — `@testing-library/react` + `@testing-library/dom` devDeps via `catalog:` (needed for `renderHook`).

## Acceptance criteria

- [x] In-house only — exercises the tiptap-wrapped headless base; no new external editor library.
- [x] `@kampus/composer` exports the canonical render-test markdown fixture covering every `baseKit()`-supported element; unsupported elements (task-list/table) omitted with a note.
- [x] T1 test round-trips the fixture through `useComposerEditor` (`setContent` → `getMarkdown()` equivalence) + asserts every expected block node type in `toJSON()`.
- [x] Fixture content matches the #2477 comprehensive example — now the single source `/lab/composer` seeds from (no drift).
- [x] `pnpm typecheck` / `lint` / `test` / `build` pass; design-token-guard clean; all deps via `catalog:`; react/react-dom stay `peerDependencies`.

Fixes #2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)