### PR TITLE
feat(pipeline-cli): fail-closed founder-approval-trace verifier (#2658)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -12,6 +12,7 @@
  */
 import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
+import {campaignCommand} from "./tools/campaign/command.ts";
 import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
 import {ciRequiredCommand} from "./tools/ci-required/command.ts";
 import {classProbeCommand} from "./tools/class-probe/command.ts";
@@ -116,4 +117,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	refGuardCommand,
 	settingsEnvGuardCommand,
 	verdictCommand,
+	campaignCommand,
 ];

--- a/packages/pipeline-cli/src/tools/campaign/README.md
+++ b/packages/pipeline-cli/src/tools/campaign/README.md
@@ -1,0 +1,53 @@
+# campaign — the fail-closed founder-approval-trace verifier
+
+`pipeline-cli campaign verify-trace <wave-label> [--founder <login>]`
+
+The campaign skill is **invoker-agnostic** — a human *or* an agent may run it — so there is no
+human-at-keyboard guard like `release`'s. The sole authorization that a wave-labeled cluster may
+become a campaign is a durable, auditable **founder-approval trace** bound to the wave label, and
+this verifier **fails closed** without it: neither an agent nor a human can conjure a campaign the
+founder never approved (issue #2658).
+
+## The founder-approval trace shape
+
+A campaign is authorized only by a **founder-authored comment** — on any issue carrying the wave
+label — whose **first line** is:
+
+```
+campaign-approve: <wave-label> · <ISO-8601-UTC>
+```
+
+- **`<wave-label>`** must equal the wave label under verification. This binds the approval to
+  *this* cluster, so a valid approval of one wave never authorizes another.
+- **`<ISO-8601-UTC>`** must be a valid ISO-8601 UTC instant (a `Z` suffix). It records *when*
+  approval was granted, making the trace auditable after the fact.
+- **author** must be the **founder**. The founder identity is injected as config
+  (`--founder`, else `$CAMPAIGN_FOUNDER_LOGIN`) — never hardcoded, so no named identity lives in a
+  committed artifact and the trust anchor stays configurable.
+
+The marker is emphasis-tolerant (a leading `**`), case-insensitive on the keyword, and anchored to
+line one — a comment that merely *quotes* the marker mid-body never counts (the same line-one
+anchoring the `verdict` and `claim` markers use).
+
+The shape is grounded in the **gated-audit-wave play**, where audit findings are returned to the
+founder for approval *before* anything is filed; this verifier is the checkable seam that pins that
+approval as a machine-verifiable artifact.
+
+## Exit contract
+
+Exit `0` **only** on a present, well-formed, founder-authored, wave-bound trace. Every other input
+fails closed (non-zero, ADR 0092):
+
+| Failure | Cause |
+| --- | --- |
+| `zero-scope` | empty wave label, no founder identity configured, or the label names zero issues |
+| `absent` | the cluster is non-empty but carries no `campaign-approve:` marker |
+| `malformed` | a marker exists but is malformed or bound to a different wave |
+| `non-founder-author` | a well-formed, wave-bound marker exists but no author is the founder |
+
+## Shape
+
+The readme-guard idiom: a pure, IO-free, unit-tested core (`campaign-trace.ts`) that owns the
+marker grammar and the default-deny decision, plus a thin `gh api` boundary (`github.ts`) that
+gathers the wave-labeled cluster and its comments. The core is tested exhaustively over fixtures
+without spawning `gh` (`campaign-trace.unit.test.ts`).

--- a/packages/pipeline-cli/src/tools/campaign/campaign-trace.ts
+++ b/packages/pipeline-cli/src/tools/campaign/campaign-trace.ts
@@ -1,0 +1,244 @@
+/**
+ * `campaign verify-trace` pure core — IO-free, total, unit-testable. Decides whether a
+ * wave-labeled cluster carries a valid **founder-approval trace**: the single durable,
+ * auditable artifact that authorizes a wave to become a campaign.
+ *
+ * The whole point is fail-closed authorization. The campaign skill is invoker-agnostic — a
+ * human OR an agent may run it (issue #2658, story 2) — so there is no human-at-keyboard guard
+ * like `release`'s; the sole authorization is this trace, and the mechanism must default-DENY
+ * so that neither an agent nor a human can conjure a campaign the founder never approved. PASS
+ * is returned ONLY on positive evidence — a present, well-formed, founder-authored, wave-bound
+ * marker; absence, malformation, a non-founder author, and zero scope each fail closed (ADR 0092).
+ *
+ * The trace shape (pinned here; grounded in the gated-audit-wave play, where audit findings are
+ * returned to the founder for approval BEFORE anything is filed). A campaign is authorized only
+ * by a founder-authored comment — on any issue carrying the wave label — whose FIRST line is:
+ *
+ *   campaign-approve: <wave-label> · <ISO-8601-UTC>
+ *
+ *   - <wave-label>   MUST equal the wave label under verification — binds the approval to THIS
+ *                    cluster, so a valid approval of one wave never authorizes another.
+ *   - <ISO-8601-UTC> MUST be a valid ISO-8601 UTC instant — records WHEN approval was granted,
+ *                    making the trace auditable after the fact.
+ *   - author         MUST be the founder — the identity is injected as config by the IO shell
+ *                    (`github.ts`), never hardcoded here (no named identity in a committed
+ *                    artifact; the founder login is a parameter this core compares against).
+ *
+ * The marker is emphasis-tolerant (a leading `**`), case-insensitive on the keyword, and anchored
+ * to line one — a comment that merely *quotes* the marker mid-body never counts (the same
+ * line-one anchoring the `verdict` and `claim` markers use). This module never touches the
+ * network or disk; the `gh api` boundary that gathers the cluster + its markers lives in `github.ts`.
+ */
+
+/** The ISO-8601 UTC instant grammar the approval timestamp must satisfy (a `Z` suffix ⇒ UTC). */
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+/**
+ * The approval-marker keyword prefix — "does this comment even attempt an approval?" Line-one
+ * anchored (no `m` flag), emphasis-tolerant, case-insensitive. Separates an approval *attempt*
+ * (which, if malformed, fails closed as `malformed`) from unrelated chatter (which is `absent`).
+ */
+const APPROVE_PREFIX_RE = /^\s*\*{0,2}\s*campaign-approve:/i;
+
+/**
+ * The full approval-marker grammar: `campaign-approve: <label> · <ts>`. Captures the wave label
+ * (everything up to the `·` separator, no whitespace) and the raw timestamp token. A structural
+ * match is necessary but NOT sufficient — the label must still bind to the queried wave and the
+ * timestamp must still be a valid ISO-8601 UTC instant (both checked in `parseApproval`).
+ */
+const APPROVE_RE = /^\s*\*{0,2}\s*campaign-approve:\s*(?<label>[^\s·]+)\s*·\s*(?<ts>\S+)\s*$/i;
+
+/**
+ * One candidate approval comment, reduced to the fields the decision needs. Gathered from the
+ * cluster at the `gh api` boundary (`github.ts`); the core never fetches it.
+ */
+export interface ApprovalComment {
+	/** Server-assigned, strictly-monotonic comment id — the tiebreak sub-key for the earliest marker. */
+	readonly id: number;
+	/** The comment author's login (compared, case-insensitively, against the founder identity). */
+	readonly author: string;
+	/** ISO-8601 UTC creation time — the primary key for picking the earliest founder approval. */
+	readonly createdAt: string;
+	/** The raw comment body (matched against the approval grammar). */
+	readonly body: string;
+	/** The cluster issue this comment was found on — carried through for the report. */
+	readonly issue: number;
+}
+
+/** The facts the decision is a pure function of — all gathered before the core runs. */
+export interface VerifyTraceInput {
+	/** The wave label whose cluster is being verified (the label the trace binds to). */
+	readonly waveLabel: string;
+	/** The founder's GitHub login — injected config, the authorization anchor. Never hardcoded. */
+	readonly founderLogin: string;
+	/** How many issues carry the wave label. Zero ⇒ the label names nothing ⇒ zero-scope. */
+	readonly clusterSize: number;
+	/** Every candidate approval comment found across the cluster (any author, any shape). */
+	readonly comments: ReadonlyArray<ApprovalComment>;
+}
+
+/**
+ * The verdict — a discriminated union so an invalid state is unrepresentable: a PASS always
+ * carries the resolved founder + timestamp evidence, and each fail shape carries exactly the
+ * evidence for *why* it failed. Every non-PASS is a fail-closed refusal (ADR 0092).
+ */
+export type TraceVerdict =
+	| {
+			readonly pass: true;
+			readonly waveLabel: string;
+			readonly approvedBy: string;
+			readonly at: string;
+			readonly commentId: number;
+			readonly issue: number;
+	  }
+	/** No wave to bind to, no founder identity, or the label names zero issues — nothing to verify. */
+	| {readonly pass: false; readonly reason: "zero-scope"; readonly detail: string}
+	/** The cluster is non-empty but carries no `campaign-approve:` attempt at all. */
+	| {readonly pass: false; readonly reason: "absent"; readonly detail: string}
+	/** An approval attempt exists but is malformed or bound to a different wave label. */
+	| {readonly pass: false; readonly reason: "malformed"; readonly detail: string}
+	/** A well-formed, wave-bound approval exists but no author is the founder. */
+	| {
+			readonly pass: false;
+			readonly reason: "non-founder-author";
+			readonly detail: string;
+			readonly authors: ReadonlyArray<string>;
+	  };
+
+/** A structurally-parsed, wave-bound, valid-timestamp approval — the only kind that can PASS. */
+interface WellFormedApproval {
+	readonly comment: ApprovalComment;
+	readonly at: string;
+}
+
+const isValidIsoUtc = (ts: string): boolean => ISO_UTC_RE.test(ts) && !Number.isNaN(Date.parse(ts));
+
+const sameLogin = (a: string, b: string): boolean =>
+	a.trim().toLowerCase() === b.trim().toLowerCase();
+
+/**
+ * Classify one comment against the queried wave: `well-formed` (grammar matches, timestamp is a
+ * valid ISO-8601 UTC instant, and the label binds to this wave), `attempt` (the keyword prefix is
+ * present but one of those checks fails — a malformed or mis-bound approval), or `null` (not an
+ * approval attempt at all). The three-way split is what lets `verifyTrace` distinguish the
+ * `malformed` failure from `absent`.
+ */
+const classify = (
+	comment: ApprovalComment,
+	waveLabel: string,
+): WellFormedApproval | "attempt" | null => {
+	if (!APPROVE_PREFIX_RE.test(comment.body)) return null;
+	const m = APPROVE_RE.exec(comment.body);
+	const label = m?.groups?.label;
+	const ts = m?.groups?.ts;
+	if (label === undefined || ts === undefined) return "attempt";
+	if (label !== waveLabel) return "attempt";
+	if (!isValidIsoUtc(ts)) return "attempt";
+	return {comment, at: ts};
+};
+
+/** Order approvals earliest-first by `(createdAt, id)` — the earliest founder approval is the one recorded. */
+const earliest = (a: WellFormedApproval, b: WellFormedApproval): number =>
+	a.comment.createdAt < b.comment.createdAt
+		? -1
+		: a.comment.createdAt > b.comment.createdAt
+			? 1
+			: a.comment.id - b.comment.id;
+
+/**
+ * Decide the verdict over the gathered facts. Default-DENY: PASS is returned ONLY when a
+ * well-formed, wave-bound approval authored by the founder exists; every other input — empty
+ * scope, no attempt, a malformed/mis-bound attempt, a well-formed approval by a non-founder —
+ * fails closed. The precedence when no founder approval exists is most-informative-first:
+ * a well-formed non-founder approval reports `non-founder-author`, else a bare attempt reports
+ * `malformed`, else `absent`.
+ */
+export const verifyTrace = (input: VerifyTraceInput): TraceVerdict => {
+	const waveLabel = input.waveLabel.trim();
+	if (waveLabel === "") {
+		return {
+			pass: false,
+			reason: "zero-scope",
+			detail: "no wave label given — nothing to bind an approval to",
+		};
+	}
+	if (input.founderLogin.trim() === "") {
+		return {
+			pass: false,
+			reason: "zero-scope",
+			detail:
+				"no founder identity configured — cannot verify founder authorship (fail-closed, never a login fallback)",
+		};
+	}
+	if (input.clusterSize <= 0) {
+		return {
+			pass: false,
+			reason: "zero-scope",
+			detail: `the wave label '${waveLabel}' names zero issues — an empty cluster cannot be approved (ADR 0092)`,
+		};
+	}
+
+	const wellFormed: Array<WellFormedApproval> = [];
+	let sawAttempt = false;
+	for (const comment of input.comments) {
+		const c = classify(comment, waveLabel);
+		if (c === null) continue;
+		if (c === "attempt") {
+			sawAttempt = true;
+			continue;
+		}
+		wellFormed.push(c);
+	}
+
+	const byFounder = wellFormed
+		.filter((w) => sameLogin(w.comment.author, input.founderLogin))
+		.sort(earliest);
+	const founderApproval = byFounder[0];
+	if (founderApproval !== undefined) {
+		return {
+			pass: true,
+			waveLabel,
+			approvedBy: founderApproval.comment.author,
+			at: founderApproval.at,
+			commentId: founderApproval.comment.id,
+			issue: founderApproval.comment.issue,
+		};
+	}
+
+	if (wellFormed.length > 0) {
+		const authors = [...new Set(wellFormed.map((w) => w.comment.author))];
+		return {
+			pass: false,
+			reason: "non-founder-author",
+			detail: `a well-formed campaign-approve marker for '${waveLabel}' exists but no author is the founder ('${input.founderLogin}') — refusing to authorize a campaign the founder never approved`,
+			authors,
+		};
+	}
+	if (sawAttempt) {
+		return {
+			pass: false,
+			reason: "malformed",
+			detail: `a campaign-approve marker was found on the '${waveLabel}' cluster but it is malformed or bound to a different wave — the trace must read exactly 'campaign-approve: ${waveLabel} · <ISO-8601-UTC>'`,
+		};
+	}
+	return {
+		pass: false,
+		reason: "absent",
+		detail: `no campaign-approve marker found on the '${waveLabel}' cluster — a founder-approval trace is required before this wave can become a campaign`,
+	};
+};
+
+/** Render the human-readable report for a verdict (ADR 0092 §1 "emit what you scanned/decided"). */
+export const renderReport = (verdict: TraceVerdict): string => {
+	if (verdict.pass) {
+		return (
+			`campaign verify-trace: PASS — wave '${verdict.waveLabel}' carries a founder-approval trace ` +
+			`(approved by ${verdict.approvedBy} at ${verdict.at}, comment ${verdict.commentId} on #${verdict.issue})`
+		);
+	}
+	const prefix = `campaign verify-trace: FAIL (${verdict.reason}) — `;
+	if (verdict.reason === "non-founder-author") {
+		return `${prefix}${verdict.detail}. Marker author(s): ${verdict.authors.join(", ") || "<none>"}.`;
+	}
+	return `${prefix}${verdict.detail}.`;
+};

--- a/packages/pipeline-cli/src/tools/campaign/campaign-trace.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/campaign/campaign-trace.unit.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Pure-core tests for `campaign verify-trace` (#2658) — the fail-closed founder-approval-trace
+ * verifier. The whole security property is default-DENY: PASS requires positive evidence of a
+ * present, well-formed, founder-authored, wave-bound marker, and every ambiguous/malformed/empty
+ * input fails closed (ADR 0092). The four fail-closed paths the acceptance criteria enumerate —
+ * absence, malformation, non-founder author, zero scope — are each covered exhaustively here. No
+ * IO: the `gh api` boundary is exercised separately; this file feeds `verifyTrace` plain fixtures.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	type ApprovalComment,
+	renderReport,
+	type TraceVerdict,
+	type VerifyTraceInput,
+	verifyTrace,
+} from "./campaign-trace.ts";
+
+const FOUNDER = "founder-login";
+const WAVE = "audit-wave-27";
+
+const comment = (over: Partial<ApprovalComment>): ApprovalComment => ({
+	id: 1,
+	author: FOUNDER,
+	createdAt: "2026-07-10T12:00:00Z",
+	body: `campaign-approve: ${WAVE} · 2026-07-10T12:00:00Z`,
+	issue: 100,
+	...over,
+});
+
+const input = (over: Partial<VerifyTraceInput>): VerifyTraceInput => ({
+	waveLabel: WAVE,
+	founderLogin: FOUNDER,
+	clusterSize: 3,
+	comments: [],
+	...over,
+});
+
+/** Narrow to a fail verdict so `reason`/`detail` are accessible without a `pass` re-check per assertion. */
+const asFail = (v: TraceVerdict): Exclude<TraceVerdict, {pass: true}> => {
+	if (v.pass) throw new Error("expected a FAIL verdict, got PASS");
+	return v;
+};
+
+describe("verifyTrace — PASS only on a present, well-formed, founder-authored, wave-bound marker", () => {
+	it("PASSES for a founder-authored marker that binds to the wave", () => {
+		const v = verifyTrace(input({comments: [comment({})]}));
+		expect(v.pass).toBe(true);
+		expect(v.pass && v.approvedBy).toBe(FOUNDER);
+		expect(v.pass && v.at).toBe("2026-07-10T12:00:00Z");
+		expect(v.pass && v.waveLabel).toBe(WAVE);
+	});
+
+	it("tolerates a leading ** emphasis and case-insensitive keyword", () => {
+		const v = verifyTrace(
+			input({comments: [comment({body: `**Campaign-Approve: ${WAVE} · 2026-07-10T12:00:00Z`})]}),
+		);
+		expect(v.pass).toBe(true);
+	});
+
+	it("accepts a fractional-second ISO-8601 UTC timestamp", () => {
+		const v = verifyTrace(
+			input({comments: [comment({body: `campaign-approve: ${WAVE} · 2026-07-10T12:00:00.500Z`})]}),
+		);
+		expect(v.pass).toBe(true);
+	});
+
+	it("compares the founder login case-insensitively", () => {
+		const v = verifyTrace(input({comments: [comment({author: "Founder-Login"})]}));
+		expect(v.pass).toBe(true);
+	});
+
+	it("records the EARLIEST founder approval when several exist", () => {
+		const v = verifyTrace(
+			input({
+				comments: [
+					comment({id: 20, createdAt: "2026-07-10T15:00:00Z"}),
+					comment({id: 10, createdAt: "2026-07-10T09:00:00Z", issue: 101}),
+				],
+			}),
+		);
+		expect(v.pass && v.commentId).toBe(10);
+		expect(v.pass && v.issue).toBe(101);
+	});
+
+	it("PASSES on a founder approval even when a malformed attempt is also present", () => {
+		const v = verifyTrace(
+			input({
+				comments: [
+					comment({id: 5, body: "campaign-approve: garbage-no-separator"}),
+					comment({id: 6}),
+				],
+			}),
+		);
+		expect(v.pass).toBe(true);
+	});
+});
+
+describe("verifyTrace — fails closed on ABSENCE", () => {
+	it("FAILS absent when the cluster carries no campaign-approve marker at all", () => {
+		const v = asFail(
+			verifyTrace(input({comments: [comment({body: "just a normal discussion comment"})]})),
+		);
+		expect(v.reason).toBe("absent");
+	});
+
+	it("FAILS absent when there are simply no comments", () => {
+		const v = asFail(verifyTrace(input({comments: []})));
+		expect(v.reason).toBe("absent");
+	});
+
+	it("does not treat a mid-body quote of the marker as an attempt (line-one anchored)", () => {
+		const v = asFail(
+			verifyTrace(
+				input({
+					comments: [
+						comment({body: `I think we should\ncampaign-approve: ${WAVE} · 2026-07-10T12:00:00Z`}),
+					],
+				}),
+			),
+		);
+		expect(v.reason).toBe("absent");
+	});
+});
+
+describe("verifyTrace — fails closed on MALFORMATION", () => {
+	it("FAILS malformed when the separator/timestamp is missing", () => {
+		const v = asFail(
+			verifyTrace(input({comments: [comment({body: `campaign-approve: ${WAVE}`})]})),
+		);
+		expect(v.reason).toBe("malformed");
+	});
+
+	it("FAILS malformed on a non-ISO timestamp", () => {
+		const v = asFail(
+			verifyTrace(input({comments: [comment({body: `campaign-approve: ${WAVE} · yesterday`})]})),
+		);
+		expect(v.reason).toBe("malformed");
+	});
+
+	it("FAILS malformed on a non-UTC (no Z) timestamp", () => {
+		const v = asFail(
+			verifyTrace(
+				input({comments: [comment({body: `campaign-approve: ${WAVE} · 2026-07-10T12:00:00`})]}),
+			),
+		);
+		expect(v.reason).toBe("malformed");
+	});
+
+	it("FAILS malformed on a calendar-invalid ISO timestamp (regex-shaped but not a real date)", () => {
+		const v = asFail(
+			verifyTrace(
+				input({comments: [comment({body: `campaign-approve: ${WAVE} · 2026-13-45T99:99:99Z`})]}),
+			),
+		);
+		expect(v.reason).toBe("malformed");
+	});
+
+	it("FAILS malformed (mis-bound) when a valid marker binds to a DIFFERENT wave — never authorizes this one", () => {
+		const v = asFail(
+			verifyTrace(
+				input({
+					comments: [comment({body: "campaign-approve: some-other-wave · 2026-07-10T12:00:00Z"})],
+				}),
+			),
+		);
+		expect(v.reason).toBe("malformed");
+	});
+});
+
+describe("verifyTrace — fails closed on a NON-FOUNDER author", () => {
+	it("FAILS non-founder-author for a well-formed marker authored by someone else", () => {
+		const v = asFail(verifyTrace(input({comments: [comment({author: "some-agent"})]})));
+		expect(v.reason).toBe("non-founder-author");
+		expect(v.reason === "non-founder-author" && v.authors).toEqual(["some-agent"]);
+	});
+
+	it("does NOT PASS when a non-founder well-formed marker coexists with the founder's malformed one", () => {
+		const v = asFail(
+			verifyTrace(
+				input({
+					comments: [
+						comment({id: 1, author: FOUNDER, body: `campaign-approve: ${WAVE}`}), // founder, malformed
+						comment({id: 2, author: "other"}), // non-founder, well-formed
+					],
+				}),
+			),
+		);
+		expect(v.reason).toBe("non-founder-author");
+	});
+});
+
+describe("verifyTrace — fails closed on ZERO SCOPE (ADR 0092)", () => {
+	it("FAILS zero-scope on an empty wave label", () => {
+		const v = asFail(verifyTrace(input({waveLabel: "   ", comments: [comment({})]})));
+		expect(v.reason).toBe("zero-scope");
+	});
+
+	it("FAILS zero-scope when no founder identity is configured (never a login fallback)", () => {
+		const v = asFail(verifyTrace(input({founderLogin: "", comments: [comment({})]})));
+		expect(v.reason).toBe("zero-scope");
+	});
+
+	it("FAILS zero-scope when the wave label names zero issues (empty cluster)", () => {
+		const v = asFail(verifyTrace(input({clusterSize: 0, comments: []})));
+		expect(v.reason).toBe("zero-scope");
+	});
+
+	it("a zero-scope cluster with a would-be founder marker still FAILS — an empty cluster cannot be approved", () => {
+		const v = asFail(verifyTrace(input({clusterSize: 0, comments: [comment({})]})));
+		expect(v.reason).toBe("zero-scope");
+	});
+});
+
+describe("renderReport", () => {
+	it("renders a PASS with the founder + timestamp evidence", () => {
+		const report = renderReport(verifyTrace(input({comments: [comment({})]})));
+		expect(report).toContain("PASS");
+		expect(report).toContain(FOUNDER);
+		expect(report).toContain(WAVE);
+	});
+
+	it("renders each FAIL reason with its detail", () => {
+		expect(renderReport(verifyTrace(input({comments: []})))).toContain("FAIL (absent)");
+		expect(renderReport(verifyTrace(input({clusterSize: 0})))).toContain("FAIL (zero-scope)");
+		expect(renderReport(verifyTrace(input({comments: [comment({author: "x"})]})))).toContain(
+			"FAIL (non-founder-author)",
+		);
+	});
+});

--- a/packages/pipeline-cli/src/tools/campaign/command.ts
+++ b/packages/pipeline-cli/src/tools/campaign/command.ts
@@ -1,0 +1,79 @@
+/**
+ * The `campaign` tool — `pipeline-cli campaign verify-trace <wave-label> [--founder <login>]`.
+ *
+ * The fail-closed founder-approval-trace verifier (issue #2658). The campaign skill is
+ * invoker-agnostic — a human OR an agent may run it — so the sole authorization that a wave may
+ * become a campaign is a durable, auditable, founder-authored approval marker bound to the wave
+ * label. This is the seam the skill calls at pre-flight, and that CI can re-check: it exits 0
+ * ONLY on a present, well-formed, founder-authored, wave-bound trace, and exits non-zero on
+ * absence, malformation, a non-founder author, or zero scope (ADR 0092). The IO-free decision
+ * lives in `campaign-trace.ts` (unit-tested exhaustively); the `gh api` boundary is `github.ts`.
+ *
+ * The founder identity is resolved from `--founder` or `$CAMPAIGN_FOUNDER_LOGIN` — never hardcoded
+ * (no named identity in a committed artifact). With neither set the verifier fails closed rather
+ * than fall back to any implicit login, so a missing config can never be mistaken for approval.
+ *
+ * `GithubLive` is baked in with `Command.provide(...)` so the registered command's residual
+ * requirement is the Node platform union (the registry seam, epic #994).
+ */
+import {Console, Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {renderReport} from "./campaign-trace.ts";
+import {Github, GithubLive} from "./github.ts";
+
+const FAIL_EXIT_CODE = 1;
+
+const waveLabelArg = Argument.string("wave-label").pipe(
+	Argument.withDescription("the wave label whose cluster's founder-approval trace to verify"),
+);
+
+const founderFlag = Flag.string("founder").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the founder's GitHub login (default: $CAMPAIGN_FOUNDER_LOGIN) — the authorization anchor",
+	),
+);
+
+/** Print `reason` on stderr and exit non-zero — the fail-closed signal a skill/CI caller branches on. */
+const fail = (reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stderr.write(`${reason}\n`);
+		process.exit(FAIL_EXIT_CODE);
+	});
+
+/** Resolve the founder login from the flag, else the env — trimmed; empty ⇒ unresolved. */
+const resolveFounder = (flag: Option.Option<string>): string =>
+	Option.getOrElse(flag, () => process.env.CAMPAIGN_FOUNDER_LOGIN ?? "").trim();
+
+const verifyTrace = Command.make(
+	"verify-trace",
+	{waveLabel: waveLabelArg, founder: founderFlag},
+	Effect.fn(function* ({waveLabel, founder}) {
+		const founderLogin = resolveFounder(founder);
+		if (founderLogin === "") {
+			return yield* fail(
+				"campaign verify-trace: FAIL (zero-scope) — no founder identity configured " +
+					"(pass --founder or set $CAMPAIGN_FOUNDER_LOGIN). Refusing to verify without an " +
+					"authorization anchor rather than fall back to any implicit login (ADR 0092).",
+			);
+		}
+		const result = yield* (yield* Github).verify(waveLabel, founderLogin);
+		if (result.verdict.pass) {
+			yield* Console.log(renderReport(result.verdict));
+			return;
+		}
+		return yield* fail(renderReport(result.verdict));
+	}),
+).pipe(
+	Command.withDescription(
+		"Verify a wave's founder-approval trace (exit 0 = present, well-formed, founder-authored, wave-bound)",
+	),
+);
+
+export const campaignCommand = Command.make("campaign").pipe(
+	Command.withSubcommands([verifyTrace]),
+	Command.withDescription(
+		"Campaign gate tooling — the fail-closed founder-approval-trace verifier (#2658)",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/campaign/github.ts
+++ b/packages/pipeline-cli/src/tools/campaign/github.ts
@@ -1,0 +1,260 @@
+/**
+ * The GitHub boundary for `campaign verify-trace`: the live `Github` capability that gathers a
+ * wave-labeled cluster and its approval markers over `gh api` REST, then drives the IO-free
+ * `campaign-trace.ts` core. Same service pattern as the `verdict` / `epic-lock` template children
+ * (epic #994): a `Context.Service` on `ChildProcessSpawner`, REST only (GraphQL is broken on the
+ * kamp-us org), every infra failure a typed error in the `E` channel, untrusted REST JSON
+ * Schema-decoded at the boundary into the domain shape the core resolves over.
+ *
+ * The founder identity is a REQUIRED input, injected by the caller (`command.ts` resolves it from
+ * `--founder` or `$CAMPAIGN_FOUNDER_LOGIN`). It is never hardcoded here — a named identity in a
+ * committed artifact is exactly what the repo forbids, and the trust anchor stays configurable.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {type ApprovalComment, type TraceVerdict, verifyTrace} from "./campaign-trace.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/campaign/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/campaign/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/campaign/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/** The gathered facts plus the verdict — returned so the command can print the report and set exit. */
+export interface VerifyResult {
+	readonly verdict: TraceVerdict;
+	readonly waveLabel: string;
+	readonly clusterSize: number;
+}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the same
+ * direct-spawn shape `verdict`/`epic-lock` use so a non-zero exit + stderr lower into a typed
+ * error rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` not on PATH) folds in as exit `-1`.
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently defaults —
+ * with no env and no resolvable current repo it fails `RepoResolutionError`.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/campaign/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// --- REST arg builders (REST only, never GraphQL) --------------------------------
+
+// `-X GET -f k=v` sends query params (with encoding), so a wave label with special chars is safe.
+const clusterArgs = (repo: string, waveLabel: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/issues`,
+	"-f",
+	`labels=${waveLabel}`,
+	"-f",
+	"state=all",
+	"-f",
+	"per_page=100",
+	"--paginate",
+];
+
+const commentsArgs = (repo: string, issue: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${issue}/comments?per_page=100`,
+];
+
+// --- boundary decoders -----------------------------------------------------------
+
+/** A raw issue as the issues endpoint returns it; `pull_request` present ⇒ it's a PR, filtered out. */
+const RawIssue = Schema.Struct({
+	number: Schema.Number,
+	pull_request: Schema.optionalKey(Schema.Unknown),
+});
+const decodeIssues = Schema.decodeUnknownEffect(Schema.Array(RawIssue));
+
+/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
+const RawComment = Schema.Struct({
+	id: Schema.Number,
+	created_at: Schema.String,
+	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
+});
+const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+// --- IO operations ---------------------------------------------------------------
+
+/** The issue numbers carrying the wave label (PRs filtered out — the label binds to issues). */
+const clusterIssues = Effect.fn("Github.clusterIssues")(function* (
+	repo: string,
+	waveLabel: string,
+) {
+	const args = clusterArgs(repo, waveLabel);
+	const raw = yield* decodeIssues(yield* json(args));
+	return raw.filter((r) => r.pull_request === undefined).map((r) => r.number);
+});
+
+/** Every comment on `issue`, mapped to the core's `ApprovalComment` (carrying the issue number). */
+const issueComments = Effect.fn("Github.issueComments")(function* (repo: string, issue: number) {
+	const args = commentsArgs(repo, issue);
+	const raw = yield* decodeComments(yield* json(args));
+	return raw.map(
+		(c): ApprovalComment => ({
+			id: c.id,
+			author: c.user?.login ?? "",
+			createdAt: c.created_at,
+			body: c.body ?? "",
+			issue,
+		}),
+	);
+});
+
+/**
+ * Gather the wave-labeled cluster and its comments, then run the pure `verifyTrace`. The founder
+ * login is handed in by the caller (never resolved here). Comments from every cluster issue are
+ * pooled and handed whole to the core, which owns the marker grammar and the fail-closed decision.
+ */
+const verify = Effect.fn("Github.verify")(function* (
+	repo: string,
+	waveLabel: string,
+	founderLogin: string,
+) {
+	const issues = yield* clusterIssues(repo, waveLabel);
+	const perIssue = yield* Effect.forEach(issues, (issue) => issueComments(repo, issue), {
+		concurrency: "unbounded",
+	});
+	const comments = perIssue.flat();
+	const verdict = verifyTrace({
+		waveLabel,
+		founderLogin,
+		clusterSize: issues.length,
+		comments,
+	});
+	return {verdict, waveLabel, clusterSize: issues.length} satisfies VerifyResult;
+});
+
+/**
+ * `Github` — the IO shell over `gh api` REST for `campaign verify-trace`. `verify` gathers the
+ * wave-labeled cluster + its comments and resolves the founder-approval-trace verdict. Built by
+ * `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly verify: (
+			waveLabel: string,
+			founderLogin: string,
+		) => Effect.Effect<
+			VerifyResult,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/campaign/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at construction
+ * and provided into each method body, so the public method carries `R = never`. Repo resolution is
+ * deferred to first use (`Effect.cached`, ADR 0062 §1): the layer build is side-effect-free, and
+ * `RepoResolutionError` lives in the method's `E` channel, raised only when `verify` actually reads.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				verify: (waveLabel, founderLogin) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(verify(r, waveLabel, founderLogin)))),
+			};
+		}),
+	);


### PR DESCRIPTION
Fixes #2658

## What

Adds `pipeline-cli campaign verify-trace <wave-label> [--founder <login>]` — a **fail-closed founder-approval-trace verifier** in the readme-guard/fanout-guard idiom (a pure, IO-free, unit-tested core + a thin Effect bin over `gh api` REST).

The campaign skill is **invoker-agnostic** — a human *or* an agent may run it — so there is no human-at-keyboard guard like `release`'s. The sole authorization that a wave-labeled cluster may become a campaign is a durable, auditable, founder-authored approval marker bound to the wave label, and this verifier **default-DENIES** so that neither an agent nor a human can conjure a campaign the founder never approved.

## The founder-approval trace shape (pinned)

A campaign is authorized only by a **founder-authored comment** — on any issue carrying the wave label — whose **first line** is:

```
campaign-approve: <wave-label> · <ISO-8601-UTC>
```

- **`<wave-label>`** must equal the wave label under verification (binds the approval to *this* cluster — a valid approval of one wave never authorizes another).
- **`<ISO-8601-UTC>`** must be a valid ISO-8601 UTC instant (records *when* approval was granted; auditable after the fact).
- **author** must be the **founder** — identity injected via config (`--founder`, else `$CAMPAIGN_FOUNDER_LOGIN`), never hardcoded (no named identity in a committed artifact).

Emphasis-tolerant leading `**`, case-insensitive keyword, line-one anchored (a mid-body quote never counts). Grounded in the gated-audit-wave play, where findings are returned to the founder for approval *before* anything is filed.

## Exit contract (ADR 0092)

Exit `0` **only** on a present, well-formed, founder-authored, wave-bound trace. Every other input fails closed (non-zero), each covered by a unit test:

| Failure | Cause |
| --- | --- |
| `zero-scope` | empty wave label, no founder identity configured, or the label names zero issues |
| `absent` | cluster non-empty but no `campaign-approve:` marker |
| `malformed` | a marker exists but is malformed or bound to a different wave |
| `non-founder-author` | a well-formed, wave-bound marker exists but no author is the founder |

## Acceptance criteria

- [x] The trace shape is pinned as a checkable, auditable artifact bound to the wave label, documented in the tool surface (command docblock + tool `README.md`).
- [x] `campaign verify-trace` (readme-guard idiom: pure core + thin Effect bin) returns pass only for a present, well-formed, founder-authored trace.
- [x] Fails closed (non-zero) on a missing trace, a malformed trace, a non-founder author, and zero scope — each covered by a unit test.
- [x] The pure core is unit-tested over fixtures without spawning `gh` (`campaign-trace.unit.test.ts`, 22 tests).

## Files

- `packages/pipeline-cli/src/tools/campaign/campaign-trace.ts` — the pure IO-free core (marker grammar + default-deny decision + report)
- `packages/pipeline-cli/src/tools/campaign/campaign-trace.unit.test.ts` — 22 unit tests, the four fail-closed paths covered exhaustively
- `packages/pipeline-cli/src/tools/campaign/github.ts` — the `gh api` REST boundary (gathers the wave-labeled cluster + its comments)
- `packages/pipeline-cli/src/tools/campaign/command.ts` — the CLI wiring
- `packages/pipeline-cli/src/tools/campaign/README.md` — the tool surface documenting the trace shape
- `packages/pipeline-cli/src/registry.ts` — registers the `campaign` command

## Local checks

- `pnpm typecheck` — clean (28/28 workspace projects)
- `pnpm lint:worktree` — clean
- unit tests — 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)