### PR TITLE
fix(pano): guard comment votes against self-voting (#2550)

### DIFF
--- a/apps/web/tests/integration/pano-mutations.test.ts
+++ b/apps/web/tests/integration/pano-mutations.test.ts
@@ -102,11 +102,11 @@ beforeAll(async () => {
 	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", `${NS}-yazar`);
 	intruder = await h.signUp(`${NS}-intruder@test.local`, "hunter2hunter2", `${NS}-davetsiz`);
 	voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", `${NS}-oycu`);
-	// `author` casts comment votes below (comment self-vote is not blocked). Post votes,
-	// however, must come from a non-author since #2216 blocks self-voting on posts — `voter`
-	// casts those. A fresh account is a çaylak and, since #1810's "earn to vote" gate, is
-	// rejected at cast, so promote both casters to yazar. `intruder` never votes
-	// (unauthorized-mutation cases), so it stays a çaylak.
+	// Votes must come from a non-author since #2216 blocks self-voting on both posts and
+	// comments — `voter` casts those. A fresh account is a çaylak and, since #1810's "earn
+	// to vote" gate, is rejected at cast, so promote both `author` (it votes on others'
+	// content elsewhere) and `voter` to yazar. `intruder` never votes (unauthorized-mutation
+	// cases), so it stays a çaylak.
 	await h.promoteToYazar(author.userId);
 	await h.promoteToYazar(voter.userId);
 });
@@ -534,9 +534,11 @@ describe("pano mutations — comment.vote / retractVote / edit", () => {
 		if (!added.ok) return;
 		const id = (added.data as CommentNode).id;
 
+		// `voter` (a non-author yazar) casts — `author` can no longer self-vote its own comment
+		// since #2216, so the vote/retract round-trip runs from a different account.
 		const voted = await h.fate(
 			{kind: "mutation", name: "comment.vote", input: {id}, select: ["id", "score", "myVote"]},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
@@ -550,7 +552,7 @@ describe("pano mutations — comment.vote / retractVote / edit", () => {
 				input: {id},
 				select: ["id", "score", "myVote"],
 			},
-			{cookie: author.cookie},
+			{cookie: voter.cookie},
 		);
 		expect(retracted.ok).toBe(true);
 		if (!retracted.ok) return;
@@ -596,6 +598,35 @@ describe("pano mutations — comment.vote / retractVote / edit", () => {
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
 		expect(result.error.code).toBe("COMMENT_NOT_FOUND");
+	});
+
+	// The self-vote block (#2216) proven end-to-end through the real `comment.vote` mutation,
+	// not just the domain unit (comment-self-vote-guard.unit.test.ts): `author` is a promoted
+	// yazar, so it clears the earn-to-vote gate (#1810) and it is the self-vote guard
+	// specifically that rejects a cast on its own comment with the `SELF_VOTE_NOT_ALLOWED`
+	// wire code the client receives — the comment twin of the `post.vote` case above.
+	it("comment.vote by the comment's own author is rejected with SELF_VOTE_NOT_ALLOWED", async () => {
+		const postId = await seedPost({title: `${NS} comment self-vote target`});
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "comment.add",
+				input: {postId, body: "my own comment"},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const id = (added.data as CommentNode).id;
+
+		const result = await h.fate(
+			{kind: "mutation", name: "comment.vote", input: {id}, select: ["id", "score", "myVote"]},
+			{cookie: author.cookie},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.code).toBe("SELF_VOTE_NOT_ALLOWED");
 	});
 
 	it("delete returns the re-resolved parent Post with the surviving commentCount", async () => {

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -309,10 +309,14 @@ export class Pano extends Context.Service<
 			commentId: string;
 		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
-		// `VoterNotEligible` (#1810) — see `voteOnPost`. Cast path only; retraction is exempt.
+		// `VoterNotEligible` (#1810) + `SelfVoteNotAllowed` (#2216) — see `voteOnPost`. Both
+		// fire on the cast path only; retraction is exempt.
 		readonly voteOnComment: (
 			input: VoteOnCommentInput,
-		) => Effect.Effect<VoteOnCommentResult, CommentNotFound | VoterNotEligible>;
+		) => Effect.Effect<
+			VoteOnCommentResult,
+			CommentNotFound | VoterNotEligible | SelfVoteNotAllowed
+		>;
 
 		readonly retractCommentVote: (
 			input: VoteOnCommentInput,

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -32,6 +32,7 @@ import {
 } from "../lifecycle/SandboxVisibility.ts";
 import type {ReactionTargetNotFound} from "../reaction/errors.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
+import {SelfVoteNotAllowed} from "../vote/errors.ts";
 import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import type {Vote} from "../vote/Vote.ts";
 import {type CommentConnectionPage, type CommentRow, toCommentRow} from "./comment-fields.ts";
@@ -769,6 +770,17 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			});
 		}
 
+		// Self-vote guard (#2216, founder-ruled) — the comment twin of `applyPostVote`'s
+		// guard: a cast on one's OWN comment is rejected at the domain, so an inflated
+		// self-score is unrepresentable rather than caught downstream. Cast-only (a
+		// retraction is exempt because a blocked cast leaves nothing to retract).
+		if (isVote && row.authorId === input.voterId) {
+			return yield* new SelfVoteNotAllowed({
+				voterId: input.voterId,
+				message: "kendi yorumuna oy veremezsin",
+			});
+		}
+
 		const voteResult = yield* voteSvc
 			.cast({
 				userId: input.voterId,
@@ -808,11 +820,15 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 	const retractCommentVote = Effect.fn("Pano.retractCommentVote")(function* (
 		input: VoteOnCommentInput,
 	) {
-		// See `retractPostVote`: the tier gate fires on the cast direction only, so a
-		// retraction never raises `VoterNotEligible` — die if it somehow does, keeping this
-		// method's channel to `CommentNotFound`.
+		// See `retractPostVote`: the tier gate and the self-vote guard both fire on the cast
+		// direction only, so a retraction never raises `VoterNotEligible` /
+		// `SelfVoteNotAllowed` — die if one somehow does, keeping this method's channel to
+		// `CommentNotFound`.
 		return yield* applyCommentVote(input, false).pipe(
-			Effect.catchTag("vote/VoterNotEligible", (e) => Effect.die(e)),
+			Effect.catchTags({
+				"vote/VoterNotEligible": (e) => Effect.die(e),
+				"vote/SelfVoteNotAllowed": (e) => Effect.die(e),
+			}),
 		);
 	});
 

--- a/apps/web/worker/features/pano/comment-self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-self-vote-guard.unit.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `Pano.applyCommentVote` self-vote guard (#2216, founder-ruled) — the comment twin of
+ * `self-vote-guard.unit.test.ts`, proven over the real `makeCommentOperations` closures
+ * with a substituted `Drizzle` `run` (the comment load) + a RECORDING `Vote`, so three
+ * things are wrong-or-right with no SQL engine:
+ *
+ *   1. self-cast rejected — `voteOnComment` where `voterId === comment.authorId` fails
+ *      `SelfVoteNotAllowed` and NEVER reaches `Vote.cast` (no score/karma write).
+ *   2. other-author cast lands — a non-author vote reaches `Vote.cast` exactly as before.
+ *   3. self-retract exempt — `retractCommentVote` on one's own comment reaches `Vote.cast`
+ *      (the guard is cast-only; a blocked cast leaves nothing to retract).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
+import type {Vote, VoteInput, VoteResult} from "../vote/Vote.ts";
+import {type CommentOperationsDeps, makeCommentOperations} from "./comment-operations.ts";
+
+const AUTHOR = "u-author";
+const OTHER = "u-other";
+const COMMENT_ID = "comment_1";
+
+// The `comment_record` the up-front load returns. Only `authorId` drives the guard; the
+// rest satisfy the fields the return projection reads.
+const commentRow = {
+	id: COMMENT_ID,
+	postId: "post_1",
+	parentId: null,
+	authorId: AUTHOR,
+	authorName: "yazar",
+	body: "yorum gövdesi",
+	score: 2,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	removedAt: null,
+};
+
+// A `Vote` double that RECORDS every cast and replays a no-op result — so "did the cast
+// path run" is observable with no engine. Only `cast` is on the vote path; every other
+// method dies on contact via the Proxy, so an off-path call is loud (the post twin's idiom).
+const recordingVote = (casts: VoteInput[]): typeof Vote.Service =>
+	new Proxy(
+		{
+			cast: (input: VoteInput) => {
+				casts.push(input);
+				return Effect.succeed({
+					targetKind: input.targetKind,
+					targetId: input.targetId,
+					authorId: AUTHOR,
+					score: commentRow.score,
+					myVote: input.value,
+					changed: false,
+				} satisfies VoteResult);
+			},
+		} as Partial<typeof Vote.Service>,
+		{
+			get(target, prop) {
+				if (prop in target) return (target as Record<string, unknown>)[prop as string];
+				return () => Effect.die(`Vote.${String(prop)} not exercised in comment-self-vote-guard`);
+			},
+		},
+	) as typeof Vote.Service;
+
+// Only `run` (the comment load) + `voteSvc` are on the vote path; the other deps are captured
+// but never invoked, so they die on contact if the guard ever falls through to them.
+const deps = (voteSvc: typeof Vote.Service): CommentOperationsDeps =>
+	({
+		run: (<A>(_fn: unknown) => Effect.succeed(commentRow as A)) as DrizzleAccessOrDie["run"],
+		voteSvc,
+		reactionSvc: {} as CommentOperationsDeps["reactionSvc"],
+		removalSeq: {} as CommentOperationsDeps["removalSeq"],
+		persistPanoStats: (() => Effect.void) as CommentOperationsDeps["persistPanoStats"],
+		readProfileIdentities: () => Effect.succeed([]),
+	}) satisfies CommentOperationsDeps;
+
+describe("Pano.applyCommentVote — the self-vote guard (#2216)", () => {
+	it.effect("(1) a self-cast fails SelfVoteNotAllowed and never reaches Vote.cast", () =>
+		Effect.gen(function* () {
+			const casts: VoteInput[] = [];
+			const ops = makeCommentOperations(deps(recordingVote(casts)));
+			const exit = yield* Effect.exit(ops.voteOnComment({commentId: COMMENT_ID, voterId: AUTHOR}));
+			assert.isTrue(Exit.isFailure(exit), "a self-cast is rejected");
+			if (Exit.isFailure(exit)) {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual((error.value as {_tag?: string})._tag, "vote/SelfVoteNotAllowed");
+				}
+			}
+			assert.deepStrictEqual(casts, [], "Vote.cast is never reached on a self-cast");
+		}),
+	);
+
+	it.effect("(2) a non-author cast reaches Vote.cast and lands", () =>
+		Effect.gen(function* () {
+			const casts: VoteInput[] = [];
+			const ops = makeCommentOperations(deps(recordingVote(casts)));
+			const result = yield* ops.voteOnComment({commentId: COMMENT_ID, voterId: OTHER});
+			assert.deepStrictEqual(casts, [
+				{userId: OTHER, targetKind: "comment", targetId: COMMENT_ID, value: true},
+			]);
+			assert.strictEqual(result.commentId, COMMENT_ID);
+		}),
+	);
+
+	it.effect("(3) a self-RETRACT is exempt — it reaches Vote.cast (cast-only guard)", () =>
+		Effect.gen(function* () {
+			const casts: VoteInput[] = [];
+			const ops = makeCommentOperations(deps(recordingVote(casts)));
+			yield* ops.retractCommentVote({commentId: COMMENT_ID, voterId: AUTHOR});
+			assert.deepStrictEqual(casts, [
+				{userId: AUTHOR, targetKind: "comment", targetId: COMMENT_ID, value: false},
+			]);
+		}),
+	);
+});

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -589,8 +589,9 @@ export const mutations = {
 			input: CommentIdInput,
 			type: CommentView,
 			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate (#1810), same as
-			// `post.vote`. Retraction is exempt for the same reason.
-			error: Schema.Union([Unauthorized, CommentNotFound, VoterNotEligible]),
+			// `post.vote`. `SelfVoteNotAllowed` (wire `SELF_VOTE_NOT_ALLOWED`, #2216) — a cast on one's
+			// own comment is rejected, mirroring `post.vote`. Retraction is exempt for the same reason.
+			error: Schema.Union([Unauthorized, CommentNotFound, VoterNotEligible, SelfVoteNotAllowed]),
 		},
 		Effect.fn("comment.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;


### PR DESCRIPTION
Fixes #2550

## Problem

The founder-ruled no-self-vote invariant (#2216) was enforced on two of three vote targets — posts (`applyPostVote`) and definitions (`Sozluk`) — but **not** comments. `applyCommentVote` loaded the comment row (which carries `authorId`) then called `Vote.cast` with no `authorId === voterId` check, so a promoted yazar could upvote their own comments and inflate their own `total_karma` through the shared vote engine. The type surface confirmed the asymmetry: `voteOnComment`'s error union lacked `SelfVoteNotAllowed` while `voteOnPost` carried it.

## Fix (mirrors the existing post/definition guards)

- **Guard** — `applyCommentVote` (`apps/web/worker/features/pano/comment-operations.ts`) now rejects `isVote && row.authorId === input.voterId` with `SelfVoteNotAllowed` **before** any `voteSvc.cast` call, so no karma is credited. Cast-only — retraction stays exempt (a blocked cast leaves nothing to retract); `retractCommentVote` dies on the tag, keeping its channel to `CommentNotFound`, exactly as `retractPostVote` does.
- **Type surface** — widened `voteOnComment`'s error union in `Pano.ts` and the `comment.vote` resolver union in `mutations.ts` to include `SelfVoteNotAllowed`. The wire code `SELF_VOTE_NOT_ALLOWED` already maps (existing `wireCodes-per-class` registration).
- **Tests** — added `comment-self-vote-guard.unit.test.ts` (the comment twin of `self-vote-guard.unit.test.ts`: self-cast rejected before `Vote.cast`, non-author cast lands, self-retract exempt) and an integration case asserting `comment.vote` by the comment's own author returns `SELF_VOTE_NOT_ALLOWED`. The existing comment vote/retract integration case now casts from a non-author, since self-voting a comment is now rejected.

## Acceptance criteria

- [x] `applyCommentVote` rejects a self-cast with `SelfVoteNotAllowed` before `voteSvc.cast` — no karma credited.
- [x] Retracting a comment vote is unaffected.
- [x] `voteOnComment`'s error union in `Pano.ts` includes `SelfVoteNotAllowed`, resolver surfaces it on the wire.
- [x] Comment self-vote-guard unit test + integration case covering the resolver path.
- [x] `pnpm typecheck` and `pnpm lint` pass.

## Gates

`pnpm typecheck` ✅ · `pnpm lint` ✅ · unit tests (`comment-self-vote-guard.unit.test.ts` + `self-vote-guard.unit.test.ts`) ✅ (6/6). The integration project deploys a real worker + D1 to Cloudflare in `globalSetup`, which needs CF credentials not present in the local sandbox — the added integration case runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)