### PR TITLE
docs(ops): fill the D1 export/restore runbook (#2703)

### DIFF
--- a/ops/runbook-d1-restore.md
+++ b/ops/runbook-d1-restore.md
@@ -1,15 +1,204 @@
 # Runbook: D1 export / restore
 
-> **Status: forthcoming.** This runbook is a stub — the D1 export/restore procedure, rehearsed
-> once, lands via issue #2703. It exists now only so [the ops index](./README.md) links resolve
-> before the content is written. Fill each section below; do not edit `ops/README.md`.
+Recover the single production D1 from a bad migration or accidental data loss by exporting a
+known-good snapshot and restoring it into a fresh stage. Grounded in phoenix's real stack — the
+alchemy-managed D1 (one per app/stage, ADR
+[0057](../.decisions/0057-multi-app-multi-worker-repo.md)), the hand-authored flat migrations
+tree applied on deploy (ADR
+[0108](../.decisions/0108-hand-authored-flat-d1-migrations.md)), and the deploy-infra-to-cloud
+dev model (ADR [0032](../.decisions/0032-alchemy-beta45-and-dev-model.md)) — not generic SQLite
+advice.
 
-**Symptoms** —
+The one non-obvious hazard this runbook exists to handle: the **FTS5 export tax**. The site-search
+FTS5 virtual tables block a naive whole-database D1 export, so the procedure exports the base
+tables only and rebuilds the search index on restore (ADR
+[0080](../.decisions/0080-site-search-lexical-bar-semantic-discovery.md)).
 
-**Preconditions** —
+## Symptoms
 
-**Procedure** —
+Reach for this runbook when the production D1 is corrupt or wrong and rolling *forward* won't fix
+it — you need a point-in-time restore, not another migration:
 
-**Verification** —
+- A migration applied bad data or dropped/altered a column, and the loss is already live (a
+  forward migration can't recover deleted rows).
+- Product reads return wrong or missing rows that trace to the store, not the read path — sözlük
+  terms / pano posts absent or truncated across clients, not just one stale live view (a stale
+  live view is the [live-plane-degraded](./runbook-live-plane-degraded.md) runbook, not this one).
+- You need a verified backup of production D1 before a risky migration or bulk operation — the
+  export half of this runbook, run proactively.
 
-**Rollback / escalation** —
+## Preconditions
+
+- **Cloudflare credentials with D1 access.** Export/restore uses the Cloudflare CLI against the
+  real remote D1; `alchemy dev`/`deploy` and the CLI both need account auth (ADR 0032 — dev and
+  prod resources are both real CF D1, there is no offline D1 emulator). The CLI is not a repo
+  dependency; invoke it with `pnpm dlx wrangler` (never `npx`).
+- **The physical D1 name for the stage you are acting on.** alchemy generates the production
+  database name; read it from the deployed stack (the `phoenix_db` resource in
+  [`apps/web/worker/db/resources.ts`](../apps/web/worker/db/resources.ts), applied by
+  `alchemy deploy`). Never guess the name.
+- **A scratch stage to restore into — never restore over production first.** `alchemy deploy
+  --stage <scratch>` yields an isolated worker + D1 + DOs (ADR 0057), with all migrations applied
+  (so the schema, including the FTS5 virtual tables from migration
+  [`0002_search_fts.sql`](../apps/web/worker/db/drizzle/migrations/0002_search_fts.sql), already
+  exists). Restore into the scratch stage, verify, and only then decide on the production cutover.
+- **Capture the current state first.** Record the failing migration id and the current
+  `drizzle_migrations` applied set before you touch anything, so you know exactly which snapshot
+  you are restoring to.
+
+## The FTS5 export tax — why a naive export fails
+
+Site search (ADR 0080) is two FTS5 **virtual** tables, `term_search` and `post_search`, declared
+by hand in migration
+[`0002_search_fts.sql`](../apps/web/worker/db/drizzle/migrations/0002_search_fts.sql) (drizzle's
+DSL cannot express a virtual table). Each FTS5 virtual table is backed by a set of **shadow
+tables** SQLite creates under the hood — `<name>_data`, `<name>_idx`, `<name>_content`,
+`<name>_docsize`, `<name>_config`. **D1 cannot export a database that contains virtual tables**
+(ADR 0080 §Sync/Trade-offs, and the export caveat recorded inline in the migration): a whole-DB
+export chokes on the virtual-table + shadow-table schema.
+
+The rows in the FTS tables are **derived, not primary**: they are an app-side dual-write of the
+Turkish-normalized title, kept in lockstep with `term_record` / `post_record` by
+[`features/search/fts-sync.ts`](../apps/web/worker/features/search/fts-sync.ts) (the `norm` column
+is computed by `normalize.ts`, not stored in the base row). So the FTS index is **reconstructable
+from the base tables** and never needs to be in the backup — which is exactly what makes the
+workaround safe: export the base tables, skip the virtual tables, rebuild the index on restore.
+
+## Procedure
+
+All commands run from the repo root. Substitute `<prod-d1-name>` / `<scratch>` from the
+preconditions; never hardcode a physical name into a committed artifact.
+
+**1 — Export the base tables only (sidestep the virtual tables).** `wrangler d1 export`'s
+`--table` flag restricts the dump to an explicit table set, so enumerating the base tables
+excludes the FTS5 virtual + shadow tables and the export succeeds. Take a data-only dump
+(`--no-schema`) — the scratch stage already carries the schema from applied migrations, so the
+restore only needs `INSERT`s:
+
+```bash
+pnpm dlx wrangler d1 export <prod-d1-name> --remote --no-schema \
+  --table term_record --table post_record --table definition_record --table comment_record \
+  --table user --table <…every base table…> \
+  --output ops-export.sql
+```
+
+Enumerate the real base-table set from the applied schema
+([`apps/web/worker/db/drizzle/schema.ts`](../apps/web/worker/db/drizzle/schema.ts)); the two
+tables you must **omit** are `term_search` and `post_search` (and, implicitly, their shadow
+tables). If you prefer a full whole-DB export instead of an enumerated one, the alternative is to
+`DROP` the two virtual tables first and recreate them after — but that is a destructive change
+against the live database, so the non-destructive `--table` enumeration above is the default; the
+drop/recreate path is only for a one-time full migration-out.
+
+**2 — Restore the base data into the scratch stage.** Deploy the scratch stage (which applies all
+migrations, creating every base table plus the empty FTS5 virtual tables), then execute the dump:
+
+```bash
+alchemy deploy --stage <scratch>
+pnpm dlx wrangler d1 execute <scratch-d1-name> --remote --file ops-export.sql
+```
+
+**3 — Rebuild the FTS5 index from the restored base tables.** The virtual tables exist (from
+migration 0002) but are empty, because the FTS rows were intentionally excluded from the export.
+Rebuild them by re-deriving each `norm` from the restored base rows the same way the write path
+does — through the app's Turkish fold in
+[`features/search/normalize.ts`](../apps/web/worker/features/search/normalize.ts) and the
+dual-write shape in [`features/search/fts-sync.ts`](../apps/web/worker/features/search/fts-sync.ts)
+(`term_search(slug, norm)` from `term_record`, `post_search(id, norm)` from `post_record`). The
+`norm` value is app-computed (not a pure-SQL `lower()`), so the rebuild must run the app
+normalizer, not a raw SQL projection.
+
+> **Known gap (follow-up).** There is no standing backfill route to rebuild the FTS index today —
+> the write path only syncs on individual mutations, and the security guard forbids resurrecting
+> an admin/seeder route (see CLAUDE.md §"Sözlük seed"). Until a sanctioned one-off backfill exists,
+> the rebuild is a manual maintenance execution deriving `norm` via `normalize.ts`. This gap is
+> tracked as a follow-up issue.
+
+## Verification
+
+Confirm the restore before you stand down or promote it toward production:
+
+- **Row counts match the source.** For each base table, the restored count equals the exported
+  count:
+
+  ```bash
+  pnpm dlx wrangler d1 execute <scratch-d1-name> --remote \
+    --command "SELECT 'term_record' t, count(*) n FROM term_record
+               UNION ALL SELECT 'post_record', count(*) FROM post_record;"
+  ```
+
+- **FTS search works post-restore.** A lexical + prefix match returns rows against the rebuilt
+  index (a green count here proves the rebuild, not just the base restore):
+
+  ```bash
+  pnpm dlx wrangler d1 execute <scratch-d1-name> --remote \
+    --command "SELECT count(*) FROM term_search WHERE term_search MATCH 'merhaba';
+               SELECT count(*) FROM term_search WHERE term_search MATCH 'mer*';"
+  ```
+
+- **`integrity_check` is clean** on the restored database (`PRAGMA integrity_check;` returns
+  `ok`).
+
+Only once all three hold is the scratch restore trustworthy enough to consider a production
+cutover.
+
+## Rollback / escalation
+
+- **The scratch restore is the rollback surface.** Because you restore into an isolated scratch
+  stage (ADR 0057), a bad restore never touches production — tear the scratch stage down
+  (`alchemy` destroy for that stage) and re-run from a different export. Production is only ever
+  cut over *after* the scratch verification passes.
+- **If the export itself fails on virtual tables**, you skipped the `--table` enumeration or named
+  a virtual table — re-run step 1 with the base-table set only (this is the FTS5 export tax, not a
+  D1 outage).
+- **If the FTS rebuild can't be run** (no backfill path yet — see the known gap), the base data is
+  still fully restored and correct; search is degraded until the index is rebuilt. Escalate the
+  backfill as a product/infra task rather than blocking the data restore on it.
+- **If D1 itself is unavailable** (not a data problem — the store is down), this is a Cloudflare
+  incident: switch to the [Cloudflare-down runbook](./runbook-cf-down.md).
+
+## Rehearsal
+
+The load-bearing, non-obvious mechanic — the **FTS5 export-tax workaround** (exclude the virtual
+tables → export base only → reimport → recreate the FTS5 tables from the migration DDL → rebuild
+the index → verify counts + working search) — was rehearsed once locally against SQLite 3.43.2
+(FTS5-enabled), using the **verbatim DDL** from migration `0002_search_fts.sql`. This proves the
+rebuild sequence and that search works after restore.
+
+Fixture: base tables `term_record` / `post_record` plus the two FTS5 virtual tables from the real
+migration DDL, seeded so search matches before restore.
+
+```
+# source: base counts + FTS search works, plus the shadow tables the export tax comes from
+term_record|2
+post_record|2
+term MATCH merhaba|1
+post MATCH kahve|1
+shadow tables: term_search{,_config,_content,_data,_docsize,_idx}, post_search{…}  (12 total)
+
+# workaround: base-only dump (no *_search shadow tables), reimport, recreate FTS from 0002 DDL,
+# rebuild rows, then verify on the restored database
+base-only dump — matches for 'search': 0
+restored term_record|2
+restored post_record|2
+restored term MATCH merhaba|1     # lexical match works post-restore
+restored post MATCH kahve|1
+restored term MATCH mer*|1        # prefix index (prefix='2 3 4') works post-restore
+restored PRAGMA integrity_check|ok
+```
+
+Result: after excluding the FTS virtual tables from the export, reimporting the base tables, and
+recreating + rebuilding the FTS5 index from the migration DDL, both exact and prefix search return
+the expected rows and the database passes `integrity_check`.
+
+**Scope of this rehearsal — read before trusting it.** It validates the FTS5 export-tax
+*mechanics* against a local FTS5 SQLite, which is where the real risk lives. It does **not**
+exercise the full production round-trip: `wrangler d1 export --remote` against the production D1
+and `alchemy deploy --stage <scratch>` require Cloudflare credentials (ADR 0032) and were not run
+here. A note on fidelity: the "naive whole-DB export is blocked by virtual tables" claim is a
+**D1-platform** behavior recorded by ADR 0080 and the migration's inline caveat — the local
+`sqlite3` shell can round-trip virtual tables via its `writable_schema` path, so this specific
+tax was *not* reproduced locally and is cited from the D1 record, not re-derived. Before this
+runbook is relied on for a real production restore, the full remote round-trip should be rehearsed
+once against a scratch stage by an operator with Cloudflare access, and the observed remote
+evidence appended here.


### PR DESCRIPTION
Fixes #2703.

Fills the forthcoming stub `ops/runbook-d1-restore.md` (created by #2702, PHASE-2 of epic #2568) with the D1 export/restore runbook, in place — **only** that file is touched (the ops index `ops/README.md` is #2702's; the PHASE-2 anti-collision seam is one-file-per-child, and the index already registers this runbook).

## What it documents
A point-in-time export/restore of the single production D1, grounded in the real stack — not generic SQLite advice:
- alchemy-managed D1 per app/stage (ADR 0057), hand-authored flat migrations applied on deploy (ADR 0108), the deploy-infra-to-cloud dev model (ADR 0032).
- Follows the shared runbook shape the index defines: Symptoms → Preconditions → Procedure → Verification → Rollback/escalation.
- Real command surface: `pnpm dlx wrangler d1 export <name> --remote --table … --no-schema` for the export, `wrangler d1 execute --file` for the restore, `alchemy deploy --stage <scratch>` for the isolated restore target.

## The FTS5 export tax (ADR 0080), concretely handled
The `term_search` / `post_search` FTS5 virtual tables block a naive whole-DB D1 export (they spawn `_data`/`_idx`/`_content`/`_docsize`/`_config` shadow tables). The runbook's workaround: export the **base tables only** (`--table` enumeration excludes the virtual tables), restore into a scratch stage whose migrations recreate the empty FTS5 tables, then **rebuild the index** from the base rows via the app's Turkish-fold normalizer (`features/search/normalize.ts` + the dual-write shape in `fts-sync.ts`). Flags the absence of a standing FTS backfill route as a known gap (a follow-up).

## Rehearsal (honest scope)
The load-bearing mechanic — the FTS5 export-tax drop/rebuild sequence — was **rehearsed once locally** against SQLite 3.43.2 (FTS5-enabled) using the **verbatim DDL** from migration `0002_search_fts.sql`: base-only export → reimport → recreate FTS from the migration DDL → rebuild rows → verify row counts + exact/prefix `MATCH` + `integrity_check`. Recorded in the doc's Rehearsal section.

It does **not** exercise the full production remote round-trip (`wrangler d1 export --remote` + `alchemy deploy --stage <scratch>`) — that needs Cloudflare credentials this docs run doesn't hold, and is flagged in the doc as the operator-run step to append remote evidence. The "D1 refuses virtual tables on export" claim is cited from ADR 0080 + the migration caveat (a D1-platform behavior), not re-derived locally — the local `sqlite3` shell can round-trip virtual tables via `writable_schema`, so that specific tax was deliberately not over-claimed as reproduced.

## Checks
- All relative markdown links resolve; no wikilinks; no local/absolute/home/sibling paths (leak-guard clean in pre-commit).
- Single file changed: `ops/runbook-d1-restore.md`. ADR citations (0057/0108/0032/0080) verified against live `.decisions/` filenames.

NON-§CP (docs) → stops at PR-open for `review-doc`.