### PR TITLE
feat(web): pano/yeni into the pano Subnav CTA + evict topbar + gönderi (#2600)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -337,6 +337,60 @@ describe("nav-IA per-product Subnav zone substrate (#2598)", () => {
 	});
 });
 
+// The atomic coupling (#2600, epic #2596): pano/yeni moves into the pano Subnav CTA slot
+// AND the topbar `+ gönderi` button is evicted — both gated on the SAME `phoenix-nav-ia`
+// seam so they release as one unit. Off ⇒ today's surface (topbar `+ gönderi`, no CTA);
+// on ⇒ the CTA lives in pano's product zone and the topbar no longer carries it. The
+// signed-out `giriş yap` affordance is untouched in either flag state.
+const SIGNED_IN = {data: {user: {id: "u1", name: "Elif", email: "elif@kamp.us"}}, isPending: false};
+describe("nav-IA coupling: pano/yeni Subnav CTA ↔ topbar + gönderi eviction (#2600)", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		flags.navIa = false;
+	});
+	afterEach(() => {
+		flags.navIa = false;
+		vi.clearAllMocks();
+	});
+
+	it("flag off, signed in: the topbar carries + gönderi and there is no Subnav CTA (today's surface)", () => {
+		renderApp("/pano");
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		expect(screen.getByRole("button", {name: "+ gönderi"})).toBeTruthy();
+		expect(screen.queryByRole("button", {name: "yeni gönderi"})).toBeNull();
+	});
+
+	it("flag on, signed in: the topbar + gönderi is evicted and the CTA lives in the pano Subnav zone", () => {
+		flags.navIa = true;
+		const {container} = renderApp("/pano");
+		act(() => {
+			setSession(SIGNED_IN);
+		});
+		// Eviction half: the topbar no longer carries the pano primary action.
+		expect(screen.queryByRole("button", {name: "+ gönderi"})).toBeNull();
+		// Landing half: the primary action is reachable from the pano product Subnav zone,
+		// not the global topbar.
+		const cta = screen.getByRole("button", {name: "yeni gönderi"});
+		expect(container.querySelector(".kp-subnav")?.contains(cta)).toBe(true);
+		expect(container.querySelector(".kp-topbar")?.contains(cta)).toBe(false);
+	});
+
+	it("flag on, signed out: the topbar giriş yap is unchanged and no CTA appears (signed-in only)", () => {
+		flags.navIa = true;
+		const {container} = renderApp("/pano");
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
+		expect(screen.queryByRole("button", {name: "yeni gönderi"})).toBeNull();
+		// The pano product zone still paints its Subnav frame — just with an empty CTA slot.
+		expect(container.querySelector(".kp-subnav")).toBeTruthy();
+	});
+});
+
 // The two-tier fate provider's public first paint (ADR 0167 / #2285): the anon-capable
 // /pano feed paints over the PUBLIC (always-anonymous) client ABOVE the session gate,
 // in parallel with `get-session`, then hands off to the authed feed once the gate

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,6 +28,7 @@ import {Footer} from "./components/layout/Footer";
 import {ProductSubnavLayout} from "./components/layout/ProductSubnavLayout";
 import {Topbar} from "./components/layout/Topbar";
 import {actorLabel} from "./components/moderation/actor-identity";
+import {PanoSubnavCta} from "./components/pano/PanoSubnavCta";
 import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
@@ -115,6 +116,11 @@ function Layout() {
 	// link on the route's own seam is what keeps it from ever pointing at a dark 404: off ⇒
 	// no entry, so subscribing (also `mecmua-feed`) and its feed destination appear together.
 	const {value: feedOn} = useFlag(MECMUA_FEED, false);
+	// The nav-IA seam (#2600, epic #2596): with it on, pano's `+ gönderi` primary action
+	// lives in the pano Subnav CTA zone (placement law #2587), so the topbar no longer
+	// carries it — the eviction half of the atomic move. Off ⇒ the topbar is exactly as
+	// today. Same read as `App`'s zone-wrapping gate; `useFlag` is fate-free, safe here.
+	const {value: navIaOn} = useFlag(PHOENIX_NAV_IA, false);
 
 	// The two-tier fate provider's public first paint (ADR 0167). While `get-session`
 	// is still in flight the authed `FateProvider` gate below returns null, so the
@@ -181,17 +187,17 @@ function Layout() {
 						onToggleTheme={toggleTheme}
 						onLogout={onSignOut}
 						actions={
-							isSignedIn ? (
+							!isSignedIn ? (
+								<button type="button" className="kp-topbar__btn" onClick={() => navigate("/auth")}>
+									giriş yap
+								</button>
+							) : navIaOn ? null : (
 								<button
 									type="button"
 									className="kp-topbar__btn"
 									onClick={() => navigate("/pano/yeni")}
 								>
 									+ gönderi
-								</button>
-							) : (
-								<button type="button" className="kp-topbar__btn" onClick={() => navigate("/auth")}>
-									giriş yap
 								</button>
 							)
 						}
@@ -344,9 +350,9 @@ function ComposerRouteFallback() {
  * layout route is transparent to matching — so wrapping a product's routes changes only
  * *what renders above them*, never *which* route matches (#2598, placement law #2587).
  */
-function productZone(navIaOn: boolean, key: string, routes: ReactNode) {
+function productZone(navIaOn: boolean, key: string, routes: ReactNode, cta?: ReactNode) {
 	return navIaOn ? (
-		<Route key={key} element={<ProductSubnavLayout />}>
+		<Route key={key} element={<ProductSubnavLayout cta={cta} />}>
 			{routes}
 		</Route>
 	) : (
@@ -415,7 +421,7 @@ export function App() {
 				<Routes>
 					<Route element={<Layout />}>
 						<Route path="/" element={<LandingPage />} />
-						{productZone(navIaOn, "pano-zone", panoRoutes)}
+						{productZone(navIaOn, "pano-zone", panoRoutes, <PanoSubnavCta />)}
 						{productZone(navIaOn, "mecmua-zone", mecmuaRoutes)}
 						{productZone(navIaOn, "sozluk-zone", sozlukRoutes)}
 						{productZone(navIaOn, "divan-zone", divanRoutes)}

--- a/apps/web/src/components/layout/ProductSubnavLayout.tsx
+++ b/apps/web/src/components/layout/ProductSubnavLayout.tsx
@@ -1,3 +1,4 @@
+import type * as React from "react";
 import {Outlet} from "react-router";
 import {Subnav} from "./Subnav";
 
@@ -6,14 +7,15 @@ import {Subnav} from "./Subnav";
  * layout-route element per product. It renders the product's `<Subnav>` once above the
  * routed `<Outlet>`, so the zone stays mounted as the user moves within `/<product>/*`
  * (no remount between that product's routes). The substrate (#2598) mounts an empty zone
- * frame; each per-product delta (#2600–#2604) fills its destinations / filters / CTA.
+ * frame; each per-product delta (#2600–#2604) fills its destinations / filters / CTA by
+ * passing the matching `<Subnav>` slot here (the pano delta #2600 fills `cta`).
  * Mounted only behind the `phoenix-nav-ia` flag (App.tsx) — off ⇒ the router is flat, as
  * today.
  */
-export function ProductSubnavLayout() {
+export function ProductSubnavLayout({cta}: {cta?: React.ReactNode}) {
 	return (
 		<>
-			<Subnav />
+			<Subnav cta={cta} />
 			<Outlet />
 		</>
 	);

--- a/apps/web/src/components/pano/PanoSubnavCta.test.tsx
+++ b/apps/web/src/components/pano/PanoSubnavCta.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * pano's primary action in its Subnav CTA slot (#2600, placement law #2587). Pins the two
+ * behavior-bearing halves: (1) a signed-in user reaches `/pano/yeni` through the CTA
+ * (reachability, verified by actually routing there on click); (2) a signed-out visitor
+ * gets no CTA — the affordance is a one-for-one replacement of the topbar's signed-in
+ * `+ gönderi`, so signed-out stays with the topbar `giriş yap`, not a Subnav CTA.
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {MemoryRouter, Route, Routes} from "react-router";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import type {useSession as useSessionType} from "../../auth/client";
+import {PanoSubnavCta} from "./PanoSubnavCta";
+
+type SessionResult = ReturnType<typeof useSessionType>;
+let sessionState: SessionResult;
+vi.mock("../../auth/client", () => ({useSession: () => sessionState}));
+
+function renderCta() {
+	return render(
+		<MemoryRouter initialEntries={["/pano"]}>
+			<Routes>
+				<Route path="/pano" element={<PanoSubnavCta />} />
+				<Route path="/pano/yeni" element={<div data-testid="pano-submit">yeni gönderi</div>} />
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("PanoSubnavCta — pano primary action in the Subnav CTA slot (#2600)", () => {
+	afterEach(() => vi.clearAllMocks());
+
+	it("signed in: renders the primary-action CTA and reaches /pano/yeni on click", () => {
+		sessionState = {data: {user: {id: "u1"}}, isPending: false} as SessionResult;
+		renderCta();
+		const cta = screen.getByRole("button", {name: "yeni gönderi"});
+		// Sanctioned primary-action treatment (#2586 taxonomy), not the utility filter/tab style.
+		expect(cta.className).toContain("kp-btn--primary");
+		expect(screen.queryByTestId("pano-submit")).toBeNull();
+		fireEvent.click(cta);
+		expect(screen.getByTestId("pano-submit")).toBeTruthy();
+	});
+
+	it("signed out: renders no CTA — the replacement affordance is signed-in only", () => {
+		sessionState = {data: null, isPending: false} as SessionResult;
+		renderCta();
+		expect(screen.queryByRole("button", {name: "yeni gönderi"})).toBeNull();
+	});
+});

--- a/apps/web/src/components/pano/PanoSubnavCta.tsx
+++ b/apps/web/src/components/pano/PanoSubnavCta.tsx
@@ -1,0 +1,22 @@
+import {useNavigate} from "react-router";
+import {useSession} from "../../auth/client";
+import {Button} from "../ui/Button";
+
+/**
+ * pano's primary action in its Subnav CTA slot (placement law #2587, epic #2596): the
+ * promoted "yeni gönderi" verb, relocated out of the global topbar into the pano product
+ * zone. Signed-in only — it replaces the topbar's signed-in `+ gönderi` affordance
+ * one-for-one, so a signed-out visitor still reaches auth via the topbar `giriş yap` and
+ * sees no CTA. Renders the sanctioned primary-action treatment (`Button` `primary`
+ * variant, #2586 taxonomy), never the utility filter/tab styling.
+ */
+export function PanoSubnavCta() {
+	const session = useSession();
+	const navigate = useNavigate();
+	if (!session.data) return null;
+	return (
+		<Button variant="primary" onClick={() => navigate("/pano/yeni")}>
+			yeni gönderi
+		</Button>
+	);
+}


### PR DESCRIPTION
Fixes #2600

The atomic **coupling** child of nav-IA epic #2596 — lands both surfaces in **one PR**, both gated on the shared default-off `phoenix-nav-ia` flag so they release as one unit. There is no safe intermediate state: inventory #2585 confirmed `pano/yeni` is reachable only via the topbar `+ gönderi` today, so evicting that button without landing the Subnav CTA in the same change would break the only path.

## What changed
1. **Land the pano primary action in the Subnav CTA slot.** The pano product zone (`ProductSubnavLayout`, substrate #2598) now fills the `<Subnav>` `cta` slot with a new `PanoSubnavCta` — the promoted "yeni gönderi" verb rendered with the sanctioned primary-action treatment (`Button` `primary` variant, #2586 taxonomy), signed-in only. `ProductSubnavLayout` gains an optional `cta` prop it forwards to `<Subnav>`; only the pano zone passes one (other products' zones stay empty — out of scope here).
2. **Evict the topbar `+ gönderi` button.** In `App.tsx` the topbar `actions` slot no longer renders the signed-in `+ gönderi` when `phoenix-nav-ia` is on (the Subnav CTA replaces it). The signed-out `giriş yap` action is untouched. Flag off ⇒ the topbar is exactly as today.

Both halves read the **same** `phoenix-nav-ia` seam — the coupling seam sibling epic #2595 depends on by number.

## Acceptance criteria
- [x] In a single PR, `pano/yeni` renders in the pano Subnav CTA slot AND the topbar signed-in `+ gönderi` is removed — both surfaces change together.
- [x] A signed-in user reaches `pano/yeni` from the pano Subnav CTA with the flag on (verified by test); the topbar no longer carries `+ gönderi`.
- [x] The signed-out topbar `giriş yap` action is unchanged.
- [x] Flag off ⇒ surface unchanged (topbar `+ gönderi` present, no Subnav CTA) — the atomic move is fully contained and releases as one unit.

## Tests
- `apps/web/src/components/pano/PanoSubnavCta.test.tsx` — signed-in reaches `/pano/yeni` via the CTA (routes there on click); signed-out renders no CTA.
- `apps/web/src/App.test.tsx` — new coupling block: flag off + signed in ⇒ topbar `+ gönderi`, no CTA; flag on + signed in ⇒ `+ gönderi` evicted, CTA lives in the pano Subnav zone (not the topbar); flag on + signed out ⇒ `giriş yap` unchanged, no CTA.

## Gates run locally
typecheck, biome lint, `vitest` (30 client tests incl. the #2598/#438/#2160 invariants), design-token-guard, fanout-guard — all green. Scope: `apps/web/src` only; no CSS added (reuses `.kp-subnav__cta` + the `Button` primitive). Per the #2598 handoff, `reachability-guard` for `phoenix-nav-ia` stays UNREACHABLE until the Phase-2 journeys land — the correct not-yet-graduatable state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)