### PR TITLE
fix(pipeline): settings.json env values are verbatim — resolve data dir in-hook, guard the class (#2495)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,6 @@
 	"enabledPlugins": {
 		"kampus-pipeline@kampus": false
 	},
-	"env": {
-		"KAMPUS_PIPELINE_DATA": "${CLAUDE_PROJECT_DIR}/.claude/.pipeline-cli-data",
-		"PATH": "${CLAUDE_PROJECT_DIR}/packages/gh-phoenix/shim:/opt/homebrew/bin:/usr/bin:/bin:${PATH}"
-	},
 	"hooks": {
 		"PreToolUse": [
 			{

--- a/.github/workflows/settings-env-guard.yml
+++ b/.github/workflows/settings-env-guard.yml
@@ -10,6 +10,11 @@ name: settings-env-guard
 on:
   pull_request:
 
+# Least-privilege GITHUB_TOKEN: the only job checks out + runs a read-only node CLI
+# (pipeline-cli settings-env-guard check), no writes — so read on contents suffices.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/settings-env-guard.yml
+++ b/.github/workflows/settings-env-guard.yml
@@ -1,0 +1,36 @@
+name: settings-env-guard
+
+# CI gate for #2495: no `.claude/settings.json` `env` value may carry an unexpanded
+# `${...}` token. Claude Code applies env values VERBATIM — it does NOT expand
+# ${VAR} in them (settings docs; verified on desktop + web) — so such a value never
+# resolves: it is consumed literally, creating a stray literal-token directory at the
+# repo root and clobbering PATH. This is the same silent-drift class the other
+# fail-closed guards cover. Reuses pipeline-cli's `settings-env-guard check` mode —
+# the scan lives once in the tool.
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: no ${...} in any .claude/settings.json env value
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 when an env value carries an unexpanded ${...} (the report is on
+      # stderr), or when settings.json is missing/unparseable (fail-closed). See #2495.
+      - name: Check no env value carries an unexpanded ${...}
+        run: node packages/pipeline-cli/src/bin.ts settings-env-guard check

--- a/claude-plugins/kampus-pipeline/hooks/guard.sh
+++ b/claude-plugins/kampus-pipeline/hooks/guard.sh
@@ -7,8 +7,9 @@
 #                                         guard.sh spawn-guard freshness
 #
 # Resolves the SessionStart-installed pipeline-cli from the pipeline data dir
-# ($KAMPUS_PIPELINE_DATA, else $CLAUDE_PLUGIN_DATA — same precedence as install.sh)
-# and dispatches `pipeline-cli <tool> [mode...]`, forwarding the hook's stdin.
+# (via resolve-data-dir.sh — the same resolver install.sh uses, robust to verbatim
+# settings.json `env` values; see that file / #2495) and dispatches
+# `pipeline-cli <tool> [mode...]`, forwarding the hook's stdin.
 #
 # #1050 FAIL-OPEN INVARIANT (HARD): when the CLI is absent — not yet installed,
 # a degraded/offline install, or a worktree-creation hook firing with a stripped
@@ -20,7 +21,8 @@
 
 set -u
 
-DATA="${KAMPUS_PIPELINE_DATA:-${CLAUDE_PLUGIN_DATA:-}}"
+. "$(dirname "${BASH_SOURCE[0]}")/resolve-data-dir.sh"
+DATA="$(resolve_pipeline_data_dir || true)"
 BIN="${DATA:+$DATA/node_modules/.bin/pipeline-cli}"
 
 # FAIL-OPEN: CLI not resolvable -> drain stdin and no-op (exit 0). Never crash.

--- a/claude-plugins/kampus-pipeline/hooks/install.sh
+++ b/claude-plugins/kampus-pipeline/hooks/install.sh
@@ -3,11 +3,10 @@
 # version-aware + idempotent + network-resilient. See ADR 0103 and
 # .patterns/plugin-sessionstart-install.md.
 #
-# Data dir (where the CLI is installed) is resolved from, in order:
-#   1. $KAMPUS_PIPELINE_DATA  — phoenix's .claude/settings.json self-wiring (#1003)
-#   2. $CLAUDE_PLUGIN_DATA    — the foreign-repo plugin surface (hooks.json)
-# guard.sh resolves the CLI from the SAME dir via the same precedence, so the two
-# stay in lockstep whether invoked by the plugin or by phoenix's settings.json.
+# Data dir (where the CLI is installed) is resolved by resolve-data-dir.sh, robust
+# to Claude Code's verbatim settings.json `env` semantics (see that file / #2495);
+# guard.sh sources the SAME resolver so the two stay in lockstep whether invoked by
+# the plugin or by phoenix's settings.json.
 #
 # Invariant: this MUST NOT hard-crash the session. Every failure path degrades
 # (logs to stderr, exit 0) so a SessionStart on an offline/npm-unreachable host
@@ -21,11 +20,11 @@ set -u
 PIN="0.1.0"
 PKG="@kampus/pipeline-cli"
 
-DATA="${KAMPUS_PIPELINE_DATA:-${CLAUDE_PLUGIN_DATA:-}}"
-if [ -z "$DATA" ]; then
-	echo "kampus-pipeline: no data dir (KAMPUS_PIPELINE_DATA / CLAUDE_PLUGIN_DATA unset); skipping install" >&2
+. "$(dirname "${BASH_SOURCE[0]}")/resolve-data-dir.sh"
+DATA="$(resolve_pipeline_data_dir)" || {
+	echo "kampus-pipeline: no resolvable data dir (env value unexpanded and CLAUDE_PROJECT_DIR unset); skipping install" >&2
 	exit 0
-fi
+}
 
 MARKER="$DATA/.pipeline-cli.version"
 BIN="$DATA/node_modules/.bin/pipeline-cli"

--- a/claude-plugins/kampus-pipeline/hooks/resolve-data-dir.sh
+++ b/claude-plugins/kampus-pipeline/hooks/resolve-data-dir.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Resolve the pipeline data dir — where install.sh drops @kampus/pipeline-cli and
+# guard.sh finds it — robust to Claude Code's VERBATIM settings.json `env` semantics.
+#
+# Claude Code applies `.claude/settings.json` `env` VALUES LITERALLY: it does NOT
+# expand ${VAR} inside them (settings docs: `env` = "Environment variables applied
+# to every session"; no interpolation is documented, and it's verified empirically
+# on BOTH the desktop and web harnesses — #2495). So a wired value such as
+# KAMPUS_PIPELINE_DATA="${CLAUDE_PROJECT_DIR}/.claude/.pipeline-cli-data" arrives
+# with the token UNEXPANDED. Consuming it verbatim (mkdir -p "$DATA") is exactly
+# what created the stray literal `${CLAUDE_PROJECT_DIR}` directory at the repo root.
+#
+# These scripts run as hook `command`s, and Claude Code DOES export the real
+# CLAUDE_PROJECT_DIR / CLAUDE_PLUGIN_DATA env vars onto a hook-spawned process
+# (hooks docs) — so we resolve from those, never from an unexpanded env value.
+# Precedence: an already-expanded KAMPUS_PIPELINE_DATA / CLAUDE_PLUGIN_DATA, else
+# the hook-provided CLAUDE_PROJECT_DIR (phoenix-native path). A value still carrying
+# a literal `${` is discarded — never returned, never mkdir'd. Fail-closed: returns
+# non-zero (and prints nothing) when nothing resolves to a real, token-free path.
+resolve_pipeline_data_dir() {
+	local d="${KAMPUS_PIPELINE_DATA:-${CLAUDE_PLUGIN_DATA:-}}"
+	case "$d" in *'${'*) d="" ;; esac
+	if [ -z "$d" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+		d="$CLAUDE_PROJECT_DIR/.claude/.pipeline-cli-data"
+	fi
+	case "$d" in '' | *'${'*) return 1 ;; esac
+	printf '%s' "$d"
+}

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -34,6 +34,7 @@ import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {refGuardCommand} from "./tools/ref-guard/command.ts";
 import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
+import {settingsEnvGuardCommand} from "./tools/settings-env-guard/command.ts";
 import {shipDigestCommand} from "./tools/ship-digest/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
@@ -110,4 +111,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	evalHarnessCommand,
 	mainSyncCommand,
 	refGuardCommand,
+	settingsEnvGuardCommand,
 ];

--- a/packages/pipeline-cli/src/tools/settings-env-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/command.ts
@@ -1,0 +1,78 @@
+/**
+ * The `settings-env-guard` tool — `pipeline-cli settings-env-guard check [--root <d>]`.
+ *
+ * The CI surface for the #2495 invariant: no `.claude/settings.json` `env` value may
+ * carry an unexpanded `${...}` token, because Claude Code applies env values verbatim
+ * (no `${VAR}` expansion) — so such a value never resolves and instead creates a
+ * literal-token directory or clobbers PATH (the stray `${CLAUDE_PROJECT_DIR}` dir).
+ * Enforced fail-closed so the class can't silently re-drift.
+ *
+ *   pipeline-cli settings-env-guard check            # CI gate: exit non-zero on any ${...} in an env value
+ *   pipeline-cli settings-env-guard check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * The scan/IO lives in `gate.ts`; this file wires it to the CLI (the thin-CLI-over-
+ * `gate.ts` idiom shared across the guards). Exit-code contract mirrors readme-guard:
+ * 0 = clean, any non-zero = failure (a `${...}` offender OR an unreadable settings
+ * file, undistinguished). `CheckFailed` is caught inside the handler (not at the
+ * bin's run boundary) so the contract survives folding into the shared bin.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../../find-root-dir.ts";
+import {type CheckFailed, checkSettingsEnv} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repo root whose .claude/settings.json to scan (default: walk up for one)",
+	),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
+// default error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkSettingsEnv(resolveRoot(rootOpt)).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the build if any .claude/settings.json env value carries an unexpanded brace token",
+	),
+);
+
+export const settingsEnvGuardCommand = Command.make("settings-env-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: no .claude/settings.json env value carries an unexpanded brace token (#2495)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/settings-env-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/gate.ts
@@ -1,0 +1,60 @@
+/**
+ * The `settings-env-guard` filesystem gate — the IO seam behind #2495's "no
+ * `.claude/settings.json` env value carries an unexpanded `${...}`" check, split
+ * from `command.ts` so it is crossable in unit tests over a fake settings file
+ * rather than only by spawning the bin (the core-in-its-own-file idiom; #855).
+ *
+ * `checkSettingsEnv` reads `<root>/.claude/settings.json`, JSON-parses it, reduces
+ * its `env` object to string-valued entries, and delegates the verdict to the pure
+ * core (`settings-env-guard.ts`). It fails `CheckFailed` (exit non-zero) when any
+ * env value carries a `${...}`; a missing/unreadable/unparseable settings.json is
+ * an `IoError` (also non-zero) — fail-closed on the file we can't scan (ADR 0092).
+ */
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {type EnvEntry, judge, renderReport} from "./settings-env-guard.ts";
+
+/** A read/parse failure: the guard couldn't scan the settings file — fail-closed (ADR 0092). */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+const SETTINGS_PATH = ".claude/settings.json";
+
+/** Reduce a parsed settings object's `env` block to string-valued entries (the core's input). */
+const envEntries = (settings: unknown): ReadonlyArray<EnvEntry> => {
+	if (typeof settings !== "object" || settings === null) return [];
+	const env = (settings as {env?: unknown}).env;
+	if (typeof env !== "object" || env === null) return [];
+	return Object.entries(env as Record<string, unknown>).flatMap(([key, value]) =>
+		typeof value === "string" ? [{key, value}] : [],
+	);
+};
+
+/** Read + JSON-parse `<root>/.claude/settings.json`; an IO/parse failure is fail-closed. */
+const readSettings = (root: string): Effect.Effect<unknown, IoError> =>
+	Effect.try({
+		try: () => JSON.parse(readFileSync(join(root, SETTINGS_PATH), "utf8")) as unknown,
+		catch: (cause) => new IoError({path: join(root, SETTINGS_PATH), cause}),
+	});
+
+/**
+ * The CI gate: succeed when no `.claude/settings.json` env value carries an
+ * unexpanded `${...}`, else `CheckFailed`. Fails closed (`IoError`) on a
+ * missing/unreadable/unparseable settings file (ADR 0092).
+ */
+export const checkSettingsEnv = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const settings = yield* readSettings(root);
+		const verdict = judge(envEntries(settings));
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/settings-env-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/gate.unit.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `checkSettingsEnv` over a fake repo dir — the filesystem-seam test (#855, #2495).
+ * The pure verdict is covered in `settings-env-guard.unit.test.ts`; this crosses the
+ * IO gate over a real temp dir, asserting the exit-code contract (a clean settings
+ * file succeeds; a `${...}` offender or a missing/unparseable settings.json all fail)
+ * from observable outcomes — never by spawning the bin.
+ */
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import {CheckFailed, checkSettingsEnv, IoError} from "./gate.ts";
+
+let root: string;
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "settings-env-guard-gate-"));
+});
+afterEach(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+
+const writeSettings = (settings: unknown) => {
+	mkdirSync(join(root, ".claude"), {recursive: true});
+	writeFileSync(
+		join(root, ".claude", "settings.json"),
+		JSON.stringify(settings, null, "\t"),
+		"utf8",
+	);
+};
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+
+const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
+	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
+const isIoError = (exit: Exit.Exit<unknown, unknown>): boolean =>
+	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof IoError;
+
+describe("checkSettingsEnv — IO gate", () => {
+	it("SUCCEEDS on a settings.json whose env values are all literal", () => {
+		writeSettings({env: {CLAUDE_CODE_ENABLE_TELEMETRY: "1", OTEL: "otlp"}});
+		return run(checkSettingsEnv(root)).then((exit) => expect(Exit.isSuccess(exit)).toBe(true));
+	});
+
+	it("SUCCEEDS on a settings.json with no env block (the post-#2495 phoenix shape)", () => {
+		writeSettings({enabledPlugins: {"kampus-pipeline@kampus": false}, hooks: {}});
+		return run(checkSettingsEnv(root)).then((exit) => expect(Exit.isSuccess(exit)).toBe(true));
+	});
+
+	it("FAILS CheckFailed on an env value carrying an unexpanded brace token (the #2495 regression)", () => {
+		// `$\{...}` builds the literal ${CLAUDE_PROJECT_DIR} token without a plain-string
+		// placeholder (biome noTemplateCurlyInString) — it is exactly the #2495 value.
+		writeSettings({
+			env: {KAMPUS_PIPELINE_DATA: `$\{CLAUDE_PROJECT_DIR}/.claude/.pipeline-cli-data`},
+		});
+		return run(checkSettingsEnv(root)).then((exit) => expect(isCheckFailed(exit)).toBe(true));
+	});
+
+	it("FAILS IoError (fail-closed, ADR 0092) when settings.json is missing", () =>
+		run(checkSettingsEnv(root)).then((exit) => expect(isIoError(exit)).toBe(true)));
+
+	it("FAILS IoError (fail-closed) when settings.json is not valid JSON", () => {
+		mkdirSync(join(root, ".claude"), {recursive: true});
+		writeFileSync(join(root, ".claude", "settings.json"), "{ not json", "utf8");
+		return run(checkSettingsEnv(root)).then((exit) => expect(isIoError(exit)).toBe(true));
+	});
+});

--- a/packages/pipeline-cli/src/tools/settings-env-guard/settings-env-guard.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/settings-env-guard.ts
@@ -1,0 +1,73 @@
+/**
+ * `settings-env-guard` pure core — decide whether any `.claude/settings.json` `env`
+ * VALUE carries an unexpanded `${...}` token (#2495). IO-free and total: a
+ * deterministic transform over already-parsed env entries. The filesystem boundary
+ * (read + JSON-parse the settings file, extract `env`) lives in `gate.ts`.
+ *
+ * The invariant this enforces, grounded once: Claude Code applies settings.json
+ * `env` VALUES VERBATIM — it does NOT expand `${VAR}` in them (settings docs: `env`
+ * = "Environment variables applied to every session"; no interpolation documented,
+ * verified on both the desktop and web harnesses). So a `${...}` in an `env` value
+ * NEVER resolves — it is consumed literally, which is what created the stray
+ * `${CLAUDE_PROJECT_DIR}` directory at the repo root and clobbered PATH (#2495).
+ * A checkout- or session-relative path an env value wants must be resolved in the
+ * consuming hook (from the hook-exported `$CLAUDE_PROJECT_DIR`), never wired as an
+ * env-value expansion. This guard reds fail-closed on the whole class.
+ *
+ * An empty `env` (or none) is a legitimate PASS, not a vacuous green: the scan
+ * covered the entire block and found nothing to expand. The fail-closed-on-missing
+ * concern (ADR 0092) is the FILE — an unreadable/unparseable settings.json — and
+ * lives at the IO boundary in `gate.ts`, not here.
+ */
+
+/** One `env` entry from settings.json, reduced to the two facts the decision needs. */
+export interface EnvEntry {
+	readonly key: string;
+	readonly value: string;
+}
+
+/**
+ * The guard verdict. A discriminated union so an invalid state is unrepresentable:
+ * a pass never carries offenders, and a failure always carries the offending
+ * entries (its evidence — ADR 0092 §1 "emit what you scanned").
+ */
+export type SettingsEnvVerdict =
+	| {readonly pass: true; readonly scanned: number}
+	| {
+			readonly pass: false;
+			readonly reason: "literal-expansion";
+			readonly offenders: ReadonlyArray<EnvEntry>;
+	  };
+
+/** Matches an unexpanded shell-style expansion token, e.g. `${CLAUDE_PROJECT_DIR}` or `${PATH}`. */
+const EXPANSION_RE = /\$\{[^}]*\}/;
+
+/** The env entries whose value carries a literal `${...}` — the offenders. */
+export const findLiteralExpansions = (env: ReadonlyArray<EnvEntry>): ReadonlyArray<EnvEntry> =>
+	env.filter((e) => EXPANSION_RE.test(e.value));
+
+/** Decide the verdict: red on any env value carrying an unexpanded `${...}`, else pass. */
+export const judge = (env: ReadonlyArray<EnvEntry>): SettingsEnvVerdict => {
+	const offenders = findLiteralExpansions(env);
+	if (offenders.length > 0) {
+		return {pass: false, reason: "literal-expansion", offenders};
+	}
+	return {pass: true, scanned: env.length};
+};
+
+/** Render the human-readable report for a verdict (ADR 0092 §1 "emit what you scanned"). */
+export const renderReport = (verdict: SettingsEnvVerdict): string => {
+	if (verdict.pass) {
+		return `settings-env-guard: all ${verdict.scanned} .claude/settings.json env value(s) are free of unexpanded \${...} tokens`;
+	}
+	const lines = verdict.offenders.map((e) => `  ${e.key} = ${e.value}`);
+	return (
+		`settings-env-guard: ${verdict.offenders.length} .claude/settings.json env value` +
+		`${verdict.offenders.length === 1 ? "" : "s"} carry an unexpanded \${...} token:\n${lines.join("\n")}\n\n` +
+		"Claude Code applies `env` values VERBATIM — it does NOT expand a brace token\n" +
+		"in them (#2495). Such a token in an env value never resolves: it is consumed\n" +
+		"literally, creating a literal-token directory or clobbering PATH. Resolve a\n" +
+		"checkout- or session-relative path in the consuming hook (from the hook-\n" +
+		"exported $CLAUDE_PROJECT_DIR), never as an env-value expansion."
+	);
+};

--- a/packages/pipeline-cli/src/tools/settings-env-guard/settings-env-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/settings-env-guard.unit.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure-core tests for `settings-env-guard` (#2495): reds on any env value carrying
+ * an unexpanded brace-expansion token, passes a clean/empty block (not a vacuous
+ * green), and reports the offenders. No IO — the filesystem seam is crossed in
+ * `gate.unit.test.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {type EnvEntry, findLiteralExpansions, judge, renderReport} from "./settings-env-guard.ts";
+
+// Build a literal `${VAR}` token without writing it as a plain-string placeholder,
+// so biome's noTemplateCurlyInString stays quiet — this guard's whole subject IS the
+// ${...} token, so spelled-out fixtures would trip the rule on nearly every line.
+const brace = (name: string): string => `$\{${name}}`;
+const DATA_VALUE = `${brace("CLAUDE_PROJECT_DIR")}/.claude/.pipeline-cli-data`;
+const PATH_VALUE = `${brace("CLAUDE_PROJECT_DIR")}/packages/gh-phoenix/shim:/usr/bin:${brace("PATH")}`;
+
+const entry = (key: string, value: string): EnvEntry => ({key, value});
+
+describe("judge — red on any unexpanded brace token in an env value", () => {
+	it("PASSES when no env value carries a brace token", () => {
+		const verdict = judge([entry("CLAUDE_CODE_ENABLE_TELEMETRY", "1"), entry("OTEL", "otlp")]);
+		expect(verdict.pass).toBe(true);
+		expect(verdict.pass && verdict.scanned).toBe(2);
+	});
+
+	it("PASSES an empty env block (real pass, not a vacuous green — the whole block was scanned)", () => {
+		const verdict = judge([]);
+		expect(verdict.pass).toBe(true);
+		expect(verdict.pass && verdict.scanned).toBe(0);
+	});
+
+	it("FAILS on the #2495 KAMPUS_PIPELINE_DATA value", () => {
+		const verdict = judge([entry("KAMPUS_PIPELINE_DATA", DATA_VALUE)]);
+		expect(verdict.pass).toBe(false);
+		expect(verdict.pass === false && verdict.reason).toBe("literal-expansion");
+		if (verdict.pass === false) {
+			expect(verdict.offenders.map((o) => o.key)).toEqual(["KAMPUS_PIPELINE_DATA"]);
+		}
+	});
+
+	it("FAILS on the #2495 PATH value (both the shim prefix and the trailing brace token)", () => {
+		const verdict = judge([entry("PATH", PATH_VALUE)]);
+		expect(verdict.pass).toBe(false);
+		if (verdict.pass === false) {
+			expect(verdict.offenders.map((o) => o.key)).toEqual(["PATH"]);
+		}
+	});
+
+	it("lists ONLY the offending entries, leaving clean ones out", () => {
+		const verdict = judge([
+			entry("CLEAN", "literal-value"),
+			entry("BAD_A", `${brace("CLAUDE_PROJECT_DIR")}/x`),
+			entry("CLEAN2", "/opt/homebrew/bin"),
+			entry("BAD_B", `prefix:${brace("PATH")}`),
+		]);
+		expect(verdict.pass).toBe(false);
+		if (verdict.pass === false) {
+			expect(verdict.offenders.map((o) => o.key)).toEqual(["BAD_A", "BAD_B"]);
+		}
+	});
+});
+
+describe("findLiteralExpansions", () => {
+	it("matches a brace token anywhere in the value, not just at the start", () => {
+		expect(findLiteralExpansions([entry("K", `a:${brace("B")}:c`)]).map((e) => e.key)).toEqual([
+			"K",
+		]);
+	});
+
+	it("does NOT match a bare $VAR (unbraced) — only the braced form is the verbatim-expansion trap", () => {
+		// A hook `command` uses unbraced $CLAUDE_PROJECT_DIR and shell-expands; this
+		// guard is about env VALUES, where the observed non-expanding form is braced.
+		expect(findLiteralExpansions([entry("K", "$HOME/x")])).toEqual([]);
+	});
+
+	it("does NOT match a literal path with no expansion token", () => {
+		expect(findLiteralExpansions([entry("K", "/usr/bin:/bin")])).toEqual([]);
+	});
+});
+
+describe("renderReport", () => {
+	it("names each offender key=value and states the verbatim-env root cause", () => {
+		const report = renderReport(judge([entry("KAMPUS_PIPELINE_DATA", DATA_VALUE)]));
+		expect(report).toContain(`KAMPUS_PIPELINE_DATA = ${DATA_VALUE}`);
+		expect(report).toContain("VERBATIM");
+		expect(report).toContain("#2495");
+	});
+
+	it("reports the scanned count on a pass", () => {
+		expect(renderReport(judge([entry("A", "1")]))).toContain("all 1");
+	});
+});


### PR DESCRIPTION
Fixes #2495

## Grounded finding — the exact harness `env`-expansion contract (flagged, not asserted)

**Claude Code applies `.claude/settings.json` `env` VALUES verbatim — it does NOT expand `${VAR}` in them. On desktop OR web.** The ticket's flagged assumption ("desktop expands, web doesn't") is **falsified**.

Sources:
- **Docs (settings):** the `env` key is documented as *"Environment variables applied to every session and to subprocesses Claude Code spawns from it."* No `${VAR}` interpolation is documented for `env` values; every example value is a literal (`"1"`, `"otlp"`). — https://docs.claude.com/en/docs/claude-code/settings
- **Docs (hooks):** `${CLAUDE_PROJECT_DIR}` / `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_DATA}` are placeholders substituted in hook `command`/`args`, and Claude Code *"export[s] them as the environment variables ... on the spawned process, so a script can read `process.env.CLAUDE_PLUGIN_ROOT` regardless of how it was launched."* — https://docs.claude.com/en/docs/claude-code/hooks
- **Empirical test on both harnesses** (CLAUDE.md accepts "an actual test against the real platform"):
  - Web harness (ticket runtime evidence): `KAMPUS_PIPELINE_DATA` and `PATH` literal; `CLAUDE_PROJECT_DIR` empty in the shell.
  - **Desktop harness (this session's shell):** `KAMPUS_PIPELINE_DATA=[${CLAUDE_PROJECT_DIR}/.claude/.pipeline-cli-data]` (literal), `CLAUDE_PROJECT_DIR=[]` (empty), `PATH` carrying the literal `${CLAUDE_PROJECT_DIR}` prefix and a literal trailing `${PATH}`, and `command -v gh` → `/opt/homebrew/bin/gh` (the shim is **not** on PATH). So the shim wiring has been **inert on desktop too**, and the env-block PATH **replaces** the inherited PATH (Claude Code then appends its own plugin bin dirs) — it does not preserve it.

**Contract, restated:** env values are verbatim; `${...}` in an env value never resolves. `CLAUDE_PROJECT_DIR` is empty in the tool shell but **is** exported into hook-`command`-spawned processes — which is the authoritative basis for resolving the data dir inside the hooks.

## The fix (root cause, not symptom)

1. **`.claude/settings.json` — remove the `env` block.** Both entries relied on non-existent expansion. Removing `PATH` stops the inherited-PATH clobber (the ticket's "quieter, more serious half"); removing `KAMPUS_PIPELINE_DATA` stops the literal-token dir at its source.
2. **`hooks/resolve-data-dir.sh` (new, sourced by `install.sh` + `guard.sh`)** — discards an unexpanded (`${`-carrying) env value and falls back to the hook-exported `$CLAUDE_PROJECT_DIR` (`$CLAUDE_PROJECT_DIR/.claude/.pipeline-cli-data`), the documented-available var in hook-command context. It **never returns or `mkdir`s a `${` path** and is fail-closed when nothing resolves. The *why* is stated once, there; the two hooks point to it.
3. **Stray dir removed** — the on-disk `${CLAUDE_PROJECT_DIR}/` tree at the repo root was deleted (untracked, so not in this diff — a filesystem cleanup). After the fix the data dir lands at exactly `.claude/.pipeline-cli-data/`, which `.gitignore:55` already covers, so it can't reappear as untracked noise.
4. **Recurrence guard — `pipeline-cli settings-env-guard check` (+ `settings-env-guard.yml` CI job).** Fail-closed gate over `.claude/settings.json`: reds if **any** env value carries an unexpanded brace token (since env values are verbatim, such a token is always a latent bug — a literal-token dir or a PATH clobber). Pure core + IO gate + 15 unit tests. This is the root-cause guard the ticket demands (not a gitignore symptom patch). Proven: it reds on the pre-fix settings (both `KAMPUS_PIPELINE_DATA` and `PATH` named) and passes the fixed tree.

## On the PATH criterion ("prepend the shim without dropping inherited PATH")

The grounding proves a checkout-relative PATH prepend is **impossible via `settings.json` `env`** (verbatim semantics + no other session-PATH mechanism), and the shim was already inert. Removing the broken `PATH` entry **preserves the inherited PATH intact** (satisfies "without dropping the inherited PATH"). Re-delivering the `gh` shim's PATH-shadowing through a mechanism that actually works is out of scope here and is filed as a follow-up.

## Verification
- `pnpm typecheck` — 28/28 pass.
- `pnpm lint` — clean (0 errors/warnings on changed files).
- `pipeline-cli settings-env-guard` — 15 unit tests pass; guard reds on pre-fix settings, passes post-fix.
- Shell resolver + both hooks smoke-tested (fallback on literal value, pass-through on expanded, fail-closed/fail-open when unresolvable); `bash -n` clean.

## §CP note
Touches `.claude/settings.json` + `claude-plugins/kampus-pipeline/hooks/**` — route through the human §CP merge gate; not self-merged.