### PR TITLE
fix(report): gate remove-resolve on winning the open→terminal transition (#2555)

### DIFF
--- a/apps/web/tests/integration/report-moderation.test.ts
+++ b/apps/web/tests/integration/report-moderation.test.ts
@@ -94,6 +94,17 @@ const listOpen = (cookie?: string) =>
 const getPost = (idOrSlug: string) =>
 	h.fate({kind: "query", name: "post", args: {idOrSlug}, select: ["id"]});
 
+const listResolved = (cookie: string) =>
+	h.fate(
+		{
+			kind: "list",
+			name: "report.listResolved",
+			args: {},
+			select: ["id", "targetKind", "targetId", "resolution"],
+		},
+		{cookie},
+	);
+
 beforeAll(async () => {
 	moderator = await h.signUp(`${NS}-mod@test.local`, "hunter2hunter2", "mod");
 	reporterA = await h.signUp(`${NS}-ra@test.local`, "hunter2hunter2", "ra");
@@ -248,5 +259,69 @@ describe("report.resolve — act-on-target via substrate + repeat-offender + reo
 				.items;
 			expect(rows.find((e) => e.node.targetId === postId)?.node.reportCount).toBe(2);
 		}
+	});
+});
+
+// #2555 regression: a `remove` resolve must be conditional on winning the open → terminal
+// transition, so it can never remove content under a verdict a concurrent moderator already
+// stamped. The interleave is driven deterministically — the concurrent terminal stamp lands
+// first (a dismiss), then the losing `remove` runs — which is exactly the state a true race
+// reaches once the dismiss's transaction commits ahead of the remove's stamp.
+describe("report.resolve — a remove that lost the transition removes nothing (#2555)", () => {
+	let racePostId = "";
+
+	it("seeds a fresh reported post for the interleave", async () => {
+		const post = await h.fate(
+			{
+				kind: "mutation",
+				name: "post.submit",
+				input: {title: `${NS} race target`, tags: [{kind: "tartışma"}]},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(post.ok).toBe(true);
+		if (!post.ok) return;
+		racePostId = (post.data as {id: string}).id;
+		expect((await reportPost(racePostId, reporterA.cookie, "spam")).ok).toBe(true);
+	});
+
+	it("a dismiss stamps the report terminal first; a later remove leaves the content live", async () => {
+		// The concurrent terminal stamp lands first: the report is now `dismissed`, content present.
+		const dismissed = await resolve(
+			{targetKind: "post", targetId: racePostId, action: "dismiss"},
+			moderator.cookie,
+		);
+		expect(dismissed.ok).toBe(true);
+		if (!dismissed.ok) return;
+		const dismissReceipt = dismissed.data as {resolution: string; collapsed: number};
+		expect(dismissReceipt.resolution).toBe("dismissed");
+		expect(dismissReceipt.collapsed).toBe(1);
+
+		// The losing `remove` runs against the now-terminal report: it wins no transition, so
+		// the removal leg is skipped — nothing collapses, nothing is removed, no fan-out fires.
+		const removed = await resolve(
+			{targetKind: "post", targetId: racePostId, action: "remove"},
+			moderator.cookie,
+		);
+		expect(removed.ok).toBe(true);
+		if (!removed.ok) return;
+		const removeReceipt = removed.data as {targetRemoved: boolean; collapsed: number};
+		expect(removeReceipt.collapsed).toBe(0);
+		expect(removeReceipt.targetRemoved).toBe(false);
+
+		// The content is still live — NOT removed under the dismissed verdict.
+		const post = await getPost(racePostId);
+		expect(post.ok && post.data !== null).toBe(true);
+
+		// Feed and reality agree: the decision feed records the target as `dismissed`, and the
+		// content it points at is present — the exact consistency the guard restores.
+		const resolvedList = await listResolved(moderator.cookie);
+		expect(resolvedList.ok).toBe(true);
+		if (!resolvedList.ok) return;
+		const decided = (
+			resolvedList.data as {items: Array<{node: {targetId: string; resolution: string}}>}
+		).items.find((e) => e.node.targetId === racePostId);
+		expect(decided?.node.resolution).toBe("dismissed");
 	});
 });

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -110,6 +110,15 @@ export interface ResolveTargetInput {
 export interface ResolveTargetResult {
 	/** How many open reports on this target were collapsed in the batch. */
 	collapsed: number;
+	/**
+	 * Whether THIS resolve owned the `open → terminal` transition — true iff it
+	 * flipped at least one open row (`collapsed > 0`). The terminal stamp is the one
+	 * point that arbitrates the transition, so the resolve mutation keys its removal
+	 * leg on this: a moderator whose concurrent resolve stamped the report terminal
+	 * first leaves `wonTransition` false here, and the removal is skipped — content is
+	 * never removed under another moderator's (e.g. dismissed) verdict (#2555).
+	 */
+	wonTransition: boolean;
 }
 
 export class Report extends Context.Service<
@@ -401,7 +410,8 @@ export const ReportLive = Layer.effect(Report)(
 					)
 					.run(),
 			);
-			return {collapsed: result.meta.changes} satisfies ResolveTargetResult;
+			const collapsed = result.meta.changes;
+			return {collapsed, wonTransition: collapsed > 0} satisfies ResolveTargetResult;
 		});
 
 		const reopenForTarget = Effect.fn("Report.reopenForTarget")(function* (input: {

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -215,12 +215,35 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 	const now = new Date();
 	let targetRemoved = false;
 
-	if (input.action === "remove") {
-		// Act on the target via the 0096 substrate (reason `Moderated`); the
-		// reportId carried into the removal is the FIRST open report id on the
-		// target, so a later restore can reopen the group.
-		const firstId = yield* report.firstOpenReportId(target.targetKind, target.targetId);
-		const reportId = firstId ?? input.reportId ?? targetKey(target.targetKind, target.targetId);
+	// Capture the representative open report id BEFORE the stamp (below) flips
+	// open → terminal: the removal links its `Moderated` reason to it so a later
+	// restore reopens the group, and after the stamp there are no open rows left to
+	// read. Only the remove leg consumes it.
+	const firstOpenId =
+		input.action === "remove"
+			? yield* report.firstOpenReportId(target.targetKind, target.targetId)
+			: null;
+
+	// Stamp first, then remove only if this resolve WON the transition (#2555): the
+	// terminal stamp is the single arbiter of open → terminal, so keying the removal on
+	// `wonTransition` makes the two legs unable to disagree. A concurrent moderator who
+	// stamped the report terminal first leaves `wonTransition` false, so the removal is
+	// skipped — content is never removed under their (e.g. dismissed) verdict.
+	const {collapsed, wonTransition} = yield* report.resolveTarget({
+		targetKind: target.targetKind,
+		targetId: target.targetId,
+		resolverId: moderatorId,
+		action: input.action,
+		resolvedAt: now,
+		// Stamp the wave grouping when this resolve is one target of a wave gesture
+		// (#1855); null on a single-target resolve.
+		waveId: input.waveId ?? null,
+	});
+
+	if (input.action === "remove" && wonTransition) {
+		// Act on the target via the 0096 substrate (reason `Moderated`), keyed to the
+		// first open report id captured above.
+		const reportId = firstOpenId ?? input.reportId ?? targetKey(target.targetKind, target.targetId);
 		targetRemoved = yield* moderateRemove(target, moderatorId, reportId);
 		// The moderator-remove hides content that lives in the subscribed
 		// `posts` / `Post.comments` / `Term.definitions` connections; publish the
@@ -231,17 +254,6 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 			yield* publishRemoved(live, target);
 		}
 	}
-
-	const {collapsed} = yield* report.resolveTarget({
-		targetKind: target.targetKind,
-		targetId: target.targetId,
-		resolverId: moderatorId,
-		action: input.action,
-		resolvedAt: now,
-		// Stamp the wave grouping when this resolve is one target of a wave gesture
-		// (#1855); null on a single-target resolve.
-		waveId: input.waveId ?? null,
-	});
 
 	return toResolveReceipt({
 		targetKind: target.targetKind,

--- a/apps/web/worker/features/report/report-live-fanout.unit.test.ts
+++ b/apps/web/worker/features/report/report-live-fanout.unit.test.ts
@@ -90,7 +90,7 @@ const reportStub = (target: {targetKind: "post" | "comment" | "definition"; targ
 	makeReportStub({
 		lookupReportTarget: () => Effect.succeed(target),
 		firstOpenReportId: () => Effect.succeed("r1"),
-		resolveTarget: () => Effect.succeed({collapsed: 1}),
+		resolveTarget: () => Effect.succeed({collapsed: 1, wonTransition: true}),
 		reopenForTarget: () => Effect.succeed({reopened: 1}),
 	});
 
@@ -477,7 +477,7 @@ describe("report.resolve — threads the wave grouping id to resolveTarget (#185
 			resolveTarget: (input) =>
 				Effect.sync(() => {
 					sink.waveId = input.waveId ?? null;
-					return {collapsed: 1};
+					return {collapsed: 1, wonTransition: true};
 				}),
 		});
 


### PR DESCRIPTION
Fixes #2555

## The bug

`resolveGated` (`apps/web/worker/features/report/mutations.ts`) removed the target **before** stamping the report, in two unsynchronized transactions. Under two concurrent moderators (A running `remove`, B running `dismiss`), B's `resolveTarget` could stamp the report `dismissed` first, A's `moderateRemove` had already removed the content, and A's `resolveTarget` then matched **0 open rows** — landing **content removed under a `dismissed` verdict**. The decision feed (the moderation audit surface) and reality disagree.

## The fix — stamp first, remove on transition-win

The terminal stamp is the single arbiter of the `open → terminal` transition, so the removal is now keyed on **winning that transition**:

- `Report.resolveTarget` surfaces `wonTransition` (`collapsed > 0`) on `ResolveTargetResult` — the domain fact "this resolve owned the transition" (the SQL `WHERE status='open'` guard already lives in `Report.ts`).
- `resolveGated` reorders to **stamp first, then run `moderateRemove` only when `wonTransition`**. A resolve that lost the transition removes nothing and the report keeps the winner's verdict, so the two legs can never disagree.
- `firstOpenReportId` is captured **before** the stamp (open rows are gone after it), so the removal's `Moderated({reportId})` reason still links to the representative report.
- `publishRemoved` stays keyed on an **actual** removal (`targetRemoved`) — no fan-out when the removal is skipped.

The crash-between-legs window collapses to the milder side (report terminal, content still present → consistent-if-incomplete; restore/re-resolve unaffected).

## Acceptance criteria

- [x] A `remove` on a report a concurrent moderator already stamped terminal does **not** remove the target (conditional on `wonTransition`).
- [x] After the interleave, the report's recorded resolution and the target's present/removed state are consistent.
- [x] Single-moderator `remove` path unchanged — an open report still removes + stamps `removed`.
- [x] `publishRemoved` fires exactly when a removal actually occurs, never when skipped.
- [x] Integration regression drives the interleave (dismiss stamps first, then the losing remove) and asserts content stays live with a `dismissed` decision.

## Testing

- `pnpm typecheck` — green.
- Report unit suite (`vitest --project unit report`) — 66/66 pass; the pre-push hook re-ran the full unit suite green (fanout stubs updated for `wonTransition`).
- `biome check` clean on all changed files.
- The integration regression (`apps/web/tests/integration/report-moderation.test.ts`) runs on the CI integration tier (deployed worker + remote D1), not offline-locally.

Scope kept localized to `report/Report.ts` + `report/mutations.ts` so #2560 rebases cleanly; no `IllegalTransition` cleanup pulled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)