### PR TITLE
fix(pipeline): guard verdict-marker SHA emission against mktemp-path leak (#2683)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1229,42 +1229,46 @@ wrapping the APPROVE call (e.g. `… 2>&1 | head` for inspection) makes the pipe
 status mask the APPROVE failure, so the `||` fallback silently never fires and no verdict
 lands.
 
-The comment fallback **upserts**, it does not append: scan the PR for *your own* prior
-`review-code:` marker comment and `PATCH` it with the fresh verdict instead of `POST`-ing a
-new one, so there is exactly **one** `review-code` verdict comment per PR (ADR 0058 rule 2).
-A re-review of a new head overwrites the same record with the new `@ <sha>`; the thread never
-accumulates a stale verdict stream. The `… | last | .id` upsert PATCHes only your *newest* own
-marker, so on a PR migrated from the pre-0058 append era a few older SHA-less own markers may
-linger — the one-per-gate invariant is **forward-looking**, and those legacy duplicates are
-tolerated because `ship-it`'s consumer SHA-refuses any marker without an `@ <sha>` on the
-current head (Step 2b), so they can never authorize a merge.
+The comment fallback **upserts**, it does not append: exactly **one** `review-code` verdict
+comment per PR (ADR 0058 rule 2) — a re-review of a new head overwrites the same record with
+the new `@ <sha>`. The upsert (scan your own prior `review-code:` marker → `PATCH` it, else
+`POST`) plus its emission guards are the ADR-0058 glue **all four gates share**, so — exactly as
+`review-doc` — post through the deterministic, unit-tested tool (`pipeline-cli verdict post`,
+#2102), never a hand-rolled `jq`. **The tool is the marker-emit choke point:** `verdict post`
+runs the `emissionDefect` gate on your body and **refuses fail-closed** unless every SHA field is
+a clean full 40-hex head SHA — closing the mktemp-path leak where a scratch path bled into the
+`@ <sha>` field (#2683), the empty-`@-` case (#2646), and any cross-namespace body. For the
+native `APPROVE` path (which posts a review, not a comment `verdict post` can guard), run the
+**same** gate as an explicit read-back assertion first — `verdict validate` — so a malformed
+marker fails loud **before** the APPROVE, never landing in a public review body.
 
 ```bash
+# resolve the verdict CLI once — in-repo-first, published-fallback (ADR 0062/0064; epic #994)
+if [ -f packages/pipeline-cli/src/bin.ts ]; then
+  VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin
+else
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"     # foreign install: the published CLI
+fi
+
 VERDICT_FILE="$(mktemp /tmp/review-code-verdict.XXXXXX)"
-BODY="$(cat "$VERDICT_FILE")"   # first line: review-code: PASS @ <HEAD_SHA> — merge-ready
+# write your composed PASS verdict into "$VERDICT_FILE" (first line: review-code: PASS @ <HEAD_SHA> — merge-ready)
+BODY="$(cat "$VERDICT_FILE")"
+# Read-back assertion BEFORE the native APPROVE: the same gate `verdict post` enforces, so a
+# malformed `@ <sha>` (e.g. an mktemp scratch path, #2683) fails loud here, never in a review body.
+$VERDICT validate --gate code --body-file "$VERDICT_FILE" || {
+  echo "FATAL: composed review-code marker is malformed — refusing to post (fix the @ <sha> field; #2683)" >&2
+  exit 1
+}
 if gh api -X POST repos/$REPO/pulls/$PR/reviews \
      -f event=APPROVE -f body="$BODY"; then
   : # native approving review posted (GitHub records its commit_id = the head you approved;
     #  ship-it reads that commit_id for the same staleness test the marker's @ <sha> drives)
 else
-  # APPROVE failed (e.g. 422 on your own PR) — upsert the structured pass comment instead,
-  # whose first line is the SHA-bound marker so a scan finds the verdict unambiguously:
-  #   review-code: PASS @ <HEAD_SHA> — merge-ready
-  ME="$(gh api user --jq .login)"
-  # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
-  # (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
-  # Find filter is namespace-anchored, NOT PASS/FAIL-only: it must also match the advisory
-  # marker (§6.6) so a polarity flip (non-blocking↔blocking across re-reviews) upserts the one
-  # prior review-code verdict instead of leaving a stale one beside the fresh one.
-  MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-          | jq -r --arg me "$ME" 'map(select(.user.login==$me
-            and (.body | test("^\\s*\\**\\s*review-code:"; "i"))))
-          | last | .id // empty')
-  if [ -n "$MINE" ]; then
-    gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
-  else
-    gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"   # first verdict
-  fi
+  # APPROVE failed (e.g. 422 on your own PR) — upsert the structured pass comment instead, through
+  # the guarded tool: it PATCHes your newest own review-code marker (namespace-anchored, so it also
+  # upserts a prior advisory across a non-blocking↔blocking flip) else POSTs the first, and it
+  # fail-closes on a malformed/cross-namespace body so a broken marker never reaches GitHub.
+  $VERDICT post --pr "$PR" --gate code --body-file "$VERDICT_FILE"
 fi
 ```
 
@@ -1409,24 +1413,19 @@ any later use are one single-sourced read, never two independent resolutions tha
 straddle a head move:
 
 ```bash
+# resolve the verdict CLI once — in-repo-first, published-fallback (ADR 0062/0064; epic #994)
+if [ -f packages/pipeline-cli/src/bin.ts ]; then
+  VERDICT="node packages/pipeline-cli/src/bin.ts verdict"
+else
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"
+fi
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # resolve ONCE, before authoring the verdict file (mirror the PASS path)
 VERDICT_FILE="$(mktemp /tmp/review-code-verdict.XXXXXX)"   # per-run temp, not a fixed/PR-namespaced path (#1465)
 # … author "$VERDICT_FILE" now, embedding `review-code: FAIL @ $HEAD_SHA — not merge-ready` as its first line …
-BODY="$(cat "$VERDICT_FILE")"   # first line: review-code: FAIL @ <HEAD_SHA> — not merge-ready (the SHA resolved just above)
-ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
-# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
-# Namespace-anchored find filter (matches advisory + PASS + FAIL), as on the pass path — so a
-# fresh FAIL upserts whatever prior review-code marker exists, advisory included.
-MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-        | jq -r --arg me "$ME" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*review-code:"; "i"))))
-        | last | .id // empty')
-if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
-else
-  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
-fi
+# Upsert through the guarded tool (resolved above), exactly as the PASS path: it upserts the one
+# review-code marker (namespace-anchored, advisory included) and fail-closes on a malformed/
+# cross-namespace body, so the mktemp-path `@ <sha>` leak (#2683) can never reach GitHub.
+$VERDICT post --pr "$PR" --gate code --body-file "$VERDICT_FILE"
 ```
 
 You *may* additionally request changes via a formal review

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -361,12 +361,15 @@ HEAD_NOW="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
 ```
 
 Write the verdict to a per-run temp file so multi-line markdown + backticks survive the shell, then
-**upsert** it: scan the PR for *your own* prior `review-design:` marker comment and `PATCH` it with
-the fresh verdict, else `POST` a new one — exactly **one** `review-design` verdict comment per PR
-(ADR 0058 rule 2). The `mktemp` handle must be run-unique (the PR number alone isn't — two concurrent
-reviews of the same PR would collide on a fixed path). Post it **as a comment, never a native
-review** (ADR 0058 rule 4): a native review can't carry the `@ <sha>` in the shape this contract
-controls, so the comment is the single carrier.
+**upsert** it — exactly **one** `review-design` verdict comment per PR (ADR 0058 rule 2), the
+`mktemp` handle run-unique (the PR number alone isn't — two concurrent reviews would collide). That
+upsert plus its emission guards are the ADR-0058 glue **all four gates share**, so — exactly as
+`review-doc` — post through the deterministic, unit-tested tool (`pipeline-cli verdict post`, #2102).
+**The tool is the marker-emit choke point:** it refuses fail-closed *before* landing unless every SHA
+field (the first-line `@ <sha>` and the `Reviewed-head:` anchor) is a clean full 40-hex head SHA —
+closing the mktemp-path leak where a scratch path bled into the `@ <sha>` field (#2683). Post it **as
+a comment, never a native review** (ADR 0058 rule 4): a native review can't carry the `@ <sha>` in
+the shape this contract controls, so the comment is the single carrier.
 
 The SHA in the first line is **load-bearing**: `ship-it` refuses any verdict not bound to the PR's
 current head (ADR 0058). **Token order is fixed** (§5): `@ <HEAD_SHA>` comes **immediately after**
@@ -379,16 +382,16 @@ from exactly that line. Every body also carries an **Evidence** section embeddin
 GitHub-hosted screenshot URLs so a human can see what you judged.
 
 ```bash
-ME="$(gh api user --jq .login)"
-find_mine() {   # the namespace-anchored find filter — matches PASS/FAIL/advisory, never a foreign gate
-  gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-    | jq -r --arg me "$ME" 'map(select(.user.login==$me
-        and (.body | test("^\\s*\\**\\s*review-design:"; "i")))) | last | .id // empty'
-}
-upsert() {   # $1 = path to the composed verdict body
-  local BODY; BODY="$(cat "$1")"; local MINE; MINE="$(find_mine)"
-  if [ -n "$MINE" ]; then gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY" --jq .id
-  else gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$BODY" --jq .id; fi
+# resolve the verdict CLI once — in-repo-first, published-fallback (ADR 0062/0064; epic #994)
+if [ -f packages/pipeline-cli/src/bin.ts ]; then
+  VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin
+else
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"     # foreign install: the published CLI
+fi
+upsert() {   # $1 = path to the composed verdict body → prints the upserted comment id; fails loud on a malformed marker
+  local out
+  out="$($VERDICT post --pr "$PR" --gate design --body-file "$1")" || return 1   # namespace-anchored upsert (PATCH own prior marker, else POST), fail-closed on a bad @ <sha>
+  printf '%s\n' "$out" | awk '{print $2}'   # `posted <id>` / `patched <id>` → the comment id
 }
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -525,10 +525,22 @@ HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you revie
 `review-skill` lands its verdict **only as the SHA-bound comment, never a native review** (ADR
 0058 rule 4 — like `review-doc`): a native review can't carry the `@ <sha>` in the shape this
 contract controls, so the comment is the single carrier. The post is an **upsert**, not an
-append: scan the PR for *your own* prior `review-skill:` marker comment and `PATCH` it with the
-fresh verdict instead of `POST`-ing a new one, so there is exactly **one** `review-skill`
-verdict comment per PR (ADR 0058 rule 2). A re-review of a new head overwrites the same record
-with the new `@ <sha>`. The `… | last | .id` upsert PATCHes only your *newest* own marker.
+append: exactly **one** `review-skill` verdict comment per PR (ADR 0058 rule 2), a re-review of
+a new head overwriting the same record. That upsert plus its emission guards are the ADR-0058
+glue **all four gates share**, so — exactly as `review-doc` — post through the deterministic,
+unit-tested tool (`pipeline-cli verdict post`, #2102), never a hand-rolled `jq`. **The tool is
+the marker-emit choke point:** it refuses fail-closed unless every SHA field (the first-line
+`@ <sha>` and the §CP advisory `Reviewed-head:` anchor) is a clean full 40-hex head SHA — closing
+the mktemp-path leak (#2683), the empty-`@-` case (#2646), and any cross-namespace body. Resolve
+the tool once — in-repo first, published fallback (ADR 0062/0064; epic #994):
+
+```bash
+if [ -f packages/pipeline-cli/src/bin.ts ]; then
+  VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin
+else
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"     # foreign install: the published CLI
+fi
+```
 
 ### Pass path — non-blocking PR (the binding signal)
 
@@ -539,23 +551,10 @@ merge on it.
 ```bash
 VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
 # write your composed PASS verdict into "$VERDICT_FILE" (first line: review-skill: PASS @ <HEAD_SHA> — merge-ready)
-BODY="$(cat "$VERDICT_FILE")"
-ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
-# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
-# Find filter is namespace-anchored, NOT PASS/FAIL-only: it must also match the advisory
-# marker (§6.6) so a polarity flip (blocking↔non-blocking across re-reviews) upserts the one
-# prior review-skill verdict instead of leaving a stale one beside the fresh one. It can't
-# cross-match review-code:/review-doc: — the literal `skill:` suffix excludes both.
-MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-        | jq -r --arg me "$ME" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*review-skill:"; "i"))))
-        | last | .id // empty')
-if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
-else
-  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"   # first verdict
-fi
+# Upsert through the guarded tool: it PATCHes your newest own review-skill marker (namespace-
+# anchored, so a blocking↔non-blocking flip upserts a prior advisory too) else POSTs, and it
+# fail-closes on a malformed/cross-namespace body — the mktemp-path `@ <sha>` leak (#2683) never lands.
+$VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
 ```
 
 Verdict body shape. The first line is the **canonical bare marker** — no leading `**`
@@ -660,17 +659,9 @@ canonical `Reviewed-head: @ <HEAD_SHA>` line (ADR 0151), which `ship-it`'s §CP 
 ```bash
 VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
 # write your composed advisory verdict into "$VERDICT_FILE" (first line: review-skill: advisory — blocking-set PR (manual merge))
-BODY="$(cat "$VERDICT_FILE")"
-ME="$(gh api user --jq .login)"
-MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-        | jq -r --arg me "$ME" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*review-skill:"; "i"))))
-        | last | .id // empty')
-if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
-else
-  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
-fi
+# The guarded tool also validates the §CP advisory's `Reviewed-head: @ <sha>` anchor line is a clean
+# full 40-hex head SHA — the exact field the #2680 mktemp path leaked into (#2683).
+$VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
 ```
 
 Post it **as a comment, never a native review** (ADR 0058 rule 4). Do **not** emit the
@@ -690,19 +681,9 @@ so the author sees how close they are. **Upsert** it exactly as the PASS path (o
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
 VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
 # write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-skill: FAIL @ <HEAD_SHA> — changes-requested)
-BODY="$(cat "$VERDICT_FILE")"
-ME="$(gh api user --jq .login)"
-# Namespace-anchored find filter (matches advisory + PASS + FAIL), as on the pass path — so a
-# fresh FAIL upserts whatever prior review-skill marker exists, advisory included.
-MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-        | jq -r --arg me "$ME" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*review-skill:"; "i"))))
-        | last | .id // empty')
-if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
-else
-  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
-fi
+# Upsert through the guarded tool (namespace-anchored, so a fresh FAIL upserts whatever prior
+# review-skill marker exists, advisory included) — fail-closed on a malformed marker (#2683).
+$VERDICT post --pr "$PR" --gate skill --body-file "$VERDICT_FILE"
 ```
 
 Verdict body shape:

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -1,5 +1,5 @@
 /**
- * The `verdict` tool — `pipeline-cli verdict read` / `pipeline-cli verdict post`.
+ * The `verdict` tool — `pipeline-cli verdict read` / `post` / `validate`.
  *
  * The ADR-0058 SHA-bound verdict read/post glue, extracted from the inline `jq` the
  * `review-*` / `ship-it` / `write-code`-repair / `heal-ci` skills each hand-rolled (#2102).
@@ -13,9 +13,13 @@
  *
  * `post --pr N --gate <g> [--body-file <f>]` upserts a SHA-bound verdict comment (ADR 0058
  * rule 2): it reads the composed verdict body from `--body-file` (or stdin), refuses fail-closed
- * if that body's first line is not this gate's marker (the cross-namespace emission bug), then
- * PATCHes our own prior marker in the namespace if one exists, else POSTs — exactly one verdict
- * comment per (PR, gate). It prints `patched <id>` / `posted <id>` on stdout.
+ * on any `emissionDefect` (wrong namespace, unbindable `@ <sha>`, or a non-full-40-hex/path-glued
+ * SHA field), then PATCHes our own prior marker in the namespace if one exists, else POSTs —
+ * exactly one verdict comment per (PR, gate). It prints `patched <id>` / `posted <id>` on stdout.
+ *
+ * `validate --gate <g> [--body-file <f>]` runs that same `emissionDefect` gate WITHOUT posting —
+ * the read-back assertion an emit path (review-code's native `APPROVE`) runs before a channel
+ * `post` can't guard, exiting non-zero on a malformed marker (the mktemp-path leak, #2683).
  *
  * `GithubLive` is baked in with `Command.provide(...)` so the registered command's residual
  * requirement is the Node platform union (the registry seam, epic #994).
@@ -24,7 +28,13 @@ import {readFileSync} from "node:fs";
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {Github, GithubLive} from "./github.ts";
-import {GATES, outcomeReason, type Polarity, type VerdictGate} from "./verdict-match.ts";
+import {
+	emissionDefect,
+	GATES,
+	outcomeReason,
+	type Polarity,
+	type VerdictGate,
+} from "./verdict-match.ts";
 
 const FAIL_EXIT_CODE = 1;
 
@@ -125,8 +135,36 @@ const post = Command.make(
 	),
 );
 
+/**
+ * `validate --gate <g> [--body-file <f>]` — the read-back assertion a marker-emit path runs on a
+ * composed body BEFORE posting it through a channel `post` can't guard (review-code's native
+ * `APPROVE` review). It runs the SAME `emissionDefect` gate `post` enforces and exits non-zero on
+ * any defect — so a malformed `@ <sha>` (the mktemp-path leak, #2683) fails loud at emission rather
+ * than landing in a public comment. Does no IO: pure body-shape validation, so it needs no `Github`.
+ */
+const validate = Command.make(
+	"validate",
+	{gate: gateFlag, bodyFile: bodyFileFlag},
+	Effect.fn(function* ({gate, bodyFile}) {
+		const g = yield* parseGate(gate);
+		const body = (yield* readBody(bodyFile)).replace(/\s+$/, "");
+		if (body.length === 0) {
+			return yield* fail(
+				"empty verdict body — nothing to validate (pass --body-file or pipe on stdin)",
+			);
+		}
+		const defect = emissionDefect(body, g);
+		if (defect !== null) return yield* fail(defect);
+		yield* Console.log("ok");
+	}),
+).pipe(
+	Command.withDescription(
+		"Assert a composed verdict body is postable (clean full-40-hex @ <sha>, right namespace) — exit 0 = ok, non-zero = malformed",
+	),
+);
+
 export const verdictCommand = Command.make("verdict").pipe(
-	Command.withSubcommands([read, post]),
+	Command.withSubcommands([read, post, validate]),
 	Command.withDescription(
 		"Read/post ADR-0058 SHA-bound gate verdicts (review-code/doc/skill/design) — the shared verdict-match glue",
 	),

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -77,6 +77,10 @@ const PR = 500;
 const P = `repos/kamp-us/phoenix`;
 const HEAD = "abc1234def5678";
 const OLD = "0000000aaaa1111";
+// A full 40-hex head SHA — the shape a real `.head.sha` carries and the ONLY shape the tightened
+// emission guard (#2683) accepts on a POSTed body. `HEAD`/`OLD` stay short: they exercise the READ
+// side, whose {7,40} staleness matcher (ADR 0058 rule 3) is deliberately looser and left unchanged.
+const HEAD40 = `${"a1b2c3d4e5f6".repeat(3)}a1b2`; // 12*3 + 4 = 40 hex
 
 const comment = (over: {
 	readonly id: number;
@@ -162,7 +166,7 @@ describe("Github.read — resolve a PR's SHA-bound verdict over a mock gh spawne
 });
 
 describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", () => {
-	const BODY = `review-doc: PASS @ ${HEAD} — merge-ready\n\nReviewed-head: @ ${HEAD}`;
+	const BODY = `review-doc: PASS @ ${HEAD40} — merge-ready\n\nReviewed-head: @ ${HEAD40}`;
 
 	it.effect("no prior marker → POST a fresh verdict comment", () =>
 		Effect.gen(function* () {
@@ -275,6 +279,68 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
 				[`POST ${P}/issues/${PR}/comments`]: "888",
+			}),
+		),
+	);
+
+	// The #2683 emission tightening: the observed leak substituted a full `mktemp` scratch path into
+	// the `@ <sha>` field. Every SHA field must be a clean full 40-hex; a partial/non-hex/path-glued
+	// value is refused fail-closed at emission, never POSTed. No write fixture: a POST would 404.
+	const MKTEMP = "/var/folders/8f/r3k3t6817cgbsxsxvxk83q4c0000gn/T/tmp.TgExIt22qT";
+
+	it.effect("a PASS marker whose `@ <sha>` is an mktemp PATH → VerdictInputError, no write", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(
+				(yield* Github).post(PR, "doc", `review-doc: PASS @${MKTEMP} — merge-ready`),
+			);
+			assert.isTrue(error instanceof VerdictInputError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+			}),
+		),
+	);
+
+	it.effect("a PASS marker with a 40-hex SHA glued to a trailing PATH → VerdictInputError", () =>
+		Effect.gen(function* () {
+			const glued = `review-doc: PASS @ ${"a".repeat(40)}${MKTEMP} — merge-ready`;
+			const error = yield* Effect.flip((yield* Github).post(PR, "doc", glued));
+			assert.isTrue(error instanceof VerdictInputError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+			}),
+		),
+	);
+
+	// The actual PR #2680 leak site: a §CP advisory (SHA-less first line, so it passes the polarity
+	// guard) whose `Reviewed-head:` anchor carries the mktemp path — the field the first-line-only
+	// guards never inspected. This is the regression the tightened guard closes.
+	it.effect("a §CP advisory whose `Reviewed-head:` is an mktemp PATH → VerdictInputError", () =>
+		Effect.gen(function* () {
+			const advisory = `review-doc: advisory — see thread\n\nReviewed-head: @${MKTEMP}`;
+			const error = yield* Effect.flip((yield* Github).post(PR, "doc", advisory));
+			assert.isTrue(error instanceof VerdictInputError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+			}),
+		),
+	);
+
+	it.effect("a §CP advisory with a clean full-40-hex `Reviewed-head:` → POSTed", () =>
+		Effect.gen(function* () {
+			const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD40}`;
+			const result = yield* (yield* Github).post(PR, "doc", advisory);
+			assert.deepStrictEqual(result, {_tag: "posted", commentId: 890});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`POST ${P}/issues/${PR}/comments`]: "890",
 			}),
 		),
 	);

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -21,9 +21,7 @@ import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import {
-	GATE_KEYWORD,
-	isNamespaceMarker,
-	isUnboundPolarityMarker,
+	emissionDefect,
 	namespaceRe,
 	type Polarity,
 	resolveVerdict,
@@ -296,12 +294,15 @@ const read = Effect.fn("Github.read")(function* (
 });
 
 /**
- * Upsert this PR's `gate` verdict (ADR 0058 rule 2). Two fail-closed emission guards run first:
- * the body's first line must be *this* gate's marker (rejects a cross-namespace body), and a
+ * Upsert this PR's `gate` verdict (ADR 0058 rule 2). Three fail-closed emission guards run first:
+ * the body's first line must be *this* gate's marker (rejects a cross-namespace body); a
  * polarity-bearing (PASS/FAIL) body must carry a well-formed `@ <sha>` (rejects the unbindable
- * empty-SHA `@-` marker the read side refuses, #2646) — an advisory SHA-less line stays postable.
- * Then scan our OWN prior marker in the namespace (newest by `(created_at, id)`) and PATCH it if
- * present else POST a fresh one. The own-authored scope means two reviewers never stomp each other's records.
+ * empty-SHA `@-` marker the read side refuses, #2646); and every SHA field it carries — the
+ * first-line `@ <sha>` and the §CP advisory `Reviewed-head:` anchor — must be a clean full 40-hex,
+ * not a partial/non-hex/path-glued value (rejects the `mktemp`-path leak of #2683). An advisory
+ * SHA-less first line stays postable. Then scan our OWN prior marker in the namespace (newest by
+ * `(created_at, id)`) and PATCH it if present else POST a fresh one. The own-authored scope means
+ * two reviewers never stomp each other's records.
  */
 const post = Effect.fn("Github.post")(function* (
 	repo: string,
@@ -309,15 +310,9 @@ const post = Effect.fn("Github.post")(function* (
 	gate: VerdictGate,
 	body: string,
 ) {
-	if (!isNamespaceMarker(body, gate)) {
-		return yield* new VerdictInputError({
-			message: `refusing to post: the body's first line is not a ${GATE_KEYWORD[gate]}: marker — a verdict must carry its own gate's marker on line one (the cross-namespace emission bug, ADR 0058 §Scope)`,
-		});
-	}
-	if (isUnboundPolarityMarker(body, gate)) {
-		return yield* new VerdictInputError({
-			message: `refusing to post: a ${GATE_KEYWORD[gate]}: PASS/FAIL verdict must carry a well-formed '@ <sha>' (≥7 hex) — this polarity-bearing body has an empty/malformed SHA, which posts an unbindable marker the fail-closed read side refuses (the '@-' emission bug, ADR 0058, #2646)`,
-		});
+	const defect = emissionDefect(body, gate);
+	if (defect !== null) {
+		return yield* new VerdictInputError({message: `refusing to post: ${defect}`});
 	}
 	const me = (yield* runGh(whoAmIArgs)).trim();
 	const comments = yield* listComments(repo, pr);

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -225,3 +225,62 @@ export const isNamespaceMarker = (body: string, gate: VerdictGate): boolean =>
  */
 export const isUnboundPolarityMarker = (body: string, gate: VerdictGate): boolean =>
 	polarityRe(gate).test(body) && !verdictRe(gate).test(body);
+
+/**
+ * A well-formed EMITTED head SHA: the full 40-hex, terminated by whitespace or line/string end —
+ * `(?=$|\s)` rejects a value that glues trailing garbage onto a hex prefix (`<40hex>/var/folders/…`)
+ * as well as a bare non-hex path. This is deliberately STRICTER than the {7,40} read matchers
+ * (`verdictRe` / ship-it's `Reviewed-head` read): staleness resolution must keep prefix-matching an
+ * abbreviated SHA (ADR 0058 rule 3), but at EMISSION the full head SHA is always in hand, so an
+ * emitted marker binds it exactly. Anything else is a defect the post guard refuses (#2683).
+ */
+const CLEAN_FULL_SHA = "[0-9a-f]{40}(?=$|\\s)";
+
+const emittedMarkerRe = (gate: VerdictGate): RegExp =>
+	new RegExp(
+		`^\\s*\\*{0,2}\\s*${GATE_KEYWORD[gate]}:\\s*(?:PASS|FAIL)\\s*@\\s*${CLEAN_FULL_SHA}`,
+		"i",
+	);
+
+const anyReviewedHeadLineRe = /^\s*Reviewed-head:/im;
+const cleanReviewedHeadRe = new RegExp(`^\\s*Reviewed-head:\\s*@?\\s*${CLEAN_FULL_SHA}`, "im");
+
+/**
+ * The post-emission SHA-shape guard (#2683). A verdict body about to be POSTed must bind the FULL
+ * 40-hex head SHA in every SHA field it carries; a partial/non-hex/path-glued value (the observed
+ * `mktemp` scratch path leaked into the `@ <sha>` field on §CP PR #2680) both false-blocks ship-it
+ * (the read side can't resolve it) and leaks a machine-local path into a public comment. Two fields
+ * carry a SHA: the first-line PASS/FAIL marker's `@ <sha>`, and the §CP advisory's `Reviewed-head:`
+ * anchor line (ADR 0151) — the latter is where the #2680 leak actually landed, invisible to the
+ * first-line-only `isUnboundPolarityMarker`. Returns a human-readable defect description, or null
+ * when every SHA field is a clean full 40-hex.
+ */
+export const malformedEmittedSha = (body: string, gate: VerdictGate): string | null => {
+	if (polarityRe(gate).test(body) && !emittedMarkerRe(gate).test(body)) {
+		return `the ${GATE_KEYWORD[gate]}: PASS/FAIL marker's '@ <sha>' is not a clean 40-hex head SHA — a partial/non-hex/path-glued value (e.g. an mktemp scratch path) false-blocks ship-it and leaks a machine-local path into a public comment (#2683)`;
+	}
+	if (anyReviewedHeadLineRe.test(body) && !cleanReviewedHeadRe.test(body)) {
+		return `the 'Reviewed-head: @ <sha>' anchor line is not a clean 40-hex head SHA — the §CP advisory head binding (ADR 0151) leaked a non-hex/path value, the #2683 leak observed on PR #2680`;
+	}
+	return null;
+};
+
+/**
+ * The single fail-closed gate every verdict EMISSION passes before it can reach GitHub — the one
+ * source `Github.post` and `verdict validate` both consume so a raw-`gh api` skill and the tool
+ * enforce identical rules. Returns the first structural defect (as a human-readable reason), or
+ * null when the body is postable. Three ordered checks:
+ *   1. cross-namespace — the first line must be *this* gate's marker (ADR 0058 §Scope);
+ *   2. unbound polarity — a PASS/FAIL first line must carry a bindable `@ <sha>` (the `@-` bug, #2646);
+ *   3. malformed emitted SHA — every SHA field (first-line marker + `Reviewed-head:` anchor) must be
+ *      a clean full 40-hex, never a partial/non-hex/path-glued value (the mktemp-path leak, #2683).
+ */
+export const emissionDefect = (body: string, gate: VerdictGate): string | null => {
+	if (!isNamespaceMarker(body, gate)) {
+		return `the body's first line is not a ${GATE_KEYWORD[gate]}: marker — a verdict must carry its own gate's marker on line one (the cross-namespace emission bug, ADR 0058 §Scope)`;
+	}
+	if (isUnboundPolarityMarker(body, gate)) {
+		return `a ${GATE_KEYWORD[gate]}: PASS/FAIL verdict must carry a well-formed '@ <sha>' (≥7 hex) — this polarity-bearing body has an empty/malformed SHA, which posts an unbindable marker the fail-closed read side refuses (the '@-' emission bug, ADR 0058, #2646)`;
+	}
+	return malformedEmittedSha(body, gate);
+};

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -1,9 +1,11 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
+	emissionDefect,
 	isBoundToHead,
 	isNamespaceMarker,
 	isReviewed,
 	isUnboundPolarityMarker,
+	malformedEmittedSha,
 	parseVerdict,
 	resolveVerdict,
 	type VerdictComment,
@@ -317,4 +319,58 @@ describe("isUnboundPolarityMarker — the post SHA-required-for-polarity guard (
 		assert.isFalse(isUnboundPolarityMarker("review-doc: advisory — see thread", "doc")));
 	it("allows another gate's marker (not this namespace's concern)", () =>
 		assert.isFalse(isUnboundPolarityMarker("review-code: PASS — merge-ready", "doc")));
+});
+
+describe("malformedEmittedSha — the post full-40-hex emission guard (#2683)", () => {
+	const SHA40 = "a".repeat(40);
+	const MKTEMP = "/var/folders/8f/r3k3t6817cgbsxsxvxk83q4c0000gn/T/tmp.TgExIt22qT";
+
+	it("flags a PASS marker whose `@ <sha>` is a full mktemp path (the observed leak shape)", () =>
+		assert.isNotNull(malformedEmittedSha(`review-code: PASS @${MKTEMP} — merge-ready`, "code")));
+	it("flags a 40-hex SHA glued to a trailing path (the ≥7-hex-prefix gap isUnbound misses)", () =>
+		assert.isNotNull(
+			malformedEmittedSha(`review-code: PASS @ ${SHA40}${MKTEMP} — merge-ready`, "code"),
+		));
+	it("flags a short (7–39 hex) first-line SHA — emission requires the FULL 40", () =>
+		assert.isNotNull(
+			malformedEmittedSha("review-code: PASS @ abc1234def5678 — merge-ready", "code"),
+		));
+	it("flags a §CP advisory whose `Reviewed-head:` anchor is an mktemp path (the PR #2680 site)", () =>
+		assert.isNotNull(
+			malformedEmittedSha(
+				`review-code: advisory — see thread\n\nReviewed-head: @${MKTEMP}`,
+				"code",
+			),
+		));
+	it("flags a §CP advisory whose `Reviewed-head:` anchor is a short SHA", () =>
+		assert.isNotNull(
+			malformedEmittedSha(`review-code: advisory\n\nReviewed-head: @ abc1234def5678`, "code"),
+		));
+
+	it("passes a clean full-40-hex PASS marker", () =>
+		assert.isNull(malformedEmittedSha(`review-code: PASS @ ${SHA40} — merge-ready`, "code")));
+	it("passes a §CP advisory with a clean full-40-hex `Reviewed-head:` anchor", () =>
+		assert.isNull(
+			malformedEmittedSha(
+				`review-code: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${SHA40}`,
+				"code",
+			),
+		));
+	it("passes a bare advisory with no SHA field at all", () =>
+		assert.isNull(malformedEmittedSha("review-code: advisory — see thread", "code")));
+});
+
+describe("emissionDefect — the one gate `post` and `validate` share (#2683)", () => {
+	const SHA40 = "a".repeat(40);
+
+	it("null (postable) for a clean full-40-hex PASS marker", () =>
+		assert.isNull(emissionDefect(`review-doc: PASS @ ${SHA40} — merge-ready`, "doc")));
+	it("defect for a cross-namespace body (review-code on the doc gate)", () =>
+		assert.isNotNull(emissionDefect(`review-code: PASS @ ${SHA40} — merge-ready`, "doc")));
+	it("defect for an unbound `@-` polarity marker (the #2646 case)", () =>
+		assert.isNotNull(emissionDefect("review-doc: PASS @ -", "doc")));
+	it("defect for a path-glued SHA field (the #2683 case)", () =>
+		assert.isNotNull(
+			emissionDefect("review-doc: PASS @ /var/folders/T/tmp.X — merge-ready", "doc"),
+		));
 });


### PR DESCRIPTION
## What & why

The `review-code` verdict marker recurred **leaking an `mktemp` scratch path into the `@ <sha>` field** (observed on §CP PR #2680, after #2646/#2654). The result is an unparseable, unbindable marker that both blocks `ship-it` (no SHA-bound PASS) **and** publishes a machine-local filesystem path into a public PR comment — a double failure.

### Root cause (grounded)

Two gaps, both on the **emit** path:

1. **`review-code` / `review-skill` / `review-design` posted their markers via raw `gh api`**, bypassing the tested `verdict post` guard entirely. (`review-doc` already routed through `verdict post` and was protected — the asymmetry is exactly why the leak only recurred on the raw-posting gates.)
2. The §CP advisory's **`Reviewed-head: @ <sha>` anchor line** — the field the #2680 path actually leaked into — was inspected by **no** emission guard: the first-line-only `isUnboundPolarityMarker` never sees it. The looser first-line guard also missed a 40-hex-prefix glued to a trailing path (`@ <40hex>/var/folders/…`), since the `{7,40}` read matcher happily captures the hex prefix.

### Fix — make the invalid state unrepresentable at the tool boundary

- **`verdict-match`**: tighten the post-emission guard (`emissionDefect` / `malformedEmittedSha`) to require a **clean FULL 40-hex head SHA** on **both** SHA fields — the first-line `PASS/FAIL @ <sha>` marker and the `Reviewed-head:` advisory anchor. Rejects a non-hex path, a short SHA, and a 40-hex prefix glued to a trailing path. The **read** matchers stay `{7,40}` — ADR 0058 rule-3 abbreviated-SHA staleness is deliberately unchanged (only emission, where the full head SHA is always in hand, is tightened).
- **`verdict validate`** (new): runs the same `emissionDefect` gate **without posting** — the read-back assertion for `review-code`'s native `APPROVE` path (a review `post` can't guard), failing loud before the review lands.
- **Skills**: route `review-code` / `review-skill` / `review-design` marker posts through the guarded `verdict post` (as `review-doc` already does), so the guard is the single fail-closed choke point — not a prose step an agent can forget. `review-code`'s `APPROVE` path runs `verdict validate` first.

### Audit across every `review-*` skill (AC #3)

| skill | before | after |
|---|---|---|
| review-code | raw `gh api` (APPROVE + comment + FAIL + §CP advisory) | `verdict validate` before APPROVE; `verdict post` for comments |
| review-skill | raw `gh api` (PASS + advisory + FAIL) | `verdict post` |
| review-design | raw `gh api` (`upsert()`) | `verdict post` via `upsert()` |
| review-doc | already `verdict post` | now covered by the tightened guard |
| review-plan | composes **no** `@ <sha>` marker | out of surface — no change needed |

## Verification

- `pnpm -C packages/pipeline-cli test` — 1148 pass (adds pure-fn cases for `malformedEmittedSha` / `emissionDefect` incl. the mktemp-path, hex-prefix-then-path, and §CP `Reviewed-head:` leak shapes; and `Github.post` integration cases that refuse them fail-closed with no write).
- `pnpm -C packages/pipeline-cli typecheck` clean; `lint:worktree` clean; `leak-guard` clean.
- CLI exercised end-to-end: `verdict validate` exits 0 on a clean 40-hex body, non-zero on an mktemp-path marker and on a mktemp `Reviewed-head:` advisory.

## §CP — control-plane, HUMAN-MERGE-ONLY

Touches gate-critical `review-*` skills and `packages/pipeline-cli/` — both match `CONTROL_PLANE_RE`. **Do not auto-ship/enqueue.**

Fixes #2683

🤖 Generated with [Claude Code](https://claude.com/claude-code)