### PR TITLE
fix(fate-live): fence a hostile SSE re-open at the DO seam (#2563)

### DIFF
--- a/apps/web/tests/integration/fate-live-owner-fence.test.ts
+++ b/apps/web/tests/integration/fate-live-owner-fence.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Live views over SSE — the owner-isolation fence on OPEN (#2563), on the run-scoped
+ * SHARED stage (ADR 0104 step 7, #1027).
+ *
+ * The invariant `subscribe` already enforces (a control message can't act on another
+ * user's connection) was ABSENT on the open path: any authenticated session that
+ * re-opened a `connectionId` already held by someone else reset that holder's stream
+ * (generation bump + subscription clear + stream teardown). This proves the fence: a
+ * foreign session opening the holder's `connectionId` is refused (403) and the holder's
+ * live subscription keeps delivering.
+ *
+ * Shared-safe: the `definition.add` publishes to the ARGS-scoped `Term.definitions`
+ * connection keyed on an `NS`-unique slug (never the global wildcard — `protocol.ts`),
+ * so a concurrent file's `definition.add` can't land a frame on this subscription (the
+ * same isolation `fate-live-scoped.test.ts` documents).
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {frameData, readEvent, readFrame} from "./_harness.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
+
+const h = sharedStack();
+
+const NS = nsToken(import.meta.url);
+
+let alice: {userId: string; cookie: string};
+let mallory: {userId: string; cookie: string};
+
+beforeAll(async () => {
+	const stamp = Date.now();
+	alice = await h.signUp(`${NS}-alice-${stamp}@test.local`, "hunter2hunter2", "alice");
+	mallory = await h.signUp(`${NS}-mallory-${stamp}@test.local`, "hunter2hunter2", "mallory");
+});
+
+describe("live views — /fate/live owner-isolation fence (#2563)", () => {
+	it("a foreign session opening the holder's connectionId is refused (403); the holder's stream survives", async () => {
+		const slug = `${NS}-term-${Date.now()}`;
+		const connectionId = `${NS}-conn-${Date.now()}`;
+
+		// Alice opens and holds the SSE stream, subscribed to an args-scoped topic.
+		const connect = await h.openSse(connectionId, alice.cookie);
+		expect(connect.status).toBe(200);
+		const reader = connect.body!.getReader();
+		const decoder = new TextDecoder();
+		const buffer = {value: ""};
+		expect(await readFrame(reader, decoder, buffer)).toContain("connected");
+
+		const sub = await h.liveControl(
+			connectionId,
+			[
+				{
+					kind: "subscribeConnection",
+					id: "sub-defs",
+					type: "Definition",
+					procedure: "Term.definitions",
+					args: {id: slug},
+					select: [],
+				},
+			],
+			alice.cookie,
+		);
+		expect(sub.status).toBe(200);
+
+		// Mallory (a DIFFERENT session user) opens the SAME connectionId. The DO is warm
+		// (Alice holds it), so the owner fence answers at once — drive it through `req`,
+		// not the ready-poll `openSse`, so the expected non-200 returns immediately
+		// instead of riding the readiness budget.
+		const hostile = await h.req(`/fate/live?connectionId=${encodeURIComponent(connectionId)}`, {
+			headers: {accept: "text/event-stream", cookie: mallory.cookie},
+		});
+		expect(hostile.status).toBe(403);
+		await hostile.body?.cancel();
+
+		// Alice's stream was not torn down: her subscription still delivers. Without the
+		// fence, Mallory's open would have bumped the generation and cleared Alice's
+		// subscriptions, so this `appendNode` would never arrive.
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "definition.add",
+				input: {termSlug: slug, body: "canlı tanım"},
+				select: ["id", "body"],
+			},
+			{cookie: alice.cookie},
+		);
+		expect(added.ok).toBe(true);
+
+		const frame = await readEvent(reader, decoder, buffer);
+		expect(frame).toContain("event: connection");
+		const payload = frameData<{kind: string; event: {type: string; edge: {node: {body: string}}}}>(
+			frame,
+		);
+		expect(payload.kind).toBe("connection");
+		expect(payload.event.type).toBe("appendNode");
+		expect(payload.event.edge.node.body).toBe("canlı tanım");
+
+		await reader.cancel();
+	});
+});

--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -1543,3 +1543,109 @@ describe("LiveDO alarm reap branches (#1369)", () => {
 		expect(stale).toEqual([0, 1]);
 	});
 });
+
+// The owner-isolation fence on OPEN (#2563): the invariant `subscribe` already
+// enforces (:owner check) was absent on `openStream`, so any session re-opening a
+// live `connectionId` reset the prior holder (generation bump + subscription clear +
+// stream teardown) — a cross-session griefing primitive. The fence refuses a foreign
+// re-open at the DO seam WITHOUT disturbing the holder; a first open (no bound owner)
+// and a same-owner reconnect pass through unchanged.
+describe("LiveDO open-owner fence (#2563)", () => {
+	const GENERATION_KEY = "connection:generation";
+	const OWNER_KEY = "connection:owner";
+
+	function makeConnectionWithState(cell: LiveCell, connectionId: string) {
+		const name = makeConnectionName(connectionId);
+		const fake = makeDurableObjectStateForTest({id: name});
+		const instance = makeLiveInstance(fake.state, cell.live as never);
+		cell.register(name, instance);
+		return {instance, fake};
+	}
+
+	it("a foreign re-open is refused (403) and leaves the holder's stream, generation and owner intact", async () => {
+		const cell = makeLiveCell();
+		const {instance: connection, fake} = makeConnectionWithState(cell, "conn-fence");
+		const topicKey = "Post:post-fence";
+		const {instance: topic} = makeTopic(cell, topicKey);
+
+		const ownerA = "owner-a";
+		const subId = "sub-a";
+		const res = await run(
+			connection.openStream({
+				ownerId: ownerA,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+		await run(connection.subscribe({subId, topics: [topicKey], ownerId: ownerA, limits: LIMITS}));
+		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBe(1);
+		expect(await run(fake.state.storage.get<string>(OWNER_KEY))).toBe(ownerA);
+
+		// A different session user re-opens the SAME connectionId.
+		const hostile = await run(
+			connection.openStream({
+				ownerId: "attacker",
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const web = HttpServerResponse.toWeb(hostile);
+		expect(web.status).toBe(403);
+		expect(web.headers.get("content-type") ?? "").not.toContain("text/event-stream");
+
+		// Nothing was disturbed: generation not bumped, owner unchanged, and A's
+		// subscription is still live — a publish reaches A. A missing fence would have
+		// bumped the generation and cleared A's row, so `delivered` would be 0.
+		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBe(1);
+		expect(await run(fake.state.storage.get<string>(OWNER_KEY))).toBe(ownerA);
+		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
+		expect(pub.delivered).toBe(1);
+		expect(payloadOf(await stream.next()).id).toBe(subId);
+
+		await stream.cancel();
+	});
+
+	it("a first open of a fresh connectionId binds the owner", async () => {
+		const cell = makeLiveCell();
+		const {instance: connection, fake} = makeConnectionWithState(cell, "conn-fresh");
+		expect(await run(fake.state.storage.get<string>(OWNER_KEY))).toBeUndefined();
+
+		const res = await run(
+			connection.openStream({
+				ownerId: "owner-fresh",
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+		expect(await run(fake.state.storage.get<string>(OWNER_KEY))).toBe("owner-fresh");
+
+		await stream.cancel();
+	});
+
+	it("a same-owner reconnect still streams and bumps the generation (reconnect path unbroken)", async () => {
+		const cell = makeLiveCell();
+		const {instance: connection, fake} = makeConnectionWithState(cell, "conn-reopen-same");
+		const ownerA = "owner-same";
+
+		await run(
+			connection.openStream({
+				ownerId: ownerA,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBe(1);
+
+		const res = await run(
+			connection.openStream({
+				ownerId: ownerA,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBe(2);
+
+		await stream.cancel();
+	});
+});

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -34,6 +34,14 @@ import {defaultLiveLimits, encodeFrame, SSE_HEADERS} from "./protocol.ts";
 
 const GENERATION_KEY = "connection:generation";
 
+/**
+ * Connection-role: the persisted owner user id. Bound on the first open and read by
+ * {@link openStream} to fence a foreign re-open (#2563) — persisted (like
+ * `generation`) so the owner-isolation guard survives eviction, not only while the
+ * held stream pins the DO warm.
+ */
+const OWNER_KEY = "connection:owner";
+
 /** Topic-role: the monotonic per-topic publish ordinal backing the replay buffer. */
 const BUFFER_SEQ_KEY = "topic:buffer:seq";
 
@@ -229,6 +237,15 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 		return generation;
 	});
 
+	// The bound owner, read from storage on first miss so the open-time fence (#2563)
+	// holds after eviction — the closure var is undefined on a fresh wake.
+	const loadOwner = Effect.gen(function* () {
+		if (ownerId === undefined) {
+			ownerId = yield* state.storage.get<string>(OWNER_KEY);
+		}
+		return ownerId;
+	});
+
 	const closeStream = Effect.gen(function* () {
 		const q = framesQueue;
 		if (q !== undefined) {
@@ -245,6 +262,19 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			if (role.kind !== "connection") {
 				return HttpServerResponse.empty({status: 404});
 			}
+			// Owner-isolation fence on OPEN (#2563): a re-open whose session user
+			// differs from the connection's bound owner is refused WITHOUT disturbing
+			// the prior holder — no generation bump, no owner overwrite, no
+			// subscription clear, no stream teardown. `subscribe` already enforces this
+			// invariant (:owner check below), but it compared against whatever the
+			// latest open wrote, so a hostile re-open reset the holder before any
+			// subscribe ran. The fence lives here at the DO seam because the DO must not
+			// trust the caller-supplied `ownerId` to self-authorize a takeover; a first
+			// open (no bound owner) and a same-owner reconnect both pass through.
+			const boundOwner = yield* loadOwner;
+			if (boundOwner !== undefined && boundOwner !== input.ownerId) {
+				return HttpServerResponse.empty({status: 403});
+			}
 			// A (re)connect bumps the persisted generation so any subscriber row a
 			// topic DO still holds from the prior stream is detected stale on the next
 			// deliver/check. The counter survives eviction, so a reconnect after
@@ -254,6 +284,9 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			epochStartedAt = Date.now();
 			yield* state.storage.put(GENERATION_KEY, next);
 			ownerId = input.ownerId;
+			if (input.ownerId !== undefined) {
+				yield* state.storage.put(OWNER_KEY, input.ownerId);
+			}
 			subscriptions.clear();
 			yield* closeStream;
 


### PR DESCRIPTION
Fixes #2563

## Problem

The `/fate/live` SSE open path never bound a `connectionId` to its opener. `openStream` ran **unconditionally** on every open — it bumped `generation`, overwrote `ownerId`, cleared `subscriptions`, and tore down the prior frames stream — never comparing the new opener to the current holder. So any authenticated session that opened `GET /fate/live?connectionId=X` for a `connectionId` already held by another user **reset that holder's stream** (a recoverable, no-disclosure cross-session griefing primitive). The owner-isolation invariant `subscribe` already enforced (`:ownerId !== input.ownerId`) was simply absent on the open path, and it only compared against whatever the *latest* open just wrote — so it never fenced a hostile re-open.

## Fix

Fence the foreign re-open **at the DO seam** (`openStream`), not in `route.ts` — the DO must not trust the caller-supplied `ownerId` to self-authorize a takeover. On open, read the connection's bound owner: if one exists and differs from the opener's session user, refuse with **403** *without* bumping `generation`, overwriting the owner, clearing subscriptions, or closing the held stream — so the prior holder's stream survives. The owner is **persisted alongside `generation`** so the guard survives eviction, not only while the held stream pins the DO warm. A first open of a fresh `connectionId` (no bound owner) binds the owner; a same-owner reconnect is unchanged (generation still bumps strictly higher, preserving the eviction-survivability guarantee).

`connectionId`s are fresh `crypto.randomUUID()`s regenerated per live-pin lifecycle (fate client), never persisted or reused across users, so persisting the owner never blocks a legitimate re-use.

## Acceptance criteria

- [x] A foreign-owner open is **refused** (no generation bump / owner overwrite / subscription clear / stream teardown) — the holder's stream survives.
- [x] A same-owner reconnect still works exactly as today (generation bumps strictly higher, subscriptions clear, fresh stream).
- [x] The fence is enforced at the DO seam, not only in `route.ts`.
- [x] A first open of a fresh `connectionId` succeeds and binds `ownerId`.
- [x] Integration coverage exercises the hostile re-open: user B opening user A's `connectionId` is refused (403) and A's live subscription keeps delivering.

## Tests

- DO-level unit tests (`do.test.ts`, `LiveDO open-owner fence (#2563)`): refused foreign re-open (holder's stream / generation / owner intact + a publish still reaches the holder), fresh-open bind, same-owner reconnect.
- Integration test (`fate-live-owner-fence.test.ts`, shared stage): a second session opening the holder's `connectionId` gets 403 and the holder's `Term.definitions` subscription still receives the `appendNode`.

Local gates green: `pnpm typecheck`, `pnpm lint`, `do.test.ts` (33 passed). Integration runs in CI (real remote CF deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)