### PR TITLE
fix(composer): guard setContent against a torn-down editor (#2593)

### DIFF
--- a/packages/composer/src/handle.ts
+++ b/packages/composer/src/handle.ts
@@ -33,8 +33,15 @@ export function createComposerHandle(editor: Editor): ComposerHandle {
 		getMarkdown: () => editor.getMarkdown(),
 		// Default the content type to "markdown" — the only value v1 accepts — so a bare
 		// setContent(md) is the common path and an explicit contentType stays type-checked.
-		setContent: (markdown, options) =>
-			editor.commands.setContent(markdown, {contentType: options?.contentType ?? "markdown"}),
+		// No-op once the editor is torn down: tiptap's `destroy()` nulls `commandManager`, so the
+		// `editor.commands` getter throws `Cannot read properties of null (reading 'commands')` — a
+		// stale re-seed after a StrictMode/remount teardown hit exactly that and hard-crashed the
+		// read-only mecmua reader (#2593). `isDestroyed` is the readiness signal safe to read
+		// post-teardown; gating here fixes every consumer of setContent, not just one call site.
+		setContent: (markdown, options) => {
+			if (editor.isDestroyed) return;
+			editor.commands.setContent(markdown, {contentType: options?.contentType ?? "markdown"});
+		},
 		toJSON: () => editor.getJSON(),
 	};
 }

--- a/packages/composer/src/setContent-readiness.render.test.tsx
+++ b/packages/composer/src/setContent-readiness.render.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Regression proof for #2593 (the mecmua-reader hard-crash regression from #2584): a re-seed
+ * `setContent` that fires against a torn-down tiptap editor must NOT throw
+ * `Cannot read properties of null (reading 'commands')`. The re-seed effect routes setContent
+ * through the handle, so the crash surfaces at that seam — pinned here, plus a check that the
+ * effect keeps re-seeding across content changes (the happy path #2584 shipped).
+ */
+import {act, render, renderHook, waitFor} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {createComposerHandle} from "./handle.ts";
+import {ReadOnlyComposer} from "./ReadOnlyComposer.tsx";
+import {useComposerEditor} from "./useComposerEditor.ts";
+
+async function surface(container: HTMLElement): Promise<HTMLElement> {
+	let el: HTMLElement | null = null;
+	await waitFor(() => {
+		el = container.querySelector<HTMLElement>(".tiptap");
+		expect(el).not.toBeNull();
+	});
+	if (!el) throw new Error("no render surface");
+	return el;
+}
+
+describe("setContent readiness guard (#2593)", () => {
+	it("handle.setContent is a no-op — no `reading 'commands'` throw — when the editor is destroyed", async () => {
+		const {result} = renderHook(() => useComposerEditor({content: "ilk gövde"}));
+		await waitFor(() => expect(result.current).not.toBeNull());
+		const editor = result.current?.editor;
+		if (!editor) throw new Error("editor did not mount");
+
+		// The bad tick: a StrictMode double-invoke / remount tears the tiptap instance down while a
+		// stale re-seed still holds a handle onto it (a fresh handle over the SAME torn-down editor
+		// is that stale route made deterministic). @tiptap/core's destroy() nulls commandManager, so
+		// the `editor.commands` getter throws `Cannot read properties of null (reading 'commands')`.
+		act(() => editor.destroy());
+		expect(editor.isDestroyed).toBe(true);
+		const staleHandle = createComposerHandle(editor);
+
+		// Before the fix, setContent read `editor.commands` unconditionally and threw right here —
+		// the exact frame the mecmua reader unwound to its error boundary on.
+		expect(() => staleHandle.setContent("yeni gövde")).not.toThrow();
+	});
+
+	it("the ReadOnlyComposer re-seed effect applies new content across renders (no happy-path regression)", async () => {
+		const {container, rerender} = render(<ReadOnlyComposer content="## Birinci" />);
+		const first = await surface(container);
+		await waitFor(() => expect(first.querySelector("h2")?.textContent).toContain("Birinci"));
+
+		// One mounted reader rendering a different post's body without a remount — the re-seed the
+		// ReadOnlyComposer effect drives — must swap the content, not stall on the seed-at-creation.
+		rerender(<ReadOnlyComposer content="## İkinci" />);
+		const second = await surface(container);
+		await waitFor(() => expect(second.querySelector("h2")?.textContent).toContain("İkinci"));
+	});
+});


### PR DESCRIPTION
Fixes #2593

## Problem

p0 live regression from #2584. The mecmua reader intermittently hard-crashed to the React error boundary with `TypeError: Cannot read properties of null (reading 'commands')`, thrown from the composer's `setContent` path. #2584 made the reader render the stored post through `@kampus/composer` in read-only mode (`setContent(markdown)`), so an intermittent hard crash replaced ugly-but-readable raw markdown.

## Root cause (grounded in @tiptap/core source)

`ReadOnlyComposer`'s re-seed effect guarded on `if (composer)` — the `ComposerHandle` wrapper being non-null. But `handle.setContent` routes to `editor.commands.setContent`, and `@tiptap/core`'s `Editor.destroy()` sets `this.commandManager = null` (Editor.ts:798), so the `get commands()` getter (Editor.ts:234, `return this.commandManager.commands`) throws once the underlying instance is torn down — a StrictMode double-invoke / remount on a bad tick. The guard was at the wrong level: handle-non-null, not editor-readiness. On a good tick the editor was ready and the post rendered — which is why every single-render check (manual snapshot + review-design) missed it.

## Fix

Gate `setContent` at the seam (`packages/composer/src/handle.ts`) on `editor.isDestroyed` — the readiness signal safe to read post-teardown (Editor.ts:805, `editorView?.isDestroyed ?? true`, nulled-safe). setContent becomes a no-op when the editor is torn down and applies normally once it is ready. Fixing at the handle seam covers every consumer of `setContent`, not just the reader, and keeps the *why* at a single load-bearing site. `ReadOnlyComposer`'s `if (composer)` existence check stays (the handle is null pre-mount) and is now safe.

## Test

`packages/composer/src/setContent-readiness.render.test.tsx`:
- Race-reproducing regression test — tears down a real tiptap editor, wraps it in a fresh handle (the stale-route made deterministic), and asserts `setContent` no longer throws. It fails before the fix (setContent hits the exact `reading 'commands'` frame) and passes after.
- Happy-path check that the re-seed effect still swaps content across renders (a mounted reader rendering a different post's body without a remount) — no regression to the #2581/#2584 read-only parity.

## Gates

- `pnpm typecheck` (composer): pass
- `biome check` (changed files): clean
- `pnpm vitest run` (composer): 14/14 pass