### PR TITLE
feat(web): divan Subnav + boxed-pill tabs containment fix (#2604)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,13 +1,4 @@
-import {
-	createContext,
-	lazy,
-	type ReactNode,
-	Suspense,
-	useContext,
-	useEffect,
-	useMemo,
-	useState,
-} from "react";
+import {createContext, lazy, Suspense, useContext, useEffect, useMemo, useState} from "react";
 import {
 	Navigate,
 	Outlet,
@@ -21,11 +12,11 @@ import {
 import {authClient, clearBearerToken, useSession} from "./auth/client";
 import {useMe} from "./auth/useMe";
 import {useBildirimUnread} from "./components/bildirim/useBildirimUnread";
+import {DivanSubnavLayout} from "./components/divan/DivanSubnavLayout";
 import {shouldShowDivanEntry} from "./components/divan/divanGating";
 import {useDivanAccess} from "./components/divan/useDivanAccess";
 import {AppShell, Main} from "./components/layout/AppShell";
 import {Footer} from "./components/layout/Footer";
-import {ProductSubnavLayout} from "./components/layout/ProductSubnavLayout";
 import {Topbar} from "./components/layout/Topbar";
 import {MecmuaSubnavLayout} from "./components/mecmua/MecmuaSubnavLayout";
 import {actorLabel} from "./components/moderation/actor-identity";
@@ -350,23 +341,6 @@ function ComposerRouteFallback() {
 	);
 }
 
-/**
- * A product's leaf routes, either wrapped under `ProductSubnavLayout` (the persistent
- * product Subnav zone, flag on) or returned flat (flag off — the router is exactly as
- * today). React Router ranks routes by path specificity, not source order, and a pathless
- * layout route is transparent to matching — so wrapping a product's routes changes only
- * *what renders above them*, never *which* route matches (#2598, placement law #2587).
- */
-function productZone(navIaOn: boolean, key: string, routes: ReactNode, cta?: ReactNode) {
-	return navIaOn ? (
-		<Route key={key} element={<ProductSubnavLayout cta={cta} />}>
-			{routes}
-		</Route>
-	) : (
-		routes
-	);
-}
-
 export function App() {
 	// The per-product Subnav zones ride the shared nav-IA seam (#2598, epic #2596),
 	// default-off. With it off the router is flat (today's structure); with it on each
@@ -460,7 +434,17 @@ export function App() {
 						) : (
 							sozlukRoutes
 						)}
-						{productZone(navIaOn, "divan-zone", divanRoutes)}
+						{/* divan's zone hosts the çaylaklar ↔ raporlar section switch, published up from
+						    the routed page as Subnav filters, so it wraps under its own `DivanSubnavLayout`
+						    rather than the generic empty/cta-only frame (#2604). Off ⇒ flat, and
+						    DivanWorkspace renders its own in-page section nav as today. */}
+						{navIaOn ? (
+							<Route key="divan-zone" element={<DivanSubnavLayout />}>
+								{divanRoutes}
+							</Route>
+						) : (
+							divanRoutes
+						)}
 						<Route path="/search" element={<SearchPage />} />
 						<Route path="/auth" element={<AuthPage />} />
 						{/* The founder/mod conversion readout (#1589) — the page self-gates on

--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -63,12 +63,16 @@
 	margin-bottom: var(--s-4);
 }
 
+/* A section switcher (utility taxonomy, #2586) carries no resting boxed chrome (#2590): the
+   border is transparent at rest — reserving space so the active accent border adds no layout
+   shift — and there is no resting fill. The active-state accent pill below is legal transient
+   paint (#2604). */
 .kp-divan__nav-tab {
 	font: var(--t-body-sm);
 	padding: var(--s-1) var(--s-3);
-	border: 1px solid var(--border);
+	border: 1px solid transparent;
 	border-radius: var(--r-sm);
-	background: var(--surface);
+	background: none;
 	color: var(--text-secondary);
 	cursor: pointer;
 }

--- a/apps/web/src/components/divan/DivanSubnavLayout.test.tsx
+++ b/apps/web/src/components/divan/DivanSubnavLayout.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * divan's persistent product Subnav zone (#2604, placement law #2587). Pins: (1) the zone is a
+ * persistent layout — its `.kp-subnav` node survives a within-divan navigation (no remount); (2)
+ * the routed page publishes its çaylaklar ↔ raporlar section switch UP into the zone, where it
+ * renders as Subnav filters (`.kp-subnav__filter` — the #2586 taxonomy switcher treatment, never a
+ * resting boxed `.kp-divan__nav-tab` pill); (3) a switch click drives the published onFilterChange;
+ * (4) a non-mod page (no second section) publishes null and the zone shows the bare substrate bar;
+ * (5) with NO zone ancestor (flag off) the publish hook returns null — the signal DivanWorkspace
+ * uses to keep painting its own in-page nav byte-identically as today.
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {useEffect, useState} from "react";
+import {Link, MemoryRouter, Route, Routes} from "react-router";
+import {describe, expect, it} from "vitest";
+import {DivanSubnavLayout, useSetDivanSubnavContent} from "./DivanSubnavLayout";
+
+const SECTION_FILTERS = [
+	{id: "caylaklar", label: "çaylaklar"},
+	{id: "raporlar", label: "raporlar"},
+];
+
+/** A stand-in for DivanWorkspace: publishes the section switch up exactly as the page does. */
+function FakeDivanLeaf({hasSwitch = true}: {hasSwitch?: boolean}) {
+	const setDivanSubnav = useSetDivanSubnavContent();
+	const [section, setSection] = useState("caylaklar");
+	useEffect(() => {
+		if (!setDivanSubnav) return;
+		setDivanSubnav(
+			hasSwitch
+				? {filters: SECTION_FILTERS, activeFilter: section, onFilterChange: setSection}
+				: null,
+		);
+	}, [setDivanSubnav, hasSwitch, section]);
+	return (
+		<div data-testid="divan-leaf">
+			section:{section}
+			<Link to="/divan/other">başka</Link>
+		</div>
+	);
+}
+
+function renderZone(hasSwitch = true, initial = "/divan") {
+	return render(
+		<MemoryRouter initialEntries={[initial]}>
+			<Routes>
+				<Route element={<DivanSubnavLayout />}>
+					<Route path="/divan" element={<FakeDivanLeaf hasSwitch={hasSwitch} />} />
+					<Route path="/divan/other" element={<FakeDivanLeaf hasSwitch={hasSwitch} />} />
+				</Route>
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("DivanSubnavLayout — divan product Subnav zone (#2604)", () => {
+	it("renders one persistent Subnav zone carrying the published section switchers above the Outlet", () => {
+		const {container} = renderZone();
+		expect(container.querySelectorAll(".kp-subnav")).toHaveLength(1);
+		const switchers = container.querySelectorAll(".kp-subnav__filter");
+		expect(switchers).toHaveLength(2);
+		expect(screen.getByRole("button", {name: "çaylaklar"})).toBeTruthy();
+		expect(screen.getByRole("button", {name: "raporlar"})).toBeTruthy();
+		expect(screen.getByTestId("divan-leaf")).toBeTruthy();
+	});
+
+	it("carries the switchers as taxonomy filters — one taxonomy class, no resting boxed pill (#2586/#2590)", () => {
+		const {container} = renderZone();
+		for (const el of container.querySelectorAll(".kp-subnav__filter")) {
+			// exactly the taxonomy filter class — never the resting-boxed `.kp-divan__nav-tab` pill
+			expect(el.classList.contains("kp-divan__nav-tab")).toBe(false);
+		}
+		expect(container.querySelector(".kp-divan__nav")).toBeNull();
+	});
+
+	it("reflects the active section via aria-pressed and drives the switch on click", () => {
+		renderZone();
+		const caylaklar = screen.getByRole("button", {name: "çaylaklar"});
+		const raporlar = screen.getByRole("button", {name: "raporlar"});
+		expect(caylaklar.getAttribute("aria-pressed")).toBe("true");
+		expect(raporlar.getAttribute("aria-pressed")).toBe("false");
+		fireEvent.click(raporlar);
+		expect(screen.getByTestId("divan-leaf").textContent).toContain("section:raporlar");
+		expect(screen.getByRole("button", {name: "raporlar"}).getAttribute("aria-pressed")).toBe(
+			"true",
+		);
+	});
+
+	it("shows the bare substrate bar when the page has no second section (non-mod publishes null)", () => {
+		const {container} = renderZone(false);
+		expect(container.querySelectorAll(".kp-subnav")).toHaveLength(1);
+		expect(container.querySelectorAll(".kp-subnav__filter")).toHaveLength(0);
+	});
+
+	it("keeps the Subnav zone mounted across a within-divan navigation — no remount", () => {
+		const {container} = renderZone();
+		const before = container.querySelector(".kp-subnav");
+		expect(before).toBeTruthy();
+		fireEvent.click(screen.getByRole("link", {name: "başka"}));
+		expect(container.querySelector(".kp-subnav")).toBe(before);
+	});
+
+	it("with no zone ancestor (flag off) the publish hook is null — the in-page-nav fallback signal", () => {
+		let observed: unknown = "unset";
+		function Probe() {
+			observed = useSetDivanSubnavContent();
+			return null;
+		}
+		render(<Probe />);
+		expect(observed).toBeNull();
+	});
+});

--- a/apps/web/src/components/divan/DivanSubnavLayout.tsx
+++ b/apps/web/src/components/divan/DivanSubnavLayout.tsx
@@ -1,0 +1,51 @@
+import {createContext, useContext, useState} from "react";
+import {Outlet} from "react-router";
+import {Subnav, type SubnavFilter} from "../layout/Subnav";
+
+/**
+ * The section-switcher content the routed divan page publishes UP into its persistent Subnav
+ * zone (#2604): the çaylaklar ↔ raporlar switch as Subnav filters (#2586 taxonomy — the
+ * conformant switcher treatment, no resting boxed chrome). Only a moderator has a second
+ * section (raporlar is mod-gated), so a non-mod viewer publishes null and the zone shows the
+ * bare substrate bar.
+ */
+export type DivanSubnavContent = {
+	filters: SubnavFilter[];
+	activeFilter: string;
+	onFilterChange: (id: string) => void;
+};
+
+const SetDivanSubnavContent = createContext<((content: DivanSubnavContent | null) => void) | null>(
+	null,
+);
+
+/**
+ * The routed divan page calls this to push its section switchers up to the persistent zone
+ * (null when it has no switcher, or on unmount). Returns null when no zone ancestor provides it
+ * — flag off — the signal DivanWorkspace uses to render its own in-page section nav as today.
+ */
+export function useSetDivanSubnavContent() {
+	return useContext(SetDivanSubnavContent);
+}
+
+/**
+ * divan's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
+ * layout-route element that renders divan's Subnav once above the routed `<Outlet>`. divan's
+ * section switch is page-local state, so the routed page publishes its switchers UP via
+ * {@link useSetDivanSubnavContent} (the same publish-up shape pano uses) and this frame holds
+ * the state. Mounted only behind the `phoenix-nav-ia` flag (App.tsx); off ⇒ the router is flat
+ * and DivanWorkspace renders its own in-page section nav as today.
+ */
+export function DivanSubnavLayout() {
+	const [content, setContent] = useState<DivanSubnavContent | null>(null);
+	return (
+		<SetDivanSubnavContent.Provider value={setContent}>
+			<Subnav
+				filters={content?.filters}
+				activeFilter={content?.activeFilter}
+				onFilterChange={content?.onFilterChange}
+			/>
+			<Outlet />
+		</SetDivanSubnavContent.Provider>
+	);
+}

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -18,20 +18,29 @@
  * The moderator-only raporlar section (#1701) sits inside this workspace behind
  * its own `phoenix-mod-queue` flag — see `raporlarGating.ts` / `Raporlar.tsx`.
  */
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {useMe} from "../auth/useMe";
 import {CaylakDetail} from "../components/divan/CaylakDetail";
 import {DecisionFeed} from "../components/divan/DecisionFeed";
 import {DivanRoster} from "../components/divan/DivanRoster";
+import {useSetDivanSubnavContent} from "../components/divan/DivanSubnavLayout";
 import {shouldRenderDivanPage} from "../components/divan/divanGating";
 import {Raporlar} from "../components/divan/Raporlar";
 import {shouldShowRaporlar} from "../components/divan/raporlarGating";
 import {TriageLoop} from "../components/divan/TriageLoop";
+import type {SubnavFilter} from "../components/layout/Subnav";
 import {Screen} from "../fate/Screen";
-import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_MOD_QUEUE} from "../flags/keys";
+import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_MOD_QUEUE, PHOENIX_NAV_IA} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {NotFoundPage} from "./NotFoundPage";
 import "../components/divan/Divan.css";
+
+// The çaylaklar ↔ raporlar section switch as Subnav filters (#2604): when the nav-IA zone is
+// mounted, the switch is published up to the persistent divan Subnav rather than painted in-page.
+const DIVAN_SECTION_FILTERS: SubnavFilter[] = [
+	{id: "caylaklar", label: "çaylaklar"},
+	{id: "raporlar", label: "raporlar"},
+];
 
 export function DivanPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
@@ -69,6 +78,39 @@ function DivanWorkspace() {
 	// de-escalates to the grid without leaving the section.
 	const [raporlarMode, setRaporlarMode] = useState<"loop" | "grid">("loop");
 
+	// nav-IA (#2604, epic #2596): with the flag on, the section switch lives in divan's persistent
+	// Subnav zone. The page owns the switch state (roster vs raporlar pane below), so it publishes
+	// the switchers UP to the zone (the pano publish-up shape) and drops its own in-page nav. Only a
+	// moderator has a second section, so a non-mod viewer publishes null (a bare Subnav bar). Off ⇒
+	// no zone ancestor ⇒ setter null ⇒ the in-page nav renders exactly as today.
+	const {value: navIaOn} = useFlag(PHOENIX_NAV_IA, false);
+	const setDivanSubnav = useSetDivanSubnavContent();
+	const inZone = navIaOn && setDivanSubnav != null;
+
+	useEffect(() => {
+		if (!inZone || !setDivanSubnav) return;
+		setDivanSubnav(
+			raporlarVisible
+				? {
+						filters: DIVAN_SECTION_FILTERS,
+						activeFilter: section,
+						onFilterChange: (id) => {
+							if (id === "raporlar") {
+								setSection("raporlar");
+								setRaporlarMode("loop");
+							} else {
+								setSection("caylaklar");
+							}
+						},
+					}
+				: null,
+		);
+	}, [inZone, setDivanSubnav, raporlarVisible, section]);
+	// Clear the zone's content on unmount, so the persistent zone falls back to the bare bar.
+	useEffect(() => {
+		return () => setDivanSubnav?.(null);
+	}, [setDivanSubnav]);
+
 	return (
 		<div className="kp-divan" data-testid="divan-page">
 			<div className="kp-divan__inner">
@@ -80,7 +122,7 @@ function DivanWorkspace() {
 					</p>
 				</header>
 
-				{raporlarVisible && (
+				{!inZone && raporlarVisible && (
 					<nav className="kp-divan__nav" aria-label="divan bölümleri">
 						<button
 							type="button"


### PR DESCRIPTION
Gives divan a persistent product Subnav zone under the nav-IA seam and fixes the boxed-pill section-tab containment violation (#2604, Four Pillars, nav-IA epic #2596). Mirrors the just-landed sözlük (#2602), pano (#2601), and mecmua (#2603) product-Subnav shape.

## What

- **`DivanSubnavLayout`** — divan's pathless layout-route Subnav zone (placement law #2587). divan's çaylaklar ↔ raporlar section switch is page-local state, so `DivanWorkspace` publishes it **UP** into the zone as Subnav filters (the pano publish-up shape via `useSetDivanSubnavContent`), and the frame holds the state. Only a moderator has a second section, so a non-mod viewer publishes `null` and the zone shows the bare substrate bar.
- **App.tsx** — wire the divan product-zone line behind `phoenix-nav-ia`, mirroring the sözlük/pano/mecmua zones. Drops the now-orphaned generic `productZone` helper (divan was its last consumer) plus its `ProductSubnavLayout` / `ReactNode` imports.
- **`.kp-divan__nav-tab` containment fix (#2590)** — the resting boxed chrome is stripped: the border is `transparent` at rest (reserving space so the active accent border adds no layout shift) and there is no resting fill. The active-state `accent-faint` fill + `accent` border on `aria-current` stays as legal transient paint (#2586).

## Flag-off behavior

Default-off. With `phoenix-nav-ia` off there is no zone ancestor, so `useSetDivanSubnavContent()` returns `null` and `DivanWorkspace` paints its own in-page section nav exactly as today (same DOM, testids, and toggle behavior). Verified by `DivanSubnavLayout.test.tsx` (the no-provider hook-null case).

## Acceptance criteria

- [x] divan has a persistent Subnav across `/divan/*` carrying the çaylaklar ↔ raporlar section switchers.
- [x] The section tabs carry no resting boxed fill/border; the active-state `accent-faint` fill + `accent` border on `aria-current` is preserved as legal transient paint.
- [x] Every divan Subnav switcher is a single taxonomy class (`.kp-subnav__filter`, #2586) with no resting-chrome violation (#2590).

## Checks

- `design-token-guard check` green (no raw-px regression).
- `tsc --noEmit` (web) clean.
- `DivanSubnavLayout.test.tsx` — 6 passing (persistence, publish-up as taxonomy filters, switch action, non-mod bare bar, flag-off fallback signal). ProductSubnavLayout + divan gating suites still green.

Fixes #2604

🤖 Generated with [Claude Code](https://claude.com/claude-code)