### PR TITLE
chore(seed-grant): Effect-v4 idiom — tryPromise + TaggedErrorClass in the D1-REST bins (#2748)

### DIFF
--- a/packages/admin-grant/src/bin.ts
+++ b/packages/admin-grant/src/bin.ts
@@ -17,12 +17,23 @@
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {makeD1Rest} from "@kampus/d1-rest";
-import {Config, Console, Data, Effect, Layer, Option} from "effect";
+import {Config, Console, Effect, Layer, Option, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {assignAdmin, listAdmins, makeGrantDb, revokeAdmin, type Selector} from "./grant.ts";
 
-class SelectorRequired extends Data.TaggedError("SelectorRequired")<{message: string}> {}
+class SelectorRequired extends Schema.TaggedErrorClass<SelectorRequired>()(
+	"@kampus/admin-grant/SelectorRequired",
+	{message: Schema.String},
+) {}
+
+/** A D1 REST call (grant/revoke/list over the query API) rejected — network/HTTP fault. */
+class D1RestError extends Schema.TaggedErrorClass<D1RestError>()(
+	"@kampus/admin-grant/D1RestError",
+	{
+		cause: Schema.Defect(),
+	},
+) {}
 
 const databaseIdFlag = Flag.string("database-id").pipe(
 	Flag.withDescription("the target stage's D1 database UUID"),
@@ -71,7 +82,10 @@ const grant = Command.make(
 		const account = yield* resolveAccount(accountId);
 		const selector = yield* resolveSelector(username, userId);
 		const db = makeDb(account, databaseId);
-		const res = yield* Effect.promise(() => assignAdmin(db, selector));
+		const res = yield* Effect.tryPromise({
+			try: () => assignAdmin(db, selector),
+			catch: (cause) => new D1RestError({cause}),
+		});
 		yield* res.subject === null
 			? Console.log(`admin-grant: no user matched ${selector.by}=${selector.value} (no change)`)
 			: res.inserted > 0
@@ -98,7 +112,10 @@ const revoke = Command.make(
 		const account = yield* resolveAccount(accountId);
 		const selector = yield* resolveSelector(username, userId);
 		const db = makeDb(account, databaseId);
-		const res = yield* Effect.promise(() => revokeAdmin(db, selector));
+		const res = yield* Effect.tryPromise({
+			try: () => revokeAdmin(db, selector),
+			catch: (cause) => new D1RestError({cause}),
+		});
 		yield* res.subject === null
 			? Console.log(`admin-grant: no user matched ${selector.by}=${selector.value} (no change)`)
 			: res.removed > 0
@@ -117,7 +134,10 @@ const list = Command.make(
 	Effect.fn(function* ({databaseId, accountId}) {
 		const account = yield* resolveAccount(accountId);
 		const db = makeDb(account, databaseId);
-		const admins = yield* Effect.promise(() => listAdmins(db));
+		const admins = yield* Effect.tryPromise({
+			try: () => listAdmins(db),
+			catch: (cause) => new D1RestError({cause}),
+		});
 		yield* Console.log(
 			admins.length === 0
 				? "admin-grant: no admins"

--- a/packages/founder-seed/src/bin.ts
+++ b/packages/founder-seed/src/bin.ts
@@ -10,10 +10,16 @@
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {makeD1Rest} from "@kampus/d1-rest";
-import {Config, Console, Effect, Layer, Option} from "effect";
+import {Config, Console, Effect, Layer, Option, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {listFounderTuples, makeSeedDb, seedFounders} from "./seed.ts";
+
+/** A D1 REST call (seed/list over the query API) rejected — network/HTTP fault. */
+class D1RestError extends Schema.TaggedErrorClass<D1RestError>()(
+	"@kampus/founder-seed/D1RestError",
+	{cause: Schema.Defect()},
+) {}
 
 const databaseIdFlag = Flag.string("database-id").pipe(
 	Flag.withDescription("the target stage's D1 database UUID"),
@@ -39,7 +45,10 @@ const seed = Command.make(
 	Effect.fn(function* ({databaseId, accountId}) {
 		const account = yield* resolveAccount(accountId);
 		const db = makeDb(account, databaseId);
-		const res = yield* Effect.promise(() => seedFounders(db));
+		const res = yield* Effect.tryPromise({
+			try: () => seedFounders(db),
+			catch: (cause) => new D1RestError({cause}),
+		});
 		yield* res.cohort === 0
 			? Console.log(
 					`founder-seed: empty cohort (FOUNDER_COHORT is unset) — nothing to mint (D1 ${databaseId})`,
@@ -60,7 +69,10 @@ const list = Command.make(
 	Effect.fn(function* ({databaseId, accountId}) {
 		const account = yield* resolveAccount(accountId);
 		const db = makeDb(account, databaseId);
-		const tuples = yield* Effect.promise(() => listFounderTuples(db));
+		const tuples = yield* Effect.tryPromise({
+			try: () => listFounderTuples(db),
+			catch: (cause) => new D1RestError({cause}),
+		});
 		yield* Console.log(
 			tuples.length === 0
 				? "founder-seed: no founder tuples"

--- a/packages/fts-backfill/src/bin.ts
+++ b/packages/fts-backfill/src/bin.ts
@@ -24,9 +24,15 @@
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {makeD1RestFromEnv} from "@kampus/d1-rest";
-import {Config, Console, Effect, Option} from "effect";
+import {Config, Console, Effect, Option, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {backfill} from "./backfill.ts";
+
+/** A D1 REST call (FTS backfill over the query API) rejected — network/HTTP fault. */
+class D1RestError extends Schema.TaggedErrorClass<D1RestError>()(
+	"@kampus/fts-backfill/D1RestError",
+	{cause: Schema.Defect()},
+) {}
 
 const databaseIdFlag = Flag.string("database-id").pipe(
 	Flag.withDescription("the target stage's D1 database UUID to backfill"),
@@ -47,7 +53,10 @@ const run = Command.make(
 			: yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
 
 		const d1 = makeD1RestFromEnv({accountId: resolvedAccount, databaseId});
-		const report = yield* Effect.promise(() => backfill(d1));
+		const report = yield* Effect.tryPromise({
+			try: () => backfill(d1),
+			catch: (cause) => new D1RestError({cause}),
+		});
 
 		yield* Console.log(
 			`fts-backfill: ok — re-indexed ${report.terms} term(s), ${report.posts} post(s) into term_search/post_search on D1 ${databaseId} (idempotent upsert)`,

--- a/packages/moderator-grant/src/bin.ts
+++ b/packages/moderator-grant/src/bin.ts
@@ -16,12 +16,21 @@
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {makeD1Rest} from "@kampus/d1-rest";
-import {Config, Console, Data, Effect, Layer, Option} from "effect";
+import {Config, Console, Effect, Layer, Option, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {listModerators, makeGrantDb, type Selector, setRole} from "./grant.ts";
 
-class SelectorRequired extends Data.TaggedError("SelectorRequired")<{message: string}> {}
+class SelectorRequired extends Schema.TaggedErrorClass<SelectorRequired>()(
+	"@kampus/moderator-grant/SelectorRequired",
+	{message: Schema.String},
+) {}
+
+/** A D1 REST call (set-role/list over the query API) rejected — network/HTTP fault. */
+class D1RestError extends Schema.TaggedErrorClass<D1RestError>()(
+	"@kampus/moderator-grant/D1RestError",
+	{cause: Schema.Defect()},
+) {}
 
 const databaseIdFlag = Flag.string("database-id").pipe(
 	Flag.withDescription("the target stage's D1 database UUID"),
@@ -70,7 +79,10 @@ const grant = Command.make(
 		const account = yield* resolveAccount(accountId);
 		const selector = yield* resolveSelector(username, userId);
 		const db = makeDb(account, databaseId);
-		const res = yield* Effect.promise(() => setRole(db, selector, "moderator"));
+		const res = yield* Effect.tryPromise({
+			try: () => setRole(db, selector, "moderator"),
+			catch: (cause) => new D1RestError({cause}),
+		});
 		yield* res.changed > 0
 			? Console.log(
 					`moderator-grant: ok — ${selector.by}=${selector.value} is now a moderator (D1 ${databaseId})`,
@@ -93,7 +105,10 @@ const revoke = Command.make(
 		const account = yield* resolveAccount(accountId);
 		const selector = yield* resolveSelector(username, userId);
 		const db = makeDb(account, databaseId);
-		const res = yield* Effect.promise(() => setRole(db, selector, "member"));
+		const res = yield* Effect.tryPromise({
+			try: () => setRole(db, selector, "member"),
+			catch: (cause) => new D1RestError({cause}),
+		});
 		yield* res.changed > 0
 			? Console.log(
 					`moderator-grant: ok — ${selector.by}=${selector.value} reverted to member (D1 ${databaseId})`,
@@ -110,7 +125,10 @@ const list = Command.make(
 	Effect.fn(function* ({databaseId, accountId}) {
 		const account = yield* resolveAccount(accountId);
 		const db = makeDb(account, databaseId);
-		const mods = yield* Effect.promise(() => listModerators(db));
+		const mods = yield* Effect.tryPromise({
+			try: () => listModerators(db),
+			catch: (cause) => new D1RestError({cause}),
+		});
 		yield* Console.log(
 			mods.length === 0
 				? "moderator-grant: no moderators"

--- a/packages/preview-seed/src/bin.ts
+++ b/packages/preview-seed/src/bin.ts
@@ -23,10 +23,16 @@
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {makeD1Rest} from "@kampus/d1-rest";
-import {Config, Console, Effect, Layer, Option} from "effect";
+import {Config, Console, Effect, Layer, Option, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {seed} from "./seed.ts";
+
+/** A D1 REST call (seed over the query API) rejected — network/HTTP fault. */
+class D1RestError extends Schema.TaggedErrorClass<D1RestError>()(
+	"@kampus/preview-seed/D1RestError",
+	{cause: Schema.Defect()},
+) {}
 
 const databaseIdFlag = Flag.string("database-id").pipe(
 	Flag.withDescription("the target stage's D1 database UUID to seed"),
@@ -50,7 +56,10 @@ const run = Command.make(
 			: yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
 
 		const d1 = makeD1Rest({accountId: resolvedAccount, databaseId, layer: restLayer});
-		const report = yield* Effect.promise(() => seed(d1));
+		const report = yield* Effect.tryPromise({
+			try: () => seed(d1),
+			catch: (cause) => new D1RestError({cause}),
+		});
 
 		yield* Console.log(
 			`preview-seed: ok — wrote ${report.terms} term(s), ${report.definitions} definition(s), ${report.posts} post(s), ${report.termsFts} term-search + ${report.postsFts} post-search FTS row(s) to D1 ${databaseId} (idempotent upsert)`,


### PR DESCRIPTION
Fixes #2748

## What
Mechanical Effect-v4 idiom remediation across the five D1-REST seed/grant CLI bins — no scope beyond the idiom fix, no behavior change.

- `packages/admin-grant/src/bin.ts`
- `packages/moderator-grant/src/bin.ts`
- `packages/founder-seed/src/bin.ts`
- `packages/preview-seed/src/bin.ts`
- `packages/fts-backfill/src/bin.ts`

## Changes (per epic #2736 rules)
- **Rule 1** — every `Effect.promise(() => <rejectable D1 REST call>)` becomes object-notation `Effect.tryPromise({ try, catch: (cause) => new D1RestError({cause}) })`. `Effect.promise` assumes a never-rejecting promise; a D1 REST call rejects on network/HTTP faults, so the rejection is now a typed fault instead of an unhandled defect.
- **Rule 3** — the typed error is a per-package `D1RestError extends Schema.TaggedErrorClass` (`cause: Schema.Defect()`); the two `SelectorRequired extends Data.TaggedError` (admin-grant, moderator-grant) move to `Schema.TaggedErrorClass`.

Idiom copied from `packages/pipeline-cli/src/tools/epic-ledger/github.ts` and `packages/fate-effect`; grounded in effect-smol `LLMS.md` (`Schema.TaggedErrorClass` + object-notation `tryPromise`).

## Scope
Out of scope per the issue: pipeline-cli sites (separate §CP child) and grit-rule authoring. None of these paths match `CONTROL_PLANE_RE`.

## Verification
- `pnpm lint` (biome, worktree-scoped): clean.
- `pnpm typecheck` for the five packages: green.
- Unit tests for all five packages: pass. Success path unchanged; only the reject path is now a typed error the CLI `runMain` still surfaces as failure.
- No `Effect.promise` / single-arg `Effect.tryPromise` / `Data.TaggedError` remains in the five bins.

## Acceptance criteria
- [x] No `Effect.promise` or single-arg `Effect.tryPromise` remains — each rejectable D1 REST call is object-notation `Effect.tryPromise` with a typed `catch`.
- [x] No `class ... extends Data.TaggedError` remains — each is `Schema.TaggedErrorClass`.
- [x] Zero idiom findings across the five packages (biome clean).
- [x] Each bin still runs and produces its prior effect (behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)