### PR TITLE
test(fts-backfill): prove the D1-restore FTS index rebuild from base rows (#2754)

### DIFF
--- a/apps/web/tests/integration/fts-backfill-restore.test.ts
+++ b/apps/web/tests/integration/fts-backfill-restore.test.ts
@@ -1,0 +1,138 @@
+/**
+ * fts-backfill as the D1-restore FTS rebuild path (#2754) — the restore-scenario
+ * complement to `fts-backfill.test.ts` (#645). That test proves ONE deleted FTS
+ * row is re-findable; this one proves the whole D1-restore condition: BOTH FTS
+ * virtual tables emptied (a restore drops the virtual tables and recreates them
+ * bare — D1 can't export them, ADR 0080), base `term_record` / `post_record` rows
+ * intact, then a single `fts-backfill run` reconstructs the entire index from
+ * those base rows alone.
+ *
+ * Why this scenario needs its own dedicated stage: it truncates `term_search` /
+ * `post_search` wholesale, which would clobber a sibling file's corpus on a shared
+ * stage. `integrationStack` gives it an isolated D1 (ADR 0104), so the wipe is
+ * scoped to this file's rows.
+ *
+ * What it pins beyond #645, closing #2754's acceptance criteria against the REAL
+ * D1 FTS5 engine (≠ `node:sqlite`'s, so an integration-tier fact per ADR 0082):
+ *   - row counts: the bin reports ≥1 term AND ≥1 post re-indexed;
+ *   - exact MATCH: a full folded token finds the rebuilt term and post;
+ *   - prefix MATCH: a 3–4 char prefix finds them too — proving the `prefix='2 3 4'`
+ *     index (`0002_search_fts.sql`) is reconstructed from base rows, not just the
+ *     full-token postings.
+ * The pre-backfill empty-search assertion is the non-vacuity guard: a post-run hit
+ * can only be the backfill's doing, never a surviving index row.
+ */
+import {execFile} from "node:child_process";
+import {join} from "node:path";
+import {promisify} from "node:util";
+import {beforeAll, describe, expect, it} from "vitest";
+import {integrationStack} from "./_integration.ts";
+
+const execFileAsync = promisify(execFile);
+
+// The shipped production CLI entrypoint, run exactly as the one-time data-op runs
+// it (`node src/bin.ts run`). `apps/web/tests/integration/` → repo root is four up.
+const BIN_PATH = join(import.meta.dirname, "../../../../packages/fts-backfill/src/bin.ts");
+
+const h = integrationStack(import.meta.url);
+
+const STAMP = Date.now();
+
+const TERM_SLUG = `fts2754-${STAMP}-sisli`;
+// Turkish-diacritic titles whose folded token streams differ from the literal and
+// share NO folded token with each other, so a term query never masks a post hit.
+const TERM_TITLE = "Şişli Büyük Buluşma"; // folds → "sisli buyuk bulusma"
+const POST_TITLE = "Kadıköy Yazılım Şenliği"; // folds → "kadikoy yazilim senligi"
+
+// Exact = a full folded token; prefix = a 3–4 char incomplete prefix of one.
+const TERM_EXACT = "sisli";
+const TERM_PREFIX = "sis";
+const POST_EXACT = "yazilim";
+const POST_PREFIX = "kadi";
+
+let author: {userId: string; cookie: string};
+let postId: string;
+
+interface Conn<N> {
+	items: Array<{node: N}>;
+}
+
+const searchTermSlugs = async (query: string): Promise<string[]> => {
+	const res = await h.fate({kind: "list", name: "searchTerms", args: {query}, select: ["slug"]});
+	expect(res.ok, `searchTerms(${query}) failed`).toBe(true);
+	if (!res.ok) return [];
+	return (res.data as Conn<{slug: string}>).items.map((e) => e.node.slug);
+};
+
+const searchPostIds = async (query: string): Promise<string[]> => {
+	const res = await h.fate(
+		{kind: "list", name: "searchPosts", args: {query}, select: ["id"]},
+		{cookie: author.cookie},
+	);
+	expect(res.ok, `searchPosts(${query}) failed`).toBe(true);
+	if (!res.ok) return [];
+	return (res.data as Conn<{id: string}>).items.map((e) => e.node.id);
+};
+
+beforeAll(async () => {
+	author = await h.signUp(`${TERM_SLUG}-author@test.local`, "hunter2hunter2", "anka");
+	// Seed both a term and a post through the PUBLIC dual-write, so each base row
+	// lands with its FTS row — the exact state a healthy DB is in before a restore.
+	await h.seedTerm({
+		slug: TERM_SLUG,
+		title: TERM_TITLE,
+		definitions: [{authorName: "anka", body: "Şişli gövde"}],
+	});
+	const submit = await h.fate(
+		{
+			kind: "mutation",
+			name: "post.submit",
+			input: {title: POST_TITLE, tags: [{kind: "tartışma"}]},
+			select: ["id"],
+		},
+		{cookie: author.cookie},
+	);
+	expect(submit.ok).toBe(true);
+	if (!submit.ok) throw new Error(`seedPost failed: ${submit.error.code}`);
+	postId = (submit.data as {id: string}).id;
+
+	// The restore condition: wipe BOTH FTS virtual tables wholesale (base rows kept),
+	// reproducing a D1 restore that recreated the search tables empty.
+	await h.execD1("DELETE FROM term_search", []);
+	await h.execD1("DELETE FROM post_search", []);
+});
+
+describe("fts-backfill rebuilds the whole FTS index from restored base rows (#2754)", () => {
+	it("reconstructs term_search + post_search from base rows alone (row counts + exact + prefix MATCH)", async () => {
+		// Non-vacuity: with both FTS tables emptied, nothing matches.
+		expect(await searchTermSlugs(TERM_EXACT)).not.toContain(TERM_SLUG);
+		expect(await searchPostIds(POST_EXACT)).not.toContain(postId);
+
+		// Run the REAL shipped bin against this stage's D1 — the D1-restore step-3
+		// rebuild path #2703's runbook cites. A non-zero exit throws and fails here.
+		const {accountId, databaseId} = await h.d1Target();
+		const {stdout} = await execFileAsync(
+			process.execPath,
+			[BIN_PATH, "run", "--database-id", databaseId, "--account-id", accountId],
+			{env: process.env},
+		);
+
+		// Row counts: the bin reports how many of each kind it re-indexed; the seeded
+		// term + post are among them (it scans the whole corpus, so assert ≥ 1 each).
+		const terms = stdout.match(/re-indexed (\d+) term/);
+		const posts = stdout.match(/(\d+) post/);
+		expect(terms, `no term count in bin output:\n${stdout}`).not.toBeNull();
+		expect(posts, `no post count in bin output:\n${stdout}`).not.toBeNull();
+		expect(Number(terms?.[1])).toBeGreaterThanOrEqual(1);
+		expect(Number(posts?.[1])).toBeGreaterThanOrEqual(1);
+
+		// Exact MATCH: a full folded token finds each rebuilt row.
+		expect(await searchTermSlugs(TERM_EXACT)).toContain(TERM_SLUG);
+		expect(await searchPostIds(POST_EXACT)).toContain(postId);
+
+		// Prefix MATCH: a 3–4 char prefix finds them too, proving the `prefix='2 3 4'`
+		// index was rebuilt from the base rows, not just the full-token postings.
+		expect(await searchTermSlugs(TERM_PREFIX)).toContain(TERM_SLUG);
+		expect(await searchPostIds(POST_PREFIX)).toContain(postId);
+	});
+});

--- a/packages/fts-backfill/README.md
+++ b/packages/fts-backfill/README.md
@@ -1,7 +1,11 @@
 # @kampus/fts-backfill
 
-One-time, direct-D1 **FTS backfill** — re-index existing sözlük/pano content for
-search (issue #534).
+Direct-D1 **FTS index rebuild** — re-derive the `term_search` / `post_search` FTS5
+index from the base `term_record` / `post_record` rows. Two callers, one command
+(`fts-backfill run`): the one-time backfill of pre-dual-write content (issue #534),
+and the standing rebuild the D1 export/restore runbook depends on (issue #2754 /
+#2703). Both are the same operation — the FTS index is fully derived from the base
+tables, so rebuilding it is always "replay the dual-write over every base row".
 
 ## Why
 
@@ -51,9 +55,8 @@ A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
 - `src/backfill.ts` — `buildBackfillStatements` (pure: source rows → FTS upsert
   SQL via the worker's sync builders) + `backfill(d1)` (reads rows, runs the
   atomic batch).
-- `src/d1-rest.ts` — a `D1Database` over the Cloudflare D1 REST API (same adapter
-  as `@kampus/preview-seed`).
-- `src/bin.ts` — the `fts-backfill run` CLI.
+- `src/bin.ts` — the `fts-backfill run` CLI. Its `D1Database` transport is the
+  shared `@kampus/d1-rest` REST adapter (same one `@kampus/preview-seed` uses).
 
 ## Running it against a real D1
 
@@ -72,3 +75,27 @@ node packages/fts-backfill/src/bin.ts run --database-id <stage-d1-uuid>
 Run **once per environment** whose data predates the FTS migration (production
 after the search rollout; any preview/staging migrated onto the FTS tables). New
 writes stay current automatically via the dual-write.
+
+## As the D1-restore FTS rebuild (restore step-3)
+
+D1 cannot export a database that contains virtual tables (ADR 0080), so the
+export/restore runbook ([#2703]) exports the base tables only and skips
+`term_search` / `post_search`; a restore therefore lands with the base rows intact
+but the FTS index **empty** (the virtual tables recreated bare by the migration).
+`fts-backfill run` **is** that runbook's restore step-3 — the first-class,
+one-command path to reconstruct the whole index from the restored base rows,
+deriving `norm` through the real `normalizeSearchText` fold (never a raw-SQL
+re-spelling):
+
+```bash
+node packages/fts-backfill/src/bin.ts run --database-id <restored-stage-d1-uuid>
+```
+
+Because each sync is a keyed delete-then-insert (see [Idempotency](#idempotency)),
+it is safe on a freshly-restored D1 whose FTS tables are already empty, and safe to
+re-run if a rebuild is interrupted. The restore-scenario proof — both FTS tables
+wiped, then one run reconstructs the full index with correct row counts + exact and
+prefix `MATCH` on real D1 — lives in
+`apps/web/tests/integration/fts-backfill-restore.test.ts` (#2754).
+
+[#2703]: https://github.com/kamp-us/phoenix/issues/2703


### PR DESCRIPTION
## What & why

Closes #2754 — a standing FTS5 index-rebuild backfill path that a clean D1 restore depends on (the runbook #2703 documents; this makes it first-class).

**Key finding — the capability already exists.** The FTS index-rebuild path this issue asks for already ships as **`@kampus/fts-backfill`** (built for #534): a §CP-NO maintenance CLI (`fts-backfill run`) that re-derives `term_search` / `post_search` from the base `term_record` / `post_record` rows through the **real** `normalizeSearchText` fold (`apps/web/worker/features/search/normalize.ts`), reusing `fts-sync.ts`'s delete-then-insert upsert builders, idempotently. It is not `packages/pipeline-cli/**` or `packages/ci-required/**`, so it is **not §CP** — building a second app-side path would only duplicate it (ADR 0099). So rather than duplicate, this PR closes the two genuine residual gaps for the restore scenario:

1. **A restore-scenario proof.** The existing integration test (`fts-backfill.test.ts`, #645) deletes *one* term's FTS row. This adds `apps/web/tests/integration/fts-backfill-restore.test.ts`: on a dedicated stage it wipes **both** FTS virtual tables wholesale — the exact post-D1-restore condition (base rows intact, index recreated empty, since D1 can't export virtual tables, ADR 0080) — then a single `fts-backfill run` reconstructs the whole index **from base rows alone**. It asserts, against the real D1 FTS5 engine (an ADR-0082 integration-tier fact):
   - **row counts** — the bin reports `>= 1` term AND `>= 1` post re-indexed;
   - **exact MATCH** — a full folded token finds the rebuilt term and post;
   - **prefix MATCH** — a 3–4 char prefix finds them too, proving the `prefix='2 3 4'` index is rebuilt, not just full-token postings.
   A pre-backfill empty-search assertion is the non-vacuity guard.

2. **Runbook-citable framing.** `packages/fts-backfill/README.md` now sanctions `fts-backfill run` as **#2703 restore step-3** (idempotent, safe on already-empty FTS tables), so the runbook has a first-class path to cite. Also fixes a stale Architecture bullet (the transport is `@kampus/d1-rest`, not a removed `src/d1-rest.ts`).

## Acceptance criteria (#2754)

- [x] Sanctioned backfill rebuilds `term_search` / `post_search` from base rows, deriving `norm` via `normalize.ts` — `@kampus/fts-backfill` (pre-existing); restore scenario now proven.
- [x] Reuses `fts-sync.ts` upsert building blocks; no second normalization path — unchanged; test pins it end-to-end.
- [x] Runs as a maintenance CLI, not a public-worker/admin/seeder route — `fts-backfill run` (bin.ts), per the CLAUDE.md Sözlük-seed guard.
- [x] Post-run FTS search correct over the full corpus (row counts + query round-trip) — new restore test, exact + prefix MATCH.
- [x] #2703 can cite this as restore step-3's first-class rebuild path — README framing.

## §CP-NO

App-side only: `apps/web/tests/integration/` + `packages/fts-backfill/README.md`. No `packages/pipeline-cli/**`, no `packages/ci-required/**`, no `.claude/` / `.github/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)