### PR TITLE
feat(sozluk): collapse the serial stamp chain via a shared parallel-stamp-wave combinator (#2709)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -63,6 +63,7 @@ import {
 	panoOptimisticPostDeleteFlag,
 	panoOptimisticSubmitFlag,
 	reactionsFlag,
+	sozlukStampWaveFlag,
 	userBanFlag,
 } from "./worker/features/flagship/resources.ts";
 import {provisionEmailSending} from "./worker/features/pasaport/email-resources.ts";
@@ -156,6 +157,10 @@ export default Alchemy.Stack(
 		// #2596) — the single cross-cutting seam the nested layout routes + Subnav CTA slot
 		// substrate + every per-product delta gate behind until a human release.
 		yield* navIaFlag(flagship.appId);
+		// The sözlük parallel-stamp-wave read-collapse dark-ship flag, default-off (#2709,
+		// epic #2567) — the concurrency knob the definition reads' stamp wave passes: off ⇒
+		// serial (today), on ⇒ one concurrent wave, until a human release.
+		yield* sozlukStampWaveFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -12,6 +12,20 @@
 export const PANO_DRAFT_SAVE = "pano-draft-save";
 
 /**
+ * Sözlük parallel-stamp-wave containment flag (#2709, epic #2567). Default-off. The
+ * sözlük definition reads (`getDefinitionsByIds` / `listDefinitionsKeyset`) always
+ * route their independent stamps through the shared `parallelStampWave`; this flag is
+ * the concurrency knob it passes — OFF ⇒ the wave runs at `concurrency: 1` (the reads
+ * stay serial, byte-for-byte today's behavior), ON ⇒ `"unbounded"` collapses the stamp
+ * chain into one concurrent wave (the #2567 win). Flipping it on is the human release
+ * act (ADR 0083). Its own `phoenix-` key — the combinator is cross-product (the pano
+ * sibling #2710 ships behind its own seam), read-path only.
+ *
+ * @reachability-exempt: server read-path performance flag, no user-facing surface (identical wire output either way; only wall time changes).
+ */
+export const PHOENIX_SOZLUK_STAMP_WAVE = "phoenix-sozluk-stamp-wave";
+
+/**
  * mecmua write-path dark-ship flag (#2497, epic #2467). The single seam the mecmua
  * write surface gates behind — the `mecmua.publish` + `mecmua.saveDraft` mutations
  * fail `MECMUA_DISABLED` with it off, so the whole write path ships dark until a

--- a/apps/web/worker/features/fate/reaction-aggregate.ts
+++ b/apps/web/worker/features/fate/reaction-aggregate.ts
@@ -17,6 +17,7 @@
  */
 import type {Effect} from "effect";
 import {Effect as Eff} from "effect";
+import type {Concurrency} from "effect/Types";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {
 	EMPTY_REACTION_AGGREGATE,
@@ -30,16 +31,22 @@ import {
  * none). One read for the whole batch — never per row. The stamped field is
  * *added* to the input row shape, so a read that wants the aggregate must route
  * through here (a path that skips the stamp never produces the field).
+ *
+ * `readAggregate` itself issues TWO D1 reads (the per-target `GROUP BY` + the
+ * viewer's `readMine`); pass `{concurrency: "unbounded"}` to fan those two out so
+ * this stamp is a single wave phase when run inside `parallelStampWave`. Default
+ * (absent) keeps them sequential — today's behavior for every non-opted caller.
  */
 export const stampReactionAggregate = <R extends {id: string}>(
 	reactionSvc: typeof Reaction.Service,
 	kind: TargetKind,
 	rows: ReadonlyArray<R>,
 	viewerId: string | null | undefined,
+	options?: {readonly concurrency?: Concurrency},
 ): Effect.Effect<Array<R & {reactions: ReactionAggregate}>> =>
 	Eff.gen(function* () {
 		const ids = rows.map((row) => row.id);
-		const byId = yield* reactionSvc.readAggregate(viewerId, kind, ids);
+		const byId = yield* reactionSvc.readAggregate(viewerId, kind, ids, options);
 		return rows.map((row) => ({
 			...row,
 			reactions: byId.get(row.id) ?? EMPTY_REACTION_AGGREGATE,

--- a/apps/web/worker/features/fate/serial-read-baseline.md
+++ b/apps/web/worker/features/fate/serial-read-baseline.md
@@ -44,6 +44,17 @@ collapse folds into **1 concurrent wave**, so each read path drops **3 serial ph
 (by-id 5 → 2; connection first-page 6 → 3). That 3-phase drop, not any absolute wall-time,
 is the placement-invariant number each collapse child proves its win against.
 
+### Realized — sözlük (#2709)
+
+The sözlük definition reads (`getDefinitionsByIds` / `listDefinitionsKeyset`) now route their
+three stamps through the shared `parallelStampWave` combinator
+([`stamp-wave.ts`](./stamp-wave.ts)), and the reaction stamp's own two reads join the wave via
+`Reaction.readAggregate`'s new `concurrency` option — so the **full 4-phase tail collapses to 1
+concurrent wave** when the flag is on: **by-id 5 → 2, connection first-page 6 → 3 (the documented
+3-phase drop).** With the default-off `phoenix-sozluk-stamp-wave` flag the wave runs at
+`concurrency: 1` — the reads stay serial, byte-for-byte today's output. The knob flips wall time
+only; the pano sibling (#2710) reuses the same combinator behind its own seam.
+
 ## Wall-time baseline (method + numbers)
 
 **Method** — reuse the 2026-07-06 production investigation's surface (#2275, ADR 0168):

--- a/apps/web/worker/features/fate/stamp-wave.ts
+++ b/apps/web/worker/features/fate/stamp-wave.ts
@@ -1,0 +1,60 @@
+/**
+ * `parallelStampWave` — collapse a read's serial stamp chain into one concurrent
+ * wave. A finalized read (`Definition`, `Comment`) is stamped with several
+ * independent facets — viewer scalars (`stampViewerScalars`), the reaction
+ * aggregate (`stampReactionAggregate`), live author identity (`stampAuthorIdentity`).
+ * Each is independent GIVEN the already-fetched rows: it reads only the base row's
+ * `id` / `authorId` and ADDS a disjoint field set, never another stamp's output.
+ * Chaining them with `yield*` therefore pays N cross-region D1 round trips strictly
+ * in sequence for no ordering reason (the #2567 baseline). This runs every stamp
+ * over the SAME base rows and merges their added fields back index-wise.
+ *
+ * The `concurrency` option is the whole point, and it is NOT optional cosmetics:
+ * `Effect.all` defaults to sequential execution — effect@4.0.0-beta.92's `Effect.all`
+ * (an iterable delegates to `forEach`) documents "Concurrency: … By default, the
+ * operations are performed sequentially" (`Effect.ts` JSDoc), backed by
+ * `internal/effect.ts` `forEach` (`concurrency ?? 1` → `if (concurrency === 1)
+ * return forEachSequential`). So a wave that omits `{concurrency}` changes nothing.
+ * Pass `"unbounded"` to actually fan the stamps out; the default `1` reproduces
+ * today's serial phase count byte-for-byte (same reads, same order, same merged
+ * rows) — the safe default the sözlük containment flag flips.
+ *
+ * Merge correctness: every stamp returns the base rows in input order, each row
+ * extended with its own disjoint fields, so `Object.assign({}, …outsAtIndex)`
+ * rebuilds `base ∪ every stamp's fields` with the same key order the serial chain
+ * produced. Independence is the caller's contract — a stamp that READ another
+ * stamp's added field would need the chain, not this wave.
+ */
+import {Effect} from "effect";
+import type {Concurrency} from "effect/Types";
+
+/** A row stamp: given the base page, return each row extended with its own fields. */
+export type RowStamp<R> = (rows: ReadonlyArray<R>) => Effect.Effect<ReadonlyArray<R>>;
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (
+	x: infer I,
+) => void
+	? I
+	: never;
+
+type StampOutput<R, S> = S extends (rows: ReadonlyArray<R>) => Effect.Effect<ReadonlyArray<infer O>>
+	? O
+	: never;
+
+export const parallelStampWave = <
+	R extends {id: string},
+	const Stamps extends ReadonlyArray<RowStamp<R>>,
+>(
+	rows: ReadonlyArray<R>,
+	stamps: Stamps,
+	options?: {readonly concurrency?: Concurrency},
+): Effect.Effect<Array<UnionToIntersection<StampOutput<R, Stamps[number]>>>> =>
+	Effect.gen(function* () {
+		const stamped = yield* Effect.all(
+			stamps.map((stamp) => stamp(rows)),
+			{concurrency: options?.concurrency ?? 1},
+		);
+		return rows.map((_, i) => Object.assign({}, ...stamped.map((out) => out[i]))) as Array<
+			UnionToIntersection<StampOutput<R, Stamps[number]>>
+		>;
+	});

--- a/apps/web/worker/features/fate/stamp-wave.unit.test.ts
+++ b/apps/web/worker/features/fate/stamp-wave.unit.test.ts
@@ -1,0 +1,181 @@
+/**
+ * `parallelStampWave` — the read-path stamp-chain collapse (#2709, epic #2567).
+ * These pin the three properties the acceptance criteria name, above any SQL engine
+ * (ADR 0082):
+ *
+ *   - the wave issues its independent stamps CONCURRENTLY when opted in, and
+ *     SEQUENTIALLY by default — proven by the observed start/end interleaving, not
+ *     merely by matching results (a serial wave would match results too, so a
+ *     result-only test could not tell the collapse happened);
+ *   - the merged row is byte-for-byte identical whichever way it runs — same fields,
+ *     same values, same key order — so the flag flips wall time and nothing else;
+ *   - the empty page short-circuits to an empty result while still invoking each
+ *     stamp once (each reader owns its own no-op read).
+ *
+ * The stamps here are in-memory doubles: a real stamp's D1 read is substituted by a
+ * `yieldNow`-punctuated recorder, so "did the reads overlap" is decidable with no
+ * database — the real reads' fidelity lives on the per-stamp unit tests.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {parallelStampWave, type RowStamp} from "./stamp-wave.ts";
+
+type Row = {id: string; authorId: string};
+
+/**
+ * A stamp that records `start-i` / `end-i` around a cooperative `yieldNow`, then adds
+ * one disjoint field `fI`. Under `concurrency: 1` each stamp completes before the next
+ * begins (`start-0, end-0, start-1, …`); under `"unbounded"` all three reach `start`
+ * before any reaches `end` — the interleaving IS the concurrency proof.
+ */
+const recordingStamp =
+	(i: number, log: string[]): RowStamp<Row> =>
+	(rows) =>
+		Effect.gen(function* () {
+			log.push(`start-${i}`);
+			yield* Effect.yieldNow;
+			log.push(`end-${i}`);
+			return rows.map((r) => ({...r, [`f${i}`]: i}));
+		});
+
+describe("parallelStampWave — concurrency is opt-in (the #2709 collapse knob)", () => {
+	it.effect("`unbounded` runs the stamps concurrently — every start precedes every end", () => {
+		const log: string[] = [];
+		const rows: Row[] = [{id: "d1", authorId: "u1"}];
+		return Effect.gen(function* () {
+			yield* parallelStampWave(
+				rows,
+				[recordingStamp(0, log), recordingStamp(1, log), recordingStamp(2, log)],
+				{concurrency: "unbounded"},
+			);
+			assert.deepStrictEqual(
+				log.slice(0, 3).map((e) => e.startsWith("start-")),
+				[true, true, true],
+				"all three stamps START before any ends — they overlap",
+			);
+			assert.deepStrictEqual(
+				log.slice(3).map((e) => e.startsWith("end-")),
+				[true, true, true],
+				"the ends only come after every start",
+			);
+		});
+	});
+
+	it.effect(
+		"default (no options) runs the stamps SEQUENTIALLY — each ends before the next starts",
+		() => {
+			const log: string[] = [];
+			const rows: Row[] = [{id: "d1", authorId: "u1"}];
+			return Effect.gen(function* () {
+				// No `{concurrency}` → the wave defaults to 1 (effect's `concurrency ?? 1`), the
+				// safe default the flag-off path relies on to reproduce today's serial reads.
+				yield* parallelStampWave(rows, [
+					recordingStamp(0, log),
+					recordingStamp(1, log),
+					recordingStamp(2, log),
+				]);
+				assert.deepStrictEqual(log, ["start-0", "end-0", "start-1", "end-1", "start-2", "end-2"]);
+			});
+		},
+	);
+
+	it.effect("`concurrency: 1` is sequential too (the flag-off value)", () => {
+		const log: string[] = [];
+		const rows: Row[] = [{id: "d1", authorId: "u1"}];
+		return Effect.gen(function* () {
+			yield* parallelStampWave(
+				rows,
+				[recordingStamp(0, log), recordingStamp(1, log), recordingStamp(2, log)],
+				{concurrency: 1},
+			);
+			assert.deepStrictEqual(log, ["start-0", "end-0", "start-1", "end-1", "start-2", "end-2"]);
+		});
+	});
+});
+
+describe("parallelStampWave — the merge is byte-for-byte identical whichever way it runs", () => {
+	// Three stamps adding disjoint fields in the same chain order a real read uses
+	// (myVote → reactions → identity), so the merge reproduces the serial chain's shape.
+	// Left un-annotated (not `RowStamp<Row>`) so each stamp's ADDED field type is inferred
+	// and flows through the combinator's merge — the exact way the real stampers do.
+	const stampA = (rows: ReadonlyArray<Row>) =>
+		Effect.succeed(rows.map((r) => ({...r, myVote: true})));
+	const stampB = (rows: ReadonlyArray<Row>) =>
+		Effect.succeed(rows.map((r) => ({...r, reactions: {counts: [], myReaction: null}})));
+	const stampC = (rows: ReadonlyArray<Row>) =>
+		Effect.succeed(rows.map((r) => ({...r, authorName: `@${r.authorId}`})));
+
+	const rows: Row[] = [
+		{id: "d1", authorId: "u1"},
+		{id: "d2", authorId: "u2"},
+	];
+
+	it.effect("each row is base ∪ every stamp's disjoint fields", () =>
+		Effect.gen(function* () {
+			const out = yield* parallelStampWave(rows, [stampA, stampB, stampC], {
+				concurrency: "unbounded",
+			});
+			assert.deepStrictEqual(out[0], {
+				id: "d1",
+				authorId: "u1",
+				myVote: true,
+				reactions: {counts: [], myReaction: null},
+				authorName: "@u1",
+			});
+			assert.deepStrictEqual(out[1], {
+				id: "d2",
+				authorId: "u2",
+				myVote: true,
+				reactions: {counts: [], myReaction: null},
+				authorName: "@u2",
+			});
+		}),
+	);
+
+	it.effect(
+		"the concurrency knob changes NOTHING about the output — same value, same key order",
+		() =>
+			Effect.gen(function* () {
+				const serial = yield* parallelStampWave(rows, [stampA, stampB, stampC], {concurrency: 1});
+				const parallel = yield* parallelStampWave(rows, [stampA, stampB, stampC], {
+					concurrency: "unbounded",
+				});
+				assert.deepStrictEqual(parallel, serial, "identical merged rows");
+				// Byte-for-byte: JSON key order must match too (the wire is order-sensitive).
+				assert.deepStrictEqual(
+					parallel.map((r) => JSON.stringify(r)),
+					serial.map((r) => JSON.stringify(r)),
+					"identical serialized bytes, including key order",
+				);
+				assert.deepStrictEqual(Object.keys(parallel[0] ?? {}), [
+					"id",
+					"authorId",
+					"myVote",
+					"reactions",
+					"authorName",
+				]);
+			}),
+	);
+
+	it.effect("an empty page → empty result, each stamp still invoked exactly once", () => {
+		const calls: number[] = [];
+		const counting =
+			(i: number): RowStamp<Row> =>
+			(rs) =>
+				Effect.sync(() => {
+					calls.push(i);
+					return rs;
+				});
+		return Effect.gen(function* () {
+			const out = yield* parallelStampWave([] as Row[], [counting(0), counting(1), counting(2)], {
+				concurrency: "unbounded",
+			});
+			assert.deepStrictEqual(out, [], "no rows → no merged rows");
+			assert.deepStrictEqual(
+				[...calls].sort(),
+				[0, 1, 2],
+				"every stamp ran once on the empty page",
+			);
+		});
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -32,6 +32,7 @@ import {
 	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
 	PHOENIX_OPTIMISTIC_EDITS,
 	PHOENIX_REACTIONS,
+	PHOENIX_SOZLUK_STAMP_WAVE,
 	PHOENIX_USER_BAN,
 } from "../../../src/flags/keys.ts";
 import {AUDIT_ENVIRONMENT} from "../../environment.ts";
@@ -894,3 +895,35 @@ export const NAV_IA_FLAG = {
  */
 export const navIaFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_nav_ia", {appId, ...NAV_IA_FLAG});
+
+/**
+ * The sözlük parallel-stamp-wave containment flag config (#2709, epic #2567).
+ * Default-OFF so the read-path collapse reaches production dark: with it off the
+ * sözlük definition reads run their stamp wave at `concurrency: 1` (serial, exactly
+ * today); flipping it on passes `"unbounded"` so the independent stamps fan out into
+ * one concurrent wave. Wire output is identical either way — only wall time changes.
+ * Flipping it on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `PANO_BASE_FEED_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           sözlük (the definition read path)
+ *   - originating:     #2709 (epic: collapse the serial stamp chain, #2567)
+ *   - removal trigger: once the wave graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline `"unbounded"`.
+ */
+export const SOZLUK_STAMP_WAVE_FLAG = {
+	key: PHOENIX_SOZLUK_STAMP_WAVE,
+	description:
+		"sözlük parallel-stamp-wave read collapse dark-ship (#2709, epic #2567). owner: sözlük. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const sozlukStampWaveFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_sozluk_stamp_wave", {appId, ...SOZLUK_STAMP_WAVE_FLAG});

--- a/apps/web/worker/features/flagship/sozluk-stamp-wave.invariant.test.ts
+++ b/apps/web/worker/features/flagship/sozluk-stamp-wave.invariant.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the sözlük parallel-stamp-wave
+ * read collapse (#2709, epic #2567). Inspected off the exported `SOZLUK_STAMP_WAVE_FLAG`
+ * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy
+ * resource is constructed — mirrors `pano-base-feed.invariant.test.ts`.
+ *
+ * Load-bearing: with the default OFF the definition reads run their stamp wave at
+ * `concurrency: 1` (serial, byte-for-byte today) — so the containment is real, the
+ * concurrent wave only reachable after a human flips the flag.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_SOZLUK_STAMP_WAVE} from "../../../src/flags/keys.ts";
+import {SOZLUK_STAMP_WAVE_FLAG, sozlukStampWaveFlag} from "./resources.ts";
+
+describe("sözlük stamp wave — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(SOZLUK_STAMP_WAVE_FLAG.defaultVariation, "off");
+		assert.strictEqual(SOZLUK_STAMP_WAVE_FLAG.variations.off, false);
+		assert.strictEqual(SOZLUK_STAMP_WAVE_FLAG.variations.on, true);
+		assert.strictEqual(SOZLUK_STAMP_WAVE_FLAG.key, "phoenix-sozluk-stamp-wave");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(SOZLUK_STAMP_WAVE_FLAG.key, PHOENIX_SOZLUK_STAMP_WAVE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof sozlukStampWaveFlag, "function");
+	});
+});

--- a/apps/web/worker/features/reaction/Reaction.ts
+++ b/apps/web/worker/features/reaction/Reaction.ts
@@ -32,6 +32,7 @@
  */
 import {and, eq, inArray, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
+import type {Concurrency} from "effect/Types";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {REACTION_EMOJI, type ReactionEmoji} from "../../db/reaction-emoji.ts";
@@ -130,11 +131,16 @@ export class Reaction extends Context.Service<
 		 * A target with no reactions is ABSENT from the map (the caller fills the empty
 		 * aggregate). Missing/empty `targetIds` short-circuits to an empty Map with no
 		 * read.
+		 *
+		 * The two reads (the `GROUP BY` tally + the viewer's `readMine`) are independent;
+		 * `options.concurrency` opts them into concurrent execution (`"unbounded"` for the
+		 * stamp-wave collapse, #2709). Absent ⇒ sequential, the unchanged default.
 		 */
 		readonly readAggregate: (
 			viewerId: string | null | undefined,
 			kind: TargetKind,
 			targetIds: ReadonlyArray<string>,
+			options?: {readonly concurrency?: Concurrency},
 		) => Effect.Effect<Map<string, ReactionAggregate>>;
 		/**
 		 * The single reaction-cleanup home for the removal substrate (ADR 0096 §3,
@@ -218,32 +224,39 @@ export const ReactionLive = Layer.effect(Reaction)(
 			viewerId: string | null | undefined,
 			kind: TargetKind,
 			targetIds: ReadonlyArray<string>,
+			options?: {readonly concurrency?: Concurrency},
 		) {
 			const out = new Map<string, ReactionAggregate>();
 			if (targetIds.length === 0) return out;
 
 			// One GROUP BY over the whole page — per (target, emoji) COUNT(*), served
 			// by the `user_reaction_target` index (schema.ts). Anonymous viewer's own
-			// reaction is `null` (readMine short-circuits with no read).
-			const [rows, mine] = yield* Effect.all([
-				run((db) =>
-					db
-						.select({
-							targetId: schema.userReaction.targetId,
-							emoji: schema.userReaction.emoji,
-							count: sql<number>`count(*)`,
-						})
-						.from(schema.userReaction)
-						.where(
-							and(
-								eq(schema.userReaction.targetKind, kind),
-								inArray(schema.userReaction.targetId, [...targetIds]),
-							),
-						)
-						.groupBy(schema.userReaction.targetId, schema.userReaction.emoji),
-				),
-				readMine(viewerId, kind, targetIds),
-			]);
+			// reaction is `null` (readMine short-circuits with no read). The two reads
+			// are independent; `Effect.all` runs them sequentially by default (effect's
+			// `concurrency ?? 1`), so `options.concurrency` is what collapses them into
+			// one wave phase for the #2709 stamp-wave — omitted ⇒ unchanged sequential.
+			const [rows, mine] = yield* Effect.all(
+				[
+					run((db) =>
+						db
+							.select({
+								targetId: schema.userReaction.targetId,
+								emoji: schema.userReaction.emoji,
+								count: sql<number>`count(*)`,
+							})
+							.from(schema.userReaction)
+							.where(
+								and(
+									eq(schema.userReaction.targetKind, kind),
+									inArray(schema.userReaction.targetId, [...targetIds]),
+								),
+							)
+							.groupBy(schema.userReaction.targetId, schema.userReaction.emoji),
+					),
+					readMine(viewerId, kind, targetIds),
+				],
+				{concurrency: options?.concurrency ?? 1},
+			);
 
 			// Fold the flat (target, emoji, count) rows into per-target count arrays.
 			const byTarget = new Map<string, ReactionCount[]>();

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -17,6 +17,7 @@ import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
 import {stampAuthorIdentity} from "../fate/author-identity.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
+import {parallelStampWave} from "../fate/stamp-wave.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import {applyRemovalTransition, swallowRefresh} from "../lifecycle/apply-removal-transition.ts";
 import {anonymousViewer, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
@@ -342,6 +343,14 @@ export class Sozluk extends Context.Service<
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				/**
+				 * Route the page's independent stamps (viewer scalars + reaction aggregate +
+				 * author identity) through the concurrent {@link parallelStampWave} instead of
+				 * the serial chain (#2709). Default/off ⇒ the wave runs at `concurrency: 1`
+				 * (serial, byte-for-byte today); the resolver flips it from the containment
+				 * flag. Output is identical either way — only wall time collapses.
+				 */
+				parallelStamps?: boolean | undefined;
 			},
 		) => Effect.Effect<DefinitionConnectionPage>;
 
@@ -353,7 +362,12 @@ export class Sozluk extends Context.Service<
 		 */
 		readonly getDefinitionsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
+			opts?: {
+				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
+				/** See {@link listDefinitionsKeyset}'s `parallelStamps` (#2709). */
+				parallelStamps?: boolean | undefined;
+			},
 		) => Effect.Effect<DefinitionRow[]>;
 
 		/**
@@ -512,6 +526,29 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			read: (viewerId: string | null | undefined, ids: ReadonlyArray<string>) =>
 				voteSvc.readMine(viewerId, "definition", ids),
 		} as const;
+
+		// The three independent finalize stamps every definition read shares — `myVote`
+		// (viewer scalar), the reaction aggregate, live author identity — each independent
+		// given the fetched rows. `parallelStampWave` runs them over the SAME rows and
+		// merges; `parallelStamps` picks the concurrency: off ⇒ `1` (serial, byte-for-byte
+		// today), on ⇒ `"unbounded"` (one wave, the #2709 collapse). The reaction stamp's
+		// own two D1 reads inherit the same knob so the whole wave is one phase when on.
+		const stampDefinitions = <R extends {id: string; authorId: string}>(
+			rows: ReadonlyArray<R>,
+			viewerId: string | null,
+			parallelStamps: boolean,
+		) => {
+			const concurrency = parallelStamps ? "unbounded" : 1;
+			return parallelStampWave(
+				rows,
+				[
+					(rs) => stampViewerScalars(rs, viewerId, [definitionVoteScalar]),
+					(rs) => stampReactionAggregate(reactionSvc, "definition", rs, viewerId, {concurrency}),
+					(rs) => stampAuthorIdentity(pasaport.getProfileIdentitiesByIds, rs),
+				],
+				{concurrency},
+			);
+		};
 
 		// Recompute one slug's `term_record` row from its live `definition_record`
 		// slice. The closure is just the port: read rows via `run`, call the pure
@@ -725,6 +762,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				parallelStamps?: boolean | undefined;
 			} = {},
 		) {
 			const first = Math.max(1, Math.min(opts.first ?? 50, 200));
@@ -803,16 +841,18 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					sandboxed: ownSandboxed(d, viewerId),
 				}),
 			);
-			const scalared = yield* stampViewerScalars(page.rows, viewerId, [definitionVoteScalar]);
-			const reacted = yield* stampReactionAggregate(reactionSvc, "definition", scalared, viewerId);
-			const rows = yield* stampAuthorIdentity(pasaport.getProfileIdentitiesByIds, reacted);
+			const rows = yield* stampDefinitions(page.rows, viewerId, opts.parallelStamps ?? false);
 
 			return {...page, rows, totalCount} satisfies DefinitionConnectionPage;
 		});
 
 		const getDefinitionsByIds = Effect.fn("Sozluk.getDefinitionsByIds")(function* (
 			ids: ReadonlyArray<string>,
-			opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
+			opts: {
+				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
+				parallelStamps?: boolean | undefined;
+			} = {},
 		) {
 			if (ids.length === 0) return [];
 			const viewerId = opts.viewerId ?? null;
@@ -835,13 +875,11 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						),
 					),
 			);
-			const scalared = yield* stampViewerScalars(
-				fetched.map((d) => ({...toDefinitionRow(d), sandboxed: ownSandboxed(d, viewerId)})),
-				viewerId,
-				[definitionVoteScalar],
-			);
-			const reacted = yield* stampReactionAggregate(reactionSvc, "definition", scalared, viewerId);
-			return yield* stampAuthorIdentity(pasaport.getProfileIdentitiesByIds, reacted);
+			const base = fetched.map((d) => ({
+				...toDefinitionRow(d),
+				sandboxed: ownSandboxed(d, viewerId),
+			}));
+			return yield* stampDefinitions(base, viewerId, opts.parallelStamps ?? false);
 		});
 
 		const listSandboxedDefinitions = Effect.fn("Sozluk.listSandboxedDefinitions")(function* (

--- a/apps/web/worker/features/sozluk/definition-stamp-wave.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-stamp-wave.unit.test.ts
@@ -1,0 +1,207 @@
+/**
+ * The sözlük stamp-wave collapse (#2709, epic #2567) — behavior equivalence + the
+ * concurrency plumbing, over the substituted-`Drizzle`/service seams (ADR 0082 litmus:
+ * wrong-or-right with no SQL engine → unit).
+ *
+ * Two properties the acceptance criteria name:
+ *
+ *   - **byte-for-byte equivalence.** `getDefinitionsByIds` / `listDefinitionsKeyset`
+ *     produce the identical stamped rows whether the wave runs serial (flag off) or
+ *     concurrent (flag on) — `myVote`, `reactions`, live author identity all unchanged.
+ *     The flag flips wall time and nothing else.
+ *   - **the concurrency actually threads through.** With `parallelStamps: true` the
+ *     reaction aggregate's own two D1 reads receive `{concurrency: "unbounded"}` (so the
+ *     wave is one phase, not one-plus-the-reaction-arm's-two); with it off/absent they
+ *     receive `{concurrency: 1}` — today's serial behavior every non-opted caller keeps.
+ *
+ * The stamps' batched reads are substituted by recording doubles (the feature's
+ * scripted-double idiom) — real read fidelity lives on the per-stamp + integration tiers.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import type {Concurrency} from "effect/Types";
+import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
+import {Reaction, type ReactionAggregate} from "../reaction/Reaction.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Sozluk, SozlukLive} from "./Sozluk.ts";
+
+// A `definition_record` shaped just enough for `toDefinitionRow` + `ownSandboxed`.
+const defRecord = (id: string, authorId: string) => ({
+	id,
+	body: `body of ${id}`,
+	bodyExcerpt: null,
+	score: 3,
+	author: null,
+	authorId,
+	authorName: `snapshot-${authorId}`,
+	termSlug: "a-term",
+	termTitle: "A Term",
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+	removedAt: null,
+	removedBy: null,
+	removedReason: null,
+	sandboxedAt: null,
+});
+
+// Vote double: viewer holds an upvote on `d1` only → `d1.myVote === true`, `d2 === false`.
+// biome-ignore lint/plugin: a service double — only `readMine` is on the read path.
+const VoteStub = Layer.succeed(Vote, {
+	cast: () => Effect.die(new Error("read path must not cast")),
+	readMine: () => Effect.succeed(new Set<string>(["d1"])),
+	clearTarget: () => Effect.void,
+} as unknown as typeof Vote.Service);
+
+const agg = (myReaction: ReactionAggregate["myReaction"]): ReactionAggregate => ({
+	counts: [{emoji: "👍", count: 2}],
+	myReaction,
+});
+
+// Reaction double that RECORDS the `options` (the concurrency knob) each `readAggregate`
+// call received, and answers a fixed aggregate for `d1`.
+const reactionRecorder = (calls: Array<{readonly concurrency?: Concurrency} | undefined>) =>
+	Layer.succeed(Reaction, {
+		react: () => Effect.die(new Error("read path must not react")),
+		readMine: () => Effect.succeed(new Map<string, ReactionEmoji>()),
+		clearTarget: () => Effect.void,
+		readAggregate: (_viewerId, _kind, _ids, options) => {
+			calls.push(options);
+			return Effect.succeed(new Map<string, ReactionAggregate>([["d1", agg("👍")]]));
+		},
+	} satisfies typeof Reaction.Service);
+
+// Pasaport double: `d1`'s author has a live handle, `d2`'s has none (→ null identity).
+const PasaportStub = makePasaportStub({
+	getProfileIdentitiesByIds: () =>
+		Effect.succeed([{userId: "u1", username: "anka", displayName: "Anka Kadın", totalKarma: 0}]),
+});
+
+const sozlukLayer = (
+	access: DrizzleAccess,
+	calls: Array<{readonly concurrency?: Concurrency} | undefined>,
+) =>
+	SozlukLive.pipe(
+		Layer.provide(VoteStub),
+		Layer.provide(reactionRecorder(calls)),
+		Layer.provide(PasaportStub),
+		Layer.provide(Layer.succeed(Drizzle, access)),
+	);
+
+// Replays `run` results in call order (the connection test's `scriptedAccess` shape);
+// `results` is `unknown`, so each answer is a single `as A` — no `as unknown as` cast.
+const scriptedAccess = (results: ReadonlyArray<unknown>): DrizzleAccess => {
+	let i = 0;
+	return {
+		run: <A>(_fn: (db: DrizzleDb) => Promise<A>) => Effect.succeed(results[i++] as A),
+		batch: () => Effect.die(new Error("read path must not batch")),
+	};
+};
+
+// `getDefinitionsByIds` issues exactly one `run` (the fetch); answer it with two records.
+const byIdAccess = (): DrizzleAccess =>
+	scriptedAccess([[defRecord("d1", "u1"), defRecord("d2", "u2")]]);
+
+describe("Sozluk.getDefinitionsByIds — stamp-wave behavior equivalence (#2709)", () => {
+	it.effect("stamped output is byte-for-byte identical with the wave serial vs concurrent", () => {
+		const serialCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+		const parallelCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+		return Effect.gen(function* () {
+			const serial = yield* Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				return yield* sozluk.getDefinitionsByIds(["d1", "d2"], {
+					viewerId: "viewer-1",
+					parallelStamps: false,
+				});
+			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), serialCalls)));
+
+			const parallel = yield* Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				return yield* sozluk.getDefinitionsByIds(["d1", "d2"], {
+					viewerId: "viewer-1",
+					parallelStamps: true,
+				});
+			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), parallelCalls)));
+
+			assert.deepStrictEqual(parallel, serial, "identical stamped rows");
+			assert.deepStrictEqual(
+				parallel.map((r) => JSON.stringify(r)),
+				serial.map((r) => JSON.stringify(r)),
+				"identical serialized bytes (fields, values, key order)",
+			);
+			// Spot the stamps actually landed (not a vacuous equality of two empty pages).
+			assert.strictEqual(parallel[0]?.myVote, true, "d1 viewer upvote stamped");
+			assert.strictEqual(parallel[1]?.myVote, false, "d2 no viewer upvote");
+			assert.deepStrictEqual(parallel[0]?.reactions, agg("👍"), "d1 reaction aggregate stamped");
+			assert.strictEqual(parallel[0]?.authorUsername, "anka", "d1 live identity stamped");
+			assert.strictEqual(parallel[1]?.authorUsername, null, "d2 has no live identity");
+		});
+	});
+
+	it.effect("the flag threads concurrency into the reaction aggregate's own two reads", () => {
+		const onCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+		const offCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+		return Effect.gen(function* () {
+			yield* Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				yield* sozluk.getDefinitionsByIds(["d1"], {viewerId: "v", parallelStamps: true});
+			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), onCalls)));
+			yield* Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				yield* sozluk.getDefinitionsByIds(["d1"], {viewerId: "v", parallelStamps: false});
+			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), offCalls)));
+			yield* Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				// No `parallelStamps` → the default-off path (today's behavior).
+				yield* sozluk.getDefinitionsByIds(["d1"], {viewerId: "v"});
+			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), offCalls)));
+
+			assert.deepStrictEqual(onCalls, [{concurrency: "unbounded"}], "flag on → unbounded");
+			assert.deepStrictEqual(
+				offCalls,
+				[{concurrency: 1}, {concurrency: 1}],
+				"flag off AND absent → sequential (concurrency 1)",
+			);
+		});
+	});
+});
+
+// `listDefinitionsKeyset` (no cursor) issues: totalCount → fetch. Script both in order.
+const keysetAccess = (): DrizzleAccess =>
+	scriptedAccess([2 /* count */, [defRecord("d1", "u1"), defRecord("d2", "u2")] /* fetch */]);
+
+describe("Sozluk.listDefinitionsKeyset — stamp-wave behavior equivalence (#2709)", () => {
+	it.effect(
+		"the connection page is byte-for-byte identical with the wave serial vs concurrent",
+		() => {
+			const serialCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+			const parallelCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+			return Effect.gen(function* () {
+				const serial = yield* Effect.gen(function* () {
+					const sozluk = yield* Sozluk;
+					return yield* sozluk.listDefinitionsKeyset("a-term", {
+						first: 10,
+						viewerId: "viewer-1",
+						parallelStamps: false,
+					});
+				}).pipe(Effect.provide(sozlukLayer(keysetAccess(), serialCalls)));
+
+				const parallel = yield* Effect.gen(function* () {
+					const sozluk = yield* Sozluk;
+					return yield* sozluk.listDefinitionsKeyset("a-term", {
+						first: 10,
+						viewerId: "viewer-1",
+						parallelStamps: true,
+					});
+				}).pipe(Effect.provide(sozlukLayer(keysetAccess(), parallelCalls)));
+
+				assert.deepStrictEqual(parallel, serial, "identical connection page");
+				assert.strictEqual(JSON.stringify(parallel), JSON.stringify(serial), "identical bytes");
+				assert.strictEqual(parallel.rows[0]?.myVote, true, "stamps landed on the page");
+				assert.deepStrictEqual(parallelCalls, [{concurrency: "unbounded"}], "flag on → unbounded");
+				assert.deepStrictEqual(serialCalls, [{concurrency: 1}], "flag off → sequential");
+			});
+		},
+	);
+});

--- a/apps/web/worker/features/sozluk/queries.ts
+++ b/apps/web/worker/features/sozluk/queries.ts
@@ -11,7 +11,10 @@ import {Fate} from "@kampus/fate-effect";
 import {hasNestedSelection} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {PHOENIX_SOZLUK_STAMP_WAVE} from "../../../src/flags/keys.ts";
 import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Sozluk} from "./Sozluk.ts";
 import {toDefinition, toTermFromPage} from "./shapers.ts";
@@ -48,10 +51,17 @@ export const queries = {
 				return base;
 			}
 
+			// Contained behind the default-off flag (#2709): off ⇒ serial stamps (today), on
+			// ⇒ one concurrent wave. Identical wire output — only wall time collapses.
+			const flags = yield* Flags;
+			const parallelStamps = yield* flags
+				.getBoolean(PHOENIX_SOZLUK_STAMP_WAVE, false)
+				.pipe(provideRequestFlags);
 			const connection = yield* sozluk.listDefinitionsKeyset(args.slug, {
 				...keysetInput(args.definitions, DEFINITIONS_PAGE_SIZE),
 				viewerId,
 				sandboxViewer,
+				parallelStamps,
 			});
 			const definitions = toConnection<(typeof connection.rows)[number], Definition>(
 				connection,

--- a/apps/web/worker/features/sozluk/sources.ts
+++ b/apps/web/worker/features/sozluk/sources.ts
@@ -6,6 +6,9 @@
  * `E = never` — see `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
+import {PHOENIX_SOZLUK_STAMP_WAVE} from "../../../src/flags/keys.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Sozluk} from "./Sozluk.ts";
 import {DefinitionView, TermView} from "./views.ts";
@@ -17,9 +20,16 @@ export const definitionSource = Fate.source(
 		byIds: function* (ids) {
 			const sozluk = yield* Sozluk;
 			const sandboxViewer = yield* currentSandboxViewer;
+			// The read-path collapse is contained behind its default-off flag (#2709): off ⇒
+			// the stamps run serially (today), on ⇒ one concurrent wave. Same wire output.
+			const flags = yield* Flags;
+			const parallelStamps = yield* flags
+				.getBoolean(PHOENIX_SOZLUK_STAMP_WAVE, false)
+				.pipe(provideRequestFlags);
 			return yield* sozluk.getDefinitionsByIds(ids, {
 				viewerId: sandboxViewer.viewerId,
 				sandboxViewer,
+				parallelStamps,
 			});
 		},
 	},


### PR DESCRIPTION
Fixes #2709

## What

Collapse the sözlük read path's strictly-serial stamp chain (`stampViewerScalars → stampReactionAggregate → stampAuthorIdentity`) into one concurrent wave, and introduce the shared combinator the pano sibling (#2710) will reuse. Approach **A** per the founder ruling — the parallel-stamp-wave combinator only; the D1-hop alternative (#2708) is not implemented.

## How

- **`worker/features/fate/stamp-wave.ts` — `parallelStampWave`.** Runs the independent stamps over the SAME fetched rows and merges their disjoint added fields index-wise. Each stamp reads only the base row's `id` / `authorId` and adds a disjoint field set, so it never needs another stamp's output — the serial chain was ordering for no reason.
- **The concurrency knob is load-bearing.** `Effect.all` is sequential by default (an iterable delegates to `forEach`, whose default is `concurrency ?? 1` → `forEachSequential`; effect@4.0.0-beta.92 `Effect.all`/`forEach` JSDoc: *"Concurrency: … By default, the operations are performed sequentially"*). The combinator passes `{concurrency}`: `1` reproduces today's serial phase count byte-for-byte, `"unbounded"` fans the stamps out.
- **`Reaction.readAggregate` gains an additive `concurrency` option** so its own two reads (the `GROUP BY` + `readMine`) join the wave under the flag. Default absent ⇒ sequential ⇒ pano/#2710 unchanged. This is what folds the full 4-phase tail into **1** wave.
- **`getDefinitionsByIds` / `listDefinitionsKeyset`** route their stamps through the combinator via a `parallelStamps` option; the sözlük resolvers (`sources.ts`, `queries.ts`) resolve it from the flag.
- **Containment:** default-off `phoenix-sozluk-stamp-wave` flag (key + IaC config + factory + alchemy wiring + default-=-off invariant test). Off ⇒ `concurrency: 1` (serial, today); on ⇒ `"unbounded"`. Anonymous / empty-page short-circuits preserved (they live inside each reader). `@reachability-exempt` — server read-path perf flag, no UI surface.

## Measured drop (vs the #2707 baseline)

The collapsible tail is **4 serial phases** (viewer-scalars, reaction-aggregate ×2, author-identity). Flag-on folds it to **1 concurrent wave**: **by-id 5 → 2, connection first-page 6 → 3** — the documented 3-phase drop. Recorded in `serial-read-baseline.md` → *Realized — sözlük (#2709)*.

## Byte-for-byte equivalence

Wire output is identical whichever way it runs — same `myVote` / `reactions` / live author identity, same empty-aggregate / null-scalar conventions, same key order. Only wall time changes.

## Tests

- `stamp-wave.unit.test.ts` — proves the stamps run **concurrently** under `"unbounded"` and **sequentially** by default/`1`, via observed start/end interleaving (not result parity — a serial wave matches results too); byte-for-byte merge equivalence + key order; empty-page short-circuit.
- `definition-stamp-wave.unit.test.ts` — `getDefinitionsByIds` / `listDefinitionsKeyset` produce identical stamped rows flag-on vs flag-off, and the concurrency knob threads into the reaction aggregate's two reads (`unbounded` on, `1` off/absent).
- `sozluk-stamp-wave.invariant.test.ts` — the flag ships `defaultVariation: off`.

Read-path only — no fate mutation added, so no fanout-guard classification needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)