### PR TITLE
chore(lint): declare 4 Effect-v4 GritQL ban rules at warn (#2746)

### DIFF
--- a/biome-plugins/no-context-tag.grit
+++ b/biome-plugins/no-context-tag.grit
@@ -1,0 +1,43 @@
+// Ban the pre-v4 service forms `Context.Tag(...)` / `Context.GenericTag(...)` /
+// `Effect.Service(...)` — require Effect-v4 `Context.Service`.
+//
+// Rationale (single site; .patterns/effect-context-service.md): phoenix is on Effect v4
+// (the effect-smol line). The v3 service idioms — `Context.Tag`, `Context.GenericTag`,
+// and the `Effect.Service` helper — are wrong here; the single v4 idiom is
+// `class S extends Context.Service<S, Shape>()("id") {}`. This rule is a pure regression
+// gate: the repo scan for #2736 found ZERO existing violations (the codebase is already
+// all-v4), so it exists only to stop a v3 form from re-entering.
+//
+// Matched on the member-access callee (`Context.Tag` etc.) rather than a call snippet,
+// because the forms differ in arity/type-args (`Context.Tag("id")<S, Shape>()`,
+// `Context.GenericTag<Shape>("id")`, `Effect.Service<S>()("id", {...})`) — the bare
+// member is the stable shape common to all of them.
+//
+// Registered via biome.jsonc `"plugins"` at `warn` (Phase 1 of #2736; the flip to
+// `error` is the Phase-3 capstone #2753). A genuine exception is a per-line
+// `// biome-ignore lint/plugin: <reason>`.
+language js;
+
+or {
+	`Context.Tag` as $ref where {
+		register_diagnostic(
+			span = $ref,
+			message = "`Context.Tag(...)` is the Effect-v3 service form and is banned — phoenix is on Effect v4 (.patterns/effect-context-service.md; #2736). Fix: define the service as `class S extends Context.Service<S, Shape>()('id') {}` — copy `packages/fate-effect/src/CurrentUser.ts` (or `apps/web/worker/db/Drizzle.ts`). Exception: // biome-ignore lint/plugin: <reason>.",
+			severity = "warn"
+		)
+	},
+	`Context.GenericTag` as $ref where {
+		register_diagnostic(
+			span = $ref,
+			message = "`Context.GenericTag(...)` is the Effect-v3 service form and is banned — phoenix is on Effect v4 (.patterns/effect-context-service.md; #2736). Fix: define the service as `class S extends Context.Service<S, Shape>()('id') {}` — copy `packages/fate-effect/src/CurrentUser.ts` (or `apps/web/worker/db/Drizzle.ts`). Exception: // biome-ignore lint/plugin: <reason>.",
+			severity = "warn"
+		)
+	},
+	`Effect.Service` as $ref where {
+		register_diagnostic(
+			span = $ref,
+			message = "`Effect.Service(...)` is not used in phoenix — v4 uses `Context.Service` only (.patterns/effect-context-service.md; #2736). Fix: define the service as `class S extends Context.Service<S, Shape>()('id') {}` — copy `packages/fate-effect/src/CurrentUser.ts` (or `apps/web/worker/db/Drizzle.ts`). Exception: // biome-ignore lint/plugin: <reason>.",
+			severity = "warn"
+		)
+	}
+}

--- a/biome-plugins/no-data-taggederror.grit
+++ b/biome-plugins/no-data-taggederror.grit
@@ -1,0 +1,24 @@
+// Ban `class ... extends Data.TaggedError(...)` — require `Schema.TaggedErrorClass`.
+//
+// Rationale (single site; .patterns/effect-errors.md): every phoenix error class is a
+// `Schema.TaggedErrorClass` so the `FateWireCode` wire-code annotation can ride the
+// class's AST — `Data.TaggedError` has nowhere to put one. The ban applies uniformly,
+// including CLI-only errors that never reach the fate wire (pipeline-cli's own gold
+// boundary files already use `Schema.TaggedErrorClass` for CLI-only errors; a
+// wire/non-wire carve-out would fragment the rule for no benefit — #2736 resolved).
+//
+// Matched on the member-access callee `Data.TaggedError` (the extends-clause is a call
+// `Data.TaggedError("Tag")<Shape>`), the stable shape across its arity/type-arg variants.
+//
+// Registered via biome.jsonc `"plugins"` at `warn` (Phase 1 of #2736; the flip to
+// `error` is the Phase-3 capstone #2753). A genuine exception is a per-line
+// `// biome-ignore lint/plugin: <reason>`.
+language js;
+
+`Data.TaggedError` as $ref where {
+	register_diagnostic(
+		span = $ref,
+		message = "`class ... extends Data.TaggedError` is banned — errors must be `Schema.TaggedErrorClass` so the `FateWireCode` annotation can ride the AST (.patterns/effect-errors.md; #2736). Fix: `class MyError extends Schema.TaggedErrorClass<MyError>()('feature/MyError', { ...fields }, { [FateWireCode]: 'CODE' }) {}` — copy `packages/fate-effect/src/CurrentUser.ts` (or `packages/pipeline-cli/src/tools/epic-ledger/github.ts` for a CLI-only error). Exception: // biome-ignore lint/plugin: <reason>.",
+		severity = "warn"
+	)
+}

--- a/biome-plugins/no-effect-promise.grit
+++ b/biome-plugins/no-effect-promise.grit
@@ -1,0 +1,37 @@
+// Ban `Effect.promise(...)` and single-arg `Effect.tryPromise(...)` — require the
+// object-notation `Effect.tryPromise({ try, catch })` with an explicit tagged-error `catch`.
+//
+// Rationale (single site; .patterns/index.md house rule "Effect.tryPromise always uses
+// object notation"): `Effect.promise` and the single-arg `Effect.tryPromise(() => p)`
+// carry no `catch`, so a rejection surfaces as an uncatchable DEFECT with an empty `E`
+// channel instead of a typed, recoverable failure — the "cosplay as Effect" tell the
+// #2736 audit found across the CLI packages. The object form forces a `catch` that maps
+// the cause into a tagged error, keeping the failure in `E`.
+//
+// Discriminator: the object form's sole argument is an object literal
+// (`JsObjectExpression`); the single-arg thunk form is anything else (an arrow, a
+// function expression, a bare identifier). So `Effect.tryPromise($arg)` is flagged only
+// when `$arg` is NOT an object literal — the object-notation call is left alone.
+//
+// Registered via biome.jsonc `"plugins"` at `warn` (Phase 1 of #2736 — the flip to
+// `error` is the Phase-3 capstone #2753; warn keeps CI green while every site is
+// remediated). A genuine exception is a per-line `// biome-ignore lint/plugin: <reason>`.
+language js;
+
+or {
+	`Effect.promise($arg)` where {
+		register_diagnostic(
+			span = $arg,
+			message = "`Effect.promise(...)` is banned — a rejection becomes an uncatchable defect with an empty error channel (.patterns/index.md; #2736). Fix: use object-notation `Effect.tryPromise({ try, catch: (cause) => new SomeError({ cause }) })` with a `Schema.TaggedErrorClass`, or lift the pure core to an `Effect.fn` returning a typed `Effect` — copy `packages/pipeline-cli/src/tools/epic-ledger/github.ts` (or `packages/fate-effect`). Exception: // biome-ignore lint/plugin: <reason>.",
+			severity = "warn"
+		)
+	},
+	`Effect.tryPromise($arg)` where {
+		$arg <: not JsObjectExpression(),
+		register_diagnostic(
+			span = $arg,
+			message = "Single-arg `Effect.tryPromise(() => ...)` is banned — with no `catch` a rejection becomes an uncatchable defect with an empty error channel (.patterns/index.md; #2736). Fix: use object-notation `Effect.tryPromise({ try, catch: (cause) => new SomeError({ cause }) })` with a `Schema.TaggedErrorClass` — copy `packages/pipeline-cli/src/tools/epic-ledger/github.ts` (or `packages/fate-effect`). Exception: // biome-ignore lint/plugin: <reason>.",
+			severity = "warn"
+		)
+	}
+}

--- a/biome-plugins/no-raw-try-catch.grit
+++ b/biome-plugins/no-raw-try-catch.grit
@@ -1,0 +1,36 @@
+// Ban raw `try/catch` in any file that imports `effect` — require `Effect.try` /
+// `Effect.tryPromise`.
+//
+// Rationale (single site; #2736): real Effect code models failure in the `E` channel
+// via `Effect.try` / `Effect.tryPromise`; a bare `try/catch` inside an effect-importing
+// file is the "cosplay as Effect" tell — the failure escapes the type system. Scoped to
+// effect-importing files (bare `"effect"` or an `"effect/…"` subpath) so a pure Node
+// script that legitimately uses try/catch is not touched.
+//
+// A genuine pre-runtime bootstrap `try/catch` (e.g. a dynamic-import guard that must run
+// before the Effect runtime loads) is exempted per-line with a
+// `// biome-ignore lint/plugin: <reason>`, never a blanket exemption.
+//
+// The match anchors on the `try` statement (so the diagnostic underlines the offending
+// try, not the whole module) but fires only when the enclosing module also imports
+// `effect`. GritQL notes at the pinned biome 2.4.15: regex patterns (`r"…"`) are not
+// honored, so the effect-import test is two exact string-snippet arms — the bare
+// `"effect"` and the metavariable subpath `"effect/$rest"`. Registered via biome.jsonc
+// `"plugins"` at `warn` (Phase 1 of #2736; the flip to `error` is the Phase-3 capstone
+// #2753).
+language js;
+
+JsTryStatement() as $try where {
+	$try <: within JsModule() as $mod,
+	$mod <: contains (JsImport() as $imp where {
+		or {
+			$imp <: contains `"effect"`,
+			$imp <: contains `"effect/$rest"`
+		}
+	}),
+	register_diagnostic(
+		span = $try,
+		message = "Raw `try/catch` is banned in an effect-importing file — real Effect code models failure in the `E` channel, not a native throw (#2736). Fix: use `Effect.try({ try, catch })` (sync) or `Effect.tryPromise({ try, catch })` (async), mapping the cause into a `Schema.TaggedErrorClass` — copy `packages/pipeline-cli/src/tools/epic-ledger/github.ts` (or `packages/fate-effect`). Exception (e.g. a pre-runtime bootstrap guard): // biome-ignore lint/plugin: <reason>.",
+		severity = "warn"
+	)
+}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -50,7 +50,11 @@
 	},
 	"plugins": [
 		"./biome-plugins/no-type-assertions.grit",
-		"./biome-plugins/no-node-sqlite-test-backing.grit"
+		"./biome-plugins/no-node-sqlite-test-backing.grit",
+		"./biome-plugins/no-effect-promise.grit",
+		"./biome-plugins/no-context-tag.grit",
+		"./biome-plugins/no-data-taggederror.grit",
+		"./biome-plugins/no-raw-try-catch.grit"
 	],
 	"linter": {
 		"enabled": true,


### PR DESCRIPTION
Fixes #2746 — Phase 1 (DECLARE) of epic #2736 "Enforce Effect-v4 idioms as GritQL bans + remediate".

## What this does
Declares the four Effect-v4 anti-idiom ban rules as `biome-plugins/*.grit` GritQL plugins and registers them in `biome.jsonc`'s `plugins` array (mirroring the existing `no-type-assertions.grit` / `no-node-sqlite-test-backing.grit` precedent). All four land at **`warn` severity, not `error`** — so `pnpm lint` surfaces every violating site to the Phase-2 remediation children without failing CI mid-sweep.

**Scope is declaration only.** No remediation of any violating site (that is Phase 2: #2747/#2748/#2750/#2751/#2752). No workflow change — the rules ride the existing `pnpm lint` in `.github/workflows/ci.yml`. The flip `warn`→`error` is the Phase-3 capstone #2753.

## The four rules
1. **`no-effect-promise.grit`** — bans `Effect.promise(...)` and single-arg `Effect.tryPromise(() => ...)`; requires object-notation `Effect.tryPromise({ try, catch })` with an explicit tagged-error `catch` (the object-notation call, whose sole arg is an object literal, is left alone). Ref `.patterns/index.md`.
2. **`no-context-tag.grit`** — bans `Context.Tag` / `Context.GenericTag` / `Effect.Service`; requires v4 `Context.Service`. Ref `.patterns/effect-context-service.md`. **Pure regression gate** — the repo scan found zero existing violations (per the epic's resolved question), so no Phase-2 child covers it.
3. **`no-data-taggederror.grit`** — bans `class ... extends Data.TaggedError`; requires `Schema.TaggedErrorClass` so the `FateWireCode` annotation can ride the AST. Ref `.patterns/effect-errors.md`. Applies uniformly incl. CLI-only pipeline-cli errors (per the epic's resolved question).
4. **`no-raw-try-catch.grit`** — bans raw `try/catch` in any file importing `effect` (bare `"effect"` or an `"effect/…"` subpath); requires `Effect.try`/`Effect.tryPromise`. A genuine pre-runtime bootstrap `try/catch` carries a per-line `// biome-ignore lint/plugin: <reason>`.

Each rule's `register_diagnostic` message follows the convention `<what's wrong> — <why + ref>. Fix: <sibling>. Exception: // biome-ignore lint/plugin: <reason>.` and names a canonical good example (`packages/pipeline-cli/src/tools/epic-ledger/github.ts` or `packages/fate-effect`).

## Verification
Authored per `.patterns/biome-custom-gritql-rules.md`. Verified with a throwaway probe matrix (deleted before commit): each rule warns on a known violating site and is silent on the idiomatic sibling — e.g. object-notation `Effect.tryPromise`, a `Context.Service` class, and a `try/catch` in a non-effect file are all correctly NOT flagged; the per-line `biome-ignore` correctly suppresses the try/catch ban.

`biome check` exits **0** — the rules are `warn`, not `error`, and CI passes no `--error-on-warnings`, so warnings never change the exit code. A broad real-source scan (`biome check apps/web/worker packages infra`) reports 156 warnings (the Phase-2 remediation surface) at **EXIT=0**; CI stays green.

## GritQL notes (pinned biome 2.4.15)
Regex patterns (`r"…"`) are not honored at this pin, so rule 4's effect-import test uses two exact string-snippet arms — the bare `"effect"` and the metavariable subpath `"effect/$rest"`. Message code identifiers use single quotes (double-quote escaping in GritQL string literals renders unreliably at this pin).

## Files changed
- `biome.jsonc` — register the 4 new plugins
- `biome-plugins/no-effect-promise.grit`
- `biome-plugins/no-context-tag.grit`
- `biome-plugins/no-data-taggederror.grit`
- `biome-plugins/no-raw-try-catch.grit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)