### PR TITLE
fix(web): lazy-split the composer routes so tiptap leaves the entry chunk (#2523)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useEffect, useMemo, useState} from "react";
+import {createContext, lazy, Suspense, useContext, useEffect, useMemo, useState} from "react";
 import {
 	Navigate,
 	Outlet,
@@ -39,10 +39,8 @@ import {AuthPage} from "./pages/AuthPage";
 import {BildirimlerPage} from "./pages/BildirimlerPage";
 import {DivanPage} from "./pages/DivanPage";
 import {FunnelPage} from "./pages/FunnelPage";
-import {LabComposerPage} from "./pages/LabComposerPage";
 import {LandingPage} from "./pages/LandingPage";
 import {MecmuaDraftsPage} from "./pages/MecmuaDraftsPage";
-import {MecmuaEditorPage} from "./pages/MecmuaEditorPage";
 import {MecmuaFeedPage} from "./pages/MecmuaFeedPage";
 import {MecmuaIndexPage} from "./pages/MecmuaIndexPage";
 import {MecmuaPostPage} from "./pages/MecmuaPostPage";
@@ -308,6 +306,26 @@ function PanoSiteFeedRoute() {
 	return <PanoFeed {...(host ? {host} : {})} />;
 }
 
+// The composer routes are the SPA's only `@kampus/composer` (tiptap/ProseMirror) consumers,
+// so lazy-loading both keeps that heavy editor payload out of the entry chunk every public
+// route pays for — the performance-pillar fix of #2523. Named-export → default shim for React.lazy.
+const LabComposerPage = lazy(() =>
+	import("./pages/LabComposerPage").then((m) => ({default: m.LabComposerPage})),
+);
+const MecmuaEditorPage = lazy(() =>
+	import("./pages/MecmuaEditorPage").then((m) => ({default: m.MecmuaEditorPage})),
+);
+
+function ComposerRouteFallback() {
+	return (
+		<div className="kp-page">
+			<div className="kp-page__inner">
+				<p>yükleniyor…</p>
+			</div>
+		</div>
+	);
+}
+
 export function App() {
 	return (
 		<ThemeProvider>
@@ -331,8 +349,22 @@ export function App() {
 						<Route path="/mecmua" element={<MecmuaIndexPage />} />
 						<Route path="/mecmua/akis" element={<MecmuaFeedPage />} />
 						<Route path="/mecmua/yazilarim" element={<MecmuaDraftsPage />} />
-						<Route path="/mecmua/yaz" element={<MecmuaEditorPage />} />
-						<Route path="/mecmua/yaz/:id" element={<MecmuaEditorPage />} />
+						<Route
+							path="/mecmua/yaz"
+							element={
+								<Suspense fallback={<ComposerRouteFallback />}>
+									<MecmuaEditorPage />
+								</Suspense>
+							}
+						/>
+						<Route
+							path="/mecmua/yaz/:id"
+							element={
+								<Suspense fallback={<ComposerRouteFallback />}>
+									<MecmuaEditorPage />
+								</Suspense>
+							}
+						/>
 						<Route path="/mecmua/:slug" element={<MecmuaPostPage />} />
 						<Route path="/sozluk" element={<SozlukHome />} />
 						<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
@@ -349,7 +381,14 @@ export function App() {
 						<Route path="/bildirimler" element={<BildirimlerPage />} />
 						{/* /lab/composer — throwaway tiptap spike (#2465), reachable by URL only,
 						    no nav entry; deletable when the rich-composer phase begins. */}
-						<Route path="/lab/composer" element={<LabComposerPage />} />
+						<Route
+							path="/lab/composer"
+							element={
+								<Suspense fallback={<ComposerRouteFallback />}>
+									<LabComposerPage />
+								</Suspense>
+							}
+						/>
 						<Route path="/profile" element={<ProfilePage />} />
 						<Route path="/u/:username" element={<UserProfilePage />} />
 						<Route path="*" element={<NotFoundPage />} />

--- a/apps/web/src/pages/MecmuaEditorPage.tsx
+++ b/apps/web/src/pages/MecmuaEditorPage.tsx
@@ -31,7 +31,6 @@ import {useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link, useNavigate, useParams} from "react-router";
 import type {MecmuaPost} from "../../worker/features/fate/views";
-import type {Tier} from "../../worker/features/kunye/standing";
 import {useSession} from "../auth/client";
 import {useMe} from "../auth/useMe";
 import {Button} from "../components/ui/Button";
@@ -39,6 +38,9 @@ import {Screen} from "../fate/Screen";
 import {useDraftSubmit} from "../fate/useDraftSubmit";
 import {MECMUA_WRITE} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
+// The publish/CTA gate lives in a composer-free module so its consumers (index, nav) don't
+// drag tiptap into the entry chunk — this page lazy-loads behind that split (#2523).
+import {mecmuaPublishAffordance} from "./mecmua-write-gate";
 import {NotFoundPage} from "./NotFoundPage";
 import "./MecmuaEditorPage.css";
 
@@ -52,44 +54,6 @@ const MecmuaEditorView = view<MecmuaPost>()({
 	title: true,
 	publishedAt: true,
 });
-
-/**
- * The publish affordance decision, factored DOM-free so the earned-gate contract —
- * publish is offered ONLY to a yazar; everyone else sees the Turkish earned-gate
- * message — is unit-testable without a DOM (the pure-extraction idiom of
- * `shouldShowOnramp` / `flagGateChild`). The tier is the trusted account level read
- * off the fate `me` view; publish is server-gated by `PublishMecmua` regardless, so
- * this only governs what the UI offers.
- */
-export type MecmuaPublishAffordance = {kind: "publish"} | {kind: "gate"; message: string};
-
-export function mecmuaPublishAffordance(
-	isSignedIn: boolean,
-	tier: Tier | undefined,
-): MecmuaPublishAffordance {
-	if (tier === "yazar") return {kind: "publish"};
-	return {
-		kind: "gate",
-		message: isSignedIn
-			? "yayımlamak için yazar olman gerekiyor — çaylakların yazıları henüz yayımlanamaz."
-			: "yayımlamak için giriş yapıp yazar olman gerekiyor.",
-	};
-}
-
-/**
- * Should the "yeni yazı" entry-point CTA (nav + index) be shown to this viewer (#2532)?
- * Gate parity with the editor is structural, not restated: the CTA appears exactly when
- * the write flag is live AND {@link mecmuaPublishAffordance} would offer publish (yazar
- * tier), so it never dead-ends a çaylak/visitor/signed-out reader into a page they'd be
- * publish-gated on. `MECMUA_WRITE` off, or any non-yazar/undefined tier, resolves false.
- */
-export function shouldShowMecmuaWriteCta(
-	flagOn: boolean,
-	isSignedIn: boolean,
-	tier: Tier | undefined,
-): boolean {
-	return flagOn && mecmuaPublishAffordance(isSignedIn, tier).kind === "publish";
-}
 
 export function MecmuaEditorPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);

--- a/apps/web/src/pages/MecmuaIndexPage.tsx
+++ b/apps/web/src/pages/MecmuaIndexPage.tsx
@@ -22,7 +22,9 @@ import {MetaRow} from "../components/ui/MetaRow";
 import {MECMUA_PUBLIC_READ, MECMUA_WRITE} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {formatDateTR} from "../lib/datetime";
-import {shouldShowMecmuaWriteCta} from "./MecmuaEditorPage";
+// The gate helper lives composer-free (#2523) so this public index never pulls the tiptap
+// editor payload into the entry chunk just to decide whether to show the "yeni yazı" CTA.
+import {shouldShowMecmuaWriteCta} from "./mecmua-write-gate";
 import {NotFoundPage} from "./NotFoundPage";
 import "./MecmuaIndexPage.css";
 

--- a/apps/web/src/pages/mecmua-write-gate.test.ts
+++ b/apps/web/src/pages/mecmua-write-gate.test.ts
@@ -2,10 +2,11 @@
  * The mecmua editor's earned-gate contract (#2499): publish is offered ONLY to a
  * yazar; a çaylak / visitor / signed-out reader sees the Turkish earned-gate copy.
  * Tests the pure `mecmuaPublishAffordance` core (DOM-free), the way `FlagGate`'s
- * `flagGateChild` and the on-ramp's `shouldShowOnramp` are tested.
+ * `flagGateChild` and the on-ramp's `shouldShowOnramp` are tested. The core lives in
+ * its own composer-free module (#2523) so the entry-point CTA can gate without tiptap.
  */
 import {describe, expect, it} from "vitest";
-import {mecmuaPublishAffordance, shouldShowMecmuaWriteCta} from "./MecmuaEditorPage";
+import {mecmuaPublishAffordance, shouldShowMecmuaWriteCta} from "./mecmua-write-gate";
 
 describe("mecmuaPublishAffordance — publish is a yazar-only affordance", () => {
 	it("offers publish to a yazar", () => {

--- a/apps/web/src/pages/mecmua-write-gate.ts
+++ b/apps/web/src/pages/mecmua-write-gate.ts
@@ -1,0 +1,43 @@
+/**
+ * The mecmua write-gate pure core, DOM-free AND composer-free (#2523). Held apart from
+ * `MecmuaEditorPage` — which pulls in `@kampus/composer` (tiptap/ProseMirror) — so the
+ * entry-point CTA consumers (`MecmuaIndexPage`, nav) can decide gating without dragging
+ * the heavy editor payload into the entry chunk. That leak is exactly what #2523 removes:
+ * lazy-splitting the editor route only helps if nothing eagerly imports it, so the gate
+ * helpers live in their own composer-free module.
+ *
+ * Publish is offered ONLY to a yazar; the tier is the trusted account level read off the
+ * fate `me` view. Publish is server-gated by `PublishMecmua` regardless — this only
+ * governs what the UI offers.
+ */
+import type {Tier} from "../../worker/features/kunye/standing";
+
+export type MecmuaPublishAffordance = {kind: "publish"} | {kind: "gate"; message: string};
+
+export function mecmuaPublishAffordance(
+	isSignedIn: boolean,
+	tier: Tier | undefined,
+): MecmuaPublishAffordance {
+	if (tier === "yazar") return {kind: "publish"};
+	return {
+		kind: "gate",
+		message: isSignedIn
+			? "yayımlamak için yazar olman gerekiyor — çaylakların yazıları henüz yayımlanamaz."
+			: "yayımlamak için giriş yapıp yazar olman gerekiyor.",
+	};
+}
+
+/**
+ * Should the "yeni yazı" entry-point CTA (nav + index) be shown to this viewer (#2532)?
+ * Gate parity with the editor is structural, not restated: the CTA appears exactly when
+ * the write flag is live AND {@link mecmuaPublishAffordance} would offer publish (yazar
+ * tier), so it never dead-ends a çaylak/visitor/signed-out reader into a page they'd be
+ * publish-gated on. `MECMUA_WRITE` off, or any non-yazar/undefined tier, resolves false.
+ */
+export function shouldShowMecmuaWriteCta(
+	flagOn: boolean,
+	isSignedIn: boolean,
+	tier: Tier | undefined,
+): boolean {
+	return flagOn && mecmuaPublishAffordance(isSignedIn, tier).kind === "publish";
+}


### PR DESCRIPTION
## What

`@kampus/composer` (tiptap/ProseMirror) shipped in the SPA's single Vite entry chunk to **every** public route (pano, sözlük, landing, `/mecmua` index), gating first paint on a heavy editor almost no one loads — a performance-pillar violation (ADR 0162).

The issue's premise that `/lab/composer` is the sole composer consumer is stale: #2544/#2549 added the mecmua editor as a **second** consumer, and `MecmuaIndexPage` eagerly imported the gate helpers off `MecmuaEditorPage`, dragging tiptap into the entry chunk regardless of any route split. So a route-split alone would not have worked — the eager helper import had to be severed first.

## How (root-cause fix, matching ACs #2/#3)

1. **Extract the composer-free gate core** — `mecmuaPublishAffordance`, `shouldShowMecmuaWriteCta`, and the `MecmuaPublishAffordance` type — out of `MecmuaEditorPage.tsx` (which imports `@kampus/composer`) into a new tiptap-free module `apps/web/src/pages/mecmua-write-gate.ts`. Repointed `MecmuaIndexPage` and the unit test. **Gate semantics unchanged** — only the pure helpers relocate.
2. **Lazy-split both composer route components** in `App.tsx` behind `React.lazy` + `<Suspense>` (Turkish `yükleniyor…` fallback): `/lab/composer` → `LabComposerPage`, and `/mecmua/yaz` + `/mecmua/yaz/:id` → `MecmuaEditorPage`.

## Proof — tiptap leaves the entry chunk (`pnpm build`)

| | entry chunk | tiptap in entry? | composer/tiptap payload |
|---|---|---|---|
| **before** (origin/main) | `index-*.js` **1,329.84 kB** (gzip 415.14 kB) | **yes** (27 prosemirror/tiptap matches) | inlined in the one entry chunk |
| **after** | `index-*.js` **827.77 kB** (gzip 258.63 kB) | **no** (0 matches) | `src-*.js` **481.13 kB** (gzip 149.92 kB), async |

After: `index.html`'s first-paint fetch set is only the entry + a small react `with-selector` shim — the composer chunk (`src-*.js`) is **not** preloaded and is reached only via dynamic `import()` from the route chunks (`LabComposerPage-*.js` 2.93 kB, `MecmuaEditorPage-*.js` 4.55 kB). Public routes no longer carry tiptap on first paint; the entry chunk shrank ~502 kB (~156 kB gzip).

## Behavior preserved

- Editor + drafts still mount and work (markdown I/O, draft load/seed) — mecmua unit/client tests green (59 passed).
- The contextual "yeni yazı" CTA still shows for signed-in yazars (gate parity unchanged; the relocated helpers keep identical logic, 9 gate tests pass).
- Suspense fallback shown while the editor chunk loads.

## Checks

`pnpm typecheck` ✅ · `pnpm lint` ✅ · gate + mecmua tests ✅ (59) · `pnpm build` chunk-manifest proof above.

Fixes #2523

🤖 Generated with [Claude Code](https://claude.com/claude-code)