### PR TITLE
feat(web): membrane notice for a failing email address + recovery CTA (#2693)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,7 @@ import {AppShell, Main} from "./components/layout/AppShell";
 import {Footer} from "./components/layout/Footer";
 import {Topbar} from "./components/layout/Topbar";
 import {MecmuaSubnavLayout} from "./components/mecmua/MecmuaSubnavLayout";
+import {EmailDeliveryNoticeMount} from "./components/membrane/EmailDeliveryNoticeMount";
 import {actorLabel} from "./components/moderation/actor-identity";
 import {PanoSubnavLayout} from "./components/pano/PanoSubnavLayout";
 import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
@@ -310,10 +311,17 @@ function LayoutContent() {
 		return () => setChips?.(null);
 	}, [chips, setChips]);
 
-	return needsBootstrap && sessionUser ? (
-		<UsernameBootstrap email={sessionUser.email} onComplete={refetch} />
-	) : (
-		<Outlet />
+	return (
+		<>
+			{/* Membrane notice for a signed-in user whose email is failing (epic #2687, #2693) —
+			    dark behind its flag, inert until the worker exposes the failing signal on `me`. */}
+			<EmailDeliveryNoticeMount me={me} />
+			{needsBootstrap && sessionUser ? (
+				<UsernameBootstrap email={sessionUser.email} onComplete={refetch} />
+			) : (
+				<Outlet />
+			)}
+		</>
 	);
 }
 

--- a/apps/web/src/components/membrane/EmailDeliveryNotice.css
+++ b/apps/web/src/components/membrane/EmailDeliveryNotice.css
@@ -35,14 +35,17 @@
 	color: var(--text-secondary);
 }
 
+/* stretch, not center: the dismiss button uses the raw --sm size (24.8px alone, below the
+   36px floor), so it inherits the CTA's row height instead — both interactive controls clear
+   the four-pillars tap-target floor and stay visually balanced at equal height (#2727). */
 .kp-email-notice__actions {
 	display: flex;
-	align-items: center;
+	align-items: stretch;
 	gap: var(--s-2);
 }
 
-/* ≥36px hit area for the recovery CTA (four-pillars tap-target floor). --s-8 is 40px at
-   the compact base and larger in every denser ramp, so the floor holds across densities. */
+/* The CTA's min-height sets the actions row's ≥36px floor (--s-8 is 40px at the compact base
+   and larger in every denser ramp); align-items: stretch above propagates it to the dismiss. */
 .kp-email-notice__cta {
 	display: inline-flex;
 	align-items: center;

--- a/apps/web/src/components/membrane/EmailDeliveryNotice.css
+++ b/apps/web/src/components/membrane/EmailDeliveryNotice.css
@@ -1,0 +1,50 @@
+.kp-email-notice {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--s-3);
+	padding: var(--s-3);
+	margin-bottom: var(--s-3);
+	border: 1px solid var(--border);
+	/* Warning-tinted left edge carries the alert weight; the copy carries the meaning,
+	   so a color-blind reader is not gated on the hue (four-pillars contrast pillar). */
+	border-left: 2px solid var(--warning);
+	border-radius: var(--r-md);
+	background: var(--surface-raised);
+	box-shadow: var(--shadow-raised);
+}
+
+.kp-email-notice__body {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	min-width: 0;
+}
+
+.kp-email-notice__title {
+	margin: 0;
+	font: var(--t-body);
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.kp-email-notice__text {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}
+
+.kp-email-notice__actions {
+	display: flex;
+	align-items: center;
+	gap: var(--s-2);
+}
+
+/* ≥36px hit area for the recovery CTA (four-pillars tap-target floor). --s-8 is 40px at
+   the compact base and larger in every denser ramp, so the floor holds across densities. */
+.kp-email-notice__cta {
+	display: inline-flex;
+	align-items: center;
+	min-height: var(--s-8);
+}

--- a/apps/web/src/components/membrane/EmailDeliveryNotice.test.tsx
+++ b/apps/web/src/components/membrane/EmailDeliveryNotice.test.tsx
@@ -4,6 +4,8 @@
  * surface + dismissal) and the mount gate (dark behind the flag, present only for a failing
  * signed-in user, hidden once dismissed).
  */
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
 import {fireEvent, render, screen} from "@testing-library/react";
 import type {ReactNode} from "react";
 import {MemoryRouter, Route, Routes} from "react-router";
@@ -100,5 +102,24 @@ describe("EmailDeliveryNoticeMount — the membrane gate (#2693)", () => {
 		renderNotice(<EmailDeliveryNoticeMount me={makeMe(true)} />);
 		fireEvent.click(screen.getByTestId("email-delivery-notice-dismiss"));
 		expect(screen.queryByTestId("email-delivery-notice")).toBeNull();
+	});
+});
+
+/**
+ * CSS-source tripwire for the four-pillars ≥36px tap-target floor (#2727 review-design). jsdom
+ * can't compute layout, so the floor is pinned against the CSS bytes: the dismiss uses the raw
+ * `--sm` size (24.8px alone), so its hit area comes from `align-items: stretch` on the actions
+ * row inheriting the CTA's `min-height: var(--s-8)` row height. Remove either and the dismiss
+ * drops below the floor — this fails here rather than only under manual design review.
+ */
+describe("EmailDeliveryNotice — tap-target floor (#2727)", () => {
+	const css = readFileSync(join(import.meta.dirname, "EmailDeliveryNotice.css"), "utf8");
+
+	it("the actions row stretches so the dismiss inherits the CTA's row height", () => {
+		expect(css).toMatch(/\.kp-email-notice__actions\s*\{[^}]*align-items:\s*stretch/s);
+	});
+
+	it("the CTA sets the row's ≥36px floor via min-height: var(--s-8)", () => {
+		expect(css).toMatch(/\.kp-email-notice__cta\s*\{[^}]*min-height:\s*var\(--s-8\)/s);
 	});
 });

--- a/apps/web/src/components/membrane/EmailDeliveryNotice.test.tsx
+++ b/apps/web/src/components/membrane/EmailDeliveryNotice.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * The failing-email membrane notice (epic #2687, Child #2693). Pins the render contract of the
+ * presentational notice (Turkish copy + a recovery CTA that actually reaches the change-email
+ * surface + dismissal) and the mount gate (dark behind the flag, present only for a failing
+ * signed-in user, hidden once dismissed).
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import type {ReactNode} from "react";
+import {MemoryRouter, Route, Routes} from "react-router";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import type {MeUser} from "../../auth/useMe";
+import {EmailDeliveryNotice} from "./EmailDeliveryNotice";
+import {EmailDeliveryNoticeMount} from "./EmailDeliveryNoticeMount";
+import type {EmailDeliveryReadable} from "./emailDeliveryNoticeGate";
+
+let flagOn: boolean;
+vi.mock("../../flags/useFlag", () => ({useFlag: () => ({value: flagOn, loading: false})}));
+
+const makeMe = (emailFailing: boolean): MeUser & EmailDeliveryReadable =>
+	({
+		id: "u1",
+		email: "a@b.co",
+		name: null,
+		image: null,
+		username: "anka",
+		tier: "çaylak",
+		isModerator: false,
+		emailFailing,
+	}) as MeUser & EmailDeliveryReadable;
+
+function renderNotice(ui: ReactNode) {
+	return render(
+		<MemoryRouter initialEntries={["/"]}>
+			<Routes>
+				<Route path="/" element={ui} />
+				<Route path="/profile" element={<div data-testid="profile-page">profil</div>} />
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("EmailDeliveryNotice — presentational (#2693)", () => {
+	it("renders the Turkish failing-email notice", () => {
+		renderNotice(<EmailDeliveryNotice recoveryHref="/profile" />);
+		const notice = screen.getByTestId("email-delivery-notice");
+		expect(notice.textContent).toContain("e-postana ulaşamıyoruz");
+		// The meaning is carried by text, not color alone (four-pillars a11y).
+		expect(notice.textContent).toContain("geri dönüyor");
+	});
+
+	it("the recovery CTA reaches the existing change-email surface on click", () => {
+		renderNotice(<EmailDeliveryNotice recoveryHref="/profile" />);
+		expect(screen.queryByTestId("profile-page")).toBeNull();
+		fireEvent.click(screen.getByTestId("email-delivery-notice-cta"));
+		expect(screen.getByTestId("profile-page")).toBeTruthy();
+	});
+
+	it("shows a dismiss button only when onDismiss is provided", () => {
+		const onDismiss = vi.fn();
+		renderNotice(<EmailDeliveryNotice recoveryHref="/profile" onDismiss={onDismiss} />);
+		fireEvent.click(screen.getByTestId("email-delivery-notice-dismiss"));
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+
+	it("omits the dismiss button with no onDismiss", () => {
+		renderNotice(<EmailDeliveryNotice recoveryHref="/profile" />);
+		expect(screen.queryByTestId("email-delivery-notice-dismiss")).toBeNull();
+	});
+});
+
+describe("EmailDeliveryNoticeMount — the membrane gate (#2693)", () => {
+	afterEach(() => vi.clearAllMocks());
+
+	it("flag on + failing user: renders the notice", () => {
+		flagOn = true;
+		renderNotice(<EmailDeliveryNoticeMount me={makeMe(true)} />);
+		expect(screen.getByTestId("email-delivery-notice")).toBeTruthy();
+	});
+
+	it("flag off: renders nothing even for a failing user (dark-ship)", () => {
+		flagOn = false;
+		renderNotice(<EmailDeliveryNoticeMount me={makeMe(true)} />);
+		expect(screen.queryByTestId("email-delivery-notice")).toBeNull();
+	});
+
+	it("flag on + not failing: renders nothing", () => {
+		flagOn = true;
+		renderNotice(<EmailDeliveryNoticeMount me={makeMe(false)} />);
+		expect(screen.queryByTestId("email-delivery-notice")).toBeNull();
+	});
+
+	it("signed-out (null me): renders nothing", () => {
+		flagOn = true;
+		renderNotice(<EmailDeliveryNoticeMount me={null} />);
+		expect(screen.queryByTestId("email-delivery-notice")).toBeNull();
+	});
+
+	it("hides after the user dismisses it", () => {
+		flagOn = true;
+		renderNotice(<EmailDeliveryNoticeMount me={makeMe(true)} />);
+		fireEvent.click(screen.getByTestId("email-delivery-notice-dismiss"));
+		expect(screen.queryByTestId("email-delivery-notice")).toBeNull();
+	});
+});

--- a/apps/web/src/components/membrane/EmailDeliveryNotice.tsx
+++ b/apps/web/src/components/membrane/EmailDeliveryNotice.tsx
@@ -1,0 +1,58 @@
+import {Link} from "react-router";
+import {Button} from "../ui/Button";
+import "./EmailDeliveryNotice.css";
+
+/**
+ * The membrane notice a signed-in user with a failing email address sees (epic #2687, Child
+ * #2693): a plain-language Turkish signal that our mail is bouncing, plus a recovery CTA into
+ * the existing change-email flow. Presentational + prop-driven — the flag/failing/dismiss gate
+ * lives in {@link EmailDeliveryNoticeMount}, so the render contract is testable in isolation.
+ *
+ * The state is carried by TEXT, never color alone (four-pillars a11y): a labelled `<section>`
+ * landmark with a `role="status"` live region so it is announced when it appears, the CTA is a
+ * real navigating anchor, and dismissal is a native button.
+ */
+export function EmailDeliveryNotice({
+	recoveryHref,
+	onDismiss,
+}: {
+	recoveryHref: string;
+	onDismiss?: () => void;
+}) {
+	return (
+		<section
+			className="kp-email-notice"
+			role="status"
+			aria-label="e-posta teslimat uyarısı"
+			data-testid="email-delivery-notice"
+		>
+			<div className="kp-email-notice__body">
+				<p className="kp-email-notice__title">e-postana ulaşamıyoruz</p>
+				<p className="kp-email-notice__text">
+					adresine gönderdiğimiz e-postalar geri dönüyor — giriş bağlantıların ve doğrulama
+					e-postaların sana ulaşmıyor olabilir. adresini güncelle ya da yeniden doğrula.
+				</p>
+			</div>
+			<div className="kp-email-notice__actions">
+				<Link
+					to={recoveryHref}
+					className="kp-btn kp-btn--primary kp-email-notice__cta"
+					data-testid="email-delivery-notice-cta"
+				>
+					e-postanı güncelle
+				</Link>
+				{onDismiss ? (
+					<Button
+						type="button"
+						variant="tertiary"
+						size="sm"
+						onClick={onDismiss}
+						data-testid="email-delivery-notice-dismiss"
+					>
+						kapat
+					</Button>
+				) : null}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/components/membrane/EmailDeliveryNoticeMount.tsx
+++ b/apps/web/src/components/membrane/EmailDeliveryNoticeMount.tsx
@@ -1,0 +1,34 @@
+import {useState} from "react";
+import type {MeUser} from "../../auth/useMe";
+import {PHOENIX_EMAIL_DELIVERY_NOTICE} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
+import {EmailDeliveryNotice} from "./EmailDeliveryNotice";
+import {
+	EMAIL_RECOVERY_HREF,
+	type EmailDeliveryReadable,
+	readEmailFailing,
+	shouldShowEmailDeliveryNotice,
+} from "./emailDeliveryNoticeGate";
+
+/**
+ * The membrane mount for the failing-email notice (epic #2687, Child #2693): reads the
+ * dark-ship flag and the signed-in user's own failing signal, renders the notice above the
+ * routed content, and holds a local per-session dismissal. Dark by default — with the flag off
+ * (or no failing signal) it renders nothing, so the membrane is unchanged until a human flips
+ * the flag at release (ADR 0083).
+ *
+ * `me` widens `MeUser` with the forward-compatible `emailFailing` seam ({@link
+ * EmailDeliveryReadable}); the caller's plain `me` is assignable, so this is inert until the
+ * worker exposes `emailFailing` on the `me` read (Child #2693 AC1).
+ */
+export function EmailDeliveryNoticeMount({me}: {me: (MeUser & EmailDeliveryReadable) | null}) {
+	const {value: flagOn} = useFlag(PHOENIX_EMAIL_DELIVERY_NOTICE, false);
+	const [dismissed, setDismissed] = useState(false);
+
+	if (!shouldShowEmailDeliveryNotice({flagOn, failing: readEmailFailing(me), dismissed})) {
+		return null;
+	}
+	return (
+		<EmailDeliveryNotice recoveryHref={EMAIL_RECOVERY_HREF} onDismiss={() => setDismissed(true)} />
+	);
+}

--- a/apps/web/src/components/membrane/emailDeliveryNoticeGate.test.ts
+++ b/apps/web/src/components/membrane/emailDeliveryNoticeGate.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, it} from "vitest";
+import {
+	EMAIL_RECOVERY_HREF,
+	readEmailFailing,
+	shouldShowEmailDeliveryNotice,
+} from "./emailDeliveryNoticeGate";
+
+describe("readEmailFailing — the user's own failing-delivery signal (#2693)", () => {
+	it("null me (signed-out / not-loaded) is deliverable", () => {
+		expect(readEmailFailing(null)).toBe(false);
+	});
+
+	it("a me row with no emailFailing field (not-yet-wired worker read) is deliverable", () => {
+		expect(readEmailFailing({})).toBe(false);
+	});
+
+	it("emailFailing:false is deliverable, emailFailing:true is failing", () => {
+		expect(readEmailFailing({emailFailing: false})).toBe(false);
+		expect(readEmailFailing({emailFailing: true})).toBe(true);
+	});
+});
+
+describe("shouldShowEmailDeliveryNotice — the membrane gate (#2693)", () => {
+	it("shows only when the flag is on AND failing AND not dismissed", () => {
+		expect(shouldShowEmailDeliveryNotice({flagOn: true, failing: true, dismissed: false})).toBe(
+			true,
+		);
+	});
+
+	it("stays dark with the flag off, even when failing", () => {
+		expect(shouldShowEmailDeliveryNotice({flagOn: false, failing: true, dismissed: false})).toBe(
+			false,
+		);
+	});
+
+	it("renders nothing when not failing", () => {
+		expect(shouldShowEmailDeliveryNotice({flagOn: true, failing: false, dismissed: false})).toBe(
+			false,
+		);
+	});
+
+	it("hides once dismissed", () => {
+		expect(shouldShowEmailDeliveryNotice({flagOn: true, failing: true, dismissed: true})).toBe(
+			false,
+		);
+	});
+});
+
+describe("EMAIL_RECOVERY_HREF — the existing change-email surface (#2693)", () => {
+	it("routes into the account profile page, not a new recovery mechanism", () => {
+		expect(EMAIL_RECOVERY_HREF).toBe("/profile");
+	});
+});

--- a/apps/web/src/components/membrane/emailDeliveryNoticeGate.ts
+++ b/apps/web/src/components/membrane/emailDeliveryNoticeGate.ts
@@ -1,0 +1,40 @@
+/**
+ * Membrane email-delivery notice — the pure seam (email-bounce epic #2687, Child #2693).
+ *
+ * A signed-in user whose transactional address is failing gets no magic-link/verification
+ * mail and, until now, no signal why. This surfaces that state on the membrane shell with a
+ * recovery affordance. The failing signal is the user's OWN projected `email-delivery` state
+ * (`resolveEmailDeliveryState`, Child #2691); the recovery CTA reuses the EXISTING change-email
+ * flow (no new recovery backend).
+ */
+
+/**
+ * The forward-compatible shape the notice reads the failing signal off — a widening of the
+ * `me` row that is inert until the worker exposes `emailFailing` on the pasaport `User` wire
+ * view (Child #2693 AC1, a worker read-surface change sequenced with admin Child #2692). A
+ * plain `me` (no such field yet) is structurally assignable here, so `readEmailFailing` reads
+ * `false` today and the notice never renders; the moment the worker stamps `emailFailing` onto
+ * the `me` row it lights up with no further client change.
+ */
+export interface EmailDeliveryReadable {
+	readonly emailFailing?: boolean;
+}
+
+/** The user's own projected failing-delivery signal — absent (not-yet-wired) reads as deliverable. */
+export const readEmailFailing = (me: EmailDeliveryReadable | null): boolean =>
+	me?.emailFailing ?? false;
+
+/**
+ * The account surface the recovery CTA routes into: the existing profile/account page, whose
+ * `e-posta` row owns the change-email affordance. Reusing it keeps the CTA off a NEW recovery
+ * mechanism (epic #2687 non-goal) — the change-email confirmation path itself already exists via
+ * better-auth (ADR 0101).
+ */
+export const EMAIL_RECOVERY_HREF = "/profile";
+
+/** Whether the membrane notice renders: gated on the dark-ship flag, the failing signal, and not-yet-dismissed. */
+export const shouldShowEmailDeliveryNotice = (input: {
+	readonly flagOn: boolean;
+	readonly failing: boolean;
+	readonly dismissed: boolean;
+}): boolean => input.flagOn && input.failing && !input.dismissed;

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -231,6 +231,14 @@ export const PHOENIX_USER_BAN = "phoenix-user-ban";
 export const PHOENIX_EMAIL_DELIVERY_ADMIN = "phoenix-email-delivery-admin";
 
 /**
+ * Failing-email membrane notice dark-ship flag (#2693, email-bounce epic #2687). The seam the
+ * user-facing notice gates behind — with it off the membrane mount renders nothing, so the
+ * surface ships dark until a human flips it at release (ADR 0083). Default-off, its own
+ * `phoenix-` key: the notice is a cross-product membrane element, not scoped to one product.
+ */
+export const PHOENIX_EMAIL_DELIVERY_NOTICE = "phoenix-email-delivery-notice";
+
+/**
  * Nav-IA (per-product Subnav zones) dark-ship flag (#2598, epic #2596). The SINGLE
  * cross-cutting seam the whole nav-IA surface gates behind — the per-product nested
  * layout routes + Subnav CTA slot substrate (#2598) and every per-product delta


### PR DESCRIPTION
Fixes #2693

## What & why

A signed-in user whose transactional email is failing gets no magic-link / verification mail and, until now, no signal why — a silent lockout. This surfaces that state on the membrane shell with a plain-language Turkish notice and a recovery affordance (email-bounce epic #2687, Geçit arc / milestone #24).

This is the **frontend surface only** (user-facing vertical slice, stories 1 & 2). It consumes the user's own projected `email-delivery` failing signal (Child #2691's `resolveEmailDeliveryState`) and routes recovery into the **existing** change-email flow — no new recovery backend.

## What's here

- **`EmailDeliveryNotice`** — presentational notice: Turkish copy ("e-postana ulaşamıyoruz / adresin geri dönüyor"), a recovery CTA (an anchor into the existing `/profile` change-email surface), dismissable, ≥36px CTA hit area, role-token-only styling. State is carried by text (not color alone) in a labelled `role="status"` section.
- **`EmailDeliveryNoticeMount`** — the membrane gate: dark behind `PHOENIX_EMAIL_DELIVERY_NOTICE` (default-off, ADR 0083); renders only for a signed-in user whose own failing signal is set, hidden once dismissed. Mounted in the `Layout` shell above the routed content (not Topbar).
- **`emailDeliveryNoticeGate.ts`** — the pure seam (`readEmailFailing`, `shouldShowEmailDeliveryNotice`, `EMAIL_RECOVERY_HREF`), unit-tested.
- Flag key `PHOENIX_EMAIL_DELIVERY_NOTICE` added to `src/flags/keys.ts`.

## ⚠️ Coordination handoff — worker read-surface exposure needed to light this up

Per the lane carve, this PR does **not** touch the pasaport worker read surface (owned/sequenced with admin Child #2692) or `email-delivery*.ts`. The failing signal is read off the `me` row via a **forward-compatible seam** (`readEmailFailing`), which is **inert (reads `false`) until the worker exposes the signal** — no existing route/loader exposes the current user's failing state today.

To fully activate the notice, two worker-side enablers must be sequenced (flagged, not silently done here):
1. **Expose `emailFailing` on the pasaport `User`/`me` read** (AC1) — add it through the `user-fields.ts` / `views.ts` / `shapers.ts` field-map idiom + stamp it on the `me` resolver from `resolveEmailDeliveryState`, and select it in `MeView` (`useMe.ts`). Once the `me` row carries `emailFailing`, this notice lights up with **no further client change** (the seam already reads it).
2. **Declare the `phoenix-email-delivery-notice` IaC flag** in `worker/features/flagship/resources.ts` (+ wire its factory) so it is flippable at release. Until then the client gate holds it default-off (safe-default).

Both are worker changes deliberately left to the EM to sequence against Child #2692 to avoid a concurrent-lane collision on `views.ts` / `shapers.ts`.

## Local checks
- `pnpm typecheck` — pass
- tests — 17 new (8 unit gate + 9 client render/gate), pass
- `pnpm lint` (biome) — clean
- `pipeline-cli design-token-guard check` — pass (no raw hex / no raw-px regression / all refs resolve)

## Design
Four-pillars (ADR 0162 / design-system-manifest.md): role-token-only, warning-tinted left edge with meaning carried by copy, focus via the shared `--focus-ring`, ≥36px CTA tap target (`min-height: var(--s-8)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
