### PR TITLE
fix(report): typed IllegalTransition, no bare throw in Effect code (#2560)

### DIFF
--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -387,7 +387,14 @@ export const ReportLive = Layer.effect(Report)(
 			// machine (open → resolved/removed | dismissed/dismissed); the `status='open'`
 			// WHERE guard below is the SQL-level counterpart that makes the transition
 			// apply only to open rows.
-			const {status, resolution} = Resolution.resolve("open", input.action);
+			// The machine now returns the transition as a typed `Result` so a bad source
+			// status surfaces in the type, never a bare throw/defect-500 (#2560). Here the
+			// source is the hardcoded-legal `"open"`, so the `Result` is always a success;
+			// `orDie` discharges the impossible `IllegalTransition` as a defect — it can only
+			// fire if this `"open"` literal is ever changed to a non-open source.
+			const {status, resolution} = yield* Effect.orDie(
+				Effect.fromResult(Resolution.resolve("open", input.action)),
+			);
 			const result = yield* run((db) =>
 				db
 					.update(schema.contentReport)
@@ -418,16 +425,20 @@ export const ReportLive = Layer.effect(Report)(
 			targetKind: TargetKind;
 			targetId: string;
 		}) {
+			// The target status AND the terminal-source guard are decided by the state
+			// machine (terminal → open); the SQL guard below is the counterpart that
+			// applies the reopen only to terminal rows. The machine returns a typed `Result`
+			// (#2560); the hardcoded-terminal `"resolved"` source is always legal, so `orDie`
+			// discharges the impossible `IllegalTransition` — reachable only if this literal
+			// is later changed to a non-terminal source.
+			const status = yield* Effect.orDie(Effect.fromResult(Resolution.reopen("resolved")));
 			const result = yield* run((db) =>
 				db
 					.update(schema.contentReport)
 					// Clearing `waveId` too keeps the invariant: an OPEN report never carries
 					// a stale wave grouping (#1855).
 					.set({
-						// The target status AND the terminal-source guard are decided by the
-						// state machine (terminal → open); the SQL guard below is the
-						// counterpart that applies the reopen only to terminal rows.
-						status: Resolution.reopen("resolved"),
+						status,
 						resolverId: null,
 						resolvedAt: null,
 						resolution: null,
@@ -446,11 +457,15 @@ export const ReportLive = Layer.effect(Report)(
 		});
 
 		const reopenForWave = Effect.fn("Report.reopenForWave")(function* (waveId: string) {
+			// Reopen is a machine transition (terminal → open). The machine returns a typed
+			// `Result` (#2560); the hardcoded-terminal `"resolved"` source is always legal, so
+			// `orDie` discharges the impossible `IllegalTransition` (see `reopenForTarget`).
+			const status = yield* Effect.orDie(Effect.fromResult(Resolution.reopen("resolved")));
 			const result = yield* run((db) =>
 				db
 					.update(schema.contentReport)
 					.set({
-						status: Resolution.reopen("resolved"),
+						status,
 						resolverId: null,
 						resolvedAt: null,
 						resolution: null,

--- a/apps/web/worker/features/report/resolution.ts
+++ b/apps/web/worker/features/report/resolution.ts
@@ -9,11 +9,14 @@
  *   resolved  ──reopen──▶ open            (a restore re-opens; bounded)
  *   dismissed ──reopen──▶ open
  *
- * Transitions are decided by `Match.tagsExhaustive` over the source status, so an
- * illegal transition (e.g. `resolved → dismissed`) is a compile error at the
- * `transition` site — the machine is a type, not a convention.
+ * Transitions are decided by `Match.tagsExhaustive` over the source status, which
+ * forces every status to be addressed. A transition from a *dynamic* source status
+ * that is illegal (e.g. re-resolving a terminal report) surfaces as a typed
+ * `Result.Failure(IllegalTransition)` — a value in the caller's error channel, never a
+ * bare `throw`: inside `Effect.fn` callers a throw becomes an untyped defect/500, so the
+ * domain condition must ride the typed channel instead (#2560).
  */
-import {Match} from "effect";
+import {Match, Result} from "effect";
 
 /**
  * The closed status set, as the one runtime tuple the `content_report.status`
@@ -67,38 +70,35 @@ export class IllegalTransition extends Error {
 
 /**
  * `resolve(action)` is legal only from `open`. The `Match.tagsExhaustive` forces
- * every status to be addressed; re-resolving an already-terminal report is
- * rejected as an `IllegalTransition` rather than silently re-stamping the audit.
+ * every status to be addressed; re-resolving an already-terminal report is a
+ * `Result.Failure(IllegalTransition)` — the caller threads it through the typed error
+ * channel rather than silently re-stamping the audit (#2560).
  */
 export const resolve = (
 	from: ReportStatus,
 	action: ResolveAction,
-): {status: ReportStatus; resolution: Resolution} =>
+): Result.Result<{status: ReportStatus; resolution: Resolution}, IllegalTransition> =>
 	Match.valueTags(tagged(from), {
 		open: () =>
-			action === "remove"
-				? ({status: "resolved", resolution: "removed"} as const)
-				: ({status: "dismissed", resolution: "dismissed"} as const),
-		resolved: () => {
-			throw new IllegalTransition(from, `resolve(${action})`);
-		},
-		dismissed: () => {
-			throw new IllegalTransition(from, `resolve(${action})`);
-		},
+			Result.succeed(
+				action === "remove"
+					? ({status: "resolved", resolution: "removed"} as const)
+					: ({status: "dismissed", resolution: "dismissed"} as const),
+			),
+		resolved: () => Result.fail(new IllegalTransition(from, `resolve(${action})`)),
+		dismissed: () => Result.fail(new IllegalTransition(from, `resolve(${action})`)),
 	});
 
 /**
  * `reopen` is legal only from a terminal state (`resolved` | `dismissed`) — a
  * restore of a moderated entity reopens its report (ADR 0096 §4 ↔ 0098 §3).
- * Reopening an already-open report is an `IllegalTransition`.
+ * Reopening an already-open report is a `Result.Failure(IllegalTransition)` (#2560).
  */
-export const reopen = (from: ReportStatus): ReportStatus =>
+export const reopen = (from: ReportStatus): Result.Result<ReportStatus, IllegalTransition> =>
 	Match.valueTags(tagged(from), {
-		open: () => {
-			throw new IllegalTransition(from, "reopen");
-		},
-		resolved: () => "open" as const,
-		dismissed: () => "open" as const,
+		open: () => Result.fail(new IllegalTransition(from, "reopen")),
+		resolved: () => Result.succeed("open" as const),
+		dismissed: () => Result.succeed("open" as const),
 	});
 
 export const isTerminal = (status: ReportStatus): boolean => status !== "open";

--- a/apps/web/worker/features/report/resolution.unit.test.ts
+++ b/apps/web/worker/features/report/resolution.unit.test.ts
@@ -3,9 +3,11 @@
  * transitions, with no database. The compile-time guarantee (a missing branch is a
  * `Match.tagsExhaustive` error) is enforced by the type-checker; this proves the
  * runtime behavior: `open` resolves, terminals reject re-resolve, terminals reopen,
- * `open` rejects reopen.
+ * `open` rejects reopen. An illegal transition is a typed `Result.Failure`, not a
+ * bare `throw` (#2560).
  */
 import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
 import {
 	IllegalTransition,
 	isTerminal,
@@ -17,36 +19,57 @@ import {
 
 describe("resolve — legal only from open", () => {
 	it("open + remove → resolved/removed", () => {
-		assert.deepStrictEqual(resolve("open", "remove"), {status: "resolved", resolution: "removed"});
+		assert.deepStrictEqual(
+			resolve("open", "remove"),
+			Result.succeed({status: "resolved", resolution: "removed"}),
+		);
 	});
 
 	it("open + dismiss → dismissed/dismissed", () => {
-		assert.deepStrictEqual(resolve("open", "dismiss"), {
-			status: "dismissed",
-			resolution: "dismissed",
-		});
+		assert.deepStrictEqual(
+			resolve("open", "dismiss"),
+			Result.succeed({status: "dismissed", resolution: "dismissed"}),
+		);
 	});
 
-	it("resolved → resolve is an IllegalTransition", () => {
-		assert.throws(() => resolve("resolved", "dismiss"), IllegalTransition);
+	it("resolved → resolve is a Result.Failure(IllegalTransition)", () => {
+		const r = resolve("resolved", "dismiss");
+		assert.isTrue(Result.isFailure(r));
+		if (Result.isFailure(r)) {
+			assert.instanceOf(r.failure, IllegalTransition);
+			assert.strictEqual(r.failure.from, "resolved");
+			assert.strictEqual(r.failure.intent, "resolve(dismiss)");
+		}
 	});
 
-	it("dismissed → resolve is an IllegalTransition", () => {
-		assert.throws(() => resolve("dismissed", "remove"), IllegalTransition);
+	it("dismissed → resolve is a Result.Failure(IllegalTransition)", () => {
+		const r = resolve("dismissed", "remove");
+		assert.isTrue(Result.isFailure(r));
+		if (Result.isFailure(r)) {
+			assert.instanceOf(r.failure, IllegalTransition);
+			assert.strictEqual(r.failure.from, "dismissed");
+			assert.strictEqual(r.failure.intent, "resolve(remove)");
+		}
 	});
 });
 
 describe("reopen — legal only from a terminal state", () => {
 	it("resolved → open", () => {
-		assert.strictEqual(reopen("resolved"), "open");
+		assert.deepStrictEqual(reopen("resolved"), Result.succeed("open"));
 	});
 
 	it("dismissed → open", () => {
-		assert.strictEqual(reopen("dismissed"), "open");
+		assert.deepStrictEqual(reopen("dismissed"), Result.succeed("open"));
 	});
 
-	it("open → reopen is an IllegalTransition", () => {
-		assert.throws(() => reopen("open"), IllegalTransition);
+	it("open → reopen is a Result.Failure(IllegalTransition)", () => {
+		const r = reopen("open");
+		assert.isTrue(Result.isFailure(r));
+		if (Result.isFailure(r)) {
+			assert.instanceOf(r.failure, IllegalTransition);
+			assert.strictEqual(r.failure.from, "open");
+			assert.strictEqual(r.failure.intent, "reopen");
+		}
 	});
 });
 
@@ -66,7 +89,7 @@ describe("TERMINAL_STATUSES — the reopen-source set, derived from the machine"
 	it("every member is reopenable and terminal", () => {
 		for (const status of TERMINAL_STATUSES) {
 			assert.isTrue(isTerminal(status));
-			assert.strictEqual(reopen(status), "open");
+			assert.strictEqual(Result.getOrThrow(reopen(status)), "open");
 		}
 	});
 });


### PR DESCRIPTION
Fixes #2560

## What & why

`resolution.ts`'s `resolve`/`reopen` signalled an illegal state transition by a **bare synchronous `throw`** inside a `Match.valueTags` callback. Through their `Effect.fn` callers (`Report.resolveTarget`, `reopenForTarget`, `reopenForWave`) a synchronous throw becomes an **untyped defect** — a domain condition (an illegal transition) would surface to the client as a **500** and never appear in the function's type. This is the loaded footgun #2560 describes: not an active fault (today's callers pass hardcoded-legal source states), but any future caller passing a non-open literal, or wiring reopen from a stale terminal read, would silently convert a domain condition into a defect-500.

## The change

The domain functions now return the transition as a typed `Result` (effect v4's `Either`), so misuse rides the typed error channel instead of a throw:

- `resolve` → `Result<{status; resolution}, IllegalTransition>`
- `reopen` → `Result<ReportStatus, IllegalTransition>`

A new caller passing an illegal source status now gets a `Result.Failure` it **cannot ignore** — misuse shows up in the type, not as a defect. `Match.valueTags` exhaustiveness over the three statuses (`open`/`resolved`/`dismissed`) is preserved: only the signalling *mechanism* changed.

The three live service methods supply a hardcoded-legal source status, so the `Result` is always a success. They consume it through the error channel (`Effect.fromResult`) and discharge the by-construction-impossible `IllegalTransition` with `Effect.orDie`, placed **local to the hardcoded literal** — reachable only if that `"open"` / `"resolved"` literal is later changed to an illegal source, with a comment flagging exactly that. The wire error schema (closed to `Denied`) and the hardcoded-`"open"` + SQL `WHERE status='open'` path are unchanged, so there is **no observable behavior change** for today's callers.

Grounded in effect-smol v4: `Either` is `Result<A, E>` (`Result.succeed`/`Result.fail`), consumed into Effect via `Effect.fromResult` (`Effect.ts`).

## Acceptance criteria

- [x] `resolve`/`reopen` no longer bare-`throw` — an illegal transition is a typed `Result.Failure(IllegalTransition)`.
- [x] `Match.valueTags` exhaustiveness over the three statuses preserved.
- [x] Callers updated to consume the typed result via the error channel; the safe `"open"` path unchanged.
- [x] No observable behavior change for today's callers.
- [x] `pnpm typecheck` and `pnpm lint` green; resolution + report unit tests pass (35 tests).

## Test plan

- `pnpm typecheck` — green.
- `pnpm lint` — green (my three files clean).
- `apps/web` unit project: `resolution.unit.test.ts` (11, updated to assert `Result.Failure`/`Result.succeed`) + `Report.unit.test.ts` + `report-mutation.unit.test.ts` + `resolved.unit.test.ts` (24) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)