### PR TITLE
chore(web): remediate Effect-v4 Rule 1 + Rule 4 idiom violations under apps/web/worker (#2747)

### DIFF
--- a/apps/web/worker/env.ts
+++ b/apps/web/worker/env.ts
@@ -21,7 +21,9 @@ const ExecOptions = Schema.Struct({
 	dev: Schema.optional(Schema.Unknown),
 	stage: Schema.optional(Schema.Unknown),
 });
-const decodeExecOptions = Schema.decodeUnknownOption(ExecOptions);
+// `fromJsonString` parses the blob AND decodes it in one step, folding a JSON
+// parse failure into a `None` — so a malformed blob needs no raw `try/catch`.
+const decodeExecOptions = Schema.decodeUnknownOption(Schema.fromJsonString(ExecOptions));
 
 /** The subset of the deploy-time process env the selector reads. */
 export interface DeployEnvInput {
@@ -66,13 +68,11 @@ const isOfflinePath = (env: DeployEnvInput): boolean => {
 	if (devOverride === "1" || devOverride === "true") return true;
 
 	if (env.ALCHEMY_EXEC_OPTIONS) {
-		try {
-			const parsed = decodeExecOptions(JSON.parse(env.ALCHEMY_EXEC_OPTIONS));
-			if (Option.isSome(parsed) && parsed.value.dev === true) return true;
-		} catch {
-			// A malformed blob is not a dev signal — fall through to deploy (shared
-			// store). Failing safe toward the shared store keeps collab/diff intact.
-		}
+		// A malformed blob decodes to `None`, so it's not a dev signal — fall through
+		// to deploy (shared store). Failing safe toward the shared store keeps
+		// collab/diff intact.
+		const parsed = decodeExecOptions(env.ALCHEMY_EXEC_OPTIONS);
+		if (Option.isSome(parsed) && parsed.value.dev === true) return true;
 	}
 
 	return false;
@@ -101,13 +101,10 @@ export const resolveStateMode = (env: DeployEnvInput): StateMode =>
  */
 export const resolveDevStage = (env: DeployEnvInput): string | undefined => {
 	if (!isOfflinePath(env) || !env.ALCHEMY_EXEC_OPTIONS) return undefined;
-	try {
-		const parsed = decodeExecOptions(JSON.parse(env.ALCHEMY_EXEC_OPTIONS));
-		if (Option.isSome(parsed) && typeof parsed.value.stage === "string" && parsed.value.stage) {
-			return parsed.value.stage;
-		}
-	} catch {
-		// Malformed blob → no stage → auto-name (matches resolveStateMode's fail-safe).
+	// Malformed blob → `None` → no stage → auto-name (matches resolveStateMode's fail-safe).
+	const parsed = decodeExecOptions(env.ALCHEMY_EXEC_OPTIONS);
+	if (Option.isSome(parsed) && typeof parsed.value.stage === "string" && parsed.value.stage) {
+		return parsed.value.stage;
 	}
 	return undefined;
 };

--- a/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
@@ -18,10 +18,16 @@ import {assert, it} from "@effect/vitest";
 import type {LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveEntityTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
 import {Effect, Exit} from "effect";
+import * as Schema from "effect/Schema";
 import {expectTypeOf, vi} from "vitest";
 import {LiveTransportError} from "./cold-start-retry.ts";
 import {livePublisherFor} from "./live-publisher.ts";
 import type {PublishMessage} from "./protocol.ts";
+
+/** A rejection from a test harness thunk (flush / gated publish) — dies the fiber. */
+class PromiseRejected extends Schema.TaggedErrorClass<PromiseRejected>()("test/PromiseRejected", {
+	cause: Schema.Unknown,
+}) {}
 
 interface Recorded {
 	readonly topicKey: string;
@@ -95,7 +101,9 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 		yield* definitions.invalidate({eventId: "e5"});
 		// no-args topic → the procedure-wide global wildcard topic
 		yield* live.topic("posts").appendNode("Post", "p1", {node: {id: "p1"}});
-		yield* Effect.promise(flush);
+		yield* Effect.tryPromise({try: flush, catch: (cause) => new PromiseRejected({cause})}).pipe(
+			Effect.orDie,
+		);
 
 		const definitionsTopic = liveConnectionTopic("Term.definitions", {slug: "effect"});
 		assert.deepStrictEqual(recorded, [
@@ -189,7 +197,9 @@ it.effect("a rejecting topic publish cannot fail the calling effect", () => {
 		);
 		assert.isTrue(Exit.isSuccess(exit));
 
-		yield* Effect.promise(flush); // the detached failure stays off the caller
+		yield* Effect.tryPromise({try: flush, catch: (cause) => new PromiseRejected({cause})}).pipe(
+			Effect.orDie,
+		); // the detached failure stays off the caller
 	}).pipe(
 		Effect.ensuring(
 			Effect.sync(() => {
@@ -225,7 +235,9 @@ it.effect(
 			);
 			assert.isTrue(Exit.isSuccess(exit), "the mutation never fails on an exhausted publish");
 
-			yield* Effect.promise(flush);
+			yield* Effect.tryPromise({try: flush, catch: (cause) => new PromiseRejected({cause})}).pipe(
+				Effect.orDie,
+			);
 			assert.isTrue(
 				logged.some((line) => line.includes("live publish to topic:")),
 				"the exhausted publish was logged through the Effect logger",
@@ -250,11 +262,13 @@ it.effect("a slow publish does not block the request path — waitUntil carries 
 			release = resolve;
 		});
 		const {live, flush} = makeHarness(() =>
-			Effect.promise(() =>
-				gate.then(() => {
-					settled = true;
-				}),
-			),
+			Effect.tryPromise({
+				try: () =>
+					gate.then(() => {
+						settled = true;
+					}),
+				catch: (cause) => new PromiseRejected({cause}),
+			}).pipe(Effect.orDie),
 		);
 
 		// The publish effect completes NOW, while the topic call is still hung —
@@ -263,7 +277,9 @@ it.effect("a slow publish does not block the request path — waitUntil carries 
 		assert.isFalse(settled);
 
 		release();
-		yield* Effect.promise(flush);
+		yield* Effect.tryPromise({try: flush, catch: (cause) => new PromiseRejected({cause})}).pipe(
+			Effect.orDie,
+		);
 		assert.isTrue(settled);
 	}),
 );

--- a/apps/web/worker/features/flagship/route-dev.ts
+++ b/apps/web/worker/features/flagship/route-dev.ts
@@ -18,6 +18,7 @@
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {AppConfig} from "../../config.ts";
@@ -32,6 +33,12 @@ import {
 } from "./dev-override.ts";
 
 const DEV_ROUTE_PATH = "/api/flags/dev";
+
+/** Reading the request form body failed — an unexpected infra failure, so it dies. */
+class RequestBodyReadError extends Schema.TaggedErrorClass<RequestBodyReadError>()(
+	"flagship/RequestBodyReadError",
+	{cause: Schema.Defect()},
+) {}
 
 /** A `404` body that names why — the route exists but is dev-only. */
 const notInDevelopment = HttpServerResponse.text(
@@ -59,7 +66,11 @@ export const flagsDevPageRoute = HttpRouter.add("GET", DEV_ROUTE_PATH, handleFla
 export const handleFlagsDevApply = Effect.gen(function* () {
 	if (!(yield* isDevelopment)) return notInDevelopment;
 	const raw = yield* Cloudflare.Request;
-	const form = new URLSearchParams(yield* Effect.promise(() => raw.text()));
+	const text = yield* Effect.tryPromise({
+		try: () => raw.text(),
+		catch: (cause) => new RequestBodyReadError({cause}),
+	}).pipe(Effect.orDie);
+	const form = new URLSearchParams(text);
 	const action = parseOverrideAction(form);
 	const current = parseOverrideCookie(raw.headers.get("cookie"));
 	const next = action ? applyOverride(current, action) : current;

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -18,6 +18,7 @@
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {currentActorContext} from "../kunye/CurrentActorLive.ts";
@@ -31,6 +32,12 @@ import {
 	makeRequestFlagsContext,
 } from "./FlagsContext.ts";
 import {overridesAuthorized} from "./override-authz.ts";
+
+/** A malformed request body — mapped then recovered to the empty-keys default below. */
+class FlagEvaluateBodyError extends Schema.TaggedErrorClass<FlagEvaluateBodyError>()(
+	"flagship/FlagEvaluateBodyError",
+	{cause: Schema.Defect()},
+) {}
 
 /** The dark-ship flag this probe gates on — undeclared, so it reads its default. */
 const PROBE_FLAG = "phoenix-flags-probe";
@@ -86,7 +93,10 @@ export const handleFlagsEvaluate = Effect.gen(function* () {
 	const pasaport = yield* Pasaport;
 	const flags = yield* Flags;
 
-	const body = yield* Effect.promise(() => raw.json().catch(() => null));
+	const body = yield* Effect.tryPromise({
+		try: () => raw.json(),
+		catch: (cause) => new FlagEvaluateBodyError({cause}),
+	}).pipe(Effect.orElseSucceed(() => null));
 	// A malformed body yields zero requested keys, so the response is `{flags:{}}`
 	// and the client stays at its defaults — the safe-default contract end to end.
 	const keys = parseFlagEvaluateRequest(body);

--- a/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
+++ b/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
@@ -28,6 +28,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
 import {Effect, Layer} from "effect";
+import * as Schema from "effect/Schema";
 import {noopPanoFeedCache} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import type {CommentRow} from "../pano/comment-fields.ts";
@@ -67,8 +68,16 @@ const recordingLive = () => {
 	return {recorded, scheduled, layer};
 };
 
+/** A rejection while draining scheduled `waitUntil` work — dies the fiber. */
+class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/DrainRejected", {
+	cause: Schema.Unknown,
+}) {}
+
 const drain = (scheduled: Array<Promise<unknown>>) =>
-	Effect.promise(() => Promise.allSettled(scheduled));
+	Effect.tryPromise({
+		try: () => Promise.allSettled(scheduled),
+		catch: (cause) => new DrainRejected({cause}),
+	}).pipe(Effect.orDie);
 
 // Service stubs (the `definition-mutation.unit.test.ts` proxy idiom): only the
 // methods the restore resolver reaches are scripted; every other method dies on

--- a/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
@@ -19,6 +19,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
+import * as Schema from "effect/Schema";
 import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
 import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import type * as Removal from "../lifecycle/removal.ts";
@@ -115,9 +116,17 @@ const deps = (run: DrizzleAccessOrDie["run"]): CommentOperationsDeps => ({
 		Effect.die(new Error("comment delete-count path must not read author identity")),
 });
 
+/** A rejection from the stubbed `run` thunk — dies, matching `run`'s `never` channel. */
+class RunRejected extends Schema.TaggedErrorClass<RunRejected>()("test/RunRejected", {
+	cause: Schema.Unknown,
+}) {}
+
 const runOverDb = (db: unknown): DrizzleAccessOrDie["run"] =>
 	(<A>(fn: (d: never) => Promise<A> | A) =>
-		Effect.promise(async () => fn(db as never))) as DrizzleAccessOrDie["run"];
+		Effect.tryPromise({
+			try: async () => fn(db as never),
+			catch: (cause) => new RunRejected({cause}),
+		}).pipe(Effect.orDie)) as DrizzleAccessOrDie["run"];
 
 describe("commentCount is sandbox-symmetric across create/delete (#1831)", () => {
 	it.effect("deleting a SANDBOXED comment leaves the public count unchanged (-0, not -1)", () =>

--- a/apps/web/worker/features/pano/feed-cache.unit.test.ts
+++ b/apps/web/worker/features/pano/feed-cache.unit.test.ts
@@ -13,8 +13,14 @@
  */
 import {assert, it} from "@effect/vitest";
 import {Effect, Exit} from "effect";
+import * as Schema from "effect/Schema";
 import {expectTypeOf, vi} from "vitest";
 import {PANO_FEED_CACHE_TAG, panoFeedCacheFor} from "./feed-cache.ts";
+
+/** A rejection from the test harness flush thunk — dies the fiber. */
+class FlushRejected extends Schema.TaggedErrorClass<FlushRejected>()("test/FlushRejected", {
+	cause: Schema.Unknown,
+}) {}
 
 interface PurgeCall {
 	readonly tags: string[];
@@ -53,7 +59,9 @@ it.effect("enabled ⇒ one tag purge scheduled through waitUntil", () =>
 		yield* cache.purge();
 		// scheduled synchronously, but the delivery is not awaited on the caller path
 		assert.strictEqual(scheduled.length, 1);
-		yield* Effect.promise(flush);
+		yield* Effect.tryPromise({try: flush, catch: (cause) => new FlushRejected({cause})}).pipe(
+			Effect.orDie,
+		);
 
 		assert.deepStrictEqual(purges, [{tags: [PANO_FEED_CACHE_TAG]}]);
 	}),
@@ -92,7 +100,9 @@ it.effect("a rejecting purge cannot fail the calling effect", () => {
 		const exit = yield* Effect.exit(cache.purge());
 		assert.isTrue(Exit.isSuccess(exit));
 
-		yield* Effect.promise(flush); // the detached rejection stays off the caller
+		yield* Effect.tryPromise({try: flush, catch: (cause) => new FlushRejected({cause})}).pipe(
+			Effect.orDie,
+		); // the detached rejection stays off the caller
 	}).pipe(
 		Effect.ensuring(
 			Effect.sync(() => {

--- a/apps/web/worker/features/pano/link-metadata-route.ts
+++ b/apps/web/worker/features/pano/link-metadata-route.ts
@@ -14,6 +14,7 @@
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {
@@ -22,11 +23,18 @@ import {
 	MAX_METADATA_BYTES,
 	MAX_REDIRECT_HOPS,
 	parseLinkMetadata,
+	resolveUrl,
 } from "./link-metadata.ts";
 import type {LinkMetadata} from "./link-metadata-contract.ts";
 
 /** The empty result — the safe-default this route returns on every failure. */
 const EMPTY: LinkMetadata = {};
+
+/** An unexpected `fetchMetadata` rejection — mapped then recovered to {@link EMPTY}. */
+class LinkMetadataFetchError extends Schema.TaggedErrorClass<LinkMetadataFetchError>()(
+	"pano/LinkMetadataFetchError",
+	{cause: Schema.Defect()},
+) {}
 
 /**
  * Read up to {@link MAX_METADATA_BYTES} of the response body as UTF-8, then
@@ -79,12 +87,8 @@ async function fetchFollowingSafeRedirects(
 		if (redirects >= MAX_REDIRECT_HOPS) return null;
 		const location = res.headers.get("location");
 		if (location === null || location === "") return null;
-		let next: URL;
-		try {
-			next = new URL(location, current);
-		} catch {
-			return null;
-		}
+		const next = resolveUrl(location, current);
+		if (next === null) return null;
 		const safe = isSafeFetchUrl(next.toString());
 		if (safe === null) return null;
 		current = safe;
@@ -116,9 +120,13 @@ export const handleLinkMetadata = Effect.gen(function* () {
 	const requested = new URL(raw.url).searchParams.get("url") ?? "";
 	const safe = isSafeFetchUrl(requested);
 	if (safe === null) return HttpServerResponse.jsonUnsafe(EMPTY);
-	// `Effect.promise` because `fetchMetadata` never rejects — it maps every
-	// failure to `EMPTY`, so the route can't surface a defect to the client.
-	const metadata = yield* Effect.promise(() => fetchMetadata(safe));
+	// `fetchMetadata` never rejects — it maps every failure to `EMPTY` — so the
+	// mapped-then-recovered `catch` is unreachable and the route can't surface a
+	// defect to the client.
+	const metadata = yield* Effect.tryPromise({
+		try: () => fetchMetadata(safe),
+		catch: (cause) => new LinkMetadataFetchError({cause}),
+	}).pipe(Effect.orElseSucceed(() => EMPTY));
 	return HttpServerResponse.jsonUnsafe(metadata);
 });
 

--- a/apps/web/worker/features/pano/link-metadata.ts
+++ b/apps/web/worker/features/pano/link-metadata.ts
@@ -118,6 +118,21 @@ export function isHttpUrl(raw: string): URL | null {
 }
 
 /**
+ * Resolve a (possibly relative) redirect `Location` against `base`, returning
+ * `null` for an unparseable ref. Lives here (a non-Effect helper) so the base-aware
+ * `new URL` parse — which throws on a malformed ref — stays a plain guarded parse
+ * rather than an `Effect.try` in the route; the caller re-screens the result through
+ * {@link isSafeFetchUrl}.
+ */
+export function resolveUrl(location: string, base: URL): URL | null {
+	try {
+		return new URL(location, base);
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Parse `raw` and return the {@link URL} only if it is safe to fetch
  * server-side; otherwise `null`. Fail-closed: an unparseable URL, a
  * non-`http(s)` scheme, or a private/loopback/link-local/CGNAT/metadata IP

--- a/apps/web/worker/features/pano/persist-pano-stats.unit.test.ts
+++ b/apps/web/worker/features/pano/persist-pano-stats.unit.test.ts
@@ -14,8 +14,15 @@
 import {describe, it} from "@effect/vitest";
 import {SQLiteDialect} from "drizzle-orm/sqlite-core";
 import {Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {assert} from "vitest";
 import type {DrizzleAccessOrDie, DrizzleDb} from "../../db/Drizzle.ts";
+
+/** A rejection from the stubbed `run` thunk — dies, matching `run`'s `never` channel. */
+class RunRejected extends Schema.TaggedErrorClass<RunRejected>()("test/RunRejected", {
+	cause: Schema.Unknown,
+}) {}
+
 import {makePersistPanoStats} from "./pano-stats.ts";
 
 const dialect = new SQLiteDialect();
@@ -41,7 +48,10 @@ function scriptedRun(counts: readonly [number, number, number]): {
 				return Promise.resolve({results: []});
 			},
 		} as unknown as DrizzleDb;
-		return Effect.promise(() => fn(captureDb));
+		return Effect.tryPromise({
+			try: () => fn(captureDb),
+			catch: (cause) => new RunRejected({cause}),
+		}).pipe(Effect.orDie);
 	}) as DrizzleAccessOrDie["run"];
 	return {
 		run,

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -27,6 +27,7 @@ import {defineRelations} from "drizzle-orm/relations";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type {} from "zod/v4/core";
@@ -42,6 +43,16 @@ import {
 } from "./email-templates.ts";
 
 type AdditionalUserFields = NonNullable<NonNullable<BetterAuthOptions["user"]>["additionalFields"]>;
+
+/**
+ * A rejection from better-auth's own `handler` — an infra failure at the `/api/auth/*`
+ * bridge that dies (mirroring the prior `Effect.promise` defect). Shared with the test
+ * layer (`better-auth.testing.ts`) so both bridges map the same boundary.
+ */
+export class BetterAuthHandlerError extends Schema.TaggedErrorClass<BetterAuthHandlerError>()(
+	"pasaport/BetterAuthHandlerError",
+	{cause: Schema.Defect()},
+) {}
 
 /**
  * The better-auth `user.additionalFields` shape. **Every field is `input:false`** —
@@ -203,9 +214,10 @@ export const BetterAuthLive = Layer.effect(
 			fetch: Effect.gen(function* () {
 				const request = yield* HttpServerRequest.HttpServerRequest;
 				const authInstance = yield* auth;
-				const response = yield* Effect.promise(() =>
-					authInstance.handler(request.source as Request),
-				);
+				const response = yield* Effect.tryPromise({
+					try: () => authInstance.handler(request.source as Request),
+					catch: (cause) => new BetterAuthHandlerError({cause}),
+				}).pipe(Effect.orDie);
 				return HttpServerResponse.fromWeb(response);
 			}),
 		};

--- a/apps/web/worker/features/pasaport/better-auth.testing.ts
+++ b/apps/web/worker/features/pasaport/better-auth.testing.ts
@@ -18,6 +18,7 @@ import * as Layer from "effect/Layer";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import * as schema from "../../db/drizzle/schema.ts";
+import {BetterAuthHandlerError} from "./better-auth-live.ts";
 
 /**
  * A REAL better-auth instance over a test `D1Database` handle, reproducing
@@ -62,7 +63,10 @@ export const layerTest = (instance: Auth): Layer.Layer<BetterAuth.BetterAuth> =>
 		auth: Effect.succeed(instance),
 		fetch: Effect.gen(function* () {
 			const request = yield* HttpServerRequest.HttpServerRequest;
-			const response = yield* Effect.promise(() => instance.handler(request.source as Request));
+			const response = yield* Effect.tryPromise({
+				try: () => instance.handler(request.source as Request),
+				catch: (cause) => new BetterAuthHandlerError({cause}),
+			}).pipe(Effect.orDie);
 			return HttpServerResponse.fromWeb(response);
 		}),
 	});

--- a/apps/web/worker/features/pasaport/lookup-profile-case-insensitive.unit.test.ts
+++ b/apps/web/worker/features/pasaport/lookup-profile-case-insensitive.unit.test.ts
@@ -13,7 +13,13 @@
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
-import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import {
+	Drizzle,
+	type DrizzleAccess,
+	type DrizzleDb,
+	DrizzleError,
+	relations,
+} from "../../db/Drizzle.ts";
 import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
 const inertAuth = {} as BetterAuthInstance;
@@ -61,15 +67,18 @@ function capturingAccess(
 	const state = {i: 0};
 	const access: DrizzleAccess = {
 		run: <A>(fn: (db: DrizzleDb) => Promise<A>) =>
-			Effect.promise(async () => {
-				const built = fn(renderDb) as unknown;
-				if (hasToSQL(built)) {
-					const compiled = built.toSQL();
-					builders.push({sql: compiled.sql, params: compiled.params});
-				} else if (isThenable(built)) {
-					await built;
-				}
-				return results[state.i++] as A;
+			Effect.tryPromise({
+				try: async () => {
+					const built = fn(renderDb) as unknown;
+					if (hasToSQL(built)) {
+						const compiled = built.toSQL();
+						builders.push({sql: compiled.sql, params: compiled.params});
+					} else if (isThenable(built)) {
+						await built;
+					}
+					return results[state.i++] as A;
+				},
+				catch: (cause) => new DrizzleError({cause}),
 			}),
 		batch: () => Effect.die(new Error("lookupProfile must not batch")),
 	};

--- a/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
@@ -32,7 +32,13 @@
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
-import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import {
+	Drizzle,
+	type DrizzleAccess,
+	type DrizzleDb,
+	DrizzleError,
+	relations,
+} from "../../db/Drizzle.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
@@ -101,14 +107,17 @@ function scriptedAccess(
 	const state = {i: 0};
 	const access: DrizzleAccess = {
 		run: <A>(fn: (db: DrizzleDb) => Promise<A>) =>
-			Effect.promise(async () => {
-				const built = fn(renderDb) as unknown;
-				if (hasToSQL(built)) {
-					builderSql.push(built.toSQL().sql);
-				} else if (isThenable(built)) {
-					await built;
-				}
-				return results[state.i++] as A;
+			Effect.tryPromise({
+				try: async () => {
+					const built = fn(renderDb) as unknown;
+					if (hasToSQL(built)) {
+						builderSql.push(built.toSQL().sql);
+					} else if (isThenable(built)) {
+						await built;
+					}
+					return results[state.i++] as A;
+				},
+				catch: (cause) => new DrizzleError({cause}),
 			}),
 		batch: () => Effect.die(new Error("profile-count reads must not batch")),
 	};

--- a/apps/web/worker/features/pasaport/promote-live.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promote-live.unit.test.ts
@@ -22,9 +22,15 @@ import {RelationStore} from "@kampus/authz";
 import {LivePublisher} from "@kampus/fate-effect";
 import {liveEntityTopic} from "@nkzw/fate/server";
 import {Effect, Layer} from "effect";
+import * as Schema from "effect/Schema";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {makePasaportStub} from "./Pasaport.testing.ts";
 import {publishPromotion} from "./promote-live.ts";
+
+/** A rejection while draining scheduled `waitUntil` work — dies the fiber. */
+class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/DrainRejected", {
+	cause: Schema.Unknown,
+}) {}
 
 // A `RelationStore` where nobody moderates — `moderatorsAmong` (the `isModerator`
 // join in `getUsersWithModerationByIds`) reads `hasSubjects`, and a promoted yazar
@@ -89,7 +95,10 @@ describe("publishPromotion — the shared post-promote live-publish (#1886)", ()
 		const {layer, recorded, scheduled} = recordingLive();
 		return Effect.gen(function* () {
 			yield* publishPromotion("u-target");
-			yield* Effect.promise(() => Promise.allSettled(scheduled));
+			yield* Effect.tryPromise({
+				try: () => Promise.allSettled(scheduled),
+				catch: (cause) => new DrainRejected({cause}),
+			}).pipe(Effect.orDie);
 			// The `User` entity topic keyed on the promoted id — what the global live pin
 			// (`.patterns/fate-live-views.md#global-pin`) subscribes, so the profile view
 			// reconciles the new tier live.
@@ -101,7 +110,10 @@ describe("publishPromotion — the shared post-promote live-publish (#1886)", ()
 		const {layer, recorded, scheduled} = recordingLive();
 		return Effect.gen(function* () {
 			yield* publishPromotion("u-gone");
-			yield* Effect.promise(() => Promise.allSettled(scheduled));
+			yield* Effect.tryPromise({
+				try: () => Promise.allSettled(scheduled),
+				catch: (cause) => new DrainRejected({cause}),
+			}).pipe(Effect.orDie);
 			assert.deepStrictEqual(recorded, []);
 		}).pipe(
 			Effect.provide(
@@ -120,7 +132,10 @@ describe("publishPromotion — the shared post-promote live-publish (#1886)", ()
 			// The helper itself must succeed even though delivery dies — the failure is
 			// caught on the detached promise, never surfacing into this effect.
 			yield* publishPromotion("u-target");
-			yield* Effect.promise(() => Promise.allSettled(scheduled));
+			yield* Effect.tryPromise({
+				try: () => Promise.allSettled(scheduled),
+				catch: (cause) => new DrainRejected({cause}),
+			}).pipe(Effect.orDie);
 		}).pipe(Effect.provide(Layer.mergeAll(pasaportWithUser, relationStoreEmpty, layer)));
 	});
 });

--- a/apps/web/worker/features/report/Report.unit.test.ts
+++ b/apps/web/worker/features/report/Report.unit.test.ts
@@ -16,7 +16,13 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
-import {createDrizzle, Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import {
+	createDrizzle,
+	Drizzle,
+	type DrizzleAccess,
+	type DrizzleDb,
+	DrizzleError,
+} from "../../db/Drizzle.ts";
 import {Report, ReportLive} from "./Report.ts";
 
 const throwingAccess: DrizzleAccess = {
@@ -69,7 +75,8 @@ function capturingDrizzle(): {
 	} as unknown as D1Database;
 	const db = createDrizzle(fakeD1);
 	const access: DrizzleAccess = {
-		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => Effect.promise(() => fn(db)),
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) =>
+			Effect.tryPromise({try: () => fn(db), catch: (cause) => new DrizzleError({cause})}),
 		batch: () => Effect.die(new Error("wave writes issue no batch")),
 	};
 	return {access, captured};

--- a/apps/web/worker/features/report/report-live-fanout.unit.test.ts
+++ b/apps/web/worker/features/report/report-live-fanout.unit.test.ts
@@ -23,6 +23,7 @@ import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveEntityTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, Effect, Layer} from "effect";
+import * as Schema from "effect/Schema";
 import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
 import {noopPanoFeedCache, noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
@@ -174,8 +175,16 @@ const recordingPublisher = () => {
 	return {recorded, scheduled, layer};
 };
 
+/** A rejection while draining scheduled `waitUntil` work — dies the fiber. */
+class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/DrainRejected", {
+	cause: Schema.Unknown,
+}) {}
+
 const flush = (scheduled: Array<Promise<unknown>>) =>
-	Effect.promise(() => Promise.allSettled(scheduled));
+	Effect.tryPromise({
+		try: () => Promise.allSettled(scheduled),
+		catch: (cause) => new DrainRejected({cause}),
+	}).pipe(Effect.orDie);
 
 describe("report.resolve remove — publishes the content-topic invalidation", () => {
 	it.effect("a moderator remove of a post evicts the entity + drops its feed edge", () => {

--- a/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
@@ -24,6 +24,7 @@ import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
+import * as Schema from "effect/Schema";
 import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
 import {Divan} from "../divan/Divan.ts";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
@@ -33,6 +34,11 @@ import {Kunye} from "../kunye/Kunye.ts";
 import {mutations} from "./mutations.ts";
 import type {AddDefinitionResult} from "./Sozluk.ts";
 import {Sozluk} from "./Sozluk.ts";
+
+/** A rejection while draining scheduled `waitUntil` work — dies the fiber. */
+class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/DrainRejected", {
+	cause: Schema.Unknown,
+}) {}
 
 const AUTHOR = {id: "u-author", email: "yazar@example.com", name: "yazar"};
 
@@ -155,7 +161,10 @@ it.effect(
 					Effect.provideService(CurrentActor, {actor: human(AUTHOR.id)}),
 					Effect.provideService(RuntimeContext, runtimeContextStub),
 				);
-			yield* Effect.promise(() => Promise.allSettled(scheduled));
+			yield* Effect.tryPromise({
+				try: () => Promise.allSettled(scheduled),
+				catch: (cause) => new DrainRejected({cause}),
+			}).pipe(Effect.orDie);
 
 			// The contract: the resolver routes the new node to the term's args-scoped
 			// connection topic (keyed by `{id: slug}`), so only that term's open page

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -17,6 +17,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {ENV_BINDINGS, envBindings, sentryDsn} from "./config.ts";
@@ -45,6 +46,16 @@ import {workerFirstGlobs} from "./http/worker-routes.ts";
 import {workerOptions} from "./lib/sentry.ts";
 import {captureUnhandled} from "./lib/sentry-capture.ts";
 import {SentryEffectLive} from "./lib/sentry-effect.ts";
+
+/**
+ * A rejection escaping `wrapRequestHandler` past the `captureErrors` backstop — an
+ * infra failure at the worker fetch boundary that dies (mirroring the prior
+ * `Effect.promise` defect).
+ */
+class RequestHandlerError extends Schema.TaggedErrorClass<RequestHandlerError>()(
+	"web/RequestHandlerError",
+	{cause: Schema.Defect()},
+) {}
 
 /**
  * Lift a publish-side `PublishMessage` to the `DeliverFrame` `LiveDO.publish`
@@ -400,15 +411,17 @@ export default Phoenix.make(
 						// backstop for anything that still rejects the thunk. Full rationale + the
 						// flush-on-die finding live in `sentry-capture.ts`.
 						const captured = captureUnhandled(httpEffect);
-						const webResponse = yield* Effect.promise(() =>
-							wrapRequestHandler(
-								{options: workerOptions(value), request, context, captureErrors: true},
-								() =>
-									Effect.runPromise(
-										toWebResponse(request, captured).pipe(Effect.provide(requestContext)),
-									),
-							),
-						);
+						const webResponse = yield* Effect.tryPromise({
+							try: () =>
+								wrapRequestHandler(
+									{options: workerOptions(value), request, context, captureErrors: true},
+									() =>
+										Effect.runPromise(
+											toWebResponse(request, captured).pipe(Effect.provide(requestContext)),
+										),
+								),
+							catch: (cause) => new RequestHandlerError({cause}),
+						}).pipe(Effect.orDie);
 						return HttpServerResponse.fromWeb(webResponse);
 					}),
 				),

--- a/apps/web/worker/lib/sentry-capture.ts
+++ b/apps/web/worker/lib/sentry-capture.ts
@@ -29,7 +29,18 @@
 import {captureException, flush} from "@sentry/cloudflare";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * A rejection from the inline capture/flush path — an infra failure that dies
+ * (mirroring the prior `Effect.promise` defect), keeping this seam's `E` channel
+ * `never` as its callers require.
+ */
+class SentryCaptureError extends Schema.TaggedErrorClass<SentryCaptureError>()(
+	"web/SentryCaptureError",
+	{cause: Schema.Defect()},
+) {}
 
 /**
  * The pure gate (unit-tested): a real (non-interrupt) failure worth capturing. Mirrors
@@ -58,16 +69,19 @@ export function captureUnhandled<E, R>(
 		if (!shouldCaptureCause(cause)) {
 			return Effect.succeed(HttpServerResponse.empty({status: 499}));
 		}
-		return Effect.promise(async () => {
-			console.error("HTTP handler failed", Cause.pretty(cause));
-			for (const error of Cause.prettyErrors(cause)) {
-				captureException(error);
-			}
-			await flush(2000);
-			return HttpServerResponse.text("Internal Server Error", {
-				status: 500,
-				statusText: "Internal Server Error",
-			});
-		});
+		return Effect.tryPromise({
+			try: async () => {
+				console.error("HTTP handler failed", Cause.pretty(cause));
+				for (const error of Cause.prettyErrors(cause)) {
+					captureException(error);
+				}
+				await flush(2000);
+				return HttpServerResponse.text("Internal Server Error", {
+					status: 500,
+					statusText: "Internal Server Error",
+				});
+			},
+			catch: (flushCause) => new SentryCaptureError({cause: flushCause}),
+		}).pipe(Effect.orDie);
 	});
 }


### PR DESCRIPTION
Fixes #2747

Remediates every Rule-1 (`Effect.promise` / single-arg `Effect.tryPromise`) and Rule-4 (raw `try/catch` in an effect-importing file) GritQL violation under `apps/web/worker/**` red-to-green under the Phase-1 rules (epic #2736). Behavior-preserving throughout (Containment: exempt — internal refactor).

## Scope note
The issue estimated "~20 Rule-1 sites"; the true count was **27 Rule-1 + 3 Rule-4** — biome's default 20-diagnostic cap hid the tail. This PR clears the full set (verified with `--max-diagnostics`), so `apps/web/worker/**` is silent under both rules.

## What changed
- **Rule 1** — each `Effect.promise(...)` becomes object-notation `Effect.tryPromise({try, catch: (cause) => new XError({cause})})` with a `Schema.TaggedErrorClass` (the `packages/fate-effect` / `Drizzle.ts` house idiom), recovered to preserve prior behavior:
  - `Effect.orDie` where a rejection was already an uncatchable defect (auth-handler bridge, worker fetch boundary, sentry inline flush, test flush/drain thunks);
  - `Effect.orElseSucceed(() => default)` where a null / `EMPTY` default already existed (`/api/flags/evaluate` body read, link-metadata fetch);
  - `DrizzleAccess.run` test stubs map their catch to the real `DrizzleError` channel the interface declares.
- **Rule 4**:
  - `env.ts` drops both `JSON.parse` + `try/catch` for `Schema.decodeUnknownOption(Schema.fromJsonString(...))` — a malformed `ALCHEMY_EXEC_OPTIONS` blob folds to `None` with no throw (the prior fail-safe-to-shared-store behavior is preserved; pinned by the existing malformed-blob unit test).
  - `link-metadata-route.ts` moves its base-aware redirect-URL parse into the pure, non-Effect `link-metadata.ts` (`resolveUrl`), where a guarded `new URL` parse is sanctioned — no `try/catch` in the effect-importing route, and no cast (the pinned `@cloudflare/workers-types` global `URL` omits `canParse`).

## Verification
- Rule 1 + Rule 4 GritQL checks: **zero findings** across `apps/web/worker/**`.
- `pnpm typecheck`: 29/29 packages pass.
- `pnpm biome check apps/web/worker`: clean (421 files, no plugin findings).
- Affected unit + invariant tests: green, behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)