### PR TITLE
feat(pipeline): single-source the §CP CONTROL_PLANE_RE + fold the ADR-0174 boundary broadenings (#2761)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,12 @@
 /claude-plugins/kampus-pipeline/skills/triage/                     @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/write-code/                 @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/plan-epic/                  @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/release/                    @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/review-trivial/             @kamp-us/control-plane
+# Control-plane: the bare gate-critical *.sh guards directly under skills/ (validate-*.sh) — the
+# §CP `skills/[^/]+\.sh$` branch (ADR 0174, #2576). `*.sh` matches a within-segment name only, so
+# it owns the loose scripts without swallowing the skill dirs already owned above.
+/claude-plugins/kampus-pipeline/skills/*.sh                        @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md  @kamp-us/control-plane
 # Control-plane: the pipeline agent definitions — the behavior of the very agents that run the
 # pipeline, including shipper.md (merge authority) and reviewer.md (verdict gate). §CP-blocking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,6 +385,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
 
+      # pnpm + node so validate-gate-path-drift.sh can read the §CP CONTROL_PLANE_RE from
+      # its single-source const via `pipeline-cli control-plane-paths` (#2761) — this job
+      # runs UNCONDITIONALLY (no path filter), so the const↔formats-doc drift check fires
+      # on a formats-doc-only edit too, closing the merge_group-only gap that ejected #2673.
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
       # Pure-bash guard, no toolchain: every .claude/skills/*/SKILL.md must carry
       # valid frontmatter (name + description, name == dir) or a skill silently
       # stops routing. Same script runs locally: `bash .claude/skills/validate-skills.sh`.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1300,8 +1300,29 @@ closing the #375 drift class).
   - `claude-plugins/kampus-pipeline/skills/review-code/**`
   - `claude-plugins/kampus-pipeline/skills/review-doc/**`
   - `claude-plugins/kampus-pipeline/skills/review-skill/**`
+  - `claude-plugins/kampus-pipeline/skills/review-design/**`
   - `claude-plugins/kampus-pipeline/skills/review-plan/**`
+  - `claude-plugins/kampus-pipeline/skills/review-trivial/**` — the trivial-diff gate emits
+    SHA-bound, merge-consumed verdicts, so it is gate-critical exactly like the other reviewers;
+    its omission was a live fail-**open** §CP-bypass (ADR
+    [0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md), #2679).
+  - `claude-plugins/kampus-pipeline/skills/triage/**`
+  - `claude-plugins/kampus-pipeline/skills/write-code/**`
+  - `claude-plugins/kampus-pipeline/skills/plan-epic/**`
+  - `claude-plugins/kampus-pipeline/skills/release/**` — the release machinery (ADR 0174, #2679).
+  - `claude-plugins/kampus-pipeline/skills/*.sh` — the bare gate-critical guard scripts directly
+    under `skills/` (`validate-gate-path-drift.sh`, `validate-skills.sh`, `validate-cycle-*.sh`):
+    executable enforcement that runs the gates, control-plane *by nature* like the guard packages.
+    The `^claude-plugins/kampus-pipeline/skills/[^/]+\.sh$` branch classifies them (ADR
+    [0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md), #2576);
+    the `[^/]+` matches a bare filename only, so it never reaches into the skill *dirs* above.
   - `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (this file)
+
+  **Deliberately OUT of §CP** (recorded so their absence is a decision, not an oversight): the
+  `heal-ci`, `what-shipped`, `doctor`, and `wayfinder` skills are operational diagnostics /
+  reporting / orientation — they neither gate a merge nor hold release authority nor sit on a
+  gate-critical path, so they auto-merge on a `review-skill` PASS like any ordinary skill. Do
+  **not** add them to the boundary (ADR 0174).
 - the **pipeline agent definitions** — `claude-plugins/kampus-pipeline/agents/**`: the behavior
   instructions for the very agents that run the pipeline, including `shipper.md` (the merge
   authority) and `reviewer.md` (the verdict gate). An agents-only PR matched **no** §CP clause
@@ -1349,7 +1370,11 @@ through the consolidated `^packages/pipeline-cli/` package per ADR
 [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md);
 the **pipeline agent definitions** (`claude-plugins/kampus-pipeline/agents/**`) added by ADR
 [0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
-since a gate/merge agent's own instructions are a self-weakening surface). Everything else — `apps/**`,
+since a gate/merge agent's own instructions are a self-weakening surface; the **bare gate-critical
+`.sh` guards** under `skills/` and the **`release`/`review-trivial` skill dirs** added by ADR
+[0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md)
+(#2576/#2679), since a guard script and a SHA-bound-verdict gate are self-weakening surfaces that
+were escaping the boundary). Everything else — `apps/**`,
 **non**-guard `packages/**`, `.decisions/**` (**except a guard-touching ADR** — see the content
 clause below), `.patterns/**`, every prose doc `*.md` (the
 §DOC class), and every **non**-gate-critical `skills/**` — is **non-blocking** and
@@ -1365,16 +1390,21 @@ code-root `*.md` is non-blocking here yet rides `review-code`, not `review-doc`,
 ### The canonical matcher
 
 Every consumer matches the set with this **one** anchored regex (POSIX ERE; the jq/`grep`
-form below). Cite this regex; do **not** re-hard-code the path list:
-
-```
-^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/
-```
+form below). The regex is **single-sourced** in the `CONTROL_PLANE_RE` const at
+[`packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts`](https://github.com/kamp-us/phoenix/blob/main/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts)
+(issue #2761) — run `pipeline-cli control-plane-paths` to print it (or `--paths` for the expanded
+§CP path set). Cite it; do **not** re-hard-code the path list. The one machine-readable
+`CONTROL_PLANE_RE=` copy below is kept **byte-in-sync with that const** — guarded by `codeowners-cp`
+and `validate-gate-path-drift.sh`, both of which fail closed on any divergence — and is retained
+**only** because the live merge-deciding gates re-resolve it from THIS file on `origin/main` (#981);
+that origin/main read is the anti-self-authorization property (a boundary-editing PR is classified
+against MAIN's boundary, not its own edit) and must not move to an in-tree import.
 
 ```bash
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
-# Step 0 all use — one definition, no fourth copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+# Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
+# re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -511,10 +511,11 @@ snapshot once mis-classified a now-control-plane PR (#981); reading §CP freshly
 
 ```bash
 # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
-# is current — a pre-amendment snapshot once mis-classified a now-control-plane PR (#981). So the
-# literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
-# live decision source: the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
+# is current — a pre-amendment snapshot once mis-classified a now-control-plane PR (#981).
+# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
+# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
+# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -218,7 +218,10 @@ drift-lockstep target, not the live decision source; a stale injected snapshot o
 now-control-plane PR, #981):
 
 ```bash
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
+# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
+# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
 CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
 if [ -n "$CP_LIVE" ]; then
   CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -165,10 +165,11 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
 
   ```bash
   # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
-  # is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981). So the
-  # literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
-  # live decision source: the regex actually classified is re-resolved from origin/main right after it.
-  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
+  # is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981).
+  # §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
+  # run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
+  # (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+  CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
   # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
   # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
   # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -204,10 +204,11 @@ path as control-plane → advisory not-auto-mergeable) if that read can't be mad
 PR=<pr number>
 # the canonical §CP probe — one definition all four gates cite. §CP travels in the INJECTED skill
 # snapshot, which can lag origin/main even when the on-disk file is current — a pre-amendment snapshot
-# once mis-flagged a now-control-plane PR as auto-mergeable (#981). So the literal below is the
-# fail-closed reference + the validate-gate-path-drift lockstep target, NOT the live decision source:
-# the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+# once mis-flagged a now-control-plane PR as auto-mergeable (#981).
+# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
+# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
+# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -258,10 +258,11 @@ and **fails closed** (treats every path as control-plane → refuses) if that re
 ```bash
 FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725)
 # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
-# is current — a pre-amendment snapshot once auto-merged a now-control-plane PR (#981). So the
-# literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
-# live decision source: the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
+# is current — a pre-amendment snapshot once auto-merged a now-control-plane PR (#981).
+# §CP boundary is single-sourced in pipeline-cli (control-plane-paths/control-plane-re.ts, #2761);
+# run `pipeline-cli control-plane-paths` to print it. It is re-resolved from origin/main right below
+# (the #981 anti-self-authorization read), so this is only a fail-closed sentinel, never the live source.
+CONTROL_PLANE_RE='.'   # fail-closed default: every path is control-plane until origin/main resolves
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-classify a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL, top-of-skill rule). origin/main's line wins over the snapshot.

--- a/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
@@ -2,20 +2,22 @@
 # Mechanical drift guard for the §CP canonical regex and the .claude/skills symlink
 # (issue #720). Two invariants, both runnable in CI/locally:
 #
-#   1. REGEX COPIES — the CONTROL_PLANE_RE= copies in ship-it, review-code,
-#      review-doc, review-skill, review-design, and gh-issue-intake-formats
-#      (§CP, the source) must be byte-identical to the §CP canonical line. A
-#      rename of the plugin path string currently requires ~11 lockstep edits
-#      with no guard; this fails CI on any copy that drifts from §CP.
+#   1. CONTROL_PLANE_RE ↔ single-source const — the §CP boundary is now single-sourced
+#      as the CONTROL_PLANE_RE const in packages/pipeline-cli (issue #2761), emitted by
+#      `pipeline-cli control-plane-paths`. The gate skills no longer carry a copy (they
+#      re-resolve the boundary from origin/main at run time, #981). The ONE un-importable
+#      copy left is the CONTROL_PLANE_RE= line of gh-issue-intake-formats.md, which the
+#      live gates read from origin/main. This invariant READS the const via the CLI and
+#      diffs it against that one line — the residual drift guard for the last prose
+#      surface, no byte-compare of N hand-copies.
 #
 #   2. SYMLINK ↔ MARKETPLACE — .claude/skills must resolve to the same directory
 #      as marketplace.json's `source` field + /skills. Both express the same plugin
 #      root; divergence means the harness loads skills from a different tree than
 #      the one the marketplace advertises.
 #
-# The source-of-truth for invariant 1 is §CP in gh-issue-intake-formats.md (ADR
-# 0073 §6): the one definition every consumer must cite. This script extracts it
-# and diffs it against the four consumer copies — no copy is re-hardcoded here.
+# The single source for invariant 1 is the pipeline-cli const (ADR 0073 §6; #2761): the
+# CLI emits it, this script diffs the formats-doc line against it — no copy re-hardcoded.
 #
 # Bash 3.2 compatible (macOS default shell). No associative arrays, no process
 # substitution with mapfile. Same self-locating idiom as validate-skills.sh.
@@ -34,72 +36,42 @@ checks=0
 fail() { echo "FAIL: $*"; errors=$((errors + 1)); }
 ok()   { echo "ok: $*";   checks=$((checks + 1)); }
 
-# ── Invariant 1: CONTROL_PLANE_RE copies match §CP ──────────────────────────
+# ── Invariant 1: formats-doc CONTROL_PLANE_RE matches the single-source const ─
 #
-# Extract the canonical value from §CP in gh-issue-intake-formats.md.
-# The canonical line has no leading whitespace and no trailing comment:
-#   CONTROL_PLANE_RE='...'
+# The §CP boundary is single-sourced in packages/pipeline-cli (#2761), emitted by
+# `pipeline-cli control-plane-paths`. Read it from THERE (not a byte-compare of N
+# hand-copies), then diff it against the one un-importable copy — the CONTROL_PLANE_RE=
+# line of gh-issue-intake-formats.md that the live gates re-resolve from origin/main (#981).
 FORMATS_MD="$skills_dir/gh-issue-intake-formats.md"
 if [ ! -f "$FORMATS_MD" ]; then
-	fail "gh-issue-intake-formats.md not found at $FORMATS_MD — cannot extract §CP canonical regex"
+	fail "gh-issue-intake-formats.md not found at $FORMATS_MD — cannot verify §CP CONTROL_PLANE_RE"
 	echo "validate-gate-path-drift: FAILED — $errors error(s)"
 	exit 1
 fi
 
-# `|| true`: under `set -euo pipefail` a no-match `grep` (exit 1) would abort the script here,
-# before the explicit empty-check + `fail` below ever runs — losing the diagnostic. Let the
-# substitution yield empty so the intended fail-with-message path handles it.
-CANONICAL=$(grep "^CONTROL_PLANE_RE=" "$FORMATS_MD" | head -n1 | sed 's/^CONTROL_PLANE_RE=//' || true)
-if [ -z "$CANONICAL" ]; then
-	fail "§CP canonical CONTROL_PLANE_RE= not found in $FORMATS_MD — line must start with CONTROL_PLANE_RE="
+# The single source: the const the CLI prints (raw regex, no surrounding quotes). `|| true`
+# so a failed run yields empty and hits the explicit empty-check below instead of aborting
+# under set -e.
+CONST_RE=$(node "$repo_root/packages/pipeline-cli/src/bin.ts" control-plane-paths 2>/dev/null || true)
+if [ -z "$CONST_RE" ]; then
+	fail "could not read the §CP CONTROL_PLANE_RE const via \`pipeline-cli control-plane-paths\` (single source: packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts) — is pipeline-cli installed?"
 	echo "validate-gate-path-drift: FAILED — $errors error(s)"
 	exit 1
 fi
-ok "§CP canonical regex extracted from gh-issue-intake-formats.md"
+ok "§CP CONTROL_PLANE_RE read from the single-source const (pipeline-cli control-plane-paths)"
 
-# The four consumer skills that carry a copy.
-# Each is compared against $CANONICAL after:
-#   - stripping leading whitespace (review-doc indents the assignment)
-#   - stripping the CONTROL_PLANE_RE= prefix
-#   - stripping any trailing whitespace + inline comment (# ...)
-CONSUMERS="
-ship-it/SKILL.md
-review-code/SKILL.md
-review-doc/SKILL.md
-review-skill/SKILL.md
-review-design/SKILL.md
-"
-
-for rel in $CONSUMERS; do
-	md="$skills_dir/$rel"
-	if [ ! -f "$md" ]; then
-		fail "$rel: file not found — cannot verify CONTROL_PLANE_RE copy"
-		continue
-	fi
-
-	# Extract the first CONTROL_PLANE_RE= line (with or without leading whitespace)
-	LINE=$(grep "CONTROL_PLANE_RE=" "$md" | head -n1 || true)   # || true: no-match must hit the fail below, not abort under set -e
-	if [ -z "$LINE" ]; then
-		fail "$rel: no CONTROL_PLANE_RE= line found — consumer must carry a copy matching §CP"
-		continue
-	fi
-
-	# Strip leading whitespace
-	STRIPPED="${LINE#"${LINE%%[![:space:]]*}"}"
-	# Strip "CONTROL_PLANE_RE=" prefix
-	VAL="${STRIPPED#CONTROL_PLANE_RE=}"
-	# Strip trailing whitespace + inline comment of the form '   # ...'
-	# The regex value ends with $' so cut at the first trailing '   #'
-	VAL_CLEAN=$(printf '%s\n' "$VAL" | sed "s/'[[:space:]]*#.*$/'/")
-
-	if [ "$VAL_CLEAN" = "$CANONICAL" ]; then
-		ok "$rel CONTROL_PLANE_RE matches §CP canonical"
-	else
-		fail "$rel CONTROL_PLANE_RE has drifted from §CP canonical
-  §CP:  $CANONICAL
-  copy: $VAL_CLEAN"
-	fi
-done
+# The one remaining copy: the origin/main-read line in gh-issue-intake-formats.md. Strip the
+# CONTROL_PLANE_RE=' … ' wrapper to compare the raw regex against the const.
+FORMATS_RE=$(grep "^CONTROL_PLANE_RE=" "$FORMATS_MD" | head -n1 | sed "s/^CONTROL_PLANE_RE='//; s/'$//" || true)
+if [ -z "$FORMATS_RE" ]; then
+	fail "§CP CONTROL_PLANE_RE= not found in $FORMATS_MD — the origin/main-read copy must be present and match the const"
+elif [ "$FORMATS_RE" = "$CONST_RE" ]; then
+	ok "gh-issue-intake-formats.md CONTROL_PLANE_RE matches the single-source const"
+else
+	fail "gh-issue-intake-formats.md CONTROL_PLANE_RE has drifted from the single-source const
+  const:   $CONST_RE
+  formats: $FORMATS_RE"
+fi
 
 # ── Invariant 1b: GUARD_ADR_RE copy matches §CP (ADR 0164) ──────────────────
 #
@@ -142,9 +114,9 @@ fi
 # 0's class fan. A stale copy mis-classes a PR's changed-path fan (the #2434
 # `.glossary/**→has-code` miss that emptied a review namespace and stalled ship-it),
 # and that drift was caught only by hand during #2434/#2486 — the exact gap this
-# invariant closes. Same grep-extract-then-diff idiom as Invariant 1; kept pure bash
-# rather than routed through `pipeline-cli class-probe` because this guard runs in the
-# toolchain-free `skills` CI job (no node/pnpm), where a class-probe call can't reach.
+# invariant closes. Kept as a pure-bash grep-extract-then-diff (the HAS_*_RE regexes
+# are not part of #2761's CONTROL_PLANE_RE single-sourcing) rather than routed through
+# `pipeline-cli class-probe`, even though Invariant 1 now makes `node` available in the job.
 HAS_NAMES="HAS_CODE_RE HAS_SKILLS_RE HAS_DOCS_EXCLUDE_RE HAS_DOCS_RE"
 # Surfaces carrying a copy of the §CP block, enumerated like Invariant 1's CONSUMERS.
 # ship-it's copies are one-per-line; reviewer.md's `class_reresolve` fail-closed reference

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -17,6 +17,7 @@ import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
 import {ciRequiredCommand} from "./tools/ci-required/command.ts";
 import {classProbeCommand} from "./tools/class-probe/command.ts";
 import {codeownersCpCommand} from "./tools/codeowners-cp/command.ts";
+import {controlPlanePathsCommand} from "./tools/control-plane-paths/command.ts";
 import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {designTokenGuardCommand} from "./tools/design-token-guard/command.ts";
@@ -106,6 +107,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	workflowContractCommand,
 	worktreeSweepCommand,
 	codeownersCpCommand,
+	controlPlanePathsCommand,
 	tokenSpendCommand,
 	trivialDiffCommand,
 	classProbeCommand,

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
@@ -15,11 +15,17 @@
  * and checks every §CP path branch has a covering CODEOWNERS entry.
  */
 
-/** One §CP path the regex marks control-plane: a path + whether it's a dir-prefix or an exact file. */
+/**
+ * One §CP path the regex marks control-plane: a path + its shape.
+ * - `dir`  — a directory prefix (keeps its trailing `/`).
+ * - `file` — an exact `$`-anchored leaf (no trailing `/`).
+ * - `glob` — a within-segment wildcard leaf: a `[^/]+` regex class translated to a
+ *   gitignore `*` (e.g. `.../skills/*.sh`), owned by a matching `*`-glob CODEOWNERS row.
+ */
 export interface CpPath {
-	/** Normalized path with no leading `/`. A `dir` keeps its trailing `/`; a `file` has none. */
+	/** Normalized path with no leading `/`. A `dir` keeps its trailing `/`; `file`/`glob` have none. */
 	readonly path: string;
-	readonly kind: "dir" | "file";
+	readonly kind: "dir" | "file" | "glob";
 }
 
 /** A CODEOWNERS pattern with at least one owner: the normalized pattern (no leading `/`) + its owners. */
@@ -61,12 +67,20 @@ export const splitTopLevelBranches = (re: string): ReadonlyArray<string> =>
  * `(\.claude|\.github)/`, `…/skills/(ship-it|review-code|…)/`, or
  * `…/hooks(/|\.json$)`. We cartesian-expand every `(…)` group, then normalize each
  * expansion to a path: unescape `\.`→`.` and drop a regex `$` end-anchor. A trailing
- * `/` ⇒ a directory prefix; otherwise an exact file (the `$`-anchored leaf).
+ * `/` ⇒ a directory prefix; a `[^/]+` within-segment class ⇒ a `glob` (translated to a
+ * gitignore `*`, e.g. `.../skills/[^/]+\.sh$` → `.../skills/*.sh`); otherwise an exact
+ * file (the `$`-anchored leaf).
  */
 export const expandBranch = (branch: string): ReadonlyArray<CpPath> => {
 	const normalize = (s: string): CpPath => {
-		const path = s.replace(/\$/g, "").replace(/\\\./g, ".");
-		return {path, kind: path.endsWith("/") ? "dir" : "file"};
+		const base = s.replace(/\$/g, "").replace(/\\\./g, ".");
+		// `[^/]+` (one-or-more non-slash) is a within-segment regex wildcard; gitignore's
+		// `*` (which CODEOWNERS uses) means the same, so translate it to a real glob a
+		// CODEOWNERS row can own (the bare gate-critical `skills/*.sh` guards — ADR 0174).
+		if (base.includes("[^/]+")) {
+			return {path: base.replace(/\[\^\/\]\+/g, "*"), kind: "glob"};
+		}
+		return {path: base, kind: base.endsWith("/") ? "dir" : "file"};
 	};
 	// Cartesian-expand each `(alt|alt|…)` group, left to right. The regex only ever
 	// carries one group per branch, but expanding all groups keeps this robust to a
@@ -137,9 +151,17 @@ export const parseCodeownersPatterns = (codeownersText: string): ReadonlyArray<O
  * - A non-directory entry covers `p` by exact match, or as an ancestor directory
  *   named without a trailing slash (`p.startsWith(e + "/")`, gitignore's bare-name
  *   dir semantics).
+ * - A `glob` §CP path (e.g. `.../skills/*.sh`) is covered by an identical `*`-glob
+ *   CODEOWNERS row, or by an ancestor directory entry that owns the whole segment it
+ *   sits in.
  */
 export const covers = (e: OwnedPattern, p: CpPath): boolean => {
 	const pat = e.pattern;
+	if (p.kind === "glob") {
+		if (pat === p.path) return true;
+		const dir = p.path.slice(0, p.path.lastIndexOf("/") + 1);
+		return pat.endsWith("/") && (dir === pat || dir.startsWith(pat));
+	}
 	if (pat.endsWith("/")) return p.path === pat || p.path.startsWith(pat);
 	return p.path === pat || p.path.startsWith(`${pat}/`);
 };

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -1,6 +1,7 @@
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
+import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
 import {
 	type CpPath,
 	covers,
@@ -13,12 +14,10 @@ import {
 	splitTopLevelBranches,
 } from "./codeowners-cp.ts";
 
-// The live CONTROL_PLANE_RE (gh-issue-intake-formats.md §CP) — kept here only as a
-// fixture for the parser; the gate reads it from disk, never from a hardcoded copy.
-// The lockstep test at the bottom of this file asserts this fixture still equals the
-// canonical §CP line on disk, so it can't silently drift again (#2343).
-const LIVE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+// The live CONTROL_PLANE_RE, IMPORTED from its single source (#2761) — never re-literaled,
+// so this fixture cannot drift from the boundary (the #2673 class). The lockstep test at the
+// bottom re-checks the const against the CONTROL_PLANE_RE= line on disk.
+const LIVE_RE = CONTROL_PLANE_RE;
 
 describe("extractControlPlaneRe", () => {
 	it("pulls the regex from the canonical CONTROL_PLANE_RE='…' assignment line", () => {
@@ -37,7 +36,8 @@ describe("splitTopLevelBranches", () => {
 		const branches = splitTopLevelBranches(LIVE_RE);
 		expect(branches).toEqual([
 			"(\\.claude|\\.github)/",
-			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/",
+			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/",
+			"claude-plugins/kampus-pipeline/skills/[^/]+\\.sh$",
 			"claude-plugins/kampus-pipeline/agents/",
 			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$",
 			"claude-plugins/kampus-pipeline/hooks(/|\\.json$)",
@@ -55,9 +55,9 @@ describe("expandBranch", () => {
 		]);
 	});
 
-	it("expands the nine skill dirs", () => {
+	it("expands the eleven skill dirs", () => {
 		const out = expandBranch(
-			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/",
+			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/",
 		);
 		expect(out.map((p) => p.path)).toEqual([
 			"claude-plugins/kampus-pipeline/skills/ship-it/",
@@ -69,8 +69,16 @@ describe("expandBranch", () => {
 			"claude-plugins/kampus-pipeline/skills/triage/",
 			"claude-plugins/kampus-pipeline/skills/write-code/",
 			"claude-plugins/kampus-pipeline/skills/plan-epic/",
+			"claude-plugins/kampus-pipeline/skills/release/",
+			"claude-plugins/kampus-pipeline/skills/review-trivial/",
 		]);
 		expect(out.every((p) => p.kind === "dir")).toBe(true);
+	});
+
+	it("expands the bare `[^/]+\\.sh$` branch to a `*.sh` glob path", () => {
+		expect(expandBranch("claude-plugins/kampus-pipeline/skills/[^/]+\\.sh$")).toEqual([
+			{path: "claude-plugins/kampus-pipeline/skills/*.sh", kind: "glob"},
+		]);
 	});
 
 	it("passes the group-free agents dir branch through as a single dir (ADR 0150)", () => {
@@ -102,7 +110,7 @@ describe("expandBranch", () => {
 });
 
 describe("cpPaths over the live regex", () => {
-	it("resolves the full §CP path set (17 paths: dirs + the two exact files)", () => {
+	it("resolves the full §CP path set (20 paths: dirs, the two exact files, + the *.sh glob)", () => {
 		expect(cpPaths(LIVE_RE).map((p) => p.path)).toEqual([
 			".claude/",
 			".github/",
@@ -115,6 +123,9 @@ describe("cpPaths over the live regex", () => {
 			"claude-plugins/kampus-pipeline/skills/triage/",
 			"claude-plugins/kampus-pipeline/skills/write-code/",
 			"claude-plugins/kampus-pipeline/skills/plan-epic/",
+			"claude-plugins/kampus-pipeline/skills/release/",
+			"claude-plugins/kampus-pipeline/skills/review-trivial/",
+			"claude-plugins/kampus-pipeline/skills/*.sh",
 			"claude-plugins/kampus-pipeline/agents/",
 			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
 			"claude-plugins/kampus-pipeline/hooks/",
@@ -174,6 +185,11 @@ describe("covers", () => {
 			covers(dir("packages/pipeline-cli"), {path: "packages/pipeline-cli/", kind: "dir"}),
 		).toBe(true);
 	});
+	it("a glob §CP path is covered by an identical `*`-glob row, not a mismatched literal", () => {
+		const glob: CpPath = {path: "claude-plugins/kampus-pipeline/skills/*.sh", kind: "glob"};
+		expect(covers(dir("claude-plugins/kampus-pipeline/skills/*.sh"), glob)).toBe(true);
+		expect(covers(dir("claude-plugins/kampus-pipeline/skills/ship-it/"), glob)).toBe(false);
+	});
 });
 
 describe("findUncovered — the drift check", () => {
@@ -192,6 +208,9 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/skills/triage/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/write-code/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/plan-epic/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/release/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-trivial/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/*.sh @usirin",
 			"/claude-plugins/kampus-pipeline/agents/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 			"/claude-plugins/kampus-pipeline/hooks/ @usirin",
@@ -216,6 +235,9 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/skills/triage/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/write-code/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/plan-epic/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/release/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-trivial/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/*.sh @usirin",
 			"/claude-plugins/kampus-pipeline/agents/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 			"/packages/ci-required/ @usirin",

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -3,10 +3,12 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit} from "effect";
+import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
 import {type CheckFailed, CODEOWNERS_PATH, checkCodeownersCp, FORMATS_PATH} from "./gate.ts";
 
-const LIVE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+// The gate derives paths from the single-source const (#2761); a fixture formats doc must
+// carry a matching CONTROL_PLANE_RE= line or the gate's const↔formats drift check fires.
+const LIVE_RE = CONTROL_PLANE_RE;
 
 const FULL_CODEOWNERS = [
 	"/.claude/ @usirin",
@@ -20,6 +22,9 @@ const FULL_CODEOWNERS = [
 	"/claude-plugins/kampus-pipeline/skills/triage/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/write-code/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/plan-epic/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/release/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/review-trivial/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/*.sh @usirin",
 	"/claude-plugins/kampus-pipeline/agents/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 	"/claude-plugins/kampus-pipeline/hooks/ @usirin",
@@ -83,10 +88,13 @@ describe("checkCodeownersCp", () => {
 		}
 	}, 30_000);
 
-	it("fails closed when the regex resolves zero §CP paths", async () => {
-		const dir = makeRepo({formats: "CONTROL_PLANE_RE=''", codeowners: FULL_CODEOWNERS});
+	it("fails closed when the formats-doc CONTROL_PLANE_RE has drifted from the single-source const", async () => {
+		// The formats line carries a stale (shorter) boundary — the exact origin/main-read copy
+		// that must never diverge from the const the gate derives from (#2761/#981).
+		const drifted = "^(\\.claude|\\.github)/|^packages/pipeline-cli/";
+		const dir = makeRepo({formats: `CONTROL_PLANE_RE='${drifted}'`, codeowners: FULL_CODEOWNERS});
 		try {
-			assert.include(await reasonOf(dir), "ZERO §CP paths");
+			assert.include(await reasonOf(dir), "has drifted from the pipeline-cli single-source const");
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
 		}

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.ts
@@ -5,16 +5,20 @@
  * #855). `command.ts` wires this effect to the Effect CLI and maps the failures to
  * the non-zero gate exit; the exit-code contract lives there.
  *
- * The gate reads the canonical `CONTROL_PLANE_RE` from `gh-issue-intake-formats.md`
- * (the SINGLE source — never a re-hardcoded copy) + `.github/CODEOWNERS`, derives
- * the §CP path set from the regex, and fails when any §CP path has no covering
- * CODEOWNERS row. It is fail-closed (ADR 0092): a missing/unreadable source, a regex
- * it cannot parse, a CODEOWNERS with zero owned entries, OR a regex that resolves to
- * ZERO §CP paths all FAIL — only a fully-covered, non-empty §CP set passes.
+ * The §CP boundary is the single-source const `CONTROL_PLANE_RE` in
+ * `control-plane-paths/control-plane-re.ts` (issue #2761). The gate derives the §CP
+ * path set from THAT const, and also reads the `CONTROL_PLANE_RE=` line the live gates
+ * consume from `gh-issue-intake-formats.md` and fails if it has drifted from the const —
+ * so this job doubles as the unconditional const↔formats-doc drift guard (the un-importable
+ * prose surface). It then fails when any §CP path has no covering `.github/CODEOWNERS` row.
+ * Fail-closed (ADR 0092): a missing/unreadable source, a formats line it cannot parse, a
+ * formats line that has drifted from the const, a CODEOWNERS with zero owned entries, OR a
+ * const that resolves to ZERO §CP paths all FAIL — only a fully-covered, in-sync §CP set passes.
  */
 import {existsSync, readFileSync} from "node:fs";
 import {dirname, join, resolve} from "node:path";
 import {Console, Data, Effect} from "effect";
+import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
 import {
 	type CpPath,
 	cpPaths,
@@ -63,7 +67,21 @@ export const checkCodeownersCp = (root: string): Effect.Effect<void, IoError | C
 			);
 		}
 
-		const paths = cpPaths(re);
+		// Drift guard for the un-importable prose surface: the live merge-deciding gates read
+		// CONTROL_PLANE_RE from this formats line on origin/main (#981), so it must stay byte-equal
+		// to the single-source const. Fail-closed on any divergence (#2761).
+		if (re !== CONTROL_PLANE_RE) {
+			return yield* Effect.fail(
+				new CheckFailed({
+					reason:
+						`CONTROL_PLANE_RE in ${FORMATS_PATH} has drifted from the pipeline-cli single-source const ` +
+						`(control-plane-paths/control-plane-re.ts) — the two must match (#2761). Re-sync the formats line ` +
+						`to \`pipeline-cli control-plane-paths\`.\n  const:   ${CONTROL_PLANE_RE}\n  formats: ${re}`,
+				}),
+			);
+		}
+
+		const paths = cpPaths(CONTROL_PLANE_RE);
 		if (paths.length === 0) {
 			return yield* Effect.fail(
 				new CheckFailed({

--- a/packages/pipeline-cli/src/tools/control-plane-paths/command.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/command.ts
@@ -1,0 +1,36 @@
+/**
+ * `control-plane-paths` — emit the canonical §CP boundary deterministically (issue #2761).
+ *
+ *   pipeline-cli control-plane-paths            # print CONTROL_PLANE_RE (the grep/jq regex)
+ *   pipeline-cli control-plane-paths --paths    # print the expanded §CP path set, one per line
+ *
+ * The single-source emitter: the shell drift guard (`validate-gate-path-drift.sh`)
+ * reads the regex from HERE instead of byte-comparing N hand-copied literals, so a
+ * boundary change is one edit to the const, not the ~11-file lockstep the copies used
+ * to force (#2673). The regex is printed with NO trailing formatting so `$(…)` capture
+ * in bash yields exactly the value to compare against the formats-doc line.
+ */
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {cpPaths} from "../codeowners-cp/codeowners-cp.ts";
+import {CONTROL_PLANE_RE} from "./control-plane-re.ts";
+
+const pathsFlag = Flag.boolean("paths").pipe(
+	Flag.withDescription("print the expanded §CP path set (one per line) instead of the regex"),
+);
+
+export const controlPlanePathsCommand = Command.make(
+	"control-plane-paths",
+	{paths: pathsFlag},
+	Effect.fn(function* ({paths}) {
+		if (paths) {
+			for (const p of cpPaths(CONTROL_PLANE_RE)) yield* Console.log(p.path);
+			return;
+		}
+		yield* Console.log(CONTROL_PLANE_RE);
+	}),
+).pipe(
+	Command.withDescription(
+		"Emit the canonical §CP CONTROL_PLANE_RE (the single source), or its expanded path set with --paths (#2761)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -1,0 +1,74 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
+import {CONTROL_PLANE_RE} from "./control-plane-re.ts";
+
+// The boundary as the live gates apply it: a POSIX-ERE `grep -Eq`, here a RegExp over the
+// same const string (every branch is `^`-anchored, so `.test` is prefix-anchored per branch).
+const isControlPlane = (path: string): boolean => new RegExp(CONTROL_PLANE_RE).test(path);
+
+describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)", () => {
+	it("classifies the NEW §CP paths as control-plane", () => {
+		// bare gate-critical `.sh` guard directly under skills/ (#2576)
+		expect(
+			isControlPlane("claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh"),
+		).toBe(true);
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/validate-skills.sh")).toBe(true);
+		// the release + review-trivial skill dirs (#2679) — review-trivial emits SHA-bound,
+		// merge-consumed verdicts, so its omission was a live fail-OPEN §CP-bypass this fix closes.
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/release/SKILL.md")).toBe(true);
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md")).toBe(
+			true,
+		);
+	});
+
+	it("does NOT classify the four deliberately-OUT skill dirs (operational, not gate-critical)", () => {
+		for (const skill of ["heal-ci", "what-shipped", "doctor", "wayfinder"]) {
+			expect(isControlPlane(`claude-plugins/kampus-pipeline/skills/${skill}/SKILL.md`)).toBe(false);
+		}
+	});
+
+	it("does NOT classify known non-§CP paths", () => {
+		expect(isControlPlane("apps/web/src/main.tsx")).toBe(false);
+		expect(isControlPlane("packages/some-other-pkg/src/index.ts")).toBe(false);
+		// a nested `.sh` UNDER a non-§CP skill dir is not the bare-guard branch (that requires the
+		// script sit directly under skills/, matched by `[^/]+\.sh$`).
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/heal-ci/helper.sh")).toBe(false);
+	});
+
+	it("still classifies every PRE-EXISTING §CP path (no branch dropped)", () => {
+		for (const path of [
+			".claude/settings.json",
+			".github/workflows/ci.yml",
+			"claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md",
+			"claude-plugins/kampus-pipeline/skills/triage/SKILL.md",
+			"claude-plugins/kampus-pipeline/agents/shipper.md",
+			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+			"claude-plugins/kampus-pipeline/hooks/install.sh",
+			"claude-plugins/kampus-pipeline/hooks.json",
+			"packages/ci-required/src/bin.ts",
+			"packages/pipeline-cli/src/registry.ts",
+		]) {
+			expect(isControlPlane(path)).toBe(true);
+		}
+	});
+});
+
+// Drift guard: the const IS the single source, and the un-importable formats-doc copy the live
+// gates read from origin/main (#981) must stay byte-equal to it. This is the cheap in-test twin
+// of the codeowners-cp + validate-gate-path-drift.sh guards that run unconditionally in CI (#2761).
+describe("the §CP const stays in lockstep with the formats-doc CONTROL_PLANE_RE line", () => {
+	const FORMATS_PATH = fileURLToPath(
+		new URL(
+			"../../../../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+			import.meta.url,
+		),
+	);
+
+	it("equals the CONTROL_PLANE_RE= line extracted from the formats doc on disk", () => {
+		const formats = extractControlPlaneRe(readFileSync(FORMATS_PATH, "utf8"));
+		expect(formats).not.toBeNull();
+		expect(CONTROL_PLANE_RE).toBe(formats);
+	});
+});

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -1,0 +1,26 @@
+/**
+ * The §CP control-plane boundary — the SINGLE source of truth (issue #2761).
+ *
+ * `CONTROL_PLANE_RE` is the one anchored regex that classifies which paths are
+ * control-plane (human-merge-only, ADR 0053/0065/0073 §6/0100/0103/0150/0174). It
+ * used to be hand-copied into ~10 live surfaces (5 gate skills, the formats-doc prose,
+ * `codeowners-cp.ts`, and 3 vitest fixtures), guarded only by a byte-compare drift
+ * check that missed the fixtures — so a stale fixture assertion ran only in
+ * `merge_group` and silently ejected 3 green PRs (#2673). This const makes that
+ * whole class unrepresentable: everything importable IMPORTS this, and the two
+ * un-importable prose surfaces (the formats-doc `CONTROL_PLANE_RE=` line the live
+ * gates read from `origin/main`, and `.github/CODEOWNERS`) are drift-guarded against
+ * it — one definition, no copies.
+ *
+ * The runtime value (what `pipeline-cli control-plane-paths` prints) is the POSIX-ERE
+ * grep/jq form the gates match against; the doubled backslashes here are TS string
+ * escapes, so `\\.` is the value `\.` and `[^/]+\\.sh$` is the value `[^/]+\.sh$`.
+ *
+ * Anti-self-authorization is preserved (#981): the live merge-deciding gates still
+ * re-resolve the boundary from the formats doc on `origin/main` at run time, so a
+ * boundary-editing PR is classified against MAIN's boundary, not its own edit. This
+ * const is the source the formats-doc line is kept in sync WITH — it does not move the
+ * runtime resolution off the origin/main read.
+ */
+export const CONTROL_PLANE_RE =
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";

--- a/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.unit.test.ts
@@ -2,14 +2,14 @@ import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
+import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
 import {type ClassifyOptions, classify, parseUnifiedDiff} from "./trivial-diff.ts";
 
-// The live CONTROL_PLANE_RE (gh-issue-intake-formats.md §CP) — a fixture only. The bin
-// re-resolves this from origin/main at run time; the core takes it as a string input.
-// The lockstep test at the bottom of this file asserts this fixture still equals the
-// canonical §CP line on disk, so it can't silently drift again (#2343).
-const LIVE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+// The live CONTROL_PLANE_RE, IMPORTED from its single source (#2761) — never re-literaled
+// here, so this fixture cannot drift from the boundary the way the old hand-copy did (the
+// #2673 class). The bin re-resolves it from origin/main at run time; the core takes it as a
+// string input. The lockstep test at the bottom re-checks the const against the formats-doc.
+const LIVE_RE = CONTROL_PLANE_RE;
 
 const opts = (over: Partial<ClassifyOptions> = {}): ClassifyOptions => ({
 	controlPlaneRe: LIVE_RE,
@@ -168,10 +168,10 @@ describe("classify — unparseable / empty diff forces non-trivial (fail-closed)
 	});
 });
 
-// Lockstep: extract the canonical §CP line from the real gh-issue-intake-formats.md on
-// disk (via the single-sourced extractControlPlaneRe) and assert LIVE_RE still equals it,
-// so this fixture can't silently drift from §CP again (#2343).
-describe("LIVE_RE fixture stays in lockstep with §CP on disk", () => {
+// Lockstep: assert the single-source const equals the CONTROL_PLANE_RE= line in the real
+// gh-issue-intake-formats.md on disk — the const↔formats-doc drift check, redundant with
+// codeowners-cp + validate-gate-path-drift.sh but cheap belt-and-suspenders (#2761/#2343).
+describe("the §CP const stays in lockstep with the formats doc on disk", () => {
 	const FORMATS_PATH = fileURLToPath(
 		new URL(
 			"../../../../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",


### PR DESCRIPTION
Fixes #2761

§CP BOUNDARY change (fail-closed broadening; ADR 0174 ACCEPTED + #2679 + #2576/#2525). **Human-merge-only — stops at cansirin. Do NOT auto-merge.**

## What this does
Collapses the ~10 hand-copied `CONTROL_PLANE_RE` literals to **one source of truth** and folds in the ADR-0174 boundary broadenings, so the fixture-drift class that silently ejected #2673 3× from `merge_group` becomes **unrepresentable**, not merely guarded.

## Single-sourcing
- **New canonical const** `CONTROL_PLANE_RE` in `packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts` — the one definition.
- **`codeowners-cp.ts` + all 3 TS fixtures** (`trivial-diff.unit.test.ts`, `codeowners-cp.unit.test.ts`, `gate.test.ts`) now **import** the const instead of re-literaling it.
- **New `pipeline-cli control-plane-paths` subcommand** emits the regex deterministically (`--paths` prints the expanded set); **`validate-gate-path-drift.sh` reads it** instead of byte-comparing copies.
- The **5 gate skills** (ship-it / review-code / review-doc / review-skill / review-design) drop their embedded literal for a pointer + a fail-closed sentinel; the formats-doc fenced prose becomes a pointer.

## Boundary delta (append-only — every existing branch byte-identical)
**Before:**
```
…skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic)/|^claude-plugins/kampus-pipeline/agents/|…
```
**After:**
```
…skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|…
```
Additions: `release` + `review-trivial` in the skill-dir alternation; one new branch `^claude-plugins/kampus-pipeline/skills/[^/]+\.sh$`. `review-trivial` is load-bearing — it emits SHA-bound merge-consumed verdicts, so its omission was a live fail-**open** §CP-bypass this closes (#2576/#2525/#2679 all subsumed).

## Anti-self-authorization preserved (#981)
The one machine-readable `CONTROL_PLANE_RE=` line is **kept** in `gh-issue-intake-formats.md` and left byte-in-sync with the const. The live merge-deciding gates still re-resolve the boundary from that file on **`origin/main`** at run time — a boundary-editing PR is classified against MAIN's boundary, not its own edit. The runtime resolution was **not** moved to an in-tree import.

## CODEOWNERS coverage
Added `release/`, `review-trivial/`, and a `skills/*.sh` glob row. `codeowners-cp check` passes with **all 20 §CP paths owned** (the `[^/]+\.sh$` branch derives to a `*.sh` glob path, matched by the glob row). `heal-ci` / `what-shipped` / `doctor` / `wayfinder` are recorded **deliberately-OUT** in the §CP prose (operational diagnostics/reporting/orientation — not gate-critical).

## Guard coverage that closes the #2673 gap
- `codeowners-cp` (node, runs on every PR) fails closed on const↔formats-doc drift.
- `validate-gate-path-drift.sh` (skills job, now unconditional with node) reads the const via the CLI and diffs the formats line — fires on a formats-doc-only edit too, the exact case that ejected #2673 from `merge_group`.
- Unit tests assert the NEW §CP paths classify §CP, the 4 deliberately-out dirs do NOT, and non-§CP paths (`apps/web/src/…`) do NOT.

All 1191 pipeline-cli tests + typecheck + biome + both guards green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)