### PR TITLE
chore(tooling): remediate Effect-v4 idiom violations across ops/tooling packages (#2751)

### DIFF
--- a/packages/audit-run/src/adapter.ts
+++ b/packages/audit-run/src/adapter.ts
@@ -40,35 +40,33 @@ const decode = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<strin
 const parseDimensions = (
 	raw: string,
 ): Effect.Effect<ReadonlyArray<DimensionResult>, StageLifecycleError> =>
-	Effect.suspend(() => {
-		let parsed: unknown;
-		try {
-			parsed = JSON.parse(raw) as unknown;
-		} catch (cause) {
-			return Effect.fail(
-				new StageLifecycleError({
-					phase: "run-hook",
-					message: `walk command did not print valid JSON findings: ${String(cause)}`,
-				}),
-			);
-		}
-		const dimensions =
-			typeof parsed === "object" && parsed !== null
-				? (parsed as {dimensions?: unknown}).dimensions
-				: undefined;
-		// Story 11: a walk that yields no dimensions is NEVER a silent pass — an empty findings
-		// set would build a vacuous PASS verdict, so refuse it here at the seam that emits it.
-		if (!Array.isArray(dimensions) || dimensions.length === 0) {
-			return Effect.fail(
-				new StageLifecycleError({
-					phase: "run-hook",
-					message:
-						"walk command produced no dimensions ({ dimensions: DimensionResult[] } expected, non-empty)",
-				}),
-			);
-		}
-		return Effect.succeed(dimensions as ReadonlyArray<DimensionResult>);
-	});
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new StageLifecycleError({
+				phase: "run-hook",
+				message: `walk command did not print valid JSON findings: ${String(cause)}`,
+			}),
+	}).pipe(
+		Effect.flatMap((parsed) => {
+			const dimensions =
+				typeof parsed === "object" && parsed !== null
+					? (parsed as {dimensions?: unknown}).dimensions
+					: undefined;
+			// Story 11: a walk that yields no dimensions is NEVER a silent pass — an empty findings
+			// set would build a vacuous PASS verdict, so refuse it here at the seam that emits it.
+			if (!Array.isArray(dimensions) || dimensions.length === 0) {
+				return Effect.fail(
+					new StageLifecycleError({
+						phase: "run-hook",
+						message:
+							"walk command produced no dimensions ({ dimensions: DimensionResult[] } expected, non-empty)",
+					}),
+				);
+			}
+			return Effect.succeed(dimensions as ReadonlyArray<DimensionResult>);
+		}),
+	);
 
 const spawnWalk = (
 	command: string,

--- a/packages/audit-stage/src/adapter.ts
+++ b/packages/audit-stage/src/adapter.ts
@@ -150,14 +150,10 @@ const resolveD1DatabaseId = (
 	});
 
 const parseJson = (phase: StagePhase, raw: string): Effect.Effect<unknown, StageLifecycleError> =>
-	Effect.suspend(() => {
-		try {
-			return Effect.succeed(JSON.parse(raw) as unknown);
-		} catch (cause) {
-			return Effect.fail(
-				new StageLifecycleError({phase, message: `expected JSON but got: ${String(cause)}`}),
-			);
-		}
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new StageLifecycleError({phase, message: `expected JSON but got: ${String(cause)}`}),
 	});
 
 // Pick the uuid of the first D1 whose name carries the stage prefix, tolerating the CF

--- a/packages/cf-credentials/src/credentials.ts
+++ b/packages/cf-credentials/src/credentials.ts
@@ -18,7 +18,8 @@ import {
 } from "@distilled.cloud/cloudflare/Credentials";
 import {ConfigError} from "@distilled.cloud/cloudflare/Errors";
 import * as flagship from "@distilled.cloud/cloudflare/flagship";
-import {ConfigProvider, Data, Effect, Layer, Stream} from "effect";
+import {ConfigProvider, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
 import type {HttpClient} from "effect/unstable/http/HttpClient";
 import {ACCOUNT_ID_ACCOUNT, API_TOKEN_ACCOUNT, Keychain} from "./keychain.ts";
 
@@ -100,9 +101,12 @@ export const credentialSources: Effect.Effect<CredentialSources, never, Keychain
 );
 
 /** The pasted credentials failed the pre-persist validating read. Nothing was stored. */
-export class CredentialValidationFailed extends Data.TaggedError("CredentialValidationFailed")<{
-	readonly reason: string;
-}> {
+export class CredentialValidationFailed extends Schema.TaggedErrorClass<CredentialValidationFailed>()(
+	"@kampus/cf-credentials/CredentialValidationFailed",
+	{
+		reason: Schema.String,
+	},
+) {
 	override get message(): string {
 		return `credential validation failed — nothing was stored: ${this.reason}`;
 	}

--- a/packages/cf-utils/src/flag.ts
+++ b/packages/cf-utils/src/flag.ts
@@ -23,7 +23,7 @@
  * `${stack}-${id}-${stage}-${suffix}`, `_`→`-` lowercased).
  */
 
-import {Data} from "effect";
+import * as Schema from "effect/Schema";
 
 const STACK = "phoenix";
 
@@ -178,10 +178,13 @@ export const ENV_HELP =
  * with BEFORE any read/write, so an unknown `--env` never reaches the mutation. Carries the
  * envs that DO resolve, so the message points the operator at a valid one.
  */
-export class FlagEnvNotFound extends Data.TaggedError("FlagEnvNotFound")<{
-	readonly env: string;
-	readonly knownEnvs: ReadonlyArray<string>;
-}> {
+export class FlagEnvNotFound extends Schema.TaggedErrorClass<FlagEnvNotFound>()(
+	"@kampus/cf-utils/FlagEnvNotFound",
+	{
+		env: Schema.String,
+		knownEnvs: Schema.Array(Schema.String),
+	},
+) {
 	override get message(): string {
 		const known = this.knownEnvs.length > 0 ? this.knownEnvs.join(", ") : "(none)";
 		return `no Flagship app for env "${this.env}" — known envs: ${known} (run \`flag list\` to see them)`;
@@ -195,10 +198,13 @@ export class FlagEnvNotFound extends Data.TaggedError("FlagEnvNotFound")<{
  * the message points the operator at a valid one. The `--env`-scoped `flag get` instead fails
  * with the SDK's `FlagshipFlagNotFound` straight off the single-flag read.
  */
-export class FlagKeyNotFound extends Data.TaggedError("FlagKeyNotFound")<{
-	readonly key: string;
-	readonly knownKeys: ReadonlyArray<string>;
-}> {
+export class FlagKeyNotFound extends Schema.TaggedErrorClass<FlagKeyNotFound>()(
+	"@kampus/cf-utils/FlagKeyNotFound",
+	{
+		key: Schema.String,
+		knownKeys: Schema.Array(Schema.String),
+	},
+) {
 	override get message(): string {
 		const known = this.knownKeys.length > 0 ? this.knownKeys.join(", ") : "(none)";
 		return `no flag "${this.key}" in any env — known flags: ${known}`;
@@ -210,9 +216,12 @@ export class FlagKeyNotFound extends Data.TaggedError("FlagKeyNotFound")<{
  * mutually exclusive and exactly one is required, enforced with a legible usage error rather
  * than a silent default.
  */
-export class FlagSetTargetInvalid extends Data.TaggedError("FlagSetTargetInvalid")<{
-	readonly reason: string;
-}> {
+export class FlagSetTargetInvalid extends Schema.TaggedErrorClass<FlagSetTargetInvalid>()(
+	"@kampus/cf-utils/FlagSetTargetInvalid",
+	{
+		reason: Schema.String,
+	},
+) {
 	override get message(): string {
 		return `flag set: ${this.reason} — pass exactly one of "on", "off", or --percent N`;
 	}
@@ -226,9 +235,12 @@ export class FlagSetTargetInvalid extends Data.TaggedError("FlagSetTargetInvalid
  * path — a human at a terminal who answered `n`/empty/EOF. The message names the recoverable fix
  * (re-run and answer the prompt affirmatively).
  */
-export class LeverGuardRefused extends Data.TaggedError("LeverGuardRefused")<{
-	readonly reason: string;
-}> {
+export class LeverGuardRefused extends Schema.TaggedErrorClass<LeverGuardRefused>()(
+	"@kampus/cf-utils/LeverGuardRefused",
+	{
+		reason: Schema.String,
+	},
+) {
 	override get message(): string {
 		return (
 			`flag set --execute refused: ${this.reason}. ` +

--- a/packages/cf-utils/src/scrub-command.ts
+++ b/packages/cf-utils/src/scrub-command.ts
@@ -12,6 +12,7 @@
 import type {Credentials} from "@distilled.cloud/cloudflare/Credentials";
 import {makeD1Rest} from "@kampus/d1-rest";
 import {Config, Console, Effect, type Layer, Option} from "effect";
+import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
 import type {HttpClient} from "effect/unstable/http/HttpClient";
 import {
@@ -41,6 +42,15 @@ const confirmFlag = Flag.string("confirm").pipe(
 
 const accountId = Config.string("CLOUDFLARE_ACCOUNT_ID");
 
+/** A D1 REST scan/scrub query rejected — keeps the failure in `E`, never a swallowed defect. */
+export class ScrubDbError extends Schema.TaggedErrorClass<ScrubDbError>()(
+	"@kampus/cf-utils/ScrubDbError",
+	{
+		op: Schema.Literals(["scan", "scrub"]),
+		cause: Schema.Unknown,
+	},
+) {}
+
 /**
  * `scrub-author-email` — the one destructive verb. It runs the dry-run scan first ALWAYS (so a
  * founder sees the per-table counts before any write), then consults the pure confirm-gate: a
@@ -62,7 +72,10 @@ export const makeScrubCommand = (restLayer: Layer.Layer<Credentials | HttpClient
 			const db = makeScrubDb(makeD1Rest({accountId: account, databaseId, layer: restLayer}));
 
 			// The dry-run scan runs ALWAYS — the count-only report a founder reads before any write.
-			const affected = yield* Effect.promise(() => scanAffected(db));
+			const affected = yield* Effect.tryPromise({
+				try: () => scanAffected(db),
+				catch: (cause) => new ScrubDbError({op: "scan", cause}),
+			});
 			yield* Console.log(renderDryRun(affected));
 
 			const decision = decideWrite({
@@ -81,7 +94,10 @@ export const makeScrubCommand = (restLayer: Layer.Layer<Credentials | HttpClient
 			}
 
 			// Gate authorized (--execute + --confirm scrub-author-email) and there ARE rows: rewrite.
-			const scrubbed = yield* Effect.promise(() => scrubEmails(db));
+			const scrubbed = yield* Effect.tryPromise({
+				try: () => scrubEmails(db),
+				catch: (cause) => new ScrubDbError({op: "scrub", cause}),
+			});
 			yield* Console.log(renderScrubbed(scrubbed));
 		}),
 	).pipe(

--- a/packages/design-capture/src/capture.ts
+++ b/packages/design-capture/src/capture.ts
@@ -17,7 +17,8 @@
 import {mkdir, writeFile} from "node:fs/promises";
 import {join} from "node:path";
 import {chromium} from "@playwright/test";
-import {Data, Effect} from "effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
 import type {Shot} from "./plan.ts";
 
 /** The captured bytes + on-disk path for one surface. */
@@ -33,10 +34,13 @@ export interface CapturedSurface {
 }
 
 /** A Playwright launch/navigation/screenshot/write failure — surfaced, never swallowed. */
-export class CaptureError extends Data.TaggedError("CaptureError")<{
-	readonly message: string;
-	readonly cause?: unknown;
-}> {}
+export class CaptureError extends Schema.TaggedErrorClass<CaptureError>()(
+	"@kampus/design-capture/CaptureError",
+	{
+		message: Schema.String,
+		cause: Schema.optional(Schema.Unknown),
+	},
+) {}
 
 export interface CaptureOptions {
 	/** Per-navigation timeout in ms (default 30s). */
@@ -100,6 +104,10 @@ export const captureShots = (
 					}),
 				{concurrency: 1},
 			),
-		(browser) => Effect.promise(() => browser.close()),
+		(browser) =>
+			Effect.tryPromise({
+				try: () => browser.close(),
+				catch: (cause) => new CaptureError({message: "failed to close chromium", cause}),
+			}),
 	);
 };

--- a/packages/design-capture/src/upload.ts
+++ b/packages/design-capture/src/upload.ts
@@ -75,6 +75,7 @@ export const parseUploadResponse = (res: RawUploadResponse): UploadOutcome => {
 		};
 	}
 	let parsed: unknown;
+	// biome-ignore lint/plugin: pure total classifier — the JSON.parse failure is fully absorbed into a returned UploadOutcome, never the E channel, so this is not the Effect-cosplay the rule targets; lifting it into Effect.try would break the documented pure/unit-tested contract (parseUploadResponse is called inside Effect.map at the seam).
 	try {
 		parsed = JSON.parse(res.body);
 	} catch {

--- a/packages/flake-rate/src/bin.ts
+++ b/packages/flake-rate/src/bin.ts
@@ -71,13 +71,8 @@ const clampWindow = (n: number): number => Math.max(1, Math.min(100, n));
 
 // Read the inventory markdown; a missing/unreadable file means "no recorded fixes" (an
 // empty discount set), never a hard failure — the budget then measures every run.
-const readInventory = (path: string): string => {
-	try {
-		return readFileSync(path, "utf8");
-	} catch {
-		return "";
-	}
-};
+const readInventory = (path: string): Effect.Effect<string> =>
+	Effect.try(() => readFileSync(path, "utf8")).pipe(Effect.orElseSucceed(() => ""));
 
 const report = Command.make(
 	"report",
@@ -92,7 +87,7 @@ const report = Command.make(
 		const perPage = clampWindow(window);
 		const github = yield* Github;
 		const runs = yield* github.workflowRuns({workflow, branch, perPage});
-		const fixes = yield* github.inventoryFixes(readInventory(inventory));
+		const fixes = yield* github.inventoryFixes(yield* readInventory(inventory));
 
 		const trend = flakeTrend(runs, Math.max(1, bucket));
 		const discounted = checkBudgetWithDiscount(runs, fixes, ZERO_FLAKE_BUDGET);

--- a/packages/gh-phoenix/src/bin.ts
+++ b/packages/gh-phoenix/src/bin.ts
@@ -25,7 +25,8 @@
 import {spawnSync} from "node:child_process";
 import {readFileSync} from "node:fs";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {Argument, Command} from "effect/unstable/cli";
 import {isZeroScope, lintCorpus, type ScanFile} from "./lint.ts";
 import {fileExists, resolveRealGh, resolveRepo} from "./resolve.ts";
@@ -74,16 +75,14 @@ const runShim = (argv: ReadonlyArray<string>): never => {
 
 // ── The `lint-skills` subcommand (the Effect CLI surface) ──────────────────────
 
-class FindingsFound extends Data.TaggedError("FindingsFound")<{readonly count: number}> {}
-class ZeroScope extends Data.TaggedError("ZeroScope")<{}> {}
+class FindingsFound extends Schema.TaggedErrorClass<FindingsFound>()(
+	"@kampus/gh-phoenix/FindingsFound",
+	{count: Schema.Number},
+) {}
+class ZeroScope extends Schema.TaggedErrorClass<ZeroScope>()("@kampus/gh-phoenix/ZeroScope", {}) {}
 
-const readFileOrSkip = (file: string): string | null => {
-	try {
-		return readFileSync(file, "utf8");
-	} catch {
-		return null;
-	}
-};
+const readFileOrSkip = (file: string): Effect.Effect<string | null> =>
+	Effect.try(() => readFileSync(file, "utf8")).pipe(Effect.orElseSucceed(() => null));
 
 const fileArg = Argument.string("file").pipe(
 	Argument.atLeast(1),
@@ -98,7 +97,7 @@ const lintSkills = Command.make(
 	Effect.fn(function* ({files}) {
 		const scanInput: ScanFile[] = [];
 		for (const file of files) {
-			const content = readFileOrSkip(file);
+			const content = yield* readFileOrSkip(file);
 			if (content !== null) scanInput.push({file, content});
 		}
 
@@ -171,8 +170,12 @@ if (sub !== undefined && sub !== "lint-skills" && !sub.startsWith("-")) {
 } else {
 	cli.pipe(
 		Command.run({version: "0.0.0"}),
-		Effect.catchTag("ZeroScope", () => Effect.sync(() => process.exit(ZERO_SCOPE_EXIT_CODE))),
-		Effect.catchTag("FindingsFound", () => Effect.sync(() => process.exit(FINDING_EXIT_CODE))),
+		Effect.catchTag("@kampus/gh-phoenix/ZeroScope", () =>
+			Effect.sync(() => process.exit(ZERO_SCOPE_EXIT_CODE)),
+		),
+		Effect.catchTag("@kampus/gh-phoenix/FindingsFound", () =>
+			Effect.sync(() => process.exit(FINDING_EXIT_CODE)),
+		),
 		Effect.provide(NodeServices.layer),
 		NodeRuntime.runMain,
 	);

--- a/packages/orphan-sweep/src/cloudflare.unit.test.ts
+++ b/packages/orphan-sweep/src/cloudflare.unit.test.ts
@@ -121,6 +121,7 @@ const renderedSurfaces = (cause: Cause.Cause<unknown>): string => {
 	return [
 		inspect(error, {depth: null}),
 		(() => {
+			// biome-ignore lint/plugin: pure total test helper — JSON.stringify can throw on a circular error object; the failure is fully absorbed into "" (one of the leak-surface strings being collected), never the E channel, so this is not Effect control flow to model.
 			try {
 				return JSON.stringify(error);
 			} catch {


### PR DESCRIPTION
Fixes #2751

## What

Phase-1 (#2736) Effect-v4 idiom remediation, red-to-green for Rules 1, 3, and 4 across the non-§CP ops/tooling packages. Mechanical, single-site-class fixes; no behavior change.

### Rule 1 — no `Effect.promise` / single-arg `Effect.tryPromise`
- `packages/cf-utils/src/scrub-command.ts` — the D1 scan/scrub calls now use object-notation `Effect.tryPromise({ try, catch })` with a new `ScrubDbError` (`Schema.TaggedErrorClass`).
- `packages/design-capture/src/capture.ts` — the `browser.close()` release finalizer now uses object-notation `Effect.tryPromise` (effect-smol's `acquireUseRelease` allows an `E3` release error channel, so this maps cleanly into `CaptureError`).

### Rule 3 — no `extends Data.TaggedError`
Converted to `Schema.TaggedErrorClass` with qualified `@kampus/<pkg>/<Tag>` identifiers:
- `cf-utils/src/flag.ts` — `FlagEnvNotFound`, `FlagKeyNotFound`, `FlagSetTargetInvalid`, `LeverGuardRefused` (their `get message()` overrides preserved).
- `cf-credentials/src/credentials.ts` — `CredentialValidationFailed`.
- `design-capture/src/capture.ts` — `CaptureError`.
- `gh-phoenix/src/bin.ts` — `FindingsFound`, `ZeroScope`. Since `TaggedErrorClass`'s identifier is the `_tag`, the two `Effect.catchTag` call-sites were updated to the qualified tags — exit-code behavior (2 findings / 3 zero-scope) unchanged.

### Rule 4 — no raw `try/catch` in effect-importing files
- `audit-run/src/adapter.ts`, `audit-stage/src/adapter.ts` — JSON.parse guards inside `Effect`-returning functions lifted to `Effect.try`.
- `gh-phoenix/src/bin.ts`, `flake-rate/src/bin.ts` — file-read helpers lifted to `Effect.try` + `Effect.orElseSucceed` (IO belongs in `Effect`); single callers updated.
- Two genuinely-pure sync classifiers carry a justified per-line `// biome-ignore lint/plugin`: `design-capture/src/upload.ts` `parseUploadResponse` (a documented PURE, unit-tested classifier whose JSON.parse failure is absorbed into the returned `UploadOutcome`, not the `E` channel) and the `orphan-sweep` test's `JSON.stringify` circular-ref guard.

Grounded in effect-smol `LLMS.md` (`Schema.TaggedErrorClass`, object-notation `tryPromise`) and `Effect.ts` `acquireUseRelease`.

## Verification
- Phase-1 rules report **zero findings** across all listed packages (`biome check` per package).
- `typecheck` clean; tests unchanged — 280 passing across the 8 packages.

Out of scope (per the epic): pipeline-cli (separate §CP child #2753) and grit-rule authoring.