### PR TITLE
docs(roadmap): ROADMAP.md v1 — founder-ratified roadmap layer (#2647)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,43 @@
+# kamp.us — Roadmap
+
+> The living roadmap of kamp.us: the founder-voice source of direction. GitHub milestones are its operational projection. Agents ground in this file the way they ground in an ADR — it says *what we build next, and why*, in order. Conversation-authored (ADR-0075 idiom); revised at arc boundaries or when the founder calls it. Not a pipeline surface — this is product direction (ADR 0078).
+
+## What kamp.us is
+
+kamp.us, reborn. A small, earnest community built around three products — **sözlük** (the community of definitions), **pano** (the shared board of links and posts), and **mecmua** (long-form publishing) — bound by **künye**, earned-authorship identity: you arrive a çaylak and become a yazar by vouch (kefil), not by signup. Quality over growth; the founders are the first users; nothing seeded. An autonomous software factory builds it.
+
+## How this roadmap works
+
+Direction flows top-down: **vision → arcs → milestones → epics → features.** An **arc** is a themed chapter of work, projected onto a GitHub milestone. **Exactly one arc is active** at a time — it defines "now," and priority is relative to it (`p1` = current arc). The intake pipeline stays deliberately direction-blind; this roadmap is the layer that gives it direction. When an arc flips active, stale priorities re-price against the new active arc.
+
+## Arcs
+
+| Arc | Milestone | State |
+|-----|-----------|-------|
+| Four Pillars | #17 | active |
+| Geçit | #24 | queued |
+| Mecmua v2 | #25 | queued |
+| Atölye | #26 | queued |
+
+**Four Pillars** — *active.* Frontend polish and the encoded design system: the four pillars — Performance, Cohesiveness, Usability, Accessibility — made real and enforced (ADR 0162, the design-system manifest). The surface of kamp.us becomes excellent and self-consistent. The nav-IA discipline is mid-flight here.
+
+**Geçit** — *the passage.* The membrane of the community: onboarding, künye (the reputation DO), and moderation. How a stranger becomes a çaylak, a çaylak becomes a yazar by vouch, and how the community governs itself. The çaylak→yazar journey — undefined today — gets designed here. (The earlier künye milestone folded in.)
+
+**Mecmua v2** — The next chapter of long-form publishing: the Thinking-Machines 3-zone reading layout, and the reading/authoring experience maturing past v1.
+
+**Atölye** — *the workshop.* The in-product museum of craft: curated exhibits, live and playable, where kamp.us shows how it is made.
+
+## Campaigns
+
+Campaigns are bounded, milestone-backed pushes that run *concurrently* with the active product arc, drained through the platform lane (ADR 0072 semantics; ADR 0078 engineering-led).
+
+| Campaign | Milestone | State |
+|----------|-----------|-------|
+| Mentor Audit | #27 | active |
+
+**Mentor Audit** — a security & architecture audit wave (the staff-mentor findings: the karma double-bump race, per-actor rate limiting, ops runbooks, `SECURITY.md`, …). To be solved ASAP; drains via the platform lane alongside Four Pillars.
+
+## Standing lanes
+
+Not everything is an arc. **Pipeline & reliability hardening** is continuous, milestone-less work carried on the `axis:pipeline-hardening` label — the factory maintaining itself. It runs always, in the platform lane, and is never a product arc.
+


### PR DESCRIPTION
Fixes #2647

Founder-ratified, conversation-authored (ADR-0075 idiom) — committed verbatim from #2647's `FOUNDER-RATIFIED` comment (umut, 2026-07-11). Non-§CP: roadmap is product area, not pipeline (ADR 0078).

Milestone numbers are already pinned in the Arcs/Campaigns content: #17 Four Pillars (active), #24 Geçit, #25 Mecmua v2, #26 Atölye, #27 Mentor Audit (campaign); künye #10 closed.

Single file changed: `ROADMAP.md` at repo root.