### PR TITLE
docs(glossary): add "branded ID schema" architecture term (#2725)

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -204,6 +204,32 @@ mutated store — `user_profile`, `content_report`, the stats singletons — is 
 too, but lives in the worker schema without the suffix, so lacking `*_record` is not a
 convention violation for those.
 
+### Branded ID schema
+
+An **entity id typed via `Schema.String.pipe(Schema.brand("Name"))`** — carrying the type
+`Brand.Branded<string, "Name">`, a **compile-time-only nominal marker** (no runtime
+allocation; the value is still a plain string) that makes passing the wrong id a typecheck
+error instead of a silent cross-entity mix-up. The term is coined by epic
+[#2700](https://github.com/kamp-us/phoenix/issues/2700) so its child `write-code` agents
+inherit one canonical name rather than re-coining "nominal id" / "id brand" synonyms (the
+one-concept-named-four-ways drift, #851); it surfaces at coinage time per ADR
+[0128](../.decisions/0128-glossary-concept-trigger-off-the-gate.md).
+
+The idiom is effect-smol's `Brand` / `Schema.brand` (ground the `Schema.brand` call site
+against effect-smol's `LLMS.md`, not intuition). Ownership splits two ways:
+
+- **Shared cross-feature id — `UserId`.** The one id every feature references is declared
+  once in the shared brand-schema module (established by the epic's tracer
+  [#2712](https://github.com/kamp-us/phoenix/issues/2712)) and imported wherever a user is
+  named. When #2712 lands, replace this note with the module's real path and a real
+  `Schema.brand` call site — this row is coinage-time canon written ahead of source.
+- **Feature-owned ids live with their feature.** `DefinitionId` (sözlük), `PostId` (pano),
+  and the like are declared in their own feature, not the shared module — only the genuinely
+  cross-feature id graduates to the shared home.
+
+The test: two ids that are both `string` at runtime are **distinct types** at compile time,
+so `getPost(userId)` is a type error, never a lookup miss.
+
 ### The LiveDO connection / topic roles
 
 Cross-isolate live (SSE) fan-out is carried by **one** `LiveDO` Durable Object class that


### PR DESCRIPTION
Adds exactly one new architecture-term row — **branded ID schema** — to `.glossary/LANGUAGE.md`, in Section 2 (phoenix structural terms), following the existing `###` structural-term shape.

## Why
Epic #2700 adopts effect-smol's `Brand` / `Schema.brand` nominal-id idiom across the worker's entity ids. Coining the canonical name at coinage time (ADR 0128 prong (c)) gives the epic's child `write-code` agents one name instead of re-coining "nominal id" / "id brand" synonyms — the #851 one-concept-named-four-ways drift class.

## Grounding note
The shared brand-schema module (epic tracer #2712) has **not** landed on `main` yet — there is no `Schema.brand` / `Brand.Branded` in `apps/web/worker/` on origin/main and #2712 is still open. Per the task's grounding rule, the row is written **conceptually against the issue seed**, and the `UserId` bullet carries an explicit note to replace it with the module's real path + a real `Schema.brand` call site once #2712 lands. This is coinage-time canon written ahead of source (the deliberate ADR 0128 prong).

## Scope
- One new register row; no other file touched.
- English technical term (English-for-technical rule); no Turkish brand noun coined.
- Row lands in `LANGUAGE.md` (architecture register), not `TERMS.md`.
- Distinguishes the shared cross-feature id (`UserId`) from feature-owned ids (`DefinitionId` / `PostId`) that live with their feature; states the compile-time-only, no-runtime-allocation property.

Fixes #2725

🤖 Generated with [Claude Code](https://claude.com/claude-code)