### PR TITLE
docs(pipeline): ground "active milestone" in ROADMAP.md's active Arcs row (#2649)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -438,10 +438,18 @@ ranking. Priority is **milestone-relative**, not an absolute urgency score: `p1`
 current arc instead of becoming the catch-all. The **default is `p2`** — most real work
 isn't the current focus.
 
+The **active milestone is not a judgment call**: it is the arc pinned by the single
+`active` row of [`ROADMAP.md`](../../../../ROADMAP.md)'s `## Arcs` table — the founder-voice
+roadmap that projects each arc onto a GitHub milestone (ADR
+[0078](https://github.com/kamp-us/phoenix/blob/main/.decisions/0078-product-driven-decisions-by-default.md);
+exactly one arc is `active` at a time). Read that row to know what `p1` is bounded to; if
+no `## Arcs` row is marked `active`, there is no active milestone and the fallbacks below
+apply.
+
 | Priority | Use when… |
 |---|---|
 | **`p0`** | **Fire only.** Drop-everything: actively breaking something people rely on, blocking other work, a data-loss or security risk, or a release gate. If it's not a genuine emergency, it's not p0 — reserve it so the bucket stays meaningful. |
-| **`p1`** | **Serves the active milestone.** Real, actionable work that belongs to the current arc — you'd pull it next. Milestone-bounded on purpose: p1 is *not* a general "worth doing soon" tier, so a solid issue that isn't part of the current focus is **not** p1. If there's no active milestone, keep p1 for the small set of things you'd genuinely pick up next; everything else is p2. |
+| **`p1`** | **Serves the active milestone** — the arc pinned by `ROADMAP.md`'s single `active` `## Arcs` row (defined just above). Real, actionable work that belongs to that active arc — you'd pull it next. Milestone-bounded on purpose: p1 is *not* a general "worth doing soon" tier, so a solid issue outside the active arc is **not** p1. If no `## Arcs` row is marked `active`, keep p1 for the small set of things you'd genuinely pick up next; everything else is p2. |
 | **`p2`** | **The default.** Real, actionable work that isn't the current focus — most of the backlog. Also nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no time pressure to pull it ahead of the active arc. |
 
 Most of a healthy backlog is `p2`, with a bounded `p1` set tracking the active

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -281,11 +281,17 @@ Milestone shapes the pick in two modes:
   candidates, **break the tie toward the active milestone**: prefer the in-milestone
   candidate over an equal-priority out-of-milestone one; fall back to oldest-first when
   the milestone dimension doesn't separate them (both in, both out, or no active
-  milestone). The "active milestone" is the campaign currently being driven — the one the
-  operator names, or the obvious single open strategic milestone; if it's ambiguous,
-  there is no active milestone and this degrades cleanly to plain oldest-first. Because
-  the tiebreaker lives *inside* a bucket, it can only reorder equal-priority issues — it
-  can never pull a lower-priority in-milestone issue ahead of a higher-priority one.
+  milestone). The "active milestone" is resolved from a **single durable surface, not a
+  per-run guess**: it is the arc pinned by the one `active` row of
+  [`ROADMAP.md`](https://github.com/kamp-us/phoenix/blob/main/ROADMAP.md)'s `## Arcs` table
+  (the founder-voice roadmap projects each arc onto a GitHub milestone; exactly one arc is
+  `active` at a time — ADR
+  [0078](https://github.com/kamp-us/phoenix/blob/main/.decisions/0078-product-driven-decisions-by-default.md)).
+  An operator's explicit `work milestone N` still overrides it (the mode below). When **no**
+  `## Arcs` row is marked `active`, there is no active milestone and this degrades cleanly
+  to plain oldest-first. Because the tiebreaker lives *inside* a bucket, it can only reorder
+  equal-priority issues — it can never pull a lower-priority in-milestone issue ahead of a
+  higher-priority one.
 
 - **Explicit `work milestone N` mode — drain that milestone.** When invoked as "work
   milestone N" (or "drain milestone N"), scope the pool to that milestone via the REST


### PR DESCRIPTION
Fixes #2649

Roadmap steering-seam **unit 3 of 3** (#2620 map, #2639 §(1)). Grounds "active milestone" — used by both gate agents' pick/priority logic — in a single durable surface: the one `active` row of `ROADMAP.md`'s `## Arcs` table, replacing the prior ad-hoc "operator names it / the obvious single open strategic milestone / else none" heuristic. Rubric-wording amendment only; no product/runtime behavior change.

## Changes (both under `claude-plugins/kampus-pipeline/skills/`)

- **`triage/SKILL.md`** — Step 6 priority rubric. Adds a one-time grounding sentence ("the active milestone is not a judgment call — it is the arc pinned by `ROADMAP.md`'s single `active` `## Arcs` row") and re-grounds the `p1` row + its no-active fallback against that surface (`If no ## Arcs row is marked active …`). Stale ad-hoc definitional phrasing repaired to read against the roadmap surface.
- **`write-code/SKILL.md`** — Milestone-aware ordering, default-mode paragraph. The "active milestone" is now resolved from `ROADMAP.md`'s active-arc row (a single durable surface, not a per-run guess); an explicit `work milestone N` still overrides; the no-active-`## Arcs`-row case degrades cleanly to oldest-first.

## Acceptance criteria

- [x] triage priority rubric defines "active milestone" as the milestone pinned by `ROADMAP.md`'s single active `## Arcs` row; stale examples repaired.
- [x] write-code Milestone-aware ordering resolves the active milestone from the same `ROADMAP.md` active-arc row (sole parsed surface), degrading to oldest-first when no arc is active.
- [x] No changes to the p0-sovereign priority spine or within-bucket ordering (only the "active milestone" definition was touched; the ordering rules are byte-identical).
- [x] §CP / reviewed-ready — routed to cansirin for human review + merge, not auto-shipped (see below).

## §CP — gate-critical, human review required

Both files are **gate-agent skill docs** governing how every triage and write-code agent prioritizes and picks work. This is §CP-by-content: **reviewed-ready → route to cansirin** for the §CP review/merge; do **not** auto-ship.

Dependency **#2647 (ROADMAP.md v1)** is landed on `main`, so the `## Arcs` active-arc row the amendments point at exists (currently `Four Pillars | #17 | active`).

## Ship-hold — do NOT auto-merge until #2669 lands

This is roadmap **unit 3 of 3** (#2620 map, #2639 §(1)). Concrete ship-hold: `triage` and
`write-code` currently **escape** `ship-it`'s `CONTROL_PLANE_RE`, so this PR classifies as
**non-§CP** to the shipper — a binding review-skill PASS on it could **auto-merge past the
human §CP gate**, the exact hole [#2669](https://github.com/kamp-us/phoenix/issues/2669)
exists to close (it amends the regex to include `triage`/`write-code`). Therefore this PR
must be **held at reviewed-ready and NOT shipped until #2669 lands**. The review verdict
here is deliberately **advisory** (not the binding `PASS @ <sha> — merge-ready` form) so it
stays out of `ship-it`'s auto-merge namespace; a maintainer (cansirin) merges by hand
once #2669 has closed the auto-merge hole.