### PR TITLE
feat(pipeline-cli): roadmap-guard enforces ROADMAP.md ↔ milestone sync (#2648)

### DIFF
--- a/.github/workflows/roadmap-guard.yml
+++ b/.github/workflows/roadmap-guard.yml
@@ -69,6 +69,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # shellcheck disable=SC2016  # backticks are intended-literal markdown in the issue body, not shell expansion
           gh issue create --repo "$GITHUB_REPOSITORY" \
             --title "roadmap-guard: ROADMAP.md ↔ milestone drift detected" \
             --label "status:needs-triage" \

--- a/.github/workflows/roadmap-guard.yml
+++ b/.github/workflows/roadmap-guard.yml
@@ -1,0 +1,83 @@
+name: roadmap-guard
+
+# CI gate for roadmap map #2620 / founder ruling #2628: ROADMAP.md's founder-voice
+# `## Arcs`/`## Campaigns` tables and the GitHub milestone projection they pin to must
+# stay in sync — sync-drift diligence is load-bearing, so it is GUARDED fail-closed, not
+# left to vigilance. The tool parses ROADMAP.md (the sole parsed surface) and validates
+# I1–I4 against the live milestone REST projection:
+#   I1 arc/campaign pinned to an existing milestone by number (a queued arc may defer)
+#   I2 exactly one active arc  ·  I3 no unclaimed open milestone
+#   I4 fail-closed on zero scope (ADR 0092)
+# The check lives once in pipeline-cli (`roadmap-guard check`); this workflow only wires
+# it to the four triggers.
+on:
+  # Block a PR that drifts ROADMAP.md ↔ milestones.
+  pull_request:
+  # Re-check when a milestone is created/edited/closed/reopened/deleted — the projection
+  # side of the contract just moved.
+  milestone:
+  # Weekly backstop: the projection can drift with no PR touching ROADMAP.md (a milestone
+  # closed out of band). On red, file a status:needs-triage issue (the report-on-drift path).
+  schedule:
+    # Monday 05:23 UTC — off-hours and off the top of the hour (the scheduler congests
+    # on-the-hour crons). Weekly keeps the filed-issue rate low enough to stay signal.
+    - cron: "23 5 * * 1"
+  # Manual re-run.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read # checkout
+  issues: write # file the drift issue on a scheduled red
+
+jobs:
+  check:
+    name: check ROADMAP.md ↔ milestone sync (I1–I4)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # The guard reads the live milestone projection over `gh api`, so it needs a token.
+      # `continue-on-error` lets a red proceed to the scheduled issue-filing step below;
+      # the final gate step re-fails the job for the blocking (non-schedule) triggers.
+      - name: roadmap-guard check
+        id: guard
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          node packages/pipeline-cli/src/bin.ts roadmap-guard check 2>&1 | tee guard-output.txt
+          echo "code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      # Scheduled red → file a status:needs-triage issue (the out-of-band drift the PR
+      # trigger can't see). No PR to block on a schedule run, so the issue IS the signal.
+      - name: File a status:needs-triage issue on scheduled drift
+        if: ${{ github.event_name == 'schedule' && steps.guard.outputs.code != '0' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "roadmap-guard: ROADMAP.md ↔ milestone drift detected" \
+            --label "status:needs-triage" \
+            --body "$(printf 'The weekly roadmap-guard sweep found ROADMAP.md ↔ GitHub-milestone drift. Reconcile ROADMAP.md'\''s `## Arcs`/`## Campaigns` tables with the milestone projection (roadmap map #2620; invariants I1–I4, #2632).\n\nGuard output:\n\n```\n%s\n```\n' "$(cat guard-output.txt)")"
+
+      # Block the PR / milestone-event / dispatch run on red. On a schedule run the drift
+      # was already reported as an issue above, so the job does not hard-fail there.
+      - name: Fail the job on drift (blocking triggers)
+        if: ${{ github.event_name != 'schedule' && steps.guard.outputs.code != '0' }}
+        run: |
+          echo "roadmap-guard: ROADMAP.md ↔ milestone drift — see the check step output above." >&2
+          exit 1

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -36,6 +36,7 @@ import {reachabilityGuardCommand} from "./tools/reachability-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {refGuardCommand} from "./tools/ref-guard/command.ts";
 import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
+import {roadmapGuardCommand} from "./tools/roadmap-guard/command.ts";
 import {settingsEnvGuardCommand} from "./tools/settings-env-guard/command.ts";
 import {shipDigestCommand} from "./tools/ship-digest/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
@@ -87,6 +88,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	epicLockCommand,
 	decisionsIndexCommand,
 	readmeGuardCommand,
+	roadmapGuardCommand,
 	worktreeGuardCommand,
 	spawnGuardCommand,
 	leakGuardCommand,

--- a/packages/pipeline-cli/src/tools/roadmap-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/command.ts
@@ -1,0 +1,83 @@
+/**
+ * The `roadmap-guard` tool — `pipeline-cli roadmap-guard check [--root <d>]`.
+ *
+ * The CI surface for the "ROADMAP.md ↔ GitHub-milestone sync is guarded, not vigilance"
+ * ruling (roadmap map #2620, founder #2628). Parses ROADMAP.md's `## Arcs`/`## Campaigns`
+ * tables (the sole parsed surface) and validates them against the live milestone
+ * projection, fail-closed:
+ *
+ *   pipeline-cli roadmap-guard check            # CI gate: exit non-zero on any I1–I4 drift
+ *   pipeline-cli roadmap-guard check --root <d> # point at a specific repo root (else: walk up)
+ *
+ * Invariants (I1–I4, extended to campaign rows; see `roadmap-guard.ts`): I1 arc/campaign
+ * pinned to an existing milestone by number (a queued arc may defer its pin); I2 exactly
+ * one active arc; I3 no unclaimed open milestone; I4 fail-closed on zero scope (ADR 0092).
+ *
+ * The pure decision lives in `roadmap-guard.ts` (unit-tested exhaustively); the file read
+ * + `gh api` milestone fetch in `gate.ts`/`github.ts`. `MilestonesLive` is baked in with
+ * `Command.provide(...)` so the registered command's residual requirement is the Node
+ * platform union (the registry seam, epic #994).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — a gate failure (I1–I4 drift;
+ * report on stderr), an IO failure (ROADMAP.md unreadable), and a `gh`/repo failure all
+ * exit non-zero, undistinguished. `CheckFailed` is caught inside the handler so the
+ * contract survives folding into the shared `pipeline-cli` bin.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../../find-root-dir.ts";
+import {type CheckFailed, checkRoadmap} from "./gate.ts";
+import {MilestonesLive} from "./github.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root holding ROADMAP.md (default: walk up for one)"),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, gh failures) still get the
+// default error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkRoadmap(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the build if ROADMAP.md's arc/campaign tables have drifted from the milestone projection",
+	),
+);
+
+export const roadmapGuardCommand = Command.make("roadmap-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: ROADMAP.md ↔ GitHub-milestone sync (I1–I4, #2620/#2632)",
+	),
+	Command.provide(MilestonesLive),
+);

--- a/packages/pipeline-cli/src/tools/roadmap-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/gate.ts
@@ -1,0 +1,63 @@
+/**
+ * The `roadmap-guard` gate — the IO seam wiring the pure core to the two facts it
+ * judges: `ROADMAP.md`'s text (read from disk) and the live milestone projection (read
+ * over `gh api` via the `Milestones` service). Split from `command.ts` so the wiring is
+ * crossable in tests, and kept thin: it reads, delegates the verdict to `roadmap-guard.ts`,
+ * and fails `CheckFailed` (exit non-zero) on any non-passing verdict — including the
+ * zero-scope fail-closed (ADR 0092). An IO/`gh` failure is a distinct typed error (also
+ * non-zero — both are failures, undistinguished, per the bin's contract).
+ */
+import {existsSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import type * as Schema from "effect/Schema";
+import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
+import {Milestones} from "./github.ts";
+import {judge, parseRoadmap, renderReport} from "./roadmap-guard.ts";
+
+/** Couldn't read `ROADMAP.md` (absent or unreadable). */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+const ROADMAP_FILE = "ROADMAP.md";
+
+const readRoadmap = (root: string): Effect.Effect<string, IoError> =>
+	Effect.try({
+		try: () => {
+			const path = join(root, ROADMAP_FILE);
+			if (!existsSync(path)) {
+				throw new Error(`${ROADMAP_FILE} not found at repo root`);
+			}
+			return readFileSync(path, "utf8");
+		},
+		catch: (cause) => new IoError({path: join(root, ROADMAP_FILE), cause}),
+	});
+
+/**
+ * The CI gate: parse `ROADMAP.md`'s `## Arcs`/`## Campaigns` tables, read the live
+ * milestone projection, and judge I1–I4 (extended to campaign rows). Succeeds only on a
+ * passing verdict; every non-pass — including zero-scope — is a `CheckFailed`.
+ */
+export const checkRoadmap = (
+	root: string,
+): Effect.Effect<
+	void,
+	IoError | CheckFailed | RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError,
+	Milestones
+> =>
+	Effect.gen(function* () {
+		const md = yield* readRoadmap(root);
+		const {arcs, campaigns} = parseRoadmap(md);
+		const milestones = yield* (yield* Milestones).list();
+		const verdict = judge(arcs, campaigns, milestones);
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/roadmap-guard/github.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/github.ts
@@ -1,0 +1,181 @@
+/**
+ * The GitHub boundary for `roadmap-guard`: the live `Milestones` capability that reads
+ * the repo's milestone projection over `gh api` REST, so the pure core can validate
+ * ROADMAP.md against it. Same service pattern as `campaign`'s `Github` (epic #994): a
+ * `Context.Service` on `ChildProcessSpawner`, REST only (GraphQL is broken on the
+ * kamp-us org), every infra failure a typed error in the `E` channel, untrusted REST
+ * JSON Schema-decoded at the boundary into the domain `Milestone` the core resolves over.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {Milestone} from "./roadmap-guard.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/roadmap-guard/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/roadmap-guard/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/roadmap-guard/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the
+ * same direct-spawn shape `campaign`/`verdict` use so a non-zero exit + stderr lower
+ * into a typed error rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` not on
+ * PATH) folds in as exit `-1`.
+ */
+const runGh = Effect.fn("Milestones.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const json = Effect.fn("Milestones.json")(function* (args: ReadonlyArray<string>) {
+	const raw = yield* runGh(args);
+	return yield* Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
+ * defaults — with no env and no resolvable current repo it fails `RepoResolutionError`.
+ */
+const resolveRepo = Effect.fn("Milestones.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/roadmap-guard/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// `state=all` so I1 can resolve a pin to a CLOSED milestone (a done arc/campaign), while
+// I3 filters to open ones — the guard needs both projections. `--paginate` for >100.
+const milestonesArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/milestones`,
+	"-f",
+	"state=all",
+	"-f",
+	"per_page=100",
+	"--paginate",
+];
+
+/** A raw milestone as the milestones endpoint returns it; only these fields are read. */
+const RawMilestone = Schema.Struct({
+	number: Schema.Number,
+	state: Schema.Literals(["open", "closed"]),
+	title: Schema.String,
+});
+const decodeMilestones = Schema.decodeUnknownEffect(Schema.Array(RawMilestone));
+
+const listMilestones = Effect.fn("Milestones.list")(function* (repo: string) {
+	const args = milestonesArgs(repo);
+	const raw = yield* decodeMilestones(yield* json(args));
+	return raw.map((m): Milestone => ({number: m.number, state: m.state, title: m.title}));
+});
+
+/**
+ * `Milestones` — the IO shell over `gh api` REST for `roadmap-guard`. `list` reads the
+ * repo's milestone projection (all states). Built by `MilestonesLive`, whose `R` is
+ * `ChildProcessSpawner`.
+ */
+export class Milestones extends Context.Service<
+	Milestones,
+	{
+		readonly list: () => Effect.Effect<
+			ReadonlyArray<Milestone>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/roadmap-guard/Milestones") {}
+
+/**
+ * The live `Milestones` layer. The `ChildProcessSpawner` dependency is captured once at
+ * construction and provided into each method body, so the public method carries
+ * `R = never`. Repo resolution is deferred to first use (`Effect.cached`, ADR 0062 §1):
+ * the layer build is side-effect-free, and `RepoResolutionError` lives in the method's
+ * `E` channel, raised only when `list` actually reads.
+ */
+export const MilestonesLive: Layer.Layer<
+	Milestones,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> = Layer.effect(Milestones)(
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const withSpawner = <A, E>(
+			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+		const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+		return {
+			list: () => repo.pipe(Effect.flatMap((r) => withSpawner(listMilestones(r)))),
+		};
+	}),
+);

--- a/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.ts
@@ -1,0 +1,296 @@
+/**
+ * `roadmap-guard` pure core — decide whether `ROADMAP.md`'s founder-voice tables
+ * (`## Arcs`, `## Campaigns`) stay in sync with GitHub milestones, their operational
+ * REST projection (roadmap map #2620, guard ruling #2628). IO-free and total: parsing
+ * is a transform over the file text, `judge` a transform over the already-gathered
+ * rows + milestones. The filesystem read of `ROADMAP.md` and the `gh api` milestone
+ * fetch live in `gate.ts`/`github.ts`; this module never touches disk or the network.
+ *
+ * ROADMAP.md is the SOLE parsed surface; milestones are the projection validated
+ * against it (#2630/#2632). The invariants (I1–I4, extended to campaign rows):
+ *   I1 — every row is pinned to its milestone BY NUMBER and that milestone exists.
+ *        A QUEUED arc gets its milestone lazily on activation, so a queued arc with
+ *        no pin is legal; every other row (active/done arc, any campaign) must pin.
+ *   I2 — EXACTLY ONE arc row is `active` (the roadmap's "one active arc" law). This
+ *        is arcs-only: campaigns run concurrently and may each be active.
+ *   I3 — NO UNCLAIMED OPEN MILESTONE: every open milestone is claimed by some row.
+ *   I4 — FAIL-CLOSED ON ZERO SCOPE (ADR 0092): zero arc rows or zero milestones ⇒
+ *        a non-passing verdict, never a vacuous green (the readme-guard precedent).
+ */
+
+/** An arc is sequenced ahead (`queued`) then made current (`active`) and retired (`done`). */
+export type ArcState = "active" | "queued" | "done";
+/** A campaign has no queued state — it opens `active` and ends `done` (ROADMAP.md § Campaigns). */
+export type CampaignState = "active" | "done";
+
+export type RowKind = "arc" | "campaign";
+
+/**
+ * One parsed roadmap table row reduced to the facts the invariants need. `milestone`
+ * is the `#N` pin resolved to its number, or `null` when the cell is blank/absent
+ * (only legal for a queued arc — I1). `state` is the raw, lowercased state cell; row
+ * well-formedness (is this state legal for this kind?) is decided in `judge`, not here.
+ */
+export interface RoadmapRow {
+	readonly kind: RowKind;
+	/** The founder-voice name in the first column, e.g. `Four Pillars`. */
+	readonly name: string;
+	readonly milestone: number | null;
+	readonly state: string;
+}
+
+/** A GitHub milestone reduced to the REST-projection facts the guard validates against. */
+export interface Milestone {
+	readonly number: number;
+	readonly state: "open" | "closed";
+	readonly title: string;
+}
+
+/** The legal states per row kind — an out-of-set state is drift (a `row-state` violation). */
+const ARC_STATES: ReadonlyArray<string> = ["active", "queued", "done"];
+const CAMPAIGN_STATES: ReadonlyArray<string> = ["active", "done"];
+
+/**
+ * One drift finding. `code` names which invariant fired (`row-state` is the row
+ * well-formedness check that backstops I1/I2 — an unrecognized state cell). `message`
+ * names the offending row/milestone so the report can print it on stderr (ADR 0092 §1).
+ */
+export interface Violation {
+	readonly code: "I1" | "I2" | "I3" | "row-state";
+	readonly message: string;
+}
+
+/**
+ * The guard verdict. A discriminated union so an invalid state is unrepresentable: a
+ * pass carries only counts, the zero-scope fail (I4) carries the two scope counts that
+ * tripped it, and the drift fail carries its non-empty violation list.
+ */
+export type RoadmapGuardVerdict =
+	| {
+			readonly pass: true;
+			readonly arcCount: number;
+			readonly campaignCount: number;
+			readonly milestoneCount: number;
+	  }
+	/** Zero arc rows or zero milestones in scope — fail closed, never a vacuous pass (ADR 0092, I4). */
+	| {
+			readonly pass: false;
+			readonly reason: "zero-scope";
+			readonly arcCount: number;
+			readonly milestoneCount: number;
+	  }
+	/** Rows/milestones were in scope but at least one of I1–I3 (or row well-formedness) failed. */
+	| {
+			readonly pass: false;
+			readonly reason: "violations";
+			readonly violations: ReadonlyArray<Violation>;
+	  };
+
+/** Legal states for a row's kind — the backstop set behind I1/I2. */
+const legalStates = (kind: RowKind): ReadonlyArray<string> =>
+	kind === "arc" ? ARC_STATES : CAMPAIGN_STATES;
+
+/** A row's milestone pin may be legally absent ONLY for a queued arc (lazy-on-activation, I1). */
+const pinMayBeAbsent = (row: RoadmapRow): boolean => row.kind === "arc" && row.state === "queued";
+
+/**
+ * Decide the verdict over the parsed rows and the live milestone projection.
+ *
+ * Order: I4 (zero-scope) fails closed first — with no arcs or no milestones there is
+ * nothing to meaningfully check, so refuse rather than pass vacuously. Otherwise every
+ * violation is collected (row well-formedness, then I1, I2, I3) so one run names all
+ * drift, not just the first.
+ */
+export const judge = (
+	arcs: ReadonlyArray<RoadmapRow>,
+	campaigns: ReadonlyArray<RoadmapRow>,
+	milestones: ReadonlyArray<Milestone>,
+): RoadmapGuardVerdict => {
+	if (arcs.length === 0 || milestones.length === 0) {
+		return {
+			pass: false,
+			reason: "zero-scope",
+			arcCount: arcs.length,
+			milestoneCount: milestones.length,
+		};
+	}
+
+	const rows = [...arcs, ...campaigns];
+	const byNumber = new Map(milestones.map((m) => [m.number, m]));
+	const violations: Array<Violation> = [];
+
+	// Row well-formedness — an unrecognized state cell is drift the invariants below
+	// would otherwise mis-read (a typo'd `activ` would silently drop out of the I2 count).
+	for (const row of rows) {
+		if (!legalStates(row.kind).includes(row.state)) {
+			violations.push({
+				code: "row-state",
+				message: `${row.kind} row "${row.name}" has an unrecognized state "${row.state}" (allowed: ${legalStates(row.kind).join(", ")})`,
+			});
+		}
+	}
+
+	// I1 — arc→/campaign→milestone pinned by number, and that milestone exists. A queued
+	// arc with no pin is tolerated (lazy on activation); any other absent pin is a fail.
+	for (const row of rows) {
+		if (row.milestone === null) {
+			if (!pinMayBeAbsent(row)) {
+				violations.push({
+					code: "I1",
+					message: `${row.kind} row "${row.name}" (state "${row.state}") has no milestone pin — only a queued arc may defer its milestone`,
+				});
+			}
+			continue;
+		}
+		if (!byNumber.has(row.milestone)) {
+			violations.push({
+				code: "I1",
+				message: `${row.kind} row "${row.name}" is pinned to milestone #${row.milestone}, which does not exist`,
+			});
+		}
+	}
+
+	// I2 — exactly one arc is active (arcs only; campaigns run concurrently).
+	const activeArcs = arcs.filter((a) => a.state === "active");
+	if (activeArcs.length !== 1) {
+		const which =
+			activeArcs.length === 0 ? "none" : activeArcs.map((a) => `"${a.name}"`).join(", ");
+		violations.push({
+			code: "I2",
+			message: `expected exactly ONE active arc, found ${activeArcs.length} (${which})`,
+		});
+	}
+
+	// I3 — no unclaimed open milestone: every open milestone is claimed by some row's pin.
+	const claimed = new Set(
+		rows.filter((r) => r.milestone !== null).map((r) => r.milestone as number),
+	);
+	for (const m of milestones) {
+		if (m.state === "open" && !claimed.has(m.number)) {
+			violations.push({
+				code: "I3",
+				message: `open milestone #${m.number} ("${m.title}") is not claimed by any arc or campaign row`,
+			});
+		}
+	}
+
+	if (violations.length > 0) {
+		return {pass: false, reason: "violations", violations};
+	}
+	return {
+		pass: true,
+		arcCount: arcs.length,
+		campaignCount: campaigns.length,
+		milestoneCount: milestones.length,
+	};
+};
+
+/** Render the human-readable report for a verdict (ADR 0092 §1 — "emit what you scanned"). */
+export const renderReport = (verdict: RoadmapGuardVerdict): string => {
+	if (verdict.pass) {
+		return (
+			`roadmap-guard: in sync — ${verdict.arcCount} arc row(s) + ${verdict.campaignCount} campaign row(s) ` +
+			`validated against ${verdict.milestoneCount} milestone(s) (I1–I4 all green).`
+		);
+	}
+	if (verdict.reason === "zero-scope") {
+		return (
+			`roadmap-guard: scanned ${verdict.arcCount} arc row(s) and ${verdict.milestoneCount} milestone(s) — ` +
+			"zero scope on one side, fail-closed (ADR 0092, I4). Is ROADMAP.md's `## Arcs` table present and " +
+			"are there milestones to project onto? A vacuous pass would hide real drift."
+		);
+	}
+	const lines = verdict.violations.map((v) => `  [${v.code}] ${v.message}`);
+	return (
+		`roadmap-guard: ${verdict.violations.length} ROADMAP.md ↔ milestone drift violation(s):\n` +
+		`${lines.join("\n")}\n\n` +
+		"ROADMAP.md's `## Arcs`/`## Campaigns` tables and the GitHub milestone projection have drifted.\n" +
+		"Reconcile the offending row(s)/milestone(s) above (roadmap map #2620; invariants I1–I4, #2632)."
+	);
+};
+
+// --- ROADMAP.md parsing (pure over the file text) --------------------------------
+
+/** Resolve a `## <heading>` markdown table's milestone cell (`#17`) to its number, else null. */
+export const parseMilestoneCell = (cell: string): number | null => {
+	const m = cell.match(/#(\d+)/);
+	return m?.[1] !== undefined ? Number(m[1]) : null;
+};
+
+/**
+ * Split one markdown table line (`| a | b | c |`) into its trimmed cells. The leading
+ * and trailing pipes yield empty edge fields, which are dropped. A separator row
+ * (`|---|---|`) has every cell made only of dashes/colons/spaces — the caller filters
+ * those; this just tokenizes.
+ */
+const splitRow = (line: string): ReadonlyArray<string> => {
+	const cells = line.split("|").map((c) => c.trim());
+	// Drop the empty fields the leading/trailing `|` produce.
+	if (cells.length > 0 && cells[0] === "") cells.shift();
+	if (cells.length > 0 && cells[cells.length - 1] === "") cells.pop();
+	return cells;
+};
+
+const isSeparatorRow = (cells: ReadonlyArray<string>): boolean =>
+	cells.length > 0 && cells.every((c) => /^:?-+:?$/.test(c));
+
+/**
+ * Extract the data rows (header + separator dropped) of the first markdown table under
+ * `## <heading>`. Returns `[]` when the heading is absent or has no table — the caller
+ * turns an empty `## Arcs` into the I4 zero-scope fail, and an empty `## Campaigns` into
+ * a legal no-campaigns roadmap.
+ */
+export const parseSectionRows = (
+	md: string,
+	heading: string,
+): ReadonlyArray<ReadonlyArray<string>> => {
+	const lines = md.split("\n");
+	const headingRe = new RegExp(`^##\\s+${heading}\\s*$`, "i");
+	let i = 0;
+	while (i < lines.length && !headingRe.test(lines[i] ?? "")) i++;
+	if (i >= lines.length) return [];
+	i++; // past the heading
+
+	const rows: Array<ReadonlyArray<string>> = [];
+	let seenTable = false;
+	for (; i < lines.length; i++) {
+		const line = (lines[i] ?? "").trim();
+		if (/^##\s+/.test(line)) break; // next section ends this one
+		const isTableLine = line.startsWith("|");
+		if (!isTableLine) {
+			// A blank/prose line after the table has started terminates it; before it, skip.
+			if (seenTable) break;
+			continue;
+		}
+		seenTable = true;
+		const cells = splitRow(line);
+		if (isSeparatorRow(cells)) continue; // the |---|---| divider
+		rows.push(cells);
+	}
+	// The first surviving row is the header (`Arc | Milestone | State`) — drop it.
+	return rows.slice(1);
+};
+
+/** Map a `## Arcs`/`## Campaigns` data row's cells (`name | #N | state`) to a `RoadmapRow`. */
+const toRow = (kind: RowKind, cells: ReadonlyArray<string>): RoadmapRow => ({
+	kind,
+	name: (cells[0] ?? "").trim(),
+	milestone: parseMilestoneCell(cells[1] ?? ""),
+	state: (cells[2] ?? "").trim().toLowerCase(),
+});
+
+/**
+ * Parse `ROADMAP.md`'s `## Arcs` and `## Campaigns` tables into rows. Rows with an
+ * empty name are dropped (a stray table artifact), never turned into a phantom row.
+ */
+export const parseRoadmap = (
+	md: string,
+): {readonly arcs: ReadonlyArray<RoadmapRow>; readonly campaigns: ReadonlyArray<RoadmapRow>} => {
+	const arcs = parseSectionRows(md, "Arcs")
+		.map((cells) => toRow("arc", cells))
+		.filter((r) => r.name !== "");
+	const campaigns = parseSectionRows(md, "Campaigns")
+		.map((cells) => toRow("campaign", cells))
+		.filter((r) => r.name !== "");
+	return {arcs, campaigns};
+};

--- a/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.unit.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Pure-core tests for `roadmap-guard` (#2648, roadmap map #2620): the parse of
+ * ROADMAP.md's `## Arcs`/`## Campaigns` tables and the I1–I4 verdict (each invariant's
+ * pass + every failure mode, plus the zero-scope fail-closed of ADR 0092). No IO — the
+ * `gh api`/filesystem seam is crossed in `gate.ts`/`github.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	judge,
+	type Milestone,
+	parseMilestoneCell,
+	parseRoadmap,
+	parseSectionRows,
+	type RoadmapRow,
+	renderReport,
+} from "./roadmap-guard.ts";
+
+const arc = (name: string, milestone: number | null, state: string): RoadmapRow => ({
+	kind: "arc",
+	name,
+	milestone,
+	state,
+});
+const campaign = (name: string, milestone: number | null, state: string): RoadmapRow => ({
+	kind: "campaign",
+	name,
+	milestone,
+	state,
+});
+const ms = (number: number, state: "open" | "closed", title = `m${number}`): Milestone => ({
+	number,
+	state,
+	title,
+});
+
+// A well-formed roadmap: one active arc + queued arcs (some with lazy pins) + one active
+// campaign, every pin resolving, every open milestone claimed.
+const goodArcs = [
+	arc("Four Pillars", 17, "active"),
+	arc("Geçit", 24, "queued"),
+	arc("Lazy", null, "queued"), // queued arc may defer its milestone (I1 tolerance)
+];
+const goodCampaigns = [campaign("Mentor Audit", 27, "active")];
+const goodMilestones = [ms(17, "open"), ms(24, "open"), ms(27, "open")];
+
+describe("judge — happy path", () => {
+	it("PASSES when I1–I4 all hold (arcs + campaigns + milestones in sync)", () => {
+		const v = judge(goodArcs, goodCampaigns, goodMilestones);
+		expect(v.pass).toBe(true);
+		if (v.pass) {
+			expect(v.arcCount).toBe(3);
+			expect(v.campaignCount).toBe(1);
+			expect(v.milestoneCount).toBe(3);
+		}
+	});
+
+	it("tolerates a queued arc with NO milestone pin (lazy on activation, I1)", () => {
+		const v = judge([arc("Now", 17, "active"), arc("Later", null, "queued")], [], [ms(17, "open")]);
+		expect(v.pass).toBe(true);
+	});
+
+	it("resolves a done arc/campaign pinned to a CLOSED milestone (I1 uses all states)", () => {
+		const v = judge(
+			[arc("Now", 17, "active"), arc("Shipped", 10, "done")],
+			[campaign("Past", 11, "done")],
+			[ms(17, "open"), ms(10, "closed"), ms(11, "closed")],
+		);
+		expect(v.pass).toBe(true);
+	});
+});
+
+describe("judge — I4 zero-scope fail-closed (ADR 0092)", () => {
+	it("FAILS zero-scope on zero arc rows", () => {
+		const v = judge([], goodCampaigns, goodMilestones);
+		expect(v.pass).toBe(false);
+		expect(v.pass === false && v.reason).toBe("zero-scope");
+	});
+
+	it("FAILS zero-scope on zero milestones", () => {
+		const v = judge(goodArcs, goodCampaigns, []);
+		expect(v.pass).toBe(false);
+		expect(v.pass === false && v.reason).toBe("zero-scope");
+	});
+});
+
+describe("judge — I1 arc/campaign pinned by number to an existing milestone", () => {
+	it("FAILS I1 when a row's pin resolves to no milestone", () => {
+		const v = judge([arc("Now", 17, "active"), arc("Ghost", 99, "queued")], [], [ms(17, "open")]);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I1" && x.message.includes("#99"))).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("FAILS I1 when a NON-queued arc has no pin", () => {
+		const v = judge([arc("Now", null, "active")], [], [ms(1, "open")]);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I1")).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("FAILS I1 when a CAMPAIGN has no pin (campaigns have no lazy tolerance)", () => {
+		const v = judge(
+			[arc("Now", 17, "active")],
+			[campaign("Unpinned", null, "active")],
+			[ms(17, "open")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I1" && x.message.includes("Unpinned"))).toBe(
+				true,
+			);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+});
+
+describe("judge — I2 exactly one active arc", () => {
+	it("FAILS I2 on zero active arcs", () => {
+		const v = judge(
+			[arc("A", 17, "queued"), arc("B", 24, "queued")],
+			[],
+			[ms(17, "open"), ms(24, "open")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I2" && x.message.includes("found 0"))).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("FAILS I2 on two active arcs", () => {
+		const v = judge(
+			[arc("A", 17, "active"), arc("B", 24, "active")],
+			[],
+			[ms(17, "open"), ms(24, "open")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I2" && x.message.includes("found 2"))).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("does NOT count active campaigns toward I2 (campaigns run concurrently)", () => {
+		const v = judge(
+			[arc("A", 17, "active")],
+			[campaign("C1", 27, "active"), campaign("C2", 28, "active")],
+			[ms(17, "open"), ms(27, "open"), ms(28, "open")],
+		);
+		expect(v.pass).toBe(true);
+	});
+});
+
+describe("judge — I3 no unclaimed open milestone", () => {
+	it("FAILS I3 when an open milestone is claimed by no row", () => {
+		const v = judge([arc("Now", 17, "active")], [], [ms(17, "open"), ms(42, "open", "Orphan")]);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I3" && x.message.includes("#42"))).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("does NOT fail I3 for an unclaimed CLOSED milestone (only open must be claimed)", () => {
+		const v = judge([arc("Now", 17, "active")], [], [ms(17, "open"), ms(9, "closed")]);
+		expect(v.pass).toBe(true);
+	});
+
+	it("counts a campaign row as a claimer of an open milestone", () => {
+		const v = judge(
+			[arc("Now", 17, "active")],
+			[campaign("Aud", 27, "active")],
+			[ms(17, "open"), ms(27, "open")],
+		);
+		expect(v.pass).toBe(true);
+	});
+});
+
+describe("judge — row-state well-formedness (backstops I1/I2)", () => {
+	it("FLAGS an unrecognized arc state", () => {
+		const v = judge(
+			[arc("Now", 17, "active"), arc("Typo", 24, "activ")],
+			[],
+			[ms(17, "open"), ms(24, "open")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "row-state")).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("FLAGS a campaign in the illegal `queued` state", () => {
+		const v = judge(
+			[arc("Now", 17, "active")],
+			[campaign("C", 27, "queued")],
+			[ms(17, "open"), ms(27, "open")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "row-state" && x.message.includes("queued"))).toBe(
+				true,
+			);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+});
+
+describe("judge — collects EVERY violation in one pass", () => {
+	it("reports I1, I2, and I3 together", () => {
+		const v = judge(
+			// two active arcs (I2), one pinned to a missing milestone (I1)
+			[arc("A", 17, "active"), arc("B", 99, "active")],
+			[],
+			// #42 open + unclaimed (I3)
+			[ms(17, "open"), ms(42, "open")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			const codes = new Set(v.violations.map((x) => x.code));
+			expect(codes.has("I1")).toBe(true);
+			expect(codes.has("I2")).toBe(true);
+			expect(codes.has("I3")).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+});
+
+describe("renderReport", () => {
+	it("names the passing scope", () => {
+		expect(renderReport(judge(goodArcs, goodCampaigns, goodMilestones))).toContain("in sync");
+	});
+
+	it("explains the fail-closed zero-scope verdict", () => {
+		const r = renderReport(judge([], goodCampaigns, goodMilestones));
+		expect(r).toContain("fail-closed");
+		expect(r).toContain("ADR 0092");
+	});
+
+	it("lists each violation with its invariant code", () => {
+		// Ghost is pinned to #99 (absent) ⇒ I1; #17 open + unclaimed ⇒ I3.
+		const r = renderReport(judge([arc("Ghost", 99, "active")], [], [ms(17, "open")]));
+		expect(r).toContain("[I1]");
+		expect(r).toContain("[I3]");
+	});
+});
+
+describe("parseMilestoneCell", () => {
+	it("extracts #N", () => {
+		expect(parseMilestoneCell("#17")).toBe(17);
+		expect(parseMilestoneCell(" #24 ")).toBe(24);
+	});
+	it("returns null for a blank/dashed cell (a queued arc's deferred pin)", () => {
+		expect(parseMilestoneCell("")).toBeNull();
+		expect(parseMilestoneCell("—")).toBeNull();
+	});
+});
+
+describe("parseSectionRows + parseRoadmap", () => {
+	const md = [
+		"# Roadmap",
+		"",
+		"## Arcs",
+		"",
+		"| Arc | Milestone | State |",
+		"|-----|-----------|-------|",
+		"| Four Pillars | #17 | active |",
+		"| Geçit | #24 | queued |",
+		"| Lazy | | queued |",
+		"",
+		"Prose after the table is ignored.",
+		"",
+		"## Campaigns",
+		"",
+		"| Campaign | Milestone | State |",
+		"|----------|-----------|-------|",
+		"| Mentor Audit | #27 | active |",
+		"",
+		"## Standing lanes",
+		"",
+		"Not a table.",
+	].join("\n");
+
+	it("drops the header + separator, keeps only data rows", () => {
+		const rows = parseSectionRows(md, "Arcs");
+		expect(rows.length).toBe(3);
+		expect(rows[0]?.[0]).toBe("Four Pillars");
+	});
+
+	it("parses arcs and campaigns into rows with pins + lowercased states", () => {
+		const {arcs, campaigns} = parseRoadmap(md);
+		expect(arcs).toEqual([
+			{kind: "arc", name: "Four Pillars", milestone: 17, state: "active"},
+			{kind: "arc", name: "Geçit", milestone: 24, state: "queued"},
+			{kind: "arc", name: "Lazy", milestone: null, state: "queued"},
+		]);
+		expect(campaigns).toEqual([
+			{kind: "campaign", name: "Mentor Audit", milestone: 27, state: "active"},
+		]);
+	});
+
+	it("the parsed roadmap PASSES judge against a matching milestone projection", () => {
+		const {arcs, campaigns} = parseRoadmap(md);
+		const v = judge(arcs, campaigns, [ms(17, "open"), ms(24, "open"), ms(27, "open")]);
+		expect(v.pass).toBe(true);
+	});
+
+	it("returns [] for an absent section", () => {
+		expect(parseSectionRows(md, "Nonexistent")).toEqual([]);
+		const {campaigns} = parseRoadmap(
+			"## Arcs\n\n| Arc | Milestone | State |\n|-|-|-|\n| A | #1 | active |",
+		);
+		expect(campaigns).toEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes #2648 — roadmap unit 2 of map #2620.

## What this adds

A CLI-first, fail-closed drift guard `pipeline-cli roadmap-guard check` enforcing `ROADMAP.md` ↔ GitHub-milestone sync, on the `readme-guard` idiom (pure unit-tested core + thin Effect command + `gh api` REST boundary), plus the CI workflow that runs it. Sync-drift diligence is load-bearing → **guarded, not vigilance** (founder ruling #2628).

### Tool — `packages/pipeline-cli/src/tools/roadmap-guard/`
- `roadmap-guard.ts` — the IO-free core: parses `ROADMAP.md`'s `## Arcs`/`## Campaigns` tables (the **sole** parsed surface, #2630/#2632) and `judge`s them against the milestone projection.
- `github.ts` — the `Milestones` service reading the live projection over `gh api` REST (mirrors `campaign`'s `Github`; REST only, GraphQL is broken on the org).
- `gate.ts` / `command.ts` — the file-read + wiring; registered in `registry.ts` and run via `node packages/pipeline-cli/src/bin.ts roadmap-guard check`.
- `roadmap-guard.unit.test.ts` — 26 tests: each invariant's pass + every failure mode + the zero-scope fail-closed path.

### Invariants (I1–I4, extended to campaign rows)
- **I1** — each arc/campaign row is pinned to an **existing** milestone by number; a **queued arc** may defer its pin (lazy on activation) — encoded explicitly, not failed.
- **I2** — **exactly one** arc is `active` (arcs only; campaigns run concurrently).
- **I3** — **no unclaimed open milestone** (an arc *or* campaign row may claim it).
- **I4** — **fail-closed on zero scope** (ADR 0092): zero arc rows or zero milestones ⇒ non-zero, never a vacuous pass. A `row-state` well-formedness check backstops I1/I2 (an unrecognized state cell, e.g. a campaign in the illegal `queued` state).

### Workflow — `.github/workflows/roadmap-guard.yml`
Four triggers: `pull_request` (blocks a drifting PR) + `on: milestone` (re-check when the projection moves) + weekly `schedule` (on red, files a `status:needs-triage` issue — the out-of-band drift the PR trigger can't see) + `workflow_dispatch`.

## §CP note
Control-plane by content (`.github/` + `packages/pipeline-cli/` both inside `CONTROL_PLANE_RE`). Both new paths are already CODEOWNERS-covered by the existing `/.github/` and `/packages/pipeline-cli/` rows, so **codeowners-cp stays green** (verified: `codeowners-cp check` → all 14 §CP paths covered) — no CODEOWNERS edit was required.

## Verification (local)
- `roadmap-guard check` against the live ROADMAP.md + milestones → `in sync — 4 arc row(s) + 1 campaign row(s) validated against 23 milestone(s) (I1–I4 all green)`, exit 0.
- `vitest run src/tools/roadmap-guard/` → 26 passed.
- `tsc --noEmit` → clean. `biome check` → clean. `codeowners-cp check` → green.

Disjoint §CP lane: touches only `packages/pipeline-cli/` (new guard dir + `registry.ts` registration) and `.github/workflows/roadmap-guard.yml`. Does not touch the `CONTROL_PLANE_RE` line (owned by a separate cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)