### PR TITLE
feat(pasaport): attribute email-delivery mark/clear to the acting admin (#2734)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0029_email_delivery_event_actor_id.sql
+++ b/apps/web/worker/db/drizzle/migrations/0029_email_delivery_event_actor_id.sql
@@ -1,0 +1,9 @@
+-- #2734 (epic #2687) — add actor attribution to the email-delivery log. A manual admin
+-- mark/clear (#2692) now stamps `actor_id` (the discharged `Admin` grant's account id, ADR
+-- 0107), mirroring `user_ban_event.actor_id` so the audit trail attributes WHICH admin acted.
+-- NULLABLE, unlike the ban precedent's NOT NULL: `email_delivery_event` is multi-writer — the
+-- send-time `SendEmailError` capture (#2691) and the CF async ingestion (#2694) are non-admin
+-- appenders with no actor, so a strict NOT NULL would reject their valid rows. Existing rows
+-- (all pre-actor) keep a NULL actor — the attribution is never fabricated; only mark/clear stamps it.
+
+ALTER TABLE `email_delivery_event` ADD `actor_id` text;

--- a/apps/web/worker/db/drizzle/migrations/meta/0029_email_delivery_event_actor_id_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0029_email_delivery_event_actor_id_snapshot.json
@@ -1,0 +1,2377 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "5676c862-8d82-4c4f-a9b0-e8b16d3c5e66",
+	"prevId": "f0c8bdbd-d18f-4390-8016-1b3ab86a9ced",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"apiKey": {
+			"name": "apiKey",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"start": {
+					"name": "start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prefix": {
+					"name": "prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"refill_interval": {
+					"name": "refill_interval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refill_amount": {
+					"name": "refill_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_refill_at": {
+					"name": "last_refill_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"rate_limit_enabled": {
+					"name": "rate_limit_enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"rate_limit_time_window": {
+					"name": "rate_limit_time_window",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rate_limit_max": {
+					"name": "rate_limit_max",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"request_count": {
+					"name": "request_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"remaining": {
+					"name": "remaining",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_request": {
+					"name": "last_request",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"permissions": {
+					"name": "permissions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"apiKey_user_id_user_id_fk": {
+					"name": "apiKey_user_id_user_id_fk",
+					"tableFrom": "apiKey",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_vote": {
+			"name": "comment_vote",
+			"columns": {
+				"comment_id": {
+					"name": "comment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"comment_vote_comment": {
+					"name": "comment_vote_comment",
+					"columns": [
+						"comment_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comment_vote_comment_id_voter_id_pk": {
+					"columns": [
+						"comment_id",
+						"voter_id"
+					],
+					"name": "comment_vote_comment_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"definition_vote": {
+			"name": "definition_vote",
+			"columns": {
+				"definition_id": {
+					"name": "definition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"definition_vote_definition": {
+					"name": "definition_vote_definition",
+					"columns": [
+						"definition_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"definition_vote_definition_id_voter_id_pk": {
+					"columns": [
+						"definition_id",
+						"voter_id"
+					],
+					"name": "definition_vote_definition_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"pano_stats": {
+			"name": "pano_stats",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"total_posts": {
+					"name": "total_posts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_comments": {
+					"name": "total_comments",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_authors": {
+					"name": "total_authors",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_record": {
+			"name": "post_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"host": {
+					"name": "host",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"comment_count": {
+					"name": "comment_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"hot_score": {
+					"name": "hot_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_draft": {
+					"name": "is_draft",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_record_hot": {
+					"name": "post_record_hot",
+					"columns": [
+						"hot_score"
+					],
+					"isUnique": false
+				},
+				"post_record_new": {
+					"name": "post_record_new",
+					"columns": [
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"post_record_top": {
+					"name": "post_record_top",
+					"columns": [
+						"score"
+					],
+					"isUnique": false
+				},
+				"post_record_discuss": {
+					"name": "post_record_discuss",
+					"columns": [
+						"comment_count"
+					],
+					"isUnique": false
+				},
+				"post_record_host": {
+					"name": "post_record_host",
+					"columns": [
+						"host"
+					],
+					"isUnique": false
+				},
+				"post_record_author_created": {
+					"name": "post_record_author_created",
+					"columns": [
+						"author_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				},
+				"post_record_one_draft_per_author": {
+					"name": "post_record_one_draft_per_author",
+					"columns": [
+						"author_id"
+					],
+					"isUnique": true,
+					"where": "`is_draft` = 1"
+				},
+				"post_record_sandboxed": {
+					"name": "post_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_vote": {
+			"name": "post_vote",
+			"columns": {
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_vote_post": {
+					"name": "post_vote_post",
+					"columns": [
+						"post_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"post_vote_post_id_voter_id_pk": {
+					"columns": [
+						"post_id",
+						"voter_id"
+					],
+					"name": "post_vote_post_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": [
+						"token"
+					],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"sozluk_stats": {
+			"name": "sozluk_stats",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"total_definitions": {
+					"name": "total_definitions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_terms": {
+					"name": "total_terms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_authors": {
+					"name": "total_authors",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"term_record": {
+			"name": "term_record",
+			"columns": {
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"first_letter": {
+					"name": "first_letter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"definition_count": {
+					"name": "definition_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_score": {
+					"name": "total_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"excerpt": {
+					"name": "excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"top_definition_id": {
+					"name": "top_definition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"first_at": {
+					"name": "first_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_edit_at": {
+					"name": "last_edit_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"term_record_recent": {
+					"name": "term_record_recent",
+					"columns": [
+						"last_activity_at"
+					],
+					"isUnique": false
+				},
+				"term_record_popular": {
+					"name": "term_record_popular",
+					"columns": [
+						"total_score"
+					],
+					"isUnique": false
+				},
+				"term_record_letter": {
+					"name": "term_record_letter",
+					"columns": [
+						"first_letter"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'human'"
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\u00e7aylak'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_username_unique": {
+					"name": "user_username_unique",
+					"columns": [
+						"username"
+					],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_profile": {
+			"name": "user_profile",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"total_karma": {
+					"name": "total_karma",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"definition_count": {
+					"name": "definition_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"post_count": {
+					"name": "post_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"comment_count": {
+					"name": "comment_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_profile_username_unique": {
+					"name": "user_profile_username_unique",
+					"columns": [
+						"username"
+					],
+					"isUnique": true
+				},
+				"user_profile_username": {
+					"name": "user_profile_username",
+					"columns": [
+						"username"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_vote": {
+			"name": "user_vote",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_vote_target": {
+					"name": "user_vote_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"user_vote_user_id_target_kind_target_id_pk": {
+					"columns": [
+						"user_id",
+						"target_kind",
+						"target_id"
+					],
+					"name": "user_vote_user_id_target_kind_target_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"content_report": {
+			"name": "content_report",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reporter_id": {
+					"name": "reporter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'open'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"resolver_id": {
+					"name": "resolver_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolution": {
+					"name": "resolution",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"wave_id": {
+					"name": "wave_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"content_report_target": {
+					"name": "content_report_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				},
+				"content_report_wave": {
+					"name": "content_report_wave",
+					"columns": [
+						"wave_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"content_report_pk": {
+					"name": "content_report_pk",
+					"columns": [
+						"reporter_id",
+						"target_kind",
+						"target_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_bookmark": {
+			"name": "post_bookmark",
+			"columns": {
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_bookmark_user_created": {
+					"name": "post_bookmark_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"post_bookmark_pk": {
+					"name": "post_bookmark_pk",
+					"columns": [
+						"post_id",
+						"user_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"definition_record": {
+			"name": "definition_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"term_slug": {
+					"name": "term_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"term_title": {
+					"name": "term_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"definition_record_author_created": {
+					"name": "definition_record_author_created",
+					"columns": [
+						"author_id",
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"definition_record_term_score": {
+					"name": "definition_record_term_score",
+					"columns": [
+						"term_slug",
+						"score"
+					],
+					"isUnique": false
+				},
+				"definition_record_sandboxed": {
+					"name": "definition_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_record": {
+			"name": "comment_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"post_title": {
+					"name": "post_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"comment_record_author_created": {
+					"name": "comment_record_author_created",
+					"columns": [
+						"author_id",
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"comment_record_post": {
+					"name": "comment_record_post",
+					"columns": [
+						"post_id"
+					],
+					"isUnique": false
+				},
+				"comment_record_parent": {
+					"name": "comment_record_parent",
+					"columns": [
+						"parent_id"
+					],
+					"isUnique": false
+				},
+				"comment_record_sandboxed": {
+					"name": "comment_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"relation_tuple": {
+			"name": "relation_tuple",
+			"columns": {
+				"subject": {
+					"name": "subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"relation": {
+					"name": "relation",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"object": {
+					"name": "object",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"relation_tuple_object": {
+					"name": "relation_tuple_object",
+					"columns": [
+						"object",
+						"relation"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"relation_tuple_subject_relation_object_pk": {
+					"name": "relation_tuple_subject_relation_object_pk",
+					"columns": [
+						"subject",
+						"relation",
+						"object"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"authorship_vouch": {
+			"name": "authorship_vouch",
+			"columns": {
+				"voucher_id": {
+					"name": "voucher_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"candidate_id": {
+					"name": "candidate_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"authorship_vouch_candidate": {
+					"name": "authorship_vouch_candidate",
+					"columns": [
+						"candidate_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"authorship_vouch_voucher_id_candidate_id_pk": {
+					"name": "authorship_vouch_voucher_id_candidate_id_pk",
+					"columns": [
+						"voucher_id",
+						"candidate_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification": {
+			"name": "notification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipient_id": {
+					"name": "recipient_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"count": {
+					"name": "count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"read_at": {
+					"name": "read_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"notification_recipient_read": {
+					"name": "notification_recipient_read",
+					"columns": [
+						"recipient_id",
+						"read_at"
+					],
+					"isUnique": false
+				},
+				"notification_recipient_created": {
+					"name": "notification_recipient_created",
+					"columns": [
+						"recipient_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_reaction": {
+			"name": "user_reaction",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emoji": {
+					"name": "emoji",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_reaction_target": {
+					"name": "user_reaction_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"user_reaction_user_id_target_kind_target_id_pk": {
+					"columns": [
+						"user_id",
+						"target_kind",
+						"target_id"
+					],
+					"name": "user_reaction_user_id_target_kind_target_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_ban_event": {
+			"name": "user_ban_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_ban_event_user_created": {
+					"name": "user_ban_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"user_ban_event_user_id_user_id_fk": {
+					"name": "user_ban_event_user_id_user_id_fk",
+					"tableFrom": "user_ban_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mecmua_post": {
+			"name": "mecmua_post",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"published_at": {
+					"name": "published_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mecmua_post_author_created": {
+					"name": "mecmua_post_author_created",
+					"columns": [
+						"author_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mecmua_subscription": {
+			"name": "mecmua_subscription",
+			"columns": {
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subscriber_id": {
+					"name": "subscriber_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mecmua_subscription_subscriber": {
+					"name": "mecmua_subscription_subscriber",
+					"columns": [
+						"subscriber_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"mecmua_subscription_subscriber_id_author_id_pk": {
+					"columns": [
+						"subscriber_id",
+						"author_id"
+					],
+					"name": "mecmua_subscription_subscriber_id_author_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"karma_event": {
+			"name": "karma_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"delta": {
+					"name": "delta",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_kind": {
+					"name": "source_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"karma_event_user_created": {
+					"name": "karma_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"karma_event_user_id_user_id_fk": {
+					"name": "karma_event_user_id_user_id_fk",
+					"tableFrom": "karma_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"email_delivery_event": {
+			"name": "email_delivery_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"email_delivery_event_address_created": {
+					"name": "email_delivery_event_address_created",
+					"columns": [
+						"address",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				},
+				"email_delivery_event_user_created": {
+					"name": "email_delivery_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"email_delivery_event_user_id_user_id_fk": {
+					"name": "email_delivery_event_user_id_user_id_fk",
+					"tableFrom": "email_delivery_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {
+			"post_record_author_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"user_ban_event_user_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"mecmua_post_author_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"mecmua_subscription_subscriber": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
 			"when": 1796000000000,
 			"tag": "0028_email_delivery_event",
 			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "6",
+			"when": 2296000000000,
+			"tag": "0029_email_delivery_event_actor_id",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -210,6 +210,12 @@ export const emailDeliveryEvent = sqliteTable(
 		// reads only the latest row, so a `clear` after a `fail` restores deliverability
 		// without mutating or deleting the fail row — full reversibility, as in ban.
 		action: text("action", {enum: ["fail", "clear"]}).notNull(),
+		// The admin who performed a manual mark/clear (the discharged `Admin` grant's account
+		// id, #2734), mirroring {@link userBanEvent}'s `actorId`. NULLABLE, unlike ban's
+		// NOT NULL: this log is multi-writer — the send-time `SendEmailError` capture (#2691)
+		// and the CF async ingestion (#2694) are non-admin appenders with no actor, and
+		// pre-#2734 rows carry none. Only the admin mark/clear stamps it.
+		actorId: text("actor_id"),
 		// The failure detail (a `SendEmailError` message, or an admin note); null for a `clear`.
 		reason: text("reason"),
 		createdAt: timestamp("created_at").notNull(),

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -327,22 +327,26 @@ export class Pasaport extends Context.Service<
 		) => Effect.Effect<EmailDeliveryResult, UserNotFound>;
 
 		// Manually mark the target account's address as failing (Child #2692): append a
-		// `fail` event carrying the admin's reason, so an out-of-band bounce report an
-		// admin learns of shares the SAME log the send-time capture writes. Returns the
-		// resolved address + resulting (failing) state. `UserNotFound` on an unknown
-		// target. The AUTHORITY is discharged at the resolver (`requireAdmin`), never here.
+		// `fail` event carrying the admin's reason and the acting admin (`actorId`, #2734),
+		// so an out-of-band bounce report an admin learns of shares the SAME log the
+		// send-time capture writes and attributes who acted. Returns the resolved address +
+		// resulting (failing) state. `UserNotFound` on an unknown target. The AUTHORITY is
+		// discharged at the resolver (`requireAdmin`), never here.
 		readonly markEmailFailing: (input: {
 			userId: string;
+			actorId: string;
 			reason: string;
 		}) => Effect.Effect<EmailDeliveryResult, UserNotFound>;
 
 		// Manually clear the target account's failing address (Child #2692): append a
-		// `clear` event, lifting the failing-state without mutating the `fail` row (full
-		// reversibility, as in unban). Returns the resolved address + resulting
-		// (deliverable) state. Idempotent — clearing a deliverable address appends a benign
-		// `clear` and still reads deliverable. `UserNotFound` on an unknown target.
+		// `clear` event stamped with the acting admin (`actorId`, #2734), lifting the
+		// failing-state without mutating the `fail` row (full reversibility, as in unban).
+		// Returns the resolved address + resulting (deliverable) state. Idempotent —
+		// clearing a deliverable address appends a benign `clear` and still reads
+		// deliverable. `UserNotFound` on an unknown target.
 		readonly clearEmailFailing: (input: {
 			userId: string;
+			actorId: string;
 		}) => Effect.Effect<EmailDeliveryResult, UserNotFound>;
 
 		// The admin failing-address roll-up (Child #2692): every address whose latest
@@ -620,8 +624,12 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 			// back its projected state. Rejects an unknown target up front so a mark/clear
 			// can't be recorded against a non-existent id (the audit log stays meaningful),
 			// and resolves the target's own `email` as the address the event is keyed by.
+			// The only caller is the admin mark/clear below, so `actorId` is always the acting
+			// admin's id (#2734) — the send-time capture writes its own actor-less rows through
+			// `EmailDeliveryLog` (`email-delivery-log.ts`), not this helper.
 			const appendEmailDeliveryEvent = (
 				userId: string,
+				actorId: string,
 				action: EmailDeliveryEvent["action"],
 				reason: string | null,
 			): Effect.Effect<EmailDeliveryResult, UserNotFound> =>
@@ -632,6 +640,7 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						db.insert(schema.emailDeliveryEvent).values({
 							id: crypto.randomUUID(),
 							userId,
+							actorId,
 							address: target.email,
 							action,
 							reason,
@@ -1124,15 +1133,17 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 
 				markEmailFailing: Effect.fn("Pasaport.markEmailFailing")(function* (input: {
 					userId: string;
+					actorId: string;
 					reason: string;
 				}) {
-					return yield* appendEmailDeliveryEvent(input.userId, "fail", input.reason);
+					return yield* appendEmailDeliveryEvent(input.userId, input.actorId, "fail", input.reason);
 				}),
 
 				clearEmailFailing: Effect.fn("Pasaport.clearEmailFailing")(function* (input: {
 					userId: string;
+					actorId: string;
 				}) {
-					return yield* appendEmailDeliveryEvent(input.userId, "clear", null);
+					return yield* appendEmailDeliveryEvent(input.userId, input.actorId, "clear", null);
 				}),
 
 				listFailingAddresses: Effect.fn("Pasaport.listFailingAddresses")(function* () {

--- a/apps/web/worker/features/pasaport/email-delivery-admin-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-delivery-admin-mutation.unit.test.ts
@@ -99,31 +99,37 @@ const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
 const noWriteReached = Layer.mergeAll(makePasaportStub(), agentAuthorityStub);
 
 describe("emailDelivery.mark — admin authority (fail closed)", () => {
-	it.effect("an admin marks a target; the append runs and reports failing", () =>
-		Effect.gen(function* () {
+	it.effect("an admin marks a target; the append runs, stamps the actor, reports failing", () => {
+		// Capture the actor threaded to the write (#2734): the mark must stamp the discharged
+		// admin's id (`u-admin`), never a client-supplied identity.
+		const seen: {actorId?: string} = {};
+		return Effect.gen(function* () {
 			const receipt = yield* mark("u-target", "user reports no magic-links");
 			assert.strictEqual((receipt as {failing: boolean}).failing, true);
 			assert.strictEqual(
 				(receipt as {reason: string | null}).reason,
 				"user reports no magic-links",
 			);
+			assert.strictEqual(seen.actorId, "u-admin");
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
 					makePasaportStub({
-						markEmailFailing: () =>
-							Effect.succeed({
+						markEmailFailing: ({actorId}) => {
+							seen.actorId = actorId;
+							return Effect.succeed({
 								address: "t@x.co",
 								state: {failing: true, reason: "user reports no magic-links"},
-							}),
+							});
+						},
 					}),
 					adminStoreOf(["u-admin"]),
 					agentAuthorityStub,
 					requestContext(human("u-admin"), true),
 				),
 			),
-		),
-	);
+		);
+	});
 
 	it.effect("a non-admin gets the invisible UNAUTHORIZED — and never reaches the write", () =>
 		Effect.gen(function* () {
@@ -197,23 +203,30 @@ describe("emailDelivery.mark — admin authority (fail closed)", () => {
 });
 
 describe("emailDelivery.clear — admin authority (fail closed)", () => {
-	it.effect("an admin clears a target; the address reads deliverable (not failing)", () =>
-		Effect.gen(function* () {
-			const receipt = yield* clear("u-target");
-			assert.strictEqual((receipt as {failing: boolean}).failing, false);
-		}).pipe(
-			Effect.provide(
-				Layer.mergeAll(
-					makePasaportStub({
-						clearEmailFailing: () =>
-							Effect.succeed({address: "t@x.co", state: {failing: false, reason: null}}),
-					}),
-					adminStoreOf(["u-admin"]),
-					agentAuthorityStub,
-					requestContext(human("u-admin"), true),
+	it.effect(
+		"an admin clears a target; the actor is stamped and the address reads deliverable",
+		() => {
+			const seen: {actorId?: string} = {};
+			return Effect.gen(function* () {
+				const receipt = yield* clear("u-target");
+				assert.strictEqual((receipt as {failing: boolean}).failing, false);
+				assert.strictEqual(seen.actorId, "u-admin");
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makePasaportStub({
+							clearEmailFailing: ({actorId}) => {
+								seen.actorId = actorId;
+								return Effect.succeed({address: "t@x.co", state: {failing: false, reason: null}});
+							},
+						}),
+						adminStoreOf(["u-admin"]),
+						agentAuthorityStub,
+						requestContext(human("u-admin"), true),
+					),
 				),
-			),
-		),
+			);
+		},
 	);
 
 	it.effect("a non-admin gets the invisible UNAUTHORIZED — and never reaches the write", () =>

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -421,31 +421,38 @@ const unbanGated = Effect.fn("user.unbanGated")(function* (input: typeof UnbanUs
 });
 
 // The post-gate mark body — runnable only with an `Admin` `Grant` in R (`requireAdmin`
-// provides it); `yield* Admin` requires the proof, so marking without a discharged grant
-// is a compile error (ADR 0107). A blank reason fails `EmailFailingReasonRequired` (a
-// manual mark must carry the out-of-band note); an unknown target fails `UserNotFound`.
-// The ack is keyed on the server-resolved address, so the roll-up read reconciles it.
+// provides it); `yield* adminOf(grant)` reads the authority-checked actor id the audit row
+// is stamped with (#2734, mirroring `banGated`), so a mark is never attributed to a
+// client-supplied identity. A blank reason fails `EmailFailingReasonRequired` (a manual mark
+// must carry the out-of-band note); an unknown target fails `UserNotFound`. The ack is keyed
+// on the server-resolved address, so the roll-up read reconciles it.
 const markEmailFailingGated = Effect.fn("emailDelivery.markGated")(function* (
 	input: typeof MarkEmailFailingInput.Type,
 ) {
-	yield* Admin;
+	const grant = yield* Admin;
+	const actorId = yield* adminOf(grant);
 	const reason = input.reason.trim();
 	if (reason.length === 0) {
 		return yield* new EmailFailingReasonRequired({message: "İşaretleme gerekçesi zorunludur."});
 	}
 	const pasaport = yield* Pasaport;
-	const {address, state} = yield* pasaport.markEmailFailing({userId: input.userId, reason});
+	const {address, state} = yield* pasaport.markEmailFailing({
+		userId: input.userId,
+		actorId,
+		reason,
+	});
 	return toEmailDeliveryState(address, state);
 });
 
 // The post-gate clear body — runnable only with an `Admin` `Grant` in R. Appends a
-// `clear` (no reason floor); `UserNotFound` on an unknown target.
+// `clear` stamped with the discharged admin's id (#2734); `UserNotFound` on an unknown target.
 const clearEmailFailingGated = Effect.fn("emailDelivery.clearGated")(function* (
 	input: typeof ClearEmailFailingInput.Type,
 ) {
-	yield* Admin;
+	const grant = yield* Admin;
+	const actorId = yield* adminOf(grant);
 	const pasaport = yield* Pasaport;
-	const {address, state} = yield* pasaport.clearEmailFailing({userId: input.userId});
+	const {address, state} = yield* pasaport.clearEmailFailing({userId: input.userId, actorId});
 	return toEmailDeliveryState(address, state);
 });
 


### PR DESCRIPTION
Adds actor attribution to the `email_delivery_event` log so a manual admin
`emailDelivery.mark`/`clear` records **which** admin acted — closing the
asymmetry with the ban surface (`user_ban_event.actor_id`).

## What changed
- **Schema + migration (AC1):** new `actor_id text` column on `email_delivery_event`,
  via hand-authored flat migration `0029_email_delivery_event_actor_id.sql`
  (ADR 0108 — journal entry + v6 snapshot hand-assembled, since `drizzle-kit generate`
  is blocked against the flat layout). Mirrors `user_ban_event.actor_id` in `schema.ts`.
- **Actor threading (AC2):** `markEmailFailingGated`/`clearEmailFailingGated` now
  discharge `adminOf(grant)` (ADR 0107, exactly as `banGated` does) and pass `actorId`
  through `Pasaport.markEmailFailing`/`clearEmailFailing` into the append — never a
  client-supplied identity.
- **Tests:** the mark/clear admin-success unit tests now assert the discharged admin's
  id (`u-admin`) reaches the write.

## Nullability + backfill choice (AC1 justification, AC3)
The column is **NULLABLE**, deliberately **not** the ban precedent's `NOT NULL`.
`email_delivery_event` is multi-writer: the send-time `SendEmailError` capture (#2691,
via `EmailDeliveryLog.recordSendFailure`) and the CF async ingestion (#2694) are
non-admin appenders with no actor. A strict `NOT NULL` would reject those valid rows.
Only the admin mark/clear stamps `actor_id`; the send path is unchanged and writes
`NULL` (AC3 holds with no edit to that path). Existing pre-#2734 rows keep a `NULL`
actor — the attribution is **never fabricated**.

## Fanned-mutations classification
`emailDelivery.mark`/`clear` remain **not fanned** (`fanned-mutations.ts` lines
314–323, already classified) — the log is not a subscribed content connection
(mirrors `user.banUser`). No `/fate/live` publish is required; classification unchanged.

## Scope / deferred AC
This is a **partial** delivery by design (kept disjoint from sibling lanes in this
hot-coupled area). AC4 — *surface the acting admin in the failing-address admin view* —
is owned by sibling **#2732** (the admin React page + its read-path exposure), which is
out of this lane's scope. `#2734` therefore stays open until #2732 renders the actor.

Part of #2734