### PR TITLE
feat(pipeline): #2778 primary-index mass-staged-deletion diagnosis + read-only attribution tripwire

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -84,6 +84,27 @@ pre-commit:
           exit 1
         fi
 
+    # Read-only ATTRIBUTION for the #2778 primary-index mass-staged-deletion corruption: the
+    # primary checkout's index accumulating a mass of staged deletions of the instruction-trust set
+    # (.claude/**, .decisions/**, …) is the loaded-gun state — a commit + push from the primary would
+    # land a control-plane mass-deletion on origin/main. This leg RECORDS (never blocks) the actor
+    # about to commit that state at the one caller-agnostic choke point git fires — pre-commit —
+    # capturing agent-type / session-id / cwd so the next occurrence is attributable. It NEVER gates
+    # a commit (the recorder always exits 0); *preventing* the staging + *blocking* the commit is the
+    # §CP hardening fix (ops/incidents/2778-primary-index-mass-staged-deletion.md), out of scope here.
+    #
+    # Fail-OPEN on an absent toolchain, exactly like leak-guard: a stripped-PATH / no-node worktree
+    # can't run the recorder — SKIP (exit 0), never abort a commit. A resolved recorder is itself
+    # non-blocking, so this leg can NEVER block a commit; CI/the §CP fix stay the real defense.
+    primary-index-tripwire:
+      run: |
+        command -v node >/dev/null 2>&1 || {
+          echo "primary-index-tripwire: no node on PATH (stripped-PATH/lean worktree); skipping #2778 attribution — read-only, non-blocking anyway" >&2
+          exit 0
+        }
+        node packages/primary-index-tripwire/src/bin.ts record || true
+        exit 0
+
 # The deps-dependent fast-fail tier (#2147): typecheck + changed-scoped unit tests fire
 # at PUSH time, not commit time, because they need `node_modules` (unlike biome). Scoped so
 # each push stays cheap — vitest `--changed origin/main` runs only the suites related to

--- a/ops/README.md
+++ b/ops/README.md
@@ -47,3 +47,13 @@ sections in the same order:
 The capacity baseline is a measurement record rather than a failure-mode procedure, so it
 documents the **numbers and the method that produced them** instead of following the shape
 above.
+
+## Incidents
+
+Post-incident diagnoses of pipeline/infra corruption — the mechanism trace, the vectors ruled
+in/out, the containment that caught it, and the follow-up fix it names. Unlike a runbook (a
+procedure to *run*), an incident diagnosis is a *record* of what happened and why.
+
+| Incident | Covers |
+|---|---|
+| [#2778 primary-index mass staged deletion](./incidents/2778-primary-index-mass-staged-deletion.md) | The shared primary checkout's index accumulating 248 staged deletions of the instruction-trust set (`.claude/**`, `.decisions/**`) under worktree-isolated agents — vectors, main-sync's incidental containment, and the read-only attribution tripwire. |

--- a/ops/incidents/2778-primary-index-mass-staged-deletion.md
+++ b/ops/incidents/2778-primary-index-mass-staged-deletion.md
@@ -1,0 +1,210 @@
+# Incident diagnosis — primary-index mass staged deletion (#2778)
+
+Investigation of [#2778](https://github.com/kamp-us/phoenix/issues/2778) (`type:investigation`,
+`p1`, `axis:pipeline-hardening`). This is the **diagnosis** artifact — a mechanism trace, a
+rule-in/out of every candidate vector, a characterization of the containment that caught it, and the
+scoped §CP hardening fix it names. The fix itself is out of scope (§CP, merge-by-hand); this unit is
+read-only diagnosis + read-only instrumentation.
+
+Related: [#2666](https://github.com/kamp-us/phoenix/issues/2666) (the inbound/milder sibling — see
+[§ Same-vs-distinct](#same-vs-distinct-vs-2666)).
+
+## The observed state
+
+Operating from the **primary** (non-worktree) checkout at repo root while worktree-isolated pipeline
+agents ran, the primary git **index** held:
+
+- **248 staged deletions** of tracked files under `.claude/**`, `.decisions/**`, and more
+  (first-column `D` in `git status`).
+- **0 unstaged modifications**, **0 commits ahead** of `origin/main`.
+- A HEAD reflog of only clean fast-forward merges — **no** `reset`/`checkout` accounting for the
+  staging.
+
+Signature: a `git rm -r --cached`- / `git add`-equivalent run over already-removed paths against the
+**primary** index (not a worktree index). Recovery was clean — `git reset --hard origin/main` (0
+commits to lose, untracked preserved); origin was never touched. Verified read-only during this
+investigation: the primary is back on `main` with 0 staged deletions.
+
+**Key forensic fact:** staging mutates only `.git/index`; it leaves **no reflog trace**. So the
+resulting index state is identical whether the staging ran from the primary operator session or from
+a worktree agent whose cwd reset to the primary — the state alone cannot attribute the actor. That is
+the whole reason the deliverable includes *instrumentation* (below), not just a root-cause name.
+
+## Where a mass staged deletion into the PRIMARY index can come from
+
+Every path by which a pipeline actor's git op can stage into the primary index, each ruled in or out
+against the current code:
+
+### 1. Git hooks in the shared `.git` — RULED OUT as the stager
+
+Linked worktrees share the primary `.git`, object store, and hook set. Auditing every hook in
+[`lefthook.yml`](../../lefthook.yml):
+
+- **`post-checkout` (`bootstrap-deps`)** — fires on `git worktree add`. It runs
+  `pnpm install --prefer-offline --ignore-scripts` and nothing else. It **stages nothing**. (It is
+  careful *not* to run lifecycle scripts precisely because the hook set is shared.) Not the stager.
+- **`pre-commit` (`leak-guard`, `biome`)** — scan-only; stage nothing.
+- **`pre-push` (`typecheck`, `unit-changed`)** — read-only checks; stage nothing.
+- **`reference-transaction` (`ref-guard`)** — refuses a *diverging* `refs/heads/main` move; it never
+  stages. (Its role in the blast radius is analyzed [below](#is-the-guard-sufficient).)
+
+No git hook stages files. The mass staging came from a **git command run by an actor**, not a hook.
+
+### 2. A managed-worktree agent whose cwd reset to primary — CONTAINED when the guard is active
+
+The leading hypothesis in the issue: a worktree-isolated agent whose Bash cwd silently reset to the
+primary checkout between tool calls (the documented `isolation:worktree` cwd-reset) ran an unscoped
+staging command there.
+
+The containment against exactly this is the `worktree-guard pre-bash` `PreToolUse` hook
+([`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`](../../packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts),
+`pinBash`). For a managed-worktree agent it:
+
+- **refuses** an auto-stage-all op (`git add -A/--all/.`, `git commit -a`) — the #2666 containment;
+- **refuses** an unscoped head-moving op (`checkout`/`switch`/`reset`/`rebase`/`stash`/`merge`);
+- otherwise **rewrites** the command to `cd "$WORKTREE_ROOT" && <command>`.
+
+That rewrite is the load-bearing fact for this vector: a bare `git add -u` or `git rm -r --cached
+.claude/` issued after a cwd reset is rewritten to run **inside the worktree**, so it stages against
+the **worktree** index — never the primary. **So when the pre-bash hook is active, a *bare*
+reset-cwd staging command cannot reach the primary index.**
+
+Therefore this hypothesis is ruled **in only for a session where the pre-bash hook was NOT active**
+— e.g. a session whose plugin hooks were not enabled/installed at `SessionStart`, or a git op issued
+outside the `Bash` tool-hook path. Two residual escapes survive even an *active* hook, but both
+require the agent to **explicitly name the primary** (not a cwd-reset accident):
+
+- `cd <primary> && git add …` — a leading `cd` is trusted and allowed (the hook does not fight an
+  explicit cwd).
+- `git -C <primary> add …` / `git -C <primary> rm --cached …` — `add`/`rm` are not in the hook's
+  head-moving set and (non-stage-all) are not refused; the `-C <primary>` overrides even the cd-pin
+  rewrite.
+
+Neither is a plausible *accidental* mass-deletion. So the cwd-reset-to-primary mechanism reduces to a
+single question — **was the pre-bash hook active in the incident session?** If yes, this vector is
+closed for bare commands; if no, it is wide open.
+
+### 3. The primary operator / orchestrator session — the ALWAYS-UNGUARDED surface (top suspect)
+
+`pinBash` is **deliberately a no-op for the orchestrator's own shell**: no `$WORKTREE_ROOT`, no
+isolation asserted, so it returns `allow` for every command (this is intentional — the orchestrator's
+legitimate `git checkout main` ff-reattach must not be refused). The consequence: **any** unscoped
+`git add` / `git rm --cached` run in the primary operator session hits the primary index with **no
+containment layer at all**, regardless of whether the worktree plugin is enabled.
+
+This surface has no guard in either regime (hook active or not), which makes it the **top suspect**:
+an operator/orchestrator-context git op (a cleanup, a botched `git add` after paths were removed, a
+tool that staged) against the primary index would produce the exact observed state and leave no
+reflog trace.
+
+### 4. Shared-index / `git worktree` plumbing side-effects — RULED OUT
+
+`git worktree add`/`remove`/`prune` and the `reap` subcommand
+([`worktree-guard`](../../packages/pipeline-cli/src/tools/worktree-guard/command.ts)) operate on
+per-worktree metadata and the worktree's own tree; none stage into the primary index. The `reap`
+path runs `git worktree remove` **without `--force`** (it refuses on a dirty tree), so it cannot mass-
+delete-and-stage. No shared-index interaction stages the primary.
+
+## Root-cause finding (narrowed, with evidence)
+
+The 248 staged deletions were an **unscoped `git add` / `git rm --cached`-class command executed
+against the PRIMARY index by an actor NOT covered by the `pinBash` cwd-pin** — narrowed to two
+indistinguishable-by-state candidates, in likelihood order:
+
+1. **The primary operator/orchestrator session (top suspect).** `pinBash` is a deliberate no-op
+   there, so this surface is unguarded in *every* regime. Any unscoped staging command run in that
+   session lands on the primary index.
+2. **A worktree agent whose pre-bash hook was inactive that session** (plugin not enabled/installed
+   at spawn), with a cwd reset to primary and a bare staging command. With the hook **active**, this
+   is contained to the worktree, so this candidate requires an inactive-hook session.
+
+Vectors 1 and 4 (hooks, worktree plumbing) are ruled out as stagers; vector 2 is contained *iff the
+hook was active*. Because staging leaves no reflog trace, the two surviving candidates cannot be
+separated from the post-hoc index state — **which is precisely what the instrumentation below exists
+to resolve on the next occurrence.**
+
+## Why main-sync caught it, and is it sufficient
+
+### What caught it
+
+`pipeline-cli main-sync`
+([`packages/pipeline-cli/src/tools/main-sync/main-sync.ts`](../../packages/pipeline-cli/src/tools/main-sync/main-sync.ts))
+surfaced the state via `decideMainRefresh`: on `main` with **tracked modifications**
+(`hasTrackedModifications` — staged deletions are staged changes to tracked files), it returns
+`leave-alone` with reason `dirty` and **refuses to fast-forward**, surfacing the dirt instead of
+advancing. That fail-closed refusal is what stopped the sanctioned sync path and made the corruption
+visible ("primary has diverged / dirty; resolve by hand").
+
+Note the drain-sync half (`decideMainSync`) would *not* have caught it on its own: HEAD was on `main`
+(0 commits ahead), so it returns `already-on-main` and does not consult dirt — it is
+`decideMainRefresh`'s `hasTrackedModifications` gate specifically that surfaced the staged deletions.
+
+### Is the guard sufficient? No — the catch was incidental.
+
+- **It detects, it does not prevent.** main-sync only observes the *resulting* dirty state the next
+  time the orchestrator runs it; it does nothing about the staging itself.
+- **It only fires on the sanctioned path.** A blind hand-rolled `git commit` + `git push` from the
+  primary **bypasses main-sync entirely**.
+- **The deeper caller-agnostic guard does not cover this.** The `reference-transaction` `ref-guard`
+  fires for every ref update regardless of caller — but it refuses only a **diverging** (non-fast-
+  forward) `refs/heads/main` move. A commit of the 248 deletions **on top of** `origin/main` is a
+  **fast-forward** of origin, so `ref-guard` **allows** it, and the subsequent push allows it. So
+  nothing in the current stack would stop a primary `git commit` + `git push` from landing a 248-file
+  control-plane deletion on `origin/main`.
+
+**The residual blast-radius surface:** a direct primary commit + push that fast-forwards the mass
+deletion onto `origin/main`. main-sync's dirty-check catches the *staged-but-uncommitted* state on
+one path; once committed as a fast-forward, only the human-merge / branch-protection layer stands
+between it and origin.
+
+## The read-only instrumentation (this unit)
+
+`@kampus/primary-index-tripwire`
+([`packages/primary-index-tripwire/`](../../packages/primary-index-tripwire/)) — a pure, unit-tested
+detection core plus a thin Effect CLI that, at commit time, records (never blocks) an **attribution
+event** when the staged index carries the #2778 signature (a mass control-plane staged deletion),
+capturing `CLAUDE_CODE_AGENT` / `CLAUDE_CODE_SESSION_ID` / cwd / primary-vs-worktree. It is wired as a
+read-only, fail-open `pre-commit` leg in [`lefthook.yml`](../../lefthook.yml).
+
+Why `pre-commit`: it is the one **caller-agnostic** choke point git itself fires — it captures the
+primary operator session (the top suspect, invisible to the `PreToolUse` Bash hook) *and* any worktree
+agent, at the exact moment before the blast (commit → push). It attributes the **actor committing the
+corrupted index**; the full *staging-command* attribution (which `git add`/`rm` ran, with its cwd)
+requires wiring into the `PreToolUse` Bash hook, which is §CP — see the fix below.
+
+Detection/attribution only: the recorder always exits 0, writes to an out-of-repo log, and mutates
+nothing. It is a tripwire, not a gate.
+
+## The §CP hardening fix (named, out of scope)
+
+The fix is §CP (merge-by-hand): it touches `claude-plugins/kampus-pipeline/skills/write-code/**`,
+`packages/pipeline-cli/**`, and/or `.claude/**` — all matching `CONTROL_PLANE_RE`. Recommended shape:
+
+1. **Close the unguarded primary-operator surface.** Extend the caller-agnostic guard so a *staging*
+   op that would delete the control-plane set from the primary index is refused (not just a diverging
+   ref move) — i.e. a primary-index guard analogous to `ref-guard`, or promote the tripwire from
+   record-only to block-on-primary. This is the real fix for the top suspect (vector 3).
+2. **Wire the tripwire's attribution into the `PreToolUse` Bash hook** (`worktree-guard pre-bash`) so
+   the *staging command + cwd + agent* is captured at the moment it runs, not just at commit — giving
+   full attribution and closing the "was the hook active?" ambiguity of vector 2.
+3. **Harden main-sync's containment into a guarantee** rather than an incidental catch — assert a
+   clean primary index on the sync path and refuse a hand-rolled primary commit path that bypasses it.
+
+## Same-vs-distinct vs #2666
+
+**Distinct-but-related; keep both open, cross-linked — do not close/dup either** (a human merge call,
+recorded here per the AC, not executed):
+
+- **#2666** — inbound/milder: an *unauthored uncommitted hunk* appearing **inside** a fresh worktree
+  (content bleeding INTO a worktree; benign, load-bearing on commit-by-explicit-path).
+- **#2778** (this) — outbound/severe: mass *staged deletions* in the **primary** index (staging
+  leaking OUT to the primary; blast radius = a control-plane mass-deletion push to `origin/main`).
+
+Shared root family — **git state crossing checkout boundaries under worktree-isolated agents on a
+shared `.git`** — but they differ in *direction* (into-worktree vs into-primary), *severity*, and
+proximate mechanism (provisioning bleed vs an unscoped/unguarded staging op against the primary).
+Neither subsumes the other. A single root-cause hardening ("worktree-isolated git ops crossing
+checkout boundaries") may resolve both; consolidating them is a deliberate human merge, not an auto-
+close. **Evidence for shared-root:** #2666's containment (`pinBash`'s stage-all refusal) and this
+diagnosis both turn on the same `pinBash`/shared-`.git` seam; the divergence is only *which side* of
+the checkout boundary the state crossed.

--- a/packages/primary-index-tripwire/README.md
+++ b/packages/primary-index-tripwire/README.md
@@ -1,0 +1,46 @@
+# @kampus/primary-index-tripwire
+
+Read-only **attribution** instrumentation for the corruption diagnosed in
+[#2778](https://github.com/kamp-us/phoenix/issues/2778): the shared **primary** (non-worktree)
+checkout's index accumulating a mass of **staged deletions** of the instruction-trust set
+(`.claude/**`, `.decisions/**`, and more) with a clean reflog — the loaded-gun state where one
+blind `git commit` + `push` from the primary would land a mass deletion of the control plane on
+`origin/main`.
+
+## What it is
+
+A pure, unit-tested detection core (`src/tripwire.ts`) plus a thin Effect CLI (`src/bin.ts`) that,
+at commit time, decides whether the staged fileset is the #2778 signature and — on a trip —
+**records an attribution event** naming *who* (agent-type, `CLAUDE_CODE_SESSION_ID`) is about to
+commit it, *where* (cwd, primary-checkout vs worktree), and *how much* (deletion counts + a sample
+of paths).
+
+Staging leaves no reflog trace, so the corrupted index state alone can't say which actor ran the
+staging — which is exactly why attribution has to be captured live, at the one caller-agnostic
+choke point git itself fires: `pre-commit`.
+
+## What it is NOT
+
+- **It never blocks.** `record` always exits 0. It observes and logs; it does not gate a commit or
+  a merge. *Preventing* the staging (scoping worktree git ops, guarding the primary index) and
+  *blocking* the dangerous commit are the §CP hardening fix, tracked out of scope of the
+  investigation — see [`ops/incidents/2778-primary-index-mass-staged-deletion.md`](../../ops/incidents/2778-primary-index-mass-staged-deletion.md).
+- **It never mutates the repo.** Git facts are gathered with read-only plumbing (`git rev-parse`,
+  `git diff --cached`); the attribution log is written to an **out-of-repo** path so recording never
+  dirties the tree it observes.
+- **Its path classifier is not `ship-it`'s `CONTROL_PLANE_RE`.** `CONTROL_PLANE_DELETION_PREFIXES`
+  is a deletion-signature heuristic for raising an attribution flag, deliberately independent of the
+  merge-blocking control-plane contract — it carries no dependency on it and never moves in lockstep.
+
+## Usage
+
+```bash
+# record an attribution event if the staged index is the #2778 signature (else silent), exit 0
+node packages/primary-index-tripwire/src/bin.ts record
+node packages/primary-index-tripwire/src/bin.ts record --threshold 20 --log /tmp/tripwire.jsonl
+```
+
+The attribution log path is `$PRIMARY_INDEX_TRIPWIRE_LOG`, else
+`${TMPDIR:-/tmp}/primary-index-tripwire.jsonl`. It is wired as a read-only `pre-commit` leg in the
+repo-root `lefthook.yml` (fail-open: a missing toolchain skips, a trip records, the commit always
+proceeds).

--- a/packages/primary-index-tripwire/package.json
+++ b/packages/primary-index-tripwire/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@kampus/primary-index-tripwire",
+	"version": "0.0.0",
+	"private": true,
+	"description": "read-only attribution tripwire for the #2778 primary-index mass-staged-deletion corruption — records (never blocks) a commit about to capture a mass control-plane deletion",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"record": "node src/bin.ts record"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/primary-index-tripwire/src/bin.ts
+++ b/packages/primary-index-tripwire/src/bin.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * `primary-index-tripwire record` — the read-only attribution leg for the #2778 corruption.
+ *
+ * Gathers git facts with READ-ONLY plumbing (`git-io.ts`), reads the agent-identity env, runs the
+ * pure {@link decideTripwire} core, and — on a trip — appends a JSON attribution record to a log path
+ * and prints a LOUD stderr warning. It NEVER blocks and NEVER mutates git or the working tree: the
+ * exit code is always 0, so wiring it into a `pre-commit` hook (see `lefthook.yml`) records the actor
+ * about to commit a mass control-plane deletion without ever preventing a legitimate commit.
+ * Prevention/blocking is the §CP hardening fix, out of scope here
+ * (`ops/incidents/2778-primary-index-mass-staged-deletion.md`).
+ *
+ * The log path is `$PRIMARY_INDEX_TRIPWIRE_LOG`, else `${TMPDIR:-/tmp}/primary-index-tripwire.jsonl`
+ * — an OUT-OF-REPO path so recording never dirties the tree it observes. Wired per effect-smol's CLI
+ * guidance (mirrors `@kampus/orphan-sweep`): `effect/unstable/cli` for typed flags over
+ * `NodeServices.layer`, run via `NodeRuntime.runMain`; the read-only git/log IO lives in `git-io.ts`.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {appendRecord, defaultLogPath, detectPrimaryCheckout, stagedDeletions} from "./git-io.ts";
+import {decideTripwire, parseNameStatus, renderWarning} from "./tripwire.ts";
+
+const thresholdFlag = Flag.integer("threshold").pipe(
+	Flag.withDefault(10),
+	Flag.withDescription("min control-plane staged deletions to record an attribution trip"),
+);
+
+const logFlag = Flag.string("log").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"attribution log path (default: $PRIMARY_INDEX_TRIPWIRE_LOG or a temp file)",
+	),
+);
+
+const record = Command.make(
+	"record",
+	{threshold: thresholdFlag, log: logFlag},
+	Effect.fn(function* ({threshold, log}) {
+		const decision = decideTripwire({
+			onPrimaryCheckout: detectPrimaryCheckout(),
+			staged: parseNameStatus(stagedDeletions()),
+			cwd: process.cwd(),
+			agentType: process.env.CLAUDE_CODE_AGENT ?? "",
+			sessionId: process.env.CLAUDE_CODE_SESSION_ID ?? "",
+			worktreeRoot: process.env.WORKTREE_ROOT ?? "",
+			threshold,
+			at: new Date().toISOString(),
+		});
+		if (decision.kind === "quiet") return;
+		const logPath = Option.getOrElse(log, defaultLogPath);
+		appendRecord(logPath, `${JSON.stringify(decision.record)}\n`);
+		yield* Console.error(`${renderWarning(decision.record)} → recorded to ${logPath}`);
+	}),
+).pipe(
+	Command.withDescription(
+		"Read-only #2778 attribution: record (never block) a mass control-plane staged deletion at commit time",
+	),
+);
+
+record.pipe(
+	Command.run({version: "0.0.0"}),
+	Effect.provide(NodeServices.layer),
+	NodeRuntime.runMain,
+);

--- a/packages/primary-index-tripwire/src/git-io.ts
+++ b/packages/primary-index-tripwire/src/git-io.ts
@@ -1,0 +1,47 @@
+/**
+ * The read-only IO boundary for the tripwire bin — plain node, no Effect import.
+ *
+ * Kept separate from `bin.ts` on purpose: these are best-effort, must-never-throw guards over `git`
+ * plumbing and a log append (the read-only contract — recording must never perturb the commit it
+ * observes), so native `try/catch`-and-swallow is the correct shape, not domain failure modeled in an
+ * Effect `E` channel. Isolating them here keeps `bin.ts` free of raw `try/catch` (the effect-file ban).
+ */
+import {execFileSync} from "node:child_process";
+import {appendFileSync} from "node:fs";
+import {resolve} from "node:path";
+
+/** Run a read-only `git` command; on any failure (git absent, not a repo) return "" rather than throw. */
+export const gitFact = (args: readonly string[]): string => {
+	try {
+		return execFileSync("git", args as string[], {encoding: "utf8"}).trim();
+	} catch {
+		return "";
+	}
+};
+
+/** `git-dir == git-common-dir` ⇒ the primary checkout; they differ in a linked worktree. */
+export const detectPrimaryCheckout = (): boolean => {
+	const gitDir = gitFact(["rev-parse", "--absolute-git-dir"]);
+	const commonRaw = gitFact(["rev-parse", "--git-common-dir"]);
+	if (gitDir === "" || commonRaw === "") return false; // unknowable ⇒ don't over-claim primary
+	const common = commonRaw.startsWith("/") ? commonRaw : resolve(process.cwd(), commonRaw);
+	return resolve(gitDir) === resolve(common);
+};
+
+/** Read the staged deletions as `git diff --cached --name-status` output (read-only). */
+export const stagedDeletions = (): string =>
+	gitFact(["diff", "--cached", "--name-status", "--diff-filter=D"]);
+
+/** Append one record line to the log; a missing/unwritable path is swallowed (best-effort attribution). */
+export const appendRecord = (logPath: string, line: string): void => {
+	try {
+		appendFileSync(logPath, line);
+	} catch {
+		// unwritable log path must never perturb the commit — read-only contract; the caller still warns.
+	}
+};
+
+/** The attribution log path: `$PRIMARY_INDEX_TRIPWIRE_LOG`, else a temp file. */
+export const defaultLogPath = (): string =>
+	process.env.PRIMARY_INDEX_TRIPWIRE_LOG ??
+	resolve(process.env.TMPDIR ?? "/tmp", "primary-index-tripwire.jsonl");

--- a/packages/primary-index-tripwire/src/index.ts
+++ b/packages/primary-index-tripwire/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./tripwire.ts";

--- a/packages/primary-index-tripwire/src/tripwire.ts
+++ b/packages/primary-index-tripwire/src/tripwire.ts
@@ -1,0 +1,144 @@
+/**
+ * `@kampus/primary-index-tripwire` pure core — decide whether a to-be-committed staged fileset
+ * carries the signature of the #2778 corruption (a mass staged-deletion of the instruction-trust
+ * set against the PRIMARY index) and build an attribution record naming WHO/WHERE is about to
+ * commit it.
+ *
+ * DETECTION + ATTRIBUTION ONLY. This core never blocks a commit and never mutates git — it emits a
+ * record so the *next* occurrence is attributable (which actor, on which checkout, from which cwd).
+ * Preventing the staging (scoping worktree git ops, guarding the primary index) and *blocking* the
+ * dangerous commit are the §CP hardening fix tracked separately — see
+ * `ops/incidents/2778-primary-index-mass-staged-deletion.md`. Read-only by construction: the caller
+ * (`bin.ts`) gathers git facts with read-only plumbing and this module is IO-free and total.
+ *
+ * The #2778 signature (from the incident, verbatim): the primary index held 248 staged deletions of
+ * tracked files under `.claude/**`, `.decisions/**`, and more — 0 unstaged modifications, 0 commits
+ * ahead, a reflog of only clean fast-forward merges. Staging leaves no reflog trace, so the resulting
+ * index state alone cannot say *which* actor ran the staging; the record this core builds captures the
+ * identity/cwd context at the one caller-agnostic choke point that git itself fires — `pre-commit`.
+ */
+
+/** One `git diff --cached --name-status` row: the status letter plus the path. */
+export interface StagedEntry {
+	/** The name-status letter — `D` for a staged deletion (the signal), `M`/`A`/`R…` otherwise. */
+	readonly status: string;
+	readonly path: string;
+}
+
+/**
+ * The instruction-trust / control-plane path prefixes whose EN-MASSE staged deletion is the #2778
+ * signature. A normal feature commit never deletes these wholesale; a mass deletion of them is the
+ * loaded-gun state (a commit + push would land it on `origin/main`). This is a DETECTION heuristic
+ * for attribution, deliberately distinct from `ship-it`'s merge-blocking `CONTROL_PLANE_RE` — it
+ * classifies *deleted paths* to raise an attribution flag, not to gate a merge, so it carries no
+ * dependency on that contract and never needs to move in lockstep with it.
+ */
+export const CONTROL_PLANE_DELETION_PREFIXES: readonly string[] = [
+	".claude/",
+	".decisions/",
+	".github/",
+	".glossary/",
+	".patterns/",
+	"claude-plugins/",
+];
+
+/** True when a path falls under one of the instruction-trust prefixes above. */
+export const isControlPlaneDeletion = (path: string): boolean =>
+	CONTROL_PLANE_DELETION_PREFIXES.some((p) => path.startsWith(p));
+
+/** The git + environment facts the decision needs, gathered read-only at the caller's IO boundary. */
+export interface TripwireInput {
+	/**
+	 * The commit is against the PRIMARY checkout (`git-dir == git-common-dir`) — the SEVERE surface
+	 * (a push here lands on `origin/main`). A linked worktree's index is contained to its own branch;
+	 * the record still fires (a worktree that reached this state is the #2666 bleed class) but the
+	 * `onPrimaryCheckout` flag records the severity.
+	 */
+	readonly onPrimaryCheckout: boolean;
+	readonly staged: readonly StagedEntry[];
+	readonly cwd: string;
+	/** `$CLAUDE_CODE_AGENT` — the agent-type context (`coder`/`reviewer`/`engineering-manager`/…), or "". */
+	readonly agentType: string;
+	/** `$CLAUDE_CODE_SESSION_ID` — the per-agent UUID that survives the shared `usirin` git login, or "". */
+	readonly sessionId: string;
+	/** `$WORKTREE_ROOT` — set for a provisioned isolation worktree; "" for the primary/operator session. */
+	readonly worktreeRoot: string;
+	/** Minimum control-plane staged deletions to trip. Below it, the record stays quiet (noise floor). */
+	readonly threshold: number;
+	/** ISO-8601-UTC stamp for the record (injected so the core stays total/deterministic). */
+	readonly at: string;
+}
+
+/** The attribution record written on a trip — everything needed to name the next occurrence's actor. */
+export interface AttributionRecord {
+	readonly at: string;
+	readonly onPrimaryCheckout: boolean;
+	readonly cwd: string;
+	readonly agentType: string;
+	readonly sessionId: string;
+	readonly worktreeRoot: string;
+	readonly stagedDeletionCount: number;
+	readonly controlPlaneDeletionCount: number;
+	/** A bounded sample of the offending paths (first few) so the log line stays readable. */
+	readonly sampleControlPlaneDeletions: readonly string[];
+}
+
+export type TripwireDecision =
+	| {readonly kind: "quiet"; readonly reason: string}
+	| {readonly kind: "trip"; readonly record: AttributionRecord};
+
+/** How many offending paths to sample into the record — enough to recognize the set, not the whole 248. */
+const SAMPLE_SIZE = 8;
+
+/**
+ * Decide whether the staged fileset is the #2778 mass-staged-deletion signature.
+ *
+ * Trips when the count of staged deletions under the instruction-trust prefixes meets `threshold`,
+ * regardless of checkout (the checkout is recorded as severity, not used to suppress). Everything
+ * else is quiet with a reason. Total and IO-free — the same input always yields the same decision.
+ */
+export const decideTripwire = (input: TripwireInput): TripwireDecision => {
+	const deletions = input.staged.filter((e) => e.status.startsWith("D"));
+	const controlPlane = deletions.filter((e) => isControlPlaneDeletion(e.path));
+	if (controlPlane.length < input.threshold) {
+		return {
+			kind: "quiet",
+			reason: `${controlPlane.length} control-plane staged deletion(s) < threshold ${input.threshold}`,
+		};
+	}
+	return {
+		kind: "trip",
+		record: {
+			at: input.at,
+			onPrimaryCheckout: input.onPrimaryCheckout,
+			cwd: input.cwd,
+			agentType: input.agentType,
+			sessionId: input.sessionId,
+			worktreeRoot: input.worktreeRoot,
+			stagedDeletionCount: deletions.length,
+			controlPlaneDeletionCount: controlPlane.length,
+			sampleControlPlaneDeletions: controlPlane.slice(0, SAMPLE_SIZE).map((e) => e.path),
+		},
+	};
+};
+
+/** Parse `git diff --cached --name-status --diff-filter=D` output into staged entries (tab-separated). */
+export const parseNameStatus = (raw: string): readonly StagedEntry[] =>
+	raw
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line !== "")
+		.map((line) => {
+			const tab = line.indexOf("\t");
+			if (tab < 0) return {status: line, path: ""};
+			return {status: line.slice(0, tab), path: line.slice(tab + 1)};
+		})
+		.filter((e) => e.path !== "");
+
+/** Render a trip record as a single-line LOUD attribution warning for stderr. */
+export const renderWarning = (r: AttributionRecord): string =>
+	`primary-index-tripwire TRIP (#2778): ${r.controlPlaneDeletionCount} control-plane staged deletion(s) ` +
+	`(${r.stagedDeletionCount} total) about to be committed on ` +
+	`${r.onPrimaryCheckout ? "the PRIMARY checkout" : "a linked worktree"} — ` +
+	`agent=${r.agentType || "unset"} session=${r.sessionId || "unset"} cwd=${r.cwd} ` +
+	`worktree-root=${r.worktreeRoot || "unset"} · sample: ${r.sampleControlPlaneDeletions.join(", ")}`;

--- a/packages/primary-index-tripwire/src/tripwire.unit.test.ts
+++ b/packages/primary-index-tripwire/src/tripwire.unit.test.ts
@@ -1,0 +1,109 @@
+import {describe, expect, it} from "@effect/vitest";
+import {
+	CONTROL_PLANE_DELETION_PREFIXES,
+	decideTripwire,
+	isControlPlaneDeletion,
+	parseNameStatus,
+	type StagedEntry,
+	type TripwireInput,
+} from "./tripwire.ts";
+
+const del = (path: string): StagedEntry => ({status: "D", path});
+
+const base: Omit<TripwireInput, "staged"> = {
+	onPrimaryCheckout: true,
+	cwd: "/repo",
+	agentType: "coder",
+	sessionId: "sess-1",
+	worktreeRoot: "",
+	threshold: 10,
+	at: "2026-07-12T00:00:00Z",
+};
+
+describe("isControlPlaneDeletion", () => {
+	it("matches every instruction-trust prefix", () => {
+		for (const prefix of CONTROL_PLANE_DELETION_PREFIXES) {
+			expect(isControlPlaneDeletion(`${prefix}some/file.md`)).toBe(true);
+		}
+	});
+
+	it("does not match ordinary source paths", () => {
+		expect(isControlPlaneDeletion("apps/web/src/App.tsx")).toBe(false);
+		expect(isControlPlaneDeletion("packages/authz/src/index.ts")).toBe(false);
+		// a substring that is not a leading prefix must not match
+		expect(isControlPlaneDeletion("docs/.claude/x")).toBe(false);
+	});
+});
+
+describe("decideTripwire", () => {
+	it("trips on a mass control-plane staged deletion (the #2778 signature)", () => {
+		const staged = Array.from({length: 30}, (_, i) => del(`.claude/skills/x${i}.md`));
+		const decision = decideTripwire({...base, staged});
+		expect(decision.kind).toBe("trip");
+		if (decision.kind !== "trip") return;
+		expect(decision.record.controlPlaneDeletionCount).toBe(30);
+		expect(decision.record.stagedDeletionCount).toBe(30);
+		expect(decision.record.onPrimaryCheckout).toBe(true);
+		expect(decision.record.sampleControlPlaneDeletions.length).toBe(8); // bounded sample
+		expect(decision.record.agentType).toBe("coder");
+	});
+
+	it("stays quiet below the threshold", () => {
+		const staged = [del(".claude/a.md"), del(".decisions/b.md")];
+		const decision = decideTripwire({...base, staged, threshold: 10});
+		expect(decision.kind).toBe("quiet");
+		if (decision.kind !== "quiet") return;
+		expect(decision.reason).toContain("< threshold 10");
+	});
+
+	it("counts only control-plane paths toward the threshold, but reports total deletions", () => {
+		const staged = [
+			...Array.from({length: 12}, (_, i) => del(`.decisions/${i}.md`)),
+			...Array.from({length: 40}, (_, i) => del(`apps/web/src/${i}.ts`)),
+		];
+		const decision = decideTripwire({...base, staged, threshold: 10});
+		expect(decision.kind).toBe("trip");
+		if (decision.kind !== "trip") return;
+		expect(decision.record.controlPlaneDeletionCount).toBe(12);
+		expect(decision.record.stagedDeletionCount).toBe(52);
+	});
+
+	it("ignores non-deletion staged entries (only D-status counts)", () => {
+		const staged: StagedEntry[] = [
+			...Array.from({length: 20}, (_, i) => ({status: "M", path: `.claude/${i}.md`})),
+			del(".claude/one.md"),
+		];
+		const decision = decideTripwire({...base, staged, threshold: 10});
+		expect(decision.kind).toBe("quiet"); // 1 deletion < 10, the 20 modifications don't count
+	});
+
+	it("still trips on a linked worktree but records the lower severity", () => {
+		const staged = Array.from({length: 15}, (_, i) => del(`.patterns/${i}.md`));
+		const decision = decideTripwire({
+			...base,
+			staged,
+			onPrimaryCheckout: false,
+			worktreeRoot: "/wt",
+		});
+		expect(decision.kind).toBe("trip");
+		if (decision.kind !== "trip") return;
+		expect(decision.record.onPrimaryCheckout).toBe(false);
+		expect(decision.record.worktreeRoot).toBe("/wt");
+	});
+});
+
+describe("parseNameStatus", () => {
+	it("parses tab-separated git name-status rows", () => {
+		const raw = "D\t.claude/a.md\nD\t.decisions/0001-x.md\n\nD\t.github/workflows/ci.yml\n";
+		expect(parseNameStatus(raw)).toEqual([
+			{status: "D", path: ".claude/a.md"},
+			{status: "D", path: ".decisions/0001-x.md"},
+			{status: "D", path: ".github/workflows/ci.yml"},
+		]);
+	});
+
+	it("returns empty for empty input", () => {
+		expect(parseNameStatus("")).toEqual([]);
+		expect(parseNameStatus("\n\n")).toEqual([]);
+	});
+});

--- a/packages/primary-index-tripwire/tsconfig.json
+++ b/packages/primary-index-tripwire/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/primary-index-tripwire/vitest.config.ts
+++ b/packages/primary-index-tripwire/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1245,6 +1245,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/primary-index-tripwire:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/worker-relevance:
     devDependencies:
       '@effect/tsgo':


### PR DESCRIPTION
## Investigation — #2778 primary-index mass staged deletion

**Type:** collapsed `type:investigation` — read-only diagnosis + read-only instrumentation. **NON-§CP** (this PR touches only `ops/**`, a new `packages/primary-index-tripwire/**` package, `lefthook.yml`, and `pnpm-lock.yaml` — none match `CONTROL_PLANE_RE`). Fixes #2778.

### Root-cause finding (narrowed, evidence-grounded)
The 248 staged deletions were an **unscoped `git add` / `git rm --cached`-class command executed against the PRIMARY index by an actor NOT covered by the `pinBash` cwd-pin**, narrowed to two candidates that the post-hoc index state cannot distinguish (staging leaves no reflog trace):

1. **Top suspect — the primary operator/orchestrator session.** `worktree-guard pre-bash` (`pinBash`) is a *deliberate no-op* there (no `$WORKTREE_ROOT`, no isolation asserted), so this surface is unguarded in **every** regime — any unscoped staging op lands on the primary index.
2. **A worktree agent whose pre-bash hook was inactive that session**, cwd reset to primary, running a bare staging command. With the hook **active**, `pinBash`'s cd-pin rewrite contains such a command to the *worktree* index, so this vector requires an inactive-hook session.

**Ruled OUT as stagers:** every git hook (post-checkout only runs `pnpm install`; no hook stages), and `git worktree` plumbing / `reap` (non-`--force`). Full trace + rule-in/out per vector in [`ops/incidents/2778-primary-index-mass-staged-deletion.md`](https://github.com/kamp-us/phoenix/blob/umut/2778-primary-index-tripwire/ops/incidents/2778-primary-index-mass-staged-deletion.md).

### Why main-sync caught it — and why it is not sufficient
`decideMainRefresh`'s `hasTrackedModifications` gate refused to fast-forward the dirty primary and surfaced it. But the catch is **incidental**: main-sync only *detects* the resulting state, only on the *sanctioned* path. The deeper caller-agnostic `ref-guard` refuses only a **diverging** `main` move — a commit of the deletions **on top of** `origin/main` is a **fast-forward**, so `ref-guard` allows it. **Residual blast-radius:** a direct primary `commit` + `push` that fast-forwards the mass deletion to `origin/main`.

### Read-only instrumentation (this unit)
`@kampus/primary-index-tripwire` — a pure, unit-tested detection core + thin Effect CLI wired as a **read-only, fail-open `pre-commit` leg** (`lefthook.yml`). It **records, never blocks**, an attribution event when the staged index carries the #2778 signature (a mass control-plane staged deletion), capturing `CLAUDE_CODE_AGENT` / `CLAUDE_CODE_SESSION_ID` / cwd / primary-vs-worktree at the one **caller-agnostic** choke point git fires — catching the primary-operator surface the `PreToolUse` Bash hook is blind to. Verified end-to-end (trips on 30 control-plane staged deletions, quiet below threshold, always exit 0). 9 unit tests.

### §CP follow-up fix (named, NOT built here)
The fix is §CP (merge-by-hand — touches `packages/pipeline-cli/**` / `write-code` skill / `.claude/**`), filed separately and cross-linked:
1. Close the unguarded **primary-operator surface** — a primary-index staging guard (analogous to `ref-guard`), or promote the tripwire from record-only to block-on-primary.
2. Wire the tripwire's attribution into the **`PreToolUse` Bash hook** so the *staging command + cwd* is captured (closing the "was the hook active?" ambiguity of vector 2).
3. Harden main-sync's incidental catch into a **guarantee** (assert a clean primary index; refuse the hand-rolled bypass path).

### Same-vs-distinct vs #2666
**Distinct-but-related; keep both open, cross-linked** (a human merge call, recorded per the AC). Shared root family (git state crossing checkout boundaries on a shared `.git`), differing in direction (into-worktree #2666 vs into-primary #2778), severity, and proximate mechanism.

### Acceptance criteria
- [x] Mechanism identified / narrowed with evidence (every vector ruled in/out)
- [x] cwd-reset-to-primary hypothesis explicitly ruled in/out (contained by `pinBash` when active; open on the unguarded primary-operator surface)
- [x] main-sync containment characterized + residual bypass named (fast-forward primary commit+push)
- [x] Same-vs-distinct-#2666 resolved with a consolidation recommendation
- [x] Diagnosis + read-only instrumentation delivered; §CP fix named and filed, not built