### PR TITLE
feat(mecmua): write path — PublishMecmua capability (yazar floor) + publish/save-draft mutations (#2497)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -47,6 +47,7 @@ import {
 	funnelReadoutFlag,
 	karmaGatesFlag,
 	mecmuaPublicReadFlag,
+	mecmuaWriteFlag,
 	modQueueFlag,
 	optimisticDefinitionAddFlag,
 	optimisticDefinitionDeleteFlag,
@@ -80,6 +81,9 @@ export default Alchemy.Stack(
 		yield* demoTargetingFlag(flagship.appId);
 		// The pano taslak (draft-save) dark-ship flag, default-off (#746).
 		yield* panoDraftSaveFlag(flagship.appId);
+		// The mecmua write-path dark-ship flag, default-off (#2497, epic #2467) — the
+		// single seam mecmua.publish + mecmua.saveDraft gate behind until a human release.
+		yield* mecmuaWriteFlag(flagship.appId);
 		// The base-feed / viewer-overlay split dark-ship flag, default-off (#2322,
 		// epic #2316 leg B) — the single seam the GET-able base feed + PostOverlay read
 		// gate behind until a human release.

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -52,6 +52,8 @@ export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	USER_NOT_FOUND: "kullanıcı bulunamadı",
 	DISPLAY_NAME_EMPTY: "görünen ad boş olamaz",
 	BAN_REASON_REQUIRED: "yasaklama gerekçesi zorunludur",
+	MECMUA_DISABLED: "mecmua şu an kapalı",
+	MECMUA_POST_NOT_FOUND: "yazı bulunamadı",
 	BAD_REQUEST: "geçersiz istek",
 	INTERNAL_SERVER_ERROR: "bir şeyler ters gitti, lütfen tekrar dene",
 };

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -12,6 +12,14 @@
 export const PANO_DRAFT_SAVE = "pano-draft-save";
 
 /**
+ * mecmua write-path dark-ship flag (#2497, epic #2467). The single seam the mecmua
+ * write surface gates behind — the `mecmua.publish` + `mecmua.saveDraft` mutations
+ * fail `MECMUA_DISABLED` with it off, so the whole write path ships dark until a
+ * human flips it at release (ADR 0083). Its own `mecmua-` product key.
+ */
+export const MECMUA_WRITE = "mecmua-write";
+
+/**
  * Pano base-feed edge-cache containment flag (#2324, epic #2316 leg B, ADR 0170).
  * Default-off. With it off, the base-feed GET emits no `Cache-Control` (nothing is
  * edge-cached) and the fanned-mutation seam fires no purge — the feature ships dark.

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -79,6 +79,12 @@ export const FATE_WIRE_CODES = [
 	// server-authoritative floor the admin `user.banUser` mutation raises against a
 	// blank gerekçe, since a ban's audit record is meaningless without one.
 	"BAN_REASON_REQUIRED",
+	// mecmua write path is gated on the `mecmua-write` flag; the server raises this
+	// when `mecmua.publish` / `mecmua.saveDraft` run with the flag off (#2497).
+	"MECMUA_DISABLED",
+	// A `mecmua.publish` target draft doesn't exist or isn't the caller's own
+	// (`mecmua/MecmuaPostNotFound`, #2497) — the ownership-scoped miss.
+	"MECMUA_POST_NOT_FOUND",
 	"BAD_REQUEST",
 	"INTERNAL_SERVER_ERROR",
 ] as const;

--- a/apps/web/worker/features/fate-live/fanned-mutations.ts
+++ b/apps/web/worker/features/fate-live/fanned-mutations.ts
@@ -266,4 +266,19 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 		fanned: false,
 		rationale: "appends an audited unban event on the identity surface — no fanned content entity",
 	},
+
+	// mecmua — long-form posts (#2497, epic #2467). mecmua Post does NOT yet live in a
+	// subscribed `/fate/live` connection (no mecmua root is wired), so neither write fans;
+	// if a mecmua mutation is later classified fanned it must publish via `WorkerLivePublisher`.
+	{
+		key: "mecmua.publish",
+		fanned: false,
+		rationale:
+			"stamps publishedAt on a mecmua post — mecmua Post is in no subscribed /fate/live connection yet (#2463)",
+	},
+	{
+		key: "mecmua.saveDraft",
+		fanned: false,
+		rationale: "writes the caller's private mecmua draft row — no subscribed connection",
+	},
 ];

--- a/apps/web/worker/features/fate/config.ts
+++ b/apps/web/worker/features/fate/config.ts
@@ -31,6 +31,7 @@ import {fateModule as bildirimModule} from "../bildirim/fate-module.ts";
 import {fateModule as divanModule} from "../divan/fate-module.ts";
 import {liveBusConfig} from "../fate-live/event-bus.ts";
 import {fateModule as funnelModule} from "../funnel/fate-module.ts";
+import {fateModule as mecmuaModule} from "../mecmua/fate-module.ts";
 import {fateModule as panoModule} from "../pano/fate-module.ts";
 import {fateModule as pasaportModule} from "../pasaport/fate-module.ts";
 import {fateModule as reportModule} from "../report/fate-module.ts";
@@ -52,6 +53,7 @@ export const modules = [
 	divanModule,
 	funnelModule,
 	bildirimModule,
+	mecmuaModule,
 ];
 
 export const fateConfig = FateServer.config({

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -31,6 +31,7 @@ import {Kunye, KunyeLive} from "../kunye/Kunye.ts";
 import {RelationStoreLive} from "../kunye/RelationStore.ts";
 import {authorshipLadder} from "../kunye/standing.ts";
 import {VouchLedgerLive} from "../kunye/VouchLedger.ts";
+import {MecmuaLive} from "../mecmua/Mecmua.ts";
 import {BookmarkLive} from "../pano/Bookmark.ts";
 import {PanoFeedCache} from "../pano/feed-cache.ts";
 import {PanoLive} from "../pano/Pano.ts";
@@ -244,6 +245,11 @@ export const makeFateLayer = Layer.mergeAll(
 	// The bildirim spine's notification store + recipient-scoped read model (#1694,
 	// epic #1666), depending only on `Drizzle` (discharged below) — merges flat.
 	NotificationLive,
+	// The mecmua long-form write service (#2497, epic #2467) — the publish + save-draft
+	// acts, depending only on `Drizzle` (discharged below), so it merges flat like the
+	// other domain layers. The publish yazar-floor is discharged at the mutation via
+	// `PublishMecmua` (CurrentActor/AgentAuthority/Kunye already in this graph), not here.
+	MecmuaLive,
 	// The authz ports the moderation gate (`report.resolve`/`restore`/`listOpen`)
 	// discharges `Moderate.over(platform)` against: `RelationStoreLive` reads the
 	// `moderates` tuple off the same `Drizzle` seam (discharged below), and

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -30,6 +30,8 @@ export {
 } from "../divan/views.ts";
 export type {FunnelSummary} from "../funnel/views.ts";
 export {funnelSummaryDataView} from "../funnel/views.ts";
+export type {MecmuaPost} from "../mecmua/views.ts";
+export {mecmuaPostDataView} from "../mecmua/views.ts";
 export type {Comment, Post, PostOverlay, Tag} from "../pano/views.ts";
 export {
 	commentDataView,

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -36,6 +36,7 @@ import {
 } from "@kampus/fate-effect";
 import {describe, expect, it} from "vitest";
 import {Denied, InsufficientKarma, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
+import {MecmuaDisabled, MecmuaPostNotFound, MecmuaTitleRequired} from "../mecmua/errors.ts";
 import {
 	CommentBodyRequired,
 	CommentBodyTooLong,
@@ -98,6 +99,12 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	[UnauthorizedPostMutation, "UNAUTHORIZED"],
 	[UnauthorizedCommentMutation, "UNAUTHORIZED"],
 	[DraftsDisabled, "DRAFTS_DISABLED"],
+	// mecmua write path (#2497) — reachable from fateConfig via `mecmua.publish` /
+	// `mecmua.saveDraft`. All message-only, so also round-trip representatives below;
+	// `MecmuaTitleRequired` shares the `TITLE_REQUIRED` code with pano's `TitleRequired`.
+	[MecmuaDisabled, "MECMUA_DISABLED"],
+	[MecmuaPostNotFound, "MECMUA_POST_NOT_FOUND"],
+	[MecmuaTitleRequired, "TITLE_REQUIRED"],
 	// sozluk
 	[BodyRequired, "BODY_REQUIRED"],
 	[BodyTooLong, "BODY_TOO_LONG"],
@@ -163,6 +170,8 @@ const ROUND_TRIP_CLASSES = [
 	ParentCommentNotFound,
 	PostDeleteFailed,
 	DraftsDisabled,
+	MecmuaDisabled,
+	MecmuaPostNotFound,
 	BodyRequired,
 	UsernameInvalidFormat,
 	UsernameTooShort,

--- a/apps/web/worker/features/flagship/mecmua-write.invariant.test.ts
+++ b/apps/web/worker/features/flagship/mecmua-write.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the mecmua write-path flag
+ * (#2497, epic #2467). Inspected off the exported `MECMUA_WRITE_FLAG` record (the
+ * same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
+ * constructed — mirrors `bildirim.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {MECMUA_WRITE} from "../../../src/flags/keys.ts";
+import {MECMUA_WRITE_FLAG, mecmuaWriteFlag} from "./resources.ts";
+
+describe("mecmua-write — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(MECMUA_WRITE_FLAG.defaultVariation, "off");
+		assert.strictEqual(MECMUA_WRITE_FLAG.variations.off, false);
+		assert.strictEqual(MECMUA_WRITE_FLAG.variations.on, true);
+		assert.strictEqual(MECMUA_WRITE_FLAG.key, "mecmua-write");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(MECMUA_WRITE_FLAG.key, MECMUA_WRITE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof mecmuaWriteFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -12,6 +12,7 @@ import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import {
 	MECMUA_PUBLIC_READ,
+	MECMUA_WRITE,
 	PANO_BASE_FEED,
 	PANO_DRAFT_SAVE,
 	PANO_FEED_EDGE_CACHE,
@@ -232,6 +233,38 @@ export const PANO_DRAFT_SAVE_FLAG = {
  */
 export const panoDraftSaveFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("pano_draft_save", {appId, ...PANO_DRAFT_SAVE_FLAG});
+
+/**
+ * The mecmua write-path dark-ship flag config (#2497, epic #2467). The SINGLE seam
+ * the mecmua write surface gates behind — `mecmua.publish` + `mecmua.saveDraft` fail
+ * `MECMUA_DISABLED` with it off, so the write path reaches production dark; flipping
+ * it on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `PANO_DRAFT_SAVE_FLAG`, #746): the
+ * factory spreads it into `FlagshipFlag`; the test asserts `defaultVariation`/
+ * `variations.off` on this same record.
+ *
+ * Per-flag metadata (`.patterns/feature-flags-schema-lifecycle.md`):
+ *   - owner:           mecmua
+ *   - originating:     #2497 (epic: mecmua v1 post feature, #2467)
+ *   - removal trigger: once the mecmua write path is on at 100% and stable for one
+ *                      release, retire the flag and delete its gate.
+ */
+export const MECMUA_WRITE_FLAG = {
+	key: MECMUA_WRITE,
+	description:
+		"mecmua write-path (publish + save-draft) dark-ship (#2497, epic #2467). owner: mecmua. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * No targeting rules — a plain boolean kill-switch (`panoDraftSaveFlag` shape). `appId`
+ * is resolved at deploy.
+ */
+export const mecmuaWriteFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("mecmua_write", {appId, ...MECMUA_WRITE_FLAG});
 
 /**
  * The earned-authorship loop (çaylak→yazar) dark-ship flag config (#1204, epic

--- a/apps/web/worker/features/mecmua/Mecmua.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.ts
@@ -1,0 +1,108 @@
+/**
+ * `Mecmua` — the mecmua long-form write service (#2497, epic #2467, #2463). The
+ * domain-object home for the two write acts, reached only through the `Drizzle` seam
+ * and dying on infra errors via `orDieAccess` (the `Report`/`Pano` service idiom):
+ * validation + the DB write live here, never in the fate resolver (ADR 0013).
+ *
+ * Two acts:
+ *   - {@link MecmuaService.saveDraft} — insert a NEW draft row (`publishedAt = null`).
+ *     Multiple drafts per author are allowed (the deliberate divergence from pano's
+ *     one-draft-per-author partial-unique index, #2463), so this always inserts a
+ *     fresh id — never a probe-then-upsert.
+ *   - {@link MecmuaService.publish} — stamp `publishedAt` on the caller's own draft
+ *     (the yazar-floored act, gated at the mutation by `PublishMecmua`). The write is
+ *     scoped `where id = ? AND author_id = ?`, so a yazar can only publish their OWN
+ *     draft; a miss is {@link MecmuaPostNotFound}.
+ *
+ * There is no `authorName` column — the byline is the LIVE identity resolved from
+ * `authorId` at read time (#2463), so a publish stamps only `publishedAt`; the byline
+ * follows the author's current identity, never a snapshot.
+ */
+
+import {id} from "@usirin/forge";
+import {and, eq} from "drizzle-orm";
+import {Context, Effect, Layer} from "effect";
+import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.ts";
+import {type MecmuaPostRow, toMecmuaPostRow} from "./post-fields.ts";
+
+export interface SaveMecmuaDraftInput {
+	authorId: string;
+	/** Optional on a draft — a half-filled form persists (empty ⇒ stored as ""). */
+	title?: string | null;
+	body?: string | null;
+	slug?: string | null;
+}
+
+export interface PublishMecmuaInput {
+	/** The draft to publish. */
+	id: string;
+	/** The caller — the write is scoped to their OWN draft. */
+	authorId: string;
+}
+
+export class Mecmua extends Context.Service<
+	Mecmua,
+	{
+		readonly saveDraft: (input: SaveMecmuaDraftInput) => Effect.Effect<MecmuaPostRow>;
+		readonly publish: (
+			input: PublishMecmuaInput,
+		) => Effect.Effect<MecmuaPostRow, MecmuaPostNotFound | MecmuaTitleRequired>;
+	}
+>()("mecmua/Mecmua") {}
+
+export const MecmuaLive = Layer.effect(Mecmua)(
+	Effect.gen(function* () {
+		// `orDieAccess`: every internal DB call dies on `DrizzleError` (infra failures are
+		// defects, `.patterns/effect-errors.md`), so method signatures carry domain errors only.
+		const {run} = orDieAccess(yield* Drizzle);
+
+		const saveDraft = Effect.fn("Mecmua.saveDraft")(function* (input: SaveMecmuaDraftInput) {
+			const now = new Date();
+			const postId = id("mecmua");
+			const row = {
+				id: postId,
+				slug: input.slug ?? null,
+				title: (input.title ?? "").trim(),
+				body: input.body ?? "",
+				authorId: input.authorId,
+				publishedAt: null,
+				createdAt: now,
+				updatedAt: now,
+			} satisfies typeof schema.mecmuaPost.$inferSelect;
+			yield* run((db) => db.insert(schema.mecmuaPost).values(row));
+			return toMecmuaPostRow(row);
+		});
+
+		const publish = Effect.fn("Mecmua.publish")(function* (input: PublishMecmuaInput) {
+			// Ownership-scoped read: only the caller's OWN row resolves, so a yazar can't
+			// publish another author's draft (a foreign/absent id is MECMUA_POST_NOT_FOUND).
+			const existing = yield* run((db) =>
+				db.query.mecmuaPost.findFirst({
+					where: {id: input.id, authorId: input.authorId},
+				}),
+			);
+			if (!existing) {
+				return yield* new MecmuaPostNotFound({message: "Yayımlanacak yazı bulunamadı."});
+			}
+			if (existing.title.trim().length === 0) {
+				return yield* new MecmuaTitleRequired({message: "Yayımlamak için bir başlık gerekli."});
+			}
+			const now = new Date();
+			// Idempotent re-publish: keep the original instant if already published, else stamp now.
+			const publishedAt = existing.publishedAt ?? now;
+			yield* run((db) =>
+				db
+					.update(schema.mecmuaPost)
+					.set({publishedAt, updatedAt: now})
+					.where(
+						and(eq(schema.mecmuaPost.id, input.id), eq(schema.mecmuaPost.authorId, input.authorId)),
+					),
+			);
+			return toMecmuaPostRow({...existing, publishedAt, updatedAt: now});
+		});
+
+		return {saveDraft, publish};
+	}),
+);

--- a/apps/web/worker/features/mecmua/Mecmua.unit.test.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.unit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit — the `Mecmua` write acts over a scripted `Drizzle` seam (the `Bookmark` /
+ * `Vote.unit.test.ts` idiom, ADR 0082): `run` replays queued results so the pure
+ * decisions are provable with no engine. Proves the ticket's write ACs (#2497):
+ * `saveDraft` writes a PRIVATE draft (`publishedAt === null`) and allows MULTIPLE
+ * drafts (distinct ids, never a probe-then-upsert), and `publish` STAMPS
+ * `publishedAt` on the caller's own draft — refusing a foreign/absent id
+ * (`MecmuaPostNotFound`) and an empty-title publish (`MecmuaTitleRequired`).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import type * as schema from "../../db/drizzle/schema.ts";
+import {MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.ts";
+import {Mecmua, MecmuaLive} from "./Mecmua.ts";
+
+type MecmuaRecord = typeof schema.mecmuaPost.$inferSelect;
+
+/** A `Drizzle` whose `run` replays a queued result sequence; `batch` is unused here. */
+const scriptedAccess = (results: ReadonlyArray<unknown>): DrizzleAccess => {
+	const state = {i: 0};
+	return {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			void fn;
+			return Effect.succeed(results[state.i++] as A);
+		},
+		batch: () => Effect.die(new Error("mecmua writes use run(), never batch()")),
+	};
+};
+
+const mecmuaLayer = (access: DrizzleAccess) =>
+	MecmuaLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+const draft = (over: Partial<MecmuaRecord> = {}): MecmuaRecord => ({
+	id: "mecmua_existing",
+	slug: null,
+	title: "Bir başlık",
+	body: "gövde",
+	authorId: "yzr",
+	publishedAt: null,
+	createdAt: new Date("2026-07-01T00:00:00.000Z"),
+	updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+	...over,
+});
+
+describe("Mecmua.saveDraft — a private draft, multiple allowed", () => {
+	it.effect("writes a draft with publishedAt === null (private) and a mecmua_ id", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const row = yield* mecmua.saveDraft({authorId: "cyl", title: " Taslak ", body: "içerik"});
+			assert.strictEqual(row.publishedAt, null);
+			assert.strictEqual(row.title, "Taslak");
+			assert.strictEqual(row.authorId, "cyl");
+			assert.match(row.id, /^mecmua_/);
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([undefined, undefined])))),
+	);
+
+	it.effect("two saveDraft calls mint DISTINCT ids (multiple drafts, no upsert)", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const a = yield* mecmua.saveDraft({authorId: "yzr", title: "A"});
+			const b = yield* mecmua.saveDraft({authorId: "yzr", title: "B"});
+			assert.notStrictEqual(a.id, b.id);
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([undefined, undefined])))),
+	);
+});
+
+describe("Mecmua.publish — stamps publishedAt on the caller's own draft", () => {
+	it.effect("stamps a non-null publishedAt on a found, titled draft", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const row = yield* mecmua.publish({id: "mecmua_existing", authorId: "yzr"});
+			assert.isNotNull(row.publishedAt);
+			assert.strictEqual(row.id, "mecmua_existing");
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([draft(), undefined])))),
+	);
+
+	it.effect("re-publish keeps the original publishedAt (idempotent)", () =>
+		Effect.gen(function* () {
+			const already = new Date("2026-06-01T00:00:00.000Z");
+			const mecmua = yield* Mecmua;
+			const row = yield* mecmua.publish({id: "mecmua_existing", authorId: "yzr"});
+			assert.strictEqual(row.publishedAt?.getTime(), already.getTime());
+		}).pipe(
+			Effect.provide(
+				mecmuaLayer(
+					scriptedAccess([draft({publishedAt: new Date("2026-06-01T00:00:00.000Z")}), undefined]),
+				),
+			),
+		),
+	);
+
+	it.effect("a foreign/absent id is refused MecmuaPostNotFound", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const err = yield* mecmua.publish({id: "mecmua_missing", authorId: "yzr"}).pipe(Effect.flip);
+			assert.instanceOf(err, MecmuaPostNotFound);
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([undefined])))),
+	);
+
+	it.effect("an empty-title draft is refused MecmuaTitleRequired", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const err = yield* mecmua.publish({id: "mecmua_existing", authorId: "yzr"}).pipe(Effect.flip);
+			assert.instanceOf(err, MecmuaTitleRequired);
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([draft({title: "   "})])))),
+	);
+});

--- a/apps/web/worker/features/mecmua/PublishMecmua.ts
+++ b/apps/web/worker/features/mecmua/PublishMecmua.ts
@@ -1,0 +1,44 @@
+/**
+ * `PublishMecmua` — the mecmua write-gate capability (#2497, epic #2467, #2463).
+ *
+ * A `Capability.Level` floored at `yazar`, modeled verbatim on `OpenTerm`
+ * (`features/kunye/Authorship.ts`): the tag IS the right, it reads the GLOBAL
+ * account-level standing off {@link Kunye.tierOf} against the {@link authorshipLadder}
+ * and denies with {@link RequiresLevel} (`FORBIDDEN`). The yazar floor is
+ * load-bearing and non-optional — a çaylak CANNOT publish (ADR 0107 §7: one global
+ * künye identity, earned authorship, not per-product). mecmua has NO çaylak sandbox
+ * (yazar is above the sandbox), so this is the whole publish authority.
+ *
+ * {@link requirePublishMecmua} is the enforcement-by-R wrapper (ADR 0107 §3, the
+ * divan `requireDivanAccess` idiom): it discharges the capability and threads the
+ * minted grant into `body`'s R channel, so `body` reads `yield* PublishMecmua` for
+ * the proof and "publishing without the gate" is a compile error, not a forgotten
+ * `if`. Draft-save is deliberately NOT gated by this floor (a private draft write is
+ * normal-auth only, #2497).
+ */
+import {Capability, Grant, type Principal} from "@kampus/authz";
+import {Effect} from "effect";
+import {RequiresLevel} from "../kunye/errors.ts";
+import {authorshipLadder, Kunye} from "../kunye/Kunye.ts";
+
+/** Read a principal's global account-level rank off the {@link Kunye} standing service. */
+const standingOf = (principal: Principal) =>
+	Effect.flatMap(Kunye, (kunye) => kunye.tierOf(principal.id));
+
+/** Publish a mecmua yazı — requires `yazar` earned standing (the çaylak-refused floor). */
+export class PublishMecmua extends Capability.Level<PublishMecmua>()("mecmua/PublishMecmua", {
+	scale: authorshipLadder,
+	min: "yazar",
+	read: standingOf,
+	deny: () => new RequiresLevel({message: "Yazı yayımlamak için yazar olmalısın.", need: "yazar"}),
+}) {}
+
+/**
+ * Gate `body` behind {@link PublishMecmua}: discharge the yazar floor (denying a
+ * çaylak/visitor/anonymous with the `FORBIDDEN` {@link RequiresLevel}) and thread the
+ * resulting grant into `body`'s R channel via `Grant.provide`. So `body` reads
+ * `yield* PublishMecmua` for the gate proof, and publishing without a grant is a
+ * compile error (enforcement-by-R, ADR 0107 §3).
+ */
+export const requirePublishMecmua = <A, E, R>(body: Effect.Effect<A, E, PublishMecmua | R>) =>
+	PublishMecmua.require.pipe(Effect.flatMap((grant) => body.pipe(Grant.provide(grant))));

--- a/apps/web/worker/features/mecmua/PublishMecmua.unit.test.ts
+++ b/apps/web/worker/features/mecmua/PublishMecmua.unit.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit — the `PublishMecmua` write-gate through the real `Capability.Level` seam
+ * (#2497, epic #2467, #2463). The load-bearing, non-optional guarantee: a **çaylak
+ * is REFUSED publish** and a **yazar is allowed** — the earned-authorship floor (ADR
+ * 0107 §7, one global künye identity). Standing is read off the real {@link Kunye}
+ * service (a {@link makeKunyeStub} keyed by account id), the actor flows through
+ * {@link CurrentActor}, and the agent arm routes the fail-closed
+ * {@link AgentAuthorityV1}, so the denial path is the real discharge — not a
+ * re-implemented check. A denied çaylak/visitor/anonymous fails {@link RequiresLevel}
+ * (`FORBIDDEN`) carrying the needed `yazar` rank.
+ */
+import {
+	type Actor,
+	type AgentAuthority,
+	agent,
+	CurrentActor,
+	type Grant,
+	human,
+	unauthenticated,
+} from "@kampus/authz";
+import {Cause, Effect, Exit, Layer, Option} from "effect";
+import {describe, expect, it} from "vitest";
+import {AgentAuthorityV1} from "../kunye/AgentAuthorityV1.ts";
+import {RequiresLevel} from "../kunye/errors.ts";
+import {makeKunyeStub} from "../kunye/Kunye.testing.ts";
+import type {Kunye, Tier} from "../kunye/Kunye.ts";
+import {PublishMecmua} from "./PublishMecmua.ts";
+
+/** Account id → earned rank, the standing the real `Kunye.tierOf` read resolves. */
+const standings: Record<string, Tier> = {yzr: "yazar", cyl: "çaylak", vis: "visitor"};
+
+const kunye = makeKunyeStub({tierOf: (id) => Effect.succeed(standings[id] ?? "visitor")});
+
+/** Discharge `PublishMecmua` against an actor through all three real ports (one merged Layer). */
+const require = (actor: Actor): Exit.Exit<Grant<PublishMecmua>, RequiresLevel> =>
+	Effect.runSyncExit(
+		PublishMecmua.require.pipe(
+			Effect.provide(Layer.mergeAll(Layer.succeed(CurrentActor, {actor}), AgentAuthorityV1, kunye)),
+		),
+	);
+
+/** The `RequiresLevel` a denied discharge failed with. */
+const denial = (exit: Exit.Exit<unknown, RequiresLevel>): RequiresLevel => {
+	const failure = Exit.isFailure(exit) ? Cause.findErrorOption(exit.cause) : Option.none();
+	if (Option.isNone(failure)) throw new Error("expected a RequiresLevel denial, got a grant");
+	return failure.value;
+};
+
+describe("PublishMecmua — requires yazar (a çaylak CANNOT publish)", () => {
+	it("a yazar clears the gate (allowed to publish)", () => {
+		expect(Exit.isSuccess(require(human("yzr")))).toBe(true);
+	});
+
+	it("a çaylak is REFUSED publish (below the yazar floor)", () => {
+		expect(Exit.isFailure(require(human("cyl")))).toBe(true);
+	});
+
+	it("a visitor is refused publish", () => {
+		expect(Exit.isFailure(require(human("vis")))).toBe(true);
+	});
+
+	it("the anonymous actor is refused publish", () => {
+		expect(Exit.isFailure(require(unauthenticated))).toBe(true);
+	});
+});
+
+describe("the refusal is a RequiresLevel (FORBIDDEN) naming the needed rank", () => {
+	it("a refused çaylak carries need = yazar", () => {
+		const refused = denial(require(human("cyl")));
+		expect(refused).toBeInstanceOf(RequiresLevel);
+		expect(refused.need).toBe("yazar");
+	});
+});
+
+describe("the agent arm routes the fail-closed v1 seam", () => {
+	it("an agent is refused publish even when its human root is a yazar", () => {
+		expect(Exit.isFailure(require(agent("bot", "yzr")))).toBe(true);
+	});
+});
+
+// The declared R channel — parity with `Authorship.typetest.ts`'s discharge assertion:
+// `.require` needs the ports + the standing read, never the proof it mints.
+const _requiresTheThreePorts: Effect.Effect<
+	Grant<PublishMecmua>,
+	RequiresLevel,
+	CurrentActor | AgentAuthority | Kunye
+> = PublishMecmua.require;
+void _requiresTheThreePorts;

--- a/apps/web/worker/features/mecmua/errors.ts
+++ b/apps/web/worker/features/mecmua/errors.ts
@@ -1,0 +1,37 @@
+/**
+ * mecmua write-path errors (#2497). Each is a `Schema.TaggedErrorClass` carrying its
+ * wire `code` as an `FateWireCode` annotation `encodeWireError` reads at the fate
+ * boundary (`.patterns/fate-effect-wire-errors.md`), the same shape as pano's.
+ *
+ * The publish yazar-floor denial is NOT here — it is the shared künye
+ * {@link ../kunye/errors.ts | RequiresLevel} (`FORBIDDEN`) minted by
+ * {@link ../mecmua/PublishMecmua.ts | PublishMecmua}, so the earned-ladder denial
+ * copy lives once at the capability, not duplicated per feature.
+ */
+import {FateWireCode} from "@kampus/fate-effect";
+import * as Schema from "effect/Schema";
+
+/**
+ * The mecmua flag is off (dark-ship, ADR 0083). Both `mecmua.publish` and
+ * `mecmua.saveDraft` fail this with the flag off, so the write path is unreachable
+ * even if a client bypasses the (not-yet-built) UI — the load-bearing containment.
+ */
+export class MecmuaDisabled extends Schema.TaggedErrorClass<MecmuaDisabled>()(
+	"mecmua/MecmuaDisabled",
+	{message: Schema.String},
+	{[FateWireCode]: "MECMUA_DISABLED"},
+) {}
+
+/** A publish target draft doesn't exist, or isn't the caller's own — the ownership-scoped miss. */
+export class MecmuaPostNotFound extends Schema.TaggedErrorClass<MecmuaPostNotFound>()(
+	"mecmua/MecmuaPostNotFound",
+	{message: Schema.String},
+	{[FateWireCode]: "MECMUA_POST_NOT_FOUND"},
+) {}
+
+/** A publish with an empty title — a published yazı needs a başlık. */
+export class MecmuaTitleRequired extends Schema.TaggedErrorClass<MecmuaTitleRequired>()(
+	"mecmua/MecmuaTitleRequired",
+	{message: Schema.String},
+	{[FateWireCode]: "TITLE_REQUIRED"},
+) {}

--- a/apps/web/worker/features/mecmua/fate-module.ts
+++ b/apps/web/worker/features/mecmua/fate-module.ts
@@ -1,0 +1,16 @@
+/** mecmua's contribution to the one fate config. See `../fate/module.ts`. */
+import {Fate} from "@kampus/fate-effect";
+import type {FateModule} from "../fate/module.ts";
+import {mutations} from "./mutations.ts";
+import {MecmuaPostView} from "./views.ts";
+
+// The write path returns `MecmuaPostView` inline, so the entity needs a source to be
+// view-reachable in codegen. A `syntheticSource` (no by-id fetch path) is the minimal
+// write-lane footprint — the mutation delivers the row in its response, no re-fetch.
+// The read path (#2498) replaces this with the real byIds `mecmuaPostSource`.
+const mecmuaPostSource = Fate.syntheticSource(MecmuaPostView);
+
+export const fateModule = {
+	mutations,
+	sources: [mecmuaPostSource],
+} satisfies FateModule;

--- a/apps/web/worker/features/mecmua/mutations.ts
+++ b/apps/web/worker/features/mecmua/mutations.ts
@@ -1,0 +1,105 @@
+/**
+ * mecmua write-path mutation resolvers (#2497, epic #2467, #2463) — the publish +
+ * save-draft acts, gated behind the default-off `mecmua-write` flag (ADR 0083, the
+ * pano `post.saveDraft` dark-ship shape): with the flag off both fail
+ * {@link MecmuaDisabled}, so the write path is unreachable even if a client bypasses
+ * the (not-yet-built) UI. Domain validation + the DB write live in {@link Mecmua}
+ * (ADR 0013); this layer resolves the identity, the flag, and the capability.
+ *
+ * The authority split is the ticket's load-bearing rule:
+ *   - `mecmua.publish` is floored at **yazar** via {@link requirePublishMecmua} — a
+ *     çaylak is refused with the `FORBIDDEN` `RequiresLevel` (the earned-authorship
+ *     gate, ADR 0107 §7). It stamps `publishedAt`; the byline is the LIVE identity
+ *     resolved from `authorId` at read (#2463), not a snapshot.
+ *   - `mecmua.saveDraft` is NOT yazar-gated — a private draft write is normal-auth
+ *     only (`CurrentUser.required`), and multiple drafts per author are allowed.
+ *
+ * Neither publishes a `/fate/live` invalidation: mecmua Post lives in no subscribed
+ * connection yet, so both are `fanned: false` in `fate-live/fanned-mutations.ts`.
+ */
+import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {MECMUA_WRITE} from "../../../src/flags/keys.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
+import {RequiresLevel} from "../kunye/errors.ts";
+import {MecmuaDisabled, MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.ts";
+import {Mecmua} from "./Mecmua.ts";
+import {PublishMecmua, requirePublishMecmua} from "./PublishMecmua.ts";
+import type {MecmuaPostRow} from "./post-fields.ts";
+import type {MecmuaPost} from "./views.ts";
+import {MecmuaPostView} from "./views.ts";
+
+/** Is the mecmua write path on for this request? Safe-default `false` (ships dark). */
+const mecmuaOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(MECMUA_WRITE, false).pipe(provideRequestFlags);
+});
+
+/** Stamp the wire `__typename` onto a service row — the one mecmua write-path shaper. */
+const toMecmuaPost = (r: MecmuaPostRow): MecmuaPost => ({__typename: "MecmuaPost", ...r});
+
+const SaveDraftInput = Schema.Struct({
+	title: Schema.optional(Schema.NullOr(Schema.String)),
+	body: Schema.optional(Schema.NullOr(Schema.String)),
+	slug: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+const PublishInput = Schema.Struct({
+	id: Schema.String,
+});
+
+export const mutations = {
+	"mecmua.publish": Fate.mutation(
+		{
+			input: PublishInput,
+			type: MecmuaPostView,
+			error: Schema.Union([
+				Unauthorized,
+				MecmuaDisabled,
+				RequiresLevel,
+				MecmuaPostNotFound,
+				MecmuaTitleRequired,
+			]),
+		},
+		Effect.fn("mecmua.publish")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			if (!(yield* mecmuaOn)) {
+				return yield* new MecmuaDisabled({message: "mecmua şu an kapalı"});
+			}
+			// The yazar floor: `requirePublishMecmua` discharges `PublishMecmua` and threads
+			// the grant into the body, so `yield* PublishMecmua` is the compile-error gate —
+			// a çaylak is refused the `FORBIDDEN` `RequiresLevel` before any write (ADR 0107 §3).
+			return yield* requirePublishMecmua(
+				Effect.gen(function* () {
+					yield* PublishMecmua;
+					const mecmua = yield* Mecmua;
+					const row = yield* mecmua.publish({id: input.id, authorId: user.id});
+					return toMecmuaPost(row);
+				}),
+			);
+		}),
+	),
+	"mecmua.saveDraft": Fate.mutation(
+		{
+			input: SaveDraftInput,
+			type: MecmuaPostView,
+			error: Schema.Union([Unauthorized, MecmuaDisabled]),
+		},
+		Effect.fn("mecmua.saveDraft")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			if (!(yield* mecmuaOn)) {
+				return yield* new MecmuaDisabled({message: "mecmua şu an kapalı"});
+			}
+			const mecmua = yield* Mecmua;
+			const row = yield* mecmua.saveDraft({
+				authorId: user.id,
+				...(input.title != null ? {title: input.title} : {}),
+				...(input.body != null ? {body: input.body} : {}),
+				...(input.slug != null ? {slug: input.slug} : {}),
+			});
+			return toMecmuaPost(row);
+		}),
+	),
+};


### PR DESCRIPTION
Fixes #2497

The mecmua long-form **write path** (epic #2467, #2463), built on the #2496 storage + read-model base. Ships dark behind the default-off `mecmua-write` flag (ADR 0083).

Flag: mecmua-write

## What this delivers (the ticket's binding ACs)

- **`PublishMecmua` — a `Capability.Level` floored at `yazar`** (`apps/web/worker/features/mecmua/PublishMecmua.ts`), modeled verbatim on kunye's `OpenTerm`: `scale: authorshipLadder`, `min: "yazar"`, reads global account-level standing via `Kunye.tierOf`, denies with a `FORBIDDEN` `RequiresLevel`. The yazar floor is load-bearing and non-optional — **a çaylak CANNOT publish** (ADR 0107 §7, one global künye identity). `requirePublishMecmua` threads the grant into the write body so publishing without the gate is a compile error (enforcement-by-R, ADR 0107 §3).
- **`mecmua.publish`** — stamps `publishedAt` on the caller's own draft (yazar-gated). No `authorName` column exists, so the byline is the **live identity** resolved from `authorId` at read (#2463), not a snapshot. Ownership-scoped `where id = ? AND author_id = ?`; a foreign/absent id is `MECMUA_POST_NOT_FOUND`.
- **`mecmua.saveDraft`** — a private draft write (`publishedAt = null`); **multiple drafts per author allowed** (no upsert); **NOT** yazar-gated — a private write is normal-auth only (`CurrentUser.required`).
- **fate-live fanout classification** — both `mecmua.*` keys registered `fanned: false` in `fate-live/fanned-mutations.ts` (mecmua Post lives in no subscribed `/fate/live` connection yet); `fanout-guard check` passes.
- **Dark-ship** — behind the default-off `mecmua-write` flag; with it off both mutations fail `MECMUA_DISABLED`, so the write path is unreachable even if a client bypasses the (not-yet-built) UI.
- **Turkish denial/user copy; English identifiers.**

## Tests

- `PublishMecmua.unit.test.ts` — **a çaylak is refused publish and a yazar is allowed** (the mandatory test), plus visitor/anonymous/agent refusals and the `RequiresLevel` (FORBIDDEN, `need: yazar`) shape.
- `Mecmua.unit.test.ts` — saveDraft writes a private draft + mints distinct ids (multiple drafts); publish stamps `publishedAt`, is idempotent on re-publish, and refuses a foreign/absent id + an empty-title draft.
- `flagship/mecmua-write.invariant.test.ts` — the flag ships default-off.
- Wire-code contract guards updated for the two new codes (`MECMUA_DISABLED`, `MECMUA_POST_NOT_FOUND`).

## Out of scope (sibling tickets)

No public read route, editor UI, or feed (#2498/#2499/#2500). No email/bülten — on-site publish only at v1. A minimal `syntheticSource` makes the mutation-returned `MecmuaPostView` codegen-reachable; the read path (#2498) replaces it with the real byIds source.

## Local gate

`pnpm typecheck`, `pnpm lint:worktree`, the mecmua unit tests, `fanout-guard check`, and the full pre-push unit suite (2030 passed) all green.