### PR TITLE
docs(ops): ops runbook doc surface — ops/ home + index + DEVELOPMENT.md pointer (#2702)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -163,6 +163,15 @@ flowchart LR
 
 Two more skills serve the docs rather than the chain: [`adr`](./.claude/skills/adr/SKILL.md) records a decision in `.decisions/`, and [`deslop-comments`](./.claude/skills/deslop-comments/SKILL.md) cuts comments that bury the code.
 
+## Ops runbooks
+
+When the running system breaks, the procedures live in **[ops/](./ops/README.md)** — a peer
+operational doc surface alongside this file. It carries the failure-mode runbooks (D1 restore,
+live plane degraded, Cloudflare down) and the measured capacity baseline, each grounded in
+phoenix's real stack. It sits apart from `.decisions/` (the *why*) and `.patterns/` (how the
+code is shaped) on purpose: `ops/` is **how to operate** the system during an incident. Start at
+[ops/README.md](./ops/README.md).
+
 ## Where to read deeper
 
 Two doc surfaces carry the rest: **[.decisions/](./.decisions/)** holds the ADRs — the *why* behind each choice and the history of how it got here; **[.patterns/](./.patterns/index.md)** describes *how* the current code is shaped. Read a pattern when you're about to write that kind of code; read an ADR when you want to revisit a decision. New decisions go through `/adr`. When a doc and `apps/web/worker/` disagree, the source wins — fix the doc.

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,49 @@
+# Ops runbooks
+
+This is phoenix's **operational** doc surface: the runbooks an operator follows during an
+incident, plus the measured capacity baseline. It is deliberately separate from the other two
+doc surfaces — `.decisions/` holds the *why* (ADRs) and `.patterns/` holds *how the code is
+shaped*; `ops/` holds **how to operate** the running system when something breaks. Reach for a
+runbook here when the product is degraded and you need a procedure grounded in phoenix's real
+stack, not generic ops boilerplate.
+
+Every runbook here is grounded in the live surfaces it covers — the per-app production D1 (ADR
+[0057](../.decisions/0057-multi-app-multi-worker-repo.md)), the unified `LiveDO` fan-out (ADRs
+[0023](../.decisions/0023-live-views-sse-livedo.md)/[0037](../.decisions/0037-unified-void-aligned-live-do.md)),
+the alchemy deploy model (ADR [0032](../.decisions/0032-alchemy-beta45-and-dev-model.md)), and
+the CI-only integration tier's real-Cloudflare coupling (ADR
+[0154](../.decisions/0154-integration-tier-is-ci-only.md)). When a runbook and the source
+disagree, the source wins — fix the runbook.
+
+## Runbooks
+
+| Runbook | Covers | Status |
+|---|---|---|
+| [D1 export / restore](./runbook-d1-restore.md) | Recover the single production D1 from a bad migration; handles the FTS5 virtual-table export tax (ADR [0080](../.decisions/0080-site-search-lexical-bar-semantic-discovery.md)). Rehearsed once. | forthcoming |
+| [Live plane degraded](./runbook-live-plane-degraded.md) | Stale views and `LIVE_UNAVAILABLE` 503s from the SSE fan-out — symptoms, triage, and the levers that exist today. | forthcoming |
+| [Cloudflare down](./runbook-cf-down.md) | A Cloudflare incident, for both the app and the agent pipeline (the integration tier + merge queue couple to real CF, ADR [0154](../.decisions/0154-integration-tier-is-ci-only.md)). | forthcoming |
+| [Capacity baseline](./capacity-baseline.md) | Measured limits: max SSE connections per `LiveDO`, hot-topic publish throughput, feed p95 under load — with the method that produced them. | forthcoming |
+
+Each row links the file its sibling task fills in; a row marked **forthcoming** points at a doc
+not yet written. The link target is the agreed filename so the surface is stable before the
+content lands.
+
+## Runbook shape
+
+A failure-mode runbook follows this shape so an operator mid-incident always finds the same
+sections in the same order:
+
+- **Symptoms** — the observable signals that select this runbook (error strings, dashboards,
+  what a user sees). What makes you reach for *this* one.
+- **Preconditions** — what must be true before you run the procedure: access/credentials you
+  need, the stage you're acting on, state to capture first.
+- **Procedure** — the ordered steps to take, grounded in phoenix's actual commands and
+  surfaces (named `alchemy` commands, real bindings, real routes), not generic advice.
+- **Verification** — how you confirm the procedure worked (row counts, a working query, a
+  green check) before you stand down.
+- **Rollback / escalation** — how to back out if the procedure makes it worse, and who/what to
+  escalate to when it's beyond the runbook.
+
+The capacity baseline is a measurement record rather than a failure-mode procedure, so it
+documents the **numbers and the method that produced them** instead of following the shape
+above.

--- a/ops/capacity-baseline.md
+++ b/ops/capacity-baseline.md
@@ -1,0 +1,14 @@
+# Capacity baseline
+
+> **Status: forthcoming.** This is a stub — the measured capacity baseline lands via issue
+> #2706. It exists now only so [the ops index](./README.md) links resolve before the numbers
+> are measured. Fill each section below with numbers measured against a real deployed stage via
+> the audit harness, plus the method; do not edit `ops/README.md`.
+
+**Max SSE connections per `LiveDO`** —
+
+**Hot-topic publish throughput** —
+
+**Feed p95 under load** —
+
+**Method** —

--- a/ops/runbook-cf-down.md
+++ b/ops/runbook-cf-down.md
@@ -1,0 +1,15 @@
+# Runbook: Cloudflare down
+
+> **Status: forthcoming.** This runbook is a stub — the Cloudflare-down playbook (app + agent
+> pipeline) lands via issue #2705. It exists now only so [the ops index](./README.md) links
+> resolve before the content is written. Fill each section below; do not edit `ops/README.md`.
+
+**Symptoms** —
+
+**Preconditions** —
+
+**Procedure** —
+
+**Verification** —
+
+**Rollback / escalation** —

--- a/ops/runbook-d1-restore.md
+++ b/ops/runbook-d1-restore.md
@@ -1,0 +1,15 @@
+# Runbook: D1 export / restore
+
+> **Status: forthcoming.** This runbook is a stub — the D1 export/restore procedure, rehearsed
+> once, lands via issue #2703. It exists now only so [the ops index](./README.md) links resolve
+> before the content is written. Fill each section below; do not edit `ops/README.md`.
+
+**Symptoms** —
+
+**Preconditions** —
+
+**Procedure** —
+
+**Verification** —
+
+**Rollback / escalation** —

--- a/ops/runbook-live-plane-degraded.md
+++ b/ops/runbook-live-plane-degraded.md
@@ -1,0 +1,15 @@
+# Runbook: live plane degraded
+
+> **Status: forthcoming.** This runbook is a stub — the live-plane-degraded playbook lands via
+> issue #2704. It exists now only so [the ops index](./README.md) links resolve before the
+> content is written. Fill each section below; do not edit `ops/README.md`.
+
+**Symptoms** —
+
+**Preconditions** —
+
+**Procedure** —
+
+**Verification** —
+
+**Rollback / escalation** —


### PR DESCRIPTION
Fixes #2702.

PHASE 1 of epic #2568 (ops runbooks — Mentor Audit). This establishes the serializing
ops doc surface every PHASE-2 runbook depends on, so #2703–#2706 can build in parallel
without colliding on the shared index.

## What this adds

- **`ops/`** — a new top-level operational doc surface, a peer to `DEVELOPMENT.md`,
  deliberately separate from `.decisions/` (the *why*) and `.patterns/` (code shape).
  `ops/` is **how to operate** the running system during an incident.
- **`ops/README.md`** — the index. States the surface's purpose, carries the shared
  runbook shape (Symptoms → Preconditions → Procedure → Verification → Rollback/escalation),
  and **pre-lists all four PHASE-2 deliverables** with links, so each sibling registers into
  a stable index by filling its own file and **never edits `ops/README.md`** (the serializing
  seam of the epic).
- **Four forthcoming stubs** so the index links resolve now (the `doc-links`/lychee gate
  fails on a broken relative link) — siblings fill each in place:
  - `ops/runbook-d1-restore.md` → filled by #2703
  - `ops/runbook-live-plane-degraded.md` → filled by #2704
  - `ops/runbook-cf-down.md` → filled by #2705
  - `ops/capacity-baseline.md` → filled by #2706
- **`DEVELOPMENT.md`** — a `## Ops runbooks` section pointing at `ops/README.md`.

## Acceptance criteria

- [x] `ops/README.md` exists, names the surface's purpose, carries the runbook template shape.
- [x] `ops/README.md` links all four sibling docs by their agreed filenames.
- [x] `DEVELOPMENT.md` has an `## Ops runbooks` section pointing at `ops/README.md`.
- [x] All internal links are repo-relative and resolve (no local/home/absolute paths).

## Local checks

- `lychee --offline` (the `doc-links` gate) — repo-wide, **0 errors**.
- `pipeline-cli leak-guard scan` on all six files — **clean**.

Docs only, non-§CP — auto-ships on a green `review-doc` gate.