### PR TITLE
docs(adr): reconcile ADR 0173's stale reactions grounding example (#2572)

### DIFF
--- a/.decisions/0173-vertical-completeness-gate.md
+++ b/.decisions/0173-vertical-completeness-gate.md
@@ -21,10 +21,14 @@ This is not one bad feature; it is a systemic blind spot with three confirmed in
 [#1943](https://github.com/kamp-us/phoenix/issues/1943)):
 
 - **reactions** — the backend vertical shipped in full (react/change/retract mutations, the
-  `reactions` view field on pano post/comment + sözlük definition, aggregate reads), the
-  `PHOENIX_REACTIONS` dark-ship flag reached 100% in production, and **zero `.tsx` in
-  `apps/web/src` consumes it** — the flag key is referenced only by its own definition in
-  `apps/web/src/flags/keys.ts`. UI slice externally owned by #1867 under epic #1840.
+  `reactions` view field on pano post/comment + sözlük definition, aggregate reads) and the
+  `PHOENIX_REACTIONS` dark-ship flag reached 100% in production while **no `.tsx` in
+  `apps/web/src` consumed it** — the flag key was referenced only by its own definition in
+  `apps/web/src/flags/keys.ts`, the exact zero-UI graduation this gate exists to prevent. (This
+  was the *motivating* instance, not a still-open one: the reactions UI slice —
+  `apps/web/src/components/reaction/ReactionBarSlot.tsx`, PR #2055, landed 2026-07-05 — has since
+  consumed the flag, so `phoenix-reactions` now **passes** the consuming-UI assertion. UI slice
+  externally owned by #1867 under epic #1840.)
 - **mecmua discovery** (#2512) — no nav entry / index page; reachable only by direct slug URL.
 - **mecmua subscribe** (#2527) — subscribe/unsubscribe mutations exist, no UI to subscribe.
 


### PR DESCRIPTION
## What

Reconcile ADR 0173's stale grounding example with live flag state.

`.decisions/0173-vertical-completeness-gate.md`'s Context cited `PHOENIX_REACTIONS` as a *currently* zero-consumer flag failing the consuming-UI reachability check ("zero `.tsx` in `apps/web/src` consumes it"). That live claim is stale: `apps/web/src/components/reaction/ReactionBarSlot.tsx` (PR #2055) landed 2026-07-05 and consumes the flag (`import {PHOENIX_REACTIONS} from "../../flags/keys"`, used as `flag={PHOENIX_REACTIONS}`), so `phoenix-reactions` now **passes** the consuming-UI assertion.

## Change (text-only)

Reframe the Context "reactions" bullet as the *motivating* (past) instance — its zero-UI graduation is precisely why this gate exists — and note the UI slice has since landed and now passes. The ADR's decision and mechanism are unchanged.

Deliberately left as-is per the issue's scope notes (genuinely-historical framing, not the stale live claim):
- the by-hand static scan the reactions reporter ran (§2, past tense — accurate at report time),
- the `@journey:phoenix-reactions` title-tag convention example (§2),
- the checker seed fixture that seeds `PHOENIX_REACTIONS` to FAIL (§4 — a synthetic test fixture, #2529's implementation choice).

## Acceptance criteria

- [x] Context no longer asserts `phoenix-reactions` as a *currently* zero-consumer / reachability-failing flag; the live-state claim matches reality (consumed by `ReactionBarSlot.tsx` as of 2026-07-05).
- [x] No new live zero-consumer example introduced (so none needs re-grounding); the still-open instances (mecmua discovery #2512, mecmua subscribe #2527) are untouched.
- [x] Genuinely-historical mentions (by-hand scan, `@journey:` tag convention, checker seed fixture) left correct in their historical framing.
- [x] Doc-only change to `.decisions/0173-vertical-completeness-gate.md`; no code/behavior change.

## Landing class

Verdict routing: **doc-class → review-doc** (single doc file).

Merge-authority: **§CP-by-content (ADR 0164)**. ADR 0173's body matches the canonical `GUARD_ADR_RE` (guard×16, gate×15, fail-closed, containment, control-plane, exempt, opt-out) — so a touched `.decisions/**` ADR whose content matches the guard-vocabulary predicate classes §CP for *who merges* (needs a current-head `@kamp-us/control-plane` approval), even though its verification gate remains `review-doc`. This edit does **not** relax any guard — it corrects a stale illustrative claim — but the content-clause is conservative/fail-closed by design. **Does not auto-ship; stops at reviewed-ready for control-plane merge routing.**

Fixes #2572

🤖 Generated with [Claude Code](https://claude.com/claude-code)