### PR TITLE
feat(pipeline): LAYER-2 worktree containment — stage-all ban + clean-tree assert (#2690)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -305,6 +305,15 @@ WT_FILE="$(mktemp /tmp/review-code-wt.XXXXXX)"
 # explicit denylist removal + absence-assert below, NOT by any include/cone pattern set.
 git worktree add "$REVIEW_WT" "$PR_REF"
 
+# LAYER-2 containment (#2666): a freshly materialized worktree MUST come up pristine — assert it
+# clean NOW, before the denylist `rm --cached` below deliberately dirties it. A dirty materialization
+# means a corrupted head checkout, and reviewing a contaminated tree is a false signal. Fail-closed
+# LOUD via the single-sourced, tested helper (packages/pipeline-cli/src/tools/worktree-guard).
+node packages/pipeline-cli/src/bin.ts worktree-guard assert-clean --path "$REVIEW_WT" || {
+  echo "FATAL: review worktree came up dirty at materialization — aborting (never review a contaminated tree; #2666)." >&2
+  exit 1
+}
+
 # Enforce the instruction denylist EXPLICITLY: remove the head's instruction surfaces from
 # the review tree so they never reach the reviewing agent's path (ADR 0049/0052 boundary; a
 # full checkout would otherwise leave root CLAUDE.md on disk). Config still comes from the

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -200,6 +200,10 @@ PR=<pr number>
 # checkout ($WORKTREE_ROOT unset — the #2452/#2453 condition), fail closed LOUD and route up rather
 # than run any git op there. Single-sourced in gh-issue-intake-formats.md §RO-iso (ADR 0172; the
 # write-code wt_preflight sibling). A genuine standalone `/ship-it` on the owner's checkout still proceeds.
+# This iso_preflight is ship-it's whole stake in the #2690 worktree-hardening consolidation: LAYER 1
+# (prevention) lives here, while LAYER 2 (the clean-tree assertion + the stage-all `git add -A` ban)
+# has NO surface in ship-it — it stages/commits nothing — so it is enforced upstream in the pre-bash
+# hook + write-code/review-code, not duplicated here.
 iso_preflight ship-it || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
 gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
 ```

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
@@ -33,6 +33,12 @@
  * The orchestrator's own shell runs no such hook, carries no `$WORKTREE_ROOT`, and asserts no
  * isolation, so its legitimate `git checkout main` (the ff-pull/reattach flow) can never reach
  * either refusal. See `.patterns/worktree-agent-constraints.md` (the guard route, now enforced).
+ *
+ * A second, distinct refusal is the **auto-stage-all containment** (#2666): `git add -A/--all/.`
+ * and `git commit -a` are refused in a guarded worktree because a fresh worktree can come up dirty
+ * (an unauthored hunk present at spawn), so staging the whole tree captures that bleed into the
+ * commit. Unlike the HEAD-move class this fires regardless of `-C "$WT"` scoping — the hazard is
+ * unauthored-hunk capture, not a primary-tree escape — so commits must stage by explicit path only.
  */
 
 export type BashDecision =
@@ -125,6 +131,76 @@ export const inspectGitHeadMove = (
 	return {isHeadMove: HEAD_MOVING.has(subcommand), worktreeScoped: scoped};
 };
 
+/**
+ * Detect a `git` invocation that AUTO-STAGES THE WHOLE TREE rather than explicit paths — `git add`
+ * with an all-staging pathspec (`-A` / `--all` / `.` / `--no-ignore-removal`), or `git commit -a`
+ * (the `-am` bundle included). Containment for #2666: a fresh worktree can come up dirty (an
+ * unauthored uncommitted hunk present at spawn), so a stage-everything op captures that bleed into
+ * the commit silently — the fix is to stage by explicit path only.
+ *
+ * The parse mirrors {@link inspectGitHeadMove}'s shallow, fail-closed philosophy but scans EVERY
+ * git segment (split on shell connectors), so a chained `git status && git add -A` is caught — and
+ * errs toward *seeing* a stage-all (ambiguity → refuse). Unlike a HEAD-move, `-C "$WT"` scoping
+ * does NOT make this safe: the hazard is unauthored-hunk capture, not a primary-tree escape, so the
+ * caller refuses it regardless of worktree-scope or a leading `cd`.
+ */
+export const inspectGitStageAll = (command: string): boolean => {
+	for (const segment of command.split(/&&|\|\||[;|]/)) {
+		if (segmentStagesAll(segment)) return true;
+	}
+	return false;
+};
+
+/** A `git add` pathspec that stages the whole tree (not an explicit path). */
+const isAddAllPathspec = (t: string): boolean =>
+	t === "." || t === "--all" || t === "--no-ignore-removal" || /^-[A-Za-z]*A[A-Za-z]*$/.test(t); // a short-flag cluster carrying `-A` (e.g. `-A`, `-Av`); NOT `--all`
+
+/** A `git commit` flag that auto-stages tracked changes (`-a` / `-am` / `--all`); NOT `--amend`. */
+const isCommitAllFlag = (t: string): boolean => t === "--all" || /^-[a-z]*a[a-z]*$/.test(t);
+
+/** Walk a segment's git global options to the subcommand token index (skips `-C`/`-c`/`--git-dir`/`--work-tree` args). */
+const gitSubcommandStart = (tokens: string[], gi: number): number => {
+	let i = gi + 1;
+	while (i < tokens.length) {
+		const t = tokens[i] ?? "";
+		if (t === "-C" || t === "--git-dir" || t === "--work-tree" || t === "-c") {
+			i += 2;
+			continue;
+		}
+		if (/^(--git-dir|--work-tree)=/.test(t)) {
+			i += 1;
+			continue;
+		}
+		if (t.startsWith("-")) {
+			i += 1;
+			continue;
+		}
+		break;
+	}
+	return i;
+};
+
+const segmentStagesAll = (segment: string): boolean => {
+	const tokens = segment
+		.trim()
+		.split(/\s+/)
+		.filter((t) => t !== "");
+	const gi = tokens.indexOf("git");
+	if (gi < 0) return false;
+	const i = gitSubcommandStart(tokens, gi);
+	const subcommand = tokens[i] ?? "";
+	const rest = tokens.slice(i + 1);
+	if (subcommand === "add") return rest.some(isAddAllPathspec);
+	if (subcommand === "commit") return rest.some(isCommitAllFlag);
+	return false;
+};
+
+const REFUSE_REASON_STAGE_ALL =
+	"refused an auto-stage-all git op (git add -A/--all/., or git commit -a) in a guarded worktree — " +
+	"a fresh worktree can come up dirty (an unauthored hunk present at spawn, #2666), so staging the " +
+	"whole tree captures that bleed into the commit silently. Stage by EXPLICIT path only: " +
+	'`git -C "$WT" add <path> …` then a plain `git -C "$WT" commit` (never `-a`).';
+
 const REFUSE_REASON =
 	"refused a bare working-state-mutating git op (checkout/switch/reset/rebase/stash/merge) in a " +
 	"guarded worktree — unscoped, it would execute against the shared PRIMARY .git after the cwd " +
@@ -179,6 +255,9 @@ export const isIsolationExpected = (args: {
  *   #2440 no-op / #2452 detach), and the $WORKTREE_ROOT-keyed branch below is disarmed, so this is
  *   the surviving refusal (ADR 0172). A non-head-move command still allows (no over-refusal).
  * - An empty/whitespace-only command → **allow** (nothing to pin).
+ * - An auto-stage-all git op (`git add -A/--all/.`, or `git commit -a`) → **refuse** even in its
+ *   `cd "$WT" &&` / `-C "$WT"` scoped form: a fresh worktree can be dirty at spawn, so staging the
+ *   whole tree captures unauthored bleed into the commit — stage by explicit path only (#2666).
  * - A command with a leading `cd ` → **allow** (it sets its own cwd; don't fight it).
  * - A working-state-mutating git op (`checkout`/`switch`/`reset`/`rebase`/`stash`/`merge`) NOT
  *   scoped to the worktree → **refuse** (issue #1571; `stash`/`merge` added #2030).
@@ -194,7 +273,11 @@ export const pinBash = (args: {
 	const {worktreeRoot, command, isolationExpected = false} = args;
 	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) {
 		// No managed worktree. Normally a clean allow — but if isolation was expected, the harness
-		// no-op'd provisioning (#2440) and a head-moving git op here hits the PRIMARY checkout (#2453).
+		// no-op'd provisioning (#2440) and a mutating git op here hits the PRIMARY checkout: a
+		// head-move detaches it (#2453), and a stage-all captures the owner's tree state (#2666).
+		if (isolationExpected && command.trim() !== "" && inspectGitStageAll(command)) {
+			return {kind: "refuse", reason: REFUSE_REASON_STAGE_ALL};
+		}
 		if (
 			isolationExpected &&
 			command.trim() !== "" &&
@@ -206,6 +289,9 @@ export const pinBash = (args: {
 		return {kind: "allow"};
 	}
 	if (command.trim() === "") return {kind: "allow"};
+	// A stage-all is refused BEFORE the leading-cd allow: `cd "$WT" && git add -A` still captures
+	// unauthored bleed, and `-C "$WT"` scoping doesn't make it safe (#2666) — so it fires regardless.
+	if (inspectGitStageAll(command)) return {kind: "refuse", reason: REFUSE_REASON_STAGE_ALL};
 	if (hasLeadingCd(command)) return {kind: "allow"};
 
 	const gm = inspectGitHeadMove(command, worktreeRoot);

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
@@ -1,5 +1,11 @@
 import {assert, describe, it} from "@effect/vitest";
-import {hasLeadingCd, inspectGitHeadMove, isIsolationExpected, pinBash} from "./bash-pin.ts";
+import {
+	hasLeadingCd,
+	inspectGitHeadMove,
+	inspectGitStageAll,
+	isIsolationExpected,
+	pinBash,
+} from "./bash-pin.ts";
 
 const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
 
@@ -235,6 +241,86 @@ describe("isIsolationExpected — the ADR-0172 gate, re-keyed onto git-dir == co
 		assert.isFalse(isIsolationExpected({agentType: "", onPrimaryCheckout: true}));
 		assert.isFalse(isIsolationExpected({agentType: "   ", onPrimaryCheckout: true}));
 		assert.isFalse(isIsolationExpected({agentType: "", onPrimaryCheckout: false}));
+	});
+});
+
+// #2666 containment: a fresh worktree can come up dirty, so an auto-stage-all captures unauthored
+// bleed into the commit — banned in a guarded worktree, commits stage by explicit path only.
+describe("pinBash — refuse an auto-stage-all git op in a guarded worktree (#2666)", () => {
+	it("refuses `git add -A`, `git add .`, and `git add --all`", () => {
+		for (const cmd of ["git add -A", "git add .", "git add --all"]) {
+			assert.strictEqual(pinBash({worktreeRoot: WT, command: cmd}).kind, "refuse", cmd);
+		}
+	});
+	it("refuses `git commit -a` / `-am` (auto-stage-then-commit)", () => {
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: "git commit -a"}).kind, "refuse");
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: 'git commit -am "wip"'}).kind, "refuse");
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: "git commit --all"}).kind, "refuse");
+	});
+	// Scoping does NOT make it safe (unauthored-hunk capture, not a primary-tree escape) — fire anyway.
+	it('refuses even the `-C "$WT"` scoped and leading-`cd` forms', () => {
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: 'git -C "$WT" add -A'}).kind, "refuse");
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: `cd "${WT}" && git add -A`}).kind,
+			"refuse",
+		);
+	});
+	// Caught even when a benign git op precedes it in a chain (fail-closed: scan every segment).
+	it("refuses a stage-all buried after a benign git op in a chain", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: "git status && git add -A"}).kind,
+			"refuse",
+		);
+	});
+	it("does NOT refuse explicit-path staging or an amend-without-`-a`", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: "git add apps/web/foo.ts"}).kind,
+			"rewrite",
+		);
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: 'git commit -m "add auth guard"'}).kind,
+			"rewrite",
+		);
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: "git commit --amend --no-edit"}).kind,
+			"rewrite",
+		);
+	});
+	it("does NOT refuse a stage-all when NOT a guarded worktree and isolation not expected", () => {
+		assert.strictEqual(pinBash({worktreeRoot: "", command: "git add -A"}).kind, "allow");
+	});
+	it("refuses a stage-all when root unset but isolation WAS expected (#2440 no-op on primary)", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: "", command: "git add -A", isolationExpected: true}).kind,
+			"refuse",
+		);
+	});
+});
+
+describe("inspectGitStageAll — the pure parse", () => {
+	it("flags the add-all pathspecs", () => {
+		for (const cmd of ["git add -A", "git add .", "git add --all", "git add -Av"]) {
+			assert.isTrue(inspectGitStageAll(cmd), cmd);
+		}
+	});
+	it("flags `git commit -a` / `-am` / `--all`", () => {
+		for (const cmd of ["git commit -a", "git commit -am x", "git commit --all"]) {
+			assert.isTrue(inspectGitStageAll(cmd), cmd);
+		}
+	});
+	it("does not flag explicit-path add, `-u`, or a `-m`-only commit", () => {
+		for (const cmd of ["git add src/foo.ts", "git add -u src", 'git commit -m "msg"']) {
+			assert.isFalse(inspectGitStageAll(cmd), cmd);
+		}
+	});
+	it("does not flag `--amend` (double dash, no `-a`)", () => {
+		assert.isFalse(inspectGitStageAll("git commit --amend --no-edit"));
+	});
+	it("does not flag a non-git command that merely contains `add`/`-A`", () => {
+		assert.isFalse(inspectGitStageAll("echo add -A"));
+	});
+	it("sees a stage-all across a `-C <path>` scope prefix", () => {
+		assert.isTrue(inspectGitStageAll('git -C "$WT" add -A'));
 	});
 });
 

--- a/packages/pipeline-cli/src/tools/worktree-guard/clean-tree.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/clean-tree.ts
@@ -1,0 +1,55 @@
+/**
+ * `worktree-guard assert-clean` decision core — the fail-closed clean-tree assertion (#2666).
+ *
+ * LAYER 2 containment for the worktree-corruption class: a freshly provisioned worktree is
+ * *supposed* to come up pristine, but #2666 caught one that came up dirty (an unauthored
+ * uncommitted hunk present at spawn) — which then rode into a commit via a stage-all. This decides
+ * whether a `git status --porcelain <path>` reading proves the tree CLEAN, so a caller (write-code
+ * before its first Edit, review-code right after `git worktree add`) can STOP LOUD on a dirty tree
+ * instead of proceeding to author on top of contamination.
+ *
+ * Fail-closed by construction: only an empty porcelain reading is `clean`; a non-empty reading is
+ * `dirty`, and an *indeterminate* reading (git couldn't run — `porcelain === null`) is also `dirty`
+ * (never a false clean). The command IS the ground truth; this core only maps its output to a stop.
+ */
+
+export type CleanTreeDecision =
+	| {readonly kind: "clean"; readonly reason: string}
+	| {readonly kind: "dirty"; readonly reason: string};
+
+/** First N porcelain lines, for a legible refusal (the whole listing can be long). */
+const preview = (porcelain: string, n = 10): string =>
+	porcelain
+		.trim()
+		.split("\n")
+		.slice(0, n)
+		.map((l) => `    ${l}`)
+		.join("\n");
+
+/**
+ * Decide whether the target tree is clean from a `git status --porcelain` reading.
+ *
+ * - `porcelain === null` (git status could not be run — not a repo, path missing) → **dirty**
+ *   (fail-closed: an indeterminate tree is never certified clean).
+ * - empty/whitespace-only reading → **clean**.
+ * - any other reading → **dirty**, with a bounded preview of the offending entries.
+ */
+export const decideCleanTree = (args: {
+	readonly path: string;
+	readonly porcelain: string | null;
+}): CleanTreeDecision => {
+	const {path, porcelain} = args;
+	if (porcelain === null) {
+		return {
+			kind: "dirty",
+			reason: `could not read \`git status --porcelain\` at ${path} — treating as DIRTY (fail-closed; an indeterminate tree is never certified clean).`,
+		};
+	}
+	if (porcelain.trim() === "") {
+		return {kind: "clean", reason: `worktree at ${path} is clean (empty porcelain).`};
+	}
+	return {
+		kind: "dirty",
+		reason: `worktree at ${path} is DIRTY — a fresh worktree must come up pristine (#2666); refusing to proceed on a contaminated tree. Entries:\n${preview(porcelain)}`,
+	};
+};

--- a/packages/pipeline-cli/src/tools/worktree-guard/clean-tree.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/clean-tree.unit.test.ts
@@ -1,0 +1,40 @@
+import {assert, describe, it} from "@effect/vitest";
+import {decideCleanTree} from "./clean-tree.ts";
+
+const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
+
+describe("decideCleanTree — the fail-closed clean-tree assertion (#2666)", () => {
+	it("certifies an empty porcelain reading as clean", () => {
+		const d = decideCleanTree({path: WT, porcelain: ""});
+		assert.strictEqual(d.kind, "clean");
+	});
+
+	it("treats a whitespace-only reading as clean (trailing newline from git)", () => {
+		assert.strictEqual(decideCleanTree({path: WT, porcelain: "\n"}).kind, "clean");
+	});
+
+	it("flags a non-empty porcelain reading as dirty (the #2666 unauthored hunk)", () => {
+		const d = decideCleanTree({path: WT, porcelain: " M apps/web/worker/foo.ts\n"});
+		assert.strictEqual(d.kind, "dirty");
+		if (d.kind === "dirty") assert.match(d.reason, /DIRTY/);
+	});
+
+	it("flags an untracked entry as dirty", () => {
+		assert.strictEqual(decideCleanTree({path: WT, porcelain: "?? stray.txt\n"}).kind, "dirty");
+	});
+
+	// Fail-closed: an indeterminate reading (git could not run) is DIRTY, never a false clean.
+	it("treats a null reading (git status could not run) as dirty — fail-closed", () => {
+		const d = decideCleanTree({path: WT, porcelain: null});
+		assert.strictEqual(d.kind, "dirty");
+		if (d.kind === "dirty") assert.match(d.reason, /fail-closed/);
+	});
+
+	it("bounds the dirty preview to the first entries", () => {
+		const many = Array.from({length: 30}, (_, i) => ` M f${i}.ts`).join("\n");
+		const d = decideCleanTree({path: WT, porcelain: many});
+		assert.strictEqual(d.kind, "dirty");
+		// preview caps at 10 lines, so the 20th entry never appears in the reason
+		if (d.kind === "dirty") assert.notMatch(d.reason, /f25\.ts/);
+	});
+});

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -2,9 +2,10 @@
  * The `worktree-guard` tool — `pipeline-cli worktree-guard <pre-file|pre-bash|pre-enter|reap>`.
  *
  * The worktree-pinning hook surface for an `isolation:worktree` subagent (issue
- * #741), moved into the pipeline-cli registry (epic #994, Phase 2 / #998). Four
- * subcommands, each reading the hook's stdin JSON envelope, running a pure core,
- * and emitting the matching hook output. All read `$WORKTREE_ROOT` from the process
+ * #741), moved into the pipeline-cli registry (epic #994, Phase 2 / #998). The four
+ * hook subcommands each read the hook's stdin JSON envelope, run a pure core, and
+ * emit the matching hook output; a fifth (`assert-clean`, #2666) is an operator/skill
+ * invocation — not a hook — that fails closed on a dirty worktree. All read `$WORKTREE_ROOT` from the process
  * env (injected at spawn for an `isolation:worktree` subagent); an UNSET root makes
  * every subcommand a clean allow/skip no-op, so a non-worktree session is never
  * affected — with ONE exception (ADR 0172): `pre-bash` still refuses a head-moving git
@@ -19,6 +20,8 @@
  *     pre-enter (matcher EnterWorktree)   — hard-block a nested worktree
  *   SubagentStop:
  *     reap                                — `git worktree remove` (no --force) when clean
+ *   Skill/operator invocation (not a hook):
+ *     assert-clean [--path <d>]           — fail closed LOUD if the tree is dirty (#2666)
  *
  * The handlers are byte-identical to the former package's `bin.run.ts`. Its thin
  * `bin.ts` #777 stale-tree shim (a dynamic import gated on a dep-resolution probe)
@@ -28,12 +31,15 @@
 import {execFileSync} from "node:child_process";
 import {existsSync, statSync} from "node:fs";
 import {resolve} from "node:path";
-import {Console, Data, Effect} from "effect";
-import {Command} from "effect/unstable/cli";
+import {Console, Data, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
 import {isIsolationExpected, pinBash} from "./bash-pin.ts";
+import {decideCleanTree} from "./clean-tree.ts";
 import {guardEnterWorktree} from "./enter-guard.ts";
 import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
 import {decideReap} from "./reap.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
 
 const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
 
@@ -260,7 +266,48 @@ const reap = Command.make(
 	),
 );
 
+const pathFlag = Flag.string("path").pipe(
+	Flag.optional,
+	Flag.withDescription("the worktree to assert clean (default: $WORKTREE_ROOT)"),
+);
+
+// Read `git status --porcelain` at a path; null when git cannot run there (not a repo, missing
+// dir) — the null is the fail-closed signal decideCleanTree maps to DIRTY, never a false clean.
+const readPorcelain = (path: string): string | null => {
+	try {
+		return execFileSync("git", ["-C", path, "status", "--porcelain"], {encoding: "utf8"});
+	} catch {
+		return null;
+	}
+};
+
+const assertClean = Command.make(
+	"assert-clean",
+	{path: pathFlag},
+	Effect.fn(function* ({path: pathOpt}) {
+		const target = Option.getOrElse(pathOpt, () => WORKTREE_ROOT);
+		if (!target) {
+			yield* Console.error(
+				"worktree-guard assert-clean: no target — pass --path or set $WORKTREE_ROOT.",
+			);
+			return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+		}
+		const decision = decideCleanTree({path: target, porcelain: readPorcelain(target)});
+		if (decision.kind === "clean") {
+			return yield* Console.error(`worktree-guard assert-clean: ${decision.reason}`);
+		}
+		yield* Console.error(
+			`worktree-guard assert-clean FAILED (fail-closed, LOUD): ${decision.reason}`,
+		);
+		return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+	}),
+).pipe(
+	Command.withDescription(
+		"Assert a worktree is clean (git status --porcelain); fail-closed LOUD on a dirty fresh tree (#2666)",
+	),
+);
+
 export const worktreeGuardCommand = Command.make("worktree-guard").pipe(
-	Command.withSubcommands([preFile, preBash, preEnter, reap]),
+	Command.withSubcommands([preFile, preBash, preEnter, reap, assertClean]),
 	Command.withDescription("Worktree-pinning PreToolUse hooks + a SubagentStop reaper (issue #741)"),
 );


### PR DESCRIPTION
## What & why

Consolidates the worktree-corruption class into one buildable unit (§CP): **#2666** (a fresh worktree that came up dirty with an unauthored uncommitted hunk) + **#2684** (the `$WORKTREE_ROOT`-unset primary-corruption vector). LAYER 1 (prevention — `iso_preflight` / write-code `wt_preflight` fail-closed when isolation was expected but `$WORKTREE_ROOT` is unset) already shipped via ADR 0172; this PR adds the **LAYER 2 containment net**.

## Changes (this lane: review-code + ship-it + pipeline-cli)

**LAYER 2 — ban auto-stage-all (`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`)**
- `pinBash` now refuses `git add -A/--all/.` and `git commit -a` in a guarded worktree. A fresh worktree can come up dirty (#2666), so staging the whole tree captures unauthored bleed into the commit silently — commits must stage by explicit path only.
- Fires structurally via the existing `pre-bash` PreToolUse hook for **every** `isolation:worktree` agent (write-code included), regardless of `-C "$WT"` scoping or a leading `cd` — unlike the HEAD-move class, scoping doesn't make it safe (the hazard is unauthored-hunk capture, not a primary-tree escape). Also fires in the isolation-expected-but-no-root branch (a `git add -A` on the primary after the #2440 no-op).
- Pure `inspectGitStageAll`, unit-tested.

**LAYER 2 — clean-tree assertion (`worktree-guard assert-clean` subcommand)**
- New fail-closed `git status --porcelain` clean-tree assertion: pure `decideCleanTree` core (`clean-tree.ts`) + thin bin subcommand. `--path` defaults to `$WORKTREE_ROOT`. An indeterminate reading (git can't run) is treated as DIRTY (never a false clean). For use right after a `git worktree add` / before an agent's first Edit.
- Unit-tested.

**review-code skill** — wires the assertion right after `git worktree add "$REVIEW_WT"` and **before** the denylist `rm --cached` dirties it: a dirty materialization means a corrupted head checkout, and reviewing a contaminated tree is a false signal. Fails closed LOUD.

**ship-it skill** — a one-line note in the `iso_preflight` block that LAYER 2 has no surface in ship-it (it stages/commits nothing, §RO), so it is enforced upstream in the pre-bash hook + write-code/review-code, not duplicated.

> Note: LAYER 2's clean-tree assertion *before write-code's first Edit* and the `git add -A` prose ban in the write-code skill are the sibling §CP lane (#2649, triage + write-code dirs) — the structural hook ban in this PR covers write-code's commits regardless.

## Verification (local)
- `pnpm --filter @kampus/pipeline-cli typecheck` — clean
- full pipeline-cli vitest: **1132 passed** (adds stage-all + clean-tree cases)
- `biome check` on the changed set — clean
- `validate-skills.sh` — 22 skills valid
- `readme-guard check` — 24/24 members OK
- end-to-end: `pre-bash` denies `git add -A` / allows explicit-path add; `assert-clean` exits 0 on a clean tree, 1 LOUD on a dirty/indeterminate tree

## §CP
YES — touches `review-code`/`ship-it` skills + `packages/pipeline-cli/`. Human-merge-only; stops at cansirin at reviewed-ready. Not self-reviewed/shipped.

Fixes #2690
