### PR TITLE
feat(mecmua): make a saved taslak reachable — yazılarım list + id-addressable editor (#2544)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -36,6 +36,7 @@ import {DivanPage} from "./pages/DivanPage";
 import {FunnelPage} from "./pages/FunnelPage";
 import {LabComposerPage} from "./pages/LabComposerPage";
 import {LandingPage} from "./pages/LandingPage";
+import {MecmuaDraftsPage} from "./pages/MecmuaDraftsPage";
 import {MecmuaEditorPage} from "./pages/MecmuaEditorPage";
 import {MecmuaFeedPage} from "./pages/MecmuaFeedPage";
 import {MecmuaIndexPage} from "./pages/MecmuaIndexPage";
@@ -313,11 +314,14 @@ export function App() {
 						{/* mecmua — each page self-gates on its flag (off ⇒ 404), so these routes
 						    are dark by default: the public index (#2512) + reader (#2498) on
 						    mecmua-public-read, the subscribed-author feed (#2500) on mecmua-feed, the
-						    authoring page (#2499) on mecmua-write. The three static paths out-rank
-						    the `/mecmua/:slug` reader below them. */}
+						    authoring page (#2499), the id-addressable draft load + the drafts list
+						    (#2544) on mecmua-write. The static/`yaz`-prefixed paths out-rank the
+						    `/mecmua/:slug` reader below them. */}
 						<Route path="/mecmua" element={<MecmuaIndexPage />} />
 						<Route path="/mecmua/akis" element={<MecmuaFeedPage />} />
+						<Route path="/mecmua/yazilarim" element={<MecmuaDraftsPage />} />
 						<Route path="/mecmua/yaz" element={<MecmuaEditorPage />} />
+						<Route path="/mecmua/yaz/:id" element={<MecmuaEditorPage />} />
 						<Route path="/mecmua/:slug" element={<MecmuaPostPage />} />
 						<Route path="/sozluk" element={<SozlukHome />} />
 						<Route path="/sozluk/:slug" element={<SozlukTermPage />} />

--- a/apps/web/src/pages/MecmuaDraftsPage.css
+++ b/apps/web/src/pages/MecmuaDraftsPage.css
@@ -1,0 +1,80 @@
+/* /mecmua/yazilarim — the author's own posts list (#2544). Layout only — colors/
+   elevation/borders come from the Card primitive and role tokens; this file owns the
+   list rhythm, heading spacing, and the draft/published badge. */
+
+.kp-mecmua-drafts__head {
+	margin-bottom: var(--s-5);
+}
+
+.kp-mecmua-drafts__head-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--s-3);
+}
+
+.kp-mecmua-drafts__title {
+	font: var(--t-h-page);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-mecmua-drafts__lede {
+	font: var(--t-body);
+	color: var(--text-secondary);
+	margin: var(--s-1) 0 0;
+}
+
+.kp-mecmua-drafts__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+}
+
+.kp-mecmua-drafts__item {
+	padding: 0;
+}
+
+.kp-mecmua-drafts__link {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	padding: var(--s-3) var(--s-4);
+	text-decoration: none;
+	color: inherit;
+}
+
+.kp-mecmua-drafts__item-title {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+}
+
+.kp-mecmua-drafts__meta {
+	color: var(--text-muted);
+	font: var(--t-meta);
+	display: flex;
+	align-items: center;
+	gap: var(--s-2);
+}
+
+.kp-mecmua-drafts__badge {
+	font: var(--t-meta);
+	color: var(--text-secondary);
+	background: var(--surface-sunken);
+	border-radius: var(--r-sm);
+	padding: 0 var(--s-2);
+}
+
+.kp-mecmua-drafts__badge--published {
+	color: var(--text-primary);
+	background: var(--surface-sunken);
+	border: 1px solid var(--border);
+}
+
+.kp-mecmua-drafts__status {
+	font: var(--t-body);
+	color: var(--text-secondary);
+}

--- a/apps/web/src/pages/MecmuaDraftsPage.tsx
+++ b/apps/web/src/pages/MecmuaDraftsPage.tsx
@@ -1,0 +1,142 @@
+/**
+ * `/mecmua/yazilarim` — the author's OWN posts (#2544): the private retrieval surface
+ * the mecmua write path lacked. It reads the `CurrentUser`-scoped `mecmuaMyPosts` fate
+ * root (drafts + published, newest-started first) and lists each as a card linking to
+ * the editor at that post's id (`/mecmua/yaz/:id`), so a saved taslak is reopenable —
+ * closing the #2429 Story 3 "keep multiple drafts" journey the write-only path broke.
+ *
+ * The whole surface ships dark behind `MECMUA_WRITE` (default-off): the page self-gates
+ * (off ⇒ 404), the same seam the editor gates on, and `mecmuaMyPosts` serves empty while
+ * the flag is off — so no unreleased authoring surface leaks (ADR 0083). Signed-out reads
+ * are empty (the read is author-scoped), rendered as the empty state.
+ */
+import {NotebookPen} from "lucide-react";
+import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import {Link} from "react-router";
+import type {MecmuaPost} from "../../worker/features/fate/views";
+import {Icon} from "../components/Icon";
+import {Card} from "../components/ui/Card";
+import {EmptyState} from "../components/ui/EmptyState";
+import {MetaRow} from "../components/ui/MetaRow";
+import {Screen} from "../fate/Screen";
+import {toIso} from "../fate/wire";
+import {MECMUA_WRITE} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
+import {formatDateTR} from "../lib/datetime";
+import {NotFoundPage} from "./NotFoundPage";
+import "./MecmuaDraftsPage.css";
+
+const MecmuaMyPostView = view<MecmuaPost>()({
+	id: true,
+	title: true,
+	publishedAt: true,
+});
+const MyPostsConnectionView = {items: {node: MecmuaMyPostView}} as const;
+const myPostsRequest = {
+	mecmuaMyPosts: {list: MyPostsConnectionView, args: {first: 50}},
+} as const;
+
+/** The "yeni yazı" entry-point link to a blank editor, styled as the primary CTA button. */
+function MecmuaWriteCta() {
+	return (
+		<Link to="/mecmua/yaz" className="kp-btn kp-btn--primary" data-testid="mecmua-drafts-new">
+			yeni yazı
+		</Link>
+	);
+}
+
+export function MecmuaDraftsPage() {
+	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);
+
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
+	// MecmuaEditorPage / MecmuaPostPage self-gate idiom).
+	if (flagLoading) {
+		return (
+			<div className="kp-page">
+				<div className="kp-page__inner">
+					<p className="kp-mecmua-drafts__status">yükleniyor…</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!flagOn) return <NotFoundPage />;
+
+	return (
+		<div className="kp-page">
+			<div className="kp-page__inner">
+				<header className="kp-mecmua-drafts__head">
+					<div className="kp-mecmua-drafts__head-row">
+						<h1 className="kp-mecmua-drafts__title">yazılarım</h1>
+						<MecmuaWriteCta />
+					</div>
+					<p className="kp-mecmua-drafts__lede">taslakların ve yayımladığın yazılar.</p>
+				</header>
+				<Screen
+					fallback={<p className="kp-mecmua-drafts__status">yükleniyor…</p>}
+					error={({code}) => (
+						<p className="kp-mecmua-drafts__status" role="alert">
+							yazılar yüklenemedi: {code.toLowerCase()}
+						</p>
+					)}
+				>
+					<MecmuaDraftsList />
+				</Screen>
+			</div>
+		</div>
+	);
+}
+
+function MecmuaDraftsList() {
+	const {mecmuaMyPosts} = useRequest(myPostsRequest);
+	const [items] = useListView(MyPostsConnectionView, mecmuaMyPosts);
+
+	if (items.length === 0) {
+		return (
+			<EmptyState
+				icon={<Icon icon={NotebookPen} size={24} />}
+				title="henüz yazın yok"
+				description="yeni bir yazıya başla; taslakların burada birikir."
+				action={<MecmuaWriteCta />}
+			/>
+		);
+	}
+
+	return (
+		<ul className="kp-mecmua-drafts__list">
+			{items.map(({node}) => (
+				<MecmuaDraftRow key={String(node.id)} node={node} />
+			))}
+		</ul>
+	);
+}
+
+function MecmuaDraftRow({node}: {node: ViewRef<"MecmuaPost">}) {
+	const post = useView(MecmuaMyPostView, node);
+	const published = post.publishedAt != null;
+	const heading = post.title.trim().length > 0 ? post.title : "(başlıksız taslak)";
+
+	return (
+		<Card as="li" interactive className="kp-mecmua-drafts__item" data-testid="mecmua-drafts-item">
+			<Link to={`/mecmua/yaz/${String(node.id)}`} className="kp-mecmua-drafts__link">
+				<span className="kp-mecmua-drafts__item-title">{heading}</span>
+				<MetaRow as="div" className="kp-mecmua-drafts__meta">
+					{published ? (
+						<>
+							<span className="kp-mecmua-drafts__badge kp-mecmua-drafts__badge--published">
+								yayımlandı
+							</span>
+							{post.publishedAt ? (
+								<time dateTime={toIso(post.publishedAt)}>
+									{formatDateTR(toIso(post.publishedAt))}
+								</time>
+							) : null}
+						</>
+					) : (
+						<span className="kp-mecmua-drafts__badge">taslak</span>
+					)}
+				</MetaRow>
+			</Link>
+		</Card>
+	);
+}

--- a/apps/web/src/pages/MecmuaEditorPage.css
+++ b/apps/web/src/pages/MecmuaEditorPage.css
@@ -16,6 +16,23 @@
 	gap: var(--s-1);
 }
 
+.kp-mecmua-editor__head-row {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--s-3);
+}
+
+.kp-mecmua-editor__yazilarim-link {
+	font: var(--t-meta);
+	color: var(--text-secondary);
+	text-decoration: none;
+}
+
+.kp-mecmua-editor__yazilarim-link:hover {
+	color: var(--text-primary);
+}
+
 .kp-mecmua-editor__title {
 	font: var(--t-h-page);
 	color: var(--text-primary);

--- a/apps/web/src/pages/MecmuaEditorPage.tsx
+++ b/apps/web/src/pages/MecmuaEditorPage.tsx
@@ -15,6 +15,12 @@
  *     visitor sees the Turkish earned-gate message instead — publish is server-gated by
  *     `PublishMecmua` regardless, this is the honest UI mirror.
  *
+ * Two routes reach this page (#2544): `/mecmua/yaz` opens a blank editor; `/mecmua/yaz/:id`
+ * loads one of the author's OWN posts (via the `CurrentUser`-scoped `mecmuaMyPosts` read)
+ * into the editor so a saved draft is reopenable. Multi-draft is unchanged — a save still
+ * mints a fresh row (no edit-in-place), so `taslak kaydet` lands on the just-saved draft's
+ * id rather than a blank editor. `taslaklarım` (`/mecmua/yazilarim`) lists them.
+ *
  * The whole surface ships dark behind `MECMUA_WRITE` (default-off): the page
  * self-gates (off ⇒ 404), mirroring `MecmuaPostPage` / `DivanPage`, so the route is
  * absent until a human flips the flag at release (ADR 0083). Storage is the markdown
@@ -22,12 +28,14 @@
  */
 import {Composer, useComposerEditor} from "@kampus/composer";
 import {useState} from "react";
-import {useFateClient, view} from "react-fate";
+import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import {Link, useNavigate, useParams} from "react-router";
 import type {MecmuaPost} from "../../worker/features/fate/views";
 import type {Tier} from "../../worker/features/kunye/standing";
 import {useSession} from "../auth/client";
 import {useMe} from "../auth/useMe";
 import {Button} from "../components/ui/Button";
+import {Screen} from "../fate/Screen";
 import {useDraftSubmit} from "../fate/useDraftSubmit";
 import {MECMUA_WRITE} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
@@ -100,21 +108,95 @@ export function MecmuaEditorPage() {
 
 	if (!flagOn) return <NotFoundPage />;
 
-	return <MecmuaEditor />;
+	return <MecmuaEditorRoute />;
 }
 
-function MecmuaEditor() {
+/** The full-post read used to reopen an author's own draft — body included so the composer seeds. */
+const MecmuaOwnPostView = view<MecmuaPost>()({
+	id: true,
+	title: true,
+	body: true,
+	publishedAt: true,
+});
+const OwnPostsConnectionView = {items: {node: MecmuaOwnPostView}} as const;
+const ownPostsRequest = {
+	mecmuaMyPosts: {list: OwnPostsConnectionView, args: {first: 100}},
+} as const;
+
+/**
+ * Route the editor by the `:id` param (#2544): no id ⇒ a blank editor; an id ⇒ load
+ * that draft (scoped to the author's own posts) and seed the editor with it. The read
+ * runs BEFORE `MecmuaEditor` mounts so the composer's initial content is ready at hook
+ * time — the composer seeds content only at creation.
+ */
+function MecmuaEditorRoute() {
+	const {id} = useParams<{id: string}>();
+	if (!id) return <MecmuaEditor initialTitle="" initialBody="" />;
+	return (
+		<Screen
+			fallback={
+				<div className="kp-page">
+					<div className="kp-page__inner">
+						<p>yükleniyor…</p>
+					</div>
+				</div>
+			}
+			error={() => <MecmuaDraftNotFound />}
+		>
+			<MecmuaDraftLoader draftId={id} />
+		</Screen>
+	);
+}
+
+function MecmuaDraftLoader({draftId}: {draftId: string}) {
+	const {mecmuaMyPosts} = useRequest(ownPostsRequest);
+	const [items] = useListView(OwnPostsConnectionView, mecmuaMyPosts);
+	// `mecmuaMyPosts` returns ONLY the caller's own posts, so a foreign/absent id simply
+	// isn't in the list — it can't disclose another author's draft, it 404s to the author.
+	const match = items.find(({node}) => String(node.id) === draftId);
+	if (!match) return <MecmuaDraftNotFound />;
+	return <MecmuaDraftEditor node={match.node} />;
+}
+
+function MecmuaDraftEditor({node}: {node: ViewRef<"MecmuaPost">}) {
+	const post = useView(MecmuaOwnPostView, node);
+	return <MecmuaEditor initialTitle={post.title} initialBody={post.body} />;
+}
+
+function MecmuaDraftNotFound() {
+	return (
+		<div className="kp-page">
+			<div className="kp-page__inner">
+				<div className="kp-mecmua-editor">
+					<p className="kp-mecmua-editor__notice" role="status">
+						taslak bulunamadı.
+					</p>
+					<Link to="/mecmua/yazilarim" className="kp-mecmua-editor__yazilarim-link">
+						yazılarıma dön
+					</Link>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function MecmuaEditor({initialTitle, initialBody}: {initialTitle: string; initialBody: string}) {
 	const session = useSession();
 	const {me} = useMe();
 	const fate = useFateClient();
+	const navigate = useNavigate();
+	const {id} = useParams<{id: string}>();
 
-	const [title, setTitle] = useState("");
+	const [title, setTitle] = useState(initialTitle);
 	const [notice, setNotice] = useState<string | null>(null);
 	// The composer holds the body; markdown is read on-demand at save/publish time
-	// (`getMarkdown()`), so no per-keystroke rerender is needed here.
-	const composer = useComposerEditor({content: ""});
+	// (`getMarkdown()`), so no per-keystroke rerender is needed here. Seeded with the
+	// loaded draft's markdown (empty for a fresh editor).
+	const composer = useComposerEditor({content: initialBody});
 
-	const {error, setError, inFlight, run} = useDraftSubmit({redirectPath: () => "/mecmua/yaz"});
+	const {error, setError, inFlight, run} = useDraftSubmit({
+		redirectPath: () => (id ? `/mecmua/yaz/${id}` : "/mecmua/yaz"),
+	});
 
 	// The trusted account tier off the fate `me` view (#1297) decides the publish
 	// affordance: a yazar is offered publish; a çaylak / visitor / signed-out reader
@@ -133,7 +215,13 @@ function MecmuaEditor() {
 					view: MecmuaEditorView,
 				}),
 			"taslak kaydedilemedi",
-			() => setNotice("taslak kaydedildi"),
+			(result) => {
+				setNotice("taslak kaydedildi");
+				// Land on the just-saved draft (id-addressable), not a blank `/mecmua/yaz`
+				// (#2544). Each save mints a fresh row, so the saved id is new — navigate to it.
+				const savedId = result?.id;
+				if (savedId && String(savedId) !== id) navigate(`/mecmua/yaz/${String(savedId)}`);
+			},
 		);
 	}
 
@@ -167,7 +255,12 @@ function MecmuaEditor() {
 			<div className="kp-page__inner">
 				<div className="kp-mecmua-editor">
 					<header className="kp-mecmua-editor__head">
-						<h1 className="kp-mecmua-editor__title">yeni yazı</h1>
+						<div className="kp-mecmua-editor__head-row">
+							<h1 className="kp-mecmua-editor__title">{id ? "yazıyı düzenle" : "yeni yazı"}</h1>
+							<Link to="/mecmua/yazilarim" className="kp-mecmua-editor__yazilarim-link">
+								yazılarım
+							</Link>
+						</div>
 						<p className="kp-mecmua-editor__lede">
 							uzun biçimli bir yazı yaz. istediğin an taslak olarak kaydet; hazır olunca yayımla.
 						</p>

--- a/apps/web/worker/features/mecmua/Mecmua.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.ts
@@ -35,7 +35,7 @@ import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import {MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.ts";
 import {selectMecmuaFeed} from "./feed-selection.ts";
 import {anonymousMecmuaViewer, mecmuaPostVisibleWhere} from "./MecmuaPostVisibility.ts";
-import {MECMUA_FEED_ORDERING} from "./ordering.ts";
+import {MECMUA_FEED_ORDERING, MECMUA_MINE_ORDERING} from "./ordering.ts";
 import {type MecmuaPostRow, toMecmuaPostRow} from "./post-fields.ts";
 
 export interface SaveMecmuaDraftInput {
@@ -64,6 +64,13 @@ export interface MecmuaSubscriptionInput {
 /** The subscribed-author feed page request — `subscriberId` + forward keyset window. */
 export interface MecmuaFeedInput {
 	subscriberId: string;
+	first?: number;
+	after?: string | null;
+}
+
+/** The author's own-posts page request (#2544) — `authorId` + forward keyset window. */
+export interface MecmuaOwnPostsInput {
+	authorId: string;
 	first?: number;
 	after?: string | null;
 }
@@ -104,6 +111,15 @@ export class Mecmua extends Context.Service<
 		 * mask); a reader with no subscriptions gets an empty page.
 		 */
 		readonly listFeedConnection: (input: MecmuaFeedInput) => Effect.Effect<MecmuaFeedPage>;
+
+		/**
+		 * The author's OWN posts (#2544): a forward keyset page of the caller's posts —
+		 * BOTH drafts (`publishedAt is null`) and published — ordered `createdAt desc, id
+		 * desc` (newest-started first). This is the PRIVATE complement of the draft-masked
+		 * public reads: it is scoped `where author_id = ?`, so only the caller's own rows
+		 * ever resolve and no other author's drafts are exposed.
+		 */
+		readonly listOwnPostsConnection: (input: MecmuaOwnPostsInput) => Effect.Effect<MecmuaFeedPage>;
 	}
 >()("mecmua/Mecmua") {}
 
@@ -275,6 +291,51 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 			return forwardPage(selected, first, (r) => r.id) satisfies MecmuaFeedPage;
 		});
 
+		const listOwnPostsConnection = Effect.fn("Mecmua.listOwnPostsConnection")(function* (
+			input: MecmuaOwnPostsInput,
+		) {
+			const first = Math.max(1, Math.min(input.first ?? FEED_DEFAULT_FIRST, FEED_MAX_FIRST));
+			const after = input.after ?? null;
+
+			// Own posts only — `author_id = ?` includes drafts (null `publishedAt`), so no
+			// visibility mask is applied: the author always sees their own rows, and the
+			// scoping guarantees another author's rows never resolve (rides the
+			// `mecmua_post_author_created` index).
+			const baseWhere = eq(schema.mecmuaPost.authorId, input.authorId);
+
+			// Resolve the `after` cursor to its `createdAt` anchor, gated by the SAME author
+			// scope so a cursor naming a foreign/absent row misses → empty page.
+			const resolvedRow = after
+				? ((yield* run((db) =>
+						db
+							.select({createdAt: schema.mecmuaPost.createdAt})
+							.from(schema.mecmuaPost)
+							.where(and(eq(schema.mecmuaPost.id, after), baseWhere))
+							.get(),
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor(after, resolvedRow);
+			if (cursor.kind === "miss") return emptyKeysetPage satisfies MecmuaFeedPage;
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
+
+			const cursorPredicate = keysetAfter(
+				keysetKeys(MECMUA_MINE_ORDERING, (field) =>
+					field === "id" ? after : (cursorRow?.createdAt ?? null),
+				),
+			);
+
+			const fetched = yield* run((db) =>
+				db
+					.select()
+					.from(schema.mecmuaPost)
+					.where(cursorPredicate ? and(baseWhere, cursorPredicate) : baseWhere)
+					.orderBy(...orderByColumns(MECMUA_MINE_ORDERING))
+					.limit(first + 1),
+			);
+
+			return forwardPage(fetched.map(toMecmuaPostRow), first, (r) => r.id) satisfies MecmuaFeedPage;
+		});
+
 		return {
 			saveDraft,
 			publish,
@@ -283,6 +344,7 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 			listSubscribedAuthorIds,
 			isSubscribed,
 			listFeedConnection,
+			listOwnPostsConnection,
 		};
 	}),
 );

--- a/apps/web/worker/features/mecmua/fate-module.ts
+++ b/apps/web/worker/features/mecmua/fate-module.ts
@@ -5,7 +5,7 @@ import {viewOrderBy} from "../../db/ordering.ts";
 import type {FateModule, FateRootsRecord} from "../fate/module.ts";
 import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
-import {MECMUA_FEED_ORDERING} from "./ordering.ts";
+import {MECMUA_FEED_ORDERING, MECMUA_MINE_ORDERING} from "./ordering.ts";
 import {queries} from "./queries.ts";
 import {
 	MecmuaPostView,
@@ -26,6 +26,10 @@ const roots: FateRootsRecord = {
 	// (`publishedAt desc, id desc`, single-sourced from `MECMUA_FEED_ORDERING`) + the
 	// published mask + the subscribed-author selection.
 	mecmuaFeed: list(mecmuaPostDataView, {orderBy: viewOrderBy(MECMUA_FEED_ORDERING)}),
+	// The author's own posts — drafts + published (#2544). `CurrentUser`-scoped, ordered
+	// `createdAt desc, id desc` (single-sourced from `MECMUA_MINE_ORDERING`), so the
+	// private drafts list has a stable retrieval surface.
+	mecmuaMyPosts: list(mecmuaPostDataView, {orderBy: viewOrderBy(MECMUA_MINE_ORDERING)}),
 	// The subscribe-affordance state read (#2527) — whether the reader follows a given
 	// author. Resolved inline by the `mecmuaSubscription` query keyed on `CurrentUser`.
 	mecmuaSubscription: mecmuaSubscriptionReceiptDataView,

--- a/apps/web/worker/features/mecmua/lists.ts
+++ b/apps/web/worker/features/mecmua/lists.ts
@@ -13,7 +13,7 @@
 import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
-import {MECMUA_FEED} from "../../../src/flags/keys.ts";
+import {MECMUA_FEED, MECMUA_WRITE} from "../../../src/flags/keys.ts";
 import {emptyKeysetPage} from "../../db/keyset.ts";
 import {toConnection} from "../fate/connection.ts";
 import {Flags} from "../flagship/Flags.ts";
@@ -44,6 +44,12 @@ const feedOn = Effect.gen(function* () {
 	return yield* flags.getBoolean(MECMUA_FEED, false).pipe(provideRequestFlags);
 });
 
+/** Is the mecmua write path on for this request? Safe-default `false` (ships dark). */
+const writeOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(MECMUA_WRITE, false).pipe(provideRequestFlags);
+});
+
 export const lists = {
 	mecmuaFeed: Fate.list(
 		{args: MecmuaFeedArgs, type: MecmuaPostView},
@@ -56,6 +62,26 @@ export const lists = {
 			const mecmua = yield* Mecmua;
 			const page = yield* mecmua.listFeedConnection({
 				subscriberId: user.id,
+				...(args.first !== undefined ? {first: args.first} : {}),
+				...(args.after !== undefined ? {after: args.after} : {}),
+			});
+			return feedConnection(page);
+		}),
+	),
+	// The author's OWN posts — drafts + published (#2544), the private retrieval surface
+	// for the write path. Scoped to `CurrentUser`, so it never exposes another author's
+	// drafts; gated behind the same `MECMUA_WRITE` seam as the editor, so it ships dark.
+	mecmuaMyPosts: Fate.list(
+		{args: MecmuaFeedArgs, type: MecmuaPostView},
+		Effect.fn("mecmuaMyPosts")(function* ({args}) {
+			// Flag off OR signed-out ⇒ empty: the write surface is dark until release, and an
+			// anonymous reader authored nothing, so there is nothing of theirs to serve.
+			const {user} = yield* CurrentUser;
+			if (!user || !(yield* writeOn)) return feedConnection(emptyKeysetPage);
+
+			const mecmua = yield* Mecmua;
+			const page = yield* mecmua.listOwnPostsConnection({
+				authorId: user.id,
 				...(args.first !== undefined ? {first: args.first} : {}),
 				...(args.after !== undefined ? {after: args.after} : {}),
 			});

--- a/apps/web/worker/features/mecmua/mecmua-own-posts.unit.test.ts
+++ b/apps/web/worker/features/mecmua/mecmua-own-posts.unit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit — the author's own-posts read (#2544), the PRIVATE complement of the draft-masked
+ * public reads. Proven on the served `Mecmua.listOwnPostsConnection` path over a scripted
+ * `Drizzle` seam (the `mecmua-feed.unit.test.ts` idiom): the load-bearing AC is that a
+ * DRAFT (null `publishedAt`) is INCLUDED — unlike the feed, this surface applies NO
+ * published mask, so the author sees both their drafts and their published posts. The
+ * author-scoping itself is the SQL `where author_id = ?` (the trusted `publish` ownership
+ * idiom), so a foreign row never reaches this JS.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import type * as schema from "../../db/drizzle/schema.ts";
+import {Mecmua, MecmuaLive} from "./Mecmua.ts";
+
+type MecmuaRecord = typeof schema.mecmuaPost.$inferSelect;
+
+const post = (over: Partial<MecmuaRecord> & {id: string}): MecmuaRecord => ({
+	slug: null,
+	title: `başlık ${over.id}`,
+	body: "gövde",
+	authorId: "A",
+	publishedAt: null,
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+	...over,
+});
+
+/** A `Drizzle` whose `run` replays a queued result sequence; `batch` is unused here. */
+const scriptedAccess = (results: ReadonlyArray<unknown>): DrizzleAccess => {
+	const state = {i: 0};
+	return {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			void fn;
+			return Effect.succeed(results[state.i++] as A);
+		},
+		batch: () => Effect.die(new Error("mecmua own-posts reads use run(), never batch()")),
+	};
+};
+
+const mecmuaLayer = (access: DrizzleAccess) =>
+	MecmuaLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+describe("Mecmua.listOwnPostsConnection — the author's own drafts + published", () => {
+	// Author A's own rows as the `author_id = ?` fetch would return them (createdAt desc):
+	// a published post AND a draft. No `after`, so `run` is called once (the fetch only).
+	const ownRows: MecmuaRecord[] = [
+		post({
+			id: "a-2",
+			authorId: "A",
+			createdAt: new Date("2026-03-01T00:00:00.000Z"),
+			publishedAt: null,
+		}),
+		post({
+			id: "a-1",
+			authorId: "A",
+			createdAt: new Date("2026-02-01T00:00:00.000Z"),
+			publishedAt: new Date("2026-02-05T00:00:00.000Z"),
+		}),
+	];
+
+	it.effect("INCLUDES a draft (null publishedAt) alongside published — no mask applied", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const page = yield* mecmua.listOwnPostsConnection({authorId: "A"});
+			assert.deepStrictEqual(
+				page.rows.map((r) => r.id),
+				["a-2", "a-1"],
+			);
+			assert.isTrue(page.rows.some((r) => r.publishedAt === null));
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([ownRows])))),
+	);
+
+	it.effect("an author with no posts gets an empty page", () =>
+		Effect.gen(function* () {
+			const mecmua = yield* Mecmua;
+			const page = yield* mecmua.listOwnPostsConnection({authorId: "A"});
+			assert.deepStrictEqual(page.rows, []);
+			assert.isFalse(page.hasNextPage);
+		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([[]])))),
+	);
+});

--- a/apps/web/worker/features/mecmua/ordering.ts
+++ b/apps/web/worker/features/mecmua/ordering.ts
@@ -17,3 +17,16 @@ export const MECMUA_FEED_ORDERING: Ordering = [
 	{field: "publishedAt", column: schema.mecmuaPost.publishedAt, dir: "desc"},
 	{field: "id", column: schema.mecmuaPost.id, dir: "desc"},
 ];
+
+/**
+ * The author's own-posts list (`mecmuaMyPosts`, #2544): `createdAt desc, id desc` —
+ * most-recently-started post/draft first, `id` breaking ties for a stable keyset
+ * cursor. Ordered on `createdAt` (not `publishedAt`) because the list includes
+ * drafts (null `publishedAt`), and it rides the `mecmua_post_author_created`
+ * index. Consumed by the `mecmuaMyPosts` root's view `orderBy` and
+ * `Mecmua.listOwnPostsConnection`'s keyset.
+ */
+export const MECMUA_MINE_ORDERING: Ordering = [
+	{field: "createdAt", column: schema.mecmuaPost.createdAt, dir: "desc"},
+	{field: "id", column: schema.mecmuaPost.id, dir: "desc"},
+];


### PR DESCRIPTION
A saved mecmua taslak (draft) was **unreachable**: `mecmua.saveDraft` persisted to D1 but no UI listed an author's own drafts, and `taslak kaydet` dropped the saved id (landing on a blank `/mecmua/yaz`). This adds the private **retrieval** half of the write journey — the slice that breaks epic #2429 Story 3 ("save and keep multiple drafts").

## What changed
- **Backend — a yazar-scoped private read.** `Mecmua.listOwnPostsConnection` + the `CurrentUser`-scoped `mecmuaMyPosts` fate root return the author's OWN posts — drafts (`published_at IS NULL`) **and** published — scoped `where author_id = ?` (`MECMUA_MINE_ORDERING` = `createdAt desc, id desc`, riding the existing `mecmua_post_author_created` index). It exposes **no** other author's drafts, and the public draft-mask (`MecmuaPostVisibility`) is untouched for anon/other-author reads.
- **Frontend — `/mecmua/yazilarim` (`MecmuaDraftsPage`).** A "yazılarım" list of the author's posts (taslak / yayımlandı badge), each row linking to the editor at that post's id.
- **Frontend — `/mecmua/yaz/:id`.** The editor loads one of the author's own drafts by id and seeds the composer with its markdown. `taslak kaydet` now navigates to the just-saved draft's id (each save mints a fresh row by design), not a blank `/mecmua/yaz`. A "yazılarım" link in the editor header makes the list reachable.

## Gating
All of it self-gates behind the existing default-off `MECMUA_WRITE` seam (the editor's own flag): the drafts page 404s with the flag off, and `mecmuaMyPosts` serves empty — so the surface ships dark until a human flips the flag at release (ADR 0083). No new flag is declared; no schema change.

## Tests
- New `mecmua-own-posts.unit.test.ts`: the served path INCLUDES a draft (no published-mask), unlike the feed; empty for an author with no posts.
- `pnpm typecheck` (28/28), `pnpm lint:worktree` clean, all 47 mecmua unit/client tests pass, `fanout-guard` clean (no new mutation).

No `/fate/live` fanout change: this adds reads only; `mecmua.saveDraft` stays `fanned: false`.

Fixes #2544
Flag: mecmua-write