### PR TITLE
fix(pipeline): reconcile UI_RE so a non-web .tsx/.css mints no phantom review-design (#2470)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -43,8 +43,8 @@ first that matches. The class set is decided by the **canonical `HAS_*_RE=` prob
 re-resolved from live `main`, per the [fan across every present class](#fan-across-every-present-class-in-lockstep-with-ship-its-live-class-probes-class_reresolve)
 invariant below.
 
-- **A UI-affecting PR** (a changed file under `apps/web/src/`, any `*.tsx`, or a style
-  surface — `*.css`/style modules) → **additionally** read and follow
+- **A UI-affecting PR** (a changed file under `apps/web/src/` — the rendered frontend surface:
+  React components, styles, tokens, routes) → **additionally** read and follow
   `claude-plugins/kampus-pipeline/skills/review-design/SKILL.md`. `review-design` is
   **additive** — dispatched **alongside** the present class gate(s) above when a changed path
   matches the UI-affecting set, never instead of them. A PR with **no** UI-affecting path
@@ -180,24 +180,28 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   (`ui_reresolve`).** `pipeline-cli class-probe classify --namespaces` (the fan invariant above)
   reads this same `UI_RE` from its single source and prints `review-design` whenever the diff is
   UI-affecting — so the **probe**, not an eyeball over the changed files, decides has-ui, and a
-  non-visual `apps/web/src/*.ts` no longer gets waved off (#2485/#2483). The prose set (`apps/web/src/`,
-  `*.tsx`, style surfaces) is the fail-closed **reference**, not the live decision source: a reviewer
-  whose worktree/injected snapshot predates the review-design merge would otherwise silently omit the
-  dispatch on a UI PR, while ship-it — grounding against live main — still *requires* the gate, so the
-  PR deadlocks (`unverified — no review-design PASS`). ship-it and this agent therefore read the **same
-  one live source**: the `UI_RE=` line in `ship-it/SKILL.md` on `origin/main`. Re-resolve it before
-  deciding to dispatch, fail-closed to **has-ui** (dispatch `review-design`) if that line is unreadable
-  — never fail-open to skip it (#2341, the #981 `?ref=main` idiom):
+  non-visual `apps/web/src/*.ts` no longer gets waved off (#2485/#2483). The prose set (a changed
+  path under `apps/web/src/`) is the fail-closed **reference**, not the live decision source: a
+  reviewer whose worktree/injected snapshot predates the review-design merge would otherwise silently
+  omit the dispatch on a UI PR, while ship-it — grounding against live main — still *requires* the
+  gate, so the PR deadlocks (`unverified — no review-design PASS`). ship-it, this agent, AND
+  review-design's own Step 0 off-ramp therefore read the **same one live source**: the `UI_RE=` line
+  in `ship-it/SKILL.md` on `origin/main` (scope `^apps/web/src/` only — a non-web `.tsx`/`.css` has no
+  rendered surface, so it is neither required nor dispatched, #2470). Re-resolve it before deciding to
+  dispatch, fail-closed to **has-ui** (dispatch `review-design`) if that line is unreadable — never
+  fail-open to skip it (#2341, the #981 `?ref=main` idiom):
   ```bash
-  UI_RE='^apps/web/src/|\.tsx$|\.css$'   # fail-closed reference; the live line below is authoritative
+  UI_RE='^apps/web/src/'   # fail-closed reference; the live line below is authoritative (#2470: scope is apps/web/src ONLY — a non-web .tsx/.css has no rendered surface, not design-gate work)
   UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
   if [ -n "$UI_LIVE" ]; then UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"; else UI_RE='.'; fi   # unreadable ⇒ '.' ⇒ every path is UI-affecting ⇒ dispatch review-design (never silently drop it)
   CHANGED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
   echo "$CHANGED" | grep -Eq "$UI_RE" && echo "UI-affecting → dispatch review-design alongside the class gate"
   ```
-  Because both sides resolve the identical live `UI_RE`, `required-gate == dispatched-gate` holds
-  by construction, not by hand-syncing two aging copies — the exact staleness that let UI PRs slip
-  the gate non-deterministically (PR #2333 merged un-design-reviewed).
+  Because all sides resolve the identical live `UI_RE`, `required-gate == dispatched-gate ==
+  satisfiable-gate` holds by construction, not by hand-syncing aging copies — the exact staleness
+  that let UI PRs slip the gate non-deterministically (PR #2333 merged un-design-reviewed), and the
+  require⊃off-ramp superset that deadlocked a non-web `.tsx`/`.css` on an unroutable phantom gate
+  (#2470).
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries; every read and write
   goes through `gh api`.

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -164,10 +164,22 @@ Pull the file list first. This gate applies to a PR that **changes rendered UI**
 under `apps/web/src/**` (React components, styles, tokens, routes). If the diff touches **no**
 UI-affecting path at all, this is the wrong gate.
 
+This off-ramp predicate is the **SAME one live `UI_RE`** ship-it *requires* on and reviewer.md
+*dispatches* on — re-resolved from `ship-it/SKILL.md@main` via the `?ref=main` idiom, NOT a
+hardcoded third copy. Wiring it to the single source is the #2470 fix: a hardcoded off-ramp narrower
+than ship-it's require (`^apps/web/src/` vs the old `^apps/web/src/|\.tsx$|\.css$`) let a `.tsx`/`.css`
+outside `apps/web/src` be *required* yet off-ramped here with no marker → an unroutable phantom gate
+that deadlocked ship-it. Fail closed to **has-ui** (proceed and verdict) if the line is unreadable —
+never silently off-ramp, which is the failure that mints the phantom gate.
+
 ```bash
 PR=<pr number>
-# UI-affecting = the rendered frontend surface (components, styles, tokens, routes)
+# UI-affecting = the ONE live source (ship-it/SKILL.md@main's `UI_RE=` line) — the SAME predicate
+# ship-it requires on and reviewer.md dispatches on, so require == dispatch == off-ramp by
+# construction (#2470). The literal is the fail-closed REFERENCE, not the live decision source.
 UI_RE='^apps/web/src/'
+UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
+if [ -n "$UI_LIVE" ]; then UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"; else UI_RE='.'; fi   # unreadable ⇒ '.' ⇒ every path is UI-affecting ⇒ proceed & verdict (never silently off-ramp)
 UI_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   --jq '.[].filename' | grep -E "$UI_RE" || true)"
 ```

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -309,20 +309,27 @@ HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed:
 echo "$FILES" | grep -Eq "$HAS_SKILLS_RE" && echo "has-skills"   # → review-skill (ADR 0073/0150); §CP-blocking for merge via CONTROL_PLANE_RE above
 echo "$FILES" | grep -Eq "$HAS_CODE_RE" && echo "has-code"       # → review-code; the has-code roots agree with the docs-exclusion below in lockstep (§CLASS/§DOC, #663/#919/#1987)
 echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs"   # → review-doc; carve out code roots/skills/.glossary first, then test for a doc path (§DOC contract)
-# UI probe → review-design (ADDITIVE, not a class): a changed path under apps/web/src, a *.tsx
-# file, or a style surface (*.css). `pipeline-cli class-probe classify` above ALSO emits `has-ui`
-# (it parses this same UI_RE from its single source, ship-it/SKILL.md) — so the reviewer fan
-# dispatches review-design off the SAME deterministic probe it fans the class gates from, rather
-# than eyeballing the files and skipping it (the #2483 deadlock; #2485). Like CONTROL_PLANE_RE/
-# GUARD_ADR_RE above, the literal below is the fail-closed REFERENCE + the validate-gate-path-drift
-# lockstep target, NOT the live decision source: it is re-resolved from origin/main right after, so
-# an injected skill snapshot that predates the review-design gate can't silently DROP the UI probe
-# and slip a UI PR past the gate (#2341 — the #981 idiom, previously only on §CP/GUARD, now extended
-# to UI_RE). ship-it/SKILL.md@main's `UI_RE=` line is the ONE live source; reviewer.md re-resolves
-# the SAME line from the same ref (reviewer.md, #2249/#2341), so required-gate == dispatched-gate
-# holds by construction — both sides read live main, not two independently-aging snapshots. When a
-# second app worker is added, generalize this one live UI_RE to apps/**/src and both sides track it.
-UI_RE='^apps/web/src/|\.tsx$|\.css$'
+# UI probe → review-design (ADDITIVE, not a class): a changed path under apps/web/src — the
+# rendered frontend surface (React components, styles, tokens, routes). `pipeline-cli class-probe
+# classify` above ALSO emits `has-ui` (it parses this same UI_RE from its single source,
+# ship-it/SKILL.md) — so the reviewer fan dispatches review-design off the SAME deterministic probe
+# it fans the class gates from, rather than eyeballing the files and skipping it (the #2483 deadlock;
+# #2485). Like CONTROL_PLANE_RE/GUARD_ADR_RE above, the literal below is the fail-closed REFERENCE +
+# the validate-gate-path-drift lockstep target, NOT the live decision source: it is re-resolved from
+# origin/main right after, so an injected skill snapshot that predates the review-design gate can't
+# silently DROP the UI probe and slip a UI PR past the gate (#2341 — the #981 idiom, previously only
+# on §CP/GUARD, now extended to UI_RE). ship-it/SKILL.md@main's `UI_RE=` line is the ONE live source;
+# reviewer.md, class-probe, AND review-design's Step 0 off-ramp all re-resolve the SAME line from the
+# same ref, so required-gate == dispatched-gate == satisfiable-gate holds by construction — all sides
+# read live main, not independently-aging snapshots. When a second app worker is added, generalize
+# this one live UI_RE to apps/**/src and every side tracks it.
+# SCOPE (#2470): UI_RE is `^apps/web/src/` ONLY — a `.tsx`/`.css` OUTSIDE apps/web/src (a Hono
+# server-JSX file, a `.tsx` test fixture, a non-web `.css`) has no rendered surface, so it is NOT
+# design-gate work and must NOT mint a required review-design. The earlier `|\.tsx$|\.css$` branches
+# made the *require* predicate a superset of review-design's own dispatch/off-ramp predicate
+# (`^apps/web/src/`): a non-web `.tsx` was required-but-unroutable — the dispatched review-design run
+# off-ramped with no marker and ship-it deadlocked on a review-design PASS no run could produce.
+UI_RE='^apps/web/src/'
 UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
 if [ -n "$UI_LIVE" ]; then
   UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"   # UI-gating tracks origin/main, not the snapshot's age (#2341)
@@ -408,23 +415,30 @@ echo "$FILES" | grep -Eq "$UI_RE" && echo "has-ui"   # UI-affecting → require 
 <a id="the-ui-affecting-detection-must-agree-with-the-reviewer"></a>
 **The UI-affecting detection must AGREE with the reviewer, or the gate is unroutable.** ship-it
 requires a `review-design` PASS *because the reviewer dispatched `review-design` on the same
-diff* — so the `UI_RE` probe above (`^apps/web/src/|\.tsx$|\.css$` — a changed path under
-`apps/web/src`, a `*.tsx` file, or a `*.css` style surface) **must be the same rule** the
-reviewer agent uses to decide whether to run `review-design` (`reviewer.md`, #2249: "changed
-files under `apps/web/src`, `*.tsx`, and style surfaces"). This is the
-same **required-gate == dispatched-gate** invariant that binds the has-code probe to review-code's
-scope: if ship-it required `review-design` on a diff the reviewer never routed to `review-design`,
-that PR would demand a `review-design: PASS` **no gate ever produces** → every UI PR **deadlocks**
-(`unverified — no review-design PASS`). Lockstep here is **not two hand-synced copies that drift as
+diff*, AND *because the dispatched `review-design` run can actually reach a rendered surface to
+verdict* — so the `UI_RE` probe above (`^apps/web/src/` — a changed path under the rendered
+frontend) **must be the same rule** the reviewer agent uses to decide whether to run
+`review-design` **and** the rule `review-design`'s own Step 0 off-ramp uses to decide it has a
+surface to gate. This is the same **required-gate == dispatched-gate == satisfiable-gate**
+invariant that binds the has-code probe to review-code's scope: if ship-it required `review-design`
+on a diff the reviewer never routed to it — or on one the dispatched `review-design` run then
+off-ramps as non-UI without emitting a marker — that PR would demand a `review-design: PASS` **no
+gate ever produces** → every such PR **deadlocks** (`unverified — no review-design PASS`). That
+second gap is exactly #2470: the earlier `UI_RE='^apps/web/src/|\.tsx$|\.css$'` was a **superset**
+of review-design's `^apps/web/src/` off-ramp, so a `.tsx`/`.css` outside `apps/web/src` was
+required-but-unroutable — now the one live `UI_RE` is `^apps/web/src/` and all three sides
+(require, dispatch, off-ramp) resolve it. Lockstep here is **not two hand-synced copies that drift as
 each side's checkout ages** — that staleness was the enforcement hole (#2341: a shipper/reviewer on
 a snapshot predating the review-design merge silently omitted the gate; PR #2333 merged
 un-design-reviewed). Both sides instead resolve `UI_RE` from **one live source — `UI_RE=` in
 `ship-it/SKILL.md` on `origin/main`**, read via `?ref=main` at run time (the `#981` idiom the §CP
-`CONTROL_PLANE_RE`/`GUARD_ADR_RE` already use): ship-it re-resolves it in the probe above, and
+`CONTROL_PLANE_RE`/`GUARD_ADR_RE` already use): ship-it re-resolves it in the probe above,
 `reviewer.md` re-resolves the **same line from the same ref** before deciding to dispatch
-`review-design`. Both fail closed to *require*/`dispatch` the gate if that line is unreadable —
-never to skip it. So the two agree by construction, not by manual sync: change the one live `UI_RE`
-(e.g. a new app worker → `apps/**/src`) and both sides track it on their next run.
+`review-design`, and `review-design`'s Step 0 off-ramp re-resolves the **same line** before
+deciding it has a rendered surface to gate (#2470). All three fail closed to
+*require*/`dispatch`/*proceed* on the gate if that line is unreadable — never to skip it. So they
+agree by construction, not by manual sync: change the one live `UI_RE` (e.g. a new app worker →
+`apps/**/src`) and every side tracks it on its next run.
 
 **The docs class must equal `review-doc`'s verification scope, or the gate it demands is
 unreachable.** ship-it requires a class's gate PASS *because that gate runs on that class* —

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
@@ -149,10 +149,12 @@ export const parseUiProbe = (shipItText: string): string =>
 	shipItText.match(/^UI_RE='([^']*)'/m)?.[1] ?? FAILCLOSED_UI_RE;
 
 /**
- * Is the diff UI-affecting (has-ui)? A non-visual `apps/web/src/*.ts` still matches `UI_RE`'s
- * `^apps/web/src/` branch — that is deliberate here, not a bug to eyeball away: ship-it requires
+ * Is the diff UI-affecting (has-ui)? A non-visual `apps/web/src/*.ts` still matches `UI_RE`
+ * (`^apps/web/src/`) — that is deliberate here, not a bug to eyeball away: ship-it requires
  * review-design on exactly this predicate, so the fan must dispatch it on exactly this predicate
- * or the PR deadlocks on a phantom-empty review-design namespace (#2485/#2483). Fail-closed: an
+ * or the PR deadlocks on a phantom-empty review-design namespace (#2485/#2483). Conversely a
+ * `.tsx`/`.css` OUTSIDE apps/web/src is NOT has-ui — the scope is `^apps/web/src/` only, so the
+ * require predicate never exceeds review-design's dispatch/off-ramp (#2470). Fail-closed: an
  * uncompilable probe matches every path ⇒ has-ui.
  */
 export const isUiAffecting = (files: ReadonlyArray<string>, uiRe: string): boolean =>

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
@@ -118,7 +118,10 @@ describe("classify — fail-closed on an unreadable source over-dispatches, neve
 
 describe("parseUiProbe — the additive UI_RE off its single source (ship-it/SKILL.md)", () => {
 	it("extracts the live single-quoted UI_RE line", () => {
-		expect(LIVE_UI_RE).toBe("^apps/web/src/|\\.tsx$|\\.css$");
+		// #2470: scope is `^apps/web/src/` ONLY. The old `|\.tsx$|\.css$` branches made the require
+		// predicate a superset of review-design's own dispatch/off-ramp (`^apps/web/src/`), so a
+		// non-web `.tsx`/`.css` was required-but-unroutable — a phantom review-design gate.
+		expect(LIVE_UI_RE).toBe("^apps/web/src/");
 	});
 
 	it("falls back to the fail-closed UI_RE for a missing/truncated source", () => {
@@ -148,7 +151,7 @@ describe("isUiAffecting — review-design reaches a marker, never a phantom-empt
 		expect(isUiAffecting(nonVisualSrcTs, LIVE_UI_RE)).toBe(true);
 	});
 
-	it("still fires on the visual surfaces (*.tsx, *.css) it already covered", () => {
+	it("fires on visual surfaces under apps/web/src (*.tsx, *.css) via the prefix", () => {
 		expect(isUiAffecting(["apps/web/src/App.tsx"], LIVE_UI_RE)).toBe(true);
 		expect(isUiAffecting(["apps/web/src/styles/theme.css"], LIVE_UI_RE)).toBe(true);
 	});
@@ -169,5 +172,33 @@ describe("isUiAffecting — review-design reaches a marker, never a phantom-empt
 		// Mirrors ship-it Step 0 / the reviewer's fail-closed `has-ui` — demand the gate, never
 		// silently drop it. Empty diff stays empty (nothing to gate).
 		expect(isUiAffecting(["packages/pipeline-cli/src/bin.ts"], FAILCLOSED_UI_RE)).toBe(true);
+	});
+});
+
+describe("isUiAffecting — a non-web .tsx/.css mints NO phantom review-design (#2470)", () => {
+	// The #2470 deadlock: ship-it's require predicate was `^apps/web/src/|\.tsx$|\.css$` — a
+	// SUPERSET of review-design's own dispatch/off-ramp predicate (`^apps/web/src/`). A `.tsx`/`.css`
+	// OUTSIDE apps/web/src (a Hono server-JSX file, a `.tsx` test fixture, a non-web `.css`) matched
+	// the require + dispatch but off-ramped at review-design Step 0 with no marker → ship-it blocked
+	// on a review-design PASS no run could produce. Now the one live UI_RE is `^apps/web/src/`, so a
+	// non-web .tsx/.css is neither required nor dispatched — no phantom gate.
+	const nonWebUi = [
+		"apps/web/worker/features/foo/index.tsx", // Hono server-JSX in the worker, no rendered surface
+		"packages/some-pkg/src/fixtures/sample.tsx", // a .tsx test fixture
+		"packages/some-pkg/src/styles.css", // a non-web .css
+	];
+
+	it("a non-apps/web/src .tsx/.css is NOT has-ui — no required/dispatched review-design", () => {
+		for (const f of nonWebUi) {
+			expect(isUiAffecting([f], LIVE_UI_RE)).toBe(false);
+		}
+		expect(isUiAffecting(nonWebUi, LIVE_UI_RE)).toBe(false);
+	});
+
+	it("a real apps/web/src UI file STILL is has-ui — the gate holds for rendered surfaces", () => {
+		expect(isUiAffecting(["apps/web/src/App.tsx"], LIVE_UI_RE)).toBe(true);
+		expect(isUiAffecting(["apps/web/src/styles/theme.css"], LIVE_UI_RE)).toBe(true);
+		// and the #2485 non-visual apps/web/src/*.ts stays has-ui via the same prefix branch
+		expect(isUiAffecting(["apps/web/src/fate/wireMessages.ts"], LIVE_UI_RE)).toBe(true);
 	});
 });


### PR DESCRIPTION
Fixes #2470

## The bug (§CP — gate-critical skills)

ship-it's **require** predicate was `UI_RE='^apps/web/src/|\.tsx$|\.css$'` — a **superset** of review-design's own Step 0 off-ramp (`^apps/web/src/`). A `.tsx`/`.css` **outside** `apps/web/src` (a Hono server-JSX file, a `.tsx` test fixture, a non-web `.css`) was therefore *required* by ship-it and *dispatched* by the reviewer fan, but the dispatched `review-design` run off-ramped at its Step 0 with **no marker** — leaving ship-it blocked on a `review-design: PASS` no run could produce. Unroutable phantom gate → founder override-merge (the report saw it twice back-to-back).

`#2341` had already unified the *require* and *dispatch* predicates onto one live `UI_RE=` source; the residual gap was review-design's **own** off-ramp still keying off a hardcoded narrower third copy.

## Root-cause fix — narrow + wire (single-source-of-truth)

1. **Narrow the ONE live source.** `ship-it/SKILL.md`'s `UI_RE` is now `^apps/web/src/` (dropped `|\.tsx$|\.css$`). A `.tsx`/`.css` outside `apps/web/src` has no rendered surface, so it is neither required nor dispatched — **not design-gate work**. Because `#2341`'s live-source resolution feeds both the require and the dispatch predicate, narrowing propagates to both automatically.
2. **Wire the third copy to the live source.** `review-design/SKILL.md`'s Step 0 off-ramp now re-resolves the **same** `UI_RE=` line from `ship-it/SKILL.md@main` (the `?ref=main` idiom ship-it/reviewer already use), fail-closed to **has-ui**. No hardcoded copy able to drift — this closes the drift *class*, not just this instance (a later `apps/**/src` broadening for a second worker won't re-open it).

Now **require == dispatch == satisfiable** holds by construction across ship-it, reviewer.md, `class-probe`, and review-design.

### Scope call (recorded per AC)

A non-`apps/web/src` `.tsx`/`.css` (Hono server-JSX, test fixtures, non-web styles) is **not** design-review work — it has no rendered surface. This matches review-design's existing off-ramp scope and does not change `#2485`'s decision: files **inside** `apps/web/src` (including non-visual `*.ts`) stay `has-ui` via the `^apps/web/src/` prefix, so the reviewer fan still dispatches `review-design` for them.

### Coordination with #2485 (closed)

`#2485`'s fix folded `has-ui` into `pipeline-cli class-probe` (deterministic dispatch) and kept the broad `UI_RE` for files *inside* `apps/web/src`. This change keeps `class-probe` reading `UI_RE` from the same single source (`ship-it/SKILL.md`), so `#2485`'s `apps/web/src/*.ts → has-ui` path is preserved; only the non-`apps/web/src` `.tsx`/`.css` superset is removed. The shared `UI_RE` scope stays single-sourced.

## Files reconciled

- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` — the one live `UI_RE` narrowed to `^apps/web/src/`; probe comment + invariant prose updated to record the #2470 scope call.
- `claude-plugins/kampus-pipeline/skills/review-design/SKILL.md` — Step 0 off-ramp wired to re-resolve the live `UI_RE` from ship-it@main (fail-closed has-ui).
- `claude-plugins/kampus-pipeline/agents/reviewer.md` — fail-closed reference literal + prose narrowed to match.
- `packages/pipeline-cli/src/tools/class-probe/class-probe.ts` — comment tidied (reads the live source, no hardcoded broad copy).
- `packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts` — `LIVE_UI_RE` pin updated to `^apps/web/src/`; added a #2470 block proving a non-web `.tsx`/`.css` is **not** has-ui while a real `apps/web/src` UI file (and the #2485 non-visual `.ts`) still is.

## Verification

`pnpm vitest run src/tools/class-probe/class-probe.unit.test.ts` → **22/22 pass**, including the new phantom-gate assertions. biome + leak-guard + ref-guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)