### PR TITLE
feat(mecmua): public read — anon GET route + reader page, draft-masked (#2498)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -46,6 +46,7 @@ import {
 	Flagship,
 	funnelReadoutFlag,
 	karmaGatesFlag,
+	mecmuaPublicReadFlag,
 	modQueueFlag,
 	optimisticDefinitionAddFlag,
 	optimisticDefinitionDeleteFlag,
@@ -133,6 +134,9 @@ export default Alchemy.Stack(
 		// seam the ban mutations + admin read + moderator-UI controls gate behind, so an
 		// unreleased ban can never refuse a real user's session until a human release.
 		yield* userBanFlag(flagship.appId);
+		// The mecmua public-read dark-ship flag, default-off (#2498, epic #2467) — the
+		// single seam the anon GET route + reader page gate behind until a human release.
+		yield* mecmuaPublicReadFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -36,6 +36,7 @@ import {DivanPage} from "./pages/DivanPage";
 import {FunnelPage} from "./pages/FunnelPage";
 import {LabComposerPage} from "./pages/LabComposerPage";
 import {LandingPage} from "./pages/LandingPage";
+import {MecmuaPostPage} from "./pages/MecmuaPostPage";
 import {NotFoundPage} from "./pages/NotFoundPage";
 import {PanoFeed} from "./pages/PanoFeed";
 import {PanoPostDetail} from "./pages/PanoPostDetail";
@@ -300,6 +301,9 @@ export function App() {
 						    the legacy bespoke route redirects so existing links don't break. */}
 						<Route path="/pano/kaydedilenler" element={<Navigate to={SAVED_HREF} replace />} />
 						<Route path="/pano/:id" element={<PanoPostDetail />} />
+						{/* The mecmua public reader (#2498) — the page self-gates on the
+						    mecmua-public-read flag (off ⇒ 404), so the route is dark by default. */}
+						<Route path="/mecmua/:slug" element={<MecmuaPostPage />} />
 						<Route path="/sozluk" element={<SozlukHome />} />
 						<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
 						<Route path="/search" element={<SearchPage />} />

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -74,6 +74,16 @@ export const PANO_OPTIMISTIC_POST_DELETE = "pano-optimistic-post-delete";
 export const PANO_BASE_FEED = "pano-base-feed";
 
 /**
+ * mecmua public-read dark-ship flag (#2498, epic #2467). The SINGLE seam the
+ * anonymous read surface gates behind — the `GET /fate/mecmua/post/:slug` route's
+ * existence (404 until flipped) AND the `/mecmua/:slug` reader page (self-404).
+ * Default-off so the whole public-read path ships dark until a human flips it at
+ * release (ADR 0083). Its own `mecmua-` key, scoped to the read surface — the
+ * authoring/publish path (#2497) ships behind its own seam.
+ */
+export const MECMUA_PUBLIC_READ = "mecmua-public-read";
+
+/**
  * Earned-authorship loop (çaylak→yazar) dark-ship flag (#1204, epic #1202). The
  * single seam every authorship-loop surface gates behind: cross-cutting
  * (`phoenix`) because the loop touches sözlük/pano/pasaport, default-off so the

--- a/apps/web/src/pages/MecmuaPostPage.tsx
+++ b/apps/web/src/pages/MecmuaPostPage.tsx
@@ -1,0 +1,127 @@
+/**
+ * `/mecmua/:slug` — the PUBLIC reader for a single published mecmua post (#2498, epic
+ * #2467). Client-only per the map (#2466 — SEO/prerender explicitly deferred): it
+ * fetches the anonymous `GET /fate/mecmua/post/:slug` route and renders the published
+ * post's başlık + markdown body, reusing the shared `lib/markdown` render (no new
+ * markdown lib). A draft / miss / off-flag all 404 server-side, surfaced here as the
+ * shared NotFoundPage.
+ *
+ * The whole surface ships dark behind `MECMUA_PUBLIC_READ` (default-off): the page
+ * self-gates (off ⇒ 404), mirroring `DivanPage`, so the route is absent until a human
+ * flips the flag at release (ADR 0083). The route itself also 404s while the flag is
+ * off — the page gate just avoids a fetch and a flash.
+ */
+import {useEffect, useState} from "react";
+import {useParams} from "react-router";
+import {MECMUA_PUBLIC_READ} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
+import {renderMarkdownInline, splitMarkdownBlocks} from "../lib/markdown";
+import {NotFoundPage} from "./NotFoundPage";
+
+/** The wire shape the anon read route returns — only başlık + body are rendered here. */
+interface MecmuaPostWire {
+	readonly id: string;
+	readonly title: string;
+	readonly body: string;
+}
+
+type FetchState =
+	| {kind: "loading"}
+	| {kind: "ok"; post: MecmuaPostWire}
+	| {kind: "not-found"}
+	| {kind: "error"};
+
+export function MecmuaPostPage() {
+	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_PUBLIC_READ, false);
+	const {slug} = useParams<{slug: string}>();
+
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
+	// DivanPage self-gate idiom).
+	if (flagLoading) {
+		return (
+			<div className="kp-page">
+				<div className="kp-page__inner">
+					<p>yükleniyor…</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!flagOn) return <NotFoundPage />;
+
+	return <MecmuaPostReader slug={slug ?? ""} />;
+}
+
+function MecmuaPostReader({slug}: {slug: string}) {
+	const [state, setState] = useState<FetchState>({kind: "loading"});
+
+	useEffect(() => {
+		let cancelled = false;
+		setState({kind: "loading"});
+		fetch(`/fate/mecmua/post/${encodeURIComponent(slug)}`, {headers: {accept: "application/json"}})
+			.then(async (res) => {
+				if (cancelled) return;
+				// 404 = a draft (masked), a genuine miss, or the flag off — all render as the
+				// not-found state. Any other non-2xx is a transient read error.
+				if (res.status === 404) return setState({kind: "not-found"});
+				if (!res.ok) return setState({kind: "error"});
+				const post = (await res.json()) as MecmuaPostWire;
+				if (!cancelled) setState({kind: "ok", post});
+			})
+			.catch(() => {
+				if (!cancelled) setState({kind: "error"});
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [slug]);
+
+	if (state.kind === "loading") {
+		return (
+			<div className="kp-page">
+				<div className="kp-page__inner">
+					<p>yükleniyor…</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (state.kind === "not-found") {
+		return (
+			<NotFoundPage
+				title="yazı bulunamadı"
+				message={`"${slug}" diye bir yazı bulamadık. başka bir şeye bakmak ister misin?`}
+			/>
+		);
+	}
+
+	if (state.kind === "error") {
+		return (
+			<div className="kp-page">
+				<div className="kp-page__inner">
+					<p role="alert">yazı yüklenemedi, tekrar dene.</p>
+				</div>
+			</div>
+		);
+	}
+
+	const blocks = splitMarkdownBlocks(state.post.body);
+	return (
+		<div className="kp-page">
+			<div className="kp-page__inner">
+				<article data-testid="mecmua-post">
+					<h1>{state.post.title}</h1>
+					<div className="kp-prose">
+						{blocks.map((block, i) =>
+							block.kind === "code" ? (
+								<pre key={i}>{block.text}</pre>
+							) : (
+								<p key={i}>{renderMarkdownInline(block.text)}</p>
+							),
+						)}
+					</div>
+				</article>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/worker/features/flagship/mecmua-public-read.invariant.test.ts
+++ b/apps/web/worker/features/flagship/mecmua-public-read.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for mecmua public read (#2498, epic
+ * #2467). Inspected off the exported `MECMUA_PUBLIC_READ_FLAG` record (the same object
+ * the factory spreads into `FlagshipFlag`), so no alchemy resource is constructed —
+ * mirrors `pano-base-feed.invariant.test.ts` (#2322).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {MECMUA_PUBLIC_READ} from "../../../src/flags/keys.ts";
+import {MECMUA_PUBLIC_READ_FLAG, mecmuaPublicReadFlag} from "./resources.ts";
+
+describe("mecmua public read — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(MECMUA_PUBLIC_READ_FLAG.defaultVariation, "off");
+		assert.strictEqual(MECMUA_PUBLIC_READ_FLAG.variations.off, false);
+		assert.strictEqual(MECMUA_PUBLIC_READ_FLAG.variations.on, true);
+		assert.strictEqual(MECMUA_PUBLIC_READ_FLAG.key, "mecmua-public-read");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(MECMUA_PUBLIC_READ_FLAG.key, MECMUA_PUBLIC_READ);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof mecmuaPublicReadFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -11,6 +11,7 @@
 import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import {
+	MECMUA_PUBLIC_READ,
 	PANO_BASE_FEED,
 	PANO_DRAFT_SAVE,
 	PANO_FEED_EDGE_CACHE,
@@ -729,3 +730,36 @@ export const USER_BAN_FLAG = {
  */
 export const userBanFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_user_ban", {appId, ...USER_BAN_FLAG});
+
+/**
+ * The mecmua public-read dark-ship flag config (#2498, epic #2467). The SINGLE seam
+ * the anonymous read surface gates behind — the `GET /fate/mecmua/post/:slug` route
+ * (404 until flipped) + the `/mecmua/:slug` reader page (self-404). Default-OFF so
+ * the whole public-read path reaches production dark: with it off the route 404s and
+ * the page renders the 404, so no unpublished-feature surface is reachable; flipping
+ * it on is the human release act (ADR 0083). Its own `mecmua-` key, scoped to reads —
+ * the authoring/publish path (#2497) ships behind its own seam.
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `PANO_BASE_FEED_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           mecmua (the long-form read surface)
+ *   - originating:     #2498 (epic: mecmua, #2467)
+ *   - removal trigger: once mecmua public read graduates to on at 100% and stable for
+ *                      one release, retire the flag and inline the route + page.
+ */
+export const MECMUA_PUBLIC_READ_FLAG = {
+	key: MECMUA_PUBLIC_READ,
+	description:
+		"mecmua public-read (anon GET route + reader page) dark-ship (#2498, epic #2467). owner: mecmua. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const mecmuaPublicReadFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("mecmua_public_read", {appId, ...MECMUA_PUBLIC_READ_FLAG});

--- a/apps/web/worker/features/mecmua/public-read-route.ts
+++ b/apps/web/worker/features/mecmua/public-read-route.ts
@@ -1,0 +1,92 @@
+/**
+ * `GET /fate/mecmua/post/:slug` (#2498, epic #2467) — the PUBLIC read of a single
+ * published mecmua post, by slug or id. A raw `HttpRouter.add` route following the
+ * anonymous-read idiom of `features/pano/base-feed-route.ts`: it never validates a
+ * session and never reads `CurrentUser`, so an anon GET does zero identity work. It
+ * reads the `anonymousMecmuaViewer` and applies `mecmuaPostVisibleWhere` (#2496), so a
+ * draft (null `published_at`) is masked from the public — only published posts are
+ * readable, no auth required. See `.patterns/alchemy-http-router.md`.
+ *
+ * Dark behind `MECMUA_PUBLIC_READ` (default-off): with the flag off the route 404s, so
+ * the whole surface ships dark until a human flips the flag at release (ADR 0083). The
+ * flag is read under the anonymous flags context (no identity), so the gate itself does
+ * no session work either.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import {and, eq, or, type SQL} from "drizzle-orm";
+import * as Effect from "effect/Effect";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {MECMUA_PUBLIC_READ} from "../../../src/flags/keys.ts";
+import {Drizzle, type DrizzleAccessOrDie, orDieAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {
+	anonymousFlagsContext,
+	FlagsContext,
+	makeRequestFlagsContext,
+} from "../flagship/FlagsContext.ts";
+import {anonymousMecmuaViewer, mecmuaPostVisibleWhere} from "./MecmuaPostVisibility.ts";
+import {type MecmuaPostRow, toMecmuaPostRow} from "./post-fields.ts";
+
+/**
+ * The WHERE for the public read: match the requested key against slug OR id, gated by
+ * the `mecmuaPostVisibleWhere` anonymous-visibility clause (#2496) — `published_at is
+ * not null`, with NO `author_id = :viewer` ownership escape (there is no viewer). So a
+ * draft is never disclosed publicly, whichever key names it.
+ */
+export const mecmuaPublicReadWhere = (key: string): SQL | undefined =>
+	and(
+		or(eq(schema.mecmuaPost.slug, key), eq(schema.mecmuaPost.id, key)),
+		mecmuaPostVisibleWhere(
+			{publishedAt: schema.mecmuaPost.publishedAt, authorId: schema.mecmuaPost.authorId},
+			anonymousMecmuaViewer,
+		),
+	);
+
+/**
+ * Read the single published mecmua post named by `key` (slug or id), or null when no
+ * published post matches (a draft, or a genuine miss — both mask to null, which the
+ * route renders as a 404).
+ */
+export const readPublishedMecmuaPost = (
+	run: DrizzleAccessOrDie["run"],
+	key: string,
+): Effect.Effect<MecmuaPostRow | null> =>
+	run((db) => db.select().from(schema.mecmuaPost).where(mecmuaPublicReadWhere(key)).limit(1)).pipe(
+		Effect.map((rows) => (rows[0] ? toMecmuaPostRow(rows[0]) : null)),
+	);
+
+export const handleMecmuaPublicRead = Effect.gen(function* () {
+	const raw = yield* Cloudflare.Request;
+
+	// The dark-ship gate, evaluated under the ANONYMOUS flags context so it reads no
+	// session — an anon GET does zero identity work even to decide the flag. Off ⇒ 404,
+	// the shipped-dark default; in local dev the `phoenix_flag_overrides` cookie can
+	// force it on (#622).
+	const flags = yield* Flags;
+	const flagsContext = yield* makeRequestFlagsContext(
+		anonymousFlagsContext,
+		raw.headers.get("cookie"),
+	);
+	const on = yield* flags
+		.getBoolean(MECMUA_PUBLIC_READ, false)
+		.pipe(Effect.provideService(FlagsContext, flagsContext));
+	if (!on) return HttpServerResponse.empty({status: 404});
+
+	const params = yield* HttpRouter.params;
+	const key = params.slug;
+	if (key === undefined || key.length === 0) return HttpServerResponse.empty({status: 404});
+
+	const {run} = orDieAccess(yield* Drizzle);
+	const post = yield* readPublishedMecmuaPost(run, key);
+	if (post === null) return HttpServerResponse.empty({status: 404});
+
+	return HttpServerResponse.jsonUnsafe(post);
+});
+
+export const mecmuaPublicReadRoute = HttpRouter.add(
+	"GET",
+	"/fate/mecmua/post/:slug",
+	handleMecmuaPublicRead,
+);

--- a/apps/web/worker/features/mecmua/public-read-route.unit.test.ts
+++ b/apps/web/worker/features/mecmua/public-read-route.unit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The mecmua public-read draft-mask gate (#2498, epic #2467). The anonymous read must
+ * route the draft decision through the one `MecmuaPostVisibility` seam
+ * (`mecmuaPostVisibleWhere`), so a visitor holding a draft's slug/id never reads an
+ * unpublished post. Two tiers, both offline-reachable:
+ *
+ *   - the SQL PREDICATE (`mecmuaPublicReadWhere`) carries `published_at is not null`
+ *     (the published gate) and NO `author_id = ?` ownership escape — so a draft is
+ *     structurally undisclosable to the public, whichever key names it;
+ *   - `readPublishedMecmuaPost` resolves null when no published row matches (a draft or
+ *     a genuine miss), which the route renders as a 404 — the masked case.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {Effect} from "effect";
+import {type DrizzleAccessOrDie, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import type {MecmuaPostRow} from "./post-fields.ts";
+import {mecmuaPublicReadWhere, readPublishedMecmuaPost} from "./public-read-route.ts";
+
+// biome-ignore lint/plugin: a host D1 binding can't be structurally faked; only `.toSQL()` rendering touches this — no query runs.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {relations});
+
+/** A `run` that ignores its query and resolves the scripted rows — the leak/mask fixtures never touch D1. */
+const scriptedRun =
+	(rows: ReadonlyArray<unknown>): DrizzleAccessOrDie["run"] =>
+	<A>(_fn: (db: DrizzleDb) => Promise<A>) =>
+		Effect.succeed(rows as A);
+
+const now = new Date("2026-07-11T00:00:00.000Z");
+
+describe("mecmuaPublicReadWhere — the anonymous read masks drafts (the visibility seam, #2498)", () => {
+	it("gates on published_at with NO ownership escape (a draft never discloses publicly)", () => {
+		const {sql, params} = renderDb
+			.select()
+			.from(schema.mecmuaPost)
+			.where(mecmuaPublicReadWhere("some-slug"))
+			.toSQL();
+		assert.match(
+			sql,
+			/"mecmua_post"\."published_at" is not null/,
+			"the published gate from mecmuaPostVisibleWhere masks a null-published draft",
+		);
+		assert.notMatch(
+			sql,
+			/"mecmua_post"\."author_id" = \?/,
+			"an anonymous read has no author-ownership disjunction — a draft never discloses to the public",
+		);
+		assert.include(params, "some-slug", "the key is bound against slug OR id");
+	});
+});
+
+describe("readPublishedMecmuaPost — masked/miss resolves null (the route's 404 path, #2498)", () => {
+	it.effect("a draft (masked by the WHERE ⇒ no row) resolves null", () =>
+		Effect.gen(function* () {
+			// The published gate drops the draft in SQL, so the query returns no rows —
+			// the read maps that to null, which the route renders as a 404.
+			const got = yield* readPublishedMecmuaPost(scriptedRun([]), "draft-slug");
+			assert.isNull(got, "a draft must not be publicly readable — masked to null (404)");
+		}),
+	);
+
+	it.effect("a published post resolves to its wire row", () =>
+		Effect.gen(function* () {
+			const published = {
+				id: "mecmua_pub1",
+				slug: "yayinda",
+				title: "yayınlanmış yazı",
+				body: "**merhaba** dünya",
+				authorId: "author-1",
+				publishedAt: now,
+				createdAt: now,
+				updatedAt: now,
+			} satisfies typeof schema.mecmuaPost.$inferSelect;
+			const got: MecmuaPostRow | null = yield* readPublishedMecmuaPost(
+				scriptedRun([published]),
+				"yayinda",
+			);
+			assert.isNotNull(got);
+			assert.strictEqual(got?.id, "mecmua_pub1");
+			assert.strictEqual(got?.title, "yayınlanmış yazı");
+			assert.strictEqual(got?.body, "**merhaba** dünya");
+		}),
+	);
+});

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -22,6 +22,7 @@ import {fateRoute} from "../features/fate/route.ts";
 import {liveRoute} from "../features/fate-live/route.ts";
 import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
 import {flagsDevApplyRoute, flagsDevPageRoute} from "../features/flagship/route-dev.ts";
+import {mecmuaPublicReadRoute} from "../features/mecmua/public-read-route.ts";
 import {baseFeedRoute} from "../features/pano/base-feed-route.ts";
 import {linkMetadataRoute} from "../features/pano/link-metadata-route.ts";
 import {authRoute} from "../features/pasaport/route.ts";
@@ -64,6 +65,10 @@ export const rawWorkerRoutes: readonly [WorkerRoute, ...WorkerRoute[]] = [
 	// The GET-able base feed (#2322, epic #2316 leg B); the `/fate/*` glob already
 	// shadows the SPA for it. Dark behind `PANO_BASE_FEED` (404 until flipped).
 	{path: "/fate/pano/feed", glob: "/fate/*", route: baseFeedRoute},
+	// The public read of a single published mecmua post (#2498, epic #2467); the
+	// `/fate/*` glob already shadows the SPA for it. Dark behind `MECMUA_PUBLIC_READ`
+	// (404 until flipped).
+	{path: "/fate/mecmua/post/:slug", glob: "/fate/*", route: mecmuaPublicReadRoute},
 	{path: "/api/auth/*", glob: "/api/*", route: authRoute},
 	{path: "/api/flags/probe", glob: "/api/*", route: flagsProbeRoute},
 	{path: "/api/flags/evaluate", glob: "/api/*", route: flagsEvaluateRoute},


### PR DESCRIPTION
The mecmua public read path (#2498, epic #2467): any visitor (no login) can read a **published** mecmua post at its own URL; drafts stay private.

## What changed
- **`GET /fate/mecmua/post/:slug`** (`worker/features/mecmua/public-read-route.ts`) — a raw `HttpRouter.add` route following the anon-read idiom of `pano/base-feed-route.ts`: it reads the **anonymous** viewer, never `CurrentUser`, so an anon GET does zero identity work. It applies `mecmuaPostVisibleWhere` from #2496 **in SQL** (`published_at is not null`, no author-ownership escape), so a draft never leaves D1 — masked to a 404. Registered in `worker-routes.ts` under the existing `/fate/*` glob.
- **`/mecmua/:slug` reader page** (`src/pages/MecmuaPostPage.tsx`) — client-only (SEO/prerender deferred, #2466): fetches the route and renders the başlık + markdown body reusing the shared `src/lib/markdown.tsx` render (no new markdown lib). Self-gates on the flag (off ⇒ 404), mirroring `DivanPage`.
- **`mecmua-public-read` flag** (default-off) declared in `flags/keys.ts` + `flagship/resources.ts`, wired in `alchemy.run.ts`. Both the route (404 when off) and the page gate behind it, so the whole surface ships dark until a human flips it at release (ADR 0083).

## Draft-mask proof (AC)
`worker/features/mecmua/public-read-route.unit.test.ts`:
- `gates on published_at with NO ownership escape (a draft never discloses publicly)` — asserts the rendered WHERE carries `"mecmua_post"."published_at" is not null` and no `author_id = ?`.
- `a draft (masked by the WHERE ⇒ no row) resolves null` — the read maps a masked query to null, the route's 404 path.

## Scope
Read surface only. No mutations/capabilities added, `fanned-mutations.ts` untouched (the write path #2497 is a sibling lane). Route paths/identifiers are English; visible copy is Turkish. No SEO/prerender, no email, no editor UI, no feed.

Local gate: `pnpm typecheck` clean, `pnpm lint:worktree` clean, mecmua + flag + worker-routes unit tests green (16 + 7 passing).

Fixes #2498
Flag: mecmua-public-read