### PR TITLE
feat(web): per-product Subnav zones + CTA slot substrate behind phoenix-nav-ia (#2598)

### DIFF
--- a/.patterns/frontend-routing.md
+++ b/.patterns/frontend-routing.md
@@ -23,6 +23,30 @@ Routes fall into two visibility classes:
 
 `/lab/*` is a third, deliberately-public class — see below.
 
+## Per-product Subnav zones — nested layout routes
+
+Each product (`/sozluk`, `/pano`, `/mecmua`, `/divan`) mounts its routes under a
+**pathless per-product layout route** whose element is
+[`ProductSubnavLayout`](../apps/web/src/components/layout/ProductSubnavLayout.tsx) — it
+renders the product's persistent `<Subnav>` zone above the routed `<Outlet>`, so the zone
+stays mounted as the user moves within `/<product>/*` (placement law #2587, epic #2596).
+This is the representable form of "every product's primary affordance lives in its product
+zone": the `Subnav`'s **`cta` slot** is the ratified home for a product's *primary-action*
+class element (e.g. `pano/yeni`), styled with the sanctioned primary-action treatment (the
+`Button` primitive's `primary` variant), never the utility filter/tab treatment.
+
+Two properties make the nesting safe to layer over the flat tree:
+
+- **A pathless layout route is transparent to matching.** React Router ranks routes by
+  path specificity, not source order, so grouping a product's routes under a layout route
+  changes only *what renders above them*, never *which* route matches. The existing
+  ordering notes (static `/mecmua/yaz` out-ranking `/mecmua/:slug`) still hold unchanged.
+- **The whole surface rides the default-off `phoenix-nav-ia` seam.** `App.tsx` reads
+  `useFlag(PHOENIX_NAV_IA, false)` and wraps each product's routes under
+  `ProductSubnavLayout` only when on; off ⇒ the router is flat, exactly as before (the
+  agents-deploy / humans-release contract, ADR 0083). The per-product delta children
+  (#2600–#2604) fill each zone's destinations / filters / CTA.
+
 ## `/lab/*` — the standing prototype space
 
 `/lab/*` is a **durable, kept** home for in-product experiments and prototypes. It is

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -50,6 +50,7 @@ import {
 	mecmuaPublicReadFlag,
 	mecmuaWriteFlag,
 	modQueueFlag,
+	navIaFlag,
 	optimisticDefinitionAddFlag,
 	optimisticDefinitionDeleteFlag,
 	optimisticEditsFlag,
@@ -146,6 +147,10 @@ export default Alchemy.Stack(
 		// the single seam the mecmuaFeed root + subscribe/unsubscribe + feed page gate behind
 		// until a human release.
 		yield* mecmuaFeedFlag(flagship.appId);
+		// The nav-IA per-product Subnav zones dark-ship flag, default-off (#2598, epic
+		// #2596) — the single cross-cutting seam the nested layout routes + Subnav CTA slot
+		// substrate + every per-product delta gate behind until a human release.
+		yield* navIaFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -149,9 +149,9 @@ vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: ()
 // (akış) nav entry (#2547) is gated on `mecmua-feed`, flipped via `flags.mecmuaFeed`.
 // Every other read (and other flag key) stays off, matching the default the shell
 // rendered under before.
-const flags = vi.hoisted(() => ({authorshipLoop: false, mecmuaFeed: false}));
+const flags = vi.hoisted(() => ({authorshipLoop: false, mecmuaFeed: false, navIa: false}));
 vi.mock("./flags/useFlag", async () => {
-	const {PHOENIX_AUTHORSHIP_LOOP, MECMUA_FEED} = await import("./flags/keys");
+	const {PHOENIX_AUTHORSHIP_LOOP, MECMUA_FEED, PHOENIX_NAV_IA} = await import("./flags/keys");
 	return {
 		useFlag: (key: string) => ({
 			value:
@@ -159,7 +159,9 @@ vi.mock("./flags/useFlag", async () => {
 					? flags.authorshipLoop
 					: key === MECMUA_FEED
 						? flags.mecmuaFeed
-						: false,
+						: key === PHOENIX_NAV_IA
+							? flags.navIa
+							: false,
 			loading: false,
 		}),
 	};
@@ -288,6 +290,50 @@ describe("mecmua feed nav entry (#2547) — gated on mecmua-feed, never a dead l
 		renderApp();
 		const link = screen.getByRole("link", {name: "akış"});
 		expect(link.getAttribute("href")).toBe("/mecmua/akis");
+	});
+});
+
+// The nav-IA substrate (#2598, epic #2596): each product mounts under a nested layout
+// route rendering a persistent product Subnav zone, gated on the default-off
+// `phoenix-nav-ia` seam. Off ⇒ the router is flat, exactly as today (no product zone);
+// on ⇒ the product route resolves under `ProductSubnavLayout`, which paints a `.kp-subnav`
+// zone above the routed page. The routed page (mocked PanoFeed) mounts below the gate, so
+// these settle the session (signed-out) to commit the routed Outlet.
+describe("nav-IA per-product Subnav zone substrate (#2598)", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		flags.navIa = false;
+	});
+	afterEach(() => {
+		flags.navIa = false;
+		vi.clearAllMocks();
+	});
+
+	it("flag off: the /pano route is flat — no product Subnav zone (the surface is exactly as before)", () => {
+		const {container} = renderApp("/pano");
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+		expect(container.querySelector(".kp-subnav")).toBeNull();
+	});
+
+	it("flag on: the /pano route mounts under the product layout — a persistent Subnav zone paints above the page", () => {
+		flags.navIa = true;
+		const {container} = renderApp("/pano");
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+		expect(container.querySelector(".kp-subnav")).toBeTruthy();
+	});
+
+	it("flag on: a non-product route (/search) mounts NO product Subnav zone", () => {
+		flags.navIa = true;
+		const {container} = renderApp("/search");
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+		expect(container.querySelector(".kp-subnav")).toBeNull();
 	});
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,13 @@
-import {createContext, lazy, Suspense, useContext, useEffect, useMemo, useState} from "react";
+import {
+	createContext,
+	lazy,
+	type ReactNode,
+	Suspense,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import {
 	Navigate,
 	Outlet,
@@ -16,6 +25,7 @@ import {shouldShowDivanEntry} from "./components/divan/divanGating";
 import {useDivanAccess} from "./components/divan/useDivanAccess";
 import {AppShell, Main} from "./components/layout/AppShell";
 import {Footer} from "./components/layout/Footer";
+import {ProductSubnavLayout} from "./components/layout/ProductSubnavLayout";
 import {Topbar} from "./components/layout/Topbar";
 import {actorLabel} from "./components/moderation/actor-identity";
 import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
@@ -28,6 +38,7 @@ import {
 	MECMUA_PUBLIC_READ,
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_BILDIRIM,
+	PHOENIX_NAV_IA,
 } from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
@@ -326,53 +337,90 @@ function ComposerRouteFallback() {
 	);
 }
 
+/**
+ * A product's leaf routes, either wrapped under `ProductSubnavLayout` (the persistent
+ * product Subnav zone, flag on) or returned flat (flag off — the router is exactly as
+ * today). React Router ranks routes by path specificity, not source order, and a pathless
+ * layout route is transparent to matching — so wrapping a product's routes changes only
+ * *what renders above them*, never *which* route matches (#2598, placement law #2587).
+ */
+function productZone(navIaOn: boolean, key: string, routes: ReactNode) {
+	return navIaOn ? (
+		<Route key={key} element={<ProductSubnavLayout />}>
+			{routes}
+		</Route>
+	) : (
+		routes
+	);
+}
+
 export function App() {
+	// The per-product Subnav zones ride the shared nav-IA seam (#2598, epic #2596),
+	// default-off. With it off the router is flat (today's structure); with it on each
+	// product's routes mount under a pathless layout route rendering its persistent Subnav
+	// zone. `useFlag` reads over `fetch` (no fate client), safe above the providers.
+	const {value: navIaOn} = useFlag(PHOENIX_NAV_IA, false);
+	const panoRoutes = [
+		<Route key="pano" path="/pano" element={<PanoFeed />} />,
+		<Route key="pano-yeni" path="/pano/yeni" element={<PanoSubmitPage />} />,
+		<Route key="pano-site" path="/pano/site/:host" element={<PanoSiteFeedRoute />} />,
+		// kaydedilenler folded into PanoFeed as the `?sort=saved` variant (#2196); the
+		// legacy bespoke route redirects so existing links don't break.
+		<Route
+			key="pano-saved"
+			path="/pano/kaydedilenler"
+			element={<Navigate to={SAVED_HREF} replace />}
+		/>,
+		<Route key="pano-detail" path="/pano/:id" element={<PanoPostDetail />} />,
+	];
+	// mecmua — each page self-gates on its flag (off ⇒ 404), so these routes are dark by
+	// default: the public index (#2512) + reader (#2498) on mecmua-public-read, the
+	// subscribed-author feed (#2500) on mecmua-feed, the authoring page (#2499), the
+	// id-addressable draft load + the drafts list (#2544) on mecmua-write. The
+	// static/`yaz`-prefixed paths out-rank the `/mecmua/:slug` reader.
+	const mecmuaRoutes = [
+		<Route key="mecmua" path="/mecmua" element={<MecmuaIndexPage />} />,
+		<Route key="mecmua-akis" path="/mecmua/akis" element={<MecmuaFeedPage />} />,
+		<Route key="mecmua-yazilarim" path="/mecmua/yazilarim" element={<MecmuaDraftsPage />} />,
+		<Route
+			key="mecmua-yaz"
+			path="/mecmua/yaz"
+			element={
+				<Suspense fallback={<ComposerRouteFallback />}>
+					<MecmuaEditorPage />
+				</Suspense>
+			}
+		/>,
+		<Route
+			key="mecmua-yaz-id"
+			path="/mecmua/yaz/:id"
+			element={
+				<Suspense fallback={<ComposerRouteFallback />}>
+					<MecmuaEditorPage />
+				</Suspense>
+			}
+		/>,
+		<Route key="mecmua-slug" path="/mecmua/:slug" element={<MecmuaPostPage />} />,
+	];
+	const sozlukRoutes = [
+		<Route key="sozluk" path="/sozluk" element={<SozlukHome />} />,
+		<Route key="sozluk-slug" path="/sozluk/:slug" element={<SozlukTermPage />} />,
+	];
+	// The divan reviewer workspace (#1290) — the page self-gates on the authorship-loop
+	// flag (off ⇒ 404), so the route is dark by default.
+	const divanRoutes = [<Route key="divan" path="/divan" element={<DivanPage />} />];
 	return (
 		<ThemeProvider>
 			<DensityProvider>
 				<Routes>
 					<Route element={<Layout />}>
 						<Route path="/" element={<LandingPage />} />
-						<Route path="/pano" element={<PanoFeed />} />
-						<Route path="/pano/yeni" element={<PanoSubmitPage />} />
-						<Route path="/pano/site/:host" element={<PanoSiteFeedRoute />} />
-						{/* kaydedilenler folded into PanoFeed as the `?sort=saved` variant (#2196);
-						    the legacy bespoke route redirects so existing links don't break. */}
-						<Route path="/pano/kaydedilenler" element={<Navigate to={SAVED_HREF} replace />} />
-						<Route path="/pano/:id" element={<PanoPostDetail />} />
-						{/* mecmua — each page self-gates on its flag (off ⇒ 404), so these routes
-						    are dark by default: the public index (#2512) + reader (#2498) on
-						    mecmua-public-read, the subscribed-author feed (#2500) on mecmua-feed, the
-						    authoring page (#2499), the id-addressable draft load + the drafts list
-						    (#2544) on mecmua-write. The static/`yaz`-prefixed paths out-rank the
-						    `/mecmua/:slug` reader below them. */}
-						<Route path="/mecmua" element={<MecmuaIndexPage />} />
-						<Route path="/mecmua/akis" element={<MecmuaFeedPage />} />
-						<Route path="/mecmua/yazilarim" element={<MecmuaDraftsPage />} />
-						<Route
-							path="/mecmua/yaz"
-							element={
-								<Suspense fallback={<ComposerRouteFallback />}>
-									<MecmuaEditorPage />
-								</Suspense>
-							}
-						/>
-						<Route
-							path="/mecmua/yaz/:id"
-							element={
-								<Suspense fallback={<ComposerRouteFallback />}>
-									<MecmuaEditorPage />
-								</Suspense>
-							}
-						/>
-						<Route path="/mecmua/:slug" element={<MecmuaPostPage />} />
-						<Route path="/sozluk" element={<SozlukHome />} />
-						<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
+						{productZone(navIaOn, "pano-zone", panoRoutes)}
+						{productZone(navIaOn, "mecmua-zone", mecmuaRoutes)}
+						{productZone(navIaOn, "sozluk-zone", sozlukRoutes)}
+						{productZone(navIaOn, "divan-zone", divanRoutes)}
 						<Route path="/search" element={<SearchPage />} />
 						<Route path="/auth" element={<AuthPage />} />
-						{/* The divan reviewer workspace (#1290) — the page self-gates on the
-					    authorship-loop flag (off ⇒ 404), so the route is dark by default. */}
-						<Route path="/divan" element={<DivanPage />} />
 						{/* The founder/mod conversion readout (#1589) — the page self-gates on
 					    the funnel-readout flag (off ⇒ 404), so the route is dark by default. */}
 						<Route path="/funnel" element={<FunnelPage />} />

--- a/apps/web/src/components/layout/ProductSubnavLayout.test.tsx
+++ b/apps/web/src/components/layout/ProductSubnavLayout.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * The persistent product Subnav zone (#2598, placement law #2587). `ProductSubnavLayout`
+ * is a pathless layout-route element that renders the product's Subnav above the routed
+ * Outlet; React Router keeps that layout element mounted as the user moves within the
+ * product's child routes — the "persistent zone, no remount" acceptance criterion. Proven
+ * here by DOM-node identity: the `.kp-subnav` node survives a within-product navigation.
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {Link, MemoryRouter, Route, Routes} from "react-router";
+import {describe, expect, it} from "vitest";
+import {ProductSubnavLayout} from "./ProductSubnavLayout";
+
+function ProductIndex() {
+	return (
+		<div data-testid="product-index">
+			<Link to="/pano/detail">detay</Link>
+		</div>
+	);
+}
+function ProductDetail() {
+	return <div data-testid="product-detail">detay</div>;
+}
+
+describe("ProductSubnavLayout — persistent product Subnav zone (#2598)", () => {
+	it("renders the product Subnav zone above the routed Outlet", () => {
+		const {container} = render(
+			<MemoryRouter initialEntries={["/pano"]}>
+				<Routes>
+					<Route element={<ProductSubnavLayout />}>
+						<Route path="/pano" element={<ProductIndex />} />
+					</Route>
+				</Routes>
+			</MemoryRouter>,
+		);
+		expect(container.querySelector(".kp-subnav")).toBeTruthy();
+		expect(screen.getByTestId("product-index")).toBeTruthy();
+	});
+
+	it("keeps the Subnav zone mounted across a within-product navigation — no remount", () => {
+		const {container} = render(
+			<MemoryRouter initialEntries={["/pano"]}>
+				<Routes>
+					<Route element={<ProductSubnavLayout />}>
+						<Route path="/pano" element={<ProductIndex />} />
+						<Route path="/pano/detail" element={<ProductDetail />} />
+					</Route>
+				</Routes>
+			</MemoryRouter>,
+		);
+		const before = container.querySelector(".kp-subnav");
+		expect(before).toBeTruthy();
+		expect(screen.getByTestId("product-index")).toBeTruthy();
+
+		fireEvent.click(screen.getByRole("link", {name: "detay"}));
+
+		// The routed Outlet swapped to the detail page…
+		expect(screen.getByTestId("product-detail")).toBeTruthy();
+		// …but the layout's Subnav zone is the SAME DOM node — the persistent product zone
+		// stays mounted across the product's child routes (a remount would replace the node).
+		expect(container.querySelector(".kp-subnav")).toBe(before);
+	});
+});

--- a/apps/web/src/components/layout/ProductSubnavLayout.tsx
+++ b/apps/web/src/components/layout/ProductSubnavLayout.tsx
@@ -1,0 +1,20 @@
+import {Outlet} from "react-router";
+import {Subnav} from "./Subnav";
+
+/**
+ * The persistent product Subnav zone (placement law #2587, epic #2596) — a pathless
+ * layout-route element per product. It renders the product's `<Subnav>` once above the
+ * routed `<Outlet>`, so the zone stays mounted as the user moves within `/<product>/*`
+ * (no remount between that product's routes). The substrate (#2598) mounts an empty zone
+ * frame; each per-product delta (#2600–#2604) fills its destinations / filters / CTA.
+ * Mounted only behind the `phoenix-nav-ia` flag (App.tsx) — off ⇒ the router is flat, as
+ * today.
+ */
+export function ProductSubnavLayout() {
+	return (
+		<>
+			<Subnav />
+			<Outlet />
+		</>
+	);
+}

--- a/apps/web/src/components/layout/Subnav.css
+++ b/apps/web/src/components/layout/Subnav.css
@@ -60,6 +60,15 @@
 	color: var(--text-muted);
 }
 
+/* CTA slot — the dedicated primary-action position (placement law #2587), pinned to
+   the trailing edge after the spacer. Positioning only: the sanctioned primary-action
+   treatment (filled --accent) lives on the passed node (the Button primitive's primary
+   variant), never a utility filter/tab fill here (#2586 taxonomy / #2590 IA rule). */
+.kp-subnav__cta {
+	display: inline-flex;
+	align-items: center;
+}
+
 .kp-subnav__crumb {
 	display: inline-flex;
 	align-items: center;

--- a/apps/web/src/components/layout/Subnav.test.tsx
+++ b/apps/web/src/components/layout/Subnav.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * The Subnav CTA slot (#2598, placement law #2587) — the dedicated primary-action
+ * position. A passed `cta` node renders in `.kp-subnav__cta`; absent, nothing renders. The
+ * slot positions only — it never wraps the node in the utility filter/tab treatment
+ * (`.kp-subnav__filter`), per the #2586 taxonomy / #2590 IA rule.
+ */
+import {render, screen} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Subnav} from "./Subnav";
+
+describe("Subnav CTA slot (#2598)", () => {
+	it("renders the passed cta node in the dedicated primary-action slot", () => {
+		const {container} = render(
+			<Subnav
+				cta={
+					<button type="button" data-testid="cta-btn">
+						yeni
+					</button>
+				}
+			/>,
+		);
+		const slot = container.querySelector(".kp-subnav__cta");
+		expect(slot).toBeTruthy();
+		expect(screen.getByTestId("cta-btn")).toBeTruthy();
+		// The CTA is NOT styled as a utility filter/tab — the slot carries no filter class,
+		// and the substrate paints no filter treatment anywhere on a CTA-only Subnav.
+		expect(slot?.querySelector(".kp-subnav__filter")).toBeNull();
+		expect(container.querySelector(".kp-subnav__filter")).toBeNull();
+	});
+
+	it("renders no cta slot when no cta is passed", () => {
+		const {container} = render(<Subnav />);
+		expect(container.querySelector(".kp-subnav__cta")).toBeNull();
+	});
+});

--- a/apps/web/src/components/layout/Subnav.tsx
+++ b/apps/web/src/components/layout/Subnav.tsx
@@ -20,6 +20,7 @@ export function Subnav({
 	links,
 	crumb,
 	meta,
+	cta,
 }: {
 	title?: React.ReactNode;
 	count?: React.ReactNode;
@@ -29,6 +30,12 @@ export function Subnav({
 	links?: SubnavLink[];
 	crumb?: {label: React.ReactNode; onClear?: () => void};
 	meta?: React.ReactNode;
+	// The primary-action slot (placement law #2587): a product's promoted verb (pano/yeni,
+	// mecmua yaz) renders here in the dedicated primary-action position. The passed node
+	// carries the sanctioned primary-action treatment itself (the `Button` primitive's
+	// `primary` variant per the #2586 taxonomy) — the slot only positions it, never the
+	// utility filter/tab treatment (#2590). Absent ⇒ nothing renders.
+	cta?: React.ReactNode;
 }) {
 	return (
 		<div className="kp-subnav">
@@ -67,6 +74,7 @@ export function Subnav({
 			<span className="kp-subnav__spacer" />
 			{count ? <span className="kp-subnav__meta">{count}</span> : null}
 			{meta ? <span className="kp-subnav__meta">{meta}</span> : null}
+			{cta ? <span className="kp-subnav__cta">{cta}</span> : null}
 		</div>
 	);
 }

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -216,3 +216,16 @@ export const PHOENIX_KARMA_GATES = "phoenix-karma-gates";
  * (the `phoenix-funnel-readout` / `phoenix-mod-queue` mod-surface precedent).
  */
 export const PHOENIX_USER_BAN = "phoenix-user-ban";
+
+/**
+ * Nav-IA (per-product Subnav zones) dark-ship flag (#2598, epic #2596). The SINGLE
+ * cross-cutting seam the whole nav-IA surface gates behind — the per-product nested
+ * layout routes + Subnav CTA slot substrate (#2598) and every per-product delta
+ * (#2600–#2604) reuse this one key rather than minting per-child flags, so one human
+ * flip releases the new product zones as a unit. Default-off so the surface ships dark
+ * until a human flips it at release (ADR 0083): with it off the router is exactly as
+ * today (flat product routes, no product Subnav zone). Its own cross-cutting (`phoenix`)
+ * key — the placement law spans all four products (sözlük/pano/mecmua/divan), the
+ * `phoenix-authorship-loop` / `phoenix-reactions` shared-seam precedent.
+ */
+export const PHOENIX_NAV_IA = "phoenix-nav-ia";

--- a/apps/web/worker/features/flagship/nav-ia.invariant.test.ts
+++ b/apps/web/worker/features/flagship/nav-ia.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the nav-IA per-product Subnav zones
+ * flag (#2598, epic #2596). Inspected off the exported `NAV_IA_FLAG` record (the same
+ * object the factory spreads into `FlagshipFlag`), so no alchemy resource is constructed —
+ * mirrors `mecmua-public-read.invariant.test.ts` (#2498).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_NAV_IA} from "../../../src/flags/keys.ts";
+import {NAV_IA_FLAG, navIaFlag} from "./resources.ts";
+
+describe("nav-IA per-product Subnav zones — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(NAV_IA_FLAG.defaultVariation, "off");
+		assert.strictEqual(NAV_IA_FLAG.variations.off, false);
+		assert.strictEqual(NAV_IA_FLAG.variations.on, true);
+		assert.strictEqual(NAV_IA_FLAG.key, "phoenix-nav-ia");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(NAV_IA_FLAG.key, PHOENIX_NAV_IA);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof navIaFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -26,6 +26,7 @@ import {
 	PHOENIX_FUNNEL_READOUT,
 	PHOENIX_KARMA_GATES,
 	PHOENIX_MOD_QUEUE,
+	PHOENIX_NAV_IA,
 	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
 	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
 	PHOENIX_OPTIMISTIC_EDITS,
@@ -828,3 +829,35 @@ export const MECMUA_PUBLIC_READ_FLAG = {
  */
 export const mecmuaPublicReadFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("mecmua_public_read", {appId, ...MECMUA_PUBLIC_READ_FLAG});
+
+/**
+ * The nav-IA (per-product Subnav zones) dark-ship flag config (#2598, epic #2596). The
+ * SINGLE cross-cutting seam the whole nav-IA surface gates behind — the substrate's
+ * nested per-product layout routes + Subnav CTA slot (#2598) and every per-product delta
+ * (#2600–#2604). Default-OFF so the surface reaches production dark: with it off the
+ * router is exactly as today (flat product routes, no product Subnav zone); flipping it
+ * on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `MECMUA_PUBLIC_READ_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           nav-ia (the placement-law surface, map #2583)
+ *   - originating:     #2598 (epic: Subnav placement law, #2596)
+ *   - removal trigger: once the nav-IA surface graduates to on at 100% and stable for
+ *                      one release, retire the flag and inline the nested layout routes.
+ */
+export const NAV_IA_FLAG = {
+	key: PHOENIX_NAV_IA,
+	description:
+		"nav-IA per-product Subnav zones + CTA slot dark-ship (#2598, epic #2596). owner: nav-ia. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const navIaFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_nav_ia", {appId, ...NAV_IA_FLAG});


### PR DESCRIPTION
## What

Land the shared **substrate** every per-product Subnav delta depends on, dark behind a new default-off flag — the root dependency (Phase 1) of the Subnav placement-law epic #2596. Scope is the substrate only: the nested layout route structure + the Subnav CTA slot mechanism. No per-product Subnav *content* (that is the Phase-2 children #2600–#2604).

Fixes #2598.

## Changes

- **Per-product nested layout routes.** Each of `/sozluk/*`, `/pano/*`, `/mecmua/*`, `/divan/*` mounts under a pathless `ProductSubnavLayout` route (`apps/web/src/components/layout/ProductSubnavLayout.tsx`) that renders a persistent product `<Subnav>` zone above the routed `<Outlet>`, so the zone stays mounted as the user moves within a product's routes (no remount). A pathless layout route is transparent to React Router's specificity ranking, so wrapping changes only *what renders above* a product's routes, never *which* route matches.
- **Subnav CTA slot.** A `cta` slot on `<Subnav>` (`apps/web/src/components/layout/Subnav.tsx` / `.css`) renders a passed primary-action node in a dedicated position, and nothing when absent. The slot positions only — the sanctioned primary-action treatment (the `Button` primitive's `primary` variant) lives on the passed node, never the utility `kp-subnav__filter` / `kp-topbar__btn` treatment (#2586 taxonomy / #2590 IA rule).
- **`phoenix-nav-ia` flag (new, default-off).** The shared cross-cutting dark-ship seam the whole nav-IA surface (this substrate + every Phase-2 delta) gates behind: the router is flat and the surface exactly as before with it off; a human flips it at release (ADR 0083). Adds the `keys.ts` constant, the IaC declaration + stack wiring, and a default-safe-state invariant test.
- **Pattern doc.** `.patterns/frontend-routing.md` documents the per-product nested-layout-route + CTA-slot pattern.

## Acceptance criteria

- [x] Each of `/sozluk/*`, `/pano/*`, `/mecmua/*`, `/divan/*` mounts under a nested layout route rendering a persistent product Subnav zone via `<Outlet>`; navigating within a product keeps the Subnav mounted (proven by DOM-node identity across a within-product navigation — `ProductSubnavLayout.test.tsx`).
- [x] `<Subnav>` accepts a `cta` slot that renders a passed primary-action element in a dedicated position, and renders nothing when absent (`Subnav.test.tsx`).
- [x] All existing product routes still resolve unchanged behind the flag — with the flag off the surface is exactly as before (`App.test.tsx` nav-IA block: `/pano` flat, no product zone with the flag off; the existing App first-paint invariants still pass unchanged).
- [x] The CTA slot uses the sanctioned primary-action treatment (not the utility filter/tab treatment) per the #2586 / #2590 rule.

## Flag key

`phoenix-nav-ia` (created here, default-off).

## Testing

- `pnpm --filter @kampus/web typecheck` — clean.
- `biome check` (changed files) — clean.
- `vitest --project client` — 147 passed (includes the new Subnav / ProductSubnavLayout / App nav-IA tests + the unchanged App first-paint invariants).
- `vitest --project unit worker/features/flagship` — 133 passed (includes the new `nav-ia.invariant.test.ts`).
- `pipeline-cli reachability-guard check phoenix-nav-ia` — reports UNREACHABLE (missing journey e2e) by design: the UI consumer exists (App.tsx), but the flag cannot graduate to 100% until the Phase-2 per-product journeys land. It is invoked only at graduation, not as a per-PR CI gate, so it does not block this PR — the dark-substrate state is correct.

## Scope notes

- Substrate only — no per-product destinations/filters/CTA content, no topbar `+ gönderi` eviction (those are the Phase-2 / coupling children).
- With the flag on, pano transiently shows both the product-zone Subnav and PanoFeed's own Subnav; the pano-delta child (#2601) reconciles PanoFeed's Subnav into the zone. Acceptable while dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)