### PR TITLE
fix(web): make pano /pano/yeni required-tag rule discoverable (#2575)

### DIFF
--- a/apps/web/src/pages/PanoSubmitPage.css
+++ b/apps/web/src/pages/PanoSubmitPage.css
@@ -109,6 +109,33 @@
 	color: var(--text-muted);
 }
 
+/* Required-tag affordance (#2575). The cues carry meaning in their copy first;
+   --warning is reinforcement, matching this form's error=--danger text idiom, and
+   is deliberately NOT --text-faint — a meaning-carrying hint must stay legible. */
+.kp-pano-submit__field-label {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 6px;
+}
+.kp-pano-submit__required {
+	font: var(--t-meta);
+	font-weight: 600;
+	color: var(--warning);
+	text-transform: lowercase;
+	letter-spacing: 0.02em;
+}
+.kp-pano-submit__tag-cue {
+	font: var(--t-meta);
+	font-weight: 500;
+	color: var(--warning);
+}
+.kp-pano-submit__disabled-reason {
+	margin: 0;
+	font: var(--t-meta);
+	color: var(--warning);
+	text-align: right;
+}
+
 .kp-pano-submit__url-preview {
 	display: grid;
 	grid-template-columns: 32px 1fr;

--- a/apps/web/src/pages/PanoSubmitPage.css
+++ b/apps/web/src/pages/PanoSubmitPage.css
@@ -115,7 +115,7 @@
 .kp-pano-submit__field-label {
 	display: inline-flex;
 	align-items: baseline;
-	gap: 6px;
+	gap: var(--s-1);
 }
 .kp-pano-submit__required {
 	font: var(--t-meta);

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -348,7 +348,13 @@ export function PanoSubmitPage() {
 
 						<fieldset className="kp-pano-submit__field kp-pano-submit__fieldset">
 							<legend className="kp-pano-submit__field-label">
-								etiketler · en az 1, en fazla 3
+								<span>etiketler · en az 1, en fazla 3</span>
+								<span
+									className="kp-pano-submit__required"
+									data-testid="pano-submit-tags-legend-required"
+								>
+									gerekli
+								</span>
 							</legend>
 							<div className="kp-pano-submit__tagrow">
 								{TAGS.map((t) => {
@@ -367,13 +373,15 @@ export function PanoSubmitPage() {
 									);
 								})}
 							</div>
-							{tagsAreSoleBlocker ? (
-								<span
-									className="kp-pano-submit__hint"
-									data-testid="pano-submit-tags-required"
-									style={{color: "var(--text-faint)"}}
-								>
-									{PANO_SUBMIT_OVERRIDES.TAGS_REQUIRED}
+							{/* The required-tag cue is the load-bearing affordance (#2575): it renders
+							    whenever a tag is missing — NOT gated on tagsAreSoleBlocker — so a cold user
+							    sees it before the rest of the form is perfect. tagsAreSoleBlocker only
+							    upgrades the phrasing to "one step left" (#2201's sole-blocker signal). */}
+							{noTags ? (
+								<span className="kp-pano-submit__tag-cue" data-testid="pano-submit-tags-required">
+									{tagsAreSoleBlocker
+										? "son adım: en az bir etiket seç"
+										: PANO_SUBMIT_OVERRIDES.TAGS_REQUIRED}
 								</span>
 							) : null}
 						</fieldset>
@@ -400,6 +408,18 @@ export function PanoSubmitPage() {
 							</p>
 						) : null}
 
+						{submitDisabled && noTags ? (
+							<p
+								id="pano-submit-disabled-reason"
+								className="kp-pano-submit__disabled-reason"
+								data-testid="pano-submit-disabled-reason"
+							>
+								{tagsAreSoleBlocker
+									? "“paylaş” için son bir adım kaldı: yukarıdan en az bir etiket seç"
+									: "“paylaş” için en az bir etiket seçmelisin"}
+							</p>
+						) : null}
+
 						<div className="kp-pano-submit__form-actions">
 							<FlagGate flag={PANO_DRAFT_SAVE}>
 								<Button
@@ -417,6 +437,10 @@ export function PanoSubmitPage() {
 								variant="primary"
 								disabled={submitDisabled}
 								data-testid="pano-submit-submit"
+								title={submitDisabled && noTags ? "en az bir etiket seç" : undefined}
+								aria-describedby={
+									submitDisabled && noTags ? "pano-submit-disabled-reason" : undefined
+								}
 							>
 								{isInFlight ? "gönderiliyor…" : "paylaş"}
 							</Button>


### PR DESCRIPTION
Fixes #2575

## Problem
On `/pano/yeni` a first-time user hits a silently-disabled "paylaş" button with no visible reason, reads the form as broken, and leaves — conversion-killing drop-off on pano's core first-post action, reported by a real founder-cohort user.

## Fix — affordance only (gate logic untouched)
The gate (`apps/web/src/lib/panoSubmitGate.ts` — `submitDisabled` / `tagsAreSoleBlocker`, #2201) is **correct and unchanged**; this is a rendering/affordance change in `apps/web/src/pages/PanoSubmitPage.tsx` (+ its CSS) that surfaces *why* the button is disabled:

- **Persistent required-tag cue.** "en az bir etiket seç" now renders whenever no tag is selected — no longer gated on `tagsAreSoleBlocker` — so a cold user sees it before every other field is perfect. `tagsAreSoleBlocker` still upgrades the phrasing to the sole-blocker "son adım: …" wording.
- **Required marker on the legend.** A "gerekli" marker on the etiketler `<legend>`, distinct from the `(opsiyonel)` copy elsewhere, so the group reads as a required field.
- **Disabled-button reason.** A reason line + `title` / `aria-describedby` on the disabled "paylaş" so it reads as "one step left", not "broken".
- **Legible, not `--text-faint`.** The meaning-carrying cues use the `--warning` role token (matching this form's existing error=`--danger`-text idiom), replacing the old `--text-faint` that buried the hint. Meaning is carried in the copy first, colour is reinforcement (four-pillars, ADR 0162).

## Acceptance criteria
- [x] Required-tag constraint discoverable before the user gives up (persistent cue, not gated on `tagsAreSoleBlocker`)
- [x] Etiketler group reads as a required field ("gerekli" marker on the legend)
- [x] Disabled "paylaş" communicates why (reason line + `aria-describedby`/`title`)
- [x] Cue is legible, not `--text-faint`
- [x] No regression to `panoSubmitGate.ts` — semantics unchanged (unit tests green)

## Verification
- `pnpm typecheck` — pass
- `biome check` — clean
- `panoSubmitGate.test.ts` (4 tests, #2201 no-regression) — pass; gate file not in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)