### PR TITLE
fix(pano): move thread rail to the children wrapper + root-only divider (#2510)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -85,14 +85,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 	const editing = editComposer != null;
 
 	const highlight = props.activeCommentId === data.id;
-	const cls = [
-		"kp-comment",
-		props.depth === 1 ? "kp-comment--depth-1" : "",
-		(props.depth ?? 0) >= 2 ? "kp-comment--depth-2" : "",
-		highlight ? "kp-comment--highlighted" : "",
-	]
-		.filter(Boolean)
-		.join(" ");
+	const cls = ["kp-comment", highlight ? "kp-comment--highlighted" : ""].filter(Boolean).join(" ");
 
 	const onUpvote = useVoteToggle({
 		voted,
@@ -225,7 +218,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 						</div>
 					) : null}
 					{props.children.length ? (
-						<div>
+						<div className="kp-comment__children">
 							{props.children.map((child) => (
 								<CommentTreeNode
 									key={child.id}

--- a/apps/web/src/components/pano/PanoComment.css
+++ b/apps/web/src/components/pano/PanoComment.css
@@ -1,4 +1,6 @@
-/* PanoComment — threaded with depth-1/depth-2 left rails. Mirrors dense .pano-comment. */
+/* PanoComment — a threaded reply subtree carries its left rail on the children
+   WRAPPER (.kp-comment__children), not the reply article, and only a root comment
+   draws the thread divider. See ADR 0162 / #2510. Mirrors dense .pano-comment. */
 
 .kp-pano-thread {
 	display: flex;
@@ -7,6 +9,13 @@
 
 .kp-comment {
 	padding: var(--comment-y) 0;
+}
+
+/* One separator per thread: only a root comment (a direct child of the thread)
+   draws the full-width divider. A nested reply must not — its border-bottom
+   stacked, indented, under the parent's, and the gap between them read as a
+   doubled/misaligned rule (#2510). */
+.kp-pano-thread > .kp-comment {
 	border-bottom: 1px solid var(--border-faint);
 }
 
@@ -133,15 +142,18 @@
 	color: var(--accent);
 }
 
-.kp-comment--depth-1 {
+/* The rail belongs to the subtree, so it lives on the children wrapper — which
+   has no vertical padding, so it spans exactly the nested replies. Authored as a
+   border-left on the padded reply article, it ran through the article's top and
+   bottom padding and left an orphaned L-corner hanging into the parent (#2510).
+   Wrappers nest, so the indent compounds per level; deeper rails soften. */
+.kp-comment__children {
 	margin-left: 18px;
 	padding-left: 12px;
 	border-left: 2px solid var(--border);
 }
-.kp-comment--depth-2 {
-	margin-left: 36px;
-	padding-left: 12px;
-	border-left: 2px solid var(--border-faint);
+.kp-comment__children .kp-comment__children {
+	border-left-color: var(--border-faint);
 }
 
 .kp-comment--highlighted {


### PR DESCRIPTION
Fixes #2510

## What was wrong
A pano comment thread that ends on a nested reply rendered two stacked CSS defects at the bottom of the thread, both on the shared comment component so they recurred everywhere:

1. **Doubled/misaligned bottom divider** — every `.kp-comment` drew `border-bottom`, so a nested reply's indented rule stacked under the parent's full-width rule, separated by the parent's vertical padding (a dead gap, left edges off by 18px).
2. **Orphaned rail "L" corner** — the thread rail was a `border-left` on the *padded* reply article, so it ran through the article's top/bottom padding and could not stop at the content, leaving a disconnected tail.

## The fix (systematic, at the root cause)
- **Rail moves to the children wrapper.** The children-wrapper `<div>` in `CommentTreeNode.tsx` gets `.kp-comment__children`; the rail + indent live there. The wrapper has no vertical padding, so the rail spans *exactly* the nested subtree — no top/bottom tail. Nesting compounds the indent per level and deeper rails soften to `--border-faint` (`.kp-comment__children .kp-comment__children`), preserving the prior depth-1/depth-2 weight distinction structurally.
- **One divider per thread.** The full-width divider is now drawn only by a root comment via `.kp-pano-thread > .kp-comment`, so a nested reply no longer draws its own — the doubled/misaligned rule is gone. The per-node `border-bottom` and the depth-class list in `cls` are removed.

## DESIGN-CONFIRM (load-bearing — for the review-design gate)
The systematic fix **drops the divider between sibling nested replies** (the HN/Reddit threaded idiom). This is a deliberate product-design change, not a pure bug-fix — it is isolated to the `.kp-pano-thread > .kp-comment` child-combinator so a reviewer can judge it. **Please confirm at the review-design gate (ADR 0162 / `design-system-manifest.md`).** If the confirmed look keeps a sibling separator, the child-combinator scoping is where to re-add it.

Secondary same-cause polish folded in per the ticket: the rail no longer hangs at the **top** either (same padded-box cause, now structurally impossible). The **highlighted-nested** combination (`.kp-comment--highlighted` accent rail + negative margins) is left unchanged and composes with the wrapper rail (grey thread rail + accent highlight border both show) — flagged for the gate to eyeball per the ticket's item (c).

## Constraints honored
- Stays within existing `--border` / `--border-faint` role tokens — no new tokens, no raw hex.
- No user-facing copy touched (pure CSS/layout).
- Not behind a flag: the page's flags gate optimistic-mutation dark-ship, not comment layout; a pure CSS polish fix matches no flag convention here.

## Local gate
- `pnpm typecheck` — clean
- `pnpm lint` (biome) — clean
- `commentTree.test.ts` (unit) — all pass; full pre-push unit suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)