### PR TITLE
feat(web): kill topbar tema toggle → theme picker (light/dark/auto), default auto (#2612)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -97,7 +97,7 @@ function Layout() {
 	const session = useSession();
 	const navigate = useNavigate();
 	const location = useLocation();
-	const {toggle: toggleTheme} = useTheme();
+	const {toggle: toggleTheme, choice: themeChoice, setChoice: setThemeChoice} = useTheme();
 	const [chips, setChips] = useState<TopbarChips | null>(null);
 	// The mecmua nav entry (#2512), dark behind `mecmua-public-read` — the same seam the
 	// reader/index gate on. `useFlag` reads over `fetch` (no fate client), so it is safe in
@@ -183,7 +183,12 @@ function Layout() {
 							const target = searchTarget(query);
 							if (target) navigate(target);
 						}}
-						onToggleTheme={toggleTheme}
+						// The tema toggle is wired only with nav-IA off; on, the three-way
+						// theme picker is the sole control (#2612), so onToggleTheme stays
+						// unwired and no tema button renders.
+						onToggleTheme={navIaOn ? undefined : toggleTheme}
+						themeChoice={themeChoice}
+						onThemeChange={setThemeChoice}
 						onLogout={onSignOut}
 						actions={
 							!isSignedIn ? (

--- a/apps/web/src/components/layout/ThemeChoicePicker.test.tsx
+++ b/apps/web/src/components/layout/ThemeChoicePicker.test.tsx
@@ -1,0 +1,37 @@
+import {fireEvent, render, screen, within} from "@testing-library/react";
+import {describe, expect, it, vi} from "vitest";
+import {ThemeChoicePicker} from "./ThemeChoicePicker";
+
+describe("ThemeChoicePicker (#2612)", () => {
+	it("renders the three choices and marks the active one via aria-pressed", () => {
+		render(<ThemeChoicePicker choice="dark" onChange={() => {}} testId="tp" />);
+		const group = screen.getByTestId("tp");
+		for (const label of ["açık", "koyu", "otomatik"]) {
+			expect(within(group).getByRole("button", {name: label})).toBeTruthy();
+		}
+		expect(within(group).getByRole("button", {name: "koyu"}).getAttribute("aria-pressed")).toBe(
+			"true",
+		);
+		expect(within(group).getByRole("button", {name: "açık"}).getAttribute("aria-pressed")).toBe(
+			"false",
+		);
+	});
+
+	it("routes each pick to onChange with its ThemeChoice value", () => {
+		const onChange = vi.fn();
+		render(<ThemeChoicePicker choice="dark" onChange={onChange} testId="tp" />);
+		fireEvent.click(screen.getByRole("button", {name: "açık"}));
+		expect(onChange).toHaveBeenLastCalledWith("light");
+		fireEvent.click(screen.getByRole("button", {name: "otomatik"}));
+		expect(onChange).toHaveBeenLastCalledWith("auto");
+	});
+
+	it("ignores a deselect click on the active option — one choice is always set", () => {
+		const onChange = vi.fn();
+		render(<ThemeChoicePicker choice="dark" onChange={onChange} testId="tp" />);
+		// Clicking the already-active option would empty a Toggle track's value; the
+		// picker drops that so it never resolves to "no theme".
+		fireEvent.click(screen.getByRole("button", {name: "koyu"}));
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/components/layout/ThemeChoicePicker.tsx
+++ b/apps/web/src/components/layout/ThemeChoicePicker.tsx
@@ -1,0 +1,43 @@
+import type {ThemeChoice} from "../../lib/theme";
+import {ToggleGroup} from "../ui/ToggleGroup";
+
+// The three-way theme control that replaces the topbar tema toggle (#2612). The
+// `segmented` ToggleGroup track paints its active option with a neutral surface token,
+// never an accent fill — so it stays inside the #2614 accent-scarcity containment law.
+const THEME_LABELS: Record<ThemeChoice, string> = {
+	light: "açık",
+	dark: "koyu",
+	auto: "otomatik",
+};
+
+export function ThemeChoicePicker({
+	choice,
+	onChange,
+	testId,
+	className = "",
+}: {
+	choice: ThemeChoice;
+	onChange: (choice: ThemeChoice) => void;
+	testId?: string;
+	className?: string;
+}) {
+	return (
+		<div className={`kp-theme-picker ${className}`.trim()} data-testid={testId}>
+			<ToggleGroup.Root
+				variant="segmented"
+				value={[choice]}
+				// Radio semantics on a Toggle track: a click on the active option would
+				// deselect it to an empty value, so drop the empty case — a theme picker
+				// always resolves to exactly one choice, never "no theme".
+				onValueChange={(v) => v[0] && onChange(v[0] as ThemeChoice)}
+				aria-label="Tema"
+			>
+				{(Object.keys(THEME_LABELS) as ThemeChoice[]).map((c) => (
+					<ToggleGroup.Item key={c} value={c}>
+						{THEME_LABELS[c]}
+					</ToggleGroup.Item>
+				))}
+			</ToggleGroup.Root>
+		</div>
+	);
+}

--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -182,3 +182,19 @@
 .kp-topbar__zone--utility .kp-topbar__btn:hover {
 	color: var(--text-primary);
 }
+
+/* The three-way theme picker (#2612) that replaces the tema toggle. In the user menu it
+   reads as a labeled settings row (label left, segmented control right); in the utility
+   zone the label is absent and the segmented control sits inline. The control is the
+   neutral `segmented` ToggleGroup, so it carries no accent fill (#2614 stays satisfied). */
+.kp-topbar__theme-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--s-3);
+	padding: var(--s-1) var(--s-2);
+}
+.kp-topbar__theme-label {
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -8,9 +8,9 @@
  */
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
-import {render, screen} from "@testing-library/react";
+import {fireEvent, render, screen, within} from "@testing-library/react";
 import {MemoryRouter} from "react-router";
-import {describe, expect, it} from "vitest";
+import {describe, expect, it, vi} from "vitest";
 import {Topbar} from "./Topbar";
 
 const NAV = [
@@ -193,5 +193,98 @@ describe("Topbar accent-scarcity containment law (#2614)", () => {
 		expect(temaHover).toBeDefined();
 		expect(temaHover?.body).toMatch(/color:\s*var\(--text-primary\)/);
 		expect(temaHover?.body).not.toMatch(/var\(--accent(-11)?\)/);
+	});
+});
+
+describe("Topbar tema toggle → theme picker (#2612)", () => {
+	it("flag off: the tema toggle still renders and behaves exactly as today", () => {
+		const onToggleTheme = vi.fn();
+		render(
+			<MemoryRouter>
+				<Topbar
+					nav={NAV}
+					onToggleTheme={onToggleTheme}
+					themeChoice="dark"
+					onThemeChange={() => {}}
+				/>
+			</MemoryRouter>,
+		);
+		const tema = screen.getByRole("button", {name: "tema"});
+		fireEvent.click(tema);
+		expect(onToggleTheme).toHaveBeenCalledOnce();
+		// The three-way picker is dark behind the flag — no picker surface renders.
+		expect(screen.queryByTestId("topbar-theme-picker")).toBeNull();
+	});
+
+	it("flag on: no tema toggle renders, in either auth state", () => {
+		const {rerender} = render(
+			<MemoryRouter>
+				<Topbar
+					navIa
+					nav={NAV}
+					onToggleTheme={vi.fn()}
+					themeChoice="auto"
+					onThemeChange={() => {}}
+					user={{name: "Elif", username: "elif"}}
+				/>
+			</MemoryRouter>,
+		);
+		expect(screen.queryByRole("button", {name: "tema"})).toBeNull();
+		rerender(
+			<MemoryRouter>
+				<Topbar
+					navIa
+					nav={NAV}
+					onToggleTheme={vi.fn()}
+					themeChoice="auto"
+					onThemeChange={() => {}}
+				/>
+			</MemoryRouter>,
+		);
+		expect(screen.queryByRole("button", {name: "tema"})).toBeNull();
+	});
+
+	it("flag on, signed in: the theme picker lives in the user menu next to ayarlar", () => {
+		const onThemeChange = vi.fn();
+		render(
+			<MemoryRouter>
+				<Topbar
+					navIa
+					nav={NAV}
+					themeChoice="dark"
+					onThemeChange={onThemeChange}
+					user={{name: "Elif", username: "elif"}}
+				/>
+			</MemoryRouter>,
+		);
+		// The picker is portaled inside the account menu — open it, then it appears.
+		fireEvent.click(screen.getByText("Elif"));
+		// `ayarlar` (the settings item) sits directly above the theme row — the picker is
+		// the next control in the account menu, not the topbar utility zone.
+		expect(screen.getByText("ayarlar")).toBeTruthy();
+		const row = screen.getByTestId("topbar-theme-row");
+		expect(within(row).getByText("tema")).toBeTruthy();
+		const picker = within(row).getByTestId("topbar-theme-picker");
+		expect(within(picker).getByRole("button", {name: "koyu"}).getAttribute("aria-pressed")).toBe(
+			"true",
+		);
+		fireEvent.click(within(picker).getByRole("button", {name: "otomatik"}));
+		expect(onThemeChange).toHaveBeenLastCalledWith("auto");
+	});
+
+	it("flag on, signed out: the same light/dark/auto picker is reachable in the topbar utility zone", () => {
+		const onThemeChange = vi.fn();
+		render(
+			<MemoryRouter>
+				<Topbar navIa nav={NAV} themeChoice="light" onThemeChange={onThemeChange} />
+			</MemoryRouter>,
+		);
+		const utility = screen.getByTestId("topbar-zone-utility");
+		const picker = within(utility).getByTestId("topbar-theme-picker");
+		for (const label of ["açık", "koyu", "otomatik"]) {
+			expect(within(picker).getByRole("button", {name: label})).toBeTruthy();
+		}
+		fireEvent.click(within(picker).getByRole("button", {name: "koyu"}));
+		expect(onThemeChange).toHaveBeenLastCalledWith("dark");
 	});
 });

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -2,10 +2,12 @@ import type * as React from "react";
 import {useEffect, useRef} from "react";
 import {Link, NavLink, useNavigate} from "react-router";
 import {isSearchShortcut} from "../../lib/searchShortcut";
+import type {ThemeChoice} from "../../lib/theme";
 import {formatUnreadBadge, showUnreadBadge} from "../bildirim/bildirim";
 import {Karma} from "../karma/Karma";
 import {Avatar} from "../ui/Avatar";
 import {Menu} from "../ui/Menu";
+import {ThemeChoicePicker} from "./ThemeChoicePicker";
 import "./Topbar.css";
 
 export type NavItem = {to: string; label: string};
@@ -22,6 +24,8 @@ export function Topbar({
 	searchQuery = "",
 	onSearchSubmit,
 	onToggleTheme,
+	themeChoice,
+	onThemeChange,
 	onLogout,
 	navIa = false,
 }: {
@@ -60,7 +64,21 @@ export function Topbar({
 	 */
 	searchQuery?: string;
 	onSearchSubmit?: (query: string) => void;
+	/**
+	 * The legacy light↔dark tema toggle (#2612). Wired by the Layout only when the
+	 * nav-IA flag is OFF — on, the three-way theme picker (below) is the sole control,
+	 * so no `tema` button renders and this stays unwired. Kept so the flag-off topbar
+	 * behaves exactly as today.
+	 */
 	onToggleTheme?: () => void;
+	/**
+	 * The current theme selection + its setter, driving the three-way theme picker
+	 * (light/dark/auto) that replaces the tema toggle under nav-IA (#2612). The picker
+	 * renders only when the flag is on: in the user menu for a signed-in visitor, and in
+	 * the utility zone for a signed-out one — so every visitor keeps one theme control.
+	 */
+	themeChoice?: ThemeChoice;
+	onThemeChange?: (choice: ThemeChoice) => void;
 	onLogout?: () => void;
 	/**
 	 * The nav-IA restructure seam (#2611, epic #2595) — the shared default-off
@@ -163,6 +181,18 @@ export function Topbar({
 			tema
 		</button>
 	) : null;
+	// The three-way theme picker (#2612), present only under the zone grammar. Null when
+	// the flag is off, so it renders nothing in the flag-off topbar (byte-identical to
+	// today) and inside the user menu below. Signed-in ⇒ it lives in the menu next to
+	// `ayarlar`; signed-out ⇒ in the utility zone (both wired in the navIa branch).
+	const themePicker =
+		navIa && themeChoice && onThemeChange ? (
+			<ThemeChoicePicker
+				choice={themeChoice}
+				onChange={onThemeChange}
+				testId="topbar-theme-picker"
+			/>
+		) : null;
 	const karmaChip =
 		typeof karma === "number" ? (
 			<Karma value={karma} variant="inline" testId="topbar-karma" className="kp-topbar__karma" />
@@ -196,6 +226,12 @@ export function Topbar({
 					</Menu.Item>
 				) : null}
 				<Menu.Item onClick={() => navigate("/profile")}>ayarlar</Menu.Item>
+				{themePicker ? (
+					<div className="kp-topbar__theme-row" data-testid="topbar-theme-row">
+						<span className="kp-topbar__theme-label">tema</span>
+						{themePicker}
+					</div>
+				) : null}
 				<Menu.Separator />
 				<Menu.Item onClick={onLogout}>çıkış</Menu.Item>
 			</Menu.Popup>
@@ -229,7 +265,10 @@ export function Topbar({
 				<span className="kp-topbar__spacer" />
 				<div className="kp-topbar__zone kp-topbar__zone--utility" data-testid="topbar-zone-utility">
 					{searchForm}
-					{themeButton}
+					{/* No `tema` toggle under the flag (#2612) — the theme picker is the sole
+					    control. Signed-out visitors reach it here; signed-in ones in the user
+					    menu (above), so exactly one theme control renders either way. */}
+					{!user ? themePicker : null}
 				</div>
 				<div
 					className="kp-topbar__zone kp-topbar__zone--status-signal"

--- a/apps/web/src/lib/theme.test.tsx
+++ b/apps/web/src/lib/theme.test.tsx
@@ -1,0 +1,54 @@
+import {render, screen} from "@testing-library/react";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {ThemeProvider, useTheme} from "./theme";
+
+function Probe() {
+	const {choice, resolved} = useTheme();
+	return <div data-testid="probe" data-choice={choice} data-resolved={resolved} />;
+}
+
+// jsdom ships no matchMedia, so stub one whose `(prefers-color-scheme: light)` match is
+// driven by `prefersLight` — this is what lets an `auto` choice resolve to a *system*
+// value under test rather than systemPrefers()'s dark fallback.
+function mockMatchMedia(prefersLight: boolean) {
+	vi.stubGlobal("matchMedia", (query: string) => ({
+		matches: query.includes("light") ? prefersLight : !prefersLight,
+		media: query,
+		onchange: null,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		addListener: () => {},
+		removeListener: () => {},
+		dispatchEvent: () => false,
+	}));
+}
+
+describe("theme default resolution (#2612)", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("a first-visit user with no stored choice defaults to auto → the system preference", () => {
+		// No storage is written in this env, so the provider takes its DEFAULT_CHOICE.
+		mockMatchMedia(true); // system prefers light
+		render(
+			<ThemeProvider>
+				<Probe />
+			</ThemeProvider>,
+		);
+		const probe = screen.getByTestId("probe");
+		expect(probe.getAttribute("data-choice")).toBe("auto");
+		expect(probe.getAttribute("data-resolved")).toBe("light");
+		expect(document.documentElement.dataset.theme).toBe("light");
+	});
+
+	it("auto follows a dark system preference too", () => {
+		mockMatchMedia(false); // system prefers dark
+		render(
+			<ThemeProvider>
+				<Probe />
+			</ThemeProvider>,
+		);
+		expect(screen.getByTestId("probe").getAttribute("data-resolved")).toBe("dark");
+	});
+});

--- a/apps/web/src/lib/theme.tsx
+++ b/apps/web/src/lib/theme.tsx
@@ -4,7 +4,9 @@ import {readStoredChoice, writeStoredChoice} from "./themeStorage";
 export type ThemeChoice = "light" | "dark" | "auto";
 type ResolvedTheme = "light" | "dark";
 
-const DEFAULT_CHOICE: ThemeChoice = "dark";
+// A first-time visitor with no stored choice follows their system preference (#2612):
+// `auto` resolves to the OS light/dark setting rather than forcing dark on everyone.
+const DEFAULT_CHOICE: ThemeChoice = "auto";
 
 function browserStorage(): Storage | undefined {
 	return typeof window === "undefined" ? undefined : window.localStorage;


### PR DESCRIPTION
Kills the topbar `tema` toggle and makes the three-way theme picker (light / dark / auto) THE theme control for every visitor — signed-in and signed-out — behind the shared `phoenix-nav-ia` flag, so the change lands with the atomic nav-commit and no user loses theme control at any point.

Builds on the #2611 zone spine and the #2614 accent-scarcity law (both on `main`), the next link in the Topbar serial chain of epic #2595.

## What changed
- **`Topbar.tsx`** — under the flag, no `tema` button renders. The picker lives in the **user menu** next to `ayarlar` for a signed-in visitor, and in the **utility zone** for a signed-out one, so exactly one theme control renders either way. Flag off ⇒ the topbar is byte-identical to today (the tema toggle still renders and behaves exactly as before).
- **`App.tsx`** — `onToggleTheme` is wired **only** with the flag off; the flag-on path passes `themeChoice`/`onThemeChange` instead (the tema toggle is no longer wired on).
- **`ThemeChoicePicker.tsx`** (new) — a `segmented` `ToggleGroup` (açık / koyu / otomatik). Its active option paints a neutral `--surface-raised` surface, **never** an accent fill, so the #2614 containment law holds (the CSS-source accent guard in `Topbar.test.tsx` still passes at exactly one accent fill). Single-select radio semantics — a click on the active option is dropped so it never resolves to "no theme".
- **`theme.tsx`** — `DEFAULT_CHOICE` `dark` → `auto`, so a first-visit user with no stored choice follows their system preference.

## Tests
- `ThemeChoicePicker.test.tsx` — three choices, routes each pick, no-deselect on the active option.
- `Topbar.test.tsx` (`#2612` block) — flag-off tema unchanged; flag-on renders no tema button in either auth state; signed-in picker in the user menu next to `ayarlar`; signed-out picker in the utility zone. The #2611 byte-identity and #2614 accent-source guards still pass.
- `theme.test.tsx` — a no-stored-choice user defaults to `auto` and resolves to the system preference (light and dark).

Local checks green: `apps/web` typecheck, full client vitest (202 passed), biome, `design-token-guard check` (token-only CSS, no raw px).

## Relationship to #2582
This PR is expected to **fully resolve #2582** ("`tema` toggle sits flush against the `+ gönderi` CTA — users misclick"): removing the tema toggle removes the misclick surface entirely (and #2614 already neutralized its accent styling). Under the flag, there is no `tema` button adjacent to any CTA — the theme control is a picker in the user menu / utility zone. Flagging for triage to close #2582; I am not closing it here (cross-issue, not authorized).

Epic: #2595 (nav-IA). Non-§CP (apps/web UI) — normal pipeline.

Fixes #2612

🤖 Generated with [Claude Code](https://claude.com/claude-code)