### PR TITLE
fix(web): strip resting accent-faint fill from Subnav crumb slot (#2599)

### DIFF
--- a/apps/web/src/components/layout/Subnav.css
+++ b/apps/web/src/components/layout/Subnav.css
@@ -111,13 +111,13 @@
 	color: var(--text-faint);
 }
 
+/* The crumb slot folds pano's active site-filter in as TRANSIENT state paint (only
+   rendered while a filter is applied) — so it carries no resting fill/pill (the
+   containment law forbids resting chrome; inventory #2585). Plain inline text + the
+   `× filtreyi kaldır` clear; the accent-faint pill was the dead resting-chrome path. */
 .kp-subnav__crumb {
 	display: inline-flex;
 	align-items: center;
-	gap: 4px;
-	padding: 2px var(--s-2);
-	background: var(--accent-faint);
-	border-radius: var(--r-sm);
 	color: var(--text-primary);
 	font: var(--t-meta);
 }


### PR DESCRIPTION
Fixes #2599.

## What

Strip the resting `background: var(--accent-faint)` fill (and its pill geometry) from the `Subnav` component's `.kp-subnav__crumb` slot, so the shared component carries **no resting chrome** on the crumb path — the containment-law conformance the issue names (inventory #2585).

## Why option 2, not delete

The issue offered two paths: delete the unused `crumb` prop (preferred *if* dead), or — if the crumb is retained for the pano-delta child — strip the resting fill to transient-only paint. The pano-delta child has since landed: `apps/web/src/components/pano/PanoSubnavLayout.tsx` publishes pano's active site-filter into the Subnav crumb slot (`crumb={content?.crumb}`), and `PanoSubnavLayout.test.tsx` asserts that transient crumb is the intended home (with **no** resting `.kp-pano-crumb` strip). So `crumb` is a **live consumer path**, not dead code — deleting it would break pano. This PR takes the retained path: keep the prop/markup, remove only the resting fill.

The crumb renders **only while a site-filter is applied**, so the remaining treatment is transient state paint (plain inline text + the `× filtreyi kaldır` clear), never resting chrome.

## Scope

- `apps/web/src/components/layout/Subnav.css` — `.kp-subnav__crumb`: drop `background: var(--accent-faint)`, `border-radius`, and the pill `padding`; keep the layout/color/font.

No `Subnav.tsx` change (prop + markup stay for the live pano consumer). Off-limits lanes untouched (Topbar.tsx / App.tsx). No behavior change for any live consumer — the crumb element still renders; only its resting paint is removed.

## Checks (local)

- `pnpm typecheck` — pass (28/28)
- `pnpm lint` (biome) — pass
- `design-token-guard check` — pass (no raw-px regression; removing the 4px gap only reduces the count)
- `vitest` — `Subnav.test.tsx` (2/2) and `PanoSubnavLayout.test.tsx` (6/6, incl. the transient-crumb / no-resting-strip assertion) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)