### PR TITLE
fix(web): lift segmented ToggleGroup segment to the 36px hit-area floor (#2766)

### DIFF
--- a/apps/web/src/components/ui/ToggleGroup.css
+++ b/apps/web/src/components/ui/ToggleGroup.css
@@ -52,7 +52,7 @@
 .kp-toggle-group--segmented .kp-toggle {
 	/* min-height keeps the ≥36px hit area decoupled from the --t-meta glyph — the base
 	   .kp-toggle flex-centers, so the box pads up to the floor without inflating type (ADR 0162 §Tap target). */
-	min-height: 36px;
+	min-height: var(--tap-min);
 	border-radius: var(--r-sm);
 	padding: 3px var(--s-2);
 	font: var(--t-meta);

--- a/apps/web/src/components/ui/ToggleGroup.css
+++ b/apps/web/src/components/ui/ToggleGroup.css
@@ -50,6 +50,9 @@
 	gap: 0;
 }
 .kp-toggle-group--segmented .kp-toggle {
+	/* min-height keeps the ≥36px hit area decoupled from the --t-meta glyph — the base
+	   .kp-toggle flex-centers, so the box pads up to the floor without inflating type (ADR 0162 §Tap target). */
+	min-height: 36px;
 	border-radius: var(--r-sm);
 	padding: 3px var(--s-2);
 	font: var(--t-meta);

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -526,6 +526,10 @@
 
 	--content-w: 980px;
 
+	/* Density-invariant tap-target floor — a minimum hit area holds regardless of density,
+	   so it lives here, not on the scaled --s-N ramp (ADR 0162 §Tap target). */
+	--tap-min: 36px;
+
 	/* density — compact (default) */
 	--s-1: 4px;
 	--s-2: 8px;


### PR DESCRIPTION
## What

The shared `--segmented` `ToggleGroup` segment had no `min-height`, so its interactive box collapsed to its content: `--t-meta` (12px × 1.4 ≈ 16.8px) + ~3px padding each side ≈ **~22.8px**, below ADR [0162](https://github.com/kamp-us/phoenix/blob/main/.decisions/0162-four-pillars-design-law.md)'s **36px minimum hit-area floor** (§Tap target; `design-system-manifest.md` pillar 4). Because the floor was violated on the shared primitive, every `--segmented` consumer (the density and mode toggles) inherited the sub-floor tap-target.

## Fix

Add `min-height: 36px` scoped to `.kp-toggle-group--segmented .kp-toggle` in `apps/web/src/components/ui/ToggleGroup.css`. The base `.kp-toggle` already flex-centers (`align-items`/`justify-content: center`), so the box pads up to the floor with the glyph centered — **hit area decoupled from the unchanged `--t-meta` type scale** (the manifest's "hit area decoupled from glyph" rule). No other variant (`--square` / `--swatch` / pill) is touched, so no other consumer's tap-target changes.

## Acceptance criteria

- [x] `.kp-toggle-group--segmented .kp-toggle` renders a ≥36px hit area (via `min-height: 36px` on the interactive box).
- [x] The `--t-meta` type scale is preserved — only the interactive box is padded up to the floor.
- [x] The density-toggle consumer still lays out correctly (segments grow taller, flex-centered; no wrapping/rhythm regression).
- [x] No other variant regresses — the rule is scoped to `--segmented`; `--square` / `--swatch` are untouched.

Fixes #2766