### PR TITLE
feat(flagship): requireAdmin flag-state view + runtime-override mutation + auditable override store (#2741)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -40,6 +40,7 @@ import {PhoenixDb} from "./worker/db/resources.ts";
 import {resolveStateMode} from "./worker/env.ts";
 import {isProductionDeploy} from "./worker/environment.ts";
 import {
+	adminConsoleFlag,
 	authorshipLoopFlag,
 	bildirimFlag,
 	demoTargetingFlag,
@@ -145,6 +146,10 @@ export default Alchemy.Stack(
 		// (#2692, epic #2687) — the single seam the emailDelivery.mark/clear mutations + the
 		// emailDelivery.failing admin roll-up gate behind until a human release.
 		yield* emailDeliveryAdminFlag(flagship.appId);
+		// The admin-console dark-ship flag, default-off (#2711) — the single seam the console
+		// shell + probe (#2740) and the worker flag-state view / runtime-flip mutation (#2741)
+		// gate behind, so no admin surface leaks until a human release.
+		yield* adminConsoleFlag(flagship.appId);
 		// The mecmua public-read dark-ship flag, default-off (#2498, epic #2467) — the
 		// single seam the anon GET route + reader page gate behind until a human release.
 		yield* mecmuaPublicReadFlag(flagship.appId);

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -231,6 +231,24 @@ export const PHOENIX_USER_BAN = "phoenix-user-ban";
 export const PHOENIX_EMAIL_DELIVERY_ADMIN = "phoenix-email-delivery-admin";
 
 /**
+ * Admin console dark-ship flag (#2711, admin-console epic). The SINGLE seam the whole
+ * admin-console surface gates behind — the lazy-loaded admin-only console shell + probe
+ * (#2740) AND the worker flag-state view / runtime-override mutation (#2741) all read this
+ * one key. Default-off so the console reaches production dark until a human flips it at
+ * release (ADR 0083): with it off the worker view/mutation fail the invisible `Denied`
+ * (like a non-admin call) and the shell never mounts, so no admin surface leaks before
+ * release. Its OWN cross-cutting (`phoenix`) key — the console is a host for many future
+ * admin modules, the `phoenix-user-ban` / `phoenix-email-delivery-admin` admin-surface
+ * precedent.
+ *
+ * OVERLAP (#2740/#2741 parallel Phase-1): both halves need this constant. Whichever of the
+ * two PRs merges SECOND drops its duplicate declaration (this constant + the IaC in
+ * `worker/features/flagship/resources.ts` + the `alchemy.run.ts` wiring) and keeps the
+ * first's — a trivial dedup, not a semantic conflict (identical key string).
+ */
+export const PHOENIX_ADMIN_CONSOLE = "phoenix-admin-console";
+
+/**
  * Nav-IA (per-product Subnav zones) dark-ship flag (#2598, epic #2596). The SINGLE
  * cross-cutting seam the whole nav-IA surface gates behind — the per-product nested
  * layout routes + Subnav CTA slot substrate (#2598) and every per-product delta

--- a/apps/web/worker/db/drizzle/migrations/0029_flag_override_event.sql
+++ b/apps/web/worker/db/drizzle/migrations/0029_flag_override_event.sql
@@ -1,0 +1,19 @@
+-- #2741 (admin-console epic #2711) — the append-only runtime feature-flag override log. The
+-- SINGLE source of both the audit trail and the current per-flag runtime override: the effective
+-- override is a projection of the latest row (see `features/flagship/flag-override.ts`), so an
+-- admin's in-app flag flip can never drift from history and every prod flip is auditable by
+-- construction. Keyed by `flag_key` (the shared `src/flags/keys.ts` constant); `action` is
+-- tri-state (`on`/`off` force the effective value, `clear` lifts the override); `actor_id` is the
+-- discharged `Admin` grant's account id (the audit stamp, no FK — mirrors `user_ban_event.actor_id`).
+-- The runtime-override `Flags` wrapper reads the latest row per key; the `flag.setOverride` mutation
+-- appends. Mirrors `user_ban_event` / `email_delivery_event`.
+
+CREATE TABLE `flag_override_event` (
+	`id` text PRIMARY KEY NOT NULL,
+	`flag_key` text NOT NULL,
+	`action` text NOT NULL,
+	`actor_id` text NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `flag_override_event_key_created` ON `flag_override_event` (`flag_key`,"created_at" DESC);

--- a/apps/web/worker/db/drizzle/migrations/meta/0029_flag_override_event_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0029_flag_override_event_snapshot.json
@@ -1,0 +1,2424 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "21672d9e-67da-43d0-bb3b-bd588ab8fdb1",
+	"prevId": "f0c8bdbd-d18f-4390-8016-1b3ab86a9ced",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"apiKey": {
+			"name": "apiKey",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"start": {
+					"name": "start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prefix": {
+					"name": "prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"refill_interval": {
+					"name": "refill_interval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refill_amount": {
+					"name": "refill_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_refill_at": {
+					"name": "last_refill_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"rate_limit_enabled": {
+					"name": "rate_limit_enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"rate_limit_time_window": {
+					"name": "rate_limit_time_window",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rate_limit_max": {
+					"name": "rate_limit_max",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"request_count": {
+					"name": "request_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"remaining": {
+					"name": "remaining",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_request": {
+					"name": "last_request",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"permissions": {
+					"name": "permissions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"apiKey_user_id_user_id_fk": {
+					"name": "apiKey_user_id_user_id_fk",
+					"tableFrom": "apiKey",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_vote": {
+			"name": "comment_vote",
+			"columns": {
+				"comment_id": {
+					"name": "comment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"comment_vote_comment": {
+					"name": "comment_vote_comment",
+					"columns": [
+						"comment_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comment_vote_comment_id_voter_id_pk": {
+					"columns": [
+						"comment_id",
+						"voter_id"
+					],
+					"name": "comment_vote_comment_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"definition_vote": {
+			"name": "definition_vote",
+			"columns": {
+				"definition_id": {
+					"name": "definition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"definition_vote_definition": {
+					"name": "definition_vote_definition",
+					"columns": [
+						"definition_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"definition_vote_definition_id_voter_id_pk": {
+					"columns": [
+						"definition_id",
+						"voter_id"
+					],
+					"name": "definition_vote_definition_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"pano_stats": {
+			"name": "pano_stats",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"total_posts": {
+					"name": "total_posts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_comments": {
+					"name": "total_comments",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_authors": {
+					"name": "total_authors",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_record": {
+			"name": "post_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"host": {
+					"name": "host",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"comment_count": {
+					"name": "comment_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"hot_score": {
+					"name": "hot_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_draft": {
+					"name": "is_draft",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_record_hot": {
+					"name": "post_record_hot",
+					"columns": [
+						"hot_score"
+					],
+					"isUnique": false
+				},
+				"post_record_new": {
+					"name": "post_record_new",
+					"columns": [
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"post_record_top": {
+					"name": "post_record_top",
+					"columns": [
+						"score"
+					],
+					"isUnique": false
+				},
+				"post_record_discuss": {
+					"name": "post_record_discuss",
+					"columns": [
+						"comment_count"
+					],
+					"isUnique": false
+				},
+				"post_record_host": {
+					"name": "post_record_host",
+					"columns": [
+						"host"
+					],
+					"isUnique": false
+				},
+				"post_record_author_created": {
+					"name": "post_record_author_created",
+					"columns": [
+						"author_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				},
+				"post_record_one_draft_per_author": {
+					"name": "post_record_one_draft_per_author",
+					"columns": [
+						"author_id"
+					],
+					"isUnique": true,
+					"where": "`is_draft` = 1"
+				},
+				"post_record_sandboxed": {
+					"name": "post_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_vote": {
+			"name": "post_vote",
+			"columns": {
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_vote_post": {
+					"name": "post_vote_post",
+					"columns": [
+						"post_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"post_vote_post_id_voter_id_pk": {
+					"columns": [
+						"post_id",
+						"voter_id"
+					],
+					"name": "post_vote_post_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": [
+						"token"
+					],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"sozluk_stats": {
+			"name": "sozluk_stats",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"total_definitions": {
+					"name": "total_definitions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_terms": {
+					"name": "total_terms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_authors": {
+					"name": "total_authors",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"term_record": {
+			"name": "term_record",
+			"columns": {
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"first_letter": {
+					"name": "first_letter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"definition_count": {
+					"name": "definition_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_score": {
+					"name": "total_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"excerpt": {
+					"name": "excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"top_definition_id": {
+					"name": "top_definition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"first_at": {
+					"name": "first_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_edit_at": {
+					"name": "last_edit_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"term_record_recent": {
+					"name": "term_record_recent",
+					"columns": [
+						"last_activity_at"
+					],
+					"isUnique": false
+				},
+				"term_record_popular": {
+					"name": "term_record_popular",
+					"columns": [
+						"total_score"
+					],
+					"isUnique": false
+				},
+				"term_record_letter": {
+					"name": "term_record_letter",
+					"columns": [
+						"first_letter"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'human'"
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\u00e7aylak'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_username_unique": {
+					"name": "user_username_unique",
+					"columns": [
+						"username"
+					],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_profile": {
+			"name": "user_profile",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"total_karma": {
+					"name": "total_karma",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"definition_count": {
+					"name": "definition_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"post_count": {
+					"name": "post_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"comment_count": {
+					"name": "comment_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_profile_username_unique": {
+					"name": "user_profile_username_unique",
+					"columns": [
+						"username"
+					],
+					"isUnique": true
+				},
+				"user_profile_username": {
+					"name": "user_profile_username",
+					"columns": [
+						"username"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_vote": {
+			"name": "user_vote",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_vote_target": {
+					"name": "user_vote_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"user_vote_user_id_target_kind_target_id_pk": {
+					"columns": [
+						"user_id",
+						"target_kind",
+						"target_id"
+					],
+					"name": "user_vote_user_id_target_kind_target_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"content_report": {
+			"name": "content_report",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reporter_id": {
+					"name": "reporter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'open'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"resolver_id": {
+					"name": "resolver_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolution": {
+					"name": "resolution",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"wave_id": {
+					"name": "wave_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"content_report_target": {
+					"name": "content_report_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				},
+				"content_report_wave": {
+					"name": "content_report_wave",
+					"columns": [
+						"wave_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"content_report_pk": {
+					"name": "content_report_pk",
+					"columns": [
+						"reporter_id",
+						"target_kind",
+						"target_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_bookmark": {
+			"name": "post_bookmark",
+			"columns": {
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_bookmark_user_created": {
+					"name": "post_bookmark_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"post_bookmark_pk": {
+					"name": "post_bookmark_pk",
+					"columns": [
+						"post_id",
+						"user_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"definition_record": {
+			"name": "definition_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"term_slug": {
+					"name": "term_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"term_title": {
+					"name": "term_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"definition_record_author_created": {
+					"name": "definition_record_author_created",
+					"columns": [
+						"author_id",
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"definition_record_term_score": {
+					"name": "definition_record_term_score",
+					"columns": [
+						"term_slug",
+						"score"
+					],
+					"isUnique": false
+				},
+				"definition_record_sandboxed": {
+					"name": "definition_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_record": {
+			"name": "comment_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"post_title": {
+					"name": "post_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"comment_record_author_created": {
+					"name": "comment_record_author_created",
+					"columns": [
+						"author_id",
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"comment_record_post": {
+					"name": "comment_record_post",
+					"columns": [
+						"post_id"
+					],
+					"isUnique": false
+				},
+				"comment_record_parent": {
+					"name": "comment_record_parent",
+					"columns": [
+						"parent_id"
+					],
+					"isUnique": false
+				},
+				"comment_record_sandboxed": {
+					"name": "comment_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"relation_tuple": {
+			"name": "relation_tuple",
+			"columns": {
+				"subject": {
+					"name": "subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"relation": {
+					"name": "relation",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"object": {
+					"name": "object",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"relation_tuple_object": {
+					"name": "relation_tuple_object",
+					"columns": [
+						"object",
+						"relation"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"relation_tuple_subject_relation_object_pk": {
+					"name": "relation_tuple_subject_relation_object_pk",
+					"columns": [
+						"subject",
+						"relation",
+						"object"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"authorship_vouch": {
+			"name": "authorship_vouch",
+			"columns": {
+				"voucher_id": {
+					"name": "voucher_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"candidate_id": {
+					"name": "candidate_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"authorship_vouch_candidate": {
+					"name": "authorship_vouch_candidate",
+					"columns": [
+						"candidate_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"authorship_vouch_voucher_id_candidate_id_pk": {
+					"name": "authorship_vouch_voucher_id_candidate_id_pk",
+					"columns": [
+						"voucher_id",
+						"candidate_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification": {
+			"name": "notification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipient_id": {
+					"name": "recipient_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"count": {
+					"name": "count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"read_at": {
+					"name": "read_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"notification_recipient_read": {
+					"name": "notification_recipient_read",
+					"columns": [
+						"recipient_id",
+						"read_at"
+					],
+					"isUnique": false
+				},
+				"notification_recipient_created": {
+					"name": "notification_recipient_created",
+					"columns": [
+						"recipient_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_reaction": {
+			"name": "user_reaction",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emoji": {
+					"name": "emoji",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_reaction_target": {
+					"name": "user_reaction_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"user_reaction_user_id_target_kind_target_id_pk": {
+					"columns": [
+						"user_id",
+						"target_kind",
+						"target_id"
+					],
+					"name": "user_reaction_user_id_target_kind_target_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_ban_event": {
+			"name": "user_ban_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_ban_event_user_created": {
+					"name": "user_ban_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"user_ban_event_user_id_user_id_fk": {
+					"name": "user_ban_event_user_id_user_id_fk",
+					"tableFrom": "user_ban_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mecmua_post": {
+			"name": "mecmua_post",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"published_at": {
+					"name": "published_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mecmua_post_author_created": {
+					"name": "mecmua_post_author_created",
+					"columns": [
+						"author_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mecmua_subscription": {
+			"name": "mecmua_subscription",
+			"columns": {
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subscriber_id": {
+					"name": "subscriber_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mecmua_subscription_subscriber": {
+					"name": "mecmua_subscription_subscriber",
+					"columns": [
+						"subscriber_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"mecmua_subscription_subscriber_id_author_id_pk": {
+					"columns": [
+						"subscriber_id",
+						"author_id"
+					],
+					"name": "mecmua_subscription_subscriber_id_author_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"karma_event": {
+			"name": "karma_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"delta": {
+					"name": "delta",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_kind": {
+					"name": "source_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"karma_event_user_created": {
+					"name": "karma_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"karma_event_user_id_user_id_fk": {
+					"name": "karma_event_user_id_user_id_fk",
+					"tableFrom": "karma_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"email_delivery_event": {
+			"name": "email_delivery_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"email_delivery_event_address_created": {
+					"name": "email_delivery_event_address_created",
+					"columns": [
+						"address",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				},
+				"email_delivery_event_user_created": {
+					"name": "email_delivery_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"email_delivery_event_user_id_user_id_fk": {
+					"name": "email_delivery_event_user_id_user_id_fk",
+					"tableFrom": "email_delivery_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"flag_override_event": {
+			"name": "flag_override_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"flag_key": {
+					"name": "flag_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"flag_override_event_key_created": {
+					"name": "flag_override_event_key_created",
+					"columns": [
+						"flag_key",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {
+			"post_record_author_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"user_ban_event_user_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"mecmua_post_author_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"mecmua_subscription_subscriber": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
 			"when": 1796000000000,
 			"tag": "0028_email_delivery_event",
 			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "6",
+			"when": 1796500000000,
+			"tag": "0029_flag_override_event",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -221,6 +221,37 @@ export const emailDeliveryEvent = sqliteTable(
 );
 
 /**
+ * Append-only runtime feature-flag override log — the SINGLE source of both the audit
+ * trail and the current per-flag runtime override (admin-console epic #2711, #2741). The
+ * effective override is a projection of the latest event for a flag key (see
+ * `features/flagship/flag-override.ts` `resolveFlagOverride`), mirroring {@link userBanEvent}
+ * / {@link emailDeliveryEvent}: latest-event-wins, so an admin's runtime flip can never
+ * drift from history and every prod flip is auditable by construction.
+ *
+ * `action` is tri-state: `on`/`off` force the flag's effective value, `clear` lifts the
+ * override (the projection then reads the real Flagship evaluation). The `actor_id` is the
+ * discharged `Admin` grant's account id (plain text, no FK — the audit stamp mirrors
+ * `user_ban_event.actor_id`). The `(flag_key, created_at DESC)` index is the projection's
+ * hot read key. No `user`/account FK — the row is keyed by flag, not account.
+ */
+export const flagOverrideEvent = sqliteTable(
+	"flag_override_event",
+	{
+		id: text("id").primaryKey(),
+		// The Flagship flag key the override targets (the shared `src/flags/keys.ts` constant).
+		flagKey: text("flag_key").notNull(),
+		// The event kind: `on`/`off` force the effective value, `clear` lifts the override.
+		// The projection reads only the latest row, so a `clear` after an `on`/`off` restores
+		// the real evaluation without mutating or deleting the forcing row — full reversibility.
+		action: text("action", {enum: ["on", "off", "clear"]}).notNull(),
+		// The admin who performed the flip (a discharged `Admin` grant's account id).
+		actorId: text("actor_id").notNull(),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(t) => [index("flag_override_event_key_created").on(t.flagKey, sql`${t.createdAt} DESC`)],
+);
+
+/**
  * Per-(definition, voter) up-vote presence row. `user_vote` and
  * `definition_record.score` (COUNT(*) under `WHERE definition_id = ?`) are both
  * denormalized off this, recomputed inline in the same D1 batch as the vote write.

--- a/apps/web/worker/features/fate-live/fanned-mutations.ts
+++ b/apps/web/worker/features/fate-live/fanned-mutations.ts
@@ -323,6 +323,15 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 			"appends a `clear` event to the email-delivery log — no fanned content entity (mirrors emailDelivery.mark)",
 	},
 
+	// flagship — the admin console's runtime flag-override write (#2741, epic #2711). A
+	// `requireAdmin`-gated admin audit surface, not a subscribed content connection.
+	{
+		key: "flag.setOverride",
+		fanned: false,
+		rationale:
+			"appends an audited runtime override event to the append-only `flag_override_event` log (an admin audit surface, epic #2711) — no Post/Comment/Definition in a subscribed content connection (mirrors emailDelivery.mark)",
+	},
+
 	// mecmua — long-form posts (#2497, epic #2467). mecmua Post does NOT yet live in a
 	// subscribed `/fate/live` connection (no mecmua root is wired), so neither write fans;
 	// if a mecmua mutation is later classified fanned it must publish via `WorkerLivePublisher`.

--- a/apps/web/worker/features/fate/config.ts
+++ b/apps/web/worker/features/fate/config.ts
@@ -30,6 +30,7 @@ import {FateServer} from "@kampus/fate-effect";
 import {fateModule as bildirimModule} from "../bildirim/fate-module.ts";
 import {fateModule as divanModule} from "../divan/fate-module.ts";
 import {liveBusConfig} from "../fate-live/event-bus.ts";
+import {fateModule as flagshipModule} from "../flagship/fate-module.ts";
 import {fateModule as funnelModule} from "../funnel/fate-module.ts";
 import {fateModule as mecmuaModule} from "../mecmua/fate-module.ts";
 import {fateModule as panoModule} from "../pano/fate-module.ts";
@@ -54,6 +55,7 @@ export const modules = [
 	funnelModule,
 	bildirimModule,
 	mecmuaModule,
+	flagshipModule,
 ];
 
 export const fateConfig = FateServer.config({

--- a/apps/web/worker/features/fate/fate-flags-dev-override.unit.test.ts
+++ b/apps/web/worker/features/fate/fate-flags-dev-override.unit.test.ts
@@ -27,6 +27,7 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import * as ConfigProvider from "effect/ConfigProvider";
 import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
+import {FlagOverrideStore} from "../flagship/FlagOverrideStore.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {FlagsContext} from "../flagship/FlagsContext.ts";
 import {Flagship} from "../flagship/Flagship.ts";
@@ -63,6 +64,17 @@ const darkFlagship: Layer.Layer<Flagship> = Layer.succeed(Flagship)(
 	}),
 );
 
+// A no-op runtime-override store (#2741): no key carries a durable override, so the
+// runtime-override wrapper `FateFlagsLive` now installs delegates straight to real eval —
+// isolating THIS test to the dev-override cookie behavior it asserts.
+const noRuntimeOverrides: Layer.Layer<FlagOverrideStore> = Layer.succeed(FlagOverrideStore)(
+	FlagOverrideStore.of({
+		record: () => Effect.void,
+		getActiveOverride: () => Effect.succeed(undefined),
+		listActiveOverrides: () => Effect.succeed(new Map()),
+	}),
+);
+
 /** Mirror the worker-scope `ConfigProvider` with a fixed `ENVIRONMENT` stage. */
 const withEnvironment = (environment: string) =>
 	Effect.provideService(
@@ -84,7 +96,10 @@ const resolveWithOverride = (environment: string) =>
 		);
 	}).pipe(
 		Effect.provide(
-			Layer.mergeAll(FateFlagsLive.pipe(Layer.provide(darkFlagship)), RuntimeContextStub),
+			Layer.mergeAll(
+				FateFlagsLive.pipe(Layer.provide(darkFlagship), Layer.provide(noRuntimeOverrides)),
+				RuntimeContextStub,
+			),
 		),
 		withEnvironment(environment),
 	);

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -22,7 +22,8 @@ import type {Database} from "../../db/Database.ts";
 import {DrizzleLive} from "../../db/Drizzle.ts";
 import {NotificationLive} from "../bildirim/Notification.ts";
 import {DivanLive} from "../divan/Divan.ts";
-import {FlagsDevOverrideLive, FlagsLive} from "../flagship/Flags.ts";
+import {FlagOverrideStoreLive} from "../flagship/FlagOverrideStore.ts";
+import {FlagsDevAndRuntimeOverrideLive, FlagsRuntimeOverrideLive} from "../flagship/Flags.ts";
 import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
 import type {Flagship} from "../flagship/Flagship.ts";
 import {FunnelLive} from "../funnel/Funnel.ts";
@@ -168,7 +169,14 @@ const VoterStandingFromKunye = Layer.effect(VoterStanding)(
 export const FateFlagsLive = Layer.unwrap(
 	Effect.gen(function* () {
 		const {environment} = yield* AppConfig.pipe(Effect.orDie);
-		return environment === "development" ? FlagsDevOverrideLive : FlagsLive;
+		// Both arms now install the DURABLE runtime-override wrapper (#2741) so an admin's
+		// in-app flag flip is honored on the fate mutation/read path in EVERY stage; the
+		// `development` arm additionally layers the dev-only cookie override (#622) on top.
+		// `FlagOverrideStore` is discharged by the `provideMerge(FlagOverrideStoreLive)` on
+		// `makeFateLayer` (its `Drizzle` seam bubbles to the same root as `Database`).
+		return environment === "development"
+			? FlagsDevAndRuntimeOverrideLive
+			: FlagsRuntimeOverrideLive;
 	}),
 );
 
@@ -281,7 +289,16 @@ export const makeFateLayer = Layer.mergeAll(
 	// `RuntimeContext`/`FlagsContext` are per-call, supplied by the resolver, not at
 	// layer build.
 	FateFlagsLive,
-).pipe(Layer.provideMerge(PasaportFromTag), Layer.provideMerge(DrizzleLive));
+).pipe(
+	// The durable runtime flag-override store (#2741) — the append-only `flag_override_event`
+	// log the flag-flip mutation writes and the flag-state view reads. `provideMerge` so the
+	// ONE instance both discharges {@link FateFlagsLive}'s build-time `FlagOverrideStore`
+	// requirement AND stays a {@link WorkerFateServices} output the mutation/view resolvers
+	// `yield*`. Its `Drizzle` seam bubbles to the final `provideMerge(DrizzleLive)` below.
+	Layer.provideMerge(FlagOverrideStoreLive),
+	Layer.provideMerge(PasaportFromTag),
+	Layer.provideMerge(DrizzleLive),
+);
 
 /**
  * The composed fate-server layer (`.patterns/fate-effect-server.md`):

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -28,6 +28,8 @@ export {
 	divanCaylakDataView,
 	divanVoteReceiptDataView,
 } from "../divan/views.ts";
+export type {FlagStateEntity as FlagState} from "../flagship/views.ts";
+export {flagStateDataView} from "../flagship/views.ts";
 export type {FunnelSummary} from "../funnel/views.ts";
 export {funnelSummaryDataView} from "../funnel/views.ts";
 export type {MecmuaPost, MecmuaSubscriptionReceipt} from "../mecmua/views.ts";

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -35,6 +35,7 @@ import {
 	wireCodeOfClass,
 } from "@kampus/fate-effect";
 import {describe, expect, it} from "vitest";
+import {UnknownFlagKey} from "../flagship/errors.ts";
 import {Denied, InsufficientKarma, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
 import {MecmuaDisabled, MecmuaPostNotFound, MecmuaTitleRequired} from "../mecmua/errors.ts";
 import {
@@ -125,6 +126,10 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	// pasaport email-failing-mark floor (#2692) — reachable via `emailDelivery.mark`'s
 	// error union. Message-only, so also a round-trip representative below.
 	[EmailFailingReasonRequired, "EMAIL_FAILING_REASON_REQUIRED"],
+	// flagship admin console (#2741) — reachable from fateConfig via `flag.setOverride`'s error
+	// union. Message-only, so also a round-trip representative below; shares the `BAD_REQUEST`
+	// code with the package-intrinsic bad-request path.
+	[UnknownFlagKey, "BAD_REQUEST"],
 	// künye moderation gate + the package-side gate the SPA already decodes for writes
 	[Denied, "UNAUTHORIZED"],
 	[Unauthorized, "UNAUTHORIZED"],
@@ -183,6 +188,7 @@ const ROUND_TRIP_CLASSES = [
 	DisplayNameEmpty,
 	BanReasonRequired,
 	EmailFailingReasonRequired,
+	UnknownFlagKey,
 	Denied,
 	Unauthorized,
 ] as const satisfies ReadonlyArray<new (props: {message: string}) => unknown>;

--- a/apps/web/worker/features/flagship/FlagOverrideStore.ts
+++ b/apps/web/worker/features/flagship/FlagOverrideStore.ts
@@ -1,0 +1,141 @@
+/**
+ * `FlagOverrideStore` — the durable, all-stages, `requireAdmin`-written override substrate
+ * over `flag_override_event` (admin-console epic #2711, #2741). It generalizes the dev-only
+ * cookie override (`dev-override.ts`, #622) into an append-only, auditable D1 log projected to
+ * current state: every admin flip appends one row (actor id, flag key, on/off/clear, time), and
+ * the effective override is the latest-event projection (`flag-override.ts`). This is the store
+ * the `Flags.getBoolean` wrapper (`withRuntimeOverrides`) reads and the flag-flip mutation writes.
+ *
+ * Read fail-soft is load-bearing (epic #2711 story 8): `getActiveOverride` and
+ * `listActiveOverrides` have error channel `never` — a D1 failure degrades to "no override" (the
+ * read then delegates to the real Flagship evaluation), so the override layer can never turn the
+ * never-throwing flag contract fail-open. The `record` write dies on a D1 failure (a defect, not a
+ * domain error, matching the pasaport write path), so the mutation's error channel stays domain-only.
+ */
+import {desc, eq} from "drizzle-orm";
+import {Context, Effect, Layer} from "effect";
+import {Drizzle, orDieDrizzle} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {
+	type FlagOverrideAction,
+	type FlagOverrideEvent,
+	type FlagOverrideEventRow,
+	resolveFlagOverride,
+	selectActiveOverrides,
+} from "./flag-override.ts";
+
+export class FlagOverrideStore extends Context.Service<
+	FlagOverrideStore,
+	{
+		/**
+		 * Append one override event for a flag key, stamped with the acting admin's account id.
+		 * Dies on a D1 failure (a defect) so the caller's error channel stays domain-only.
+		 */
+		readonly record: (input: {
+			readonly flagKey: string;
+			readonly action: FlagOverrideAction;
+			readonly actorId: string;
+		}) => Effect.Effect<void>;
+		/**
+		 * The flag's effective runtime override, or `undefined` for no active override. Fail-soft
+		 * (`E = never`): a D1 failure resolves `undefined` (delegate to the real evaluation), so the
+		 * `getBoolean` wrapper this feeds never throws.
+		 */
+		readonly getActiveOverride: (flagKey: string) => Effect.Effect<boolean | undefined>;
+		/**
+		 * The map of flag key → forced boolean for every key with an active override — the flag-state
+		 * view's read. Fail-soft (`E = never`): a D1 failure resolves an empty map (the view then shows
+		 * all-real-evaluation), never a broken admin read.
+		 */
+		readonly listActiveOverrides: () => Effect.Effect<ReadonlyMap<string, boolean>>;
+	}
+>()("@kampus/flagship/FlagOverrideStore") {}
+
+/**
+ * The Drizzle-backed adapter. `run` is captured at layer build, so each method's Effect carries
+ * no `R` — a drop-in the isolate-scoped `Flags` wrapper closes over (mirroring `EmailDeliveryLog`).
+ */
+export const FlagOverrideStoreLive: Layer.Layer<FlagOverrideStore, never, Drizzle> = Layer.effect(
+	FlagOverrideStore,
+	Effect.gen(function* () {
+		const {run} = yield* Drizzle;
+
+		// The latest event for one key, projected to its effective override. Fail-soft: any D1
+		// error logs and resolves `undefined` (the real evaluation wins), keeping `E = never`.
+		const readActiveOverride = (flagKey: string): Effect.Effect<boolean | undefined> =>
+			run((db) =>
+				db
+					.select({
+						action: schema.flagOverrideEvent.action,
+						createdAt: schema.flagOverrideEvent.createdAt,
+					})
+					.from(schema.flagOverrideEvent)
+					.where(eq(schema.flagOverrideEvent.flagKey, flagKey))
+					.orderBy(desc(schema.flagOverrideEvent.createdAt), desc(schema.flagOverrideEvent.id))
+					.limit(1)
+					.then((rows): boolean | undefined => {
+						const row = rows[0];
+						if (!row) return undefined;
+						const latest: FlagOverrideEvent = {
+							action: row.action,
+							createdAt: row.createdAt ?? new Date(0),
+						};
+						return resolveFlagOverride(latest);
+					}),
+			).pipe(
+				Effect.catchCause((cause) =>
+					Effect.logWarning(
+						`flag-override: read of "${flagKey}" failed — delegating to real evaluation`,
+						cause,
+					).pipe(Effect.as(undefined)),
+				),
+			);
+
+		return FlagOverrideStore.of({
+			record: ({flagKey, action, actorId}) =>
+				run((db) =>
+					db.insert(schema.flagOverrideEvent).values({
+						id: crypto.randomUUID(),
+						flagKey,
+						action,
+						actorId,
+						createdAt: new Date(),
+					}),
+				).pipe(Effect.asVoid, orDieDrizzle),
+
+			getActiveOverride: readActiveOverride,
+
+			listActiveOverrides: () =>
+				run((db) =>
+					db
+						.select({
+							id: schema.flagOverrideEvent.id,
+							flagKey: schema.flagOverrideEvent.flagKey,
+							action: schema.flagOverrideEvent.action,
+							createdAt: schema.flagOverrideEvent.createdAt,
+						})
+						.from(schema.flagOverrideEvent),
+				).pipe(
+					Effect.map(
+						(rows): ReadonlyMap<string, boolean> =>
+							selectActiveOverrides(
+								rows.map(
+									(row): FlagOverrideEventRow => ({
+										id: row.id,
+										flagKey: row.flagKey,
+										action: row.action,
+										createdAt: row.createdAt ?? new Date(0),
+									}),
+								),
+							),
+					),
+					Effect.catchCause((cause) =>
+						Effect.logWarning(
+							"flag-override: roll-up read failed — degrading to no active overrides",
+							cause,
+						).pipe(Effect.as(new Map<string, boolean>() as ReadonlyMap<string, boolean>)),
+					),
+				),
+		});
+	}),
+);

--- a/apps/web/worker/features/flagship/Flags.ts
+++ b/apps/web/worker/features/flagship/Flags.ts
@@ -23,6 +23,7 @@
  */
 import type {RuntimeContext} from "alchemy";
 import {type Cause, Context, Effect, Layer} from "effect";
+import {FlagOverrideStore} from "./FlagOverrideStore.ts";
 import {FlagsContext, toEvaluationContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
 
@@ -175,5 +176,64 @@ export const FlagsDevOverrideLive = Layer.effect(
 	Effect.gen(function* () {
 		const flagship = yield* Flagship;
 		return Flags.of(withDevOverrides(buildRealFlags(flagship)));
+	}),
+);
+
+/**
+ * Decorate a real {@link FlagsAccess} with the DURABLE, all-stages runtime override
+ * (admin-console epic #2711, #2741): a boolean read whose key carries an active
+ * `FlagOverrideStore` override returns the forced value; every other read (and every
+ * typed/non-boolean read) delegates unchanged to `inner`.
+ *
+ * Unlike {@link withDevOverrides} (a dev-only, per-request cookie map), this reads the
+ * durable, `requireAdmin`-written, append-only-projected override store — the admin's
+ * in-app flip persisted in D1, honored in EVERY stage. `store.getActiveOverride` is
+ * fail-soft (`E = never`): a store outage resolves `undefined`, so the read delegates to
+ * `inner` and a Flagship outage still degrades to the caller's safe default — the override
+ * layer never turns the never-throwing flag contract fail-open (epic #2711 story 8). Pure
+ * decorator (no Layer) so the short-circuit is unit-testable over stub `FlagsAccess` +
+ * store, with no binding.
+ */
+export const withRuntimeOverrides = (
+	inner: FlagsAccess,
+	store: FlagOverrideStore["Service"],
+): FlagsAccess => ({
+	...inner,
+	getBoolean: (key, defaultValue) =>
+		Effect.gen(function* () {
+			const override = yield* store.getActiveOverride(key);
+			return override !== undefined ? override : yield* inner.getBoolean(key, defaultValue);
+		}),
+});
+
+/**
+ * The durable runtime-override `Flags` layer (#2741): `FlagsLive`'s surface decorated with
+ * {@link withRuntimeOverrides}. Installed on EVERY stage (the admin console operates on local
+ * AND prod), so the override branch is present in every deployed flag path — the opposite of
+ * the dev-only {@link FlagsDevOverrideLive} gate. Requires `Flagship` + `FlagOverrideStore`,
+ * both discharged at the composition root (`fate/layers.ts`).
+ */
+export const FlagsRuntimeOverrideLive = Layer.effect(
+	Flags,
+	Effect.gen(function* () {
+		const flagship = yield* Flagship;
+		const store = yield* FlagOverrideStore;
+		return Flags.of(withRuntimeOverrides(buildRealFlags(flagship), store));
+	}),
+);
+
+/**
+ * The `development`-stage flag layer: the durable runtime override composed UNDER the dev-only
+ * cookie override, so a local dev's `phoenix_flag_overrides` cookie flip (#622) still wins
+ * outermost, falling through to the durable admin override, then the real evaluation. In every
+ * deployed stage {@link FlagsRuntimeOverrideLive} (no dev-cookie branch) is built instead — the
+ * same fail-closed dev-only gate the raw path applies, now over the runtime-override base.
+ */
+export const FlagsDevAndRuntimeOverrideLive = Layer.effect(
+	Flags,
+	Effect.gen(function* () {
+		const flagship = yield* Flagship;
+		const store = yield* FlagOverrideStore;
+		return Flags.of(withDevOverrides(withRuntimeOverrides(buildRealFlags(flagship), store)));
 	}),
 );

--- a/apps/web/worker/features/flagship/admin-gate.ts
+++ b/apps/web/worker/features/flagship/admin-gate.ts
@@ -1,0 +1,20 @@
+/**
+ * The `phoenix-admin-console` dark-ship gate, shared by the admin flag-state view
+ * (`lists.ts`) and the runtime-flip mutation (`mutations.ts`) so the flag key is read once.
+ *
+ * Safe-default `false` (dark), the `userBanOn` / `emailDeliveryAdminOn` idiom: with the flag
+ * off (default / Flagship outage) both surfaces fail the invisible `Denied` exactly like a
+ * non-admin call, so the console's worker half stays dark until a human flips it at release
+ * (ADR 0083). The whole surface pairs this with `requireAdmin` (ADR 0107): two gates, both
+ * enforced at the resolver.
+ */
+import {Effect} from "effect";
+import {PHOENIX_ADMIN_CONSOLE} from "../../../src/flags/keys.ts";
+import {Flags} from "./Flags.ts";
+import {provideRequestFlags} from "./FlagsContext.ts";
+
+/** Is the #2711 admin-console dark-ship flag on for this request? Safe-default `false` (dark). */
+export const adminConsoleOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(PHOENIX_ADMIN_CONSOLE, false).pipe(provideRequestFlags);
+});

--- a/apps/web/worker/features/flagship/declared-flags.ts
+++ b/apps/web/worker/features/flagship/declared-flags.ts
@@ -1,0 +1,74 @@
+/**
+ * The declared boolean feature-flag registry (admin-console epic #2711, #2741) — every
+ * boolean dark-ship flag the admin flag-state view lists, paired with its declared default.
+ * The single in-worker source of "which flags exist + their default", read by the
+ * `flags.state` view resolver to enumerate the console's flag list.
+ *
+ * Keys come from the shared `src/flags/keys.ts` register (the one home the gate and the
+ * Flagship IaC declaration both name), so this list can never name a string neither half
+ * knows. All current flags are default-OFF dark-ship booleans (ADR 0083) — `defaultValue:
+ * false`; a future non-default-off flag adds its own row. The non-boolean demo/targeting flag
+ * (`phoenix-flags-targeting-demo`) is deliberately absent — the runtime-override surface is
+ * the boolean dark-ship primitive (mirroring `DEV_OVERRIDABLE_FLAGS`), not typed variations.
+ */
+import {
+	MECMUA_FEED,
+	MECMUA_PUBLIC_READ,
+	MECMUA_WRITE,
+	PANO_BASE_FEED,
+	PANO_DRAFT_SAVE,
+	PANO_FEED_EDGE_CACHE,
+	PANO_OPTIMISTIC_COMMENT_ADD,
+	PANO_OPTIMISTIC_COMMENT_DELETE,
+	PANO_OPTIMISTIC_POST_DELETE,
+	PANO_OPTIMISTIC_SUBMIT,
+	PHOENIX_ADMIN_CONSOLE,
+	PHOENIX_AUTHORSHIP_LOOP,
+	PHOENIX_BILDIRIM,
+	PHOENIX_EMAIL_DELIVERY_ADMIN,
+	PHOENIX_FUNNEL_READOUT,
+	PHOENIX_KARMA_GATES,
+	PHOENIX_MOD_QUEUE,
+	PHOENIX_NAV_IA,
+	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
+	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
+	PHOENIX_OPTIMISTIC_EDITS,
+	PHOENIX_REACTIONS,
+	PHOENIX_USER_BAN,
+} from "../../../src/flags/keys.ts";
+
+/** One declared boolean flag: its key and the default the safe-path evaluation falls back to. */
+export interface DeclaredFlag {
+	readonly key: string;
+	readonly defaultValue: boolean;
+}
+
+// Every boolean dark-ship flag defaults OFF (ADR 0083), so the list is the key set at
+// `defaultValue: false`; a flag that ever ships default-on adds an explicit `true` row.
+const declared = (key: string): DeclaredFlag => ({key, defaultValue: false});
+
+export const DECLARED_FLAGS: ReadonlyArray<DeclaredFlag> = [
+	declared(PANO_DRAFT_SAVE),
+	declared(PANO_FEED_EDGE_CACHE),
+	declared(PANO_OPTIMISTIC_SUBMIT),
+	declared(PANO_OPTIMISTIC_COMMENT_ADD),
+	declared(PANO_OPTIMISTIC_COMMENT_DELETE),
+	declared(PANO_OPTIMISTIC_POST_DELETE),
+	declared(PANO_BASE_FEED),
+	declared(MECMUA_WRITE),
+	declared(MECMUA_PUBLIC_READ),
+	declared(MECMUA_FEED),
+	declared(PHOENIX_AUTHORSHIP_LOOP),
+	declared(PHOENIX_BILDIRIM),
+	declared(PHOENIX_FUNNEL_READOUT),
+	declared(PHOENIX_MOD_QUEUE),
+	declared(PHOENIX_OPTIMISTIC_EDITS),
+	declared(PHOENIX_OPTIMISTIC_DEFINITION_ADD),
+	declared(PHOENIX_OPTIMISTIC_DEFINITION_DELETE),
+	declared(PHOENIX_REACTIONS),
+	declared(PHOENIX_KARMA_GATES),
+	declared(PHOENIX_USER_BAN),
+	declared(PHOENIX_EMAIL_DELIVERY_ADMIN),
+	declared(PHOENIX_NAV_IA),
+	declared(PHOENIX_ADMIN_CONSOLE),
+];

--- a/apps/web/worker/features/flagship/errors.ts
+++ b/apps/web/worker/features/flagship/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Tagged errors raised by the flagship admin surface (#2741). The wire `code` annotation is
+ * read by `encodeWireError` at the fate boundary (`.patterns/fate-effect-wire-errors.md`); the
+ * shared `Denied` (invisible admin denial) is not redeclared here.
+ */
+import {FateWireCode} from "@kampus/fate-effect";
+import * as Schema from "effect/Schema";
+
+// A `flag.setOverride` for a key absent from the declared-flags registry — a bad request, so
+// the override write never lands against an unknown/typo'd key (the audit log stays meaningful).
+export class UnknownFlagKey extends Schema.TaggedErrorClass<UnknownFlagKey>()(
+	"flagship/UnknownFlagKey",
+	{message: Schema.String},
+	{[FateWireCode]: "BAD_REQUEST"},
+) {}

--- a/apps/web/worker/features/flagship/fate-module.ts
+++ b/apps/web/worker/features/flagship/fate-module.ts
@@ -1,0 +1,20 @@
+/** flagship's contribution to the one fate config (#2741). See `../fate/module.ts`. */
+import {list} from "@nkzw/fate/server";
+import type {FateModule, FateRootsRecord} from "../fate/module.ts";
+import {lists} from "./lists.ts";
+import {mutations} from "./mutations.ts";
+import {flagStateSource} from "./sources.ts";
+import {flagStateDataView} from "./views.ts";
+
+const roots: FateRootsRecord = {
+	// The admin flag-state roll-up (#2741) — `requireAdmin`-gated + behind `phoenix-admin-console`;
+	// the `flags.state` list resolver owns the gate.
+	"flags.state": list(flagStateDataView),
+};
+
+export const fateModule = {
+	mutations,
+	lists,
+	sources: [flagStateSource],
+	roots,
+} satisfies FateModule;

--- a/apps/web/worker/features/flagship/flag-override.ts
+++ b/apps/web/worker/features/flagship/flag-override.ts
@@ -1,0 +1,79 @@
+/**
+ * Runtime flag-override domain (admin-console epic #2711, #2741). Pure logic, no I/O: the
+ * current runtime override for a flag is a PROJECTION of the append-only
+ * `flag_override_event` log — the latest event decides, so the effective override can never
+ * drift from the audit history and a stale "forced-on flag" is unrepresentable. This mirrors
+ * `resolveBanState` (`ban.ts`) / `resolveEmailDeliveryState` (`email-delivery.ts`) verbatim:
+ * a projection over an append-only log.
+ *
+ * The override wraps `Flags.getBoolean` (`Flags.ts` `withRuntimeOverrides`): a key whose
+ * latest event is `on`/`off` short-circuits to that forced value; a `clear` (or no events)
+ * projects to `undefined` and the read delegates to the real Flagship evaluation — so a
+ * Flagship outage still degrades to the caller's safe default (the override never turns the
+ * never-throwing flag contract fail-open, epic #2711 story 8).
+ */
+
+/** The tri-state an admin flip appends: force `on`/`off`, or `clear` the override. */
+export type FlagOverrideAction = "on" | "off" | "clear";
+
+/** One row of the append-only override log, as the projection needs it. */
+export interface FlagOverrideEvent {
+	readonly action: FlagOverrideAction;
+	readonly createdAt: Date;
+}
+
+/**
+ * Project a flag's effective runtime override from its LATEST event.
+ *
+ * The caller passes the single newest event (by `createdAt`) or null when the log is empty.
+ * `on` → `true`, `off` → `false` — the forced effective value; `clear` (or no events) →
+ * `undefined`, meaning "no override, read the real evaluation". `undefined` is the load-bearing
+ * absence signal the wrapper delegates on, distinct from a forced-`false` override.
+ */
+export const resolveFlagOverride = (latest: FlagOverrideEvent | null): boolean | undefined => {
+	if (latest === null || latest.action === "clear") return undefined;
+	return latest.action === "on";
+};
+
+/**
+ * One append-only log row as the admin flag-state roll-up (#2741) needs it: the projection
+ * fields plus the flag key the row is keyed by and the server `id`/`createdAt` ordering pair
+ * used to pick the latest event per flag.
+ */
+export interface FlagOverrideEventRow extends FlagOverrideEvent {
+	readonly id: string;
+	readonly flagKey: string;
+}
+
+// Latest wins by (createdAt, id) — the same server-assigned ordering the ban/email reads and
+// the per-key index (`flag_override_event_key_created`) resolve by, so the pure roll-up and a
+// DB `ORDER BY … DESC LIMIT 1` per key agree.
+const isNewer = (a: FlagOverrideEventRow, b: FlagOverrideEventRow): boolean => {
+	const at = a.createdAt.getTime();
+	const bt = b.createdAt.getTime();
+	return at !== bt ? at > bt : a.id > b.id;
+};
+
+/**
+ * The active-overrides projection (#2741): the map of flag key → forced boolean for every key
+ * whose LATEST event is `on`/`off`, derived from the SAME append-only log the per-key
+ * `resolveFlagOverride` read uses — never a separate stored flag. Reduces the rows to the newest
+ * event per key and keeps those that project to a defined override (a `clear`-latest key is
+ * absent from the map, so it reads the real evaluation). Pure over the full override log (small —
+ * only admin flips land here), so the roll-up is unit-testable without D1.
+ */
+export const selectActiveOverrides = (
+	rows: ReadonlyArray<FlagOverrideEventRow>,
+): ReadonlyMap<string, boolean> => {
+	const latest = new Map<string, FlagOverrideEventRow>();
+	for (const row of rows) {
+		const seen = latest.get(row.flagKey);
+		if (!seen || isNewer(row, seen)) latest.set(row.flagKey, row);
+	}
+	const active = new Map<string, boolean>();
+	for (const [key, row] of latest) {
+		const override = resolveFlagOverride(row);
+		if (override !== undefined) active.set(key, override);
+	}
+	return active;
+};

--- a/apps/web/worker/features/flagship/flag-override.unit.test.ts
+++ b/apps/web/worker/features/flagship/flag-override.unit.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The runtime flag-override projection (#2741) — latest-event-wins, mirroring
+ * `resolveBanState` / `resolveEmailDeliveryState`. `resolveFlagOverride` reads the single
+ * newest event; `selectActiveOverrides` rolls the full log up to the active map. No I/O,
+ * driven over hand-built rows.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type FlagOverrideEventRow,
+	resolveFlagOverride,
+	selectActiveOverrides,
+} from "./flag-override.ts";
+
+const row = (
+	id: string,
+	flagKey: string,
+	action: FlagOverrideEventRow["action"],
+	createdAt: string,
+): FlagOverrideEventRow => ({id, flagKey, action, createdAt: new Date(createdAt)});
+
+describe("resolveFlagOverride", () => {
+	it("no events → undefined (no override, read the real evaluation)", () => {
+		assert.strictEqual(resolveFlagOverride(null), undefined);
+	});
+
+	it("latest `on` → true; latest `off` → false (the forced effective value)", () => {
+		assert.strictEqual(resolveFlagOverride({action: "on", createdAt: new Date()}), true);
+		assert.strictEqual(resolveFlagOverride({action: "off", createdAt: new Date()}), false);
+	});
+
+	it("latest `clear` → undefined (a clear lifts the override, distinct from forced-false)", () => {
+		assert.strictEqual(resolveFlagOverride({action: "clear", createdAt: new Date()}), undefined);
+	});
+});
+
+describe("selectActiveOverrides", () => {
+	it("no events → empty map", () => {
+		assert.strictEqual(selectActiveOverrides([]).size, 0);
+	});
+
+	it("a key whose latest event is on/off is in the map with the forced value", () => {
+		const active = selectActiveOverrides([
+			row("1", "phoenix-reactions", "on", "2026-01-01T00:00:00Z"),
+		]);
+		assert.strictEqual(active.get("phoenix-reactions"), true);
+	});
+
+	it("a clear newer than the force lifts the key (latest-event-wins) — absent from the map", () => {
+		const active = selectActiveOverrides([
+			row("1", "phoenix-reactions", "on", "2026-01-01T00:00:00Z"),
+			row("2", "phoenix-reactions", "clear", "2026-01-02T00:00:00Z"),
+		]);
+		assert.strictEqual(active.has("phoenix-reactions"), false);
+	});
+
+	it("a re-force after a clear brings the key back (newest event decides)", () => {
+		const active = selectActiveOverrides([
+			row("1", "phoenix-reactions", "on", "2026-01-01T00:00:00Z"),
+			row("2", "phoenix-reactions", "clear", "2026-01-02T00:00:00Z"),
+			row("3", "phoenix-reactions", "off", "2026-01-03T00:00:00Z"),
+		]);
+		assert.strictEqual(active.get("phoenix-reactions"), false);
+	});
+
+	it("each key is projected independently", () => {
+		const active = selectActiveOverrides([
+			row("1", "phoenix-reactions", "on", "2026-01-01T06:00:00Z"),
+			row("2", "phoenix-user-ban", "off", "2026-01-01T12:00:00Z"),
+			row("3", "phoenix-mod-queue", "clear", "2026-01-01T09:00:00Z"),
+		]);
+		assert.strictEqual(active.get("phoenix-reactions"), true);
+		assert.strictEqual(active.get("phoenix-user-ban"), false);
+		assert.strictEqual(active.has("phoenix-mod-queue"), false);
+		assert.strictEqual(active.size, 2);
+	});
+
+	it("breaks a same-instant tie by id, so the latest event is deterministic", () => {
+		const at = "2026-01-01T12:00:00Z";
+		const active = selectActiveOverrides([
+			row("id-1", "phoenix-reactions", "on", at),
+			row("id-2", "phoenix-reactions", "clear", at),
+		]);
+		// id-2 > id-1 at the same timestamp ⇒ the clear is the latest ⇒ lifted.
+		assert.strictEqual(active.has("phoenix-reactions"), false);
+	});
+});

--- a/apps/web/worker/features/flagship/lists.ts
+++ b/apps/web/worker/features/flagship/lists.ts
@@ -1,0 +1,75 @@
+/**
+ * Flagship admin root list resolver — `flags.state`, the flag-state roll-up (admin-console
+ * epic #2711, #2741). `Fate.list` def + `Effect.fn` pair (`.patterns/fate-effect-operations.md`);
+ * the list is delivered inline (no source `connection`), so the resolver builds the wire shape.
+ *
+ * Two gates, both enforced HERE (the store read is unconditional), mirroring `pasaport/lists.ts`:
+ *   1. The `phoenix-admin-console` dark-ship flag (`adminConsoleOn`, default-off, ADR 0083). Off ⇒
+ *      the invisible `Denied`, so the roll-up never leaks before release.
+ *   2. `requireAdmin` (ADR 0107) — `yield* Admin` makes the read unreachable without the
+ *      discharged grant, so a non-admin gets the SAME invisible `Denied`.
+ *
+ * Each flag's `effective` value is read through `Flags.getBoolean` — the SAME override-applied
+ * surface a real gate reads — so the view reflects an active override by construction (#2711
+ * story 4). `overridden` comes from the store's active-override map. A single-page private read
+ * (no live view, no cursor), so `hasNext: false`, mirroring `emailDelivery.failing`.
+ */
+import {Fate} from "@kampus/fate-effect";
+import type {ConnectionResult} from "@nkzw/fate/server";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {Admin, requireAdmin} from "../kunye/admin.ts";
+import {Denied} from "../kunye/errors.ts";
+import {adminConsoleOn} from "./admin-gate.ts";
+import {DECLARED_FLAGS} from "./declared-flags.ts";
+import {FlagOverrideStore} from "./FlagOverrideStore.ts";
+import {Flags} from "./Flags.ts";
+import {provideRequestFlags} from "./FlagsContext.ts";
+import {toFlagState} from "./shapers.ts";
+import type {FlagStateEntity} from "./views.ts";
+import {FlagStateView} from "./views.ts";
+
+const FlagsStateArgs = Schema.Struct({});
+
+// The post-gate roll-up read — `Admin`-gated in R (`requireAdmin` provides the grant).
+// `yield* Admin` requires the proof; the roll-up is unreachable without a discharged grant.
+const flagsStateGated = Effect.fn("flags.stateGated")(function* () {
+	yield* Admin;
+	const flags = yield* Flags;
+	const store = yield* FlagOverrideStore;
+	const overrides = yield* store.listActiveOverrides();
+	const items = yield* Effect.forEach(DECLARED_FLAGS, (flag) =>
+		Effect.gen(function* () {
+			const effective = yield* flags
+				.getBoolean(flag.key, flag.defaultValue)
+				.pipe(provideRequestFlags);
+			const node = toFlagState({
+				key: flag.key,
+				defaultValue: flag.defaultValue,
+				effective,
+				overridden: overrides.has(flag.key),
+			});
+			return {cursor: node.id, node};
+		}),
+	);
+	return {
+		items,
+		pagination: {hasNext: false, hasPrevious: false},
+	} satisfies ConnectionResult<FlagStateEntity>;
+});
+
+export const lists = {
+	"flags.state": Fate.list(
+		{
+			args: FlagsStateArgs,
+			type: FlagStateView,
+			error: Schema.Union([Denied]),
+		},
+		Effect.fn("flags.state")(function* () {
+			if (!(yield* adminConsoleOn)) {
+				return yield* Effect.fail(new Denied({message: "Bu işlem şu an kapalı."}));
+			}
+			return yield* requireAdmin(flagsStateGated());
+		}),
+	),
+};

--- a/apps/web/worker/features/flagship/mutations.ts
+++ b/apps/web/worker/features/flagship/mutations.ts
@@ -1,0 +1,85 @@
+/**
+ * Flagship admin mutation resolver — `flag.setOverride`, the runtime flag-flip (admin-console
+ * epic #2711, #2741). `Fate.mutation` def + `Effect.fn` pair (`.patterns/fate-effect-operations.md`).
+ *
+ * Two gates, both enforced HERE, mirroring `user.banUser`:
+ *   1. The `phoenix-admin-console` dark-ship flag (`adminConsoleOn`, default-off, ADR 0083). Off ⇒
+ *      the invisible `Denied` (like a non-admin call), so an unreleased flip never lands.
+ *   2. `requireAdmin` (ADR 0107) — the write stamps the discharged `Admin` grant's account id
+ *      (`adminOf`), never a client-supplied identity, so every prod flip is auditable by construction.
+ *
+ * The write appends ONE event to the append-only `flag_override_event` log (the store), never a
+ * destructive update — the effective override is the latest-event projection (`flag-override.ts`).
+ * After the write, the ack re-reads `Flags.getBoolean` for the key, which the runtime-override
+ * wrapper short-circuits, so the returned `effective` (and a subsequent gate read) reflect the flip
+ * (#2711 story 5). NOT fanned (`fate-live/fanned-mutations.ts`): the override log is an admin audit
+ * surface, not a subscribed Post/Comment/Definition connection (mirrors `emailDelivery.mark`).
+ */
+import {Fate} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {Admin, adminOf, requireAdmin} from "../kunye/admin.ts";
+import {Denied} from "../kunye/errors.ts";
+import {adminConsoleOn} from "./admin-gate.ts";
+import {DECLARED_FLAGS} from "./declared-flags.ts";
+import {UnknownFlagKey} from "./errors.ts";
+import {FlagOverrideStore} from "./FlagOverrideStore.ts";
+import {Flags} from "./Flags.ts";
+import {provideRequestFlags} from "./FlagsContext.ts";
+import {toFlagState} from "./shapers.ts";
+import {FlagStateView} from "./views.ts";
+
+// Set a flag's runtime override: the target `key` (validated against the declared-flags
+// registry in the gated body) and the tri-state `state` (`on`/`off` force the effective
+// value, `clear` lifts the override). A `Schema.Literal` union makes a malformed `state`
+// an input-DECODE failure — the body never runs on a bad state. No `actor` arg: the acting
+// admin is the discharged `Admin` grant's id, never client-supplied.
+const SetOverrideInput = Schema.Struct({
+	key: Schema.String,
+	state: Schema.Literals(["on", "off", "clear"]),
+});
+
+export const mutations = {
+	"flag.setOverride": Fate.mutation(
+		{
+			input: SetOverrideInput,
+			type: FlagStateView,
+			error: Schema.Union([Denied, UnknownFlagKey]),
+		},
+		Effect.fn("flag.setOverride")(function* ({input}) {
+			if (!(yield* adminConsoleOn)) {
+				return yield* Effect.fail(new Denied({message: "Bu işlem şu an kapalı."}));
+			}
+			return yield* requireAdmin(setOverrideGated(input));
+		}),
+	),
+};
+
+// The post-gate flip body — runnable only with an `Admin` `Grant` in R (`requireAdmin`
+// provides it); `yield* adminOf(grant)` reads the authority-checked actor id the audit row
+// is stamped with. An unknown/typo'd key fails `UnknownFlagKey` up front so the override log
+// stays meaningful; otherwise the event is appended and the ack re-reads the (now override-
+// applied) effective state.
+const setOverrideGated = Effect.fn("flag.setOverrideGated")(function* (
+	input: typeof SetOverrideInput.Type,
+) {
+	const grant = yield* Admin;
+	const actorId = yield* adminOf(grant);
+
+	const flag = DECLARED_FLAGS.find((f) => f.key === input.key);
+	if (!flag) {
+		return yield* new UnknownFlagKey({message: `Bilinmeyen bayrak: ${input.key}`});
+	}
+
+	const store = yield* FlagOverrideStore;
+	yield* store.record({flagKey: flag.key, action: input.state, actorId});
+
+	const flags = yield* Flags;
+	const effective = yield* flags.getBoolean(flag.key, flag.defaultValue).pipe(provideRequestFlags);
+	return toFlagState({
+		key: flag.key,
+		defaultValue: flag.defaultValue,
+		effective,
+		overridden: input.state !== "clear",
+	});
+});

--- a/apps/web/worker/features/flagship/phoenix-admin-console.invariant.test.ts
+++ b/apps/web/worker/features/flagship/phoenix-admin-console.invariant.test.ts
@@ -1,0 +1,25 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the admin console surface (#2711). Inspected
+ * off the exported `ADMIN_CONSOLE_FLAG` record (the same object the factory spreads into
+ * `FlagshipFlag`), so no alchemy resource is constructed — mirrors `email-delivery-admin.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_ADMIN_CONSOLE} from "../../../src/flags/keys.ts";
+import {ADMIN_CONSOLE_FLAG, adminConsoleFlag} from "./resources.ts";
+
+describe("admin console surface — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(ADMIN_CONSOLE_FLAG.defaultVariation, "off");
+		assert.strictEqual(ADMIN_CONSOLE_FLAG.variations.off, false);
+		assert.strictEqual(ADMIN_CONSOLE_FLAG.variations.on, true);
+		assert.strictEqual(ADMIN_CONSOLE_FLAG.key, "phoenix-admin-console");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(ADMIN_CONSOLE_FLAG.key, PHOENIX_ADMIN_CONSOLE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof adminConsoleFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -21,6 +21,7 @@ import {
 	PANO_OPTIMISTIC_COMMENT_DELETE,
 	PANO_OPTIMISTIC_POST_DELETE,
 	PANO_OPTIMISTIC_SUBMIT,
+	PHOENIX_ADMIN_CONSOLE,
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_BILDIRIM,
 	PHOENIX_EMAIL_DELIVERY_ADMIN,
@@ -829,6 +830,42 @@ export const EMAIL_DELIVERY_ADMIN_FLAG = {
  */
 export const emailDeliveryAdminFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_email_delivery_admin", {appId, ...EMAIL_DELIVERY_ADMIN_FLAG});
+
+/**
+ * The admin-console dark-ship flag config (#2711, admin-console epic). The SINGLE seam the
+ * whole console surface gates behind — the lazy-loaded shell + probe (#2740) AND the worker
+ * flag-state view / runtime-override mutation (#2741). Default-OFF so the console reaches
+ * production dark: with it off the worker view/mutation fail the invisible `Denied` (like a
+ * non-admin call) and the shell never mounts, so no admin surface leaks. Flipping it on is the
+ * human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable WITHOUT
+ * constructing the alchemy resource (mirrors `EMAIL_DELIVERY_ADMIN_FLAG`).
+ *
+ * OVERLAP (#2740/#2741 parallel Phase-1): both halves declare this flag. Whichever PR merges
+ * SECOND drops its duplicate (this config + factory, the `src/flags/keys.ts` constant, and the
+ * `alchemy.run.ts` wiring) and keeps the first's — a trivial dedup (identical key/config).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           flagship (the flag-eval + admin-console surface)
+ *   - originating:     #2711 (admin-console epic)
+ *   - removal trigger: once the admin console graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline the always-on console.
+ */
+export const ADMIN_CONSOLE_FLAG = {
+	key: PHOENIX_ADMIN_CONSOLE,
+	description:
+		"admin console (shell + flags module) dark-ship (#2711). owner: flagship. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const adminConsoleFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_admin_console", {appId, ...ADMIN_CONSOLE_FLAG});
 
 /**
  * The mecmua public-read dark-ship flag config (#2498, epic #2467). The SINGLE seam

--- a/apps/web/worker/features/flagship/runtime-override.unit.test.ts
+++ b/apps/web/worker/features/flagship/runtime-override.unit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit coverage for `withRuntimeOverrides` (#2741) — the durable-override decorator over a
+ * `FlagsAccess`. Drives it over a stub inner surface + stub `FlagOverrideStore` (no binding, no
+ * D1), asserting the three load-bearing contracts:
+ *   - an active override short-circuits `getBoolean` to the forced value (on AND off);
+ *   - no active override (or a store that resolved `undefined`) delegates to the real evaluation,
+ *     so a Flagship outage still degrades to the caller's safe default — the override layer never
+ *     turns the never-throwing flag contract fail-open (epic #2711 story 8).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import type {FlagOverrideStore} from "./FlagOverrideStore.ts";
+import {type FlagsAccess, withRuntimeOverrides} from "./Flags.ts";
+import {anonymousFlagsContext, FlagsContext} from "./FlagsContext.ts";
+
+const runtimeContext: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+const RuntimeContextStub = Layer.succeed(RuntimeContext)(runtimeContext);
+
+// A stub inner surface whose boolean read returns `innerValue` (standing in for the real,
+// possibly-degraded Flagship evaluation). The typed reads die — the override surface is boolean-only.
+const stubInner = (innerValue: boolean): FlagsAccess => ({
+	getBoolean: (_key, _default) => Effect.succeed(innerValue),
+	getString: () => Effect.die("getString not exercised"),
+	getNumber: () => Effect.die("getNumber not exercised"),
+	getObject: () => Effect.die("getObject not exercised"),
+});
+
+// A stub store whose per-key read resolves `override` (the fail-soft `undefined` stands in for
+// both "no override" and "a swallowed store outage"). `record`/`listActiveOverrides` are unused.
+const stubStore = (override: boolean | undefined): FlagOverrideStore["Service"] => ({
+	record: () => Effect.void,
+	getActiveOverride: () => Effect.succeed(override),
+	listActiveOverrides: () => Effect.succeed(new Map()),
+});
+
+const readBoolean = (inner: FlagsAccess, store: FlagOverrideStore["Service"]) =>
+	withRuntimeOverrides(inner, store)
+		.getBoolean("phoenix-reactions", false)
+		.pipe(
+			Effect.provideService(FlagsContext, anonymousFlagsContext),
+			Effect.provide(RuntimeContextStub),
+		);
+
+describe("withRuntimeOverrides", () => {
+	it.effect("an active `on` override short-circuits to true, ignoring the real evaluation", () =>
+		Effect.gen(function* () {
+			// inner would say false; the override forces true.
+			const value = yield* readBoolean(stubInner(false), stubStore(true));
+			assert.strictEqual(value, true);
+		}),
+	);
+
+	it.effect("an active `off` override short-circuits to false, ignoring the real evaluation", () =>
+		Effect.gen(function* () {
+			// inner would say true; the override forces false.
+			const value = yield* readBoolean(stubInner(true), stubStore(false));
+			assert.strictEqual(value, false);
+		}),
+	);
+
+	it.effect("no active override delegates to the real evaluation (the inner value wins)", () =>
+		Effect.gen(function* () {
+			const value = yield* readBoolean(stubInner(true), stubStore(undefined));
+			assert.strictEqual(value, true);
+		}),
+	);
+
+	it.effect(
+		"a store that resolved undefined (fail-soft) degrades to the caller's safe default",
+		() =>
+			Effect.gen(function* () {
+				// Simulate a Flagship outage: the real evaluation already degraded to the `false`
+				// default. With no override, the wrapper must surface that safe default, never throw.
+				const value = yield* readBoolean(stubInner(false), stubStore(undefined));
+				assert.strictEqual(value, false);
+			}),
+	);
+});

--- a/apps/web/worker/features/flagship/shapers.ts
+++ b/apps/web/worker/features/flagship/shapers.ts
@@ -1,0 +1,27 @@
+/**
+ * Flagship admin wire-entity shapers (#2741). The `{__typename, …}` `FlagState` literal is
+ * built here (the pasaport-shapers idiom) so the `flags.state` roll-up and the
+ * `flag.setOverride` ack produce one identical shape.
+ */
+import type {FlagStateEntity} from "./views.ts";
+
+/**
+ * Build the `FlagState` row for one declared flag. `effective` is the override-applied value
+ * a real gate would read right now (from `Flags.getBoolean`, which the runtime-override wrapper
+ * short-circuits); `overridden` is whether an active override forces it (distinguishing a
+ * forced-`false` from a real-evaluation `false`). `id` === the flag key (the client
+ * normalization key).
+ */
+export const toFlagState = (input: {
+	readonly key: string;
+	readonly defaultValue: boolean;
+	readonly effective: boolean;
+	readonly overridden: boolean;
+}): FlagStateEntity => ({
+	__typename: "FlagState",
+	id: input.key,
+	key: input.key,
+	defaultValue: input.defaultValue,
+	effective: input.effective,
+	overridden: input.overridden,
+});

--- a/apps/web/worker/features/flagship/sources.ts
+++ b/apps/web/worker/features/flagship/sources.ts
@@ -1,0 +1,11 @@
+/**
+ * Flagship admin fate sources (#2741). `FlagState` has no by-id fetch path — it is produced
+ * ONLY past the `requireAdmin` gate, by the `flags.state` roll-up (delivered inline) and the
+ * `flag.setOverride` mutation ack, never a public by-id load (a by-id source would be an
+ * ungated leak of flag state). Registered with ZERO capabilities so source-completeness
+ * accepts the view-reachable result type; mirrors `banStateSource` / `failingAddressSource`.
+ */
+import {Fate} from "@kampus/fate-effect";
+import {FlagStateView} from "./views.ts";
+
+export const flagStateSource = Fate.syntheticSource(FlagStateView);

--- a/apps/web/worker/features/flagship/views.ts
+++ b/apps/web/worker/features/flagship/views.ts
@@ -1,0 +1,35 @@
+/**
+ * Flagship admin fate data views (admin-console epic #2711, #2741). The `FlagState` view is
+ * the per-flag row the `requireAdmin`-gated `flags.state` roll-up and the `flag.setOverride`
+ * mutation ack both produce: a declared flag's key, its declared default, its current effective
+ * state (real Flagship evaluation with any active runtime override applied), and whether an
+ * override is currently forcing it. It carries ONLY flag state — no session, no PII — and is only
+ * ever produced past the `requireAdmin` gate + the `phoenix-admin-console` dark-ship flag, so it
+ * never leaks (the `BanState` / `EmailDeliveryState` admin-view precedent).
+ */
+import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
+import type {ViewRow} from "../fate/view-types.ts";
+
+// `id` === the flag key (the client normalization key), so the roll-up rows and the
+// per-flag mutation ack reconcile the SAME entity. `effective` is what a real gate would
+// read for this flag right now (override-applied); `overridden` distinguishes a
+// forced-`false` override from a real-evaluation `false`.
+export type FlagStateViewRow = ViewRow<{
+	id: string;
+	key: string;
+	defaultValue: boolean;
+	effective: boolean;
+	overridden: boolean;
+}>;
+
+export class FlagStateView extends FateDataView<FlagStateViewRow>()("FlagState")({
+	id: true,
+	key: true,
+	defaultValue: true,
+	effective: true,
+	overridden: true,
+} satisfies {[K in keyof FlagStateViewRow]: true}) {}
+
+export const flagStateDataView = FlagStateView.view;
+
+export type FlagStateEntity = WorkerEntity<typeof FlagStateView>;


### PR DESCRIPTION
Worker half of the admin-console flags module #1 (epic #2711, Geçit #24, Phase 1). Independent of the shell (#2740); builds in parallel. Behind the default-off `phoenix-admin-console` dark-ship flag.

## What this delivers

**Durable, auditable, append-only override substrate** (projected-to-state, mirroring the ban precedent):
- `flag_override_event` D1 table (migration `0029`) + pure projection `flag-override.ts` (`resolveFlagOverride` / `selectActiveOverrides`), mirroring `user_ban_event` → `resolveBanState`. Each flip appends ONE audited row (admin account id via `adminOf`, flag key, on/off/clear, time); the effective override is the latest-event projection — never a destructive update. Every prod flip is auditable by construction.
- `FlagOverrideStore` (Drizzle port) + `withRuntimeOverrides` `Flags` wrapper, installed on **every** stage (`FlagsRuntimeOverrideLive`; dev composes it under the dev-cookie override). Reads are fail-soft (`E = never`): a store/Flagship outage degrades to the caller's safe default — the override layer never turns the never-throwing flag contract fail-open.

**`requireAdmin`-gated fate surface** (behind `phoenix-admin-console`, on the `flagship`/`kunye` seam):
- `flags.state` list view — every declared flag key + its default + current effective state (real eval with any active override applied) + `overridden`. Non-admin/anonymous → the invisible `Denied`.
- `flag.setOverride` mutation — set a flag's runtime override (on/off/clear). After the write, the view and a subsequent `Flags.getBoolean` reflect the flip. Unknown key → `UnknownFlagKey`.

## Acceptance criteria
- [x] `requireAdmin`-gated view returns every declared flag + default + effective state; non-admin → invisible `Denied`.
- [x] `requireAdmin`-gated mutation sets on/off/clear; view + subsequent `getBoolean` reflect it.
- [x] Each flip appends one audited event (admin id, key, state, time); effective = latest-event projection (unit-tested, mirroring `resolveBanState`).
- [x] Cleared/none → `getBoolean` returns real eval; Flagship outage still degrades safe; override never fail-opens.
- [x] `flag.setOverride` classified `fanned: false` in `fanned-mutations.ts`; fanout-guard passes; whole surface behind default-off `phoenix-admin-console`.

## fanned-mutations classification
`flag.setOverride` → **`fanned: false`**. The override log is an admin audit surface, not a subscribed Post/Comment/Definition connection (mirrors `emailDelivery.mark`). `fanout-guard check` passes (47 mutations, 24 fanned).

## Overlap with #2740 (parallel Phase-1) — needs dedup on the second merge
Both halves need the `phoenix-admin-console` flag. To keep this half complete + genuinely ship-dark, the flag is declared here in three places: `apps/web/src/flags/keys.ts` (`PHOENIX_ADMIN_CONSOLE`), `apps/web/worker/features/flagship/resources.ts` (`ADMIN_CONSOLE_FLAG` + `adminConsoleFlag`), and `apps/web/alchemy.run.ts` (deploy wiring). **Whichever of #2740/#2741 merges second must drop its identical duplicate declaration** — a trivial dedup (same key string/config), not a semantic conflict. No shell code was built here (that is #2740); this half only consumes the flag constant.

## Tests (TDD: yes)
- `flag-override.unit.test.ts` — projection (latest-event-wins), mirroring `resolveBanState` coverage.
- `runtime-override.unit.test.ts` — wrapper short-circuit (on/off) + degrade-safe delegation on no-override / fail-soft.
- `phoenix-admin-console.invariant.test.ts` — default-off IaC invariant.
- Updated `fate-flags-dev-override.unit.test.ts` (no-op store stub) and `wireCodes-per-class.unit.test.ts` (`UnknownFlagKey` → `BAD_REQUEST`) for the new seams.

typecheck + biome + fanout-guard green; 19 new/affected unit tests pass.

Fixes #2741

🤖 Generated with [Claude Code](https://claude.com/claude-code)