### PR TITLE
fix(fate-live): retry cold-start topic publishes + log exhaustion (#2551)

### DIFF
--- a/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
@@ -82,6 +82,27 @@ it.effect("withColdStartRetry: a surviving RpcCallError failure → LiveTranspor
 	}),
 );
 
+it.effect(
+	"withColdStartRetry: a cold `topic:`-DO publish retries the RpcCallError, then LiveTransportError (#2551)",
+	() =>
+		// The publish seam now shares the RPC-channel retry (index.ts `LiveTopics.publish`):
+		// a publish to an idle-evicted `topic:` DO fails on the cold first RPC and must be
+		// retried across the bounded window, not dropped bare. Assert the retry FIRES (five
+		// attempts: one + four retries) and the surviving transport failure is the typed
+		// `LiveTransportError` — never an unretried rejection.
+		Effect.gen(function* () {
+			let attempts = 0;
+			const coldPublish = Effect.suspend(() => {
+				attempts += 1;
+				return Effect.fail(rpcCallError(new Error("cold topic DO"), "publish"));
+			});
+			const exit = yield* runPastBackoff(withColdStartRetry("publish", coldPublish));
+			assert.strictEqual(attempts, 5, "the bounded retry fired (1 attempt + 4 retries)");
+			assert.isTrue(Exit.isFailure(exit));
+			assert.instanceOf(failureValue(exit), LiveTransportError);
+		}),
+);
+
 it.effect("withColdStartRetry: a non-transport app error fails fast, unconverted", () =>
 	Effect.gen(function* () {
 		const exit = yield* runPastBackoff(

--- a/apps/web/worker/features/fate-live/live-publisher.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.ts
@@ -25,6 +25,7 @@
 import type {LivePublisher} from "@kampus/fate-effect";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+import type {LiveTransportError} from "./cold-start-retry.ts";
 import {
 	type ConnectionFrame,
 	type EntityFrame,
@@ -50,10 +51,15 @@ export class LivePublishError extends Schema.TaggedErrorClass<LivePublishError>(
 export interface LivePublisherOptions {
 	/**
 	 * Deliver one resolved topic publish — in production the worker-init
-	 * `LiveTopics.publish`, in tests a recording/failing/slow stub. `E = never` by
-	 * contract; a misbehaving delivery is caught on the detached promise below.
+	 * `LiveTopics.publish`, in tests a recording/failing/slow stub. Its only failure
+	 * is `LiveTransportError`, the cold-start-retry-exhausted publish (#842, #2551);
+	 * it is swallowed-and-logged on the detached promise below, never reaching the
+	 * committed mutation.
 	 */
-	readonly publish: (topicKey: string, message: PublishMessage) => Effect.Effect<void>;
+	readonly publish: (
+		topicKey: string,
+		message: PublishMessage,
+	) => Effect.Effect<void, LiveTransportError>;
 	/** The request's `ExecutionContext.waitUntil`. */
 	readonly waitUntil: (promise: Promise<unknown>) => void;
 }
@@ -78,13 +84,20 @@ const nodeFrame = (
 
 /** Build the per-request `LivePublisher` service value. */
 export function livePublisherFor(options: LivePublisherOptions): typeof LivePublisher.Service {
-	// One topic publish = one detached promise; the terminal `.catch` is the async
-	// half of the swallow-with-log contract.
+	// One topic publish = one detached promise. `ignoreCause({log: "Warn"})` is the
+	// async half of the swallow-with-log contract: it collapses the whole failure
+	// cause (an exhausted-cold-start `LiveTransportError` OR a defect) to `void` and
+	// logs it at Warn through the Effect logger — so an exhausted publish reaches the
+	// logger and Sentry breadcrumbs, not a bare `console.error` nothing watches (#2551).
 	const schedule: PublishToTopic = (topicKey, message) => {
 		options.waitUntil(
-			Effect.runPromise(options.publish(topicKey, message)).catch((error: unknown) => {
-				console.error(`live publish to topic:${topicKey} failed`, error);
-			}),
+			Effect.runPromise(
+				options
+					.publish(topicKey, message)
+					.pipe(
+						Effect.ignoreCause({log: "Warn", message: `live publish to topic:${topicKey} failed`}),
+					),
+			),
 		);
 	};
 

--- a/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
@@ -19,6 +19,7 @@ import type {LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveEntityTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
 import {Effect, Exit} from "effect";
 import {expectTypeOf, vi} from "vitest";
+import {LiveTransportError} from "./cold-start-retry.ts";
 import {livePublisherFor} from "./live-publisher.ts";
 import type {PublishMessage} from "./protocol.ts";
 
@@ -32,7 +33,9 @@ interface Recorded {
  * `waitUntil` collects the scheduled promises so a test can `flush` (or
  * deliberately NOT flush) the fire-and-forget work.
  */
-function makeHarness(publish?: (topicKey: string, message: PublishMessage) => Effect.Effect<void>) {
+function makeHarness(
+	publish?: (topicKey: string, message: PublishMessage) => Effect.Effect<void, LiveTransportError>,
+) {
 	const recorded: Array<Recorded> = [];
 	const scheduled: Array<Promise<unknown>> = [];
 	const live = livePublisherFor({
@@ -175,8 +178,9 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 );
 
 it.effect("a rejecting topic publish cannot fail the calling effect", () => {
-	// Silence the publisher's failure log so the run stays quiet.
-	const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	// Silence the publisher's Warn failure log (the `ignoreCause({log: "Warn"})` default sink
+	// is `console.log`) so the run stays quiet.
+	const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 	return Effect.gen(function* () {
 		const {live, flush} = makeHarness(() => Effect.die(new Error("DO unreachable")));
 
@@ -189,11 +193,54 @@ it.effect("a rejecting topic publish cannot fail the calling effect", () => {
 	}).pipe(
 		Effect.ensuring(
 			Effect.sync(() => {
-				errorSpy.mockRestore();
+				logSpy.mockRestore();
 			}),
 		),
 	);
 });
+
+it.effect(
+	"an exhausted-cold-start publish is logged through the Effect logger, never a bare console.error or a silent drop (#2551)",
+	() => {
+		// The bug: the detached publish's terminal catch routed an exhausted-cold-start
+		// LiveTransportError to a bare `console.error` — invisible to the Effect logger and
+		// Sentry breadcrumbs, so the lost invalidation was silent by construction. It now
+		// flows through `Effect.ignoreCause({log: "Warn"})`: logged at Warn through the Effect
+		// logger (whose default runtime sink emits one `console.log` line; a Sentry logger
+		// layer routes it to breadcrumbs), OFF the bare `console.error`, and still swallowed
+		// (the calling mutation never fails). The detached fiber runs on the default runtime,
+		// so its logger writes to the real `console.log` this test captures.
+		const logged: Array<string> = [];
+		const logSpy = vi.spyOn(console, "log").mockImplementation((...args: Array<unknown>) => {
+			logged.push(args.map(String).join(" "));
+		});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		return Effect.gen(function* () {
+			const {live, flush} = makeHarness(() =>
+				Effect.fail(new LiveTransportError({method: "publish", cause: new Error("cold topic DO")})),
+			);
+
+			const exit = yield* Effect.exit(
+				live.topic("Term.definitions", {slug: "effect"}).invalidate(),
+			);
+			assert.isTrue(Exit.isSuccess(exit), "the mutation never fails on an exhausted publish");
+
+			yield* Effect.promise(flush);
+			assert.isTrue(
+				logged.some((line) => line.includes("live publish to topic:")),
+				"the exhausted publish was logged through the Effect logger",
+			);
+			assert.strictEqual(errorSpy.mock.calls.length, 0, "off the bare console.error sink");
+		}).pipe(
+			Effect.ensuring(
+				Effect.sync(() => {
+					logSpy.mockRestore();
+					errorSpy.mockRestore();
+				}),
+			),
+		);
+	},
+);
 
 it.effect("a slow publish does not block the request path — waitUntil carries it", () =>
 	Effect.gen(function* () {

--- a/apps/web/worker/features/fate-live/topics.ts
+++ b/apps/web/worker/features/fate-live/topics.ts
@@ -18,14 +18,19 @@ export class LiveTopics extends Context.Service<
 	LiveTopics,
 	{
 		/**
-		 * Fire the typed `LiveDO.publish` RPC for one resolved topic key. Cannot
-		 * fail — the DO RPC's errors are swallowed best-effort at the call site.
+		 * Fire the typed `LiveDO.publish` RPC for one resolved topic key.
+		 * `LiveTransportError` is the truthful channel the alchemy stub's `never`
+		 * hides (#842, #2551): a publish to an idle-evicted `topic:` DO can fail on
+		 * the cold first RPC, so the worker seam wraps this in `withColdStartRetry`
+		 * (the same bounded retry the sibling `subscribe`/`unsubscribe` use) and
+		 * surfaces this on exhaustion. The publisher swallows-and-logs it best-effort
+		 * off the request path — a publish still must not fail the committed mutation.
 		 */
 		readonly publish: (
 			topicKey: string,
 			message: PublishMessage,
 			limits: LiveLimits,
-		) => Effect.Effect<void, never, never>;
+		) => Effect.Effect<void, LiveTransportError, never>;
 	}
 >()("@kampus/LiveTopics") {}
 

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -286,11 +286,17 @@ export default Phoenix.make(
 		const liveLayer = Layer.mergeAll(
 			Layer.succeed(LiveTopics)(
 				LiveTopics.of({
+					// Cold-start resilience via the same `withColdStartRetry` as the sibling
+					// `subscribe`/`unsubscribe` below (rationale there, #842). Bare, a publish
+					// to an idle-evicted `topic:` DO dropped its invalidation silently (#2551).
 					publish: (topicKey, message, limits) =>
 						Effect.asVoid(
-							topicOf(live, topicKey)
-								.publish({topicKey, frame: deliverFrameOf(message), limits})
-								.pipe(Effect.provideService(RuntimeContext, runtimeContext)),
+							withColdStartRetry(
+								"publish",
+								topicOf(live, topicKey)
+									.publish({topicKey, frame: deliverFrameOf(message), limits})
+									.pipe(Effect.provideService(RuntimeContext, runtimeContext)),
+							),
 						),
 				}),
 			),


### PR DESCRIPTION
`LiveTopics.publish` called the cross-DO topic RPC **bare**, while every sibling `LiveConnections` closure in the same `liveLayer` wraps its call in `withColdStartRetry`. So a publish to an idle-evicted `topic:` DO could fail on the cold first RPC — the same `RpcCallError` transport failure #842 documented and closed for the subscribe path — with **no retry**, and the loss landed in a detached `.catch(console.error)`: invisible to the Effect logger and Sentry. That silently staleness-breaks every other client's live view of that topic (the load-bearing fate-live invalidation invariant).

## What changed

- **`apps/web/worker/index.ts`** — wrap the `topicOf(...).publish(...)` call in the existing `withColdStartRetry` (RPC-channel variant), matching the sibling `subscribe`/`unsubscribe` closures: bounded exponential backoff, a typed `LiveTransportError` on exhaustion, and a genuine non-transport DO failure still fails fast (unretried).
- **`apps/web/worker/features/fate-live/live-publisher.ts`** — route the detached async catch through `Effect.ignoreCause({log: "Warn"})` instead of a bare `console.error`, so an exhausted publish is logged through the Effect logger (Sentry breadcrumbs) rather than dropped silently.
- **`apps/web/worker/features/fate-live/topics.ts`** — widen `LiveTopics.publish` (and `LivePublisherOptions.publish`) to the truthful `LiveTransportError` channel the alchemy stub's `never` hid, mirroring `LiveConnections.subscribe`.

Scoped tightly to the publish seam — the retry shrinks the cold-start loss window and makes the residual loss observable; a durable buffer/replay of a publish that never reached the DO is a larger design, out of scope.

## Tests

- `cold-start-retry.unit.test.ts` — a cold `topic:`-DO publish retries the `RpcCallError` (5 attempts: 1 + 4 bounded retries) then surfaces `LiveTransportError`. A non-transport app error still fails fast, unconverted (existing).
- `live-publisher.unit.test.ts` — an exhausted-cold-start publish is logged through the Effect logger, never a bare `console.error` or a silent drop, and the calling mutation never fails.

Local gates green: `pnpm typecheck` (28/28), `pnpm lint:worktree`, affected unit suites.

Fixes #2551