### PR TITLE
docs(pipeline): move kampus-pipeline README to plugin root + rewrite as a first-timer guide (#2511)

### DIFF
--- a/.decisions/0110-plugin-carries-no-version-continuous-ship.md
+++ b/.decisions/0110-plugin-carries-no-version-continuous-ship.md
@@ -48,7 +48,7 @@ install by git commit SHA, and every commit is the new "version".
   contract. The absence is the correct state.
 - Because `plugin.json` is strict JSON (no comments), the rationale cannot live inline in the
   manifest. The builder-facing note lives in
-  [`claude-plugins/kampus-pipeline/skills/README.md`](../claude-plugins/kampus-pipeline/skills/README.md),
+  [`claude-plugins/kampus-pipeline/README.md`](../claude-plugins/kampus-pipeline/README.md),
   which points at this ADR for the why + history; this ADR is the canonical decision record.
 
 ## Consequences

--- a/.decisions/0171-kampus-pipeline-plugin-spec-conformance.md
+++ b/.decisions/0171-kampus-pipeline-plugin-spec-conformance.md
@@ -92,7 +92,7 @@ against `https://json.schemastore.org/claude-code-marketplace.json` (already cor
    ADR [0087](0087-plugin-dedicated-subdir-source.md) §2 / ADR
    [0062](0062-repo-as-config-plugin.md) §5 arrangement; the full rationale (and the
    accepted in-repo discovery doubling, ADR 0062 §5) is documented in
-   [`claude-plugins/kampus-pipeline/skills/README.md`](../claude-plugins/kampus-pipeline/skills/README.md).
+   [`claude-plugins/kampus-pipeline/README.md`](../claude-plugins/kampus-pipeline/README.md).
 
 6. **The marketplace catalog entry keeps its dedicated-subdir `source`** —
    `"./claude-plugins/kampus-pipeline"` — so an install receives only that subtree, not the

--- a/claude-plugins/kampus-pipeline/README.md
+++ b/claude-plugins/kampus-pipeline/README.md
@@ -8,16 +8,23 @@ each handoff a durable artifact (a label, a comment, a PR) the next stage reads 
 The suite is **repo-agnostic**: install it once and point it at whatever repo you're
 working in.
 
-This directory (`skills/`) is the **canonical home** for the suite and the plugin's
-documented entry point. It holds every `SKILL.md` plus the shared contract doc
-[`gh-issue-intake-formats.md`](gh-issue-intake-formats.md) (the label semantics and the
-body/comment/dependency formats every skill reads and writes).
+**This plugin is the entry point.** You are reading its root README — the front door.
+The skills themselves live one level down in [`skills/`](skills/) (every `SKILL.md` plus
+the shared contract doc [`gh-issue-intake-formats.md`](skills/gh-issue-intake-formats.md),
+which defines the label semantics and the body/comment/dependency formats every skill
+reads and writes). You don't invoke those files directly — you install the plugin and run
+the skills by name (`report`, `triage`, `write-code`, …). The [How the pipeline works](#how-the-pipeline-works)
+section below is the fastest way to understand the whole flow before you touch a skill.
 
-The plugin carries **no per-plugin `version`** (neither in the marketplace plugin entry nor in [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json)): Claude Code then content-addresses the install by git commit SHA, so every commit is a new "version" and skill additions/edits reach already-installed users on the normal update path — a fixed semver pin froze the cache and silently served stale content (#945). This omission is **deliberate, not a defect — do not add a `version`**; the decision record (why + history) is [ADR 0110](https://github.com/kamp-us/phoenix/blob/main/.decisions/0110-plugin-carries-no-version-continuous-ship.md).
+## How the pipeline works
 
-The whole plugin surface was audited against the official Claude Code plugin spec ([plugins reference](https://docs.claude.com/en/docs/claude-code/plugins-reference), [marketplaces](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)); the conformance record — the corrected manifest `$schema` URL plus every deliberate deviation (no `version`, the root-level `hooks.json`, the absent `commands/`, the `.claude/skills` discovery symlink) and its forcing constraint — is [ADR 0171](https://github.com/kamp-us/phoenix/blob/main/.decisions/0171-kampus-pipeline-plugin-spec-conformance.md). A future audit that re-flags any of those reads the disposition there: documented-intentional, not an open defect.
+If you're new here, read this section first. The pipeline is a **conveyor belt for issues**:
+raw work enters at one end and a merged, closed PR comes out the other. Each stage is one
+skill. A stage never keeps state in its head — it writes its output as a GitHub artifact (a
+label, a comment, a PR) that the next stage picks up **cold**, so a fresh agent (or a
+different one) can always continue where the last left off.
 
-## The pipeline
+### The flow
 
 The core flow runs left to right; each stage consumes the previous stage's output:
 
@@ -25,32 +32,51 @@ The core flow runs left to right; each stage consumes the previous stage's outpu
 report → triage → plan-epic → review-plan → write-code → review-code / review-doc / review-skill → ship-it
 ```
 
-- **`report`** files raw intake (`status:needs-triage`).
-- **`triage`** classifies, prioritizes, and either splits an epic or marks an issue
-  `status:triaged` (pickable).
-- **`plan-epic`** turns a triaged epic into a child-issue ledger with a `## Dependencies`
-  topology; **`review-plan`** gates that ledger and flips its children to `status:triaged`.
-- **`write-code`** picks the next triaged issue, implements it on a branch, and opens a PR.
-- **`review-code`** (code PRs) / **`review-doc`** (doc PRs) / **`review-skill`** (skill PRs)
-  verify the PR against its issue's acceptance criteria — `review-doc` adds a doc-hygiene
-  checklist, `review-skill` adds a behavioral-rigor checklist — and emit a PASS/FAIL verdict;
-  `write-code` consumes a FAIL and re-submits; the loop is bounded. The three split on
-  artifact class (code / docs / skills — ADR 0073, superseding 0063's `skills/**` →
-  `review-code` routing).
-- **`ship-it`** is the only skill with merge authority: on a PASS verdict + green CI it
-  squash-merges, closing the linked issue.
+### What each stage consumes and emits
 
-Three skills run **standalone**, outside the linear flow:
+| Stage | Consumes | Emits |
+|-------|----------|-------|
+| **`report`** | A raw observation (a bug, a refactor, a missing test) | A type-blind issue labelled `status:needs-triage` |
+| **`triage`** | A `status:needs-triage` issue | Either a `status:triaged` issue (classified + prioritized, pickable) or an epic to be planned |
+| **`plan-epic`** | A triaged epic | A ledger of child issues with a pinned `## Dependencies` topology (`status:planned`) |
+| **`review-plan`** | A `status:planned` ledger | The same ledger gated against the structural floor; on a clean pass its children flip to `status:triaged` |
+| **`write-code`** | The next `status:triaged` issue | A branch + a PR that closes it (`Fixes #N`); on a gate FAIL, a fix pushed to the same branch |
+| **`review-code` / `review-doc` / `review-skill`** | An open PR + its issue's acceptance criteria | A SHA-bound `PASS`/`FAIL` verdict comment (the three split by artifact class: code / docs / skills) |
+| **`ship-it`** | A PASS verdict + green CI | A squash-merge that closes the linked issue — the only stage with merge authority |
+
+The split at the review step is by **artifact class**: `review-code` for code PRs,
+`review-doc` for docs (`.decisions`/`.patterns`/prose), `review-skill` for `skills/**` PRs
+(each adds a class-specific checklist). `write-code` consumes a FAIL and re-submits on the
+same branch; the fix loop is bounded, and an independent reviewer — never the author —
+re-gates each round (the split-role firewall: implementer ≠ reviewer).
+
+### Three standalone skills (outside the linear flow)
 
 - **`heal-ci`** triages a red CI run (flake vs. defect) and routes it.
 - **`adr`** records an architecture decision into `.decisions/`.
 - **`deslop-comments`** strips noise comments from the working tree.
+- **`doctor`** preflights a repo against the pipeline's prerequisites and prints a pass/fail
+  checklist with the exact fix command for each gap.
 
-One skill runs **upstream** of the linear flow, in the ideation layer:
+### One upstream skill (the ideation layer)
 
-- **`wayfinder`** charts a fuzzy destination into a living `wayfinder:map` issue and works its
-  open frontier of investigation/decision tickets until a concrete plan is ready to hand to
-  `triage` / `plan-epic` — the pre-triage front door (epic #2421).
+- **`wayfinder`** runs *before* triage: it charts a fuzzy destination into a living
+  `wayfinder:map` issue and works its frontier of investigation/decision tickets until a
+  concrete plan is ready to hand to `triage` / `plan-epic` — the pre-triage front door
+  (epic #2421).
+
+### How to kick it off
+
+1. **Install the plugin** (see [Install](#install) below) and make sure `gh` is logged in —
+   the only prerequisite.
+2. **Run `doctor` once** in the target repo to confirm the prerequisites (gh auth + scope,
+   the required labels, a CI signal). It turns "did I wire this up right?" into one command.
+3. **Enter work through `report`** (or `wayfinder` for something still fuzzy). From there the
+   pipeline pulls it forward: `triage` makes it pickable, `write-code` picks the next triaged
+   issue and opens a PR, a review skill gates it, and `ship-it` merges on green.
+
+You drive it stage by stage — each skill is a named action you invoke — and because every
+handoff is a durable GitHub artifact, you can stop after any stage and resume later.
 
 ## The 14 skills
 
@@ -82,7 +108,7 @@ Claude Code:
 ```
 
 `kamp-us/phoenix` is the marketplace repository; `kampus-pipeline@kampus` is the plugin
-`kampus-pipeline` from the `kampus` marketplace. After install, the 11 skills are
+`kampus-pipeline` from the `kampus` marketplace. After install, the 14 skills are
 available in the picker (e.g. `triage`, `write-code`, `ship-it`).
 
 ## Configuration — point the pipeline at your repo
@@ -107,9 +133,15 @@ the wrong repo — the default-to-current-repo path is the safe one; the overrid
 The skills use the [GitHub CLI (`gh`)](https://cli.github.com/) for all reads and writes,
 so a logged-in `gh` is the only prerequisite.
 
+## Design notes — versioning and spec conformance
+
+The plugin carries **no per-plugin `version`** (neither in the marketplace plugin entry nor in [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json)): Claude Code then content-addresses the install by git commit SHA, so every commit is a new "version" and skill additions/edits reach already-installed users on the normal update path — a fixed semver pin froze the cache and silently served stale content (#945). This omission is **deliberate, not a defect — do not add a `version`**; the decision record (why + history) is [ADR 0110](https://github.com/kamp-us/phoenix/blob/main/.decisions/0110-plugin-carries-no-version-continuous-ship.md).
+
+The whole plugin surface was audited against the official Claude Code plugin spec ([plugins reference](https://docs.claude.com/en/docs/claude-code/plugins-reference), [marketplaces](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)); the conformance record — the corrected manifest `$schema` URL plus every deliberate deviation (no `version`, the root-level `hooks.json`, the absent `commands/`, the `.claude/skills` discovery symlink) and its forcing constraint — is [ADR 0171](https://github.com/kamp-us/phoenix/blob/main/.decisions/0171-kampus-pipeline-plugin-spec-conformance.md). A future audit that re-flags any of those reads the disposition there: documented-intentional, not an open defect.
+
 ## Portability boundary (ADR 0062)
 
-**All 11 skills are fully repo-agnostic** — they carry no repo literals beyond the
+**All 14 skills are fully repo-agnostic** — they carry no repo literals beyond the
 resolved `$REPO`, so they operate on your repo out of the box.
 
 This includes **`review-plan`**, which is now **portable** too. Its deterministic ledger
@@ -123,7 +155,7 @@ both phoenix and a foreign install invoke the **same** `pipeline-cli epic-ledger
 non-phoenix install **runs** the gate (validates the ledger, flips `status:planned →
 status:triaged` on a clean one, posts a per-defect FAIL on a dirty one) instead of degrading.
 The CLI resolves its target repo from `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo
-view`, fail-closed (#408). This closed the last `10/11 → 11/11` gap — the follow-up epic
+view`, fail-closed (#408). This closed the last portability gap — the follow-up epic
 [#362](https://github.com/kamp-us/phoenix/issues/362) that ADR 0062 §3 deferred — and was
 proven end-to-end against a real foreign repo (#368).
 
@@ -224,6 +256,7 @@ phoenix/
 │   └── kampus-pipeline/                 # this plugin — source: "./claude-plugins/kampus-pipeline"
 │       ├── .claude-plugin/
 │       │   └── plugin.json
+│       ├── README.md                    # this file — the plugin's front-door entry point
 │       └── skills/                      # canonical — plugin source-root discovery
 │           ├── <name>/SKILL.md
 │           └── gh-issue-intake-formats.md

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -18,7 +18,7 @@ you verify and verdict, you never write code, edit a file, or merge.
 Spawned subagents do not inherit the parent's skills, so your intelligence is not
 pre-loaded — **read the right skill(s) yourself before doing anything else.** Classifying a
 PR is **not "pick one class and stop"** — a single PR routinely spans several artifact
-classes (an ADR + a `skills/README.md` + a `plugin.json` is docs **and** skills **and**
+classes (an ADR + a `README.md` + a `plugin.json` is docs **and** skills **and**
 code), and **each present class needs its own gate run in this one review pass**. This is
 the *routing-completeness rule* the three review skills' Step 0 already carry (`review-code`,
 `review-doc`, `review-skill`): *"run the matching gate for every non-blocking artifact class


### PR DESCRIPTION
Fixes #2511

Moves the kampus-pipeline plugin's front-door README from `claude-plugins/kampus-pipeline/skills/README.md` to the **plugin root** (`claude-plugins/kampus-pipeline/README.md`) via `git mv` (history preserved), and rewrites it as a first-time-user guide to the pipeline.

## What changed

- **Moved** `skills/README.md` → `README.md` at the plugin root; no README remains in `skills/`.
- **Rewrite (the substantive half):** the doc now **leads with a first-timer `## How the pipeline works` section** — the `report → triage → plan-epic → review-plan → write-code → review-code/review-doc/review-skill → ship-it` flow, a per-stage **consumes/emits** table, the standalone + upstream skills, and a **How to kick it off** quickstart — placed **before** the conformance/ADR notes.
- **Entry-point reframing:** the old self-description framing the `skills/` directory as "the canonical home / documented entry point" is reworded to frame the **plugin** as the entry point.
- **Relative-link re-basing (file moved up one level):**
  - `gh-issue-intake-formats.md` → `skills/gh-issue-intake-formats.md`
  - `../.claude-plugin/plugin.json` → `.claude-plugin/plugin.json`
  - Every other in-doc link is an absolute GitHub permalink (unaffected by the move); audited all relative links.
- **Inbound ADR links repointed** to the new path:
  - `.decisions/0110-plugin-carries-no-version-continuous-ship.md` (line 51)
  - `.decisions/0171-kampus-pipeline-plugin-spec-conformance.md` (line 95)
- **reviewer.md code-span** reconciled: the illustrative ```a `skills/README.md` ``` example no longer names a path that will not exist (reworded to `README.md`; it is a code-span, not a resolvable link).
- ADR 0110 (no per-plugin `version`) and ADR 0171 (plugin spec conformance) remain cited and intact.

## Verification

- `pnpm lint`: clean (markdown-only change; biome clean-skips).
- `bash .claude/skills/validate-skills.sh`: OK — 22 skills valid.
- `lychee --offline` (the `doc-links` CI gate, v0.24.2) over all 323 tracked `.md` files: **0 errors** — every internal link resolves, including the two repointed ADR links and the two re-based relative links.
- `readme-guard` scopes to `packages/*` workspace members, so `claude-plugins/` is out of scope — the move does not trip it.
- No machine-local paths in the doc; leak-guard pre-commit hook clean.

Routing: §CP + code-class-by-path (touches `claude-plugins/kampus-pipeline/`), verified against this issue's `### Acceptance criteria`. Human-merge via §CP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)