### PR TITLE
fix(pipeline): spawn-guard accepts harness model aliases (opus / opus[1m]) (#2565)

### DIFF
--- a/packages/pipeline-cli/src/tools/spawn-guard/command.envelope.test.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.envelope.test.ts
@@ -50,6 +50,19 @@ describe("spawn-guard guard CLI — PreToolUse envelope", () => {
 		assert.notProperty(out.hookSpecificOutput, "updatedInput");
 	}, 30_000);
 
+	it("ALLOWS an explicit `opus` harness alias — the model param the caller actually passes (#2565)", async () => {
+		const {stdout} = await run(["guard"], envelope("opus"));
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.notProperty(out.hookSpecificOutput, "updatedInput");
+	}, 30_000);
+
+	it("DENIES an off-family alias (`sonnet`) — fail-closed on the caller's vocabulary too (ADR 0092)", async () => {
+		const {stdout} = await run(["guard"], envelope("sonnet"));
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+	}, 30_000);
+
 	it("DENIES an off-allowlist model with no pin and emits what it checked (ADR 0092)", async () => {
 		const {stdout} = await run(["guard"], envelope("claude-fable-5"));
 		const out = JSON.parse(stdout);

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.ts
@@ -31,6 +31,21 @@
 export const ALLOWLIST: ReadonlyArray<string> = ["claude-opus-4-8", "claude-opus-4-8[1m]"] as const;
 
 /**
+ * Harness model aliases → canonical allowlist IDs. The Task/Workflow `model` param is
+ * expressed in the harness's short vocabulary (`opus`, `opus[1m]`), never the canonical
+ * `claude-opus-4-8*` id — so an explicit `opus` spawn (the very Opus-4.8 family the
+ * allowlist exists to permit) was denied by an allowlist that held only canonical ids
+ * (#2565). Only the Opus-4.8 family has an entry — `sonnet` / `haiku` are deliberately
+ * absent, so they never canonicalize onto the allowlist and stay a fail-closed DENY
+ * (ADR 0092). Mapping resolves an alias for the allowlist *check* only; the guard never
+ * rewrites the request to the canonical id (#776 — the Task tool rejects the full id).
+ */
+export const MODEL_ALIASES: Readonly<Record<string, string>> = {
+	opus: "claude-opus-4-8",
+	"opus[1m]": "claude-opus-4-8[1m]",
+};
+
+/**
  * The committed, allowlisted pin an unset `WORKFLOW_MODEL` falls back to (ADR 0116).
  * Durable in source, so an unset spawn resolves to allow-inherit regardless of the
  * launching shell — the fix for the #943 fragility where the inherit path depended on
@@ -62,8 +77,18 @@ const norm = (m: string | null | undefined): string | null => {
 	return t.length === 0 ? null : t;
 };
 
-export const isOnAllowlist = (model: string | null | undefined): boolean => {
+/**
+ * Resolve a harness alias to its canonical id; a value that is not an alias (including a
+ * canonical id already) passes through unchanged. Null/empty normalizes to null.
+ */
+export const canonicalModel = (model: string | null | undefined): string | null => {
 	const m = norm(model);
+	if (m === null) return null;
+	return MODEL_ALIASES[m] ?? m;
+};
+
+export const isOnAllowlist = (model: string | null | undefined): boolean => {
+	const m = canonicalModel(model);
 	return m !== null && ALLOWLIST.includes(m);
 };
 

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
@@ -1,10 +1,12 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
 	ALLOWLIST,
+	canonicalModel,
 	DEFAULT_PIN,
 	decideSpawn,
 	formatSessionCost,
 	isOnAllowlist,
+	MODEL_ALIASES,
 } from "./spawn-guard.ts";
 
 describe("isOnAllowlist — only the opus-4.8 family", () => {
@@ -33,6 +35,53 @@ describe("isOnAllowlist — only the opus-4.8 family", () => {
 		assert.isFalse(isOnAllowlist(undefined));
 		assert.isFalse(isOnAllowlist(""));
 		assert.isFalse(isOnAllowlist("   "));
+	});
+
+	it("accepts the harness aliases the caller actually passes (opus / opus[1m], #2565)", () => {
+		assert.isTrue(isOnAllowlist("opus"));
+		assert.isTrue(isOnAllowlist("opus[1m]"));
+		assert.isTrue(isOnAllowlist("  opus  ")); // still trimmed before alias resolution
+	});
+
+	it("rejects off-family aliases — sonnet / haiku have no allowlist mapping (ADR 0092)", () => {
+		assert.isFalse(isOnAllowlist("sonnet"));
+		assert.isFalse(isOnAllowlist("haiku"));
+		assert.isFalse(isOnAllowlist("fable-5"));
+		assert.isFalse(isOnAllowlist("opusplan"));
+	});
+});
+
+describe("canonicalModel — harness alias → canonical id resolution", () => {
+	it("maps the opus-family aliases to their canonical ids", () => {
+		assert.strictEqual(canonicalModel("opus"), "claude-opus-4-8");
+		assert.strictEqual(canonicalModel("opus[1m]"), "claude-opus-4-8[1m]");
+	});
+
+	it("passes a canonical id through unchanged (idempotent — no double mapping)", () => {
+		assert.strictEqual(canonicalModel("claude-opus-4-8"), "claude-opus-4-8");
+		assert.strictEqual(canonicalModel("claude-opus-4-8[1m]"), "claude-opus-4-8[1m]");
+	});
+
+	it("passes an unknown value through unchanged (the allowlist check then denies it)", () => {
+		assert.strictEqual(canonicalModel("sonnet"), "sonnet");
+		assert.strictEqual(canonicalModel("garbage"), "garbage");
+	});
+
+	it("normalizes null / empty / whitespace to null", () => {
+		assert.strictEqual(canonicalModel(null), null);
+		assert.strictEqual(canonicalModel(undefined), null);
+		assert.strictEqual(canonicalModel(""), null);
+		assert.strictEqual(canonicalModel("   "), null);
+	});
+
+	it("maps only the opus-4.8 family — every alias target is on the allowlist", () => {
+		assert.deepStrictEqual(MODEL_ALIASES, {
+			opus: "claude-opus-4-8",
+			"opus[1m]": "claude-opus-4-8[1m]",
+		});
+		for (const canonical of Object.values(MODEL_ALIASES)) {
+			assert.isTrue(ALLOWLIST.includes(canonical));
+		}
 	});
 });
 
@@ -123,6 +172,40 @@ describe("decideSpawn — allowlist guard (allow / allow-inherit / deny)", () =>
 
 	it("the allowlist is exactly the opus-4.8 family", () => {
 		assert.deepStrictEqual([...ALLOWLIST], ["claude-opus-4-8", "claude-opus-4-8[1m]"]);
+	});
+
+	it("ALLOWS an explicit `opus` alias spawn — the family the allowlist exists to permit (#2565)", () => {
+		const d = decideSpawn("opus", null);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("ALLOWS the explicit `opus[1m]` alias spawn (the 1m variant, #2565)", () => {
+		const d = decideSpawn("opus[1m]", null);
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("does NOT rewrite an alias request to the full pin id — the allow carries the raw request (#776)", () => {
+		// The Task tool rejects the full id `claude-opus-4-8[1m]`, so the decision must never
+		// surface it as a rewrite; the allow echoes what the caller asked (`opus[1m]`), not the
+		// canonical id the allowlist check resolved internally.
+		const d = decideSpawn("opus[1m]", null);
+		assert.strictEqual(d.kind === "allow" ? d.model : "", "opus[1m]");
+		assert.notStrictEqual(d.kind === "allow" ? d.model : "", "claude-opus-4-8[1m]");
+	});
+
+	it("DENIES off-family aliases (sonnet / haiku / fable-5 / garbage) — fail-closed preserved (ADR 0092)", () => {
+		for (const alias of ["sonnet", "haiku", "fable-5", "opusplan", "not-a-model"]) {
+			const d = decideSpawn(alias, null);
+			assert.strictEqual(d.kind, "deny", `expected ${alias} to deny`);
+			// The absent env pin defaults to the valid DEFAULT_PIN, so an off-family REQUEST is the
+			// explicit-off-allowlist deny (the pin can't override it, #776) — not the no-valid-pin one.
+			assert.strictEqual(d.kind === "deny" ? d.explicitOffAllowlist : false, true);
+		}
+	});
+
+	it("an unset request still resolves to allow-inherit — alias support is request-only (ADR 0116 unchanged)", () => {
+		const d = decideSpawn(null, null);
+		assert.strictEqual(d.kind, "allow-inherit");
 	});
 });
 


### PR DESCRIPTION
Fixes #2565

## Problem

`spawn-guard`'s `ALLOWLIST` held only the canonical Opus-4.8 ids (`claude-opus-4-8`, `claude-opus-4-8[1m]`), and `norm()` only trimmed whitespace — no alias mapping. But the Task/Workflow `model` param is expressed in the harness's short vocabulary (`opus`, `opus[1m]`), never the canonical id. So an explicit `model="opus"` spawn — the very Opus-4.8 family the allowlist exists to permit — was denied (`explicitOffAllowlist`), and callers learned to omit the model instead, silently degrading an asserted Opus spawn to "whatever the session runs".

## Fix

Map the harness alias vocabulary → canonical id *before* the allowlist check, failing closed on any alias with no entry:

- `MODEL_ALIASES` — `opus` → `claude-opus-4-8`, `opus[1m]` → `claude-opus-4-8[1m]`. Only the Opus-4.8 family is mapped.
- `canonicalModel()` — resolves an alias to its canonical id; a non-alias (including a canonical id already) passes through; null/empty normalizes to null.
- `isOnAllowlist()` now canonicalizes before the membership test, so both the explicit-request and effective-pin paths speak the caller's vocabulary uniformly.

Resolution is **check-only**: the `allow` decision still echoes the raw request, so the guard never rewrites the request to the full pin id the Task tool rejects (#776).

### Grounding of the alias set

- `opus` / `sonnet` / `haiku` are the harness's model-param vocabulary, confirmed in-repo by `packages/pipeline-cli/src/tools/eval-harness/report.unit.test.ts` (rows keyed `model: "opus"` / `"sonnet"`).
- The `[1m]` suffix on the canonical id `claude-opus-4-8[1m]` (per ADR 0116 / #776, the id the Task `model` field rejects) maps to the `opus[1m]` alias.
- `sonnet` / `haiku` / `fable-5` are deliberately **absent** from the map, so they never canonicalize onto the allowlist and stay a fail-closed DENY.

## Invariants preserved

- **Allow-inherit on unset** (ADR 0116) — unchanged; alias support is request-only, and `DEFAULT_PIN` (`claude-opus-4-8[1m]`) is a canonical id that passes `canonicalModel` untouched.
- **Fail-closed on off-allowlist** (ADR 0092) — off-family aliases and ids still DENY.
- **#776** — the guard does not rewrite the request to the full pin id; the `allow` decision carries the raw request (`opus[1m]`), never `claude-opus-4-8[1m]`.

## Tests

`spawn-guard.unit.test.ts` (+ `command.envelope.test.ts` for the real `tool_input.model` path): explicit `opus` / `opus[1m]` allow; off-family aliases (`sonnet`/`haiku`/`fable-5`/`opusplan`/garbage) deny with `explicitOffAllowlist`; unset still allow-inherit; the no-rewrite-to-full-pin-id assertion; `canonicalModel` idempotence + every alias target on the allowlist. 48 tests pass; biome + typecheck clean.

## §CP

spawn-guard is gate-critical pipeline-cli tooling — §CP-by-content. Not for auto-ship; route to human §CP merge after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)