### PR TITLE
feat(throttle): per-actor mutation rate limiting at the fate seam (#2561)

### DIFF
--- a/.decisions/0177-per-actor-mutation-rate-limiting.md
+++ b/.decisions/0177-per-actor-mutation-rate-limiting.md
@@ -1,0 +1,104 @@
+---
+id: 0177
+title: Per-actor mutation rate limiting at the fate seam, token bucket over a swappable store
+status: accepted
+date: 2026-07-11
+tags: [security, fate, throttle, abuse, durable-objects]
+---
+
+# 0177 — Per-actor mutation rate limiting at the fate seam
+
+## Context
+
+The worker had **no per-time / per-actor write throttle anywhere** (#2561). Authenticated
+writes — content, votes, reactions, reports — are per-item-bounded (one vote per post, one
+reaction per target) but carry **no bound on write *volume***. The onboarding rite sandboxes
+a newcomer's *reach* (the çaylak containment), not their *write cadence*, so sandbox floods,
+report spam, and reaction churn are unthrottled. Cloudflare's platform request limiting sits
+*beneath* the app and cannot distinguish one authenticated writer's volume from another's.
+
+An external security audit ranked a per-actor mutation limiter the single highest-leverage
+defense-in-depth control to land **before opening registration to real users**. Today's
+cohort is founders-only and vouch-gated, so there is no active exploit — hence p2 — but the
+primitive must exist and be wired before that arc becomes active.
+
+## Decision
+
+Add a **per-actor mutation-volume throttle** as a cross-cutting primitive, wired **once** at
+the fate composition root (`apps/web/worker/features/fate/layers.ts`) over the merged
+mutations record, so it bounds **every** feature's mutation path without touching a single
+feature.
+
+Three seams, each doing one job:
+
+1. **`TokenBucket`** (`features/throttle/TokenBucket.ts`) — the algorithm as a **pure domain
+   object**: state + policy + the two transitions (refill-by-elapsed-time, try-consume). No
+   clock, no store, no Effect; `nowMs` is passed in. This is what keeps the higher layers thin
+   and makes the algorithm exhaustively unit-testable, independent of where its state lives.
+
+2. **`RateLimiter`** (`features/throttle/RateLimiter.ts`) — the isolate-level service. It owns
+   the actor→budget-key mapping (`CurrentActor`, ADR 0107) and the policy, and delegates the
+   state's storage + RMW atomicity to a `RateLimitStore` port. `check(actor)` spends one token
+   and fails with `RateLimitExceeded` on empty. Anonymous actors carry no key and pass through
+   (their writes are refused by each mutation's own auth gate).
+
+3. **`RateLimitStore`** (`features/throttle/RateLimitStore.ts`) — the **dependency-inverted
+   backing-store port**, discharged at the composition root exactly like Vote's `KarmaBump` /
+   `VoterStanding` seams. This is the storage swap point.
+
+The wire denial is a dedicated fate wire error, `throttle/RateLimitExceeded` →
+`RATE_LIMIT_EXCEEDED` (`features/throttle/errors.ts`), following the `VOUCH_LIMIT_REACHED`
+precedent — a throttled write is a clear, distinguishable denial, never a generic 500.
+
+### The storage fork — in-isolate for v1, Durable Object as the named upgrade
+
+The audit framed the choice as **Durable Object vs D1**. Grounded in the existing patterns
+(ADR 0037's `LiveDO`; `.patterns/feature-services.md`'s Drizzle/D1 seam), the fork resolves to
+a **third option for v1 behind the same port**:
+
+- **D1 — rejected for v1.** A token bucket is a hot read-modify-write on *every* mutation.
+  Routing that through D1 doubles the write load on the primary content DB and needs careful
+  atomic SQL to avoid an interleaved RMW letting two writes spend the last token. Coupling the
+  throttle's availability to the primary DB is the wrong trade for a defense-in-depth control.
+
+- **Durable Object — deferred, not dismissed.** A per-actor DO (`idFromName(actorId)`) is the
+  idiomatic Cloudflare *global* rate limiter: its single-threaded execution gives the exact
+  per-key RMW atomicity the port demands, across all isolates. But it costs a new DO binding in
+  `alchemy.run.ts`, a DO class, and a storage round-trip (latency) on every mutation — real
+  infra for a control whose v1 job is defense-in-depth under a founders-only vouch-gated cohort,
+  and not exercisable in the unit tier.
+
+- **In-isolate `Map` — chosen for v1.** A per-isolate `Map`, built once per isolate via the fate
+  runtime's memoMap; JS's single-threaded event loop makes the RMW atomic per key with no lock.
+  Zero new infra, no per-mutation network/DB round-trip, fully unit-testable. Because a single
+  flooding actor's burst lands on one (or few) reused isolates, a per-isolate bucket already
+  bounds the exact abuse named (sandbox floods, report spam, reaction churn).
+
+  Its one limit is honest and recorded: the bound is **per-isolate, not global**. That is the
+  explicit **v1→v1.1 upgrade trigger** — swap `InIsolateRateLimitStoreLive` for a DO-backed store
+  behind the same `RateLimitStore` port at the composition root, **without touching
+  `RateLimiter` or any feature**, when registration opens (the issue's own sequencing).
+
+### Limit values
+
+One default class covers every mutation: **60 tokens of burst, refilling 1/s** (≈60
+writes/minute sustained). Chosen well clear of a human's real write cadence yet tight enough to
+bound a scripted flood. A single aggregate per-actor bucket (not per-mutation-class sub-buckets)
+is the v1 shape: floods, report spam, and reaction churn all draw from the same actor budget, so
+one bucket bounds the aggregate volume the audit cares about. Per-mutation-class values would
+slot in as a `Record<class, TokenBucketPolicy>` keyed off the mutation wire name if a class ever
+needs a distinct rate; v1 does not.
+
+## Consequences
+
+- Every mutation is throttled per actor at one seam; adding a feature inherits the throttle for
+  free (no per-feature wiring).
+- `RATE_LIMIT_EXCEEDED` is injected at the composition seam, not through any declared error
+  union, so `declaredWireCodes(fateConfig)` does not see it. The SPA-coverage guard
+  (`fate/wireCodes.unit.test.ts`) unions `THROTTLE_WIRE_CODES` onto the declared set, so the SPA
+  `FATE_WIRE_CODES` list must still cover it — the wire contract stays bound, not hoped.
+- The v1 bound is per-isolate. This is deliberate and sufficient for the current cohort; the DO
+  upgrade is a one-Layer swap when a registration-opening milestone becomes active (pull #2561 to
+  p1 then, per triage).
+- Only the *serving* path is throttled; the build-time codegen path (`schema.ts`) consumes the
+  plain `fateConfig`, so codegen is untouched.

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -30,6 +30,7 @@ export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	SELF_VOTE_NOT_ALLOWED: "kendi içeriğine oy veremezsin",
 	VOUCH_LIMIT_REACHED: "kefil olma sınırına ulaştın",
 	INSUFFICIENT_KARMA: "bunu yapmak için karman yetersiz",
+	RATE_LIMIT_EXCEEDED: "çok hızlısın, biraz yavaşla",
 	DEFINITION_NOT_FOUND: "tanım bulunamadı",
 	POST_NOT_FOUND: "başlık bulunamadı",
 	POST_DELETE_FAILED: "gönderi silinemedi, lütfen tekrar dene",

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -42,6 +42,12 @@ export const FATE_WIRE_CODES = [
 	// flagging (≥ 50). Distinct from the tier-ladder `FORBIDDEN` — this is a raw
 	// karma-count anti-abuse floor, a separate axis (no double-gating, #150 rescope).
 	"INSUFFICIENT_KARMA",
+	// The per-actor mutation throttle tripped — the actor is issuing writes faster
+	// than their token bucket refills (`throttle/RateLimitExceeded`, ADR 0177).
+	// Cross-cutting: injected at the fate mutation seam, so ANY mutation can surface
+	// it. Not in `declaredWireCodes` (no declared union carries it); the coverage
+	// guard unions `THROTTLE_WIRE_CODES` so this list must still cover it.
+	"RATE_LIMIT_EXCEEDED",
 	"DEFINITION_NOT_FOUND",
 	"POST_NOT_FOUND",
 	// A pano post's removal WRITE failed at the D1 layer (`pano/PostDeleteFailed`,

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -43,6 +43,9 @@ import {SearchLive} from "../search/Search.ts";
 import {SozlukLive} from "../sozluk/Sozluk.ts";
 import {StatsLive} from "../stats/Stats.ts";
 import {type TelemetryClient, TelemetryLive} from "../telemetry/Telemetry.ts";
+import {RateLimiterLive} from "../throttle/RateLimiter.ts";
+import {InIsolateRateLimitStoreLive} from "../throttle/RateLimitStore.ts";
+import {throttleMutations} from "../throttle/throttle-mutations.ts";
 import {KarmaBump, VoteLive, VoterStanding} from "../vote/Vote.ts";
 import {fateConfig} from "./config.ts";
 
@@ -263,6 +266,13 @@ export const makeFateLayer = Layer.mergeAll(
 	// The authorship-vouch ledger (#1206) — the `user.vouch` recorded-act store.
 	// Reads/writes the `authorship_vouch` table off the same `Drizzle` seam below.
 	VouchLedgerLive,
+	// The per-actor mutation throttle (ADR 0177) — a cross-cutting service bounding
+	// each actor's write volume, applied over the merged mutations record in
+	// `PhoenixFateLive` (`throttleMutations`). Its `RateLimitStore` backing is
+	// discharged HERE with `Layer.provide` (the storage swap point, in-isolate for
+	// v1) so `RateLimiter` reaches the composition root's captured services with no
+	// external R — the same internal-seam idiom as `KarmaBumpFromPasaport`.
+	RateLimiterLive.pipe(Layer.provide(InIsolateRateLimitStoreLive)),
 	// `Flags` is the dark-ship read surface fate resolvers/mutations gate on (#746,
 	// #1868). Environment-selected by {@link FateFlagsLive}: the dev-override wrapper
 	// under `development` (so the #622 override cookie is honored on the fate mutation
@@ -294,6 +304,12 @@ export const PhoenixFateLive: Layer.Layer<
 	WorkerFateServices | FateServer,
 	never,
 	Database | BetterAuth.BetterAuth | Flagship | TelemetryClient | RuntimeContext
-> = FateServer.layer(fateConfig, [CurrentActor, RequestFlagOverrides, PanoFeedCache]).pipe(
-	Layer.provideMerge(makeFateLayer),
-);
+> = FateServer.layer(
+	// The served config, with every mutation's `resolve` wrapped by the per-actor
+	// throttle (ADR 0177). Only the serving path is throttled — the codegen path
+	// (`schema.ts`) consumes the plain `fateConfig`, so build-time codegen is
+	// untouched. `RateLimiter`/`CurrentActor` are provided at run time (worker
+	// layer / per-request), so the wrapped config keeps `fateConfig`'s type.
+	{...fateConfig, mutations: throttleMutations(fateConfig.mutations)},
+	[CurrentActor, RequestFlagOverrides, PanoFeedCache],
+).pipe(Layer.provideMerge(makeFateLayer));

--- a/apps/web/worker/features/fate/wireCodes.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes.unit.test.ts
@@ -20,12 +20,20 @@ import * as FateEffect from "@kampus/fate-effect";
 import {declaredWireCodes} from "@kampus/fate-effect";
 import {describe, expect, it} from "vitest";
 import {decodeFateWireCode, FATE_WIRE_CODES} from "../../../src/lib/fateWireCodes.ts";
+import {THROTTLE_WIRE_CODES} from "../throttle/wire-codes.ts";
 import {fateConfig} from "./config.ts";
 
 describe("wire-code contract", () => {
 	const spaCodes: ReadonlySet<string> = new Set(FATE_WIRE_CODES);
 
-	const serverCodes = declaredWireCodes(fateConfig);
+	// The server can emit two flavors: codes from a mutation's DECLARED error union
+	// (what `declaredWireCodes` walks) PLUS the throttle codes injected at the fate
+	// composition seam (ADR 0177) — the latter have no declared union to walk, so
+	// they are unioned in here so the SPA-coverage assertion still binds them.
+	const serverCodes: ReadonlySet<string> = new Set([
+		...declaredWireCodes(fateConfig),
+		...THROTTLE_WIRE_CODES,
+	]);
 
 	it("the annotation key is exported under its one canonical name `FateWireCode`", () => {
 		// Names drift under a value-only guard (#1032): the codec reads the

--- a/apps/web/worker/features/throttle/RateLimitStore.ts
+++ b/apps/web/worker/features/throttle/RateLimitStore.ts
@@ -1,0 +1,49 @@
+/**
+ * `RateLimitStore` — the dependency-inverted backing-store port for the token
+ * bucket (ADR 0177). The `RateLimiter` service owns the algorithm (the pure
+ * `TokenBucket`); the store owns only *where the state lives and how the
+ * read-modify-write is made atomic*. That split is the storage swap point: the
+ * in-isolate `Map` ships today; a per-actor Durable Object (ADR 0037) drops in
+ * behind this same port at the composition root when registration opens, without
+ * touching `RateLimiter` — the same inversion idiom as Vote's `KarmaBump` /
+ * `VoterStanding` (`.patterns/feature-services.md`).
+ */
+import {Context, Effect, Layer} from "effect";
+import type {TokenBucketState} from "./TokenBucket.ts";
+
+export interface RateLimitStoreAccess {
+	/**
+	 * Atomically read the bucket state for `key`, apply the pure `transition`,
+	 * persist the returned state, and yield the transition's result. The per-key
+	 * atomicity of this read-apply-write IS the store's whole contract — an
+	 * interleaved RMW would let two concurrent mutations both spend the last
+	 * token. Each backing guarantees it at its own seam: the isolate's single
+	 * event loop below, a Durable Object's single-threaded execution later.
+	 */
+	readonly transition: <R>(
+		key: string,
+		transition: (state: TokenBucketState | undefined) => readonly [TokenBucketState, R],
+	) => Effect.Effect<R>;
+}
+
+export class RateLimitStore extends Context.Service<RateLimitStore, RateLimitStoreAccess>()(
+	"@kampus/throttle/RateLimitStore",
+) {}
+
+/**
+ * The in-isolate backing: a per-isolate `Map` built once per isolate (via the
+ * fate runtime's memoMap). JS's single-threaded event loop makes the synchronous
+ * read-apply-write atomic per key with no lock. Its bound is per-isolate, not
+ * global — ADR 0177 records that as the v1→Durable-Object upgrade trigger.
+ */
+export const InIsolateRateLimitStoreLive = Layer.sync(RateLimitStore)(() => {
+	const buckets = new Map<string, TokenBucketState>();
+	return {
+		transition: (key, transition) =>
+			Effect.sync(() => {
+				const [next, result] = transition(buckets.get(key));
+				buckets.set(key, next);
+				return result;
+			}),
+	};
+});

--- a/apps/web/worker/features/throttle/RateLimiter.ts
+++ b/apps/web/worker/features/throttle/RateLimiter.ts
@@ -1,0 +1,70 @@
+/**
+ * `RateLimiter` — the per-actor mutation-volume throttle (ADR 0177). It owns the
+ * token-bucket algorithm ({@link TokenBucket}) and the actor→budget-key mapping;
+ * the state's home and RMW atomicity are the {@link RateLimitStore} port's job
+ * (the DO-vs-in-isolate swap point). Wired once at the fate composition root
+ * (`fate/layers.ts`) over the merged mutations record, so it bounds every
+ * feature's mutation path without touching a single feature.
+ */
+import {type Actor, matchActor} from "@kampus/authz";
+import {Clock, Context, Effect, Layer, Option} from "effect";
+import {RateLimitExceeded} from "./errors.ts";
+import {RateLimitStore} from "./RateLimitStore.ts";
+import {type TokenBucketPolicy, tokenBucketPolicy, tryConsume} from "./TokenBucket.ts";
+
+/**
+ * The per-actor mutation budget: one default class covers every mutation — 60
+ * tokens of burst refilling 1/s (≈60 writes/minute sustained). Chosen well clear
+ * of a human's real write cadence (a fast reader voting/reacting rarely nears
+ * one write/second sustained) yet tight enough to bound a scripted flood — the
+ * abuse the audit named (sandbox floods, report spam, reaction churn). ADR 0177
+ * records why a single aggregate bucket (not per-mutation-class sub-buckets) is
+ * the v1 shape and where per-class values would slot in.
+ */
+export const DEFAULT_MUTATION_POLICY: TokenBucketPolicy = tokenBucketPolicy(60, 1);
+
+export interface RateLimiterAccess {
+	/**
+	 * Spend one token of the actor's mutation budget; fail with
+	 * {@link RateLimitExceeded} when the bucket is empty. Anonymous actors carry
+	 * no budget key — their writes are refused by each mutation's own auth gate —
+	 * so they pass through untouched.
+	 */
+	readonly check: (actor: Actor) => Effect.Effect<void, RateLimitExceeded>;
+}
+
+export class RateLimiter extends Context.Service<RateLimiter, RateLimiterAccess>()(
+	"@kampus/throttle/RateLimiter",
+) {}
+
+/** The per-actor budget key; `None` for anonymous traffic (not throttled here). */
+const actorKey = (actor: Actor): Option.Option<string> =>
+	matchActor(actor, {
+		onUnauthenticated: () => Option.none(),
+		onHuman: (h) => Option.some(`human:${h.id}`),
+		onAgent: (a) => Option.some(`agent:${a.id}`),
+	});
+
+export const RateLimiterLive = Layer.effect(RateLimiter)(
+	Effect.gen(function* () {
+		const store = yield* RateLimitStore;
+		const policy = DEFAULT_MUTATION_POLICY;
+		return {
+			check: Effect.fn("RateLimiter.check")(function* (actor: Actor) {
+				const key = actorKey(actor);
+				if (Option.isNone(key)) return;
+				const nowMs = yield* Clock.currentTimeMillis;
+				const outcome = yield* store.transition(key.value, (state) => {
+					const result = tryConsume(state, policy, nowMs);
+					return [result.state, result] as const;
+				});
+				if (!outcome.allowed) {
+					return yield* new RateLimitExceeded({
+						message: "çok hızlısın, biraz yavaşla",
+						retryAfterMs: outcome.retryAfterMs,
+					});
+				}
+			}),
+		};
+	}),
+);

--- a/apps/web/worker/features/throttle/RateLimiter.unit.test.ts
+++ b/apps/web/worker/features/throttle/RateLimiter.unit.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `RateLimiter` service coverage (ADR 0177) — the per-actor mutation budget over
+ * the real in-isolate store and `TestClock`: an actor under the ceiling is
+ * allowed, at the ceiling is denied with `RATE_LIMIT_EXCEEDED`, refills over
+ * time, buckets are per-actor, and anonymous traffic is never throttled here.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {human, unauthenticated} from "@kampus/authz";
+import {failureOf, wireCodeOf} from "@kampus/fate-effect";
+import {Effect, Exit, Layer} from "effect";
+import {TestClock} from "effect/testing";
+import {DEFAULT_MUTATION_POLICY, RateLimiter, RateLimiterLive} from "./RateLimiter.ts";
+import {InIsolateRateLimitStoreLive} from "./RateLimitStore.ts";
+
+const TestRateLimiter = RateLimiterLive.pipe(Layer.provide(InIsolateRateLimitStoreLive));
+const CAPACITY = DEFAULT_MUTATION_POLICY.capacity;
+
+describe("RateLimiter — per-actor mutation budget (ADR 0177)", () => {
+	it.effect("under the ceiling every write is allowed; the write past it is denied", () =>
+		Effect.gen(function* () {
+			const limiter = yield* RateLimiter;
+			const actor = human("u-flooder");
+			for (let i = 0; i < CAPACITY; i++) yield* limiter.check(actor);
+			const exit = yield* limiter.check(actor).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) {
+				assert.strictEqual(wireCodeOf(failureOf(exit.cause)), "RATE_LIMIT_EXCEEDED");
+			}
+		}).pipe(Effect.provide(TestRateLimiter)),
+	);
+
+	it.effect("the bucket refills over time — a denied actor is allowed again after the window", () =>
+		Effect.gen(function* () {
+			const limiter = yield* RateLimiter;
+			const actor = human("u-steady");
+			for (let i = 0; i < CAPACITY; i++) yield* limiter.check(actor);
+			assert.isTrue(Exit.isFailure(yield* limiter.check(actor).pipe(Effect.exit)));
+			yield* TestClock.adjust("1 seconds"); // one token back at 1/s
+			assert.isTrue(Exit.isSuccess(yield* limiter.check(actor).pipe(Effect.exit)));
+		}).pipe(Effect.provide(TestRateLimiter)),
+	);
+
+	it.effect("each actor gets an independent bucket", () =>
+		Effect.gen(function* () {
+			const limiter = yield* RateLimiter;
+			for (let i = 0; i < CAPACITY; i++) yield* limiter.check(human("u-a"));
+			// u-a is drained; u-b is untouched and still allowed
+			assert.isTrue(Exit.isSuccess(yield* limiter.check(human("u-b")).pipe(Effect.exit)));
+		}).pipe(Effect.provide(TestRateLimiter)),
+	);
+
+	it.effect("anonymous traffic carries no budget key and is never throttled here", () =>
+		Effect.gen(function* () {
+			const limiter = yield* RateLimiter;
+			for (let i = 0; i < CAPACITY * 2; i++) yield* limiter.check(unauthenticated);
+		}).pipe(Effect.provide(TestRateLimiter)),
+	);
+});

--- a/apps/web/worker/features/throttle/TokenBucket.ts
+++ b/apps/web/worker/features/throttle/TokenBucket.ts
@@ -1,0 +1,94 @@
+/**
+ * The token-bucket rate-limit algorithm as a pure domain object (ADR 0177):
+ * state + policy + the two transitions (refill-by-elapsed-time, try-consume).
+ * No clock, no store, no Effect — `nowMs` is passed in, so the algorithm is
+ * exhaustively unit-testable and byte-identical whether its state lives in an
+ * isolate `Map` today or a per-actor Durable Object when registration opens.
+ */
+
+/** A bucket's state: tokens remaining and the wall time they were last refilled. */
+export interface TokenBucketState {
+	readonly tokens: number;
+	readonly lastRefillMs: number;
+}
+
+/**
+ * A bucket's fixed shape: `capacity` is the burst ceiling (and the full-bucket
+ * start), `refillPerSecond` the sustained rate. Both are positive by
+ * construction — {@link tokenBucketPolicy} is the only constructor and rejects a
+ * non-positive value, so an unfillable bucket is unrepresentable.
+ */
+export interface TokenBucketPolicy {
+	readonly capacity: number;
+	readonly refillPerSecond: number;
+}
+
+/** The only `TokenBucketPolicy` constructor — throws on a non-positive value (a
+ * misconfiguration, i.e. a programmer error, never a runtime input). */
+export const tokenBucketPolicy = (capacity: number, refillPerSecond: number): TokenBucketPolicy => {
+	if (!(capacity > 0) || !(refillPerSecond > 0)) {
+		throw new Error(
+			`invalid token-bucket policy: capacity=${capacity} refillPerSecond=${refillPerSecond} (both must be > 0)`,
+		);
+	}
+	return {capacity, refillPerSecond};
+};
+
+/** A brand-new, full bucket at `nowMs`. */
+export const initialState = (policy: TokenBucketPolicy, nowMs: number): TokenBucketState => ({
+	tokens: policy.capacity,
+	lastRefillMs: nowMs,
+});
+
+/**
+ * Refill by elapsed wall time, capped at `capacity`. Clock-skew-safe: a
+ * backwards `nowMs` clamps elapsed to 0, so a bucket never loses tokens and
+ * `lastRefillMs` only advances.
+ */
+export const refill = (
+	state: TokenBucketState,
+	policy: TokenBucketPolicy,
+	nowMs: number,
+): TokenBucketState => {
+	const elapsedMs = Math.max(0, nowMs - state.lastRefillMs);
+	if (elapsedMs === 0) return state;
+	const refilled = Math.min(
+		policy.capacity,
+		state.tokens + (elapsedMs / 1000) * policy.refillPerSecond,
+	);
+	return {tokens: refilled, lastRefillMs: nowMs};
+};
+
+/** The outcome of a {@link tryConsume}: whether it was allowed, the resulting
+ * state to persist, and the wait until the next token when denied (0 if allowed). */
+export interface ConsumeResult {
+	readonly allowed: boolean;
+	readonly state: TokenBucketState;
+	readonly retryAfterMs: number;
+}
+
+/**
+ * Spend one token: refill first, then consume iff at least one token remains. On
+ * denial the state is still the refilled bucket (so the next call sees the
+ * elapsed time) and `retryAfterMs` is the wait until one token accrues.
+ */
+export const tryConsume = (
+	prev: TokenBucketState | undefined,
+	policy: TokenBucketPolicy,
+	nowMs: number,
+): ConsumeResult => {
+	const state = prev === undefined ? initialState(policy, nowMs) : refill(prev, policy, nowMs);
+	if (state.tokens >= 1) {
+		return {
+			allowed: true,
+			state: {tokens: state.tokens - 1, lastRefillMs: state.lastRefillMs},
+			retryAfterMs: 0,
+		};
+	}
+	const deficit = 1 - state.tokens;
+	return {
+		allowed: false,
+		state,
+		retryAfterMs: Math.ceil((deficit / policy.refillPerSecond) * 1000),
+	};
+};

--- a/apps/web/worker/features/throttle/TokenBucket.unit.test.ts
+++ b/apps/web/worker/features/throttle/TokenBucket.unit.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The token-bucket domain object (ADR 0177) — the rate-limit algorithm proven
+ * store-free: refill-by-elapsed-time, consume, deny-at-empty, clock-skew safety.
+ * The `RateLimiter` service and the DO/in-isolate backing reuse this same math,
+ * so pinning it here is what lets those higher layers stay thin.
+ */
+import {describe, expect, it} from "vitest";
+import {initialState, refill, tokenBucketPolicy, tryConsume} from "./TokenBucket.ts";
+
+const policy = tokenBucketPolicy(3, 1); // 3-token burst, refilling 1/s
+
+describe("TokenBucket (ADR 0177)", () => {
+	it("rejects a non-positive policy at construction", () => {
+		expect(() => tokenBucketPolicy(0, 1)).toThrow();
+		expect(() => tokenBucketPolicy(3, 0)).toThrow();
+		expect(() => tokenBucketPolicy(-1, 1)).toThrow();
+	});
+
+	it("starts full, consumes down to empty, then denies with a retry hint", () => {
+		let state = initialState(policy, 0);
+		for (let i = 0; i < 3; i++) {
+			const r = tryConsume(state, policy, 0);
+			expect(r.allowed).toBe(true);
+			state = r.state;
+		}
+		const denied = tryConsume(state, policy, 0);
+		expect(denied.allowed).toBe(false);
+		expect(denied.retryAfterMs).toBe(1000); // one token at 1/s
+	});
+
+	it("refills by elapsed wall time, capped at capacity", () => {
+		const empty = {tokens: 0, lastRefillMs: 0};
+		expect(refill(empty, policy, 2000).tokens).toBe(2); // 2s × 1/s
+		expect(refill(empty, policy, 10_000).tokens).toBe(3); // capped at capacity
+	});
+
+	it("a denied bucket is allowed again once a token refills", () => {
+		const empty = {tokens: 0, lastRefillMs: 0};
+		expect(tryConsume(empty, policy, 0).allowed).toBe(false);
+		expect(tryConsume(empty, policy, 1000).allowed).toBe(true);
+	});
+
+	it("is clock-skew safe — a backwards clock never adds or removes tokens", () => {
+		const state = {tokens: 1, lastRefillMs: 5000};
+		expect(refill(state, policy, 1000).tokens).toBe(1); // now < lastRefill
+	});
+
+	it("treats an absent bucket as a fresh full one", () => {
+		const r = tryConsume(undefined, policy, 0);
+		expect(r.allowed).toBe(true);
+		expect(r.state.tokens).toBe(2); // capacity 3, minus the token just spent
+	});
+});

--- a/apps/web/worker/features/throttle/errors.ts
+++ b/apps/web/worker/features/throttle/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * The throttle wire-coded denial (ADR 0177) — a `Schema.TaggedErrorClass` with a
+ * `FateWireCode` annotation, so `encodeWireError` derives the wire shape with no
+ * registry edit, the same path as `kunye/VouchLimitReached`. Distinct from that
+ * business cap: `VOUCH_LIMIT_REACHED` rations one domain act (concurrent
+ * vouches), whereas this bounds an actor's aggregate mutation *volume* across
+ * every feature at the fate seam.
+ */
+import {FateWireCode} from "@kampus/fate-effect";
+import * as Schema from "effect/Schema";
+
+/**
+ * The per-actor mutation budget is exhausted — the actor is issuing writes
+ * faster than the token bucket refills. Carries `retryAfterMs` so the surface
+ * can name the wait; its own `RATE_LIMIT_EXCEEDED` code (not a generic 500) so a
+ * throttled write is a clear, distinguishable denial.
+ */
+export class RateLimitExceeded extends Schema.TaggedErrorClass<RateLimitExceeded>()(
+	"throttle/RateLimitExceeded",
+	{message: Schema.String, retryAfterMs: Schema.Number},
+	{[FateWireCode]: "RATE_LIMIT_EXCEEDED"},
+) {}

--- a/apps/web/worker/features/throttle/errors.unit.test.ts
+++ b/apps/web/worker/features/throttle/errors.unit.test.ts
@@ -1,0 +1,23 @@
+/**
+ * The throttle wire-error annotation pin (ADR 0177) — `RateLimitExceeded` carries
+ * `RATE_LIMIT_EXCEEDED` and round-trips through `encodeWireError` with its own
+ * message. The aggregate `fate/wireCodes.unit.test.ts` guard proves the SPA list
+ * covers this seam-injected code; this pins the class→code binding itself, the
+ * throttle twin of `fate/wireCodes-per-class.unit.test.ts` (the seam-injected
+ * code has no declared union, so it can't be pinned by that staleness guard).
+ */
+import {encodeWireError, wireCodeOfClass} from "@kampus/fate-effect";
+import {describe, expect, it} from "vitest";
+import {RateLimitExceeded} from "./errors.ts";
+
+describe("throttle wire error", () => {
+	it("RateLimitExceeded carries RATE_LIMIT_EXCEEDED", () => {
+		expect(wireCodeOfClass(RateLimitExceeded)).toBe("RATE_LIMIT_EXCEEDED");
+	});
+
+	it("encodes to its wire code with its own message", () => {
+		const wire = encodeWireError(new RateLimitExceeded({message: "slow down", retryAfterMs: 1000}));
+		expect(wire.code).toBe("RATE_LIMIT_EXCEEDED");
+		expect(wire.message).toBe("slow down");
+	});
+});

--- a/apps/web/worker/features/throttle/throttle-mutations.ts
+++ b/apps/web/worker/features/throttle/throttle-mutations.ts
@@ -1,0 +1,38 @@
+/**
+ * `throttleMutations` — wrap every mutation's `resolve` with the per-actor
+ * throttle (ADR 0177), applied ONCE at the fate composition root
+ * (`fate/layers.ts`) over the merged mutations record so it reaches every
+ * feature's mutation path without touching a single feature. The token is spent
+ * BEFORE the handler runs, so a denial fails the mutation with
+ * `RATE_LIMIT_EXCEEDED` and the handler — its write AND its `/fate/live` publish
+ * — never runs; a throttled mutation is transparent to the fanout invariant
+ * because it simply doesn't execute.
+ */
+import {CurrentActor} from "@kampus/authz";
+import type {AnyFateMutation, FateMutationsRecord} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import {RateLimiter} from "./RateLimiter.ts";
+
+/**
+ * The wrapped `resolve` gains `RateLimiter` + `CurrentActor` in its true
+ * requirements; the return type is preserved as the input record `M` because
+ * both are provided at run time — `RateLimiter` from the worker layer,
+ * `CurrentActor` per request off the session (ADR 0107 §7) — the same re-pin the
+ * fate provision pipeline applies to every erased entry effect.
+ */
+export const throttleMutations = <M extends FateMutationsRecord>(mutations: M): M => {
+	const throttled: Record<string, AnyFateMutation> = {};
+	for (const [name, entry] of Object.entries(mutations)) {
+		throttled[name] = {
+			...entry,
+			resolve: (input) =>
+				Effect.gen(function* () {
+					const limiter = yield* RateLimiter;
+					const {actor} = yield* CurrentActor;
+					yield* limiter.check(actor);
+					return yield* entry.resolve(input);
+				}),
+		};
+	}
+	return throttled as M;
+};

--- a/apps/web/worker/features/throttle/throttle-mutations.unit.test.ts
+++ b/apps/web/worker/features/throttle/throttle-mutations.unit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `throttleMutations` seam coverage (ADR 0177) — the wrapper is transparent to a
+ * mutation's handler when the actor is under budget (its write AND its
+ * `/fate/live` publish still fire), and short-circuits with `RATE_LIMIT_EXCEEDED`
+ * BEFORE the handler when over budget (so a throttled write never publishes — the
+ * fanout invariant is preserved because the handler simply doesn't run).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentActor, human} from "@kampus/authz";
+import {
+	type AnyFateMutation,
+	type FateMutationsRecord,
+	failureOf,
+	wireCodeOf,
+} from "@kampus/fate-effect";
+import {Effect, Exit, Layer} from "effect";
+import * as Schema from "effect/Schema";
+import {DEFAULT_MUTATION_POLICY, type RateLimiter, RateLimiterLive} from "./RateLimiter.ts";
+import {InIsolateRateLimitStoreLive} from "./RateLimitStore.ts";
+import {throttleMutations} from "./throttle-mutations.ts";
+
+const TestRateLimiter = RateLimiterLive.pipe(Layer.provide(InIsolateRateLimitStoreLive));
+const CAPACITY = DEFAULT_MUTATION_POLICY.capacity;
+
+/**
+ * A stand-in fanned mutation whose `resolve` records a "publish" — the
+ * `/fate/live` invalidation a real fanned mutation fires after its write. The
+ * `published` array is the observable proof of whether the handler ran.
+ */
+const makeFannedMutations = (published: Array<string>): FateMutationsRecord => ({
+	"post.submit": {
+		kind: "mutation",
+		definition: {input: Schema.Unknown, type: "Post"},
+		type: "Post",
+		handler: (() => Effect.succeed(null)) as AnyFateMutation["handler"],
+		resolve: (() =>
+			Effect.sync(() => {
+				published.push("post.invalidated");
+				return {ok: true};
+			})) as AnyFateMutation["resolve"],
+	},
+});
+
+/** Drive the throttled `post.submit` resolve, re-pinning its erased `R` to the
+ * services the wrapper truly needs (both provided by {@link runAsWriter}). */
+const submit = (published: Array<string>) => {
+	const entry = throttleMutations(makeFannedMutations(published))["post.submit"] as AnyFateMutation;
+	return entry.resolve({input: {}, select: []}) as Effect.Effect<
+		unknown,
+		unknown,
+		RateLimiter | CurrentActor
+	>;
+};
+
+const runAsWriter = <A, E>(effect: Effect.Effect<A, E, RateLimiter | CurrentActor>) =>
+	effect.pipe(
+		Effect.provideService(CurrentActor, {actor: human("u-writer")}),
+		Effect.provide(TestRateLimiter),
+	);
+
+describe("throttleMutations (ADR 0177)", () => {
+	it.effect("under budget the wrapped handler runs — the fanned publish still fires", () =>
+		runAsWriter(
+			Effect.gen(function* () {
+				const published: Array<string> = [];
+				const result = yield* submit(published);
+				assert.deepStrictEqual(published, ["post.invalidated"]);
+				assert.deepStrictEqual(result, {ok: true});
+			}),
+		),
+	);
+
+	it.effect(
+		"over budget the wrapped mutation fails RATE_LIMIT_EXCEEDED and the handler (write + publish) never runs",
+		() =>
+			runAsWriter(
+				Effect.gen(function* () {
+					const published: Array<string> = [];
+					for (let i = 0; i < CAPACITY; i++) yield* submit(published);
+					const publishedBefore = published.length;
+					const exit = yield* submit(published).pipe(Effect.exit);
+					assert.isTrue(Exit.isFailure(exit));
+					if (Exit.isFailure(exit)) {
+						assert.strictEqual(wireCodeOf(failureOf(exit.cause)), "RATE_LIMIT_EXCEEDED");
+					}
+					assert.strictEqual(published.length, publishedBefore); // handler skipped
+				}),
+			),
+	);
+});

--- a/apps/web/worker/features/throttle/wire-codes.ts
+++ b/apps/web/worker/features/throttle/wire-codes.ts
@@ -1,0 +1,9 @@
+/**
+ * The wire codes the per-actor mutation throttle (ADR 0177) injects at the fate
+ * composition seam — NOT through any feature's declared error union, so
+ * `declaredWireCodes(fateConfig)` (which walks declared unions) does not see
+ * them. The SPA-coverage guard (`fate/wireCodes.unit.test.ts`) unions this set
+ * onto the declared set, so the SPA `FATE_WIRE_CODES` list must still cover it —
+ * the single source both the guard and any future throttle code read from.
+ */
+export const THROTTLE_WIRE_CODES = ["RATE_LIMIT_EXCEEDED"] as const;


### PR DESCRIPTION
Fixes #2561

## What

No per-time / per-actor write throttle existed anywhere on the worker: authenticated writes were per-item-bounded but carried **no volume bound**, so sandbox floods, report spam, and reaction churn were unthrottled. This adds a cross-cutting per-actor mutation throttle **wired once at the fate composition root** (`apps/web/worker/features/fate/layers.ts`) so it bounds **every** feature's mutation path.

## Design (three seams, one job each)

- **`TokenBucket`** (`features/throttle/TokenBucket.ts`) — the rate-limit algorithm as a **pure domain object**: refill-by-elapsed-time, try-consume, clock-skew safe. No clock/store/Effect; `nowMs` is passed in, so it is exhaustively unit-testable and identical whether state lives in an isolate `Map` or a future Durable Object.
- **`RateLimiter`** (`features/throttle/RateLimiter.ts`) — the isolate-level service, keyed on `CurrentActor` (ADR 0107). `check(actor)` spends one token, failing with the dedicated **`RATE_LIMIT_EXCEEDED`** wire error (following the `VOUCH_LIMIT_REACHED` precedent), never a generic 500. Anonymous actors carry no key and pass through.
- **`RateLimitStore`** (`features/throttle/RateLimitStore.ts`) — the **dependency-inverted backing-store port** (the DO-vs-D1 swap point), discharged at the composition root exactly like Vote's `KarmaBump`/`VoterStanding`.

`throttleMutations` wraps every mutation's `resolve` in `layers.ts`; a throttled write short-circuits **before** its handler, so its `/fate/live` publish never fires — the fanout invariant is preserved because the handler simply doesn't run. Only the serving path is throttled; codegen (`schema.ts`) consumes the plain `fateConfig`.

## Storage fork + limits (ADR 0177)

The audit framed the choice as **DO vs D1**; grounded in ADR 0037 (`LiveDO`) and the D1 patterns, it resolves to a **third option behind the same port for v1**: an **in-isolate `Map`** — zero new infra, no per-mutation round-trip, fully unit-testable, and (because a flooder's burst lands on one/few reused isolates) already bounds the named abuse. Its per-isolate (not global) bound is the explicit **v1→Durable-Object upgrade trigger** — a one-Layer swap behind `RateLimitStore` when registration opens. **D1** was rejected for v1 (hot RMW on every write, doubles primary-DB write load, race-prone). Limit: one aggregate per-actor bucket, **60 burst refilling 1/s** (≈60 writes/min). Full rationale in [`.decisions/0177-per-actor-mutation-rate-limiting.md`](.decisions/0177-per-actor-mutation-rate-limiting.md).

## Acceptance criteria

- [x] Limiter service added + wired once at `fate/layers.ts`, reaching every mutation path.
- [x] Per-actor, per-time-window token bucket keyed on `CurrentActor`, at the mutation seam (not per-item).
- [x] Dedicated `RATE_LIMIT_EXCEEDED` wire error (VOUCH_LIMIT_REACHED precedent), not a 500.
- [x] Backing store (in-isolate for v1, DO documented as the upgrade) + limit values chosen; rationale in ADR 0177.
- [x] Unit coverage: over-limit denied / under-limit allowed; a fanned mutation still publishes when allowed (fanout-guard green).

## Gates (local)

`pnpm typecheck` ✅ · `pnpm lint` ✅ · full `apps/web` unit suite (242 files / 2094 tests) ✅ · `fanout-guard check` ✅ (44 mutations, 24 fanned, all publish). Integration tier not run locally — the sandbox has no Cloudflare API token, so the `@distilled.cloud/cloudflare` setup fails at auth before any test (unrelated to this change; CI runs it with creds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)