### PR TITLE
feat(design-capture): fail review-design on a thrown render exception (#2594)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -83,6 +83,23 @@ specific prohibition in the verdict:
 6. **Colour-alone meaning.** State or meaning signalled by **colour alone** — a selected/active/error
    state distinguished only by hue, with no second channel (icon, text, shape, weight). (Pillar 4.)
 
+### The render-exception hard-FAIL — a thrown runtime error fails the gate, regardless of the pixels (#2594)
+
+The six above are **visual facts**. This seventh is a **deterministic** one: a UI that throws an
+**uncaught runtime exception** during the capture render (e.g. a `TypeError`) hard-FAILs the gate —
+**even when the captured frame looks acceptable on that tick**. A single screenshot only sees pixels,
+so a mount/init race that crashes on a "bad tick" while rendering fine on a "good tick" (the
+`@kampus/composer` read-only null-editor `TypeError: Cannot read properties of null (reading
+'commands')`, #2593) slipped straight through the visual six and reached live. So the capture render
+also **listens for page errors**, and a thrown exception is a FAIL by itself.
+
+This check is **not a taste call** — it reads the capture helper's per-surface `pageErrors` (Step 2),
+so it is exact and needs no vision judgment. Its verdict is **conjunctive with the six**: a surface
+that threw fails the gate no matter how its screenshot scores. Only an **uncaught exception**
+(`kind: "pageerror"`) hard-FAILs; a bare `console.error` (`kind: "console.error"`) rides **advisory**,
+because dev console.error is noisy (React key/prop warnings) and failing on it would trip the gate on
+benign output — consistent with the fail-conservative calibration.
+
 **Holistic / taste** — cohesiveness drift, muddy hierarchy, cramped rhythm, an off-brand
 composition, a primitive that *could* have been reached for but wasn't yet renders acceptably — is
 **advisory**, surfaced in the same comment under an **Advisory (non-blocking)** heading. Advisory
@@ -291,10 +308,12 @@ implementation legs land to match):
 - **Input:** the preview URL, the route+state surface list (Step 1), an output dir for the PNG bytes,
   and the target `repository_id` (for the upload).
 - **Output (stdout JSON):** one record per captured surface —
-  `{ surface, route, state, localPath, hostedUrl, uploadError }`. `localPath` is the on-disk PNG the
-  gate judges; `hostedUrl` is the GitHub user-attachments URL for evidence (or `null` with
-  `uploadError` set when the undocumented upload endpoint fails — a **tolerated** degradation: the
-  gate still judges `localPath`).
+  `{ surface, route, state, localPath, hostedUrl, uploadError, pageErrors }`. `localPath` is the
+  on-disk PNG the gate judges; `hostedUrl` is the GitHub user-attachments URL for evidence (or `null`
+  with `uploadError` set when the undocumented upload endpoint fails — a **tolerated** degradation:
+  the gate still judges `localPath`). **`pageErrors`** is the array of runtime errors thrown into the
+  page during that surface's render — each `{ kind: "pageerror" | "console.error", text }` — the
+  deterministic #2594 crash signal (a `pageerror` is the hard-FAIL; a `console.error` is advisory).
 
 ```bash
 # Drive the helper (the seam; #2247 owns the Playwright + upload mechanics):
@@ -312,6 +331,24 @@ multimodal input — you look at the actual rendered pixels. The `hostedUrl` is 
 it is embedded in the verdict as evidence only (ADR 0165). If a capture's `hostedUrl` is `null` (an
 upload failure), that does **not** affect the verdict — you judged the local bytes; note the upload
 degradation in the evidence section and proceed.
+
+**Then extract the deterministic render-exception signal** (#2594) — no vision needed, just read
+`pageErrors`. A surface that threw an **uncaught exception** (`kind == "pageerror"`) during its render
+hard-FAILs the gate regardless of how its screenshot looks; a bare `console.error` is advisory. The
+`design-capture` bin also prints a `render FAILED — …` summary to stderr when any surface threw:
+
+```bash
+# uncaught exceptions → hard-FAIL rows (surface + message); console.error → advisory
+RENDER_CRASHES="$(printf '%s' "$CAPTURES" | jq -r '
+  [ .[] | . as $r | $r.pageErrors[]? | select(.kind=="pageerror")
+    | "\($r.surface): \(.text)" ] | .[]')"
+RENDER_ADVISORIES="$(printf '%s' "$CAPTURES" | jq -r '
+  [ .[] | . as $r | $r.pageErrors[]? | select(.kind=="console.error")
+    | "\($r.surface): \(.text)" ] | .[]')"
+```
+
+A non-empty `RENDER_CRASHES` is a **FAIL** (Step 3), naming each thrown error + its surface so a
+`write-code` repair round can act on it cold.
 
 ---
 
@@ -343,9 +380,11 @@ hierarchy, cramped rhythm, a primitive that could have been reached for, an off-
 plus every borderline call you downgraded. These ride in the same comment and **never** flip the
 verdict.
 
-**The design verdict is conjunctive over the six hard-FAIL prohibitions:** every applicable
-prohibition must PASS (or be N/A). One objective FAIL → the PR fails the gate. Advisory notes do not
-count against the verdict.
+**The design verdict is conjunctive over the six hard-FAIL prohibitions plus the deterministic
+render-exception check (#2594):** every applicable prohibition must PASS (or be N/A) **and** no
+surface may have thrown an uncaught exception during its render (`RENDER_CRASHES` empty). One
+objective visual FAIL, or one thrown render exception, → the PR fails the gate. Advisory notes
+(taste + `console.error`) do not count against the verdict.
 
 ---
 
@@ -413,9 +452,10 @@ Reviewed-head: @ <HEAD_SHA>
 - [N/A]  Void empty state — no list/detail empty state in the changed surfaces
 - [PASS] Sub-36px tap target — <surface>: hit area ≥ 36px
 - [PASS] Colour-alone meaning — <surface>: state carries a second channel
+- [PASS] Render exception (#2594) — no surface threw an uncaught exception during render
 
 **Advisory (non-blocking)**
-- <holistic/taste note, or "none">
+- <holistic/taste note, or a captured console.error, or "none">
 
 **Evidence**
 - <surface>[:state] — ![<surface>](<hostedUrl>)
@@ -447,6 +487,7 @@ screenshots are evidence only) — all objective prohibitions pass:
 
 **Hard-FAIL prohibitions (ADR 0162)**
 - [PASS/N/A] <the six, as above>
+- [PASS] Render exception (#2594) — no surface threw an uncaught exception during render
 
 **Advisory (non-blocking)**
 - <note, or "none">
@@ -455,9 +496,10 @@ screenshots are evidence only) — all objective prohibitions pass:
 - <surface>[:state] — ![<surface>](<hostedUrl>)
 ```
 
-### Fail path — an objective prohibition violated
+### Fail path — an objective prohibition violated, or a render exception was thrown
 
-One or more of the six hard-FAIL prohibitions is **objectively** violated. **Nothing merges. The PR
+One or more of the six hard-FAIL prohibitions is **objectively** violated, **or** a surface threw an
+uncaught exception during its render (`RENDER_CRASHES` non-empty, #2594). **Nothing merges. The PR
 stays open; the linked issue stays open and assigned** — don't unassign, relabel, or close. Post the
 SHA-bound FAIL marker (the seam `write-code`'s fix round-trip keys on) with the full per-prohibition
 table — the passing rows too, so the author sees how close they are — and the **specific prohibition
@@ -475,15 +517,17 @@ Reviewed-head: @ <HEAD_SHA>
 - [PASS] <prohibition> — <surface>: <what you saw>
 - [FAIL] Missing focus ring — <surface>: the <control> shows no focus ring in :focus-visible
   (ADR 0162 Pillar 4 — "never ship an interactive control with no focus ring")
+- [FAIL] Render exception (#2594) — <surface>: threw `TypeError: …` during render (uncaught
+  pageerror; the frame looked acceptable on this tick but the surface crashes on a bad tick)
 - [PASS/N/A] <the rest>
 
 **Advisory (non-blocking)**
-- <note, or "none">
+- <note, or a captured console.error, or "none">
 
 **Evidence**
 - <surface>[:state] — ![<surface>](<hostedUrl>)
 
-The FAILed prohibition(s) above must be fixed before this PR can merge. The PR stays open and
+The FAILed prohibition(s) / render exception(s) above must be fixed before this PR can merge. The PR stays open and
 unmerged; #<ISSUE> stays open and assigned. `write-code` repair mode consumes this FAIL — fix on the
 same branch and re-request review.
 ```
@@ -520,10 +564,12 @@ match to paper over a moved head.
 A single invocation gates one UI PR end to end: classify UI-affecting + blocking/non-blocking via the
 canonical §CP set (Step 0, mis-route off-ramp if not a UI PR), resolve the PR / head SHA / preview
 URL / changed surfaces (Step 1), drive the #2247 helper to capture over the preview deploy and read
-the **local bytes** (Step 2), judge each surface against the six objective ADR-0162 prohibitions with
-advisory taste alongside — calibrated to FAIL conservatively (Step 3), then land the SHA-bound
+the **local bytes** + the per-surface `pageErrors` (Step 2), judge each surface against the six
+objective ADR-0162 prohibitions plus the deterministic render-exception check (#2594), with advisory
+taste alongside — calibrated to FAIL conservatively (Step 3), then land the SHA-bound
 `review-design` verdict — PASS (non-blocking) / advisory (blocking) on a full pass, or FAIL on an
-objective violation — with the hosted screenshots embedded as evidence, and close with the read-back
+objective violation or a thrown render exception — with the hosted screenshots embedded as evidence,
+and close with the read-back
 guard (Step 4). **You never merge, and you never emit a `review-code`/`review-doc`/`review-skill`
 marker.**
 

--- a/packages/design-capture/README.md
+++ b/packages/design-capture/README.md
@@ -37,10 +37,13 @@ const records = yield* captureAndUpload({
   token: process.env.GITHUB_TOKEN!,                  // write access to the target repo
 });
 // records: CaptureRecord[] — one per surface:
-//   { surface, route, state, localPath, hostedUrl, uploadError }
+//   { surface, route, state, localPath, hostedUrl, uploadError, pageErrors }
 //   • localPath  — ALWAYS present on a successful capture: the PNG the gate JUDGES
 //   • hostedUrl  — the GitHub asset URL to embed, or null when the upload fell back
 //   • uploadError — the diagnostic when the fallback fired, else null
+//   • pageErrors — runtime errors thrown into the page during THIS render (#2594):
+//       [{ kind: "pageerror" | "console.error", text }] — a `pageerror` (uncaught
+//       exception) hard-fails the gate; a `console.error` is advisory
 ```
 
 - `captureAndUpload(request): Effect<CaptureRecord[], CaptureError, HttpClient>` —
@@ -56,8 +59,10 @@ const records = yield* captureAndUpload({
 
 Pure cores also exported for reuse/testing: `parseSurfaceSpec`,
 `buildCapturePlan`, `joinPreviewUrl`, `surfaceFileName`, `mergeRecord`,
-`parseUploadResponse`, `uploadEndpoint`, and the viewport constants
-(`DESKTOP_VIEWPORT` 1280×800, `MOBILE_VIEWPORT` 390×844, `DEFAULT_VIEWPORT`).
+`parseUploadResponse`, `uploadEndpoint`, `renderCrashFailure` / `isRenderCrash` /
+`toPageError` (the render-exception gate decision, #2594), and the viewport
+constants (`DESKTOP_VIEWPORT` 1280×800, `MOBILE_VIEWPORT` 390×844,
+`DEFAULT_VIEWPORT`).
 
 ## `localPath` is the primary judged artifact — never lost to an upload failure
 
@@ -67,6 +72,20 @@ afterward (`mergeRecord`). So even when the upload endpoint is down, the record
 still carries `localPath` — the gate has bytes to judge **exactly** when hosting
 fails. (This is the correctness fix over an earlier shape that dropped the image
 on the fallback path.)
+
+## A thrown render exception fails the gate — regardless of the pixels (#2594)
+
+A single screenshot only sees pixels, so a mount/init race that throws on a "bad
+tick" but renders fine on a "good tick" (the `@kampus/composer` read-only
+null-editor `TypeError`, #2593) slipped past the visual prohibitions and reached
+live. So the capture render **listens for page errors** across the whole
+navigation window (`page.on("pageerror" | "console")`, attached before `goto`) and
+returns them per surface as `pageErrors`. An uncaught exception (`kind:
+"pageerror"`) is a **hard FAIL** for the `review-design` gate; a `console.error` is
+**advisory** (dev console.error is noisy — React key/prop warnings — so failing on
+it would trip the gate on benign output). The pure decision core
+(`renderCrashFailure`) is unit-tested against the #2593 crash class; the `capture`
+bin also prints a `render FAILED — …` summary to stderr when any surface threw.
 
 ## The undocumented endpoint + the fallback (load-bearing)
 

--- a/packages/design-capture/src/bin.ts
+++ b/packages/design-capture/src/bin.ts
@@ -23,6 +23,7 @@ import {Config, Console, Effect, Redacted} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {captureAndUpload} from "./orchestrate.ts";
+import {renderCrashFailure} from "./page-errors.ts";
 import {parseSurfaceSpec} from "./plan.ts";
 
 const previewUrlFlag = Flag.string("preview-url").pipe(
@@ -61,6 +62,12 @@ const capture = Command.make(
 			token: Redacted.value(token),
 		}).pipe(Effect.provide(FetchHttpClient.layer));
 		yield* Console.log(JSON.stringify(records, null, 2));
+		// stdout stays the clean JSON array (the gate's input); the crash summary
+		// goes to stderr as a loud operator signal without perturbing the contract.
+		const crash = renderCrashFailure(records);
+		if (crash !== null) {
+			yield* Console.error(`design-capture: render FAILED — ${crash}`);
+		}
 	}),
 ).pipe(Command.withDescription("Capture a PR's changed surfaces over its preview and host them"));
 

--- a/packages/design-capture/src/capture.ts
+++ b/packages/design-capture/src/capture.ts
@@ -13,12 +13,17 @@
  * Captures over the EXISTING per-PR preview deploy (#2247): the caller passes
  * URLs already rooted at the preview the `preview-deploy` bot stood up — this
  * helper never serves the app itself.
+ *
+ * Each capture also collects the runtime errors thrown into the page during the
+ * render (`pageErrors`) — the crash signal the gate fails on when a mount/init
+ * race throws on a bad tick (see `page-errors.ts`, #2594).
  */
 import {mkdir, writeFile} from "node:fs/promises";
 import {join} from "node:path";
 import {chromium} from "@playwright/test";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {type PageError, toPageError} from "./page-errors.ts";
 import type {Shot} from "./plan.ts";
 
 /** The captured bytes + on-disk path for one surface. */
@@ -31,6 +36,8 @@ export interface CapturedSurface {
 	/** The filesystem-safe PNG name (basename of `localPath`) — also the upload attachment name. */
 	readonly fileName: string;
 	readonly pngBytes: Uint8Array;
+	/** Runtime errors thrown into the page during this render — the #2594 crash signal. */
+	readonly pageErrors: readonly PageError[];
 }
 
 /** A Playwright launch/navigation/screenshot/write failure — surfaced, never swallowed. */
@@ -79,6 +86,17 @@ export const captureShots = (
 							const page = await browser.newPage({
 								viewport: {width: shot.viewport.width, height: shot.viewport.height},
 							});
+							// Listen across the WHOLE navigation window (attached before goto), so a
+							// runtime error thrown during mount/init is caught even when the frame
+							// still renders acceptably (#2594). `networkidle` already settles past
+							// React mount + effects, so no arbitrary sleep is needed — the events
+							// have fired by the time goto resolves.
+							const pageErrors: PageError[] = [];
+							page.on("pageerror", (err) => pageErrors.push(toPageError("pageerror", String(err))));
+							page.on("console", (msg) => {
+								if (msg.type() === "error")
+									pageErrors.push(toPageError("console.error", msg.text()));
+							});
 							try {
 								await page.goto(shot.url, {waitUntil: "networkidle", timeout: navigationTimeoutMs});
 								const buffer = await page.screenshot({type: "png", fullPage});
@@ -91,6 +109,7 @@ export const captureShots = (
 									localPath,
 									fileName: shot.fileName,
 									pngBytes: new Uint8Array(buffer),
+									pageErrors,
 								};
 							} finally {
 								await page.close();

--- a/packages/design-capture/src/index.ts
+++ b/packages/design-capture/src/index.ts
@@ -13,6 +13,8 @@ export type {CapturedSurface, CaptureOptions} from "./capture.ts";
 export {CaptureError, captureShots} from "./capture.ts";
 export type {CaptureAndUploadRequest, CaptureRecord} from "./orchestrate.ts";
 export {captureAndUpload, hostedUrls, mergeRecord} from "./orchestrate.ts";
+export type {PageError, SurfacePageErrors} from "./page-errors.ts";
+export {isRenderCrash, renderCrashFailure, toPageError} from "./page-errors.ts";
 export type {Shot, Surface, Viewport} from "./plan.ts";
 export {
 	buildCapturePlan,

--- a/packages/design-capture/src/orchestrate.ts
+++ b/packages/design-capture/src/orchestrate.ts
@@ -21,6 +21,7 @@
 import {Effect} from "effect";
 import type {HttpClient} from "effect/unstable/http/HttpClient";
 import {type CapturedSurface, CaptureError, type CaptureOptions, captureShots} from "./capture.ts";
+import type {PageError} from "./page-errors.ts";
 import {buildCapturePlan, type Surface, type Viewport} from "./plan.ts";
 import {type UploadOutcome, uploadAsset} from "./upload.ts";
 
@@ -35,6 +36,8 @@ export interface CaptureRecord {
 	readonly hostedUrl: string | null;
 	/** The upload diagnostic when the fallback fired, else `null`. */
 	readonly uploadError: string | null;
+	/** Runtime errors thrown into the page during the render — the #2594 crash signal. */
+	readonly pageErrors: readonly PageError[];
 }
 
 export interface CaptureAndUploadRequest {
@@ -67,6 +70,7 @@ export const mergeRecord = (captured: CapturedSurface, outcome: UploadOutcome): 
 	localPath: captured.localPath,
 	hostedUrl: outcome.hostedUrl,
 	uploadError: outcome.uploadError,
+	pageErrors: captured.pageErrors,
 });
 
 /**

--- a/packages/design-capture/src/orchestrate.unit.test.ts
+++ b/packages/design-capture/src/orchestrate.unit.test.ts
@@ -16,6 +16,7 @@ const captured: CapturedSurface = {
 	localPath: "/tmp/out/sozluk-empty@desktop.png",
 	fileName: "sozluk-empty@desktop.png",
 	pngBytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+	pageErrors: [],
 };
 
 describe("mergeRecord — localPath is always preserved", () => {
@@ -29,7 +30,21 @@ describe("mergeRecord — localPath is always preserved", () => {
 			localPath: "/tmp/out/sozluk-empty@desktop.png",
 			hostedUrl: url,
 			uploadError: null,
+			pageErrors: [],
 		});
+	});
+
+	it("carries the captured pageErrors through onto the record (#2594 crash signal)", () => {
+		const crashed: CapturedSurface = {
+			...captured,
+			pageErrors: [
+				{kind: "pageerror", text: "TypeError: Cannot read properties of null (reading 'commands')"},
+			],
+		};
+		const rec = mergeRecord(crashed, {hostedUrl: null, uploadError: null});
+		assert.deepStrictEqual(rec.pageErrors, [
+			{kind: "pageerror", text: "TypeError: Cannot read properties of null (reading 'commands')"},
+		]);
 	});
 
 	it("KEEPS localPath when the upload fell back (hostedUrl null, uploadError set)", () => {
@@ -40,11 +55,12 @@ describe("mergeRecord — localPath is always preserved", () => {
 		assert.strictEqual(rec.uploadError, "HTTP 500: boom");
 	});
 
-	it("emits exactly the {surface, route, state, localPath, hostedUrl, uploadError} shape", () => {
+	it("emits the {surface, route, state, localPath, hostedUrl, uploadError, pageErrors} shape", () => {
 		const rec = mergeRecord(captured, {hostedUrl: null, uploadError: "x"});
 		assert.deepStrictEqual(Object.keys(rec).sort(), [
 			"hostedUrl",
 			"localPath",
+			"pageErrors",
 			"route",
 			"state",
 			"surface",

--- a/packages/design-capture/src/page-errors.ts
+++ b/packages/design-capture/src/page-errors.ts
@@ -1,0 +1,65 @@
+/**
+ * The render-crash signal the review-design gate fails on (#2594).
+ *
+ * A single screenshot only sees pixels. A mount/init race — e.g. the #2593
+ * composer null-editor `TypeError: Cannot read properties of null (reading
+ * 'commands')`, thrown when `setContent` runs before the tiptap instance exists —
+ * throws a runtime exception into the page on a "bad tick" while the captured
+ * frame still looks acceptable. The six visual prohibitions never see it, so the
+ * gate green-lit a component that hard-crashes for a fraction of loads. The fix:
+ * the capture render also LISTENS for runtime errors, and a thrown uncaught
+ * exception is a hard FAIL regardless of how the frame looks.
+ *
+ * This is the pure classification + failure-formatting core (`capture.ts` wires
+ * the Playwright `pageerror`/`console` listeners that feed it; the review-design
+ * skill reads each surface's `pageErrors` to decide the deterministic FAIL). An
+ * uncaught `pageerror` is the crash signal; a `console.error` is captured too but
+ * only advises — console.error is noisy in dev (React key/prop warnings), so
+ * failing on it would trip the gate on benign output, against its
+ * fail-conservative calibration.
+ */
+
+/** A runtime error observed in the page during a capture render. */
+export interface PageError {
+	/**
+	 * `pageerror` = an uncaught exception (the hard-FAIL crash signal);
+	 * `console.error` = an error logged via the console (advisory — noisy in dev).
+	 */
+	readonly kind: "pageerror" | "console.error";
+	/** The error text as the page reported it (message, or `(no message)`). */
+	readonly text: string;
+}
+
+/** One captured surface's observed page errors — the input to the gate decision. */
+export interface SurfacePageErrors {
+	readonly surface: string;
+	readonly pageErrors: readonly PageError[];
+}
+
+/** Normalize a raw page-event string into a {@link PageError}, defaulting empty text. */
+export const toPageError = (kind: PageError["kind"], text: string): PageError => {
+	const trimmed = text.trim();
+	return {kind, text: trimmed.length === 0 ? "(no message)" : trimmed};
+};
+
+/** Only an uncaught exception hard-fails the gate; console.error rides advisory. */
+export const isRenderCrash = (error: PageError): boolean => error.kind === "pageerror";
+
+/**
+ * The deterministic gate FAIL: name every uncaught exception thrown during the
+ * capture render plus the surface it crashed on, or `null` when nothing threw.
+ * `console.error` entries are excluded here — they surface as advisory, never a
+ * hard FAIL. The summary is what the review-design verdict cites so a `write-code`
+ * repair round can act on it cold (the error message + the surface under review).
+ */
+export const renderCrashFailure = (surfaces: readonly SurfacePageErrors[]): string | null => {
+	const lines = surfaces.flatMap((s) =>
+		s.pageErrors.filter(isRenderCrash).map((e) => `- ${s.surface}: ${e.text}`),
+	);
+	if (lines.length === 0) {
+		return null;
+	}
+	const n = lines.length;
+	const noun = n === 1 ? "exception" : "exceptions";
+	return `${n} uncaught runtime ${noun} thrown during capture render:\n${lines.join("\n")}`;
+};

--- a/packages/design-capture/src/page-errors.unit.test.ts
+++ b/packages/design-capture/src/page-errors.unit.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The render-crash gate decision (#2594): an uncaught runtime exception thrown
+ * during the capture render hard-fails review-design regardless of how the frame
+ * looks, and the failure names the error + the surface it crashed on. The
+ * load-bearing case is the concrete #2593 escape — the `@kampus/composer`
+ * read-only null-editor `TypeError` — which a single good-tick screenshot missed.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	isRenderCrash,
+	type PageError,
+	renderCrashFailure,
+	type SurfacePageErrors,
+	toPageError,
+} from "./page-errors.ts";
+
+describe("toPageError — normalization", () => {
+	it("trims the reported text", () => {
+		assert.deepStrictEqual(toPageError("pageerror", "  TypeError: boom  "), {
+			kind: "pageerror",
+			text: "TypeError: boom",
+		});
+	});
+
+	it("defaults empty text to a placeholder rather than an empty string", () => {
+		assert.strictEqual(toPageError("console.error", "   ").text, "(no message)");
+	});
+});
+
+describe("isRenderCrash — only uncaught exceptions hard-fail", () => {
+	it("treats an uncaught pageerror as a crash", () => {
+		assert.strictEqual(isRenderCrash({kind: "pageerror", text: "TypeError: x"}), true);
+	});
+
+	it("does NOT treat a console.error as a crash (advisory — noisy in dev)", () => {
+		assert.strictEqual(isRenderCrash({kind: "console.error", text: "Warning: bad key"}), false);
+	});
+});
+
+describe("renderCrashFailure — the deterministic gate FAIL", () => {
+	it("returns null when no surface threw", () => {
+		const surfaces: SurfacePageErrors[] = [
+			{surface: "/sozluk", pageErrors: []},
+			{surface: "/pano", pageErrors: []},
+		];
+		assert.strictEqual(renderCrashFailure(surfaces), null);
+	});
+
+	it("catches the #2593 composer null-editor TypeError on a bad tick, naming error + surface", () => {
+		// The concrete escape: the read-only composer calls setContent before the
+		// tiptap editor exists — a good-tick screenshot rendered fine, so the six
+		// visual prohibitions passed while THIS uncaught exception was thrown.
+		const nullEditor: PageError = {
+			kind: "pageerror",
+			text: "TypeError: Cannot read properties of null (reading 'commands')",
+		};
+		const surfaces: SurfacePageErrors[] = [
+			{surface: "/mecmua/read-only", pageErrors: [nullEditor]},
+		];
+		const failure = renderCrashFailure(surfaces);
+		assert.isNotNull(failure);
+		assert.match(failure as string, /1 uncaught runtime exception thrown during capture render/);
+		assert.include(failure as string, "/mecmua/read-only");
+		assert.include(failure as string, "reading 'commands'");
+	});
+
+	it("ignores console.error entries — they never flip the verdict", () => {
+		const surfaces: SurfacePageErrors[] = [
+			{
+				surface: "/sozluk",
+				pageErrors: [{kind: "console.error", text: "Warning: missing key prop"}],
+			},
+		];
+		assert.strictEqual(renderCrashFailure(surfaces), null);
+	});
+
+	it("pluralizes and lists every crashed surface", () => {
+		const surfaces: SurfacePageErrors[] = [
+			{surface: "/a", pageErrors: [{kind: "pageerror", text: "TypeError: a"}]},
+			{surface: "/b", pageErrors: [{kind: "console.error", text: "warn"}]},
+			{surface: "/c", pageErrors: [{kind: "pageerror", text: "ReferenceError: c"}]},
+		];
+		const failure = renderCrashFailure(surfaces);
+		assert.match(failure as string, /2 uncaught runtime exceptions thrown during capture render/);
+		assert.include(failure as string, "/a: TypeError: a");
+		assert.include(failure as string, "/c: ReferenceError: c");
+		assert.notInclude(failure as string, "/b");
+	});
+});


### PR DESCRIPTION
## What & why

`review-design` took a **single Playwright render** and judged only the pixels. A mount/init race that throws on a "bad tick" but renders fine on a "good tick" — the `@kampus/composer` read-only null-editor `TypeError: Cannot read properties of null (reading 'commands')` (#2593) — slipped straight past the six visual prohibitions and reached live. The gate never even *listened* for the thrown error: it judged a frame while a `TypeError` was thrown into the page console.

This makes the gate fail on a thrown runtime exception **regardless of how the captured frame looks**.

## The change

- **`packages/design-capture/src/capture.ts`** — the capture render now attaches `page.on("pageerror")` + `page.on("console")` listeners **before `goto`**, across the whole navigation window, and returns the collected errors per surface as `pageErrors`. No arbitrary sleep: `networkidle` (already in place) settles past React mount + effects, so the events have fired by the time `goto` resolves — a deterministic readiness signal, not a guess.
- **`packages/design-capture/src/page-errors.ts`** (new, pure core) — `renderCrashFailure` is the deterministic gate decision: it names every **uncaught exception** (`kind: "pageerror"`) + the surface it crashed on, or `null` when nothing threw. A bare `console.error` (`kind: "console.error"`) rides **advisory** — dev `console.error` is noisy (React key/prop warnings), so failing on it would trip the gate on benign output, against its fail-conservative calibration.
- **`orchestrate.ts` / `index.ts` / `bin.ts`** — `pageErrors` flows onto each `CaptureRecord`; the `capture` bin keeps its stdout JSON-array contract and additionally prints a `render FAILED — …` summary to **stderr** when any surface threw.
- **`review-design/SKILL.md`** — states the render-exception check as part of the gate's contract: a new deterministic hard-FAIL alongside the six visual prohibitions, the `pageErrors` record field, the jq extraction, and a `Render exception` row in all three verdict templates.

## Tests

- **`page-errors.unit.test.ts`** (new) — verifies the decision against the concrete #2593 case: a `TypeError: Cannot read properties of null (reading 'commands')` on `/mecmua/read-only` produces a FAIL naming the error + surface; `console.error` never flips the verdict; plural/multi-surface formatting.
- **`orchestrate.unit.test.ts`** — pins that `pageErrors` flows through `mergeRecord` and the record shape.
- Full package: 46 unit tests pass; typecheck + biome clean.

## Scope

Per the issue's triage note, this is the **console-exception capture** fix that closes the described gap on its own. Multi-sample / remount-stress renders (for tick-dependent races that do *not* throw) remain a separate follow-up, not scoped here.

## §CP — control-plane change, human-merge only

This touches a gate-critical pipeline skill (`review-design`), so `CONTROL_PLANE_RE` matches → **do not auto-ship / enqueue**. Reviewed-ready → cansirin.

Fixes #2594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
