### PR TITLE
fix(pipeline): fold has-ui/review-design into class-probe so the fan can't skip it (#2485)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -147,8 +147,16 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   third copy) and dispatch a gate for **exactly** each namespace it prints:
   ```bash
   gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
-    | pipeline-cli class-probe classify --namespaces   # → review-code / review-doc / review-skill, one per present class
+    | pipeline-cli class-probe classify --namespaces   # → review-code / review-doc / review-skill (+ review-design when has-ui), one per present gate
   ```
+  The probe **also folds in the additive `review-design`** (`ui_reresolve`, below): it reads the
+  live `UI_RE` from its single source (`ship-it/SKILL.md`) and appends `review-design` to
+  `--namespaces` when the diff is UI-affecting, so the one command names **every** gate ship-it
+  will require — class **and** design. **Dispatch exactly each namespace it prints**, review-design
+  included; do not re-decide has-ui by eye. This is the #2485/#2483 fix: a non-visual
+  `apps/web/src/*.ts` matches `UI_RE`'s `^apps/web/src/` branch, so the probe names `review-design`
+  and the fan dispatches it — where the old eyeball-the-files step skipped it and deadlocked ship-it
+  on a phantom-empty `review-design` namespace.
   The equivalent shell, kept as the **fail-closed reference** for what the tool computes (the tool
   is authoritative — its core mirrors these exact lines, `packages/pipeline-cli/src/tools/class-probe/`):
   ```bash
@@ -163,20 +171,23 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   echo "$CHANGED" | grep -Eq "$HAS_SKILLS_RE" && echo "has-skills → dispatch review-skill"
   echo "$CHANGED" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs → dispatch review-doc"
   ```
-  Dispatch each gate the probe names and post its SHA-bound marker in this same pass; `review-design`
-  rides additively on top per `ui_reresolve`. A single-class PR simply fires one probe — the fan
-  degenerates to today's behavior, never a regression.
+  Dispatch each gate the probe names — class gates **and** the additive `review-design` when it
+  appears — and post its SHA-bound marker in this same pass. A single-class PR simply fires one
+  probe — the fan degenerates to today's behavior, never a regression.
 <a id="dispatch-review-design-in-lockstep-with-ship-its-live-ui_re"></a>
-- **Dispatch `review-design` in lockstep with ship-it's LIVE `UI_RE` — resolve the
-  UI-affecting set from `origin/main`, never this snapshot (`ui_reresolve`).** The prose set
-  above (`apps/web/src/`, `*.tsx`, style surfaces) is the fail-closed **reference**, not the
-  live decision source: a reviewer whose worktree/injected snapshot predates the review-design
-  merge would otherwise silently omit the dispatch on a UI PR, while ship-it — grounding against
-  live main — still *requires* the gate, so the PR deadlocks (`unverified — no review-design
-  PASS`). ship-it and this agent therefore read the **same one live source**: the `UI_RE=` line
-  in `ship-it/SKILL.md` on `origin/main`. Re-resolve it before deciding to dispatch, fail-closed
-  to **has-ui** (dispatch `review-design`) if that line is unreadable — never fail-open to skip
-  it (#2341, the #981 `?ref=main` idiom):
+- **Dispatch `review-design` in lockstep with ship-it's LIVE `UI_RE` — the `class-probe` output
+  is the deterministic dispatch signal; the shell below is its fail-closed reference
+  (`ui_reresolve`).** `pipeline-cli class-probe classify --namespaces` (the fan invariant above)
+  reads this same `UI_RE` from its single source and prints `review-design` whenever the diff is
+  UI-affecting — so the **probe**, not an eyeball over the changed files, decides has-ui, and a
+  non-visual `apps/web/src/*.ts` no longer gets waved off (#2485/#2483). The prose set (`apps/web/src/`,
+  `*.tsx`, style surfaces) is the fail-closed **reference**, not the live decision source: a reviewer
+  whose worktree/injected snapshot predates the review-design merge would otherwise silently omit the
+  dispatch on a UI PR, while ship-it — grounding against live main — still *requires* the gate, so the
+  PR deadlocks (`unverified — no review-design PASS`). ship-it and this agent therefore read the **same
+  one live source**: the `UI_RE=` line in `ship-it/SKILL.md` on `origin/main`. Re-resolve it before
+  deciding to dispatch, fail-closed to **has-ui** (dispatch `review-design`) if that line is unreadable
+  — never fail-open to skip it (#2341, the #981 `?ref=main` idiom):
   ```bash
   UI_RE='^apps/web/src/|\.tsx$|\.css$'   # fail-closed reference; the live line below is authoritative
   UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1578,7 +1578,10 @@ HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed:
 `review-design`/`has-ui` is **additive** and stays single-sourced in `ship-it/SKILL.md`'s
 `UI_RE=` (dispatched alongside whatever class gate(s) fire, never as a class of its own — see the
 `ui_reresolve` invariant in `reviewer.md`); the `HAS_*` lines above cover the three mutually-inclusive
-verdict classes.
+verdict classes. `pipeline-cli class-probe classify` folds the additive gate in — it parses `UI_RE`
+from that same single source and appends `has-ui` (`--namespaces`: `review-design`) — so the reviewer
+fan dispatches review-design off the same deterministic probe, never an eyeball that skips a non-visual
+`apps/web/src/*.ts` and deadlocks ship-it on a phantom-empty `review-design` namespace (#2485/#2483).
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -310,15 +310,18 @@ echo "$FILES" | grep -Eq "$HAS_SKILLS_RE" && echo "has-skills"   # → review-sk
 echo "$FILES" | grep -Eq "$HAS_CODE_RE" && echo "has-code"       # → review-code; the has-code roots agree with the docs-exclusion below in lockstep (§CLASS/§DOC, #663/#919/#1987)
 echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs"   # → review-doc; carve out code roots/skills/.glossary first, then test for a doc path (§DOC contract)
 # UI probe → review-design (ADDITIVE, not a class): a changed path under apps/web/src, a *.tsx
-# file, or a style surface (*.css). Like CONTROL_PLANE_RE/GUARD_ADR_RE above, the literal below
-# is the fail-closed REFERENCE + the validate-gate-path-drift lockstep target, NOT the live
-# decision source: it is re-resolved from origin/main right after, so an injected skill snapshot
-# that predates the review-design gate can't silently DROP the UI probe and slip a UI PR past the
-# gate (#2341 — the #981 idiom, previously only on §CP/GUARD, now extended to UI_RE). ship-it/
-# SKILL.md@main's `UI_RE=` line is the ONE live source; reviewer.md re-resolves the SAME line from
-# the same ref (reviewer.md, #2249/#2341), so required-gate == dispatched-gate holds by
-# construction — both sides read live main, not two independently-aging snapshots. When a second
-# app worker is added, generalize this one live UI_RE to apps/**/src and both sides track it.
+# file, or a style surface (*.css). `pipeline-cli class-probe classify` above ALSO emits `has-ui`
+# (it parses this same UI_RE from its single source, ship-it/SKILL.md) — so the reviewer fan
+# dispatches review-design off the SAME deterministic probe it fans the class gates from, rather
+# than eyeballing the files and skipping it (the #2483 deadlock; #2485). Like CONTROL_PLANE_RE/
+# GUARD_ADR_RE above, the literal below is the fail-closed REFERENCE + the validate-gate-path-drift
+# lockstep target, NOT the live decision source: it is re-resolved from origin/main right after, so
+# an injected skill snapshot that predates the review-design gate can't silently DROP the UI probe
+# and slip a UI PR past the gate (#2341 — the #981 idiom, previously only on §CP/GUARD, now extended
+# to UI_RE). ship-it/SKILL.md@main's `UI_RE=` line is the ONE live source; reviewer.md re-resolves
+# the SAME line from the same ref (reviewer.md, #2249/#2341), so required-gate == dispatched-gate
+# holds by construction — both sides read live main, not two independently-aging snapshots. When a
+# second app worker is added, generalize this one live UI_RE to apps/**/src and both sides track it.
 UI_RE='^apps/web/src/|\.tsx$|\.css$'
 UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
 if [ -n "$UI_LIVE" ]; then

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
@@ -12,7 +12,11 @@
  *
  * Single source: the four `HAS_*_RE` regexes are NOT re-declared here — they are parsed
  * from `gh-issue-intake-formats.md` §CLASS, the one definition ship-it Step 0 and the
- * reviewer fan both re-resolve. There is no third copy to drift out of lockstep.
+ * reviewer fan both re-resolve. There is no third copy to drift out of lockstep. The
+ * additive `UI_RE` (has-ui → the `review-design` gate) is parsed the same way but from its
+ * own single source, `ship-it/SKILL.md` (§CLASS keeps it there deliberately, never in
+ * §CLASS itself) — folding it in here is what makes review-design a deterministic probe
+ * output the reviewer fan dispatches rather than an eyeball it can skip (#2485/#2483).
  */
 
 /** The three artifact classes a PR diff can span — each maps to one `review-*` gate. */
@@ -121,3 +125,35 @@ export const classify = (
 export const requiredNamespaces = (
 	classes: ReadonlyArray<ArtifactClass>,
 ): ReadonlyArray<ReviewNamespace> => classes.map((c) => NAMESPACE_OF[c]);
+
+/**
+ * The additive UI gate — required *alongside* the class gate(s), never as a class of its
+ * own (§CLASS). A UI-affecting diff must reach ship-it with a `review-design` marker present.
+ */
+export const DESIGN_NAMESPACE = "review-design" as const;
+
+/**
+ * Fail-closed UI probe: `.` ⇒ every path is UI-affecting ⇒ has-ui, so an unreadable/incomplete
+ * `UI_RE` demands review-design rather than silently dropping the gate (mirrors ship-it Step 0 /
+ * the reviewer's `ui_reresolve` fail-closed `has-ui`).
+ */
+export const FAILCLOSED_UI_RE = ".";
+
+/**
+ * Parse the canonical `UI_RE='…'` line out of `ship-it/SKILL.md` — the single source for the
+ * additive has-ui/review-design gate (§CLASS keeps `UI_RE` in ship-it, not in §CLASS itself).
+ * A missing line falls back to the fail-closed default; the source is single, so this only
+ * bites on a truncated read.
+ */
+export const parseUiProbe = (shipItText: string): string =>
+	shipItText.match(/^UI_RE='([^']*)'/m)?.[1] ?? FAILCLOSED_UI_RE;
+
+/**
+ * Is the diff UI-affecting (has-ui)? A non-visual `apps/web/src/*.ts` still matches `UI_RE`'s
+ * `^apps/web/src/` branch — that is deliberate here, not a bug to eyeball away: ship-it requires
+ * review-design on exactly this predicate, so the fan must dispatch it on exactly this predicate
+ * or the PR deadlocks on a phantom-empty review-design namespace (#2485/#2483). Fail-closed: an
+ * uncompilable probe matches every path ⇒ has-ui.
+ */
+export const isUiAffecting = (files: ReadonlyArray<string>, uiRe: string): boolean =>
+	files.some(matcher(uiRe, () => true));

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
@@ -2,16 +2,28 @@ import {readFileSync} from "node:fs";
 import {dirname, join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
-import {classify, FAILCLOSED_PROBES, parseClassProbes, requiredNamespaces} from "./class-probe.ts";
+import {
+	classify,
+	FAILCLOSED_PROBES,
+	FAILCLOSED_UI_RE,
+	isUiAffecting,
+	parseClassProbes,
+	parseUiProbe,
+	requiredNamespaces,
+} from "./class-probe.ts";
 
 // The real, single-sourced §CLASS probes — read off the on-disk contract so these tests
 // pin the LIVE classification, not a fixture that could drift from it (#2434). This is the
 // same source ship-it Step 0 and the reviewer fan re-resolve from origin/main.
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../../..");
 const FORMATS_PATH = join(
-	dirname(fileURLToPath(import.meta.url)),
-	"../../../../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+	REPO_ROOT,
+	"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
 );
 const LIVE_PROBES = parseClassProbes(readFileSync(FORMATS_PATH, "utf8"));
+// The additive UI_RE off its live single source (ship-it/SKILL.md) — same discipline.
+const SHIP_IT_PATH = join(REPO_ROOT, "claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md");
+const LIVE_UI_RE = parseUiProbe(readFileSync(SHIP_IT_PATH, "utf8"));
 
 describe("parseClassProbes", () => {
 	it("extracts the four single-quoted §CLASS probes off the live contract", () => {
@@ -101,5 +113,61 @@ describe("classify — fail-closed on an unreadable source over-dispatches, neve
 		// the worst case is an extra gate run, never a silently-missing namespace.
 		const classes = classify(["some/file.txt"], FAILCLOSED_PROBES);
 		expect(classes).toEqual(["has-code", "has-docs", "has-skills"]);
+	});
+});
+
+describe("parseUiProbe — the additive UI_RE off its single source (ship-it/SKILL.md)", () => {
+	it("extracts the live single-quoted UI_RE line", () => {
+		expect(LIVE_UI_RE).toBe("^apps/web/src/|\\.tsx$|\\.css$");
+	});
+
+	it("falls back to the fail-closed UI_RE for a missing/truncated source", () => {
+		expect(parseUiProbe("")).toBe(FAILCLOSED_UI_RE);
+		expect(FAILCLOSED_UI_RE).toBe(".");
+	});
+});
+
+describe("isUiAffecting — review-design reaches a marker, never a phantom-empty namespace (#2485/#2483)", () => {
+	// The #2483 stall: two NON-VISUAL fate wire-code registries under apps/web/src tripped
+	// has-ui via UI_RE's `^apps/web/src/` branch, but the reviewer fan eyeballed them as
+	// non-visual and skipped review-design — so ship-it fail-closed on an empty review-design
+	// namespace. The probe must class them has-ui DETERMINISTICALLY so the fan dispatches
+	// review-design and ship-it's required gate is one the fan actually resolves to a marker.
+	const nonVisualSrcTs = ["apps/web/src/fate/wireMessages.ts", "apps/web/src/lib/fateWireCodes.ts"];
+
+	it("classes a non-visual apps/web/src/*.ts diff has-ui (the #2483 files)", () => {
+		expect(isUiAffecting(nonVisualSrcTs, LIVE_UI_RE)).toBe(true);
+	});
+
+	it("the same diff is also has-code — fan must dispatch BOTH review-code AND review-design", () => {
+		const classes = classify(nonVisualSrcTs, LIVE_PROBES);
+		expect(classes).toEqual(["has-code"]);
+		// The lockstep contract: what ship-it requires (has-code + has-ui) == what the fan
+		// dispatches. The additive review-design rides on top of the class namespace(s).
+		expect(requiredNamespaces(classes)).toEqual(["review-code"]);
+		expect(isUiAffecting(nonVisualSrcTs, LIVE_UI_RE)).toBe(true);
+	});
+
+	it("still fires on the visual surfaces (*.tsx, *.css) it already covered", () => {
+		expect(isUiAffecting(["apps/web/src/App.tsx"], LIVE_UI_RE)).toBe(true);
+		expect(isUiAffecting(["apps/web/src/styles/theme.css"], LIVE_UI_RE)).toBe(true);
+	});
+
+	it("does not fire on a non-UI diff — no phantom review-design on a docs/skill-only PR", () => {
+		expect(isUiAffecting([".decisions/0173-x.md"], LIVE_UI_RE)).toBe(false);
+		expect(
+			isUiAffecting(["claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md"], LIVE_UI_RE),
+		).toBe(false);
+	});
+
+	it("an empty diff is never UI-affecting (no review-design required)", () => {
+		expect(isUiAffecting([], LIVE_UI_RE)).toBe(false);
+		expect(isUiAffecting([], FAILCLOSED_UI_RE)).toBe(false);
+	});
+
+	it("fail-closed: an unreadable UI_RE treats every changed path as UI-affecting", () => {
+		// Mirrors ship-it Step 0 / the reviewer's fail-closed `has-ui` — demand the gate, never
+		// silently drop it. Empty diff stays empty (nothing to gate).
+		expect(isUiAffecting(["packages/pipeline-cli/src/bin.ts"], FAILCLOSED_UI_RE)).toBe(true);
 	});
 });

--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -11,9 +11,14 @@
  * they cannot disagree on a diff's required class coverage (#2434, the `.glossary/**→has-code`
  * miss on PR #2430). Reads the changed-file list from stdin (or `--files-from`), reads the
  * four canonical `HAS_*_RE` probes from the local `gh-issue-intake-formats.md` §CLASS (the
- * single source — never a third inline copy), and prints one present class per line to
- * **stdout** (`--namespaces` prints the `review-*` set instead). A human summary goes to
- * **stderr**; exit is always 0 — this classifies, it does not gate.
+ * single source — never a third inline copy) plus the additive `UI_RE` from the local
+ * `ship-it/SKILL.md` (its single source), and prints one present class per line to **stdout**
+ * — appending `has-ui` when the diff is UI-affecting (`--namespaces` prints the `review-*` set
+ * instead, appending `review-design`). Folding has-ui in here is the #2485/#2483 fix: the
+ * reviewer fan dispatches review-design deterministically off this output instead of eyeballing
+ * a non-visual `apps/web/src/*.ts` away and deadlocking ship-it on an empty review-design
+ * namespace. A human summary goes to **stderr**; exit is always 0 — this classifies, it does
+ * not gate.
  *
  * IO here (the thin bin), classification in `class-probe.ts` (the pure core). An
  * unreadable §CLASS falls back to the fail-closed probes (`FAILCLOSED_PROBES`), which
@@ -25,9 +30,19 @@ import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
-import {classify, parseClassProbes, requiredNamespaces} from "./class-probe.ts";
+import {
+	classify,
+	DESIGN_NAMESPACE,
+	isUiAffecting,
+	parseClassProbes,
+	parseUiProbe,
+	requiredNamespaces,
+} from "./class-probe.ts";
 
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+/** The single source for the additive `UI_RE` (has-ui → review-design), read locally like §CLASS. */
+const SHIP_IT_PATH = "claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md";
 
 const defaultRoot = (from: string = process.cwd()): string => {
 	const start = resolve(from);
@@ -81,6 +96,15 @@ const readFormats = (root: string): string | null => {
 	}
 };
 
+/** Read local ship-it/SKILL.md text; null (⇒ fail-closed `UI_RE`) if the file is unreadable. */
+const readShipIt = (root: string): string | null => {
+	try {
+		return readFileSync(join(root, SHIP_IT_PATH), "utf8");
+	} catch {
+		return null;
+	}
+};
+
 const classifyCmd = Command.make(
 	"classify",
 	{filesFrom: filesFromFlag, root: rootFlag, namespaces: namespacesFlag},
@@ -88,8 +112,11 @@ const classifyCmd = Command.make(
 		const rootDir = Option.getOrElse(root, () => defaultRoot());
 		const formats = readFormats(rootDir);
 		const probes = parseClassProbes(formats ?? "");
+		const shipIt = readShipIt(rootDir);
+		const uiRe = parseUiProbe(shipIt ?? "");
 		const files = readFiles(filesFrom);
 		const classes = classify(files, probes);
+		const uiAffecting = isUiAffecting(files, uiRe);
 
 		if (formats === null) {
 			yield* Effect.sync(() =>
@@ -98,13 +125,21 @@ const classifyCmd = Command.make(
 				),
 			);
 		}
+		if (shipIt === null) {
+			yield* Effect.sync(() =>
+				process.stderr.write(
+					`class-probe: could not read ${SHIP_IT_PATH} under ${rootDir} — using fail-closed UI_RE (require review-design).\n`,
+				),
+			);
+		}
 		yield* Effect.sync(() =>
 			process.stderr.write(
-				`class-probe: ${files.length} changed file(s) → ${classes.length > 0 ? classes.join(", ") : "no artifact class"}\n`,
+				`class-probe: ${files.length} changed file(s) → ${classes.length > 0 ? classes.join(", ") : "no artifact class"}${uiAffecting ? " + has-ui (review-design)" : ""}\n`,
 			),
 		);
 
-		const out = namespaces ? requiredNamespaces(classes) : classes;
+		const base = namespaces ? requiredNamespaces(classes) : classes;
+		const out = uiAffecting ? [...base, namespaces ? DESIGN_NAMESPACE : "has-ui"] : base;
 		for (const line of out) {
 			yield* Console.log(line);
 		}


### PR DESCRIPTION
Fixes #2485

## The defect (grounded)

A `has-ui` diff whose only `UI_RE` match is a **non-visual** `apps/web/src/*.ts` module deadlocked at ship-it. On PR #2483 two changed files (`apps/web/src/fate/wireMessages.ts`, `apps/web/src/lib/fateWireCodes.ts` — fate wire-code registries, no visual surface) tripped `has-ui` via `UI_RE`'s `^apps/web/src/` branch, but the reviewer fan eyeballed them as non-visual, dispatched only `review-code`, and left the `review-design` namespace **phantom-empty**. `ship-it` then correctly fail-closed at Step 2 (`awaiting review-design — no review-design PASS`) on a required gate no run ever emitted. Every real gate was green.

## Framing chosen: (a) — a required gate must be one the fan resolves to a marker

I picked **framing (a)**, not (b), and here is why it fits the landed `class-probe` architecture:

- The #2434/#2486 fix made the **three artifact classes** a deterministic, unit-tested `pipeline-cli class-probe` output the reviewer fan dispatches off — precisely so `required-gate == dispatched-gate` holds by construction rather than by an LLM eyeballing prose. #2485 is the **exact same eyeball-miss class**, one gate over: `review-design` was still computed by a manual shell snippet the reviewer could (and on #2483 did) skip.
- The clean fix is therefore to **route review-design detection through the same probe.** `class-probe classify` now parses `UI_RE` from its single source and appends `has-ui` (`--namespaces`: `review-design`) when the diff is UI-affecting. The fan dispatches review-design off the same probe it fans the class gates from — no separate eyeball step to skip. `required-gate == dispatched-gate` now holds for review-design too, by construction.
- **`UI_RE`'s value and scope are unchanged** — I did **not** narrow `^apps/web/src/`, and I did **not** relocate `UI_RE` out of `ship-it/SKILL.md` (§CLASS deliberately keeps it there). So the `ship-it UI_RE ⊃ review-design dispatch UI_RE` scope-narrowing question stays **#2470's surface** — no drift, no duplication. Framing (b) is #2470's held-open half; this PR does not touch it.

## Changes

- `packages/pipeline-cli/src/tools/class-probe/class-probe.ts` — pure core: `parseUiProbe` (reads `UI_RE` from ship-it/SKILL.md, fail-closed default `.`), `isUiAffecting`, `DESIGN_NAMESPACE`, `FAILCLOSED_UI_RE`.
- `packages/pipeline-cli/src/tools/class-probe/command.ts` — reads local `ship-it/SKILL.md`, appends `has-ui` (classes) / `review-design` (`--namespaces`) when UI-affecting; fail-closed stderr note when ship-it is unreadable.
- `packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts` — pins the #2483 scenario (non-visual `apps/web/src/*.ts` → has-ui → review-design), the has-code+review-design lockstep, `*.tsx`/`*.css` still fire, no phantom on docs/skill-only/empty diffs, and fail-closed UI_RE.
- `claude-plugins/kampus-pipeline/agents/reviewer.md`, `.../skills/ship-it/SKILL.md`, `.../skills/gh-issue-intake-formats.md` §CLASS — reconciled to the new probe output: the fan/Step-0 get has-ui/review-design from the deterministic probe; the `ui_reresolve` shell stays the fail-closed `?ref=main` reference.

## Acceptance criteria

- [x] A non-visual `apps/web/src/*.ts`-only `has-ui` diff no longer deadlocks: the probe emits `review-design`, the fan dispatches it, ship-it's namespace resolves to a marker.
- [x] Fan and ship-it stay in lockstep — the gate ship-it requires is exactly the gate the probe names (review-design folded into the same deterministic source).
- [x] The (a)-vs-(b) call is recorded here; (b)/`UI_RE`-narrowing is left to #2470 (no scope change, no drift).
- [x] Reproduced against the #2483-shaped diff — `class-probe classify --namespaces` prints `review-code` + `review-design`; docs-only and empty diffs print no `review-design`.

## Verification

`pnpm vitest run` in `packages/pipeline-cli`: 74 files / 940 tests pass. `pnpm typecheck` + biome clean. Manual CLI repro of the #2483 diff confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)