### PR TITLE
feat(web): sözlük Subnav + relocate the go-to-or-create box into it (#2602)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -31,6 +31,7 @@ import {MecmuaSubnavLayout} from "./components/mecmua/MecmuaSubnavLayout";
 import {actorLabel} from "./components/moderation/actor-identity";
 import {PanoSubnavLayout} from "./components/pano/PanoSubnavLayout";
 import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
+import {SozlukSubnavLayout} from "./components/sozluk/SozlukSubnavLayout";
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
@@ -448,7 +449,17 @@ export function App() {
 						) : (
 							mecmuaRoutes
 						)}
-						{productZone(navIaOn, "sozluk-zone", sozlukRoutes)}
+						{/* sözlük's zone hosts its persistent go-to-or-create box (the Subnav input
+						    slot) + the URL-driven alphabet filter row, so it wraps under its own
+						    `SozlukSubnavLayout` rather than the generic empty/cta-only frame (#2602).
+						    Off ⇒ flat, and SozlukHome renders its own masthead box + alphabet as today. */}
+						{navIaOn ? (
+							<Route key="sozluk-zone" element={<SozlukSubnavLayout />}>
+								{sozlukRoutes}
+							</Route>
+						) : (
+							sozlukRoutes
+						)}
 						{productZone(navIaOn, "divan-zone", divanRoutes)}
 						<Route path="/search" element={<SearchPage />} />
 						<Route path="/auth" element={<AuthPage />} />

--- a/apps/web/src/components/layout/Subnav.css
+++ b/apps/web/src/components/layout/Subnav.css
@@ -69,6 +69,48 @@
 	align-items: center;
 }
 
+/* Input slot (#2602) — a product-scoped on-demand utility box (sözlük go-to-or-create),
+   pinned after the spacer. The wrapper positions; the box treatment (sunken input, accent
+   focus) lives on `.kp-subnav__input` — an input affordance's own chrome, not a resting
+   filter/CTA fill (#2586 taxonomy / #2590 IA rule). Mirrors the masthead searchbar so the
+   flag-on box reads identically to today's flag-off one. */
+.kp-subnav__input-slot {
+	display: inline-flex;
+	align-items: center;
+}
+.kp-subnav__input {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	height: 28px;
+	padding: 0 10px;
+	background: var(--surface-sunken);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	width: 280px;
+	max-width: 40vw;
+}
+.kp-subnav__input:focus-within {
+	border-color: var(--accent);
+}
+/* The accent `+` glyph marks it go-to-or-create, not search (#1669) — the topbar `ara`
+   keeps the muted magnifier. */
+.kp-subnav__input svg {
+	color: var(--accent);
+	flex-shrink: 0;
+}
+.kp-subnav__input input {
+	flex: 1;
+	background: transparent;
+	border: 0;
+	outline: none;
+	font: var(--t-body-sm);
+	min-width: 0;
+}
+.kp-subnav__input input::placeholder {
+	color: var(--text-faint);
+}
+
 .kp-subnav__crumb {
 	display: inline-flex;
 	align-items: center;

--- a/apps/web/src/components/layout/Subnav.tsx
+++ b/apps/web/src/components/layout/Subnav.tsx
@@ -19,6 +19,7 @@ export function Subnav({
 	onFilterChange,
 	links,
 	crumb,
+	input,
 	meta,
 	cta,
 }: {
@@ -29,6 +30,11 @@ export function Subnav({
 	onFilterChange?: (id: string) => void;
 	links?: SubnavLink[];
 	crumb?: {label: React.ReactNode; onClear?: () => void};
+	// The input slot (#2602): a product-scoped on-demand utility control — sözlük's
+	// go-to-or-create box (distinct from the topbar `ara`, #1669). Carries the input
+	// treatment itself; the slot only positions it (never the filter/CTA treatment,
+	// #2586 taxonomy / #2590 IA rule). Absent ⇒ nothing renders.
+	input?: React.ReactNode;
 	meta?: React.ReactNode;
 	// The primary-action slot (placement law #2587): a product's promoted verb (pano/yeni,
 	// mecmua yaz) renders here in the dedicated primary-action position. The passed node
@@ -72,6 +78,7 @@ export function Subnav({
 				</span>
 			) : null}
 			<span className="kp-subnav__spacer" />
+			{input ? <span className="kp-subnav__input-slot">{input}</span> : null}
 			{count ? <span className="kp-subnav__meta">{count}</span> : null}
 			{meta ? <span className="kp-subnav__meta">{meta}</span> : null}
 			{cta ? <span className="kp-subnav__cta">{cta}</span> : null}

--- a/apps/web/src/components/sozluk/SozlukGoToCreate.tsx
+++ b/apps/web/src/components/sozluk/SozlukGoToCreate.tsx
@@ -1,0 +1,51 @@
+import type * as React from "react";
+import {useNavigate} from "react-router";
+import {slugifyTerm} from "../../lib/slugifyTerm";
+
+/**
+ * The sözlük go-to-or-create box, extracted so the flag-off masthead (SozlukHome) and
+ * the flag-on persistent Subnav zone (SozlukSubnavLayout) render the identical control.
+ * Go-to-or-create, NOT search (#1669): on Enter it routes the typed term to the
+ * fresh-slug composer branch at `/sozluk/:slug` (create dead-end handled there, issue
+ * #97) — deliberately distinct from the topbar's federated `ara`, marked by the
+ * accent `+` glyph rather than a magnifier. `className` is the only surface that
+ * differs between the two hosts (the masthead's `kp-sozluk-home__searchbar` box vs the
+ * Subnav's `kp-subnav__input` taxonomy slot); the markup + submit behavior are one.
+ */
+export function SozlukGoToCreate({
+	className,
+	query,
+	setQuery,
+}: {
+	className: string;
+	query: string;
+	setQuery: (q: string) => void;
+}) {
+	const navigate = useNavigate();
+	function onGoToOrCreate(e: React.SyntheticEvent) {
+		e.preventDefault();
+		const slug = slugifyTerm(query);
+		if (slug) navigate(`/sozluk/${slug}`);
+	}
+	return (
+		<form className={className} onSubmit={onGoToOrCreate}>
+			<svg
+				width="11"
+				height="11"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2.4"
+				aria-hidden="true"
+			>
+				<path d="M12 5v14M5 12h14" />
+			</svg>
+			<input
+				value={query}
+				onChange={(e) => setQuery(e.currentTarget.value)}
+				placeholder="terime git ya da oluştur: race condition, idempotent…"
+				aria-label="Terime git ya da oluştur"
+			/>
+		</form>
+	);
+}

--- a/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * sözlük's persistent product Subnav zone (#2602, placement law #2587). Pins: (1) the zone is a
+ * persistent layout — its `.kp-subnav` node survives a within-sozluk navigation (no remount);
+ * (2) the go-to-or-create box lives in the zone's `input` slot and performs a term-to-term
+ * jump-or-create mid-browse from a term page (not just the home), distinct from the topbar `ara`;
+ * (3) the alphabet filter row sits in the zone with its active-letter accent left as-is; (4) the
+ * input box carries the `.kp-subnav__input` taxonomy class, never a filter/CTA treatment (#2586/#2590).
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {Link, MemoryRouter, Route, Routes, useParams} from "react-router";
+import {describe, expect, it} from "vitest";
+import {SozlukSubnavLayout} from "./SozlukSubnavLayout";
+
+function TermLeaf() {
+	const {slug} = useParams<{slug: string}>();
+	return (
+		<div data-testid="term-leaf">
+			term:{slug}
+			<Link to="/sozluk/mevcut-terim">başka terim</Link>
+		</div>
+	);
+}
+
+function renderZone(initial = "/sozluk") {
+	return render(
+		<MemoryRouter initialEntries={[initial]}>
+			<Routes>
+				<Route element={<SozlukSubnavLayout />}>
+					<Route path="/sozluk" element={<div data-testid="home-leaf">home</div>} />
+					<Route path="/sozluk/:slug" element={<TermLeaf />} />
+				</Route>
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("SozlukSubnavLayout — sözlük product Subnav zone (#2602)", () => {
+	it("renders one persistent Subnav zone with the go-to-or-create box + alphabet above the Outlet", () => {
+		const {container} = renderZone();
+		expect(container.querySelectorAll(".kp-subnav")).toHaveLength(1);
+		expect(container.querySelector(".kp-subnav__input")).toBeTruthy();
+		expect(screen.getByLabelText("Terime git ya da oluştur")).toBeTruthy();
+		// the alphabet filter row is present in the zone (a couple of populated letters)
+		expect(container.querySelector(".kp-sozluk-alphabet")).toBeTruthy();
+		expect(screen.getByTestId("home-leaf")).toBeTruthy();
+	});
+
+	it("go-to-or-create performs a term-to-term jump-or-create mid-browse from a term page", () => {
+		renderZone("/sozluk/mevcut-terim");
+		expect(screen.getByTestId("term-leaf").textContent).toContain("term:mevcut-terim");
+		const box = screen.getByLabelText("Terime git ya da oluştur");
+		fireEvent.change(box, {target: {value: "yeni terim"}});
+		const form = box.closest("form");
+		if (!form) throw new Error("go-to-or-create input is not inside a form");
+		fireEvent.submit(form);
+		// slugifyTerm("yeni terim") === "yeni-terim" — a mid-browse jump to a fresh slug.
+		expect(screen.getByTestId("term-leaf").textContent).toContain("term:yeni-terim");
+	});
+
+	it("keeps the Subnav zone mounted across a within-sozluk navigation — no remount", () => {
+		const {container} = renderZone("/sozluk/mevcut-terim");
+		const before = container.querySelector(".kp-subnav");
+		expect(before).toBeTruthy();
+		fireEvent.click(screen.getByRole("link", {name: "başka terim"}));
+		expect(container.querySelector(".kp-subnav")).toBe(before);
+	});
+
+	it("the go-to-or-create box carries only the input taxonomy class — not a filter/CTA treatment", () => {
+		const {container} = renderZone();
+		const box = container.querySelector(".kp-subnav__input");
+		expect(box).toBeTruthy();
+		expect(box?.classList.contains("kp-subnav__filter")).toBe(false);
+		// the input slot is not the CTA slot, and no CTA/filter treatment leaks onto the box
+		expect(container.querySelector(".kp-subnav__cta")).toBeNull();
+	});
+});

--- a/apps/web/src/components/sozluk/SozlukSubnavLayout.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavLayout.tsx
@@ -1,0 +1,47 @@
+import {createContext, useContext, useState} from "react";
+import {Outlet, useSearchParams} from "react-router";
+import {Subnav} from "../layout/Subnav";
+import {SozlukAlphabet} from "./index";
+import {SozlukGoToCreate} from "./SozlukGoToCreate";
+
+/**
+ * The shared go-to-or-create query, owned by the persistent zone and read DOWN by the
+ * routed SozlukHome for its client-side column filter. The box lives in the zone (so a
+ * term-to-term jump works mid-browse from any `/sozluk/*` route, term pages included),
+ * but SozlukHome still filters its loaded columns by the same typed text — so the zone
+ * provides the query rather than owning a box SozlukHome can't see. Null when no zone
+ * ancestor provides it (flag off), the signal SozlukHome uses to fall back to its own
+ * masthead box + local query state exactly as today.
+ */
+const SozlukSubnavQuery = createContext<{query: string; setQuery: (q: string) => void} | null>(
+	null,
+);
+
+export function useSozlukSubnavQuery() {
+	return useContext(SozlukSubnavQuery);
+}
+
+/**
+ * sözlük's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
+ * layout-route element that renders sözlük's Subnav once above the routed `<Outlet>`, so the
+ * zone stays mounted across `/sozluk/*` (no per-page remount). The go-to-or-create box (a
+ * product-scoped utility, #2586 taxonomy — distinct from the topbar `ara`, #1669) fills the
+ * Subnav's `input` slot; the URL-driven alphabet (`?harf=<letter>`) is the filters row, its
+ * active-letter accent legal transient state paint left as-is. Mounted only behind the
+ * `phoenix-nav-ia` flag (App.tsx); off ⇒ the router is flat and SozlukHome renders its own
+ * masthead box + alphabet as today.
+ */
+export function SozlukSubnavLayout() {
+	const [query, setQuery] = useState("");
+	const [params] = useSearchParams();
+	const letter = params.get("harf") ?? undefined;
+	return (
+		<SozlukSubnavQuery.Provider value={{query, setQuery}}>
+			<Subnav
+				input={<SozlukGoToCreate className="kp-subnav__input" query={query} setQuery={setQuery} />}
+			/>
+			<SozlukAlphabet value={letter} />
+			<Outlet />
+		</SozlukSubnavQuery.Provider>
+	);
+}

--- a/apps/web/src/pages/SozlukHome.tsx
+++ b/apps/web/src/pages/SozlukHome.tsx
@@ -11,6 +11,8 @@ import * as React from "react";
 import {useListView, useRequest, useView, type ViewRef} from "react-fate";
 import {useNavigate, useSearchParams} from "react-router";
 import {SozlukAlphabet} from "../components/sozluk/index";
+import {SozlukGoToCreate} from "../components/sozluk/SozlukGoToCreate";
+import {useSozlukSubnavQuery} from "../components/sozluk/SozlukSubnavLayout";
 import {TermRow, TermRowView} from "../components/sozluk/TermRow";
 import {Button} from "../components/ui/Button";
 import {Screen} from "../fate/Screen";
@@ -36,14 +38,28 @@ type TermConnection = ReturnType<typeof useRequest<typeof homeRequest>>["recentT
 export function SozlukHome() {
 	const [params] = useSearchParams();
 	const letter = params.get("harf") ?? undefined;
-	const [query, setQuery] = React.useState("");
+	// The go-to-or-create query is shared with the persistent Subnav zone when it owns the
+	// box (flag on, #2602): read the zone's query so the client-side column filter still
+	// tracks the typed text even though the box now lives up in the Subnav. Off ⇒ no zone
+	// ancestor, so own the local query state and render the masthead box, exactly as today.
+	const zone = useSozlukSubnavQuery();
+	const [localQuery, setLocalQuery] = React.useState("");
+	const inZone = zone != null;
+	const query = zone ? zone.query : localQuery;
+	const setQuery = zone ? zone.setQuery : setLocalQuery;
 
 	return (
 		<div className="kp-page">
 			<div className="kp-page__inner">
 				<Screen
 					fallback={
-						<SozlukHomeChrome letter={letter} query={query} setQuery={setQuery} status="loading">
+						<SozlukHomeChrome
+							letter={letter}
+							query={query}
+							setQuery={setQuery}
+							inZone={inZone}
+							status="loading"
+						>
 							{null}
 						</SozlukHomeChrome>
 					}
@@ -52,6 +68,7 @@ export function SozlukHome() {
 							letter={letter}
 							query={query}
 							setQuery={setQuery}
+							inZone={inZone}
 							status="error"
 							errorMessage={code.toLowerCase()}
 						>
@@ -59,7 +76,7 @@ export function SozlukHome() {
 						</SozlukHomeChrome>
 					)}
 				>
-					<SozlukHomeContent letter={letter} query={query} setQuery={setQuery} />
+					<SozlukHomeContent letter={letter} query={query} setQuery={setQuery} inZone={inZone} />
 				</Screen>
 			</div>
 		</div>
@@ -70,13 +87,16 @@ interface ContentProps {
 	letter: string | undefined;
 	query: string;
 	setQuery: (q: string) => void;
+	// True when the persistent Subnav zone owns the go-to-or-create box + alphabet (#2602),
+	// so this page must not paint a second copy of either.
+	inZone: boolean;
 }
 
-function SozlukHomeContent({letter, query, setQuery}: ContentProps) {
+function SozlukHomeContent({letter, query, setQuery, inZone}: ContentProps) {
 	const {recentTerms, popularTerms} = useRequest(homeRequest);
 
 	return (
-		<SozlukHomeChrome letter={letter} query={query} setQuery={setQuery} status="ok">
+		<SozlukHomeChrome letter={letter} query={query} setQuery={setQuery} inZone={inZone} status="ok">
 			<RecentColumn connection={recentTerms} letter={letter} query={query} />
 			<PopularColumn connection={popularTerms} letter={letter} query={query} />
 		</SozlukHomeChrome>
@@ -89,20 +109,16 @@ interface ChromeProps extends ContentProps {
 	children: React.ReactNode;
 }
 
-function SozlukHomeChrome({letter, query, setQuery, status, errorMessage, children}: ChromeProps) {
-	const navigate = useNavigate();
+function SozlukHomeChrome({
+	letter,
+	query,
+	setQuery,
+	inZone,
+	status,
+	errorMessage,
+	children,
+}: ChromeProps) {
 	const totalsLine = status === "ok" ? "" : status === "loading" ? "yükleniyor…" : "yüklenemedi";
-
-	// Go-to-or-create, NOT search (#1669). Deliberately distinct from the topbar's
-	// federated `ara` (icon+"ara" = ranked `/search?q=` site-wide): on Enter this routes
-	// the typed term to the fresh-slug composer branch at `/sozluk/:slug` — no new creation
-	// backend (issue #97). Signed-in users land on `NewTermComposer`; signed-out users get
-	// that page's unchanged 404/sign-in.
-	function onGoToOrCreate(e: React.SyntheticEvent) {
-		e.preventDefault();
-		const slug = slugifyTerm(query);
-		if (slug) navigate(`/sozluk/${slug}`);
-	}
 
 	return (
 		<>
@@ -112,31 +128,18 @@ function SozlukHomeChrome({letter, query, setQuery, status, errorMessage, childr
 						sözlük {totalsLine ? <small>{totalsLine}</small> : null}
 					</h1>
 				</div>
-				<form
-					className="kp-sozluk-home__searchbar kp-sozluk-home__gotocreate"
-					onSubmit={onGoToOrCreate}
-				>
-					<svg
-						width="11"
-						height="11"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2.4"
-						aria-hidden="true"
-					>
-						<path d="M12 5v14M5 12h14" />
-					</svg>
-					<input
-						value={query}
-						onChange={(e) => setQuery(e.currentTarget.value)}
-						placeholder="terime git ya da oluştur: race condition, idempotent…"
-						aria-label="Terime git ya da oluştur"
+				{/* Flag on: the go-to-or-create box lives in the persistent Subnav zone (#2602),
+				    so the masthead drops it here to avoid a duplicate. Off ⇒ render it as today. */}
+				{inZone ? null : (
+					<SozlukGoToCreate
+						className="kp-sozluk-home__searchbar kp-sozluk-home__gotocreate"
+						query={query}
+						setQuery={setQuery}
 					/>
-				</form>
+				)}
 			</header>
 
-			<SozlukAlphabet value={letter} />
+			{inZone ? null : <SozlukAlphabet value={letter} />}
 
 			{status === "error" ? (
 				<p style={{font: "var(--t-meta)", color: "var(--danger)", padding: "var(--s-3) 0"}}>

--- a/apps/web/src/styles/design-token-lint.config.json
+++ b/apps/web/src/styles/design-token-lint.config.json
@@ -37,7 +37,7 @@
 		"apps/web/src/components/ui/Button.css": 4,
 		"apps/web/src/components/ui/Form.css": 4,
 		"apps/web/src/components/bildirim/Bildirim.css": 3,
-		"apps/web/src/components/layout/Subnav.css": 3,
+		"apps/web/src/components/layout/Subnav.css": 7,
 		"apps/web/src/components/sozluk/Sozluk.css": 3,
 		"apps/web/src/components/ui/atoms.css": 3,
 		"apps/web/src/pages/SearchPage.css": 3,


### PR DESCRIPTION
Fixes #2602

## What

Give sözlük a persistent product Subnav zone behind the default-off `phoenix-nav-ia` flag, and move the founder-ratified go-to-or-create box into it — following the landed pano/mecmua per-product-layout precedent (#2601/#2603).

- **`SozlukSubnavLayout`** — the pathless layout-route element wrapping `/sozluk/*`, rendering sözlük's Subnav once above the routed `<Outlet>`, so the zone stays mounted across a within-sozluk navigation (no per-page remount). Wired into `App.tsx`'s sözlük zone line, replacing the generic `productZone` frame, mirroring how pano/mecmua wrap under their own layouts.
- **New shared `input` slot on `Subnav`** — additive alongside the crumb slot #2601 landed (does not disturb it). The slot carries the `.kp-subnav__input` taxonomy class: a product-scoped on-demand utility box with its own input treatment, never a filter/CTA fill (#2586 taxonomy / #2590 IA rule).
- **Relocated go-to-or-create box** — extracted to a shared `SozlukGoToCreate` so the flag-off masthead and the flag-on Subnav render the identical control. It performs a term-to-term jump-or-create mid-browse from **any** `/sozluk/*` route, including a term page — distinct from the topbar `ara` (#1669), marked by the accent `+` glyph. Create dead-end handled at `/sozluk/:slug` as today (#97).
- **Alphabet filter row** — the URL-driven alphabet (`?harf=<letter>`) sits in the zone as the filters row, its active-letter accent left as-is (legal transient state paint).
- **`SozlukHome`** reads the zone's shared query so its client-side column filter still tracks the typed text even though the box moved up into the Subnav.

## Flag-off = byte-identical to main

With `phoenix-nav-ia` off there is no zone ancestor, so `useSozlukSubnavQuery()` returns null → `SozlukHome` renders its own masthead box + alphabet with local query state exactly as today (the box markup is the extracted-but-identical `SozlukGoToCreate`), and `App.tsx` mounts the sözlük routes flat.

## Tests

- `SozlukSubnavLayout.test.tsx` (new): one persistent Subnav zone with the box + alphabet; term-to-term jump-or-create mid-browse from a term page; zone survives a within-sozluk navigation (no remount); the box carries only the input taxonomy class (no filter/CTA treatment).
- Existing `Subnav`, `SozlukAlphabet`, `SozlukTermPage` client tests still green.
- `tsc --noEmit` and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)