### PR TITLE
feat(web): mecmua editor UI — composer-based authoring page (#2499)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -36,6 +36,7 @@ import {DivanPage} from "./pages/DivanPage";
 import {FunnelPage} from "./pages/FunnelPage";
 import {LabComposerPage} from "./pages/LabComposerPage";
 import {LandingPage} from "./pages/LandingPage";
+import {MecmuaEditorPage} from "./pages/MecmuaEditorPage";
 import {MecmuaPostPage} from "./pages/MecmuaPostPage";
 import {NotFoundPage} from "./pages/NotFoundPage";
 import {PanoFeed} from "./pages/PanoFeed";
@@ -301,6 +302,10 @@ export function App() {
 						    the legacy bespoke route redirects so existing links don't break. */}
 						<Route path="/pano/kaydedilenler" element={<Navigate to={SAVED_HREF} replace />} />
 						<Route path="/pano/:id" element={<PanoPostDetail />} />
+						{/* The mecmua authoring page (#2499) — the page self-gates on the
+						    mecmua-write flag (off ⇒ 404), so the route is dark by default. The
+						    static `/mecmua/yaz` out-ranks the `/mecmua/:slug` reader below it. */}
+						<Route path="/mecmua/yaz" element={<MecmuaEditorPage />} />
 						{/* The mecmua public reader (#2498) — the page self-gates on the
 						    mecmua-public-read flag (off ⇒ 404), so the route is dark by default. */}
 						<Route path="/mecmua/:slug" element={<MecmuaPostPage />} />

--- a/apps/web/src/pages/MecmuaEditorPage.css
+++ b/apps/web/src/pages/MecmuaEditorPage.css
@@ -1,0 +1,146 @@
+/* /mecmua/yaz — the mecmua authoring surface (#2499). App-side chrome for the shared
+   headless @kampus/composer base; role tokens only (design-system-manifest.md). The
+   editor's paint lives here — the base ships no styling. */
+
+.kp-mecmua-editor {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-5);
+	max-width: 720px;
+	margin: 0 auto;
+}
+
+.kp-mecmua-editor__head {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-mecmua-editor__title {
+	font: var(--t-h-page);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-mecmua-editor__lede {
+	font: var(--t-body);
+	color: var(--text-muted);
+	margin: 0;
+}
+
+.kp-mecmua-editor__field {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+}
+
+.kp-mecmua-editor__label {
+	font: var(--t-meta);
+	color: var(--text-secondary);
+}
+
+/* Strip the fieldset's native chrome — it groups the composer for a11y only; the
+   spacing matches the other fields. `legend` sits inline as a plain label. */
+.kp-mecmua-editor__fieldset {
+	border: 0;
+	margin: 0;
+	padding: 0;
+	min-inline-size: 0;
+}
+
+.kp-mecmua-editor__fieldset > legend {
+	padding: 0;
+	margin-bottom: var(--s-2);
+}
+
+.kp-mecmua-editor__title-input {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+	padding: var(--s-2) var(--s-3);
+}
+
+.kp-mecmua-editor__title-input::placeholder {
+	color: var(--text-faint);
+}
+
+/* The composer surface. The base renders tiptap's `.tiptap` contenteditable inside;
+   the ProseMirror default outline is dropped so the shared `:focus-visible` spacer
+   ring (global.css) is the sole focus treatment — never a hand-rolled outline. */
+.kp-mecmua-editor__body {
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+}
+
+.kp-mecmua-editor__body .tiptap {
+	min-height: calc(var(--s-8) * 6);
+	padding: var(--s-3);
+	font: var(--t-body);
+	color: var(--text-primary);
+	outline: none;
+}
+
+.kp-mecmua-editor__body .tiptap > :first-child {
+	margin-top: 0;
+}
+
+.kp-mecmua-editor__body .tiptap > :last-child {
+	margin-bottom: 0;
+}
+
+.kp-mecmua-editor__body .tiptap :is(h1, h2, h3, h4, h5, h6) {
+	color: var(--text-primary);
+	line-height: 1.25;
+}
+
+.kp-mecmua-editor__body .tiptap p {
+	margin: var(--s-3) 0;
+}
+
+.kp-mecmua-editor__body .tiptap code {
+	font: var(--t-mono);
+	background: var(--surface-sunken);
+	border-radius: var(--r-sm);
+	padding: 0 var(--s-1);
+}
+
+.kp-mecmua-editor__body .tiptap pre {
+	background: var(--surface-sunken);
+	border: 1px solid var(--border-faint);
+	border-radius: var(--r-md);
+	padding: var(--s-3);
+	overflow-x: auto;
+}
+
+.kp-mecmua-editor__body .tiptap blockquote {
+	border-left: 2px solid var(--border-strong);
+	margin: var(--s-3) 0;
+	padding-left: var(--s-3);
+	color: var(--text-secondary);
+}
+
+.kp-mecmua-editor__notice {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+	margin: 0;
+}
+
+.kp-mecmua-editor__notice--error {
+	color: var(--danger);
+}
+
+.kp-mecmua-editor__actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--s-3);
+}
+
+.kp-mecmua-editor__gate {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+	margin: 0;
+}

--- a/apps/web/src/pages/MecmuaEditorPage.css
+++ b/apps/web/src/pages/MecmuaEditorPage.css
@@ -6,7 +6,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--s-5);
-	max-width: 720px;
+	max-width: calc(var(--s-8) * 18);
 	margin: 0 auto;
 }
 

--- a/apps/web/src/pages/MecmuaEditorPage.test.tsx
+++ b/apps/web/src/pages/MecmuaEditorPage.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * The mecmua editor's earned-gate contract (#2499): publish is offered ONLY to a
+ * yazar; a çaylak / visitor / signed-out reader sees the Turkish earned-gate copy.
+ * Tests the pure `mecmuaPublishAffordance` core (DOM-free), the way `FlagGate`'s
+ * `flagGateChild` and the on-ramp's `shouldShowOnramp` are tested.
+ */
+import {describe, expect, it} from "vitest";
+import {mecmuaPublishAffordance} from "./MecmuaEditorPage";
+
+describe("mecmuaPublishAffordance — publish is a yazar-only affordance", () => {
+	it("offers publish to a yazar", () => {
+		expect(mecmuaPublishAffordance(true, "yazar")).toEqual({kind: "publish"});
+	});
+
+	it("gates a signed-in çaylak with the earned-gate message (not a login prompt)", () => {
+		const affordance = mecmuaPublishAffordance(true, "çaylak");
+		expect(affordance.kind).toBe("gate");
+		expect(affordance).toMatchObject({message: expect.stringContaining("yazar olman gerekiyor")});
+		expect(affordance).toMatchObject({message: expect.stringContaining("çaylak")});
+	});
+
+	it("gates a signed-out reader with the sign-in-and-earn message", () => {
+		const affordance = mecmuaPublishAffordance(false, undefined);
+		expect(affordance.kind).toBe("gate");
+		expect(affordance).toMatchObject({message: expect.stringContaining("giriş yap")});
+	});
+
+	it("gates a visitor tier the same as any non-yazar", () => {
+		expect(mecmuaPublishAffordance(true, "visitor").kind).toBe("gate");
+	});
+});

--- a/apps/web/src/pages/MecmuaEditorPage.tsx
+++ b/apps/web/src/pages/MecmuaEditorPage.tsx
@@ -1,0 +1,235 @@
+/**
+ * `/mecmua/yaz` — the mecmua authoring surface (#2499, epic #2467). The first
+ * PRODUCT consumer of the shared headless `@kampus/composer` base (`/lab/composer`
+ * was the first lab consumer): the composer owns the tiptap-wrapped editing
+ * (StarterKit + `@tiptap/markdown`), this page owns only chrome + persistence,
+ * wiring the composer's markdown output into `mecmua.saveDraft` / `mecmua.publish`.
+ * Nothing here imports tiptap directly and no external editor lib is added.
+ *
+ * Two authority tiers (the ticket's load-bearing split):
+ *   - taslak kaydet — any signed-in user may save a private draft (`mecmua.saveDraft`,
+ *     normal-auth). Each save inserts a fresh draft row; multiple drafts per author
+ *     are allowed by design (#2463), so there is no edit-in-place here (out of v1).
+ *   - yayımla — offered ONLY to a yazar (`me.tier === "yazar"`), the trusted account
+ *     tier read off the fate `me` view (never the untrusted session field). A çaylak /
+ *     visitor sees the Turkish earned-gate message instead — publish is server-gated by
+ *     `PublishMecmua` regardless, this is the honest UI mirror.
+ *
+ * The whole surface ships dark behind `MECMUA_WRITE` (default-off): the page
+ * self-gates (off ⇒ 404), mirroring `MecmuaPostPage` / `DivanPage`, so the route is
+ * absent until a human flips the flag at release (ADR 0083). Storage is the markdown
+ * STRING the composer emits — no D1 schema change here.
+ */
+import {Composer, useComposerEditor} from "@kampus/composer";
+import {useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {MecmuaPost} from "../../worker/features/fate/views";
+import type {Tier} from "../../worker/features/kunye/standing";
+import {useSession} from "../auth/client";
+import {useMe} from "../auth/useMe";
+import {Button} from "../components/ui/Button";
+import {useDraftSubmit} from "../fate/useDraftSubmit";
+import {MECMUA_WRITE} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
+import {NotFoundPage} from "./NotFoundPage";
+import "./MecmuaEditorPage.css";
+
+/**
+ * The write-back selection for both mecmua write mutations. `id` is load-bearing —
+ * `saveDraft` returns the fresh draft id that `publish` then references.
+ */
+const MecmuaEditorView = view<MecmuaPost>()({
+	id: true,
+	slug: true,
+	title: true,
+	publishedAt: true,
+});
+
+/**
+ * The publish affordance decision, factored DOM-free so the earned-gate contract —
+ * publish is offered ONLY to a yazar; everyone else sees the Turkish earned-gate
+ * message — is unit-testable without a DOM (the pure-extraction idiom of
+ * `shouldShowOnramp` / `flagGateChild`). The tier is the trusted account level read
+ * off the fate `me` view; publish is server-gated by `PublishMecmua` regardless, so
+ * this only governs what the UI offers.
+ */
+export type MecmuaPublishAffordance = {kind: "publish"} | {kind: "gate"; message: string};
+
+export function mecmuaPublishAffordance(
+	isSignedIn: boolean,
+	tier: Tier | undefined,
+): MecmuaPublishAffordance {
+	if (tier === "yazar") return {kind: "publish"};
+	return {
+		kind: "gate",
+		message: isSignedIn
+			? "yayımlamak için yazar olman gerekiyor — çaylakların yazıları henüz yayımlanamaz."
+			: "yayımlamak için giriş yapıp yazar olman gerekiyor.",
+	};
+}
+
+export function MecmuaEditorPage() {
+	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);
+
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
+	// MecmuaPostPage / DivanPage self-gate idiom).
+	if (flagLoading) {
+		return (
+			<div className="kp-page">
+				<div className="kp-page__inner">
+					<p>yükleniyor…</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!flagOn) return <NotFoundPage />;
+
+	return <MecmuaEditor />;
+}
+
+function MecmuaEditor() {
+	const session = useSession();
+	const {me} = useMe();
+	const fate = useFateClient();
+
+	const [title, setTitle] = useState("");
+	const [notice, setNotice] = useState<string | null>(null);
+	// The composer holds the body; markdown is read on-demand at save/publish time
+	// (`getMarkdown()`), so no per-keystroke rerender is needed here.
+	const composer = useComposerEditor({content: ""});
+
+	const {error, setError, inFlight, run} = useDraftSubmit({redirectPath: () => "/mecmua/yaz"});
+
+	// The trusted account tier off the fate `me` view (#1297) decides the publish
+	// affordance: a yazar is offered publish; a çaylak / visitor / signed-out reader
+	// sees the earned-gate message instead.
+	const publishAffordance = mecmuaPublishAffordance(!!session.data, me?.tier);
+	const titleReady = title.trim().length > 0;
+	const bodyMarkdown = () => (composer ? composer.getMarkdown() : "");
+
+	async function onSaveDraft() {
+		setNotice(null);
+		setError(null);
+		await run(
+			() =>
+				fate.mutations.mecmua.saveDraft({
+					input: {title: title.trim(), body: bodyMarkdown()},
+					view: MecmuaEditorView,
+				}),
+			"taslak kaydedilemedi",
+			() => setNotice("taslak kaydedildi"),
+		);
+	}
+
+	async function onPublish() {
+		setNotice(null);
+		setError(null);
+		// Publish operates on a draft id, so save the current content as a fresh draft
+		// first, then stamp it published — this guarantees the published post matches
+		// what's on screen (no stale prior-draft publish).
+		await run(
+			async () => {
+				const saved = await fate.mutations.mecmua.saveDraft({
+					input: {title: title.trim(), body: bodyMarkdown()},
+					view: MecmuaEditorView,
+				});
+				if (saved.error) return saved;
+				const draftId = saved.result?.id;
+				if (!draftId) return {error: {message: "taslak kaydedilemedi"}};
+				return fate.mutations.mecmua.publish({
+					input: {id: draftId},
+					view: MecmuaEditorView,
+				});
+			},
+			"yazı yayımlanamadı",
+			() => setNotice("yazın yayımlandı"),
+		);
+	}
+
+	return (
+		<div className="kp-page">
+			<div className="kp-page__inner">
+				<div className="kp-mecmua-editor">
+					<header className="kp-mecmua-editor__head">
+						<h1 className="kp-mecmua-editor__title">yeni yazı</h1>
+						<p className="kp-mecmua-editor__lede">
+							uzun biçimli bir yazı yaz. istediğin an taslak olarak kaydet; hazır olunca yayımla.
+						</p>
+					</header>
+
+					<div className="kp-mecmua-editor__field">
+						<label className="kp-mecmua-editor__label" htmlFor="mecmua-title">
+							başlık
+						</label>
+						<input
+							id="mecmua-title"
+							className="kp-mecmua-editor__title-input"
+							data-testid="mecmua-editor-title"
+							type="text"
+							placeholder="yazının başlığı"
+							value={title}
+							onChange={(e) => setTitle(e.currentTarget.value)}
+						/>
+					</div>
+
+					{/* The composer is a headless contenteditable region (no native label
+					    slot), so a fieldset/legend names the group around it. */}
+					<fieldset className="kp-mecmua-editor__field kp-mecmua-editor__fieldset">
+						<legend className="kp-mecmua-editor__label">metin</legend>
+						<Composer composer={composer} className="kp-mecmua-editor__body" />
+					</fieldset>
+
+					{error ? (
+						<p
+							className="kp-mecmua-editor__notice kp-mecmua-editor__notice--error"
+							role="alert"
+							data-testid="mecmua-editor-error"
+						>
+							{error}
+						</p>
+					) : null}
+
+					{notice ? (
+						<p
+							className="kp-mecmua-editor__notice"
+							role="status"
+							data-testid="mecmua-editor-notice"
+						>
+							{notice}
+						</p>
+					) : null}
+
+					<div className="kp-mecmua-editor__actions">
+						<Button
+							type="button"
+							variant="tertiary"
+							data-testid="mecmua-editor-save"
+							loading={inFlight}
+							onClick={onSaveDraft}
+						>
+							taslak kaydet
+						</Button>
+
+						{publishAffordance.kind === "publish" ? (
+							<Button
+								type="button"
+								variant="primary"
+								data-testid="mecmua-editor-publish"
+								loading={inFlight}
+								disabled={!titleReady}
+								onClick={onPublish}
+							>
+								yayımla
+							</Button>
+						) : (
+							<p className="kp-mecmua-editor__gate" role="note" data-testid="mecmua-editor-gate">
+								{publishAffordance.message}
+							</p>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## What

The mecmua authoring surface at `/mecmua/yaz` — the first **product** consumer of the shared headless `@kampus/composer` base (`/lab/composer` was the first *lab* consumer). The composer owns the tiptap wrapping (`baseKit()` = StarterKit + `@tiptap/markdown`); this page owns only chrome + persistence.

## How it meets the acceptance criteria

- **Built on `@kampus/composer`.** Root-import surface only: `useComposerEditor` + the headless `<Composer>` + `getMarkdown()`. No new external editor lib, no inline tiptap re-instantiation (nothing here imports `@tiptap/*` directly).
- **App-side chrome.** Own `MecmuaEditorPage.css` using **role tokens only** and no hand-rolled focus outline (the shared `:focus-visible` spacer ring paints the composer + inputs) per `design-system-manifest.md`. Buttons via the `Button` primitive; the composer field is a `<fieldset>`/`<legend>` labelled group.
- **Draft + publish wired to #2497.** `taslak kaydet` → `mecmua.saveDraft`; `yayımla` saves a fresh draft then `mecmua.publish` on its id (so the published post matches on-screen content).
- **Yazar-gated publish.** Publish is offered only to a yazar (`me.tier === "yazar"`, the trusted account tier off the fate `me` view); a çaylak / visitor / signed-out reader sees the Turkish earned-gate message. Server-gated by `PublishMecmua` regardless — this is the honest UI mirror. Extracted as a DOM-free pure core `mecmuaPublishAffordance` + unit test (the `shouldShowOnramp` / `flagGateChild` idiom).
- **Turkish copy, English identifiers.** başlık / taslak / yayımla; route `/mecmua/yaz`, testids/identifiers English.
- **Markdown-string storage.** Persists the composer's `getMarkdown()` output (matches the sözlük/pano markdown contract) — **no D1 schema change**.
- **Default-off flag.** Ships dark behind `mecmua-write`; the page self-gates (off ⇒ 404), mirroring `MecmuaPostPage` / `DivanPage`. The static `/mecmua/yaz` route out-ranks the `/mecmua/:slug` reader.

## Out of scope (respected)

Public reader route, feed (sibling #2500), new marks (tagging/embedding/mentions), email. No backend fate-wiring / feed routes / subscription edges touched — editor surface only.

## Gate

`pnpm typecheck` (28/28) · `pnpm lint` (clean) · `src/App.test.tsx` (18/18) · `src/pages/MecmuaEditorPage.test.tsx` (4/4).

Fixes #2499

🤖 Generated with [Claude Code](https://claude.com/claude-code)