### PR TITLE
feat(web): yazar-gated "yeni yazı" CTA into the mecmua editor (#2532)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,7 +23,12 @@ import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
 import {teardownAuthedSnapshot} from "./fate/snapshot";
-import {MECMUA_PUBLIC_READ, PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
+import {
+	MECMUA_PUBLIC_READ,
+	MECMUA_WRITE,
+	PHOENIX_AUTHORSHIP_LOOP,
+	PHOENIX_BILDIRIM,
+} from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
 import {SAVED_HREF} from "./lib/panoNav";
@@ -36,7 +41,7 @@ import {DivanPage} from "./pages/DivanPage";
 import {FunnelPage} from "./pages/FunnelPage";
 import {LabComposerPage} from "./pages/LabComposerPage";
 import {LandingPage} from "./pages/LandingPage";
-import {MecmuaEditorPage} from "./pages/MecmuaEditorPage";
+import {MecmuaEditorPage, shouldShowMecmuaWriteCta} from "./pages/MecmuaEditorPage";
 import {MecmuaFeedPage} from "./pages/MecmuaFeedPage";
 import {MecmuaIndexPage} from "./pages/MecmuaIndexPage";
 import {MecmuaPostPage} from "./pages/MecmuaPostPage";
@@ -64,6 +69,9 @@ type TopbarChips = {
 	karma: number | undefined;
 	divanTo: string | undefined;
 	bildirim: {to: string; unread: number} | undefined;
+	// The mecmua "yaz" nav entry's visibility (#2532), computed below the fate gate where
+	// `me.tier` lives and published up to the always-painting nav frame via this bridge.
+	mecmuaWrite: boolean;
 };
 
 /**
@@ -147,6 +155,9 @@ function Layout() {
 							{to: "/sozluk", label: "sözlük"},
 							{to: "/pano", label: "pano"},
 							...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
+							// The yazar-gated "yaz" entry to the editor (#2532), shown once fate
+							// settles the write affordance — chip-published from below the gate.
+							...(chips?.mecmuaWrite ? [{to: "/mecmua/yaz", label: "yaz"}] : []),
 						]}
 						divanTo={chips?.divanTo}
 						{...(chips?.userProps ?? {})}
@@ -233,6 +244,10 @@ function LayoutContent() {
 	// today: disabled ⇒ the read never touches the wire and reports 0.
 	const {value: bildirimOn} = useFlag(PHOENIX_BILDIRIM, false);
 	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data, me?.id ?? null);
+	// The yazar-gated mecmua "yaz" nav entry (#2532), dark behind `mecmua-write`. The
+	// visibility shares the editor's own publish gate (shouldShowMecmuaWriteCta), so the
+	// nav entry never dead-ends a çaylak/visitor into a page they can't publish from.
+	const {value: mecmuaWriteOn} = useFlag(MECMUA_WRITE, false);
 	// #1888: hold the off-/auth redirect while a chosen-username signup is still
 	// resolving. `signUp.email` establishes the session before the separate
 	// `setUsername` lands; without this hold the redirect unmounts AuthPage and
@@ -273,8 +288,20 @@ function LayoutContent() {
 			karma: selfKarma,
 			divanTo: showDivan ? "/divan" : undefined,
 			bildirim: bildirimOn && isSignedIn ? {to: "/bildirimler", unread: bildirimUnread} : undefined,
+			mecmuaWrite: shouldShowMecmuaWriteCta(mecmuaWriteOn, isSignedIn, me?.tier),
 		}),
-		[sessionUser, me?.name, username, selfKarma, showDivan, bildirimOn, isSignedIn, bildirimUnread],
+		[
+			sessionUser,
+			me?.name,
+			me?.tier,
+			username,
+			selfKarma,
+			showDivan,
+			bildirimOn,
+			isSignedIn,
+			bildirimUnread,
+			mecmuaWriteOn,
+		],
 	);
 
 	// Publish the computed chips up to the shell frame; clear them on unmount (the

--- a/apps/web/src/pages/MecmuaEditorPage.test.tsx
+++ b/apps/web/src/pages/MecmuaEditorPage.test.tsx
@@ -5,7 +5,7 @@
  * `flagGateChild` and the on-ramp's `shouldShowOnramp` are tested.
  */
 import {describe, expect, it} from "vitest";
-import {mecmuaPublishAffordance} from "./MecmuaEditorPage";
+import {mecmuaPublishAffordance, shouldShowMecmuaWriteCta} from "./MecmuaEditorPage";
 
 describe("mecmuaPublishAffordance — publish is a yazar-only affordance", () => {
 	it("offers publish to a yazar", () => {
@@ -27,5 +27,27 @@ describe("mecmuaPublishAffordance — publish is a yazar-only affordance", () =>
 
 	it("gates a visitor tier the same as any non-yazar", () => {
 		expect(mecmuaPublishAffordance(true, "visitor").kind).toBe("gate");
+	});
+});
+
+describe("shouldShowMecmuaWriteCta — the entry-point CTA shares the editor's publish gate", () => {
+	it("shows the CTA to a yazar with the write flag on", () => {
+		expect(shouldShowMecmuaWriteCta(true, true, "yazar")).toBe(true);
+	});
+
+	it("hides the CTA when the write flag is off, even for a yazar", () => {
+		expect(shouldShowMecmuaWriteCta(false, true, "yazar")).toBe(false);
+	});
+
+	it("hides the CTA from a signed-in çaylak (would be publish-gated at the editor)", () => {
+		expect(shouldShowMecmuaWriteCta(true, true, "çaylak")).toBe(false);
+	});
+
+	it("hides the CTA from a signed-out visitor with no tier", () => {
+		expect(shouldShowMecmuaWriteCta(true, false, undefined)).toBe(false);
+	});
+
+	it("hides the CTA from a visitor tier the same as any non-yazar", () => {
+		expect(shouldShowMecmuaWriteCta(true, true, "visitor")).toBe(false);
 	});
 });

--- a/apps/web/src/pages/MecmuaEditorPage.tsx
+++ b/apps/web/src/pages/MecmuaEditorPage.tsx
@@ -68,6 +68,21 @@ export function mecmuaPublishAffordance(
 	};
 }
 
+/**
+ * Should the "yeni yazı" entry-point CTA (nav + index) be shown to this viewer (#2532)?
+ * Gate parity with the editor is structural, not restated: the CTA appears exactly when
+ * the write flag is live AND {@link mecmuaPublishAffordance} would offer publish (yazar
+ * tier), so it never dead-ends a çaylak/visitor/signed-out reader into a page they'd be
+ * publish-gated on. `MECMUA_WRITE` off, or any non-yazar/undefined tier, resolves false.
+ */
+export function shouldShowMecmuaWriteCta(
+	flagOn: boolean,
+	isSignedIn: boolean,
+	tier: Tier | undefined,
+): boolean {
+	return flagOn && mecmuaPublishAffordance(isSignedIn, tier).kind === "publish";
+}
+
 export function MecmuaEditorPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);
 

--- a/apps/web/src/pages/MecmuaIndexPage.css
+++ b/apps/web/src/pages/MecmuaIndexPage.css
@@ -5,6 +5,13 @@
 	margin-bottom: var(--s-5);
 }
 
+.kp-mecmua-index__head-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--s-3);
+}
+
 .kp-mecmua-index__title {
 	font: var(--t-h-page);
 	color: var(--text-primary);

--- a/apps/web/src/pages/MecmuaIndexPage.tsx
+++ b/apps/web/src/pages/MecmuaIndexPage.tsx
@@ -13,13 +13,16 @@
 import {BookOpenText} from "lucide-react";
 import {useEffect, useState} from "react";
 import {Link} from "react-router";
+import {useSession} from "../auth/client";
+import {useMe} from "../auth/useMe";
 import {Icon} from "../components/Icon";
 import {Card} from "../components/ui/Card";
 import {EmptyState} from "../components/ui/EmptyState";
 import {MetaRow} from "../components/ui/MetaRow";
-import {MECMUA_PUBLIC_READ} from "../flags/keys";
+import {MECMUA_PUBLIC_READ, MECMUA_WRITE} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {formatDateTR} from "../lib/datetime";
+import {shouldShowMecmuaWriteCta} from "./MecmuaEditorPage";
 import {NotFoundPage} from "./NotFoundPage";
 import "./MecmuaIndexPage.css";
 
@@ -57,8 +60,23 @@ export function MecmuaIndexPage() {
 	return <MecmuaIndex />;
 }
 
+/** The "yeni yazı" entry-point link to the editor, styled as the primary CTA button. */
+function MecmuaWriteCta() {
+	return (
+		<Link to="/mecmua/yaz" className="kp-btn kp-btn--primary" data-testid="mecmua-write-cta">
+			yeni yazı
+		</Link>
+	);
+}
+
 function MecmuaIndex() {
 	const [state, setState] = useState<FetchState>({kind: "loading"});
+	const session = useSession();
+	const {me} = useMe();
+	// The write CTA shares the editor's own publish gate (yazar tier + MECMUA_WRITE live),
+	// so it never dead-ends a çaylak/visitor into a page they can't publish from (#2532).
+	const {value: writeFlagOn} = useFlag(MECMUA_WRITE, false);
+	const showWriteCta = shouldShowMecmuaWriteCta(writeFlagOn, !!session.data, me?.tier);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -82,16 +100,19 @@ function MecmuaIndex() {
 		<div className="kp-page">
 			<div className="kp-page__inner">
 				<header className="kp-mecmua-index__head">
-					<h1 className="kp-mecmua-index__title">mecmua</h1>
+					<div className="kp-mecmua-index__head-row">
+						<h1 className="kp-mecmua-index__title">mecmua</h1>
+						{showWriteCta ? <MecmuaWriteCta /> : null}
+					</div>
 					<p className="kp-mecmua-index__lede">topluluğun uzun yazıları</p>
 				</header>
-				<MecmuaIndexBody state={state} />
+				<MecmuaIndexBody state={state} showWriteCta={showWriteCta} />
 			</div>
 		</div>
 	);
 }
 
-function MecmuaIndexBody({state}: {state: FetchState}) {
+function MecmuaIndexBody({state, showWriteCta}: {state: FetchState; showWriteCta: boolean}) {
 	if (state.kind === "loading") {
 		return <p className="kp-mecmua-index__status">yükleniyor…</p>;
 	}
@@ -110,6 +131,7 @@ function MecmuaIndexBody({state}: {state: FetchState}) {
 				icon={<Icon icon={BookOpenText} size={24} />}
 				title="henüz yazı yok"
 				description="ilk mecmua yazısı yayımlandığında burada görünecek."
+				action={showWriteCta ? <MecmuaWriteCta /> : undefined}
 			/>
 		);
 	}


### PR DESCRIPTION
## What

mecmua is live (`mecmua-public-read` + `mecmua-write` both `on@100%`) but the editor at `/mecmua/yaz` had **no UI entry point** — a yazar could reach the core authoring action only by typing the URL. This adds a Turkish "yeni yazı" / "yaz" CTA into the mecmua surface, gated with parity to the editor's own publish gate.

## Changes

- **`shouldShowMecmuaWriteCta(flagOn, isSignedIn, tier)`** (`apps/web/src/pages/MecmuaEditorPage.tsx`) — the entry-point gate, built *by reusing* the editor's own `mecmuaPublishAffordance`: it returns true exactly when `MECMUA_WRITE` is live AND the affordance would offer publish (yazar tier). Parity is structural, not restated — a çaylak / visitor / signed-out reader (whom the editor publish-gates) never sees the CTA, so it can't dead-end them.
- **Nav entry** (`apps/web/src/App.tsx`) — a yazar-gated `"yaz"` → `/mecmua/yaz` entry beside the existing `/mecmua` nav item. `me.tier` lives below the fate gate, so visibility rides the existing topbar chip-bridge (the same seam `divanTo` / `bildirim` use): `LayoutContent` computes it and publishes it up to the always-painting nav frame. Additive to the existing nav array (no change to the `mecmua` entry).
- **Index-page CTA** (`apps/web/src/pages/MecmuaIndexPage.tsx` + `.css`) — the same gated `"yeni yazı"` link in the index header and, when the list is empty, as the empty-state action so a yazar has a first-write affordance.
- **Tests** (`apps/web/src/pages/MecmuaEditorPage.test.tsx`) — 5 cases for `shouldShowMecmuaWriteCta` (yazar-on shows; flag-off hides; çaylak / signed-out / visitor hide).

No change to the editor route, its `MECMUA_WRITE` self-gate, or the publish flow — this adds only the entry-point affordance.

## Acceptance criteria

- [x] A signed-in yazar sees a "yeni yazı" / "yaz" CTA navigating to `/mecmua/yaz` (nav + index page).
- [x] CTA visibility gated on the same condition the editor enforces (signed-in + yazar tier + `mecmua-write`) via `shouldShowMecmuaWriteCta` reusing `mecmuaPublishAffordance`.
- [x] A non-yazar / signed-out visitor does not see the CTA (no dead-end into a gated editor).
- [x] CTA copy is Turkish (`yeni yazı` / `yaz`).
- [x] No change to the editor route, its gate, or the publish flow.

## Verification

- `pnpm typecheck` — clean (28/28).
- `pnpm lint:worktree` — clean.
- `pnpm --filter @kampus/web test:client MecmuaEditorPage` — 9/9 pass.

## Concurrent-lane note

Branched off current `main` (594ac476, includes #2512). PR #2516 (mecmua subscribed feed) was **still open / unmerged** at push time and also edits `App.tsx` (adds `/mecmua/akis`) + `MecmuaIndexPage.tsx`. The edits here are additive on different lines (nav-array append; a header-row wrapper + gated CTA), so they should merge cleanly — but a **post-#2516 rebase may be needed** if it lands first; re-run typecheck/lint/tests at the reconciled head after any rebase (rebase invalidates the review PASS).

Fixes #2532