### PR TITLE
fix(web): lift topbar icon-only nav-links to the 36px tap-target floor (#2782)

### DIFF
--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -46,6 +46,12 @@
 .kp-topbar__signal-link {
 	display: inline-flex;
 	align-items: center;
+	/* Icon-only links (the divan Gavel glyph) carry no text width to pad out, so the box
+	   floors to --tap-min in both axes and flex-centers the glyph — hit area decoupled from
+	   the glyph, text links unaffected (they already exceed it). ADR 0162 §Tap target. */
+	justify-content: center;
+	min-height: var(--tap-min);
+	min-width: var(--tap-min);
 	padding: 4px 8px;
 	font: var(--t-body-sm);
 	font-weight: 500;


### PR DESCRIPTION
Fixes #2782

## What

Icon-only topbar nav-links (`.kp-topbar__nav a` / `.kp-topbar__signal-link` — the divan Gavel glyph from #2780) rendered a ~24×32px hit area, below the ADR [0162](https://github.com/kamp-us/phoenix/blob/main/.decisions/0162-four-pillars-design-law.md) §Tap target 36px minimum.

## Change

One shared rule in `apps/web/src/components/layout/Topbar.css`:
- `min-height: var(--tap-min)` + `min-width: var(--tap-min)` — floor the hit area to 36px in both axes.
- `justify-content: center` — centers the glyph in the widened box so the hit area is **decoupled** from the visible glyph (glyph not inflated; design-system-manifest pillar 4).

Uses the `--tap-min` token, matching the sibling #2766 ToggleGroup idiom rather than hardcoding a raw px. Text nav-links already exceed the floor (min-* is a no-op for them), so existing spacing/alignment is unaffected. Topbar row height (`--topbar-h` = 38px at the compact base) accommodates the 36px min-height.

## Acceptance criteria

- [x] Icon-only links render a ≥36px hit area in both dimensions via `--tap-min`.
- [x] Glyph not inflated — hit area decoupled via `justify-content: center`.
- [x] Text nav-links + topbar spacing/alignment unaffected (min-* no-op for wider text links).
- [x] The divan Gavel-glyph link now meets the floor as an instance of the systemic fix.

Scope: `apps/web/src/components/layout/Topbar.css` only. Non-§CP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)