### PR TITLE
feat(pasaport): worker enabler for the email-delivery membrane notice (#2730)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -45,6 +45,7 @@ import {
 	bildirimFlag,
 	demoTargetingFlag,
 	emailDeliveryAdminFlag,
+	emailDeliveryNoticeFlag,
 	Flagship,
 	funnelReadoutFlag,
 	karmaGatesFlag,
@@ -148,6 +149,10 @@ export default Alchemy.Stack(
 		// (#2692, epic #2687) — the single seam the emailDelivery.mark/clear mutations + the
 		// emailDelivery.failing admin roll-up gate behind until a human release.
 		yield* emailDeliveryAdminFlag(flagship.appId);
+		// The member email-delivery membrane notice release flag, default-off (#2693,
+		// worker enabler #2730, epic #2687) — the single release seam the member-facing
+		// "your email is bouncing" notice gates behind until a human release.
+		yield* emailDeliveryNoticeFlag(flagship.appId);
 		// The mecmua public-read dark-ship flag, default-off (#2498, epic #2467) — the
 		// single seam the anon GET route + reader page gate behind until a human release.
 		yield* mecmuaPublicReadFlag(flagship.appId);

--- a/apps/web/src/auth/useMe.ts
+++ b/apps/web/src/auth/useMe.ts
@@ -28,11 +28,13 @@ import {useSession} from "./client";
  * over the exact scalars `MeView` selects, never a hand-restated interface. `tier`
  * and `isModerator` are trusted account-level signals read server-side (the stored
  * column via `Kunye.tierOf` / the `moderates` relation), surfaced on the row, never
- * inferred from the session.
+ * inferred from the session. `emailFailing` (#2730) is the SELF email-delivery signal
+ * the membrane notice reads — selected here so the notice lights up once its release
+ * flag is flipped, with no further client change.
  */
 export type MeUser = Pick<
 	User,
-	"id" | "email" | "name" | "image" | "username" | "tier" | "isModerator"
+	"id" | "email" | "name" | "image" | "username" | "tier" | "isModerator" | "emailFailing"
 >;
 
 export type MeStatus = "idle" | "loading" | "ok" | "error";
@@ -45,6 +47,7 @@ const MeView = view<User>()({
 	username: true,
 	tier: true,
 	isModerator: true,
+	emailFailing: true,
 });
 
 export function useMe(): {

--- a/apps/web/worker/features/flagship/email-delivery-notice.invariant.test.ts
+++ b/apps/web/worker/features/flagship/email-delivery-notice.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the member email-delivery membrane
+ * notice (#2693, worker enabler #2730, epic #2687). Inspected off the exported
+ * `EMAIL_DELIVERY_NOTICE_FLAG` record (the same object the factory spreads into
+ * `FlagshipFlag`), so no alchemy resource is constructed — mirrors `email-delivery-admin.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_EMAIL_DELIVERY_NOTICE} from "../../../src/flags/keys.ts";
+import {EMAIL_DELIVERY_NOTICE_FLAG, emailDeliveryNoticeFlag} from "./resources.ts";
+
+describe("member email-delivery notice — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.defaultVariation, "off");
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.variations.off, false);
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.variations.on, true);
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.key, "phoenix-email-delivery-notice");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.key, PHOENIX_EMAIL_DELIVERY_NOTICE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof emailDeliveryNoticeFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -25,6 +25,7 @@ import {
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_BILDIRIM,
 	PHOENIX_EMAIL_DELIVERY_ADMIN,
+	PHOENIX_EMAIL_DELIVERY_NOTICE,
 	PHOENIX_FUNNEL_READOUT,
 	PHOENIX_KARMA_GATES,
 	PHOENIX_MOD_QUEUE,
@@ -832,6 +833,34 @@ export const EMAIL_DELIVERY_ADMIN_FLAG = {
  */
 export const emailDeliveryAdminFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_email_delivery_admin", {appId, ...EMAIL_DELIVERY_ADMIN_FLAG});
+
+/**
+ * The member-facing email-delivery membrane notice release flag (#2693, epic #2687).
+ * Default-off so the (already-shipped, inert) notice reaches production dark until a
+ * human flips it at release (ADR 0083). Exported as a plain object so the
+ * default-=-safe-state invariant is unit-inspectable WITHOUT constructing the alchemy
+ * resource (mirrors `EMAIL_DELIVERY_ADMIN_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           pasaport (the membrane notice surface)
+ *   - originating:     #2693 (worker enabler #2730, epic: #2687)
+ *   - removal trigger: once the notice graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline the notice.
+ */
+export const EMAIL_DELIVERY_NOTICE_FLAG = {
+	key: PHOENIX_EMAIL_DELIVERY_NOTICE,
+	description:
+		"member email-delivery membrane notice release (#2693, epic #2687). owner: pasaport. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const emailDeliveryNoticeFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_email_delivery_notice", {appId, ...EMAIL_DELIVERY_NOTICE_FLAG});
 
 /**
  * The mecmua public-read dark-ship flag config (#2498, epic #2467). The SINGLE seam

--- a/apps/web/worker/features/pasaport/Pasaport.testing.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.testing.ts
@@ -41,6 +41,7 @@ const failOnContact: PasaportShape = {
 	markEmailFailing: die("markEmailFailing"),
 	clearEmailFailing: die("clearEmailFailing"),
 	listFailingAddresses: die("listFailingAddresses"),
+	readEmailFailing: die("readEmailFailing"),
 };
 
 export const makePasaportStub = (overrides: Partial<PasaportShape> = {}): Layer.Layer<Pasaport> =>

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -353,6 +353,12 @@ export class Pasaport extends Context.Service<
 		// event projects to `failing`, newest-first. Read only past `requireAdmin`; the
 		// set is derived from the log, never a stored flag.
 		readonly listFailingAddresses: () => Effect.Effect<ReadonlyArray<FailingAddress>>;
+
+		// The SELF email-delivery signal for the membrane notice (#2730): `true` when the
+		// given address's latest `email_delivery_event` projects to `failing`. A boolean
+		// over the same per-address projection the admin per-target read uses; the `me`
+		// resolver calls it with the viewer's own email to stamp `User.emailFailing`.
+		readonly readEmailFailing: (address: string) => Effect.Effect<boolean>;
 	}
 >()("@kampus/pasaport/Pasaport") {}
 
@@ -1173,6 +1179,14 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 					}));
 					return selectFailingAddresses(events, new Date());
 				}),
+
+				// The SELF membrane-notice read (#2730): does the given address currently
+				// project to `failing`? A boolean projection over the same per-address
+				// latest-event read the admin per-target read uses (`readEmailDeliveryState`),
+				// exposed for the `me` resolver to stamp `User.emailFailing`. Keyed by address
+				// (the viewer's own email), not userId — the caller already holds it.
+				readEmailFailing: (address: string) =>
+					readEmailDeliveryState(address).pipe(Effect.map((state) => state.failing)),
 			};
 		}),
 	);

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -169,14 +169,20 @@ export const mutations = {
 			const result = yield* pasaport.setUsername({userId: user.id, value: input.value});
 			// email comes from the session, the rest from the service result; the trusted
 			// standing (tier + moderator signal) and the `User` shape come from the one
-			// shared `toTrustedUser` home `me` also routes through (#1297/#1320).
-			return yield* toTrustedUser({
-				id: result.userId,
-				email: user.email,
-				name: result.displayName,
-				image: result.image,
-				username: result.username,
-			});
+			// shared `toTrustedUser` home `me` also routes through (#1297/#1320). The
+			// self-only `emailFailing` (#2730) is resolved here too so the ack's `User`
+			// matches the `me` read byte-for-byte (a username edit never touches it).
+			const emailFailing = yield* pasaport.readEmailFailing(user.email);
+			return yield* toTrustedUser(
+				{
+					id: result.userId,
+					email: user.email,
+					name: result.displayName,
+					image: result.image,
+					username: result.username,
+				},
+				emailFailing,
+			);
 		}),
 	),
 
@@ -207,13 +213,20 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pasaport = yield* Pasaport;
 			const result = yield* pasaport.setDisplayName({userId: user.id, value: input.value});
-			const trusted = yield* toTrustedUser({
-				id: result.userId,
-				email: user.email,
-				name: result.displayName,
-				image: result.image,
-				username: result.username,
-			});
+			// Resolve the self-only `emailFailing` (#2730) so the published reconcile carries
+			// the viewer's true delivery state — a display-name edit must not transiently
+			// clear the membrane notice over the live pin (the notice reads it off this row).
+			const emailFailing = yield* pasaport.readEmailFailing(user.email);
+			const trusted = yield* toTrustedUser(
+				{
+					id: result.userId,
+					email: user.email,
+					name: result.displayName,
+					image: result.image,
+					username: result.username,
+				},
+				emailFailing,
+			);
 			// `trusted` is already the wire `User` (`toTrustedUser` → `toUser`), so publish
 			// it inline as the reconcile data — the same byte-identical shape a fresh fetch
 			// yields, masked per-client (the inline-data contract).

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -61,27 +61,39 @@ export const queries = {
 			const user = yield* CurrentUser.required;
 			const pasaport = yield* Pasaport;
 			const fresh = yield* pasaport.getUserById(user.id);
+			// The SELF email-delivery signal (#2730): resolve the viewer's OWN failing state
+			// off the `email_delivery_event` log so `me` lights the (flag-gated) membrane
+			// notice. The account's email is stable across a username edit, so the session
+			// email keys it in both branches. `toTrustedUser` takes it as a param — resolving
+			// it inside that shared home would cycle (its mutation-ack callers are in Pasaport).
+			const emailFailing = yield* pasaport.readEmailFailing(user.email);
 			// `toTrustedUser` resolves the trusted standing (tier via `Kunye.tierOf`,
 			// the moderator signal via the `moderates` tuple) — one shared home for the
 			// `User` shape `setUsername` and the by-id loader also build. The session
 			// supplies email/name/image; the canonical row, when present, overrides them
 			// so a fresh `username` round-trips before better-auth's session catches up.
 			if (!fresh) {
-				return yield* toTrustedUser({
-					id: user.id,
-					email: user.email,
-					name: user.name ?? null,
-					image: user.image ?? null,
-					username: null,
-				});
+				return yield* toTrustedUser(
+					{
+						id: user.id,
+						email: user.email,
+						name: user.name ?? null,
+						image: user.image ?? null,
+						username: null,
+					},
+					emailFailing,
+				);
 			}
-			return yield* toTrustedUser({
-				id: fresh.id,
-				email: fresh.email,
-				name: fresh.name,
-				image: fresh.image,
-				username: fresh.username,
-			});
+			return yield* toTrustedUser(
+				{
+					id: fresh.id,
+					email: fresh.email,
+					name: fresh.name,
+					image: fresh.image,
+					username: fresh.username,
+				},
+				emailFailing,
+			);
 		}),
 	),
 	// `contributions` is delivered inline (not via a source `connection`

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -62,7 +62,13 @@ const storedUser = (tier: StoredTier): UserRow => ({
 });
 
 const pasaportWithStoredTier = (tier: StoredTier) =>
-	({getUserById: () => Effect.succeed(storedUser(tier))}) as never;
+	({
+		getUserById: () => Effect.succeed(storedUser(tier)),
+		// The `me` resolver reads the self-only `emailFailing` (#2730) off the
+		// `email_delivery_event` projection; these tests assert `tier`/`isModerator`, so a
+		// fixed deliverable (`false`) keeps the read from dying without affecting them.
+		readEmailFailing: () => Effect.succeed(false),
+	}) as never;
 
 // Drive `me` to the resolved wire object's `tier` scalar over the REAL `Kunye`
 // (KunyeLive) layered on a stored-tier Pasaport stub — exercising the trusted
@@ -154,7 +160,12 @@ it.effect("me ranks a row-missing principal as visitor (Kunye.tierOf fallback)",
 		} satisfies CurrentUserInfo;
 		// No stored row → both the canonical read and Kunye.tierOf see null → visitor,
 		// the read-time rank the column can never store.
-		const noRowPasaport = {getUserById: () => Effect.succeed(null)} as never;
+		const noRowPasaport = {
+			getUserById: () => Effect.succeed(null),
+			// The `!fresh` branch still resolves the self-only `emailFailing` (#2730) off the
+			// session email; a fixed deliverable (`false`) keeps it from dying (this asserts tier).
+			readEmailFailing: () => Effect.succeed(false),
+		} as never;
 		const tier = yield* resolveMeTier(user, noRowPasaport);
 		assert.strictEqual(tier, "visitor");
 	}),

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -33,6 +33,7 @@ export const toUser = (r: UserFields): User => ({
 	username: r.username,
 	tier: r.tier,
 	isModerator: r.isModerator,
+	emailFailing: r.emailFailing,
 });
 
 // Stamps the client normalization key `id` === `userId` (a `Profile` is

--- a/apps/web/worker/features/pasaport/sources.unit.test.ts
+++ b/apps/web/worker/features/pasaport/sources.unit.test.ts
@@ -161,7 +161,7 @@ it.effect("userSource.byIds carries through the underlying row fields unchanged"
 			Effect.provideService(Pasaport, pasaportWithCorpus),
 			Effect.provideService(RelationStore, relationStoreFor(new Set())),
 		);
-		assert.deepStrictEqual(rows[0], {...storedUser("u1"), isModerator: false});
+		assert.deepStrictEqual(rows[0], {...storedUser("u1"), isModerator: false, emailFailing: false});
 	}),
 );
 

--- a/apps/web/worker/features/pasaport/trusted-user.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.ts
@@ -31,15 +31,23 @@ export interface TrustedUserBase {
  * column, never the session field) + OWN moderator signal (`isModerator`, the
  * `moderates` tuple) stamped onto `toUser`. `me` and `setUsername` route through
  * here so their `User` shape can't drift.
+ *
+ * `emailFailing` (#2730) is the third self-only trusted field, but — unlike `tier`
+ * and `isModerator`, which this home resolves — it is passed IN by the caller: it
+ * projects off the `email_delivery_event` log (`Pasaport.readEmailFailing`), and
+ * requiring `Pasaport` here would cycle (the mutation acks that call `toTrustedUser`
+ * live inside the Pasaport service). The caller already holds `Pasaport`, so it
+ * resolves the boolean and threads it through.
  */
 export const toTrustedUser = (
 	base: TrustedUserBase,
+	emailFailing: boolean,
 ): Effect.Effect<User, never, Kunye | RelationStore> =>
 	Effect.gen(function* () {
 		const kunye = yield* Kunye;
 		const tier = yield* kunye.tierOf(base.id);
 		const isMod = yield* isModerator(base.id);
-		return toUser({...base, tier, isModerator: isMod});
+		return toUser({...base, tier, isModerator: isMod, emailFailing});
 	});
 
 /**
@@ -55,5 +63,7 @@ export const getUsersWithModerationByIds = (ids: ReadonlyArray<string>) =>
 		const pasaport = yield* Pasaport;
 		const rows = yield* pasaport.getUsersByIds(ids);
 		const mods = yield* moderatorsAmong(rows.map((row) => row.id));
-		return rows.map((row) => ({...row, isModerator: mods.has(row.id)}));
+		// `emailFailing` is self-only (#2730): a by-id load is another account's row, so it
+		// never carries that account's delivery state — always `false` on the batch path.
+		return rows.map((row) => ({...row, isModerator: mods.has(row.id), emailFailing: false}));
 	});

--- a/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
@@ -54,15 +54,18 @@ const relationStoreOf = (mods: ReadonlyArray<string>): Layer.Layer<RelationStore
 	});
 
 describe("toTrustedUser — the SELF trusted User shape", () => {
-	it.effect("stamps the trusted tier + moderator signal onto toUser", () =>
+	it.effect("stamps the trusted tier + moderator signal + emailFailing onto toUser", () =>
 		Effect.gen(function* () {
-			const user = yield* toTrustedUser({
-				id: "u1",
-				email: "u1@kamp.us",
-				name: "U One",
-				image: null,
-				username: "u-one",
-			}).pipe(Effect.provide(Layer.mergeAll(kunyeOf({u1: "yazar"}), relationStoreOf(["u1"]))));
+			const user = yield* toTrustedUser(
+				{
+					id: "u1",
+					email: "u1@kamp.us",
+					name: "U One",
+					image: null,
+					username: "u-one",
+				},
+				true,
+			).pipe(Effect.provide(Layer.mergeAll(kunyeOf({u1: "yazar"}), relationStoreOf(["u1"]))));
 			assert.deepStrictEqual(user, {
 				__typename: "User",
 				id: "u1",
@@ -72,21 +75,27 @@ describe("toTrustedUser — the SELF trusted User shape", () => {
 				username: "u-one",
 				tier: "yazar",
 				isModerator: true,
+				emailFailing: true,
 			});
 		}),
 	);
 
 	it.effect("a non-moderator reads isModerator false, tier off the stored column", () =>
 		Effect.gen(function* () {
-			const user = yield* toTrustedUser({
-				id: "u2",
-				email: "u2@kamp.us",
-				name: null,
-				image: null,
-				username: null,
-			}).pipe(Effect.provide(Layer.mergeAll(kunyeOf({u2: "çaylak"}), relationStoreOf([]))));
+			const user = yield* toTrustedUser(
+				{
+					id: "u2",
+					email: "u2@kamp.us",
+					name: null,
+					image: null,
+					username: null,
+				},
+				false,
+			).pipe(Effect.provide(Layer.mergeAll(kunyeOf({u2: "çaylak"}), relationStoreOf([]))));
 			assert.strictEqual(user.tier, "çaylak");
 			assert.isFalse(user.isModerator);
+			// `emailFailing` is passed IN by the caller (self-only #2730), threaded to `toUser`.
+			assert.isFalse(user.emailFailing);
 		}),
 	);
 });
@@ -113,6 +122,12 @@ describe("getUsersWithModerationByIds — the batched by-id user rows + moderato
 					{id: "u2", tier: "çaylak", isModerator: false},
 					{id: "u3", tier: "yazar", isModerator: true},
 				],
+			);
+			// `emailFailing` is self-only (#2730): the batch by-id path never carries another
+			// account's delivery state, so every row defaults `false`.
+			assert.deepStrictEqual(
+				users.map((u) => u.emailFailing),
+				[false, false, false],
 			);
 		}),
 	);

--- a/apps/web/worker/features/pasaport/user-fields.ts
+++ b/apps/web/worker/features/pasaport/user-fields.ts
@@ -48,6 +48,15 @@ export type UserRow = {
 export interface UserFields extends Omit<UserRow, "tier"> {
 	tier: Tier;
 	isModerator: boolean;
+	/**
+	 * The SELF email-delivery signal (#2730): `true` when the viewer's OWN address is
+	 * currently failing, projected from the latest `email_delivery_event` row
+	 * (`resolveEmailDeliveryState`, the #2691 projection) and stamped by the resolver,
+	 * never read from the `user` record. Like `isModerator` it is per-viewer and
+	 * self-only — the batched by-id path (`getUsersWithModerationByIds`) never leaks
+	 * another account's delivery state, so it defaults `false` there.
+	 */
+	emailFailing: boolean;
 }
 
 /**
@@ -65,6 +74,7 @@ export const userViewFields = {
 	username: true,
 	tier: true,
 	isModerator: true,
+	emailFailing: true,
 } as const satisfies Record<keyof UserFields, true>;
 
 /**

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -37,6 +37,11 @@ export type ContributionViewRow = ViewRow<ContributionRow>;
 // ever the viewer's OWN mod status. Like `tier` it is always present (the divan
 // "yazar yap" affordance is gated frontend-side); a dual-role yazar+moderator reads
 // `tier: "yazar"` + `isModerator: true`, which `tier` alone cannot express.
+//
+// `emailFailing` is the SELF email-delivery signal (#2730): the `me` resolver stamps
+// it from the viewer's own `email_delivery_event` projection (`Pasaport.readEmailFailing`)
+// so the flag-gated membrane notice can render; like `isModerator` it is self-only and
+// defaults `false` on the batched by-id path (never another account's delivery state).
 export class UserView extends FateDataView<UserViewRow>()("User")(userViewFields) {}
 
 // The **discriminant** view for the profile contributions feed: fate has no


### PR DESCRIPTION
Worker-side enabler that lights up the already-shipped, inert #2693 membrane notice (the client landed forward-compatible in PR #2727). Its AC1 worker enabler — two tightly-coupled facets kept as one pickable unit.

## What this delivers

**1 — Expose the self-only `emailFailing` field on the pasaport `User`/`me` read.**
- Rides `UserFields` (the resolver-stamped row) alongside `tier` / `isModerator` — never a `user` record column — via the field-map idiom (`user-fields.ts` → `shapers.ts` → `views.ts`, in compiler-enforced lockstep).
- Stamped in the `me` resolver from the viewer's OWN `email_delivery_event` projection through a new `Pasaport.readEmailFailing(address)` — a boolean over the SAME per-address latest-event read the admin per-target read already uses (`resolveEmailDeliveryState`, #2691).
- **Self-only, like `isModerator`:** passed INTO `toTrustedUser` by its callers rather than resolved inside it (requiring `Pasaport` there would cycle — the mutation acks that call it live inside the Pasaport service). The batched by-id path defaults `false` — a by-id load is another account's row and never carries its delivery state.
- `MeView` (`useMe.ts`) selects it, so #2727's notice lights up with **no further client change**.

**2 — Declare the `phoenix-email-delivery-notice` IaC release flag** in `flagship/resources.ts` (+ yield it in the stack), default-off — agents deploy the declaration, a human flips the release (ADR 0083). The flag KEY already shipped with the client notice (#2727); this adds only the worker-side IaC declaration + its default-=-safe-state invariant test.

## Acceptance criteria
- [x] `User`/`me` exposes an `emailFailing` boolean stamped from the #2691 projection, via the field-map idiom.
- [x] `MeView` selects `emailFailing`; the notice lights up with no further client change.
- [x] `phoenix-email-delivery-notice` IaC flag declared, deployed dark (ADR 0083).
- [x] No fate-live fanout change (read field, not a mutation) — the state write lives in #2691's projection.

## Verification (offline; worker not bootable on this Windows box)
- `pnpm typecheck` clean.
- Unit suites pass: the new flag invariant, `trusted-user` (incl. the emailFailing stamp + the batch `false` default), `sources`, `email-delivery`, plus the membrane client tests.
- `biome check` clean on all changed files.

The self-only DB read path (`readEmailFailing`) and the flag provisioning are left to CI integration — mirror of the proven admin per-target read.

Fixes #2730

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
