### PR TITLE
feat(web): mecmua Subnav — destinations + primary action, CTA de-dup, flag-composed links into the product zone (#2603)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -391,6 +391,57 @@ describe("nav-IA coupling: pano/yeni Subnav CTA ↔ topbar + gönderi eviction (
 	});
 });
 
+// The mecmua nav-IA delta (#2603, epic #2596): the akış sub-destination is pulled OUT of the
+// global topbar product-noun row and into the mecmua Subnav zone. Off ⇒ today's surface (akış
+// in the topbar, gated on mecmua-feed); on ⇒ akış leaves the topbar and lives in the mecmua
+// product zone, still gated on the same mecmua-feed seam (never a dead link).
+describe("nav-IA mecmua delta: akış moves from topbar into the mecmua Subnav zone (#2603)", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		flags.navIa = false;
+		flags.mecmuaFeed = false;
+	});
+	afterEach(() => {
+		flags.navIa = false;
+		flags.mecmuaFeed = false;
+		vi.clearAllMocks();
+	});
+
+	it("flag off: akış stays in the topbar (today's surface, gated on mecmua-feed)", () => {
+		flags.mecmuaFeed = true;
+		const {container} = renderApp("/mecmua");
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+		const akis = screen.getByRole("link", {name: "akış"});
+		expect(container.querySelector(".kp-topbar")?.contains(akis)).toBe(true);
+	});
+
+	it("flag on: akış is evicted from the topbar and lives in the mecmua Subnav zone", () => {
+		flags.navIa = true;
+		flags.mecmuaFeed = true;
+		const {container} = renderApp("/mecmua");
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+		const akis = screen.getByRole("link", {name: "akış"});
+		// Eviction half: the topbar product-noun row no longer carries akış.
+		expect(container.querySelector(".kp-topbar")?.contains(akis)).toBe(false);
+		// Landing half: akış lives in the mecmua product Subnav zone.
+		expect(container.querySelector(".kp-subnav")?.contains(akis)).toBe(true);
+	});
+
+	it("flag on, mecmua-feed off: no akış link anywhere (still gated on its own seam)", () => {
+		flags.navIa = true;
+		renderApp("/mecmua");
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+		expect(screen.queryByRole("link", {name: "akış"})).toBeNull();
+	});
+});
+
 // The two-tier fate provider's public first paint (ADR 0167 / #2285): the anon-capable
 // /pano feed paints over the PUBLIC (always-anonymous) client ABOVE the session gate,
 // in parallel with `get-session`, then hands off to the authed feed once the gate

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,6 +27,7 @@ import {AppShell, Main} from "./components/layout/AppShell";
 import {Footer} from "./components/layout/Footer";
 import {ProductSubnavLayout} from "./components/layout/ProductSubnavLayout";
 import {Topbar} from "./components/layout/Topbar";
+import {MecmuaSubnavLayout} from "./components/mecmua/MecmuaSubnavLayout";
 import {actorLabel} from "./components/moderation/actor-identity";
 import {PanoSubnavCta} from "./components/pano/PanoSubnavCta";
 import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
@@ -115,6 +116,8 @@ function Layout() {
 	// the SAME flag the `/mecmua/akis` route self-gates on (self-404 when off). Gating the
 	// link on the route's own seam is what keeps it from ever pointing at a dark 404: off ⇒
 	// no entry, so subscribing (also `mecmua-feed`) and its feed destination appear together.
+	// Under nav-IA (below) akış is a mecmua SUB-destination, so it moves out of this topbar
+	// product-noun row into the mecmua Subnav zone (#2603) — hence gated off here when navIaOn.
 	const {value: feedOn} = useFlag(MECMUA_FEED, false);
 	// The nav-IA seam (#2600, epic #2596): with it on, pano's `+ gönderi` primary action
 	// lives in the pano Subnav CTA zone (placement law #2587), so the topbar no longer
@@ -173,7 +176,10 @@ function Layout() {
 							{to: "/sozluk", label: "sözlük"},
 							{to: "/pano", label: "pano"},
 							...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
-							...(feedOn ? [{to: "/mecmua/akis", label: "akış"}] : []),
+							// akış stays a topbar entry only while nav-IA is off; on, it lives in
+							// the mecmua Subnav zone (#2603) — the topbar keeps just the `mecmua`
+							// product noun (a cross-product destination, per placement law #2587).
+							...(feedOn && !navIaOn ? [{to: "/mecmua/akis", label: "akış"}] : []),
 						]}
 						divanTo={chips?.divanTo}
 						{...(chips?.userProps ?? {})}
@@ -422,7 +428,16 @@ export function App() {
 					<Route element={<Layout />}>
 						<Route path="/" element={<LandingPage />} />
 						{productZone(navIaOn, "pano-zone", panoRoutes, <PanoSubnavCta />)}
-						{productZone(navIaOn, "mecmua-zone", mecmuaRoutes)}
+						{/* mecmua's zone hosts flag-composed destinations + a primary-action CTA,
+						    so it wraps under its own `MecmuaSubnavLayout` (which composes both)
+						    rather than the generic empty/cta-only frame (#2603). Off ⇒ flat, as today. */}
+						{navIaOn ? (
+							<Route key="mecmua-zone" element={<MecmuaSubnavLayout />}>
+								{mecmuaRoutes}
+							</Route>
+						) : (
+							mecmuaRoutes
+						)}
 						{productZone(navIaOn, "sozluk-zone", sozlukRoutes)}
 						{productZone(navIaOn, "divan-zone", divanRoutes)}
 						<Route path="/search" element={<SearchPage />} />

--- a/apps/web/src/components/mecmua/MecmuaSubnavCta.test.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavCta.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * mecmua's primary action in its Subnav CTA slot (#2603, placement law #2587). Pins the
+ * gate-parity halves: (1) a yazar with the write flag live reaches `/mecmua/yaz` through the
+ * CTA (reachability, verified by actually routing there on click) and sees the sanctioned
+ * primary-action treatment; (2) a non-yazar / signed-out / flag-off viewer gets no CTA —
+ * the CTA rides the exact {@link shouldShowMecmuaWriteCta} gate the editor does, so it never
+ * dead-ends a viewer into a page they'd be publish-gated on.
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {MemoryRouter, Route, Routes} from "react-router";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import type {useSession as useSessionType} from "../../auth/client";
+import {MecmuaSubnavCta} from "./MecmuaSubnavCta";
+
+type SessionResult = ReturnType<typeof useSessionType>;
+let sessionState: SessionResult;
+let meTier: string | undefined;
+let writeFlag: boolean;
+vi.mock("../../auth/client", () => ({useSession: () => sessionState}));
+vi.mock("../../auth/useMe", () => ({
+	useMe: () => ({
+		me: meTier ? {tier: meTier} : null,
+		status: "ok",
+		loading: false,
+		refetch: vi.fn(),
+	}),
+}));
+vi.mock("../../flags/useFlag", () => ({useFlag: () => ({value: writeFlag, loading: false})}));
+
+function renderCta() {
+	return render(
+		<MemoryRouter initialEntries={["/mecmua"]}>
+			<Routes>
+				<Route path="/mecmua" element={<MecmuaSubnavCta />} />
+				<Route path="/mecmua/yaz" element={<div data-testid="mecmua-editor">editör</div>} />
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("MecmuaSubnavCta — mecmua primary action in the Subnav CTA slot (#2603)", () => {
+	afterEach(() => vi.clearAllMocks());
+
+	it("yazar + write flag on: renders the primary-action CTA and reaches /mecmua/yaz on click", () => {
+		sessionState = {data: {user: {id: "u1"}}, isPending: false} as SessionResult;
+		meTier = "yazar";
+		writeFlag = true;
+		renderCta();
+		const cta = screen.getByRole("button", {name: "yeni yazı"});
+		// Sanctioned primary-action treatment (#2586 taxonomy), not the utility filter/tab style.
+		expect(cta.className).toContain("kp-btn--primary");
+		expect(screen.queryByTestId("mecmua-editor")).toBeNull();
+		fireEvent.click(cta);
+		expect(screen.getByTestId("mecmua-editor")).toBeTruthy();
+	});
+
+	it("çaylak (non-yazar): renders no CTA — publish is earned, the CTA never dead-ends them", () => {
+		sessionState = {data: {user: {id: "u1"}}, isPending: false} as SessionResult;
+		meTier = "caylak";
+		writeFlag = true;
+		renderCta();
+		expect(screen.queryByRole("button", {name: "yeni yazı"})).toBeNull();
+	});
+
+	it("signed out: renders no CTA", () => {
+		sessionState = {data: null, isPending: false} as SessionResult;
+		meTier = undefined;
+		writeFlag = true;
+		renderCta();
+		expect(screen.queryByRole("button", {name: "yeni yazı"})).toBeNull();
+	});
+
+	it("write flag off: renders no CTA even for a yazar (the write path is dark)", () => {
+		sessionState = {data: {user: {id: "u1"}}, isPending: false} as SessionResult;
+		meTier = "yazar";
+		writeFlag = false;
+		renderCta();
+		expect(screen.queryByRole("button", {name: "yeni yazı"})).toBeNull();
+	});
+});

--- a/apps/web/src/components/mecmua/MecmuaSubnavCta.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavCta.tsx
@@ -1,0 +1,31 @@
+import {useNavigate} from "react-router";
+import {useSession} from "../../auth/client";
+import {useMe} from "../../auth/useMe";
+import {MECMUA_WRITE} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
+// The gate helper is composer-free (#2523), so consuming it here never drags the tiptap
+// editor payload into the entry chunk just to decide whether to offer the write CTA.
+import {shouldShowMecmuaWriteCta} from "../../pages/mecmua-write-gate";
+import {Button} from "../ui/Button";
+
+/**
+ * mecmua's primary action in its Subnav CTA slot (placement law #2587, epic #2596): the
+ * promoted "yeni yazı" verb, hosted in the mecmua product zone rather than duplicated as
+ * in-page buttons (the #2603 CTA de-dup). Shown exactly when the editor would accept the
+ * author — the shared {@link shouldShowMecmuaWriteCta} gate (MECMUA_WRITE live + yazar
+ * tier, #2532) — so it never dead-ends a çaylak/visitor into a page they'd be publish-
+ * gated on. Renders the sanctioned primary-action treatment (`Button` `primary` variant,
+ * #2586 taxonomy), never the utility filter/tab styling.
+ */
+export function MecmuaSubnavCta() {
+	const session = useSession();
+	const {me} = useMe();
+	const navigate = useNavigate();
+	const {value: writeFlagOn} = useFlag(MECMUA_WRITE, false);
+	if (!shouldShowMecmuaWriteCta(writeFlagOn, !!session.data, me?.tier)) return null;
+	return (
+		<Button variant="primary" onClick={() => navigate("/mecmua/yaz")}>
+			yeni yazı
+		</Button>
+	);
+}

--- a/apps/web/src/components/mecmua/MecmuaSubnavLayout.test.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavLayout.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * mecmua's persistent product Subnav zone (#2603, placement law #2587). Pins two things:
+ * (1) the zone is a persistent layout — its `.kp-subnav` node survives a within-mecmua
+ * navigation (no remount); (2) each destination is flag-composed on the SAME seam its
+ * route self-gates on, so a link never points at a dark 404 — keşfet on mecmua-public-read,
+ * akış on mecmua-feed, yazılarım on the write path (yazar-gated, #2579's missing home).
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {Link, MemoryRouter, Route, Routes} from "react-router";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {MECMUA_FEED, MECMUA_PUBLIC_READ, MECMUA_WRITE} from "../../flags/keys";
+import {MecmuaSubnavLayout} from "./MecmuaSubnavLayout";
+
+const flags = {read: false, feed: false, write: false};
+let signedIn: boolean;
+let meTier: string | undefined;
+vi.mock("../../auth/client", () => ({
+	useSession: () => ({data: signedIn ? {user: {id: "u1"}} : null, isPending: false}),
+}));
+vi.mock("../../auth/useMe", () => ({
+	useMe: () => ({
+		me: meTier ? {tier: meTier} : null,
+		status: "ok",
+		loading: false,
+		refetch: vi.fn(),
+	}),
+}));
+vi.mock("../../flags/useFlag", () => ({
+	useFlag: (key: string) => ({
+		value:
+			key === MECMUA_PUBLIC_READ
+				? flags.read
+				: key === MECMUA_FEED
+					? flags.feed
+					: key === MECMUA_WRITE
+						? flags.write
+						: false,
+		loading: false,
+	}),
+}));
+
+function MecmuaIndex() {
+	return (
+		<div data-testid="mecmua-index">
+			<Link to="/mecmua/akis">git</Link>
+		</div>
+	);
+}
+
+function renderZone(initial = "/mecmua") {
+	return render(
+		<MemoryRouter initialEntries={[initial]}>
+			<Routes>
+				<Route element={<MecmuaSubnavLayout />}>
+					<Route path="/mecmua" element={<MecmuaIndex />} />
+					<Route path="/mecmua/akis" element={<div data-testid="mecmua-akis">akış</div>} />
+				</Route>
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("MecmuaSubnavLayout — mecmua product Subnav zone (#2603)", () => {
+	afterEach(() => {
+		flags.read = false;
+		flags.feed = false;
+		flags.write = false;
+		signedIn = false;
+		meTier = undefined;
+		vi.clearAllMocks();
+	});
+
+	it("renders the mecmua Subnav zone above the routed Outlet", () => {
+		const {container} = renderZone();
+		expect(container.querySelector(".kp-subnav")).toBeTruthy();
+		expect(screen.getByTestId("mecmua-index")).toBeTruthy();
+	});
+
+	it("keeps the Subnav zone mounted across a within-mecmua navigation — no remount", () => {
+		flags.feed = true;
+		const {container} = renderZone();
+		const before = container.querySelector(".kp-subnav");
+		expect(before).toBeTruthy();
+		fireEvent.click(screen.getByRole("link", {name: "git"}));
+		expect(screen.getByTestId("mecmua-akis")).toBeTruthy();
+		expect(container.querySelector(".kp-subnav")).toBe(before);
+	});
+
+	it("composes destinations per flag: keşfet on public-read, akış on feed, all flag-off ⇒ none", () => {
+		renderZone();
+		expect(screen.queryByRole("link", {name: "keşfet"})).toBeNull();
+		expect(screen.queryByRole("link", {name: "akış"})).toBeNull();
+		expect(screen.queryByRole("link", {name: "yazılarım"})).toBeNull();
+	});
+
+	it("read flag on ⇒ keşfet destination points at the public index /mecmua", () => {
+		flags.read = true;
+		renderZone();
+		expect(screen.getByRole("link", {name: "keşfet"}).getAttribute("href")).toBe("/mecmua");
+	});
+
+	it("feed flag on ⇒ akış destination points at /mecmua/akis (moved out of the topbar)", () => {
+		flags.feed = true;
+		renderZone();
+		expect(screen.getByRole("link", {name: "akış"}).getAttribute("href")).toBe("/mecmua/akis");
+	});
+
+	it("write flag on + yazar ⇒ yazılarım destination appears (its nav home, #2579) and points at /mecmua/yazilarim", () => {
+		flags.write = true;
+		signedIn = true;
+		meTier = "yazar";
+		renderZone();
+		expect(screen.getByRole("link", {name: "yazılarım"}).getAttribute("href")).toBe(
+			"/mecmua/yazilarim",
+		);
+	});
+
+	it("write flag on but çaylak ⇒ no yazılarım destination (gate parity with the editor, no dead-end)", () => {
+		flags.write = true;
+		signedIn = true;
+		meTier = "caylak";
+		renderZone();
+		expect(screen.queryByRole("link", {name: "yazılarım"})).toBeNull();
+	});
+});

--- a/apps/web/src/components/mecmua/MecmuaSubnavLayout.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavLayout.tsx
@@ -1,0 +1,42 @@
+import {Outlet} from "react-router";
+import {useSession} from "../../auth/client";
+import {useMe} from "../../auth/useMe";
+import {MECMUA_FEED, MECMUA_PUBLIC_READ, MECMUA_WRITE} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
+import {shouldShowMecmuaWriteCta} from "../../pages/mecmua-write-gate";
+import {Subnav, type SubnavLink} from "../layout/Subnav";
+import {MecmuaSubnavCta} from "./MecmuaSubnavCta";
+
+/**
+ * mecmua's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
+ * layout-route element that hosts mecmua's product destinations + its primary action, so
+ * they live in the product zone instead of leaking into the global topbar (#2603). Mounted
+ * only behind the `phoenix-nav-ia` flag (App.tsx); off ⇒ the router is flat, exactly as
+ * today.
+ *
+ * Each destination is composed on the SAME flag its route/page self-gates on, so a link
+ * never points at a dark 404 (the #2547 "never a dead link" rule): keşfet (the public index)
+ * on `mecmua-public-read`, akış (the subscribed-author feed) on `mecmua-feed`, yazılarım
+ * (the author's own drafts, #2579's missing home) on the write path. yazılarım rides the
+ * same {@link shouldShowMecmuaWriteCta} gate as the CTA (yazar + write live) — gate parity
+ * with the editor keeps a çaylak/visitor out of an author-scoped page they can't write to.
+ */
+export function MecmuaSubnavLayout() {
+	const session = useSession();
+	const {me} = useMe();
+	const {value: readOn} = useFlag(MECMUA_PUBLIC_READ, false);
+	const {value: feedOn} = useFlag(MECMUA_FEED, false);
+	const {value: writeOn} = useFlag(MECMUA_WRITE, false);
+	const canAuthor = shouldShowMecmuaWriteCta(writeOn, !!session.data, me?.tier);
+	const links: SubnavLink[] = [
+		...(readOn ? [{to: "/mecmua", label: "keşfet", end: true}] : []),
+		...(feedOn ? [{to: "/mecmua/akis", label: "akış"}] : []),
+		...(canAuthor ? [{to: "/mecmua/yazilarim", label: "yazılarım"}] : []),
+	];
+	return (
+		<>
+			<Subnav links={links} cta={<MecmuaSubnavCta />} />
+			<Outlet />
+		</>
+	);
+}

--- a/apps/web/src/pages/MecmuaDraftsPage.tsx
+++ b/apps/web/src/pages/MecmuaDraftsPage.tsx
@@ -20,7 +20,7 @@ import {EmptyState} from "../components/ui/EmptyState";
 import {MetaRow} from "../components/ui/MetaRow";
 import {Screen} from "../fate/Screen";
 import {toIso} from "../fate/wire";
-import {MECMUA_WRITE} from "../flags/keys";
+import {MECMUA_WRITE, PHOENIX_NAV_IA} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {formatDateTR} from "../lib/datetime";
 import {NotFoundPage} from "./NotFoundPage";
@@ -47,6 +47,11 @@ function MecmuaWriteCta() {
 
 export function MecmuaDraftsPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);
+	// Under nav-IA the write CTA lives once in the mecmua Subnav's primary-action slot, so
+	// the in-page copies (header + empty state) are suppressed to leave exactly one mecmua
+	// write CTA (#2603 de-dup). Off ⇒ today's in-page CTA, unchanged.
+	const {value: navIaOn} = useFlag(PHOENIX_NAV_IA, false);
+	const showInlineCta = !navIaOn;
 
 	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
 	// MecmuaEditorPage / MecmuaPostPage self-gate idiom).
@@ -68,7 +73,7 @@ export function MecmuaDraftsPage() {
 				<header className="kp-mecmua-drafts__head">
 					<div className="kp-mecmua-drafts__head-row">
 						<h1 className="kp-mecmua-drafts__title">yazılarım</h1>
-						<MecmuaWriteCta />
+						{showInlineCta ? <MecmuaWriteCta /> : null}
 					</div>
 					<p className="kp-mecmua-drafts__lede">taslakların ve yayımladığın yazılar.</p>
 				</header>
@@ -80,14 +85,14 @@ export function MecmuaDraftsPage() {
 						</p>
 					)}
 				>
-					<MecmuaDraftsList />
+					<MecmuaDraftsList showInlineCta={showInlineCta} />
 				</Screen>
 			</div>
 		</div>
 	);
 }
 
-function MecmuaDraftsList() {
+function MecmuaDraftsList({showInlineCta}: {showInlineCta: boolean}) {
 	const {mecmuaMyPosts} = useRequest(myPostsRequest);
 	const [items] = useListView(MyPostsConnectionView, mecmuaMyPosts);
 
@@ -97,7 +102,7 @@ function MecmuaDraftsList() {
 				icon={<Icon icon={NotebookPen} size={24} />}
 				title="henüz yazın yok"
 				description="yeni bir yazıya başla; taslakların burada birikir."
-				action={<MecmuaWriteCta />}
+				action={showInlineCta ? <MecmuaWriteCta /> : undefined}
 			/>
 		);
 	}

--- a/apps/web/src/pages/MecmuaIndexPage.test.tsx
+++ b/apps/web/src/pages/MecmuaIndexPage.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * The mecmua index write-CTA de-dup under nav-IA (#2603). With nav-IA on, mecmua's single
+ * write CTA lives in the Subnav primary-action slot, so the in-page copy is suppressed — no
+ * duplicate CTA remains. Off ⇒ today's in-page CTA is unchanged (still yazar-gated, #2532).
+ */
+import {render, screen} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {MECMUA_PUBLIC_READ, MECMUA_WRITE, PHOENIX_NAV_IA} from "../flags/keys";
+import {MecmuaIndexPage} from "./MecmuaIndexPage";
+
+const flags = {read: true, write: true, navIa: false};
+let meTier: string | undefined;
+vi.mock("../auth/client", () => ({
+	useSession: () => ({data: {user: {id: "u1"}}, isPending: false}),
+}));
+vi.mock("../auth/useMe", () => ({
+	useMe: () => ({
+		me: meTier ? {tier: meTier} : null,
+		status: "ok",
+		loading: false,
+		refetch: vi.fn(),
+	}),
+}));
+vi.mock("../flags/useFlag", () => ({
+	useFlag: (key: string) => ({
+		value:
+			key === MECMUA_PUBLIC_READ
+				? flags.read
+				: key === MECMUA_WRITE
+					? flags.write
+					: key === PHOENIX_NAV_IA
+						? flags.navIa
+						: false,
+		loading: false,
+	}),
+}));
+
+function renderPage() {
+	return render(
+		<MemoryRouter initialEntries={["/mecmua"]}>
+			<MecmuaIndexPage />
+		</MemoryRouter>,
+	);
+}
+
+describe("MecmuaIndexPage — write-CTA de-dup under nav-IA (#2603)", () => {
+	beforeEach(() => {
+		flags.read = true;
+		flags.write = true;
+		flags.navIa = false;
+		meTier = "yazar";
+		// A published post so the page renders its list (not the empty state) — isolates the
+		// header CTA as the single in-page write affordance under test.
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify([{id: "p1", slug: "p1", title: "yazı", publishedAt: null}]), {
+						status: 200,
+					}),
+			),
+		);
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("nav-IA off, yazar: the in-page write CTA renders (today's surface)", async () => {
+		renderPage();
+		expect(await screen.findByTestId("mecmua-write-cta")).toBeTruthy();
+	});
+
+	it("nav-IA on: the in-page write CTA is suppressed — the single CTA lives in the Subnav", async () => {
+		flags.navIa = true;
+		renderPage();
+		// The list still renders (proves we got past the flag gate), but no in-page CTA remains.
+		expect(await screen.findByText("mecmua")).toBeTruthy();
+		expect(screen.queryByTestId("mecmua-write-cta")).toBeNull();
+	});
+});

--- a/apps/web/src/pages/MecmuaIndexPage.tsx
+++ b/apps/web/src/pages/MecmuaIndexPage.tsx
@@ -19,7 +19,7 @@ import {Icon} from "../components/Icon";
 import {Card} from "../components/ui/Card";
 import {EmptyState} from "../components/ui/EmptyState";
 import {MetaRow} from "../components/ui/MetaRow";
-import {MECMUA_PUBLIC_READ, MECMUA_WRITE} from "../flags/keys";
+import {MECMUA_PUBLIC_READ, MECMUA_WRITE, PHOENIX_NAV_IA} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {formatDateTR} from "../lib/datetime";
 // The gate helper lives composer-free (#2523) so this public index never pulls the tiptap
@@ -78,7 +78,10 @@ function MecmuaIndex() {
 	// The write CTA shares the editor's own publish gate (yazar tier + MECMUA_WRITE live),
 	// so it never dead-ends a çaylak/visitor into a page they can't publish from (#2532).
 	const {value: writeFlagOn} = useFlag(MECMUA_WRITE, false);
-	const showWriteCta = shouldShowMecmuaWriteCta(writeFlagOn, !!session.data, me?.tier);
+	// Under nav-IA the write CTA lives once in the mecmua Subnav's primary-action slot, so
+	// the in-page copy is suppressed to leave exactly one mecmua write CTA (#2603 de-dup).
+	const {value: navIaOn} = useFlag(PHOENIX_NAV_IA, false);
+	const showWriteCta = !navIaOn && shouldShowMecmuaWriteCta(writeFlagOn, !!session.data, me?.tier);
 
 	useEffect(() => {
 		let cancelled = false;


### PR DESCRIPTION
Builds mecmua's product Subnav into the mecmua zone the nav-IA substrate (#2598) created, gated on the shared default-off `phoenix-nav-ia` flag — **flag off = today's mecmua nav exactly**. Follows the pano precedent from #2600 (`PanoSubnavCta` + `productZone` wiring). Part of nav-IA epic #2596 (Phase 2, the largest single delta).

## What changed

- **`MecmuaSubnavLayout`** (`apps/web/src/components/mecmua/MecmuaSubnavLayout.tsx`) — the mecmua product Subnav zone. Hosts mecmua's flag-composed **destinations**, each on the SAME seam its route/page self-gates on so a link never points at a dark 404 (the #2547 rule):
  - **keşfet** → `/mecmua` (public index) on `mecmua-public-read`
  - **akış** → `/mecmua/akis` (subscribed feed) on `mecmua-feed`
  - **yazılarım** → `/mecmua/yazilarim` (own drafts) on the write path + yazar (gate parity with the editor via `shouldShowMecmuaWriteCta`, so a çaylak/visitor is never dead-ended into an author-scoped page)
- **`MecmuaSubnavCta`** (`.../mecmua/MecmuaSubnavCta.tsx`) — the `yaz` **primary action** ("yeni yazı") in the Subnav CTA slot, `Button` `primary` variant per the #2586 taxonomy, shown exactly when the editor would accept the author.
- **Pull the flag-composed link set out of the topbar** (`App.tsx`) — `akış` is a mecmua sub-destination, so under nav-IA it moves out of the topbar product-noun row into the mecmua Subnav zone. The topbar keeps only the `mecmua` cross-product destination (per placement law #2587). Gated `feedOn && !navIaOn`.
- **CTA de-dup** — the in-page write CTAs in `MecmuaIndexPage` and `MecmuaDraftsPage` are suppressed under nav-IA, leaving exactly one mecmua write CTA (the Subnav slot). Flag off ⇒ today's in-page CTAs, unchanged.

## Taxonomy / containment (#2586 / #2590)

Every mecmua Subnav element carries exactly one taxonomy class: destinations render in the Subnav `links` row (NavLinks, `aria-current`), the primary action in the `cta` slot (Button primary). No new CSS — reuses the substrate's `kp-subnav__filter` (transparent resting border, accent only on active — legal transient paint) and `kp-subnav__cta`. No resting-chrome violation.

## Subsumes #2579

The `yazılarım` (mecmua drafts) nav-orphan — previously discoverable only from inside the editor — now has a proper home in the mecmua Subnav IA. This PR resolves #2579; closing keyword stays on #2603.

## Files touched in App.tsx (for sibling-lane carving)

- `Layout()`: `akış` topbar entry now gated `feedOn && !navIaOn` (topbar keeps `mecmua` noun).
- `App()`: the mecmua zone wraps `mecmuaRoutes` under `<MecmuaSubnavLayout>` when `navIaOn` (replaces the generic `productZone(..., "mecmua-zone", ...)` call). pano/sözlük/divan zones untouched.

## Gates (local)

- typecheck ✅ · lint ✅ · client tests ✅ (168 passing incl. new mecmua + App specs) · design-token-guard ✅ · leak-guard ✅
- `reachability-guard phoenix-nav-ia` reports UNREACHABLE (no `@journey` e2e) — the expected not-yet-graduatable state until Phase-2 journeys land (per the #2596 handoff); the flag is not being flipped here.

## Out of scope (untouched)

pano-delta #2601 / sözlük #2602 / divan #2604 zones; topbar zone-grammar #2611; mecmua write-path behavior (nav placement only).

Fixes #2603