### PR TITLE
fix(web): move mecmua write CTA out of the global top nav (#2543)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,12 +23,7 @@ import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
 import {teardownAuthedSnapshot} from "./fate/snapshot";
-import {
-	MECMUA_PUBLIC_READ,
-	MECMUA_WRITE,
-	PHOENIX_AUTHORSHIP_LOOP,
-	PHOENIX_BILDIRIM,
-} from "./flags/keys";
+import {MECMUA_PUBLIC_READ, PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
 import {SAVED_HREF} from "./lib/panoNav";
@@ -41,7 +36,7 @@ import {DivanPage} from "./pages/DivanPage";
 import {FunnelPage} from "./pages/FunnelPage";
 import {LabComposerPage} from "./pages/LabComposerPage";
 import {LandingPage} from "./pages/LandingPage";
-import {MecmuaEditorPage, shouldShowMecmuaWriteCta} from "./pages/MecmuaEditorPage";
+import {MecmuaEditorPage} from "./pages/MecmuaEditorPage";
 import {MecmuaFeedPage} from "./pages/MecmuaFeedPage";
 import {MecmuaIndexPage} from "./pages/MecmuaIndexPage";
 import {MecmuaPostPage} from "./pages/MecmuaPostPage";
@@ -69,9 +64,6 @@ type TopbarChips = {
 	karma: number | undefined;
 	divanTo: string | undefined;
 	bildirim: {to: string; unread: number} | undefined;
-	// The mecmua "yaz" nav entry's visibility (#2532), computed below the fate gate where
-	// `me.tier` lives and published up to the always-painting nav frame via this bridge.
-	mecmuaWrite: boolean;
 };
 
 /**
@@ -155,9 +147,6 @@ function Layout() {
 							{to: "/sozluk", label: "sözlük"},
 							{to: "/pano", label: "pano"},
 							...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
-							// The yazar-gated "yaz" entry to the editor (#2532), shown once fate
-							// settles the write affordance — chip-published from below the gate.
-							...(chips?.mecmuaWrite ? [{to: "/mecmua/yaz", label: "yaz"}] : []),
 						]}
 						divanTo={chips?.divanTo}
 						{...(chips?.userProps ?? {})}
@@ -244,10 +233,6 @@ function LayoutContent() {
 	// today: disabled ⇒ the read never touches the wire and reports 0.
 	const {value: bildirimOn} = useFlag(PHOENIX_BILDIRIM, false);
 	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data, me?.id ?? null);
-	// The yazar-gated mecmua "yaz" nav entry (#2532), dark behind `mecmua-write`. The
-	// visibility shares the editor's own publish gate (shouldShowMecmuaWriteCta), so the
-	// nav entry never dead-ends a çaylak/visitor into a page they can't publish from.
-	const {value: mecmuaWriteOn} = useFlag(MECMUA_WRITE, false);
 	// #1888: hold the off-/auth redirect while a chosen-username signup is still
 	// resolving. `signUp.email` establishes the session before the separate
 	// `setUsername` lands; without this hold the redirect unmounts AuthPage and
@@ -288,20 +273,8 @@ function LayoutContent() {
 			karma: selfKarma,
 			divanTo: showDivan ? "/divan" : undefined,
 			bildirim: bildirimOn && isSignedIn ? {to: "/bildirimler", unread: bildirimUnread} : undefined,
-			mecmuaWrite: shouldShowMecmuaWriteCta(mecmuaWriteOn, isSignedIn, me?.tier),
 		}),
-		[
-			sessionUser,
-			me?.name,
-			me?.tier,
-			username,
-			selfKarma,
-			showDivan,
-			bildirimOn,
-			isSignedIn,
-			bildirimUnread,
-			mecmuaWriteOn,
-		],
+		[sessionUser, me?.name, username, selfKarma, showDivan, bildirimOn, isSignedIn, bildirimUnread],
 	);
 
 	// Publish the computed chips up to the shell frame; clear them on unmount (the


### PR DESCRIPTION
## What & why

Fixes #2543.

The mecmua **yaz** write affordance (added by #2536) shipped as a **global top-nav entry** — a verb sitting among the product nouns (`sözlük · pano · mecmua · divan`) — so it rendered as a second orange pill glued to `mecmua` and read like a rendering bug. Access gating was correct; only the placement/IA was wrong.

## Change

- **Drop** the `{to: "/mecmua/yaz", label: "yaz"}` entry from the `Topbar` `nav` array in `apps/web/src/App.tsx` — no verb pill in the global top nav on any page.
- **Remove** the now-dead chip plumbing that only fed that entry: the `mecmuaWrite` `TopbarChips` field, the `MECMUA_WRITE` `useFlag` read, and the `shouldShowMecmuaWriteCta` import (App.tsx).
- The contextual, yazar-gated **"yeni yazı"** CTA already lives on the mecmua index surface (`apps/web/src/pages/MecmuaIndexPage.tsx`, header row + empty-state), reusing `shouldShowMecmuaWriteCta` **unchanged** — so it is now the **sole** write CTA. No new access plumbing was added; the gate and its tests are untouched.
- The `/mecmua/yaz` route is untouched — the editor stays reachable; only its entry point moves.

## Acceptance criteria

- [x] The `{to: "/mecmua/yaz", label: "yaz"}` nav entry is removed from `App.tsx` — no verb pill in the global top nav.
- [x] A yazar-gated "yeni yazı" CTA exists on the mecmua index (`MecmuaIndexPage.tsx`), linking to `/mecmua/yaz` — pre-existing from #2536, now the sole placement (no duplication).
- [x] The CTA reuses `shouldShowMecmuaWriteCta` unchanged — same yazar-only, `MECMUA_WRITE`-dark gating; no change to the access logic or its tests.
- [x] Gate-parity preserved: signed-in yazar + flag-on sees the CTA on the index and nowhere in the global nav; çaylak / signed-out / flag-off sees no write CTA anywhere.
- [x] The `/mecmua/yaz` route itself is untouched.

## Verification

- `pnpm typecheck` (web) — passes.
- `pnpm lint` (biome) — clean on the touched file.
- `MecmuaEditorPage.test.tsx` — 9/9 pass (the `shouldShowMecmuaWriteCta` gate is untouched).