### PR TITLE
fix(web): wire the mecmua feed (akış) into nav behind mecmua-feed (#2547)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -145,14 +145,21 @@ vi.mock("./components/divan/useDivanAccess", () => ({useDivanAccess: () => false
 vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: () => 0}));
 
 // Controllable flag mock. The eager `/profile` Katkıların skeleton (#2188) is gated on
-// the authorship-loop flag, so its tests flip `flags.authorshipLoop`; every other read
-// (and other flag key) stays off, matching the default the shell rendered under before.
-const flags = vi.hoisted(() => ({authorshipLoop: false}));
+// the authorship-loop flag, so its tests flip `flags.authorshipLoop`; the mecmua feed
+// (akış) nav entry (#2547) is gated on `mecmua-feed`, flipped via `flags.mecmuaFeed`.
+// Every other read (and other flag key) stays off, matching the default the shell
+// rendered under before.
+const flags = vi.hoisted(() => ({authorshipLoop: false, mecmuaFeed: false}));
 vi.mock("./flags/useFlag", async () => {
-	const {PHOENIX_AUTHORSHIP_LOOP} = await import("./flags/keys");
+	const {PHOENIX_AUTHORSHIP_LOOP, MECMUA_FEED} = await import("./flags/keys");
 	return {
 		useFlag: (key: string) => ({
-			value: key === PHOENIX_AUTHORSHIP_LOOP ? flags.authorshipLoop : false,
+			value:
+				key === PHOENIX_AUTHORSHIP_LOOP
+					? flags.authorshipLoop
+					: key === MECMUA_FEED
+						? flags.mecmuaFeed
+						: false,
 			loading: false,
 		}),
 	};
@@ -254,6 +261,33 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 
 		expect(fateMounts).toHaveLength(1);
 		expect(fateMounts[0]?.key).toBe("anon");
+	});
+});
+
+// The mecmua feed (akış) nav entry (#2547) gates on the SAME `mecmua-feed` seam the
+// `/mecmua/akis` route self-gates on — so the link never points at a dark 404. These
+// pin that gating: absent when the flag is off, present (→ /mecmua/akis) when it flips.
+describe("mecmua feed nav entry (#2547) — gated on mecmua-feed, never a dead link", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		flags.mecmuaFeed = false;
+	});
+	afterEach(() => {
+		flags.mecmuaFeed = false;
+		vi.clearAllMocks();
+	});
+
+	it("off: the flag dark ⇒ no akış nav link (subscribe's destination stays hidden with its route)", () => {
+		renderApp();
+		expect(screen.queryByRole("link", {name: "akış"})).toBeNull();
+	});
+
+	it("on: the flag flipped ⇒ the akış nav link paints and points at /mecmua/akis", () => {
+		flags.mecmuaFeed = true;
+		renderApp();
+		const link = screen.getByRole("link", {name: "akış"});
+		expect(link.getAttribute("href")).toBe("/mecmua/akis");
 	});
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,7 +23,12 @@ import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
 import {teardownAuthedSnapshot} from "./fate/snapshot";
-import {MECMUA_PUBLIC_READ, PHOENIX_AUTHORSHIP_LOOP, PHOENIX_BILDIRIM} from "./flags/keys";
+import {
+	MECMUA_FEED,
+	MECMUA_PUBLIC_READ,
+	PHOENIX_AUTHORSHIP_LOOP,
+	PHOENIX_BILDIRIM,
+} from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
 import {SAVED_HREF} from "./lib/panoNav";
@@ -95,6 +100,11 @@ function Layout() {
 	// this always-painting shell frame: the entry simply appears once the flag resolves on,
 	// never blocking first paint (Pillar 1). Off ⇒ the nav is exactly as before.
 	const {value: mecmuaOn} = useFlag(MECMUA_PUBLIC_READ, false);
+	// The mecmua feed (akış) nav entry (#2547), dark behind its own `mecmua-feed` seam —
+	// the SAME flag the `/mecmua/akis` route self-gates on (self-404 when off). Gating the
+	// link on the route's own seam is what keeps it from ever pointing at a dark 404: off ⇒
+	// no entry, so subscribing (also `mecmua-feed`) and its feed destination appear together.
+	const {value: feedOn} = useFlag(MECMUA_FEED, false);
 
 	// The two-tier fate provider's public first paint (ADR 0167). While `get-session`
 	// is still in flight the authed `FateProvider` gate below returns null, so the
@@ -147,6 +157,7 @@ function Layout() {
 							{to: "/sozluk", label: "sözlük"},
 							{to: "/pano", label: "pano"},
 							...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
+							...(feedOn ? [{to: "/mecmua/akis", label: "akış"}] : []),
 						]}
 						divanTo={chips?.divanTo}
 						{...(chips?.userProps ?? {})}


### PR DESCRIPTION
Fixes #2547

## What & why

The `/mecmua/akis` subscribed-author feed shipped fully built — a registered route (`apps/web/src/App.tsx` → `apps/web/src/pages/MecmuaFeedPage.tsx`) plus the subscribe button on the reader (#2527/#2500) — but **nav-orphaned**: the only mecmua nav entry was `/mecmua`, so a reader who subscribed to an author had no UI path to the feed those subscriptions populate. Subscribe was a dead-end (the #1943 vertical-completeness class; capability built, connective affordance dropped).

This wires the built page into nav: an **akış** top-nav entry pointing at `/mecmua/akis`.

## The flag seam (no dead link when dark)

The entry is gated on the **same** `mecmua-feed` seam the `/mecmua/akis` route self-gates on (the page self-404s when the flag is off). Gating the link on the route's own seam is what keeps it from ever pointing at a dark 404: flag off ⇒ no nav entry; flag on ⇒ the akış link and the subscribe capability it makes reachable appear together. This mirrors how the existing `/mecmua` entry gates on `mecmua-public-read`. **No flag is flipped** — the feed ships dark, as before.

## Acceptance criteria

- [x] A reader has a discoverable UI path to `/mecmua/akis` from the mecmua surface (an `akış` top-nav entry).
- [x] The feed entry point is gated on the same flag seam its route self-gates on (`mecmua-feed`) — never a link to a 404 when the feed is dark.
- [x] The entry point is consistent with how the rest of the mecmua surface is presented (a top-nav item alongside `mecmua`, same conditional-spread gating pattern).

## Changes

- `apps/web/src/App.tsx` — the **nav region** of `Layout` (~line 149): read `MECMUA_FEED` via `useFlag`, spread an `{to: "/mecmua/akis", label: "akış"}` nav entry when the flag is on. (Route table untouched.)
- `apps/web/src/App.test.tsx` — two tests pinning the gating: no `akış` link when the flag is dark; the link paints and points at `/mecmua/akis` when it flips.

## Verification

- `pnpm typecheck` — clean (28/28).
- `pnpm lint:worktree` — clean.
- `apps/web` client tests — 20/20 pass (`App.test.tsx`), including the two new gating tests.

## Note (concurrent lane)

Touched only the **nav region** (~line 149) of `App.tsx`. #2544 (mecmua drafts) edits the route table (~line 345) — a different region; whichever lands first, the other rebases.