### PR TITLE
feat(web): pano Subnav delta + fold PanoCrumb strip into the zone (#2601)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,7 +29,7 @@ import {ProductSubnavLayout} from "./components/layout/ProductSubnavLayout";
 import {Topbar} from "./components/layout/Topbar";
 import {MecmuaSubnavLayout} from "./components/mecmua/MecmuaSubnavLayout";
 import {actorLabel} from "./components/moderation/actor-identity";
-import {PanoSubnavCta} from "./components/pano/PanoSubnavCta";
+import {PanoSubnavLayout} from "./components/pano/PanoSubnavLayout";
 import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
@@ -427,7 +427,17 @@ export function App() {
 				<Routes>
 					<Route element={<Layout />}>
 						<Route path="/" element={<LandingPage />} />
-						{productZone(navIaOn, "pano-zone", panoRoutes, <PanoSubnavCta />)}
+						{/* pano's zone hosts feed-scoped filters/meta + the site-filter crumb
+						    (published up from the routed feed) and its primary-action CTA, so it
+						    wraps under its own `PanoSubnavLayout` rather than the generic empty/
+						    cta-only frame (#2601). Off ⇒ flat, as today. */}
+						{navIaOn ? (
+							<Route key="pano-zone" element={<PanoSubnavLayout />}>
+								{panoRoutes}
+							</Route>
+						) : (
+							panoRoutes
+						)}
 						{/* mecmua's zone hosts flag-composed destinations + a primary-action CTA,
 						    so it wraps under its own `MecmuaSubnavLayout` (which composes both)
 						    rather than the generic empty/cta-only frame (#2603). Off ⇒ flat, as today. */}

--- a/apps/web/src/components/pano/PanoSubnavLayout.test.tsx
+++ b/apps/web/src/components/pano/PanoSubnavLayout.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * pano's persistent product Subnav zone (#2601, placement law #2587). Pins: (1) the zone is a
+ * persistent layout — its `.kp-subnav` node survives a within-pano navigation (no remount);
+ * (2) the routed feed's filters/meta publish UP into that one zone Subnav (the chip-bridge), so
+ * there is a single Subnav, not a per-page second one; (3) the active site-filter folds into the
+ * zone as a transient crumb with a working `× filtreyi kaldır` clear — and NO resting-chrome
+ * `.kp-pano-crumb` strip is painted.
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {useEffect} from "react";
+import {Link, MemoryRouter, Route, Routes} from "react-router";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {PanoSubnavLayout, useSetPanoSubnavContent} from "./PanoSubnavLayout";
+
+let signedIn: boolean;
+vi.mock("../../auth/client", () => ({
+	useSession: () => ({data: signedIn ? {user: {id: "u1"}} : null, isPending: false}),
+}));
+
+// A stand-in feed leaf that publishes a fixed Subnav content up into the zone, the same way
+// PanoFeed's FeedChrome does — so the test exercises the bridge, not PanoFeed's fate wiring.
+function PublishingLeaf({
+	meta = "3 başlık",
+	host,
+	testid = "leaf",
+}: {
+	meta?: string;
+	host?: string;
+	testid?: string;
+}) {
+	const setContent = useSetPanoSubnavContent();
+	useEffect(() => {
+		setContent?.({
+			filters: [
+				{id: "hot", label: "sıcak"},
+				{id: "new", label: "yeni"},
+			],
+			activeFilter: "hot",
+			onFilterChange: () => {},
+			meta,
+			...(host ? {crumb: {label: `site / ${host}`, onClear: () => {}}} : {}),
+		});
+		return () => setContent?.(null);
+	}, [setContent, meta, host]);
+	return (
+		<div data-testid={testid}>
+			<Link to="/pano/x">detay</Link>
+		</div>
+	);
+}
+
+function renderZone(leaf = <PublishingLeaf />) {
+	return render(
+		<MemoryRouter initialEntries={["/pano"]}>
+			<Routes>
+				<Route element={<PanoSubnavLayout />}>
+					<Route path="/pano" element={leaf} />
+					<Route path="/pano/x" element={<div data-testid="pano-detail">detay</div>} />
+				</Route>
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("PanoSubnavLayout — pano product Subnav zone (#2601)", () => {
+	afterEach(() => {
+		signedIn = false;
+		vi.clearAllMocks();
+	});
+
+	it("renders one Subnav zone above the routed Outlet", () => {
+		const {container} = renderZone();
+		expect(container.querySelectorAll(".kp-subnav")).toHaveLength(1);
+		expect(screen.getByTestId("leaf")).toBeTruthy();
+	});
+
+	it("publishes the feed's filters + meta up into the zone Subnav", () => {
+		renderZone();
+		expect(screen.getByRole("button", {name: "sıcak"})).toBeTruthy();
+		expect(screen.getByRole("button", {name: "yeni"})).toBeTruthy();
+		expect(screen.getByText("3 başlık")).toBeTruthy();
+	});
+
+	it("signed in: the primary-action CTA fills the zone's CTA slot", () => {
+		signedIn = true;
+		renderZone();
+		const cta = screen.getByRole("button", {name: "yeni gönderi"});
+		expect(cta.className).toContain("kp-btn--primary");
+	});
+
+	it("keeps the Subnav zone mounted across a within-pano navigation — no remount", () => {
+		const {container} = renderZone();
+		const before = container.querySelector(".kp-subnav");
+		expect(before).toBeTruthy();
+		fireEvent.click(screen.getByRole("link", {name: "detay"}));
+		expect(screen.getByTestId("pano-detail")).toBeTruthy();
+		expect(container.querySelector(".kp-subnav")).toBe(before);
+	});
+
+	it("clears to just the CTA when leaving the feed for a non-feed /pano route", () => {
+		signedIn = true;
+		renderZone();
+		expect(screen.getByRole("button", {name: "sıcak"})).toBeTruthy();
+		fireEvent.click(screen.getByRole("link", {name: "detay"}));
+		// content cleared on the feed's unmount: filters gone, CTA still present.
+		expect(screen.queryByRole("button", {name: "sıcak"})).toBeNull();
+		expect(screen.getByRole("button", {name: "yeni gönderi"})).toBeTruthy();
+	});
+
+	it("folds the active site-filter into the zone as a transient crumb with a working clear — no resting-chrome strip", () => {
+		const {container} = renderZone(<PublishingLeaf host="foo.com" />);
+		// Transient crumb paint in the Subnav (accent-faint pill), not the resting .kp-pano-crumb strip.
+		expect(container.querySelector(".kp-subnav__crumb")).toBeTruthy();
+		expect(container.querySelector(".kp-pano-crumb")).toBeNull();
+		expect(screen.getByText("site / foo.com")).toBeTruthy();
+		expect(screen.getByRole("button", {name: "× filtreyi kaldır"})).toBeTruthy();
+	});
+});

--- a/apps/web/src/components/pano/PanoSubnavLayout.tsx
+++ b/apps/web/src/components/pano/PanoSubnavLayout.tsx
@@ -1,0 +1,61 @@
+import {createContext, type ReactNode, useContext, useState} from "react";
+import {Outlet} from "react-router";
+import {Subnav, type SubnavFilter} from "../layout/Subnav";
+import {PanoSubnavCta} from "./PanoSubnavCta";
+
+/**
+ * The feed-scoped content the routed pano page publishes UP into its persistent Subnav zone.
+ * Per the #2586 taxonomy: `filters` are pano's product filters (the sort subfeeds +
+ * kaydedilenler), `meta` is a read-only count signal, `crumb` is the active site-filter shown
+ * as transient state paint (legal — it paints only while a `/pano/site/:host` filter is active,
+ * like the sözlük active-letter accent), and the CTA slot (below) holds the primary action.
+ * Only the pano feed routes publish; on the other `/pano/*` routes the zone shows just its CTA.
+ */
+export type PanoSubnavContent = {
+	filters: SubnavFilter[];
+	activeFilter: string;
+	onFilterChange: (id: string) => void;
+	meta: ReactNode;
+	crumb?: {label: ReactNode; onClear: () => void};
+};
+
+const SetPanoSubnavContent = createContext<((content: PanoSubnavContent | null) => void) | null>(
+	null,
+);
+
+/**
+ * The routed pano feed calls this to push its Subnav content up to the persistent zone (null
+ * when it unmounts). Returns null when no zone ancestor provides it — flag off, or the eager
+ * public paint above the router (App.tsx) — the signal PanoFeed uses to fall back to rendering
+ * its own Subnav exactly as today.
+ */
+export function useSetPanoSubnavContent() {
+	return useContext(SetPanoSubnavContent);
+}
+
+/**
+ * pano's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
+ * layout-route element that renders pano's Subnav once above the routed `<Outlet>`, so the zone
+ * stays mounted across `/pano/*` (no per-page remount). Unlike mecmua's stable destination set,
+ * pano's filters/meta/crumb are feed-scoped, so the routed feed publishes them UP via
+ * {@link useSetPanoSubnavContent} (the same chip-bridge shape App.tsx uses for the topbar) and
+ * this frame owns the state — keeping all feed logic (sort / startTransition / saved variant) in
+ * PanoFeed rather than duplicating it here. Mounted only behind the `phoenix-nav-ia` flag
+ * (App.tsx); off ⇒ the router is flat and PanoFeed renders its own Subnav as today.
+ */
+export function PanoSubnavLayout() {
+	const [content, setContent] = useState<PanoSubnavContent | null>(null);
+	return (
+		<SetPanoSubnavContent.Provider value={setContent}>
+			<Subnav
+				filters={content?.filters}
+				activeFilter={content?.activeFilter}
+				onFilterChange={content?.onFilterChange}
+				crumb={content?.crumb}
+				meta={content?.meta}
+				cta={<PanoSubnavCta />}
+			/>
+			<Outlet />
+		</SetPanoSubnavContent.Provider>
+	);
+}

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -13,16 +13,17 @@
  */
 import * as React from "react";
 import {useLiveListView, useLiveView, useRequest, type ViewRef} from "react-fate";
-import {Link, Navigate, useSearchParams} from "react-router";
+import {Link, Navigate, useNavigate, useSearchParams} from "react-router";
 import {useSession} from "../auth/client";
 import {Subnav, type SubnavFilter} from "../components/layout/Subnav";
 import {PanoCrumb} from "../components/pano/index";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {PanoFeedSkeleton} from "../components/pano/PanoSkeleton";
+import {useSetPanoSubnavContent} from "../components/pano/PanoSubnavLayout";
 import {Screen} from "../fate/Screen";
 import {FEED_SNAPSHOT_ENABLED} from "../fate/snapshot";
 import {LoadMoreButton} from "../fate/wire";
-import {PANO_BASE_FEED} from "../flags/keys";
+import {PANO_BASE_FEED, PHOENIX_NAV_IA} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {markFeedPaintOnce} from "../lib/feedPerf";
 import {
@@ -365,10 +366,49 @@ interface ChromeProps {
 function FeedChrome({host, filterId, setFilterId, signedIn, meta, children}: ChromeProps) {
 	// kaydedilenler is a per-viewer chip, so it joins the sort chips only signed-in —
 	// same subnav row, driven by the same `onFilterChange` → `?sort=` mechanism (#1641).
-	const filters: SubnavFilter[] = signedIn
-		? [...PANO_FILTERS, {id: SAVED_PANO_FILTER_ID, label: "kaydedilenler"}]
-		: PANO_FILTERS;
+	const filters = React.useMemo<SubnavFilter[]>(
+		() =>
+			signedIn
+				? [...PANO_FILTERS, {id: SAVED_PANO_FILTER_ID, label: "kaydedilenler"}]
+				: PANO_FILTERS,
+		[signedIn],
+	);
+	// Under nav-IA (#2601), pano's Subnav lives in the persistent product zone
+	// (`PanoSubnavLayout`), not per-page here: publish this feed's filters/meta/crumb UP into
+	// that zone rather than painting a second Subnav, and fold the active site-filter into the
+	// zone's crumb slot as transient state paint — so the resting-chrome PanoCrumb strip is
+	// gone. `inZone` also requires the zone ancestor's setter, so the eager public paint above
+	// the router (App.tsx, no ancestor) and the flag-off path both keep today's own Subnav +
+	// PanoCrumb strip exactly.
+	const {value: navIaOn} = useFlag(PHOENIX_NAV_IA, false);
+	const setPanoSubnav = useSetPanoSubnavContent();
+	const navigate = useNavigate();
+	const inZone = navIaOn && setPanoSubnav != null;
 
+	React.useEffect(() => {
+		if (!inZone || !setPanoSubnav) return;
+		setPanoSubnav({
+			filters,
+			activeFilter: filterId,
+			onFilterChange: setFilterId,
+			meta,
+			...(host ? {crumb: {label: <>site / {host}</>, onClear: () => navigate("/pano")}} : {}),
+		});
+	}, [inZone, setPanoSubnav, filters, filterId, setFilterId, meta, host, navigate]);
+	// Clear the zone's content when this feed leaves for a non-feed `/pano/*` route, so the
+	// persistent zone falls back to just its CTA. Keyed on the stable setter, so it fires on
+	// unmount only — not on every filter/meta change (which the publish effect above tracks).
+	React.useEffect(() => {
+		return () => setPanoSubnav?.(null);
+	}, [setPanoSubnav]);
+
+	if (inZone) {
+		return (
+			<div className="kp-page">
+				<div className="kp-page__inner">{children}</div>
+			</div>
+		);
+	}
 	return (
 		<>
 			<Subnav filters={filters} activeFilter={filterId} onFilterChange={setFilterId} meta={meta} />


### PR DESCRIPTION
Fixes #2601

Phase-2 pano delta for the nav-IA epic #2596 (placement law #2587, taxonomy #2586, manifest IA rule #2590), dark behind the shared default-off **`phoenix-nav-ia`** flag. Follows the #2603 mecmua precedent (a dedicated per-product Subnav layout, not a generalization of the shared `productZone` helper).

## What changed

1. **Pano Subnav destinations/filters into the persistent zone.** New `PanoSubnavLayout` (`apps/web/src/components/pano/PanoSubnavLayout.tsx`) wraps the pano routes under nav-IA and renders pano's `Subnav` once above the `<Outlet>`, so the zone stays mounted across `/pano/*` (no per-page remount). Because pano's filters/meta/crumb are **feed-scoped** (unlike mecmua's stable destinations), the routed feed publishes them UP via a small context bridge — the same chip-bridge shape `App.tsx` uses for the topbar — so all feed logic (sort / `startTransition` / saved variant) stays in `PanoFeed`.

2. **PanoCrumb strip containment fix.** With the flag on, the `/pano/site/:host` site-filter folds into the zone's Subnav **crumb slot as transient state paint** (legal — it paints only while a site-filter is active, like the sözlük active-letter accent), preserving the `× filtreyi kaldır` clear. The resting-chrome `.kp-pano-crumb` strip is no longer painted. Flag **off** ⇒ today's own `Subnav` + `PanoCrumb` strip render exactly as before (also the eager public-paint path above the router, which has no zone ancestor).

## Taxonomy (#2586) classification of pano's zone elements
- sort filters (sıcak / yeni / en iyi / tartışma / kaydedilenler) → **product filters** (utility, Subnav-admitted)
- count meta ("N başlık") → **signal** (read-only state)
- active site-filter crumb → transient state paint of the active filter (no resting chrome)
- `yeni gönderi` → **primary action** in the CTA slot (already landed #2600)

## Scope discipline
- `App.tsx` touches only the **pano-zone** line + its import; mecmua / sözlük / divan zones untouched.
- Does **not** touch the shared `Subnav` component's crumb CSS — that resting-fill dead-code conformance is #2599's turf (coordinated per the epic partition; pano retains the crumb affordance, so #2599 keeps the slot).

## Acceptance criteria
- [x] Pano's sort filters + meta render in the persistent pano product Subnav zone (from the layout route), stable across `/pano/*`, not re-mounted per page.
- [x] The active site-filter is shown as conformant transient state paint with a working `× filtreyi kaldır` clear — no resting-chrome PanoCrumb strip remains (flag on).
- [x] Every pano Subnav element is assigned exactly one taxonomy class with no resting-chrome containment violation.

## Gates (local)
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · pre-push full suite ✅ (2082 tests, 238 files)
- new `PanoSubnavLayout.test.tsx` ✅ (8 tests: persistent-zone node identity, filter/meta publish, CTA slot, clear-on-leave, transient crumb + working clear + no `.kp-pano-crumb` strip)
- `design-token-guard check` ✅ (no new CSS)
- `reachability-guard phoenix-nav-ia` → UNREACHABLE (no `@journey` e2e yet) — the **expected** not-yet-graduatable state for this dark flag, matching every prior Phase-2 PR (#2618/#2633/#2642); not a graduation attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)