### PR TITLE
feat(web): topbar zone grammar + taxonomy classing behind nav-IA flag (#2611)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -164,6 +164,7 @@ function Layout() {
 				<AppShell>
 					<Topbar
 						brandName="kamp.us"
+						navIa={navIaOn}
 						nav={[
 							{to: "/sozluk", label: "sözlük"},
 							{to: "/pano", label: "pano"},

--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -38,7 +38,11 @@
 	display: flex;
 	gap: 2px;
 }
-.kp-topbar__nav a {
+/* The status-signal zone's divan link (#2611) reuses the destination nav-link
+   treatment for now — it left `.kp-topbar__nav` under the taxonomy reclass but its
+   affordance rework is the status/signal child's (#2613) job. Grouped, not duplicated. */
+.kp-topbar__nav a,
+.kp-topbar__signal-link {
 	padding: 4px 8px;
 	font: var(--t-body-sm);
 	font-weight: 500;
@@ -46,15 +50,27 @@
 	border-radius: var(--r-sm);
 	text-decoration: none;
 }
-.kp-topbar__nav a:hover {
+.kp-topbar__nav a:hover,
+.kp-topbar__signal-link:hover {
 	color: var(--text-primary);
 	background: var(--surface-raised);
 	text-decoration: none;
 }
-.kp-topbar__nav a[aria-current="page"] {
+.kp-topbar__nav a[aria-current="page"],
+.kp-topbar__signal-link[aria-current="page"] {
 	color: var(--accent-fg);
 	background: var(--accent);
 	font-weight: 600;
+}
+
+/* Nav-IA zone grammar (#2611, epic #2595). Each taxonomy zone (destination / utility /
+   status-signal / primary-action) is a semantic grouping with a stable class +
+   data-testid for headless targeting; `display: contents` keeps its children in the
+   topbar's flex row, so the reclass adds zones without disturbing spacing. The
+   primary-action zone stays empty/reserved in the global bar — #2600 moved the promoted
+   verb to the pano Subnav CTA. Present only under the flag; off ⇒ no zone markup. */
+.kp-topbar__zone {
+	display: contents;
 }
 
 .kp-topbar__spacer {

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Nav-IA topbar zone grammar + taxonomy classing (#2611, epic #2595). Pins the
+ * structural spine the tema/status/accent-scarcity children (#2612–#2614) build on:
+ * with the shared `phoenix-nav-ia` flag OFF the topbar is byte-identical to today; ON,
+ * every surviving element sits in its one lawful taxonomy zone (destination / utility /
+ * status-signal / primary-action, #2586/#2587), each zone stably classed + testid'd. The
+ * two states are total — never a half-migrated mix.
+ */
+import {render, screen} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {describe, expect, it} from "vitest";
+import {Topbar} from "./Topbar";
+
+const NAV = [
+	{to: "/sozluk", label: "sözlük"},
+	{to: "/pano", label: "pano"},
+];
+
+function renderTopbar(navIa: boolean) {
+	return render(
+		<MemoryRouter>
+			<Topbar
+				navIa={navIa}
+				nav={NAV}
+				divanTo="/divan"
+				karma={42}
+				user={{name: "Elif", username: "elif"}}
+			/>
+		</MemoryRouter>,
+	);
+}
+
+const ZONE_TESTIDS = [
+	"topbar-zone-destination",
+	"topbar-zone-utility",
+	"topbar-zone-status-signal",
+	"topbar-zone-primary-action",
+];
+
+// Base UI's Menu trigger mints a per-instance `id="base-ui-…"`, the only non-structural
+// difference between two renders of the same tree — normalize it so the byte-identity
+// comparison measures the topbar structure, not that unstable id.
+const stripMenuId = (html: string) => html.replace(/id="base-ui-[^"]*"/g, 'id="base-ui"');
+
+describe("Topbar nav-IA zone grammar (#2611)", () => {
+	it("flag off: renders today's structure — divan sits in the nav row, no zones exist", () => {
+		const {container} = renderTopbar(false);
+		// No taxonomy zone markup leaks into the flag-off topbar.
+		for (const id of ZONE_TESTIDS) expect(screen.queryByTestId(id)).toBeNull();
+		// divan renders back inside the destination nav (the pre-restructure placement) and
+		// carries no zone class — the same empty NavLink class the product nouns render today.
+		const divan = screen.getByTestId("topbar-divan-link");
+		expect(container.querySelector(".kp-topbar__nav")?.contains(divan)).toBe(true);
+		expect(divan.classList.contains("kp-topbar__signal-link")).toBe(false);
+	});
+
+	it("flag on: each element renders inside a zone carrying its taxonomy class", () => {
+		renderTopbar(true);
+		const destination = screen.getByTestId("topbar-zone-destination");
+		const utility = screen.getByTestId("topbar-zone-utility");
+		const statusSignal = screen.getByTestId("topbar-zone-status-signal");
+		// The zone class is present on each zone (the headless targeting contract).
+		expect(destination.classList.contains("kp-topbar__zone")).toBe(true);
+		expect(destination.classList.contains("kp-topbar__zone--destination")).toBe(true);
+		expect(utility.classList.contains("kp-topbar__zone--utility")).toBe(true);
+		expect(statusSignal.classList.contains("kp-topbar__zone--status-signal")).toBe(true);
+		// destination = product-noun nav; utility = the ambient search control;
+		// status-signal = the read-only karma + divan affordances.
+		expect(destination.contains(screen.getByRole("link", {name: "sözlük"}))).toBe(true);
+		expect(destination.contains(screen.getByRole("link", {name: "pano"}))).toBe(true);
+		expect(utility.contains(screen.getByRole("textbox", {name: "Ara"}))).toBe(true);
+		expect(statusSignal.contains(screen.getByTestId("topbar-divan-link"))).toBe(true);
+		expect(statusSignal.contains(screen.getByTestId("topbar-karma"))).toBe(true);
+	});
+
+	it("flag on: the global bar's primary-action zone is empty/reserved (no occupant)", () => {
+		renderTopbar(true);
+		const primaryAction = screen.getByTestId("topbar-zone-primary-action");
+		expect(primaryAction.classList.contains("kp-topbar__zone--primary-action")).toBe(true);
+		// #2600 relocated `+ gönderi` to the pano Subnav CTA — no product-scoped verb lands here.
+		expect(primaryAction.childElementCount).toBe(0);
+	});
+
+	it("no half-migrated state: off is byte-identical to the default, and differs from on", () => {
+		const off = renderTopbar(false);
+		const offHtml = stripMenuId(off.container.querySelector(".kp-topbar")?.outerHTML ?? "");
+		off.unmount();
+		const dflt = render(
+			<MemoryRouter>
+				<Topbar nav={NAV} divanTo="/divan" karma={42} user={{name: "Elif", username: "elif"}} />
+			</MemoryRouter>,
+		);
+		// Omitting `navIa` is the same as passing false — the safe, unchanged default.
+		expect(stripMenuId(dflt.container.querySelector(".kp-topbar")?.outerHTML ?? "")).toBe(offHtml);
+		dflt.unmount();
+		const on = renderTopbar(true);
+		expect(stripMenuId(on.container.querySelector(".kp-topbar")?.outerHTML ?? "")).not.toBe(
+			offHtml,
+		);
+	});
+});

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -23,6 +23,7 @@ export function Topbar({
 	onSearchSubmit,
 	onToggleTheme,
 	onLogout,
+	navIa = false,
 }: {
 	brandName?: string;
 	brandTo?: string;
@@ -61,6 +62,18 @@ export function Topbar({
 	onSearchSubmit?: (query: string) => void;
 	onToggleTheme?: () => void;
 	onLogout?: () => void;
+	/**
+	 * The nav-IA restructure seam (#2611, epic #2595) — the shared default-off
+	 * `phoenix-nav-ia` flag #2600 rides. Off (the default) ⇒ the topbar renders its
+	 * pre-restructure shape, byte-identical to today. On ⇒ every surviving element is
+	 * classed by the #2586 taxonomy (destination / utility / status-signal /
+	 * primary-action) and rendered inside its one lawful zone (the #2587 Model-2 zone
+	 * grammar). The two states are total — the flag either fully reclasses or leaves the
+	 * topbar untouched, never a half-migrated mix. This child establishes the zones +
+	 * classes + flag substrate the tema/status/accent-scarcity children (#2612–#2614)
+	 * build on; it does no status-affordance rework of its own.
+	 */
+	navIa?: boolean;
 }) {
 	const navigate = useNavigate();
 	const searchInputRef = useRef<HTMLInputElement>(null);
@@ -81,103 +94,173 @@ export function Topbar({
 	const before = dotAt >= 0 ? brandName.slice(0, dotAt) : brandName;
 	const after = dotAt >= 0 ? brandName.slice(dotAt + 1) : "";
 
+	// The topbar's leaf elements, built once and arranged by the flag branch below. The
+	// off/on renders share these exact nodes, so `navIa` decides only *which zone* each
+	// sits in — never a second, drifting copy of the search form or user menu.
+	const brand = (
+		<Link className="kp-topbar__brand" to={brandTo}>
+			{before}
+			{dotAt >= 0 ? <span className="dot">.</span> : null}
+			{after}
+		</Link>
+	);
+	// NavLink sets aria-current="page" on the active link by default.
+	const destinationLinks = nav.map((n) => (
+		<NavLink key={n.to} to={n.to}>
+			{n.label}
+		</NavLink>
+	));
+	// Under the zone grammar divan leaves `.kp-topbar__nav`, so it carries
+	// `kp-topbar__signal-link` to keep the nav-link treatment (grouped in the CSS). Off,
+	// it stays inside the nav and needs no class — omitting it keeps the flag-off DOM
+	// byte-identical to today (`undefined` renders no `class` attribute).
+	const divanLink = divanTo ? (
+		<NavLink
+			key={divanTo}
+			to={divanTo}
+			data-testid="topbar-divan-link"
+			className={navIa ? "kp-topbar__signal-link" : undefined}
+		>
+			divan
+		</NavLink>
+	) : null;
+	const searchForm = (
+		<form
+			className="kp-topbar__search"
+			onSubmit={(e) => {
+				e.preventDefault();
+				const input = e.currentTarget.elements.namedItem("q") as HTMLInputElement | null;
+				onSearchSubmit?.(input?.value ?? "");
+			}}
+		>
+			<svg
+				width="11"
+				height="11"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2.4"
+				aria-hidden="true"
+			>
+				<circle cx="11" cy="11" r="7" />
+				<path d="m20 20-3.5-3.5" />
+			</svg>
+			{/* key + defaultValue: uncontrolled so it stays editable, yet a query→query
+			    navigation re-seeds the echoed value by remounting with the new default. */}
+			<input
+				key={searchQuery}
+				ref={searchInputRef}
+				name="q"
+				defaultValue={searchQuery}
+				placeholder="ara…"
+				aria-label="Ara"
+			/>
+			<kbd>⌘K</kbd>
+		</form>
+	);
+	const themeButton = onToggleTheme ? (
+		<button type="button" className="kp-topbar__btn" onClick={onToggleTheme}>
+			tema
+		</button>
+	) : null;
+	const karmaChip =
+		typeof karma === "number" ? (
+			<Karma value={karma} variant="inline" testId="topbar-karma" className="kp-topbar__karma" />
+		) : null;
+	const userMenu = user ? (
+		<Menu.Root>
+			<Menu.Trigger className="kp-topbar__user">
+				<Avatar name={user.name} src={user.src} />
+				<span>{user.name}</span>
+				{bildirim && showUnreadBadge(bildirim.unread) ? (
+					<span
+						className="kp-topbar__bildirim-badge"
+						data-testid="topbar-bildirim-badge"
+						role="status"
+						aria-label={`${bildirim.unread} okunmamış bildirim`}
+					>
+						{formatUnreadBadge(bildirim.unread)}
+					</span>
+				) : null}
+			</Menu.Trigger>
+			<Menu.Popup align="end">
+				<Menu.Item
+					data-testid="topbar-profile-link"
+					onClick={() => navigate(user.username ? `/u/${user.username}` : "/profile")}
+				>
+					profil
+				</Menu.Item>
+				{bildirim ? (
+					<Menu.Item data-testid="topbar-bildirim-link" onClick={() => navigate(bildirim.to)}>
+						bildirimler
+					</Menu.Item>
+				) : null}
+				<Menu.Item onClick={() => navigate("/profile")}>ayarlar</Menu.Item>
+				<Menu.Separator />
+				<Menu.Item onClick={onLogout}>çıkış</Menu.Item>
+			</Menu.Popup>
+		</Menu.Root>
+	) : null;
+
+	// Nav-IA zone grammar (#2611): every element is classed by the #2586 taxonomy and
+	// placed in its one lawful zone (#2587 Model-2). Zones carry a stable class +
+	// data-testid so the structure is headlessly targetable; brand + account (actions /
+	// user menu) are the structural spine, not a taxonomy class. The primary-action zone
+	// is empty/reserved — #2600 relocated the promoted `+ gönderi` verb to the pano
+	// Subnav CTA, so no product-scoped occupant lives in the global bar (it does not
+	// re-add one). divan/karma move into the status-signal zone here; their affordance
+	// rework is the status/signal child's (#2613) job, not this spine's.
+	if (navIa) {
+		return (
+			<header className="kp-topbar">
+				{brand}
+				<span className="kp-topbar__sep" />
+				<div
+					className="kp-topbar__zone kp-topbar__zone--destination"
+					data-testid="topbar-zone-destination"
+				>
+					<nav className="kp-topbar__nav">{destinationLinks}</nav>
+				</div>
+				<span
+					className="kp-topbar__zone kp-topbar__zone--primary-action"
+					data-testid="topbar-zone-primary-action"
+					aria-hidden="true"
+				/>
+				<span className="kp-topbar__spacer" />
+				<div className="kp-topbar__zone kp-topbar__zone--utility" data-testid="topbar-zone-utility">
+					{searchForm}
+					{themeButton}
+				</div>
+				<div
+					className="kp-topbar__zone kp-topbar__zone--status-signal"
+					data-testid="topbar-zone-status-signal"
+				>
+					{divanLink}
+					{karmaChip}
+				</div>
+				{actions}
+				{userMenu}
+			</header>
+		);
+	}
+
+	// Flag off — the pre-restructure topbar, byte-identical to today. divan renders back
+	// inside the destination nav (its `kp-topbar__signal-link` class only takes effect
+	// under the zone grammar, where the nav-link treatment is grouped onto it).
 	return (
 		<header className="kp-topbar">
-			<Link className="kp-topbar__brand" to={brandTo}>
-				{before}
-				{dotAt >= 0 ? <span className="dot">.</span> : null}
-				{after}
-			</Link>
+			{brand}
 			<span className="kp-topbar__sep" />
-			{/* NavLink sets aria-current="page" on the active link by default */}
 			<nav className="kp-topbar__nav">
-				{nav.map((n) => (
-					<NavLink key={n.to} to={n.to}>
-						{n.label}
-					</NavLink>
-				))}
-				{divanTo ? (
-					<NavLink key={divanTo} to={divanTo} data-testid="topbar-divan-link">
-						divan
-					</NavLink>
-				) : null}
+				{destinationLinks}
+				{divanLink}
 			</nav>
 			<span className="kp-topbar__spacer" />
-			<form
-				className="kp-topbar__search"
-				onSubmit={(e) => {
-					e.preventDefault();
-					const input = e.currentTarget.elements.namedItem("q") as HTMLInputElement | null;
-					onSearchSubmit?.(input?.value ?? "");
-				}}
-			>
-				<svg
-					width="11"
-					height="11"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					strokeWidth="2.4"
-					aria-hidden="true"
-				>
-					<circle cx="11" cy="11" r="7" />
-					<path d="m20 20-3.5-3.5" />
-				</svg>
-				{/* key + defaultValue: uncontrolled so it stays editable, yet a query→query
-				    navigation re-seeds the echoed value by remounting with the new default. */}
-				<input
-					key={searchQuery}
-					ref={searchInputRef}
-					name="q"
-					defaultValue={searchQuery}
-					placeholder="ara…"
-					aria-label="Ara"
-				/>
-				<kbd>⌘K</kbd>
-			</form>
-			{onToggleTheme ? (
-				<button type="button" className="kp-topbar__btn" onClick={onToggleTheme}>
-					tema
-				</button>
-			) : null}
+			{searchForm}
+			{themeButton}
 			{actions}
-			{typeof karma === "number" ? (
-				<Karma value={karma} variant="inline" testId="topbar-karma" className="kp-topbar__karma" />
-			) : null}
-			{user ? (
-				<Menu.Root>
-					<Menu.Trigger className="kp-topbar__user">
-						<Avatar name={user.name} src={user.src} />
-						<span>{user.name}</span>
-						{bildirim && showUnreadBadge(bildirim.unread) ? (
-							<span
-								className="kp-topbar__bildirim-badge"
-								data-testid="topbar-bildirim-badge"
-								role="status"
-								aria-label={`${bildirim.unread} okunmamış bildirim`}
-							>
-								{formatUnreadBadge(bildirim.unread)}
-							</span>
-						) : null}
-					</Menu.Trigger>
-					<Menu.Popup align="end">
-						<Menu.Item
-							data-testid="topbar-profile-link"
-							onClick={() => navigate(user.username ? `/u/${user.username}` : "/profile")}
-						>
-							profil
-						</Menu.Item>
-						{bildirim ? (
-							<Menu.Item data-testid="topbar-bildirim-link" onClick={() => navigate(bildirim.to)}>
-								bildirimler
-							</Menu.Item>
-						) : null}
-						<Menu.Item onClick={() => navigate("/profile")}>ayarlar</Menu.Item>
-						<Menu.Separator />
-						<Menu.Item onClick={onLogout}>çıkış</Menu.Item>
-					</Menu.Popup>
-				</Menu.Root>
-			) : null}
+			{karmaChip}
+			{userMenu}
 		</header>
 	);
 }


### PR DESCRIPTION
Fixes #2611

## What

Establishes the Topbar's **structural spine** — the ratified element taxonomy (#2586) + Model-2 two-tier zone grammar (#2587) — behind the shared default-off **`phoenix-nav-ia`** seam (the same flag #2600 rides), so the topbar reclass and the Subnav CTA landing flip together as one atomic nav-commit. This is the substrate the theme-picker (#2612), status-zone (#2613), and accent-scarcity (#2614) children build on; it does no status-affordance rework of its own.

With the flag **on**, every surviving topbar element is assigned exactly one taxonomy class and rendered inside its one lawful zone, each zone carrying a stable class + `data-testid` for headless targeting:

- **destination** (`topbar-zone-destination`) — the product-noun nav (sözlük / pano / mecmua / akış)
- **utility** (`topbar-zone-utility`) — the ambient search control (+ the tema toggle, untouched — its kill is the tema child's job)
- **status-signal** (`topbar-zone-status-signal`) — the read-only karma + divan affordances
- **primary-action** (`topbar-zone-primary-action`) — **empty/reserved**: #2600 relocated the promoted `+ gönderi` verb to the pano Subnav CTA, so no product-scoped occupant lives in the global bar (it does not re-add one)

Brand + account (giriş-yap / user menu) are the structural bookends, not a taxonomy class. Zones use `display: contents`, so the reclass adds semantic/testable groupings without disturbing the topbar's flex spacing.

## Flag off = byte-identical

The whole restructure is gated on `phoenix-nav-ia` (wired through `App.tsx`'s topbar region via a new `navIa` prop). With the flag off the topbar renders exactly as today — the off/default renders share the same leaf nodes, so `navIa` decides only *which zone* each sits in, never a second drifting copy. No half-migrated state is reachable at runtime: either the pre-restructure topbar (off) or the fully reclassed topbar (on), never a mix. Verified by test.

## Tests / checks (local)

- `apps/web/src/components/layout/Topbar.test.tsx` — 4 new component tests: flag-off legacy structure (divan back in the nav, no zones), flag-on per-zone taxonomy classing, empty/reserved primary-action zone, and the byte-identical-off / total-flip pin.
- Full client suite: 188 passed. Typecheck: clean. `design-token-guard check`: green (zone CSS uses `--s-N` tokens only — no new raw px, Topbar.css stays at its ceiling of 14). biome + leak-guard + ref-guard: green.

## Scope

Touches only `apps/web/src/App.tsx`'s topbar region + the Topbar component/CSS/test. No pipeline-cli, product Subnav zones, or §CP skills touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)