### PR TITLE
feat(pipeline-cli): roadmap view — arcs → milestones → epic trees → PRs (#2651)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -36,6 +36,7 @@ import {reachabilityGuardCommand} from "./tools/reachability-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {refGuardCommand} from "./tools/ref-guard/command.ts";
 import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
+import {roadmapCommand} from "./tools/roadmap/command.ts";
 import {roadmapGuardCommand} from "./tools/roadmap-guard/command.ts";
 import {settingsEnvGuardCommand} from "./tools/settings-env-guard/command.ts";
 import {shipDigestCommand} from "./tools/ship-digest/command.ts";
@@ -88,6 +89,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	epicLockCommand,
 	decisionsIndexCommand,
 	readmeGuardCommand,
+	roadmapCommand,
 	roadmapGuardCommand,
 	worktreeGuardCommand,
 	spawnGuardCommand,

--- a/packages/pipeline-cli/src/tools/roadmap/README.md
+++ b/packages/pipeline-cli/src/tools/roadmap/README.md
@@ -1,0 +1,70 @@
+# roadmap — the read-only roadmap view
+
+`pipeline-cli roadmap view [--root <dir>]`
+
+The **observability surface** of the steering seam (roadmap map #2620; part 3 of the three-part
+seam settled in #2639 — parts 1–2 are the active-milestone grounding + the arc-flip re-triage
+sweep, tracked separately). It renders the roadmap work-tree top-down and flags the drift a puller
+cares about, so the founder can see "the tree + what agents are building on it right now" with one
+command.
+
+## What it renders
+
+```
+Roadmap — active arc: Four Pillars (milestone #17)
+
+Arcs:
+▸ Four Pillars [active] → milestone #17 "…" [open]  ← ACTIVE ARC
+    ◆ epic #123 [open] p1 …
+        · #124 [open] …
+        · #125 [closed] …
+    · #130 [open] …            (loose, non-epic issue)
+    PRs:
+        ⇢ PR #200 build … → #124
+▸ Geçit [queued] → milestone #24 "…" [open]
+    (no open work)
+
+Campaigns:
+▸ Mentor Audit [active] → milestone #27 "…" [open]
+    …
+
+⚠ Drift: 2 stale p1(s) — open p1 outside the active-arc milestone #17 (…):
+    #140 … (milestone #24)
+    #141 … (no milestone)
+```
+
+The hierarchy is **arcs → milestones → epic trees → open PRs**, driven by:
+
+- **ROADMAP.md's `## Arcs` / `## Campaigns` tables** — the sole parsed roadmap surface (#2630/#2632).
+  The table parse is reused from `roadmap-guard` so the view and the guard agree on the grammar by
+  construction. The active-arc row (`state = active`) is the source of truth for the stale-p1 check.
+- **Live GitHub state via `gh api` REST** — milestones, open issues (+ each epic's sub-issue
+  children), and open PRs. Never GraphQL (the org's legacy Projects-classic integration errors
+  GraphQL issue/PR queries).
+
+## Drift: stale p1s
+
+The one flagged drift is **stale p1s** — open `p1` issues sitting *outside* the active-arc
+milestone. These are the issues a puller would keep draining after an arc flip if the lever were
+decorative; surfacing them is the point of the view (#2639). With no single resolvable active arc,
+every open p1 is flagged (fail-loud).
+
+## Read-only
+
+The command **mutates nothing** — no labels, no milestones, no issue/PR writes. Every `gh api` call
+is a GET. It is a *render*, not a guard: `roadmap-guard` (#2632) owns the fail-closed ROADMAP.md ↔
+milestone sync enforcement; this view owns human-legible display. They are separate tools.
+
+## Shape
+
+The pipeline-cli view idiom (the `decisions-index compact` / `roadmap-guard` house style): a pure,
+IO-free, unit-tested core (`roadmap.ts` — the table join, the tree assembly, the stale-p1
+derivation, the render) plus a thin `gh api` boundary (`github.ts`) and IO seam (`view.ts`). The
+core is tested exhaustively over fixtures without spawning `gh` (`roadmap.unit.test.ts`). The
+target repo resolves per ADR 0062 §1: `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`.
+
+## §CP
+
+This lands under `/packages/pipeline-cli/`, a control-plane surface per CODEOWNERS
+(`/packages/pipeline-cli/ @kamp-us/control-plane`, ADR 0100). Read-only-ness does not exempt it —
+§CP is a path-based code-owner gate, so any PR touching this path merges via the §CP review path.

--- a/packages/pipeline-cli/src/tools/roadmap/command.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/command.ts
@@ -1,0 +1,69 @@
+/**
+ * The `roadmap` tool — `pipeline-cli roadmap view [--root <d>]`.
+ *
+ * The observability surface of the steering seam (#2639 part 3, roadmap map #2620): a read-only
+ * view that renders the roadmap work-tree top-down — arcs → milestones → epic trees → open PRs —
+ * from ROADMAP.md's `## Arcs`/`## Campaigns` tables (the sole parsed roadmap surface) joined to the
+ * live GitHub milestone/issue/PR projection, and flags stale p1s (open p1s outside the active-arc
+ * milestone) as drift:
+ *
+ *   pipeline-cli roadmap view            # render the tree + stale-p1 drift to stdout
+ *   pipeline-cli roadmap view --root <d> # point at a specific repo root (else: walk up)
+ *
+ * READ-ONLY: it mutates nothing (no labels, milestones, or issue/PR writes). It is distinct from
+ * `roadmap-guard`, which owns the fail-closed ROADMAP.md ↔ milestone sync enforcement — this view
+ * owns human-legible display. All GitHub reads go through `gh api` REST, never GraphQL (the org's
+ * legacy Projects-classic integration errors GraphQL issue/PR queries).
+ *
+ * The pure decision lives in `roadmap.ts` (unit-tested exhaustively); the file read + `gh api`
+ * fetch in `view.ts`/`github.ts`. `GithubLive` is baked in with `Command.provide(...)` so the
+ * registered command's residual requirement is the Node platform union (the registry seam, #994).
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../../find-root-dir.ts";
+import {GithubLive} from "./github.ts";
+import {renderRoadmap} from "./view.ts";
+
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root holding ROADMAP.md (default: walk up for one)"),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+const view = Command.make(
+	"view",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* renderRoadmap(resolveRoot(rootOpt));
+	}),
+).pipe(
+	Command.withDescription(
+		"Render the roadmap tree (arcs → milestones → epic trees → open PRs) + stale-p1 drift to stdout",
+	),
+);
+
+export const roadmapCommand = Command.make("roadmap").pipe(
+	Command.withSubcommands([view]),
+	Command.withDescription(
+		"Read-only roadmap view: arcs → milestones → epic trees → open PRs, flagging stale p1s (#2639/#2651)",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/roadmap/github.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/github.ts
@@ -1,0 +1,318 @@
+/**
+ * The GitHub boundary for `roadmap view`: the live `Github` capability that gathers the
+ * read-only projection — milestones, open issues (+ each epic's sub-issue children), and open
+ * PRs — over `gh api` REST, so the IO-free `roadmap.ts` core can assemble the tree. Same service
+ * pattern as `roadmap-guard`'s `Milestones` / `campaign`'s `Github` (epic #994): a
+ * `Context.Service` on `ChildProcessSpawner`, REST only (GraphQL is broken on the kamp-us org),
+ * every infra failure a typed error in the `E` channel, untrusted REST JSON Schema-decoded at the
+ * boundary into the domain shapes the core resolves over.
+ *
+ * READ-ONLY by construction: every `gh api` call here is a GET; the view mutates no labels,
+ * milestones, or issues/PRs (the AC's read-only invariant, #2651).
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {
+	type Issue,
+	isEpic,
+	type Milestone,
+	type PullRequest,
+	parseLinkedIssues,
+	priorityOf,
+	type RoadmapFacts,
+} from "./roadmap.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/roadmap/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/roadmap/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/roadmap/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the same
+ * direct-spawn shape `roadmap-guard`/`campaign` use so a non-zero exit + stderr lower into a typed
+ * error rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` not on PATH) folds in as exit `-1`.
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	const raw = yield* runGh(args);
+	return yield* Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently defaults —
+ * with no env and no resolvable current repo it fails `RepoResolutionError`.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/roadmap/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// --- REST arg builders (REST only, never GraphQL) --------------------------------
+
+// `state=all` so I can resolve a done arc's CLOSED milestone by number; `--paginate` for >100.
+const milestonesArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/milestones`,
+	"-f",
+	"state=all",
+	"-f",
+	"per_page=100",
+	"--paginate",
+];
+
+// Open issues only — the tree renders live open work; sub-issue children (which may be closed)
+// are gathered per-epic below. PRs come back on this endpoint too and are filtered out.
+const openIssuesArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/issues`,
+	"-f",
+	"state=open",
+	"-f",
+	"per_page=100",
+	"--paginate",
+];
+
+const subIssuesArgs = (repo: string, epic: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${epic}/sub_issues?per_page=100`,
+];
+
+const openPullsArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"GET",
+	`repos/${repo}/pulls`,
+	"-f",
+	"state=open",
+	"-f",
+	"per_page=100",
+	"--paginate",
+];
+
+// --- boundary decoders -----------------------------------------------------------
+
+/** A raw issue as the issues endpoint returns it; `pull_request` present ⇒ it's a PR, filtered out. */
+const RawIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	state: Schema.Literals(["open", "closed"]),
+	labels: Schema.Array(Schema.Struct({name: Schema.String})),
+	milestone: Schema.NullOr(Schema.Struct({number: Schema.Number})),
+	pull_request: Schema.optionalKey(Schema.Unknown),
+});
+const decodeIssues = Schema.decodeUnknownEffect(Schema.Array(RawIssue));
+
+/** A raw sub-issue as the sub_issues endpoint returns it — the epic's children. */
+const RawSubIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	state: Schema.Literals(["open", "closed"]),
+	labels: Schema.Array(Schema.Struct({name: Schema.String})),
+	milestone: Schema.NullOr(Schema.Struct({number: Schema.Number})),
+});
+const decodeSubIssues = Schema.decodeUnknownEffect(Schema.Array(RawSubIssue));
+
+const RawMilestone = Schema.Struct({
+	number: Schema.Number,
+	state: Schema.Literals(["open", "closed"]),
+	title: Schema.String,
+});
+const decodeMilestones = Schema.decodeUnknownEffect(Schema.Array(RawMilestone));
+
+const RawPull = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	body: Schema.NullOr(Schema.String),
+	head: Schema.Struct({ref: Schema.String}),
+});
+const decodePulls = Schema.decodeUnknownEffect(Schema.Array(RawPull));
+
+// --- IO operations ---------------------------------------------------------------
+
+const toIssue = (
+	raw: {
+		readonly number: number;
+		readonly title: string;
+		readonly state: "open" | "closed";
+		readonly labels: ReadonlyArray<{readonly name: string}>;
+		readonly milestone: {readonly number: number} | null;
+	},
+	parent: number | null,
+): Issue => {
+	const labels = raw.labels.map((l) => l.name);
+	return {
+		number: raw.number,
+		title: raw.title,
+		state: raw.state,
+		labels,
+		milestone: raw.milestone?.number ?? null,
+		parent,
+		isEpic: isEpic(labels),
+		priority: priorityOf(labels),
+	};
+};
+
+const listMilestones = Effect.fn("Github.milestones")(function* (repo: string) {
+	const raw = yield* decodeMilestones(yield* json(milestonesArgs(repo)));
+	return raw.map((m): Milestone => ({number: m.number, state: m.state, title: m.title}));
+});
+
+const listOpenIssues = Effect.fn("Github.openIssues")(function* (repo: string) {
+	const raw = yield* decodeIssues(yield* json(openIssuesArgs(repo)));
+	return raw.filter((r) => r.pull_request === undefined).map((r) => toIssue(r, null));
+});
+
+const listSubIssues = Effect.fn("Github.subIssues")(function* (repo: string, epic: number) {
+	const raw = yield* decodeSubIssues(yield* json(subIssuesArgs(repo, epic)));
+	return raw.map((r) => toIssue(r, epic));
+});
+
+const listOpenPulls = Effect.fn("Github.openPulls")(function* (repo: string) {
+	const raw = yield* decodePulls(yield* json(openPullsArgs(repo)));
+	return raw.map(
+		(p): PullRequest => ({
+			number: p.number,
+			title: p.title,
+			branch: p.head.ref,
+			linkedIssues: parseLinkedIssues(p.body ?? "", p.head.ref),
+		}),
+	);
+});
+
+/**
+ * Gather the whole read-only projection. Open issues are fetched once; each epic among them then
+ * has its sub-issue children fetched (bounded by the epic count) and merged in with `parent` set —
+ * children the open-issues page may already carry are de-duped by number so no issue doubles up.
+ */
+const gather = Effect.fn("Github.gather")(function* (repo: string) {
+	const [milestones, openIssues, pulls] = yield* Effect.all(
+		[listMilestones(repo), listOpenIssues(repo), listOpenPulls(repo)],
+		{concurrency: "unbounded"},
+	);
+	const epics = openIssues.filter((i) => i.isEpic);
+	const childLists = yield* Effect.forEach(epics, (e) => listSubIssues(repo, e.number), {
+		concurrency: "unbounded",
+	});
+	const byNumber = new Map<number, Issue>();
+	for (const i of openIssues) byNumber.set(i.number, i);
+	// A child fetched via sub_issues carries the authoritative parent pin; let it win over the
+	// same issue seen parent-less on the open-issues page (de-dupe, parent-aware).
+	for (const child of childLists.flat()) byNumber.set(child.number, child);
+	return {milestones, issues: [...byNumber.values()], pulls} satisfies RoadmapFacts;
+});
+
+/**
+ * `Github` — the IO shell over `gh api` REST for `roadmap view`. `gather` reads the milestone /
+ * issue / epic-child / open-PR projection. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly gather: () => Effect.Effect<
+			RoadmapFacts,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/roadmap/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at construction
+ * and provided into each method body, so the public method carries `R = never`. Repo resolution is
+ * deferred to first use (`Effect.cached`, ADR 0062 §1): the layer build is side-effect-free, and
+ * `RepoResolutionError` lives in the method's `E` channel, raised only when `gather` actually reads.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				gather: () => repo.pipe(Effect.flatMap((r) => withSpawner(gather(r)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/roadmap/roadmap.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/roadmap.ts
@@ -1,0 +1,278 @@
+/**
+ * `roadmap view` pure core — assemble ROADMAP.md's founder-voice `## Arcs`/`## Campaigns`
+ * tables and the live GitHub projection (milestones + issues + open PRs) into a legible
+ * top-down tree, and derive the stale-p1 drift set. IO-free and total: `buildView` is a
+ * transform over the already-gathered rows/milestones/issues/pulls, `renderView` a transform
+ * over that view model. The `ROADMAP.md` read + the `gh api` REST fetch live in
+ * `view.ts`/`github.ts`; this module never touches disk or the network.
+ *
+ * This is the observability half of the steering seam (#2639 part 3): a render, not a guard.
+ * `roadmap-guard` (#2632) owns the fail-closed ROADMAP.md ↔ milestone sync enforcement; this
+ * view owns human-legible display and surfaces the one piece of drift a puller cares about —
+ * stale p1s: open `p1` issues sitting OUTSIDE the active-arc milestone, the work a puller would
+ * keep draining after an arc flip if the lever were decorative (#2639).
+ *
+ * ROADMAP.md is the SOLE parsed roadmap surface (#2630/#2632): the arc/campaign table parse is
+ * reused from `roadmap-guard` so the view and the guard agree on the table grammar by
+ * construction rather than re-deriving it here. Everything else is the live REST projection.
+ */
+import {parseRoadmap, type RoadmapRow} from "../roadmap-guard/roadmap-guard.ts";
+
+export {parseRoadmap, type RoadmapRow};
+
+/** The three intake priority buckets, highest-urgency first. */
+export type Priority = "p0" | "p1" | "p2";
+
+/** A GitHub milestone reduced to the projection facts the view renders. */
+export interface Milestone {
+	readonly number: number;
+	readonly title: string;
+	readonly state: "open" | "closed";
+}
+
+/**
+ * A GitHub issue reduced to the facts the tree + stale-p1 derivation need. `milestone` is the
+ * pinned milestone number, or `null` when unmilestoned. `parent` is the epic this issue is a
+ * sub-issue of (`null` for a top-level issue), populated at the boundary from the sub-issues
+ * endpoint. `isEpic`/`priority` are classified from `labels` by the pure helpers below.
+ */
+export interface Issue {
+	readonly number: number;
+	readonly title: string;
+	readonly state: "open" | "closed";
+	readonly labels: ReadonlyArray<string>;
+	readonly milestone: number | null;
+	readonly parent: number | null;
+	readonly isEpic: boolean;
+	readonly priority: Priority | null;
+}
+
+/** An open pull request reduced to number/title + the issues it declares it closes. */
+export interface PullRequest {
+	readonly number: number;
+	readonly title: string;
+	readonly branch: string;
+	readonly linkedIssues: ReadonlyArray<number>;
+}
+
+/** The live GitHub projection the view renders ROADMAP.md against — all read-only, REST-sourced. */
+export interface RoadmapFacts {
+	readonly milestones: ReadonlyArray<Milestone>;
+	readonly issues: ReadonlyArray<Issue>;
+	readonly pulls: ReadonlyArray<PullRequest>;
+}
+
+const EPIC_LABEL = "type:epic";
+const PRIORITY_LABELS: ReadonlyArray<Priority> = ["p0", "p1", "p2"];
+
+/** True when the label set marks this issue as an epic (`type:epic`). */
+export const isEpic = (labels: ReadonlyArray<string>): boolean => labels.includes(EPIC_LABEL);
+
+/** The issue's priority bucket from its labels, or `null` if none of `p0`/`p1`/`p2` is present. */
+export const priorityOf = (labels: ReadonlyArray<string>): Priority | null =>
+	PRIORITY_LABELS.find((p) => labels.includes(p)) ?? null;
+
+// Closing-keyword refs (`fixes/closes/resolves #N`, GitHub's own set) plus the branch-name
+// number (`<prefix>/<N>-slug`, the pipeline's branch idiom) are the two signals that tie an
+// open PR to the issue it builds — parsed here so the view can hang PRs under their epic tree.
+const CLOSES_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+const BRANCH_NUM_RE = /^[^/]+\/(\d+)-/;
+
+/** Resolve the issue numbers an open PR links, from its body's closing keywords + its branch name. */
+export const parseLinkedIssues = (body: string, branch: string): ReadonlyArray<number> => {
+	const nums = new Set<number>();
+	for (const m of body.matchAll(CLOSES_RE)) {
+		if (m[1] !== undefined) nums.add(Number(m[1]));
+	}
+	const b = branch.match(BRANCH_NUM_RE);
+	if (b?.[1] !== undefined) nums.add(Number(b[1]));
+	return [...nums];
+};
+
+// --- view model -------------------------------------------------------------------
+
+/** One epic and its sub-issue children (both states shown; a puller wants the whole tree). */
+export interface EpicNode {
+	readonly epic: Issue;
+	readonly children: ReadonlyArray<Issue>;
+}
+
+/** One rendered arc/campaign row: its resolved milestone + the epic trees, loose issues, and PRs under it. */
+export interface RowNode {
+	readonly kind: "arc" | "campaign";
+	readonly name: string;
+	readonly state: string;
+	readonly isActiveArc: boolean;
+	readonly milestoneNumber: number | null;
+	readonly milestone: Milestone | null;
+	readonly epics: ReadonlyArray<EpicNode>;
+	/** Milestone issues that are neither an epic nor a child of one — top-level standalone work. */
+	readonly looseIssues: ReadonlyArray<Issue>;
+	readonly pulls: ReadonlyArray<PullRequest>;
+}
+
+/** The whole assembled view: the active-arc pointer, the arc/campaign rows, and the stale-p1 drift set. */
+export interface RoadmapView {
+	readonly activeArcName: string | null;
+	readonly activeMilestone: number | null;
+	readonly arcs: ReadonlyArray<RowNode>;
+	readonly campaigns: ReadonlyArray<RowNode>;
+	readonly staleP1s: ReadonlyArray<Issue>;
+}
+
+/** The single `active` arc row, or `null` when none/several are active (a guard-owned concern, #2632). */
+export const activeArc = (arcs: ReadonlyArray<RoadmapRow>): RoadmapRow | null => {
+	const active = arcs.filter((a) => a.state === "active");
+	return active.length === 1 ? (active[0] ?? null) : null;
+};
+
+/**
+ * Stale p1 drift: open `p1` issues sitting outside the active-arc milestone (#2639). With no
+ * resolvable active milestone every open p1 is "outside" it, so all are flagged — the fail-loud
+ * reading, since a decorative lever is exactly what this surfaces. An epic is included like any
+ * other issue: a p1 epic parked off the active arc is itself drift.
+ */
+export const deriveStaleP1s = (
+	issues: ReadonlyArray<Issue>,
+	activeMilestone: number | null,
+): ReadonlyArray<Issue> =>
+	issues.filter(
+		(i) =>
+			i.state === "open" &&
+			i.priority === "p1" &&
+			// No active milestone ⇒ every open p1 is outside it (an unmilestoned p1 must NOT
+			// slip through on `null === null`); otherwise stale iff pinned to a different milestone.
+			(activeMilestone === null || i.milestone !== activeMilestone),
+	);
+
+/** Assemble the arc/campaign rows for a milestone: its epic trees, loose top-level issues, and linked PRs. */
+const buildRows = (
+	rows: ReadonlyArray<RoadmapRow>,
+	kind: "arc" | "campaign",
+	facts: RoadmapFacts,
+	activeArcName: string | null,
+): ReadonlyArray<RowNode> => {
+	const msByNumber = new Map(facts.milestones.map((m) => [m.number, m]));
+	return rows.map((row): RowNode => {
+		const ms = row.milestone !== null ? (msByNumber.get(row.milestone) ?? null) : null;
+		const inMilestone =
+			row.milestone !== null ? facts.issues.filter((i) => i.milestone === row.milestone) : [];
+		const epics = inMilestone
+			.filter((i) => i.isEpic)
+			.map(
+				(epic): EpicNode => ({
+					epic,
+					children: facts.issues.filter((c) => c.parent === epic.number),
+				}),
+			);
+		const epicNumbers = new Set(epics.map((e) => e.epic.number));
+		const looseIssues = inMilestone.filter((i) => !i.isEpic && i.parent === null);
+		// Children live under sub_issues and may not carry the milestone pin themselves — count
+		// them in too so a PR closing a sub-issue still hangs under this row.
+		const claimed = new Set(inMilestone.map((i) => i.number));
+		for (const e of epics) for (const c of e.children) claimed.add(c.number);
+		const pulls = facts.pulls.filter((p) =>
+			p.linkedIssues.some((n) => claimed.has(n) || epicNumbers.has(n)),
+		);
+		return {
+			kind,
+			name: row.name,
+			state: row.state,
+			isActiveArc: kind === "arc" && row.name === activeArcName,
+			milestoneNumber: row.milestone,
+			milestone: ms,
+			epics,
+			looseIssues,
+			pulls,
+		};
+	});
+};
+
+/**
+ * Build the full view model from the parsed roadmap rows and the live projection. Pure and
+ * total — every derivation (active arc, per-row trees, stale p1s) is a fold over the inputs.
+ */
+export const buildView = (
+	arcs: ReadonlyArray<RoadmapRow>,
+	campaigns: ReadonlyArray<RoadmapRow>,
+	facts: RoadmapFacts,
+): RoadmapView => {
+	const active = activeArc(arcs);
+	const activeArcName = active?.name ?? null;
+	const activeMilestone = active?.milestone ?? null;
+	return {
+		activeArcName,
+		activeMilestone,
+		arcs: buildRows(arcs, "arc", facts, activeArcName),
+		campaigns: buildRows(campaigns, "campaign", facts, activeArcName),
+		staleP1s: deriveStaleP1s(facts.issues, activeMilestone),
+	};
+};
+
+// --- rendering (pure over the view model) -----------------------------------------
+
+const issueLine = (i: Issue): string => {
+	const prio = i.priority ? ` ${i.priority}` : "";
+	return `#${i.number} [${i.state}]${prio} ${i.title}`;
+};
+
+const milestoneLabel = (row: RowNode): string => {
+	if (row.milestoneNumber === null) return "(no milestone pin)";
+	const title = row.milestone ? ` "${row.milestone.title}"` : " (milestone not found)";
+	const state = row.milestone ? ` [${row.milestone.state}]` : "";
+	return `milestone #${row.milestoneNumber}${title}${state}`;
+};
+
+const renderRow = (row: RowNode): ReadonlyArray<string> => {
+	const marker = row.isActiveArc ? "  ← ACTIVE ARC" : "";
+	const out: Array<string> = [`▸ ${row.name} [${row.state}] → ${milestoneLabel(row)}${marker}`];
+	for (const {epic, children} of row.epics) {
+		out.push(`    ◆ epic ${issueLine(epic)}`);
+		for (const c of children) out.push(`        · ${issueLine(c)}`);
+	}
+	for (const i of row.looseIssues) out.push(`    · ${issueLine(i)}`);
+	if (row.pulls.length > 0) {
+		out.push("    PRs:");
+		for (const p of row.pulls) {
+			const links =
+				p.linkedIssues.length > 0 ? ` → ${p.linkedIssues.map((n) => `#${n}`).join(", ")}` : "";
+			out.push(`        ⇢ PR #${p.number} ${p.title}${links}`);
+		}
+	}
+	if (row.epics.length === 0 && row.looseIssues.length === 0 && row.pulls.length === 0) {
+		out.push("    (no open work)");
+	}
+	return out;
+};
+
+/** Render the assembled view model as the legible top-down tree the command emits to stdout. */
+export const renderView = (view: RoadmapView): string => {
+	const lines: Array<string> = [];
+	lines.push(
+		view.activeArcName
+			? `Roadmap — active arc: ${view.activeArcName} (milestone ${view.activeMilestone !== null ? `#${view.activeMilestone}` : "unpinned"})`
+			: "Roadmap — no single active arc (see roadmap-guard, #2632)",
+	);
+	lines.push("");
+	lines.push("Arcs:");
+	for (const row of view.arcs) lines.push(...renderRow(row));
+	if (view.campaigns.length > 0) {
+		lines.push("");
+		lines.push("Campaigns:");
+		for (const row of view.campaigns) lines.push(...renderRow(row));
+	}
+	lines.push("");
+	if (view.staleP1s.length === 0) {
+		lines.push("Drift: no stale p1s — every open p1 sits inside the active-arc milestone.");
+	} else {
+		lines.push(
+			`⚠ Drift: ${view.staleP1s.length} stale p1(s) — open p1 outside the active-arc milestone` +
+				`${view.activeMilestone !== null ? ` #${view.activeMilestone}` : ""} (a puller would keep draining these; #2639):`,
+		);
+		for (const i of view.staleP1s) {
+			const ms = i.milestone !== null ? `milestone #${i.milestone}` : "no milestone";
+			lines.push(`    #${i.number} ${i.title} (${ms})`);
+		}
+	}
+	return lines.join("\n");
+};

--- a/packages/pipeline-cli/src/tools/roadmap/roadmap.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/roadmap.unit.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Pure-core tests for `roadmap view` (#2651, roadmap map #2620 / steering seam #2639): the
+ * label classification, PR→issue linkage parse, active-arc resolution, the stale-p1 drift
+ * derivation, the tree assembly, and the render. No IO — the `gh api`/filesystem seam is crossed
+ * in `view.ts`/`github.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	activeArc,
+	buildView,
+	deriveStaleP1s,
+	type Issue,
+	isEpic,
+	type Milestone,
+	type PullRequest,
+	parseLinkedIssues,
+	parseRoadmap,
+	priorityOf,
+	type RoadmapFacts,
+	renderView,
+} from "./roadmap.ts";
+
+const issue = (n: number, over: Partial<Issue> = {}): Issue => ({
+	number: n,
+	title: `issue ${n}`,
+	state: "open",
+	labels: [],
+	milestone: null,
+	parent: null,
+	isEpic: false,
+	priority: null,
+	...over,
+});
+const ms = (
+	number: number,
+	state: "open" | "closed" = "open",
+	title = `m${number}`,
+): Milestone => ({
+	number,
+	state,
+	title,
+});
+const facts = (over: Partial<RoadmapFacts> = {}): RoadmapFacts => ({
+	milestones: [],
+	issues: [],
+	pulls: [],
+	...over,
+});
+
+describe("label classification", () => {
+	it("isEpic reads the type:epic label", () => {
+		expect(isEpic(["type:epic", "p1"])).toBe(true);
+		expect(isEpic(["type:feature"])).toBe(false);
+		expect(isEpic([])).toBe(false);
+	});
+
+	it("priorityOf picks the highest-urgency bucket present, else null", () => {
+		expect(priorityOf(["p0", "p1"])).toBe("p0");
+		expect(priorityOf(["type:feature", "p1"])).toBe("p1");
+		expect(priorityOf(["p2"])).toBe("p2");
+		expect(priorityOf(["type:chore"])).toBe(null);
+	});
+});
+
+describe("parseLinkedIssues", () => {
+	it("reads GitHub closing keywords from the body", () => {
+		expect(parseLinkedIssues("Fixes #12 and closes #34", "")).toEqual([12, 34]);
+		expect(parseLinkedIssues("resolved #7", "")).toEqual([7]);
+	});
+
+	it("reads the issue number off the branch name idiom", () => {
+		expect(parseLinkedIssues("", "umut/2651-roadmap-view")).toEqual([2651]);
+	});
+
+	it("unions body + branch, de-duped", () => {
+		expect(parseLinkedIssues("Fixes #2651", "umut/2651-roadmap-view")).toEqual([2651]);
+	});
+
+	it("returns [] when neither signal is present", () => {
+		expect(parseLinkedIssues("no refs here", "main")).toEqual([]);
+	});
+
+	it("does not match a bare #N without a closing keyword (avoids false links)", () => {
+		expect(parseLinkedIssues("see #99 for context", "")).toEqual([]);
+	});
+});
+
+describe("activeArc", () => {
+	const {arcs} = parseRoadmap(
+		"## Arcs\n\n| Arc | Milestone | State |\n|--|--|--|\n" +
+			"| Four Pillars | #17 | active |\n| Geçit | #24 | queued |\n",
+	);
+
+	it("resolves the single active arc row", () => {
+		const a = activeArc(arcs);
+		expect(a?.name).toBe("Four Pillars");
+		expect(a?.milestone).toBe(17);
+	});
+
+	it("returns null when zero or several arcs are active (guard-owned, #2632)", () => {
+		expect(activeArc([])).toBe(null);
+		const two = parseRoadmap(
+			"## Arcs\n\n| Arc | Milestone | State |\n|--|--|--|\n" +
+				"| A | #1 | active |\n| B | #2 | active |\n",
+		).arcs;
+		expect(activeArc(two)).toBe(null);
+	});
+});
+
+describe("deriveStaleP1s", () => {
+	const issues = [
+		issue(1, {priority: "p1", milestone: 17}), // in active milestone → not stale
+		issue(2, {priority: "p1", milestone: 24}), // other milestone → stale
+		issue(3, {priority: "p1", milestone: null}), // unmilestoned → stale
+		issue(4, {priority: "p2", milestone: 24}), // not p1 → ignored
+		issue(5, {priority: "p1", milestone: 24, state: "closed"}), // closed → ignored
+	];
+
+	it("flags open p1s outside the active-arc milestone", () => {
+		expect(deriveStaleP1s(issues, 17).map((i) => i.number)).toEqual([2, 3]);
+	});
+
+	it("with no active milestone, every open p1 is stale (fail-loud)", () => {
+		expect(deriveStaleP1s(issues, null).map((i) => i.number)).toEqual([1, 2, 3]);
+	});
+
+	it("counts a p1 epic parked off the active arc as drift", () => {
+		const epic = issue(9, {priority: "p1", milestone: 24, isEpic: true});
+		expect(deriveStaleP1s([epic], 17).map((i) => i.number)).toEqual([9]);
+	});
+});
+
+const roadmapMd =
+	"## Arcs\n\n| Arc | Milestone | State |\n|--|--|--|\n" +
+	"| Four Pillars | #17 | active |\n| Geçit | #24 | queued |\n\n" +
+	"## Campaigns\n\n| Campaign | Milestone | State |\n|--|--|--|\n" +
+	"| Mentor Audit | #27 | active |\n";
+
+describe("buildView — tree assembly", () => {
+	const {arcs, campaigns} = parseRoadmap(roadmapMd);
+	const epic = issue(100, {
+		isEpic: true,
+		milestone: 17,
+		labels: ["type:epic"],
+		title: "Pillars epic",
+	});
+	const child = issue(101, {parent: 100, milestone: 17, title: "a pillar child"});
+	const loose = issue(102, {milestone: 17, title: "standalone in 17"});
+	const p1Off = issue(200, {priority: "p1", milestone: 24, title: "off-arc p1"});
+	const pr: PullRequest = {
+		number: 500,
+		title: "build the child",
+		branch: "umut/101-x",
+		linkedIssues: [101],
+	};
+	const view = buildView(
+		arcs,
+		campaigns,
+		facts({milestones: [ms(17), ms(24), ms(27)], issues: [epic, child, loose, p1Off], pulls: [pr]}),
+	);
+
+	it("marks the active arc and resolves its milestone", () => {
+		const fourPillars = view.arcs.find((r) => r.name === "Four Pillars");
+		expect(fourPillars?.isActiveArc).toBe(true);
+		expect(fourPillars?.milestone?.number).toBe(17);
+		expect(view.activeMilestone).toBe(17);
+	});
+
+	it("hangs the epic tree, loose issue, and linked PR under the arc milestone", () => {
+		const fourPillars = view.arcs.find((r) => r.name === "Four Pillars");
+		expect(fourPillars?.epics.map((e) => e.epic.number)).toEqual([100]);
+		expect(fourPillars?.epics[0]?.children.map((c) => c.number)).toEqual([101]);
+		expect(fourPillars?.looseIssues.map((i) => i.number)).toEqual([102]);
+		expect(fourPillars?.pulls.map((p) => p.number)).toEqual([500]);
+	});
+
+	it("renders campaigns and flags the off-arc p1 as stale", () => {
+		expect(view.campaigns.map((c) => c.name)).toEqual(["Mentor Audit"]);
+		expect(view.staleP1s.map((i) => i.number)).toEqual([200]);
+	});
+
+	it("does not treat a queued arc as active", () => {
+		expect(view.arcs.find((r) => r.name === "Geçit")?.isActiveArc).toBe(false);
+	});
+});
+
+describe("renderView", () => {
+	const {arcs, campaigns} = parseRoadmap(roadmapMd);
+
+	it("renders the header, the ACTIVE ARC marker, and a clean drift line", () => {
+		const out = renderView(
+			buildView(arcs, campaigns, facts({milestones: [ms(17), ms(24), ms(27)], issues: []})),
+		);
+		expect(out).toContain("active arc: Four Pillars");
+		expect(out).toContain("← ACTIVE ARC");
+		expect(out).toContain("no stale p1s");
+	});
+
+	it("renders a stale-p1 drift warning block when drift exists", () => {
+		const out = renderView(
+			buildView(
+				arcs,
+				campaigns,
+				facts({
+					milestones: [ms(17), ms(24), ms(27)],
+					issues: [issue(200, {priority: "p1", milestone: 24, title: "off-arc p1"})],
+				}),
+			),
+		);
+		expect(out).toContain("⚠ Drift: 1 stale p1(s)");
+		expect(out).toContain("#200 off-arc p1 (milestone #24)");
+	});
+
+	it("notes when no single arc is active", () => {
+		const out = renderView(buildView([], [], facts()));
+		expect(out).toContain("no single active arc");
+	});
+});

--- a/packages/pipeline-cli/src/tools/roadmap/view.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/view.ts
@@ -1,0 +1,53 @@
+/**
+ * The `roadmap view` IO seam — wiring the pure `roadmap.ts` core to the two facts it renders:
+ * `ROADMAP.md`'s text (read from disk) and the live GitHub projection (read over `gh api` via the
+ * `Github` service). Split from `command.ts` so the wiring is crossable in tests, and kept thin:
+ * it reads ROADMAP.md, parses the arc/campaign tables, gathers the projection, builds + renders the
+ * tree, and prints it to stdout. Read-only — no verdict, no `CheckFailed`; the only failure is a
+ * genuine IO/`gh` crash (also non-zero, per the bin's contract). This is a render, not a guard.
+ */
+import {existsSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import type * as Schema from "effect/Schema";
+import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
+import {Github} from "./github.ts";
+import {buildView, parseRoadmap, renderView} from "./roadmap.ts";
+
+/** Couldn't read `ROADMAP.md` (absent or unreadable). */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+const ROADMAP_FILE = "ROADMAP.md";
+
+const readRoadmap = (root: string): Effect.Effect<string, IoError> =>
+	Effect.try({
+		try: () => {
+			const path = join(root, ROADMAP_FILE);
+			if (!existsSync(path)) {
+				throw new Error(`${ROADMAP_FILE} not found at repo root`);
+			}
+			return readFileSync(path, "utf8");
+		},
+		catch: (cause) => new IoError({path: join(root, ROADMAP_FILE), cause}),
+	});
+
+/**
+ * Render the roadmap tree: parse `ROADMAP.md`'s `## Arcs`/`## Campaigns` tables, gather the live
+ * milestone/issue/PR projection, and emit `buildView`'s assembled tree + stale-p1 drift to stdout.
+ */
+export const renderRoadmap = (
+	root: string,
+): Effect.Effect<
+	void,
+	IoError | RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError,
+	Github
+> =>
+	Effect.gen(function* () {
+		const md = yield* readRoadmap(root);
+		const {arcs, campaigns} = parseRoadmap(md);
+		const facts = yield* (yield* Github).gather();
+		yield* Console.log(renderView(buildView(arcs, campaigns, facts)));
+	});


### PR DESCRIPTION
## What & why

Roadmap **unit 5** / steering-seam **part 3** (#2639): a read-only `pipeline-cli roadmap view` — the observability surface of the steering seam. It renders the roadmap work-tree top-down and flags the drift a puller cares about, so the founder can see "the tree + what agents are building on it right now" with one command.

Fixes #2651

## What it does

`pipeline-cli roadmap view [--root <d>]` renders **arcs → milestones → epic trees → open PRs** and a **stale-p1 drift** block:

- **ROADMAP.md `## Arcs` / `## Campaigns` tables** are the sole parsed roadmap surface (#2630/#2632). The arc/campaign table parse is **reused from `roadmap-guard`** so the view and the guard agree on the grammar by construction rather than re-deriving it.
- **Live GitHub projection via `gh api` REST** (never GraphQL — the org's legacy Projects-classic breaks GraphQL issue/PR queries): milestones, open issues + each epic's sub-issue children, and open PRs. PRs hang under their milestone via closing-keyword refs + the branch-name idiom.
- **Stale-p1 drift** = open `p1` issues sitting *outside* the active-arc milestone — the work a puller would keep draining after an arc flip if the lever were decorative (#2639). Fail-loud: with no single active arc, every open p1 is flagged.

## Read-only

Mutates nothing — no labels, milestones, or issue/PR writes; every `gh api` call is a GET. It is a *render*, not a guard: `roadmap-guard` (#2632) owns the fail-closed ROADMAP.md ↔ milestone sync enforcement; this view owns human-legible display. Separate tools.

## Shape (house style)

Pure IO-free core (`roadmap.ts` — table join, tree assembly, stale-p1 derivation, render) + `gh api` boundary (`github.ts`) + IO seam (`view.ts`) + thin `command.ts`, registered in `registry.ts`. The core is unit-tested exhaustively (`roadmap.unit.test.ts`, 19 cases) without spawning `gh`.

## Verification

- `pnpm --filter @kampus/pipeline-cli typecheck` — clean
- `pnpm vitest run` (pipeline-cli) — 84 files / 1151 tests pass (19 new)
- `pnpm biome check` on touched files — clean
- `pipeline-cli readme-guard check` — green (new tool carries a README)
- Live smoke run against `kamp-us/phoenix`: renders the full tree, flags 15 stale p1s, exit 0

## §CP

Lands under `/packages/pipeline-cli/` — a control-plane surface per CODEOWNERS (`@kamp-us/control-plane`, ADR 0100). Read-only-ness does not exempt it; §CP is a path-based code-owner gate, so this merges via the §CP review path (human approval owns the merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
