### PR TITLE
fix(web): left-anchor the sözlük Subnav go-to-create box, differentiate from ara (#2790)

### DIFF
--- a/apps/web/src/components/layout/Subnav.css
+++ b/apps/web/src/components/layout/Subnav.css
@@ -70,14 +70,19 @@
 }
 
 /* Input slot (#2602) — a product-scoped on-demand utility box (sözlük go-to-or-create),
-   pinned after the spacer. The wrapper positions; the box treatment (sunken input, accent
-   focus) lives on `.kp-subnav__input` — an input affordance's own chrome, not a resting
-   filter/CTA fill (#2586 taxonomy / #2590 IA rule). Mirrors the masthead searchbar so the
-   flag-on box reads identically to today's flag-off one. */
+   left-anchored in the leading zone before the spacer (#2790) so it can't right-jam under
+   the topbar's trailing-edge `ara` and read as a second search. The wrapper positions; the
+   box treatment (sunken input, accent focus) lives on `.kp-subnav__input` — an input
+   affordance's own chrome, not a resting filter/CTA fill (#2586 taxonomy / #2590 IA rule).
+   Mirrors the masthead searchbar so the flag-on box reads identically to today's flag-off one. */
 .kp-subnav__input-slot {
 	display: inline-flex;
 	align-items: center;
 }
+/* Width fits the go-to-or-create placeholder with room to spare so it never clips mid-word;
+   the old `max-width: 40vw` clamp shrank the box below the placeholder on narrow viewports
+   (the #2790 `…ic` truncation). Fluid down to the container via max-width, and the ≤640px
+   reflow fills the row like the masthead's phone rule (SozlukHome.css). */
 .kp-subnav__input {
 	display: flex;
 	align-items: center;
@@ -87,8 +92,9 @@
 	background: var(--surface-sunken);
 	border: 1px solid var(--border);
 	border-radius: var(--r-sm);
-	width: 280px;
-	max-width: 40vw;
+	width: 260px;
+	max-width: 100%;
+	min-width: 0;
 }
 .kp-subnav__input:focus-within {
 	border-color: var(--accent);
@@ -109,6 +115,16 @@
 }
 .kp-subnav__input input::placeholder {
 	color: var(--text-faint);
+}
+/* Phone reflow (≤640px, the repo's 640px container convention) — let the box fill the
+   Subnav row instead of a fixed 260px, so it shrinks fluidly rather than overflowing. */
+@media (max-width: 640px) {
+	.kp-subnav__input-slot {
+		flex: 1;
+	}
+	.kp-subnav__input {
+		width: 100%;
+	}
 }
 
 /* The crumb slot folds pano's active site-filter in as TRANSIENT state paint (only

--- a/apps/web/src/components/layout/Subnav.tsx
+++ b/apps/web/src/components/layout/Subnav.tsx
@@ -31,8 +31,10 @@ export function Subnav({
 	links?: SubnavLink[];
 	crumb?: {label: React.ReactNode; onClear?: () => void};
 	// The input slot (#2602): a product-scoped on-demand utility control — sözlük's
-	// go-to-or-create box (distinct from the topbar `ara`, #1669). Carries the input
-	// treatment itself; the slot only positions it (never the filter/CTA treatment,
+	// go-to-or-create box (distinct from the topbar `ara`, #1669). Left-anchored in the
+	// LEADING zone (before the spacer, #2790) so it can't right-jam directly under the
+	// topbar's trailing-edge `ara` and read as a second, competing search. Carries the
+	// input treatment itself; the slot only positions it (never the filter/CTA treatment,
 	// #2586 taxonomy / #2590 IA rule). Absent ⇒ nothing renders.
 	input?: React.ReactNode;
 	meta?: React.ReactNode;
@@ -77,8 +79,8 @@ export function Subnav({
 					) : null}
 				</span>
 			) : null}
-			<span className="kp-subnav__spacer" />
 			{input ? <span className="kp-subnav__input-slot">{input}</span> : null}
+			<span className="kp-subnav__spacer" />
 			{count ? <span className="kp-subnav__meta">{count}</span> : null}
 			{meta ? <span className="kp-subnav__meta">{meta}</span> : null}
 			{cta ? <span className="kp-subnav__cta">{cta}</span> : null}

--- a/apps/web/src/components/sozluk/SozlukGoToCreate.tsx
+++ b/apps/web/src/components/sozluk/SozlukGoToCreate.tsx
@@ -43,7 +43,7 @@ export function SozlukGoToCreate({
 			<input
 				value={query}
 				onChange={(e) => setQuery(e.currentTarget.value)}
-				placeholder="terime git ya da oluştur: race condition, idempotent…"
+				placeholder="terime git ya da oluştur…"
 				aria-label="Terime git ya da oluştur"
 			/>
 		</form>


### PR DESCRIPTION
Fixes #2790

## What was wrong

The sözlük Subnav's go-to-or-create box (`SozlukGoToCreate` in the `input` slot) rendered right-jammed and mid-word truncated (`…ic`), reading as a second search competing with the topbar's federated `ara`:

- Its `input` slot sat **after** the `.kp-subnav__spacer` (`flex:1`) in `Subnav.tsx`, pinning it to the trailing edge — directly under the topbar's right-aligned `ara`.
- `Subnav.css` `.kp-subnav__input` capped width at `280px` / `max-width: 40vw`; on narrow viewports the `40vw` clamp shrank the box below the placeholder, clipping it mid-word.

## The fix

- **Left-anchor the box** — move the `input` slot into the Subnav's leading zone, *before* the spacer. Only `SozlukSubnavLayout` passes `input`, so no other Subnav consumer changes. This pulls the box to the opposite side from the topbar's trailing-edge `ara`, so the two no longer stack as competing search affordances.
- **Kill the mid-word clip** — drop the `max-width: 40vw` clamp; size the box to fit its placeholder, with a ≤640px phone reflow mirroring `SozlukHome.css`'s established masthead rule.
- **Sharpen create-vs-search copy** — shorten the shared placeholder to `terime git ya da oluştur…`. The old placeholder's example query terms (`race condition, idempotent`) read like search suggestions, reinforcing the "second search" confusion and driving the clip. The accent `+` glyph vs the topbar's muted magnifier is preserved.

## Reconciliation against the design law

Per `design-system-manifest.md` (ADR 0162) + the nav-IA discipline (ADR 0176): the box is a **product-scoped utility** in the Subnav zone (a legal class for that zone), not the primary action — no accent-fill / resting-chrome / slot-treatment violation introduced; it keeps carrying only the `.kp-subnav__input` taxonomy chrome. Differentiation from `ara` now holds on three axes — **position** (leading-zone left-anchor vs topbar trailing edge), **glyph** (accent `+` vs muted magnifier), and **copy** (create/navigate language vs terse `ara…` search).

## Acceptance criteria

- [x] Box no longer right-jams — seated in a deliberate leading slot, not pinned after the spacer.
- [x] Placeholder no longer truncates mid-word across the viewport range (short placeholder + width fits + phone reflow).
- [x] Go-to-create and `ara` no longer read as competing search — position + `+` glyph + create copy keep the distinction legible.
- [x] Placement checked against the four pillars (ADR 0162) + nav-IA discipline (ADR 0176); no new resting chrome / slot-treatment violation.
- [x] Flag-off parity holds — the masthead (`SozlukHome`) renders the identical `SozlukGoToCreate` control (same shortened placeholder); only the host slot's positioning differs.

## Verification

- `pnpm typecheck` — green (FULL TURBO).
- `pnpm biome check` on the three changed files — clean.
- `pnpm vitest run --project client src/components/sozluk/SozlukSubnavLayout.test.tsx` — 4/4 pass (tests match `aria-label`, unaffected by the placeholder copy change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)