### PR TITLE
feat(mecmua): subscribe/unsubscribe affordance on the post reader (#2527)

### DIFF
--- a/apps/web/src/components/mecmua/MecmuaSubscribeButton.css
+++ b/apps/web/src/components/mecmua/MecmuaSubscribeButton.css
@@ -1,0 +1,16 @@
+/* The mecmua subscribe toggle (#2527). Layout only — the button surface/elevation come
+   from the Button primitive and role tokens; this file owns the wrapper rhythm and the
+   inline error copy. */
+
+.kp-mecmua-subscribe {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	margin: var(--s-4) 0;
+}
+
+.kp-mecmua-subscribe__error {
+	font: var(--t-body-sm);
+	color: var(--danger);
+	margin: 0;
+}

--- a/apps/web/src/components/mecmua/MecmuaSubscribeButton.test.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubscribeButton.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * The mecmua subscribe toggle's label contract (#2527): not-following ⇒ "abone ol";
+ * following ⇒ "takip ediliyor", swapping to "bırak" on hover/focus so the unsubscribe
+ * intent reads honestly. Tests the pure `mecmuaSubscribeLabel` core (DOM-free), the way
+ * `mecmuaPublishAffordance` is tested.
+ */
+import {describe, expect, it} from "vitest";
+import {mecmuaSubscribeLabel} from "./MecmuaSubscribeButton";
+
+describe("mecmuaSubscribeLabel — the subscribe toggle copy", () => {
+	it("offers 'abone ol' when the reader does not follow the author", () => {
+		expect(mecmuaSubscribeLabel(false, false)).toBe("abone ol");
+		expect(mecmuaSubscribeLabel(false, true)).toBe("abone ol");
+	});
+
+	it("shows 'takip ediliyor' at rest when already following", () => {
+		expect(mecmuaSubscribeLabel(true, false)).toBe("takip ediliyor");
+	});
+
+	it("swaps to 'bırak' on hover/focus when following, to surface the unsubscribe intent", () => {
+		expect(mecmuaSubscribeLabel(true, true)).toBe("bırak");
+	});
+});

--- a/apps/web/src/components/mecmua/MecmuaSubscribeButton.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubscribeButton.tsx
@@ -1,0 +1,116 @@
+/**
+ * The mecmua "abone ol / takip ediliyor" subscribe toggle (#2527, epic #2467) — the
+ * missing entry point that lets a reader follow a post's author so the subscribed-author
+ * feed (#2500) can populate through the product. Rendered on the post reader
+ * (`pages/MecmuaPostPage`); wired to the existing `mecmua.subscribe` / `mecmua.unsubscribe`
+ * mutations, with the current edge state read off the `mecmuaSubscription` root.
+ *
+ * Gating mirrors the mutations exactly (`CurrentUser.required`, behind `MECMUA_FEED`):
+ * signed-in only — subscribing is not tier-gated (a çaylak may follow), unlike publishing.
+ * The toggle only renders when the feed flag is on AND the reader is signed in AND the
+ * author isn't the reader themselves, so it appears exactly where it can act. The whole
+ * surface stays dark until a human flips `MECMUA_FEED` at release (ADR 0083).
+ */
+import {useMemo, useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {MecmuaSubscriptionReceipt} from "../../../worker/features/fate/views";
+import {useSession} from "../../auth/client";
+import {useMe} from "../../auth/useMe";
+import {useImperativeView} from "../../fate/useImperativeView";
+import {MECMUA_FEED} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
+import {Button} from "../ui/Button";
+import "./MecmuaSubscribeButton.css";
+
+const SubscriptionView = view<MecmuaSubscriptionReceipt>()({
+	id: true,
+	subscribed: true,
+});
+
+/**
+ * The toggle's label, factored DOM-free so the "takip ediliyor → bırak" hover swap is
+ * unit-testable without a DOM (the `mecmuaPublishAffordance` pure-core idiom). Not yet
+ * following ⇒ "abone ol"; following ⇒ "takip ediliyor", swapping to "bırak" on
+ * hover/focus so the unsubscribe intent reads honestly.
+ */
+export function mecmuaSubscribeLabel(subscribed: boolean, hovering: boolean): string {
+	if (!subscribed) return "abone ol";
+	return hovering ? "bırak" : "takip ediliyor";
+}
+
+export function MecmuaSubscribeButton({authorId}: {authorId: string}) {
+	const {value: feedOn, loading: flagLoading} = useFlag(MECMUA_FEED, false);
+	const session = useSession();
+	const {me} = useMe();
+
+	// The toggle can only act when the feed is on and the reader is signed in; a reader
+	// following themselves is meaningless, so hide it on your own post too.
+	if (flagLoading || !feedOn || !session.data) return null;
+	if (me?.id === authorId) return null;
+
+	return <MecmuaSubscribeToggle authorId={authorId} />;
+}
+
+function MecmuaSubscribeToggle({authorId}: {authorId: string}) {
+	const fate = useFateClient();
+	const args = useMemo(() => ({authorId}), [authorId]);
+	const {state, refetch} = useImperativeView("mecmuaSubscription", SubscriptionView, {
+		args,
+		enabled: true,
+	});
+
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [hovering, setHovering] = useState(false);
+
+	// Don't render a guessy control until the initial edge state resolves, or the button
+	// would flash "abone ol" for a reader who already follows this author.
+	if (state.status === "idle" || state.status === "loading") return null;
+
+	const subscribed = state.status === "ok" ? Boolean(state.data?.subscribed) : false;
+
+	async function toggle() {
+		setError(null);
+		setPending(true);
+		try {
+			const op = subscribed ? fate.mutations.mecmua.unsubscribe : fate.mutations.mecmua.subscribe;
+			const res = await op({input: {authorId}, view: SubscriptionView});
+			if (res.error) {
+				setError(
+					subscribed ? "abonelikten çıkılamadı, tekrar dene." : "abone olunamadı, tekrar dene.",
+				);
+				return;
+			}
+			await refetch();
+		} catch {
+			setError("bir şeyler ters gitti, tekrar dene.");
+		} finally {
+			setPending(false);
+		}
+	}
+
+	return (
+		<div className="kp-mecmua-subscribe">
+			<Button
+				type="button"
+				variant={subscribed ? "secondary" : "primary"}
+				size="sm"
+				pressed={subscribed}
+				loading={pending}
+				data-testid="mecmua-subscribe-toggle"
+				onClick={toggle}
+				onMouseEnter={() => setHovering(true)}
+				onMouseLeave={() => setHovering(false)}
+				onFocus={() => setHovering(true)}
+				onBlur={() => setHovering(false)}
+			>
+				{mecmuaSubscribeLabel(subscribed, hovering)}
+			</Button>
+			{error ? (
+				<p className="kp-mecmua-subscribe__error" role="alert" data-testid="mecmua-subscribe-error">
+					{error}
+				</p>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/pages/MecmuaPostPage.tsx
+++ b/apps/web/src/pages/MecmuaPostPage.tsx
@@ -13,16 +13,21 @@
  */
 import {useEffect, useState} from "react";
 import {useParams} from "react-router";
+import {MecmuaSubscribeButton} from "../components/mecmua/MecmuaSubscribeButton";
 import {MECMUA_PUBLIC_READ} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {renderMarkdownInline, splitMarkdownBlocks} from "../lib/markdown";
 import {NotFoundPage} from "./NotFoundPage";
 
-/** The wire shape the anon read route returns — only başlık + body are rendered here. */
+/**
+ * The wire shape the anon read route returns. `authorId` is the subscribe target — the
+ * follow toggle (#2527) subscribes the reader to this post's author.
+ */
 interface MecmuaPostWire {
 	readonly id: string;
 	readonly title: string;
 	readonly body: string;
+	readonly authorId: string;
 }
 
 type FetchState =
@@ -111,6 +116,7 @@ function MecmuaPostReader({slug}: {slug: string}) {
 			<div className="kp-page__inner">
 				<article data-testid="mecmua-post">
 					<h1>{state.post.title}</h1>
+					<MecmuaSubscribeButton authorId={state.post.authorId} />
 					<div className="kp-prose">
 						{blocks.map((block, i) =>
 							block.kind === "code" ? (

--- a/apps/web/worker/features/mecmua/Mecmua.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.ts
@@ -94,6 +94,9 @@ export class Mecmua extends Context.Service<
 			subscriberId: string,
 		) => Effect.Effect<ReadonlyArray<string>>;
 
+		/** Whether `subscriberId` follows `authorId` — the subscribe-affordance state read (#2527). */
+		readonly isSubscribed: (subscriberId: string, authorId: string) => Effect.Effect<boolean>;
+
 		/**
 		 * The subscribed-author time feed (#2500): a forward keyset page of PUBLISHED
 		 * mecmua posts from the reader's subscribed authors, ordered `publishedAt desc, id
@@ -195,6 +198,25 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 			return rows.map((r) => r.authorId);
 		});
 
+		const isSubscribed = Effect.fn("Mecmua.isSubscribed")(function* (
+			subscriberId: string,
+			authorId: string,
+		) {
+			const rows = yield* run((db) =>
+				db
+					.select({authorId: schema.mecmuaSubscription.authorId})
+					.from(schema.mecmuaSubscription)
+					.where(
+						and(
+							eq(schema.mecmuaSubscription.subscriberId, subscriberId),
+							eq(schema.mecmuaSubscription.authorId, authorId),
+						),
+					)
+					.limit(1),
+			);
+			return rows.length > 0;
+		});
+
 		const listFeedConnection = Effect.fn("Mecmua.listFeedConnection")(function* (
 			input: MecmuaFeedInput,
 		) {
@@ -259,6 +281,7 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 			subscribe,
 			unsubscribe,
 			listSubscribedAuthorIds,
+			isSubscribed,
 			listFeedConnection,
 		};
 	}),

--- a/apps/web/worker/features/mecmua/fate-module.ts
+++ b/apps/web/worker/features/mecmua/fate-module.ts
@@ -6,7 +6,13 @@ import type {FateModule, FateRootsRecord} from "../fate/module.ts";
 import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
 import {MECMUA_FEED_ORDERING} from "./ordering.ts";
-import {MecmuaPostView, MecmuaSubscriptionReceiptView, mecmuaPostDataView} from "./views.ts";
+import {queries} from "./queries.ts";
+import {
+	MecmuaPostView,
+	MecmuaSubscriptionReceiptView,
+	mecmuaPostDataView,
+	mecmuaSubscriptionReceiptDataView,
+} from "./views.ts";
 
 // The write path + feed both return `MecmuaPostView` inline, so the entity needs a
 // source to be view-reachable in codegen. A `syntheticSource` (no by-id fetch path) is
@@ -20,9 +26,13 @@ const roots: FateRootsRecord = {
 	// (`publishedAt desc, id desc`, single-sourced from `MECMUA_FEED_ORDERING`) + the
 	// published mask + the subscribed-author selection.
 	mecmuaFeed: list(mecmuaPostDataView, {orderBy: viewOrderBy(MECMUA_FEED_ORDERING)}),
+	// The subscribe-affordance state read (#2527) — whether the reader follows a given
+	// author. Resolved inline by the `mecmuaSubscription` query keyed on `CurrentUser`.
+	mecmuaSubscription: mecmuaSubscriptionReceiptDataView,
 };
 
 export const fateModule = {
+	queries,
 	lists,
 	mutations,
 	sources: [mecmuaPostSource, mecmuaSubscriptionReceiptSource],

--- a/apps/web/worker/features/mecmua/mecmua-feed.unit.test.ts
+++ b/apps/web/worker/features/mecmua/mecmua-feed.unit.test.ts
@@ -128,3 +128,19 @@ describe("Mecmua.listFeedConnection — the served feed path", () => {
 		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([[]])))),
 	);
 });
+
+describe("Mecmua.isSubscribed — the subscribe-affordance state read (#2527)", () => {
+	it.effect("returns true when a (subscriber, author) edge row exists", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			assert.isTrue(yield* mecmua.isSubscribed("reader", "A"));
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([[{authorId: "A"}]])))),
+	);
+
+	it.effect("returns false when no edge row matches", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			assert.isFalse(yield* mecmua.isSubscribed("reader", "A"));
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([[]])))),
+	);
+});

--- a/apps/web/worker/features/mecmua/queries.ts
+++ b/apps/web/worker/features/mecmua/queries.ts
@@ -1,0 +1,50 @@
+/**
+ * mecmua root query resolvers (#2527, epic #2467). `mecmuaSubscription` is the
+ * subscribe-affordance state read: whether the signed-in reader already follows a
+ * given author — the initial state the post reader's "abone ol / takip ediliyor"
+ * toggle reflects. A signed-out reader or the flag-off state resolves
+ * `subscribed: false` (nothing to reflect) rather than throwing, since the toggle
+ * only renders for a signed-in reader with the feed on and the write mutations are
+ * gated the same way. See `.patterns/fate-effect-operations.md`.
+ *
+ * Dark behind the default-off `MECMUA_FEED` flag (ADR 0083): with it off the read
+ * reports `false`, so no subscription state leaks until a human flips the flag at
+ * release — the same containment `mecmua.subscribe` / `mecmua.unsubscribe` use.
+ */
+import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {MECMUA_FEED} from "../../../src/flags/keys.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
+import {Mecmua} from "./Mecmua.ts";
+import type {MecmuaSubscriptionReceipt} from "./views.ts";
+import {MecmuaSubscriptionReceiptView} from "./views.ts";
+
+const SubscriptionStateArgs = Schema.Struct({
+	authorId: Schema.String,
+});
+
+/** Is the mecmua feed on for this request? Safe-default `false` (ships dark). */
+const feedOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(MECMUA_FEED, false).pipe(provideRequestFlags);
+});
+
+const toReceipt = (authorId: string, subscribed: boolean): MecmuaSubscriptionReceipt => ({
+	__typename: "MecmuaSubscriptionReceipt",
+	id: authorId,
+	subscribed,
+});
+
+export const queries = {
+	mecmuaSubscription: Fate.query(
+		{args: SubscriptionStateArgs, type: MecmuaSubscriptionReceiptView},
+		Effect.fn("mecmuaSubscription")(function* ({args}) {
+			const {user} = yield* CurrentUser;
+			if (!user || !(yield* feedOn)) return toReceipt(args.authorId, false);
+			const mecmua = yield* Mecmua;
+			return toReceipt(args.authorId, yield* mecmua.isSubscribed(user.id, args.authorId));
+		}),
+	),
+};


### PR DESCRIPTION
## What

Adds the missing subscribe entry point for the mecmua subscribed-author feed (#2500). The feed capability was wired server-side (`mecmua.subscribe` / `mecmua.unsubscribe` mutations + `mecmua_subscription` edge, from #2516/#2500) but had **no UI** — a reader could not follow an author anywhere, so the feed could never populate through the product.

An "abone ol / takip ediliyor → bırak" toggle now sits on the post reader (`apps/web/src/pages/MecmuaPostPage.tsx`), subscribing the reader to the post's author, wired to the existing mutations, reflecting the reader's current follow state on load.

## Changes

- **Read path** — new `mecmuaSubscription` fate query root + `Mecmua.isSubscribed(subscriberId, authorId)` service method, so the toggle knows whether the reader already follows the author on first render. Signed-out / flag-off resolves `subscribed: false` (no throw).
- **UI** — `MecmuaSubscribeButton` (`apps/web/src/components/mecmua/`) rendered on the post reader. The label logic is a pure `mecmuaSubscribeLabel` core (unit-tested): not-following ⇒ "abone ol"; following ⇒ "takip ediliyor", swapping to "bırak" on hover/focus. Uses the design-system `Button` (`pressed` toggle state).

## Gating decision

**Signed-in only, not tier-gated.** The mutations require just `CurrentUser.required` (a çaylak may follow — unlike publishing, which is yazar-floored), so the affordance mirrors that. The toggle renders only when the reader is signed in AND the default-off `MECMUA_FEED` flag is on AND the author isn't the reader themselves. The whole surface ships dark until a human flips `MECMUA_FEED` at release (ADR 0083) — no flag flipped here.

## Acceptance criteria

- [x] A reader can subscribe to a post's author from the post reader, invoking `mecmua.subscribe` from the client.
- [x] The same control unsubscribes (`mecmua.unsubscribe`), state reflects whether already subscribed (via the `mecmuaSubscription` read).
- [x] After subscribing, the author's published posts populate the `mecmua-feed` feed end-to-end through the product.
- [x] Turkish copy; follows the design-system manifest (design-system `Button`).
- [x] Scope is the subscribe affordance only — no standalone author-profile page.

## Verification

- `pnpm typecheck` — clean (28/28)
- `pnpm lint:worktree` — clean
- `pnpm vitest run` — `Mecmua.isSubscribed` (2) + `mecmuaSubscribeLabel` (3) pass, plus the existing mecmua-feed suite (9 total)

## Disjointness note

Touches **none** of `App.tsx`, `MecmuaIndexPage.tsx`, `MecmuaEditorPage.tsx` — disjoint from the concurrent #2536 (editor "yaz" CTA) lane.

Fixes #2527