### PR TITLE
docs(roadmap): pin `## Campaigns` state grammar as a parsed contract (#2657)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,6 +35,11 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 |----------|-----------|-------|
 | Mentor Audit | #27 | active |
 
+**The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
+
+- **Columns** are `Campaign | Milestone | State`, in that order. `Campaign` is the founder-voice name; `Milestone` pins the campaign to its GitHub milestone **by number** (`#N`) — the same row→milestone-by-number binding the roadmap-guard already enforces on `## Arcs`, and that number is the one link to the operational projection. `State` is the lifecycle cell.
+- **`State ∈ {active, done}`** — the symmetric two-state lifecycle. A campaign is `active` while its milestone is draining, and flips to `done` once that milestone is fully drained (its GitHub milestone closed). There is no `queued` state: unlike an arc, a campaign is not sequenced ahead — it opens `active` when the founder starts it and ends `done`, running concurrently with whichever arc is active.
+
 **Mentor Audit** — a security & architecture audit wave (the staff-mentor findings: the karma double-bump race, per-actor rate limiting, ops runbooks, `SECURITY.md`, …). To be solved ASAP; drains via the platform lane alongside Four Pillars.
 
 ## Standing lanes


### PR DESCRIPTION
## What

Formalize the `## Campaigns` section of `ROADMAP.md` as a **parsed contract** so the campaign skill (#2659, the writer) and the lifecycle guard (#2660, the reader) bind to one grammar instead of each re-deriving the format. The section itself landed at `@507fd439`; this pins its *format and state grammar*:

- **Columns** `Campaign | Milestone | State`, documented in order.
- **Row→milestone-by-number binding** — a campaign row pins its milestone by `#N`, mirroring the `## Arcs` arc→milestone discipline the roadmap-guard already enforces.
- **`State ∈ {active, done}`** — the symmetric two-state lifecycle: `active` while the milestone drains, `done` once it is fully drained (milestone closed); no `queued` state, since a campaign runs concurrently with the active arc rather than being sequenced ahead.

The prose lead-in already carries the *why* (bounded, milestone-backed, drains via the platform lane concurrent with the active arc — ADR 0072 / 0078); this change states the format once beneath it without re-narrating that rationale.

## Scope

Docs-only, `ROADMAP.md` alone (5 lines added). The existing `Mentor Audit | #27 | active` row is the validation case — it conforms to the pinned format unchanged. No new milestone created and no campaign row added (milestone curation is a human roadmap act, ADR 0072 §3). The guard (#2660) and skill (#2659) are out of scope — their own children.

Fixes #2657