### PR TITLE
docs(workspace): sync alchemy patch inventory with the ADR 0170 cache hunks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,12 +80,17 @@ onlyBuiltDependencies:
 # Local patches (policy: patch deps locally, don't depend on an upstream/fork
 # release — ADR 0038). Re-key each on that dep's next version bump.
 #
-# alchemy — ONE hunk on beta.59:
+# alchemy — two patches on beta.59:
 # 1. Cloudflare/Flagship/Flag.js — `FlagshipFlag.reconcile` UPDATE path reconciles
 #    only the schema/metadata IaC owns ({variations, description}) and preserves the
 #    live serving the dashboard owns ({defaultVariation, rules, enabled}); the no-op
 #    skip compares only the schema. Implements ADR 0106; fixes the full-body PUT that
 #    clobbered live serving on every deploy (#840). Still NOT upstreamed in beta.59.
+# 2. Cloudflare/Workers/{Worker.d.ts, WorkerProvider.js} — expose per-Worker Workers
+#    Caching: add the `cache?: {enabled?}` prop to `WorkerProps` (the .d.ts) and
+#    thread it through the provider as the script-upload metadata's `cache_options`
+#    field, sent only when set. Implements ADR 0170; beta.59 predates the native
+#    knob. Retire both hunks when a future alchemy release ships the field natively.
 #
 # The prior beta.56 second hunk (DurableObjectNamespace.d.ts — adding
 # `DurableObjectNamespaceScope` to the `DurableObjectServices` union) was DROPPED:


### PR DESCRIPTION
## What I observed

`patches/alchemy@2.0.0-beta.59.patch` carries **three hunks across three files**:

1. `lib/Cloudflare/Flagship/Flag.js` — the `FlagshipFlag.reconcile` schema-only reconcile (ADR 0106).
2. `lib/Cloudflare/Workers/Worker.d.ts` — adds the `cache?: {enabled?}` prop to `WorkerProps` (ADR 0170).
3. `lib/Cloudflare/Workers/WorkerProvider.js` — threads that prop through as the script-upload `cache_options` field (ADR 0170).

But the local-patch inventory comment in `pnpm-workspace.yaml` still reads **"alchemy — ONE hunk on beta.59"** and documents only hunk 1. The ADR 0170 cache hunks were added to the patch without updating the inventory.

## Why it matters

The inventory comment is the human-readable map of what we patch and why (the ADR 0038 local-patch policy). When it drifts from the actual `.patch` file, the next reader re-keying the patch on alchemy's next version bump can miss the ADR 0170 hunks — the exact failure mode the inventory exists to prevent.

## What this changes

Comment-only edit to `pnpm-workspace.yaml`: relabel to "two patches on beta.59" and add item 2 describing the `cache_options` hunks, mirroring the patch file's own inline rationale (ADR 0170; "retire when a future alchemy release ships the field natively"). No dependency behavior change; the `.patch` file is untouched.

## Verification

Cross-checked the comment against `patches/alchemy@2.0.0-beta.59.patch` hunk-by-hunk; both ADRs (0106, 0170) exist in `.decisions/`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
