### PR TITLE
fix(flagship): make the Flagship eval-error catch observable (#2685)

### DIFF
--- a/apps/web/worker/features/flagship/Flags.ts
+++ b/apps/web/worker/features/flagship/Flags.ts
@@ -22,7 +22,7 @@
  * targeting/percentage is #511.
  */
 import type {RuntimeContext} from "alchemy";
-import {Context, Effect, Layer} from "effect";
+import {type Cause, Context, Effect, Layer} from "effect";
 import {FlagsContext, toEvaluationContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
 
@@ -74,6 +74,23 @@ export interface FlagsAccess {
 export class Flags extends Context.Service<Flags, FlagsAccess>()("@kampus/Flags") {}
 
 /**
+ * Collapse any evaluation failure to the caller's safe default — the single site
+ * of contract 1 (safe-default, error channel `never`). `catchCause` (not a typed
+ * `catch`) so a binding DEFECT degrades safe too, matching the fire-and-forget
+ * swallow-with-log idiom of the bildirim emitters (`swallow`). The discarded cause
+ * is now LOGGED (`logWarning`) before the default is returned, so a misconfigured
+ * or unreachable Flagship binding is observable instead of silently absorbed
+ * (#2685) — the safe-default behavior is unchanged, only the silence is removed.
+ * A telemetry counter is deliberately out of scope here (it rides #1821).
+ */
+const swallowToDefault = <A>(key: string, defaultValue: A) =>
+	Effect.catchCause((cause: Cause.Cause<unknown>) =>
+		Effect.logWarning(`flags: evaluation of "${key}" failed — falling back to default`, cause).pipe(
+			Effect.as(defaultValue),
+		),
+	);
+
+/**
  * Build the real {@link FlagsAccess} over a resolved `Flagship` client — the
  * per-isolate read surface, captured at layer build so each read's only
  * per-request requirement is the `FlagsContext` it reads at call time. Extracted
@@ -85,31 +102,28 @@ const buildRealFlags = (flagship: Flagship["Service"]): FlagsAccess => ({
 			const context = yield* FlagsContext;
 			return yield* flagship
 				.getBooleanValue(key, defaultValue, toEvaluationContext(context))
-				// Any `FlagshipError` (misconfigured/unreachable binding) collapses to
-				// the supplied default — the safe-default contract that makes a
-				// Flagship outage degrade safe (contract 1 above).
-				.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+				.pipe(swallowToDefault(key, defaultValue));
 		}),
 	getString: (key, defaultValue) =>
 		Effect.gen(function* () {
 			const context = yield* FlagsContext;
 			return yield* flagship
 				.getStringValue(key, defaultValue, toEvaluationContext(context))
-				.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+				.pipe(swallowToDefault(key, defaultValue));
 		}),
 	getNumber: (key, defaultValue) =>
 		Effect.gen(function* () {
 			const context = yield* FlagsContext;
 			return yield* flagship
 				.getNumberValue(key, defaultValue, toEvaluationContext(context))
-				.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+				.pipe(swallowToDefault(key, defaultValue));
 		}),
 	getObject: (key, defaultValue) =>
 		Effect.gen(function* () {
 			const context = yield* FlagsContext;
 			return yield* flagship
 				.getObjectValue(key, defaultValue, toEvaluationContext(context))
-				.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+				.pipe(swallowToDefault(key, defaultValue));
 		}),
 });
 

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -5,12 +5,14 @@
  *
  *   - on/off branching: a flag returning true/false surfaces that value;
  *   - safe-default fallback: a `FlagshipError` from the client collapses to the
- *     supplied default, and the public `getBoolean` error channel is `never`.
+ *     supplied default, and the public `getBoolean` error channel is `never`;
+ *   - observability (#2685): the swallowed cause is LOGGED at warn before the
+ *     default is returned, so a misconfigured binding is no longer silent.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Flagship as CfFlagship} from "alchemy/Cloudflare";
-import {Effect, Layer} from "effect";
+import {Effect, Layer, Logger} from "effect";
 import {Flags, type FlagsAccess, FlagsLive, withDevOverrides} from "./Flags.ts";
 import {anonymousFlagsContext, FlagsContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
@@ -28,6 +30,30 @@ const RuntimeContextStub = Layer.succeed(RuntimeContext)(runtimeContext);
 
 const unexercised = (method: string) => () =>
 	Effect.die(`Flagship.${method} not exercised in Flags.unit.test`);
+
+/**
+ * Capture warn-level log lines into `lines` for the duration of `effect` (#2685):
+ * a scoped {@link Logger.layer} whose logger pushes each warn message's head
+ * string, so a test can assert the swallowed cause was actually logged rather than
+ * silently absorbed. The head is the first `logWarning` argument (its message
+ * template); the `Cause` argument is not serialized.
+ */
+const captureWarnings = <A, E, R>(
+	effect: Effect.Effect<A, E, R>,
+): Effect.Effect<{value: A; warnings: ReadonlyArray<string>}, E, R> =>
+	Effect.suspend(() => {
+		const lines: string[] = [];
+		const capture = Logger.layer([
+			Logger.make(({logLevel, message}) => {
+				if (logLevel !== "Warn") return;
+				lines.push(String(Array.isArray(message) ? message[0] : message));
+			}),
+		]);
+		return effect.pipe(
+			Effect.provide(capture),
+			Effect.map((value) => ({value, warnings: lines as ReadonlyArray<string>})),
+		);
+	});
 
 /**
  * A `Flagship` stub whose `getBooleanValue` is supplied by the test; every other
@@ -86,6 +112,30 @@ describe("Flags.getBoolean", () => {
 				.getBoolean("feature-erroring", false)
 				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
 			assert.strictEqual(enabled, false);
+		}).pipe(
+			Effect.provide(
+				flagsOver(() =>
+					Effect.fail(
+						new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined}),
+					),
+				),
+			),
+		),
+	);
+
+	it.effect("a FlagshipError is LOGGED at warn before the default is returned (#2685)", () =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			// The swallow must be OBSERVABLE: the default is still returned (degrade
+			// safe), AND a warn line naming the failing key was emitted — no longer silent.
+			const {value, warnings} = yield* captureWarnings(
+				flags
+					.getBoolean("feature-erroring", false)
+					.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext)),
+			);
+			assert.strictEqual(value, false);
+			assert.isAtLeast(warnings.length, 1);
+			assert.isTrue(warnings.some((line) => line.includes("feature-erroring")));
 		}).pipe(
 			Effect.provide(
 				flagsOver(() =>


### PR DESCRIPTION
Fixes #2685

## What
The four typed `Flags` reads (`getBoolean`/`getString`/`getNumber`/`getObject`) collapsed a `FlagshipError` to the caller's safe default via a **silent** `Effect.catch(() => Effect.succeed(defaultValue))`. A misconfigured or unreachable Flagship binding therefore degraded safe with **zero signal** — the outage was invisible (from resolved investigation #2553).

## Change
Route all four swallows through one `swallowToDefault` combinator that **logs the discarded cause at warn before returning the default**, using the repo's swallow-with-log idiom (the bildirim emitters' `swallow`):

`Effect.catchCause` → `Effect.logWarning(cause)` → `Effect.as(defaultValue)`

`catchCause` (not the typed `catch`) also degrades safe on a binding **defect**, matching the fire-and-forget posture. The *why* lives once on the helper docblock; the four reads just `.pipe(swallowToDefault(key, defaultValue))`.

## Invariants preserved
- **Safe-default behavior unchanged** — still returns `defaultValue` on error (ADR 0083).
- **Public error channel stays `never`** — email/flag reads never start failing their callers.
- **No new route, no new service.**
- **Telemetry counter is out of scope** (rides #1821) — log-now only, no counter/metric added.

## Test
Added a unit test `a FlagshipError is LOGGED at warn before the default is returned (#2685)` — a scoped capturing `Logger` asserts a warn line naming the failing key is emitted *while* the safe default is still returned. `apps/web/worker/features/flagship/Flags.unit.test.ts`: 17/17 pass; `pnpm typecheck` 28/28; biome clean.

## Scope
Disjoint lane — touches ONLY `Flags.ts` + its unit test. No overlap with #2604 (frontend) or #2686 (pipeline-cli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)