### PR TITLE
test(e2e): tolerate CF edge-placeholder-404 on smoke's fresh-context first paint (#2667)

### DIFF
--- a/apps/web/tests/e2e/00-smoke.spec.ts
+++ b/apps/web/tests/e2e/00-smoke.spec.ts
@@ -1,4 +1,5 @@
-import {expect, test} from "@playwright/test";
+import {expect, type Page, test} from "@playwright/test";
+import {isCloudflarePlaceholder404} from "../integration/_edge-ready";
 
 /**
  * Smoke pass — for every route the SPA serves, navigate, assert the page
@@ -10,8 +11,40 @@ import {expect, test} from "@playwright/test";
 
 const STATIC_ROUTES = ["/", "/pano", "/pano/yeni", "/sozluk", "/auth"] as const;
 
+// Each smoke `test()` gets a fresh Playwright context whose own connection can route to a
+// Cloudflare edge PoP the single-context `preview-ready` warm gate never touched — one that hasn't
+// yet propagated the SPA fallback for a route and so serves the typed CF edge-placeholder-404 on
+// first paint (config runs the suite serially: `workers:1` + `fullyParallel:false`, so this is the
+// fresh-per-test-context vs. one-warm-context gap, not a parallel-worker fan-out). `gotoSpaReady`
+// polls THROUGH that bounded readiness window (ADR 0127) on the context until the real shell is
+// served. Tolerance is scoped to the typed placeholder ONLY: a structured worker JSON 404, or any
+// other response, returns at once for the caller's assertion to judge — a genuine failure still reds.
+const SPA_READY_DEADLINE_MS = 30_000;
+const SPA_READY_POLL_MS = 1_500;
+
+async function gotoSpaReady(page: Page, route: string): Promise<void> {
+	const deadline = Date.now() + SPA_READY_DEADLINE_MS;
+	// Poll until the served page is not the typed CF placeholder-404, or the budget lapses — then
+	// leave the last navigation in place so the caller's assertion reports the truth (a genuinely
+	// cold edge past the budget still reds).
+	while (Date.now() < deadline) {
+		const res = await page.goto(route);
+		if (!res || res.status() !== 404) return; // 200 SPA shell, or a non-404 the caller must judge
+		if (!isCloudflarePlaceholder404(res.status(), await res.text())) return; // real worker JSON 404
+		await page.waitForTimeout(SPA_READY_POLL_MS);
+	}
+}
+
 for (const route of STATIC_ROUTES) {
 	test(`smoke: ${route} renders without console errors`, async ({page}) => {
+		// Room past the default 15s per-test cap for the placeholder-404 readiness poll.
+		test.setTimeout(SPA_READY_DEADLINE_MS + 15_000);
+
+		// Ride the cold-PoP placeholder window BEFORE wiring console capture, so the transit's
+		// `Failed to load resource: 404` noise never poisons the real-error assertion below; then
+		// re-navigate with listeners attached to capture the authoritative SPA-shell load.
+		await gotoSpaReady(page, route);
+
 		const errors: string[] = [];
 		page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
 		page.on("console", (msg) => {
@@ -30,19 +63,21 @@ for (const route of STATIC_ROUTES) {
 }
 
 test("smoke: /sozluk/<slug> renders for a real seeded term", async ({page}) => {
-	await page.goto("/sozluk");
+	test.setTimeout(SPA_READY_DEADLINE_MS + 15_000);
+	await gotoSpaReady(page, "/sozluk");
 	const firstTerm = page.locator(".kp-sozluk-term-row").first();
 	await expect(firstTerm).toBeVisible({timeout: 10_000});
 	const href = await firstTerm.getAttribute("href");
 	expect(href).toMatch(/^\/sozluk\/.+/);
 
-	await page.goto(href ?? "/sozluk");
+	await gotoSpaReady(page, href ?? "/sozluk");
 	await expect(page.locator(".kp-topbar")).toBeVisible();
 	await expect(page.locator(".kp-sozluk-term__title")).toBeVisible({timeout: 10_000});
 });
 
 test("smoke: /pano/<id> renders for a real seeded post", async ({page}) => {
-	await page.goto("/pano");
+	test.setTimeout(SPA_READY_DEADLINE_MS + 15_000);
+	await gotoSpaReady(page, "/pano");
 	const firstPost = page.locator(".kp-pano-post").first();
 	await expect(firstPost).toBeVisible({timeout: 10_000});
 	// The title link uses `post.url ?? post.href` (so external links navigate


### PR DESCRIPTION
## What

`00-smoke` intermittently false-reds on the blocking `e2e` gate for `/pano/yeni`: `expect(.kp-topbar).toBeVisible()` times out because the edge served the typed **Cloudflare edge-placeholder-404** instead of the SPA shell, so React never mounts and the run also emits Nx `console.error: Failed to load resource: 404`. A plain unchanged re-run goes green — a propagation transient, not a code defect.

## Mechanism (grounded in the config)

The suite runs **serially** — `apps/web/playwright.config.cjs` sets `workers: 1` + `fullyParallel: false` — so this is **not** a parallel-worker fan-out (correcting the original hypothesis). `apps/web/tests/e2e/_setup/preview-ready.cjs` warms `WARM_ROUTES` (which already includes `/pano/yeni`) through **one** reused Chromium context; each smoke `test()` then runs under Playwright's **fresh per-test context**, whose own connection can route to a cold edge PoP the single-context warm gate never covered, so first paint draws the CF placeholder-404. The real gap is **fresh-per-test-context vs. one-warm-context**, not concurrency.

## Fix (option A)

Reuse the typed `isCloudflarePlaceholder404` detector (`apps/web/tests/integration/_edge-ready.ts`, ADR 0127) via a small `gotoSpaReady` poll that navigates the fresh context **through** the placeholder window until the real SPA shell is served, **then** asserts. The poll runs **before** console capture is wired, so the transit's `Failed to load resource: 404` noise never poisons the real-error assertion.

Tolerance is **scoped to the typed placeholder only**: a structured worker JSON 404, a genuine non-render, or real console errors still red — never a blanket retry.

## Scope

Confined to `apps/web/tests/e2e/00-smoke.spec.ts`, reusing (not duplicating) the `_edge-ready.ts` detector. No workflow or `playwright.config.cjs` changes — non-CP (`apps/**` is outside `CONTROL_PLANE_RE`).

## Acceptance criteria

- [x] `/pano/yeni` assertion no longer false-reds on the placeholder-404 first paint — the readiness window is polled through, not asserted against.
- [x] Real-error assertion preserved: a worker JSON 404, a genuine non-render, or console errors still fail — tolerance narrowed to the typed placeholder per ADR 0127.
- [x] Approach grounded in the actual config (`workers: 1`, `fullyParallel: false`) — addresses the fresh-per-test-context vs. single-warm-context gap.
- [x] Fix confined to `apps/web/tests/e2e/` — non-CP.

Fixes #2667

🤖 Generated with [Claude Code](https://claude.com/claude-code)