### PR TITLE
feat(pasaport): email-delivery event log + failing-address projection + send-time capture (#2691)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0028_email_delivery_event.sql
+++ b/apps/web/worker/db/drizzle/migrations/0028_email_delivery_event.sql
@@ -1,0 +1,21 @@
+-- #2691 (epic #2687) — the append-only transactional-email delivery-failure log. The
+-- SINGLE source of both the audit trail and the current per-address failing-state: state
+-- is a projection of the latest row (see `features/pasaport/email-delivery.ts`), so it can
+-- never drift from history. Keyed by `address` (always known from the send) with a nullable
+-- `user_id` FK when the address resolves to an account; `ON DELETE set null` keeps the
+-- delivery history when the account is deleted. Fed today by the synchronous send-time
+-- `SendEmailError` (Child #2691); the admin mark/clear (#2692) and CF async ingestion
+-- (#2694) append to the same log.
+
+CREATE TABLE `email_delivery_event` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text,
+	`address` text NOT NULL,
+	`action` text NOT NULL,
+	`reason` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `email_delivery_event_address_created` ON `email_delivery_event` (`address`,"created_at" DESC);--> statement-breakpoint
+CREATE INDEX `email_delivery_event_user_created` ON `email_delivery_event` (`user_id`,"created_at" DESC);

--- a/apps/web/worker/db/drizzle/migrations/meta/0028_email_delivery_event_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0028_email_delivery_event_snapshot.json
@@ -1,0 +1,2370 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f0c8bdbd-d18f-4390-8016-1b3ab86a9ced",
+  "prevId": "0ccad404-33ee-4d93-ae7b-2abfd6a2601d",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        },
+        "post_record_sandboxed": {
+          "name": "post_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'çaylak'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wave_id": {
+          "name": "wave_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "content_report_wave": {
+          "name": "content_report_wave",
+          "columns": [
+            "wave_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        },
+        "definition_record_sandboxed": {
+          "name": "definition_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_sandboxed": {
+          "name": "comment_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authorship_vouch": {
+      "name": "authorship_vouch",
+      "columns": {
+        "voucher_id": {
+          "name": "voucher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authorship_vouch_candidate": {
+          "name": "authorship_vouch_candidate",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "authorship_vouch_voucher_id_candidate_id_pk": {
+          "name": "authorship_vouch_voucher_id_candidate_id_pk",
+          "columns": [
+            "voucher_id",
+            "candidate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_recipient_read": {
+          "name": "notification_recipient_read",
+          "columns": [
+            "recipient_id",
+            "read_at"
+          ],
+          "isUnique": false
+        },
+        "notification_recipient_created": {
+          "name": "notification_recipient_created",
+          "columns": [
+            "recipient_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_reaction": {
+      "name": "user_reaction",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_reaction_target": {
+          "name": "user_reaction_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_reaction_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_reaction_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_ban_event": {
+      "name": "user_ban_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_ban_event_user_created": {
+          "name": "user_ban_event_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_ban_event_user_id_user_id_fk": {
+          "name": "user_ban_event_user_id_user_id_fk",
+          "tableFrom": "user_ban_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mecmua_post": {
+      "name": "mecmua_post",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mecmua_post_author_created": {
+          "name": "mecmua_post_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mecmua_subscription": {
+      "name": "mecmua_subscription",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mecmua_subscription_subscriber": {
+          "name": "mecmua_subscription_subscriber",
+          "columns": [
+            "subscriber_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "mecmua_subscription_subscriber_id_author_id_pk": {
+          "columns": [
+            "subscriber_id",
+            "author_id"
+          ],
+          "name": "mecmua_subscription_subscriber_id_author_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "karma_event": {
+      "name": "karma_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "karma_event_user_created": {
+          "name": "karma_event_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "karma_event_user_id_user_id_fk": {
+          "name": "karma_event_user_id_user_id_fk",
+          "tableFrom": "karma_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_delivery_event": {
+      "name": "email_delivery_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_delivery_event_address_created": {
+          "name": "email_delivery_event_address_created",
+          "columns": [
+            "address",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "email_delivery_event_user_created": {
+          "name": "email_delivery_event_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "email_delivery_event_user_id_user_id_fk": {
+          "name": "email_delivery_event_user_id_user_id_fk",
+          "tableFrom": "email_delivery_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "user_ban_event_user_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "mecmua_post_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "mecmua_subscription_subscriber": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -1,202 +1,209 @@
 {
-  "version": "7",
-  "dialect": "sqlite",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "6",
-      "when": 1779059966153,
-      "tag": "0000_d1_baseline",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "6",
-      "when": 1781469752872,
-      "tag": "0001_content_report",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "6",
-      "when": 1782000000000,
-      "tag": "0002_search_fts",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "6",
-      "when": 1782500000000,
-      "tag": "0003_post_bookmark",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "6",
-      "when": 1783000000000,
-      "tag": "0004_pano_draft",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "6",
-      "when": 1783500000000,
-      "tag": "0005_removal_substrate",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "6",
-      "when": 1784000000000,
-      "tag": "0006_account_deletion_tombstone_silinen",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "6",
-      "when": 1784500000000,
-      "tag": "0007_moderation_role_resolution",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "6",
-      "when": 1785000000000,
-      "tag": "0008_rename_store_of_record",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "6",
-      "when": 1785500000000,
-      "tag": "0009_summary_to_record",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "6",
-      "when": 1786000000000,
-      "tag": "0010_relation_tuple",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "6",
-      "when": 1786500000000,
-      "tag": "0011_authorship_tier",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "6",
-      "when": 1787000000000,
-      "tag": "0012_caylak_sandbox",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "6",
-      "when": 1787500000000,
-      "tag": "0013_authorship_vouch",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "6",
-      "when": 1788000000000,
-      "tag": "0014_imge_object",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "6",
-      "when": 1788500000000,
-      "tag": "0015_drop_last_event_id",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "6",
-      "when": 1790000000000,
-      "tag": "0016_yazar_promoted_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "6",
-      "when": 1790500000000,
-      "tag": "0017_notification",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "6",
-      "when": 1791000000000,
-      "tag": "0018_reaction",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "6",
-      "when": 1791500000000,
-      "tag": "0019_remove_the_wave",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "6",
-      "when": 1792000000000,
-      "tag": "0020_drop_imge_object",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "6",
-      "when": 1792500000000,
-      "tag": "0021_hot_score_backfill",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "6",
-      "when": 1793000000000,
-      "tag": "0022_display_name_backfill",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "6",
-      "when": 1793500000000,
-      "tag": "0023_drop_hot_score_backfill",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "6",
-      "when": 1794000000000,
-      "tag": "0024_user_ban_event",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "6",
-      "when": 1794500000000,
-      "tag": "0025_mecmua_post",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "6",
-      "when": 1795000000000,
-      "tag": "0026_mecmua_subscription",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "6",
-      "when": 1795500000000,
-      "tag": "0027_karma_event",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1779059966153,
+			"tag": "0000_d1_baseline",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1781469752872,
+			"tag": "0001_content_report",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "6",
+			"when": 1782000000000,
+			"tag": "0002_search_fts",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1782500000000,
+			"tag": "0003_post_bookmark",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1783000000000,
+			"tag": "0004_pano_draft",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1783500000000,
+			"tag": "0005_removal_substrate",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "6",
+			"when": 1784000000000,
+			"tag": "0006_account_deletion_tombstone_silinen",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "6",
+			"when": 1784500000000,
+			"tag": "0007_moderation_role_resolution",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "6",
+			"when": 1785000000000,
+			"tag": "0008_rename_store_of_record",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "6",
+			"when": 1785500000000,
+			"tag": "0009_summary_to_record",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "6",
+			"when": 1786000000000,
+			"tag": "0010_relation_tuple",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "6",
+			"when": 1786500000000,
+			"tag": "0011_authorship_tier",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "6",
+			"when": 1787000000000,
+			"tag": "0012_caylak_sandbox",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "6",
+			"when": 1787500000000,
+			"tag": "0013_authorship_vouch",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "6",
+			"when": 1788000000000,
+			"tag": "0014_imge_object",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "6",
+			"when": 1788500000000,
+			"tag": "0015_drop_last_event_id",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "6",
+			"when": 1790000000000,
+			"tag": "0016_yazar_promoted_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "6",
+			"when": 1790500000000,
+			"tag": "0017_notification",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "6",
+			"when": 1791000000000,
+			"tag": "0018_reaction",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "6",
+			"when": 1791500000000,
+			"tag": "0019_remove_the_wave",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "6",
+			"when": 1792000000000,
+			"tag": "0020_drop_imge_object",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "6",
+			"when": 1792500000000,
+			"tag": "0021_hot_score_backfill",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "6",
+			"when": 1793000000000,
+			"tag": "0022_display_name_backfill",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "6",
+			"when": 1793500000000,
+			"tag": "0023_drop_hot_score_backfill",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "6",
+			"when": 1794000000000,
+			"tag": "0024_user_ban_event",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "6",
+			"when": 1794500000000,
+			"tag": "0025_mecmua_post",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "6",
+			"when": 1795000000000,
+			"tag": "0026_mecmua_subscription",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "6",
+			"when": 1795500000000,
+			"tag": "0027_karma_event",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "6",
+			"when": 1796000000000,
+			"tag": "0028_email_delivery_event",
+			"breakpoints": true
+		}
+	]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -187,6 +187,40 @@ export const userBanEvent = sqliteTable(
 );
 
 /**
+ * Append-only transactional-email delivery-failure log — the SINGLE source of both
+ * the audit trail and the current per-address failing-state (email-bounce epic #2687).
+ * Failing-state is a projection of the latest event for an address (see
+ * `features/pasaport/email-delivery.ts` `resolveEmailDeliveryState`), mirroring
+ * {@link userBanEvent}: latest-event-wins, so a stale "bouncing flag" is
+ * unrepresentable. Every feed appends here — the send-time capture (Child #2691), the
+ * admin mark/clear (Child #2692), and the CF async ingestion (Child #2694).
+ *
+ * The recipient is keyed by `address` (always known from the send), with `userId` a
+ * nullable FK when the address resolves to an account — a send can target an address
+ * with no `user` row. `onDelete: set null` keeps the delivery history when the account
+ * is deleted (the address remains the stable key).
+ */
+export const emailDeliveryEvent = sqliteTable(
+	"email_delivery_event",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id").references(() => user.id, {onDelete: "set null"}),
+		address: text("address").notNull(),
+		// A `fail` opens/refreshes a failing-state, a `clear` lifts it. The projection
+		// reads only the latest row, so a `clear` after a `fail` restores deliverability
+		// without mutating or deleting the fail row — full reversibility, as in ban.
+		action: text("action", {enum: ["fail", "clear"]}).notNull(),
+		// The failure detail (a `SendEmailError` message, or an admin note); null for a `clear`.
+		reason: text("reason"),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(t) => [
+		index("email_delivery_event_address_created").on(t.address, sql`${t.createdAt} DESC`),
+		index("email_delivery_event_user_created").on(t.userId, sql`${t.createdAt} DESC`),
+	],
+);
+
+/**
  * Per-(definition, voter) up-vote presence row. `user_vote` and
  * `definition_record.score` (COUNT(*) under `WHERE definition_id = ?`) are both
  * denormalized off this, recomputed inline in the same D1 batch as the vote write.

--- a/apps/web/worker/features/pasaport/email-delivery-log.ts
+++ b/apps/web/worker/features/pasaport/email-delivery-log.ts
@@ -1,0 +1,69 @@
+/**
+ * `EmailDeliveryLog` — the append-only write port over `email_delivery_event` (epic
+ * #2687). It is the seam the send adapter (`email-sender.ts`) records a send-time
+ * rejection through, kept separate from `EmailSender` so the adapter depends on a
+ * fakeable port, not on `Drizzle` directly.
+ *
+ * `recordSendFailure` is fail-soft by contract — its error channel is `never`. The send
+ * path it feeds must never throw into better-auth's email callbacks (an email can't fail
+ * the auth flow, `email-sender.ts`), so the audit append is best-effort: a D1 failure is
+ * logged and swallowed inside the layer rather than surfaced. See `email-delivery.ts` for
+ * the projection this log feeds and the honest limit of the send-time signal.
+ */
+import {eq} from "drizzle-orm";
+import {Context, Effect, Layer} from "effect";
+import {Drizzle} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+
+export class EmailDeliveryLog extends Context.Service<
+	EmailDeliveryLog,
+	{
+		/**
+		 * Append a `fail` event for a synchronous send-time rejection. Resolves the
+		 * recipient's `userId` from the address when a `user` row exists (else records the
+		 * event by address alone). Fail-soft — `E = never`.
+		 */
+		readonly recordSendFailure: (input: {
+			readonly address: string;
+			readonly reason: string;
+		}) => Effect.Effect<void>;
+	}
+>()("@kampus/pasaport/EmailDeliveryLog") {}
+
+/**
+ * The Drizzle-backed adapter. The `userId` lookup and the insert both run against D1; a
+ * `DrizzleError` from either is swallowed (`Effect.ignore`) so the public method stays
+ * `E = never` — the append is audit, never load-bearing on the send.
+ */
+export const EmailDeliveryLogLive: Layer.Layer<EmailDeliveryLog, never, Drizzle> = Layer.effect(
+	EmailDeliveryLog,
+	Effect.gen(function* () {
+		const {run} = yield* Drizzle;
+		return EmailDeliveryLog.of({
+			recordSendFailure: ({address, reason}) =>
+				run((db) =>
+					db
+						.select({id: schema.user.id})
+						.from(schema.user)
+						.where(eq(schema.user.email, address))
+						.limit(1)
+						.then((rows) => rows[0]?.id ?? null),
+				).pipe(
+					Effect.flatMap((userId) =>
+						run((db) =>
+							db.insert(schema.emailDeliveryEvent).values({
+								id: crypto.randomUUID(),
+								userId,
+								address,
+								action: "fail",
+								reason,
+								createdAt: new Date(),
+							}),
+						),
+					),
+					Effect.asVoid,
+					Effect.ignore({log: "Warn"}),
+				),
+		});
+	}),
+);

--- a/apps/web/worker/features/pasaport/email-delivery.ts
+++ b/apps/web/worker/features/pasaport/email-delivery.ts
@@ -1,0 +1,50 @@
+/**
+ * Failing-address delivery-state domain (email-bounce epic #2687). Pure logic, no I/O:
+ * the current per-address delivery-state is a PROJECTION of the append-only
+ * `email_delivery_event` log — the latest event decides, so state can never drift from
+ * history and a stale "bouncing flag" is unrepresentable. This mirrors `resolveBanState`
+ * (`ban.ts`, ADR 0107) verbatim: a projection over an append-only log.
+ *
+ * Today's only feed is the send-time capture (Child #2691); the honest limit of that
+ * signal is stated where it is captured (`email-sender.ts`). The admin mark/clear (Child
+ * #2692) and the CF async ingestion (Child #2694) append to the same log.
+ */
+
+/** The two event kinds appended to the log: a `fail` opens a failing-state, a `clear` lifts it. */
+export type EmailDeliveryEventAction = "fail" | "clear";
+
+/** One row of the append-only delivery log, as the projection needs it. */
+export interface EmailDeliveryEvent {
+	readonly action: EmailDeliveryEventAction;
+	readonly reason: string | null;
+	readonly createdAt: Date;
+}
+
+/** The projected current delivery-state for one address. */
+export interface EmailDeliveryState {
+	readonly failing: boolean;
+	/** The active failure's reason, or null when deliverable. */
+	readonly reason: string | null;
+}
+
+/** The deliverable state — an address with no events, or one whose latest event is a `clear`. */
+export const DELIVERABLE: EmailDeliveryState = {failing: false, reason: null};
+
+/**
+ * Project the current delivery-state from the address's LATEST event.
+ *
+ * The caller passes the single newest event (by `createdAt`) or null when the log is
+ * empty. Failing iff that latest event is a `fail` — so a `clear` after a `fail` restores
+ * deliverability without touching the fail row (full reversibility, as in `resolveBanState`).
+ * `now` is carried for signature parity with `resolveBanState` and to leave room for a
+ * future time-decayed failing-state (Child #2694); today's send-rejection signal has no
+ * expiry, so it is not read.
+ */
+export const resolveEmailDeliveryState = (
+	latest: EmailDeliveryEvent | null,
+	now: Date,
+): EmailDeliveryState => {
+	void now;
+	if (latest === null || latest.action === "clear") return DELIVERABLE;
+	return {failing: true, reason: latest.reason};
+};

--- a/apps/web/worker/features/pasaport/email-delivery.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-delivery.unit.test.ts
@@ -1,0 +1,42 @@
+/**
+ * `resolveEmailDeliveryState` — the pure failing-address projection (epic #2687). Latest
+ * event wins, exactly like `resolveBanState`: no events → deliverable, a `fail` →
+ * failing, a `fail` then a `clear` → deliverable again. No I/O, driven directly over
+ * hand-built latest events.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {DELIVERABLE, type EmailDeliveryEvent, resolveEmailDeliveryState} from "./email-delivery.ts";
+
+const NOW = new Date("2026-01-01T00:00:00Z");
+
+const event = (
+	action: EmailDeliveryEvent["action"],
+	reason: string | null,
+	createdAt: Date,
+): EmailDeliveryEvent => ({action, reason, createdAt});
+
+describe("resolveEmailDeliveryState", () => {
+	it("no events → deliverable", () => {
+		assert.deepStrictEqual(resolveEmailDeliveryState(null, NOW), DELIVERABLE);
+	});
+
+	it("latest fail → failing, carrying the reason", () => {
+		const latest = event("fail", "550 mailbox unavailable", new Date("2025-12-31T12:00:00Z"));
+		assert.deepStrictEqual(resolveEmailDeliveryState(latest, NOW), {
+			failing: true,
+			reason: "550 mailbox unavailable",
+		});
+	});
+
+	it("fail then clear → deliverable (a clear lifts a fail, latest-event-wins)", () => {
+		// The projection only ever sees the single newest event; a `clear` newer than the
+		// `fail` is what the caller passes, and it projects to deliverable.
+		const latest = event("clear", null, new Date("2026-01-01T06:00:00Z"));
+		assert.deepStrictEqual(resolveEmailDeliveryState(latest, NOW), DELIVERABLE);
+	});
+
+	it("a failing state carries a null reason through when the fail had none", () => {
+		const latest = event("fail", null, new Date("2025-12-31T12:00:00Z"));
+		assert.deepStrictEqual(resolveEmailDeliveryState(latest, NOW), {failing: true, reason: null});
+	});
+});

--- a/apps/web/worker/features/pasaport/email-sender.ts
+++ b/apps/web/worker/features/pasaport/email-sender.ts
@@ -28,6 +28,7 @@ import {Email} from "alchemy/Cloudflare";
 import {Context, Effect, Layer} from "effect";
 import {environment} from "../../config.ts";
 import {type Environment, isProduction} from "../../environment.ts";
+import {EmailDeliveryLog} from "./email-delivery-log.ts";
 
 /**
  * A transactional message. Invalid states are unrepresentable: `to` + `subject`
@@ -80,14 +81,20 @@ export const EmailSenderBinding = Email.SendEmail("EmailSender", {
 /**
  * Production adapter — delivers via the Cloudflare Email Service `send_email`
  * binding (alchemy `Cloudflare.SendEmail`, runtime `.send(...)`). The binding's
- * `send` already wraps any failure in a typed `SendEmailError`; this adapter
- * swallows it (`Effect.ignore({log: "Warn"})`) so the callback never throws and
- * the public method's `E = never`.
+ * `send` already wraps any failure in a typed `SendEmailError`; on that rejection
+ * the adapter appends a `fail` event to the delivery log (`EmailDeliveryLog`) and
+ * swallows the error so the callback never throws and the public method's `E = never`.
  *
- * The binding's `.send` carries `R = RuntimeContext`; it's resolved once at
- * layer build (ambient at worker scope, stable for the isolate) and baked into
- * the closure, so the public `send` is `Effect<void, never, never>` — runnable
- * standalone from better-auth's async callbacks without re-threading context.
+ * The captured signal's honest limit (epic #2687, Child #2691): a synchronous
+ * `SendEmailError` is a send REJECTION caught at send time — NOT an asynchronous hard
+ * bounce or spam complaint, which arrive after the SMTP handshake and need the CF
+ * delivery-event surface (Child #2694, CF-gated). That buildable-today vs CF-gated
+ * fault line is what the epic splits on; this adapter only records the synchronous half.
+ *
+ * The binding's `.send` carries `R = RuntimeContext`; it and `EmailDeliveryLog` are
+ * resolved once at layer build (ambient/stable for the isolate) and baked into the
+ * closure, so the public `send` is `Effect<void, never, never>` — runnable standalone
+ * from better-auth's async callbacks without re-threading context.
  */
 export const EmailSenderCloudflareLive = Layer.effect(
 	EmailSender,
@@ -95,6 +102,7 @@ export const EmailSenderCloudflareLive = Layer.effect(
 		const descriptor = yield* EmailSenderBinding;
 		const email = yield* Email.Send(descriptor);
 		const runtimeContext = yield* RuntimeContext;
+		const deliveryLog = yield* EmailDeliveryLog;
 		return EmailSender.of({
 			send: (message) =>
 				email
@@ -107,7 +115,9 @@ export const EmailSenderCloudflareLive = Layer.effect(
 					.pipe(
 						Effect.provideService(RuntimeContext, runtimeContext),
 						Effect.asVoid,
-						Effect.ignore({log: "Warn"}),
+						Effect.catch((error) =>
+							deliveryLog.recordSendFailure({address: message.to, reason: error.message}),
+						),
 					),
 		});
 	}),
@@ -121,19 +131,22 @@ export const EmailSenderCloudflareLive = Layer.effect(
  */
 export const emailSenderLayerFor = (
 	env: Environment,
-): Layer.Layer<EmailSender, never, RuntimeContext | Email.Send> =>
+): Layer.Layer<EmailSender, never, RuntimeContext | Email.Send | EmailDeliveryLog> =>
 	isProduction(env) ? EmailSenderCloudflareLive : EmailSenderLog;
 
 /**
  * The resolved-from-Config layer used at the worker entry. Reads `ENVIRONMENT`
  * (fail-closed default `production`, ADR 0088) and defers to `emailSenderLayerFor`.
  */
-export const EmailSenderLive: Layer.Layer<EmailSender, never, RuntimeContext | Email.Send> =
-	Layer.unwrap(
-		Effect.gen(function* () {
-			// `orDie`: a value outside the three literals is a malformed env, unrecoverable
-			// (same stance as `better-auth-live.ts`).
-			const env = yield* environment.pipe(Effect.orDie);
-			return emailSenderLayerFor(env);
-		}),
-	);
+export const EmailSenderLive: Layer.Layer<
+	EmailSender,
+	never,
+	RuntimeContext | Email.Send | EmailDeliveryLog
+> = Layer.unwrap(
+	Effect.gen(function* () {
+		// `orDie`: a value outside the three literals is a malformed env, unrecoverable
+		// (same stance as `better-auth-live.ts`).
+		const env = yield* environment.pipe(Effect.orDie);
+		return emailSenderLayerFor(env);
+	}),
+);

--- a/apps/web/worker/features/pasaport/email-sender.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-sender.unit.test.ts
@@ -4,8 +4,9 @@
  *
  *   - `EmailSenderCloudflareLive` over a FAKE `Email.Send`: asserts it
  *     calls the binding's `.send` with the correct from/to/subject/body shape,
- *     and that a binding failure is swallowed (the public `send` is `E = never`,
- *     so a delivery failure never throws into better-auth);
+ *     and that a binding `SendEmailError` is recorded to the delivery log AND
+ *     swallowed (the public `send` is `E = never`, so a delivery failure never
+ *     throws into better-auth — epic #2687, Child #2691);
  *   - `EmailSenderLog`: the dev/preview sink resolves without a binding;
  *   - `emailSenderLayerFor`: the ENVIRONMENT gate picks the log sink for
  *     development/preview and the CF adapter for production.
@@ -14,6 +15,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {RuntimeContext} from "alchemy";
 import {Email} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
+import {EmailDeliveryLog} from "./email-delivery-log.ts";
 import {
 	EMAIL_FROM,
 	EmailSender,
@@ -29,6 +31,19 @@ const runtimeContext = Layer.succeed(RuntimeContext)({
 	get: () => Effect.succeed(undefined),
 	set: (id) => Effect.succeed(id),
 });
+
+type RecordedFailure = {address: string; reason: string};
+
+/**
+ * A fake `EmailDeliveryLog` that captures every `recordSendFailure` call into `sink`,
+ * so the CF adapter's send-time capture is assertable without a `Drizzle`/D1.
+ */
+const fakeDeliveryLog = (sink: RecordedFailure[]): Layer.Layer<EmailDeliveryLog> =>
+	Layer.succeed(EmailDeliveryLog)(
+		EmailDeliveryLog.of({
+			recordSendFailure: (input) => Effect.sync(() => void sink.push(input)),
+		}),
+	);
 
 type SentMessage = Parameters<Email.SendClient["send"]>[0];
 
@@ -69,6 +84,7 @@ describe("EmailSenderCloudflareLive", () => {
 							}),
 						),
 						Layer.provide(runtimeContext),
+						Layer.provide(fakeDeliveryLog([])),
 					),
 				),
 			);
@@ -100,6 +116,7 @@ describe("EmailSenderCloudflareLive", () => {
 							}),
 						),
 						Layer.provide(runtimeContext),
+						Layer.provide(fakeDeliveryLog([])),
 					),
 				),
 			);
@@ -113,14 +130,16 @@ describe("EmailSenderCloudflareLive", () => {
 		}),
 	);
 
-	it.effect("fails soft: a binding send error never throws into the caller", () =>
+	it.effect("records a SendEmailError to the delivery log AND stays fail-soft", () =>
 		Effect.gen(function* () {
+			const recorded: RecordedFailure[] = [];
 			const program = Effect.flatMap(EmailSender, (sender) =>
 				sender.send({to: "user@example.com", subject: "x", text: "y"}),
 			);
 
-			// The send fails at the binding, but the public `send` is E = never — the
-			// program completes with void rather than failing.
+			// The send is REJECTED at the binding. The adapter must (1) append the rejection
+			// to the delivery log for that recipient, and (2) still complete with void — the
+			// public `send` is E = never, so a delivery failure never fails the auth flow.
 			const result = yield* program.pipe(
 				Effect.provide(
 					EmailSenderCloudflareLive.pipe(
@@ -128,12 +147,14 @@ describe("EmailSenderCloudflareLive", () => {
 							fakeBinding(() => Effect.fail(new Email.SendEmailError({message: "binding boom"}))),
 						),
 						Layer.provide(runtimeContext),
+						Layer.provide(fakeDeliveryLog(recorded)),
 					),
 				),
 				Effect.exit,
 			);
 
 			assert.isTrue(result._tag === "Success");
+			assert.deepStrictEqual(recorded, [{address: "user@example.com", reason: "binding boom"}]);
 		}),
 	);
 });

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -21,6 +21,7 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {AppConfig, ENV_BINDINGS, envBindings, sentryDsn} from "./config.ts";
 import {Database, DatabaseLive} from "./db/Database.ts";
+import {DrizzleLive} from "./db/Drizzle.ts";
 import {customHostname, resolveStateMode} from "./env.ts";
 import {makeFateRuntime, PhoenixFateLive} from "./features/fate/layers.ts";
 import {
@@ -34,6 +35,7 @@ import {Flagship, FlagshipLive} from "./features/flagship/Flagship.ts";
 import {Flagship as FlagshipResource} from "./features/flagship/resources.ts";
 import {subscribeHotScoreDecay} from "./features/pano/hot-score-decay-cron.ts";
 import {BetterAuthLive} from "./features/pasaport/better-auth-live.ts";
+import {EmailDeliveryLogLive} from "./features/pasaport/email-delivery-log.ts";
 import {EmailSenderLive} from "./features/pasaport/email-sender.ts";
 import {subscribeSozlukReconcile} from "./features/sozluk/sozluk-reconcile-cron.ts";
 import {Events as TelemetryEvents} from "./features/telemetry/resources.ts";
@@ -437,10 +439,20 @@ export default Phoenix.make(
 				// `send_email` descriptor through alchemy's `SendEmailBindingLive`
 				// (`WorkerEnvironment`/`RuntimeContext` ambient), the same binding-graph
 				// shape as Flagship below; dev/preview pick the log sink and never touch
-				// the binding.
+				// the binding. The CF adapter also records a send-time rejection to the
+				// append-only delivery log (epic #2687), so `EmailDeliveryLogLive` (over its
+				// own `DrizzleLive`/`DatabaseLive`, D1 binding satisfied at the base) is
+				// provided in alongside the send binding.
 				BetterAuthLive.pipe(
 					Layer.provideMerge(DatabaseLive),
-					Layer.provide(EmailSenderLive.pipe(Layer.provide(Cloudflare.Email.SendBinding))),
+					Layer.provide(
+						EmailSenderLive.pipe(
+							Layer.provide(Cloudflare.Email.SendBinding),
+							Layer.provide(
+								EmailDeliveryLogLive.pipe(Layer.provide(DrizzleLive), Layer.provide(DatabaseLive)),
+							),
+						),
+					),
 				),
 				// The `Flagship` seam (`bind()`-in-init) resolves through alchemy's
 				// Flagship binding graph: `FlagshipBindingLive` turns the app resource


### PR DESCRIPTION
Fixes #2691 — the FOUNDATION child of email-bounce epic #2687 (Geçit). Lays the log+projection every other child (#2692 admin, #2693 notice, #2694 CF-gated) reads.

## What this builds

Backend foundation for app-level failing-address visibility, mirroring the ban-state pattern verbatim (`user_ban_event` + `resolveBanState`, ADR 0107): a projection over an append-only log so current state can never drift from history and a stale "bouncing flag" is unrepresentable.

- **Event log** — a new append-only `email_delivery_event` D1 table (Drizzle migration `0028`), mirroring `user_ban_event`: `address` (always known from the send) + a nullable `userId` FK (`ON DELETE set null`, so history survives account deletion), an `action` (`fail` | `clear`), a nullable `reason`, `createdAt`. The admin mark/clear (#2692) and CF async ingestion (#2694) append to this same log.
- **Projection** — `resolveEmailDeliveryState(latest, now)` in `features/pasaport/email-delivery.ts`: a pure, no-I/O, latest-event-wins projection to `{failing, reason}` (a `clear` lifts a `fail`), unit-tested directly.
- **Write port** — `EmailDeliveryLog` (`email-delivery-log.ts`): a fakeable seam over `Drizzle` that resolves the recipient's `userId` from the address and appends a `fail` event. Best-effort (`E = never`) — a D1 failure is swallowed so the audit append can never break the send.
- **Send-time capture** — `EmailSenderCloudflareLive` now, on the binding's `SendEmailError`, appends a `fail` event instead of only logging-and-dropping. The public `send` stays fail-soft by contract (`E = never` — an email must never fail the auth flow).

## The scope fault line (stated in the code)

The captured signal's honest limit is stated at the capture site (`email-sender.ts` docblock): a synchronous `SendEmailError` is a send **rejection**, caught at send time — **not** an asynchronous hard bounce or spam complaint, which arrive after the SMTP handshake and need Child #2694's CF delivery-event surface. This child only captures the synchronous send-time signal we already hold. Out of scope: any UI (#2693), any admin mutation/read surface (#2692), async CF event ingestion (#2694).

## Acceptance criteria

- [x] Drizzle migration adds the append-only `email_delivery_event` table (address, nullable userId, action `fail`|`clear`, nullable reason, createdAt).
- [x] Pure `resolveEmailDeliveryState` returns `{failing, reason}` latest-event-wins; unit-tested: no events → not failing, `fail` → failing, `fail` then `clear` → not failing (+ null-reason passthrough).
- [x] `EmailSenderCloudflareLive` appends a `fail` event on `SendEmailError` while `send` stays `E = never`; unit test asserts both the append and the preserved fail-soft contract.
- [x] `pnpm typecheck` and the pasaport unit tests pass.

## Local checks

- `pnpm turbo typecheck --filter=@kampus/web` — pass
- pasaport unit suite (`vitest --project unit worker/features/pasaport`) — 162 passed
- `biome check` (changed files) — clean
- `migrations-guard check` — consistency/ordering/immutability hold
- `fanout-guard check` — clean (no new fate mutation; the delivery-log append is not a fanned subscribed entity)

Stops at PR-open for the independent review gate.