### PR TITLE
chore(web): drop stale vite/client type + dead topic-do.ts comment from worker tsconfig (#2524)

### DIFF
--- a/apps/web/tsconfig.worker.json
+++ b/apps/web/tsconfig.worker.json
@@ -11,11 +11,7 @@
 		// The alchemy stack (`alchemy.run.ts`) is loaded directly by Node's ESM
 		// loader, which requires explicit `.ts` import specifiers; allow them here.
 		"allowImportingTsExtensions": true,
-		// `vite/client` types are included for `import.meta.glob` — used by
-		// `features/fate-live/topic-do.ts` to load Effect SQL migrations as bundled dynamic
-		// imports. Vite resolves the glob at build time; the worker bundle ships
-		// each migration module statically.
-		"types": ["@cloudflare/workers-types", "node", "vite/client"]
+		"types": ["@cloudflare/workers-types", "node"]
 	},
 	"include": [
 		"worker",


### PR DESCRIPTION
Fixes #2524

## What

The `types` array in `apps/web/tsconfig.worker.json` carried `vite/client`, justified by a comment claiming `import.meta.glob` was "used by `features/fate-live/topic-do.ts` to load Effect SQL migrations as bundled dynamic imports." Both halves of that justification are dead:

- No `topic-do.ts` — the DO roles were unified into `LiveDO` (ADR 0037); `apps/web/worker/features/fate-live/` has `live-do.ts` etc.
- No `import.meta.glob` anywhere in `apps/web/worker/`.

## Resolution

Per the acceptance criteria, I removed `vite/client` from the `types` array and ran `pnpm typecheck`: it passes green (28/28 tasks), proving the entry is **not** load-bearing in the worker typecheck project. So I dropped the entry and deleted its now-orphaned justifying comment — no rewrite needed.

## Acceptance criteria

- [x] Determined whether the worker typecheck project still needs `vite/client` — removed the entry and ran `pnpm typecheck`; it stays green, so it is not needed.
- [x] `vite/client` dropped from the `types` array **and** the orphaned comment deleted.
- [x] No `topic-do.ts` reference remains anywhere in `apps/web/tsconfig.worker.json`.
- [x] `pnpm typecheck` passes (exit 0, 28/28).

Scope is strictly the worker tsconfig; `apps/web/tsconfig.app.json` (where `vite/client` is legitimately used by the SPA) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)