### PR TITLE
feat(pipeline-cli): extract the SHA-bound verdict read/post glue into a verdict tool (#2102)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -589,31 +589,32 @@ controls, so emitting one would leave `ship-it` comparing a review against a com
 doc lane — two incomparable records. The comment is the single carrier, resolving the
 APPROVE-vs-comment duality #258 flagged.
 
-The post is an **upsert**, not an append: scan the PR for *your own* prior `review-doc:`
-marker comment and `PATCH` it with the fresh verdict instead of `POST`-ing a new one, so
-there is exactly **one** `review-doc` verdict comment per PR (ADR 0058 rule 2). A re-review of
-a new head overwrites the same record with the new `@ <sha>`. The `… | last | .id` upsert
-PATCHes only your *newest* own marker, so on a PR migrated from the pre-0058 append era a few
-older SHA-less own markers may linger — the one-per-gate invariant is **forward-looking**, and
-those legacy duplicates are tolerated because `ship-it`'s consumer SHA-refuses any marker
-without an `@ <sha>` on the current head (Step 2b), so they can never authorize a merge.
+The post is an **upsert**, not an append: exactly **one** `review-doc` verdict comment per PR
+(ADR 0058 rule 2) — a re-review of a new head overwrites the same record with the new `@ <sha>`.
+The upsert (scan your own prior `review-doc:` marker → `PATCH` it, else `POST`) plus its
+namespace guard are the ADR-0058 glue **all four gates share**, so they live in one
+deterministic, unit-tested tool — `pipeline-cli verdict post` (#2102) — rather than re-hand-rolled
+`jq` here. `verdict post` PATCHes only your *newest* own marker, so on a PR migrated from the
+pre-0058 append era a few older SHA-less own markers may linger — the one-per-gate invariant is
+**forward-looking**, and those legacy duplicates are tolerated because `ship-it`'s consumer
+SHA-refuses any marker without an `@ <sha>` on the current head (Step 2b). It also refuses
+fail-closed if the body's first line is not a `review-doc:` marker — the cross-namespace
+emission guard (§the never-a-`review-code`-marker invariant) enforced by the tool, not by care.
+
+Resolve the tool once — in-repo first, published fallback (ADR 0062/0064; epic #994) — and pass
+your composed verdict body by file:
 
 ```bash
+# resolve the verdict CLI once — in-repo-first, published-fallback (ADR 0062/0064; epic #994)
+if [ -f packages/pipeline-cli/src/bin.ts ]; then
+  VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin
+else
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"     # foreign install: the published CLI
+fi
+
 VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed PASS verdict into "$VERDICT_FILE" (first line: review-doc: PASS @ <HEAD_SHA> — merge-ready)
-BODY="$(cat "$VERDICT_FILE")"
-ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
-# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
-MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-        | jq -r --arg me "$ME" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*review-doc:"; "i"))))
-        | last | .id // empty')
-if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
-else
-  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"   # first verdict
-fi
+$VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"   # upsert (PATCH own prior marker, else POST)
 ```
 
 Verdict body shape. The first line is the **canonical bare marker** — no leading `**`
@@ -714,21 +715,12 @@ rule 4). Upsert it the same way (`PATCH` your own prior `review-doc:` marker if 
 else `POST`):
 
 ```bash
+# $VERDICT resolved above (in-repo-first, published-fallback; ADR 0062/0064). The advisory line
+# opens with `review-doc:` too, so `verdict post`'s namespace guard accepts it and upserts it the
+# same way — one comment per gate, PATCH own prior marker else POST.
 VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed advisory verdict into "$VERDICT_FILE" (first line: review-doc: advisory — blocking-set PR (manual merge))
-BODY="$(cat "$VERDICT_FILE")"
-ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
-# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
-MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-        | jq -r --arg me "$ME" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*review-doc:"; "i"))))
-        | last | .id // empty')
-if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
-else
-  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
-fi
+$VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"
 ```
 
 Do **not** emit the `review-doc: PASS @ <sha> — merge-ready` marker for a blocking PR — that marker is a
@@ -751,19 +743,8 @@ verdict comment per PR (ADR 0058 rule 2):
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
 VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-doc: FAIL @ <HEAD_SHA> — changes-requested)
-BODY="$(cat "$VERDICT_FILE")"
-ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
-# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
-MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-        | jq -r --arg me "$ME" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*review-doc:"; "i"))))
-        | last | .id // empty')
-if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
-else
-  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
-fi
+# $VERDICT resolved above (ADR 0062/0064) — same one-per-gate upsert as the PASS path.
+$VERDICT post --pr "$PR" --gate doc --body-file "$VERDICT_FILE"
 ```
 
 Verdict body shape:

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -83,6 +83,40 @@ node packages/pipeline-cli/src/bin.ts epic-lock acquire 1234 && echo "hold the l
 node packages/pipeline-cli/src/bin.ts epic-lock release 1234
 ```
 
+### `verdict` — the ADR-0058 SHA-bound gate-verdict read/post glue (#2102)
+
+The SHA-bound verdict read/post glue the `review-*` / `ship-it` / `write-code`-repair skills
+each hand-rolled inline as `jq`, extracted into one deterministic, unit-tested tool. The
+**pure core** (`verdict-match.ts`) is the verdict-match decision: given a PR's comment bodies
++ the current HEAD sha + the write+ authorized-author set, is HEAD reviewed in this gate's
+namespace, and by which marker? — with the discriminator the inline reads got subtly wrong
+made explicit (a SHA-less advisory does **not** satisfy a SHA-bound check; a verdict bound to a
+stale head does **not** pass; newest-authorized-marker wins). It re-encodes the ADR-0058 match
+semantics; it does **not** change what any gate verifies.
+
+- **`verdict read --pr N --gate <code|doc|skill|design> [--expect PASS|FAIL] [--head <sha>]`** —
+  resolve the (PR, gate) verdict against the PR's current head (author-gated to write+
+  collaborators, ADR 0055). Prints the resolved outcome as JSON on stdout (`_tag` of
+  `current`/`stale`/`sha-less`/`none`, plus the bound sha + comment id); **exits 0 only when HEAD
+  is reviewed with the `--expect` polarity** (default `PASS`; `FAIL` is the `write-code`-repair
+  seam), non-zero with a named refusal reason on stderr otherwise — so a caller branches on exit
+  status.
+- **`verdict post --pr N --gate <g> [--body-file <f>]`** — the ADR-0058 rule-2 **upsert**: read
+  the composed verdict body (from `--body-file` or stdin), refuse fail-closed if its first line is
+  not *this* gate's marker (the cross-namespace emission bug), then PATCH our own prior marker in
+  the namespace if one exists, else POST — exactly one verdict comment per (PR, gate). Prints
+  `patched <id>` / `posted <id>`.
+
+The pure match core (`verdict-match.ts`) is IO-free and unit-tested table-driven; `github.ts` is
+the REST-only `gh api` boundary (the `epic-lock` `github.ts` service pattern).
+
+```bash
+# is PR 123's doc verdict a current-head PASS? (exit 0 = reviewed)
+node packages/pipeline-cli/src/bin.ts verdict read --pr 123 --gate doc && echo "merge-ready"
+# upsert a composed review-doc verdict (one comment per gate)
+node packages/pipeline-cli/src/bin.ts verdict post --pr 123 --gate doc --body-file "$VERDICT_FILE"
+```
+
 ### `leak-guard` — personal-data leak gate for shared artifacts (#173, #2357)
 
 Two modes, one deny-list-per-mode core:

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -40,6 +40,7 @@ import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
 import {tokenSpendCommand} from "./tools/token-spend/command.ts";
 import {trivialDiffCommand} from "./tools/trivial-diff/command.ts";
+import {verdictCommand} from "./tools/verdict/command.ts";
 import {wayfinderMapCommand} from "./tools/wayfinder-map/command.ts";
 import {workflowContractCommand} from "./tools/workflow-contract/command.ts";
 import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
@@ -112,4 +113,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	mainSyncCommand,
 	refGuardCommand,
 	settingsEnvGuardCommand,
+	verdictCommand,
 ];

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -1,0 +1,134 @@
+/**
+ * The `verdict` tool — `pipeline-cli verdict read` / `pipeline-cli verdict post`.
+ *
+ * The ADR-0058 SHA-bound verdict read/post glue, extracted from the inline `jq` the
+ * `review-*` / `ship-it` / `write-code`-repair / `heal-ci` skills each hand-rolled (#2102).
+ *
+ * `read --pr N --gate <g> [--expect PASS|FAIL] [--head <sha>]` resolves the (PR, gate)
+ * verdict against the PR's current head (author-gated to write+ collaborators, ADR 0055) and
+ * **exits 0 only when HEAD is reviewed with the expected polarity** (default PASS) — every
+ * refusal (`none`/`sha-less`/`stale`, or a current verdict of the wrong polarity) prints its
+ * reason on stderr and exits non-zero, so a caller branches on exit status. The resolved
+ * outcome is printed as JSON on stdout for a caller that wants the detail (comment id, sha).
+ *
+ * `post --pr N --gate <g> [--body-file <f>]` upserts a SHA-bound verdict comment (ADR 0058
+ * rule 2): it reads the composed verdict body from `--body-file` (or stdin), refuses fail-closed
+ * if that body's first line is not this gate's marker (the cross-namespace emission bug), then
+ * PATCHes our own prior marker in the namespace if one exists, else POSTs — exactly one verdict
+ * comment per (PR, gate). It prints `patched <id>` / `posted <id>` on stdout.
+ *
+ * `GithubLive` is baked in with `Command.provide(...)` so the registered command's residual
+ * requirement is the Node platform union (the registry seam, epic #994).
+ */
+import {readFileSync} from "node:fs";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {Github, GithubLive} from "./github.ts";
+import {GATES, outcomeReason, type Polarity, type VerdictGate} from "./verdict-match.ts";
+
+const FAIL_EXIT_CODE = 1;
+
+const prFlag = Flag.integer("pr").pipe(Flag.withDescription("the pull request number"));
+
+const gateFlag = Flag.string("gate").pipe(
+	Flag.withDescription(`the gate namespace: one of ${GATES.join(" | ")} (review-<gate>)`),
+);
+
+const headFlag = Flag.string("head").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"override the head SHA to bind against (default: the PR's current head via REST)",
+	),
+);
+
+const expectFlag = Flag.string("expect").pipe(
+	Flag.optional,
+	Flag.withDescription("the polarity a `read` treats as satisfied: PASS (default) or FAIL"),
+);
+
+const bodyFileFlag = Flag.string("body-file").pipe(
+	Flag.optional,
+	Flag.withDescription("path to the composed verdict body (default: read the body from stdin)"),
+);
+
+/** Print `reason` on stderr and exit non-zero — the "not satisfied / bad input" signal a caller branches on. */
+const fail = (reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stderr.write(`verdict: ${reason}\n`);
+		process.exit(FAIL_EXIT_CODE);
+	});
+
+const parseGate = (raw: string): Effect.Effect<VerdictGate, never> => {
+	const gate = raw.trim().toLowerCase();
+	return (GATES as ReadonlyArray<string>).includes(gate)
+		? Effect.succeed(gate as VerdictGate)
+		: fail(`unknown gate '${raw}' — expected one of ${GATES.join(" | ")}`);
+};
+
+const parseExpect = (raw: Option.Option<string>): Effect.Effect<Polarity, never> => {
+	const value = Option.getOrElse(raw, () => "PASS")
+		.trim()
+		.toUpperCase();
+	if (value === "PASS" || value === "FAIL") return Effect.succeed(value);
+	return fail(`invalid --expect '${Option.getOrElse(raw, () => "")}' — expected PASS or FAIL`);
+};
+
+const read = Command.make(
+	"read",
+	{pr: prFlag, gate: gateFlag, head: headFlag, expect: expectFlag},
+	Effect.fn(function* ({pr, gate, head, expect}) {
+		const g = yield* parseGate(gate);
+		const polarity = yield* parseExpect(expect);
+		const result = yield* (yield* Github).read(pr, g, polarity, Option.getOrUndefined(head));
+		// The resolved detail goes to stdout as JSON (a caller may want the comment id / bound sha);
+		// the human-readable verdict + refusal reason goes to stderr, mirroring resume-policy.
+		yield* Console.log(JSON.stringify({...result.outcome, headSha: result.headSha, gate: g}));
+		if (result.satisfied) {
+			process.stderr.write(`verdict: ${outcomeReason(result.outcome, polarity)}\n`);
+			return;
+		}
+		return yield* fail(outcomeReason(result.outcome, polarity));
+	}),
+).pipe(
+	Command.withDescription(
+		"Resolve a PR's SHA-bound gate verdict against its current head (exit 0 = reviewed with --expect polarity)",
+	),
+);
+
+const readBody = (bodyFile: Option.Option<string>): Effect.Effect<string, never> =>
+	Effect.sync(() =>
+		Option.match(bodyFile, {
+			onNone: () => readFileSync(0, "utf8"),
+			onSome: (path) => readFileSync(path, "utf8"),
+		}),
+	);
+
+const post = Command.make(
+	"post",
+	{pr: prFlag, gate: gateFlag, bodyFile: bodyFileFlag},
+	Effect.fn(function* ({pr, gate, bodyFile}) {
+		const g = yield* parseGate(gate);
+		const body = (yield* readBody(bodyFile)).replace(/\s+$/, "");
+		if (body.length === 0) {
+			return yield* fail(
+				"empty verdict body — nothing to post (pass --body-file or pipe the body on stdin)",
+			);
+		}
+		const result = yield* (yield* Github)
+			.post(pr, g, body)
+			.pipe(Effect.catchTag("@kampus/verdict/VerdictInputError", (error) => fail(error.message)));
+		yield* Console.log(`${result._tag} ${result.commentId}`);
+	}),
+).pipe(
+	Command.withDescription(
+		"Upsert a SHA-bound verdict comment for a PR gate (PATCH own prior marker, else POST — one per gate, ADR 0058 rule 2)",
+	),
+);
+
+export const verdictCommand = Command.make("verdict").pipe(
+	Command.withSubcommands([read, post]),
+	Command.withDescription(
+		"Read/post ADR-0058 SHA-bound gate verdicts (review-code/doc/skill/design) — the shared verdict-match glue",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -1,0 +1,227 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Github, GithubLive, type RepoResolutionError, VerdictInputError} from "./github.ts";
+
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+const methodOf = (args: ReadonlyArray<string>): string => {
+	const i = args.indexOf("-X");
+	return i >= 0 ? (args[i + 1] ?? "GET") : "GET";
+};
+
+/** A `ChildProcessSpawner` answering `gh api`/`gh repo`/`gh user` from a `${method} ${key}` fixture map. */
+const mockSpawner = (
+	responses: Record<string, Response>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				// route on the REST path when present, else on the `gh <sub> <verb>` shape (user/repo)
+				const rawPath =
+					args.find((a) => a.startsWith("repos/")) ??
+					(args[0] === "api" ? (args[1] ?? "") : args.slice(0, 2).join(" "));
+				const path = rawPath.replace(/\?.*$/, "");
+				const key = `${methodOf(args)} ${path}`;
+				const canned =
+					key in responses
+						? normalize(responses[key]!)
+						: {stdout: "", exitCode: 1, stderr: `not found: ${key}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	responses: Record<string, Response>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const PR = 500;
+const P = `repos/kamp-us/phoenix`;
+const HEAD = "abc1234def5678";
+const OLD = "0000000aaaa1111";
+
+const comment = (over: {
+	readonly id: number;
+	readonly login: string;
+	readonly body: string;
+	readonly at?: string;
+}) =>
+	({
+		id: over.id,
+		created_at: over.at ?? "2026-07-11T00:00:00Z",
+		user: {login: over.login},
+		body: over.body,
+	}) as const;
+
+describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawner", () => {
+	it.effect("current-head PASS from a write+ author → satisfied", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			assert.strictEqual(result.outcome._tag, "current");
+			assert.isTrue(result.satisfied);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "usirin", body: `review-doc: PASS @ ${HEAD} — merge-ready`}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "admin",
+			}),
+		),
+	);
+
+	it.effect("a stale-sha PASS → not satisfied (unverified)", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			assert.strictEqual(result.outcome._tag, "stale");
+			assert.isFalse(result.satisfied);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "usirin", body: `review-doc: PASS @ ${OLD} — merge-ready`}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+			}),
+		),
+	);
+
+	it.effect("a forged PASS from a non-collaborator is invisible → none", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).read(PR, "doc", "PASS");
+			assert.strictEqual(result.outcome._tag, "none");
+			assert.isFalse(result.satisfied);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/pulls/${PR}`]: HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "attacker", body: `review-doc: PASS @ ${HEAD} — merge-ready`}),
+				]),
+				[`GET ${P}/collaborators/attacker/permission`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 404: Not Found",
+				},
+			}),
+		),
+	);
+
+	it.effect("a --head override binds against the supplied head, not the PR's live head", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).read(PR, "skill", "PASS", HEAD);
+			assert.strictEqual(result.outcome._tag, "current");
+			assert.strictEqual(result.headSha, HEAD);
+		}).pipe((effect) =>
+			provide(effect, {
+				// no pulls fixture: a live-head lookup would 404 — the override must be used instead
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "usirin", body: `review-skill: PASS @ ${HEAD} — merge-ready`}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "maintain",
+			}),
+		),
+	);
+});
+
+describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", () => {
+	const BODY = `review-doc: PASS @ ${HEAD} — merge-ready\n\nReviewed-head: @ ${HEAD}`;
+
+	it.effect("no prior marker → POST a fresh verdict comment", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).post(PR, "doc", BODY);
+			assert.deepStrictEqual(result, {_tag: "posted", commentId: 999});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 1, login: "someone", body: "just chatter"}),
+				]),
+				[`POST ${P}/issues/${PR}/comments`]: "999",
+			}),
+		),
+	);
+
+	it.effect("our own prior marker exists → PATCH it (upsert, not append)", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).post(PR, "doc", BODY);
+			assert.deepStrictEqual(result, {_tag: "patched", commentId: 42});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 42, login: "usirin", body: `review-doc: FAIL @ ${OLD} — changes-requested`}),
+				]),
+				[`PATCH ${P}/issues/comments/42`]: "42",
+			}),
+		),
+	);
+
+	it.effect("only ANOTHER author's marker exists → POST ours, never PATCH theirs", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).post(PR, "doc", BODY);
+			assert.strictEqual(result._tag, "posted");
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
+					comment({id: 7, login: "cansirin", body: `review-doc: PASS @ ${OLD} — merge-ready`}),
+				]),
+				[`POST ${P}/issues/${PR}/comments`]: "1000",
+			}),
+		),
+	);
+
+	it.effect(
+		"a cross-namespace body (review-code on a doc post) → VerdictInputError, no write",
+		() =>
+			Effect.gen(function* () {
+				const error = yield* Effect.flip(
+					(yield* Github).post(PR, "doc", `review-code: PASS @ ${HEAD} — merge-ready`),
+				);
+				assert.isTrue(error instanceof VerdictInputError);
+			}).pipe((effect) =>
+				provide(effect, {
+					"GET user": "usirin",
+					[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				}),
+			),
+	);
+});

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -1,0 +1,387 @@
+/**
+ * The GitHub boundary for `verdict`: the live `Github` capability that reads and upserts
+ * ADR-0058 SHA-bound gate verdicts over `gh api` REST, driving the IO-free
+ * `verdict-match.ts` core.
+ *
+ * Same service pattern as the `epic-lock` template child (epic #994): a `Context.Service`
+ * on `ChildProcessSpawner`, REST only (GraphQL is broken on the kamp-us org), every infra
+ * failure a typed error in the `E` channel (`GhCommandError` / `GhParseError` /
+ * `RepoResolutionError`), untrusted REST JSON Schema-decoded at the boundary into the domain
+ * `VerdictComment` the core resolves over.
+ *
+ * Two verbs:
+ *  - `read(pr, gate, expect, headOverride)` — resolve the PR's current head (REST), author-gate
+ *    marker authors to write+ collaborators (ADR 0055), and run `resolveVerdict` to classify
+ *    the namespace against that head. The consumer branches on the returned outcome.
+ *  - `post(pr, gate, body)` — the ADR-0058 rule-2 UPSERT: guard the body's first line is *this*
+ *    gate's marker (fail-closed on a cross-namespace body), then PATCH our own prior marker in
+ *    the namespace if one exists, else POST a fresh one — exactly one verdict comment per (PR, gate).
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {
+	GATE_KEYWORD,
+	isNamespaceMarker,
+	namespaceRe,
+	type Polarity,
+	resolveVerdict,
+	type VerdictComment,
+	type VerdictGate,
+	type VerdictOutcome,
+} from "./verdict-match.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/verdict/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/verdict/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/verdict/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/** A malformed request the caller must fix — e.g. a `post` body whose first line is the wrong gate's marker. */
+export class VerdictInputError extends Schema.TaggedErrorClass<VerdictInputError>()(
+	"@kampus/verdict/VerdictInputError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/** The `read` verdict — the resolved outcome plus the head it was resolved against. */
+export interface ReadResult {
+	readonly outcome: VerdictOutcome;
+	readonly headSha: string;
+	readonly gate: VerdictGate;
+	/** Does the outcome satisfy the caller's expected polarity (a current-head match)? */
+	readonly satisfied: boolean;
+	readonly expect: Polarity;
+}
+
+/** The `post` verdict — whether we upserted an existing marker or posted the first one, and the comment id. */
+export interface PostResult {
+	readonly _tag: "patched" | "posted";
+	readonly commentId: number;
+}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the same
+ * direct-spawn shape `epic-lock` uses so a non-zero exit + stderr lower into a typed error
+ * rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` not on PATH) folds in as exit `-1`.
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently defaults —
+ * with no env and no resolvable current repo it fails `RepoResolutionError`.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/verdict/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// --- REST arg builders (REST only, never GraphQL) --------------------------------
+
+const headShaArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/pulls/${pr}`,
+	"--jq",
+	".head.sha",
+];
+
+const listCommentsArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${pr}/comments?per_page=100`,
+];
+
+const whoAmIArgs: ReadonlyArray<string> = ["api", "user", "--jq", ".login"];
+
+const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/collaborators/${login}/permission`,
+	"--jq",
+	".permission",
+];
+
+const postCommentArgs = (repo: string, pr: number, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${pr}/comments`,
+	"-f",
+	`body=${body}`,
+	"--jq",
+	".id",
+];
+
+const patchCommentArgs = (repo: string, id: number, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"PATCH",
+	`repos/${repo}/issues/comments/${id}`,
+	"-f",
+	`body=${body}`,
+	"--jq",
+	".id",
+];
+
+// --- boundary decoders -----------------------------------------------------------
+
+/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
+const RawComment = Schema.Struct({
+	id: Schema.Number,
+	created_at: Schema.String,
+	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
+});
+const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+const toVerdictComment = (raw: (typeof RawComment)["Type"]): VerdictComment => ({
+	id: raw.id,
+	author: raw.user?.login ?? "",
+	createdAt: raw.created_at,
+	body: raw.body ?? "",
+});
+
+// --- IO operations ---------------------------------------------------------------
+
+const currentHead = Effect.fn("Github.currentHead")(function* (repo: string, pr: number) {
+	return (yield* runGh(headShaArgs(repo, pr))).trim();
+});
+
+const listComments = Effect.fn("Github.listComments")(function* (repo: string, pr: number) {
+	const args = listCommentsArgs(repo, pr);
+	const raw = yield* decodeComments(yield* json(args));
+	return raw.map(toVerdictComment);
+});
+
+/**
+ * The write+ collaborator subset of `logins` — the ADR 0055 trust root. Each login is probed
+ * with `collaborators/<login>/permission`; a non-`admin|maintain|write` permission, or any `gh`
+ * fault on the probe (a non-collaborator commonly 404s), drops the login. A forged marker from a
+ * non-collaborator therefore never enters the authorized set the core resolves over.
+ */
+const authorizedAuthors = Effect.fn("Github.authorizedAuthors")(function* (
+	repo: string,
+	logins: ReadonlyArray<string>,
+) {
+	const results = yield* Effect.forEach(
+		logins,
+		(login) =>
+			runGh(permissionArgs(repo, login)).pipe(
+				Effect.map((out) => ({login, permission: out.trim()})),
+				Effect.catchTag("@kampus/verdict/GhCommandError", () =>
+					Effect.succeed({login, permission: "none"}),
+				),
+			),
+		{concurrency: "unbounded"},
+	);
+	return results
+		.filter(
+			(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
+		)
+		.map((r) => r.login);
+});
+
+/**
+ * Read the PR's verdict for `gate` against its current head (or `headOverride` when the caller
+ * already resolved it — e.g. a reviewer binding to the exact head it read). Author-gates the
+ * distinct marker authors to write+ collaborators, then runs the pure `resolveVerdict`.
+ */
+const read = Effect.fn("Github.read")(function* (
+	repo: string,
+	pr: number,
+	gate: VerdictGate,
+	expect: Polarity,
+	headOverride: string | undefined,
+) {
+	const headSha = headOverride?.trim() || (yield* currentHead(repo, pr));
+	const comments = yield* listComments(repo, pr);
+	const re = namespaceRe(gate);
+	const markerAuthors = [
+		...new Set(
+			comments
+				.filter((c) => re.test(c.body))
+				.map((c) => c.author)
+				.filter((a) => a.length > 0),
+		),
+	];
+	const authorized = yield* authorizedAuthors(repo, markerAuthors);
+	const outcome = resolveVerdict({comments, authorizedAuthors: authorized, gate, headSha});
+	const satisfied = outcome._tag === "current" && outcome.polarity === expect;
+	return {outcome, headSha, gate, satisfied, expect} satisfies ReadResult;
+});
+
+/**
+ * Upsert this PR's `gate` verdict (ADR 0058 rule 2): guard `body`'s first line is *this* gate's
+ * marker (fail-closed `VerdictInputError` on a cross-namespace body — the emission bug), scan our
+ * OWN prior marker in the namespace (newest by `(created_at, id)`), then PATCH it if present else
+ * POST a fresh one. The own-authored scope means two reviewers never stomp each other's records.
+ */
+const post = Effect.fn("Github.post")(function* (
+	repo: string,
+	pr: number,
+	gate: VerdictGate,
+	body: string,
+) {
+	if (!isNamespaceMarker(body, gate)) {
+		return yield* new VerdictInputError({
+			message: `refusing to post: the body's first line is not a ${GATE_KEYWORD[gate]}: marker — a verdict must carry its own gate's marker on line one (the cross-namespace emission bug, ADR 0058 §Scope)`,
+		});
+	}
+	const me = (yield* runGh(whoAmIArgs)).trim();
+	const comments = yield* listComments(repo, pr);
+	const re = namespaceRe(gate);
+	const mine = comments
+		.filter((c) => c.author === me && re.test(c.body))
+		.sort((a, b) => (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id));
+	const priorId = mine[mine.length - 1]?.id;
+	if (priorId !== undefined) {
+		const decoded = yield* json(patchCommentArgs(repo, priorId, body));
+		return {
+			_tag: "patched",
+			commentId: typeof decoded === "number" ? decoded : priorId,
+		} satisfies PostResult;
+	}
+	const decoded = yield* json(postCommentArgs(repo, pr, body));
+	if (typeof decoded !== "number") {
+		return yield* new GhParseError({
+			args: postCommentArgs(repo, pr, "<body>"),
+			message: "comment POST did not return a numeric id",
+		});
+	}
+	return {_tag: "posted", commentId: decoded} satisfies PostResult;
+});
+
+/**
+ * `Github` — the IO shell over `gh api` REST for the ADR-0058 verdict read/post glue. `read`
+ * resolves a (PR, gate) verdict against the current head; `post` upserts a SHA-bound verdict
+ * comment. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly read: (
+			pr: number,
+			gate: VerdictGate,
+			expect: Polarity,
+			headOverride?: string,
+		) => Effect.Effect<
+			ReadResult,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+		readonly post: (
+			pr: number,
+			gate: VerdictGate,
+			body: string,
+		) => Effect.Effect<
+			PostResult,
+			RepoResolutionError | GhCommandError | GhParseError | VerdictInputError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/verdict/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at construction
+ * and provided into each method body, so the public methods carry `R = never`. Repo resolution is
+ * deferred to first use (`Effect.cached`, ADR 0062 §1): the layer build is side-effect-free, and
+ * `RepoResolutionError` lives in each method's `E` channel, raised only when a verb actually reads or writes.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				read: (pr, gate, expect, headOverride) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(read(r, pr, gate, expect, headOverride)))),
+				post: (pr, gate, body) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(post(r, pr, gate, body)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -1,0 +1,216 @@
+/**
+ * The pure verdict-match core of `verdict` — IO-free, total, unit-testable.
+ *
+ * The single discriminator the `review-*` / `ship-it` / `write-code`-repair / `heal-ci`
+ * skills each hand-rolled inline as `jq` reads: given a PR's comment bodies + the PR's
+ * current HEAD sha, is HEAD reviewed in this gate's namespace, and by which marker? The
+ * exact decision the inline reads get subtly wrong — a SHA-less advisory must NOT satisfy
+ * a SHA-bound check, and a verdict bound to a *stale* head must NOT pass — re-encoded here
+ * as one deterministic, table-tested function (ADR 0058, the SHA-bound verdict contract).
+ *
+ * The marker grammar, the emphasis-tolerant anchor, and the `@ <sha>` capture are
+ * single-sourced from gh-issue-intake-formats.md §5/§6 and ADR 0058; this core is the
+ * deterministic decision the IO shell (`github.ts`) drives at the boundary. The author-gate
+ * (ADR 0055 write+ trust root) is resolved by the shell and handed in as `authorizedAuthors`,
+ * exactly as `epic-lock`'s claim core takes it — a forged marker from a non-collaborator
+ * never enters the candidate set, and an empty authorized set resolves NO verdict (fail-closed).
+ */
+
+/** The four PR-layer gate namespaces (ADR 0058 §Scope + ADR 0150/0162). */
+export type VerdictGate = "code" | "doc" | "skill" | "design";
+
+/** A resolved verdict's polarity — the reviewer's go/no-go. */
+export type Polarity = "PASS" | "FAIL";
+
+/** The marker keyword for each gate — `review-<gate>:` is the namespaced first token. */
+export const GATE_KEYWORD: Record<VerdictGate, string> = {
+	code: "review-code",
+	doc: "review-doc",
+	skill: "review-skill",
+	design: "review-design",
+};
+
+export const GATES: ReadonlyArray<VerdictGate> = ["code", "doc", "skill", "design"];
+
+/**
+ * Namespace-membership matcher: does the body's first line open with this gate's marker?
+ * PASS / FAIL / advisory all match (they share the `review-<gate>:` prefix) — this is the
+ * "is this a marker in my namespace at all" test the `post` upsert scans with, and the
+ * cross-namespace guard (`review-code:` never matches the `doc` namespace and vice versa).
+ * Anchored at string start with no `m` flag, so it tests the very first line only — a
+ * comment that merely *quotes* a marker mid-body never matches (§5/§6).
+ */
+export const namespaceRe = (gate: VerdictGate): RegExp =>
+	new RegExp(`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:`, "i");
+
+/**
+ * Bindable-verdict matcher: `review-<gate>: (PASS|FAIL) @ <sha>` — captures the polarity
+ * (group 1) and the bound head SHA (group 2, ≥7 hex). The `@ <sha>` **immediately after**
+ * PASS/FAIL is the fixed token order (§5) — a trailing `@ <sha>` after the em-dash tail does
+ * NOT match, exactly as `ship-it`'s capture refuses it (#625).
+ */
+export const verdictRe = (gate: VerdictGate): RegExp =>
+	new RegExp(
+		`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:\\s*(PASS|FAIL)\\s*@\\s*([0-9a-f]{7,40})`,
+		"i",
+	);
+
+/**
+ * Polarity-only matcher: `review-<gate>: (PASS|FAIL)` with no `@ <sha>` requirement. This is
+ * the looser namespace-verdict test `ship-it` filters candidates with before the SHA capture —
+ * it matches a legacy/pre-0058 SHA-less PASS/FAIL marker too, which the resolution then
+ * classifies as `sha-less` (never a current-head PASS). An `advisory` line is deliberately
+ * NOT matched (it carries no PASS/FAIL), so it never enters the machine-verdict namespace.
+ */
+export const polarityRe = (gate: VerdictGate): RegExp =>
+	new RegExp(`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:\\s*(PASS|FAIL)`, "i");
+
+/** A PR/issue comment as the issues/comments REST endpoint surfaces it (only these fields matter). */
+export interface VerdictComment {
+	/** Server-assigned, strictly-monotonic, globally-unique comment id (the tiebreak sub-key). */
+	readonly id: number;
+	/** The comment author's login (checked against the authorized set). */
+	readonly author: string;
+	/** ISO-8601 UTC creation time (the latest-wins primary key). */
+	readonly createdAt: string;
+	/** The raw comment body (matched against the namespace/verdict matchers). */
+	readonly body: string;
+}
+
+/** A parsed verdict first line: its polarity and its bound head SHA (`null` when SHA-less). */
+export interface ParsedVerdict {
+	readonly polarity: Polarity;
+	readonly sha: string | null;
+}
+
+/**
+ * Parse the polarity + bound SHA out of a first-line marker, or `null` when the body is not
+ * a PASS/FAIL verdict in this gate's namespace. A bindable marker yields `{polarity, sha}`;
+ * a namespaced-but-SHA-less PASS/FAIL yields `{polarity, sha: null}` (a legacy marker); a
+ * non-verdict (chatter, an `advisory` line, another gate's marker) yields `null`.
+ */
+export const parseVerdict = (body: string, gate: VerdictGate): ParsedVerdict | null => {
+	const bound = verdictRe(gate).exec(body);
+	if (bound?.[1] && bound[2]) {
+		return {polarity: bound[1].toUpperCase() as Polarity, sha: bound[2].toLowerCase()};
+	}
+	const bare = polarityRe(gate).exec(body);
+	if (bare?.[1]) {
+		return {polarity: bare[1].toUpperCase() as Polarity, sha: null};
+	}
+	return null;
+};
+
+/**
+ * Is a verdict's bound SHA bound to the PR's current head? Prefix-match in either direction —
+ * either side may be abbreviated (§ADR 0058 rule 3). A `null`/empty bound SHA, or an empty
+ * head, is **never** current (the load-bearing fail-closed: a legacy SHA-less marker must not
+ * read as current, the exact ship-it `is_current` short-circuit that a jq `sha: null` broke).
+ */
+export const isBoundToHead = (sha: string | null | undefined, head: string): boolean => {
+	if (!sha || !head) return false;
+	const a = sha.toLowerCase();
+	const b = head.toLowerCase();
+	return a.startsWith(b) || b.startsWith(a);
+};
+
+/** The resolved verdict for a (PR, gate) — exactly one of four states against the current head. */
+export type VerdictOutcome =
+	/** No authorized PASS/FAIL marker exists in this namespace (or the authorized set was empty). */
+	| {readonly _tag: "none"}
+	/** The latest authorized marker carries no `@ <sha>` (a pre-0058 legacy marker) — refuse. */
+	| {readonly _tag: "sha-less"; readonly commentId: number; readonly polarity: Polarity}
+	/** The latest authorized marker is bound to a different (stale) head — refuse. */
+	| {
+			readonly _tag: "stale";
+			readonly commentId: number;
+			readonly polarity: Polarity;
+			readonly sha: string;
+	  }
+	/** The latest authorized marker is bound to the current head — its polarity decides. */
+	| {
+			readonly _tag: "current";
+			readonly commentId: number;
+			readonly polarity: Polarity;
+			readonly sha: string;
+	  };
+
+export interface ResolveVerdictInput {
+	readonly comments: ReadonlyArray<VerdictComment>;
+	/** The write+ collaborator logins — the ADR 0055 trust root (resolved by the IO shell). */
+	readonly authorizedAuthors: ReadonlyArray<string>;
+	readonly gate: VerdictGate;
+	/** The PR's current head SHA every verdict must be bound to (ADR 0058 rule 3). */
+	readonly headSha: string;
+}
+
+/**
+ * Resolve the (PR, gate) verdict against the current head, re-encoding ADR 0058 rule 3
+ * exactly: author-gate to write+ collaborators (a forged marker is invisible), keep only
+ * PASS/FAIL markers in this namespace, take the **newest** by `(createdAt, id)` (latest-wins,
+ * so a newer FAIL vetoes an older PASS and a re-review overwrites), then classify by the
+ * SHA-staleness test — `current` iff its `@ <sha>` prefix-matches the head, else `stale`;
+ * `sha-less` when the newest marker carries no `@ <sha>`; `none` when the authorized candidate
+ * set is empty. Fail-closed everywhere: an empty authorized set is `none`, never a false win.
+ */
+export const resolveVerdict = (input: ResolveVerdictInput): VerdictOutcome => {
+	const authorized = new Set(input.authorizedAuthors);
+	const re = polarityRe(input.gate);
+	const candidates = input.comments.filter(
+		(comment) => authorized.has(comment.author) && re.test(comment.body),
+	);
+	candidates.sort((a, b) =>
+		a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
+	);
+	const latest = candidates[candidates.length - 1];
+	// `latest` is absent only for an empty candidate set, and `parseVerdict` is null only for a
+	// non-PASS/FAIL body — but polarityRe already filtered candidates to PASS/FAIL markers, so both
+	// guards collapse to the same fail-closed `none` (no consumable verdict in this namespace).
+	const parsed = latest ? parseVerdict(latest.body, input.gate) : null;
+	if (latest === undefined || parsed === null) return {_tag: "none"};
+	if (parsed.sha === null) {
+		return {_tag: "sha-less", commentId: latest.id, polarity: parsed.polarity};
+	}
+	if (!isBoundToHead(parsed.sha, input.headSha)) {
+		return {_tag: "stale", commentId: latest.id, polarity: parsed.polarity, sha: parsed.sha};
+	}
+	return {_tag: "current", commentId: latest.id, polarity: parsed.polarity, sha: parsed.sha};
+};
+
+/**
+ * The `read` verb's decision: is HEAD reviewed with the expected polarity? True **only** for a
+ * current-head-bound verdict whose polarity matches — a `sha-less`, `stale`, or `none` outcome
+ * is never satisfied. `ship-it` expects `PASS`; `write-code`-repair expects `FAIL` (the seam it
+ * consumes). This is the single boolean the inline `is_current`-then-polarity checks recomputed.
+ */
+export const isReviewed = (outcome: VerdictOutcome, expect: Polarity): boolean =>
+	outcome._tag === "current" && outcome.polarity === expect;
+
+/**
+ * A machine-readable reason for a non-satisfying `read` outcome — the named refusal `ship-it`
+ * prints (`unverified (verdict not bound to current head)` for `sha-less`/`stale`).
+ */
+export const outcomeReason = (outcome: VerdictOutcome, expect: Polarity): string => {
+	switch (outcome._tag) {
+		case "none":
+			return "no authorized verdict in this namespace";
+		case "sha-less":
+			return "unverified (verdict not bound to current head): latest marker is SHA-less (pre-0058)";
+		case "stale":
+			return `unverified (verdict not bound to current head): latest marker bound to ${outcome.sha}, not the current head`;
+		case "current":
+			return outcome.polarity === expect
+				? `reviewed: current-head ${outcome.polarity} @ ${outcome.sha}`
+				: `current-head verdict is ${outcome.polarity}, expected ${expect}`;
+	}
+};
+
+/**
+ * The `post` namespace guard: does this body's first line open with the gate's marker? A
+ * verdict body must carry its OWN gate's marker on line one — `post`-ing a `review-code`
+ * marker on a doc PR is the cross-namespace emission bug this refuses fail-closed. Accepts
+ * every valid first line for the gate (PASS / FAIL / advisory), rejects any other gate's
+ * marker and any non-marker first line.
+ */
+export const isNamespaceMarker = (body: string, gate: VerdictGate): boolean =>
+	namespaceRe(gate).test(body);

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -1,0 +1,304 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	isBoundToHead,
+	isNamespaceMarker,
+	isReviewed,
+	parseVerdict,
+	resolveVerdict,
+	type VerdictComment,
+	type VerdictGate,
+	type VerdictOutcome,
+} from "./verdict-match.ts";
+
+const HEAD = "abc1234def5678";
+const OLD = "0000000aaaa1111";
+
+const marker = (over: Partial<VerdictComment> & {readonly id: number}): VerdictComment => ({
+	author: "usirin",
+	createdAt: "2026-07-11T00:00:00Z",
+	body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+	...over,
+});
+
+describe("parseVerdict — polarity + bound SHA out of a first-line marker", () => {
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly body: string;
+		readonly gate: VerdictGate;
+		readonly expected: ReturnType<typeof parseVerdict>;
+	}> = [
+		{
+			name: "bindable PASS captures polarity + sha",
+			body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+			gate: "doc",
+			expected: {polarity: "PASS", sha: HEAD},
+		},
+		{
+			name: "bindable FAIL captures polarity + sha",
+			body: `review-code: FAIL @ ${HEAD} — not merge-ready`,
+			gate: "code",
+			expected: {polarity: "FAIL", sha: HEAD},
+		},
+		{
+			name: "leading bold emphasis is tolerated (§5 \\**)",
+			body: `**review-skill: PASS @ ${HEAD}** — merge-ready`,
+			gate: "skill",
+			expected: {polarity: "PASS", sha: HEAD},
+		},
+		{
+			name: "SHA-less PASS marker → sha null (legacy/pre-0058)",
+			body: "review-doc: PASS — merge-ready",
+			gate: "doc",
+			expected: {polarity: "PASS", sha: null},
+		},
+		{
+			name: "advisory line is NOT a PASS/FAIL verdict → null",
+			body: "review-doc: advisory — blocking-set PR (manual merge)",
+			gate: "doc",
+			expected: null,
+		},
+		{
+			name: "another gate's marker does not match this namespace",
+			body: `review-code: PASS @ ${HEAD} — merge-ready`,
+			gate: "doc",
+			expected: null,
+		},
+		{
+			name: "a mid-body quote does not match (anchored to first line)",
+			body: `discussing the review-doc: PASS @ ${HEAD} marker`,
+			gate: "doc",
+			expected: null,
+		},
+		{
+			name: "trailing @sha after the em-dash tail does NOT bind (fixed token order, #625)",
+			body: `review-doc: PASS — merge-ready @ ${HEAD}`,
+			gate: "doc",
+			expected: {polarity: "PASS", sha: null},
+		},
+	];
+	for (const {name, body, gate, expected} of cases) {
+		it(name, () => assert.deepStrictEqual(parseVerdict(body, gate), expected));
+	}
+});
+
+describe("isBoundToHead — SHA-staleness prefix-match, fail-closed on empty", () => {
+	it("exact match is current", () => assert.isTrue(isBoundToHead(HEAD, HEAD)));
+	it("abbreviated verdict SHA prefixes the full head", () =>
+		assert.isTrue(isBoundToHead("abc1234", HEAD)));
+	it("full verdict SHA is prefixed by an abbreviated head", () =>
+		assert.isTrue(isBoundToHead(HEAD, "abc1234")));
+	it("case-insensitive", () => assert.isTrue(isBoundToHead(HEAD.toUpperCase(), HEAD)));
+	it("a different head is not current", () => assert.isFalse(isBoundToHead(OLD, HEAD)));
+	it("null bound SHA is never current (legacy marker fail-closed)", () =>
+		assert.isFalse(isBoundToHead(null, HEAD)));
+	it("empty head is never current (the unguarded-glob bug, ADR 0058 rule 3)", () =>
+		assert.isFalse(isBoundToHead(HEAD, "")));
+});
+
+describe("resolveVerdict — the SHA-bound verdict decision (table-driven, ADR 0058 rule 3)", () => {
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly comments: ReadonlyArray<VerdictComment>;
+		readonly authorized: ReadonlyArray<string>;
+		readonly gate: VerdictGate;
+		readonly head: string;
+		readonly expected: VerdictOutcome;
+		readonly reviewedPass: boolean;
+	}> = [
+		{
+			name: "matching @sha PASS → current PASS (reviewed)",
+			comments: [marker({id: 1})],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+			reviewedPass: true,
+		},
+		{
+			name: "SHA-less advisory PASS does NOT satisfy the SHA-bound check",
+			comments: [marker({id: 1, body: "review-doc: PASS — merge-ready"})],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "sha-less", commentId: 1, polarity: "PASS"},
+			reviewedPass: false,
+		},
+		{
+			name: "a verdict bound to a stale sha does NOT pass",
+			comments: [marker({id: 1, body: `review-doc: PASS @ ${OLD} — merge-ready`})],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "stale", commentId: 1, polarity: "PASS", sha: OLD},
+			reviewedPass: false,
+		},
+		{
+			name: "newest matching verdict wins when several exist (FAIL after PASS → not reviewed)",
+			comments: [
+				marker({
+					id: 1,
+					createdAt: "2026-07-11T00:00:00Z",
+					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+				}),
+				marker({
+					id: 2,
+					createdAt: "2026-07-11T00:00:05Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+			],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+			reviewedPass: false,
+		},
+		{
+			name: "newest matching verdict wins (PASS after FAIL → reviewed)",
+			comments: [
+				marker({
+					id: 2,
+					createdAt: "2026-07-11T00:00:05Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+				marker({
+					id: 1,
+					createdAt: "2026-07-11T00:00:00Z",
+					body: `review-doc: PASS @ ${OLD} — merge-ready`,
+				}),
+			],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+			reviewedPass: false,
+		},
+		{
+			name: "equal createdAt → newest by the larger comment id",
+			comments: [
+				marker({
+					id: 10,
+					createdAt: "2026-07-11T00:00:00Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+				marker({
+					id: 20,
+					createdAt: "2026-07-11T00:00:00Z",
+					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+				}),
+			],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "current", commentId: 20, polarity: "PASS", sha: HEAD},
+			reviewedPass: true,
+		},
+		{
+			name: "a forged PASS from a non-collaborator is dropped (author-gate, ADR 0055)",
+			comments: [
+				marker({
+					id: 1,
+					author: "attacker",
+					createdAt: "2026-07-11T00:00:09Z",
+					body: `review-doc: PASS @ ${HEAD} — merge-ready`,
+				}),
+				marker({
+					id: 2,
+					author: "usirin",
+					createdAt: "2026-07-11T00:00:00Z",
+					body: `review-doc: FAIL @ ${HEAD} — changes-requested`,
+				}),
+			],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+			reviewedPass: false,
+		},
+		{
+			name: "empty authorized set → none (fail-closed, never a false win)",
+			comments: [marker({id: 1})],
+			authorized: [],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "none"},
+			reviewedPass: false,
+		},
+		{
+			name: "no marker in the namespace → none",
+			comments: [marker({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`})],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "none"},
+			reviewedPass: false,
+		},
+		{
+			name: "an advisory-only namespace → none (advisory is not a machine PASS)",
+			comments: [marker({id: 1, body: "review-doc: advisory — blocking-set PR (manual merge)"})],
+			authorized: ["usirin"],
+			gate: "doc",
+			head: HEAD,
+			expected: {_tag: "none"},
+			reviewedPass: false,
+		},
+	];
+	for (const {name, comments, authorized, gate, head, expected, reviewedPass} of cases) {
+		it(name, () => {
+			const outcome = resolveVerdict({
+				comments,
+				authorizedAuthors: authorized,
+				gate,
+				headSha: head,
+			});
+			assert.deepStrictEqual(outcome, expected);
+			assert.strictEqual(isReviewed(outcome, "PASS"), reviewedPass);
+		});
+	}
+
+	it("cross-namespace isolation: the same PASS resolves per gate", () => {
+		const comments = [
+			marker({id: 1, body: `review-code: PASS @ ${HEAD} — merge-ready`}),
+			marker({id: 2, body: `review-skill: FAIL @ ${HEAD} — changes-requested`}),
+		];
+		assert.deepStrictEqual(
+			resolveVerdict({comments, authorizedAuthors: ["usirin"], gate: "code", headSha: HEAD}),
+			{_tag: "current", commentId: 1, polarity: "PASS", sha: HEAD},
+		);
+		assert.deepStrictEqual(
+			resolveVerdict({comments, authorizedAuthors: ["usirin"], gate: "skill", headSha: HEAD}),
+			{_tag: "current", commentId: 2, polarity: "FAIL", sha: HEAD},
+		);
+		assert.deepStrictEqual(
+			resolveVerdict({comments, authorizedAuthors: ["usirin"], gate: "doc", headSha: HEAD}),
+			{_tag: "none"},
+		);
+	});
+});
+
+describe("isReviewed — read-verb decision over expected polarity", () => {
+	it("current FAIL satisfies an expect-FAIL read (write-code repair seam)", () => {
+		const outcome: VerdictOutcome = {_tag: "current", commentId: 1, polarity: "FAIL", sha: HEAD};
+		assert.isTrue(isReviewed(outcome, "FAIL"));
+		assert.isFalse(isReviewed(outcome, "PASS"));
+	});
+	it("a stale verdict never satisfies either polarity", () => {
+		const outcome: VerdictOutcome = {_tag: "stale", commentId: 1, polarity: "PASS", sha: OLD};
+		assert.isFalse(isReviewed(outcome, "PASS"));
+		assert.isFalse(isReviewed(outcome, "FAIL"));
+	});
+});
+
+describe("isNamespaceMarker — the post cross-namespace guard", () => {
+	it("accepts this gate's PASS marker", () =>
+		assert.isTrue(isNamespaceMarker(`review-doc: PASS @ ${HEAD} — merge-ready`, "doc")));
+	it("accepts this gate's advisory line", () =>
+		assert.isTrue(
+			isNamespaceMarker("review-doc: advisory — blocking-set PR (manual merge)", "doc"),
+		));
+	it("accepts a leading-bold marker", () =>
+		assert.isTrue(isNamespaceMarker(`**review-doc: FAIL @ ${HEAD}** — changes-requested`, "doc")));
+	it("rejects another gate's marker (the emission bug)", () =>
+		assert.isFalse(isNamespaceMarker(`review-code: PASS @ ${HEAD} — merge-ready`, "doc")));
+	it("rejects a non-marker first line", () =>
+		assert.isFalse(isNamespaceMarker("just a normal comment", "doc")));
+});


### PR DESCRIPTION
Fixes #2102

Extracts the ADR-0058 SHA-bound verdict read/post/match glue — hand-rolled inline as `jq` across the `review-*` / `ship-it` / `write-code`-repair skills — into a `pipeline-cli verdict` tool, following the `epic-lock` template (pure core + `.unit.test.ts` + `command.ts` + `github.ts`).

## What landed

- **`packages/pipeline-cli/src/tools/verdict/`**
  - `verdict-match.ts` — the **pure verdict-match core** (IO-free, total): given a PR's comment bodies + the current HEAD sha + the write+ authorized-author set, is HEAD reviewed in this gate's namespace, and by which marker? Re-encodes the ADR-0058 discriminator the inline reads got subtly wrong — a SHA-less advisory does **not** satisfy a SHA-bound check; a verdict bound to a **stale** head does **not** pass; the **newest** authorized marker wins.
  - `verdict-match.unit.test.ts` — table-driven over exactly those cases (matching `@sha` PASS passes; SHA-less advisory fails; stale sha fails; newest-wins), plus author-gate / cross-namespace / polarity / prefix-match / fail-closed-on-empty.
  - `github.ts` — the REST-only `gh api` boundary (the `epic-lock` `github.ts` service pattern), with a `github-service.unit.test.ts` over a mock spawner.
  - `command.ts` — exposes `read` (exit 0 only when HEAD is reviewed with the `--expect` polarity, default PASS; JSON detail on stdout) and `post` (the rule-2 upsert: namespace-guard the body → PATCH own prior marker else POST).
- **Registered** via a single append in `registry.ts`; `router.ts` / `bin.ts` unchanged.
- **Rewired `review-doc`** to call `pipeline-cli verdict post` in place of its **three identical inline upsert blocks** (PASS / advisory / FAIL), with the ADR-0062/0064 in-repo-first / published-fallback resolution preserved — the raw-glue line count drops measurably.
- **README** section documenting the new command.

## Behavior parity

No gate's verification semantics change: the tool re-encodes the same match/upsert semantics, made deterministic and tested. `pnpm typecheck`, `biome check`, and the unit tests pass (996 pipeline-cli tests green; 41 in the new tool).

## §CP — human-merge

Edits `packages/pipeline-cli/` and rewires `review-doc` (a gate-critical / CODEOWNERS skill) — human-merge by cansirin (ADR 0135). Not enqueued; built to reviewed-ready only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)