### PR TITLE
fix(pipeline-cli): reject unbindable polarity verdicts at emission (#2646)

### DIFF
--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -224,4 +224,58 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				}),
 			),
 	);
+
+	// The #2646 emission guard: a polarity-bearing (PASS/FAIL) body with an empty/malformed SHA is
+	// the observed unbindable `@-` marker — refused fail-closed at emission, never POSTed, so the
+	// read side never has to false-BLOCK it. No POST/PATCH fixture is supplied: a write would 404.
+	it.effect("a PASS body with an EMPTY `@ <sha>` → VerdictInputError, no write", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip((yield* Github).post(PR, "doc", "review-doc: PASS @ -"));
+			assert.isTrue(error instanceof VerdictInputError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+			}),
+		),
+	);
+
+	it.effect("a FAIL body with a too-short (<7 hex) SHA → VerdictInputError, no write", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip((yield* Github).post(PR, "doc", "review-doc: FAIL @ abc12"));
+			assert.isTrue(error instanceof VerdictInputError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+			}),
+		),
+	);
+
+	it.effect("a well-formed `PASS @ <40hex>` body → POSTed (the guard passes it through)", () =>
+		Effect.gen(function* () {
+			const sha40 = "a".repeat(40);
+			const result = yield* (yield* Github).post(PR, "doc", `review-doc: PASS @ ${sha40}`);
+			assert.deepStrictEqual(result, {_tag: "posted", commentId: 777});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`POST ${P}/issues/${PR}/comments`]: "777",
+			}),
+		),
+	);
+
+	it.effect("an advisory (SHA-less, no polarity) body is still POSTed", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).post(PR, "doc", "review-doc: advisory — see thread");
+			assert.deepStrictEqual(result, {_tag: "posted", commentId: 888});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`POST ${P}/issues/${PR}/comments`]: "888",
+			}),
+		),
+	);
 });

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -23,6 +23,7 @@ import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import {
 	GATE_KEYWORD,
 	isNamespaceMarker,
+	isUnboundPolarityMarker,
 	namespaceRe,
 	type Polarity,
 	resolveVerdict,
@@ -295,10 +296,12 @@ const read = Effect.fn("Github.read")(function* (
 });
 
 /**
- * Upsert this PR's `gate` verdict (ADR 0058 rule 2): guard `body`'s first line is *this* gate's
- * marker (fail-closed `VerdictInputError` on a cross-namespace body — the emission bug), scan our
- * OWN prior marker in the namespace (newest by `(created_at, id)`), then PATCH it if present else
- * POST a fresh one. The own-authored scope means two reviewers never stomp each other's records.
+ * Upsert this PR's `gate` verdict (ADR 0058 rule 2). Two fail-closed emission guards run first:
+ * the body's first line must be *this* gate's marker (rejects a cross-namespace body), and a
+ * polarity-bearing (PASS/FAIL) body must carry a well-formed `@ <sha>` (rejects the unbindable
+ * empty-SHA `@-` marker the read side refuses, #2646) — an advisory SHA-less line stays postable.
+ * Then scan our OWN prior marker in the namespace (newest by `(created_at, id)`) and PATCH it if
+ * present else POST a fresh one. The own-authored scope means two reviewers never stomp each other's records.
  */
 const post = Effect.fn("Github.post")(function* (
 	repo: string,
@@ -309,6 +312,11 @@ const post = Effect.fn("Github.post")(function* (
 	if (!isNamespaceMarker(body, gate)) {
 		return yield* new VerdictInputError({
 			message: `refusing to post: the body's first line is not a ${GATE_KEYWORD[gate]}: marker — a verdict must carry its own gate's marker on line one (the cross-namespace emission bug, ADR 0058 §Scope)`,
+		});
+	}
+	if (isUnboundPolarityMarker(body, gate)) {
+		return yield* new VerdictInputError({
+			message: `refusing to post: a ${GATE_KEYWORD[gate]}: PASS/FAIL verdict must carry a well-formed '@ <sha>' (≥7 hex) — this polarity-bearing body has an empty/malformed SHA, which posts an unbindable marker the fail-closed read side refuses (the '@-' emission bug, ADR 0058, #2646)`,
 		});
 	}
 	const me = (yield* runGh(whoAmIArgs)).trim();

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -214,3 +214,14 @@ export const outcomeReason = (outcome: VerdictOutcome, expect: Polarity): string
  */
 export const isNamespaceMarker = (body: string, gate: VerdictGate): boolean =>
 	namespaceRe(gate).test(body);
+
+/**
+ * The `post` emission guard: does this body declare a PASS/FAIL polarity but carry no bindable
+ * `@ <sha>` (≥7 hex)? Such a body posts an unbindable marker — the observed empty-SHA `@-` case
+ * (#2646) — that the fail-closed read side then refuses (`sha-less`), false-BLOCKing a legitimate
+ * ship until a manual re-post. `post` rejects it fail-closed at emission so the broken marker never
+ * reaches GitHub. Keys on "polarity present ⇒ SHA required": an advisory (namespaced, no PASS/FAIL)
+ * carries no polarity, so it returns false and stays postable SHA-less.
+ */
+export const isUnboundPolarityMarker = (body: string, gate: VerdictGate): boolean =>
+	polarityRe(gate).test(body) && !verdictRe(gate).test(body);

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -3,6 +3,7 @@ import {
 	isBoundToHead,
 	isNamespaceMarker,
 	isReviewed,
+	isUnboundPolarityMarker,
 	parseVerdict,
 	resolveVerdict,
 	type VerdictComment,
@@ -301,4 +302,19 @@ describe("isNamespaceMarker — the post cross-namespace guard", () => {
 		assert.isFalse(isNamespaceMarker(`review-code: PASS @ ${HEAD} — merge-ready`, "doc")));
 	it("rejects a non-marker first line", () =>
 		assert.isFalse(isNamespaceMarker("just a normal comment", "doc")));
+});
+
+describe("isUnboundPolarityMarker — the post SHA-required-for-polarity guard (#2646)", () => {
+	it("flags a PASS with an empty `@ -` SHA (the observed `@-` case)", () =>
+		assert.isTrue(isUnboundPolarityMarker("review-doc: PASS @ -", "doc")));
+	it("flags a PASS with no `@ <sha>` at all", () =>
+		assert.isTrue(isUnboundPolarityMarker("review-doc: PASS — merge-ready", "doc")));
+	it("flags a FAIL with a too-short (<7 hex) SHA", () =>
+		assert.isTrue(isUnboundPolarityMarker("review-doc: FAIL @ abc12", "doc")));
+	it("allows a well-formed PASS @ <sha>", () =>
+		assert.isFalse(isUnboundPolarityMarker(`review-doc: PASS @ ${HEAD} — merge-ready`, "doc")));
+	it("allows an advisory (SHA-less, no polarity) line", () =>
+		assert.isFalse(isUnboundPolarityMarker("review-doc: advisory — see thread", "doc")));
+	it("allows another gate's marker (not this namespace's concern)", () =>
+		assert.isFalse(isUnboundPolarityMarker("review-code: PASS — merge-ready", "doc")));
 });


### PR DESCRIPTION
Fixes #2646

## Problem

`Github.post` (`packages/pipeline-cli/src/tools/verdict/github.ts`) guarded a verdict body only with `isNamespaceMarker` — the `review-<gate>:` **prefix** — never requiring a well-formed `@ <sha>`. So a PASS/FAIL body whose SHA interpolated empty posted a malformed `@-` marker. The fail-closed read side (`resolveVerdict` / `isBoundToHead`) then correctly classified it `sha-less` and refused it — false-BLOCKing a legitimately-passing PR from shipping until a manual re-post (bit PR #2643 this session).

The gate itself was never at risk of a bad merge (the read path is fail-closed); the live defect is a false BLOCK + re-post toil under parallel review, on the **verdict-emission boundary**.

## Fix

Add `isUnboundPolarityMarker(body, gate)` to `verdict-match.ts` — `polarityRe` matches (a PASS/FAIL is declared) but `verdictRe` does not (no bindable `@ <sha>` ≥7 hex). `Github.post` now rejects such a body fail-closed with `VerdictInputError` **before any POST/PATCH**, so the broken `@-` marker never reaches GitHub. The guard keys on "polarity present ⇒ SHA required".

Reuses the existing `polarityRe` + `verdictRe` matchers from `verdict-match.ts` — no divergent pattern.

**Advisory posting is untouched:** an advisory line (`review-<gate>: advisory …`) carries no PASS/FAIL polarity, so `isUnboundPolarityMarker` returns false and it stays postable without a `@ <sha>`.

## Acceptance criteria

- [x] `verdict post` refuses, fail-closed, a polarity-bearing body with no well-formed `@ <sha>` (≥7 hex) — `VerdictInputError` before any POST/PATCH.
- [x] A namespace **advisory** line (SHA-less, no polarity) is still accepted — no regression.
- [x] Unit coverage in `packages/pipeline-cli/src/tools/verdict/`: empty-SHA PASS → refused; well-formed `PASS @ <40hex>` → posted; advisory SHA-less → still posted. (Plus pure-core coverage of `isUnboundPolarityMarker`.)
- [x] wt/ref scratchpad contamination: confirmed **not a live source defect** in the current tree — the fixed `wt.txt`/`ref.txt` handles do not exist under `claude-plugins/kampus-pipeline/skills/review-*/`; the per-run `mktemp` discipline already landed (#1816). No separate issue filed; nothing to widen here.

## Scope

Four files, all under `packages/pipeline-cli/src/tools/verdict/`. The wt/ref half is out of scope per triage (already fixed by #1816).

## §CP

Under `packages/pipeline-cli/` (`CONTROL_PLANE_RE`) + it changes the ADR-0058 gate mechanism → **§CP**. Stops at reviewed-ready; routes to `@kamp-us/control-plane` approval before enqueue (ADR 0135), never autonomous ship.

## Local gates (against the worktree)

- `pnpm --filter @kampus/pipeline-cli typecheck` — clean
- `biome check` on the changed files — clean
- `vitest run src/tools/verdict/` — 51 passed

Refs: ADR 0058 (SHA-bound verdict contract), ADR 0135 (control-plane approve-then-enqueue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)