### PR TITLE
feat(flags): un-gate the #622 per-browser override wrapper to admin-on-prod (#2741)

### DIFF
--- a/apps/web/worker/features/fate/fate-flags-dev-override.unit.test.ts
+++ b/apps/web/worker/features/fate/fate-flags-dev-override.unit.test.ts
@@ -1,26 +1,21 @@
 /**
- * The fate data-plane `Flags` layer honors the dev-override cookie ONLY under
- * `development` — the fate-runtime twin of the raw-route selection in `http/app.ts`
- * (the #622 gate), proven here at the seam that broke #1868.
+ * The fate data-plane `Flags` layer installs the #622 local-override wrapper — so a
+ * flag-gated fate resolver/mutation honors an `overrides` entry in its per-request
+ * `FlagsContext`. This is the #1868 regression guard (before it, `makeFateLayer` baked
+ * the PLAIN `FlagsLive`, so the decorator was never on the fate path and the flag-flip
+ * cookie had no effect on a mutation).
  *
- * The gap this covers: `makeFateLayer` baked the PLAIN `FlagsLive` unconditionally, so
- * the `withDevOverrides` decorator was never on the fate mutation/resolver path — a
- * flag-gated `definition.react` on the integration `development` stage ignored the
- * `phoenix_flag_overrides` cookie `provideRequestFlags` threads, and the live-reconcile
- * integration test's flag-flip had no effect. `FateFlagsLive` (`layers.ts`) selects the
- * dev-override wrapper under `development` and the plain layer everywhere else.
+ * As of #2741 the wrapper is installed UNCONDITIONALLY (not env-selected): whether an
+ * override is HONORED is decided upstream, per request, by `overridesAuthorized` (dev,
+ * or an admin with `phoenix-admin-console` on) which populates `FlagsContext.overrides`.
+ * That gate — including the prod fail-closed "a non-admin's cookie is inert" invariant —
+ * is proven in `flagship/override-authz.unit.test.ts`. This test proves only the
+ * mechanism it feeds: given an override in context, the fate layer honors it.
  *
- * Two properties, no binding / no I/O — `FateFlagsLive` over a stub `Flagship` whose
- * real eval always returns the dark-ship default OFF, with the environment supplied via
- * a `ConfigProvider` (mirroring the worker-scope `AppConfig` read):
- *
- *   - `development` — the override in `FlagsContext.overrides` forces the flag ON even
- *     though real eval says OFF: the decorator is installed, so the cookie takes effect.
- *   - `production` / `preview` — the SAME override in context is IGNORED and the flag
- *     stays at the real-eval default OFF: the plain layer is installed, so an
- *     attacker-supplied override cookie can never flip a flag on a deployed stage (the
- *     load-bearing prod fail-closed gate). This is the fate-path complement to
- *     `http/app.ts`'s `environment === "development"` install gate.
+ * No binding / no I/O — `FateFlagsLive` over a stub `Flagship` whose real eval always
+ * returns the supplied default (dark-ship OFF for `phoenix-reactions`): the only way the
+ * flag reads ON is the override decorator short-circuiting on `FlagsContext.overrides`,
+ * so a passing ON assertion proves the wrapper is installed — not that real eval flipped.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
@@ -44,10 +39,6 @@ const RuntimeContextStub = Layer.succeed(RuntimeContext)(runtimeContext);
 const unexercised = (method: string) => () =>
 	Effect.die(`Flagship.${method} not exercised in fate-flags-dev-override.unit.test`);
 
-// A `Flagship` whose real boolean eval ALWAYS returns the supplied default (dark-ship
-// OFF for `phoenix-reactions`): the only way the flag reads ON is the dev-override
-// decorator short-circuiting on `FlagsContext.overrides`, so a passing ON assertion
-// proves the wrapper is installed — not that real eval flipped.
 const darkFlagship: Layer.Layer<Flagship> = Layer.succeed(Flagship)(
 	Flagship.of({
 		raw: Effect.die("Flagship.raw not exercised"),
@@ -63,49 +54,43 @@ const darkFlagship: Layer.Layer<Flagship> = Layer.succeed(Flagship)(
 	}),
 );
 
-/** Mirror the worker-scope `ConfigProvider` with a fixed `ENVIRONMENT` stage. */
 const withEnvironment = (environment: string) =>
 	Effect.provideService(
 		ConfigProvider.ConfigProvider,
 		ConfigProvider.fromUnknown({ENVIRONMENT: environment}),
 	);
 
-// Read `phoenix-reactions` (default OFF) through the environment-selected fate `Flags`
-// layer, with an override forcing it ON present in the request `FlagsContext` — the
-// exact shape `provideRequestFlags` builds from the threaded cookie under development.
-const resolveWithOverride = (environment: string) =>
+// Read `phoenix-reactions` (default OFF) through the fate `Flags` layer with a given
+// `FlagsContext` — `overrides` populated or not — mirroring what `provideRequestFlags`
+// hands a resolver once `overridesAuthorized` has decided.
+const resolveWith = (context: {environment: string; overrides?: Record<string, boolean>}) =>
 	Effect.gen(function* () {
 		const flags = yield* Flags;
-		return yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(
-			Effect.provideService(FlagsContext, {
-				environment,
-				overrides: {[PHOENIX_REACTIONS]: true},
-			}),
-		);
+		return yield* flags
+			.getBoolean(PHOENIX_REACTIONS, false)
+			.pipe(Effect.provideService(FlagsContext, context));
 	}).pipe(
 		Effect.provide(
 			Layer.mergeAll(FateFlagsLive.pipe(Layer.provide(darkFlagship)), RuntimeContextStub),
 		),
-		withEnvironment(environment),
+		withEnvironment(context.environment),
 	);
 
-describe("fate Flags layer — dev-override honored only under development", () => {
-	it.effect("development: the override cookie forces phoenix-reactions ON", () =>
+describe("fate Flags layer — the override wrapper is installed (#1868/#2741)", () => {
+	it.effect("an override in context forces phoenix-reactions ON (real eval says OFF)", () =>
 		Effect.gen(function* () {
-			// Real eval says OFF; the ON result can only come from the dev-override wrapper.
-			assert.strictEqual(yield* resolveWithOverride("development"), true);
+			const value = yield* resolveWith({
+				environment: "production",
+				overrides: {[PHOENIX_REACTIONS]: true},
+			});
+			// The ON result can only come from the installed override wrapper.
+			assert.strictEqual(value, true);
 		}),
 	);
 
-	it.effect("production: the same override is IGNORED — flag stays OFF (prod fail-closed)", () =>
+	it.effect("no override in context delegates to real eval — stays OFF", () =>
 		Effect.gen(function* () {
-			assert.strictEqual(yield* resolveWithOverride("production"), false);
-		}),
-	);
-
-	it.effect("preview: the same override is IGNORED — flag stays OFF (deployed fail-closed)", () =>
-		Effect.gen(function* () {
-			assert.strictEqual(yield* resolveWithOverride("preview"), false);
+			assert.strictEqual(yield* resolveWith({environment: "production"}), false);
 		}),
 	);
 });

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -17,12 +17,11 @@ import {FateServer} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import * as ManagedRuntime from "effect/ManagedRuntime";
-import {AppConfig} from "../../config.ts";
 import type {Database} from "../../db/Database.ts";
 import {DrizzleLive} from "../../db/Drizzle.ts";
 import {NotificationLive} from "../bildirim/Notification.ts";
 import {DivanLive} from "../divan/Divan.ts";
-import {FlagsDevOverrideLive, FlagsLive} from "../flagship/Flags.ts";
+import {FlagsDevOverrideLive} from "../flagship/Flags.ts";
 import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
 import type {Flagship} from "../flagship/Flagship.ts";
 import {FunnelLive} from "../funnel/Funnel.ts";
@@ -150,27 +149,18 @@ const VoterStandingFromKunye = Layer.effect(VoterStanding)(
 ).pipe(Layer.provide(KunyeLive));
 
 /**
- * The `Flags` layer for the fate data plane, environment-selected at layer build —
- * the fate-runtime twin of the raw-route selection in `http/app.ts` (the #622 gate).
- * Under `development` it installs the dev-override wrapper (`FlagsDevOverrideLive`) so
- * a flag-gated fate resolver/mutation honors the `phoenix_flag_overrides` cookie that
- * `provideRequestFlags` threads off `RequestFlagOverrides`; every other stage
- * (including the `production` fail-closed default of `AppConfig.environment`,
- * `config.ts`) builds the plain `FlagsLive`, so the override branch is structurally
- * absent from every deployed stage's fate flag path — the same fail-closed gate as
- * the raw routes, applied at the one place the fate runtime resolves `Flags` (#1868:
- * without this, `makeFateLayer` baked `FlagsLive` unconditionally, so the dev-override
- * decorator was never on the fate mutation path and the integration flag-flip cookie
- * had no effect). `AppConfig` reads off the ConfigProvider alchemy auto-wires at
- * worker scope — the same read `makeRequestFlagsContext` uses; both selector arms need
- * only `Flagship`, discharged at the composition root like `FlagsLive` was.
+ * The `Flags` layer for the fate data plane: the local-override wrapper
+ * (`FlagsDevOverrideLive`) installed UNCONDITIONALLY (#2741, epic #2711). The wrapper
+ * is a no-op unless the per-request `FlagsContext.overrides` is populated, and that
+ * population is now the load-bearing gate — resolved per request by
+ * `overridesAuthorized` (dev, or an admin with `phoenix-admin-console` on) and threaded
+ * through `provideRequestFlags`. So a non-admin request on a deployed stage carries no
+ * `overrides` and reads exactly as the plain `FlagsLive` did (#1868 kept intact: the
+ * decorator is on the fate mutation path so a flag-gated resolver honors an authorized
+ * cookie; before this the env gate lived here, but admin-ness is per-request and cannot
+ * be selected at layer build). Needs only `Flagship`, discharged at the composition root.
  */
-export const FateFlagsLive = Layer.unwrap(
-	Effect.gen(function* () {
-		const {environment} = yield* AppConfig.pipe(Effect.orDie);
-		return environment === "development" ? FlagsDevOverrideLive : FlagsLive;
-	}),
-);
+export const FateFlagsLive = FlagsDevOverrideLive;
 
 /**
  * The worker-level data-plane layer (ADR 0029, ADR 0040). Derives everything from
@@ -274,12 +264,12 @@ export const makeFateLayer = Layer.mergeAll(
 	// external R — the same internal-seam idiom as `KarmaBumpFromPasaport`.
 	RateLimiterLive.pipe(Layer.provide(InIsolateRateLimitStoreLive)),
 	// `Flags` is the dark-ship read surface fate resolvers/mutations gate on (#746,
-	// #1868). Environment-selected by {@link FateFlagsLive}: the dev-override wrapper
-	// under `development` (so the #622 override cookie is honored on the fate mutation
-	// path), the plain `FlagsLive` on every deployed stage. Needs only `Flagship` (a new
-	// R seam, discharged at the composition root like `Database`); `getBoolean`'s
-	// `RuntimeContext`/`FlagsContext` are per-call, supplied by the resolver, not at
-	// layer build.
+	// #1868). {@link FateFlagsLive} installs the local-override wrapper unconditionally
+	// (#2741) — the #622 cookie is honored on the fate mutation path whenever the
+	// per-request `overridesAuthorized` verdict allows it (dev, or admin + flag), and is
+	// inert otherwise. Needs only `Flagship` (a new R seam, discharged at the composition
+	// root like `Database`); `getBoolean`'s `RuntimeContext`/`FlagsContext` are per-call,
+	// supplied by the resolver, not at layer build.
 	FateFlagsLive,
 ).pipe(Layer.provideMerge(PasaportFromTag), Layer.provideMerge(DrizzleLive));
 

--- a/apps/web/worker/features/fate/resolve-wire.testing.ts
+++ b/apps/web/worker/features/fate/resolve-wire.testing.ts
@@ -44,7 +44,10 @@ import {PanoFeedCache} from "../pano/feed-cache.ts";
  * effect DIRECTLY (not through `resolveWire`) merges {@link noRequestFlagOverrides}
  * into its context layer instead.
  */
-const NO_COOKIE_OVERRIDES = RequestFlagOverrides.of({cookieHeader: null});
+const NO_COOKIE_OVERRIDES = RequestFlagOverrides.of({
+	cookieHeader: null,
+	overridesAllowed: false,
+});
 
 /** The shared no-cookie {@link RequestFlagOverrides} stub layer — see {@link NO_COOKIE_OVERRIDES}. */
 export const noRequestFlagOverrides: Layer.Layer<RequestFlagOverrides> = Layer.succeed(

--- a/apps/web/worker/features/fate/route.ts
+++ b/apps/web/worker/features/fate/route.ts
@@ -28,6 +28,7 @@ import {
 	makeRequestFlagsContext,
 	RequestFlagOverrides,
 } from "../flagship/FlagsContext.ts";
+import {overridesAuthorized} from "../flagship/override-authz.ts";
 import {currentActorContext} from "../kunye/CurrentActorLive.ts";
 import {PanoFeedCache, panoFeedCacheFor} from "../pano/feed-cache.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
@@ -68,18 +69,30 @@ export const handleFate = Effect.gen(function* () {
 		waitUntil,
 	});
 
+	// May this request honor its `phoenix_flag_overrides` cookie (#2741)? Resolved ONCE
+	// at the edge (dev, or an admin with `phoenix-admin-console` on) over the request's
+	// actor, then threaded on `RequestFlagOverrides` so `provideRequestFlags` gates every
+	// resolver's flag read off it — the admin verdict can't be recomputed per resolver.
+	// The gate flag reads against the anonymous `flagsContext` (no cookie), so a cookie
+	// can never self-authorize the gate.
+	const overridesAllowed = yield* overridesAuthorized(flagsContext).pipe(
+		Effect.provide(currentActorContext(session?.user)),
+	);
+
 	// ONE context object for the whole request — never copy or rebuild it per
 	// resolver. No `signal` field: interruption is wired at this edge (below).
 	// `requestServices` fulfills the `[CurrentActor, RequestFlagOverrides]`
 	// registered in `layers.ts`: `CurrentActor` derived from the validated session
-	// (ADR 0107 §7), `RequestFlagOverrides` carrying the raw `Cookie` header so a
-	// flag-gated resolver's `provideRequestFlags` can source the dev-override cookie
-	// (#622) — the environment gate stays in `makeRequestFlagsContext`, so it is
-	// inert in every deployed stage.
+	// (ADR 0107 §7), `RequestFlagOverrides` carrying the raw `Cookie` header + the
+	// `overridesAllowed` verdict so a flag-gated resolver's `provideRequestFlags` can
+	// source the #622 cookie only when authorized (dev, or admin + flag; #2741).
 	const requestServices = Context.merge(
 		currentActorContext(session?.user),
 		Context.merge(
-			Context.make(RequestFlagOverrides, {cookieHeader: raw.headers.get("cookie")}),
+			Context.make(RequestFlagOverrides, {
+				cookieHeader: raw.headers.get("cookie"),
+				overridesAllowed,
+			}),
 			Context.make(PanoFeedCache, feedCache),
 		),
 	);

--- a/apps/web/worker/features/flagship/FlagsContext.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.ts
@@ -40,13 +40,14 @@ export interface FlagsContextValue {
 	 */
 	readonly environment?: string;
 	/**
-	 * Dev-only local flag overrides (#622), read from the request's
-	 * `phoenix_flag_overrides` cookie. ONLY ever populated by `provideRequestFlags`
-	 * when `environment === "development"` (fail-closed); in every deployed stage it
-	 * stays `undefined` and the dev-only override wrapper that reads it isn't even
-	 * installed (`http/app.ts`), so this never affects a deployed flag read. Carried
-	 * here — not mapped into the provider wire shape (`toEvaluationContext` ignores
-	 * it) — because it is a local short-circuit, not a targeting attribute.
+	 * Per-browser local flag overrides (#622), read from the request's
+	 * `phoenix_flag_overrides` cookie. Populated by the request path ONLY when the
+	 * request may honor overrides — `environment === "development"`, OR an admin
+	 * request with the `phoenix-admin-console` flag on (#2741, `overridesAuthorized`);
+	 * every other request leaves it `undefined` (fail-closed), so an attacker-supplied
+	 * cookie is a no-op for a non-admin on a deployed stage. Carried here — not mapped
+	 * into the provider wire shape (`toEvaluationContext` ignores it) — because it is a
+	 * local short-circuit, not a targeting attribute.
 	 */
 	readonly overrides?: FlagOverrides;
 }
@@ -64,14 +65,17 @@ export class FlagsContext extends Context.Service<FlagsContext, FlagsContextValu
  * declared to `FateServer.layer` (`layers.ts`), so — like `CurrentActor` — it is
  * excluded from build-time `R` and never provided by a worker-level layer.
  *
- * `header` is `null` when the request carries no `Cookie` header. The dev-only
- * gate stays in {@link makeRequestFlagsContext} (environment === "development"), so
- * this service is inert in every deployed stage: it merely transports the header,
- * it grants no capability of its own.
+ * `cookieHeader` is `null` when the request carries no `Cookie` header.
+ * `overridesAllowed` is the per-request authorization verdict (#2741) resolved once
+ * at the `/fate` route edge by {@link overridesAuthorized} — `true` under
+ * `development` or for an admin request with `phoenix-admin-console` on. The service
+ * grants no capability of its own: it merely transports the header + the verdict, and
+ * {@link makeRequestFlagsContext} is the single site that decides (from both) whether
+ * to parse the cookie.
  */
 export class RequestFlagOverrides extends Context.Service<
 	RequestFlagOverrides,
-	{readonly cookieHeader: string | null}
+	{readonly cookieHeader: string | null; readonly overridesAllowed: boolean}
 >()("@kampus/RequestFlagOverrides") {}
 
 /** The anonymous request context — no identity to bucket on. */
@@ -91,25 +95,29 @@ export const anonymousFlagsContext: FlagsContextValue = {};
  * unauthenticated request. The environment is always populated from the stage —
  * it is a deploy-time fact about the request, not a per-user one.
  *
- * `cookieHeader` is the request's raw `Cookie` header (#622). Dev overrides are
- * parsed from it ONLY when `environment === "development"` — the load-bearing
- * fail-closed gate: since `ENVIRONMENT` defaults to `"production"` (`config.ts`),
- * a deployed stage never reads the cookie, so `overrides` stays `undefined` and an
- * attacker-supplied `phoenix_flag_overrides` cookie can never flip a flag in prod.
+ * `cookieHeader` is the request's raw `Cookie` header (#622). Overrides are parsed
+ * from it ONLY when `environment === "development"` OR `overridesAllowed` — the
+ * latter the per-request admin verdict (#2741). The load-bearing fail-closed gate:
+ * since `ENVIRONMENT` defaults to `"production"` (`config.ts`) and `overridesAllowed`
+ * defaults `false`, a deployed non-admin request never reads the cookie, so
+ * `overrides` stays `undefined` and an attacker-supplied `phoenix_flag_overrides`
+ * cookie can never flip a flag in prod.
  */
 export const makeRequestFlagsContext = (
 	identity: FlagsContextValue,
 	cookieHeader?: string | null,
+	overridesAllowed = false,
 ) =>
 	Effect.gen(function* () {
 		// `orDie`: a `ConfigError` (value outside the two literals) is a malformed
 		// env, unrecoverable — match the health route's read of the same var.
 		const {environment} = yield* AppConfig.pipe(Effect.orDie);
-		// THE GATE: overrides exist only under `development`. Any other stage (incl.
-		// the `production` fail-closed default) drops the cookie entirely. An empty
-		// map (no cookie / a cleared one) is dropped too, so the context carries
-		// `overrides` only when there's an actual local flip to apply.
-		const parsed = environment === "development" ? parseOverrideCookie(cookieHeader) : undefined;
+		// THE GATE: overrides exist only under `development` (the #622 dev convenience)
+		// or for an authorized admin-on-prod request (#2741). Any other request drops the
+		// cookie entirely. An empty map (no cookie / a cleared one) is dropped too, so the
+		// context carries `overrides` only when there's an actual local flip to apply.
+		const honorOverrides = environment === "development" || overridesAllowed;
+		const parsed = honorOverrides ? parseOverrideCookie(cookieHeader) : undefined;
 		const overrides = parsed && Object.keys(parsed).length > 0 ? parsed : undefined;
 		return {
 			...identity,
@@ -134,15 +142,16 @@ export const provideRequestFlags = <A, E, R>(
 ): Effect.Effect<A, E, Exclude<R, FlagsContext> | CurrentUser | RequestFlagOverrides> =>
 	Effect.gen(function* () {
 		const {user} = yield* CurrentUser;
-		// The dev-override cookie (#622) rides the per-request `RequestFlagOverrides`
-		// service, fulfilled at the `/fate` route edge — so a flag-gated resolver's
-		// override is honored on the mutation path, not only on the flagship route.
-		// The environment gate stays in `makeRequestFlagsContext`, so this is inert in
-		// every deployed stage.
-		const {cookieHeader} = yield* RequestFlagOverrides;
+		// The override cookie (#622) rides the per-request `RequestFlagOverrides` service,
+		// fulfilled at the `/fate` route edge — so a flag-gated resolver's override is
+		// honored on the mutation path, not only on the flagship route. `overridesAllowed`
+		// is the admin-on-prod verdict the edge resolved once (#2741); the gate itself
+		// lives in `makeRequestFlagsContext`, so this stays a thin pass-through.
+		const {cookieHeader, overridesAllowed} = yield* RequestFlagOverrides;
 		const context = yield* makeRequestFlagsContext(
 			user ? {userId: user.id} : anonymousFlagsContext,
 			cookieHeader,
+			overridesAllowed,
 		);
 		return yield* effect.pipe(Effect.provideService(FlagsContext, context));
 	});

--- a/apps/web/worker/features/flagship/override-authz.ts
+++ b/apps/web/worker/features/flagship/override-authz.ts
@@ -1,0 +1,41 @@
+/**
+ * `overridesAuthorized` — may THIS request honor its per-browser
+ * `phoenix_flag_overrides` cookie (#622)? The per-request gate that un-gates the
+ * local-override read-wrapper to production for an admin (#2741, epic #2711),
+ * replacing #622's isolate-wide `environment === "development"` install gate.
+ *
+ * `true` iff either:
+ *   - `environment === "development"` — the #622 local-dev convenience, unchanged; OR
+ *   - the request actor holds platform {@link Admin} authority AND the
+ *     `phoenix-admin-console` dark-ship flag is ON (default-off, ADR 0083).
+ *
+ * Fail-safe by construction: a non-admin (the invisible `Denied` from
+ * `Admin.over`), an anonymous request, a flag-off / Flagship-outage read all
+ * resolve `false`, so `makeRequestFlagsContext` drops the cookie and the override
+ * wrapper no-ops — byte-identical to a plain `FlagsLive` read. The gate flag is read
+ * against the caller's BASELINE (no-override) context, so an attacker-supplied
+ * cookie can never self-authorize the gate (the load-bearing #622 /
+ * `FlagsContext.ts` invariant, now honored on prod only for an admin).
+ */
+import {Effect} from "effect";
+import {PHOENIX_ADMIN_CONSOLE} from "../../../src/flags/keys.ts";
+import {Admin, platform} from "../kunye/admin.ts";
+import {Flags} from "./Flags.ts";
+import {FlagsContext, type FlagsContextValue} from "./FlagsContext.ts";
+
+export const overridesAuthorized = (baseline: FlagsContextValue) =>
+	Effect.gen(function* () {
+		if (baseline.environment === "development") return true;
+		// Read the dark-ship gate against the baseline context (no overrides) — so the
+		// cookie cannot flip the flag that decides whether the cookie is honored — then,
+		// only if the console is on, discharge platform-admin authority. Ordered flag-then-
+		// admin so a flag-off request skips the `RelationStore` (D1) admin read entirely.
+		const flags = yield* Flags;
+		const consoleOn = yield* flags
+			.getBoolean(PHOENIX_ADMIN_CONSOLE, false)
+			.pipe(Effect.provideService(FlagsContext, baseline));
+		if (!consoleOn) return false;
+		return yield* Admin.over(platform).pipe(
+			Effect.match({onFailure: () => false, onSuccess: () => true}),
+		);
+	});

--- a/apps/web/worker/features/flagship/override-authz.unit.test.ts
+++ b/apps/web/worker/features/flagship/override-authz.unit.test.ts
@@ -1,0 +1,173 @@
+/**
+ * `overridesAuthorized` — the per-request gate that un-gates the #622 local-override
+ * read-wrapper to production for an admin (#2741, epic #2711). Proven here with NO
+ * binding / NO I/O: `Flags` over a stub `Flagship` (real eval returns the supplied
+ * default, so the only ON signal for `phoenix-admin-console` is this stub flipping it),
+ * a `CurrentActor` stub, and a `RelationStore` stub whose `has` fixes the
+ * `(actor, "admin", platform)` verdict `Admin.over` reads.
+ *
+ * The truth table the load-bearing prod fail-closed invariant rests on:
+ *   - `development` — always authorized (the #622 dev convenience, unchanged).
+ *   - prod, admin + flag ON  — authorized (the new admin-on-prod path).
+ *   - prod, non-admin        — NOT authorized (an attacker cookie stays inert).
+ *   - prod, admin + flag OFF — NOT authorized (dark-ship default holds).
+ *   - prod, anonymous        — NOT authorized (`Admin.over` denies the anon arm).
+ *
+ * The second block proves the verdict is consumed: `makeRequestFlagsContext` populates
+ * `overrides` from the cookie ONLY when the verdict is `true` — so on prod a non-admin's
+ * `phoenix_flag_overrides` cookie yields no overrides at all.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type Actor,
+	AgentAuthority,
+	CurrentActor,
+	human,
+	RelationStore,
+	unauthenticated,
+} from "@kampus/authz";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import * as ConfigProvider from "effect/ConfigProvider";
+import {PHOENIX_ADMIN_CONSOLE} from "../../../src/flags/keys.ts";
+import {encodeOverrideCookieValue, FLAG_OVERRIDE_COOKIE} from "./dev-override.ts";
+import {FlagsLive} from "./Flags.ts";
+import {makeRequestFlagsContext} from "./FlagsContext.ts";
+import {Flagship} from "./Flagship.ts";
+import {overridesAuthorized} from "./override-authz.ts";
+
+const runtimeContext: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+const RuntimeContextStub = Layer.succeed(RuntimeContext)(runtimeContext);
+
+const unexercised = (method: string) => () =>
+	Effect.die(`Flagship.${method} not exercised in override-authz.unit.test`);
+
+// Real eval returns the supplied default for every key EXCEPT `phoenix-admin-console`,
+// which reads `adminConsoleOn` — so an ON verdict can only come from the stub flip.
+const flagshipWith = (adminConsoleOn: boolean): Layer.Layer<Flagship> =>
+	Layer.succeed(Flagship)(
+		Flagship.of({
+			raw: Effect.die("Flagship.raw not exercised"),
+			get: unexercised("get"),
+			getBooleanValue: (key, defaultValue) =>
+				Effect.succeed(key === PHOENIX_ADMIN_CONSOLE ? adminConsoleOn : defaultValue),
+			getStringValue: unexercised("getStringValue"),
+			getNumberValue: unexercised("getNumberValue"),
+			getObjectValue: unexercised("getObjectValue"),
+			getBooleanDetails: unexercised("getBooleanDetails"),
+			getStringDetails: unexercised("getStringDetails"),
+			getNumberDetails: unexercised("getNumberDetails"),
+			getObjectDetails: unexercised("getObjectDetails"),
+		}),
+	);
+
+// `Admin.over` reads the `(actor, "admin", platform)` tuple through `RelationStore.has`.
+const relationStoreWith = (isAdmin: boolean): Layer.Layer<RelationStore> =>
+	Layer.succeed(RelationStore, {has: () => Effect.succeed(isAdmin)} as never);
+
+const authorize = (
+	environment: string,
+	opts: {adminConsoleOn: boolean; isAdmin: boolean; actor: Actor},
+) =>
+	overridesAuthorized({environment}).pipe(
+		Effect.provide(
+			Layer.mergeAll(
+				FlagsLive.pipe(Layer.provide(flagshipWith(opts.adminConsoleOn))),
+				Layer.succeed(CurrentActor, {actor: opts.actor}),
+				Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(true)}),
+				relationStoreWith(opts.isAdmin),
+				RuntimeContextStub,
+			),
+		),
+	);
+
+describe("overridesAuthorized — may this request honor its per-browser cookie (#2741)", () => {
+	it.effect("development: always authorized (the #622 dev convenience)", () =>
+		Effect.gen(function* () {
+			const allowed = yield* authorize("development", {
+				adminConsoleOn: false,
+				isAdmin: false,
+				actor: unauthenticated,
+			});
+			assert.strictEqual(allowed, true);
+		}),
+	);
+
+	it.effect("prod, admin + flag ON: authorized (admin-on-prod)", () =>
+		Effect.gen(function* () {
+			const allowed = yield* authorize("production", {
+				adminConsoleOn: true,
+				isAdmin: true,
+				actor: human("admin-1"),
+			});
+			assert.strictEqual(allowed, true);
+		}),
+	);
+
+	it.effect("prod, non-admin (flag ON): NOT authorized — an attacker cookie stays inert", () =>
+		Effect.gen(function* () {
+			const allowed = yield* authorize("production", {
+				adminConsoleOn: true,
+				isAdmin: false,
+				actor: human("user-1"),
+			});
+			assert.strictEqual(allowed, false);
+		}),
+	);
+
+	it.effect("prod, admin + flag OFF: NOT authorized — the dark-ship default holds", () =>
+		Effect.gen(function* () {
+			const allowed = yield* authorize("production", {
+				adminConsoleOn: false,
+				isAdmin: true,
+				actor: human("admin-1"),
+			});
+			assert.strictEqual(allowed, false);
+		}),
+	);
+
+	it.effect("prod, anonymous (flag ON): NOT authorized — Admin.over denies the anon arm", () =>
+		Effect.gen(function* () {
+			const allowed = yield* authorize("production", {
+				adminConsoleOn: true,
+				isAdmin: true,
+				actor: unauthenticated,
+			});
+			assert.strictEqual(allowed, false);
+		}),
+	);
+});
+
+const OVERRIDDEN_FLAG = "phoenix-reactions";
+const cookieForcing = (value: boolean): string =>
+	`${FLAG_OVERRIDE_COOKIE}=${encodeOverrideCookieValue({[OVERRIDDEN_FLAG]: value})}`;
+
+const contextOverrides = (environment: string, overridesAllowed: boolean) =>
+	makeRequestFlagsContext({}, cookieForcing(true), overridesAllowed).pipe(
+		Effect.map((ctx) => ctx.overrides),
+		Effect.provideService(
+			ConfigProvider.ConfigProvider,
+			ConfigProvider.fromUnknown({ENVIRONMENT: environment}),
+		),
+	);
+
+describe("makeRequestFlagsContext — the verdict gates cookie parsing (#2741)", () => {
+	it.effect("prod, verdict false: the cookie is dropped — no overrides", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* contextOverrides("production", false), undefined);
+		}),
+	);
+
+	it.effect("prod, verdict true: the cookie is honored — overrides carried", () =>
+		Effect.gen(function* () {
+			const overrides = yield* contextOverrides("production", true);
+			assert.deepStrictEqual(overrides, {[OVERRIDDEN_FLAG]: true});
+		}),
+	);
+});

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -20,6 +20,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {currentActorContext} from "../kunye/CurrentActorLive.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {type FlagEvaluateResult, parseFlagEvaluateRequest} from "./evaluate-contract.ts";
 import {Flags} from "./Flags.ts";
@@ -29,6 +30,7 @@ import {
 	type FlagsContextValue,
 	makeRequestFlagsContext,
 } from "./FlagsContext.ts";
+import {overridesAuthorized} from "./override-authz.ts";
 
 /** The dark-ship flag this probe gates on — undeclared, so it reads its default. */
 const PROBE_FLAG = "phoenix-flags-probe";
@@ -90,13 +92,24 @@ export const handleFlagsEvaluate = Effect.gen(function* () {
 	const keys = parseFlagEvaluateRequest(body);
 
 	const session = yield* pasaport.validateSession(raw.headers);
-	// Same per-request context as the probe: session-derived identity plus the
-	// stage `environment` (#512), so every key is evaluated under the full
-	// targeting context — identity stays server-side, never from the body. The
-	// cookie carries any dev-only local override (#622), dev-gated in the builder.
+	const identity = contextFromSession(session);
+	// May this request honor its `phoenix_flag_overrides` cookie (#2741)? The SPA
+	// delivery seam (#510) must reflect an admin's local override, so resolve the
+	// verdict here (dev, or admin + `phoenix-admin-console`) over the session actor,
+	// reading the gate flag against the baseline (no-cookie) context so a cookie can
+	// never self-authorize.
+	const baseline = yield* makeRequestFlagsContext(identity, null);
+	const overridesAllowed = yield* overridesAuthorized(baseline).pipe(
+		Effect.provide(currentActorContext(session?.user)),
+	);
+	// Same per-request context as the probe: session-derived identity plus the stage
+	// `environment` (#512), so every key is evaluated under the full targeting context —
+	// identity stays server-side, never from the body. The cookie is honored only when
+	// authorized (#622/#2741).
 	const context = yield* makeRequestFlagsContext(
-		contextFromSession(session),
+		identity,
 		raw.headers.get("cookie"),
+		overridesAllowed,
 	);
 
 	// Evaluate every requested flag server-side under the session-derived context.

--- a/apps/web/worker/features/kunye/privilege.unit.test.ts
+++ b/apps/web/worker/features/kunye/privilege.unit.test.ts
@@ -80,7 +80,7 @@ const run = (
 					kunyeWithKarma(opts.karma),
 					flagsStub(opts.flagOn),
 					Layer.succeed(CurrentUser, {user: opts.user}),
-					Layer.succeed(RequestFlagOverrides, {cookieHeader: null}),
+					Layer.succeed(RequestFlagOverrides, {cookieHeader: null, overridesAllowed: false}),
 					Layer.succeed(
 						ConfigProvider.ConfigProvider,
 						ConfigProvider.fromUnknown({ENVIRONMENT: "production"}),

--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -16,10 +16,9 @@ import type {FateServer} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
-import type {Environment} from "../config.ts";
 import type {WorkerFateServices} from "../features/fate/layers.ts";
 import type {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
-import {FlagsDevOverrideLive, FlagsLive} from "../features/flagship/Flags.ts";
+import {FlagsDevOverrideLive} from "../features/flagship/Flags.ts";
 import type {Flagship} from "../features/flagship/Flagship.ts";
 import {healthApiLayer} from "./health.ts";
 import {rawWorkerRouteLayers} from "./worker-routes.ts";
@@ -61,15 +60,6 @@ export const makeAppLive = (options: {
 	 * prove the binding resolves end-to-end; the flag Effect service lands in #508.
 	 */
 	readonly flagshipLayer: Layer.Layer<Flagship>;
-	/**
-	 * The deploy environment (`ENVIRONMENT`, ADR 0057/0088), resolved in init. THE
-	 * load-bearing #622 gate: the dev-only flag-override `Flags` wrapper
-	 * (`FlagsDevOverrideLive`) is installed instead of `FlagsLive` ONLY when this is
-	 * `"development"`. Since `ENVIRONMENT` fail-closes to `"production"` (`config.ts`),
-	 * the override branch is structurally absent from every deployed stage's flag
-	 * path — not merely guarded, but never built.
-	 */
-	readonly environment: Environment;
 }) => {
 	// The health route's only worker-level requirement is the `Flagship` client
 	// (its `ConfigProvider` is auto-wired at worker scope); discharge it here.
@@ -79,12 +69,12 @@ export const makeAppLive = (options: {
 	// isolate-level, so it's built once here from `flagshipLayer` and provided into
 	// the per-request set. The probe route reads it; `getBoolean`'s `FlagsContext`
 	// is supplied inline by the handler from the session, so it isn't wired here.
-	// Under local `alchemy dev` ONLY, the dev-override wrapper replaces the real
-	// layer so a local flip can force a flag on (#622) — the gate is the install
-	// site here, fail-closed: any deployed stage builds `FlagsLive`, never the
-	// wrapper.
-	const flagsBase = options.environment === "development" ? FlagsDevOverrideLive : FlagsLive;
-	const flagsLayer = flagsBase.pipe(Layer.provide(options.flagshipLayer));
+	// The local-override wrapper is installed UNCONDITIONALLY (#2741): it is a no-op
+	// unless the per-request `FlagsContext.overrides` is populated, which
+	// `makeRequestFlagsContext` does only when the request is authorized (dev, or an
+	// admin with `phoenix-admin-console` on) — so a deployed non-admin read is
+	// byte-identical to the plain `FlagsLive`.
+	const flagsLayer = FlagsDevOverrideLive.pipe(Layer.provide(options.flagshipLayer));
 
 	// `provideRequest` discharges the route-requirement markers `HttpRouter.add`
 	// lifts (plain `Layer.provide` does not). All provided layers are

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -19,7 +19,7 @@ import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import {AppConfig, ENV_BINDINGS, envBindings, sentryDsn} from "./config.ts";
+import {ENV_BINDINGS, envBindings, sentryDsn} from "./config.ts";
 import {Database, DatabaseLive} from "./db/Database.ts";
 import {DrizzleLive} from "./db/Drizzle.ts";
 import {customHostname, resolveStateMode} from "./env.ts";
@@ -234,12 +234,6 @@ export default Phoenix.make(
 		// per-call requirement); `makeAppLive` reuses it for the `/api/auth/*` route.
 		const runtimeContext = yield* RuntimeContext;
 
-		// The deploy environment, resolved once in init (off the auto-wired
-		// ConfigProvider). `makeAppLive` uses it for the load-bearing #622 gate:
-		// install the dev-only flag-override wrapper ONLY under `development`. `orDie`:
-		// a value outside the three literals is a malformed env, unrecoverable.
-		const {environment: appEnvironment} = yield* AppConfig.pipe(Effect.orDie);
-
 		// The one worker-level runtime (ADR 0041/0043 — init-only wiring): exactly
 		// one per isolate from `PhoenixFateLive` (`R = Database | BetterAuth`, both
 		// provided here). It is a layer-build vehicle only, no runtime on the
@@ -350,7 +344,6 @@ export default Phoenix.make(
 			betterAuthLayer,
 			flagshipLayer,
 			runtimeContext,
-			environment: appEnvironment,
 		});
 
 		// The optional Sentry DSN, read once in init off the auto-wired ConfigProvider.


### PR DESCRIPTION
Un-gate the #622 local-override read-path so an **admin** can honor a `phoenix_flag_overrides` cookie in **that one browser** on a deployed stage, behind the default-off `phoenix-admin-console` flag (epic #2711). This is the **worker half of flags module #1** — a single gate relax. **No** new endpoint / route / store / D1 table / migration / mutation / event (supersedes the rejected global-plane PR #2762).

## The problem
The #622 override wrapper (`FlagsDevOverrideLive`) was env-gated at its **install site** (dev-only, per-isolate). Admin-ness is **per-request**, so a per-isolate layer selection can't express it. The gate therefore moves out of the install site and into the request path.

## The change
- **Install the wrapper unconditionally** (fate `layers.ts` + raw route `http/app.ts`). It is a **no-op** unless `FlagsContext.overrides` is populated — so a non-override read is byte-identical to the plain `FlagsLive`. The now-dead per-isolate `environment` plumbing (`makeAppLive` option + its `index.ts` caller) is deleted.
- **`overridesAuthorized`** (new, `flagship/override-authz.ts`) is the per-request verdict: `development`, **OR** an actor holding platform `Admin` **AND** `phoenix-admin-console` ON. The gate flag reads against the **baseline (no-cookie)** context, so an attacker-supplied cookie can never self-authorize the gate. Reuses `Admin.over(platform)` (kunye/admin) — salvaged the admin predicate, did not rebuild #2762's plane.
- **`makeRequestFlagsContext`** parses the cookie only when `development` OR the verdict is true. The verdict rides `RequestFlagOverrides` on the fate path (resolved once at the `/fate` edge) and is computed at the `/api/flags/evaluate` edge for the SPA delivery seam (#510).

## Fail-safe
No admin / flag-off / anonymous / Flagship-outage ⇒ no override wrapper effect. The #622 / `FlagsContext.ts:98` invariant ("an attacker cookie can never flip a flag in prod") **holds on prod** — now honored only for an admin with the flag on. `route-dev.ts` remains dev-only; no worker-side writer (the prod writer is the client panel, #2742).

## Tests
- `flagship/override-authz.unit.test.ts` (new) — the truth table: dev ⇒ authorized; prod admin+flag-on ⇒ authorized; prod non-admin / flag-off / anonymous ⇒ NOT authorized; plus `makeRequestFlagsContext` drops the cookie unless the verdict is true.
- `fate/fate-flags-dev-override.unit.test.ts` — rewritten: the fate layer installs the wrapper (honors an override in context) now unconditionally; the honoring gate is proven in the authz test.
- Full worker unit suite green (2175 tests); `pnpm typecheck` green (29/29).

## Dark-ship
Ships dark behind the **prior-declared** (`#2758`) default-off `phoenix-admin-console` flag — the default-off IaC invariant is already covered by `flagship/admin-console.invariant.test.ts`. Reaches prod deployed-but-inert until a human flips the flag (ADR 0083).

Fixes #2741
Flag: phoenix-admin-console