### PR TITLE
fix(vote): guard the karma bump on pre-mutation vote-row state (#2552)

### DIFF
--- a/apps/web/tests/integration/pasaport.test.ts
+++ b/apps/web/tests/integration/pasaport.test.ts
@@ -385,6 +385,80 @@ describe("pasaport — profile reads", () => {
 		expect(await karmaOf()).toBe(0);
 	});
 
+	it("concurrent duplicate casts bump total_karma exactly once — no double-bump (#2552)", async () => {
+		// The double-bump race: `Vote.castImpl` probes idempotency OUTSIDE the atomic batch, so
+		// two concurrent identical casts both see `alreadyCast=false` and both run the batch. The
+		// vote row (`onConflictDoNothing`) and the `COUNT(*)` score stay correct, but before #2552
+		// the unconditional karma UPDATE bumped `total_karma` TWICE (and appended a second ledger
+		// row). The fix gates the karma bump + its ledger row on the vote row's PRE-mutation
+		// presence, so the duplicate is a karma no-op. This is the real-D1 reproduction: fire the
+		// two casts truly concurrently and assert the author gains exactly one karma — a value that
+		// is invariant under the fix whether or not the probes actually raced, and was `2` (flaky)
+		// before it. The retract direction is symmetric (a single net -1, never -2).
+		const authorUsername = uname("race");
+		const author = await h.signUp(`${NS}-race@test.local`, "hunter2hunter2", "Race Author");
+		await setUsername(author.cookie, authorUsername);
+
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "definition.add",
+				input: {
+					termSlug: `${NS}-race-term`,
+					termTitle: "Race Term",
+					body: "a definition whose concurrent votes must not double-credit karma",
+				},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const definitionId = (added.data as {id: string}).id;
+
+		const karmaOf = async (): Promise<number> => {
+			const res = await h.fate({
+				kind: "query",
+				name: "profile",
+				args: {username: authorUsername},
+				select: ["totalKarma"],
+			});
+			expect(res.ok).toBe(true);
+			if (!res.ok) throw new Error("profile read failed");
+			return (res.data as ProfileNode).totalKarma;
+		};
+
+		expect(await karmaOf()).toBe(0);
+
+		// One promoted voter casts the SAME up-vote twice concurrently (two tabs / a retry).
+		const voter = await h.signUp(`${NS}-race-voter@test.local`, "hunter2hunter2", "Race Voter");
+		await h.promoteToYazar(voter.userId);
+		const castOnce = () =>
+			h.fate(
+				{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
+				{cookie: voter.cookie},
+			);
+		const casts = await Promise.all([castOnce(), castOnce()]);
+		for (const c of casts) expect(c.ok).toBe(true);
+		// Both casts committed, but the author gained ONE karma, not two.
+		expect(await karmaOf()).toBe(1);
+
+		// Symmetric on retract: two concurrent retractions net a single -1, not -2.
+		const retractOnce = () =>
+			h.fate(
+				{
+					kind: "mutation",
+					name: "definition.retractVote",
+					input: {id: definitionId},
+					select: ["score"],
+				},
+				{cookie: voter.cookie},
+			);
+		const retracts = await Promise.all([retractOnce(), retractOnce()]);
+		for (const r of retracts) expect(r.ok).toBe(true);
+		expect(await karmaOf()).toBe(0);
+	});
+
 	it("Profile.contributions paginates by keyset with no skips/dupes, discriminant preserved", async () => {
 		// Page 1: first 2 in (createdAt desc, id desc) order.
 		const page1 = await h.fate({

--- a/apps/web/worker/db/target-table.ts
+++ b/apps/web/worker/db/target-table.ts
@@ -13,7 +13,7 @@
  * nothing of the feature services, so a `report/mutations.ts` *service* fan-out
  * (Sözlük/Pano) is a different seam and stays out of here.
  */
-import {and, eq, sql} from "drizzle-orm";
+import {and, eq, exists, notExists, type SQL, sql} from "drizzle-orm";
 import type {DrizzleDb, Stmt} from "./Drizzle.ts";
 import * as schema from "./drizzle/schema.ts";
 import {hotMultiplier} from "./hotScore.ts";
@@ -48,6 +48,21 @@ export interface TargetTableDescriptor {
 	readonly loadMeta: (db: DrizzleDb, targetId: string) => Promise<TargetRecordMeta | null>;
 	/** Vote-presence point lookup on `(targetId, voterId)` — the idempotency probe. */
 	readonly probeVote: (db: DrizzleDb, targetId: string, voterId: string) => Promise<boolean>;
+	/**
+	 * The karma-change guard: an `SQL` predicate true iff the vote write will
+	 * actually change the row's presence — `NOT EXISTS(vote row)` on a cast,
+	 * `EXISTS(vote row)` on a retract. Threaded into the karma bump + ledger
+	 * statements and ordered ahead of the vote-row write, so it reads PRE-mutation
+	 * state: a duplicate concurrent cast finds the row already present (cast) or
+	 * already gone (retract) and applies the karma delta zero times (#2552). This
+	 * is the in-batch backstop the out-of-batch `probeVote` fast-path can race past.
+	 */
+	readonly voteChangeGuard: (
+		db: DrizzleDb,
+		targetId: string,
+		voterId: string,
+		isCast: boolean,
+	) => SQL;
 	/** The truth-derived score cached on the record row (0 when the row is gone). */
 	readonly readScore: (db: DrizzleDb, targetId: string) => Promise<number>;
 	/** Insert the per-target vote row (idempotent on the PK). */
@@ -89,6 +104,18 @@ export const targetTable: {readonly [K in TargetKind]: TargetTableDescriptor} = 
 			db.query.definitionVote
 				.findFirst({where: {definitionId: targetId, voterId}})
 				.then((row) => row != null),
+		voteChangeGuard: (db, targetId, voterId, isCast) => {
+			const probe = db
+				.select({one: sql`1`})
+				.from(schema.definitionVote)
+				.where(
+					and(
+						eq(schema.definitionVote.definitionId, targetId),
+						eq(schema.definitionVote.voterId, voterId),
+					),
+				);
+			return isCast ? notExists(probe) : exists(probe);
+		},
 		readScore: (db, targetId) =>
 			db.query.definitionRecord
 				.findFirst({where: {id: targetId}, columns: {score: true}})
@@ -124,6 +151,13 @@ export const targetTable: {readonly [K in TargetKind]: TargetTableDescriptor} = 
 				.then((row) => (row ? metaOf(row) : null)),
 		probeVote: (db, targetId, voterId) =>
 			db.query.postVote.findFirst({where: {postId: targetId, voterId}}).then((row) => row != null),
+		voteChangeGuard: (db, targetId, voterId, isCast) => {
+			const probe = db
+				.select({one: sql`1`})
+				.from(schema.postVote)
+				.where(and(eq(schema.postVote.postId, targetId), eq(schema.postVote.voterId, voterId)));
+			return isCast ? notExists(probe) : exists(probe);
+		},
 		readScore: (db, targetId) =>
 			db.query.postRecord
 				.findFirst({where: {id: targetId}, columns: {score: true}})
@@ -164,6 +198,15 @@ export const targetTable: {readonly [K in TargetKind]: TargetTableDescriptor} = 
 			db.query.commentVote
 				.findFirst({where: {commentId: targetId, voterId}})
 				.then((row) => row != null),
+		voteChangeGuard: (db, targetId, voterId, isCast) => {
+			const probe = db
+				.select({one: sql`1`})
+				.from(schema.commentVote)
+				.where(
+					and(eq(schema.commentVote.commentId, targetId), eq(schema.commentVote.voterId, voterId)),
+				);
+			return isCast ? notExists(probe) : exists(probe);
+		},
 		readScore: (db, targetId) =>
 			db.query.commentRecord
 				.findFirst({where: {id: targetId}, columns: {score: true}})

--- a/apps/web/worker/features/pasaport/karma.ts
+++ b/apps/web/worker/features/pasaport/karma.ts
@@ -8,7 +8,7 @@
  * atomically with the vote, or not at all. Vote never imports this module — it
  * passes the {@link KarmaBumpInput} context and this side owns the karma schema.
  */
-import {eq, sql} from "drizzle-orm";
+import {and, eq, sql} from "drizzle-orm";
 import type {DrizzleDb, Stmt} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import type {KarmaBumpInput} from "../vote/Vote.ts";
@@ -18,22 +18,27 @@ import type {KarmaBumpInput} from "../vote/Vote.ts";
  * retraction records a `-1` `karma_event`, never a deletion of the prior row — the
  * ledger is append-only, so `SUM(delta)` reconciles to `total_karma`). Never call
  * `.run()` on either — they are meant for a `batch((db) => [...])` tuple.
+ *
+ * BOTH statements carry `input.guard` — the pre-mutation vote-change predicate — so a
+ * duplicate cast that raced the out-of-batch idempotency probe writes NEITHER the delta
+ * NOR a ledger row, keeping the two in lockstep (#2552). The event is an
+ * `INSERT … SELECT … WHERE guard` (a plain `.values()` can't carry a predicate) — the
+ * same guarded-insert idiom as bildirim's `insertUnlessUnreadStatement`; its raw select
+ * bypasses drizzle's `{mode:"timestamp"}` codec, so `created_at` is bound as the epoch
+ * SECONDS the column stores.
  */
 export function karmaBumpStatements(db: DrizzleDb, input: KarmaBumpInput): readonly [Stmt, Stmt] {
 	const bump = db
 		.update(schema.userProfile)
 		.set({totalKarma: sql`${schema.userProfile.totalKarma} + ${input.delta}`})
-		.where(eq(schema.userProfile.userId, input.recipientId));
+		.where(and(eq(schema.userProfile.userId, input.recipientId), input.guard));
 
-	const event = db.insert(schema.karmaEvent).values({
-		id: crypto.randomUUID(),
-		userId: input.recipientId,
-		delta: input.delta,
-		sourceKind: input.source.kind,
-		sourceId: input.source.id,
-		reason: input.reason,
-		createdAt: input.at,
-	});
+	const createdAtSeconds = Math.floor(input.at.getTime() / 1000);
+	const event = db
+		.insert(schema.karmaEvent)
+		.select(
+			sql`select ${crypto.randomUUID()}, ${input.recipientId}, ${input.delta}, ${input.source.kind}, ${input.source.id}, ${input.reason}, ${createdAtSeconds} where ${input.guard}`,
+		);
 
 	return [bump, event];
 }

--- a/apps/web/worker/features/pasaport/karma.unit.test.ts
+++ b/apps/web/worker/features/pasaport/karma.unit.test.ts
@@ -13,6 +13,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
 import {relations, type Stmt} from "../../db/Drizzle.ts";
+import {targetTable} from "../../db/target-table.ts";
 import type {KarmaBumpInput} from "../vote/Vote.ts";
 import {karmaBumpStatements} from "./karma.ts";
 
@@ -46,6 +47,11 @@ const render = (s: Stmt) =>
 	// biome-ignore lint/plugin: drizzle's `Stmt`/`BatchItem` carries `.toSQL()` at runtime but doesn't expose it on the type; render it to assert the built SQL.
 	(s as unknown as {toSQL: () => {sql: string; params: unknown[]}}).toSQL();
 
+// The pre-mutation vote-change guard the real batch threads in (`targetTable[kind]`),
+// so these render tests exercise the SAME guard SQL production sees, not a stand-in.
+const guardFor = (kind: "definition" | "post" | "comment", targetId: string, isCast: boolean) =>
+	targetTable[kind].voteChangeGuard(renderDb, targetId, "voter-1", isCast);
+
 describe("karmaBumpStatements — the bump + its append-only ledger row (#2592)", () => {
 	it("a cast (+1) emits the total_karma bump AND a matching karma_event INSERT", () => {
 		const input: KarmaBumpInput = {
@@ -54,6 +60,7 @@ describe("karmaBumpStatements — the bump + its append-only ledger row (#2592)"
 			source: {kind: "definition", id: "def-1"},
 			reason: "vote",
 			at: new Date("2026-01-02T03:04:05Z"),
+			guard: guardFor("definition", "def-1", true),
 		};
 		const stmts = karmaBumpStatements(renderDb, input);
 		assert.strictEqual(stmts.length, 2, "exactly two statements: bump + event");
@@ -62,9 +69,13 @@ describe("karmaBumpStatements — the bump + its append-only ledger row (#2592)"
 		assert.match(bump.sql, /update .*user_profile.* set .*total_karma/i);
 		assert.include(bump.params, "author-1", "bump targets the recipient");
 		assert.include(bump.params, 1, "bump adds the delta");
+		// A cast bumps only if the vote row does NOT yet exist (#2552).
+		assert.match(bump.sql, /where.*not exists.*select.*definition_vote/is);
 
 		const event = render(stmts[1]);
 		assert.match(event.sql, /insert into .*karma_event/i);
+		// The ledger row is gated by the SAME guard — it can't land without the delta.
+		assert.match(event.sql, /not exists.*select.*definition_vote/is);
 		assert.include(event.params, "author-1", "event.user_id is the recipient");
 		assert.include(event.params, 1, "event.delta is the signed delta");
 		assert.include(event.params, "definition", "event.source_kind");
@@ -79,10 +90,15 @@ describe("karmaBumpStatements — the bump + its append-only ledger row (#2592)"
 			source: {kind: "post", id: "post-9"},
 			reason: "retract",
 			at: new Date("2026-01-02T03:04:05Z"),
+			guard: guardFor("post", "post-9", false),
 		};
 		const stmts = karmaBumpStatements(renderDb, input);
+		const bump = render(stmts[0]);
+		// A retract debits only if the vote row STILL exists (the mirror of the cast guard, #2552).
+		assert.match(bump.sql, /where.*(?<!not )exists.*select.*post_vote/is);
 		const event = render(stmts[1]);
 		assert.match(event.sql, /insert into .*karma_event/i);
+		assert.match(event.sql, /(?<!not )exists.*select.*post_vote/is);
 		assert.include(event.params, -1, "a retraction is a negative delta, not a deletion");
 		assert.include(event.params, "retract", "event.reason distinguishes the retraction");
 		assert.include(event.params, "post", "event.source_kind carries the target");
@@ -100,9 +116,40 @@ describe("karmaBumpStatements — the bump + its append-only ledger row (#2592)"
 				source: {kind: "comment", id: "c-1"},
 				reason: delta > 0 ? "vote" : "retract",
 				at: new Date(0),
+				guard: guardFor("comment", "c-1", delta > 0),
 			});
 			assert.include(render(stmts[0]).params, delta, "bump carries the delta");
 			assert.include(render(stmts[1]).params, delta, "event carries the same delta");
+		}
+	});
+});
+
+describe("karmaBumpStatements — the pre-mutation guard blocks a raced double-bump (#2552)", () => {
+	// The double-bump defect: `Vote.castImpl` probes idempotency OUTSIDE the batch, so two
+	// concurrent identical casts both see `alreadyCast=false` and both run the batch. Before
+	// #2552 the karma UPDATE was unconditional, so `total_karma` bumped twice (and a second
+	// ledger row landed). The fix gates BOTH statements on `input.guard` — the vote row's
+	// PRE-mutation presence — and Vote orders the pair ahead of the vote write. Here we prove
+	// the statement-level invariant that makes the second cast a no-op: bump and event carry
+	// the SAME `NOT EXISTS(vote row)` predicate, so they commit together or not at all.
+	it("bump AND event are gated by the identical vote-row predicate — they can't diverge", () => {
+		const stmts = karmaBumpStatements(renderDb, {
+			recipientId: "author-1",
+			delta: 1,
+			source: {kind: "definition", id: "def-1"},
+			reason: "vote",
+			at: new Date("2026-01-02T03:04:05Z"),
+			guard: guardFor("definition", "def-1", true),
+		});
+		// The one guard subquery, keyed on the exact vote row (target + voter) whose presence
+		// decides whether the cast changed state, appears verbatim in BOTH statements — so a
+		// duplicate that finds the row present writes neither the delta nor the ledger row.
+		const subquery = 'not exists (select 1 from "definition_vote"';
+		assert.include(render(stmts[0]).sql, subquery, "the bump is gated on the vote row");
+		assert.include(render(stmts[1]).sql, subquery, "the ledger row is gated by the same predicate");
+		for (const stmt of stmts) {
+			assert.include(render(stmt).params, "def-1", "guard keys on the target");
+			assert.include(render(stmt).params, "voter-1", "guard keys on the voter");
 		}
 	});
 });

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -16,7 +16,7 @@
  * bump (via {@link KarmaBump}) — in one batch that commits or rolls back as a
  * unit. See ADR 0014 (batch as service method).
  */
-import {and, eq, inArray} from "drizzle-orm";
+import {and, eq, inArray, type SQL} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -77,6 +77,15 @@ export interface KarmaBumpInput {
 	readonly reason: KarmaEventReason;
 	/** Commit timestamp, shared with the rest of the cast batch. */
 	readonly at: Date;
+	/**
+	 * The pre-mutation vote-change guard (`targetTable[kind].voteChangeGuard`): an
+	 * `SQL` predicate gating BOTH statements so the karma delta commits only when the
+	 * vote write actually changes the row's presence. A duplicate concurrent cast that
+	 * raced the out-of-batch idempotency probe finds the vote row already present (or
+	 * already gone) and bumps `total_karma` — and appends its ledger row — zero times,
+	 * so `SUM(karma_event.delta)` still reconciles to `total_karma` (#2552).
+	 */
+	readonly guard: SQL;
 }
 
 /**
@@ -365,9 +374,13 @@ function buildClearTargetStatements(db: DrizzleDb, kind: TargetKind, targetId: s
 
 /**
  * The tuple of statements making up one atomic state-change, in order:
- * vote-table mutation (truth source), score-cache update, `user_vote` mirror,
- * karma bump + its provenance ledger row (both from `KarmaBump`, #2592).
- * `db.batch([...])` commits all or none. See ADR 0014.
+ * karma bump + its provenance ledger row (both from `KarmaBump`, #2592, guarded on
+ * the PRE-mutation vote-row state), then the vote-table mutation (truth source),
+ * score-cache update, and `user_vote` mirror. `db.batch([...])` commits all or none
+ * (ADR 0014) and runs the tuple in order, so the karma pair is evaluated BEFORE the
+ * vote write it credits — the guard reads the row's presence as it was, which is what
+ * makes a raced duplicate cast a karma no-op (#2552). The vote/score/mirror writes are
+ * each already collision-tolerant (`onConflictDoNothing`, `COUNT(*)` recompute).
  */
 function buildBatchStatements(
 	db: DrizzleDb,
@@ -379,6 +392,16 @@ function buildBatchStatements(
 	karmaBump: KarmaBumpService,
 ) {
 	const table = targetTable[input.targetKind];
+
+	const [karmaBumpRow, karmaEventRow] = karmaBump.statements(db, {
+		recipientId: meta.authorId,
+		delta: karmaDelta,
+		source: {kind: input.targetKind, id: input.targetId},
+		reason: isCast ? "vote" : "retract",
+		at: now,
+		guard: table.voteChangeGuard(db, input.targetId, input.userId, isCast),
+	});
+
 	const voteRow = isCast
 		? table.voteInsert(db, input.targetId, input.userId, now)
 		: table.voteDelete(db, input.targetId, input.userId);
@@ -405,13 +428,5 @@ function buildBatchStatements(
 					),
 				);
 
-	const [karmaBumpRow, karmaEventRow] = karmaBump.statements(db, {
-		recipientId: meta.authorId,
-		delta: karmaDelta,
-		source: {kind: input.targetKind, id: input.targetId},
-		reason: isCast ? "vote" : "retract",
-		at: now,
-	});
-
-	return [voteRow, scoreUpdate, userVoteRow, karmaBumpRow, karmaEventRow] as const;
+	return [karmaBumpRow, karmaEventRow, voteRow, scoreUpdate, userVoteRow] as const;
 }

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -490,6 +490,52 @@ describe("Vote.cast — karma provenance ledger (#2592, mocked Drizzle seam)", (
 	});
 });
 
+describe("Vote.cast — the guarded karma pair leads the batch (#2552, mocked Drizzle seam)", () => {
+	// The double-bump fix: the karma bump + its ledger row are gated on the vote row's
+	// PRE-mutation presence, so a duplicate cast that raced the out-of-batch probe writes
+	// neither. That guard is only correct if the karma pair is evaluated BEFORE the vote-row
+	// write in the batch — so this pins the ordering. `recordingKarma` returns the two karma
+	// sentinels; the vote/score/mirror statements come from the db proxy, so the sentinels
+	// leading `batches[0]` proves karma is sequenced first, and `inputs[0].guard` proves Vote
+	// threaded the pre-mutation predicate through.
+	it.effect(
+		"karma bump + ledger row are the first two batch statements, and carry the guard",
+		() => {
+			const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
+			const {layer: karma, inputs} = recordingKarma();
+			return Effect.gen(function* () {
+				const vote = yield* Vote;
+				yield* vote.cast({
+					userId: "voter-1",
+					targetKind: "definition",
+					targetId: "def-1",
+					value: true,
+				});
+				const stmts = batches[0] as ReadonlyArray<{__karmaBump?: true; __karmaEvent?: true}>;
+				assert.strictEqual(stmts.length, 5, "the full atomic batch");
+				assert.isTrue(
+					stmts[0]?.__karmaBump,
+					"the karma bump is sequenced first (pre-mutation guard)",
+				);
+				assert.isTrue(stmts[1]?.__karmaEvent, "its ledger row is second — ahead of the vote write");
+				assert.isDefined(
+					inputs[0]?.guard,
+					"Vote threads the pre-mutation vote-change guard through",
+				);
+			}).pipe(
+				Effect.provide(
+					VoteLive.pipe(
+						Layer.provide(karma),
+						Layer.provide(VoterStandingStub(true)),
+						Layer.provide(recordingTelemetry([])),
+						Layer.provide(Layer.succeed(Drizzle, access)),
+					),
+				),
+			);
+		},
+	);
+});
+
 describe("Vote.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle seam)", () => {
 	for (const kind of TARGET_KINDS) {
 		it.effect(`${kind}: one batch of exactly two statements, karma KEPT`, () => {


### PR DESCRIPTION
## What

`Vote.castImpl` reads its idempotency probe (`probeExisting`) **outside** the atomic batch, then includes the karma bump **unconditionally** inside it. Two concurrent identical casts (two tabs, a retry-after-timeout, a non-browser client) both probe `alreadyCast=false` and both run the batch: the vote row dedupes (`onConflictDoNothing`), the score recomputes from `COUNT(*)`, but `total_karma` bumps **twice** — and, since #2592, a **second `karma_event` ledger row** lands. A permanent, invisible ledger error in the currency that gates the çaylak→yazar promotion (bar 15) and the karma privilege gates. Retract mirrors it (a doubled −2).

## Fix

Gate the karma bump **and** its ledger row on the vote row's **pre-mutation presence**, and order the karma pair ahead of the vote write so the guard reads the row as it was — the same guarded-statement idiom as bildirim's `insertUnlessUnreadStatement`:

- **`db/target-table.ts`** — `voteChangeGuard(db, targetId, voterId, isCast)`: the per-kind vote-existence predicate (`NOT EXISTS(vote row)` on a cast, `EXISTS(vote row)` on a retract). The vote-table SQL stays owned here, beside `voteInsert`/`voteDelete`.
- **`vote/Vote.ts`** — thread the guard through `KarmaBumpInput`; reorder `buildBatchStatements` so the guarded karma pair leads the batch (evaluated before the vote-row write it credits).
- **`pasaport/karma.ts`** — `WHERE`-guard the `total_karma` UPDATE; make the event an `INSERT … SELECT … WHERE guard` (a plain `.values()` can't carry a predicate). Both statements carry the **same** predicate, so the delta and its ledger row commit together or not at all — `SUM(karma_event.delta)` still reconciles to `total_karma`.

A duplicate that raced the probe finds the row already present (cast) or already gone (retract) and writes **neither** the delta nor the ledger row.

## Tests

- **Unit (`karma.unit.test.ts`, `Vote.unit.test.ts`)** — the guard SQL is applied to *both* statements with the exact vote-row keys; the guarded karma pair *leads* the batch (the ordering the guard's pre-mutation read depends on). These are the wrong-or-right-with-no-database decisions (ADR 0082).
- **Integration (`pasaport.test.ts`)** — a real-D1 reproduction: two concurrent identical `definition.vote` casts assert the author gains **exactly one** karma (not two); two concurrent retracts net a single −1 (not −2). The asserted value is invariant under the fix whether or not the probes actually raced, and was `2` (flaky) before it. (Real-D1 batch execution lives only at the integration tier — `node:sqlite` as a D1 fake is banned, ADR 0082/#614.)

## Acceptance criteria

- [x] Karma bump commits only when the vote write changes state, in the same atomic batch — a duplicate concurrent cast bumps `total_karma` exactly once.
- [x] A concurrent-identical-cast scenario nets a single `total_karma` delta; retract is symmetric.
- [x] Vote row and cached score unchanged (already idempotent).
- [x] Regression coverage for the double-cast / double-retract race.

Fixes #2552