### PR TITLE
feat(composer,mecmua): mecmua reader via composer read-only mode (editor≈reader parity) (#2581)

### DIFF
--- a/apps/web/src/components/mecmua/MecmuaPostBody.tsx
+++ b/apps/web/src/components/mecmua/MecmuaPostBody.tsx
@@ -1,0 +1,15 @@
+import {ReadOnlyComposer} from "@kampus/composer";
+
+/**
+ * The mecmua reader's body — the published post's stored markdown rendered through
+ * `@kampus/composer` in read-only mode (#2581): the reader is the editor with editing switched
+ * off (the Medium/Notion editor≈reader parity), so write and read share ONE tiptap render path
+ * and can't re-diverge (the two-render-path bug #2578, superseding its bespoke-renderer fix).
+ *
+ * This module is the tiptap-import boundary: `MecmuaPostPage` `React.lazy`-loads it so tiptap
+ * (~156kB gz) stays OFF mecmua public first-paint (the #2523 editor lazy-split, applied to the
+ * reader). Default export so `React.lazy(() => import(...))` resolves the component directly.
+ */
+export default function MecmuaPostBody({body}: {body: string}) {
+	return <ReadOnlyComposer content={body} className="kp-prose" />;
+}

--- a/apps/web/src/pages/MecmuaPostPage.tsx
+++ b/apps/web/src/pages/MecmuaPostPage.tsx
@@ -2,22 +2,30 @@
  * `/mecmua/:slug` — the PUBLIC reader for a single published mecmua post (#2498, epic
  * #2467). Client-only per the map (#2466 — SEO/prerender explicitly deferred): it
  * fetches the anonymous `GET /fate/mecmua/post/:slug` route and renders the published
- * post's başlık + markdown body, reusing the shared `lib/markdown` render (no new
- * markdown lib). A draft / miss / off-flag all 404 server-side, surfaced here as the
- * shared NotFoundPage.
+ * post's başlık + markdown body through `@kampus/composer` in read-only mode (#2581) —
+ * the reader is the editor with editing switched off, so write and read share ONE tiptap
+ * render path (editor≈reader parity) and can't re-diverge (the raw-markdown bug #2578).
+ * A draft / miss / off-flag all 404 server-side, surfaced here as the shared NotFoundPage.
+ *
+ * Tiptap is kept OFF public first-paint: the body renders through `MecmuaPostBody`, a
+ * `React.lazy` chunk that alone imports the composer (the #2523 lazy-split applied to the
+ * reader) — landing/index/other routes carry no tiptap; opening a post loads that chunk.
  *
  * The whole surface ships dark behind `MECMUA_PUBLIC_READ` (default-off): the page
  * self-gates (off ⇒ 404), mirroring `DivanPage`, so the route is absent until a human
  * flips the flag at release (ADR 0083). The route itself also 404s while the flag is
  * off — the page gate just avoids a fetch and a flash.
  */
-import {useEffect, useState} from "react";
+import {lazy, Suspense, useEffect, useState} from "react";
 import {useParams} from "react-router";
 import {MecmuaSubscribeButton} from "../components/mecmua/MecmuaSubscribeButton";
 import {MECMUA_PUBLIC_READ} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
-import {renderMarkdownInline, splitMarkdownBlocks} from "../lib/markdown";
 import {NotFoundPage} from "./NotFoundPage";
+
+// The composer (and tiptap) live behind this dynamic import so they stay off mecmua public
+// first-paint — the reader route's own module graph never statically references tiptap.
+const MecmuaPostBody = lazy(() => import("../components/mecmua/MecmuaPostBody"));
 
 /**
  * The wire shape the anon read route returns. `authorId` is the subscribe target — the
@@ -110,22 +118,21 @@ function MecmuaPostReader({slug}: {slug: string}) {
 		);
 	}
 
-	const blocks = splitMarkdownBlocks(state.post.body);
 	return (
 		<div className="kp-page">
 			<div className="kp-page__inner">
 				<article data-testid="mecmua-post">
 					<h1>{state.post.title}</h1>
 					<MecmuaSubscribeButton authorId={state.post.authorId} />
-					<div className="kp-prose">
-						{blocks.map((block, i) =>
-							block.kind === "code" ? (
-								<pre key={i}>{block.text}</pre>
-							) : (
-								<p key={i}>{renderMarkdownInline(block.text)}</p>
-							),
-						)}
-					</div>
+					<Suspense
+						fallback={
+							<div className="kp-prose">
+								<p>yükleniyor…</p>
+							</div>
+						}
+					>
+						<MecmuaPostBody body={state.post.body} />
+					</Suspense>
 				</article>
 			</div>
 		</div>

--- a/packages/composer/src/ReadOnlyComposer.render.test.tsx
+++ b/packages/composer/src/ReadOnlyComposer.render.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * The reader-half render proof (#2581, resolving #2578's symptoms through the shared path):
+ * markdown authored via the composer, then rendered through {@link ReadOnlyComposer}, renders
+ * as rich read-only DOM — headings/links/lists/emphasis, with NONE of #2578's raw-markup leaks
+ * (`## text`, escaped `\[ \]`, literal `&nbsp;`). It also pins editor≈reader parity (the editable
+ * and read-only paths produce the same rendered markup) and XSS-safety (the baseKit ProseMirror
+ * schema drops script/event-handler/js-url payloads).
+ */
+import {act, render, renderHook, waitFor} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Composer} from "./Composer.tsx";
+import {ReadOnlyComposer} from "./ReadOnlyComposer.tsx";
+import {useComposerEditor} from "./useComposerEditor.ts";
+
+/** Author markdown through the editable composer and return `getMarkdown()` — the exact storage form. */
+async function authorAndStore(input: string): Promise<string> {
+	const {result} = renderHook(() => useComposerEditor());
+	await waitFor(() => expect(result.current).not.toBeNull());
+	const handle = result.current;
+	if (!handle) throw new Error("editor did not mount");
+	act(() => handle.setContent(input));
+	return handle.getMarkdown();
+}
+
+/** The ProseMirror render surface for a mounted composer/reader — the `.tiptap` element. */
+async function surface(container: HTMLElement): Promise<HTMLElement> {
+	let el: HTMLElement | null = null;
+	await waitFor(() => {
+		el = container.querySelector<HTMLElement>(".tiptap");
+		expect(el).not.toBeNull();
+	});
+	if (!el) throw new Error("no render surface");
+	return el;
+}
+
+const SAMPLE = `## Başlık
+
+Bir paragraf **kalın** ve *italik* içerir. [kamp.us](https://kamp.us) bağlantısı da var.
+
+- birinci
+- ikinci`;
+
+describe("ReadOnlyComposer render path (#2581)", () => {
+	it("renders composer-authored markdown as rich read-only DOM (no raw ## / \\[ \\] / &nbsp;)", async () => {
+		// The real reader flow: author via composer → the stored markdown → render read-only.
+		const stored = await authorAndStore(SAMPLE);
+		const {container} = render(<ReadOnlyComposer content={stored} />);
+		const el = await surface(container);
+
+		// #2578's symptoms are gone — real elements, not literal markup.
+		expect(el.querySelector("h2")?.textContent).toContain("Başlık");
+		const anchor = el.querySelector("a");
+		expect(anchor).not.toBeNull();
+		expect(anchor?.getAttribute("href")).toBe("https://kamp.us");
+		expect(el.querySelectorAll("li").length).toBe(2);
+		expect(el.querySelector("strong")?.textContent).toBe("kalın");
+		expect(el.querySelector("em")?.textContent).toBe("italik");
+
+		// No raw markdown / escaping / entity leaks in the visible text (the #2578 bug).
+		const text = el.textContent ?? "";
+		expect(text).not.toContain("##");
+		expect(text).not.toContain("\\[");
+		expect(text).not.toContain("\\]");
+		expect(text).not.toContain("&nbsp;");
+	});
+
+	it("is non-editable (no editing affordances on the reader surface)", async () => {
+		const {container} = render(<ReadOnlyComposer content={SAMPLE} />);
+		const el = await surface(container);
+		expect(el.getAttribute("contenteditable")).toBe("false");
+	});
+
+	it("legacy escaped-link markdown renders without visible \\[ \\] backslashes and links live", async () => {
+		// The exact #2578 stored form — the shared path consumes the backslash escaping (no leak)
+		// and the URL renders as a live anchor.
+		const {container} = render(
+			<ReadOnlyComposer content={"\\[naber\\](https://phoenix.kamp.us)"} />,
+		);
+		const el = await surface(container);
+		const text = el.textContent ?? "";
+		expect(text).not.toContain("\\[");
+		expect(text).not.toContain("\\]");
+		expect(el.querySelector('a[href="https://phoenix.kamp.us"]')).not.toBeNull();
+	});
+
+	it("editor≈reader parity: editable and read-only render the same markup", async () => {
+		const stored = await authorAndStore(SAMPLE);
+		const rw = render(<AuthoredEditor content={stored} />);
+		const ro = render(<ReadOnlyComposer content={stored} />);
+		const rwEl = await surface(rw.container);
+		const roEl = await surface(ro.container);
+		// The rendered node markup is identical (the reader is the editor, editing off) — the two
+		// halves share one path, so the only difference is the contenteditable flag itself.
+		expect(roEl.getAttribute("contenteditable")).toBe("false");
+		expect(rwEl.getAttribute("contenteditable")).toBe("true");
+		expect(roEl.innerHTML).toBe(rwEl.innerHTML);
+	});
+
+	it("XSS-safe: script / onerror / javascript: payloads are neutralized by the schema", async () => {
+		const payload = [
+			"<script>window.__pwned = 1</script>",
+			'<img src=x onerror="window.__pwned = 1">',
+			"[tık](javascript:window.__pwned=1)",
+		].join("\n\n");
+		const {container} = render(<ReadOnlyComposer content={payload} />);
+		const el = await surface(container);
+
+		// No script node, no surviving event-handler attribute, no javascript: href.
+		expect(container.querySelectorAll("script").length).toBe(0);
+		expect(el.querySelector("[onerror]")).toBeNull();
+		for (const a of el.querySelectorAll("a")) {
+			expect(a.getAttribute("href") ?? "").not.toContain("javascript:");
+		}
+	});
+});
+
+/** An editable composer seeded with markdown — the parity baseline for the read-only surface. */
+function AuthoredEditor({content}: {content: string}) {
+	const composer = useComposerEditor({content});
+	return <Composer composer={composer} />;
+}

--- a/packages/composer/src/ReadOnlyComposer.tsx
+++ b/packages/composer/src/ReadOnlyComposer.tsx
@@ -1,0 +1,28 @@
+import {useEffect} from "react";
+import {Composer} from "./Composer.tsx";
+import {useComposerEditor} from "./useComposerEditor.ts";
+
+export interface ReadOnlyComposerProps {
+	/** The markdown to render — parsed + rendered through the SAME baseKit path the editor uses. */
+	content: string;
+	/** App-supplied class for the render surface — the base ships no styling of its own. */
+	className?: string;
+}
+
+/**
+ * The reader half of editor≈reader parity (#2581): renders stored markdown through the composer's
+ * own tiptap/baseKit path with editing switched off (`editable: false`), non-editable and
+ * chromeless. Because read and write share this ONE render path, the two halves can't re-diverge —
+ * the two-render-path bug (#2578) is structurally gone. XSS-safety comes from the baseKit
+ * ProseMirror schema: markup outside the schema (a `<script>`, `onerror`/event-handler attributes,
+ * arbitrary raw HTML) is dropped on parse, so untrusted stored content can't inject.
+ */
+export function ReadOnlyComposer({content, className}: ReadOnlyComposerProps) {
+	const composer = useComposerEditor({content, editable: false});
+	// The editor seeds content only at creation; re-seed on change so one mounted reader can
+	// render a different post's body without a remount.
+	useEffect(() => {
+		if (composer) composer.setContent(content);
+	}, [composer, content]);
+	return <Composer composer={composer} {...(className !== undefined ? {className} : {})} />;
+}

--- a/packages/composer/src/index.ts
+++ b/packages/composer/src/index.ts
@@ -1,5 +1,6 @@
 export {type BaseKitOptions, baseKit, type ComposerContentType} from "./baseKit.ts";
 export {Composer, type ComposerProps} from "./Composer.tsx";
 export type {ComposerHandle, ComposerJSON, SetContentOptions} from "./handle.ts";
+export {ReadOnlyComposer, type ReadOnlyComposerProps} from "./ReadOnlyComposer.tsx";
 export {renderTestMarkdown} from "./renderTestMarkdown.ts";
 export {type UseComposerEditorOptions, useComposerEditor} from "./useComposerEditor.ts";

--- a/packages/composer/src/public-surface.unit.test.ts
+++ b/packages/composer/src/public-surface.unit.test.ts
@@ -25,7 +25,29 @@ describe("public export surface", () => {
 		expect(typeof composer.useComposerEditor).toBe("function");
 		expect(typeof composer.Composer).toBe("function");
 		expect(typeof composer.baseKit).toBe("function");
+		// The read-only render mode (#2581) is part of the public surface — a consumer (mecmua
+		// reader) renders through it without importing tiptap or reaching a deep path.
+		expect(typeof composer.ReadOnlyComposer).toBe("function");
 		// No deep-path import is required of a consumer: everything above resolves from the root.
+	});
+});
+
+describe("read-only render mode over baseKit() (#2581)", () => {
+	// The reader is the editor with editing switched off: the SAME baseKit path, `editable:false`.
+	// This no-render unit pins that the mode is non-editable and serializes the stored markdown
+	// identically to the editable path — the render-path DOM assertions live in the .render test.
+	it("an editable:false editor is non-editable yet round-trips the same markdown", () => {
+		const ro = createComposerHandle(new Editor({...baseKit(), editable: false}));
+		const rw = createComposerHandle(new Editor(baseKit()));
+		expect(ro.editor.isEditable).toBe(false);
+		expect(rw.editor.isEditable).toBe(true);
+
+		ro.setContent(SAMPLE);
+		rw.setContent(SAMPLE);
+		// Editor≈reader parity at the serialization layer: the same input yields identical
+		// markdown regardless of editability — one render path, no divergence.
+		expect(ro.getMarkdown()).toBe(rw.getMarkdown());
+		expect(ro.getMarkdown()).toContain("# Başlık");
 	});
 });
 

--- a/packages/composer/src/useComposerEditor.ts
+++ b/packages/composer/src/useComposerEditor.ts
@@ -8,6 +8,14 @@ export interface UseComposerEditorOptions {
 	content?: string;
 	/** Fires on every editor transaction — e.g. to re-derive the live markdown/JSON views. */
 	onUpdate?: () => void;
+	/**
+	 * When `false`, the editor renders through the SAME baseKit render path but with tiptap's
+	 * `editable` off — a non-editable (`contenteditable="false"`) surface with no editing
+	 * affordances. This is what makes the reader the editor with editing switched off: one
+	 * render path for write and read (the editor≈reader parity of #2581), so the two halves
+	 * cannot re-diverge (the two-render-path bug #2578). Defaults to editable (`true`).
+	 */
+	editable?: boolean;
 }
 
 /**
@@ -22,6 +30,7 @@ export function useComposerEditor(options: UseComposerEditorOptions = {}): Compo
 		...baseKit(),
 		...(options.content !== undefined ? {content: options.content} : {}),
 		...(options.onUpdate ? {onUpdate: options.onUpdate} : {}),
+		...(options.editable !== undefined ? {editable: options.editable} : {}),
 	});
 	// Keyed on the stable editor identity so the handle only changes when the instance does.
 	return useMemo(() => (editor ? createComposerHandle(editor) : null), [editor]);


### PR DESCRIPTION
## What & why

Renders the **mecmua reader through `@kampus/composer` in a new read-only mode**, so the write and read halves share ONE tiptap/ProseMirror render path — the Medium/Notion "editor ≈ reader" model. This resolves **#2578**'s raw-markdown symptoms (`## heading`, escaped `\[label\](url)`, literal `&nbsp;`) **at the root** and deletes the two-divergent-render-path class that caused them. The bespoke reader-side-renderer approach originally sketched on #2578 is **superseded** by this shared path.

Founder-directed product direction (editor≈reader parity), per ADR 0078 — no ADR authored, #2581 is its home.

## Two parts, one change

**(a) Read-only render mode on `@kampus/composer`'s public surface**
- `useComposerEditor` gains an `editable?: boolean` option (defaults editable) → tiptap `editable`.
- New `ReadOnlyComposer` component (exported from `packages/composer/src/index.ts`): renders markdown through the same `baseKit` path with `editable: false` — non-editable (`contenteditable="false"`), no toolbar/chrome. Re-seeds on `content` change.
- Storage stays markdown — the composer round-trips it byte-identically (no migration, no schema change).

**(b) Swap `MecmuaPostPage` onto the read-only composer**
- The body renders through a new `MecmuaPostBody` read-only subcomponent, `React.lazy`-loaded **inside `MecmuaPostPage`** with a Turkish `yükleniyor…` `<Suspense>` fallback — **not** in `App.tsx` (kept disjoint from #2580/#2579, which own App.tsx). `MecmuaPostBody` is the sole tiptap-import boundary, so the reader route's own module never statically references tiptap (the #2523 lazy-split applied to the reader).
- The mecmua reader no longer uses `renderMarkdownInline`/`splitMarkdownBlocks`; the shared sözlük/pano inline renderer (`lib/markdown.tsx`) is **untouched** and still consumed by sözlük/pano/profile.

## Tests (`packages/composer`)
- **Round-trip** — markdown authored via the composer → `getMarkdown()` (storage form) → rendered through `ReadOnlyComposer` produces rich DOM (`<h2>`, `<a href>`, `<li>`, `<strong>`/`<em>`) with **no** literal `##`, escaped `\[ \]`, or `&nbsp;`.
- **Legacy escaped-link** — a stored `\[naber\](url)` renders with no visible backslash escaping and the URL as a live anchor.
- **Editor≈reader parity** — the editable and read-only surfaces render identical markup (differ only by the `contenteditable` flag).
- **Non-editable** — the reader surface is `contenteditable="false"`.
- **XSS-safety** — a `<script>` / `onerror` / `javascript:` payload is neutralized by the baseKit ProseMirror schema (0 script nodes, no surviving event-handler attr, no js: href).

## Chunk proof (tiptap off reader first-paint)
`pnpm build` emits `MecmuaPostBody-*.js` as a **separate dynamic chunk**; `MecmuaPostPage`'s module has **no** static `@kampus/composer`/`@tiptap` import — its only composer edge is `import("../components/mecmua/MecmuaPostBody")`. tiptap currently sits in the entry chunk **only** via the still-static editor pages (`MecmuaEditorPage`/`LabComposerPage`) — that is #2580's lane; once it lands, tiptap leaves the entry and the reader keeps it off first-paint through this lazy chunk with no further change.

Fixes #2581
Refs #2578 (closes when this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)