### PR TITLE
feat(sozluk): branded ID schemas end-to-end + shared brand-schema module (#2712)

### DIFF
--- a/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
+++ b/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
@@ -29,6 +29,7 @@ import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
 import {Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
+import {DefinitionId} from "../../lib/ids.ts";
 import {noopPanoFeedCache} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import type {CommentRow} from "../pano/comment-fields.ts";
@@ -265,7 +266,7 @@ describe("çaylak sandbox-escape via delete→restore is structurally prevented 
 				getTerm: () => Effect.succeed(termPage()),
 			});
 			yield* sozlukMutations["definition.restore"]
-				.handler({input: {id: "def-1"}, select: ["id"]})
+				.handler({input: {id: DefinitionId.make("def-1")}, select: ["id"]})
 				.pipe(
 					Effect.provide(Layer.mergeAll(sozluk, layer)),
 					Effect.provideService(CurrentUser, {user: AUTHOR}),

--- a/apps/web/worker/features/lifecycle/create-path-refresh-swallow.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/create-path-refresh-swallow.unit.test.ts
@@ -17,6 +17,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {type Context, Effect, Exit, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, DrizzleError} from "../../db/Drizzle.ts";
+import {TermSlug, UserId} from "../../lib/ids.ts";
 import {Bookmark} from "../pano/Bookmark.ts";
 import {Pano, PanoLive} from "../pano/Pano.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
@@ -106,9 +107,9 @@ describe("addDefinition — a post-commit refresh die cannot 500 a committed ins
 				Effect.gen(function* () {
 					const sozluk = yield* Sozluk;
 					return yield* sozluk.addDefinition({
-						termSlug: "x",
+						termSlug: TermSlug.make("x"),
 						termTitle: "X",
-						authorId: "a1",
+						authorId: UserId.make("a1"),
 						authorName: "n",
 						body: "a valid definition body",
 					});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -15,6 +15,7 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import type {DefinitionId, TermSlug, UserId} from "../../lib/ids.ts";
 import {stampAuthorIdentity} from "../fate/author-identity.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {parallelStampWave} from "../fate/stamp-wave.ts";
@@ -225,8 +226,8 @@ export const scanReconcileChunks = (
 export type ListSort = TermSummarySort;
 
 export interface AddDefinitionInput {
-	termSlug: string;
-	authorId: string;
+	termSlug: TermSlug;
+	authorId: UserId;
 	authorName: string;
 	body: string;
 	/** Optional human title. Falls back to slug-with-spaces. */
@@ -249,9 +250,12 @@ export interface AddDefinitionResult {
 	updatedAt: Date;
 }
 
+// `definitionId` and `voterId` are distinct brands (DefinitionId vs UserId), so
+// transposing them at a call site is a compile error — the #2712 arg-swap the
+// bare-`string` shape allowed is now unrepresentable.
 export interface VoteDefinitionInput {
-	definitionId: string;
-	voterId: string;
+	definitionId: DefinitionId;
+	voterId: UserId;
 }
 
 export interface VoteDefinitionResult {
@@ -269,8 +273,8 @@ export interface VoteDefinitionResult {
 }
 
 export interface ReactDefinitionInput {
-	definitionId: string;
-	reactorId: string;
+	definitionId: DefinitionId;
+	reactorId: UserId;
 	/**
 	 * The reaction intent, a curated-`REACTION_EMOJI` member or a retract. A palette
 	 * emoji sets/changes the reactor's single reaction; `null` retracts it. The type
@@ -281,8 +285,8 @@ export interface ReactDefinitionInput {
 }
 
 export interface EditDefinitionInput {
-	definitionId: string;
-	actorId: string;
+	definitionId: DefinitionId;
+	actorId: UserId;
 	body: string;
 }
 
@@ -297,8 +301,8 @@ export interface EditDefinitionResult {
 }
 
 export interface DeleteDefinitionInput {
-	definitionId: string;
-	actorId: string;
+	definitionId: DefinitionId;
+	actorId: UserId;
 	/**
 	 * Why the definition is being removed (ADR 0096). Defaults to `AuthorDeletion`
 	 * — the author-delete mutation passes nothing; account-deletion (0097) and

--- a/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
@@ -25,6 +25,7 @@ import {liveConnectionTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server"
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
+import {TermSlug} from "../../lib/ids.ts";
 import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
 import {Divan} from "../divan/Divan.ts";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
@@ -143,7 +144,7 @@ it.effect(
 			);
 
 			yield* mutations["definition.add"]
-				.handler({input: {termSlug: slug, body: ADD_RESULT.body}, select: ["id"]})
+				.handler({input: {termSlug: TermSlug.make(slug), body: ADD_RESULT.body}, select: ["id"]})
 				.pipe(
 					Effect.provide(
 						Layer.mergeAll(
@@ -196,7 +197,7 @@ it.effect("definition.add never persists a null-name author's email as authorNam
 		);
 
 		yield* mutations["definition.add"]
-			.handler({input: {termSlug: "gizli", body: ADD_RESULT.body}, select: ["id"]})
+			.handler({input: {termSlug: TermSlug.make("gizli"), body: ADD_RESULT.body}, select: ["id"]})
 			.pipe(
 				Effect.provide(
 					Layer.mergeAll(

--- a/apps/web/worker/features/sozluk/definition-reaction-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-reaction-mutation.unit.test.ts
@@ -18,6 +18,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, Effect, Exit, Layer} from "effect";
+import {DefinitionId, UserId} from "../../lib/ids.ts";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {Flags} from "../flagship/Flags.ts";
@@ -113,7 +114,13 @@ describe("definition.react — dark-ship + delegation", () => {
 				input: {id: "def-1", emoji: "👍"},
 				select: ["id", "reactions"],
 			});
-			assert.deepStrictEqual(calls, [{definitionId: "def-1", reactorId: "u-reactor", emoji: "👍"}]);
+			assert.deepStrictEqual(calls, [
+				{
+					definitionId: DefinitionId.make("def-1"),
+					reactorId: UserId.make("u-reactor"),
+					emoji: "👍",
+				},
+			]);
 			assert.deepStrictEqual((def as {reactions: unknown}).reactions, {
 				counts: [{emoji: "👍", count: 1}],
 				myReaction: "👍",

--- a/apps/web/worker/features/sozluk/definition-validation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-validation.unit.test.ts
@@ -21,6 +21,7 @@ import {it} from "@effect/vitest";
 import {Cause, type Context, Effect, Exit, Layer} from "effect";
 import {assert} from "vitest";
 import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import {DefinitionId, TermSlug, UserId} from "../../lib/ids.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Reaction} from "../reaction/Reaction.ts";
 import {Vote} from "../vote/Vote.ts";
@@ -64,14 +65,14 @@ const expectTag = (exit: Exit.Exit<unknown, unknown>, tag: string) => {
 	}
 };
 
-const ownerId = "u1";
+const ownerId = UserId.make("u1");
 
 const runAdd = (body: string | undefined) =>
 	Effect.gen(function* () {
 		const sozluk = yield* Sozluk;
 		return yield* sozluk
 			.addDefinition({
-				termSlug: "fate",
+				termSlug: TermSlug.make("fate"),
 				authorId: ownerId,
 				authorName: "umut",
 				body: body as string,
@@ -83,7 +84,11 @@ const runEdit = (body: string | undefined) =>
 	Effect.gen(function* () {
 		const sozluk = yield* Sozluk;
 		return yield* sozluk
-			.editDefinition({definitionId: "def_1", actorId: ownerId, body: body as string})
+			.editDefinition({
+				definitionId: DefinitionId.make("def_1"),
+				actorId: ownerId,
+				body: body as string,
+			})
 			.pipe(Effect.exit);
 	}).pipe(Effect.provide(sozlukLayer));
 

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -15,6 +15,7 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
 import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
+import {DefinitionId, TermSlug, UserId} from "../../lib/ids.ts";
 import {notifyCaylakEntersDivan} from "../bildirim/mod-emitters.ts";
 import {notifyContentVote} from "../bildirim/vote-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
@@ -37,19 +38,22 @@ import {toDefinition, toTermFromPage} from "./shapers.ts";
 import type {Definition} from "./views.ts";
 import {DefinitionView, TermView} from "./views.ts";
 
+// Branded id schemas decode byte-identically (the brand is type-only) but carry
+// the nominal tag downstream, so `input.id` / `input.termSlug` arrive already
+// typed as DefinitionId / TermSlug for the service-call surface below.
 const AddDefinitionInput = Schema.Struct({
-	termSlug: Schema.String,
+	termSlug: TermSlug,
 	termTitle: Schema.optional(Schema.NullOr(Schema.String)),
 	body: Schema.String,
 });
 
 const EditDefinitionInput = Schema.Struct({
-	id: Schema.String,
+	id: DefinitionId,
 	body: Schema.String,
 });
 
 const DefinitionIdInput = Schema.Struct({
-	id: Schema.String,
+	id: DefinitionId,
 });
 
 // The reaction intent decodes against the curated `REACTION_EMOJI` palette at the
@@ -57,7 +61,7 @@ const DefinitionIdInput = Schema.Struct({
 // retracts it, and a NON-palette string fails to decode — so an arbitrary emoji is
 // structurally unrepresentable, never reaching the service (#1865 AC#1).
 const ReactDefinitionInput = Schema.Struct({
-	id: Schema.String,
+	id: DefinitionId,
 	emoji: Schema.NullOr(ReactionEmojiSchema),
 });
 
@@ -101,7 +105,7 @@ export const mutations = {
 				const sandboxedAt = yield* sandboxedAtForAuthor(user.id, new Date());
 				const result = yield* sozluk.addDefinition({
 					termSlug: input.termSlug,
-					authorId: user.id,
+					authorId: UserId.make(user.id),
 					authorName: authorDisplayLabel(user),
 					body: input.body,
 					sandboxedAt,
@@ -140,7 +144,10 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
 			const live = sozlukLive(yield* WorkerLivePublisher);
-			const result = yield* sozluk.voteDefinition({definitionId: input.id, voterId: user.id});
+			const result = yield* sozluk.voteDefinition({
+				definitionId: input.id,
+				voterId: UserId.make(user.id),
+			});
 			const definition = shapeDefinition(result);
 			// `myVote` is viewer-specific, so it's omitted from `changed`.
 			yield* live.definition.update(definition.id, {changed: ["score"], data: definition});
@@ -170,7 +177,7 @@ export const mutations = {
 			const live = sozlukLive(yield* WorkerLivePublisher);
 			const result = yield* sozluk.retractDefinitionVote({
 				definitionId: input.id,
-				voterId: user.id,
+				voterId: UserId.make(user.id),
 			});
 			const definition = shapeDefinition(result);
 			yield* live.definition.update(definition.id, {changed: ["score"], data: definition});
@@ -217,7 +224,7 @@ export const mutations = {
 			const live = sozlukLive(yield* WorkerLivePublisher);
 			const row = yield* sozluk.reactToDefinition({
 				definitionId: input.id,
-				reactorId: user.id,
+				reactorId: UserId.make(user.id),
 				emoji: input.emoji,
 			});
 			const definition = toDefinition(row);
@@ -243,7 +250,7 @@ export const mutations = {
 			const live = sozlukLive(yield* WorkerLivePublisher);
 			const result = yield* sozluk.editDefinition({
 				definitionId: input.id,
-				actorId: user.id,
+				actorId: UserId.make(user.id),
 				body: input.body,
 			});
 			// Re-read the viewer's vote so the edit doesn't drop `myVote` (edit
@@ -268,7 +275,7 @@ export const mutations = {
 			const live = sozlukLive(yield* WorkerLivePublisher);
 			// Resolve the parent slug before the delete, while the row still exists.
 			const slug = yield* sozluk.lookupDefinitionTermSlug(input.id);
-			yield* sozluk.deleteDefinition({definitionId: input.id, actorId: user.id});
+			yield* sozluk.deleteDefinition({definitionId: input.id, actorId: UserId.make(user.id)});
 			yield* live.definition.delete(input.id);
 			if (slug) {
 				yield* live.definition.term(slug).deleteEdge(input.id);
@@ -294,7 +301,7 @@ export const mutations = {
 			const live = sozlukLive(yield* WorkerLivePublisher);
 			const restoreResult = yield* sozluk.restoreDefinition({
 				definitionId: input.id,
-				actorId: user.id,
+				actorId: UserId.make(user.id),
 			});
 			const slug = yield* sozluk.lookupDefinitionTermSlug(input.id);
 			if (!slug) return null;

--- a/apps/web/worker/features/sozluk/persist-term-summary.unit.test.ts
+++ b/apps/web/worker/features/sozluk/persist-term-summary.unit.test.ts
@@ -18,6 +18,7 @@ import {drizzle} from "drizzle-orm/d1";
 import {type Context, Effect, Layer} from "effect";
 import {assert} from "vitest";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import {DefinitionId, UserId} from "../../lib/ids.ts";
 import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
 import {Vote} from "../vote/Vote.ts";
@@ -87,7 +88,7 @@ const sozlukOver = (access: DrizzleAccess) =>
 
 const SLUG = "kelime";
 const TITLE = "Kelime";
-const OWNER = "u1";
+const OWNER = UserId.make("u1");
 
 // The definition `editDefinition` resolves first (its findFirst result) — author
 // matches the actor so the mutation proceeds to the summary recompute.
@@ -122,7 +123,11 @@ const renderUpsert = () =>
 		const {access, batched} = scriptedAccess([editedDefinition, {}, liveDefs]);
 		yield* Effect.gen(function* () {
 			const sozluk = yield* Sozluk;
-			yield* sozluk.editDefinition({definitionId: "def_1", actorId: OWNER, body: "a fresh body"});
+			yield* sozluk.editDefinition({
+				definitionId: DefinitionId.make("def_1"),
+				actorId: OWNER,
+				body: "a fresh body",
+			});
 		}).pipe(Effect.provide(sozlukOver(access)));
 		return batched;
 	});

--- a/apps/web/worker/features/sozluk/reaction-definition.unit.test.ts
+++ b/apps/web/worker/features/sozluk/reaction-definition.unit.test.ts
@@ -19,6 +19,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer} from "effect";
 import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import {DefinitionId, UserId} from "../../lib/ids.ts";
 import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import {
 	EMPTY_REACTION_AGGREGATE,
@@ -30,8 +31,8 @@ import {
 import {Vote} from "../vote/Vote.ts";
 import {Sozluk, SozlukLive} from "./Sozluk.ts";
 
-const DEF_ID = "def-1";
-const REACTOR = "u-reactor";
+const DEF_ID = DefinitionId.make("def-1");
+const REACTOR = UserId.make("u-reactor");
 
 // The scripted `definition_record` the up-front load returns (or `undefined` for the
 // not-found path). The reads only touch `toDefinitionRow`'s columns; the rest satisfy

--- a/apps/web/worker/features/sozluk/recompute-sozluk-stats-public-live.unit.test.ts
+++ b/apps/web/worker/features/sozluk/recompute-sozluk-stats-public-live.unit.test.ts
@@ -17,6 +17,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {createDrizzle, Drizzle, makeDrizzleAccess} from "../../db/Drizzle.ts";
+import {TermSlug, UserId} from "../../lib/ids.ts";
 import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
 import {Vote} from "../vote/Vote.ts";
@@ -67,9 +68,9 @@ const recordRecomputeCounts = Effect.gen(function* () {
 	yield* Effect.gen(function* () {
 		const sozluk = yield* Sozluk;
 		yield* sozluk.addDefinition({
-			termSlug: "x",
+			termSlug: TermSlug.make("x"),
 			termTitle: "X",
-			authorId: "a1",
+			authorId: UserId.make("a1"),
 			authorName: "n",
 			body: "a valid definition body",
 		});

--- a/apps/web/worker/features/sozluk/self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/sozluk/self-vote-guard.unit.test.ts
@@ -12,15 +12,16 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer} from "effect";
 import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import {DefinitionId, UserId} from "../../lib/ids.ts";
 import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import {Reaction} from "../reaction/Reaction.ts";
 import type {VoteInput, VoteResult} from "../vote/Vote.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Sozluk, SozlukLive} from "./Sozluk.ts";
 
-const AUTHOR = "u-author";
-const OTHER = "u-other";
-const DEF_ID = "def-1";
+const AUTHOR = UserId.make("u-author");
+const OTHER = UserId.make("u-other");
+const DEF_ID = DefinitionId.make("def-1");
 
 // The `definition_record` the up-front load returns. Only `authorId` drives the guard; the
 // rest satisfy the row shape the return projection reads. `changed:false` from the Vote

--- a/apps/web/worker/lib/ids.ts
+++ b/apps/web/worker/lib/ids.ts
@@ -1,0 +1,44 @@
+/**
+ * Branded ID schemas — the shared home for nominal id types (epic #2700).
+ *
+ * Two ids that are both `string` at runtime (a user id, a definition id) are
+ * indistinguishable to the type checker, so an argument swap like
+ * `voteDefinition({definitionId, voterId})` compiles even when the two are
+ * transposed (#2712). `Schema.brand` fixes that: it intersects a schema's
+ * output type with a nominal `Brand`, so `UserId` and `DefinitionId` become
+ * distinct types that can't be passed for one another — while staying plain
+ * strings at runtime (the brand is type-only: `.make`/decode return the input
+ * unchanged, so wire and D1 bytes are byte-identical).
+ *
+ * Idiom grounded in effect-smol `SCHEMA.md` §Branding — the top-level
+ * `Schema.String.pipe(Schema.brand("UserId"))` form (not a hand-rolled phantom
+ * symbol) — and `Brand.ts`. Feature-local ids (sözlük's DefinitionId, TermSlug)
+ * live here beside the cross-feature UserId so every Phase-2 child of #2700
+ * imports one module.
+ */
+import * as Schema from "effect/Schema";
+
+/**
+ * Mint a branded id schema: a bare string nominally tagged `B`. Type-only — it
+ * adds no runtime check or transform (per effect-smol `SCHEMA.md` §Branding,
+ * `brand` narrows the output type without validating). This is the API Phase-2
+ * children call to declare their own feature ids.
+ */
+export const brandedId = <const B extends string>(brand: B) =>
+	Schema.String.pipe(Schema.brand(brand));
+
+/**
+ * The authenticated user's id (`CurrentUser.user.id`) — cross-feature, threaded
+ * as every write's actor/author/voter/reactor argument. Minted from the session
+ * string at each write boundary via `UserId.make(user.id)`.
+ */
+export const UserId = brandedId("UserId");
+export type UserId = typeof UserId.Type;
+
+/** A sözlük definition (entry) id. */
+export const DefinitionId = brandedId("DefinitionId");
+export type DefinitionId = typeof DefinitionId.Type;
+
+/** A sözlük term (başlık) slug — the başlık's stable identifier. */
+export const TermSlug = brandedId("TermSlug");
+export type TermSlug = typeof TermSlug.Type;

--- a/apps/web/worker/lib/ids.unit.test.ts
+++ b/apps/web/worker/lib/ids.unit.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Branded id pins (#2712, epic #2700). Two tiers:
+ *
+ *  - TYPE tier: nominal distinctness is compile-enforced — a `UserId` is not
+ *    assignable where a `DefinitionId` is expected, and transposing the two at
+ *    the `voteDefinition` arg surface fails to type. Assignability is encoded as
+ *    a conditional-type boolean checked with `expectTypeOf` (not
+ *    `@ts-expect-error`, which the effect LSP plugin's TS377003 escapes — the
+ *    recurring finding in `domain-error-boundary.unit.test.ts`).
+ *  - RUNTIME tier: the brand is type-only — `.make` and decode return the input
+ *    string unchanged, so wire/D1 bytes are byte-identical (no allocation or
+ *    serialization delta).
+ */
+import * as Schema from "effect/Schema";
+import {describe, expect, expectTypeOf, it} from "vitest";
+import type {VoteDefinitionInput} from "../features/sozluk/Sozluk.ts";
+import {DefinitionId, type TermSlug, UserId} from "./ids.ts";
+
+// `A extends B` as a checkable boolean — `true` iff an `A` is assignable to a `B`.
+type Assignable<A, B> = [A] extends [B] ? true : false;
+
+describe("branded ids — nominal distinctness is compile-enforced", () => {
+	it("a wrong-branded id is not assignable where a specific branded id is expected", () => {
+		// The core guarantee: distinct brands are mutually unassignable.
+		expectTypeOf<Assignable<UserId, DefinitionId>>().toEqualTypeOf<false>();
+		expectTypeOf<Assignable<DefinitionId, UserId>>().toEqualTypeOf<false>();
+		expectTypeOf<Assignable<TermSlug, DefinitionId>>().toEqualTypeOf<false>();
+	});
+
+	it("every branded id is still assignable to string (byte-identical shape)", () => {
+		expectTypeOf<Assignable<UserId, string>>().toEqualTypeOf<true>();
+		expectTypeOf<Assignable<DefinitionId, string>>().toEqualTypeOf<true>();
+		expectTypeOf<Assignable<TermSlug, string>>().toEqualTypeOf<true>();
+		// ...but a bare string is NOT assignable to a brand (must be minted).
+		expectTypeOf<Assignable<string, UserId>>().toEqualTypeOf<false>();
+	});
+
+	it("transposing definitionId/voterId at the voteDefinition surface fails to type", () => {
+		// The correct shape is a VoteDefinitionInput; the swapped shape is not —
+		// this is the #2712 arg-swap, now a compile error at every call site.
+		expectTypeOf<
+			Assignable<{definitionId: DefinitionId; voterId: UserId}, VoteDefinitionInput>
+		>().toEqualTypeOf<true>();
+		expectTypeOf<
+			Assignable<{definitionId: UserId; voterId: DefinitionId}, VoteDefinitionInput>
+		>().toEqualTypeOf<false>();
+	});
+});
+
+describe("branded ids — the brand is type-only (runtime byte-identical)", () => {
+	it("make() returns the input string unchanged", () => {
+		expect(DefinitionId.make("def_abc")).toBe("def_abc");
+		expect(UserId.make("user_1")).toBe("user_1");
+	});
+
+	it("decode returns the input string unchanged", () => {
+		expect(Schema.decodeUnknownSync(DefinitionId)("def_xyz")).toBe("def_xyz");
+		expect(Schema.decodeUnknownSync(UserId)("user_2")).toBe("user_2");
+	});
+});


### PR DESCRIPTION
Fixes #2712 — child of epic #2700 (branded ID schemas). This is the **tracer**: it establishes the shared brand-schema module every Phase-2 child imports and proves the pattern on sözlük, and it makes the `voteDefinition` id-swap unrepresentable.

## Shared module — `apps/web/worker/lib/ids.ts`
The home every Phase-2 child (#2713/#2714/#2715/#2721/#2722/#2723/#2724) imports. API:

- `brandedId(brand)` — mints a nominal id schema via effect-smol's top-level idiom `Schema.String.pipe(Schema.brand(...))` (grounded in effect-smol `SCHEMA.md` §Branding + `Brand.ts`, not intuition). Type-only: no runtime check/transform.
- Seeded ids: cross-feature `UserId` (threaded via `CurrentUser.user.id`), sözlük's `DefinitionId` (entry) and `TermSlug` (başlık).

Phase-2 coders: import branded ids from `apps/web/worker/lib/ids.ts`; declare a new feature id with `export const PostId = brandedId("PostId"); export type PostId = typeof PostId.Type;`.

## The voteDefinition arg-swap is now a compile error
`Sozluk.voteDefinition` takes `{definitionId: DefinitionId, voterId: UserId}` — two **distinct** brands, so transposing the two args at `features/sozluk/mutations.ts` fails `pnpm typecheck`. Verified live: swapping the two fields raises `TS2322: Type 'string & Brand<"UserId">' is not assignable to type 'string & Brand<"DefinitionId">'` (and the reverse) on both fields, then reverted.

`CurrentUser.user.id` (a plain `string`, unchanged — the shared `@kampus/fate-effect` type is out of this tracer's scope) is minted at each sözlük write boundary via `UserId.make(user.id)`.

## Scope
- Branded: sözlük mutation-input schemas + `Sozluk` service-input interfaces (`AddDefinitionInput`, `VoteDefinitionInput`, `ReactDefinitionInput`, `EditDefinitionInput`, `DeleteDefinitionInput`) + their test call-sites.
- **Deliberately NOT branded** (would cascade out of scope): result types, `errors.ts` id fields (a branded `DefinitionNotFound.definitionId` would break `report/mutations.ts` — a moderation surface), and `CurrentUserInfo.id`. Branded ids are `string` subtypes, so they flow into every unbranded `string` sink (DB queries, `Vote.cast`, error constructors, results) with no change.
- Two cross-feature test files (`lifecycle`, `flagship`) call sözlük methods and were updated to mint their id fixtures.

## Runtime is byte-identical
The brand is type-only — `.make`/decode return the input string unchanged (pinned in `lib/ids.unit.test.ts`), so wire and D1 bytes are unchanged. No allocation, no serialization delta. `Containment: exempt` per the issue.

## Tests
- `apps/web/worker/lib/ids.unit.test.ts`: type-tier pins (a wrong-branded id is not assignable where a specific brand is expected; the swapped `voteDefinition` shape fails to type; every brand is assignable to `string`) using `expectTypeOf` (not `@ts-expect-error`, per the repo's TS377003 finding) + runtime byte-identity of make/decode.
- Sözlük service/mutation test call-sites mint branded id fixtures.

## Local checks
- `pnpm typecheck`: 28/28 pass.
- Affected tests (`lib/ids`, sözlük mutation/service tests, flagship sandbox-restore, lifecycle create-path): 11 files / 38 tests pass.
- `biome check`: clean (pre-commit biome + leak-guard passed).