### PR TITLE
feat(pipeline-cli): reachability-guard — a flag can't graduate while its UI slice is unbuilt (#2529)

### DIFF
--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -26,6 +26,8 @@ export const MECMUA_WRITE = "mecmua-write";
  * Flipping it on is the human release act (ADR 0083). Its OWN key, distinct from
  * `pano-base-feed` (which gates the base-feed route's existence): the viewer-invariant
  * base feed can serve without the edge cache, so caching has an independent lifecycle.
+ *
+ * @reachability-exempt: infra edge-cache flag — no user-facing surface by design (ADR 0170).
  */
 export const PANO_FEED_EDGE_CACHE = "pano-feed-edge-cache";
 

--- a/apps/web/tests/e2e/28-reaction-bar-darkship.spec.ts
+++ b/apps/web/tests/e2e/28-reaction-bar-darkship.spec.ts
@@ -18,7 +18,9 @@ import {expect, test} from "@playwright/test";
  * seeded reaction, landing at release), so this e2e stays on the off-path — the
  * same split as `26-pano-draft-save.spec.ts`.
  */
-test.describe("Reaction bar (dark-ship, phoenix-reactions default off)", () => {
+// @journey:phoenix-reactions — the registered reachability journey for the reactions
+// vertical (ADR 0173 §2). reachability-guard asserts this tag exists; the e2e job runs it.
+test.describe("Reaction bar (dark-ship, phoenix-reactions default off) @journey:phoenix-reactions", () => {
 	test("no reaction bar renders on pano post cards while the flag defaults off", async ({page}) => {
 		await page.goto("/pano");
 		// The feed rendered (a post card is present)…

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -473,6 +473,38 @@ node packages/pipeline-cli/src/bin.ts wayfinder-map 2421
 node packages/pipeline-cli/src/bin.ts wayfinder-map 2421 --json
 ```
 
+### `reachability-guard` — a flag can't graduate while its UI slice is unbuilt (ADR 0173, #2529)
+
+The single deterministic reachability contract both `plan-epic` (#2530) and `/release`
+(#2531) key off — the enforcement seam that makes an unreachable-feature graduation
+unrepresentable (ADR [0173](../../.decisions/0173-vertical-completeness-gate.md), epic
+[#1943](https://github.com/kamp-us/phoenix/issues/1943)). Given a Flagship flag key, it
+asserts the flag's vertical has a **user-facing slice** before the flag can reach 100%:
+
+- **Consuming UI** — the flag-key constant declared in `apps/web/src/flags/keys.ts` is
+  referenced by ≥1 `apps/web/src/**/*.tsx` component (the static scan the reactions reporter
+  ran by hand; ADR 0173 §1a/§2).
+- **Registered journey e2e** — a spec under `apps/web/tests/e2e/` carries an in-title
+  `@journey:<flag-key>` tag (ADR 0173 §2). The checker asserts *registration*; the e2e job
+  runs the spec.
+- **Exemption** — a legitimately UI-less infra/containment flag (e.g. `pano-feed-edge-cache`)
+  opts out with a `@reachability-exempt: <reason>` marker at its `keys.ts` definition (ADR
+  0173 §3), so the gate refuses unreachable *user-facing* flags without blocking infra flags.
+
+It **fails closed** (ADR 0092) and **names precisely** which assertion failed (missing UI
+consumer / missing journey e2e / unknown flag / zero scope), so `/release` can surface the
+gap to the human. The pure core (`reachability-guard.ts` — keys.ts parse, `@journey` tag
+parse, `judge`) is unit-tested directly; the filesystem boundary (`gate.ts` — walk `.tsx` +
+e2e specs) is crossed over a fake repo dir.
+
+```bash
+# exit 0 iff <flag-key> is reachable (consuming UI + registered journey) or @reachability-exempt
+node packages/pipeline-cli/src/bin.ts reachability-guard check phoenix-reactions
+
+# point at a specific repo root (default: walk up for a workspace marker)
+node packages/pipeline-cli/src/bin.ts reachability-guard check pano-feed-edge-cache --root /path/to/repo
+```
+
 ```bash
 pnpm --filter @kampus/pipeline-cli typecheck
 pnpm --filter @kampus/pipeline-cli test

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -31,6 +31,7 @@ import {mainSyncCommand} from "./tools/main-sync/command.ts";
 import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
 import {pathFilterGuardCommand} from "./tools/path-filter-guard/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
+import {reachabilityGuardCommand} from "./tools/reachability-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {refGuardCommand} from "./tools/ref-guard/command.ts";
 import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
@@ -107,6 +108,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	glossaryDriftCommand,
 	failureClassifierCommand,
 	fanoutGuardCommand,
+	reachabilityGuardCommand,
 	designTokenGuardCommand,
 	resumePolicyCommand,
 	evalHarnessCommand,

--- a/packages/pipeline-cli/src/tools/reachability-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/command.ts
@@ -1,0 +1,88 @@
+/**
+ * The `reachability-guard` tool — `pipeline-cli reachability-guard check <flag-key> [--root <d>]`
+ * (ADR 0173).
+ *
+ * The one shared reachability contract both `plan-epic` (#2530) and `/release` (#2531)
+ * key off — a flag can't graduate to 100% while its vertical's user-facing slice is
+ * unbuilt:
+ *
+ *   pipeline-cli reachability-guard check <flag-key>            # exit non-zero if the flag is unreachable
+ *   pipeline-cli reachability-guard check <flag-key> --root <d> # point at a specific repo root
+ *
+ * SCOPE — the flag-key module `apps/web/src/flags/keys.ts`, the SPA `.tsx` source under
+ * `apps/web/src`, and the e2e specs under `apps/web/tests/e2e`. The guard fails on: a
+ * user-facing flag with no consuming `.tsx` and/or no `@journey:<flag-key>`-tagged e2e
+ * (unreachable), an unknown/unclassified flag key, or zero parsed flag definitions
+ * (fail-closed, ADR 0092). A UI-less infra flag opts out with `@reachability-exempt:
+ * <reason>` at its keys.ts definition. The scan/IO lives in `gate.ts`; this file wires it
+ * to the CLI (mirrors `fanout-guard`).
+ *
+ * With no --root the repo root is resolved by walking UP from cwd for a workspace marker
+ * (so `pnpm --filter <pkg> …`, whose cwd is the package dir, scans the whole repo).
+ *
+ * Exit-code contract: 0 = reachable/exempt, any non-zero = failure — both a gate failure
+ * (report on stderr) and an IO failure exit non-zero, undistinguished. `CheckFailed` is
+ * caught inside the handler (not at the bin's run boundary) so the contract survives
+ * folding into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../../find-root-dir.ts";
+import {type CheckFailed, checkReachability} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const flagKeyArg = Argument.string("flag-key").pipe(
+	Argument.withDescription("the Flagship flag key to assert reachable (e.g. phoenix-reactions)"),
+);
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root to scan flags/UI/e2e under (default: walk up for one)"),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
+// error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{flagKey: flagKeyArg, root: rootFlag},
+	Effect.fn(function* ({flagKey, root: rootOpt}) {
+		yield* checkReachability(resolveRoot(rootOpt), flagKey).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail if a flag is unreachable — no consuming UI and/or no registered journey e2e",
+	),
+);
+
+export const reachabilityGuardCommand = Command.make("reachability-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: a flag can't graduate while its user-facing slice is unbuilt (ADR 0173, #2529)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
@@ -1,0 +1,119 @@
+/**
+ * The `reachability-guard` filesystem gate (ADR 0173) — the IO seam behind the
+ * flag-reachability check, split from `command.ts` so it is crossable in unit tests over
+ * a fake repo dir rather than only by spawning the bin (the core-in-its-own-file idiom;
+ * #855).
+ *
+ * `checkReachability` is the gate: it reads the flag-key module, walks the SPA `.tsx`
+ * source for consuming references and the e2e specs for `@journey` registrations, and
+ * delegates the verdict to the pure core (`reachability-guard.ts`). It fails `CheckFailed`
+ * (exit non-zero) on an unreachable user-facing flag, an unknown flag key, or zero parsed
+ * flag definitions (fail-closed, ADR 0092). A directory/file IO failure is an `IoError`
+ * (also non-zero — both failures, undistinguished, per the bin's contract).
+ */
+import {existsSync, readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {
+	consumedConstantsIn,
+	type FlagDefinition,
+	judge,
+	parseFlagDefinitions,
+	parseJourneyTags,
+	renderReport,
+} from "./reachability-guard.ts";
+
+/** A directory/file IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+const KEYS_PATH = join("apps", "web", "src", "flags", "keys.ts");
+const SRC_ROOT = join("apps", "web", "src");
+const E2E_DIR = join("apps", "web", "tests", "e2e");
+
+// A missing UI/e2e dir is zero files, NOT an IO failure — the fail-closed scope anchor is
+// the keys.ts read (zero parsed definitions ⇒ zero-scope). An absent .tsx/e2e tree then
+// resolves as "no consumer / no journey", which judge correctly reports as unreachable.
+const walk = (dir: string, matches: (name: string) => boolean, acc: Array<string>): void => {
+	if (!existsSync(dir)) return;
+	for (const entry of readdirSync(dir, {withFileTypes: true})) {
+		const abs = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "node_modules" || entry.name === "dist") continue;
+			walk(abs, matches, acc);
+		} else if (matches(entry.name)) {
+			acc.push(abs);
+		}
+	}
+};
+
+/** Read + parse the flag-key module; a missing module fails as IO (not a vacuous pass). */
+const readDefinitions = (root: string): Effect.Effect<ReadonlyArray<FlagDefinition>, IoError> =>
+	Effect.try({
+		try: () => parseFlagDefinitions(readFileSync(join(root, KEYS_PATH), "utf8")),
+		catch: (cause) => new IoError({path: join(root, KEYS_PATH), cause}),
+	});
+
+/** Collect the constant names referenced by ≥1 `.tsx` under `apps/web/src`. */
+const gatherConsumers = (
+	root: string,
+	candidateNames: ReadonlyArray<string>,
+): Effect.Effect<ReadonlySet<string>, IoError> =>
+	Effect.try({
+		try: () => {
+			const files: Array<string> = [];
+			walk(join(root, SRC_ROOT), (name) => name.endsWith(".tsx"), files);
+			const consumed = new Set<string>();
+			for (const abs of files) {
+				for (const name of consumedConstantsIn(readFileSync(abs, "utf8"), candidateNames)) {
+					consumed.add(name);
+				}
+			}
+			return consumed;
+		},
+		catch: (cause) => new IoError({path: join(root, SRC_ROOT), cause}),
+	});
+
+/** Collect the flag keys registered via `@journey:<key>` across the e2e specs. */
+const gatherJourneyKeys = (root: string): Effect.Effect<ReadonlySet<string>, IoError> =>
+	Effect.try({
+		try: () => {
+			const files: Array<string> = [];
+			walk(join(root, E2E_DIR), (name) => name.endsWith(".spec.ts"), files);
+			const keys = new Set<string>();
+			for (const abs of files) {
+				for (const key of parseJourneyTags(readFileSync(abs, "utf8"))) keys.add(key);
+			}
+			return keys;
+		},
+		catch: (cause) => new IoError({path: join(root, E2E_DIR), cause}),
+	});
+
+/**
+ * The gate: succeed when `flagKey` is reachable (a consuming `.tsx` + a registered journey
+ * e2e) or exempt, else `CheckFailed`. Fails closed on zero parsed flag definitions and on
+ * an unknown flag key (ADR 0092 / 0173 §1).
+ */
+export const checkReachability = (
+	root: string,
+	flagKey: string,
+): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const definitions = yield* readDefinitions(root);
+		const consumingConstants = yield* gatherConsumers(
+			root,
+			definitions.map((d) => d.constantName),
+		);
+		const journeyKeys = yield* gatherJourneyKeys(root);
+		const verdict = judge({flagKey, definitions, consumingConstants, journeyKeys});
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/reachability-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/gate.unit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `checkReachability` over a fake repo dir — the filesystem-seam test (ADR 0173, #2529).
+ * The pure verdict (reachable / unreachable / exempt / unknown / zero-scope) is covered in
+ * `reachability-guard.unit.test.ts`; this crosses the IO gate over a real temp dir,
+ * asserting the exit-code contract from observable outcomes — never by spawning the bin.
+ *
+ * The working proof: a flag with a consuming `.tsx` + a `@journey`-tagged spec SUCCEEDS;
+ * the same tree with the consumer removed `CheckFailed` (the reactions-class falsification).
+ */
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import {CheckFailed, checkReachability} from "./gate.ts";
+
+let root: string;
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "reachability-guard-gate-"));
+});
+afterEach(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+
+const KEYS_DIR = join("apps", "web", "src", "flags");
+const COMPONENTS_DIR = join("apps", "web", "src", "components");
+const E2E_DIR = join("apps", "web", "tests", "e2e");
+
+const write = (rel: string, contents: string) => {
+	const abs = join(root, rel);
+	mkdirSync(join(abs, ".."), {recursive: true});
+	writeFileSync(abs, contents, "utf8");
+};
+
+const writeKeys = (
+	rows: ReadonlyArray<{constantName: string; flagKey: string; exemptReason?: string}>,
+) => {
+	const body = rows
+		.map((r) => {
+			const doc = r.exemptReason
+				? `/**\n * A flag.\n * @reachability-exempt: ${r.exemptReason}\n */\n`
+				: "/** A flag. */\n";
+			return `${doc}export const ${r.constantName} = "${r.flagKey}";`;
+		})
+		.join("\n");
+	write(join(KEYS_DIR, "keys.ts"), `${body}\n`);
+};
+
+const writeConsumer = (file: string, constantName: string) =>
+	write(
+		join(COMPONENTS_DIR, file),
+		`import {${constantName}} from "../flags/keys";\nexport const C = () => <FlagGate flag={${constantName}} />;\n`,
+	);
+
+const writeJourneySpec = (file: string, flagKey: string) =>
+	write(
+		join(E2E_DIR, file),
+		`test.describe("some journey @journey:${flagKey}", () => { test("x", () => {}); });\n`,
+	);
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
+	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
+
+describe("checkReachability — the exit-code gate over a fake repo dir", () => {
+	it("SUCCEEDS when a .tsx consumes the constant AND a journey spec is registered (the proof)", async () => {
+		writeKeys([{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions"}]);
+		writeConsumer("ReactionBar.tsx", "PHOENIX_REACTIONS");
+		writeJourneySpec("28-reactions.spec.ts", "phoenix-reactions");
+		const exit = await run(checkReachability(root, "phoenix-reactions"));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed) when no .tsx consumes the constant (the reactions-class falsification)", async () => {
+		writeKeys([{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions"}]);
+		// journey registered, but NO consuming component ⇒ unreachable on the UI slice
+		writeJourneySpec("28-reactions.spec.ts", "phoenix-reactions");
+		const exit = await run(checkReachability(root, "phoenix-reactions"));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed) when no spec registers the journey", async () => {
+		writeKeys([{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions"}]);
+		writeConsumer("ReactionBar.tsx", "PHOENIX_REACTIONS");
+		const exit = await run(checkReachability(root, "phoenix-reactions"));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("SUCCEEDS for a UI-less flag marked @reachability-exempt, with neither consumer nor journey", async () => {
+		writeKeys([
+			{
+				constantName: "PANO_FEED_EDGE_CACHE",
+				flagKey: "pano-feed-edge-cache",
+				exemptReason: "infra edge-cache flag — no user-facing surface by design.",
+			},
+		]);
+		const exit = await run(checkReachability(root, "pano-feed-edge-cache"));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed) for an unknown/unclassified flag key", async () => {
+		writeKeys([{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions"}]);
+		writeConsumer("ReactionBar.tsx", "PHOENIX_REACTIONS");
+		writeJourneySpec("28-reactions.spec.ts", "phoenix-reactions");
+		const exit = await run(checkReachability(root, "not-a-real-flag"));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed, fail-closed) when keys.ts parses zero flag definitions", async () => {
+		write(join(KEYS_DIR, "keys.ts"), "export const notAFlag = 1;\n");
+		mkdirSync(join(root, COMPONENTS_DIR), {recursive: true});
+		mkdirSync(join(root, E2E_DIR), {recursive: true});
+		const exit = await run(checkReachability(root, "phoenix-reactions"));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+});

--- a/packages/pipeline-cli/src/tools/reachability-guard/reachability-guard.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/reachability-guard.ts
@@ -1,0 +1,241 @@
+/**
+ * `reachability-guard` pure core (ADR 0173) — decide whether a Flagship flag key is
+ * *reachable*: its vertical's user-facing slice is built before the flag can graduate
+ * to 100%. IO-free and total: every decision is a deterministic transform over
+ * already-gathered facts. The filesystem boundary (read `keys.ts`, walk the SPA `.tsx`
+ * source, walk the e2e specs) lives in `gate.ts`; this module never touches disk.
+ *
+ * Per ADR 0173 §1 a flag is reachable iff BOTH assertions hold, unless it is exempt:
+ *   (a) a consuming UI exists — ≥1 `apps/web/src/**\/*.tsx` references the flag-key
+ *       constant declared in `apps/web/src/flags/keys.ts`, beyond the definition itself
+ *       (the exact static scan the reactions reporter ran by hand);
+ *   (b) a registered journey e2e exists — a spec under `apps/web/tests/e2e/` bears the
+ *       in-title `@journey:<flag-key>` tag (ADR 0173 §2; the checker asserts *registration*,
+ *       never runs playwright).
+ *
+ * The exemption model (ADR 0173 §3): a legitimately UI-less infra/containment flag opts
+ * out with a stated reason via a `@reachability-exempt: <reason>` marker in its `keys.ts`
+ * doc-comment. An exempt flag graduates without a UI consumer or a journey — because a
+ * human wrote down *why* it has no UI. There is no silent skip and no blanket allowlist.
+ *
+ * Fail-closed on zero scope (ADR 0092): zero parsed flag definitions is a broken scope
+ * assumption (wrong root, a `keys.ts` reshape), NOT a vacuous pass; an unknown/unclassified
+ * flag key is likewise a failure, never a silent pass (ADR 0173 §1).
+ */
+
+/** One flag declared in `apps/web/src/flags/keys.ts`. */
+export interface FlagDefinition {
+	/** The exported constant name — e.g. `PHOENIX_REACTIONS` (the token a `.tsx` consumer imports). */
+	readonly constantName: string;
+	/** The flag-key string the constant binds — e.g. `phoenix-reactions` (the Flagship key). */
+	readonly flagKey: string;
+	/** The stated reason from a `@reachability-exempt: <reason>` marker, or null when unmarked. */
+	readonly exemptReason: string | null;
+}
+
+/** The facts the pure verdict is computed over — all gathered at the IO boundary (`gate.ts`). */
+export interface ReachabilityFacts {
+	/** The flag key the run was asked to check. */
+	readonly flagKey: string;
+	/** Every flag parsed from `keys.ts`. */
+	readonly definitions: ReadonlyArray<FlagDefinition>;
+	/** Constant names referenced by ≥1 `apps/web/src/**\/*.tsx` (the `.tsx` walk excludes `keys.ts`). */
+	readonly consumingConstants: ReadonlySet<string>;
+	/** Flag keys carrying a `@journey:<key>` tag in some `apps/web/tests/e2e/` spec. */
+	readonly journeyKeys: ReadonlySet<string>;
+}
+
+/**
+ * The guard verdict — a discriminated union so an invalid state is unrepresentable: a
+ * pass never carries a failure list, and each failure shape carries exactly its evidence.
+ */
+export type ReachabilityVerdict =
+	| {readonly pass: true; readonly flagKey: string; readonly mode: "reachable"}
+	| {
+			readonly pass: true;
+			readonly flagKey: string;
+			readonly mode: "exempt";
+			readonly exemptReason: string;
+	  }
+	/** No flag definitions parsed at all — fail closed, never a vacuous pass (ADR 0092). */
+	| {readonly pass: false; readonly flagKey: string; readonly reason: "zero-scope"}
+	/** The requested key is not declared in `keys.ts` — unclassified, fail closed (ADR 0173 §1). */
+	| {readonly pass: false; readonly flagKey: string; readonly reason: "unknown-flag"}
+	/** A user-facing flag missing its UI consumer and/or its journey e2e. */
+	| {
+			readonly pass: false;
+			readonly flagKey: string;
+			readonly reason: "unreachable";
+			readonly constantName: string;
+			readonly missingConsumer: boolean;
+			readonly missingJourney: boolean;
+	  };
+
+/**
+ * Decide the verdict over the gathered facts. Order: fail-closed on zero scope, then
+ * resolve the requested key (unknown ⇒ fail), then honor an exemption before the two
+ * assertions (an exempt flag needs neither a consumer nor a journey — ADR 0173 §3), then
+ * assert consumer + journey.
+ */
+export const judge = (facts: ReachabilityFacts): ReachabilityVerdict => {
+	const {flagKey, definitions, consumingConstants, journeyKeys} = facts;
+
+	if (definitions.length === 0) {
+		return {pass: false, flagKey, reason: "zero-scope"};
+	}
+
+	const def = definitions.find((d) => d.flagKey === flagKey);
+	if (def === undefined) {
+		return {pass: false, flagKey, reason: "unknown-flag"};
+	}
+
+	if (def.exemptReason !== null) {
+		return {pass: true, flagKey, mode: "exempt", exemptReason: def.exemptReason};
+	}
+
+	const missingConsumer = !consumingConstants.has(def.constantName);
+	const missingJourney = !journeyKeys.has(flagKey);
+	if (missingConsumer || missingJourney) {
+		return {
+			pass: false,
+			flagKey,
+			reason: "unreachable",
+			constantName: def.constantName,
+			missingConsumer,
+			missingJourney,
+		};
+	}
+
+	return {pass: true, flagKey, mode: "reachable"};
+};
+
+/** Render the human-readable report (ADR 0092 §1 "emit what you scanned"). */
+export const renderReport = (verdict: ReachabilityVerdict): string => {
+	if (verdict.pass) {
+		if (verdict.mode === "exempt") {
+			return (
+				`reachability-guard: ${verdict.flagKey} is @reachability-exempt — passing without a UI ` +
+				`consumer or journey e2e. Stated reason: ${verdict.exemptReason}`
+			);
+		}
+		return (
+			`reachability-guard: ${verdict.flagKey} is reachable — a consuming .tsx references its ` +
+			"keys.ts constant AND a @journey-tagged e2e is registered."
+		);
+	}
+	if (verdict.reason === "zero-scope") {
+		return (
+			"reachability-guard: parsed ZERO flag definitions from apps/web/src/flags/keys.ts — " +
+			"fail-closed (ADR 0092). Is the repo root correct, or did the flag-key module layout change?"
+		);
+	}
+	if (verdict.reason === "unknown-flag") {
+		return (
+			`reachability-guard: '${verdict.flagKey}' is not declared in apps/web/src/flags/keys.ts — ` +
+			"an unknown/unclassified flag key fails closed (ADR 0173 §1). Add the flag-key constant, or " +
+			"check the key you passed."
+		);
+	}
+	const lines: Array<string> = [];
+	if (verdict.missingConsumer) {
+		lines.push(
+			`  MISSING UI CONSUMER — no apps/web/src/**/*.tsx references ${verdict.constantName} ` +
+				`(the keys.ts constant for ${verdict.flagKey}). Build + wire the user-facing slice, or, if ` +
+				"the flag is UI-less by design, mark it @reachability-exempt: <reason> at its keys.ts definition.",
+		);
+	}
+	if (verdict.missingJourney) {
+		lines.push(
+			`  MISSING JOURNEY E2E — no spec under apps/web/tests/e2e/ carries a @journey:${verdict.flagKey} ` +
+				"tag. Tag the vertical's journey spec's test/describe title with it (ADR 0173 §2).",
+		);
+	}
+	return (
+		`reachability-guard: ${verdict.flagKey} is UNREACHABLE — its vertical's user-facing slice is ` +
+		`unbuilt, so it must not graduate to 100% (ADR 0173):\n${lines.join("\n")}`
+	);
+};
+
+/**
+ * Extract every `{constantName, flagKey, exemptReason}` row from the `keys.ts` source.
+ * Pure over the text so `gate.ts` grounds the scan in the checked-in module without a
+ * cross-package import (pipeline-cli must not depend on apps/web). Matches the module's
+ * flat `export const NAME = "flag-key";` shape and pairs each with the doc-comment
+ * immediately preceding it (only whitespace between) to read an optional
+ * `@reachability-exempt: <reason>` marker. Dependency-free; sufficient for this file's
+ * shape, not a general TS parser.
+ */
+export const parseFlagDefinitions = (source: string): ReadonlyArray<FlagDefinition> => {
+	const comments: Array<{readonly end: number; readonly body: string}> = [];
+	const commentRe = /\/\*\*([\s\S]*?)\*\//g;
+	for (const m of source.matchAll(commentRe)) {
+		if (m.index !== undefined && m[1] !== undefined) {
+			comments.push({end: m.index + m[0].length, body: m[1]});
+		}
+	}
+
+	const out: Array<FlagDefinition> = [];
+	const defRe = /export\s+const\s+([A-Z][A-Z0-9_]*)\s*=\s*["']([a-z0-9-]+)["']/g;
+	for (const m of source.matchAll(defRe)) {
+		const constantName = m[1];
+		const flagKey = m[2];
+		if (constantName === undefined || flagKey === undefined || m.index === undefined) continue;
+		const exemptReason = exemptReasonForDefinition(source, comments, m.index);
+		out.push({constantName, flagKey, exemptReason});
+	}
+	return out;
+};
+
+/**
+ * The exemption reason attached to the definition starting at `defStart`, or null. The
+ * marker is honored only from the doc-comment IMMEDIATELY preceding the definition (only
+ * whitespace between comment end and the `export`) — a distant comment never leaks its
+ * marker onto an unrelated flag.
+ */
+const exemptReasonForDefinition = (
+	source: string,
+	comments: ReadonlyArray<{readonly end: number; readonly body: string}>,
+	defStart: number,
+): string | null => {
+	let nearest: {readonly end: number; readonly body: string} | undefined;
+	for (const c of comments) {
+		if (c.end <= defStart && /^\s*$/.test(source.slice(c.end, defStart))) {
+			if (nearest === undefined || c.end > nearest.end) nearest = c;
+		}
+	}
+	if (nearest === undefined) return null;
+	const marker = nearest.body.match(/@reachability-exempt:\s*(.+)/);
+	if (marker?.[1] === undefined) return null;
+	return (
+		marker[1]
+			.trim()
+			.replace(/\s*\*\/?\s*$/, "")
+			.trim() || null
+	);
+};
+
+/**
+ * Which of `candidateNames` appear as a whole-word reference in a `.tsx` source. The
+ * consuming-UI signal (ADR 0173 §1a): a constant referenced by a component — an import,
+ * a `useFlag(NAME)`, a `<FlagGate flag={NAME}>`. Whole-word so `PANO_BASE_FEED` never
+ * matches inside `PANO_BASE_FEED_EDGE` and vice-versa.
+ */
+export const consumedConstantsIn = (
+	source: string,
+	candidateNames: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+	candidateNames.filter((name) => new RegExp(`\\b${name}\\b`).test(source));
+
+/**
+ * The flag keys a spec registers via `@journey:<flag-key>` tags in its source (ADR 0173
+ * §2). Pure over the spec text; the tag lives in a `test`/`describe` title but a plain
+ * text scan is sufficient to assert *registration* (the e2e job runs the spec).
+ */
+export const parseJourneyTags = (source: string): ReadonlyArray<string> => {
+	const out: Array<string> = [];
+	const re = /@journey:([a-z0-9-]+)/g;
+	for (const m of source.matchAll(re)) {
+		if (m[1] !== undefined) out.push(m[1]);
+	}
+	return out;
+};

--- a/packages/pipeline-cli/src/tools/reachability-guard/reachability-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/reachability-guard.unit.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Pure-core tests for `reachability-guard` (ADR 0173, #2529): the reachable pass (a
+ * consuming .tsx + a registered journey), both fail modes (missing consumer / missing
+ * journey), the exemption pass, the unknown-flag fail, the fail-closed-on-zero verdict
+ * (ADR 0092), and the keys.ts / journey-tag source parses. No IO — the filesystem seam is
+ * crossed in `gate.unit.test.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	consumedConstantsIn,
+	type FlagDefinition,
+	judge,
+	parseFlagDefinitions,
+	parseJourneyTags,
+	type ReachabilityFacts,
+	renderReport,
+} from "./reachability-guard.ts";
+
+const def = (
+	constantName: string,
+	flagKey: string,
+	exemptReason: string | null = null,
+): FlagDefinition => ({constantName, flagKey, exemptReason});
+
+const facts = (
+	flagKey: string,
+	definitions: ReadonlyArray<FlagDefinition>,
+	consuming: ReadonlyArray<string>,
+	journeys: ReadonlyArray<string>,
+): ReachabilityFacts => ({
+	flagKey,
+	definitions,
+	consumingConstants: new Set(consuming),
+	journeyKeys: new Set(journeys),
+});
+
+describe("judge — fail-closed on zero scope (ADR 0092)", () => {
+	it("FAILS with zero-scope when no flag definitions are parsed", () => {
+		const verdict = judge(facts("phoenix-reactions", [], [], []));
+		expect(verdict.pass).toBe(false);
+		expect(verdict.pass === false && verdict.reason).toBe("zero-scope");
+	});
+});
+
+describe("judge — unknown/unclassified flag fails closed (ADR 0173 §1)", () => {
+	it("FAILS with unknown-flag when the key is not declared in keys.ts", () => {
+		const verdict = judge(
+			facts("made-up-key", [def("PHOENIX_REACTIONS", "phoenix-reactions")], [], []),
+		);
+		expect(verdict.pass).toBe(false);
+		expect(verdict.pass === false && verdict.reason).toBe("unknown-flag");
+	});
+});
+
+describe("judge — the reachable pass (consumer + journey)", () => {
+	it("PASSES when a .tsx consumes the constant AND a journey e2e is registered", () => {
+		const verdict = judge(
+			facts(
+				"phoenix-reactions",
+				[def("PHOENIX_REACTIONS", "phoenix-reactions")],
+				["PHOENIX_REACTIONS"],
+				["phoenix-reactions"],
+			),
+		);
+		expect(verdict.pass).toBe(true);
+		expect(verdict.pass && verdict.mode).toBe("reachable");
+	});
+});
+
+describe("judge — the two fail modes name what's missing", () => {
+	it("FAILS unreachable with missingConsumer when no .tsx references the constant", () => {
+		// The grounding shape: a flag whose journey is registered but whose UI slice is unbuilt.
+		const verdict = judge(
+			facts(
+				"phoenix-karma-gates",
+				[def("PHOENIX_KARMA_GATES", "phoenix-karma-gates")],
+				[],
+				["phoenix-karma-gates"],
+			),
+		);
+		expect(verdict.pass).toBe(false);
+		expect(verdict.pass === false && verdict.reason).toBe("unreachable");
+		expect(
+			verdict.pass === false && verdict.reason === "unreachable" && verdict.missingConsumer,
+		).toBe(true);
+		expect(
+			verdict.pass === false && verdict.reason === "unreachable" && verdict.missingJourney,
+		).toBe(false);
+	});
+
+	it("FAILS unreachable with missingJourney when no e2e registers the flag key", () => {
+		const verdict = judge(
+			facts(
+				"phoenix-reactions",
+				[def("PHOENIX_REACTIONS", "phoenix-reactions")],
+				["PHOENIX_REACTIONS"],
+				[],
+			),
+		);
+		expect(verdict.pass).toBe(false);
+		expect(
+			verdict.pass === false && verdict.reason === "unreachable" && verdict.missingConsumer,
+		).toBe(false);
+		expect(
+			verdict.pass === false && verdict.reason === "unreachable" && verdict.missingJourney,
+		).toBe(true);
+	});
+
+	it("FAILS unreachable with BOTH missing when neither a consumer nor a journey exists", () => {
+		const verdict = judge(
+			facts("phoenix-reactions", [def("PHOENIX_REACTIONS", "phoenix-reactions")], [], []),
+		);
+		expect(
+			verdict.pass === false &&
+				verdict.reason === "unreachable" &&
+				verdict.missingConsumer &&
+				verdict.missingJourney,
+		).toBe(true);
+	});
+});
+
+describe("judge — the exemption path (ADR 0173 §3)", () => {
+	it("PASSES a UI-less flag that declares @reachability-exempt, needing neither consumer nor journey", () => {
+		const verdict = judge(
+			facts(
+				"pano-feed-edge-cache",
+				[
+					def(
+						"PANO_FEED_EDGE_CACHE",
+						"pano-feed-edge-cache",
+						"infra edge-cache flag — no user-facing surface by design",
+					),
+				],
+				[],
+				[],
+			),
+		);
+		expect(verdict.pass).toBe(true);
+		expect(verdict.pass && verdict.mode).toBe("exempt");
+		expect(verdict.pass && verdict.mode === "exempt" && verdict.exemptReason).toContain(
+			"edge-cache",
+		);
+	});
+});
+
+describe("renderReport", () => {
+	it("names the missing UI consumer on an unreachable fail", () => {
+		const report = renderReport({
+			pass: false,
+			flagKey: "phoenix-karma-gates",
+			reason: "unreachable",
+			constantName: "PHOENIX_KARMA_GATES",
+			missingConsumer: true,
+			missingJourney: false,
+		});
+		expect(report).toContain("MISSING UI CONSUMER");
+		expect(report).toContain("PHOENIX_KARMA_GATES");
+		expect(report).not.toContain("MISSING JOURNEY E2E");
+	});
+
+	it("names the missing journey e2e on an unreachable fail", () => {
+		const report = renderReport({
+			pass: false,
+			flagKey: "phoenix-reactions",
+			reason: "unreachable",
+			constantName: "PHOENIX_REACTIONS",
+			missingConsumer: false,
+			missingJourney: true,
+		});
+		expect(report).toContain("MISSING JOURNEY E2E");
+		expect(report).toContain("@journey:phoenix-reactions");
+	});
+
+	it("names the unknown flag key on an unknown-flag fail", () => {
+		const report = renderReport({pass: false, flagKey: "made-up-key", reason: "unknown-flag"});
+		expect(report).toContain("made-up-key");
+		expect(report).toContain("not declared");
+	});
+
+	it("states the exemption reason on an exempt pass", () => {
+		const report = renderReport({
+			pass: true,
+			flagKey: "pano-feed-edge-cache",
+			mode: "exempt",
+			exemptReason: "infra edge-cache flag",
+		});
+		expect(report).toContain("@reachability-exempt");
+		expect(report).toContain("infra edge-cache flag");
+	});
+});
+
+describe("parseFlagDefinitions — read constant/key/exemption rows from keys.ts source", () => {
+	it('parses each export const NAME = "flag-key" row', () => {
+		const source = `
+			/** Pano taslak flag. */
+			export const PANO_DRAFT_SAVE = "pano-draft-save";
+			/** Reactions flag. */
+			export const PHOENIX_REACTIONS = "phoenix-reactions";
+		`;
+		expect(parseFlagDefinitions(source)).toEqual([
+			{constantName: "PANO_DRAFT_SAVE", flagKey: "pano-draft-save", exemptReason: null},
+			{constantName: "PHOENIX_REACTIONS", flagKey: "phoenix-reactions", exemptReason: null},
+		]);
+	});
+
+	it("reads a @reachability-exempt: <reason> marker from the immediately-preceding doc-comment", () => {
+		const source = `
+			/**
+			 * Edge-cache containment flag.
+			 * @reachability-exempt: infra edge-cache flag — no user-facing surface by design.
+			 */
+			export const PANO_FEED_EDGE_CACHE = "pano-feed-edge-cache";
+		`;
+		const defs = parseFlagDefinitions(source);
+		expect(defs).toHaveLength(1);
+		expect(defs[0]?.exemptReason).toBe("infra edge-cache flag — no user-facing surface by design.");
+	});
+
+	it("does not leak a distant comment's marker onto an unrelated later flag", () => {
+		const source = `
+			/**
+			 * @reachability-exempt: infra flag.
+			 */
+			export const PANO_FEED_EDGE_CACHE = "pano-feed-edge-cache";
+			/** A normal user-facing flag. */
+			export const PHOENIX_REACTIONS = "phoenix-reactions";
+		`;
+		const defs = parseFlagDefinitions(source);
+		expect(defs.find((d) => d.constantName === "PANO_FEED_EDGE_CACHE")?.exemptReason).toBe(
+			"infra flag.",
+		);
+		expect(defs.find((d) => d.constantName === "PHOENIX_REACTIONS")?.exemptReason).toBeNull();
+	});
+
+	it("returns [] on a module with no flag definitions", () => {
+		expect(parseFlagDefinitions("export const x = 1;")).toEqual([]);
+	});
+});
+
+describe("consumedConstantsIn — whole-word .tsx reference detection", () => {
+	it("matches a constant imported and used in a component", () => {
+		const source = `import {PHOENIX_REACTIONS} from "../../flags/keys";\n<FlagGate flag={PHOENIX_REACTIONS} />`;
+		expect(consumedConstantsIn(source, ["PHOENIX_REACTIONS", "PANO_DRAFT_SAVE"])).toEqual([
+			"PHOENIX_REACTIONS",
+		]);
+	});
+
+	it("does not match a constant name embedded in a longer identifier", () => {
+		expect(consumedConstantsIn("const PANO_BASE_FEED_EDGE = 1;", ["PANO_BASE_FEED"])).toEqual([]);
+	});
+});
+
+describe("parseJourneyTags — read @journey:<key> registrations from a spec source", () => {
+	it("extracts the flag key from a @journey tag in a describe title", () => {
+		const source = `test.describe("Reaction bar @journey:phoenix-reactions", () => {});`;
+		expect(parseJourneyTags(source)).toEqual(["phoenix-reactions"]);
+	});
+
+	it("returns [] when a spec registers no journey", () => {
+		expect(parseJourneyTags(`test("plain", () => {});`)).toEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes #2529

Builds the single deterministic **reachability checker** both `plan-epic` (#2530) and `/release` (#2531) key off — the enforcement seam ADR [0173](../blob/main/.decisions/0173-vertical-completeness-gate.md) pins for epic #1943. Given a Flagship flag key, `pipeline-cli reachability-guard check <flag-key>` asserts the vertical's user-facing slice exists before the flag can graduate to 100%.

## What it asserts (grounded in ADR 0173)
- **Consuming UI** (§1a / §2) — the flag-key constant declared in `apps/web/src/flags/keys.ts` is referenced by ≥1 `apps/web/src/**/*.tsx` (the exact static scan the reactions reporter ran by hand).
- **Registered journey e2e** (§2) — a spec under `apps/web/tests/e2e/` carries an in-title `@journey:<flag-key>` tag. The checker asserts *registration*; the e2e job runs the spec.
- **Exemption** (§3) — a legitimately UI-less infra/containment flag opts out with a `@reachability-exempt: <reason>` marker at its `keys.ts` definition, so the gate refuses unreachable *user-facing* flags without blocking infra flags.
- **Fail-closed** (ADR [0092](../blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)) on an unknown/unclassified flag key and on zero parsed flag definitions; the verdict **names precisely** which assertion failed.

## Shape
Pure core + thin Effect bin (the `fanout-guard`/`readme-guard` idiom): `reachability-guard.ts` (keys.ts parse, `@journey` tag parse, `judge`, `renderReport`) is unit-tested directly; `gate.ts` (walk `.tsx` + e2e specs) is crossed over a fake repo dir. Unit tests cover pass, both fail modes, exemption, unknown-flag, and zero-scope.

## Seeded against real flags
- Marked `PANO_FEED_EDGE_CACHE` `@reachability-exempt` (the ADR-named infra flag) — passes as exempt.
- Tagged the reactions dark-ship spec `@journey:phoenix-reactions`.

**Note on the ADR grounding example:** ADR 0173 §Context cites `PHOENIX_REACTIONS` as failing the consuming-UI check, but the reactions UI slot (`ReactionBarSlot.tsx`, #2055) landed 2026-07-05, so `phoenix-reactions` now *passes* both assertions. The current real-repo zero-consumer flag is `PHOENIX_KARMA_GATES` — the checker correctly reports it UNREACHABLE (missing UI consumer + missing journey), which is the live grounding instance.

## Scope
Wires the tool into the registry only. **Does NOT add a CI workflow job** — that blocking wire is #2530/#2531's concern, and keeping the diff off `.github/` keeps ship-it's §CP classifier narrow. This is `packages/pipeline-cli/**` (+ two inert doc-comment/title edits in `apps/web`), likely §CP: built to reviewed-ready, not shipped.

## Verification
- `pnpm --filter @kampus/pipeline-cli test` — 1021 passed (25 new).
- `pnpm typecheck` (full workspace, tsgo) — clean.
- `pnpm lint:worktree` — clean.
- Real-repo runs: `pano-feed-edge-cache`→exempt (exit 0), `phoenix-reactions`→reachable (exit 0), `phoenix-karma-gates`→UNREACHABLE (exit 1, names both gaps), `not-a-real-flag`→unknown-flag fail-closed (exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)