### PR TITLE
feat(pipeline): block a primary-index mass control-plane staged deletion (#2784)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -105,6 +105,31 @@ pre-commit:
         node packages/primary-index-tripwire/src/bin.ts record || true
         exit 0
 
+    # The BLOCKING §CP containment for the #2778 corruption (#2784) — the prevention half the
+    # record-only tripwire above names. It REFUSES a commit carrying the mass-staged-deletion
+    # signature (a mass control-plane staged deletion) on the PRIMARY checkout: the one
+    # caller-agnostic choke point that fires as the loaded-gun commit is CREATED, before a push can
+    # fast-forward it to origin/main (ref-guard allows a fast-forward, so it can't catch this).
+    # Scoped to the primary — a linked worktree's commit lands on a PR-reviewed feature branch.
+    #
+    # Fail-CLOSED on the guard's own refuse, fail-OPEN when the CLI can't RUN — same contract as
+    # ref-guard: a not-yet-installed / stripped-PATH env (#787) or a bin remediation exit (#1798)
+    # must NOT abort every commit repo-wide, so the guard signals a deliberate refuse with a
+    # DEDICATED code (REFUSE_EXIT_CODE = 3), distinct from success (0) and any infra failure. ONLY
+    # code 3 blocks; every other non-zero swallows to a clean allow.
+    primary-index-guard:
+      run: |
+        command -v node >/dev/null 2>&1 || {
+          echo "primary-index-guard: no node on PATH (stripped-PATH/lean worktree); skipping #2778 block — CI/the §CP fix stay the authority" >&2
+          exit 0
+        }
+        status=0
+        node packages/pipeline-cli/src/bin.ts primary-index-guard pre-commit || status=$?
+        # exit 3 == the guard's deliberate refuse (abort the commit); any other non-zero == the CLI
+        # couldn't run (node/CLI/module absent, crash) → fail-OPEN, allow.
+        [ "$status" -eq 3 ] && exit 1
+        exit 0
+
 # The deps-dependent fast-fail tier (#2147): typecheck + changed-scoped unit tests fire
 # at PUSH time, not commit time, because they need `node_modules` (unlike biome). Scoped so
 # each push stays cheap — vitest `--changed origin/main` runs only the suites related to

--- a/packages/pipeline-cli/package.json
+++ b/packages/pipeline-cli/package.json
@@ -38,6 +38,7 @@
 		"@effect/platform-node": "catalog:",
 		"@kampus/ci-required": "workspace:*",
 		"@kampus/gh-phoenix": "workspace:*",
+		"@kampus/primary-index-tripwire": "workspace:*",
 		"effect": "catalog:",
 		"fast-xml-parser": "catalog:",
 		"yaml": "catalog:"

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -32,6 +32,7 @@ import {mainSyncCommand} from "./tools/main-sync/command.ts";
 import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
 import {pathFilterGuardCommand} from "./tools/path-filter-guard/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
+import {primaryIndexGuardCommand} from "./tools/primary-index-guard/command.ts";
 import {reachabilityGuardCommand} from "./tools/reachability-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {refGuardCommand} from "./tools/ref-guard/command.ts";
@@ -119,6 +120,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	evalHarnessCommand,
 	mainSyncCommand,
 	refGuardCommand,
+	primaryIndexGuardCommand,
 	settingsEnvGuardCommand,
 	verdictCommand,
 	campaignCommand,

--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -37,6 +37,7 @@
  * provides.
  */
 import {execFileSync} from "node:child_process";
+import {isControlPlaneDeletion, parseNameStatus} from "@kampus/primary-index-tripwire";
 import {Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {decideMainRefresh, decideMainSync, type HeadState, MAIN_BRANCH} from "./main-sync.ts";
@@ -91,6 +92,19 @@ const treeHasTrackedModifications = (): boolean => {
 };
 
 /**
+ * The count of staged deletions under the instruction-trust prefixes — the #2778 signature (#2784),
+ * classified with `@kampus/primary-index-tripwire`'s detection so main-sync's guaranteed refusal and
+ * the §CP `primary-index-guard` block share one definition. Indeterminate probe (command failed) ⇒ 0:
+ * this count only ever TIGHTENS the guard (a positive count refuses), so a 0 fallback never
+ * false-refuses; the incidental dirty checks still stand behind it.
+ */
+const stagedControlPlaneDeletionCount = (): number => {
+	const r = runGit(["diff", "--cached", "--name-status", "--diff-filter=D"]);
+	if (!r.ok) return 0;
+	return parseNameStatus(r.stdout).filter((e) => isControlPlaneDeletion(e.path)).length;
+};
+
+/**
  * The gentle post-merge refresh (#2056) — the HEAD-preserving counterpart to the drain-sync
  * below. `decideMainRefresh` is the safety policy; this runs it. A `leave-alone` plan is a
  * clean exit-0 no-op (the whole point: a stale checkout is acceptable, disturbing the owner
@@ -110,6 +124,15 @@ const runPostMergeRefresh = Effect.fn(function* (head: HeadState, execute: boole
 	yield* Console.log(
 		`main-sync --post-merge: HEAD ${head.branch ?? "(detached)"}, tree ${treeLabel} — plan: ${plan.action}${execute ? " (EXECUTE)" : " (dry-run)"}`,
 	);
+
+	if (plan.action === "refuse-mass-deletion") {
+		// The one refresh outcome that is LOUD (exit 1), not a silent no-op: the #2778 loaded-gun
+		// state must surface, never be skipped as ordinary dirt (#2784).
+		yield* Console.error(
+			`main-sync --post-merge REFUSED (fail-closed): the primary index carries ${plan.count} control-plane staged deletion(s) — the #2778 mass-staged-deletion signature. Refusing to refresh a primary in the loaded-gun state (a commit + push would fast-forward this control-plane mass deletion to origin/main). Unstage and recover by hand (0 commits ahead ⇒ \`git reset --hard origin/main\`), then re-run.`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
 
 	if (plan.action === "leave-alone") {
 		yield* Console.log(
@@ -169,6 +192,7 @@ const mainSync = Command.make(
 			branch: headBranch(),
 			isDirty: treeIsDirty(),
 			hasTrackedModifications: treeHasTrackedModifications(),
+			stagedControlPlaneDeletionCount: stagedControlPlaneDeletionCount(),
 		};
 
 		if (postMerge) {
@@ -181,6 +205,15 @@ const mainSync = Command.make(
 		yield* Console.log(
 			`main-sync: HEAD ${head.branch ?? "(detached)"}, tree ${head.isDirty ? "DIRTY" : "clean"} — plan: ${plan.action}${execute ? " (EXECUTE)" : " (dry-run)"}`,
 		);
+
+		if (plan.action === "blocked-mass-deletion") {
+			// The guaranteed catch (#2784): refuse by NAME on the #2778 signature, before any reattach
+			// or merge — not the incidental dirty gate. Detection + refusal only, never a `git reset`.
+			yield* Console.error(
+				`main-sync REFUSED (fail-closed): the primary index carries ${plan.count} control-plane staged deletion(s) — the #2778 mass-staged-deletion signature. Refusing to sync a primary in the loaded-gun state (a commit + push would fast-forward this control-plane mass deletion to origin/main). Unstage and recover by hand (0 commits ahead ⇒ \`git reset --hard origin/main\`), then re-run.`,
+			);
+			return yield* Effect.sync(() => process.exit(1));
+		}
 
 		if (plan.action === "blocked-dirty") {
 			// Detect-and-surface, never discard: refuse the reattach on a dirty tree (#1494 AC #3).

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
@@ -32,6 +32,17 @@
  * than today; yanking the owner off their feature branch or clobbering their tracked work is).
  * It ff's through untracked-only dirt, which a fast-forward never touches (see
  * `decideMainRefresh`, #2455). Failing-to-refresh is acceptable; failing-loudly or clobbering is not.
+ *
+ * A THIRD guard, orthogonal to both above (#2784): an EXPLICIT refusal on the #2778
+ * mass-staged-deletion signature. The #2778 incident was caught only INCIDENTALLY — the mass of
+ * staged deletions happened to trip `hasTrackedModifications`, so `decideMainRefresh` left the tree
+ * alone. That is not a guarantee: it is a side-effect of one dirt probe, and a future variant (e.g.
+ * a mass deletion already committed, or a config where the incidental gate doesn't fire) could slip
+ * through. So both decide functions now check the mass-deletion signature FIRST and refuse it by
+ * NAME — a guaranteed, LOUD fail-closed refusal keyed on the same signature the §CP
+ * `primary-index-guard` blocks at pre-commit, not a byproduct of the generic dirty check. The
+ * signature count is classified with `@kampus/primary-index-tripwire`'s detection at the git
+ * boundary (single source of "what is a #2778 mass deletion"); this core reads the resulting count.
  */
 
 /**
@@ -65,10 +76,27 @@ export interface HeadState {
 	 * through (see #2455). Implies `isDirty` (tracked dirt is a subset of all dirt).
 	 */
 	readonly hasTrackedModifications: boolean;
+	/**
+	 * The count of staged deletions under the instruction-trust prefixes (`.claude/**`,
+	 * `.decisions/**`, …) — the #2778 signature, classified at the git boundary with
+	 * `@kampus/primary-index-tripwire`'s detection. Its own value is what makes the catch a
+	 * GUARANTEE rather than the incidental `hasTrackedModifications` side-effect it was (#2784).
+	 */
+	readonly stagedControlPlaneDeletionCount: number;
 }
 
 /** The name of the branch the primary checkout must be attached to for a clean main-sync. */
 export const MAIN_BRANCH = "main";
+
+// Re-exported single source: main-sync refuses at the SAME "mass" threshold the §CP
+// `primary-index-guard` blocks at, so the sync-path refusal and the pre-commit block agree.
+export {MASS_DELETION_BLOCK_THRESHOLD} from "@kampus/primary-index-tripwire";
+
+import {MASS_DELETION_BLOCK_THRESHOLD} from "@kampus/primary-index-tripwire";
+
+/** True when the primary index carries a #2778 mass control-plane staged deletion (at/above the block threshold). */
+export const isMassControlPlaneDeletion = (head: HeadState): boolean =>
+	head.stagedControlPlaneDeletionCount >= MASS_DELETION_BLOCK_THRESHOLD;
 
 /**
  * What the orchestrator should do to bring the primary checkout to a state where
@@ -76,6 +104,12 @@ export const MAIN_BRANCH = "main";
  * safety policy.
  */
 export type MainSyncPlan =
+	/**
+	 * The primary index carries a #2778 mass control-plane staged deletion — REFUSE, by name,
+	 * before any other consideration (#2784). This is the guaranteed catch: the orchestrator must
+	 * NOT sync a primary in the loaded-gun state; a human resolves the staged deletion first.
+	 */
+	| {readonly action: "blocked-mass-deletion"; readonly count: number}
 	/**
 	 * HEAD is already on `main` — no reattach needed. The orchestrator proceeds
 	 * straight to `fetch` + `merge --ff-only`. This is the healthy steady state.
@@ -106,6 +140,9 @@ const fromLabel = (branch: string | null): string => branch ?? DETACHED_LABEL;
 /**
  * Decide the main-sync plan from the primary checkout's HEAD state:
  *
+ *   0. #2778 mass control-plane staged deletion present → `blocked-mass-deletion`. Checked FIRST,
+ *      by name — the guaranteed catch (#2784), not the incidental dirt gate. Refuse to sync a
+ *      primary in the loaded-gun state regardless of branch/dirt.
  *   1. On `main` → `already-on-main`. No HEAD move needed; sync can proceed. The
  *      dirty flag is irrelevant here — `merge --ff-only` fails safe on its own if
  *      the tree conflicts, and this tool never touches a tree that is already on the
@@ -120,6 +157,9 @@ const fromLabel = (branch: string | null): string => branch ?? DETACHED_LABEL;
  * surfaced, never checked out.
  */
 export const decideMainSync = (head: HeadState): MainSyncPlan => {
+	if (isMassControlPlaneDeletion(head)) {
+		return {action: "blocked-mass-deletion", count: head.stagedControlPlaneDeletionCount};
+	}
 	if (head.branch === MAIN_BRANCH) {
 		return {action: "already-on-main", branch: MAIN_BRANCH};
 	}
@@ -136,6 +176,13 @@ export const decideMainSync = (head: HeadState): MainSyncPlan => {
  * #2056): either a fast-forward is safe, or the checkout is left exactly as it is.
  */
 export type MainRefreshPlan =
+	/**
+	 * The primary index carries a #2778 mass control-plane staged deletion — a LOUD fail-closed
+	 * REFUSAL (#2784), distinct from the silent `leave-alone` no-op below. The refresh's normal
+	 * failure mode is "do nothing quietly", but the loaded-gun state must SURFACE, not be silently
+	 * skipped — so this exits non-zero at the command boundary, unlike every other refresh outcome.
+	 */
+	| {readonly action: "refuse-mass-deletion"; readonly count: number}
 	/**
 	 * HEAD is on `main` AND free of tracked modifications — the state in which a `git merge
 	 * --ff-only origin/main` is both possible and non-destructive (untracked-only dirt is
@@ -161,6 +208,10 @@ export type MainRefreshPlan =
 /**
  * Decide the post-merge refresh plan from the primary checkout's HEAD state (#2056):
  *
+ *   0. #2778 mass control-plane staged deletion present → `refuse-mass-deletion`. Checked FIRST,
+ *      by name — a LOUD fail-closed refusal (#2784), NOT the silent `leave-alone` no-op. The
+ *      incidental `hasTrackedModifications` gate below would also skip the ff, but silently; the
+ *      loaded-gun state must surface loudly instead.
  *   1. Not on `main` → `leave-alone` (reason `off-main`). The owner is on their own
  *      feature branch (or detached); a fast-forward of `main` cannot advance it, and
  *      yanking them onto `main` is exactly the disruption the refresh must avoid. No-op.
@@ -182,6 +233,9 @@ export type MainRefreshPlan =
  * consults dirt once already on `main`.
  */
 export const decideMainRefresh = (head: HeadState): MainRefreshPlan => {
+	if (isMassControlPlaneDeletion(head)) {
+		return {action: "refuse-mass-deletion", count: head.stagedControlPlaneDeletionCount};
+	}
 	if (head.branch !== MAIN_BRANCH) {
 		return {action: "leave-alone", reason: "off-main", branch: fromLabel(head.branch)};
 	}

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.unit.test.ts
@@ -4,7 +4,9 @@ import {
 	decideMainRefresh,
 	decideMainSync,
 	type HeadState,
+	isMassControlPlaneDeletion,
 	MAIN_BRANCH,
+	MASS_DELETION_BLOCK_THRESHOLD,
 	type MainRefreshPlan,
 	type MainSyncPlan,
 } from "./main-sync.ts";
@@ -13,6 +15,7 @@ const head = (over: Partial<HeadState> = {}): HeadState => ({
 	branch: "main",
 	isDirty: false,
 	hasTrackedModifications: false,
+	stagedControlPlaneDeletionCount: 0,
 	...over,
 });
 
@@ -55,8 +58,8 @@ describe("decideMainSync — blocked-dirty (detect-and-surface, never discard)",
 
 	it("dirty NEVER yields a reattach on the off-main path (safety invariant)", () => {
 		const plans: MainSyncPlan[] = [
-			decideMainSync({branch: null, isDirty: true, hasTrackedModifications: true}),
-			decideMainSync({branch: "x", isDirty: true, hasTrackedModifications: true}),
+			decideMainSync(head({branch: null, isDirty: true, hasTrackedModifications: true})),
+			decideMainSync(head({branch: "x", isDirty: true, hasTrackedModifications: true})),
 		];
 		for (const plan of plans) {
 			assert.notStrictEqual(plan.action, "reattach");
@@ -67,12 +70,12 @@ describe("decideMainSync — blocked-dirty (detect-and-surface, never discard)",
 describe("decideMainSync — totality", () => {
 	it("every HeadState maps to exactly one of the three actions", () => {
 		const cases: HeadState[] = [
-			{branch: "main", isDirty: false, hasTrackedModifications: false},
-			{branch: "main", isDirty: true, hasTrackedModifications: true},
-			{branch: null, isDirty: false, hasTrackedModifications: false},
-			{branch: null, isDirty: true, hasTrackedModifications: true},
-			{branch: "feature", isDirty: false, hasTrackedModifications: false},
-			{branch: "feature", isDirty: true, hasTrackedModifications: true},
+			head({branch: "main", isDirty: false, hasTrackedModifications: false}),
+			head({branch: "main", isDirty: true, hasTrackedModifications: true}),
+			head({branch: null, isDirty: false, hasTrackedModifications: false}),
+			head({branch: null, isDirty: true, hasTrackedModifications: true}),
+			head({branch: "feature", isDirty: false, hasTrackedModifications: false}),
+			head({branch: "feature", isDirty: true, hasTrackedModifications: true}),
 		];
 		const actions = new Set(["already-on-main", "reattach", "blocked-dirty"]);
 		for (const c of cases) {
@@ -131,17 +134,61 @@ describe("decideMainRefresh — leave-alone (never move HEAD, never error)", () 
 
 	it("NEVER yields a HEAD-moving action — leave-alone or fast-forward only, no reattach/checkout", () => {
 		const cases: HeadState[] = [
-			{branch: "main", isDirty: false, hasTrackedModifications: false},
-			{branch: "main", isDirty: true, hasTrackedModifications: true},
-			{branch: "main", isDirty: true, hasTrackedModifications: false},
-			{branch: null, isDirty: false, hasTrackedModifications: false},
-			{branch: null, isDirty: true, hasTrackedModifications: true},
-			{branch: "feature", isDirty: false, hasTrackedModifications: false},
-			{branch: "feature", isDirty: true, hasTrackedModifications: true},
+			head({branch: "main", isDirty: false, hasTrackedModifications: false}),
+			head({branch: "main", isDirty: true, hasTrackedModifications: true}),
+			head({branch: "main", isDirty: true, hasTrackedModifications: false}),
+			head({branch: null, isDirty: false, hasTrackedModifications: false}),
+			head({branch: null, isDirty: true, hasTrackedModifications: true}),
+			head({branch: "feature", isDirty: false, hasTrackedModifications: false}),
+			head({branch: "feature", isDirty: true, hasTrackedModifications: true}),
 		];
 		const actions = new Set<MainRefreshPlan["action"]>(["fast-forward", "leave-alone"]);
 		for (const c of cases) {
 			assert.isTrue(actions.has(decideMainRefresh(c).action));
 		}
+	});
+});
+
+describe("#2778 mass-staged-deletion refusal — the guaranteed catch, not incidental (#2784)", () => {
+	const T = MASS_DELETION_BLOCK_THRESHOLD;
+
+	it("isMassControlPlaneDeletion trips at/above the threshold, quiet below", () => {
+		assert.isFalse(isMassControlPlaneDeletion(head({stagedControlPlaneDeletionCount: T - 1})));
+		assert.isTrue(isMassControlPlaneDeletion(head({stagedControlPlaneDeletionCount: T})));
+		assert.isTrue(isMassControlPlaneDeletion(head({stagedControlPlaneDeletionCount: 248})));
+	});
+
+	it("decideMainSync refuses by NAME on the mass-deletion signature, before branch/dirt", () => {
+		// The whole point: even a clean HEAD on main is refused when the signature is present —
+		// the catch is now the signature itself, not the incidental dirty gate.
+		const plan = decideMainSync(
+			head({branch: "main", isDirty: false, stagedControlPlaneDeletionCount: 248}),
+		);
+		assert.deepStrictEqual(plan, {action: "blocked-mass-deletion", count: 248});
+	});
+
+	it("decideMainSync mass-deletion refusal outranks reattach and blocked-dirty", () => {
+		const detachedDirty = decideMainSync(
+			head({branch: null, isDirty: true, stagedControlPlaneDeletionCount: T}),
+		);
+		assert.strictEqual(detachedDirty.action, "blocked-mass-deletion");
+	});
+
+	it("decideMainRefresh refuses LOUDLY (refuse-mass-deletion), not the silent leave-alone", () => {
+		// On main + the signature: the incidental hasTrackedModifications gate would ALSO skip the ff,
+		// but silently (leave-alone). The signature must surface as an explicit refusal instead.
+		const plan = decideMainRefresh(
+			head({branch: "main", hasTrackedModifications: true, stagedControlPlaneDeletionCount: T}),
+		);
+		assert.deepStrictEqual(plan, {action: "refuse-mass-deletion", count: T});
+	});
+
+	it("a below-threshold control-plane deletion does NOT refuse (no false-block of a small refactor)", () => {
+		const sync = decideMainSync(head({branch: "main", stagedControlPlaneDeletionCount: T - 1}));
+		assert.strictEqual(sync.action, "already-on-main");
+		const refresh = decideMainRefresh(
+			head({branch: "main", stagedControlPlaneDeletionCount: T - 1}),
+		);
+		assert.strictEqual(refresh.action, "fast-forward");
 	});
 });

--- a/packages/pipeline-cli/src/tools/primary-index-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/primary-index-guard/command.ts
@@ -1,0 +1,113 @@
+/**
+ * The `primary-index-guard` tool — `pipeline-cli primary-index-guard pre-commit`.
+ *
+ * The BLOCKING §CP promotion of the read-only `@kampus/primary-index-tripwire` (PR #2783). Wired as
+ * git's own `pre-commit` hook (`lefthook.yml`), it fires as a commit carrying the #2778
+ * mass-staged-deletion signature is CREATED on the PRIMARY checkout — the one caller-agnostic choke
+ * point before a push can fast-forward that control-plane mass deletion onto `origin/main` (the
+ * residual vector #2783 named: `ref-guard` allows a fast-forward, `main-sync` only catches its own
+ * path). The read-only `record` leg stays alongside this block: record for attribution, refuse for
+ * containment.
+ *
+ * Safe by construction (the pure `decidePrimaryIndexCommit` is the first enforcement line, this
+ * command's flow is the second): DETECTION + REFUSAL only — it reads staged state read-only
+ * (`git diff --cached`) and aborts the commit by exit code; it NEVER mutates git or the tree (no
+ * `git reset`, no `worktree remove`), so evaluating the guard can never itself corrupt the checkout.
+ *
+ * Fail-CLOSED on the guard's own refusal, fail-OPEN when the CLI can't RUN — mirrors `ref-guard`:
+ * a not-yet-installed / stripped-PATH env (#787) or a bin remediation exit (#1798) must NOT abort
+ * every commit, so a deliberate refuse carries the DEDICATED {@link REFUSE_EXIT_CODE} (3); the
+ * `lefthook.yml` wrapper aborts the commit only on code 3 and swallows every other non-zero to a
+ * clean allow.
+ */
+import {execFileSync} from "node:child_process";
+import {resolve} from "node:path";
+import {appendRecord, defaultLogPath, parseNameStatus} from "@kampus/primary-index-tripwire";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {decidePrimaryIndexCommit, MASS_DELETION_BLOCK_THRESHOLD} from "./primary-index-guard.ts";
+
+/** The dedicated refuse exit code — see `ref-guard`'s `REFUSE_EXIT_CODE`; the lefthook wrapper aborts only on this. */
+export const REFUSE_EXIT_CODE = 3;
+
+const runGit = (args: ReadonlyArray<string>): {ok: boolean; stdout: string} => {
+	try {
+		const stdout = execFileSync("git", [...args], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		return {ok: true, stdout};
+	} catch {
+		return {ok: false, stdout: ""};
+	}
+};
+
+/** The staged deletions as `git diff --cached --name-status --diff-filter=D` (read-only). */
+const stagedDeletions = (): string => {
+	const r = runGit(["diff", "--cached", "--name-status", "--diff-filter=D"]);
+	return r.ok ? r.stdout : "";
+};
+
+/**
+ * `true` iff this commit fires against the shared PRIMARY checkout — the per-tree git-dir equals the
+ * shared git-common-dir on the primary, differs in a linked worktree (the same signal write-code's
+ * worktree preflight and ref-guard use). Indeterminate ⇒ `false` (fail-OPEN: a checkout we cannot
+ * prove is the primary is not blocked, so a worktree agent is never false-refused).
+ */
+const resolvePrimaryCheckout = (): boolean => {
+	const gd = runGit(["rev-parse", "--path-format=absolute", "--git-dir"]);
+	const cd = runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+	if (!gd.ok || !cd.ok) return false;
+	const gitDir = gd.stdout.trim();
+	const commonDir = cd.stdout.trim();
+	if (gitDir === "" || commonDir === "") return false;
+	return resolve(gitDir) === resolve(commonDir);
+};
+
+const thresholdFlag = Flag.integer("threshold").pipe(
+	Flag.withDefault(MASS_DELETION_BLOCK_THRESHOLD),
+	Flag.withDescription("min control-plane staged deletions to REFUSE the primary commit"),
+);
+
+const logFlag = Flag.string("log").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"attribution log path (default: $PRIMARY_INDEX_TRIPWIRE_LOG or a temp file)",
+	),
+);
+
+const preCommit = Command.make(
+	"pre-commit",
+	{threshold: thresholdFlag, log: logFlag},
+	Effect.fn(function* ({threshold, log}) {
+		const decision = decidePrimaryIndexCommit({
+			onPrimaryCheckout: resolvePrimaryCheckout(),
+			staged: parseNameStatus(stagedDeletions()),
+			cwd: process.cwd(),
+			agentType: process.env.CLAUDE_CODE_AGENT ?? "",
+			sessionId: process.env.CLAUDE_CODE_SESSION_ID ?? "",
+			worktreeRoot: process.env.WORKTREE_ROOT ?? "",
+			threshold,
+			at: new Date().toISOString(),
+		});
+		if (decision.kind === "allow") return; // silent clean allow (a pre-commit hook that exits 0)
+
+		// Record the blocked attempt through the SAME out-of-repo log the read-only tripwire uses,
+		// then abort the commit with the dedicated refuse code. Never mutates git or the tree.
+		const logPath = Option.getOrElse(log, defaultLogPath);
+		appendRecord(logPath, `${JSON.stringify({...decision.record, blocked: true})}\n`);
+		yield* Console.error(`primary-index-guard REFUSED (fail-closed): ${decision.reason}`);
+		return yield* Effect.sync(() => process.exit(REFUSE_EXIT_CODE));
+	}),
+).pipe(
+	Command.withDescription(
+		"git pre-commit hook: REFUSE a commit carrying the #2778 mass control-plane staged-deletion signature on the PRIMARY checkout — caller-agnostic, fail-closed (#2784)",
+	),
+);
+
+export const primaryIndexGuardCommand = Command.make("primary-index-guard").pipe(
+	Command.withSubcommands([preCommit]),
+	Command.withDescription(
+		"Blocking primary-index staging guard — refuse a mass control-plane staged deletion committed on the shared primary checkout (#2784, promotes the #2783 read-only tripwire)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/primary-index-guard/primary-index-guard.ts
+++ b/packages/pipeline-cli/src/tools/primary-index-guard/primary-index-guard.ts
@@ -1,0 +1,93 @@
+/**
+ * `primary-index-guard` pure core — the BLOCKING §CP promotion of the read-only
+ * `@kampus/primary-index-tripwire` (PR #2783). Decides whether a commit carrying the #2778
+ * mass-staged-deletion signature (a mass control-plane staged deletion) against the PRIMARY
+ * checkout is REFUSED. IO-free and total: a deterministic transform over already-gathered git
+ * facts; the git boundary (staged-deletion probe, primary-checkout resolution) lives in
+ * `command.ts`, wired as git's own `pre-commit` hook (`lefthook.yml`).
+ *
+ * Why THIS choke point (the residual vector #2783 named). `ref-guard`'s `reference-transaction`
+ * hook refuses only a DIVERGING `refs/heads/main` move; a commit of the mass deletion on top of
+ * `origin/main` is a FAST-FORWARD (origin/main is an ancestor of the new tip), so ref-guard allows
+ * it. `main-sync` catches a dirty primary only on its sanctioned path. The one caller-agnostic
+ * boundary that fires as the loaded-gun commit is CREATED — before any push can fast-forward it to
+ * `origin/main` — is `pre-commit`. This guard blocks there; the tripwire's read-only record leg is
+ * preserved alongside (record for attribution, block for containment).
+ *
+ * Scoped to the PRIMARY checkout. A linked worktree's commit lands on its own feature branch behind
+ * PR review, never a fast-forward to `origin/main`, so a worktree commit is ALLOWED here (the
+ * tripwire still records it as the #2666 bleed class). Reuses the tripwire's `decideTripwire`
+ * detection verbatim — single source of the signature, no reinvention.
+ */
+import {
+	type AttributionRecord,
+	decideTripwire,
+	MASS_DELETION_BLOCK_THRESHOLD,
+	renderWarning,
+	type StagedEntry,
+} from "@kampus/primary-index-tripwire";
+
+export {MASS_DELETION_BLOCK_THRESHOLD};
+
+/** The git + environment facts the block decision needs, gathered read-only at the caller's boundary. */
+export interface PrimaryIndexCommitInput {
+	/** The commit target is the PRIMARY checkout (`git-dir == git-common-dir`). The guard blocks ONLY here. */
+	readonly onPrimaryCheckout: boolean;
+	readonly staged: readonly StagedEntry[];
+	readonly cwd: string;
+	readonly agentType: string;
+	readonly sessionId: string;
+	readonly worktreeRoot: string;
+	/** Minimum control-plane staged deletions to REFUSE (default {@link MASS_DELETION_BLOCK_THRESHOLD}). */
+	readonly threshold: number;
+	readonly at: string;
+}
+
+export type PrimaryIndexDecision =
+	| {readonly kind: "allow"; readonly reason: string}
+	| {readonly kind: "refuse"; readonly reason: string; readonly record: AttributionRecord};
+
+/**
+ * Decide whether to REFUSE a commit carrying the #2778 signature on the PRIMARY checkout:
+ *
+ *   1. NOT the primary checkout → `allow`. A linked worktree's commit is contained to its own
+ *      branch (PR-reviewed), so it can never fast-forward to `origin/main`; the tripwire records it.
+ *   2. On the primary, staged fileset BELOW the mass threshold → `allow`. A legitimate multi-file
+ *      control-plane refactor is not the corruption; only a MASS deletion trips (see the threshold).
+ *   3. On the primary, staged fileset AT/above the threshold → `refuse`. The loaded-gun state: a
+ *      commit + push would fast-forward a control-plane mass deletion onto `origin/main`. Fail-closed.
+ *
+ * Total over every input; delegates the signature classification to the tripwire core so "what is a
+ * #2778 mass deletion" has exactly one definition.
+ */
+export const decidePrimaryIndexCommit = (input: PrimaryIndexCommitInput): PrimaryIndexDecision => {
+	if (!input.onPrimaryCheckout) {
+		return {
+			kind: "allow",
+			reason:
+				"not the PRIMARY checkout (a linked worktree) — the commit lands on a feature branch behind PR review, never a fast-forward to origin/main; the read-only tripwire still records it",
+		};
+	}
+	const decision = decideTripwire({
+		onPrimaryCheckout: true,
+		staged: input.staged,
+		cwd: input.cwd,
+		agentType: input.agentType,
+		sessionId: input.sessionId,
+		worktreeRoot: input.worktreeRoot,
+		threshold: input.threshold,
+		at: input.at,
+	});
+	if (decision.kind === "quiet") {
+		return {kind: "allow", reason: decision.reason};
+	}
+	return {
+		kind: "refuse",
+		reason:
+			`refusing a commit carrying the #2778 mass-staged-deletion signature on the PRIMARY checkout — ${renderWarning(decision.record)}. ` +
+			"A commit + push here fast-forwards this control-plane mass deletion onto origin/main (ref-guard allows a fast-forward). " +
+			"Recover with `git reset` (unstage; 0 commits ahead ⇒ `git reset --hard origin/main` restores tracked files, preserves untracked). " +
+			"If this deletion is genuinely intended, do it on a worktree branch through a reviewed PR, never a direct primary commit.",
+		record: decision.record,
+	};
+};

--- a/packages/pipeline-cli/src/tools/primary-index-guard/primary-index-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/primary-index-guard/primary-index-guard.unit.test.ts
@@ -1,0 +1,74 @@
+import {assert, describe, it} from "@effect/vitest";
+import type {StagedEntry} from "@kampus/primary-index-tripwire";
+import {
+	decidePrimaryIndexCommit,
+	MASS_DELETION_BLOCK_THRESHOLD,
+	type PrimaryIndexCommitInput,
+} from "./primary-index-guard.ts";
+
+const del = (path: string): StagedEntry => ({status: "D", path});
+
+const input = (over: Partial<PrimaryIndexCommitInput> = {}): PrimaryIndexCommitInput => ({
+	onPrimaryCheckout: true,
+	staged: [],
+	cwd: "/repo",
+	agentType: "engineering-manager",
+	sessionId: "sess-1",
+	worktreeRoot: "",
+	threshold: MASS_DELETION_BLOCK_THRESHOLD,
+	at: "2026-07-12T00:00:00Z",
+	...over,
+});
+
+const massDeletion = (n: number): StagedEntry[] =>
+	Array.from({length: n}, (_, i) => del(`.claude/skills/x${i}.md`));
+
+describe("decidePrimaryIndexCommit — blocks the #2778 signature on the PRIMARY checkout", () => {
+	it("refuses a mass control-plane staged deletion on the primary (the loaded-gun commit)", () => {
+		const decision = decidePrimaryIndexCommit(input({staged: massDeletion(248)}));
+		assert.strictEqual(decision.kind, "refuse");
+		if (decision.kind === "refuse") {
+			assert.match(decision.reason, /#2778/);
+			assert.strictEqual(decision.record.controlPlaneDeletionCount, 248);
+			assert.isTrue(decision.record.onPrimaryCheckout);
+		}
+	});
+
+	it("refuses exactly at the block threshold", () => {
+		const decision = decidePrimaryIndexCommit(
+			input({staged: massDeletion(MASS_DELETION_BLOCK_THRESHOLD)}),
+		);
+		assert.strictEqual(decision.kind, "refuse");
+	});
+});
+
+describe("decidePrimaryIndexCommit — allows normal commits", () => {
+	it("allows a below-threshold control-plane deletion (a legit small refactor is not the corruption)", () => {
+		const decision = decidePrimaryIndexCommit(
+			input({staged: massDeletion(MASS_DELETION_BLOCK_THRESHOLD - 1)}),
+		);
+		assert.strictEqual(decision.kind, "allow");
+	});
+
+	it("allows a normal commit with no control-plane deletions (a mass of ordinary-source deletions is fine)", () => {
+		const staged = Array.from({length: 300}, (_, i) => del(`apps/web/src/old/x${i}.ts`));
+		const decision = decidePrimaryIndexCommit(input({staged}));
+		assert.strictEqual(decision.kind, "allow");
+	});
+
+	it("allows an empty staged set", () => {
+		assert.strictEqual(decidePrimaryIndexCommit(input({staged: []})).kind, "allow");
+	});
+});
+
+describe("decidePrimaryIndexCommit — scoped to the primary checkout", () => {
+	it("ALLOWS a mass control-plane deletion in a linked worktree (it lands on a PR-reviewed branch)", () => {
+		// The worktree's commit can never fast-forward origin/main; the read-only tripwire still
+		// records it. Blocking here would false-refuse a legitimate worktree branch.
+		const decision = decidePrimaryIndexCommit(
+			input({onPrimaryCheckout: false, staged: massDeletion(248)}),
+		);
+		assert.strictEqual(decision.kind, "allow");
+		if (decision.kind === "allow") assert.match(decision.reason, /worktree/);
+	});
+});

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -31,6 +31,12 @@
 import {execFileSync} from "node:child_process";
 import {existsSync, statSync} from "node:fs";
 import {resolve} from "node:path";
+import {
+	appendRecord,
+	decideBashStagingAttribution,
+	defaultLogPath,
+	renderBashStagingNote,
+} from "@kampus/primary-index-tripwire";
 import {Console, Data, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {isIsolationExpected, pinBash} from "./bash-pin.ts";
@@ -65,6 +71,32 @@ const onPrimaryCheckout = (cwd: string): boolean => {
 		return gitDir === commonDir;
 	} catch {
 		return false;
+	}
+};
+
+/**
+ * Run-time #2778 attribution (#2784, part 2): record — never block — a bulk-staging Bash command at
+ * the `pre-bash` boundary, where the offending COMMAND string + cwd are still in hand (the
+ * pre-commit tripwire sees only post-hoc index state). Best-effort and total: any failure is
+ * swallowed so it can NEVER perturb the pin decision this hook actually emits. Writes through the
+ * same out-of-repo log the read-only `primary-index-tripwire record` bin uses (no second surface).
+ */
+const recordBashStaging = (command: string, cwd: string): void => {
+	try {
+		const decision = decideBashStagingAttribution({
+			command,
+			cwd,
+			onPrimaryCheckout: onPrimaryCheckout(cwd),
+			agentType: process.env.CLAUDE_CODE_AGENT ?? "",
+			sessionId: process.env.CLAUDE_CODE_SESSION_ID ?? "",
+			worktreeRoot: WORKTREE_ROOT,
+			at: new Date().toISOString(),
+		});
+		if (decision.kind !== "record") return;
+		appendRecord(defaultLogPath(), `${JSON.stringify(decision.record)}\n`);
+		process.stderr.write(`${renderBashStagingNote(decision.record)}\n`);
+	} catch {
+		// Attribution is best-effort; a recording failure must never affect the pin decision.
 	}
 };
 
@@ -162,6 +194,9 @@ const preBash = Command.make(
 		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
 		const command = str(toolInput.command);
 		const cwd = str(field(input, "cwd"));
+		// Run-time #2778 attribution (#2784): record a bulk-staging op before deciding the pin. Purely
+		// additive and best-effort — it never changes the pin decision emitted below.
+		recordBashStaging(command, cwd);
 		const decision = pinBash({
 			worktreeRoot: WORKTREE_ROOT,
 			command,

--- a/packages/primary-index-tripwire/src/bash-attribution.ts
+++ b/packages/primary-index-tripwire/src/bash-attribution.ts
@@ -1,0 +1,176 @@
+/**
+ * Run-time (pre-Bash) attribution for the #2778 corruption — the complement to the pre-commit
+ * {@link import("./tripwire.ts").decideTripwire} core.
+ *
+ * The pre-commit tripwire sees only the POST-HOC index state (a mass of staged deletions), which
+ * cannot say WHICH command produced it (staging leaves no reflog trace, #2778). This core runs at
+ * the `PreToolUse` Bash boundary instead, where the offending staging COMMAND string + cwd + agent
+ * are still in hand — so wiring it into the `worktree-guard pre-bash` hook captures the actor at
+ * the moment a bulk-staging op is issued, closing the "which command staged it?" ambiguity for the
+ * primary-operator surface the pre-commit leg is blind to.
+ *
+ * RECORD-ONLY, like the pre-commit tripwire: this decides only whether to WRITE an attribution
+ * record; it never blocks a command (blocking is the §CP guard on the pre-commit/sync path). It is
+ * scoped to the HIGH-SIGNAL bulk-staging shapes that stage deletions EN MASSE — a stage-everything
+ * (`git add -A/--all/.`, `git commit -a`), or an index removal (`git rm --cached`, the literal
+ * `git rm -r --cached`-class the #2778 signature names). A plain `git add <one-path>` of a
+ * modification is deliberately NOT recorded — it is low-signal and would drown the log.
+ */
+import {CONTROL_PLANE_DELETION_PREFIXES, isControlPlaneDeletion} from "./tripwire.ts";
+
+export {CONTROL_PLANE_DELETION_PREFIXES};
+
+/** The git + environment facts the run-time attribution needs, gathered read-only at the hook boundary. */
+export interface BashStagingInput {
+	/** The raw Bash command the agent is about to run (the hook's `tool_input.command`). */
+	readonly command: string;
+	readonly cwd: string;
+	/** The commit target is the PRIMARY checkout (`git-dir == git-common-dir`) — the severe surface. */
+	readonly onPrimaryCheckout: boolean;
+	readonly agentType: string;
+	readonly sessionId: string;
+	readonly worktreeRoot: string;
+	readonly at: string;
+}
+
+/** Which bulk-staging shape was detected — the two the #2778 signature is produced by. */
+export type BashStagingKind = "stage-all" | "rm-cached";
+
+/** The run-time attribution record written when a bulk-staging command is seen at the Bash boundary. */
+export interface BashStagingRecord {
+	readonly at: string;
+	readonly source: "pre-bash";
+	readonly kind: BashStagingKind;
+	readonly command: string;
+	readonly cwd: string;
+	readonly onPrimaryCheckout: boolean;
+	readonly agentType: string;
+	readonly sessionId: string;
+	readonly worktreeRoot: string;
+	/** Control-plane path args named explicitly in the command (empty for a bare stage-all). */
+	readonly controlPlanePathArgs: readonly string[];
+}
+
+export type BashStagingDecision =
+	| {readonly kind: "quiet"; readonly reason: string}
+	| {readonly kind: "record"; readonly record: BashStagingRecord};
+
+/** Split a command into its git-bearing segments across the common shell connectors (`&&`, `||`, `;`, `|`). */
+const segmentsOf = (command: string): readonly string[] => command.split(/&&|\|\||[;|]/);
+
+const tokensOf = (segment: string): readonly string[] =>
+	segment
+		.trim()
+		.split(/\s+/)
+		.filter((t) => t !== "");
+
+// The flag predicates below split "is a single-dash letter cluster" (a linear `^-[letters]$`
+// test) from "contains the staging letter" (`includes`), deliberately NOT the ambiguous
+// `^-[A-Za-z]*A[A-Za-z]*$` bash-pin uses — that overlapping-quantifier form is polynomial
+// backtracking on `-AAA…` (a CodeQL ReDoS finding), and the split form is equivalent and linear.
+
+/** A `git add` pathspec that stages the whole tree rather than an explicit path. */
+const isAddAllPathspec = (t: string): boolean =>
+	t === "." ||
+	t === "--all" ||
+	t === "--no-ignore-removal" ||
+	(/^-[A-Za-z]*$/.test(t) && t.includes("A")); // a short-flag cluster carrying `-A` (e.g. `-A`, `-Av`)
+
+/** A `git commit` flag that auto-stages tracked changes (`-a` / `-am` / `--all`); NOT `--amend`. */
+const isCommitAllFlag = (t: string): boolean =>
+	t === "--all" || (/^-[a-z]*$/.test(t) && t.includes("a"));
+
+/** Walk a segment's git global options to the subcommand index (skips `-C`/`-c`/`--git-dir`/`--work-tree` args). */
+const subcommandStart = (tokens: readonly string[], gi: number): number => {
+	let i = gi + 1;
+	while (i < tokens.length) {
+		const t = tokens[i] ?? "";
+		if (t === "-C" || t === "--git-dir" || t === "--work-tree" || t === "-c") {
+			i += 2;
+			continue;
+		}
+		if (/^(--git-dir|--work-tree)=/.test(t)) {
+			i += 1;
+			continue;
+		}
+		if (t.startsWith("-")) {
+			i += 1;
+			continue;
+		}
+		break;
+	}
+	return i;
+};
+
+const dequote = (s: string): string => s.replace(/^["']/, "").replace(/["']$/, "");
+
+/** Strip trailing slashes without a `\/+$` regex (that `+` is a CodeQL ReDoS finding on many-slash input). */
+const stripTrailingSlashes = (s: string): string => {
+	let end = s.length;
+	while (end > 0 && s[end - 1] === "/") end--;
+	return s.slice(0, end);
+};
+
+/** The control-plane path args named in the command's tail (positional, non-flag tokens under a trust prefix). */
+const controlPlanePathArgs = (rest: readonly string[]): string[] =>
+	rest
+		.filter((t) => !t.startsWith("-"))
+		.map(dequote)
+		.filter(
+			(t) => isControlPlaneDeletion(`${stripTrailingSlashes(t)}/`) || isControlPlaneDeletion(t),
+		);
+
+/**
+ * Classify a single segment as a bulk-staging op, or `null`. Shallow, fail-toward-detection parse
+ * (the same philosophy as bash-pin's `inspectGitStageAll`): a stage-everything (`git add` all /
+ * `git commit -a`) or an index removal (`git rm --cached`).
+ */
+const classifySegment = (segment: string): {kind: BashStagingKind; paths: string[]} | null => {
+	const tokens = tokensOf(segment);
+	const gi = tokens.indexOf("git");
+	if (gi < 0) return null;
+	const i = subcommandStart(tokens, gi);
+	const subcommand = tokens[i] ?? "";
+	const rest = tokens.slice(i + 1);
+	if (subcommand === "add" && rest.some(isAddAllPathspec)) return {kind: "stage-all", paths: []};
+	if (subcommand === "commit" && rest.some(isCommitAllFlag)) return {kind: "stage-all", paths: []};
+	if (subcommand === "rm" && rest.includes("--cached")) {
+		return {kind: "rm-cached", paths: controlPlanePathArgs(rest)};
+	}
+	return null;
+};
+
+/**
+ * Decide whether a Bash command warrants a run-time attribution record. Records the FIRST bulk-staging
+ * segment found (stage-all or `rm --cached`); everything else is quiet. Total and IO-free — the caller
+ * (`worktree-guard pre-bash`) does the read-only log append and never lets it perturb the pin decision.
+ */
+export const decideBashStagingAttribution = (input: BashStagingInput): BashStagingDecision => {
+	for (const segment of segmentsOf(input.command)) {
+		const hit = classifySegment(segment);
+		if (hit === null) continue;
+		return {
+			kind: "record",
+			record: {
+				at: input.at,
+				source: "pre-bash",
+				kind: hit.kind,
+				command: input.command,
+				cwd: input.cwd,
+				onPrimaryCheckout: input.onPrimaryCheckout,
+				agentType: input.agentType,
+				sessionId: input.sessionId,
+				worktreeRoot: input.worktreeRoot,
+				controlPlanePathArgs: hit.paths,
+			},
+		};
+	}
+	return {kind: "quiet", reason: "no bulk-staging op (stage-all / rm --cached) in the command"};
+};
+
+/** Render a run-time attribution record as a single-line stderr note (mirrors the pre-commit `renderWarning`). */
+export const renderBashStagingNote = (r: BashStagingRecord): string =>
+	`primary-index-tripwire pre-bash ATTRIBUTION (#2778): a ${r.kind} git op on ` +
+	`${r.onPrimaryCheckout ? "the PRIMARY checkout" : "a linked worktree"} — ` +
+	`agent=${r.agentType || "unset"} session=${r.sessionId || "unset"} cwd=${r.cwd} ` +
+	`worktree-root=${r.worktreeRoot || "unset"}${r.controlPlanePathArgs.length > 0 ? ` · control-plane args: ${r.controlPlanePathArgs.join(", ")}` : ""} · command: ${r.command}`;

--- a/packages/primary-index-tripwire/src/bash-attribution.unit.test.ts
+++ b/packages/primary-index-tripwire/src/bash-attribution.unit.test.ts
@@ -1,0 +1,106 @@
+import {describe, expect, it} from "@effect/vitest";
+import {
+	type BashStagingInput,
+	decideBashStagingAttribution,
+	renderBashStagingNote,
+} from "./bash-attribution.ts";
+
+const input = (command: string, over: Partial<BashStagingInput> = {}): BashStagingInput => ({
+	command,
+	cwd: "/repo",
+	onPrimaryCheckout: true,
+	agentType: "engineering-manager",
+	sessionId: "sess-1",
+	worktreeRoot: "",
+	at: "2026-07-12T00:00:00Z",
+	...over,
+});
+
+describe("decideBashStagingAttribution — records bulk-staging commands (the #2778 vectors)", () => {
+	it("records a stage-everything `git add -A`", () => {
+		const d = decideBashStagingAttribution(input("git add -A"));
+		expect(d.kind).toBe("record");
+		if (d.kind === "record") {
+			expect(d.record.kind).toBe("stage-all");
+			expect(d.record.command).toBe("git add -A");
+			expect(d.record.cwd).toBe("/repo");
+			expect(d.record.onPrimaryCheckout).toBe(true);
+		}
+	});
+
+	it("records `git add .`", () => {
+		const d = decideBashStagingAttribution(input("git add ."));
+		expect(d.kind).toBe("record");
+	});
+
+	it("records `git commit -a` (auto-stages tracked deletions)", () => {
+		const d = decideBashStagingAttribution(input('git commit -am "wip"'));
+		expect(d.kind).toBe("record");
+		if (d.kind === "record") expect(d.record.kind).toBe("stage-all");
+	});
+
+	it("records `git rm -r --cached` and captures the control-plane path arg (the literal #2778 shape)", () => {
+		const d = decideBashStagingAttribution(input("git rm -r --cached .claude"));
+		expect(d.kind).toBe("record");
+		if (d.kind === "record") {
+			expect(d.record.kind).toBe("rm-cached");
+			expect(d.record.controlPlanePathArgs).toContain(".claude");
+		}
+	});
+
+	it("finds the staging op inside a chained command (`git status && git add -A`)", () => {
+		const d = decideBashStagingAttribution(input("git status && git add -A"));
+		expect(d.kind).toBe("record");
+	});
+});
+
+describe("decideBashStagingAttribution — quiet on low-signal / non-staging commands", () => {
+	it("is quiet on a plain `git add <one-path>` (a single explicit add is low-signal)", () => {
+		expect(decideBashStagingAttribution(input("git add packages/x/index.ts")).kind).toBe("quiet");
+	});
+
+	it("is quiet on a plain `git commit` (no auto-stage flag)", () => {
+		expect(decideBashStagingAttribution(input('git commit -m "msg"')).kind).toBe("quiet");
+	});
+
+	it("is quiet on `git commit --amend` (the `a` in amend must not read as -a)", () => {
+		expect(decideBashStagingAttribution(input("git commit --amend --no-edit")).kind).toBe("quiet");
+	});
+
+	it("is quiet on non-git commands", () => {
+		expect(decideBashStagingAttribution(input("ls -A")).kind).toBe("quiet");
+		expect(decideBashStagingAttribution(input("rm --cached foo")).kind).toBe("quiet");
+	});
+
+	it("is quiet on `git status`", () => {
+		expect(decideBashStagingAttribution(input("git status --porcelain")).kind).toBe("quiet");
+	});
+});
+
+describe("decideBashStagingAttribution — carries severity + identity for attribution", () => {
+	it("records the worktree severity + agent identity in the record", () => {
+		const d = decideBashStagingAttribution(
+			input("git add -A", {
+				onPrimaryCheckout: false,
+				agentType: "coder",
+				sessionId: "sess-9",
+				worktreeRoot: "/repo/.claude/worktrees/w1",
+			}),
+		);
+		expect(d.kind).toBe("record");
+		if (d.kind === "record") {
+			expect(d.record.onPrimaryCheckout).toBe(false);
+			expect(d.record.agentType).toBe("coder");
+			expect(d.record.sessionId).toBe("sess-9");
+			expect(renderBashStagingNote(d.record)).toContain("a linked worktree");
+		}
+	});
+
+	it("renders a primary-checkout note LOUDLY", () => {
+		const d = decideBashStagingAttribution(input("git add -A"));
+		if (d.kind === "record") {
+			expect(renderBashStagingNote(d.record)).toContain("the PRIMARY checkout");
+			expect(renderBashStagingNote(d.record)).toContain("#2778");
+		}
+	});
+});

--- a/packages/primary-index-tripwire/src/index.ts
+++ b/packages/primary-index-tripwire/src/index.ts
@@ -1,1 +1,6 @@
+export * from "./bash-attribution.ts";
+// The read-only log IO — re-exported so a consumer wiring run-time attribution (the §CP
+// `worktree-guard pre-bash` leg) writes through the SAME best-effort, never-throw log append and
+// out-of-repo default path the pre-commit `record` bin uses (no second log surface).
+export {appendRecord, defaultLogPath, detectPrimaryCheckout} from "./git-io.ts";
 export * from "./tripwire.ts";

--- a/packages/primary-index-tripwire/src/tripwire.ts
+++ b/packages/primary-index-tripwire/src/tripwire.ts
@@ -46,6 +46,19 @@ export const CONTROL_PLANE_DELETION_PREFIXES: readonly string[] = [
 export const isControlPlaneDeletion = (path: string): boolean =>
 	CONTROL_PLANE_DELETION_PREFIXES.some((p) => path.startsWith(p));
 
+/**
+ * The count of control-plane staged deletions at which the #2778 signature is treated as a
+ * MASS deletion that a downstream guard REFUSES (not merely records). Single-sourced here so the
+ * two §CP block sites — `pipeline-cli primary-index-guard` (the pre-commit block) and `main-sync`
+ * (the sync-path refusal) — agree on what "mass" means. Deliberately HIGHER than the record-only
+ * noise floor (`bin.ts`'s `--threshold` default of 10): recording trips early for observability,
+ * but blocking is consequential, so it needs a stronger signal to never false-refuse a legitimate
+ * multi-file control-plane refactor — and it only ever fires on the PRIMARY checkout, where a
+ * direct commit is already off the sanctioned worktree+PR path (a mass deletion committed there is
+ * the corruption, not routine work). The 248-deletion incident sits far above it.
+ */
+export const MASS_DELETION_BLOCK_THRESHOLD = 25;
+
 /** The git + environment facts the decision needs, gathered read-only at the caller's IO boundary. */
 export interface TripwireInput {
 	/**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1167,6 +1167,9 @@ importers:
       '@kampus/gh-phoenix':
         specifier: workspace:*
         version: link:../gh-phoenix
+      '@kampus/primary-index-tripwire':
+        specifier: workspace:*
+        version: link:../primary-index-tripwire
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92


### PR DESCRIPTION
## Prevention build for the #2778 primary-index mass-staged-deletion corruption class

Fixes #2784. **§CP — human-merge-only (cansirin).** Touches `packages/pipeline-cli/**` + the `.claude`/pipeline hook surface (`lefthook.yml`, `worktree-guard pre-bash`), matching `CONTROL_PLANE_RE`.

The diagnosis (#2778, PR #2783 — merged) named the root cause: the primary-operator surface has **no staging containment** (`pinBash` deliberately no-ops there), and `ref-guard` allows a **fast-forward** commit of a mass deletion onto `origin/main` (it refuses only *diverging* moves) — so `main-sync`'s catch was **incidental, not guaranteed**. This PR is the containment that **blocks**, composing on the merged read-only tripwire.

### The three defense-in-depth parts (all landed)

**1. Primary-index staging guard — the residual-vector closer.** New `pipeline-cli primary-index-guard pre-commit` tool: a **BLOCKING** gate that refuses a commit carrying the #2778 signature (a mass control-plane staged deletion) on the **PRIMARY checkout**. It reuses the merged tripwire's `decideTripwire` detection **verbatim** (single source of the signature) and is scoped to the primary — a linked worktree's commit lands on a PR-reviewed feature branch, so it's allowed (the read-only tripwire still records it). Wired as a fail-closed `lefthook` `pre-commit` leg with the dedicated `REFUSE_EXIT_CODE=3` (fail-**open** on infra absence, exactly like `ref-guard`). `pre-commit` is the one caller-agnostic choke point that fires as the loaded-gun commit is *created* — before a push can fast-forward it to `origin/main` (which `ref-guard` allows). The record-only tripwire leg is preserved alongside.

**2. Run-time attribution wired into the `worktree-guard pre-bash` hook.** The merged tripwire sees only post-hoc index state; this captures the offending **staging command + cwd + agent** at run time. New pure `decideBashStagingAttribution` (in the tripwire package) detects a bulk-staging op (`git add -A/./--all`, `git commit -a`, `git rm --cached`) and **records — never blocks** — through the same out-of-repo log the pre-commit tripwire uses. Purely additive: it never changes the pin decision the hook emits.

**3. main-sync hardened — the incidental catch becomes a guarantee.** `decideMainSync` / `decideMainRefresh` now check the #2778 signature **first** and refuse it **by name** (`blocked-mass-deletion` / `refuse-mass-deletion`, a LOUD exit-1), replacing the incidental `hasTrackedModifications` side-effect. The signature count is classified with the tripwire's detection at the git boundary, and both block sites share the single-sourced `MASS_DELETION_BLOCK_THRESHOLD`.

### Safety
Detection + refusal only — **never** a blanket `git reset` / `worktree remove --force`. The guard cannot itself corrupt a checkout: it reads staged state read-only and aborts by exit code. Fail-closed on the signature; fail-open on infra absence (stripped-PATH / uninstalled CLI), mirroring `ref-guard`'s `REFUSE_EXIT_CODE` contract.

### Tests + gates (local, green)
- **Unit tests each part:** `primary-index-guard` blocks the signature on the primary + allows a normal commit / a worktree commit / a below-threshold refactor; `main-sync` refuses the mass deletion by name (and does **not** false-block below threshold); `bash-attribution` captures command + cwd + agent for each bulk-staging shape and stays quiet on low-signal commands.
- `pnpm typecheck` ✓ · `pnpm lint` ✓ (0 errors) · pipeline-cli **1162** tests ✓ · tripwire **21** tests ✓.
- The new blocking `pre-commit` + `ref-guard` legs both ran green on this branch's own commit.

Merge by hand (§CP, cansirin), not auto-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)