### PR TITLE
fix(create-paths): swallow post-commit cache refresh so a die can't mint a duplicate row (#2556)

### DIFF
--- a/apps/web/worker/features/lifecycle/apply-removal-transition.ts
+++ b/apps/web/worker/features/lifecycle/apply-removal-transition.ts
@@ -46,10 +46,12 @@ const noop: RemovalTransitionOutcome = {committed: false};
 
 /**
  * Wrap a recomputable-cache refresh in the uniform swallow-and-log (#2012, #1639): the
- * transition has committed, so a refresh die must not fail it. One place, so every arm
- * shares the policy.
+ * write it follows has already committed, so a refresh die (a recomputable cache over
+ * `DrizzleAccessOrDie`, ADR 0011/0117) must not flip it into a raw 500 — totals reconverge
+ * on the next write. One place, so the removal/restore arms AND the create paths that
+ * committed-then-refresh (`addDefinition`, `submitPost`, #2556) share the single policy.
  */
-const swallowRefresh = (label: string, refresh: Effect.Effect<void>): Effect.Effect<void> =>
+export const swallowRefresh = (label: string, refresh: Effect.Effect<void>): Effect.Effect<void> =>
 	refresh.pipe(
 		Effect.catchCause((cause) => Effect.logWarning(`${label}: cache refresh failed`, cause)),
 	);

--- a/apps/web/worker/features/lifecycle/create-path-refresh-swallow.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/create-path-refresh-swallow.unit.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Create-path partial-failure guard (#2556, the create twin of #2012). A create's
+ * post-commit cache refresh is a recomputable cache (ADR 0011/0117), so a die there must
+ * NOT flip an already-committed insert into a raw 500: the id is minted server-side per
+ * call, so a caller that retries the 500 (agent clients retry mechanically) mints a SECOND
+ * row — a duplicate that reads as user intent. Both create paths — sözlük `addDefinition`
+ * and pano `submitPost` — route their post-commit refresh through the shared
+ * `swallowRefresh` ceremony, so a refresh die returns success and no retry (hence no
+ * duplicate) is provoked.
+ *
+ * Driven at the SERVICE seam over a scripted `Drizzle` whose commit lands but whose
+ * post-commit refresh dies (the same shape as `post-delete-undeclared-failure` part b).
+ * The teeth: a client that retries on failure is modeled explicitly and the committed-row
+ * counter is asserted to stay at 1 — without the swallow the first attempt would 500, the
+ * client would retry, and the counter would climb past 1 (the duplicate).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {type Context, Effect, Exit, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, DrizzleError} from "../../db/Drizzle.ts";
+import {Bookmark} from "../pano/Bookmark.ts";
+import {Pano, PanoLive} from "../pano/Pano.ts";
+import {Pasaport} from "../pasaport/Pasaport.ts";
+import {Reaction} from "../reaction/Reaction.ts";
+import {Sozluk, SozlukLive} from "../sozluk/Sozluk.ts";
+import {Vote} from "../vote/Vote.ts";
+
+// A refresh over the raw `Drizzle` fails with `DrizzleError`, which `orDieAccess` collapses
+// to a die inside the feature service — the exact channel `swallowRefresh` must absorb.
+const refreshDies = <A>(): Effect.Effect<A, DrizzleError> =>
+	Effect.fail(new DrizzleError({cause: new Error("post-commit cache refresh dies")}));
+
+// Sözlük `addDefinition` reaches the DB as: run#1 existing-term lookup → run#2 the
+// `definitionRecord` insert (the commit) → run#3+ the `persistTermSummary` /
+// `recomputeSozlukStats` refresh. Fresh per attempt so the order counter resets; the shared
+// `onCommit` accumulates committed rows across a client's retries.
+const sozlukCommitThenRefreshDies = (onCommit: () => void): DrizzleAccess => {
+	let runs = 0;
+	return {
+		run: <A>(_fn: unknown) => {
+			runs += 1;
+			if (runs === 1) return Effect.succeed(undefined as A);
+			if (runs === 2) {
+				onCommit();
+				return Effect.succeed(undefined as A);
+			}
+			return refreshDies<A>();
+		},
+		batch: () => refreshDies<never>(),
+	} as DrizzleAccess;
+};
+
+// Pano `submitPost` commits through its only `batch` (the `postRecord` insert + `post_search`
+// dual-write) and refreshes through `persistPanoStats`' `run` — so method alone discriminates
+// commit from refresh, no order counter needed.
+const panoCommitThenRefreshDies = (onCommit: () => void): DrizzleAccess =>
+	({
+		run: () => refreshDies<never>(),
+		batch: () => {
+			onCommit();
+			return Effect.succeed(undefined as never);
+		},
+	}) as DrizzleAccess;
+
+const inertVote = Layer.succeed(Vote, {} as Context.Service.Shape<typeof Vote>);
+const inertBookmark = Layer.succeed(Bookmark, {} as Context.Service.Shape<typeof Bookmark>);
+const inertReaction = Layer.succeed(Reaction, {} as Context.Service.Shape<typeof Reaction>);
+const inertPasaport = Layer.succeed(Pasaport, {} as Context.Service.Shape<typeof Pasaport>);
+
+const sozlukLayer = (access: DrizzleAccess) =>
+	SozlukLive.pipe(
+		Layer.provide(Layer.succeed(Drizzle, access)),
+		Layer.provide(inertVote),
+		Layer.provide(inertReaction),
+		Layer.provide(inertPasaport),
+	);
+
+const panoLayer = (access: DrizzleAccess) =>
+	PanoLive.pipe(
+		Layer.provide(Layer.succeed(Drizzle, access)),
+		Layer.provide(inertVote),
+		Layer.provide(inertBookmark),
+		Layer.provide(inertReaction),
+		Layer.provide(inertPasaport),
+	);
+
+// A caller that retries a failed create up to `maxAttempts` (an agent client's mechanical
+// retry), returning the first success or the last failure.
+const clientRetries = <A, E>(
+	attempt: () => Effect.Effect<A, E>,
+	maxAttempts: number,
+): Effect.Effect<Exit.Exit<A, E>> =>
+	Effect.gen(function* () {
+		let last!: Exit.Exit<A, E>;
+		for (let i = 0; i < maxAttempts; i += 1) {
+			last = yield* Effect.exit(attempt());
+			if (Exit.isSuccess(last)) break;
+		}
+		return last;
+	});
+
+describe("addDefinition — a post-commit refresh die cannot 500 a committed insert (#2556)", () => {
+	it.effect("returns success, and a retrying client mints exactly one definition row", () =>
+		Effect.gen(function* () {
+			let committed = 0;
+			const attempt = () =>
+				Effect.gen(function* () {
+					const sozluk = yield* Sozluk;
+					return yield* sozluk.addDefinition({
+						termSlug: "x",
+						termTitle: "X",
+						authorId: "a1",
+						authorName: "n",
+						body: "a valid definition body",
+					});
+				}).pipe(
+					Effect.provide(
+						sozlukLayer(
+							sozlukCommitThenRefreshDies(() => {
+								committed += 1;
+							}),
+						),
+					),
+				);
+
+			const exit = yield* clientRetries(attempt, 3);
+			assert.isTrue(
+				Exit.isSuccess(exit),
+				"a refresh die after the definition insert commits must still succeed",
+			);
+			if (Exit.isSuccess(exit)) {
+				assert.isString(exit.value.definitionId);
+				assert.strictEqual(exit.value.termCreated, true);
+			}
+			assert.strictEqual(
+				committed,
+				1,
+				"the create succeeded first try → no retry → exactly one row (no duplicate)",
+			);
+		}),
+	);
+});
+
+describe("submitPost — a post-commit refresh die cannot 500 a committed insert (#2556)", () => {
+	it.effect("returns success, and a retrying client mints exactly one post row", () =>
+		Effect.gen(function* () {
+			let committed = 0;
+			const attempt = () =>
+				Effect.gen(function* () {
+					const pano = yield* Pano;
+					return yield* pano.submitPost({
+						title: "geçerli başlık",
+						body: "gövde",
+						url: undefined,
+						tags: [{kind: "soru"}],
+						authorId: "u1",
+						authorName: "umut",
+					});
+				}).pipe(
+					Effect.provide(
+						panoLayer(
+							panoCommitThenRefreshDies(() => {
+								committed += 1;
+							}),
+						),
+					),
+				);
+
+			const exit = yield* clientRetries(attempt, 3);
+			assert.isTrue(
+				Exit.isSuccess(exit),
+				"a refresh die after the post insert commits must still succeed",
+			);
+			if (Exit.isSuccess(exit)) {
+				assert.isString(exit.value.postId);
+			}
+			assert.strictEqual(
+				committed,
+				1,
+				"the create succeeded first try → no retry → exactly one row (no duplicate)",
+			);
+		}),
+	);
+});

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -29,7 +29,7 @@ import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
 import {type ReadProfileIdentities, stampAuthorIdentity} from "../fate/author-identity.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
-import {applyRemovalTransition} from "../lifecycle/apply-removal-transition.ts";
+import {applyRemovalTransition, swallowRefresh} from "../lifecycle/apply-removal-transition.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
@@ -760,7 +760,10 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			...syncPostSearch(db, postId, title),
 		]);
 
-		yield* persistPanoStats(now);
+		// The post row committed in the batch above; its stats refresh is a recomputable
+		// cache, so swallow-and-log a die rather than 500 the mutation and provoke a retry
+		// that mints a duplicate row (#2556, the create-path twin of #2012).
+		yield* swallowRefresh("Pano.submitPost", persistPanoStats(now));
 
 		return {
 			postId,

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -18,7 +18,7 @@ import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
 import {stampAuthorIdentity} from "../fate/author-identity.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
-import {applyRemovalTransition} from "../lifecycle/apply-removal-transition.ts";
+import {applyRemovalTransition, swallowRefresh} from "../lifecycle/apply-removal-transition.ts";
 import {anonymousViewer, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
@@ -946,8 +946,16 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				}),
 			);
 
-			yield* persistTermSummary(slug, title, now);
-			yield* recomputeSozlukStats(now);
+			// The definition row committed above; its convergent cache refreshes are
+			// recomputable, so swallow-and-log a die here rather than 500 the mutation and
+			// provoke a retry that mints a duplicate row (#2556, the create-path twin of #2012).
+			yield* swallowRefresh(
+				"Sozluk.addDefinition",
+				Effect.gen(function* () {
+					yield* persistTermSummary(slug, title, now);
+					yield* recomputeSozlukStats(now);
+				}),
+			);
 
 			return {
 				definitionId,


### PR DESCRIPTION
## What

Fixes #2556 — a create-path partial failure could mint a **duplicate** content row.

Both create paths committed the content insert as its own step, then ran the convergent cache refresh **un-swallowed** through `orDieAccess`. A D1 hiccup in the refresh *dies* and surfaces as a raw 500 on a mutation whose write already landed. Because the row id is minted server-side per call, the caller's retry (agent clients retry mechanically) inserts a **second** row — a duplicate that afterwards reads as user intent.

## The fix

Extend the #2012 swallow-and-log ceremony (`apply-removal-transition.ts`) to the create-path post-commit refreshes — the precedent-consistent, cheaper fix named in the issue's Fix direction:

- Export the canonical `swallowRefresh` from `apply-removal-transition.ts` and reuse it — **one policy, three call sites** (removal/restore + the two creates).
- **Sözlük `addDefinition`**: `persistTermSummary` + `recomputeSozlukStats` are wrapped, so a `DrizzleError`/refresh die no longer 500s an already-committed `definitionRecord` insert.
- **Pano `submitPost`**: `persistPanoStats` is wrapped, same shape.

The refresh is a recomputable cache (ADR 0011/0117) — totals reconverge on the next write — so swallowing a die is correct: the create returns success, no retry is provoked, and no duplicate row is minted. A swallowed failure is logged (warning + cause) via `swallowRefresh`, so staleness stays observable.

## Acceptance criteria

- [x] Sözlük `addDefinition` post-commit refreshes no longer surface a refresh die as a 500 after the insert commits — swallowed-and-logged, consistent with #2012.
- [x] Pano `submitPost` post-commit `persistPanoStats` likewise swallowed-and-logged.
- [x] A refresh failure on either create path returns success to the caller (no partial-commit-then-500).
- [x] A swallowed refresh failure is logged (warning + cause), mirroring `swallowRefresh`.
- [x] Coverage: `create-path-refresh-swallow.unit.test.ts` drives a create whose post-commit refresh dies and asserts (a) success with the committed row, (b) a modeled retrying client mints exactly one row.

## Gates (local)

- `pnpm typecheck` — clean
- `biome check` (touched files) — clean
- Unit suites for lifecycle + sözlük + pano — 335 passed

## Scope note

Minimal/localized so the siblings that also touch these files (#2558 on `Sozluk.ts`, #2559 on `post-operations.ts`) rebase cleanly. Part of the backend-correctness audit cluster #2550–#2555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)