### PR TITLE
fix(pipeline): class-probe fails closed on no-class — root tooling requires a review gate (#2765)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -170,6 +170,10 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   echo "$CHANGED" | grep -Eq "$HAS_CODE_RE"   && echo "has-code → dispatch review-code"
   echo "$CHANGED" | grep -Eq "$HAS_SKILLS_RE" && echo "has-skills → dispatch review-skill"
   echo "$CHANGED" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs → dispatch review-doc"
+  # No-class fail-closed (#2765): a file matching NONE of the three classes above — root tooling
+  # outside the code roots (biome-plugins/**, biome.jsonc, turbo.json) — rides has-code → dispatch
+  # review-code (§CLASS no-class fail-closed rule). `class-probe classify` folds this in, so the fan
+  # never leaves a non-empty diff with zero dispatched gates. Not a widened HAS_CODE_RE (that is #2761).
   ```
   Dispatch each gate the probe names — class gates **and** the additive `review-design` when it
   appears — and post its SHA-bound marker in this same pass. A single-class PR simply fires one

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1593,6 +1593,22 @@ HAS_DOCS_EXCLUDE_RE="$(reresolve_re HAS_DOCS_EXCLUDE_RE '\$^')"   # fail-closed:
 HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed: every path is a doc
 ```
 
+**No-class fail-closed — a non-empty diff can never require zero gates (#2765).** A changed file
+that matches **none** of the three class probes above — root-level executable build/lint tooling
+outside the code roots (`biome-plugins/**`, `biome.jsonc`, `turbo.json`, `pnpm-workspace.yaml`, a
+root `tsconfig`) — used to leave the diff spanning **no** class, so `ship-it` required **zero**
+review verdicts and the PR could merge un-gated (PR #2760's GritQL biome plugins shipped safe only
+by carrying an *unrequired* `review-code` PASS). That is a fail-**open** in the gate itself. The
+fix is the same ADR 0092 fail-closed idiom the `reresolve_re` defaults use: **any unclassified
+changed file rides `has-code` → `review-code`** (the general logic gate), so a non-empty diff always
+requires at least one gate. This is **not** a fourth class or a widened `HAS_CODE_RE` (single-sourcing
+the whole regex is the separate #2761) — it is the fail-closed *default* of the existing classes,
+implemented once in the shared core (`pipeline-cli class-probe`, which `ship-it` Step 0 and the
+reviewer fan both run) so `required == dispatched` holds. An **empty** diff still spans no class —
+the default fires only on a real unclassified file, never on nothing. Note the §CP interaction (which
+this fix leaves untouched): a no-class PR that is *also* control-plane already stops at human merge
+via `CONTROL_PLANE_RE`; this closes the gap for the no-class PR that is **not** control-plane.
+
 `review-design`/`has-ui` is **additive** and stays single-sourced in `ship-it/SKILL.md`'s
 `UI_RE=` (dispatched alongside whatever class gate(s) fire, never as a class of its own — see the
 `ui_reresolve` invariant in `reviewer.md`); the `HAS_*` lines above cover the three mutually-inclusive

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -313,6 +313,11 @@ HAS_DOCS_RE="$(reresolve_re HAS_DOCS_RE '.')"                     # fail-closed:
 echo "$FILES" | grep -Eq "$HAS_SKILLS_RE" && echo "has-skills"   # → review-skill (ADR 0073/0150); §CP-blocking for merge via CONTROL_PLANE_RE above
 echo "$FILES" | grep -Eq "$HAS_CODE_RE" && echo "has-code"       # → review-code; the has-code roots agree with the docs-exclusion below in lockstep (§CLASS/§DOC, #663/#919/#1987)
 echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && echo "has-docs"   # → review-doc; carve out code roots/skills/.glossary first, then test for a doc path (§DOC contract)
+# No-class fail-closed (#2765): a NON-EMPTY diff whose files match NONE of the three classes above
+# — root tooling outside the code roots (biome-plugins/**, biome.jsonc, turbo.json) — must NOT ship
+# un-gated. `pipeline-cli class-probe classify` (the live decision source above) folds this in: any
+# unclassified changed file rides has-code → review-code, so a non-empty diff never requires zero
+# gates. This is the §CLASS "no-class fail-closed" rule, NOT a widened HAS_CODE_RE (that is #2761).
 # UI probe → review-design (ADDITIVE, not a class): a changed path under apps/web/src — the
 # rendered frontend surface (React components, styles, tokens, routes). `pipeline-cli class-probe
 # classify` above ALSO emits `has-ui` (it parses this same UI_RE from its single source,

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
@@ -103,6 +103,16 @@ const matcher = (
  * set, identical to ship-it's required-namespace set for the same diff). Mirrors the
  * §CLASS bash exactly: has-code / has-skills are direct matches; has-docs is
  * carve-then-test (`grep -Ev exclude | grep -Eq docs`).
+ *
+ * No-class fail-closed (#2765): a changed file matching NONE of the three class probes —
+ * root-level executable build/lint tooling outside the code roots (`biome-plugins/**`,
+ * `biome.jsonc`, `turbo.json`, `pnpm-workspace.yaml`, …) — used to leave the diff spanning
+ * zero classes, so ship-it required zero gates and it could merge un-reviewed (PR #2760 was
+ * safe only by carrying an unrequired review-code PASS). Such a file now rides **has-code**
+ * (review-code, the general logic gate), making the invalid "non-empty diff, zero required
+ * gates" state unrepresentable. An empty diff still spans no class — nothing to gate. This
+ * is not a fourth class or a widened regex (that regex single-source is #2761); it is the
+ * fail-closed default of the same ADR 0092 idiom the FAILCLOSED_PROBES over-dispatch uses.
  */
 export const classify = (
 	files: ReadonlyArray<string>,
@@ -112,11 +122,13 @@ export const classify = (
 	const isSkills = matcher(probes.hasSkills, () => true);
 	const isExcluded = matcher(probes.docsExclude, () => false);
 	const isDocPath = matcher(probes.docs, () => true);
+	const isDoc = (f: string): boolean => !isExcluded(f) && isDocPath(f);
+	const isClassified = (f: string): boolean => isCode(f) || isSkills(f) || isDoc(f);
 
 	const present = new Set<ArtifactClass>();
-	if (files.some(isCode)) present.add("has-code");
+	if (files.some(isCode) || files.some((f) => !isClassified(f))) present.add("has-code");
 	if (files.some(isSkills)) present.add("has-skills");
-	if (files.some((f) => !isExcluded(f) && isDocPath(f))) present.add("has-docs");
+	if (files.some(isDoc)) present.add("has-docs");
 
 	return CLASS_ORDER.filter((c) => present.has(c));
 };

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
@@ -107,6 +107,50 @@ describe("classify — the other artifact classes still route correctly", () => 
 	});
 });
 
+describe("classify — the no-class fail-open is closed: root tooling requires a gate (#2765)", () => {
+	// The #2765 fail-open: root-level executable build/lint tooling sits outside the four
+	// code roots, so it matched HAS_CODE_RE / HAS_SKILLS_RE / HAS_DOCS_RE none-for-none and
+	// classed as "no artifact class" → ship-it required ZERO gates → un-reviewed merge. PR
+	// #2760 (GritQL biome plugins) shipped safe only by carrying an unrequired review-code
+	// PASS. An unclassified changed file now rides has-code (review-code) — a non-empty diff
+	// can never require zero gates.
+	it("classifies biome.jsonc as has-code (was: no artifact class)", () => {
+		const classes = classify(["biome.jsonc"], LIVE_PROBES);
+		expect(classes).toEqual(["has-code"]);
+		expect(requiredNamespaces(classes)).toEqual(["review-code"]);
+	});
+
+	it("classifies a biome-plugins/*.grit lint rule as has-code", () => {
+		expect(classify(["biome-plugins/no-console.grit"], LIVE_PROBES)).toEqual(["has-code"]);
+	});
+
+	it("gates the PR #2760 shape (biome-plugins/*.grit + biome.jsonc) with review-code", () => {
+		const files = ["biome-plugins/no-console.grit", "biome.jsonc"];
+		const classes = classify(files, LIVE_PROBES);
+		expect(classes).toEqual(["has-code"]);
+		// The load-bearing assertion: the required namespace set is NOT empty — a gate runs.
+		expect(requiredNamespaces(classes)).toEqual(["review-code"]);
+		expect(requiredNamespaces(classes).length).toBeGreaterThan(0);
+	});
+
+	it("routes other root build/lint governors the same way (turbo.json, pnpm-workspace.yaml)", () => {
+		expect(classify(["turbo.json"], LIVE_PROBES)).toEqual(["has-code"]);
+		expect(classify(["pnpm-workspace.yaml"], LIVE_PROBES)).toEqual(["has-code"]);
+	});
+
+	it("an unclassified file rides review-code ALONGSIDE a classified sibling's gate", () => {
+		// A docs+tooling diff: the .md is has-docs, the un-classed biome.jsonc pulls in has-code
+		// (review-code), so the executable tooling is not left gated only by review-doc.
+		const classes = classify([".decisions/0173-x.md", "biome.jsonc"], LIVE_PROBES);
+		expect(classes).toEqual(["has-code", "has-docs"]);
+		expect(requiredNamespaces(classes)).toContain("review-code");
+	});
+
+	it("an empty diff is still un-gated — the fail-closed default fires only on a real file", () => {
+		expect(classify([], LIVE_PROBES)).toEqual([]);
+	});
+});
+
 describe("classify — fail-closed on an unreadable source over-dispatches, never skips", () => {
 	it("dispatches every class when the source is empty (fail-closed probes)", () => {
 		// A single arbitrary path matches every class under the fail-closed defaults —


### PR DESCRIPTION
## What & why

`pipeline-cli class-probe` classifies a PR's changed files into artifact classes (`has-code` / `has-docs` / `has-skills`), and that class set drives which `review-*` verdicts `ship-it` requires. A changed file matching **none** of the three §CLASS probes — root-level executable build/lint tooling outside the code roots (`biome-plugins/**`, `biome.jsonc`, `turbo.json`, `pnpm-workspace.yaml`, a root `tsconfig`) — left the diff spanning **zero** classes, so `ship-it` required **zero** review verdicts and the PR could merge **un-gated**. That is a fail-**open** in the review gate itself. Surfaced by PR #2760 (GritQL biome plugins), which shipped safe only because it happened to carry an *unrequired* `review-code` PASS.

## Fix (triage's preferred option 1 — fail closed)

Any **unclassified** changed file now rides `has-code` → `review-code` (the general logic gate), so a **non-empty diff can never require zero gates**. An empty diff still spans no class (nothing to gate — the default fires only on a real file). This is the ADR 0092 fail-closed idiom applied as the *default* of the existing classes — **not** a fourth class and **not** a widened `HAS_CODE_RE`. It lives once in the shared `class-probe` core that `ship-it` Step 0 and the reviewer fan both run, so `required == dispatched` holds.

Proof (e2e CLI):
```
$ printf 'biome-plugins/no-console.grit\nbiome.jsonc\n' | pipeline-cli class-probe classify --namespaces
class-probe: 2 changed file(s) → has-code
review-code
```

## Scope guard — no regex change (stays out of #2761)

**No `HAS_*_RE` regex is touched**, so the drift-guard and every lockstep copy (ship-it, reviewer.md, the vitest live-probe fixtures) remain byte-identical and green. Single-sourcing the whole regex is the **separate held issue #2761** — this change does not collide with it: it adds a fail-closed *default* rule, not a regex edit. `§CLASS` prose + the ship-it/reviewer inline references were updated to document the new rule (citing the core as authoritative).

## §CP interaction (unchanged)

This targets the **verification** axis (which gate runs), not the who-merges axis. A no-class PR that is *also* control-plane already stops at human merge via `CONTROL_PLANE_RE`; this closes the gap for the no-class PR that is **not** control-plane.

## Tests

- `class-probe.unit.test.ts` gains a `#2765` describe block: `biome.jsonc`, `biome-plugins/*.grit`, the PR #2760 shape, `turbo.json`/`pnpm-workspace.yaml`, and a mixed docs+tooling diff all assert a non-empty required-namespace set (`review-code`); empty diff stays un-gated.
- Full `@kampus/pipeline-cli` suite: 1138 passed. Drift-guard: OK (22 checks). Typecheck + biome clean.

## §CP — human merge only

This PR lands in `packages/pipeline-cli/**` and `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §CLASS — both match `CONTROL_PLANE_RE`. It is control-plane (a gate the pipeline enforces on itself). **Do not auto-merge / enqueue — a `@kamp-us/control-plane` human approves and merges.**

Fixes #2765