### PR TITLE
refactor(effect): remediate Effect-v4 idiom violations in fate-effect + depo (#2750)

### DIFF
--- a/packages/depo/src/client.ts
+++ b/packages/depo/src/client.ts
@@ -24,6 +24,7 @@ import {
 } from "./domain.ts";
 import {
 	ContentAddressConflict,
+	type DigestError,
 	FileReadError,
 	PayloadTooLarge,
 	Unauthorized,
@@ -66,6 +67,7 @@ interface DoormanSuccessBody {
 }
 
 const parseSuccess = (body: string): DoormanSuccessBody | null => {
+	// biome-ignore lint/plugin: a malformed doorman body is a benign null ("not a success body" → fall back to the client-derived URL), not a failure to lift into E — wrapping this JSON.parse guard in Effect.try only to re-collapse the error to null is noise.
 	try {
 		const parsed = JSON.parse(body) as Partial<DoormanSuccessBody>;
 		if (typeof parsed.key === "string" && typeof parsed.url === "string") {
@@ -94,7 +96,12 @@ export const putBytes = (input: {
 	readonly body: Uint8Array;
 }): Effect.Effect<
 	string,
-	Unauthorized | UnsupportedMediaType | PayloadTooLarge | ContentAddressConflict | UploadFailed,
+	| DigestError
+	| Unauthorized
+	| UnsupportedMediaType
+	| PayloadTooLarge
+	| ContentAddressConflict
+	| UploadFailed,
 	DoormanClient
 > =>
 	Effect.gen(function* () {

--- a/packages/depo/src/command.ts
+++ b/packages/depo/src/command.ts
@@ -15,6 +15,7 @@ import {Argument, Command, Flag} from "effect/unstable/cli";
 import {put} from "./client.ts";
 import type {
 	ContentAddressConflict,
+	DigestError,
 	FileReadError,
 	MissingCredential,
 	PayloadTooLarge,
@@ -30,6 +31,7 @@ type PutFailure =
 	| MissingCredential
 	| UnsupportedFile
 	| FileReadError
+	| DigestError
 	| Unauthorized
 	| UnsupportedMediaType
 	| PayloadTooLarge
@@ -67,6 +69,8 @@ const reasonOf = (error: PutFailure): string => {
 			return `unsupported file ${error.filename} (.${error.ext}) — allowed: png, jpg, jpeg, webp`;
 		case "depo/FileReadError":
 			return `cannot read ${error.path}: ${String(error.cause)}`;
+		case "depo/DigestError":
+			return `could not compute content address: ${String(error.cause)}`;
 		case "depo/Unauthorized":
 			return `unauthorized (401): ${error.message}`;
 		case "depo/UnsupportedMediaType":

--- a/packages/depo/src/domain.ts
+++ b/packages/depo/src/domain.ts
@@ -10,7 +10,7 @@
  * unit tier).
  */
 import * as Effect from "effect/Effect";
-import {UnsupportedFile} from "./errors.ts";
+import {DigestError, UnsupportedFile} from "./errors.ts";
 
 /**
  * The content-type allowlist and its extension — the single source the client
@@ -57,10 +57,13 @@ export const contentTypeForFile = (
 };
 
 /** Lowercase hex of a SHA-256 digest — the content-address stem. */
-export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string> =>
-	// `.slice()` yields a fresh `Uint8Array<ArrayBuffer>` (never a SharedArrayBuffer),
-	// which is what `crypto.subtle.digest`'s `BufferSource` requires under strict TS.
-	Effect.promise(() => crypto.subtle.digest("SHA-256", bytes.slice())).pipe(
+export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string, DigestError> =>
+	Effect.tryPromise({
+		// `.slice()` yields a fresh `Uint8Array<ArrayBuffer>` (never a SharedArrayBuffer),
+		// which is what `crypto.subtle.digest`'s `BufferSource` requires under strict TS.
+		try: () => crypto.subtle.digest("SHA-256", bytes.slice()),
+		catch: (cause) => new DigestError({cause}),
+	}).pipe(
 		Effect.map((buf) =>
 			Array.from(new Uint8Array(buf))
 				.map((b) => b.toString(16).padStart(2, "0"))
@@ -72,7 +75,7 @@ export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string> =>
 export const contentAddressKey = (
 	bytes: Uint8Array,
 	contentType: AllowedContentType,
-): Effect.Effect<string> =>
+): Effect.Effect<string, DigestError> =>
 	sha256Hex(bytes).pipe(Effect.map((hex) => `${hex}.${ALLOWED_TYPES[contentType]}`));
 
 /** The permanent public URL for a stored key: `https://depo.kamp.us/<key>`. */

--- a/packages/depo/src/errors.ts
+++ b/packages/depo/src/errors.ts
@@ -1,61 +1,73 @@
 /**
  * depo client's tagged errors — one file for the whole put path (the
- * `.patterns/effect-errors.md` one-`errors.ts`-per-surface rule). Each is a plain
- * `Data.TaggedError`. The set is the client-side image of the doorman's HTTP
- * contract (#1970): every 4xx the doorman can return maps to exactly one error
- * here, so a caller `catch`es a typed failure rather than parsing a status code.
+ * `.patterns/effect-errors.md` one-`errors.ts`-per-surface rule). Each is a
+ * `Schema.TaggedErrorClass` (the repo-wide error constructor — #2736). These are
+ * CLI-only and never reach the fate wire, so they carry no `FateWireCode`
+ * annotation. The set is the client-side image of the doorman's HTTP contract
+ * (#1970): every 4xx the doorman can return maps to exactly one error here, so a
+ * caller `catch`es a typed failure rather than parsing a status code.
  *
  *   doorman 401 → Unauthorized          doorman 415 → UnsupportedMediaType
  *   doorman 413 → PayloadTooLarge        doorman 409 → ContentAddressConflict
  *
- * Plus two client-local faults with no server counterpart: `MissingCredential`
+ * Plus the client-local faults with no server counterpart: `MissingCredential`
  * (no apiKey resolved before any request), `FileReadError` (the local file could
- * not be read), and `UploadFailed` (transport failure or an unmapped status).
+ * not be read), `DigestError` (the SHA-256 content address could not be computed),
+ * and `UploadFailed` (transport failure or an unmapped status).
  */
-import * as Data from "effect/Data";
+import * as Schema from "effect/Schema";
 
 /** No apiKey could be resolved (flag / `KAMPUS_TOKEN` / stored credential all empty). */
-export class MissingCredential extends Data.TaggedError("depo/MissingCredential")<{
-	readonly reason: string;
-}> {}
+export class MissingCredential extends Schema.TaggedErrorClass<MissingCredential>()(
+	"depo/MissingCredential",
+	{reason: Schema.String},
+) {}
 
 /** The local file could not be read (missing / unreadable). */
-export class FileReadError extends Data.TaggedError("depo/FileReadError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class FileReadError extends Schema.TaggedErrorClass<FileReadError>()("depo/FileReadError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** File extension outside the PNG/JPEG/WebP allowlist — refused before upload (mirrors 415). */
-export class UnsupportedFile extends Data.TaggedError("depo/UnsupportedFile")<{
-	readonly filename: string;
-	readonly ext: string;
-}> {}
+export class UnsupportedFile extends Schema.TaggedErrorClass<UnsupportedFile>()(
+	"depo/UnsupportedFile",
+	{filename: Schema.String, ext: Schema.String},
+) {}
 
 /** Doorman 401 — the presented apiKey was missing or invalid. Nothing was stored. */
-export class Unauthorized extends Data.TaggedError("depo/Unauthorized")<{
-	readonly message: string;
-}> {}
+export class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()("depo/Unauthorized", {
+	message: Schema.String,
+}) {}
 
 /** Doorman 415 — the content-type was outside the allowlist. */
-export class UnsupportedMediaType extends Data.TaggedError("depo/UnsupportedMediaType")<{
-	readonly message: string;
-}> {}
+export class UnsupportedMediaType extends Schema.TaggedErrorClass<UnsupportedMediaType>()(
+	"depo/UnsupportedMediaType",
+	{message: Schema.String},
+) {}
 
 /** Doorman 413 — the body exceeded the size cap. */
-export class PayloadTooLarge extends Data.TaggedError("depo/PayloadTooLarge")<{
-	readonly message: string;
-}> {}
+export class PayloadTooLarge extends Schema.TaggedErrorClass<PayloadTooLarge>()(
+	"depo/PayloadTooLarge",
+	{message: Schema.String},
+) {}
 
 /**
  * Doorman 409 — a second upload to an existing content-address key whose stored
  * bytes differ (a sha256 collision the doorman refuses rather than overwrites).
  */
-export class ContentAddressConflict extends Data.TaggedError("depo/ContentAddressConflict")<{
-	readonly message: string;
-}> {}
+export class ContentAddressConflict extends Schema.TaggedErrorClass<ContentAddressConflict>()(
+	"depo/ContentAddressConflict",
+	{message: Schema.String},
+) {}
+
+/** The SHA-256 content address could not be computed (`crypto.subtle.digest` rejected). */
+export class DigestError extends Schema.TaggedErrorClass<DigestError>()("depo/DigestError", {
+	cause: Schema.Unknown,
+}) {}
 
 /** Transport failure, a 5xx, or any status the client does not map — the catch-all. */
-export class UploadFailed extends Data.TaggedError("depo/UploadFailed")<{
-	readonly status: number | null;
-	readonly message: string;
-}> {}
+export class UploadFailed extends Schema.TaggedErrorClass<UploadFailed>()("depo/UploadFailed", {
+	status: Schema.NullOr(Schema.Number),
+	message: Schema.String,
+}) {}

--- a/packages/depo/src/index.ts
+++ b/packages/depo/src/index.ts
@@ -26,6 +26,7 @@ export {
 } from "./domain.ts";
 export {
 	ContentAddressConflict,
+	DigestError,
 	FileReadError,
 	MissingCredential,
 	PayloadTooLarge,

--- a/packages/fate-effect/src/Executor.test.ts
+++ b/packages/fate-effect/src/Executor.test.ts
@@ -100,6 +100,15 @@ const makeContext = (
 	livePublisher: options.publisher ?? recordingPublisher().publisher,
 });
 
+/**
+ * The barrier's promise never rejects, but object-notation `Effect.tryPromise` (the
+ * #2736 idiom) requires a `catch` mapping to a tagged error; `orDie` then keeps the
+ * handler's error channel `never` (the query declares no errors).
+ */
+class BarrierRejected extends Schema.TaggedErrorClass<BarrierRejected>()("test/BarrierRejected", {
+	cause: Schema.Unknown,
+}) {}
+
 /** Resolve once `count` callers have arrived — holds requests concurrently in flight. */
 const makeBarrier = (count: number): {arrive: () => Promise<void>} => {
 	const waiters: Array<() => void> = [];
@@ -375,8 +384,14 @@ describe("FateExecutor — per-request services", () => {
 			{type: "Session"},
 			Effect.fn("whoami")(function* () {
 				const {user: sessionUser} = yield* CurrentUser;
-				// Hold until BOTH requests are in flight — the two resolutions overlap.
-				yield* Effect.promise(() => barrier.arrive());
+				// Hold until BOTH requests are in flight — the two resolutions overlap. The
+				// barrier never rejects, and the query declares no errors (E = never), so a
+				// rejection is a defect (orDie) — the faithful object-notation form of the old
+				// `Effect.promise` (#2736).
+				yield* Effect.tryPromise({
+					try: () => barrier.arrive(),
+					catch: (cause) => new BarrierRejected({cause}),
+				}).pipe(Effect.orDie);
 				const live = yield* LivePublisher;
 				const id = sessionUser?.id ?? "anon";
 				yield* live.update("Session", id);

--- a/packages/fate-effect/src/Interpreter.batch.test.ts
+++ b/packages/fate-effect/src/Interpreter.batch.test.ts
@@ -10,6 +10,7 @@
  * both backends from the shared sozluk world (`Oracle.fixture.ts`).
  */
 import {Effect, Layer, ManagedRuntime, Tracer} from "effect";
+import * as Schema from "effect/Schema";
 import {describe, expect, it} from "vitest";
 import {FateDataView} from "./DataView.ts";
 import {FateInterpreter} from "./Interpreter.ts";
@@ -250,10 +251,20 @@ describe("FateInterpreter — concurrent dispatch", () => {
 					}
 				}
 			});
+		// The barrier never rejects, but object-notation `Effect.tryPromise` (the #2736 idiom)
+		// requires a `catch` mapping to a tagged error; `orDie` then keeps the handler's error
+		// channel `never` (the query declares no errors).
+		class BarrierRejected extends Schema.TaggedErrorClass<BarrierRejected>()(
+			"test/BarrierRejected",
+			{cause: Schema.Unknown},
+		) {}
 		const paired = Fate.query(
 			{type: "Paired"},
 			Effect.fn("paired")(function* () {
-				yield* Effect.promise(() => arrive());
+				yield* Effect.tryPromise({
+					try: () => arrive(),
+					catch: (cause) => new BarrierRejected({cause}),
+				}).pipe(Effect.orDie);
 				return {ok: true};
 			}),
 		);


### PR DESCRIPTION
Fixes #2750

Mechanical red-to-green for the #2736 Phase-1 idiom rules (Rules 1, 3, 4) across the two data-layer packages `packages/fate-effect` and `packages/depo`. Behavior unchanged; no product/design decision.

## Changes

**depo**
- `src/errors.ts`: all 8 `Data.TaggedError` classes → `Schema.TaggedErrorClass` (Rule 3). These are CLI-only client errors that never reach the fate wire, so they carry no `FateWireCode` annotation (the pattern's CLI-only error form, per `.patterns/effect-errors.md` and the `no-data-taggederror` rule rationale). Adds a `DigestError`.
- `src/domain.ts`: `Effect.promise` on the SHA-256 digest → object-notation `Effect.tryPromise({try, catch})` mapping the rejection to the new tagged `DigestError` (Rule 1). `sha256Hex` / `contentAddressKey` error channels widen to `DigestError`, threaded through `putBytes` (`src/client.ts`) and the `PutFailure` union + `reasonOf` switch in `src/command.ts`; `DigestError` is exported from `src/index.ts` alongside the rest of the public error set.
- `src/client.ts`: the `parseSuccess` `JSON.parse` guard is a benign parse→`null` narrowing (a malformed doorman body falls back to the client-derived URL), not an `E`-channel failure — lifting it into `E` only to re-collapse it to `null` is noise, so it keeps its `try/catch` under a justified per-line `// biome-ignore lint/plugin` (Rule 4, the sanctioned exception).

**fate-effect** (test barriers only)
- `src/Executor.test.ts`, `src/Interpreter.batch.test.ts`: the two test-barrier `Effect.promise` awaits → object-notation `Effect.tryPromise` mapping to a `Schema.TaggedErrorClass` (`BarrierRejected`), `.pipe(Effect.orDie)` so the no-error query handler's `E` stays `never` — the faithful form of the old `Effect.promise` (reject → defect). `Interpreter.ts` / `Walk.ts` already used object-notation `tryPromise` (no change needed).

## Acceptance
- [x] No `Effect.promise` / single-arg `Effect.tryPromise` remains in either package.
- [x] No `extends Data.TaggedError` remains in `packages/depo` — all `Schema.TaggedErrorClass`.
- [x] No raw `try/catch` in an effect-importing file except the one justified per-line `// biome-ignore`.
- [x] Phase-1 rules report zero findings across both packages (`biome check packages/fate-effect packages/depo` clean).
- [x] Existing tests pass (depo 18, fate-effect 151); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)