### PR TITLE
feat(web): bildirim bell → interactive recent-notifications popover (#2787)

### DIFF
--- a/apps/web/src/components/bildirim/BildirimPopover.css
+++ b/apps/web/src/components/bildirim/BildirimPopover.css
@@ -1,0 +1,82 @@
+/* The interactive status-zone bildirim bell + its popover (#2787). Role tokens
+   only; the bell is a signal, never the promoted action, so it carries NO accent
+   fill (accent-scarcity law, design-manifest §Nav IA). Focus is the shared
+   spacer ring from global.css — never a per-component outline. Kept in its own
+   scoped file (not Topbar.css) so the popover styling is disjoint from the shared
+   topbar sheet. */
+
+/* The trigger: a button-reset bell. The glyph is 16px (dense/inline, ADR 0166),
+   decoupled from the 36px minimum hit area — padding fills the target, the glyph
+   does not inflate (design-manifest §Tap target / icon idiom). */
+.kp-bildirim-pop__trigger {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--s-1);
+	min-width: 36px;
+	min-height: 36px;
+	padding: 0 var(--s-1);
+	border: 0;
+	border-radius: var(--r-md);
+	background: none;
+	color: var(--text-secondary);
+	cursor: pointer;
+}
+.kp-bildirim-pop__trigger:hover {
+	color: var(--text-primary);
+}
+.kp-bildirim-pop__trigger .kp-icon {
+	color: inherit;
+}
+.kp-bildirim-pop__count {
+	font: var(--t-meta);
+	color: var(--text-primary);
+}
+
+/* The Positioner carries the stacking rank (the `position: fixed` element), the
+   same rule the Menu/Tooltip wrappers document — outrank the sticky Subnav. */
+.kp-bildirim-pop__positioner {
+	z-index: 70;
+}
+
+.kp-bildirim-pop__popup {
+	display: flex;
+	flex-direction: column;
+	width: 340px;
+	max-width: calc(100vw - var(--s-4));
+	max-height: min(70vh, 480px);
+	background: var(--surface-raised);
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+	box-shadow: var(--shadow-dropdown);
+	overflow: hidden;
+}
+
+.kp-bildirim-pop__head {
+	padding: var(--s-2) var(--s-3);
+	border-bottom: 1px solid var(--border-faint);
+}
+.kp-bildirim-pop__title {
+	margin: 0;
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+}
+
+/* The list body scrolls within the popover; the head + footer stay pinned. */
+.kp-bildirim-pop__body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: var(--s-1) var(--s-3);
+}
+
+.kp-bildirim-pop__foot {
+	display: flex;
+	justify-content: center;
+	padding: var(--s-2) var(--s-3);
+	border-top: 1px solid var(--border-faint);
+}
+.kp-bildirim-pop__see-all {
+	font: var(--t-body-sm);
+	color: var(--link);
+}

--- a/apps/web/src/components/bildirim/BildirimPopover.test.tsx
+++ b/apps/web/src/components/bildirim/BildirimPopover.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * BildirimPopover (#2787) — the interactive status-zone bell. These pin the
+ * popover SHELL: the trigger opens on click, the popover renders the reused list
+ * body + a "tümünü gör → /bildirimler" footer, Escape closes it, and the unread
+ * count is the trigger's accessible name (+ a live region). `BildirimList` is
+ * stubbed — its fate-backed data path is covered by its own suite; this measures
+ * the disclosure behavior, not the list internals.
+ */
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {describe, expect, it, vi} from "vitest";
+
+vi.mock("./BildirimList", () => ({
+	BildirimList: () => <div data-testid="bildirim-list-stub">liste</div>,
+}));
+
+import {BildirimPopover} from "./BildirimPopover";
+
+function renderPopover(unread = 3) {
+	return render(
+		<MemoryRouter>
+			<BildirimPopover to="/bildirimler" unread={unread} />
+		</MemoryRouter>,
+	);
+}
+
+describe("BildirimPopover (#2787)", () => {
+	it("the bell is a disclosure button whose accessible name is the unread count", () => {
+		renderPopover(3);
+		const trigger = screen.getByTestId("topbar-bildirim-badge");
+		expect(trigger.tagName).toBe("BUTTON");
+		expect(trigger.getAttribute("aria-label")).toBe("3 okunmamış bildirim");
+		expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+		// The bell glyph + count are both present; the count is not the accessible name.
+		expect(trigger.querySelector("svg")).not.toBeNull();
+		expect(trigger.textContent).toContain("3");
+		// The live region preserves the #2613 unread announcement now the trigger is a button.
+		expect(screen.getByRole("status").textContent).toBe("3 okunmamış bildirim");
+	});
+
+	it("clicking the bell opens the popover with the reused list body", () => {
+		renderPopover();
+		expect(screen.queryByTestId("topbar-bildirim-popover")).toBeNull();
+		fireEvent.click(screen.getByTestId("topbar-bildirim-badge"));
+		const popover = screen.getByTestId("topbar-bildirim-popover");
+		expect(popover).toBeTruthy();
+		// The popover reuses BildirimList (stubbed here) as its body, under a "bildirimler" title.
+		expect(screen.getByTestId("bildirim-list-stub")).toBeTruthy();
+		expect(screen.getByText("bildirimler")).toBeTruthy();
+		expect(screen.getByTestId("topbar-bildirim-badge").getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("the footer links to the full /bildirimler center page (tümünü gör)", () => {
+		renderPopover();
+		fireEvent.click(screen.getByTestId("topbar-bildirim-badge"));
+		const seeAll = screen.getByTestId("topbar-bildirim-see-all");
+		expect(seeAll.textContent).toBe("tümünü gör");
+		expect(seeAll.getAttribute("href")).toBe("/bildirimler");
+	});
+
+	it("closes on Escape", async () => {
+		renderPopover();
+		fireEvent.click(screen.getByTestId("topbar-bildirim-badge"));
+		const popover = screen.getByTestId("topbar-bildirim-popover");
+		fireEvent.keyDown(popover, {key: "Escape"});
+		await waitFor(() => expect(screen.queryByTestId("topbar-bildirim-popover")).toBeNull());
+	});
+
+	it("clamps a large unread count in the label and count chip (99+)", () => {
+		renderPopover(250);
+		const trigger = screen.getByTestId("topbar-bildirim-badge");
+		expect(trigger.getAttribute("aria-label")).toBe("250 okunmamış bildirim");
+		expect(trigger.textContent).toContain("99+");
+	});
+});

--- a/apps/web/src/components/bildirim/BildirimPopover.tsx
+++ b/apps/web/src/components/bildirim/BildirimPopover.tsx
@@ -1,0 +1,92 @@
+/**
+ * `BildirimPopover` — the topbar status-zone bell as an INTERACTIVE disclosure
+ * (#2787). #2613 placed a display-only bell + unread count in the status/signal
+ * zone; this turns it into a proper button that opens an in-place popover of
+ * recent bildirimler (reusing {@link BildirimList} as the body), with a
+ * "tümünü gör" footer to the full `/bildirimler` center page — which stays the
+ * canonical "see all" destination, not replaced.
+ *
+ * a11y: the trigger keeps the unread count as its accessible NAME (#2613 / ADR
+ * 0166), and a polite visually-hidden live region preserves the announcement the
+ * old `role="status"` bell gave — a button can't also be a live region, so the
+ * two roles split. Base UI's Popover supplies the rest (aria-haspopup/expanded on
+ * the trigger, Escape-to-close, focus trap + restore).
+ */
+import {Popover} from "@base-ui/react/popover";
+import {Bell} from "lucide-react";
+import {useState} from "react";
+import {Link} from "react-router";
+import {Screen} from "../../fate/Screen";
+import {Icon} from "../Icon";
+import {BildirimList} from "./BildirimList";
+import {formatUnreadBadge} from "./bildirim";
+import "./Bildirim.css";
+import "./BildirimPopover.css";
+
+export function BildirimPopover({to, unread}: {to: string; unread: number}) {
+	const [open, setOpen] = useState(false);
+	const label = `${unread} okunmamış bildirim`;
+
+	return (
+		<>
+			{/* The live-unread announcement #2613's status bell carried — preserved as a
+			    polite region since the interactive trigger below is a button, not a status. */}
+			<span role="status" className="kp-visually-hidden">
+				{label}
+			</span>
+			<Popover.Root open={open} onOpenChange={setOpen}>
+				<Popover.Trigger
+					className="kp-bildirim-pop__trigger"
+					data-testid="topbar-bildirim-badge"
+					aria-label={label}
+				>
+					<Icon icon={Bell} size={16} />
+					<span className="kp-bildirim-pop__count" aria-hidden="true">
+						{formatUnreadBadge(unread)}
+					</span>
+				</Popover.Trigger>
+				<Popover.Portal>
+					{/* z-index on the Positioner (the fixed portal-root), not the static Popup —
+					    the same stacking-context rule the Menu/Tooltip wrappers document (#2041/#2046). */}
+					<Popover.Positioner
+						className="kp-bildirim-pop__positioner"
+						side="bottom"
+						align="end"
+						sideOffset={6}
+						positionMethod="fixed"
+					>
+						<Popover.Popup className="kp-bildirim-pop__popup" data-testid="topbar-bildirim-popover">
+							<header className="kp-bildirim-pop__head">
+								<Popover.Title className="kp-bildirim-pop__title">bildirimler</Popover.Title>
+							</header>
+							<div className="kp-bildirim-pop__body">
+								<Screen
+									fallback={<p className="kp-bildirim__loading">yükleniyor…</p>}
+									error={({code}) => (
+										<p className="kp-bildirim__error" role="alert">
+											{code === "UNAUTHORIZED" || code === "FORBIDDEN"
+												? "bildirimlerini görmek için giriş yapmalısın."
+												: "bildirimler yüklenemedi, tekrar dene."}
+										</p>
+									)}
+								>
+									<BildirimList />
+								</Screen>
+							</div>
+							<footer className="kp-bildirim-pop__foot">
+								<Link
+									to={to}
+									className="kp-bildirim-pop__see-all"
+									data-testid="topbar-bildirim-see-all"
+									onClick={() => setOpen(false)}
+								>
+									tümünü gör
+								</Link>
+							</footer>
+						</Popover.Popup>
+					</Popover.Positioner>
+				</Popover.Portal>
+			</Popover.Root>
+		</>
+	);
+}

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -211,7 +211,7 @@ describe("Topbar status/signal zone (#2613)", () => {
 		);
 	}
 
-	it("flag on: the unread bildirim renders a bell affordance in the status zone, not a bare number", () => {
+	it("flag on: the unread bildirim renders an INTERACTIVE bell in the status zone, not a bare number (#2787)", () => {
 		const {container} = renderStatus({navIa: true, bildirim: {to: "/bildirimler", unread: 3}});
 		const signal = screen.getByTestId("topbar-bildirim-badge");
 		// Lives in the status-signal zone, not on the user-menu trigger (its today's home).
@@ -221,8 +221,15 @@ describe("Topbar status/signal zone (#2613)", () => {
 		// bare number; the count text is still present and the accessible name carries it.
 		expect(signal.querySelector("svg")).not.toBeNull();
 		expect(signal.textContent).toContain("3");
-		expect(signal.getAttribute("role")).toBe("status");
+		// #2787 evolves the display-only status bell into a disclosure button: it is now an
+		// interactive popover trigger (aria-haspopup/expanded), and the unread count stays its
+		// accessible name (ADR 0166). The live announcement moves to a sibling role="status".
+		expect(signal.tagName).toBe("BUTTON");
+		expect(signal.getAttribute("aria-haspopup")).toBe("dialog");
+		expect(signal.getAttribute("aria-expanded")).toBe("false");
 		expect(signal.getAttribute("aria-label")).toBe("3 okunmamış bildirim");
+		const live = within(screen.getByTestId("topbar-zone-status-signal")).getByRole("status");
+		expect(live.textContent).toBe("3 okunmamış bildirim");
 	});
 
 	it("flag on: no bildirim signal renders when unread is 0", () => {

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,9 +1,10 @@
-import {Bell, Gavel} from "lucide-react";
+import {Gavel} from "lucide-react";
 import type * as React from "react";
 import {useEffect, useRef} from "react";
 import {Link, NavLink, useNavigate} from "react-router";
 import {isSearchShortcut} from "../../lib/searchShortcut";
 import type {ThemeChoice} from "../../lib/theme";
+import {BildirimPopover} from "../bildirim/BildirimPopover";
 import {formatUnreadBadge, showUnreadBadge} from "../bildirim/bildirim";
 import {Icon} from "../Icon";
 import {Karma} from "../karma/Karma";
@@ -203,25 +204,16 @@ export function Topbar({
 		typeof karma === "number" ? (
 			<Karma value={karma} variant="inline" testId="topbar-karma" className="kp-topbar__karma" />
 		) : null;
-	// The unread bildirim signal in the status zone (#2613). Under the zone grammar the count
-	// carries a legible Bell affordance (ADR 0166) so it reads as "unread notifications" at a
-	// glance, not a bare number. Same render rule as the flag-off badge — only when the
-	// `phoenix-bildirim` flag put a `bildirim` here AND unread > 0 (the badge's a11y label is
-	// the accessible name; the bell is decorative). Off, the count stays the bare chip on the
-	// user-menu trigger below (byte-identical to today).
+	// The unread bildirim signal in the status zone (#2613), now an INTERACTIVE bell that
+	// opens an in-place popover of recent bildirimler (#2787) — the near-universal
+	// bell→dropdown pattern, with the full `/bildirimler` page kept as the "tümünü gör"
+	// destination. The count is still the trigger's accessible name (ADR 0166). Same render
+	// rule as the flag-off badge — only when the `phoenix-bildirim` flag put a `bildirim`
+	// here AND unread > 0. Off, the count stays the bare chip on the user-menu trigger below
+	// (byte-identical to today).
 	const bildirimSignal =
 		navIa && bildirim && showUnreadBadge(bildirim.unread) ? (
-			<span
-				className="kp-topbar__bildirim-signal"
-				data-testid="topbar-bildirim-badge"
-				role="status"
-				aria-label={`${bildirim.unread} okunmamış bildirim`}
-			>
-				<Icon icon={Bell} size={16} />
-				<span className="kp-topbar__bildirim-count" aria-hidden="true">
-					{formatUnreadBadge(bildirim.unread)}
-				</span>
-			</span>
+			<BildirimPopover to={bildirim.to} unread={bildirim.unread} />
 		) : null;
 	const userMenu = user ? (
 		<Menu.Root>

--- a/apps/web/src/styles/design-token-lint.config.json
+++ b/apps/web/src/styles/design-token-lint.config.json
@@ -36,6 +36,7 @@
 		"apps/web/src/components/ui/Switch.css": 5,
 		"apps/web/src/components/ui/Button.css": 4,
 		"apps/web/src/components/ui/Form.css": 4,
+		"apps/web/src/components/bildirim/BildirimPopover.css": 4,
 		"apps/web/src/components/bildirim/Bildirim.css": 3,
 		"apps/web/src/components/layout/Subnav.css": 7,
 		"apps/web/src/components/sozluk/Sozluk.css": 3,


### PR DESCRIPTION
## What

Turns the nav-IA topbar status/signal-zone bildirim bell (#2613) from a display-only signal into an **interactive disclosure**: clicking it opens an in-place popover of recent bildirimler, with a **"tümünü gör → /bildirimler"** footer. Notifications were previously only reachable via user-menu → the full page.

Fixes #2787

## How

- **New scoped `BildirimPopover` component** (`apps/web/src/components/bildirim/BildirimPopover.tsx`) + its own **`BildirimPopover.css`** — a Base UI `Popover` wrapping the bell trigger and a popup that reuses **`BildirimList`** as its body (the fate request fires only on open, since the popup is portaled/mounted lazily).
- **`Topbar.tsx`** swaps the display-only `bildirimSignal` span for `<BildirimPopover>` (same render gate: `navIa && bildirim && unread > 0`). The flag-off path (bare user-menu chip) is untouched.
- The `/bildirimler` center page is preserved as the canonical "see all" destination.

## Design / a11y (four-pillars law + ADR 0166)

- Trigger is a real button; the **unread count is its accessible name** (`aria-label="N okunmamış bildirim"`), Base UI supplies `aria-haspopup`/`aria-expanded`, Escape-to-close, focus trap + restore.
- A sibling **visually-hidden `role="status"`** preserves #2613's live unread announcement (a button can't also be a live region).
- **36px min hit area** (glyph stays 16px, padding fills — Tap-target pillar), **role tokens only**, **dropdown elevation**, shared **`--focus-ring`** — **no accent fill** (accent-scarcity: the bell is a signal, not the promoted action).
- Turkish product copy (`bildirimler`, `tümünü gör`).

## Collision avoidance (#2782)

Junior's in-flight #2782 edits `Topbar.css` (tap-target fix). To stay **disjoint**, all popover styling lives in the **new** `BildirimPopover.css`; I edited only `Topbar.tsx` (the bell element → trigger), never `Topbar.css`. As a consequence the two now-orphaned Topbar.css rules (`.kp-topbar__bildirim-signal`, `.kp-topbar__bildirim-count`) are intentionally left in place to keep the diff off the shared sheet — prunable in a follow-up once #2782 lands.

## Flag / dark-ship

**Not a new dark flag.** The bell renders only under the already-live `phoenix-nav-ia` + `phoenix-bildirim` flags — it rides the existing live substrate, so this ships to everyone already seeing the nav-IA bell. No flag wiring added.

## Tests

- New `BildirimPopover.test.tsx`: trigger is a disclosure button with count as accessible name; opens on click rendering the reused list body + title; footer links to `/bildirimler`; closes on Escape; unread live-region + 99+ clamp.
- Updated the #2613 `Topbar.test.tsx` status-zone case to assert the bell is now an interactive trigger (button + `aria-haspopup`/`aria-expanded`, count still the accessible name, live region present).
- Full `client` tier green (225 tests); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)