### PR TITLE
docs(adr-0174): point stale CONTROL_PLANE_RE example at the canonical source (#2756)

### DIFF
--- a/.decisions/0174-bare-sh-guards-control-plane-gate.md
+++ b/.decisions/0174-bare-sh-guards-control-plane-gate.md
@@ -17,13 +17,11 @@ decides whether a PR is §CP (human-merge-gated by a `@kamp-us/control-plane` ap
 `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (line 1359, §CP) and copied
 verbatim into the gate consumers; `ship-it` Step 0 resolves it from `origin/main` at run time
 and classifies against it (`ship-it/SKILL.md` §Step 0, lines 190–266). Its
-`claude-plugins/kampus-pipeline/skills/` alternative is:
-
-```
-^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan)/
-```
-
-— it matches only a **gate subdir** (note the trailing `/`), plus the exact file
+`claude-plugins/kampus-pipeline/skills/` alternative — the gate-subdir clause of the canonical
+`CONTROL_PLANE_RE` (defined once in
+`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, §CP; read it there rather
+than trust a copy inlined here, which re-drifts every time the gate-subdir set changes) — matches
+only a **gate subdir** (note the trailing `/`), plus the exact file
 `^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$`. A **bare `.sh` sitting
 directly under `skills/`** matches neither alternative.
 


### PR DESCRIPTION
## What

Replace the stale, inlined `CONTROL_PLANE_RE` example in `.decisions/0174-bare-sh-guards-control-plane-gate.md`'s Context with a **pointer** to the canonical source.

## Why

0174's prose embedded a verbatim copy of `CONTROL_PLANE_RE`'s `skills/` gate-subdir alternative to illustrate what it matches. That inline copy drifted stale when #2673 added the `triage|write-code|plan-epic` skill dirs to the canonical regex — the ADR example no longer reflected the real classifier.

Rather than re-sync the literal (which would drift again on the next gate-subdir change, and would carry an anticipatory-sequencing hazard — it would have to land with/after the regex change), this points the reader at the single canonical `CONTROL_PLANE_RE` in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §CP. A pointer is sequence-independent and can never go stale.

The prose still conveys exactly what the example illustrated: the `skills/` alternative matches only a gate subdir (trailing `/`), plus the exact `gh-issue-intake-formats.md` file, and a bare `.sh` directly under `skills/` matches neither.

## Scope

- One prose block in the ADR's Context. No other part of 0174 changed — frontmatter, status (`accepted`), Decision, and Consequences are untouched. No renumber.

Fixes #2756