### PR TITLE
feat(sozluk): backstop-reconcile a swallowed cache refresh via a cron sweep (#2558)

### DIFF
--- a/apps/web/tests/integration/sozluk-cache-reconcile.test.ts
+++ b/apps/web/tests/integration/sozluk-cache-reconcile.test.ts
@@ -1,0 +1,156 @@
+/**
+ * sözlük backstop-reconciliation → the AC5 end-to-end guard for #2558.
+ *
+ * The gap (#2558): the remove/restore + create ceremony SWALLOWS-and-logs a cache-refresh die
+ * (`swallowRefresh`, #2012 — the substrate write already committed, so a recomputable-cache die
+ * must not 500 the request). That swallow is correct and stays. But the convergence contract is
+ * only "heals on the NEXT write", and no reconciliation job existed — so a low-traffic term whose
+ * LAST write's refresh died stayed stale indefinitely (wrong `definition_count`/`total_score`/
+ * `excerpt`, stale `term_search` FTS row, drifted `sozluk_stats`), invisible to Sentry. The fix
+ * is `Sozluk.reconcileCaches` (`Sozluk.ts`), driven periodically by a cron trigger
+ * (`sozluk-reconcile-cron.ts`): re-run the convergent cache refresh for EVERY term.
+ *
+ * The pure sweep control flow (`scanReconcileChunks`) is unit-tested off-DB
+ * (`sozluk-reconcile-scan.unit.test.ts`). This is the integration tier AC5 names (ADR 0082
+ * §irreducible-integration): the real re-derivation from `definition_record` → the `term_record`
+ * + `sozluk_stats` write-back that the unit test can't reach. It:
+ *   1. seeds a real term with one definition over the PUBLIC fate seam (`seedTerm`), which
+ *      converges `term_record` (`definition_count = 1`) and `sozluk_stats`;
+ *   2. constructs the exact #2558 stale state via setup-only D1 writes (`execD1`) — the divergence
+ *      a swallowed last-write refresh leaves: `term_record` corrupted to a WRONG summary
+ *      (`definition_count = 99`, a bogus `excerpt`) and `sozluk_stats.total_definitions` drifted to
+ *      999, while the underlying `definition_record` (the source of truth) is untouched;
+ *   3. runs the REAL `Sozluk.reconcileCaches(now)` against this stage's REAL remote D1 (the
+ *      fts-backfill / hot-decay precedent, #645/#2027: the SHIPPED service over `@kampus/d1-rest`,
+ *      never a `node:sqlite` oracle — banned by ADR 0082 — and never a re-implementation of the
+ *      fold; `SozlukLive` built over the real D1 with inert Vote/Reaction/Pasaport stubs, since
+ *      the reconcile path touches none of them);
+ *   4. asserts `term_record` re-converged to the TRUE summary (`definition_count = 1`, the real
+ *      definition's excerpt, not the bogus one) and `sozluk_stats.total_definitions` back to 1 —
+ *      the staleness healed with NO user write.
+ *
+ * There is no HTTP route to trigger the cron on a deployed worker (the scheduled handler fires on
+ * Cloudflare's schedule, not on demand), so — like `fts-backfill` / `pano-hot-score-decay` — the
+ * test drives the real method directly against this stage's real D1 REST target. Per-file
+ * `integrationStack`: this file owns its own worker + D1, so the direct-D1 reconcile and the
+ * seeded rows see one isolated table (and `sozluk_stats` counts only this file's definitions).
+ */
+import {makeD1RestFromEnv} from "@kampus/d1-rest";
+import {eq} from "drizzle-orm";
+import {type Context, Effect, Layer} from "effect";
+import {beforeAll, describe, expect, it} from "vitest";
+import {createDrizzle, Drizzle, makeDrizzleAccess, orDieAccess} from "../../worker/db/Drizzle.ts";
+import * as schema from "../../worker/db/drizzle/schema.ts";
+import {PasaportIdentityStub} from "../../worker/features/pasaport/Pasaport.testing.ts";
+import {ReactionStub} from "../../worker/features/reaction/Reaction.testing.ts";
+import {Sozluk, SozlukLive} from "../../worker/features/sozluk/Sozluk.ts";
+import {Vote} from "../../worker/features/vote/Vote.ts";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+const SLUG = `reconcile-${Date.now().toString(36)}`;
+const TITLE = "Reconcile Term";
+const DEF_BODY = "the one true live definition body for the reconcile term";
+
+// reconcileCaches touches only `run`/`batch` (persistTermSummary + recomputeSozlukStats), never
+// Vote/Reaction/Pasaport — so inert stubs satisfy the layer without an implementation.
+const inertVote = Layer.succeed(Vote, {} as Context.Service.Shape<typeof Vote>);
+
+/**
+ * Build the REAL `Sozluk` service bound to this stage's REAL remote D1 over `@kampus/d1-rest`
+ * — the shipped worker code path (`createDrizzle` → `makeDrizzleAccess` → `SozlukLive`), never a
+ * re-implementation of its fold. Returns a runner for `reconcileCaches` plus a `read` escape hatch
+ * that runs a select against the same real D1 for the assertions.
+ */
+async function realSozluk() {
+	const target = await h.d1Target();
+	const db = createDrizzle(makeD1RestFromEnv(target));
+	const access = orDieAccess(makeDrizzleAccess(db));
+	const sozlukLayer = SozlukLive.pipe(
+		Layer.provide(Layer.succeed(Drizzle, makeDrizzleAccess(db))),
+		Layer.provide(inertVote),
+		Layer.provide(ReactionStub),
+		Layer.provide(PasaportIdentityStub),
+	);
+	const reconcile = (now: Date) =>
+		Effect.runPromise(
+			Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				return yield* sozluk.reconcileCaches(now);
+			}).pipe(Effect.provide(sozlukLayer)),
+		);
+	const read = <A>(fn: (a: typeof access) => Effect.Effect<A>) => Effect.runPromise(fn(access));
+	return {reconcile, read};
+}
+
+const readTerm = (s: Awaited<ReturnType<typeof realSozluk>>) =>
+	s.read((a) =>
+		a.run((db) =>
+			db.select().from(schema.termRecord).where(eq(schema.termRecord.slug, SLUG)).get(),
+		),
+	);
+
+const readStats = (s: Awaited<ReturnType<typeof realSozluk>>) =>
+	s.read((a) =>
+		a.run((db) => db.select().from(schema.sozlukStats).where(eq(schema.sozlukStats.id, 1)).get()),
+	);
+
+beforeAll(async () => {
+	const seeded = await h.seedTerm({
+		slug: SLUG,
+		title: TITLE,
+		definitions: [{authorName: "reconcile-yazar", body: DEF_BODY}],
+	});
+	expect(seeded.insertedDefinitions).toBe(1);
+});
+
+describe("sözlük backstop-reconciliation (#2558 AC5) — a swallowed-refresh stale term re-converges", () => {
+	it("reconcileCaches re-derives term_record + sozluk_stats from definition_record, healing staleness with no user write", async () => {
+		const s = await realSozluk();
+
+		// The seeded true state: one live definition ⇒ term_record.definition_count == 1.
+		const seededTerm = await readTerm(s);
+		expect(seededTerm?.definitionCount).toBe(1);
+		const trueExcerpt = seededTerm?.excerpt;
+		expect(trueExcerpt).toBeTruthy();
+
+		// Construct the exact #2558 stale state the swallowed last-write refresh leaves: the
+		// summary caches diverge from the (untouched) definition_record source of truth. This is
+		// the setup-only fault-injection the public seam can't reach — the swallowed refresh means
+		// term_record/sozluk_stats never caught up to a committed definition write.
+		const staleTerm = await h.execD1(
+			"UPDATE term_record SET definition_count = ?, total_score = ?, excerpt = ? WHERE slug = ?",
+			[99, 99, "STALE-SWALLOWED-REFRESH", SLUG],
+		);
+		expect(staleTerm).toBe(1);
+		const staleStats = await h.execD1(
+			"UPDATE sozluk_stats SET total_definitions = ? WHERE id = 1",
+			[999],
+		);
+		expect(staleStats).toBe(1);
+
+		// Pre-reconcile: the corrupted summary is what a read now surfaces — the bug state.
+		const before = await readTerm(s);
+		expect(before?.definitionCount).toBe(99);
+		expect(before?.excerpt).toBe("STALE-SWALLOWED-REFRESH");
+		const statsBefore = await readStats(s);
+		expect(statsBefore?.totalDefinitions).toBe(999);
+
+		// Run the REAL reconcile against real remote D1 — the shipped full sweep + write-back.
+		const result = await s.reconcile(new Date());
+		expect(result.scanned).toBeGreaterThanOrEqual(1); // the seeded term is swept
+
+		// Post-reconcile: term_record re-derived from the untouched definition_record — the true
+		// count and excerpt are back, the bogus values gone. The staleness healed with NO user
+		// write (no add/edit/vote happened between the corruption and here).
+		const after = await readTerm(s);
+		expect(after?.definitionCount).toBe(1);
+		expect(after?.excerpt).toBe(trueExcerpt);
+		expect(after?.excerpt).not.toBe("STALE-SWALLOWED-REFRESH");
+
+		// And the stats leg re-converged too: total_definitions back to the one seeded live def.
+		const statsAfter = await readStats(s);
+		expect(statsAfter?.totalDefinitions).toBe(1);
+	});
+});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -8,7 +8,7 @@
  * its wire codes unit-test off-DB THROUGH the mutation (ADR 0013 / 0082).
  */
 import {id} from "@usirin/forge";
-import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
+import {and, asc, desc, eq, gt, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -162,6 +162,63 @@ export const recomputeTermSummary = (
 		lastEditAt: latestEditAt(rows) ?? now,
 	};
 };
+
+/**
+ * The backstop-reconciliation chunk size (#2558): the slug-keyset page width the periodic
+ * sweep pages `term_record` in. Sized well above the v1 cohort so today's pass is a single
+ * short page, while the bound holds as the table grows — mirrors `HOT_SCORE_DECAY_CHUNK`.
+ */
+export const SOZLUK_RECONCILE_CHUNK = 200;
+
+/** One term the reconciliation sweep re-converges: the slug + its stored title. */
+export interface TermRef {
+	readonly slug: string;
+	readonly title: string;
+}
+
+/**
+ * The DB seam the reconciliation sweep drives (#2558), factored so {@link scanReconcileChunks}'s
+ * cursor-advance + full-coverage control flow is unit-testable over in-memory ports (ADR 0082
+ * litmus — wrong-or-right with no SQL engine). `fetchChunk(afterSlug, limit)` returns up to
+ * `limit` term rows with `slug > afterSlug` in ascending slug order (`null` ⇒ from the head);
+ * `refreshTerm` re-runs the convergent cache refresh for one term.
+ */
+export interface SozlukReconcileScanPorts {
+	readonly fetchChunk: (
+		afterSlug: string | null,
+		limit: number,
+	) => Effect.Effect<ReadonlyArray<TermRef>>;
+	readonly refreshTerm: (term: TermRef) => Effect.Effect<void>;
+}
+
+/**
+ * Keyset-chunk the backstop reconciliation sweep (#2558): page slug-ordered slices of at most
+ * `chunkSize` terms, re-running the convergent refresh for each before fetching the next, so no
+ * single query materializes the whole `term_record` table (mirrors the #2559 decay-sweep bound).
+ * Every term is visited each pass — the slug-keyset cursor bounds each page, it never excludes a
+ * term. Loops until a short (`< chunkSize`) page marks the tail; an exact-multiple table takes
+ * one extra empty page to terminate. Returns the pass's scanned count.
+ */
+export const scanReconcileChunks = (
+	ports: SozlukReconcileScanPorts,
+	chunkSize: number,
+): Effect.Effect<{scanned: number}> =>
+	Effect.gen(function* () {
+		let after: string | null = null;
+		let scanned = 0;
+		for (;;) {
+			const rows: ReadonlyArray<TermRef> = yield* ports.fetchChunk(after, chunkSize);
+			if (rows.length === 0) break;
+			for (const term of rows) {
+				yield* ports.refreshTerm(term);
+				scanned++;
+			}
+			const last = rows[rows.length - 1];
+			if (rows.length < chunkSize || !last) break;
+			after = last.slug;
+		}
+		return {scanned};
+	});
 
 // The term-summary list sort — defined with the orderings it selects (`ordering.ts`).
 export type ListSort = TermSummarySort;
@@ -412,6 +469,20 @@ export class Sozluk extends Context.Service<
 		readonly reactToDefinition: (
 			input: ReactDefinitionInput,
 		) => Effect.Effect<DefinitionRow, DefinitionNotFound>;
+
+		/**
+		 * Backstop reconciliation (#2558): re-run the recomputable-cache refresh
+		 * (`persistTermSummary` — the term summary + its `term_search` FTS dual-write — and
+		 * `recomputeSozlukStats`) for EVERY sözlük term, so a term/stat left stale by a
+		 * swallowed last-write refresh (`swallowRefresh`, #2012) is eventually re-converged
+		 * WITHOUT waiting for a next user write. Driven by a periodic cron trigger
+		 * (`sozluk-reconcile-cron.ts`); the request-path swallow is unchanged — this is the
+		 * additive long-tail backstop. The sweep pages `term_record` in slug-keyset chunks
+		 * (`scanReconcileChunks`). Idempotent: `persistTermSummary` is a pure convergent fold,
+		 * so re-running it on an already-fresh term rewrites the identical row. Returns the
+		 * pass's scanned count for observability.
+		 */
+		readonly reconcileCaches: (now: Date) => Effect.Effect<{readonly scanned: number}>;
 	}
 >()("@kampus/sozluk/Sozluk") {}
 
@@ -575,6 +646,34 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				yield* persistTermSummary(slug, title, now);
 				yield* recomputeSozlukStats(now);
 			});
+
+		// The backstop reconciliation sweep (#2558): re-run the convergent cache refresh for
+		// EVERY term so a term/stat left stale by a swallowed last-write refresh
+		// (`swallowRefresh`, #2012) is eventually re-converged without a next user write. Pages
+		// `term_record` in slug-keyset chunks (bounded scan, mirrors #2559) refreshing each term
+		// summary + its FTS row, then refreshes `sozluk_stats` once for the whole pass. Driven by
+		// the cron trigger (`index.ts` → `sozluk-reconcile-cron.ts`). Idempotent by construction —
+		// `persistTermSummary` is a pure convergent fold, so an already-fresh term rewrites the
+		// identical row, meaning a full sweep needs no persisted "refresh failed" flag to target.
+		const reconcileCaches = Effect.fn("Sozluk.reconcileCaches")(function* (now: Date) {
+			const ports: SozlukReconcileScanPorts = {
+				fetchChunk: (afterSlug, limit) =>
+					run((db) =>
+						db
+							.select({slug: schema.termRecord.slug, title: schema.termRecord.title})
+							.from(schema.termRecord)
+							.where(afterSlug === null ? undefined : gt(schema.termRecord.slug, afterSlug))
+							.orderBy(asc(schema.termRecord.slug))
+							.limit(limit),
+					),
+				refreshTerm: (term) => persistTermSummary(term.slug, term.title, now),
+			};
+			const {scanned} = yield* scanReconcileChunks(ports, SOZLUK_RECONCILE_CHUNK);
+			// One stats refresh for the whole pass — `sozluk_stats` totals are table-wide, not
+			// per-term, so re-deriving them once after the term sweep is sufficient and cheapest.
+			yield* recomputeSozlukStats(now);
+			return {scanned};
+		});
 
 		const getTerm = Effect.fn("Sozluk.getTerm")(function* (
 			slug: string,
@@ -1320,6 +1419,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			voteDefinition,
 			retractDefinitionVote,
 			reactToDefinition,
+			reconcileCaches,
 		};
 	}),
 );

--- a/apps/web/worker/features/sozluk/sozluk-reconcile-cron.ts
+++ b/apps/web/worker/features/sozluk/sozluk-reconcile-cron.ts
@@ -1,0 +1,55 @@
+/**
+ * The sözlük backstop-reconciliation cron wiring (#2558) — a Cloudflare Cron Trigger that
+ * periodically re-runs the recomputable-cache refresh for every sözlük term, so a term/stat
+ * left stale by a SWALLOWED last-write refresh is eventually re-converged.
+ *
+ * The gap it closes (#2558): the remove/restore + create ceremony swallows-and-logs a
+ * cache-refresh die (`swallowRefresh`, #2012/#1639 — the substrate write already committed,
+ * so a recomputable-cache die must not 500 the request). That swallow is correct and stays.
+ * But the convergence contract is only "heals on the NEXT write", and no reconciliation job
+ * existed — so a low-traffic term whose LAST write's refresh died stayed stale indefinitely
+ * (wrong count/excerpt, stale `term_search` FTS row), on exactly the corners nobody revisits
+ * and invisible to Sentry (the failure was swallowed). This backstop is ADDITIVE: the request
+ * path is untouched.
+ *
+ * The mechanism is alchemy's idiomatic scheduled-worker seam (`Cloudflare.cron(expr, handler)`,
+ * beta.59), the SAME substrate the sıcak/hot decay refresh rides (`hot-score-decay-cron.ts`) —
+ * not a new bespoke scheduler. Two crons coexist cleanly: each `cron()` attaches its own
+ * `Cron(<expr>)` binding, and the runtime `scheduled` listener dispatches by
+ * `controller.cron === expression`, so the 15-minute decay tick runs only the decay and this
+ * 6-hourly tick runs only the reconcile (`CronEventSource.ts`).
+ *
+ * Cadence + strategy (#2558 AC4): every 6 hours, a FULL sweep — `Sozluk.reconcileCaches`
+ * re-runs `persistTermSummary` for every `term_record` row (slug-keyset chunked, bounded scan)
+ * plus one `recomputeSozlukStats`. A full re-run (not sampled, not failure-flagged) is the
+ * simplest correct backstop: there is no persisted "refresh failed" flag to target — adding one
+ * would put a write back on the swallow path the #2012 trade deliberately keeps clean — and
+ * `persistTermSummary` is a pure convergent fold, so re-running it on an already-fresh term
+ * rewrites the identical row. A full sweep is therefore idempotent and self-correcting with no
+ * failure bookkeeping. Six hours is far coarser than hot-decay's 15 minutes because staleness
+ * here is a rare long-tail event (a refresh die on a term's LAST write), not a continuous drift,
+ * and each pass rewrites every term row.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import type * as Layer from "effect/Layer";
+import {Sozluk} from "./Sozluk.ts";
+
+/** Every 6 hours (standard 5-field cron). */
+export const SOZLUK_RECONCILE_CRON = "0 */6 * * *";
+
+/**
+ * The worker-init effect that subscribes the reconciliation sweep to the cron trigger.
+ * `fateLayer` is the built worker context (`makeFateRuntime`'s `contextLayer`) carrying
+ * `Sozluk`; the handler runs `Sozluk.reconcileCaches` at the controller's scheduled instant (so
+ * the pass's clock is the trigger's, not a fresh `Date.now()`). `CronEventSource` already
+ * swallows handler failures (`Effect.catchCause`), so a bad pass never crashes the scheduled
+ * invocation. `subscribe` only registers a listener (no async/timer work), so it is init-safe.
+ */
+export const subscribeSozlukReconcile = (fateLayer: Layer.Layer<Sozluk>) =>
+	Cloudflare.cron(SOZLUK_RECONCILE_CRON, (controller) =>
+		Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			yield* sozluk.reconcileCaches(new Date(controller.scheduledTime));
+		}).pipe(Effect.provide(fateLayer)),
+	);

--- a/apps/web/worker/features/sozluk/sozluk-reconcile-scan.unit.test.ts
+++ b/apps/web/worker/features/sozluk/sozluk-reconcile-scan.unit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The backstop-reconciliation keyset-chunk sweep (`scanReconcileChunks`, #2558), unit-reachable
+ * over in-memory ports — the cursor-advance + full-coverage control flow is wrong-or-right with
+ * no SQL engine (ADR 0082 litmus), so it is driven here over a JS-array table, never real D1.
+ * The real-D1 chunk EXECUTION (the paged walk over `term_record` + the actual re-convergence of
+ * a term left stale by a swallowed refresh) stays integration-tier (`sozluk-cache-reconcile.test.ts`).
+ *
+ * The two properties this guards, both the point of #2558's bounded full sweep:
+ *   - FULL coverage: the sweep visits EVERY term across its pages, so a term beyond the first
+ *     chunk is still re-refreshed — chunking is not a recency/subset window.
+ *   - BOUNDED pages: each `fetchChunk` asks for at most `chunkSize` rows and resumes at a cursor
+ *     strictly past the previous page's last slug — no single unbounded scan.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {type SozlukReconcileScanPorts, scanReconcileChunks, type TermRef} from "./Sozluk.ts";
+
+const term = (slug: string): TermRef => ({slug, title: slug});
+
+interface Harness {
+	readonly ports: SozlukReconcileScanPorts;
+	/** Every `fetchChunk(afterSlug, limit)` call, in order — the paging trace. */
+	readonly fetchCalls: Array<{afterSlug: string | null; limit: number}>;
+	/** Every slug passed to `refreshTerm`, across all pages — the coverage trace. */
+	readonly refreshed: string[];
+}
+
+/**
+ * In-memory ports over a fixed, slug-sorted table: `fetchChunk` serves the keyset page
+ * (`slug > afterSlug`, capped at `limit`) and records the cursor + limit it was asked for;
+ * `refreshTerm` records every re-refreshed slug. This is the exact contract `reconcileCaches`
+ * wires D1 into — so the driver's paging behavior is proven without a database.
+ */
+function harness(table: ReadonlyArray<string>): Harness {
+	const sorted = [...table].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+	const fetchCalls: Array<{afterSlug: string | null; limit: number}> = [];
+	const refreshed: string[] = [];
+	const ports: SozlukReconcileScanPorts = {
+		fetchChunk: (afterSlug, limit) =>
+			Effect.sync(() => {
+				fetchCalls.push({afterSlug, limit});
+				return sorted
+					.filter((s) => afterSlug === null || s > afterSlug)
+					.slice(0, limit)
+					.map(term);
+			}),
+		refreshTerm: (t) =>
+			Effect.sync(() => {
+				refreshed.push(t.slug);
+			}),
+	};
+	return {ports, fetchCalls, refreshed};
+}
+
+describe("scanReconcileChunks — keyset-chunks the full reconciliation sweep (#2558)", () => {
+	it.effect("a table larger than the chunk size is fully covered — every term is refreshed", () =>
+		Effect.gen(function* () {
+			const h = harness(["a", "b", "c", "d", "e"]);
+			const result = yield* scanReconcileChunks(h.ports, 2);
+
+			assert.strictEqual(result.scanned, 5, "every term is scanned across the pages");
+			// A term in the THIRD page ("e") is refreshed just like "a" — no subset window.
+			assert.deepStrictEqual(
+				[...h.refreshed].sort(),
+				["a", "b", "c", "d", "e"],
+				"the sweep covers the whole table, not just the first chunk",
+			);
+		}),
+	);
+
+	it.effect("pages are bounded and the cursor advances strictly past each page's last slug", () =>
+		Effect.gen(function* () {
+			const h = harness(["a", "b", "c", "d", "e"]);
+			yield* scanReconcileChunks(h.ports, 2);
+
+			// Pages of [a,b],[c,d],[e] — the short third page (1 < 2) marks the tail, so no fourth
+			// fetch. Each call asks for at most `chunkSize`, resuming at the prior last slug.
+			assert.deepStrictEqual(
+				h.fetchCalls,
+				[
+					{afterSlug: null, limit: 2},
+					{afterSlug: "b", limit: 2},
+					{afterSlug: "d", limit: 2},
+				],
+				"cursor walks null → b → d, limit stays chunkSize, short page terminates",
+			);
+		}),
+	);
+
+	it.effect("an exact-multiple table takes one extra empty page to terminate", () =>
+		Effect.gen(function* () {
+			const h = harness(["a", "b", "c", "d"]);
+			const result = yield* scanReconcileChunks(h.ports, 2);
+
+			assert.strictEqual(result.scanned, 4, "all four terms scanned");
+			// Pages [a,b],[c,d] are both full, so the loop cannot know it is done until an empty
+			// page after "d" — three fetches, the last returning zero rows.
+			assert.deepStrictEqual(
+				h.fetchCalls,
+				[
+					{afterSlug: null, limit: 2},
+					{afterSlug: "b", limit: 2},
+					{afterSlug: "d", limit: 2},
+				],
+				"a full final page forces one terminating empty fetch",
+			);
+		}),
+	);
+
+	it.effect("an empty table scans nothing and refreshes nothing in a single head fetch", () =>
+		Effect.gen(function* () {
+			const h = harness([]);
+			const result = yield* scanReconcileChunks(h.ports, 2);
+
+			assert.deepStrictEqual(result, {scanned: 0});
+			assert.deepStrictEqual(h.fetchCalls, [{afterSlug: null, limit: 2}], "one empty head fetch");
+			assert.deepStrictEqual(h.refreshed, []);
+		}),
+	);
+});

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -35,6 +35,7 @@ import {Flagship as FlagshipResource} from "./features/flagship/resources.ts";
 import {subscribeHotScoreDecay} from "./features/pano/hot-score-decay-cron.ts";
 import {BetterAuthLive} from "./features/pasaport/better-auth-live.ts";
 import {EmailSenderLive} from "./features/pasaport/email-sender.ts";
+import {subscribeSozlukReconcile} from "./features/sozluk/sozluk-reconcile-cron.ts";
 import {Events as TelemetryEvents} from "./features/telemetry/resources.ts";
 import {TelemetryClient} from "./features/telemetry/Telemetry.ts";
 import {makeAppLive} from "./http/app.ts";
@@ -276,6 +277,15 @@ export default Phoenix.make(
 		// Provided the built `fateLayer` so it resolves `Pano` at dispatch. `subscribe` only
 		// registers a listener (no async/timer work), so it is init-safe.
 		yield* subscribeHotScoreDecay(fateLayer);
+
+		// The sözlük backstop-reconciliation Cron Trigger (#2558): re-runs the recomputable
+		// cache refresh (term summary + FTS + sözlük stats) for every term on a 6-hourly
+		// schedule, so a term/stat left stale by a SWALLOWED last-write refresh
+		// (`swallowRefresh`, #2012) is eventually re-converged without waiting for a next
+		// user write. Rides the SAME `CronEventSourceLive` seam as the decay above (a second
+		// `Cron(<expr>)` binding, dispatched at runtime by `controller.cron`, so the two
+		// coexist); the built `fateLayer` resolves `Sozluk` at dispatch. Init-safe.
+		yield* subscribeSozlukReconcile(fateLayer);
 
 		// The live path (ADR 0028/0029): the unified `LiveDO` namespace resolved
 		// once above, wrapped as worker-level services. One namespace plays both


### PR DESCRIPTION
Fixes #2558

## Problem

`swallowRefresh` (`apps/web/worker/features/lifecycle/apply-removal-transition.ts`) catches-and-logs a recomputable-cache-refresh die on the sözlük committed-then-refresh paths (remove/restore + create). That swallow is correct and stays (#2012): the substrate write already committed, so a refresh die over `DrizzleAccessOrDie` must not flip an already-committed transition into a raw 500. But the convergence contract is only *"heals on the NEXT write"*, and no reconciliation/drift job existed anywhere (the worker's only cron was the hot-score decay). So a low-traffic term/stat whose **last** write's refresh died stayed stale **indefinitely** — wrong `definition_count`/`total_score`/`excerpt`, a stale `term_search` FTS row, a drifted `sozluk_stats` — on exactly the corners nobody revisits, and invisible to Sentry because the failure was swallowed.

## Fix

Add `Sozluk.reconcileCaches(now)` and drive it from a new **6-hourly Cron Trigger** (`sozluk-reconcile-cron.ts`), so a swallowed last-write refresh is eventually re-converged without waiting for a next user write.

- **Reuses the existing cron substrate** (AC2): rides the same `Cloudflare.cron(...).subscribe` / `CronEventSourceLive` seam the sıcak/hot decay refresh already uses (`hot-score-decay-cron.ts`) — not a new bespoke scheduler. Two crons coexist cleanly: each `cron()` attaches its own `Cron(<expr>)` binding, and the runtime `scheduled` handler dispatches by `controller.cron === expression`, so the 15-minute decay tick and this 6-hourly reconcile tick never cross-fire (verified against `alchemy/Cloudflare/Workers/CronEventSource.ts`).
- **The swallow is untouched** (AC3): the request path is unchanged; the backstop is purely additive.

## Reconciliation strategy + rationale (AC4)

**A full sweep, every 6 hours** — `reconcileCaches` re-runs `persistTermSummary` (term summary + its `term_search` FTS dual-write, which also covers the removal-routed FTS refresh) for **every** `term_record` row, then one `recomputeSozlukStats`.

- **Full, not sampled/failure-flagged.** There is no persisted "refresh failed" flag to target, and adding one would put a write back on the swallow path the #2012 trade deliberately keeps clean. `persistTermSummary` is a pure convergent fold, so re-running it on an already-fresh term rewrites the identical row — a full sweep is therefore idempotent and self-correcting with **no** failure bookkeeping.
- **Bounded scan.** The sweep pages `term_record` in slug-keyset chunks (`scanReconcileChunks`, `SOZLUK_RECONCILE_CHUNK = 200`), mirroring the #2559 decay-sweep bound, so no single query materializes the whole table as it grows.
- **Cadence.** 6 hours is far coarser than hot-decay's 15 minutes because staleness here is a rare long-tail event (a refresh die on a term's *last* write), not a continuous drift, and each pass rewrites every term row.

## Coverage (AC5)

- **Unit** (`sozluk-reconcile-scan.unit.test.ts`): `scanReconcileChunks`'s cursor-advance + full-coverage control flow over in-memory ports (ADR 0082 litmus — no SQL engine): full coverage across pages, bounded pages, exact-multiple termination, empty table.
- **Integration** (`sozluk-cache-reconcile.test.ts`): seeds a real term over the public fate seam, corrupts `term_record` (`definition_count`/`excerpt`) and `sozluk_stats.total_definitions` via setup-only D1 to construct the exact swallowed-last-write stale state, runs the **real** `Sozluk.reconcileCaches` against this stage's real remote D1, and asserts both re-converge to the true values derived from the untouched `definition_record` — the staleness healed with no user write.

`pnpm typecheck`, `biome check`, and the full sözlük unit suite (53 tests) pass locally. The integration test runs in CI (needs a deployed stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)