### PR TITLE
fix(web): keep pano feed title inline + ellipsized beside its tag

### DIFF
--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -81,8 +81,12 @@
 	display: flex;
 	align-items: baseline;
 	gap: var(--title-row-gap);
-	row-gap: 4px;
-	flex-wrap: wrap;
+	/* nowrap so a wide title shrinks + ellipsizes beside the tag instead of dropping to
+	   its own line below it: under flex-wrap the row wraps the title before shrinking,
+	   defeating the one-line clamp it's built around (#2573, regressing #2303). The title
+	   is the flex-growing item (`flex: 1 1 0` + `min-width: 0`) so it takes the leftover
+	   track and ellipsizes; the tag and site keep their content width. */
+	flex-wrap: nowrap;
 }
 
 .kp-pano-post__title {
@@ -92,8 +96,9 @@
 	text-decoration: none;
 	/* Clamp a long feed title to one line so the row stays uniform and the feed
 	   scans (#2303); the full title lives on the detail-page h1 + this link's
-	   `title`. `min-width: 0` lets the anchor shrink below its content — without it
-	   the `flex-wrap` title-row grows it full-width instead of ellipsizing. */
+	   `title`. `flex: 1 1 0` + `min-width: 0` make the anchor the shrinking item on the
+	   nowrap title-row, so it ellipsizes beside the tag rather than growing full-width. */
+	flex: 1 1 0;
 	min-width: 0;
 	display: -webkit-box;
 	-webkit-line-clamp: 1;


### PR DESCRIPTION
The pano feed post title-row was `flex-wrap: wrap`, so a title wider than the remaining track wrapped to its own line **below** the namespace tag instead of shrinking — defeating the one-line clamp the row was built around (#2303).

## Change
`apps/web/src/components/pano/PanoPost.css`:
- `.kp-pano-post__title-row` → `flex-wrap: nowrap` (drops the now-dead `row-gap`).
- `.kp-pano-post__title` → `flex: 1 1 0` (keeping the existing `min-width: 0`) so the title is the shrinking item and ellipsizes beside the tag on one line.

Tag and site keep their content width; the tag sits first, the title shrinks + ellipsizes between them. Short titles that already fit are unchanged. The `-webkit-line-clamp: 1` clamp is untouched, and the full title stays available on the detail-page h1 and the anchor `title`.

CSS-only, scoped to the pano feed post row; no change to the shared MetaRow primitive.

Gates: `pnpm typecheck`, `pnpm lint:worktree`, `design-token-guard check`, and the pano client tests all pass locally.

Fixes #2573