### PR TITLE
feat(web): divan moderation IA + Turkish copy pass (#2726)

### DIFF
--- a/apps/web/src/components/divan/ActorDrawer.tsx
+++ b/apps/web/src/components/divan/ActorDrawer.tsx
@@ -98,14 +98,14 @@ export function ActorDrawer({
 					</div>
 				)}
 				<div className="kp-actor__tell">
-					<dt className="kp-actor__tell-key">bildirilen</dt>
+					<dt className="kp-actor__tell-key">bildiren</dt>
 					<dd className="kp-actor__tell-val" data-testid="actor-bildirilen">
 						{bildirilenLabel(standing.distinctReporters)}
 					</dd>
 				</div>
 				{kefilDurumu !== null && (
 					<div className="kp-actor__tell">
-						<dt className="kp-actor__tell-key">kefil durumu</dt>
+						<dt className="kp-actor__tell-key">kefil</dt>
 						<dd className="kp-actor__tell-val" data-testid="actor-kefil">
 							{kefilDurumu}
 						</dd>

--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -440,13 +440,36 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: baseline;
-	gap: var(--s-2);
+	gap: var(--s-3);
+	flex-wrap: wrap;
 	font: var(--t-meta);
 	color: var(--text-muted);
 }
 
-.kp-triage__keys {
+.kp-triage__pos {
+	font-variant-numeric: tabular-nums;
+}
+
+/* The keyboard legend (#2726): the founder-flagged dense strip rebuilt as a scannable
+   row of keycap chips + their action, wrapping on narrow surfaces. */
+.kp-triage__legend {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--s-1) var(--s-3);
+}
+
+.kp-triage__legend-item {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--s-1);
+}
+
+.kp-triage__legend-label {
 	text-transform: lowercase;
+	color: var(--text-muted);
 }
 
 /* Shell (surface-raised · border · r-sm · pad-lg) is the shared Surface primitive

--- a/apps/web/src/components/divan/TriageLoop.tsx
+++ b/apps/web/src/components/divan/TriageLoop.tsx
@@ -17,6 +17,7 @@
 import {useCallback, useEffect, useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {OpenReport, ResolveReceipt} from "../../../worker/features/report/views";
+import {Kbd} from "../ui/atoms";
 import {Surface} from "../ui/Card";
 import {ActorDrawer} from "./ActorDrawer";
 import {type Chamber, drawerDefaultOpen, drawerKeyToAction, hopTarget} from "./actor-drawer";
@@ -53,6 +54,7 @@ import {
 	moveFocus,
 	needsConfirm,
 	reporterDiversityLabel,
+	triageLegend,
 	type Verdict,
 } from "./triage-loop";
 
@@ -384,12 +386,19 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 	return (
 		<div className="kp-triage" data-testid="triage-loop">
 			<div className="kp-triage__hud" aria-hidden="true">
-				<span>
+				<span className="kp-triage__pos">
 					{Math.min(index, live.length - 1) + 1} / {live.length}
 				</span>
-				<span className="kp-triage__keys">
-					j/k gez · Y yoksay · R kaldır · U geri al · O göster · A künye · V/M oda · X dalga
-				</span>
+				<ul className="kp-triage__legend">
+					{triageLegend.map((entry) => (
+						<li className="kp-triage__legend-item" key={entry.label}>
+							{entry.keys.map((k) => (
+								<Kbd key={k}>{k}</Kbd>
+							))}
+							<span className="kp-triage__legend-label">{entry.label}</span>
+						</li>
+					))}
+				</ul>
 			</div>
 
 			<div className="kp-triage__stage" data-drawer={drawerOpen}>

--- a/apps/web/src/components/divan/actor-drawer.test.ts
+++ b/apps/web/src/components/divan/actor-drawer.test.ts
@@ -112,19 +112,19 @@ describe("uretimLabel — the actor's live content footprint", () => {
 
 describe("kaldirilanLabel — the prior-removals trust tell", () => {
 	it("counts removals when the actor has them", () => {
-		expect(kaldirilanLabel(2)).toBe("2 kaldırılan");
+		expect(kaldirilanLabel(2)).toBe("2 kaldırıldı");
 	});
 
-	it("reads temiz sicil at zero, null when unresolved", () => {
-		expect(kaldirilanLabel(0)).toBe("temiz sicil");
+	it("reads temiz at zero (the value no longer re-states the sicil key), null when unresolved", () => {
+		expect(kaldirilanLabel(0)).toBe("temiz");
 		expect(kaldirilanLabel(null)).toBeNull();
 	});
 });
 
 describe("bildirilenLabel — the pile-on breadth tell", () => {
-	it("counts distinct reporters, clamped to at least 1", () => {
-		expect(bildirilenLabel(7)).toBe("7 kişi bildirdi");
-		expect(bildirilenLabel(0)).toBe("1 kişi bildirdi");
+	it("counts distinct reporters (bare count under the bildiren key), clamped to at least 1", () => {
+		expect(bildirilenLabel(7)).toBe("7 kişi");
+		expect(bildirilenLabel(0)).toBe("1 kişi");
 	});
 });
 
@@ -137,13 +137,13 @@ describe("kefilDurumuLabel — the vouch tell", () => {
 });
 
 describe("buAktorLabel — the #1855 remove-the-wave entry point", () => {
-	it("counts the actor's other reported targets", () => {
-		expect(buAktorLabel(3)).toBe("bu aktörün 3 raporlu içeriği var");
+	it("counts the actor's other reported targets (bare under the bu aktör key)", () => {
+		expect(buAktorLabel(3)).toBe("3 raporlu içerik");
 	});
 
-	it("reads the clean singular line at 0/1, null when unresolved", () => {
-		expect(buAktorLabel(1)).toBe("bu aktörün başka raporlu içeriği yok");
-		expect(buAktorLabel(0)).toBe("bu aktörün başka raporlu içeriği yok");
+	it("reads the clean line at 0/1, null when unresolved", () => {
+		expect(buAktorLabel(1)).toBe("başka raporlu içerik yok");
+		expect(buAktorLabel(0)).toBe("başka raporlu içerik yok");
 		expect(buAktorLabel(null)).toBeNull();
 	});
 });

--- a/apps/web/src/components/divan/actor-drawer.ts
+++ b/apps/web/src/components/divan/actor-drawer.ts
@@ -131,24 +131,26 @@ export function uretimLabel(standing: ActorStanding): string | null {
 }
 
 /**
- * The `kaldırılan` trust tell (ADR 0138): `N kaldırılan` when the actor has prior
- * removals, else the clean `temiz sicil`. `null` when unresolved — the drawer then
+ * The `sicil` trust tell (ADR 0138): `N kaldırıldı` when the actor has prior removals,
+ * else the clean `temiz` — read under the `sicil` key, so the value no longer re-states
+ * the noun (the old `temiz sicil` doubled it). `null` when unresolved — the drawer then
  * renders no removal line rather than a false "temiz".
  */
 export function kaldirilanLabel(priorRemovals: number | null): string | null {
 	if (priorRemovals === null) return null;
-	if (priorRemovals <= 0) return "temiz sicil";
-	return `${priorRemovals} kaldırılan`;
+	if (priorRemovals <= 0) return "temiz";
+	return `${priorRemovals} kaldırıldı`;
 }
 
 /**
- * The `bildirilen` trust tell (ADR 0138): `N kişi bildirdi` — how many distinct
- * reporters stand behind the focused report, the pile-on's real breadth. Clamped to ≥1
- * for a real reported target; the diversity numerator #1855's wave slice also reads.
+ * The `bildiren` trust tell (ADR 0138): `N kişi` — how many distinct reporters stand
+ * behind the focused report, the pile-on's real breadth. Read under the `bildiren` key,
+ * so the value is the bare count (the old `N kişi bildirdi` re-stated the verb). Clamped
+ * to ≥1 for a real reported target; the diversity numerator #1855's wave slice also reads.
  */
 export function bildirilenLabel(distinctReporters: number): string {
 	const n = Math.max(1, Math.floor(distinctReporters));
-	return `${n} kişi bildirdi`;
+	return `${n} kişi`;
 }
 
 /**
@@ -162,12 +164,13 @@ export function kefilDurumuLabel(kefil: boolean | null): string | null {
 }
 
 /**
- * The "bu aktör" line (ADR 0138): `bu aktörün N raporlu içeriği var` — the entry point
- * #1855's remove-the-wave grows from (actor-grouped selection). `null` when unresolved.
- * Zero renders the singular clean line (`bu aktörün başka raporlu içeriği yok`).
+ * The "bu aktör" line (ADR 0138): `N raporlu içerik` — the entry point #1855's
+ * remove-the-wave grows from (actor-grouped selection). Read under the `bu aktör` key,
+ * so the value no longer re-states "bu aktörün" (the old line doubled it). `null` when
+ * unresolved. Zero/one renders the clean `başka raporlu içerik yok`.
  */
 export function buAktorLabel(reportedTargets: number | null): string | null {
 	if (reportedTargets === null) return null;
-	if (reportedTargets <= 1) return "bu aktörün başka raporlu içeriği yok";
-	return `bu aktörün ${reportedTargets} raporlu içeriği var`;
+	if (reportedTargets <= 1) return "başka raporlu içerik yok";
+	return `${reportedTargets} raporlu içerik`;
 }

--- a/apps/web/src/components/divan/triage-loop.test.ts
+++ b/apps/web/src/components/divan/triage-loop.test.ts
@@ -20,6 +20,7 @@ import {
 	needsConfirm,
 	nextChamber,
 	reporterDiversityLabel,
+	triageLegend,
 } from "./triage-loop";
 
 const q = (...ids: string[]): ReadonlyArray<{targetKind: TargetKind; targetId: string}> =>
@@ -165,7 +166,7 @@ describe("authorReputationLabel — the reputation-in-row copy", () => {
 
 describe("maskedExcerpt — the reveal-on-O gate (never force-fed a slur)", () => {
 	it("masks the excerpt by default, hinting O to reveal", () => {
-		expect(maskedExcerpt("kötü söz", false)).toBe("içerik gizli — göstermek için O");
+		expect(maskedExcerpt("kötü söz", false)).toBe("içerik gizli · O ile göster");
 	});
 
 	it("shows the excerpt once revealed", () => {
@@ -185,5 +186,24 @@ describe("drainedLabel — the earned empty state", () => {
 
 	it("reads clean without a count for an already-empty queue", () => {
 		expect(drainedLabel(0)).toBe("raporlar temiz");
+	});
+});
+
+describe("triageLegend — the HUD key legend (#2726)", () => {
+	it("names every bound gesture with keycap(s) + a lowercase action", () => {
+		const byLabel = new Map(triageLegend.map((e) => [e.label, e.keys]));
+		expect(byLabel.get("gez")).toEqual(["j", "k"]);
+		expect(byLabel.get("yoksay")).toEqual(["Y"]);
+		expect(byLabel.get("kaldır")).toEqual(["R"]);
+		expect(byLabel.get("bölme")).toEqual(["V", "M"]);
+		expect(byLabel.get("dalga")).toEqual(["X"]);
+	});
+
+	it("carries a keycap for every verdict/undo/reveal binding keyToAction maps", () => {
+		const legendKeys = new Set(triageLegend.flatMap((e) => e.keys));
+		for (const k of ["j", "k", "Y", "R", "U", "O"]) {
+			expect(keyToAction(k)).not.toBeNull();
+			expect(legendKeys.has(k)).toBe(true);
+		}
 	});
 });

--- a/apps/web/src/components/divan/triage-loop.ts
+++ b/apps/web/src/components/divan/triage-loop.ts
@@ -182,8 +182,31 @@ export function authorReputationLabel(
 export function maskedExcerpt(excerpt: string | null, revealed: boolean): string {
 	const trimmed = excerpt?.trim();
 	if (!trimmed) return "içerik yüklenemedi";
-	return revealed ? trimmed : "içerik gizli — göstermek için O";
+	return revealed ? trimmed : "içerik gizli · O ile göster";
 }
+
+/**
+ * The keyboard legend the HUD renders (ADR 0138): one entry per bound gesture — the
+ * keycap(s) plus its lowercase-Turkish action. The founder-flagged dense strip is
+ * replaced by this structured legend so a moderator can scan the loop's grammar; the
+ * keycaps render as `<kbd>` chips (the manifest's key-legend rule). Copy lives here,
+ * DOM-free, beside the `keyToAction` map it mirrors.
+ */
+export interface LegendEntry {
+	readonly keys: ReadonlyArray<string>;
+	readonly label: string;
+}
+
+export const triageLegend: ReadonlyArray<LegendEntry> = [
+	{keys: ["j", "k"], label: "gez"},
+	{keys: ["Y"], label: "yoksay"},
+	{keys: ["R"], label: "kaldır"},
+	{keys: ["U"], label: "geri al"},
+	{keys: ["O"], label: "göster"},
+	{keys: ["A"], label: "künye"},
+	{keys: ["V", "M"], label: "bölme"},
+	{keys: ["X"], label: "dalga"},
+];
 
 /**
  * The earned drained-queue line (ADR 0138): `raporlar temiz` plus today's decision

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -117,8 +117,8 @@ function DivanWorkspace() {
 				<header className="kp-divan__masthead">
 					<h1 className="kp-divan__title">divan</h1>
 					<p className="kp-divan__lead">
-						çaylakların incelemedeki katkılarını burada değerlendirirsin. en çok katkı veren, en az
-						incelenen çaylaklar üstte.
+						çaylakların ürettiklerini burada değerlendirirsin. en çok üreten, en az incelenmiş
+						çaylaklar üstte.
 					</p>
 				</header>
 


### PR DESCRIPTION
## What

IA redesign + Turkish copy pass on the `/divan` moderation surface — both dimensions the founder flagged on the live page (issue #2726). Scoped to the moderation-page IA + copy; the divan Subnav containment (#2604) is untouched.

### Information architecture
- **Triage HUD legend.** The dense, cryptic shortcut strip (`j/k gez · Y yoksay · R kaldır · …`) is rebuilt as a scannable legend of keycap chips + their action, reaching for the shared `Kbd` atom (the manifest's key-legend idiom: keycaps belong in `<kbd>`). The chips wrap on narrow surfaces; the position counter gets `tabular-nums`.
- **Actor künye card.** The tell rows no longer double the noun in key **and** value — `sicil: temiz`, `bildiren: N kişi`, `bu aktör: N raporlu içerik` (was `sicil: temiz sicil`, `bildirilen: N kişi bildirdi`, `bu aktör: bu aktörün N raporlu içeriği var`), so the künye reads as a clean key→value card.

### Turkish copy pass (grounded in `.glossary/LANGUAGE.md`)
- masthead lead → `çaylakların ürettiklerini burada değerlendirirsin. en çok üreten, en az incelenmiş çaylaklar üstte.`
- masked excerpt → `içerik gizli · O ile göster` (was `içerik gizli — göstermek için O`)
- HUD chamber action label `oda` → `bölme`

The reveal-on-`O` masking behavior (ADR 0138 — a mod isn't force-fed a slur) is preserved; only the copy is corrected. The `rapor`/`raporlu` noun is left as-is — reclassifying it to `bildirim` is the separate #2613.

## Testing
- `pnpm --filter @kampus/web test:unit` — 2141 pass (updated the divan copy assertions + added a `triageLegend` test asserting every verdict/undo/reveal binding carries a keycap).
- `pnpm --filter @kampus/web test:client` — 204 pass.
- `pnpm --filter @kampus/web typecheck` — clean. Biome clean (one pre-existing `.kp-wave` descending-specificity warning, untouched).

Fixes #2726

🤖 Generated with [Claude Code](https://claude.com/claude-code)