### PR TITLE
feat(web): topbar status/signal zone — bildirim bell, karma glyph, divan reclass (#2613)

### DIFF
--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -38,17 +38,25 @@
 	display: flex;
 	gap: 2px;
 }
-/* The status-signal zone's divan link (#2611) reuses the destination nav-link
-   treatment for now — it left `.kp-topbar__nav` under the taxonomy reclass but its
-   affordance rework is the status/signal child's (#2613) job. Grouped, not duplicated. */
+/* The status-signal zone's divan link (#2611) reuses the destination nav-link treatment —
+   it left `.kp-topbar__nav` under the taxonomy reclass. Under #2613 it renders the Gavel
+   glyph, so it is an inline-flex box centering the icon; the glyph inherits the link's role
+   token (below) so hover/active stay monochrome. Grouped with the nav links, not duplicated. */
 .kp-topbar__nav a,
 .kp-topbar__signal-link {
+	display: inline-flex;
+	align-items: center;
 	padding: 4px 8px;
 	font: var(--t-body-sm);
 	font-weight: 500;
 	color: var(--text-secondary);
 	border-radius: var(--r-sm);
 	text-decoration: none;
+}
+/* The divan glyph follows its link's role token (icon.css pins `--text-secondary` by
+   default, so without this the parent hover/active color wouldn't reach it). */
+.kp-topbar__signal-link .kp-icon {
+	color: inherit;
 }
 .kp-topbar__nav a:hover,
 .kp-topbar__signal-link:hover {
@@ -154,7 +162,8 @@
 }
 
 /* The quiet unread bildirim chip on the user-menu trigger (#1694) — count is
-   text in a subtle outline, never color-only state. */
+   text in a subtle outline, never color-only state. Flag-off shape (nav-IA on relocates
+   the signal to the status-zone bell below). */
 .kp-topbar__bildirim-badge {
 	font: var(--t-meta);
 	color: var(--text-primary);
@@ -163,6 +172,23 @@
 	padding: 0 var(--s-1);
 	min-width: 1.25em;
 	text-align: center;
+}
+
+/* The status-zone unread bildirim signal (#2613) — the Bell glyph (ADR 0166) + count read
+   as "unread notifications" at a glance. A read-only signal: neutral role tokens, no accent,
+   no button/link chrome; the icon inherits the signal's color. */
+.kp-topbar__bildirim-signal {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--s-1);
+	color: var(--text-secondary);
+}
+.kp-topbar__bildirim-signal .kp-icon {
+	color: inherit;
+}
+.kp-topbar__bildirim-count {
+	font: var(--t-meta);
+	color: var(--text-primary);
 }
 
 /* Accent-scarcity containment law (#2614, epic #2595). Under the nav-IA zone grammar the

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -196,6 +196,87 @@ describe("Topbar accent-scarcity containment law (#2614)", () => {
 	});
 });
 
+describe("Topbar status/signal zone (#2613)", () => {
+	function renderStatus(props: Partial<Parameters<typeof Topbar>[0]>) {
+		return render(
+			<MemoryRouter>
+				<Topbar
+					nav={NAV}
+					divanTo="/divan"
+					karma={42}
+					user={{name: "Elif", username: "elif"}}
+					{...props}
+				/>
+			</MemoryRouter>,
+		);
+	}
+
+	it("flag on: the unread bildirim renders a bell affordance in the status zone, not a bare number", () => {
+		const {container} = renderStatus({navIa: true, bildirim: {to: "/bildirimler", unread: 3}});
+		const signal = screen.getByTestId("topbar-bildirim-badge");
+		// Lives in the status-signal zone, not on the user-menu trigger (its today's home).
+		expect(screen.getByTestId("topbar-zone-status-signal").contains(signal)).toBe(true);
+		expect(container.querySelector(".kp-topbar__user")?.contains(signal)).toBe(false);
+		// A drawn Lucide bell (an <svg>), so the count reads as "unread notifications", not a
+		// bare number; the count text is still present and the accessible name carries it.
+		expect(signal.querySelector("svg")).not.toBeNull();
+		expect(signal.textContent).toContain("3");
+		expect(signal.getAttribute("role")).toBe("status");
+		expect(signal.getAttribute("aria-label")).toBe("3 okunmamış bildirim");
+	});
+
+	it("flag on: no bildirim signal renders when unread is 0", () => {
+		renderStatus({navIa: true, bildirim: {to: "/bildirimler", unread: 0}});
+		expect(screen.queryByTestId("topbar-bildirim-badge")).toBeNull();
+	});
+
+	it("flag off: the unread bildirim stays the bare chip on the user-menu trigger (today's shape)", () => {
+		const {container} = renderStatus({navIa: false, bildirim: {to: "/bildirimler", unread: 3}});
+		const badge = screen.getByTestId("topbar-bildirim-badge");
+		expect(container.querySelector(".kp-topbar__user")?.contains(badge)).toBe(true);
+		// The flag-off chip is the bare number — no bell glyph.
+		expect(badge.querySelector("svg")).toBeNull();
+		expect(badge.textContent).toBe("3");
+	});
+
+	it("flag on: karma is a read-only status glyph — no button/link/accent affordance", () => {
+		renderStatus({navIa: true});
+		const karma = screen.getByTestId("topbar-karma");
+		expect(screen.getByTestId("topbar-zone-status-signal").contains(karma)).toBe(true);
+		// A read-only glyph, never a control: not rendered as (nor wrapped by) a button/link.
+		expect(karma.tagName).toBe("SPAN");
+		expect(karma.closest("button")).toBeNull();
+		expect(karma.closest("a")).toBeNull();
+	});
+
+	it("flag on: the divan entry renders as a status glyph (Lucide icon) with an accessible name", () => {
+		renderStatus({navIa: true});
+		const divan = screen.getByTestId("topbar-divan-link");
+		expect(screen.getByTestId("topbar-zone-status-signal").contains(divan)).toBe(true);
+		expect(divan.classList.contains("kp-topbar__signal-link")).toBe(true);
+		// A drawn glyph, not a text peer-noun — an <svg>, with "divan" carried as the link's
+		// accessible name so it stays discoverable without reading as a destination noun.
+		expect(divan.querySelector("svg")).not.toBeNull();
+		expect(screen.getByRole("link", {name: "divan"})).toBe(divan);
+	});
+
+	it("flag off: divan stays a plain-text entry in the nav row (byte-identical to today)", () => {
+		const {container} = renderStatus({navIa: false});
+		const divan = screen.getByTestId("topbar-divan-link");
+		expect(container.querySelector(".kp-topbar__nav")?.contains(divan)).toBe(true);
+		expect(divan.querySelector("svg")).toBeNull();
+		expect(divan.textContent).toBe("divan");
+	});
+
+	it("flag off: karma / bildirim / divan render exactly as today (the AC-4 no-op)", () => {
+		// Same three signals passed, flag off ⇒ no bell, no glyph, no zones — the pre-#2613 shape.
+		const {container} = renderStatus({navIa: false, bildirim: {to: "/bildirimler", unread: 3}});
+		for (const id of ZONE_TESTIDS) expect(screen.queryByTestId(id)).toBeNull();
+		expect(container.querySelector(".kp-topbar__bildirim-signal")).toBeNull();
+		expect(screen.getByTestId("topbar-divan-link").querySelector("svg")).toBeNull();
+	});
+});
+
 describe("Topbar tema toggle → theme picker (#2612)", () => {
 	it("flag off: the tema toggle still renders and behaves exactly as today", () => {
 		const onToggleTheme = vi.fn();

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,9 +1,11 @@
+import {Bell, Gavel} from "lucide-react";
 import type * as React from "react";
 import {useEffect, useRef} from "react";
 import {Link, NavLink, useNavigate} from "react-router";
 import {isSearchShortcut} from "../../lib/searchShortcut";
 import type {ThemeChoice} from "../../lib/theme";
 import {formatUnreadBadge, showUnreadBadge} from "../bildirim/bildirim";
+import {Icon} from "../Icon";
 import {Karma} from "../karma/Karma";
 import {Avatar} from "../ui/Avatar";
 import {Menu} from "../ui/Menu";
@@ -52,7 +54,8 @@ export function Topbar({
 	 * The bildirim entry (#1694). Rendered only when set — the Layout passes it
 	 * solely when the `phoenix-bildirim` flag is on AND the viewer is signed in,
 	 * so with the flag off (the dark default) the topbar is exactly as before.
-	 * The unread chip on the trigger renders only when `unread > 0` (the AC).
+	 * The unread signal renders only when `unread > 0`: the bare chip on the
+	 * user-menu trigger with nav-IA off, the status-zone bell with it on (#2613).
 	 */
 	bildirim?: {to: string; unread: number};
 	actions?: React.ReactNode;
@@ -128,18 +131,21 @@ export function Topbar({
 			{n.label}
 		</NavLink>
 	));
-	// Under the zone grammar divan leaves `.kp-topbar__nav`, so it carries
-	// `kp-topbar__signal-link` to keep the nav-link treatment (grouped in the CSS). Off,
-	// it stays inside the nav and needs no class — omitting it keeps the flag-off DOM
-	// byte-identical to today (`undefined` renders no `class` attribute).
+	// Under the zone grammar divan is a status/signal glyph (#2613): a gated signal, not a
+	// peer product noun, so it leaves `.kp-topbar__nav` for the status zone and reads as the
+	// canonical Gavel icon (ADR 0166) with an accessible "divan" name, keeping the
+	// `kp-topbar__signal-link` treatment (grouped in the CSS). Off, it stays the plain text
+	// nav entry with no class — keeping the flag-off DOM byte-identical to today.
 	const divanLink = divanTo ? (
 		<NavLink
 			key={divanTo}
 			to={divanTo}
 			data-testid="topbar-divan-link"
 			className={navIa ? "kp-topbar__signal-link" : undefined}
+			aria-label={navIa ? "divan" : undefined}
+			title={navIa ? "divan" : undefined}
 		>
-			divan
+			{navIa ? <Icon icon={Gavel} size={16} /> : "divan"}
 		</NavLink>
 	) : null;
 	const searchForm = (
@@ -197,12 +203,35 @@ export function Topbar({
 		typeof karma === "number" ? (
 			<Karma value={karma} variant="inline" testId="topbar-karma" className="kp-topbar__karma" />
 		) : null;
+	// The unread bildirim signal in the status zone (#2613). Under the zone grammar the count
+	// carries a legible Bell affordance (ADR 0166) so it reads as "unread notifications" at a
+	// glance, not a bare number. Same render rule as the flag-off badge — only when the
+	// `phoenix-bildirim` flag put a `bildirim` here AND unread > 0 (the badge's a11y label is
+	// the accessible name; the bell is decorative). Off, the count stays the bare chip on the
+	// user-menu trigger below (byte-identical to today).
+	const bildirimSignal =
+		navIa && bildirim && showUnreadBadge(bildirim.unread) ? (
+			<span
+				className="kp-topbar__bildirim-signal"
+				data-testid="topbar-bildirim-badge"
+				role="status"
+				aria-label={`${bildirim.unread} okunmamış bildirim`}
+			>
+				<Icon icon={Bell} size={16} />
+				<span className="kp-topbar__bildirim-count" aria-hidden="true">
+					{formatUnreadBadge(bildirim.unread)}
+				</span>
+			</span>
+		) : null;
 	const userMenu = user ? (
 		<Menu.Root>
 			<Menu.Trigger className="kp-topbar__user">
 				<Avatar name={user.name} src={user.src} />
 				<span>{user.name}</span>
-				{bildirim && showUnreadBadge(bildirim.unread) ? (
+				{/* Flag off, the unread count is the bare chip on the trigger (today's shape); on,
+				    it moves to the status-zone bell (`bildirimSignal`) so the signal sits in its
+				    lawful zone (#2613) and the trigger stays unbadged. */}
+				{!navIa && bildirim && showUnreadBadge(bildirim.unread) ? (
 					<span
 						className="kp-topbar__bildirim-badge"
 						data-testid="topbar-bildirim-badge"
@@ -244,8 +273,9 @@ export function Topbar({
 	// user menu) are the structural spine, not a taxonomy class. The primary-action zone
 	// is empty/reserved — #2600 relocated the promoted `+ gönderi` verb to the pano
 	// Subnav CTA, so no product-scoped occupant lives in the global bar (it does not
-	// re-add one). divan/karma move into the status-signal zone here; their affordance
-	// rework is the status/signal child's (#2613) job, not this spine's.
+	// re-add one). The status-signal zone carries the read-only signals reworked in #2613:
+	// the divan glyph, the karma glyph, and the bildirim bell — each a legible affordance in
+	// its lawful zone, none a control or accent.
 	if (navIa) {
 		return (
 			<header className="kp-topbar">
@@ -276,6 +306,7 @@ export function Topbar({
 				>
 					{divanLink}
 					{karmaChip}
+					{bildirimSignal}
 				</div>
 				{actions}
 				{userMenu}


### PR DESCRIPTION
## What

Reworks the topbar's read-only **status/signal** elements so each carries a legible affordance in its lawful zone under the nav-IA grammar (taxonomy #2586, per-element verdicts #2591; epic #2595). Scoped to the topbar status/signal zone — no divan moderation page change, no shared `ToggleGroup`/`tokens.css` change.

- **bildirim bell.** The unread count moves off the user-menu trigger into the status zone as a **Bell** glyph (canonical icon idiom, ADR 0166) + count, so it reads as "unread notifications" at a glance rather than a bare number. Same render rule as today — only when the `phoenix-bildirim` flag put a `bildirim` here **and** unread > 0.
- **karma glyph.** Stays the read-only inline `Karma` glyph in the status zone — no button, no accent affordance.
- **divan signal.** Renders as the **Gavel** status glyph (a gated signal, not a peer product noun) with an accessible "divan" name, preserving its yazar/mod gating (`divanTo`) and the `topbar-divan-link` testid.

With the shared nav-IA flag **off**, karma / bildirim / divan render exactly as today (byte-identical): the bare bildirim chip stays on the trigger, divan stays a plain-text nav entry, no zones exist.

## Tests

Extends `apps/web/src/components/layout/Topbar.test.tsx` with a `#2613` block: the bell affordance renders in the status zone (not on the trigger) only when the flag is on and unread > 0; no signal at unread 0; the flag-off bare chip stays on the trigger; karma is a read-only span (not a button/link); divan renders as a Lucide glyph with an accessible name; and the flag-off no-op (AC 4). Full file: 20 passed. `pnpm typecheck` + biome clean.

## Design law

Follows `design-system-manifest.md` §canonical icon idiom (drawn Lucide via the `Icon` wrapper, monochrome `currentColor` role tokens, 16px on the ruled scale) and the accent-scarcity containment law — the status zone paints zero accent fills (the existing #2614 CSS-source guard still passes).

Fixes #2613