### PR TITLE
feat(web): mecmua public chronological index + nav entry (#2512)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,7 +23,7 @@ import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
 import {teardownAuthedSnapshot} from "./fate/snapshot";
-import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
+import {MECMUA_PUBLIC_READ, PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
 import {SAVED_HREF} from "./lib/panoNav";
@@ -37,6 +37,7 @@ import {FunnelPage} from "./pages/FunnelPage";
 import {LabComposerPage} from "./pages/LabComposerPage";
 import {LandingPage} from "./pages/LandingPage";
 import {MecmuaEditorPage} from "./pages/MecmuaEditorPage";
+import {MecmuaIndexPage} from "./pages/MecmuaIndexPage";
 import {MecmuaPostPage} from "./pages/MecmuaPostPage";
 import {NotFoundPage} from "./pages/NotFoundPage";
 import {PanoFeed} from "./pages/PanoFeed";
@@ -88,6 +89,11 @@ function Layout() {
 	const location = useLocation();
 	const {toggle: toggleTheme} = useTheme();
 	const [chips, setChips] = useState<TopbarChips | null>(null);
+	// The mecmua nav entry (#2512), dark behind `mecmua-public-read` — the same seam the
+	// reader/index gate on. `useFlag` reads over `fetch` (no fate client), so it is safe in
+	// this always-painting shell frame: the entry simply appears once the flag resolves on,
+	// never blocking first paint (Pillar 1). Off ⇒ the nav is exactly as before.
+	const {value: mecmuaOn} = useFlag(MECMUA_PUBLIC_READ, false);
 
 	// The two-tier fate provider's public first paint (ADR 0167). While `get-session`
 	// is still in flight the authed `FateProvider` gate below returns null, so the
@@ -139,6 +145,7 @@ function Layout() {
 						nav={[
 							{to: "/sozluk", label: "sözlük"},
 							{to: "/pano", label: "pano"},
+							...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
 						]}
 						divanTo={chips?.divanTo}
 						{...(chips?.userProps ?? {})}
@@ -302,12 +309,12 @@ export function App() {
 						    the legacy bespoke route redirects so existing links don't break. */}
 						<Route path="/pano/kaydedilenler" element={<Navigate to={SAVED_HREF} replace />} />
 						<Route path="/pano/:id" element={<PanoPostDetail />} />
-						{/* The mecmua authoring page (#2499) — the page self-gates on the
-						    mecmua-write flag (off ⇒ 404), so the route is dark by default. The
-						    static `/mecmua/yaz` out-ranks the `/mecmua/:slug` reader below it. */}
+						{/* mecmua — each page self-gates on its flag (off ⇒ 404), so these routes
+						    are dark by default: the index (#2512) + reader (#2498) on
+						    mecmua-public-read, the authoring page (#2499) on mecmua-write. The two
+						    static paths out-rank the `/mecmua/:slug` reader below them. */}
+						<Route path="/mecmua" element={<MecmuaIndexPage />} />
 						<Route path="/mecmua/yaz" element={<MecmuaEditorPage />} />
-						{/* The mecmua public reader (#2498) — the page self-gates on the
-						    mecmua-public-read flag (off ⇒ 404), so the route is dark by default. */}
 						<Route path="/mecmua/:slug" element={<MecmuaPostPage />} />
 						<Route path="/sozluk" element={<SozlukHome />} />
 						<Route path="/sozluk/:slug" element={<SozlukTermPage />} />

--- a/apps/web/src/pages/MecmuaIndexPage.css
+++ b/apps/web/src/pages/MecmuaIndexPage.css
@@ -1,0 +1,55 @@
+/* The public mecmua index (#2512). Layout only — colors/elevation/borders come from
+   the Card primitive and role tokens; this file owns the list rhythm + heading spacing. */
+
+.kp-mecmua-index__head {
+	margin-bottom: var(--s-5);
+}
+
+.kp-mecmua-index__title {
+	font: var(--t-h-page);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-mecmua-index__lede {
+	font: var(--t-body);
+	color: var(--text-secondary);
+	margin: var(--s-1) 0 0;
+}
+
+.kp-mecmua-index__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+}
+
+.kp-mecmua-index__item {
+	padding: 0;
+}
+
+.kp-mecmua-index__link {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	padding: var(--s-3) var(--s-4);
+	text-decoration: none;
+	color: inherit;
+}
+
+.kp-mecmua-index__item-title {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+}
+
+.kp-mecmua-index__meta {
+	color: var(--text-muted);
+	font: var(--t-meta);
+}
+
+.kp-mecmua-index__status {
+	font: var(--t-body);
+	color: var(--text-secondary);
+}

--- a/apps/web/src/pages/MecmuaIndexPage.tsx
+++ b/apps/web/src/pages/MecmuaIndexPage.tsx
@@ -1,0 +1,139 @@
+/**
+ * `/mecmua` — the PUBLIC chronological index of published mecmua posts (#2512, epic
+ * #2467), the discovery surface the reader (`/mecmua/:slug`) lacked. It fetches the
+ * anonymous `GET /fate/mecmua/index` route (published-only, newest-first) and lists each
+ * post as a card linking to its reader. This is the PUBLIC index (all published posts) —
+ * distinct from the personalized subscribed-author feed (#2500).
+ *
+ * The whole surface ships dark behind `MECMUA_PUBLIC_READ` (default-off): the page
+ * self-gates (off => 404), mirroring `MecmuaPostPage` / `DivanPage`, so the route is
+ * absent until a human flips the flag at release (ADR 0083). The index route itself also
+ * 404s while the flag is off — the page gate just avoids a fetch and a flash.
+ */
+import {BookOpenText} from "lucide-react";
+import {useEffect, useState} from "react";
+import {Link} from "react-router";
+import {Icon} from "../components/Icon";
+import {Card} from "../components/ui/Card";
+import {EmptyState} from "../components/ui/EmptyState";
+import {MetaRow} from "../components/ui/MetaRow";
+import {MECMUA_PUBLIC_READ} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
+import {formatDateTR} from "../lib/datetime";
+import {NotFoundPage} from "./NotFoundPage";
+import "./MecmuaIndexPage.css";
+
+/** The lean wire shape `GET /fate/mecmua/index` returns — no body, the reader fetches that. */
+interface MecmuaIndexEntry {
+	readonly id: string;
+	readonly slug: string | null;
+	readonly title: string;
+	/** ISO string (a serialized `Date`); always set for a published post. */
+	readonly publishedAt: string | null;
+}
+
+type FetchState =
+	| {kind: "loading"}
+	| {kind: "ok"; posts: ReadonlyArray<MecmuaIndexEntry>}
+	| {kind: "error"};
+
+export function MecmuaIndexPage() {
+	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_PUBLIC_READ, false);
+
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
+	// MecmuaPostPage / DivanPage self-gate idiom).
+	if (flagLoading) {
+		return (
+			<div className="kp-page">
+				<div className="kp-page__inner">
+					<p>yükleniyor…</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!flagOn) return <NotFoundPage />;
+
+	return <MecmuaIndex />;
+}
+
+function MecmuaIndex() {
+	const [state, setState] = useState<FetchState>({kind: "loading"});
+
+	useEffect(() => {
+		let cancelled = false;
+		setState({kind: "loading"});
+		fetch("/fate/mecmua/index", {headers: {accept: "application/json"}})
+			.then(async (res) => {
+				if (cancelled) return;
+				if (!res.ok) return setState({kind: "error"});
+				const posts = (await res.json()) as ReadonlyArray<MecmuaIndexEntry>;
+				if (!cancelled) setState({kind: "ok", posts});
+			})
+			.catch(() => {
+				if (!cancelled) setState({kind: "error"});
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return (
+		<div className="kp-page">
+			<div className="kp-page__inner">
+				<header className="kp-mecmua-index__head">
+					<h1 className="kp-mecmua-index__title">mecmua</h1>
+					<p className="kp-mecmua-index__lede">topluluğun uzun yazıları</p>
+				</header>
+				<MecmuaIndexBody state={state} />
+			</div>
+		</div>
+	);
+}
+
+function MecmuaIndexBody({state}: {state: FetchState}) {
+	if (state.kind === "loading") {
+		return <p className="kp-mecmua-index__status">yükleniyor…</p>;
+	}
+
+	if (state.kind === "error") {
+		return (
+			<p className="kp-mecmua-index__status" role="alert">
+				yazılar yüklenemedi, tekrar dene.
+			</p>
+		);
+	}
+
+	if (state.posts.length === 0) {
+		return (
+			<EmptyState
+				icon={<Icon icon={BookOpenText} size={24} />}
+				title="henüz yazı yok"
+				description="ilk mecmua yazısı yayımlandığında burada görünecek."
+			/>
+		);
+	}
+
+	return (
+		<ul className="kp-mecmua-index__list">
+			{state.posts.map((post) => (
+				<Card
+					as="li"
+					interactive
+					key={post.id}
+					className="kp-mecmua-index__item"
+					data-testid="mecmua-index-item"
+				>
+					<Link to={`/mecmua/${post.slug ?? post.id}`} className="kp-mecmua-index__link">
+						<span className="kp-mecmua-index__item-title">{post.title}</span>
+						{post.publishedAt ? (
+							<MetaRow as="div" className="kp-mecmua-index__meta">
+								<time dateTime={post.publishedAt}>{formatDateTR(post.publishedAt)}</time>
+							</MetaRow>
+						) : null}
+					</Link>
+				</Card>
+			))}
+		</ul>
+	);
+}

--- a/apps/web/worker/features/mecmua/index-route.ts
+++ b/apps/web/worker/features/mecmua/index-route.ts
@@ -1,0 +1,100 @@
+/**
+ * `GET /fate/mecmua/index` (#2512, epic #2467) — the PUBLIC chronological index of
+ * published mecmua posts, newest-first by `published_at`. A raw `HttpRouter.add` route
+ * following the anonymous-read idiom of `public-read-route.ts` / pano's
+ * `base-feed-route.ts`: it never validates a session and never reads `CurrentUser`, so
+ * an anon GET does zero identity work. It applies `mecmuaPostVisibleWhere` (#2496) under
+ * the `anonymousMecmuaViewer`, so a draft (null `published_at`) is structurally masked —
+ * only published posts appear in the index, no auth required.
+ *
+ * This is the PUBLIC index (all published posts) — distinct from the personalized
+ * subscribed-author feed (#2500). The list is lean (id + slug + başlık + publishedAt),
+ * not the full markdown body, since the reader (`/mecmua/:slug`) fetches the body on
+ * demand.
+ *
+ * Dark behind `MECMUA_PUBLIC_READ` (default-off), the same seam the read route gates on:
+ * with the flag off the route 404s, so the whole discovery surface ships dark until a
+ * human flips the flag at release (ADR 0083). The flag is read under the anonymous flags
+ * context (no identity), so the gate itself does no session work either.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import {desc, type SQL} from "drizzle-orm";
+import * as Effect from "effect/Effect";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {MECMUA_PUBLIC_READ} from "../../../src/flags/keys.ts";
+import {Drizzle, type DrizzleAccessOrDie, orDieAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {
+	anonymousFlagsContext,
+	FlagsContext,
+	makeRequestFlagsContext,
+} from "../flagship/FlagsContext.ts";
+import {anonymousMecmuaViewer, mecmuaPostVisibleWhere} from "./MecmuaPostVisibility.ts";
+
+/** The default (and max) index page size — a lean first page, no cursor pagination in v1. */
+const DEFAULT_LIMIT = 50;
+
+/**
+ * The lean wire row for the index — identity + slug + başlık + the publish marker, but
+ * NOT the markdown body (the reader fetches that per-slug). `publishedAt` is non-null in
+ * practice because the WHERE masks drafts; the `Date | null` type just mirrors the column.
+ */
+export interface MecmuaIndexRow {
+	readonly id: string;
+	readonly slug: string | null;
+	readonly title: string;
+	readonly publishedAt: Date | null;
+}
+
+/**
+ * The index WHERE: the `mecmuaPostVisibleWhere` published gate (#2496) under the
+ * anonymous viewer — `published_at is not null`, with NO `author_id = :viewer` ownership
+ * escape (there is no viewer). So a draft never appears in the public index.
+ */
+export const mecmuaPublishedIndexWhere: SQL | undefined = mecmuaPostVisibleWhere(
+	{publishedAt: schema.mecmuaPost.publishedAt, authorId: schema.mecmuaPost.authorId},
+	anonymousMecmuaViewer,
+);
+
+/** List the published mecmua posts newest-first by `published_at`, lean rows only. */
+export const listPublishedMecmuaPosts = (
+	run: DrizzleAccessOrDie["run"],
+	limit = DEFAULT_LIMIT,
+): Effect.Effect<ReadonlyArray<MecmuaIndexRow>> =>
+	run((db) =>
+		db
+			.select({
+				id: schema.mecmuaPost.id,
+				slug: schema.mecmuaPost.slug,
+				title: schema.mecmuaPost.title,
+				publishedAt: schema.mecmuaPost.publishedAt,
+			})
+			.from(schema.mecmuaPost)
+			.where(mecmuaPublishedIndexWhere)
+			.orderBy(desc(schema.mecmuaPost.publishedAt))
+			.limit(limit),
+	);
+
+export const handleMecmuaIndex = Effect.gen(function* () {
+	const raw = yield* Cloudflare.Request;
+
+	// The dark-ship gate under the ANONYMOUS flags context — an anon GET does zero
+	// identity work even to decide the flag. Off => 404, the shipped-dark default.
+	const flags = yield* Flags;
+	const flagsContext = yield* makeRequestFlagsContext(
+		anonymousFlagsContext,
+		raw.headers.get("cookie"),
+	);
+	const on = yield* flags
+		.getBoolean(MECMUA_PUBLIC_READ, false)
+		.pipe(Effect.provideService(FlagsContext, flagsContext));
+	if (!on) return HttpServerResponse.empty({status: 404});
+
+	const {run} = orDieAccess(yield* Drizzle);
+	const posts = yield* listPublishedMecmuaPosts(run);
+	return HttpServerResponse.jsonUnsafe(posts);
+});
+
+export const mecmuaIndexRoute = HttpRouter.add("GET", "/fate/mecmua/index", handleMecmuaIndex);

--- a/apps/web/worker/features/mecmua/index-route.unit.test.ts
+++ b/apps/web/worker/features/mecmua/index-route.unit.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The mecmua public-index draft-mask + ordering (#2512, epic #2467). The public index
+ * must (a) route the draft decision through the one `MecmuaPostVisibility` seam
+ * (`mecmuaPostVisibleWhere`) so an anonymous visitor never sees an unpublished post, and
+ * (b) order newest-first by `published_at`. Both are offline-reachable off `.toSQL()`
+ * (no query runs) plus a scripted-`run` mapping check.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {desc} from "drizzle-orm";
+import {drizzle} from "drizzle-orm/d1";
+import {Effect} from "effect";
+import {type DrizzleAccessOrDie, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {
+	listPublishedMecmuaPosts,
+	type MecmuaIndexRow,
+	mecmuaPublishedIndexWhere,
+} from "./index-route.ts";
+
+// biome-ignore lint/plugin: a host D1 binding can't be structurally faked; only `.toSQL()` rendering touches this — no query runs.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {relations});
+
+/** A `run` that ignores its query and resolves the scripted rows — the mapping fixtures never touch D1. */
+const scriptedRun =
+	(rows: ReadonlyArray<unknown>): DrizzleAccessOrDie["run"] =>
+	<A>(_fn: (db: DrizzleDb) => Promise<A>) =>
+		Effect.succeed(rows as A);
+
+const now = new Date("2026-07-11T00:00:00.000Z");
+
+describe("the public index masks drafts + orders newest-first (#2512)", () => {
+	it("gates on published_at with NO ownership escape and orders by published_at DESC", () => {
+		const {sql} = renderDb
+			.select({
+				id: schema.mecmuaPost.id,
+				slug: schema.mecmuaPost.slug,
+				title: schema.mecmuaPost.title,
+				publishedAt: schema.mecmuaPost.publishedAt,
+			})
+			.from(schema.mecmuaPost)
+			.where(mecmuaPublishedIndexWhere)
+			.orderBy(desc(schema.mecmuaPost.publishedAt))
+			.toSQL();
+		assert.match(
+			sql,
+			/"mecmua_post"\."published_at" is not null/,
+			"the published gate masks a null-published draft from the public index",
+		);
+		assert.notMatch(
+			sql,
+			/"mecmua_post"\."author_id" = \?/,
+			"an anonymous index read has no author-ownership disjunction — a draft never appears",
+		);
+		assert.match(
+			sql,
+			/order by "mecmua_post"\."published_at" desc/,
+			"the index is chronological, newest published first",
+		);
+	});
+
+	it.effect(
+		"maps scripted published rows onto lean wire rows (id + slug + title + publishedAt)",
+		() =>
+			Effect.gen(function* () {
+				const rows = [
+					{id: "mecmua_2", slug: "ikinci", title: "ikinci yazı", publishedAt: now},
+					{id: "mecmua_1", slug: "birinci", title: "birinci yazı", publishedAt: now},
+				];
+				const got: ReadonlyArray<MecmuaIndexRow> = yield* listPublishedMecmuaPosts(
+					scriptedRun(rows),
+				);
+				assert.strictEqual(got.length, 2);
+				assert.strictEqual(got[0]?.id, "mecmua_2");
+				assert.strictEqual(got[0]?.title, "ikinci yazı");
+				assert.strictEqual(got[1]?.slug, "birinci");
+			}),
+	);
+});

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -22,6 +22,7 @@ import {fateRoute} from "../features/fate/route.ts";
 import {liveRoute} from "../features/fate-live/route.ts";
 import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
 import {flagsDevApplyRoute, flagsDevPageRoute} from "../features/flagship/route-dev.ts";
+import {mecmuaIndexRoute} from "../features/mecmua/index-route.ts";
 import {mecmuaPublicReadRoute} from "../features/mecmua/public-read-route.ts";
 import {baseFeedRoute} from "../features/pano/base-feed-route.ts";
 import {linkMetadataRoute} from "../features/pano/link-metadata-route.ts";
@@ -69,6 +70,10 @@ export const rawWorkerRoutes: readonly [WorkerRoute, ...WorkerRoute[]] = [
 	// `/fate/*` glob already shadows the SPA for it. Dark behind `MECMUA_PUBLIC_READ`
 	// (404 until flipped).
 	{path: "/fate/mecmua/post/:slug", glob: "/fate/*", route: mecmuaPublicReadRoute},
+	// The public chronological index of published mecmua posts (#2512, epic #2467); the
+	// `/fate/*` glob already shadows the SPA for it. Dark behind `MECMUA_PUBLIC_READ`
+	// (404 until flipped).
+	{path: "/fate/mecmua/index", glob: "/fate/*", route: mecmuaIndexRoute},
 	{path: "/api/auth/*", glob: "/api/*", route: authRoute},
 	{path: "/api/flags/probe", glob: "/api/*", route: flagsProbeRoute},
 	{path: "/api/flags/evaluate", glob: "/api/*", route: flagsEvaluateRoute},


### PR DESCRIPTION
mecmua v1 had a working single-post reader (`/mecmua/:slug`) but no discovery surface — no nav affordance and no index page, so mecmua was reachable only by already knowing a post's exact slug. This adds both facets of the discovery surface as one unit, all dark behind the existing default-off `mecmua-public-read` flag (the same seam #2498's reader gates on).

## What changed
- **`GET /fate/mecmua/index`** (`apps/web/worker/features/mecmua/index-route.ts`) — anon read of published mecmua posts, newest-first by `published_at`, reusing `mecmuaPostVisibleWhere` under the `anonymousMecmuaViewer` so drafts are structurally masked. Lean wire rows (id/slug/title/publishedAt), no body. 404 while the flag is off. Follows the anon-read idiom of `public-read-route.ts` / pano's `base-feed-route.ts`. Registered in `worker-routes.ts` under the existing `/fate/*` glob.
- **`/mecmua` index page** (`apps/web/src/pages/MecmuaIndexPage.tsx`) — self-gating (off ⇒ 404, mirroring the reader), lists published posts each linking to `/mecmua/:slug`. Built on the `Card` / `MetaRow` / `EmptyState` primitives and role tokens only; Turkish product copy, English identifiers/routes.
- **A flag-gated `mecmua` nav entry** in the Topbar (`App.tsx` shell frame, via `useFlag(MECMUA_PUBLIC_READ, false)`) — appears only when the flag is on, never blocking first paint (Pillar 1).

This is the **public** index (all published posts) — distinct from the personalized subscribed-author feed (#2500), which stays a separate route/view.

## Acceptance criteria
- [x] mecmua nav entry in the layout, consistent with sözlük/pano, gated on `mecmua-public-read`.
- [x] Public index lists published posts newest-first, links to `/mecmua/:slug`, 404/dark when the flag is off.
- [x] Drafts never appear — same `MecmuaPostVisibility` seam as #2498's read route (no ownership escape for anon).
- [x] Turkish copy (nav label, page heading/lede, empty state).
- [x] UI built for the review-design gate (role tokens, Lucide via the `Icon` wrapper, composite primitives).

Tests: `index-route.unit.test.ts` (draft-mask + newest-first ordering + row mapping); the `worker-routes` lockstep test covers the new route's glob. `pnpm typecheck`, `pnpm lint:worktree`, and the affected unit/client suites are green.

Fixes #2512
Flag: mecmua-public-read