### PR TITLE
fix(pipeline): owner-gate the SubagentStop worktree reaper (#2798)

### DIFF
--- a/packages/pipeline-cli/src/tools/worktree-guard/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.hook.test.ts
@@ -1,5 +1,5 @@
 import {execFile, execFileSync} from "node:child_process";
-import {existsSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
@@ -125,6 +125,21 @@ describe("worktree-guard reap — SubagentStop reaper against a REAL git worktre
 	const git = (cwd: string, ...args: string[]) =>
 		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
 
+	// The #2798 owner signal lives in the payload: `transcript_path` points at the stopping agent's
+	// transcript, whose sibling `.meta.json` records the worktree that agent OWNS. Build that sidecar
+	// so a reap invocation carries a real owner (or nested-descendant) stop payload.
+	const ownerStopPayload = (owningWorktree: string, slug: string) => {
+		const subDir = join(mainRepo, "subagents");
+		mkdirSync(subDir, {recursive: true});
+		const transcript = join(subDir, `${slug}.jsonl`);
+		writeFileSync(transcript, "");
+		writeFileSync(
+			join(subDir, `${slug}.meta.json`),
+			JSON.stringify({worktreePath: owningWorktree}),
+		);
+		return {hook_event_name: "SubagentStop", transcript_path: transcript};
+	};
+
 	beforeAll(() => {
 		// A real main checkout with a worktree under the managed .claude/worktrees layout.
 		mainRepo = mkdtempSync(join(tmpdir(), "wtg-main-"));
@@ -144,18 +159,35 @@ describe("worktree-guard reap — SubagentStop reaper against a REAL git worktre
 		rmSync(mainRepo, {recursive: true, force: true});
 	});
 
-	it("REAPS a clean worktree (it is removed)", async () => {
+	it("REAPS a clean worktree under an OWNER stop payload (it is removed)", async () => {
 		assert.isTrue(existsSync(wtRoot));
-		const {stderr} = await run("reap", {hook_event_name: "SubagentStop"}, {WORKTREE_ROOT: wtRoot});
+		const {stderr} = await run("reap", ownerStopPayload(wtRoot, "agent-owner"), {
+			WORKTREE_ROOT: wtRoot,
+		});
 		assert.include(stderr, "reaped clean worktree");
 		assert.isFalse(existsSync(wtRoot));
 	}, 30_000);
 
-	it("REFUSES (keeps) a dirty worktree — never --force", async () => {
+	it("KEEPS a live worktree on a NESTED-DESCENDANT stop (inherited $WORKTREE_ROOT, owns another tree)", async () => {
+		const liveWt = join(mainRepo, ".claude", "worktrees", "wf_live");
+		git(mainRepo, "worktree", "add", "-q", "--detach", liveWt, "HEAD");
+		// The nested child owns a DIFFERENT worktree; it only inherited WORKTREE_ROOT=liveWt.
+		const {stderr} = await run(
+			"reap",
+			ownerStopPayload("/some/other/.claude/worktrees/wf_child", "agent-child"),
+			{WORKTREE_ROOT: liveWt},
+		);
+		assert.match(stderr, /does not own|KEEP/);
+		assert.isTrue(existsSync(liveWt), "a live parent's worktree must survive a nested-child stop");
+	}, 30_000);
+
+	it("REFUSES (keeps) a dirty worktree — never --force (under an owner stop)", async () => {
 		const dirtyWt = join(mainRepo, ".claude", "worktrees", "wf_dirty");
 		git(mainRepo, "worktree", "add", "-q", "--detach", dirtyWt, "HEAD");
 		writeFileSync(join(dirtyWt, "uncommitted.txt"), "unpushed work");
-		const {stderr} = await run("reap", {hook_event_name: "SubagentStop"}, {WORKTREE_ROOT: dirtyWt});
+		const {stderr} = await run("reap", ownerStopPayload(dirtyWt, "agent-dirty"), {
+			WORKTREE_ROOT: dirtyWt,
+		});
 		assert.include(stderr, "KEPT");
 		assert.isTrue(existsSync(dirtyWt), "dirty worktree must be kept");
 		assert.isTrue(existsSync(join(dirtyWt, "uncommitted.txt")), "unpushed file must survive");

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -19,7 +19,8 @@
  *     pre-bash  (matcher Bash)            — pin cwd to $WORKTREE_ROOT
  *     pre-enter (matcher EnterWorktree)   — hard-block a nested worktree
  *   SubagentStop:
- *     reap                                — `git worktree remove` (no --force) when clean
+ *     reap                                — `git worktree remove` (no --force) when clean AND the
+ *                                           stopping agent OWNS $WORKTREE_ROOT (the #2798 owner gate)
  *   Skill/operator invocation (not a hook):
  *     assert-clean [--path <d>]           — fail closed LOUD if the tree is dirty (#2666)
  *
@@ -29,7 +30,7 @@
  * by the time a subcommand runs the runtime dep is always resolved.
  */
 import {execFileSync} from "node:child_process";
-import {existsSync, statSync} from "node:fs";
+import {existsSync, readFileSync, statSync} from "node:fs";
 import {resolve} from "node:path";
 import {
 	appendRecord,
@@ -231,6 +232,27 @@ const preEnter = Command.make(
 	Command.withDescription("PreToolUse EnterWorktree: hard-block when already inside a worktree"),
 );
 
+/**
+ * Derive the STOPPING agent's OWN worktree from the SubagentStop payload — the owner signal the
+ * #2798 gate turns on. The harness writes a per-subagent sidecar next to each subagent transcript
+ * (`…/subagents/agent-<id>.meta.json`) recording the worktree that agent OWNS (`worktreePath`), and
+ * the payload's `transcript_path` points at that transcript. A nested descendant that merely
+ * inherited `$WORKTREE_ROOT` carries its OWN (different, or absent) `worktreePath`, so this
+ * distinguishes an owner-stop from a nested stop. Anything unreadable ⇒ "" ⇒ ownership unprovable ⇒
+ * `decideReap` KEEPs (fail-closed: never reap a possibly-live parent tree).
+ */
+const ownedWorktreeFromPayload = (input: unknown): string => {
+	const transcriptPath = str(field(input, "transcript_path"));
+	if (!transcriptPath) return "";
+	const metaPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+	if (metaPath === transcriptPath || !existsSync(metaPath)) return "";
+	try {
+		return str(field(JSON.parse(readFileSync(metaPath, "utf8")) as unknown, "worktreePath"));
+	} catch {
+		return "";
+	}
+};
+
 /** Is the worktree dirty? `git status --porcelain` non-empty ⇒ dirty (also dirty if we can't tell — fail-safe to KEEP). */
 const worktreeIsDirty = (root: string): boolean => {
 	try {
@@ -248,7 +270,7 @@ const reap = Command.make(
 	"reap",
 	{},
 	Effect.fn(function* () {
-		yield* readStdin();
+		const input = yield* readStdin();
 		if (!WORKTREE_ROOT || !existsSync(WORKTREE_ROOT)) {
 			return yield* Console.error("worktree-guard reap: no $WORKTREE_ROOT to reap (skip)");
 		}
@@ -263,6 +285,7 @@ const reap = Command.make(
 		}
 		const decision = decideReap({
 			worktreeRoot: WORKTREE_ROOT,
+			ownedWorktree: ownedWorktreeFromPayload(input),
 			isDirty: worktreeIsDirty(WORKTREE_ROOT),
 		});
 		switch (decision.kind) {

--- a/packages/pipeline-cli/src/tools/worktree-guard/reap.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/reap.ts
@@ -12,6 +12,14 @@
  * tree by design. The bin runs exactly that command, so even a misclassification
  * here can never discard unpushed work — the safety lives in the command, and the
  * decision here only chooses WHETHER to attempt it (and never adds `--force`).
+ *
+ * The OWNER gate (#2798): the reaper fires on `SubagentStop`, and `$WORKTREE_ROOT` is inherited
+ * by every nested descendant. So a nested child's stop would reap its LIVE parent coder's worktree
+ * unless we check ownership. No worktree-STATE signal distinguishes an owner-stop from a
+ * nested-child-stop (both present identical clean/managed state, and cwd resets to primary between
+ * calls) — the distinguishing fact lives in the SubagentStop PAYLOAD: the stopping agent's own
+ * worktree (`ownedWorktree`, derived in the impure shell from the payload's transcript_path meta
+ * sidecar). We reap only when the stopping agent OWNS `$WORKTREE_ROOT`; unprovable ownership ⇒ KEEP.
  */
 
 export type ReapDecision =
@@ -25,21 +33,34 @@ const WORKTREE_SEGMENT = "/.claude/worktrees/";
 export const isManagedWorktree = (worktreeRoot: string): boolean =>
 	worktreeRoot.replace(/\\/g, "/").indexOf(WORKTREE_SEGMENT) > 0;
 
+const normalizePath = (p: string): string => p.replace(/\\/g, "/").replace(/\/+$/, "");
+
 /**
  * Decide whether to reap a finished subagent's worktree.
  *
  * - Empty root, or a root NOT under the managed `.claude/worktrees/` layout →
  *   **skip** (never reap an arbitrary path; the reaper only touches its own dir).
- * - A **dirty** tree → **refuse**: keep it, never `--force` (unpushed work is sacred).
- * - A **clean** tree → **reap**: `git worktree remove` (no `--force`) reclaims it.
+ * - The stopping agent does NOT own `$WORKTREE_ROOT` (a nested descendant that merely inherited the
+ *   env var, or ownership unprovable from the payload) → **skip**: KEEP — never reap a live parent's
+ *   worktree (the owner gate, #2798).
+ * - A **dirty** owned tree → **refuse**: keep it, never `--force` (unpushed work is sacred).
+ * - A **clean** owned tree → **reap**: `git worktree remove` (no `--force`) reclaims it.
  */
 export const decideReap = (args: {
 	readonly worktreeRoot: string;
+	readonly ownedWorktree: string;
 	readonly isDirty: boolean;
 }): ReapDecision => {
-	const {worktreeRoot, isDirty} = args;
+	const {worktreeRoot, ownedWorktree, isDirty} = args;
 	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) {
 		return {kind: "skip", reason: "not a managed agent worktree; nothing to reap"};
+	}
+	if (!ownedWorktree || normalizePath(ownedWorktree) !== normalizePath(worktreeRoot)) {
+		return {
+			kind: "skip",
+			reason:
+				"stopping agent does not own $WORKTREE_ROOT (nested-descendant stop, or ownership unprovable from the payload); KEEP — never reap a live parent's worktree (#2798)",
+		};
 	}
 	if (isDirty) {
 		return {

--- a/packages/pipeline-cli/src/tools/worktree-guard/reap.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/reap.unit.test.ts
@@ -2,6 +2,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {decideReap, isManagedWorktree} from "./reap.ts";
 
 const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
+const OTHER_WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_nested999";
 
 describe("isManagedWorktree", () => {
 	it("recognizes the managed worktree layout", () => {
@@ -12,22 +13,67 @@ describe("isManagedWorktree", () => {
 });
 
 describe("decideReap — the safe-worktree-prune rule (AC: clean → reap, dirty → refuse-and-keep)", () => {
-	it("CLEAN → reap (git worktree remove, no --force)", () => {
-		const d = decideReap({worktreeRoot: WT, isDirty: false});
+	it("OWNER + CLEAN → reap (git worktree remove, no --force)", () => {
+		const d = decideReap({worktreeRoot: WT, ownedWorktree: WT, isDirty: false});
 		assert.strictEqual(d.kind, "reap");
 	});
 
-	it("DIRTY → refuse-and-keep (NEVER --force; unpushed work is sacred)", () => {
-		const d = decideReap({worktreeRoot: WT, isDirty: true});
+	it("OWNER + DIRTY → refuse-and-keep (NEVER --force; unpushed work is sacred)", () => {
+		const d = decideReap({worktreeRoot: WT, ownedWorktree: WT, isDirty: true});
 		assert.strictEqual(d.kind, "refuse");
 	});
 
+	it("a trailing slash on either side still matches the owner (path normalized)", () => {
+		assert.strictEqual(
+			decideReap({worktreeRoot: WT, ownedWorktree: `${WT}/`, isDirty: false}).kind,
+			"reap",
+		);
+	});
+
 	it("non-managed path → skip (the reaper only touches its own worktree)", () => {
-		assert.strictEqual(decideReap({worktreeRoot: "/some/bespoke/wt", isDirty: false}).kind, "skip");
-		assert.strictEqual(decideReap({worktreeRoot: "", isDirty: false}).kind, "skip");
+		assert.strictEqual(
+			decideReap({
+				worktreeRoot: "/some/bespoke/wt",
+				ownedWorktree: "/some/bespoke/wt",
+				isDirty: false,
+			}).kind,
+			"skip",
+		);
+		assert.strictEqual(
+			decideReap({worktreeRoot: "", ownedWorktree: "", isDirty: false}).kind,
+			"skip",
+		);
 	});
 
 	it("a dirty NON-managed path still skips, never reaps", () => {
-		assert.strictEqual(decideReap({worktreeRoot: "/other", isDirty: true}).kind, "skip");
+		assert.strictEqual(
+			decideReap({worktreeRoot: "/other", ownedWorktree: "/other", isDirty: true}).kind,
+			"skip",
+		);
+	});
+});
+
+describe("decideReap — the #2798 owner gate (ownership from the PAYLOAD, not worktree state)", () => {
+	it("NESTED-CHILD stop (owns a DIFFERENT worktree) → skip/KEEP the parent's live tree", () => {
+		// A descendant that merely inherited $WORKTREE_ROOT=WT but owns its own OTHER_WT.
+		const d = decideReap({worktreeRoot: WT, ownedWorktree: OTHER_WT, isDirty: false});
+		assert.strictEqual(d.kind, "skip");
+	});
+
+	it("ownership UNPROVABLE (empty owned path) → skip/KEEP (fail-closed)", () => {
+		const d = decideReap({worktreeRoot: WT, ownedWorktree: "", isDirty: false});
+		assert.strictEqual(d.kind, "skip");
+	});
+
+	it("the owner gate PRECEDES the dirty check: a non-owner on a dirty tree → skip, not refuse", () => {
+		// Proves the decision keys on the payload-derived owner, not on clean/dirty worktree state:
+		// a non-owner is a plain no-op regardless of the tree's dirtiness.
+		const d = decideReap({worktreeRoot: WT, ownedWorktree: OTHER_WT, isDirty: true});
+		assert.strictEqual(d.kind, "skip");
+	});
+
+	it("OWNER on a clean leaked tree → reap (the legitimate reclaim still works)", () => {
+		const d = decideReap({worktreeRoot: WT, ownedWorktree: WT, isDirty: false});
+		assert.strictEqual(d.kind, "reap");
 	});
 });


### PR DESCRIPTION
## What

Owner-gate the `SubagentStop` worktree reaper so it can no longer reap a **live parent coder's** worktree when a **nested descendant** stops.

Fixes #2798 (the in-repo half; the out-of-repo harness half — don't inherit `$WORKTREE_ROOT` into nested subagents / scope the trigger — is a #2440-class item, out of scope here).

## Root cause (re-scoped, confirmed from source)

The reaper (`packages/pipeline-cli/src/tools/worktree-guard/command.ts`, `reap`) read `process.env.WORKTREE_ROOT` and removed it on **every** `SubagentStop`, **discarding the stdin payload** and checking **no ownership**. A nested descendant inherits the parent's `$WORKTREE_ROOT`; its stop reaped the parent's **live** worktree, resetting cwd to primary `main` — a #832/#1103 primary-corruption trigger.

## The owner signal (grounded, AC #2)

I verified the `SubagentStop` payload actually carries owner identity before building — it does:

- Payload fields (from the Claude Code 2.1.207 binary): `session_id`, `transcript_path`, `cwd`, `hook_event_name`, `stop_hook_active`, `permission_mode`. There is **no** `subagent_id`/`subagent_type` field.
- `cwd` is **useless** for ownership: a worktree agent's recorded cwd is the **primary** checkout (the cwd-reset hazard) for both an owner and a nested child — identical.
- But `transcript_path` points at `<session>/subagents/agent-<id>.jsonl`, and the harness writes a **sibling `agent-<id>.meta.json`** recording the worktree that agent **OWNS** (`worktreePath`, plus `agentType`/`spawnDepth`). Proven on a live run: the subagent id equals the worktree basename (`agent-a0482d137a75e68c5` appears in **both** the live-worktree list and the subagent-transcript list), and the meta `worktreePath` is the exact worktree.

So ownership is derived from the **payload** (`transcript_path` → sibling `.meta.json` `worktreePath`), not from worktree state.

## Fix

- `command.ts`: consume the payload; `ownedWorktreeFromPayload(input)` reads `transcript_path` → sibling `.meta.json` → `worktreePath`. Unreadable ⇒ `""` ⇒ ownership unprovable ⇒ KEEP (fail-closed).
- `reap.ts` `decideReap` grows an `ownedWorktree` input and is **owner-gated**: reap only when `ownedWorktree` normalizes-equal to `$WORKTREE_ROOT`. A nested-descendant stop (different/absent owned path) or unprovable ownership → `skip`/KEEP. The gate **precedes** the dirty check, so a non-owner is a plain no-op regardless of tree state.
- Safety unchanged: still **no `--force`**; a dirty owned tree is still refused/KEPT.

## Tests

`reap.unit.test.ts` + `command.hook.test.ts` (20 pass, `tsc` clean):
- Owner + clean → reap (the existing "REAPS a clean worktree" case, now under an owner-stop payload — a real sibling `.meta.json`).
- **Nested-descendant stop** (inherited `$WORKTREE_ROOT`, owns a different tree) → KEEP; the live worktree survives.
- Unprovable ownership (empty owned path) → KEEP.
- Owner gate **precedes** dirty: non-owner on a dirty tree → skip, not refuse (proves the decision keys on the payload-derived owner, not worktree state).
- Dirty owned tree → still refused/KEPT, no `--force`.

## Notes

- **Defense-in-depth (AC #5, optional):** not added — the owner gate fully covers the analysis-phase incident (no PR, no lock), and `hasOpenPr`/`locked` were both false there. Kept the diff tight; the gate is the complete fix.
- **§CP:** touches `packages/pipeline-cli/` → control-plane, **human-merge-only (cansirin)**. Do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)