### PR TITLE
feat(pano): collapse the serial stamp chain in thread/comment reads via the shared parallel-stamp-wave combinator (#2710)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -62,6 +62,7 @@ import {
 	panoOptimisticCommentDeleteFlag,
 	panoOptimisticPostDeleteFlag,
 	panoOptimisticSubmitFlag,
+	panoStampWaveFlag,
 	reactionsFlag,
 	sozlukStampWaveFlag,
 	userBanFlag,
@@ -161,6 +162,11 @@ export default Alchemy.Stack(
 		// epic #2567) — the concurrency knob the definition reads' stamp wave passes: off ⇒
 		// serial (today), on ⇒ one concurrent wave, until a human release.
 		yield* sozlukStampWaveFlag(flagship.appId);
+		// The pano parallel-stamp-wave read-collapse dark-ship flag, default-off (#2710,
+		// epic #2567) — the pano sibling of the sözlük flag above: the concurrency knob the
+		// thread/comment reads' stamp wave passes: off ⇒ serial (today), on ⇒ one concurrent
+		// wave, until a human release.
+		yield* panoStampWaveFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -26,6 +26,21 @@ export const PANO_DRAFT_SAVE = "pano-draft-save";
 export const PHOENIX_SOZLUK_STAMP_WAVE = "phoenix-sozluk-stamp-wave";
 
 /**
+ * Pano parallel-stamp-wave containment flag (#2710, epic #2567) — the pano sibling of
+ * {@link PHOENIX_SOZLUK_STAMP_WAVE}, behind its own seam. The pano thread/comment reads
+ * (`getCommentsByIds` / `listCommentsKeyset`) always route their independent stamps
+ * through the shared `parallelStampWave`; this flag is the concurrency knob it passes —
+ * OFF ⇒ the wave runs at `concurrency: 1` (the reads stay serial, byte-for-byte today's
+ * behavior), ON ⇒ `"unbounded"` collapses the stamp chain into one concurrent wave (the
+ * #2567 win). Flipping it on is the human release act (ADR 0083). Scoped to the thread
+ * read only — NOT the pano feed (`listPostsConnection`), which is the #2322 base/overlay
+ * split.
+ *
+ * @reachability-exempt: server read-path performance flag, no user-facing surface (identical wire output either way; only wall time changes).
+ */
+export const PHOENIX_PANO_STAMP_WAVE = "phoenix-pano-stamp-wave";
+
+/**
  * mecmua write-path dark-ship flag (#2497, epic #2467). The single seam the mecmua
  * write surface gates behind — the `mecmua.publish` + `mecmua.saveDraft` mutations
  * fail `MECMUA_DISABLED` with it off, so the whole write path ships dark until a

--- a/apps/web/worker/features/fate/serial-read-baseline.md
+++ b/apps/web/worker/features/fate/serial-read-baseline.md
@@ -55,6 +55,18 @@ concurrent wave** when the flag is on: **by-id 5 → 2, connection first-page 6 
 `concurrency: 1` — the reads stay serial, byte-for-byte today's output. The knob flips wall time
 only; the pano sibling (#2710) reuses the same combinator behind its own seam.
 
+### Realized — pano (#2710)
+
+The pano thread/comment reads (`getCommentsByIds` / `listCommentsKeyset`) now route their three
+stamps through the same shared `parallelStampWave` combinator ([`stamp-wave.ts`](./stamp-wave.ts)),
+and the reaction stamp's own two reads join the wave via `Reaction.readAggregate`'s `concurrency`
+option — so the **full 4-phase tail collapses to 1 concurrent wave** when the flag is on: **by-id
+5 → 2, connection first-page 6 → 3 (the documented 3-phase drop).** With the default-off
+`phoenix-pano-stamp-wave` flag the wave runs at `concurrency: 1` — the reads stay serial,
+byte-for-byte today's output. Scoped to the thread read only; the pano feed
+(`listPostsConnection`, the #2322 base/overlay split) is untouched — it is the reference pattern,
+not a target.
+
 ## Wall-time baseline (method + numbers)
 
 **Method** — reuse the 2026-07-06 production investigation's surface (#2275, ADR 0168):

--- a/apps/web/worker/features/flagship/pano-stamp-wave.invariant.test.ts
+++ b/apps/web/worker/features/flagship/pano-stamp-wave.invariant.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the pano parallel-stamp-wave read
+ * collapse (#2710, epic #2567). Inspected off the exported `PANO_STAMP_WAVE_FLAG` record
+ * (the same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
+ * constructed — mirrors `sozluk-stamp-wave.invariant.test.ts`.
+ *
+ * Load-bearing: with the default OFF the pano thread/comment reads run their stamp wave at
+ * `concurrency: 1` (serial, byte-for-byte today) — so the containment is real, the
+ * concurrent wave only reachable after a human flips the flag.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_PANO_STAMP_WAVE} from "../../../src/flags/keys.ts";
+import {PANO_STAMP_WAVE_FLAG, panoStampWaveFlag} from "./resources.ts";
+
+describe("pano stamp wave — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(PANO_STAMP_WAVE_FLAG.defaultVariation, "off");
+		assert.strictEqual(PANO_STAMP_WAVE_FLAG.variations.off, false);
+		assert.strictEqual(PANO_STAMP_WAVE_FLAG.variations.on, true);
+		assert.strictEqual(PANO_STAMP_WAVE_FLAG.key, "phoenix-pano-stamp-wave");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(PANO_STAMP_WAVE_FLAG.key, PHOENIX_PANO_STAMP_WAVE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof panoStampWaveFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -31,6 +31,7 @@ import {
 	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
 	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
 	PHOENIX_OPTIMISTIC_EDITS,
+	PHOENIX_PANO_STAMP_WAVE,
 	PHOENIX_REACTIONS,
 	PHOENIX_SOZLUK_STAMP_WAVE,
 	PHOENIX_USER_BAN,
@@ -927,3 +928,37 @@ export const SOZLUK_STAMP_WAVE_FLAG = {
  */
 export const sozlukStampWaveFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_sozluk_stamp_wave", {appId, ...SOZLUK_STAMP_WAVE_FLAG});
+
+/**
+ * The pano parallel-stamp-wave containment flag config (#2710, epic #2567) — the pano
+ * sibling of `SOZLUK_STAMP_WAVE_FLAG`, behind its own seam. Default-OFF so the read-path
+ * collapse reaches production dark: with it off the pano thread/comment reads
+ * (`getCommentsByIds` / `listCommentsKeyset`) run their stamp wave at `concurrency: 1`
+ * (serial, exactly today); flipping it on passes `"unbounded"` so the independent stamps
+ * fan out into one concurrent wave. Wire output is identical either way — only wall time
+ * changes. Flipping it on is the human release act (ADR 0083). Scoped to the thread read,
+ * not the pano feed (the #2322 base/overlay split).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `PANO_BASE_FEED_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           pano (the thread/comment read path)
+ *   - originating:     #2710 (epic: collapse the serial stamp chain, #2567)
+ *   - removal trigger: once the wave graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline `"unbounded"`.
+ */
+export const PANO_STAMP_WAVE_FLAG = {
+	key: PHOENIX_PANO_STAMP_WAVE,
+	description:
+		"pano parallel-stamp-wave read collapse dark-ship (#2710, epic #2567). owner: pano. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const panoStampWaveFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_pano_stamp_wave", {appId, ...PANO_STAMP_WAVE_FLAG});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -160,6 +160,8 @@ export class Pano extends Context.Service<
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				/** Collapse the finalize stamps into one concurrent wave (#2710). Default off. */
+				parallelStamps?: boolean | undefined;
 			},
 		) => Effect.Effect<CommentConnectionPage>;
 
@@ -185,7 +187,12 @@ export class Pano extends Context.Service<
 		/** Comment source `byIds` — batched read avoiding the relation N+1. */
 		readonly getCommentsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
+			opts?: {
+				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
+				/** Collapse the finalize stamps into one concurrent wave (#2710). Default off. */
+				parallelStamps?: boolean | undefined;
+			},
 		) => Effect.Effect<ReadonlyArray<CommentRow>>;
 
 		/**

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -21,6 +21,7 @@ import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
 import {type ReadProfileIdentities, stampAuthorIdentity} from "../fate/author-identity.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
+import {parallelStampWave} from "../fate/stamp-wave.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import {applyRemovalTransition} from "../lifecycle/apply-removal-transition.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
@@ -267,6 +268,30 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			voteSvc.readMine(viewerId, "comment", ids),
 	} as const;
 
+	// The three independent finalize stamps every comment read shares — `myVote` (viewer
+	// scalar), the reaction aggregate, live author identity — each independent given the
+	// fetched rows. `parallelStampWave` runs them over the SAME rows and merges; the
+	// `parallelStamps` flag picks the concurrency: off ⇒ `1` (serial, byte-for-byte today),
+	// on ⇒ `"unbounded"` (one wave, the #2710 collapse). The reaction stamp's own two D1
+	// reads inherit the same knob so the whole wave is one phase when on. Mirrors sözlük's
+	// `stampDefinitions` (#2709), reusing the same combinator behind pano's own seam.
+	const stampComments = <R extends {id: string; authorId: string}>(
+		rows: ReadonlyArray<R>,
+		viewerId: string | null,
+		parallelStamps: boolean,
+	) => {
+		const concurrency = parallelStamps ? "unbounded" : 1;
+		return parallelStampWave(
+			rows,
+			[
+				(rs) => stampViewerScalars(rs, viewerId, [commentVoteScalar]),
+				(rs) => stampReactionAggregate(reactionSvc, "comment", rs, viewerId, {concurrency}),
+				(rs) => stampAuthorIdentity(readProfileIdentities, rs),
+			],
+			{concurrency},
+		);
+	};
+
 	// The tombstone is rendered HERE, from the lifecycle projection — not written
 	// into the canonical body by the delete path (ADR 0096 §5). A `Removed`
 	// comment surfaces as the `[silindi]` placeholder with author elided; its real
@@ -295,6 +320,13 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			after?: string | null | undefined;
 			viewerId?: string | null | undefined;
 			sandboxViewer?: SandboxViewer | undefined;
+			/**
+			 * Route the finalize stamps through the concurrent {@link parallelStampWave}
+			 * instead of the serial chain (#2710). Default/off ⇒ the wave runs at
+			 * `concurrency: 1` — byte-for-byte today. The resolver resolves it from the
+			 * default-off `phoenix-pano-stamp-wave` flag.
+			 */
+			parallelStamps?: boolean | undefined;
 		} = {},
 	) {
 		const first = Math.max(1, Math.min(opts.first ?? 50, 200));
@@ -361,16 +393,19 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		);
 
 		const page = forwardPage(fetched, first, (r: CommentRow) => r.id, rowToCommentRow);
-		const scalared = yield* stampViewerScalars(page.rows, viewerId, [commentVoteScalar]);
-		const reacted = yield* stampReactionAggregate(reactionSvc, "comment", scalared, viewerId);
-		const rows = yield* stampAuthorIdentity(readProfileIdentities, reacted);
+		const rows = yield* stampComments(page.rows, viewerId, opts.parallelStamps ?? false);
 
 		return {...page, rows, totalCount} satisfies CommentConnectionPage;
 	});
 
 	const getCommentsByIds = Effect.fn("Pano.getCommentsByIds")(function* (
 		ids: ReadonlyArray<string>,
-		opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
+		opts: {
+			viewerId?: string | null | undefined;
+			sandboxViewer?: SandboxViewer | undefined;
+			/** See `listCommentsKeyset`'s `parallelStamps` (#2710). */
+			parallelStamps?: boolean | undefined;
+		} = {},
 	) {
 		if (ids.length === 0) return [];
 		const viewerId = opts.viewerId ?? null;
@@ -391,11 +426,11 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 					),
 				),
 		);
-		const scalared = yield* stampViewerScalars(fetched.map(rowToCommentRow), viewerId, [
-			commentVoteScalar,
-		]);
-		const reacted = yield* stampReactionAggregate(reactionSvc, "comment", scalared, viewerId);
-		return yield* stampAuthorIdentity(readProfileIdentities, reacted);
+		return yield* stampComments(
+			fetched.map(rowToCommentRow),
+			viewerId,
+			opts.parallelStamps ?? false,
+		);
 	});
 
 	// The moderator sandbox-queue / promotion-backlog read model (#1205, the #1206

--- a/apps/web/worker/features/pano/comment-stamp-wave.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-stamp-wave.unit.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The pano thread/comment stamp-wave collapse (#2710, epic #2567) — behavior equivalence
+ * + the concurrency plumbing, over the real `makeCommentOperations` closures with a
+ * substituted `Drizzle` `run` + recording service doubles (ADR 0082 litmus: wrong-or-right
+ * with no SQL engine → unit). The pano twin of `sozluk/definition-stamp-wave.unit.test.ts`,
+ * reusing the same shared `parallelStampWave` combinator behind pano's own seam.
+ *
+ * Two properties the acceptance criteria name:
+ *
+ *   - **byte-for-byte equivalence.** `getCommentsByIds` / `listCommentsKeyset` produce the
+ *     identical stamped rows whether the wave runs serial (flag off) or concurrent (flag
+ *     on) — `myVote`, `reactions`, live author identity all unchanged. The flag flips wall
+ *     time and nothing else.
+ *   - **the concurrency actually threads through.** With `parallelStamps: true` the reaction
+ *     aggregate's own two D1 reads receive `{concurrency: "unbounded"}` (so the wave is one
+ *     phase, not one-plus-the-reaction-arm's-two); with it off/absent they receive
+ *     `{concurrency: 1}` — today's serial behavior every non-opted caller keeps.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import type {Concurrency} from "effect/Types";
+import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
+import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import type {Reaction, ReactionAggregate} from "../reaction/Reaction.ts";
+import type {Vote} from "../vote/Vote.ts";
+import {type CommentOperationsDeps, makeCommentOperations} from "./comment-operations.ts";
+
+// A `comment_record` shaped just enough for `toCommentRow` + `Removal.fromColumns`.
+const commentRecord = (id: string, authorId: string) => ({
+	id,
+	postId: "post_1",
+	postTitle: "A Post",
+	parentId: null,
+	authorId,
+	authorName: `snapshot-${authorId}`,
+	body: `body of ${id}`,
+	bodyExcerpt: null,
+	score: 3,
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+	removedAt: null,
+	removedBy: null,
+	removedReason: null,
+	sandboxedAt: null,
+});
+
+const agg = (myReaction: ReactionAggregate["myReaction"]): ReactionAggregate => ({
+	counts: [{emoji: "👍", count: 2}],
+	myReaction,
+});
+
+// Vote double: viewer holds an upvote on `comment_1` only → `myVote === true`, `_2 === false`.
+// biome-ignore lint/plugin: a service double — only `readMine` is on the read path.
+const VoteStub = {
+	cast: () => Effect.die(new Error("read path must not cast")),
+	readMine: () => Effect.succeed(new Set<string>(["comment_1"])),
+	clearTarget: () => Effect.void,
+} as unknown as typeof Vote.Service;
+
+// Reaction double that RECORDS the `options` (the concurrency knob) each `readAggregate`
+// call received, and answers a fixed aggregate for `comment_1`.
+const reactionRecorder = (
+	calls: Array<{readonly concurrency?: Concurrency} | undefined>,
+): typeof Reaction.Service =>
+	({
+		react: () => Effect.die(new Error("read path must not react")),
+		readMine: () => Effect.succeed(new Map<string, ReactionEmoji>()),
+		clearTarget: () => Effect.void,
+		readAggregate: (_viewerId, _kind, _ids, options) => {
+			calls.push(options);
+			return Effect.succeed(new Map<string, ReactionAggregate>([["comment_1", agg("👍")]]));
+		},
+	}) satisfies typeof Reaction.Service;
+
+// Pasaport identity double: `comment_1`'s author has a live handle, `_2`'s has none.
+const readProfileIdentities = () =>
+	Effect.succeed([{userId: "u1", username: "anka", displayName: "Anka Kadın", totalKarma: 0}]);
+
+// Replays `run` results in call order (the sözlük test's `scriptedAccess` shape); each
+// answer is a single `as A` — `run` ignores its query fn (no engine), returning the script.
+const scriptedRun = (results: ReadonlyArray<unknown>): DrizzleAccessOrDie["run"] => {
+	let i = 0;
+	return (<A>(_fn: unknown) => Effect.succeed(results[i++] as A)) as DrizzleAccessOrDie["run"];
+};
+
+const deps = (
+	run: DrizzleAccessOrDie["run"],
+	calls: Array<{readonly concurrency?: Concurrency} | undefined>,
+): CommentOperationsDeps => ({
+	run,
+	voteSvc: VoteStub,
+	reactionSvc: reactionRecorder(calls),
+	removalSeq: {} as CommentOperationsDeps["removalSeq"],
+	persistPanoStats: (() => Effect.void) as CommentOperationsDeps["persistPanoStats"],
+	readProfileIdentities,
+});
+
+// `getCommentsByIds` issues exactly one `run` (the fetch); answer it with two records.
+const byIdRun = () =>
+	scriptedRun([[commentRecord("comment_1", "u1"), commentRecord("comment_2", "u2")]]);
+
+describe("Pano.getCommentsByIds — stamp-wave behavior equivalence (#2710)", () => {
+	it.effect("stamped output is byte-for-byte identical with the wave serial vs concurrent", () => {
+		const serialCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+		const parallelCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+		return Effect.gen(function* () {
+			const serialOps = makeCommentOperations(deps(byIdRun(), serialCalls));
+			const serial = yield* serialOps.getCommentsByIds(["comment_1", "comment_2"], {
+				viewerId: "viewer-1",
+				parallelStamps: false,
+			});
+
+			const parallelOps = makeCommentOperations(deps(byIdRun(), parallelCalls));
+			const parallel = yield* parallelOps.getCommentsByIds(["comment_1", "comment_2"], {
+				viewerId: "viewer-1",
+				parallelStamps: true,
+			});
+
+			assert.deepStrictEqual(parallel, serial, "identical stamped rows");
+			assert.deepStrictEqual(
+				parallel.map((r) => JSON.stringify(r)),
+				serial.map((r) => JSON.stringify(r)),
+				"identical serialized bytes (fields, values, key order)",
+			);
+			// Spot the stamps actually landed (not a vacuous equality of two empty pages).
+			assert.strictEqual(parallel[0]?.myVote, true, "comment_1 viewer upvote stamped");
+			assert.strictEqual(parallel[1]?.myVote, false, "comment_2 no viewer upvote");
+			assert.deepStrictEqual(
+				parallel[0]?.reactions,
+				agg("👍"),
+				"comment_1 reaction aggregate stamped",
+			);
+			assert.strictEqual(parallel[0]?.authorUsername, "anka", "comment_1 live identity stamped");
+			assert.strictEqual(parallel[1]?.authorUsername, null, "comment_2 has no live identity");
+		});
+	});
+
+	it.effect("the flag threads concurrency into the reaction aggregate's own two reads", () => {
+		const onCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+		const offCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+		return Effect.gen(function* () {
+			yield* makeCommentOperations(deps(byIdRun(), onCalls)).getCommentsByIds(["comment_1"], {
+				viewerId: "v",
+				parallelStamps: true,
+			});
+			yield* makeCommentOperations(deps(byIdRun(), offCalls)).getCommentsByIds(["comment_1"], {
+				viewerId: "v",
+				parallelStamps: false,
+			});
+			// No `parallelStamps` → the default-off path (today's behavior).
+			yield* makeCommentOperations(deps(byIdRun(), offCalls)).getCommentsByIds(["comment_1"], {
+				viewerId: "v",
+			});
+
+			assert.deepStrictEqual(onCalls, [{concurrency: "unbounded"}], "flag on → unbounded");
+			assert.deepStrictEqual(
+				offCalls,
+				[{concurrency: 1}, {concurrency: 1}],
+				"flag off AND absent → sequential (concurrency 1)",
+			);
+		});
+	});
+});
+
+// `listCommentsKeyset` (no cursor) issues: totalCount → fetch. Script both in order.
+const keysetRun = () =>
+	scriptedRun([
+		2 /* count */,
+		[commentRecord("comment_1", "u1"), commentRecord("comment_2", "u2")] /* fetch */,
+	]);
+
+describe("Pano.listCommentsKeyset — stamp-wave behavior equivalence (#2710)", () => {
+	it.effect(
+		"the connection page is byte-for-byte identical with the wave serial vs concurrent",
+		() => {
+			const serialCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+			const parallelCalls: Array<{readonly concurrency?: Concurrency} | undefined> = [];
+			return Effect.gen(function* () {
+				const serialOps = makeCommentOperations(deps(keysetRun(), serialCalls));
+				const serial = yield* serialOps.listCommentsKeyset("post_1", {
+					first: 10,
+					viewerId: "viewer-1",
+					parallelStamps: false,
+				});
+
+				const parallelOps = makeCommentOperations(deps(keysetRun(), parallelCalls));
+				const parallel = yield* parallelOps.listCommentsKeyset("post_1", {
+					first: 10,
+					viewerId: "viewer-1",
+					parallelStamps: true,
+				});
+
+				assert.deepStrictEqual(parallel, serial, "identical connection page");
+				assert.strictEqual(JSON.stringify(parallel), JSON.stringify(serial), "identical bytes");
+				assert.strictEqual(parallel.rows[0]?.myVote, true, "stamps landed on the page");
+				assert.deepStrictEqual(parallelCalls, [{concurrency: "unbounded"}], "flag on → unbounded");
+				assert.deepStrictEqual(serialCalls, [{concurrency: 1}], "flag off → sequential");
+			});
+		},
+	);
+});

--- a/apps/web/worker/features/pano/queries.ts
+++ b/apps/web/worker/features/pano/queries.ts
@@ -10,7 +10,10 @@ import {Fate} from "@kampus/fate-effect";
 import {hasNestedSelection} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {PHOENIX_PANO_STAMP_WAVE} from "../../../src/flags/keys.ts";
 import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Pano} from "./Pano.ts";
 import {toComment, toPostFromPage} from "./shapers.ts";
@@ -62,10 +65,17 @@ export const queries = {
 				return base;
 			}
 
+			// The thread read's stamp collapse is contained behind its default-off flag
+			// (#2710): off ⇒ the stamps run serially (today), on ⇒ one concurrent wave.
+			const flags = yield* Flags;
+			const parallelStamps = yield* flags
+				.getBoolean(PHOENIX_PANO_STAMP_WAVE, false)
+				.pipe(provideRequestFlags);
 			const connection = yield* pano.listCommentsKeyset(page.id, {
 				...keysetInput(args.comments, COMMENTS_PAGE_SIZE),
 				viewerId,
 				sandboxViewer,
+				parallelStamps,
 			});
 			const comments = toConnection<(typeof connection.rows)[number], Comment>(
 				connection,

--- a/apps/web/worker/features/pano/sources.ts
+++ b/apps/web/worker/features/pano/sources.ts
@@ -7,7 +7,7 @@
  * in `.patterns/feature-services.md`). See `.patterns/fate-effect-sources.md`.
  */
 import {CurrentUser, Fate} from "@kampus/fate-effect";
-import {PANO_BASE_FEED} from "../../../src/flags/keys.ts";
+import {PANO_BASE_FEED, PHOENIX_PANO_STAMP_WAVE} from "../../../src/flags/keys.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
@@ -60,7 +60,17 @@ export const commentSource = Fate.source(
 		byIds: function* (ids) {
 			const pano = yield* Pano;
 			const sandboxViewer = yield* currentSandboxViewer;
-			return yield* pano.getCommentsByIds(ids, {viewerId: sandboxViewer.viewerId, sandboxViewer});
+			// The read-path collapse is contained behind its default-off flag (#2710): off ⇒
+			// the stamps run serially (today), on ⇒ one concurrent wave. Same wire output.
+			const flags = yield* Flags;
+			const parallelStamps = yield* flags
+				.getBoolean(PHOENIX_PANO_STAMP_WAVE, false)
+				.pipe(provideRequestFlags);
+			return yield* pano.getCommentsByIds(ids, {
+				viewerId: sandboxViewer.viewerId,
+				sandboxViewer,
+				parallelStamps,
+			});
 		},
 	},
 );


### PR DESCRIPTION
Fixes #2710

## What

Collapse the pano thread/comment read path's strictly-serial stamp chain
(`stampViewerScalars → stampReactionAggregate → stampAuthorIdentity`) into one
concurrent wave, reusing the shared `parallelStampWave` combinator the sözlük
sibling landed (#2709 / PR #2764) behind pano's own seam. The sibling of the
sözlük collapse — no new shared abstraction, no D1-hop alternative.

## How

- **`comment-operations.ts` — `stampComments`.** The pano twin of sözlük's
  `stampDefinitions`: runs the three independent finalize stamps over the SAME
  fetched rows via `parallelStampWave` and merges their disjoint added fields
  index-wise. `getCommentsByIds` / `listCommentsKeyset` route through it instead
  of the serial `yield*` chain.
- **The concurrency knob is load-bearing.** `Effect.all` is sequential by
  default (`concurrency ?? 1` → `forEachSequential`; effect@4.0.0-beta.92
  `Effect.all`/`forEach` JSDoc: *"By default, the operations are performed
  sequentially"*). The combinator passes `{concurrency}`: `1` reproduces today's
  serial phase count byte-for-byte, `"unbounded"` fans the stamps out. The
  reaction stamp's own two reads inherit the same knob (via
  `Reaction.readAggregate`'s `concurrency` option from #2709), so the full
  4-phase tail folds to **1** wave.
- **Resolvers** (`sources.ts`, `queries.ts`) resolve the default-off flag and
  thread `parallelStamps`; anonymous / empty-page short-circuits preserved (they
  live inside each reader).
- **Containment:** default-off `phoenix-pano-stamp-wave` flag (key + IaC config +
  factory + alchemy wiring + default-=-off invariant test). Off ⇒
  `concurrency: 1` (serial, today); on ⇒ `"unbounded"`. `@reachability-exempt` —
  server read-path perf flag, identical wire output, no UI surface.

## Scope

Strictly the pano **thread/comment** read (`getCommentsByIds` /
`listCommentsKeyset`) — explicitly NOT the pano **feed** (`listPostsConnection`,
the #2322 base/overlay split), which is already optimized and untouched. No
sözlük files touched. No `Sozluk` re-invention of the combinator.

## Measured drop (vs the #2707 baseline)

The collapsible tail is **4 serial phases** (viewer-scalars, reaction-aggregate
×2, author-identity). Flag-on folds it to **1 concurrent wave**: **by-id 5 → 2,
connection first-page 6 → 3** — the documented 3-phase drop. Recorded in
`serial-read-baseline.md` → *Realized — pano (#2710)*.

## Byte-for-byte equivalence

Wire output is identical whichever way it runs — same `myVote` / `reactions` /
live author identity, same empty/anonymous conventions, same key order. Only
wall time changes.

## Tests

- `comment-stamp-wave.unit.test.ts` — `getCommentsByIds` / `listCommentsKeyset`
  produce byte-for-byte identical stamped rows flag-on vs flag-off, and the
  concurrency knob threads into the reaction aggregate's two reads (`unbounded`
  on, `1` off/absent).
- `pano-stamp-wave.invariant.test.ts` — the flag ships `defaultVariation: off`.

Read-path only — no fate mutation added, so no fanout-guard classification
needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)