### PR TITLE
fix(integration): classify CF D1 429/971 TooManyRequests as a transient deploy error (#2638)

### DIFF
--- a/apps/web/tests/integration/_deploy-transient.ts
+++ b/apps/web/tests/integration/_deploy-transient.ts
@@ -22,11 +22,21 @@
 // proof it's transient: the SAME commit re-runs green (`search-error-vs-empty` red main with
 // `{_tag:'BadRequest'}`; #1146 added 2 more dedicated stages, widening the surface — #1153). The
 // bounded `deployTransientRetry` preserves fail-fast: a real malformed script's 400 exhausts the cap.
+// `TooManyRequests` (a WHOLE-tag transient, unlike the message-scoped cases below): the CF D1
+// control-plane rate-limit that reds `integration` on unrelated PRs when two PRs' CI overlap on
+// the one shared account (#2638; observed on PR #2625/#2635). Grounded in the
+// `@distilled.cloud/cloudflare` decode (`src/client/api.ts`): the in-band `code: 971` ("Please
+// wait and consider throttling your request speed"), a bare HTTP-429, and the global rate-limit
+// message ALL decode to `_tag: "TooManyRequests"` (`GLOBAL_ERROR_CODE_MAP[971]` and the
+// `status === 429` branch). It joins the set UNSCOPED — no message match — because core marks the
+// class `Category.withRetryable({throttling: true})`: a rate limit is transient by construction, so
+// the whole tag rides the bounded backoff (a persistent limit still exhausts the cap and fails fast).
 const DEPLOY_TRANSIENT_TAGS = new Set([
 	"WorkerNotFound",
 	"InternalServerError",
 	"UnknownCloudflareError",
 	"BadRequest",
+	"TooManyRequests",
 ]);
 
 // One more eventually-consistent signature, decoded NOT to a code-specific tag but to the

--- a/apps/web/tests/integration/_deploy-transient.unit.test.ts
+++ b/apps/web/tests/integration/_deploy-transient.unit.test.ts
@@ -19,6 +19,15 @@ describe("isTransientDeployError", () => {
 		// signature from the `search-error-vs-empty` main-red was `{retryAfter: undefined,
 		// _tag: 'BadRequest'}` — the core `BadRequest` class has no `retryAfter` field.
 		["BadRequest", {_tag: "BadRequest", retryAfter: undefined, message: "Bad Request"}],
+		// #2638: the CF D1 control-plane rate-limit (code 971 / HTTP 429 / rate-limit message all
+		// decode to `_tag: "TooManyRequests"` per `@distilled.cloud/cloudflare` `src/client/api.ts`).
+		// A whole-tag transient — core marks the class retryable/throttling — so a bare tag classifies
+		// transient regardless of message; the two shapes below pin the code-971 and HTTP-429 paths.
+		[
+			"TooManyRequests (code 971 envelope)",
+			{_tag: "TooManyRequests", message: "Please wait and consider throttling your request speed"},
+		],
+		["TooManyRequests (HTTP 429)", {_tag: "TooManyRequests", message: "Too Many Requests"}],
 	])("retries the transient deploy tag %s", (_label, err) => {
 		expect(isTransientDeployError(err)).toBe(true);
 	});


### PR DESCRIPTION
## What

Extends `isTransientDeployError` (`apps/web/tests/integration/_deploy-transient.ts`) so a Cloudflare **D1 `429` / code-`971` / `TooManyRequests`** rate-limit raised during per-stage provisioning classifies as **transient** and rides the harness's existing bounded exponential `deployTransientRetry` backoff — instead of failing the `integration` `ci-required` job fast and false-redding unrelated PRs across the fleet.

## Why

The harness already self-heals eventually-consistent CF deploy errors (`WorkerNotFound`, `BadRequest`, …) via `deployTransientRetry`, gated by `isTransientDeployError`. But the allow-set **omitted the D1 control-plane rate-limit signature**, so a `429 {"code":971,"message":"…throttling…"}` during deploy fell through to a hard fail. Because it's a shared-account rate limit, it reds otherwise-green PRs and forces manual re-runs (observed on PR #2625 and PR #2635; both cleared on a same-SHA re-run).

## Path confirmed — deploy, not teardown

The per-file/shared-stage **deploy** is what `deployTransientRetry` wraps (`_integration.ts` `beforeAll(deploy(...))`, `_global-setup.ts`). Teardown (`afterAll(destroy(...))`) is already best-effort-swallowed via `Effect.catchCause(...logWarning)`, so a teardown 429 would never red a green suite — which is why the observed red points squarely at the deploy/provisioning classifier gap, the surface this PR fixes.

## Grounding (dep source, not intuition)

Verified in `@distilled.cloud/cloudflare` `src/client/api.ts`: the in-band `code: 971` (`GLOBAL_ERROR_CODE_MAP[971]`), a bare HTTP-`429`, and the global rate-limit message all decode to **`_tag: "TooManyRequests"`**, which `@distilled.cloud/core` marks `Category.withRetryable({throttling: true})`. So the tag joins `DEPLOY_TRANSIENT_TAGS` **unscoped** (no message matcher, unlike the `NotFound`/`AuthError` message-scoped cases) — a rate limit is transient by construction. Fail-fast is preserved: a persistent limit still exhausts the bounded cap, and any non-rate-limit error carries a different tag.

## Tests

Unit coverage in `apps/web/tests/integration/_deploy-transient.unit.test.ts` pins the code-971 and HTTP-429 `TooManyRequests` shapes as transient; the existing fail-fast cases (auth/config/bare-NotFound) already assert a non-rate-limit error stays non-retryable. `pnpm test:unit` (16/16), `typecheck`, and `biome` all green locally.

## Scope

Entirely under `apps/web/tests/integration/**`. **No `.github/**` change** — not a control-plane (§CP) PR. The secondary concurrency-cap / CI-stagger levers (which would be §CP) were deliberately not taken; the classifier fix is the cheaper, non-§CP path.

Fixes #2638