### PR TITLE
feat(pipeline): fanout-guard proves publish topic-aim, not just presence (#2554)

### DIFF
--- a/apps/web/worker/features/fate-live/fanned-mutations.ts
+++ b/apps/web/worker/features/fate-live/fanned-mutations.ts
@@ -12,7 +12,8 @@
  * whole reason for this manifest + the `fanout-guard` CI check.
  *
  * Every `entity.verb` mutation key MUST appear here with a `fanned` flag and a
- * one-line rationale. `pipeline-cli fanout-guard check` enforces two invariants:
+ * one-line rationale; every `fanned: true` row MUST also declare its `topics`.
+ * `pipeline-cli fanout-guard check` enforces three invariants:
  *
  *   1. Drift — the set of keys here EQUALS the set discovered in
  *      `apps/web/worker/features/*.mutations.ts`. A new mutation with no row here
@@ -20,17 +21,31 @@
  *   2. Publish — every `fanned: true` mutation's feature references a
  *      `WorkerLivePublisher` publish. A fanned mutation whose feature omits the
  *      publish fails the build.
+ *   3. Topic aim — every `fanned: true` row declares the `/fate/live` target(s) it
+ *      publishes to, and each declared target is reachable from the feature's
+ *      `live.ts` binding. A fanned row with no `topics`, or a `topics` value the
+ *      feature's `live.ts` no longer targets (a mis-aimed publish, #2554), fails the
+ *      build. Invariant 2 proves a publish EXISTS; this proves it AIMS correctly.
  *
- * The rationale field is for the human reader (and the guard's report); the guard
- * keys only on `fanned`.
+ * A `topics` value is either a connection topic (a `LiveTopic` value — `posts` /
+ * `Post.comments` / `Term.definitions`) or an entity-update typename (`Post` /
+ * `Comment` / `Definition` / `User`) — the two shapes a publish takes. Declare EVERY
+ * target the mutation fans into (a delete that drops an edge AND touches a parent field
+ * lists both). The rationale field is for the human reader (and the guard's report);
+ * the guard keys on `fanned` and `topics`.
  */
 
-/** One mutation's fanned classification + the rationale for it. */
+/** One mutation's fanned classification, its publish target(s), and the rationale. */
 export interface FannedMutationEntry {
 	/** The `entity.verb` mutation key, exactly as it appears in `Fate.mutation("<key>", …)`. */
 	readonly key: string;
 	/** True ⇒ writes a fanned entity ⇒ must publish a `/fate/live` invalidation. */
 	readonly fanned: boolean;
+	/**
+	 * The `/fate/live` target(s) a `fanned: true` mutation publishes to — a `LiveTopic`
+	 * value or an entity typename (see the module docblock). Omitted on a not-fanned row.
+	 */
+	readonly topics?: ReadonlyArray<string>;
 	/** One line: WHY it does / does not fan (which subscribed connection it touches, or why none). */
 	readonly rationale: string;
 }
@@ -45,6 +60,7 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 	{
 		key: "post.submit",
 		fanned: true,
+		topics: ["posts"],
 		rationale: "prepends a new Post edge into the `posts` feed connection",
 	},
 	{
@@ -60,16 +76,19 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 	{
 		key: "post.vote",
 		fanned: true,
+		topics: ["Post"],
 		rationale: "updates the Post's score/myVote fields other clients subscribe to",
 	},
 	{
 		key: "post.retractVote",
 		fanned: true,
+		topics: ["Post"],
 		rationale: "updates the Post's score/myVote fields other clients subscribe to",
 	},
 	{
 		key: "post.react",
 		fanned: true,
+		topics: ["Post"],
 		rationale: "updates the Post's reaction aggregate other clients subscribe to",
 	},
 	{
@@ -87,52 +106,64 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 	{
 		key: "post.edit",
 		fanned: true,
+		topics: ["Post"],
 		rationale: "updates the Post's body/title fields other clients subscribe to",
 	},
 	{
 		key: "post.delete",
 		fanned: true,
+		topics: ["Post", "posts"],
 		rationale: "drops the Post edge from the `posts` feed connection",
 	},
 	{
 		key: "post.restore",
 		fanned: true,
+		topics: ["posts"],
 		rationale: "re-appends the Post edge into the `posts` feed connection",
 	},
 	{
 		key: "comment.add",
 		fanned: true,
+		topics: ["Post.comments"],
 		rationale: "appends a new Comment edge into the post's `Post.comments` connection",
 	},
 	{
 		key: "comment.vote",
 		fanned: true,
+		topics: ["Comment"],
 		rationale: "updates the Comment's score/myVote fields other clients subscribe to",
 	},
 	{
 		key: "comment.retractVote",
 		fanned: true,
+		topics: ["Comment"],
 		rationale: "updates the Comment's score/myVote fields other clients subscribe to",
 	},
 	{
 		key: "comment.react",
 		fanned: true,
+		topics: ["Comment"],
 		rationale: "updates the Comment's reaction aggregate other clients subscribe to",
 	},
 	{
 		key: "comment.edit",
 		fanned: true,
+		topics: ["Comment"],
 		rationale: "updates the Comment's body other clients subscribe to",
 	},
 	{
 		key: "comment.delete",
 		fanned: true,
-		rationale: "tombstones/drops the Comment edge in `Post.comments`",
+		topics: ["Comment", "Post.comments", "Post"],
+		rationale:
+			"tombstones/drops the Comment edge in `Post.comments` and updates the parent Post's commentCount",
 	},
 	{
 		key: "comment.restore",
 		fanned: true,
-		rationale: "re-appends the Comment edge into `Post.comments`",
+		topics: ["Post.comments", "Post"],
+		rationale:
+			"re-appends the Comment edge into `Post.comments` and updates the parent Post's commentCount",
 	},
 
 	// sözlük — terms + definitions. Definition membership + field changes fan into
@@ -140,36 +171,43 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 	{
 		key: "definition.add",
 		fanned: true,
+		topics: ["Term.definitions"],
 		rationale: "appends a new Definition edge into the term's `Term.definitions` connection",
 	},
 	{
 		key: "definition.vote",
 		fanned: true,
+		topics: ["Definition"],
 		rationale: "updates the Definition's score/myVote fields other clients subscribe to",
 	},
 	{
 		key: "definition.retractVote",
 		fanned: true,
+		topics: ["Definition"],
 		rationale: "updates the Definition's score/myVote fields other clients subscribe to",
 	},
 	{
 		key: "definition.react",
 		fanned: true,
+		topics: ["Definition"],
 		rationale: "updates the Definition's reaction aggregate other clients subscribe to",
 	},
 	{
 		key: "definition.edit",
 		fanned: true,
+		topics: ["Definition"],
 		rationale: "updates the Definition's body other clients subscribe to",
 	},
 	{
 		key: "definition.delete",
 		fanned: true,
+		topics: ["Definition", "Term.definitions"],
 		rationale: "drops the Definition edge from `Term.definitions`",
 	},
 	{
 		key: "definition.restore",
 		fanned: true,
+		topics: ["Term.definitions"],
 		rationale: "re-appends the Definition edge into `Term.definitions`",
 	},
 
@@ -181,20 +219,26 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 		fanned: false,
 		rationale: "writes a report row on the moderation queue — no subscribed content connection",
 	},
+	// report publishes THROUGH pano/sözlük's bindings (report/live.ts delegates to
+	// `panoLive`/`sozlukLive`), so its target set is their union — the moderated target
+	// may be any fanned kind. The guard resolves the delegation to reach these topics.
 	{
 		key: "report.resolve",
 		fanned: true,
+		topics: ["Post", "posts", "Comment", "Post.comments", "Definition", "Term.definitions"],
 		rationale:
 			"a `remove` action evicts a fanned Post/Comment/Definition from its subscribed connection",
 	},
 	{
 		key: "report.restore",
 		fanned: true,
+		topics: ["Post", "posts", "Comment", "Post.comments", "Definition", "Term.definitions"],
 		rationale: "re-enters a moderator-restored fanned entity into its subscribed connection",
 	},
 	{
 		key: "report.restoreWave",
 		fanned: true,
+		topics: ["Post", "posts", "Comment", "Post.comments", "Definition", "Term.definitions"],
 		rationale: "re-enters every fanned entity in the restored wave into its subscribed connection",
 	},
 

--- a/packages/pipeline-cli/src/tools/fanout-guard/fanout-guard.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/fanout-guard.ts
@@ -1,12 +1,13 @@
 /**
  * `fanout-guard` pure core (ADR 0155) — decide whether every worker `Fate.mutation`
- * is classified in the fanned-mutation manifest, and whether every fanned mutation's
- * feature publishes a `/fate/live` invalidation. IO-free and total: every decision is
- * a deterministic transform over already-gathered facts. The filesystem boundary
- * (discover mutation keys per feature, parse the manifest, detect the publisher
- * reference) lives in `gate.ts`; this module never touches disk.
+ * is classified in the fanned-mutation manifest, whether every fanned mutation's
+ * feature publishes a `/fate/live` invalidation, and whether that publish AIMS at the
+ * manifest-declared topic. IO-free and total: every decision is a deterministic
+ * transform over already-gathered facts. The filesystem boundary (discover mutation
+ * keys per feature, parse the manifest, detect the publisher reference, gather each
+ * feature's reachable topics) lives in `gate.ts`; this module never touches disk.
  *
- * Two invariants, each a distinct failure shape:
+ * Three invariants, each a distinct failure shape:
  *
  *   1. Drift — the discovered mutation-key set EQUALS the manifest's key set. A
  *      discovered key with no manifest row (`unclassified`) OR a manifest row for a
@@ -15,6 +16,26 @@
  *      be silently omitted.
  *   2. Publish — every `fanned: true` mutation's feature references a
  *      `WorkerLivePublisher` publish. A fanned mutation whose feature omits it fails.
+ *   3. Topic aim — every `fanned: true` mutation declares its expected `/fate/live`
+ *      target(s) in the manifest, and each declared target is reachable from its
+ *      feature's `live.ts` binding. Closes the mis-aim class (#2554): invariant 2 only
+ *      proves a publish EXISTS; this proves it AIMS at the declared topic. A fanned row
+ *      with no declared topic fails (parity with `drift` forcing the classification);
+ *      a declared topic the feature's `live.ts` no longer targets (a topic edit that
+ *      re-aimed the publish) fails as `topic-mismatch`.
+ *
+ * A `/fate/live` target is either a connection topic (a `LiveTopic` value, e.g.
+ * `posts` / `Post.comments` / `Term.definitions`) or an entity-update typename
+ * (`Post` / `Comment` / `Definition` / `User`) — the two shapes a publish can take.
+ * The topic check is feature-scoped by construction, exactly as invariant 2 is: it
+ * reuses the per-feature `live.ts` scan the way invariant 2 reuses the per-feature
+ * publisher scan. It proves the declared topic is still REACHABLE in the feature's
+ * binding, not that this exact resolver wired that exact topic — which closes the
+ * concrete mis-aim edit (a `LiveTopic.x → LiveTopic.y` swap in `live.ts` drops `x`
+ * from the feature's reachable set), the change that passes review and CI today.
+ * Reachability resolves one graph of `*Live(...)` delegation: a feature whose
+ * `live.ts` publishes THROUGH another feature's binding (report → pano/sözlük)
+ * inherits that feature's targets.
  *
  * Fail-closed on zero scope (ADR 0092): zero discovered mutations is a
  * misconfiguration (wrong root, a features-dir reshape), NOT a vacuous pass.
@@ -28,10 +49,16 @@ export interface DiscoveredMutation {
 	readonly feature: string;
 }
 
-/** One manifest row — a key's fanned classification (the rationale is not needed by the core). */
+/**
+ * One manifest row — a key's fanned classification plus, for a fanned row, the
+ * `/fate/live` target(s) it publishes to (a `LiveTopic` value or an entity typename).
+ * `topics` is empty for a not-fanned row (nothing to aim) and its presence is required
+ * for a fanned row by invariant 3. The rationale is not needed by the core.
+ */
 export interface ManifestEntry {
 	readonly key: string;
 	readonly fanned: boolean;
+	readonly topics: ReadonlyArray<string>;
 }
 
 /**
@@ -42,11 +69,28 @@ export interface ManifestEntry {
  */
 export type FeaturePublishes = ReadonlyMap<string, boolean>;
 
+/**
+ * The `/fate/live` targets each feature's `live.ts` binding can reach, delegation
+ * already resolved (see `resolveReachableTargets`). A fanned mutation's declared topic
+ * must be a member of its feature's set — the feature-scoped aim check (invariant 3).
+ */
+export type FeatureTargets = ReadonlyMap<string, ReadonlySet<string>>;
+
 /** The facts the pure verdict is computed over — all gathered at the IO boundary. */
 export interface FanoutGuardFacts {
 	readonly discovered: ReadonlyArray<DiscoveredMutation>;
 	readonly manifest: ReadonlyArray<ManifestEntry>;
 	readonly featurePublishes: FeaturePublishes;
+	readonly featureTargets: FeatureTargets;
+}
+
+/** One mis-aimed fanned mutation: its declared topics and the subset the feature can't reach. */
+export interface MisaimedMutation {
+	readonly key: string;
+	readonly feature: string;
+	readonly declared: ReadonlyArray<string>;
+	/** The declared topics NOT reachable from the feature's `live.ts` — the mis-aim evidence. */
+	readonly unreachable: ReadonlyArray<string>;
 }
 
 /**
@@ -73,16 +117,28 @@ export type FanoutGuardVerdict =
 			readonly reason: "missing-publish";
 			/** The `entity.verb` keys whose feature omits the publish. */
 			readonly omitted: ReadonlyArray<string>;
+	  }
+	/**
+	 * A fanned mutation's publish does not aim where the manifest declares (#2554):
+	 * `undeclared` is a fanned row with no expected topic; `misaimed` is a declared
+	 * topic the feature's `live.ts` no longer targets.
+	 */
+	| {
+			readonly pass: false;
+			readonly reason: "topic-mismatch";
+			readonly undeclared: ReadonlyArray<string>;
+			readonly misaimed: ReadonlyArray<MisaimedMutation>;
 	  };
 
 /**
  * Decide the verdict over the gathered facts. Order: fail-closed on zero scope, then
- * the drift check (the key sets must agree), then the publish check over the fanned
- * subset. Drift is checked before publish because an unclassified key has no `fanned`
- * flag to check a publish against — the classification must exist first.
+ * drift (the key sets must agree), then publish (over the fanned subset), then topic
+ * aim. Each stage presupposes the prior: drift before publish because an unclassified
+ * key has no `fanned` flag to check a publish against; publish before aim because a
+ * feature that omits the publish entirely can't be checked for WHERE it aims.
  */
 export const judge = (facts: FanoutGuardFacts): FanoutGuardVerdict => {
-	const {discovered, manifest, featurePublishes} = facts;
+	const {discovered, manifest, featurePublishes, featureTargets} = facts;
 
 	if (discovered.length === 0) {
 		return {pass: false, reason: "zero-scope"};
@@ -113,6 +169,30 @@ export const judge = (facts: FanoutGuardFacts): FanoutGuardVerdict => {
 		return {pass: false, reason: "missing-publish", omitted};
 	}
 
+	// Topic aim: each fanned mutation must declare its target(s), and every declared
+	// target must be reachable from its feature's live.ts binding.
+	const undeclared: Array<string> = [];
+	const misaimed: Array<MisaimedMutation> = [];
+	for (const key of fannedKeys) {
+		const declared = manifestByKey.get(key)?.topics ?? [];
+		if (declared.length === 0) {
+			undeclared.push(key);
+			continue;
+		}
+		const feature = featureOf.get(key) ?? "";
+		const reachable = featureTargets.get(feature) ?? new Set<string>();
+		const unreachable = declared.filter((t) => !reachable.has(t)).sort();
+		if (unreachable.length > 0) misaimed.push({key, feature, declared, unreachable});
+	}
+	if (undeclared.length > 0 || misaimed.length > 0) {
+		return {
+			pass: false,
+			reason: "topic-mismatch",
+			undeclared: undeclared.sort(),
+			misaimed: misaimed.sort((a, b) => a.key.localeCompare(b.key)),
+		};
+	}
+
 	return {pass: true, checked: discovered.length, fanned: fannedKeys.length};
 };
 
@@ -121,7 +201,8 @@ export const renderReport = (verdict: FanoutGuardVerdict): string => {
 	if (verdict.pass) {
 		return (
 			`fanout-guard: ${verdict.checked} mutations classified, ` +
-			`${verdict.fanned} fanned — every fanned mutation's feature publishes a /fate/live invalidation`
+			`${verdict.fanned} fanned — every fanned mutation's feature publishes a /fate/live ` +
+			"invalidation aimed at its declared topic"
 		);
 	}
 	if (verdict.reason === "zero-scope") {
@@ -153,37 +234,66 @@ export const renderReport = (verdict: FanoutGuardVerdict): string => {
 			"omit its /fate/live publish (ADR 0155)."
 		);
 	}
-	const lines = verdict.omitted.map((k) => `  ${k}`);
+	if (verdict.reason === "missing-publish") {
+		const lines = verdict.omitted.map((k) => `  ${k}`);
+		return (
+			`fanout-guard: ${verdict.omitted.length} fanned mutation` +
+			`${verdict.omitted.length === 1 ? "" : "s"} whose feature omits the /fate/live publish:\n` +
+			`${lines.join("\n")}\n\n` +
+			"A fanned mutation writes an entity in a subscribed connection, so it MUST publish the " +
+			"invalidation through WorkerLivePublisher after the write — else every other client's live " +
+			"view goes stale (ADR 0155; .patterns/fate-live-views.md). Add the publish, or reclassify " +
+			"the mutation fanned: false in the manifest if it truly fans nothing."
+		);
+	}
+	const lines: Array<string> = [];
+	if (verdict.undeclared.length > 0) {
+		lines.push(
+			`  UNDECLARED-TOPIC (${verdict.undeclared.length}) — add topics: [...] to the fanned row in ` +
+				"apps/web/worker/features/fate-live/fanned-mutations.ts naming its /fate/live target(s):",
+		);
+		for (const k of verdict.undeclared) lines.push(`    ${k}`);
+	}
+	if (verdict.misaimed.length > 0) {
+		lines.push(
+			`  MIS-AIMED (${verdict.misaimed.length}) — declared topic(s) the feature's live.ts no longer targets:`,
+		);
+		for (const m of verdict.misaimed) {
+			lines.push(`    ${m.key} (${m.feature}) → unreachable: ${m.unreachable.join(", ")}`);
+		}
+	}
 	return (
-		`fanout-guard: ${verdict.omitted.length} fanned mutation` +
-		`${verdict.omitted.length === 1 ? "" : "s"} whose feature omits the /fate/live publish:\n` +
-		`${lines.join("\n")}\n\n` +
-		"A fanned mutation writes an entity in a subscribed connection, so it MUST publish the " +
-		"invalidation through WorkerLivePublisher after the write — else every other client's live " +
-		"view goes stale (ADR 0155; .patterns/fate-live-views.md). Add the publish, or reclassify " +
-		"the mutation fanned: false in the manifest if it truly fans nothing."
+		"fanout-guard: a fanned mutation's /fate/live publish does not aim where the manifest " +
+		`declares (#2554):\n${lines.join("\n")}\n\n` +
+		"Invariant 2 proves a publish EXISTS; this proves it AIMS at the declared topic. Fix the " +
+		"live.ts binding to publish to the declared topic, or correct the manifest row's topics: " +
+		"[...] to the topic the feature actually fans into (ADR 0155; .patterns/fate-live-views.md)."
 	);
 };
 
 /**
- * Extract `{key, fanned}` rows from the manifest module's source text. Pure over the
- * text so `gate.ts` grounds the classification in the checked-in manifest without a
- * cross-package import (pipeline-cli must not depend on apps/web). Reads the
- * `{key: "<entity.verb>", fanned: true|false, …}` object-literal rows the manifest
- * declares — a minimal, dependency-free slice, sufficient for this file's flat shape,
- * not a general TS parser.
+ * Extract `{key, fanned, topics}` rows from the manifest module's source text. Pure
+ * over the text so `gate.ts` grounds the classification in the checked-in manifest
+ * without a cross-package import (pipeline-cli must not depend on apps/web). Reads the
+ * `{key: "<entity.verb>", fanned: true|false, topics: [...]? …}` object-literal rows —
+ * a minimal, dependency-free slice, sufficient for this file's flat shape, not a
+ * general TS parser. `topics` is authored after `fanned` on a fanned row and omitted on
+ * a not-fanned one; a missing `topics` parses to `[]` (invariant 3 then flags the
+ * fanned row as undeclared).
  */
 export const parseManifestEntries = (source: string): ReadonlyArray<ManifestEntry> => {
 	const out: Array<ManifestEntry> = [];
-	// Match each `{ key: "x.y", fanned: true|false, … }` row. `key` and `fanned` are
-	// authored in that order in the manifest; the rationale that follows is ignored.
-	const re = /\bkey:\s*["']([a-zA-Z]+\.[a-zA-Z]+)["']\s*,\s*fanned:\s*(true|false)\b/g;
+	const re =
+		/\bkey:\s*["']([a-zA-Z]+\.[a-zA-Z]+)["']\s*,\s*fanned:\s*(true|false)\b\s*,?\s*(?:topics:\s*\[([^\]]*)\])?/g;
 	for (const m of source.matchAll(re)) {
 		const key = m[1];
 		const fanned = m[2];
-		if (key !== undefined && fanned !== undefined) {
-			out.push({key, fanned: fanned === "true"});
-		}
+		if (key === undefined || fanned === undefined) continue;
+		const topicsRaw = m[3];
+		const topics = topicsRaw
+			? [...topicsRaw.matchAll(/["']([^"']+)["']/g)].map((t) => t[1] as string)
+			: [];
+		out.push({key, fanned: fanned === "true", topics});
 	}
 	return out;
 };
@@ -210,3 +320,98 @@ export const parseMutationKeys = (source: string): ReadonlyArray<string> => {
  * worker accessor, not the un-narrowed package tag).
  */
 export const referencesPublisher = (source: string): boolean => /WorkerLivePublisher/.test(source);
+
+/**
+ * Parse the `LiveTopic` object literal from `fate-live/protocol.ts` into a
+ * property-name → wire-value map (e.g. `postComments → "Post.comments"`). Scoped to the
+ * `export const LiveTopic = { … } as const` block and matched per-line
+ * (`<prop>: "<value>"`), so the interspersed docblock prose can't be mistaken for an
+ * entry. This resolves the `LiveTopic.<prop>` references a `live.ts` binding uses back
+ * to the wire topics the manifest declares.
+ */
+export const parseLiveTopicMap = (protocolSource: string): ReadonlyMap<string, string> => {
+	const out = new Map<string, string>();
+	const block = /export const LiveTopic\s*=\s*\{([\s\S]*?)\}\s*as const/.exec(protocolSource);
+	if (block?.[1] === undefined) return out;
+	for (const m of block[1].matchAll(/^\s*([A-Za-z]\w*):\s*"([^"]+)"/gm)) {
+		if (m[1] !== undefined && m[2] !== undefined) out.set(m[1], m[2]);
+	}
+	return out;
+};
+
+/**
+ * The `/fate/live` targets a feature's `live.ts` binding references DIRECTLY (before
+ * delegation resolution). Two shapes, matching how a publish is wired:
+ *
+ *   - connection topics — a `LiveTopic.<prop>` reference, resolved to its wire value
+ *     via `liveTopicMap` (an unknown prop, e.g. a typo, resolves to nothing);
+ *   - entity updates — an `<Entity>View.typeName` reference, whose value equals the
+ *     view name minus its `View` suffix (`PostView.typeName === "Post"`, the ADR-0155
+ *     view-sourced-typename convention, #1127). Anchored on `.typeName` so an unrelated
+ *     `<Name>View` mention can't be mistaken for a publish target.
+ */
+export const parseFeatureTargets = (
+	liveSource: string,
+	liveTopicMap: ReadonlyMap<string, string>,
+): ReadonlySet<string> => {
+	const out = new Set<string>();
+	for (const m of liveSource.matchAll(/\bLiveTopic\.(\w+)/g)) {
+		const value = m[1] !== undefined ? liveTopicMap.get(m[1]) : undefined;
+		if (value !== undefined) out.add(value);
+	}
+	for (const m of liveSource.matchAll(/\b([A-Z]\w*)View\.typeName\b/g)) {
+		if (m[1] !== undefined) out.add(m[1]);
+	}
+	return out;
+};
+
+/**
+ * The features a `live.ts` binding delegates to — the `<feature>Live(` helpers it calls
+ * (report's binding publishes THROUGH `panoLive(...)` / `sozlukLive(...)`). Captures the
+ * lowercase-led `<name>` before the `Live(` call so it can't match `WorkerLivePublisher`
+ * (uppercase-led, no trailing `(`); a self-reference is dropped in the closure.
+ */
+export const parseFeatureDelegations = (liveSource: string): ReadonlySet<string> => {
+	const out = new Set<string>();
+	for (const m of liveSource.matchAll(/\b([a-z]\w*)Live\s*\(/g)) {
+		if (m[1] !== undefined) out.add(m[1]);
+	}
+	return out;
+};
+
+/**
+ * Resolve each feature's REACHABLE targets: its direct targets unioned with those of
+ * every feature it delegates to, transitively (a bounded fixpoint over the small
+ * feature graph). A feature that only appears as a delegation target still gets an
+ * entry. Self-delegation is a no-op.
+ */
+export const resolveReachableTargets = (
+	direct: ReadonlyMap<string, ReadonlySet<string>>,
+	delegations: ReadonlyMap<string, ReadonlySet<string>>,
+): FeatureTargets => {
+	const result = new Map<string, Set<string>>();
+	for (const [feature, targets] of direct) result.set(feature, new Set(targets));
+	for (const feature of delegations.keys())
+		if (!result.has(feature)) result.set(feature, new Set());
+
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const [feature, deps] of delegations) {
+			const set = result.get(feature);
+			if (set === undefined) continue;
+			for (const dep of deps) {
+				if (dep === feature) continue;
+				const depSet = result.get(dep);
+				if (depSet === undefined) continue;
+				for (const t of depSet) {
+					if (!set.has(t)) {
+						set.add(t);
+						changed = true;
+					}
+				}
+			}
+		}
+	}
+	return result;
+};

--- a/packages/pipeline-cli/src/tools/fanout-guard/fanout-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/fanout-guard.unit.test.ts
@@ -1,33 +1,47 @@
 /**
- * Pure-core tests for `fanout-guard` (ADR 0155, #1898): the drift check (a mutation
- * must be classified), the fanned-must-publish check (the fixture pair — a fanned
- * mutation with a publish passes, one without fails), the fail-closed-on-zero verdict
- * (ADR 0092), and the manifest/mutation-key/publisher source parses. No IO — the
- * filesystem seam is crossed in `gate.unit.test.ts`.
+ * Pure-core tests for `fanout-guard` (ADR 0155, #1898, #2554): the drift check (a
+ * mutation must be classified), the fanned-must-publish check (the fixture pair — a
+ * fanned mutation with a publish passes, one without fails), the topic-aim check (a
+ * fanned mutation must declare a topic its feature's live.ts reaches), the
+ * fail-closed-on-zero verdict (ADR 0092), and the manifest/mutation-key/publisher/
+ * topic/delegation source parses. No IO — the filesystem seam is crossed in
+ * `gate.unit.test.ts`.
  */
 import {describe, expect, it} from "@effect/vitest";
 import {
 	type DiscoveredMutation,
 	type FanoutGuardFacts,
+	type FeatureTargets,
 	judge,
 	type ManifestEntry,
+	parseFeatureDelegations,
+	parseFeatureTargets,
+	parseLiveTopicMap,
 	parseManifestEntries,
 	parseMutationKeys,
 	referencesPublisher,
 	renderReport,
+	resolveReachableTargets,
 } from "./fanout-guard.ts";
 
 const disc = (key: string, feature: string): DiscoveredMutation => ({key, feature});
-const man = (key: string, fanned: boolean): ManifestEntry => ({key, fanned});
+const man = (key: string, fanned: boolean, topics: ReadonlyArray<string> = []): ManifestEntry => ({
+	key,
+	fanned,
+	topics,
+});
+const targets = (pairs: ReadonlyArray<readonly [string, ReadonlyArray<string>]>): FeatureTargets =>
+	new Map(pairs.map(([f, t]) => [f, new Set(t)]));
 const facts = (
 	discovered: ReadonlyArray<DiscoveredMutation>,
 	manifest: ReadonlyArray<ManifestEntry>,
 	featurePublishes: ReadonlyMap<string, boolean>,
-): FanoutGuardFacts => ({discovered, manifest, featurePublishes});
+	featureTargets: FeatureTargets = new Map(),
+): FanoutGuardFacts => ({discovered, manifest, featurePublishes, featureTargets});
 
 describe("judge — fail-closed on zero scope (ADR 0092)", () => {
 	it("FAILS with zero-scope when no mutations are discovered", () => {
-		const verdict = judge(facts([], [man("post.submit", true)], new Map()));
+		const verdict = judge(facts([], [man("post.submit", true, ["posts"])], new Map()));
 		expect(verdict.pass).toBe(false);
 		expect(verdict.pass === false && verdict.reason).toBe("zero-scope");
 	});
@@ -46,8 +60,9 @@ describe("judge — drift (every mutation must be classified)", () => {
 		const verdict = judge(
 			facts(
 				[disc("post.submit", "pano")],
-				[man("post.submit", true), man("post.gone", true)],
+				[man("post.submit", true, ["posts"]), man("post.gone", true, ["posts"])],
 				new Map([["pano", true]]),
+				targets([["pano", ["posts"]]]),
 			),
 		);
 		expect(verdict.pass).toBe(false);
@@ -58,9 +73,14 @@ describe("judge — drift (every mutation must be classified)", () => {
 });
 
 describe("judge — the fixture pair: a fanned mutation must publish", () => {
-	it("PASSES when a fanned mutation's feature references a publish", () => {
+	it("PASSES when a fanned mutation's feature references a publish AND aims at its topic", () => {
 		const verdict = judge(
-			facts([disc("post.submit", "pano")], [man("post.submit", true)], new Map([["pano", true]])),
+			facts(
+				[disc("post.submit", "pano")],
+				[man("post.submit", true, ["posts"])],
+				new Map([["pano", true]]),
+				targets([["pano", ["posts"]]]),
+			),
 		);
 		expect(verdict.pass).toBe(true);
 		expect(verdict.pass && verdict.fanned).toBe(1);
@@ -70,9 +90,10 @@ describe("judge — the fixture pair: a fanned mutation must publish", () => {
 		const verdict = judge(
 			facts(
 				[disc("post.submit", "pano")],
-				[man("post.submit", true)],
+				[man("post.submit", true, ["posts"])],
 				// pano does NOT reference the publisher — the omission the guard exists to catch
 				new Map([["pano", false]]),
+				targets([["pano", ["posts"]]]),
 			),
 		);
 		expect(verdict.pass).toBe(false);
@@ -97,13 +118,110 @@ describe("judge — the fixture pair: a fanned mutation must publish", () => {
 		const verdict = judge(
 			facts(
 				[disc("post.submit", "pano"), disc("post.saveDraft", "pano")],
-				[man("post.submit", true), man("post.saveDraft", false)],
+				[man("post.submit", true, ["posts"]), man("post.saveDraft", false)],
 				new Map([["pano", true]]),
+				targets([["pano", ["posts"]]]),
 			),
 		);
 		expect(verdict.pass).toBe(true);
 		expect(verdict.pass && verdict.checked).toBe(2);
 		expect(verdict.pass && verdict.fanned).toBe(1);
+	});
+});
+
+describe("judge — topic aim (#2554): a fanned mutation must publish to its declared topic", () => {
+	it("PASSES when the declared topic is reachable from the feature's live.ts", () => {
+		const verdict = judge(
+			facts(
+				[disc("comment.add", "pano")],
+				[man("comment.add", true, ["Post.comments"])],
+				new Map([["pano", true]]),
+				targets([["pano", ["posts", "Post.comments", "Post", "Comment"]]]),
+			),
+		);
+		expect(verdict.pass).toBe(true);
+	});
+
+	it("FAILS (topic-mismatch, mis-aimed) when the declared topic is NOT reachable — the wrong-topic edit", () => {
+		const verdict = judge(
+			facts(
+				[disc("comment.add", "pano")],
+				[man("comment.add", true, ["Post.comments"])],
+				new Map([["pano", true]]),
+				// pano/live.ts was re-aimed and no longer targets Post.comments
+				targets([["pano", ["posts", "Post"]]]),
+			),
+		);
+		expect(verdict.pass).toBe(false);
+		if (verdict.pass === false && verdict.reason === "topic-mismatch") {
+			expect(verdict.misaimed).toEqual([
+				{
+					key: "comment.add",
+					feature: "pano",
+					declared: ["Post.comments"],
+					unreachable: ["Post.comments"],
+				},
+			]);
+			expect(verdict.undeclared).toEqual([]);
+		} else {
+			expect.unreachable("expected topic-mismatch verdict");
+		}
+	});
+
+	it("FAILS (topic-mismatch, undeclared) when a fanned mutation declares NO topic — parity with drift", () => {
+		const verdict = judge(
+			facts(
+				[disc("post.submit", "pano")],
+				[man("post.submit", true)],
+				new Map([["pano", true]]),
+				targets([["pano", ["posts"]]]),
+			),
+		);
+		expect(verdict.pass).toBe(false);
+		expect(
+			verdict.pass === false && verdict.reason === "topic-mismatch" && verdict.undeclared,
+		).toEqual(["post.submit"]);
+	});
+
+	it("a mutation with multiple declared topics passes only when ALL are reachable", () => {
+		const declared = man("post.delete", true, ["Post", "posts"]);
+		const reachable = judge(
+			facts(
+				[disc("post.delete", "pano")],
+				[declared],
+				new Map([["pano", true]]),
+				targets([["pano", ["posts", "Post"]]]),
+			),
+		);
+		expect(reachable.pass).toBe(true);
+
+		const partial = judge(
+			facts(
+				[disc("post.delete", "pano")],
+				[declared],
+				new Map([["pano", true]]),
+				targets([["pano", ["Post"]]]),
+			),
+		);
+		expect(partial.pass).toBe(false);
+		expect(
+			partial.pass === false &&
+				partial.reason === "topic-mismatch" &&
+				partial.misaimed[0]?.unreachable,
+		).toEqual(["posts"]);
+	});
+
+	it("a delegated feature (report → pano/sözlük) reaches its declared topics through the closure", () => {
+		const verdict = judge(
+			facts(
+				[disc("report.resolve", "report")],
+				[man("report.resolve", true, ["Post", "Term.definitions"])],
+				new Map([["report", true]]),
+				// report/live.ts has no direct targets; the closure gave it pano ∪ sözlük
+				targets([["report", ["posts", "Post.comments", "Post", "Comment", "Term.definitions"]]]),
+			),
+		);
+		expect(verdict.pass).toBe(true);
 	});
 });
 
@@ -128,20 +246,48 @@ describe("renderReport", () => {
 		expect(report).toContain("post.newthing");
 		expect(report).toContain("UNCLASSIFIED");
 	});
+
+	it("surfaces both undeclared and mis-aimed rows legibly on a topic-mismatch fail", () => {
+		const report = renderReport({
+			pass: false,
+			reason: "topic-mismatch",
+			undeclared: ["post.newfan"],
+			misaimed: [
+				{
+					key: "comment.add",
+					feature: "pano",
+					declared: ["Post.comments"],
+					unreachable: ["Post.comments"],
+				},
+			],
+		});
+		expect(report).toContain("UNDECLARED-TOPIC");
+		expect(report).toContain("post.newfan");
+		expect(report).toContain("MIS-AIMED");
+		expect(report).toContain("comment.add");
+		expect(report).toContain("Post.comments");
+	});
 });
 
-describe("parseManifestEntries — read {key, fanned} rows from manifest source", () => {
-	it("parses fanned + not-fanned rows, ignoring the rationale", () => {
+describe("parseManifestEntries — read {key, fanned, topics} rows from manifest source", () => {
+	it("parses a fanned row's topics and a not-fanned row (no topics ⇒ [])", () => {
 		const source = `
 			export const FANNED_MUTATIONS = [
-				{key: "post.submit", fanned: true, rationale: "prepends a Post edge"},
+				{key: "post.submit", fanned: true, topics: ["posts"], rationale: "prepends a Post edge"},
+				{key: "post.delete", fanned: true, topics: ["Post", "posts"], rationale: "drops the edge"},
 				{key: "bildirim.markRead", fanned: false, rationale: "per-user, no connection"},
 			];
 		`;
 		expect(parseManifestEntries(source)).toEqual([
-			{key: "post.submit", fanned: true},
-			{key: "bildirim.markRead", fanned: false},
+			{key: "post.submit", fanned: true, topics: ["posts"]},
+			{key: "post.delete", fanned: true, topics: ["Post", "posts"]},
+			{key: "bildirim.markRead", fanned: false, topics: []},
 		]);
+	});
+
+	it("a fanned row that OMITS topics parses to [] (the guard then flags it undeclared)", () => {
+		const source = `{key: "post.submit", fanned: true, rationale: "oops, no topics"},`;
+		expect(parseManifestEntries(source)).toEqual([{key: "post.submit", fanned: true, topics: []}]);
 	});
 
 	it("returns [] on an empty/unparseable manifest (gate.ts fails closed on this)", () => {
@@ -176,5 +322,101 @@ describe("referencesPublisher — feature-scoped publish detection", () => {
 		expect(referencesPublisher("const marked = yield* bildirim.markRead(user.id, input.id);")).toBe(
 			false,
 		);
+	});
+});
+
+describe("parseLiveTopicMap — resolve LiveTopic.<prop> to its wire value", () => {
+	it("parses the object entries, ignoring interspersed docblock prose", () => {
+		const source = `
+			export const LiveTopic = {
+				/** pano feed (no-args, global). */
+				posts: "posts",
+				/** pano post → comments (args: \`{id: postId}\`). */
+				postComments: "Post.comments",
+				termDefinitions: "Term.definitions",
+			} as const;
+		`;
+		const map = parseLiveTopicMap(source);
+		expect(map.get("posts")).toBe("posts");
+		expect(map.get("postComments")).toBe("Post.comments");
+		expect(map.get("termDefinitions")).toBe("Term.definitions");
+		expect(map.size).toBe(3);
+	});
+
+	it("returns an empty map when the LiveTopic block is absent", () => {
+		expect(parseLiveTopicMap("export const Other = {a: 1};").size).toBe(0);
+	});
+});
+
+describe("parseFeatureTargets — the /fate/live targets a live.ts binding reaches directly", () => {
+	const map = new Map([
+		["posts", "posts"],
+		["postComments", "Post.comments"],
+		["termDefinitions", "Term.definitions"],
+	]);
+
+	it("resolves LiveTopic.<prop> refs and <Entity>View.typeName refs", () => {
+		const live = `
+			const POST = PostView.typeName;
+			const COMMENT = CommentView.typeName;
+			live.topic(LiveTopic.posts);
+			live.topic(LiveTopic.postComments, {id});
+		`;
+		expect([...parseFeatureTargets(live, map)].sort()).toEqual([
+			"Comment",
+			"Post",
+			"Post.comments",
+			"posts",
+		]);
+	});
+
+	it("ignores an unknown LiveTopic prop and a bare <Name>View without .typeName", () => {
+		const live = "live.topic(LiveTopic.mystery); const V = SomeView; PostView.typeName;";
+		expect([...parseFeatureTargets(live, map)]).toEqual(["Post"]);
+	});
+});
+
+describe("parseFeatureDelegations — the *Live( bindings a feature publishes through", () => {
+	it("captures delegated feature bindings, not WorkerLivePublisher", () => {
+		const live = `
+			const pano = panoLive(live, feedCache);
+			const sozluk = sozlukLive(live);
+			const p = yield* WorkerLivePublisher;
+		`;
+		expect([...parseFeatureDelegations(live)].sort()).toEqual(["pano", "sozluk"]);
+	});
+
+	it("does not capture its own export def (name = ( with no immediate call)", () => {
+		expect([...parseFeatureDelegations("export const reportLive = (live) => ({});")]).toEqual([]);
+	});
+});
+
+describe("resolveReachableTargets — union direct targets with delegated ones, transitively", () => {
+	it("report inherits pano ∪ sözlük through delegation", () => {
+		const direct = new Map<string, ReadonlySet<string>>([
+			["pano", new Set(["posts", "Post"])],
+			["sozluk", new Set(["Term.definitions", "Definition"])],
+			["report", new Set()],
+		]);
+		const delegations = new Map<string, ReadonlySet<string>>([
+			["report", new Set(["pano", "sozluk"])],
+		]);
+		const resolved = resolveReachableTargets(direct, delegations);
+		expect([...(resolved.get("report") ?? [])].sort()).toEqual([
+			"Definition",
+			"Post",
+			"Term.definitions",
+			"posts",
+		]);
+		// a non-delegating feature is unchanged
+		expect([...(resolved.get("pano") ?? [])].sort()).toEqual(["Post", "posts"]);
+	});
+
+	it("self-delegation is a no-op and does not loop", () => {
+		const direct = new Map<string, ReadonlySet<string>>([["pano", new Set(["posts"])]]);
+		const delegations = new Map<string, ReadonlySet<string>>([["pano", new Set(["pano"])]]);
+		expect([...(resolveReachableTargets(direct, delegations).get("pano") ?? [])]).toEqual([
+			"posts",
+		]);
 	});
 });

--- a/packages/pipeline-cli/src/tools/fanout-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/gate.ts
@@ -19,12 +19,17 @@ import {Console, Data, Effect} from "effect";
 import {
 	type DiscoveredMutation,
 	type FeaturePublishes,
+	type FeatureTargets,
 	judge,
 	type ManifestEntry,
+	parseFeatureDelegations,
+	parseFeatureTargets,
+	parseLiveTopicMap,
 	parseManifestEntries,
 	parseMutationKeys,
 	referencesPublisher,
 	renderReport,
+	resolveReachableTargets,
 } from "./fanout-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
@@ -38,39 +43,79 @@ export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reaso
 
 const FEATURES_DIR = join("apps", "web", "worker", "features");
 const MUTATIONS_FILE = "mutations.ts";
+const LIVE_FILE = "live.ts";
 const MANIFEST_PATH = join(FEATURES_DIR, "fate-live", "fanned-mutations.ts");
+const PROTOCOL_PATH = join(FEATURES_DIR, "fate-live", "protocol.ts");
 
-/** The gathered facts across all feature mutation files. */
+/** The gathered facts across all feature mutation + live files. */
 interface GatheredFeatures {
 	readonly discovered: ReadonlyArray<DiscoveredMutation>;
 	readonly featurePublishes: FeaturePublishes;
+	readonly featureTargets: FeatureTargets;
 }
 
 /**
  * Enumerate `<root>/apps/web/worker/features/*` and, for each that holds a
- * `mutations.ts`, parse its `Fate.mutation` keys and whether it references a publish.
+ * `mutations.ts`, parse its `Fate.mutation` keys and whether it references a publish;
+ * for each that holds a `live.ts`, gather the `/fate/live` targets it reaches (topics +
+ * one-hop delegation, resolved via the `LiveTopic` map). `live.ts` is scanned even for a
+ * feature with no `mutations.ts`, so a delegated-through binding (report → pano/sözlük)
+ * contributes its targets to the closure.
  */
-const gatherFeatures = (root: string): Effect.Effect<GatheredFeatures, IoError> =>
+const gatherFeatures = (
+	root: string,
+	liveTopicMap: ReadonlyMap<string, string>,
+): Effect.Effect<GatheredFeatures, IoError> =>
 	Effect.try({
 		try: () => {
 			const base = join(root, FEATURES_DIR);
 			const entries = readdirSync(base, {withFileTypes: true});
 			const discovered: Array<DiscoveredMutation> = [];
 			const featurePublishes = new Map<string, boolean>();
+			const directTargets = new Map<string, ReadonlySet<string>>();
+			const delegations = new Map<string, ReadonlySet<string>>();
 			for (const entry of entries) {
 				const abs = join(base, entry.name);
 				if (!statSync(abs).isDirectory()) continue;
 				const mutationsPath = join(abs, MUTATIONS_FILE);
-				if (!existsSync(mutationsPath)) continue;
-				const source = readFileSync(mutationsPath, "utf8");
-				for (const key of parseMutationKeys(source)) {
-					discovered.push({key, feature: entry.name});
+				if (existsSync(mutationsPath)) {
+					const source = readFileSync(mutationsPath, "utf8");
+					for (const key of parseMutationKeys(source)) {
+						discovered.push({key, feature: entry.name});
+					}
+					featurePublishes.set(entry.name, referencesPublisher(source));
 				}
-				featurePublishes.set(entry.name, referencesPublisher(source));
+				const livePath = join(abs, LIVE_FILE);
+				if (existsSync(livePath)) {
+					const liveSource = readFileSync(livePath, "utf8");
+					directTargets.set(entry.name, parseFeatureTargets(liveSource, liveTopicMap));
+					delegations.set(entry.name, parseFeatureDelegations(liveSource));
+				}
 			}
-			return {discovered, featurePublishes};
+			return {
+				discovered,
+				featurePublishes,
+				featureTargets: resolveReachableTargets(directTargets, delegations),
+			};
 		},
 		catch: (cause) => new IoError({path: join(root, FEATURES_DIR), cause}),
+	});
+
+/**
+ * Read + parse the `LiveTopic` map from `fate-live/protocol.ts` — the source of truth
+ * mapping a `LiveTopic.<prop>` reference (as a `live.ts` binding uses it) to its wire
+ * value (as the manifest declares it). A missing protocol file yields an empty map; the
+ * topic check then reports every declared connection topic as unreachable, which
+ * fail-closes loudly (a moved protocol file is a real misconfiguration).
+ */
+const readLiveTopicMap = (root: string): Effect.Effect<ReadonlyMap<string, string>, IoError> =>
+	Effect.try({
+		try: () => {
+			const protocolPath = join(root, PROTOCOL_PATH);
+			if (!existsSync(protocolPath)) return new Map<string, string>();
+			return parseLiveTopicMap(readFileSync(protocolPath, "utf8"));
+		},
+		catch: (cause) => new IoError({path: join(root, PROTOCOL_PATH), cause}),
 	});
 
 /** Read + parse the fanned-mutation manifest; a missing manifest fails closed. */
@@ -99,15 +144,19 @@ const readManifest = (
 	});
 
 /**
- * The CI gate: succeed when every worker mutation is classified and every fanned
- * mutation's feature publishes a `/fate/live` invalidation, else `CheckFailed`. Fails
- * closed on zero mutations in scope (ADR 0092).
+ * The CI gate: succeed when every worker mutation is classified, every fanned mutation's
+ * feature publishes a `/fate/live` invalidation, and each publish aims at its declared
+ * topic, else `CheckFailed`. Fails closed on zero mutations in scope (ADR 0092).
  */
 export const checkFanout = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
 	Effect.gen(function* () {
 		const manifest = yield* readManifest(root);
-		const {discovered, featurePublishes} = yield* gatherFeatures(root);
-		const verdict = judge({discovered, manifest, featurePublishes});
+		const liveTopicMap = yield* readLiveTopicMap(root);
+		const {discovered, featurePublishes, featureTargets} = yield* gatherFeatures(
+			root,
+			liveTopicMap,
+		);
+		const verdict = judge({discovered, manifest, featurePublishes, featureTargets});
 		if (verdict.pass) {
 			yield* Console.log(renderReport(verdict));
 			return;

--- a/packages/pipeline-cli/src/tools/fanout-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/gate.unit.test.ts
@@ -1,11 +1,12 @@
 /**
- * `checkFanout` over a fake repo dir — the filesystem-seam test (ADR 0155, #1898). The
- * pure verdict (drift, missing-publish, zero-scope) is covered in
- * `fanout-guard.unit.test.ts`; this crosses the IO gate over a real temp dir, asserting
- * the exit-code contract from observable outcomes — never by spawning the bin.
+ * `checkFanout` over a fake repo dir — the filesystem-seam test (ADR 0155, #1898,
+ * #2554). The pure verdict (drift, missing-publish, zero-scope, topic-mismatch) is
+ * covered in `fanout-guard.unit.test.ts`; this crosses the IO gate over a real temp dir,
+ * asserting the exit-code contract from observable outcomes — never by spawning the bin.
  *
  * The fixture pair is the working proof: a feature whose fanned mutation references the
- * publisher SUCCEEDS; the same tree with the publisher reference removed `CheckFailed`.
+ * publisher AND aims a live.ts binding at its declared topic SUCCEEDS; break either
+ * (drop the publisher, or re-aim the topic) and it `CheckFailed`.
  */
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
@@ -24,11 +25,30 @@ afterEach(() => {
 
 const FEATURES = join("apps", "web", "worker", "features");
 
-const writeManifest = (rows: ReadonlyArray<{key: string; fanned: boolean}>) => {
+/** The `LiveTopic` map, written to the protocol file the gate resolves topic refs against. */
+const writeProtocol = () => {
+	const dir = join(root, FEATURES, "fate-live");
+	mkdirSync(dir, {recursive: true});
+	writeFileSync(
+		join(dir, "protocol.ts"),
+		'export const LiveTopic = {\n\tposts: "posts",\n\tpostComments: "Post.comments",\n} as const;\n',
+		"utf8",
+	);
+};
+
+interface ManifestRow {
+	readonly key: string;
+	readonly fanned: boolean;
+	readonly topics?: ReadonlyArray<string>;
+}
+const writeManifest = (rows: ReadonlyArray<ManifestRow>) => {
 	const dir = join(root, FEATURES, "fate-live");
 	mkdirSync(dir, {recursive: true});
 	const body = rows
-		.map((r) => `\t{key: "${r.key}", fanned: ${r.fanned}, rationale: "x"},`)
+		.map((r) => {
+			const topics = r.topics ? ` topics: [${r.topics.map((t) => `"${t}"`).join(", ")}],` : "";
+			return `\t{key: "${r.key}", fanned: ${r.fanned},${topics} rationale: "x"},`;
+		})
 		.join("\n");
 	writeFileSync(
 		join(dir, "fanned-mutations.ts"),
@@ -37,7 +57,17 @@ const writeManifest = (rows: ReadonlyArray<{key: string; fanned: boolean}>) => {
 	);
 };
 
-const writeFeature = (feature: string, keys: ReadonlyArray<string>, publishes: boolean) => {
+/**
+ * Write a feature's `mutations.ts` (its keys + whether it references the publisher) and,
+ * optionally, a `live.ts` whose text carries the given topic/delegation references so the
+ * gate's target scan can reach them.
+ */
+const writeFeature = (
+	feature: string,
+	keys: ReadonlyArray<string>,
+	publishes: boolean,
+	live?: string,
+) => {
 	const dir = join(root, FEATURES, feature);
 	mkdirSync(dir, {recursive: true});
 	const decls = keys.map((k) => `\t"${k}": Fate.mutation({}, fn),`).join("\n");
@@ -47,6 +77,7 @@ const writeFeature = (feature: string, keys: ReadonlyArray<string>, publishes: b
 		`export const mutations = {\n${decls}\n};\n${publishLine}`,
 		"utf8",
 	);
+	if (live !== undefined) writeFileSync(join(dir, "live.ts"), live, "utf8");
 };
 
 const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
@@ -54,21 +85,54 @@ const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
 
 describe("checkFanout — the CI exit-code gate over a fake repo dir", () => {
-	it("SUCCEEDS when a fanned mutation's feature references the publisher (the proof)", async () => {
-		writeManifest([{key: "post.submit", fanned: true}]);
-		writeFeature("pano", ["post.submit"], true);
+	it("SUCCEEDS when a fanned mutation publishes AND its live.ts aims at the declared topic (the proof)", async () => {
+		writeProtocol();
+		writeManifest([{key: "post.submit", fanned: true, topics: ["posts"]}]);
+		writeFeature("pano", ["post.submit"], true, "live.topic(LiveTopic.posts);");
 		const exit = await run(checkFanout(root));
 		expect(Exit.isSuccess(exit)).toBe(true);
 	});
 
 	it("FAILS (CheckFailed) when a fanned mutation's feature omits the publisher (the falsification)", async () => {
-		writeManifest([{key: "post.submit", fanned: true}]);
-		writeFeature("pano", ["post.submit"], false);
+		writeProtocol();
+		writeManifest([{key: "post.submit", fanned: true, topics: ["posts"]}]);
+		writeFeature("pano", ["post.submit"], false, "live.topic(LiveTopic.posts);");
 		const exit = await run(checkFanout(root));
 		expect(isCheckFailed(exit)).toBe(true);
 	});
 
+	it("FAILS (CheckFailed, topic-mismatch) when live.ts no longer aims at the declared topic", async () => {
+		writeProtocol();
+		writeManifest([{key: "comment.add", fanned: true, topics: ["Post.comments"]}]);
+		// live.ts targets only `posts` — the Post.comments aim was edited away
+		writeFeature("pano", ["comment.add"], true, "live.topic(LiveTopic.posts);");
+		const exit = await run(checkFanout(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed, topic-mismatch) when a fanned mutation declares NO topic", async () => {
+		writeProtocol();
+		writeManifest([{key: "post.submit", fanned: true}]);
+		writeFeature("pano", ["post.submit"], true, "live.topic(LiveTopic.posts);");
+		const exit = await run(checkFanout(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("SUCCEEDS when a feature reaches its declared topic THROUGH a delegated *Live binding", async () => {
+		writeProtocol();
+		writeManifest([
+			{key: "post.submit", fanned: true, topics: ["posts"]},
+			{key: "report.resolve", fanned: true, topics: ["posts"]},
+		]);
+		writeFeature("pano", ["post.submit"], true, "live.topic(LiveTopic.posts);");
+		// report/live.ts has no direct topic; it publishes THROUGH panoLive(...)
+		writeFeature("report", ["report.resolve"], true, "const p = panoLive(live);");
+		const exit = await run(checkFanout(root));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
 	it("SUCCEEDS for a not-fanned mutation whose feature omits the publisher", async () => {
+		writeProtocol();
 		writeManifest([{key: "bildirim.markRead", fanned: false}]);
 		writeFeature("bildirim", ["bildirim.markRead"], false);
 		const exit = await run(checkFanout(root));
@@ -76,14 +140,16 @@ describe("checkFanout — the CI exit-code gate over a fake repo dir", () => {
 	});
 
 	it("FAILS (CheckFailed, drift) when a discovered mutation has no manifest row", async () => {
-		writeManifest([{key: "post.submit", fanned: true}]);
-		writeFeature("pano", ["post.submit", "post.newthing"], true);
+		writeProtocol();
+		writeManifest([{key: "post.submit", fanned: true, topics: ["posts"]}]);
+		writeFeature("pano", ["post.submit", "post.newthing"], true, "live.topic(LiveTopic.posts);");
 		const exit = await run(checkFanout(root));
 		expect(isCheckFailed(exit)).toBe(true);
 	});
 
 	it("FAILS (CheckFailed, fail-closed) when zero mutations are discovered", async () => {
-		writeManifest([{key: "post.submit", fanned: true}]);
+		writeProtocol();
+		writeManifest([{key: "post.submit", fanned: true, topics: ["posts"]}]);
 		// a feature dir with no mutations.ts ⇒ zero discovered
 		mkdirSync(join(root, FEATURES, "empty"), {recursive: true});
 		const exit = await run(checkFanout(root));
@@ -91,13 +157,14 @@ describe("checkFanout — the CI exit-code gate over a fake repo dir", () => {
 	});
 
 	it("FAILS (CheckFailed, fail-closed) when the manifest is empty", async () => {
+		writeProtocol();
 		mkdirSync(join(root, FEATURES, "fate-live"), {recursive: true});
 		writeFileSync(
 			join(root, FEATURES, "fate-live", "fanned-mutations.ts"),
 			"export const FANNED_MUTATIONS = [];\n",
 			"utf8",
 		);
-		writeFeature("pano", ["post.submit"], true);
+		writeFeature("pano", ["post.submit"], true, "live.topic(LiveTopic.posts);");
 		const exit = await run(checkFanout(root));
 		expect(isCheckFailed(exit)).toBe(true);
 	});


### PR DESCRIPTION
Fixes #2554

## Problem

`fanout-guard` proved every `fanned: true` mutation's feature *references* a publish, but never that the publish AIMS at the right `/fate/live` topic. A topic/args edit in a `features/*/live.ts` binding that re-aimed a publish shipped green and silently staled every subscribed client for that mutation type — the **mis-aim** class, open while the `#1893–#1896` **omission** class was closed.

## Approach (the audit's named highest-leverage path — option (a))

Extend the manifest row with an **expected topic** and teach `judge()` to check the feature's `live.ts` binding against it — a cheap static check reusing the guard's existing per-feature scanning.

- **Manifest** (`fanned-mutations.ts`): `FannedMutationEntry` gains a `topics` field naming each fanned mutation's `/fate/live` target(s) — a `LiveTopic` connection value (`posts` / `Post.comments` / `Term.definitions`) or an entity-update typename (`Post` / `Comment` / `Definition` / `User`), the two shapes a publish takes. All 24 fanned rows now declare their target(s).
- **`judge()`** gains a third invariant, **topic aim**, with a new `topic-mismatch` verdict:
  - a fanned row with **no** declared topic fails (`undeclared`) — parity with how `drift` forces the fanned/not classification;
  - a declared topic the feature's `live.ts` **no longer targets** fails (`misaimed`) — the concrete `LiveTopic.x → LiveTopic.y` re-aim edit drops `x` from the feature's reachable set.
- **Gate** (`gate.ts`) gathers, per feature, the `/fate/live` targets its `live.ts` reaches: `LiveTopic.<prop>` refs resolved via the `protocol.ts` `LiveTopic` map, `<Entity>View.typeName` refs, and one graph of `*Live(...)` delegation (so `report` reaches pano/sözlük's topics, since it publishes THROUGH them). `judge()` asserts each declared topic is a member of that set.

## Granularity (stated honestly)

The check is **feature-scoped** by construction, exactly as the existing missing-publish check is — it proves the declared topic is still *reachable* in the feature's binding, not that this exact resolver wired that exact topic. That closes the concrete mis-aim edit (a re-aim in `live.ts` that drops a topic from the feature's set), which is the change that passes review and CI today. Finer per-resolver binding would need a real TS parser, which this tool deliberately avoids.

## Acceptance criteria

- [x] `FannedMutationEntry` records the expected `/fate/live` topic for each `fanned: true` mutation (`topics`).
- [x] `judge()` fails closed with a new `topic-mismatch` reason when a fanned mutation's `live.ts` binding no longer targets its manifest-declared topic.
- [x] Fail-closed-on-zero-scope, drift, and missing-publish preserved unchanged (no regression).
- [x] A new fanned mutation cannot pass without declaring its topic (the `undeclared` fail — parity with drift).
- [x] `renderReport` surfaces both `UNDECLARED-TOPIC` and `MIS-AIMED` legibly (ADR 0092 §1).
- [x] Unit tests cover matching topic (pass), mismatched topic (fail), and a fanned mutation missing its topic (fail), plus the new parse/resolve helpers and the IO gate.

## Verification

- `pnpm --filter @kampus/pipeline-cli typecheck` + `pnpm --filter @kampus/web typecheck` clean.
- `pnpm vitest run src/tools/fanout-guard/` — 39 passed.
- `node src/bin.ts fanout-guard check` against the repo: `44 mutations classified, 24 fanned — every fanned mutation's feature publishes a /fate/live invalidation aimed at its declared topic`.

Follow-up (not a prerequisite, per triage note): growing the integration mutate→observe frame matrix toward every fanned mutation — option (b), complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)