### PR TITLE
feat(karma): append-only karma-events ledger co-committed with the bump

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0027_karma_event.sql
+++ b/apps/web/worker/db/drizzle/migrations/0027_karma_event.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `karma_event` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`delta` integer NOT NULL,
+	`source_kind` text NOT NULL,
+	`source_id` text NOT NULL,
+	`reason` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `karma_event_user_created` ON `karma_event` (`user_id`,"created_at" DESC);

--- a/apps/web/worker/db/drizzle/migrations/meta/0027_karma_event_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0027_karma_event_snapshot.json
@@ -1,0 +1,2287 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0ccad404-33ee-4d93-ae7b-2abfd6a2601d",
+  "prevId": "2ca9b1dc-a732-47a0-89d4-0d3858e5f1aa",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        },
+        "post_record_sandboxed": {
+          "name": "post_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\u00e7aylak'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wave_id": {
+          "name": "wave_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "content_report_wave": {
+          "name": "content_report_wave",
+          "columns": [
+            "wave_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        },
+        "definition_record_sandboxed": {
+          "name": "definition_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_sandboxed": {
+          "name": "comment_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authorship_vouch": {
+      "name": "authorship_vouch",
+      "columns": {
+        "voucher_id": {
+          "name": "voucher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authorship_vouch_candidate": {
+          "name": "authorship_vouch_candidate",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "authorship_vouch_voucher_id_candidate_id_pk": {
+          "name": "authorship_vouch_voucher_id_candidate_id_pk",
+          "columns": [
+            "voucher_id",
+            "candidate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_recipient_read": {
+          "name": "notification_recipient_read",
+          "columns": [
+            "recipient_id",
+            "read_at"
+          ],
+          "isUnique": false
+        },
+        "notification_recipient_created": {
+          "name": "notification_recipient_created",
+          "columns": [
+            "recipient_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_reaction": {
+      "name": "user_reaction",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_reaction_target": {
+          "name": "user_reaction_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_reaction_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_reaction_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_ban_event": {
+      "name": "user_ban_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_ban_event_user_created": {
+          "name": "user_ban_event_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_ban_event_user_id_user_id_fk": {
+          "name": "user_ban_event_user_id_user_id_fk",
+          "tableFrom": "user_ban_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mecmua_post": {
+      "name": "mecmua_post",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mecmua_post_author_created": {
+          "name": "mecmua_post_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mecmua_subscription": {
+      "name": "mecmua_subscription",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mecmua_subscription_subscriber": {
+          "name": "mecmua_subscription_subscriber",
+          "columns": [
+            "subscriber_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "mecmua_subscription_subscriber_id_author_id_pk": {
+          "columns": [
+            "subscriber_id",
+            "author_id"
+          ],
+          "name": "mecmua_subscription_subscriber_id_author_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "karma_event": {
+      "name": "karma_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "karma_event_user_created": {
+          "name": "karma_event_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "karma_event_user_id_user_id_fk": {
+          "name": "karma_event_user_id_user_id_fk",
+          "tableFrom": "karma_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "user_ban_event_user_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "mecmua_post_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "mecmua_subscription_subscriber": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1795000000000,
       "tag": "0026_mecmua_subscription",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1795500000000,
+      "tag": "0027_karma_event",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -10,6 +10,7 @@ import {index, integer, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-
 import {NOTIFICATION_TARGET_KINDS} from "../../features/bildirim/target.ts";
 import {STORED_TIERS} from "../../features/kunye/standing.ts";
 import {REPORT_STATUSES, RESOLUTIONS} from "../../features/report/resolution.ts";
+import {KARMA_EVENT_REASONS} from "../karma-event.ts";
 import {REACTION_EMOJI} from "../reaction-emoji.ts";
 import {TARGET_KINDS} from "../target-kind.ts";
 
@@ -330,7 +331,8 @@ export const userReaction = sqliteTable(
 /**
  * Per-user denormalized profile row. `total_karma` is the running sum of upvotes
  * received across all of this user's contributions, maintained inline by
- * `Vote.cast`'s atomic batch (D1-direct, see ADR 0009).
+ * `Vote.cast`'s atomic batch (D1-direct, see ADR 0009). Its provenance — one row
+ * per bump — lives in {@link karmaEvent}, co-committed in that same batch (#2592).
  */
 export const userProfile = sqliteTable(
 	"user_profile",
@@ -348,6 +350,34 @@ export const userProfile = sqliteTable(
 		updatedAt: timestamp("updated_at").notNull(),
 	},
 	(t) => [index("user_profile_username").on(t.username)],
+);
+
+/**
+ * Append-only provenance ledger for `user_profile.total_karma` (#2592) — one row
+ * per karma bump, co-committed in `Vote.cast`'s atomic batch (via the `KarmaBump`
+ * contract's pasaport implementation, `features/pasaport/karma.ts`), so a delta
+ * can never land without its event nor an event without its delta. The same
+ * append-only-log shape as {@link userBanEvent}: a retraction is a NEGATIVE-`delta`
+ * row, never a mutation or deletion of a prior one, so `SUM(delta)` per `user_id`
+ * reconstructs the accumulator exactly. `reason` distinguishes the event kind
+ * (`vote` cast / `retract`); `(source_kind, source_id)` names the vote target the
+ * delta came from. `onDelete: cascade` ties the ledger to the account row (an
+ * account deletion is a kept tombstone, ADR 0097, so this history survives it).
+ */
+export const karmaEvent = sqliteTable(
+	"karma_event",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, {onDelete: "cascade"}),
+		delta: integer("delta").notNull(),
+		sourceKind: text("source_kind", {enum: [...TARGET_KINDS]}).notNull(),
+		sourceId: text("source_id").notNull(),
+		reason: text("reason", {enum: [...KARMA_EVENT_REASONS]}).notNull(),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(t) => [index("karma_event_user_created").on(t.userId, sql`${t.createdAt} DESC`)],
 );
 
 /**

--- a/apps/web/worker/db/karma-event.ts
+++ b/apps/web/worker/db/karma-event.ts
@@ -1,0 +1,16 @@
+/**
+ * The karma-event **reason** — the closed set of events that move a user's
+ * `total_karma`, recorded on every `karma_event` row so an earned balance is
+ * reconstructable (issue #2592). Today Vote is the only karma writer, so the set
+ * is a cast (`vote`) or its reversal (`retract`); a new karma source adds a member.
+ *
+ * Lives in `db/` — below both the `vote/` and `pasaport/` feature directories,
+ * like {@link ./target-kind.ts} — because `schema.ts` sources the `karma_event.reason`
+ * D1 enum from this tuple while `vote/Vote.ts` (the `KarmaBump` contract owner) types
+ * its input against the same set. `schema.ts` can't import that vocabulary from
+ * `vote/Vote.ts` (Vote imports `schema.ts`, so that edge is a cycle), so the one set
+ * both need lives here, imported by both with no cycle.
+ */
+export const KARMA_EVENT_REASONS = ["vote", "retract"] as const;
+
+export type KarmaEventReason = (typeof KARMA_EVENT_REASONS)[number];

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -35,7 +35,7 @@ import {MecmuaLive} from "../mecmua/Mecmua.ts";
 import {BookmarkLive} from "../pano/Bookmark.ts";
 import {PanoFeedCache} from "../pano/feed-cache.ts";
 import {PanoLive} from "../pano/Pano.ts";
-import {karmaBumpStatement} from "../pasaport/karma.ts";
+import {karmaBumpStatements} from "../pasaport/karma.ts";
 import {makePasaportLive} from "../pasaport/Pasaport.ts";
 import {ReactionLive} from "../reaction/Reaction.ts";
 import {ReportLive} from "../report/Report.ts";
@@ -124,7 +124,7 @@ const PasaportFromTag = Layer.unwrap(
  * arrow exists only at this seam, never inside Vote; künye later swaps this for a
  * DO-backed bump without touching Vote.
  */
-const KarmaBumpFromPasaport = Layer.succeed(KarmaBump, {statement: karmaBumpStatement});
+const KarmaBumpFromPasaport = Layer.succeed(KarmaBump, {statements: karmaBumpStatements});
 
 /**
  * Künye's implementation of the `VoterStanding` contract Vote owns (dependency

--- a/apps/web/worker/features/pasaport/karma.ts
+++ b/apps/web/worker/features/pasaport/karma.ts
@@ -1,20 +1,39 @@
 /**
- * Returns an **unexecuted** drizzle `UPDATE` against `user_profile.total_karma` —
- * pasaport's implementation of the `KarmaBump` contract VOTE owns (`vote/Vote.ts`,
- * dependency inversion). `fate/layers.ts` wraps it in `Layer.succeed(KarmaBump, …)`;
- * the Vote service includes the statement inside its `batch((db) => [...])` so the
- * karma adjustment commits atomically with the vote. Vote never imports this module.
+ * Pasaport's implementation of the `KarmaBump` contract VOTE owns (`vote/Vote.ts`,
+ * dependency inversion): the **unexecuted** `total_karma` UPDATE PLUS its
+ * append-only `karma_event` ledger row (#2592), so every bump leaves a
+ * reconstructable origin record co-committed with the balance change.
+ * `fate/layers.ts` wraps this in `Layer.succeed(KarmaBump, …)`; the Vote service
+ * includes both statements in its `batch((db) => [...])` so bump + event commit
+ * atomically with the vote, or not at all. Vote never imports this module — it
+ * passes the {@link KarmaBumpInput} context and this side owns the karma schema.
  */
 import {eq, sql} from "drizzle-orm";
-import type {DrizzleDb} from "../../db/Drizzle.ts";
+import type {DrizzleDb, Stmt} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import type {KarmaBumpInput} from "../vote/Vote.ts";
 
-// `delta` may be negative (vote retraction). Never call `.run()` on the result —
-// it's meant for a `batch((db) => [...])` tuple. For a one-off bump outside a
-// batch, wrap in `run((db) => karmaBumpStatement(db, ...).run())`.
-export function karmaBumpStatement(db: DrizzleDb, userId: string, delta: number) {
-	return db
+/**
+ * The bump + its provenance event, in that order. `delta` may be negative (a vote
+ * retraction records a `-1` `karma_event`, never a deletion of the prior row — the
+ * ledger is append-only, so `SUM(delta)` reconciles to `total_karma`). Never call
+ * `.run()` on either — they are meant for a `batch((db) => [...])` tuple.
+ */
+export function karmaBumpStatements(db: DrizzleDb, input: KarmaBumpInput): readonly [Stmt, Stmt] {
+	const bump = db
 		.update(schema.userProfile)
-		.set({totalKarma: sql`${schema.userProfile.totalKarma} + ${delta}`})
-		.where(eq(schema.userProfile.userId, userId));
+		.set({totalKarma: sql`${schema.userProfile.totalKarma} + ${input.delta}`})
+		.where(eq(schema.userProfile.userId, input.recipientId));
+
+	const event = db.insert(schema.karmaEvent).values({
+		id: crypto.randomUUID(),
+		userId: input.recipientId,
+		delta: input.delta,
+		sourceKind: input.source.kind,
+		sourceId: input.source.id,
+		reason: input.reason,
+		createdAt: input.at,
+	});
+
+	return [bump, event];
 }

--- a/apps/web/worker/features/pasaport/karma.unit.test.ts
+++ b/apps/web/worker/features/pasaport/karma.unit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * `karmaBumpStatements` — pasaport's `KarmaBump` implementation (#2592). Proves the
+ * two co-committed statements by rendering their `.toSQL()` over a no-op D1 (the
+ * `promotion-sweep.unit.test.ts` / `set-display-name.unit.test.ts` idiom) — no engine,
+ * so this is a unit test; the execute-and-read-back over real D1 is the integration
+ * tier (`tests/integration/pasaport.test.ts` drives the same batch via `totalKarma`).
+ *
+ * The load-bearing correctness concern is that every bump emits BOTH a `total_karma`
+ * UPDATE and a `karma_event` INSERT carrying the same signed delta — so a delta can't
+ * land without its provenance row, and `SUM(karma_event.delta)` reconciles to
+ * `total_karma`. A retraction is a NEGATIVE-delta INSERT, never a deletion (append-only).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {relations, type Stmt} from "../../db/Drizzle.ts";
+import type {KarmaBumpInput} from "../vote/Vote.ts";
+import {karmaBumpStatements} from "./karma.ts";
+
+// A real drizzle client over a no-op D1 — used ONLY to render statements' `.toSQL()`.
+// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; nothing here executes against it.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {relations});
+
+const render = (s: Stmt) =>
+	// biome-ignore lint/plugin: drizzle's `Stmt`/`BatchItem` carries `.toSQL()` at runtime but doesn't expose it on the type; render it to assert the built SQL.
+	(s as unknown as {toSQL: () => {sql: string; params: unknown[]}}).toSQL();
+
+describe("karmaBumpStatements — the bump + its append-only ledger row (#2592)", () => {
+	it("a cast (+1) emits the total_karma bump AND a matching karma_event INSERT", () => {
+		const input: KarmaBumpInput = {
+			recipientId: "author-1",
+			delta: 1,
+			source: {kind: "definition", id: "def-1"},
+			reason: "vote",
+			at: new Date("2026-01-02T03:04:05Z"),
+		};
+		const stmts = karmaBumpStatements(renderDb, input);
+		assert.strictEqual(stmts.length, 2, "exactly two statements: bump + event");
+
+		const bump = render(stmts[0]);
+		assert.match(bump.sql, /update .*user_profile.* set .*total_karma/i);
+		assert.include(bump.params, "author-1", "bump targets the recipient");
+		assert.include(bump.params, 1, "bump adds the delta");
+
+		const event = render(stmts[1]);
+		assert.match(event.sql, /insert into .*karma_event/i);
+		assert.include(event.params, "author-1", "event.user_id is the recipient");
+		assert.include(event.params, 1, "event.delta is the signed delta");
+		assert.include(event.params, "definition", "event.source_kind");
+		assert.include(event.params, "def-1", "event.source_id");
+		assert.include(event.params, "vote", "event.reason");
+	});
+
+	it("a retraction (-1) records a NEGATIVE-delta event with reason 'retract' (append-only)", () => {
+		const input: KarmaBumpInput = {
+			recipientId: "author-1",
+			delta: -1,
+			source: {kind: "post", id: "post-9"},
+			reason: "retract",
+			at: new Date("2026-01-02T03:04:05Z"),
+		};
+		const stmts = karmaBumpStatements(renderDb, input);
+		const event = render(stmts[1]);
+		assert.match(event.sql, /insert into .*karma_event/i);
+		assert.include(event.params, -1, "a retraction is a negative delta, not a deletion");
+		assert.include(event.params, "retract", "event.reason distinguishes the retraction");
+		assert.include(event.params, "post", "event.source_kind carries the target");
+		assert.include(event.params, "post-9", "event.source_id carries the target");
+	});
+
+	it("the bump delta and the event delta are the SAME value — they can't diverge", () => {
+		// The reconciliation invariant at the statement level: `total_karma += delta` and
+		// `karma_event.delta = delta` read the one `input.delta`, so SUM(events) tracks the
+		// accumulator by construction (#2592).
+		for (const delta of [1, -1]) {
+			const stmts = karmaBumpStatements(renderDb, {
+				recipientId: "u",
+				delta,
+				source: {kind: "comment", id: "c-1"},
+				reason: delta > 0 ? "vote" : "retract",
+				at: new Date(0),
+			});
+			assert.include(render(stmts[0]).params, delta, "bump carries the delta");
+			assert.include(render(stmts[1]).params, delta, "event carries the same delta");
+		}
+	});
+});

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -20,6 +20,7 @@ import {and, eq, inArray} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import type {KarmaEventReason} from "../../db/karma-event.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {type TargetRecordMeta, targetTable} from "../../db/target-table.ts";
 import {Telemetry} from "../telemetry/Telemetry.ts";
@@ -60,13 +61,33 @@ export interface VoteResult {
 }
 
 /**
- * The karma-bump capability as Vote consumes it: given recipient and delta
- * (`+1` cast, `-1` retraction), the **unexecuted** statement to include in the
- * cast batch — so the karma adjustment commits atomically with the vote, or
- * not at all.
+ * The context of one karma bump, passed from Vote (which knows the cast) to the
+ * `KarmaBump` implementation (which owns the karma schema) so the implementation
+ * can write the provenance ledger row without Vote importing its internals —
+ * preserving the dependency inversion (#2592).
+ */
+export interface KarmaBumpInput {
+	/** The karma recipient — the vote target's author. */
+	readonly recipientId: string;
+	/** Signed karma delta: `+1` cast, `-1` retraction. */
+	readonly delta: number;
+	/** The vote target the delta came from — its kind and id. */
+	readonly source: {readonly kind: TargetKind; readonly id: string};
+	/** The event kind driving the bump (`vote` cast / `retract`). */
+	readonly reason: KarmaEventReason;
+	/** Commit timestamp, shared with the rest of the cast batch. */
+	readonly at: Date;
+}
+
+/**
+ * The karma-bump capability as Vote consumes it: given the bump's context, the
+ * **unexecuted** statements to include in the cast batch — the `total_karma`
+ * adjustment AND its append-only ledger row (#2592) — so both commit atomically
+ * with the vote, or not at all. Two statements, never one: a bump can't land
+ * without its provenance event.
  */
 export interface KarmaBumpService {
-	readonly statement: (db: DrizzleDb, userId: string, delta: number) => Stmt;
+	readonly statements: (db: DrizzleDb, input: KarmaBumpInput) => readonly [Stmt, Stmt];
 }
 
 /**
@@ -345,7 +366,8 @@ function buildClearTargetStatements(db: DrizzleDb, kind: TargetKind, targetId: s
 /**
  * The tuple of statements making up one atomic state-change, in order:
  * vote-table mutation (truth source), score-cache update, `user_vote` mirror,
- * karma bump. `db.batch([...])` commits all or none. See ADR 0014.
+ * karma bump + its provenance ledger row (both from `KarmaBump`, #2592).
+ * `db.batch([...])` commits all or none. See ADR 0014.
  */
 function buildBatchStatements(
 	db: DrizzleDb,
@@ -383,7 +405,13 @@ function buildBatchStatements(
 					),
 				);
 
-	const karma = karmaBump.statement(db, meta.authorId, karmaDelta);
+	const [karmaBumpRow, karmaEventRow] = karmaBump.statements(db, {
+		recipientId: meta.authorId,
+		delta: karmaDelta,
+		source: {kind: input.targetKind, id: input.targetId},
+		reason: isCast ? "vote" : "retract",
+		at: now,
+	});
 
-	return [voteRow, scoreUpdate, userVoteRow, karma] as const;
+	return [voteRow, scoreUpdate, userVoteRow, karmaBumpRow, karmaEventRow] as const;
 }

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -19,7 +19,7 @@ import {TARGET_KINDS} from "../../db/target-kind.ts";
 import type {TelemetryEvent} from "../telemetry/schema.ts";
 import {Telemetry} from "../telemetry/Telemetry.ts";
 import {VOTE_ELIGIBILITY_WIRE_CODE, VOTE_REQUIRED_TIER, VoterNotEligible} from "./errors.ts";
-import {KarmaBump, Vote, VoteLive, VoterStanding} from "./Vote.ts";
+import {KarmaBump, type KarmaBumpInput, Vote, VoteLive, VoterStanding} from "./Vote.ts";
 
 // A recording `Telemetry` seam: `emit` pushes each event into `sink` and succeeds,
 // so a test can assert the exact `{feature, action, surface, userId}` a cast emitted
@@ -72,8 +72,8 @@ function scriptedAccess(results: ReadonlyArray<unknown>): {access: DrizzleAccess
 }
 
 const KarmaBumpStub = Layer.succeed(KarmaBump, {
-	statement: () => {
-		throw new Error("KarmaBump.statement must not be reached on a no-op cast");
+	statements: () => {
+		throw new Error("KarmaBump.statements must not be reached on a no-op cast");
 	},
 });
 
@@ -222,20 +222,26 @@ function recordingCastAccess(reads: ReadonlyArray<unknown>): {
 	return {access, batches};
 }
 
-// A KarmaBump that RECORDS each bump (recipient + delta) and returns a sentinel
-// statement, so a cast's karma credit is observable: who got karma and by how much.
+// A KarmaBump that RECORDS each bump's full context and returns the TWO sentinel
+// statements the real contract now emits (the `total_karma` bump + its `karma_event`
+// provenance row, #2592), so a cast's karma credit is observable: who got karma, by how
+// much, from which source, and why. `calls` keeps the recipient+delta shape prior
+// assertions read; `inputs` exposes the source/reason/timestamp the ledger row carries.
 function recordingKarma(): {
 	layer: Layer.Layer<KarmaBump>;
 	calls: {userId: string; delta: number}[];
+	inputs: KarmaBumpInput[];
 } {
 	const calls: {userId: string; delta: number}[] = [];
+	const inputs: KarmaBumpInput[] = [];
 	const layer = Layer.succeed(KarmaBump, {
-		statement: ((_db: unknown, userId: string, delta: number) => {
-			calls.push({userId, delta});
-			return {__karma: true} as never;
-		}) as KarmaBump["Service"]["statement"],
+		statements: ((_db: unknown, input: KarmaBumpInput) => {
+			inputs.push(input);
+			calls.push({userId: input.recipientId, delta: input.delta});
+			return [{__karmaBump: true}, {__karmaEvent: true}] as never;
+		}) as KarmaBump["Service"]["statements"],
 	});
-	return {layer, calls};
+	return {layer, calls, inputs};
 }
 
 const sandboxedMeta = {authorId: "caylak-1", createdAtMs: 0, sandboxed: true};
@@ -259,7 +265,7 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 		// reads: loadMeta (sandboxed) → probe (not yet cast) → post-batch score. The cast
 		// reaches the atomic batch; the recording karma proves +1 credited to the AUTHOR.
 		const {access, batches} = recordingCastAccess([sandboxedMeta, false, 1]);
-		const {layer: karma, calls} = recordingKarma();
+		const {layer: karma, calls, inputs} = recordingKarma();
 		return Effect.gen(function* () {
 			const vote = yield* Vote;
 			const result = yield* vote.castOnSandboxed({
@@ -271,12 +277,19 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 			assert.isTrue(result.changed, "the sandboxed vote is a real state change");
 			assert.strictEqual(result.score, 1);
 			assert.strictEqual(batches.length, 1, "scoring + karma land in one atomic batch (ADR 0014)");
-			assert.strictEqual(batches[0]?.length, 4, "vote + score-cache + user_vote + karma");
+			assert.strictEqual(
+				batches[0]?.length,
+				5,
+				"vote + score-cache + user_vote + karma-bump + karma-event (#2592: the ledger row co-commits)",
+			);
 			assert.deepStrictEqual(
 				calls,
 				[{userId: "caylak-1", delta: 1}],
 				"karma credited to the content author, +1 (D2 global karma, D3 equal weight)",
 			);
+			// The provenance the ledger row records: source target + reason (#2592).
+			assert.deepStrictEqual(inputs[0]?.source, {kind: "definition", id: "def-sb"});
+			assert.strictEqual(inputs[0]?.reason, "vote");
 		}).pipe(
 			Effect.provide(
 				VoteLive.pipe(
@@ -293,7 +306,7 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 
 	it.effect("cast on a LIVE target is unaffected — the inline path still scores + credits", () => {
 		const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
-		const {layer: karma, calls} = recordingKarma();
+		const {layer: karma, calls, inputs} = recordingKarma();
 		return Effect.gen(function* () {
 			const vote = yield* Vote;
 			const result = yield* vote.cast({
@@ -303,8 +316,14 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 				value: true,
 			});
 			assert.isTrue(result.changed);
-			assert.strictEqual(batches[0]?.length, 4, "live vote still writes the full batch");
+			assert.strictEqual(
+				batches[0]?.length,
+				5,
+				"live vote still writes the full batch + ledger row",
+			);
 			assert.deepStrictEqual(calls, [{userId: "author-1", delta: 1}]);
+			assert.deepStrictEqual(inputs[0]?.source, {kind: "definition", id: "def-live"});
+			assert.strictEqual(inputs[0]?.reason, "vote");
 		}).pipe(
 			Effect.provide(
 				VoteLive.pipe(
@@ -382,7 +401,7 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 				value: true,
 			});
 			assert.isTrue(result.changed, "a promoted voter's cast is a real state change");
-			assert.strictEqual(batches[0]?.length, 4, "the full vote batch still writes");
+			assert.strictEqual(batches[0]?.length, 5, "the full vote batch + ledger row still writes");
 			assert.deepStrictEqual(calls, [{userId: "author-1", delta: 1}], "author credited +1");
 		}).pipe(
 			Effect.provide(
@@ -435,6 +454,40 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 				assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /VoteTargetSandboxed/);
 			}).pipe(Effect.provide(voteLayer(scriptedAccess([sandboxedMeta]).access, true))),
 	);
+});
+
+describe("Vote.cast — karma provenance ledger (#2592, mocked Drizzle seam)", () => {
+	it.effect("a real retraction co-commits a -1 ledger event with reason 'retract'", () => {
+		// reads: loadMeta (live) → probe (already cast) → post-batch score. `value:false` on an
+		// existing vote is a state change, so it reaches the batch with karmaDelta -1 — and the
+		// ledger row records the negative delta as an event, never a deletion (append-only).
+		const {access, batches} = recordingCastAccess([liveMeta, true, 0]);
+		const {layer: karma, calls, inputs} = recordingKarma();
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			const result = yield* vote.cast({
+				userId: "voter-1",
+				targetKind: "post",
+				targetId: "post-9",
+				value: false,
+			});
+			assert.isTrue(result.changed, "retracting an existing vote is a real state change");
+			assert.strictEqual(batches[0]?.length, 5, "retraction batch still carries the ledger row");
+			assert.deepStrictEqual(calls, [{userId: "author-1", delta: -1}], "author debited -1");
+			assert.deepStrictEqual(inputs[0]?.source, {kind: "post", id: "post-9"});
+			assert.strictEqual(inputs[0]?.reason, "retract");
+			assert.strictEqual(inputs[0]?.delta, -1, "the ledger event carries the negative delta");
+		}).pipe(
+			Effect.provide(
+				VoteLive.pipe(
+					Layer.provide(karma),
+					Layer.provide(VoterStandingStub(true)),
+					Layer.provide(recordingTelemetry([])),
+					Layer.provide(Layer.succeed(Drizzle, access)),
+				),
+			),
+		);
+	});
 });
 
 describe("Vote.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle seam)", () => {

--- a/apps/web/worker/features/vote/vote-boundary.unit.test.ts
+++ b/apps/web/worker/features/vote/vote-boundary.unit.test.ts
@@ -16,7 +16,7 @@ import type {Effect, Layer} from "effect";
 import {describe, expectTypeOf, it} from "vitest";
 import type {Drizzle, DrizzleDb, Stmt} from "../../db/Drizzle.ts";
 import type {Telemetry} from "../telemetry/Telemetry.ts";
-import type {KarmaBump, Vote, VoteLive, VoterStanding} from "./Vote.ts";
+import type {KarmaBump, KarmaBumpInput, Vote, VoteLive, VoterStanding} from "./Vote.ts";
 
 describe("Vote's public surface is feature-clean (type pins)", () => {
 	it("VoteLive requires the db seam + Vote's own KarmaBump + VoterStanding + the shared Telemetry seam", () => {
@@ -32,12 +32,14 @@ describe("Vote's public surface is feature-clean (type pins)", () => {
 		>();
 	});
 
-	it("the KarmaBump contract names only db primitives (DrizzleDb in, Stmt out)", () => {
-		// Nothing pasaport-shaped is nameable through the contract. Also künye's
-		// swap point — a DO-backed bump replaces the provided value in
-		// `fate/layers.ts`, never Vote's internals.
+	it("the KarmaBump contract names only db primitives (DrizzleDb + KarmaBumpInput in, Stmt pair out)", () => {
+		// Nothing pasaport-shaped is nameable through the contract: `KarmaBumpInput` names only
+		// db-level primitives (`TargetKind`/`KarmaEventReason` from `db/`, not a pasaport type),
+		// and the output is the bump + its ledger row as a `[Stmt, Stmt]` pair (#2592). Also
+		// künye's swap point — a DO-backed bump replaces the provided value in `fate/layers.ts`,
+		// never Vote's internals.
 		expectTypeOf<typeof KarmaBump.Service>().toEqualTypeOf<{
-			readonly statement: (db: DrizzleDb, userId: string, delta: number) => Stmt;
+			readonly statements: (db: DrizzleDb, input: KarmaBumpInput) => readonly [Stmt, Stmt];
 		}>();
 	});
 


### PR DESCRIPTION
`user_profile.total_karma` was a bare accumulator: the sole writer added `delta`
inside Vote's atomic batch and discarded the origin at write time. This adds an
append-only provenance ledger so every bump leaves a reconstructable record.

## What changed
- **`karma_event` table + migration `0027_karma_event.sql`** (append-only, modeled on
  `user_ban_event`): `id`, `user_id` (recipient, FK `user` cascade), signed `delta`,
  `source_kind` (`definition|post|comment`), `source_id`, `reason` (`vote|retract`),
  `created_at`, indexed `(user_id, created_at DESC)`.
- **The ledger row co-commits in the SAME atomic `batch(...)` as the `total_karma`
  bump** — `buildBatchStatements` now spreads both the bump and the event into the
  cast batch, so a bump can never land without its event nor vice versa.
- **`KarmaBump` contract extended** (`vote/Vote.ts`): a `KarmaBumpInput` struct
  (recipient, delta, source, reason, timestamp) in, a `[Stmt, Stmt]` pair out. Vote
  forwards the cast's context; the pasaport implementation (`pasaport/karma.ts`) owns
  the `karma_event` write — Vote never imports pasaport internals (dependency
  inversion preserved). The reason vocabulary is a `db/`-level leaf
  (`db/karma-event.ts`), the same placement rationale as `db/target-kind.ts`.
- A retraction is a **negative-delta row, never a deletion** (append-only), so
  `SUM(delta)` per user reconciles to `total_karma`.

## Acceptance criteria
- Ledger table + migration, append-only, carries userId / signed delta / source
  (kind+id) / reason / timestamp — done.
- Written in the same atomic `batch(...)` as the bump — done (`buildBatchStatements`).
- `KarmaBump` contract carries source+reason without Vote importing pasaport — done.
- Every karma write (vote + retraction, ±delta) produces a ledger row — done.
- `sum(delta)` reconciles to `total_karma` — structural (one `input.delta` drives both
  statements) + asserted in `pasaport/karma.unit.test.ts`.

## Testing
- `pasaport/karma.unit.test.ts` (new): renders `karmaBumpStatements` over a no-op D1
  (`set-display-name.unit.test.ts` idiom) — asserts the bump + `karma_event` INSERT
  columns for a cast (+1, `vote`) and a retraction (-1, `retract`), and that the bump
  and event carry the **same** delta (the reconciliation invariant at statement level).
- `vote/Vote.unit.test.ts`: the cast/retract batch now co-commits the ledger row
  (batch length 4->5) with the correct source + reason; a real retraction records a
  -1 event with reason `retract`.
- Integration: the existing `tests/integration/pasaport.test.ts` `totalKarma 0->1->0`
  drives this exact batch on real D1, so a malformed ledger insert would break the
  batch and fail it; rolled-back-leaves-neither is the generic `db.batch`
  all-or-nothing property (`db/Drizzle.test.ts`) applied to the co-committed pair. The
  ledger has no read view by the issue's explicit scope (the "how I earned it" view is
  separate downstream intake), so the row's shape is asserted at the unit tier.
- Full local gates green: `pnpm typecheck`, `pnpm lint:worktree`, `vitest --project unit`
  (2065 passing), `migrations-guard check`.

Coordination: kept the batch write-site change minimal and localized so the parked
mentor-audit #2552 (same atomic batch) can rebase cleanly; no #2552 scope pulled in.

Fixes #2592