### PR TITLE
feat(mecmua): subscribed-author time feed — publishedAt-ordered feed of followed authors (#2500)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -46,6 +46,7 @@ import {
 	Flagship,
 	funnelReadoutFlag,
 	karmaGatesFlag,
+	mecmuaFeedFlag,
 	mecmuaPublicReadFlag,
 	mecmuaWriteFlag,
 	modQueueFlag,
@@ -141,6 +142,10 @@ export default Alchemy.Stack(
 		// The mecmua public-read dark-ship flag, default-off (#2498, epic #2467) — the
 		// single seam the anon GET route + reader page gate behind until a human release.
 		yield* mecmuaPublicReadFlag(flagship.appId);
+		// The mecmua subscribed-author feed dark-ship flag, default-off (#2500, epic #2467) —
+		// the single seam the mecmuaFeed root + subscribe/unsubscribe + feed page gate behind
+		// until a human release.
+		yield* mecmuaFeedFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,6 +37,7 @@ import {FunnelPage} from "./pages/FunnelPage";
 import {LabComposerPage} from "./pages/LabComposerPage";
 import {LandingPage} from "./pages/LandingPage";
 import {MecmuaEditorPage} from "./pages/MecmuaEditorPage";
+import {MecmuaFeedPage} from "./pages/MecmuaFeedPage";
 import {MecmuaIndexPage} from "./pages/MecmuaIndexPage";
 import {MecmuaPostPage} from "./pages/MecmuaPostPage";
 import {NotFoundPage} from "./pages/NotFoundPage";
@@ -310,10 +311,12 @@ export function App() {
 						<Route path="/pano/kaydedilenler" element={<Navigate to={SAVED_HREF} replace />} />
 						<Route path="/pano/:id" element={<PanoPostDetail />} />
 						{/* mecmua — each page self-gates on its flag (off ⇒ 404), so these routes
-						    are dark by default: the index (#2512) + reader (#2498) on
-						    mecmua-public-read, the authoring page (#2499) on mecmua-write. The two
-						    static paths out-rank the `/mecmua/:slug` reader below them. */}
+						    are dark by default: the public index (#2512) + reader (#2498) on
+						    mecmua-public-read, the subscribed-author feed (#2500) on mecmua-feed, the
+						    authoring page (#2499) on mecmua-write. The three static paths out-rank
+						    the `/mecmua/:slug` reader below them. */}
 						<Route path="/mecmua" element={<MecmuaIndexPage />} />
+						<Route path="/mecmua/akis" element={<MecmuaFeedPage />} />
 						<Route path="/mecmua/yaz" element={<MecmuaEditorPage />} />
 						<Route path="/mecmua/:slug" element={<MecmuaPostPage />} />
 						<Route path="/sozluk" element={<SozlukHome />} />

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -92,6 +92,16 @@ export const PANO_BASE_FEED = "pano-base-feed";
 export const MECMUA_PUBLIC_READ = "mecmua-public-read";
 
 /**
+ * mecmua subscribed-author feed dark-ship flag (#2500, epic #2467). The SINGLE seam
+ * the feed surface gates behind — the `mecmuaFeed` list root (empty when off), the
+ * `mecmua.subscribe` / `mecmua.unsubscribe` mutations, AND the `/mecmua` feed page
+ * (self-404). Default-off so the whole feed path ships dark until a human flips it at
+ * release (ADR 0083). Its own `mecmua-` key, scoped to the feed — the read (#2498) and
+ * write (#2497) paths ship behind their own seams.
+ */
+export const MECMUA_FEED = "mecmua-feed";
+
+/**
  * Earned-authorship loop (çaylak→yazar) dark-ship flag (#1204, epic #1202). The
  * single seam every authorship-loop surface gates behind: cross-cutting
  * (`phoenix`) because the loop touches sözlük/pano/pasaport, default-off so the

--- a/apps/web/src/pages/MecmuaFeedPage.css
+++ b/apps/web/src/pages/MecmuaFeedPage.css
@@ -1,0 +1,64 @@
+/* The mecmua subscribed-author feed (#2500). Layout only — surface/elevation/border come
+   from the Card primitive and role tokens; this file owns the list rhythm, heading spacing,
+   and the row's title/meta/excerpt stack. Mirrors MecmuaIndexPage.css so the two mecmua
+   surfaces share one shape. */
+
+.kp-mecmua-feed__head {
+	margin-bottom: var(--s-5);
+}
+
+.kp-mecmua-feed__title {
+	font: var(--t-h-page);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-mecmua-feed__lede {
+	font: var(--t-body);
+	color: var(--text-secondary);
+	margin: var(--s-1) 0 0;
+}
+
+.kp-mecmua-feed {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+}
+
+.kp-mecmua-feed__item {
+	padding: 0;
+}
+
+.kp-mecmua-feed__link {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	padding: var(--s-3) var(--s-4);
+	text-decoration: none;
+	color: inherit;
+}
+
+.kp-mecmua-feed__row-title {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-mecmua-feed__meta {
+	color: var(--text-muted);
+	font: var(--t-meta);
+}
+
+.kp-mecmua-feed__excerpt {
+	font: var(--t-body);
+	color: var(--text-secondary);
+	margin: 0;
+}
+
+.kp-mecmua-feed__status {
+	font: var(--t-body);
+	color: var(--text-secondary);
+}

--- a/apps/web/src/pages/MecmuaFeedPage.tsx
+++ b/apps/web/src/pages/MecmuaFeedPage.tsx
@@ -120,9 +120,7 @@ function MecmuaFeedRow({node}: {node: ViewRef<"MecmuaPost">}) {
 				<h2 className="kp-mecmua-feed__row-title">{post.title}</h2>
 				{post.publishedAt ? (
 					<MetaRow as="div" className="kp-mecmua-feed__meta">
-						<time dateTime={toIso(post.publishedAt)}>
-							{formatAgoTR(toIso(post.publishedAt))}
-						</time>
+						<time dateTime={toIso(post.publishedAt)}>{formatAgoTR(toIso(post.publishedAt))}</time>
 					</MetaRow>
 				) : null}
 				<p className="kp-mecmua-feed__excerpt">{excerpt}</p>

--- a/apps/web/src/pages/MecmuaFeedPage.tsx
+++ b/apps/web/src/pages/MecmuaFeedPage.tsx
@@ -1,0 +1,132 @@
+/**
+ * `/mecmua/akis` — the subscribed-author feed (#2500, epic #2467): a time-ordered list of
+ * published mecmua posts from the authors the reader follows, newest-first by
+ * `publishedAt`. Reads the `mecmuaFeed` fate root in one batched `useRequest` and renders
+ * each post as a card linking to its reader page (`/mecmua/:slug`) — the same Card /
+ * EmptyState / MetaRow shell the public index (#2512) uses, so the two mecmua surfaces read
+ * as one family. On-site reading only — there is NO email/bülten path here by design (map
+ * #2467/#2466).
+ *
+ * The whole surface ships dark behind `MECMUA_FEED` (default-off): the page self-gates
+ * (off ⇒ 404), mirroring `MecmuaPostPage`, so the route is absent until a human flips the
+ * flag at release (ADR 0083). The `mecmuaFeed` root also serves empty while the flag is
+ * off, so no unreleased feed content leaks even if the page is reached.
+ */
+import {Newspaper} from "lucide-react";
+import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import {Link} from "react-router";
+import type {MecmuaPost} from "../../worker/features/fate/views";
+import {Icon} from "../components/Icon";
+import {Card} from "../components/ui/Card";
+import {EmptyState} from "../components/ui/EmptyState";
+import {MetaRow} from "../components/ui/MetaRow";
+import {Screen} from "../fate/Screen";
+import {toIso} from "../fate/wire";
+import {MECMUA_FEED} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
+import {formatAgoTR} from "../lib/datetime";
+import {NotFoundPage} from "./NotFoundPage";
+import "./MecmuaFeedPage.css";
+
+const MecmuaFeedPostView = view<MecmuaPost>()({
+	id: true,
+	slug: true,
+	title: true,
+	body: true,
+	publishedAt: true,
+});
+
+/** A connection "view" is a plain `{items: {node: View}}` selection, not a `view<T>()`. */
+const FeedConnectionView = {items: {node: MecmuaFeedPostView}} as const;
+
+const FEED_PAGE_SIZE = 20;
+
+const feedRequest = {
+	mecmuaFeed: {list: FeedConnectionView, args: {first: FEED_PAGE_SIZE}},
+} as const;
+
+export function MecmuaFeedPage() {
+	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_FEED, false);
+
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
+	// MecmuaPostPage self-gate idiom).
+	if (flagLoading) {
+		return (
+			<div className="kp-page">
+				<div className="kp-page__inner">
+					<p className="kp-mecmua-feed__status">yükleniyor…</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!flagOn) return <NotFoundPage />;
+
+	return (
+		<div className="kp-page">
+			<div className="kp-page__inner">
+				<header className="kp-mecmua-feed__head">
+					<h1 className="kp-mecmua-feed__title">mecmua</h1>
+					<p className="kp-mecmua-feed__lede">takip ettiğin yazarların son yazıları.</p>
+				</header>
+				<Screen
+					fallback={<p className="kp-mecmua-feed__status">yükleniyor…</p>}
+					error={({code}) => (
+						<p className="kp-mecmua-feed__status" role="alert">
+							akış yüklenemedi: {code.toLowerCase()}
+						</p>
+					)}
+				>
+					<MecmuaFeedList />
+				</Screen>
+			</div>
+		</div>
+	);
+}
+
+function MecmuaFeedList() {
+	const {mecmuaFeed} = useRequest(feedRequest);
+	const [items] = useListView(FeedConnectionView, mecmuaFeed);
+
+	if (items.length === 0) {
+		return (
+			<EmptyState
+				icon={<Icon icon={Newspaper} size={24} />}
+				title="henüz akışında yazı yok"
+				description="birkaç yazar takip et, yazıları burada belirsin."
+			/>
+		);
+	}
+
+	return (
+		<ol className="kp-mecmua-feed">
+			{items.map(({node}) => (
+				<MecmuaFeedRow key={String(node.id)} node={node} />
+			))}
+		</ol>
+	);
+}
+
+function MecmuaFeedRow({node}: {node: ViewRef<"MecmuaPost">}) {
+	const post = useView(MecmuaFeedPostView, node);
+	// The reader page is keyed by slug or id; a draft-less feed row is always published,
+	// so `slug ?? id` always resolves to a readable `/mecmua/:key`.
+	const href = `/mecmua/${encodeURIComponent(post.slug ?? String(post.id))}`;
+	const excerpt = post.body.length > 240 ? `${post.body.slice(0, 240).trimEnd()}…` : post.body;
+
+	return (
+		<Card as="li" interactive className="kp-mecmua-feed__item">
+			<Link to={href} className="kp-mecmua-feed__link">
+				<h2 className="kp-mecmua-feed__row-title">{post.title}</h2>
+				{post.publishedAt ? (
+					<MetaRow as="div" className="kp-mecmua-feed__meta">
+						<time dateTime={toIso(post.publishedAt)}>
+							{formatAgoTR(toIso(post.publishedAt))}
+						</time>
+					</MetaRow>
+				) : null}
+				<p className="kp-mecmua-feed__excerpt">{excerpt}</p>
+			</Link>
+		</Card>
+	);
+}

--- a/apps/web/worker/db/drizzle/migrations/0026_mecmua_subscription.sql
+++ b/apps/web/worker/db/drizzle/migrations/0026_mecmua_subscription.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `mecmua_subscription` (
+	`author_id` text NOT NULL,
+	`subscriber_id` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`subscriber_id`, `author_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `mecmua_subscription_subscriber` ON `mecmua_subscription` (`subscriber_id`,"created_at" DESC);

--- a/apps/web/worker/db/drizzle/migrations/meta/0026_mecmua_subscription_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0026_mecmua_subscription_snapshot.json
@@ -1,0 +1,2205 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2ca9b1dc-a732-47a0-89d4-0d3858e5f1aa",
+  "prevId": "c58c76f5-8830-4078-9784-b67f2e2afce2",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        },
+        "post_record_sandboxed": {
+          "name": "post_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\u00e7aylak'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wave_id": {
+          "name": "wave_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "content_report_wave": {
+          "name": "content_report_wave",
+          "columns": [
+            "wave_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        },
+        "definition_record_sandboxed": {
+          "name": "definition_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_sandboxed": {
+          "name": "comment_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authorship_vouch": {
+      "name": "authorship_vouch",
+      "columns": {
+        "voucher_id": {
+          "name": "voucher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authorship_vouch_candidate": {
+          "name": "authorship_vouch_candidate",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "authorship_vouch_voucher_id_candidate_id_pk": {
+          "name": "authorship_vouch_voucher_id_candidate_id_pk",
+          "columns": [
+            "voucher_id",
+            "candidate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_recipient_read": {
+          "name": "notification_recipient_read",
+          "columns": [
+            "recipient_id",
+            "read_at"
+          ],
+          "isUnique": false
+        },
+        "notification_recipient_created": {
+          "name": "notification_recipient_created",
+          "columns": [
+            "recipient_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_reaction": {
+      "name": "user_reaction",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_reaction_target": {
+          "name": "user_reaction_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_reaction_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_reaction_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_ban_event": {
+      "name": "user_ban_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_ban_event_user_created": {
+          "name": "user_ban_event_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_ban_event_user_id_user_id_fk": {
+          "name": "user_ban_event_user_id_user_id_fk",
+          "tableFrom": "user_ban_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mecmua_post": {
+      "name": "mecmua_post",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mecmua_post_author_created": {
+          "name": "mecmua_post_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mecmua_subscription": {
+      "name": "mecmua_subscription",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mecmua_subscription_subscriber": {
+          "name": "mecmua_subscription_subscriber",
+          "columns": [
+            "subscriber_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "mecmua_subscription_subscriber_id_author_id_pk": {
+          "columns": [
+            "subscriber_id",
+            "author_id"
+          ],
+          "name": "mecmua_subscription_subscriber_id_author_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "user_ban_event_user_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "mecmua_post_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "mecmua_subscription_subscriber": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1794500000000,
       "tag": "0025_mecmua_post",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1795000000000,
+      "tag": "0026_mecmua_subscription",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -522,3 +522,29 @@ export const mecmuaPost = sqliteTable(
 		index("mecmua_post_author_created").on(t.authorId, sql`${t.createdAt} DESC`),
 	],
 );
+
+/**
+ * The mecmua subscribed-author edge (#2500, epic #2467) — the reader→author
+ * follow relation the subscribed-author time feed reads to select authors. One row
+ * per (subscriber, author) pair: `subscriber_id` follows `author_id`. Deliberately
+ * MINIMAL (v1) — no display name, no notification prefs, no named-publication scope;
+ * just the edge the feed keysets over. A dedicated table (not the generic
+ * `relation_tuple`, which has no runtime write path) so the feed join is a plain
+ * index read and the subscribe/unsubscribe writes are ordinary D1-direct mutations.
+ * Worker-private, so it lives here and not the shared `@kampus/db-schema` leaf.
+ */
+export const mecmuaSubscription = sqliteTable(
+	"mecmua_subscription",
+	{
+		authorId: text("author_id").notNull(),
+		subscriberId: text("subscriber_id").notNull(),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(t) => [
+		// The edge identity — one subscription per (subscriber, author); a re-subscribe is
+		// an idempotent no-op, not a duplicate row.
+		primaryKey({columns: [t.subscriberId, t.authorId]}),
+		// WHERE subscriber_id = ? — the feed's "which authors does this reader follow" read.
+		index("mecmua_subscription_subscriber").on(t.subscriberId, sql`${t.createdAt} DESC`),
+	],
+);

--- a/apps/web/worker/features/fate-live/fanned-mutations.ts
+++ b/apps/web/worker/features/fate-live/fanned-mutations.ts
@@ -281,4 +281,16 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 		fanned: false,
 		rationale: "writes the caller's private mecmua draft row — no subscribed connection",
 	},
+	{
+		key: "mecmua.subscribe",
+		fanned: false,
+		rationale:
+			"writes the caller's private reader→author subscription edge; the `mecmuaFeed` connection is per-viewer subscribe-only, so a publish onto its login-blind shared topic would leak viewer-private membership — no cross-client fan-out",
+	},
+	{
+		key: "mecmua.unsubscribe",
+		fanned: false,
+		rationale:
+			"clears the caller's private reader→author subscription edge; per-viewer `mecmuaFeed` connection, same no-leak rationale as `mecmua.subscribe`",
+	},
 ];

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -30,8 +30,8 @@ export {
 } from "../divan/views.ts";
 export type {FunnelSummary} from "../funnel/views.ts";
 export {funnelSummaryDataView} from "../funnel/views.ts";
-export type {MecmuaPost} from "../mecmua/views.ts";
-export {mecmuaPostDataView} from "../mecmua/views.ts";
+export type {MecmuaPost, MecmuaSubscriptionReceipt} from "../mecmua/views.ts";
+export {mecmuaPostDataView, mecmuaSubscriptionReceiptDataView} from "../mecmua/views.ts";
 export type {Comment, Post, PostOverlay, Tag} from "../pano/views.ts";
 export {
 	commentDataView,

--- a/apps/web/worker/features/flagship/mecmua-feed.invariant.test.ts
+++ b/apps/web/worker/features/flagship/mecmua-feed.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the mecmua subscribed-author feed
+ * flag (#2500, epic #2467). Inspected off the exported `MECMUA_FEED_FLAG` record (the
+ * same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
+ * constructed — mirrors `mecmua-write.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {MECMUA_FEED} from "../../../src/flags/keys.ts";
+import {MECMUA_FEED_FLAG, mecmuaFeedFlag} from "./resources.ts";
+
+describe("mecmua-feed — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(MECMUA_FEED_FLAG.defaultVariation, "off");
+		assert.strictEqual(MECMUA_FEED_FLAG.variations.off, false);
+		assert.strictEqual(MECMUA_FEED_FLAG.variations.on, true);
+		assert.strictEqual(MECMUA_FEED_FLAG.key, "mecmua-feed");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(MECMUA_FEED_FLAG.key, MECMUA_FEED);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof mecmuaFeedFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -11,6 +11,7 @@
 import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import {
+	MECMUA_FEED,
 	MECMUA_PUBLIC_READ,
 	MECMUA_WRITE,
 	PANO_BASE_FEED,
@@ -265,6 +266,37 @@ export const MECMUA_WRITE_FLAG = {
  */
 export const mecmuaWriteFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("mecmua_write", {appId, ...MECMUA_WRITE_FLAG});
+
+/**
+ * The mecmua subscribed-author feed dark-ship flag config (#2500, epic #2467). The
+ * SINGLE seam the feed surface gates behind — the `mecmuaFeed` list root (empty when
+ * off), the `mecmua.subscribe` / `mecmua.unsubscribe` mutations, and the `/mecmua` feed
+ * page. Default-OFF so the whole feed path reaches production dark; flipping it on is the
+ * human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
+ *
+ * Per-flag metadata (`.patterns/feature-flags-schema-lifecycle.md`):
+ *   - owner:           mecmua (the long-form feed surface)
+ *   - originating:     #2500 (epic: mecmua v1 post feature, #2467)
+ *   - removal trigger: once the mecmua feed is on at 100% and stable for one release,
+ *                      retire the flag and inline the feed root + page.
+ */
+export const MECMUA_FEED_FLAG = {
+	key: MECMUA_FEED,
+	description:
+		"mecmua subscribed-author feed (mecmuaFeed root + subscribe/unsubscribe + feed page) dark-ship (#2500, epic #2467). owner: mecmua. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (mirrors `mecmuaWriteFlag`).
+ */
+export const mecmuaFeedFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("mecmua_feed", {appId, ...MECMUA_FEED_FLAG});
 
 /**
  * The earned-authorship loop (çaylak→yazar) dark-ship flag config (#1204, epic

--- a/apps/web/worker/features/mecmua/Mecmua.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.ts
@@ -20,11 +20,22 @@
  */
 
 import {id} from "@usirin/forge";
-import {and, eq} from "drizzle-orm";
+import {and, eq, inArray} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import {
+	emptyKeysetPage,
+	forwardPage,
+	type KeysetPage,
+	keysetAfter,
+	resolveCursor,
+} from "../../db/keyset.ts";
+import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import {MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.ts";
+import {selectMecmuaFeed} from "./feed-selection.ts";
+import {anonymousMecmuaViewer, mecmuaPostVisibleWhere} from "./MecmuaPostVisibility.ts";
+import {MECMUA_FEED_ORDERING} from "./ordering.ts";
 import {type MecmuaPostRow, toMecmuaPostRow} from "./post-fields.ts";
 
 export interface SaveMecmuaDraftInput {
@@ -42,6 +53,28 @@ export interface PublishMecmuaInput {
 	authorId: string;
 }
 
+/** One reader→author subscription edge (#2500). */
+export interface MecmuaSubscriptionInput {
+	/** The reader who follows. */
+	subscriberId: string;
+	/** The author followed. */
+	authorId: string;
+}
+
+/** The subscribed-author feed page request — `subscriberId` + forward keyset window. */
+export interface MecmuaFeedInput {
+	subscriberId: string;
+	first?: number;
+	after?: string | null;
+}
+
+/** A forward page of the subscribed-author feed — plain `MecmuaPostRow`s, keyset-ordered. */
+export type MecmuaFeedPage = KeysetPage<MecmuaPostRow>;
+
+/** The feed page size default + clamp bound (mirrors the pano feed clamp). */
+const FEED_DEFAULT_FIRST = 20;
+const FEED_MAX_FIRST = 100;
+
 export class Mecmua extends Context.Service<
 	Mecmua,
 	{
@@ -49,6 +82,25 @@ export class Mecmua extends Context.Service<
 		readonly publish: (
 			input: PublishMecmuaInput,
 		) => Effect.Effect<MecmuaPostRow, MecmuaPostNotFound | MecmuaTitleRequired>;
+
+		/** Follow an author (#2500). Idempotent — a re-subscribe is a no-op, never a dup row. */
+		readonly subscribe: (input: MecmuaSubscriptionInput) => Effect.Effect<void>;
+
+		/** Unfollow an author (#2500). A miss is a no-op. */
+		readonly unsubscribe: (input: MecmuaSubscriptionInput) => Effect.Effect<void>;
+
+		/** The author ids a reader is subscribed to — the feed's author-selection edge read. */
+		readonly listSubscribedAuthorIds: (
+			subscriberId: string,
+		) => Effect.Effect<ReadonlyArray<string>>;
+
+		/**
+		 * The subscribed-author time feed (#2500): a forward keyset page of PUBLISHED
+		 * mecmua posts from the reader's subscribed authors, ordered `publishedAt desc, id
+		 * desc` (newest-first). Drafts never appear (the `MecmuaPostVisibility` published
+		 * mask); a reader with no subscriptions gets an empty page.
+		 */
+		readonly listFeedConnection: (input: MecmuaFeedInput) => Effect.Effect<MecmuaFeedPage>;
 	}
 >()("mecmua/Mecmua") {}
 
@@ -103,6 +155,111 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 			return toMecmuaPostRow({...existing, publishedAt, updatedAt: now});
 		});
 
-		return {saveDraft, publish};
+		const subscribe = Effect.fn("Mecmua.subscribe")(function* (input: MecmuaSubscriptionInput) {
+			// Idempotent: the (subscriber, author) primary key makes a re-subscribe a no-op
+			// rather than a duplicate-key failure — one follow edge, at most.
+			yield* run((db) =>
+				db
+					.insert(schema.mecmuaSubscription)
+					.values({
+						subscriberId: input.subscriberId,
+						authorId: input.authorId,
+						createdAt: new Date(),
+					})
+					.onConflictDoNothing(),
+			);
+		});
+
+		const unsubscribe = Effect.fn("Mecmua.unsubscribe")(function* (input: MecmuaSubscriptionInput) {
+			yield* run((db) =>
+				db
+					.delete(schema.mecmuaSubscription)
+					.where(
+						and(
+							eq(schema.mecmuaSubscription.subscriberId, input.subscriberId),
+							eq(schema.mecmuaSubscription.authorId, input.authorId),
+						),
+					),
+			);
+		});
+
+		const listSubscribedAuthorIds = Effect.fn("Mecmua.listSubscribedAuthorIds")(function* (
+			subscriberId: string,
+		) {
+			const rows = yield* run((db) =>
+				db
+					.select({authorId: schema.mecmuaSubscription.authorId})
+					.from(schema.mecmuaSubscription)
+					.where(eq(schema.mecmuaSubscription.subscriberId, subscriberId)),
+			);
+			return rows.map((r) => r.authorId);
+		});
+
+		const listFeedConnection = Effect.fn("Mecmua.listFeedConnection")(function* (
+			input: MecmuaFeedInput,
+		) {
+			const first = Math.max(1, Math.min(input.first ?? FEED_DEFAULT_FIRST, FEED_MAX_FIRST));
+			const after = input.after ?? null;
+
+			const authorIds = yield* listSubscribedAuthorIds(input.subscriberId);
+			// No subscriptions ⇒ no feed. Short-circuit before any post read (and avoid an
+			// empty `IN ()`), returning the shared empty page.
+			if (authorIds.length === 0) return emptyKeysetPage satisfies MecmuaFeedPage;
+
+			// The published mask (drafts excluded for everyone, author included) reused from
+			// `MecmuaPostVisibility` against the anonymous viewer — a feed is a reading surface.
+			const publishedWhere = mecmuaPostVisibleWhere(
+				{publishedAt: schema.mecmuaPost.publishedAt, authorId: schema.mecmuaPost.authorId},
+				anonymousMecmuaViewer,
+			);
+			const baseWhere = and(inArray(schema.mecmuaPost.authorId, authorIds), publishedWhere);
+
+			// Resolve the `after` cursor to its `publishedAt` anchor, gated by the SAME
+			// published mask so a cursor naming a now-draft/absent row misses → empty page.
+			const resolvedRow = after
+				? ((yield* run((db) =>
+						db
+							.select({publishedAt: schema.mecmuaPost.publishedAt})
+							.from(schema.mecmuaPost)
+							.where(and(eq(schema.mecmuaPost.id, after), publishedWhere))
+							.get(),
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor(after, resolvedRow);
+			if (cursor.kind === "miss") return emptyKeysetPage satisfies MecmuaFeedPage;
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
+
+			// Predicate + `orderBy` both derive from `MECMUA_FEED_ORDERING`; the opaque `id`
+			// cursor value is the `after` string (the anchor row carries only `publishedAt`).
+			const cursorPredicate = keysetAfter(
+				keysetKeys(MECMUA_FEED_ORDERING, (field) =>
+					field === "id" ? after : (cursorRow?.publishedAt ?? null),
+				),
+			);
+
+			const fetched = yield* run((db) =>
+				db
+					.select()
+					.from(schema.mecmuaPost)
+					.where(cursorPredicate ? and(baseWhere, cursorPredicate) : baseWhere)
+					.orderBy(...orderByColumns(MECMUA_FEED_ORDERING))
+					.limit(first + 1),
+			);
+
+			// The published-mask + ordering are enforced authoritatively in JS here (the SQL
+			// above mirrors them for an index-friendly pre-filter), so the feed's two ACs hold
+			// on the served path, not only in the query planner — see `feed-selection.ts`.
+			const selected = selectMecmuaFeed(fetched.map(toMecmuaPostRow), new Set(authorIds));
+			return forwardPage(selected, first, (r) => r.id) satisfies MecmuaFeedPage;
+		});
+
+		return {
+			saveDraft,
+			publish,
+			subscribe,
+			unsubscribe,
+			listSubscribedAuthorIds,
+			listFeedConnection,
+		};
 	}),
 );

--- a/apps/web/worker/features/mecmua/fate-module.ts
+++ b/apps/web/worker/features/mecmua/fate-module.ts
@@ -1,16 +1,30 @@
 /** mecmua's contribution to the one fate config. See `../fate/module.ts`. */
 import {Fate} from "@kampus/fate-effect";
-import type {FateModule} from "../fate/module.ts";
+import {list} from "@nkzw/fate/server";
+import {viewOrderBy} from "../../db/ordering.ts";
+import type {FateModule, FateRootsRecord} from "../fate/module.ts";
+import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
-import {MecmuaPostView} from "./views.ts";
+import {MECMUA_FEED_ORDERING} from "./ordering.ts";
+import {MecmuaPostView, MecmuaSubscriptionReceiptView, mecmuaPostDataView} from "./views.ts";
 
-// The write path returns `MecmuaPostView` inline, so the entity needs a source to be
-// view-reachable in codegen. A `syntheticSource` (no by-id fetch path) is the minimal
-// write-lane footprint — the mutation delivers the row in its response, no re-fetch.
-// The read path (#2498) replaces this with the real byIds `mecmuaPostSource`.
+// The write path + feed both return `MecmuaPostView` inline, so the entity needs a
+// source to be view-reachable in codegen. A `syntheticSource` (no by-id fetch path) is
+// the minimal footprint — the mutation/feed resolver delivers the rows in its response.
 const mecmuaPostSource = Fate.syntheticSource(MecmuaPostView);
+// The subscribe/unsubscribe receipt is delivered inline by its mutation (#2500).
+const mecmuaSubscriptionReceiptSource = Fate.syntheticSource(MecmuaSubscriptionReceiptView);
+
+const roots: FateRootsRecord = {
+	// The subscribed-author time feed (#2500). The `mecmuaFeed` resolver owns the order
+	// (`publishedAt desc, id desc`, single-sourced from `MECMUA_FEED_ORDERING`) + the
+	// published mask + the subscribed-author selection.
+	mecmuaFeed: list(mecmuaPostDataView, {orderBy: viewOrderBy(MECMUA_FEED_ORDERING)}),
+};
 
 export const fateModule = {
+	lists,
 	mutations,
-	sources: [mecmuaPostSource],
+	sources: [mecmuaPostSource, mecmuaSubscriptionReceiptSource],
+	roots,
 } satisfies FateModule;

--- a/apps/web/worker/features/mecmua/feed-selection.ts
+++ b/apps/web/worker/features/mecmua/feed-selection.ts
@@ -1,0 +1,47 @@
+/**
+ * The subscribed-author feed's pure selection decision (#2500) — DB-free, so the
+ * two load-bearing feed ACs are unit-provable with no SQL engine (ADR 0082, the
+ * `src/lib/panoFeedSort.ts` role): given a candidate row set and the reader's
+ * subscribed author ids, keep only the PUBLISHED posts authored by a subscribed
+ * author and order them newest-published-first (`publishedAt desc, id desc`).
+ *
+ * `Mecmua.listFeedConnection` runs this over the rows its keyset SQL fetched, so the
+ * feed's published-mask + ordering are enforced HERE (in JS), the same guarantee the
+ * SQL `WHERE`/`ORDER BY` (derived from `MecmuaPostVisibility` + `MECMUA_FEED_ORDERING`)
+ * mirror. Draft exclusion reuses `mecmuaPostVisibleTo` against the anonymous viewer —
+ * a null `publishedAt` (draft) is masked from the feed for everyone, its author
+ * included (the feed is a reading surface, not a drafts list).
+ */
+import {anonymousMecmuaViewer, mecmuaPostVisibleTo} from "./MecmuaPostVisibility.ts";
+import type {MecmuaPostRow} from "./post-fields.ts";
+
+/**
+ * Select the subscribed-author feed from `rows`: published posts whose author is in
+ * `subscribedAuthorIds`, newest-published first (ties broken by descending `id`).
+ * Pure and total — no DB, no clock.
+ */
+export const selectMecmuaFeed = (
+	rows: ReadonlyArray<MecmuaPostRow>,
+	subscribedAuthorIds: ReadonlySet<string>,
+): MecmuaPostRow[] =>
+	rows
+		.filter(
+			(row) =>
+				subscribedAuthorIds.has(row.authorId) &&
+				// The published mask — a draft (null `publishedAt`) never appears in the feed,
+				// reusing the same decision the public read applies (`MecmuaPostVisibility`).
+				mecmuaPostVisibleTo(row.publishedAt, row.authorId, anonymousMecmuaViewer),
+		)
+		.sort(compareFeedRows);
+
+/**
+ * The `publishedAt desc, id desc` comparator — the JS mirror of `MECMUA_FEED_ORDERING`.
+ * A filtered feed row always has a non-null `publishedAt` (the mask dropped the drafts),
+ * so the `?? 0` fallbacks are unreachable defense, never a live branch.
+ */
+const compareFeedRows = (a: MecmuaPostRow, b: MecmuaPostRow): number => {
+	const at = a.publishedAt?.getTime() ?? 0;
+	const bt = b.publishedAt?.getTime() ?? 0;
+	if (at !== bt) return bt - at;
+	return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+};

--- a/apps/web/worker/features/mecmua/lists.ts
+++ b/apps/web/worker/features/mecmua/lists.ts
@@ -1,0 +1,65 @@
+/**
+ * mecmua root list resolvers (#2500, epic #2467). `mecmuaFeed` is the subscribed-author
+ * time feed: a `CurrentUser`-scoped connection of PUBLISHED `MecmuaPostView` edges from
+ * the reader's subscribed authors, ordered `publishedAt desc` (newest-first). Per ADR
+ * 0019 the service owns the keyset + cursor (`Mecmua.listFeedConnection`); this layer
+ * only reshapes the page into a `ConnectionResult`, mirroring pano's `savedPosts`
+ * (per-viewer, signed-out → empty). See `.patterns/fate-connections.md`.
+ *
+ * Dark behind the default-off `MECMUA_FEED` flag (ADR 0083): with it off the resolver
+ * serves an empty connection, so the whole feed surface ships dark until a human flips
+ * the flag at release — the same containment the mecmua write/read paths use.
+ */
+import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {MECMUA_FEED} from "../../../src/flags/keys.ts";
+import {emptyKeysetPage} from "../../db/keyset.ts";
+import {toConnection} from "../fate/connection.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
+import {Mecmua, type MecmuaFeedPage} from "./Mecmua.ts";
+import type {MecmuaPostRow} from "./post-fields.ts";
+import type {MecmuaPost} from "./views.ts";
+import {MecmuaPostView} from "./views.ts";
+
+const MecmuaFeedArgs = Schema.Struct({
+	first: Schema.optional(Schema.Number),
+	after: Schema.optional(Schema.String),
+});
+
+/** Stamp the wire `__typename` onto a feed row — the one feed-read shaper. */
+const toMecmuaPost = (r: MecmuaPostRow): MecmuaPost => ({__typename: "MecmuaPost", ...r});
+
+const feedConnection = (page: MecmuaFeedPage) =>
+	toConnection<MecmuaPostRow, MecmuaPost>(
+		page,
+		(row) => row.id,
+		(row) => toMecmuaPost(row),
+	);
+
+/** Is the mecmua feed on for this request? Safe-default `false` (ships dark). */
+const feedOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(MECMUA_FEED, false).pipe(provideRequestFlags);
+});
+
+export const lists = {
+	mecmuaFeed: Fate.list(
+		{args: MecmuaFeedArgs, type: MecmuaPostView},
+		Effect.fn("mecmuaFeed")(function* ({args}) {
+			// Flag off OR signed-out ⇒ empty feed: the surface is dark until release, and an
+			// anonymous reader subscribes to no one, so there is nothing to serve either way.
+			const {user} = yield* CurrentUser;
+			if (!user || !(yield* feedOn)) return feedConnection(emptyKeysetPage);
+
+			const mecmua = yield* Mecmua;
+			const page = yield* mecmua.listFeedConnection({
+				subscriberId: user.id,
+				...(args.first !== undefined ? {first: args.first} : {}),
+				...(args.after !== undefined ? {after: args.after} : {}),
+			});
+			return feedConnection(page);
+		}),
+	),
+};

--- a/apps/web/worker/features/mecmua/mecmua-feed.unit.test.ts
+++ b/apps/web/worker/features/mecmua/mecmua-feed.unit.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit — the subscribed-author feed's two load-bearing ACs (#2500), proven with no DB
+ * (ADR 0082): (a) the feed returns PUBLISHED posts from SUBSCRIBED authors ordered by
+ * `publishedAt` newest-first, and (b) draft/unpublished posts NEVER appear. Both are
+ * proven twice: on the pure `selectMecmuaFeed` decision (the DB-free spec) AND on the
+ * served `Mecmua.listFeedConnection` path over a scripted `Drizzle` seam (the `Bookmark`
+ * / `Mecmua.unit.test.ts` idiom), so the guarantee holds where the feed is served, not
+ * only in a helper.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import type * as schema from "../../db/drizzle/schema.ts";
+import {selectMecmuaFeed} from "./feed-selection.ts";
+import {Mecmua, MecmuaLive} from "./Mecmua.ts";
+import type {MecmuaPostRow} from "./post-fields.ts";
+
+type MecmuaRecord = typeof schema.mecmuaPost.$inferSelect;
+
+const post = (over: Partial<MecmuaRecord> & {id: string}): MecmuaRecord => ({
+	slug: null,
+	title: `başlık ${over.id}`,
+	body: "gövde",
+	authorId: "A",
+	publishedAt: null,
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+	...over,
+});
+
+const AT = (iso: string) => new Date(iso);
+
+// Author A (subscribed) + B (subscribed) publish; A also has a draft; C (NOT subscribed)
+// publishes. The feed should be [B-May, A-Mar] — newest published first, drafts + C gone.
+const rows: MecmuaRecord[] = [
+	post({id: "a-mar", authorId: "A", publishedAt: AT("2026-03-01T00:00:00.000Z")}),
+	post({id: "b-may", authorId: "B", publishedAt: AT("2026-05-01T00:00:00.000Z")}),
+	post({id: "a-draft", authorId: "A", publishedAt: null}),
+	post({id: "c-apr", authorId: "C", publishedAt: AT("2026-04-01T00:00:00.000Z")}),
+];
+
+const toRow = (r: MecmuaRecord): MecmuaPostRow => ({...r});
+
+describe("selectMecmuaFeed — the pure feed decision (ordering + draft mask)", () => {
+	const subscribed = new Set(["A", "B"]);
+
+	it("orders subscribed-author PUBLISHED posts by publishedAt newest-first", () => {
+		const feed = selectMecmuaFeed(rows.map(toRow), subscribed);
+		assert.deepStrictEqual(
+			feed.map((r) => r.id),
+			["b-may", "a-mar"],
+		);
+	});
+
+	it("NEVER includes a draft (null publishedAt), even from a subscribed author", () => {
+		const feed = selectMecmuaFeed(rows.map(toRow), subscribed);
+		assert.isFalse(feed.some((r) => r.id === "a-draft"));
+		assert.isTrue(feed.every((r) => r.publishedAt !== null));
+	});
+
+	it("excludes a non-subscribed author's published post", () => {
+		const feed = selectMecmuaFeed(rows.map(toRow), subscribed);
+		assert.isFalse(feed.some((r) => r.id === "c-apr"));
+	});
+
+	it("breaks a publishedAt tie by descending id (stable keyset order)", () => {
+		const tie = AT("2026-06-01T00:00:00.000Z");
+		const feed = selectMecmuaFeed(
+			[
+				post({id: "x1", authorId: "A", publishedAt: tie}),
+				post({id: "x2", authorId: "A", publishedAt: tie}),
+			].map(toRow),
+			new Set(["A"]),
+		);
+		assert.deepStrictEqual(
+			feed.map((r) => r.id),
+			["x2", "x1"],
+		);
+	});
+});
+
+/** A `Drizzle` whose `run` replays a queued result sequence; `batch` is unused here. */
+const scriptedAccess = (results: ReadonlyArray<unknown>): DrizzleAccess => {
+	const state = {i: 0};
+	return {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			void fn;
+			return Effect.succeed(results[state.i++] as A);
+		},
+		batch: () => Effect.die(new Error("mecmua feed reads use run(), never batch()")),
+	};
+};
+
+const mecmuaLayer = (access: DrizzleAccess) =>
+	MecmuaLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+describe("Mecmua.listFeedConnection — the served feed path", () => {
+	// Call order of `run`: (1) subscribed author ids, (2) fetch candidate posts (no `after`).
+	const subscribedRows = [{authorId: "A"}, {authorId: "B"}];
+
+	it.effect("returns subscribed-author published posts ordered publishedAt newest-first", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const page = yield* mecmua.listFeedConnection({subscriberId: "reader"});
+			assert.deepStrictEqual(
+				page.rows.map((r) => r.id),
+				["b-may", "a-mar"],
+			);
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([subscribedRows, rows])))),
+	);
+
+	it.effect("excludes drafts and non-subscribed authors from the served page", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const page = yield* mecmua.listFeedConnection({subscriberId: "reader"});
+			assert.isFalse(page.rows.some((r) => r.id === "a-draft"));
+			assert.isFalse(page.rows.some((r) => r.id === "c-apr"));
+			assert.isTrue(page.rows.every((r) => r.publishedAt !== null));
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([subscribedRows, rows])))),
+	);
+
+	it.effect("a reader with no subscriptions gets an empty page (no post read)", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const page = yield* mecmua.listFeedConnection({subscriberId: "loner"});
+			assert.deepStrictEqual(page.rows, []);
+			assert.isFalse(page.hasNextPage);
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([[]])))),
+	);
+});

--- a/apps/web/worker/features/mecmua/mutations.ts
+++ b/apps/web/worker/features/mecmua/mutations.ts
@@ -20,7 +20,7 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
-import {MECMUA_WRITE} from "../../../src/flags/keys.ts";
+import {MECMUA_FEED, MECMUA_WRITE} from "../../../src/flags/keys.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {RequiresLevel} from "../kunye/errors.ts";
@@ -28,8 +28,8 @@ import {MecmuaDisabled, MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.
 import {Mecmua} from "./Mecmua.ts";
 import {PublishMecmua, requirePublishMecmua} from "./PublishMecmua.ts";
 import type {MecmuaPostRow} from "./post-fields.ts";
-import type {MecmuaPost} from "./views.ts";
-import {MecmuaPostView} from "./views.ts";
+import type {MecmuaPost, MecmuaSubscriptionReceipt} from "./views.ts";
+import {MecmuaPostView, MecmuaSubscriptionReceiptView} from "./views.ts";
 
 /** Is the mecmua write path on for this request? Safe-default `false` (ships dark). */
 const mecmuaOn = Effect.gen(function* () {
@@ -37,8 +37,28 @@ const mecmuaOn = Effect.gen(function* () {
 	return yield* flags.getBoolean(MECMUA_WRITE, false).pipe(provideRequestFlags);
 });
 
+/** Is the mecmua feed (subscribe/unsubscribe) on for this request? Safe-default `false`. */
+const feedOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(MECMUA_FEED, false).pipe(provideRequestFlags);
+});
+
 /** Stamp the wire `__typename` onto a service row — the one mecmua write-path shaper. */
 const toMecmuaPost = (r: MecmuaPostRow): MecmuaPost => ({__typename: "MecmuaPost", ...r});
+
+/** The subscribe/unsubscribe receipt shaper — the target author + the post-write edge state. */
+const toSubscriptionReceipt = (
+	authorId: string,
+	subscribed: boolean,
+): MecmuaSubscriptionReceipt => ({
+	__typename: "MecmuaSubscriptionReceipt",
+	id: authorId,
+	subscribed,
+});
+
+const SubscriptionInput = Schema.Struct({
+	authorId: Schema.String,
+});
 
 const SaveDraftInput = Schema.Struct({
 	title: Schema.optional(Schema.NullOr(Schema.String)),
@@ -100,6 +120,34 @@ export const mutations = {
 				...(input.slug != null ? {slug: input.slug} : {}),
 			});
 			return toMecmuaPost(row);
+		}),
+	),
+	"mecmua.subscribe": Fate.mutation(
+		{
+			input: SubscriptionInput,
+			type: MecmuaSubscriptionReceiptView,
+			error: Schema.Union([Unauthorized, MecmuaDisabled]),
+		},
+		Effect.fn("mecmua.subscribe")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			if (!(yield* feedOn)) return yield* new MecmuaDisabled({message: "mecmua şu an kapalı"});
+			const mecmua = yield* Mecmua;
+			yield* mecmua.subscribe({subscriberId: user.id, authorId: input.authorId});
+			return toSubscriptionReceipt(input.authorId, true);
+		}),
+	),
+	"mecmua.unsubscribe": Fate.mutation(
+		{
+			input: SubscriptionInput,
+			type: MecmuaSubscriptionReceiptView,
+			error: Schema.Union([Unauthorized, MecmuaDisabled]),
+		},
+		Effect.fn("mecmua.unsubscribe")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			if (!(yield* feedOn)) return yield* new MecmuaDisabled({message: "mecmua şu an kapalı"});
+			const mecmua = yield* Mecmua;
+			yield* mecmua.unsubscribe({subscriberId: user.id, authorId: input.authorId});
+			return toSubscriptionReceipt(input.authorId, false);
 		}),
 	),
 };

--- a/apps/web/worker/features/mecmua/ordering.ts
+++ b/apps/web/worker/features/mecmua/ordering.ts
@@ -1,0 +1,19 @@
+/**
+ * mecmua connection orderings the view `orderBy` and the service keyset share
+ * (ADR 0019; see `db/ordering.ts`). Mirrors `features/pano/ordering.ts`, but the
+ * subscribed-author feed is a TIME feed: it orders on `published_at` (newest-first),
+ * not pano's `hot_score`.
+ */
+
+import * as schema from "../../db/drizzle/schema.ts";
+import type {Ordering} from "../../db/ordering.ts";
+
+/**
+ * The subscribed-author feed (`mecmuaFeed`): `publishedAt desc, id desc` — newest
+ * published post first, `id` breaking ties for a stable keyset cursor. Consumed by
+ * the `mecmuaFeed` root's view `orderBy` and `Mecmua.listFeedConnection`'s keyset.
+ */
+export const MECMUA_FEED_ORDERING: Ordering = [
+	{field: "publishedAt", column: schema.mecmuaPost.publishedAt, dir: "desc"},
+	{field: "id", column: schema.mecmuaPost.id, dir: "desc"},
+];

--- a/apps/web/worker/features/mecmua/views.ts
+++ b/apps/web/worker/features/mecmua/views.ts
@@ -21,8 +21,31 @@ export class MecmuaPostView extends FateDataView<MecmuaPostViewRow>()("MecmuaPos
 ) {}
 
 // Kernel view value for the fate `Root` map + cross-feature surfaces (as pano's
-// `postDataView`); no mecmua root is wired yet (#2496 lands storage + read-model only).
+// `postDataView`). The `mecmuaFeed` root (#2500) is a `list(mecmuaPostDataView, …)`.
 export const mecmuaPostDataView = MecmuaPostView.view;
+
+/**
+ * The subscribe/unsubscribe write receipt (#2500) — the minimal shape the
+ * `mecmua.subscribe` / `mecmua.unsubscribe` mutations return (the `NotificationMarkReceipt`
+ * idiom): `id` is the target author, `subscribed` the edge state AFTER the write. A
+ * synthetic view (no fetch path) — the mutation delivers it inline, never re-fetched.
+ */
+export type MecmuaSubscriptionReceiptViewRow = ViewRow<{
+	/** The target author id — the receipt's identity. */
+	id: string;
+	/** The edge state after the write: true ⇒ subscribed, false ⇒ unsubscribed. */
+	subscribed: boolean;
+}>;
+
+export class MecmuaSubscriptionReceiptView extends FateDataView<MecmuaSubscriptionReceiptViewRow>()(
+	"MecmuaSubscriptionReceipt",
+)({
+	id: true,
+	subscribed: true,
+} satisfies {[K in keyof MecmuaSubscriptionReceiptViewRow]: true}) {}
+
+export const mecmuaSubscriptionReceiptDataView = MecmuaSubscriptionReceiptView.view;
+export type MecmuaSubscriptionReceipt = WorkerEntity<typeof MecmuaSubscriptionReceiptView>;
 
 // `createdAt`/`updatedAt`/`publishedAt` ride the standard timestamp correction (wire
 // `string` / `string | null` → `Date` / `Date | null`); `StringToDate` preserves the


### PR DESCRIPTION
## What

A time-ordered **subscribed-author feed** for mecmua (#2500, epic #2467): published mecmua posts from the authors a reader follows, newest-first by `publishedAt`, **on-site reading only** — no email/bülten path (explicitly out of v1 scope, map #2467/#2466).

Mirrors the pano feed connection + ordering single-source idiom (`features/pano/views.ts` / `ordering.ts` / `base-feed-route.ts`), but orders on `publishedAt` (NOT hotScore) and reuses `MecmuaPostVisibility` so drafts never appear.

## How

- **Subscription edge** — a minimal `mecmua_subscription` table (`subscriber_id`, `author_id`, composite PK; migration `0026`). The reader→author follow relation the feed reads to select authors; deliberately *not* a full follow product. Written by `mecmua.subscribe` / `mecmua.unsubscribe` (behind the feed flag), read by `Mecmua.listSubscribedAuthorIds`.
- **Feed connection** — `mecmuaFeed` fate `list` root (CurrentUser-scoped, empty for anon/flag-off), backed by `Mecmua.listFeedConnection`: a forward keyset over `MECMUA_FEED_ORDERING` (`publishedAt desc, id desc`) with the `mecmuaPostVisibleWhere` published mask + `author_id IN (subscribed)`. The pure `selectMecmuaFeed` decision enforces the published mask + ordering on the served path (the `panoFeedSort` DB-free-spec role), so both ACs hold where the feed is served.
- **Feed page** — `/mecmua` React page rendering the time-ordered list, behind the default-off `mecmua-feed` flag (self-404 when off, the `MecmuaPostPage` idiom).
- Both new mutations classified `fanned: false` in `fanned-mutations.ts` (per-viewer subscribe-only connection — a publish would leak viewer-private membership).

## Tests

`worker/features/mecmua/mecmua-feed.unit.test.ts` proves both ACs, on the pure `selectMecmuaFeed` decision AND on the served `Mecmua.listFeedConnection` path (scripted `Drizzle` seam):

- **ordering** — `orders subscribed-author PUBLISHED posts by publishedAt newest-first` + `returns subscribed-author published posts ordered publishedAt newest-first`
- **draft exclusion** — `NEVER includes a draft (null publishedAt), even from a subscribed author` + `excludes drafts and non-subscribed authors from the served page`
- plus non-subscribed-author exclusion, publishedAt-tie → id-desc, and no-subscriptions → empty page.

`worker/features/flagship/mecmua-feed.invariant.test.ts` pins the flag default = safe (off).

Local gate green: `pnpm typecheck`, `pnpm lint`, `fanout-guard check` (44 classified / 24 fanned), `migrations-guard check` (OK), 208 mecmua/flagship/fate-live unit tests.

## Out of scope (v1 horizon)

Email/newsletter delivery, named publications, autopost-to-pano, recommendation/ranking. Identifiers/routes English, copy Turkish.

Fixes #2500

🤖 Generated with [Claude Code](https://claude.com/claude-code)