### PR TITLE
feat(web): admin console module for the email-delivery failing-address surface (#2732)

### DIFF
--- a/apps/web/src/admin/app-modules.ts
+++ b/apps/web/src/admin/app-modules.ts
@@ -17,4 +17,10 @@ consoleRegistry.register({
 	panel: lazy(() => import("./flags/FlagsPanel.tsx")),
 });
 
+consoleRegistry.register({
+	id: "e-posta-teslimati",
+	label: "e-posta teslimatı",
+	panel: lazy(() => import("./email-delivery/EmailDeliveryPanel.tsx")),
+});
+
 export {consoleRegistry};

--- a/apps/web/src/admin/email-delivery/EmailDeliveryPanel.css
+++ b/apps/web/src/admin/email-delivery/EmailDeliveryPanel.css
@@ -1,0 +1,92 @@
+/* Email-delivery console module (#2732). Role tokens only; the controls carry the 36px
+   hit-area floor (design law pillar 4). */
+
+.kp-email-delivery {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+}
+
+.kp-email-delivery__form {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-end;
+	gap: var(--s-2);
+	padding: var(--s-2) var(--s-3);
+	border: 1px solid var(--border-faint);
+	border-radius: var(--r-md);
+	background: var(--surface-raised);
+}
+
+.kp-email-delivery__field {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	color: var(--text-secondary);
+	font: var(--t-body-sm);
+}
+
+.kp-email-delivery__user-input,
+.kp-email-delivery__reason {
+	min-height: var(--tap-min);
+	padding: var(--s-1) var(--s-2);
+	border: 1px solid var(--border-faint);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+	color: var(--text-primary);
+	font: var(--t-body-sm);
+}
+
+.kp-email-delivery__reason {
+	min-width: 16rem;
+	resize: vertical;
+}
+
+/* Design law pillar 4: the 36px minimum hit area, from the --tap-min floor token. */
+.kp-email-delivery__btn {
+	min-height: var(--tap-min);
+	min-width: var(--tap-min);
+}
+
+.kp-email-delivery__table {
+	width: 100%;
+	border-collapse: collapse;
+	font: var(--t-body-sm);
+	color: var(--text-primary);
+}
+
+.kp-email-delivery__caption {
+	text-align: left;
+	color: var(--text-secondary);
+	font: var(--t-meta);
+	padding-bottom: var(--s-1);
+}
+
+.kp-email-delivery__table th,
+.kp-email-delivery__table td {
+	text-align: left;
+	padding: var(--s-1) var(--s-2);
+	border-bottom: 1px solid var(--border-faint);
+	vertical-align: top;
+}
+
+.kp-email-delivery__table th {
+	color: var(--text-muted);
+	font: var(--t-meta);
+	font-weight: 600;
+}
+
+.kp-email-delivery__address {
+	font-weight: 600;
+}
+
+.kp-email-delivery__empty,
+.kp-email-delivery__loading {
+	color: var(--text-muted);
+	font: var(--t-body-sm);
+}
+
+.kp-email-delivery__message {
+	color: var(--text-primary);
+	font: var(--t-body-sm);
+}

--- a/apps/web/src/admin/email-delivery/EmailDeliveryPanel.tsx
+++ b/apps/web/src/admin/email-delivery/EmailDeliveryPanel.tsx
@@ -1,0 +1,252 @@
+/**
+ * `EmailDeliveryPanel` — the email-delivery admin console module (#2732, email-bounce epic
+ * #2687), the React consumer of the worker admin surface #2731 landed. It lists the
+ * currently-failing addresses off the `emailDelivery.failing` roll-up and drives the
+ * `emailDelivery.mark` / `emailDelivery.clear` admin mutations.
+ *
+ * Gated behind the default-off `phoenix-email-delivery-admin` flag via `FlagGate` (the
+ * ban-controls stance): with it off nothing renders and no roll-up request fires, so the
+ * surface ships dark until a human flips the flag (ADR 0083) — the client half of the
+ * two-gate contract whose worker half fails the invisible `Denied`. The mutations are
+ * account-keyed (`userId`), so a failing address with no resolved account (`userId: null`)
+ * shows in the roll-up but carries no clear affordance — there is no account to target.
+ *
+ * Render decisions live DOM-free in `email-delivery.ts` (unit-tested); this is the thin
+ * shell. a11y: a labelled region + table; the mark form is a real `<form>` with a required
+ * `gerekçe`; outcomes are text in a `role="status"` live region, never color; lowercase
+ * Turkish copy per the design law.
+ */
+import {Suspense, useState} from "react";
+import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import type {EmailDeliveryState, FailingAddress} from "../../../worker/features/fate/views";
+import {Button} from "../../components/ui/Button";
+import {codeOf} from "../../fate/wire";
+import {FlagGate} from "../../flags/FlagGate";
+import {PHOENIX_EMAIL_DELIVERY_ADMIN} from "../../flags/keys";
+import type {FateWireCode} from "../../lib/fateWireCodes";
+import "./EmailDeliveryPanel.css";
+import {
+	emailDeliveryOutcomeMessage,
+	reasonLabel,
+	resolvedUserLabel,
+	sinceLabel,
+} from "./email-delivery";
+
+const FailingRowView = view<FailingAddress>()({
+	id: true,
+	address: true,
+	userId: true,
+	reason: true,
+	since: true,
+});
+
+const FailingConnectionView = {items: {node: FailingRowView}} as const;
+
+const EmailDeliveryStateSelect = view<EmailDeliveryState>()({
+	id: true,
+	failing: true,
+	reason: true,
+});
+
+export default function EmailDeliveryPanel() {
+	return (
+		<FlagGate flag={PHOENIX_EMAIL_DELIVERY_ADMIN}>
+			<EmailDeliveryAdmin />
+		</FlagGate>
+	);
+}
+
+function EmailDeliveryAdmin() {
+	// A refetch nonce: the mark/clear mutations return an `EmailDeliveryState` (keyed on the
+	// address), which never removes/adds a row in the `FailingAddress` roll-up connection, so
+	// after a successful write we remount the reader (`key={reloadKey}`) to re-read it fresh.
+	const [reloadKey, setReloadKey] = useState(0);
+	const [message, setMessage] = useState("");
+
+	function report(action: "mark" | "clear", code: FateWireCode | null, ok: boolean) {
+		setMessage(emailDeliveryOutcomeMessage(action, code));
+		if (ok) setReloadKey((k) => k + 1);
+	}
+
+	return (
+		<section
+			className="kp-email-delivery"
+			aria-label="e-posta teslimatı"
+			data-testid="email-delivery-panel"
+		>
+			<MarkForm onResult={(code, ok) => report("mark", code, ok)} />
+			{message ? (
+				<p
+					className="kp-email-delivery__message"
+					role="status"
+					aria-live="polite"
+					data-testid="email-delivery-message"
+				>
+					{message}
+				</p>
+			) : null}
+			<Suspense fallback={<p className="kp-email-delivery__loading">yükleniyor…</p>}>
+				<FailingList key={reloadKey} onResult={(code, ok) => report("clear", code, ok)} />
+			</Suspense>
+		</section>
+	);
+}
+
+/** The manual mark form — target a user by id + a required reason (mirrors the ban form). */
+function MarkForm({
+	onResult,
+}: {
+	readonly onResult: (code: FateWireCode | null, ok: boolean) => void;
+}) {
+	const fate = useFateClient();
+	const [userId, setUserId] = useState("");
+	const [reason, setReason] = useState("");
+	const [busy, setBusy] = useState(false);
+
+	async function onSubmit(event: React.FormEvent) {
+		event.preventDefault();
+		if (busy) return;
+		setBusy(true);
+		try {
+			const {error} = await fate.mutations.emailDelivery.mark({
+				input: {userId, reason},
+				view: EmailDeliveryStateSelect,
+			});
+			onResult(error ? codeOf(error) : null, !error);
+			if (!error) {
+				setUserId("");
+				setReason("");
+			}
+		} catch (caught) {
+			onResult(codeOf(caught), false);
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	return (
+		<form className="kp-email-delivery__form" onSubmit={onSubmit} aria-label="adres işaretle">
+			<label className="kp-email-delivery__field">
+				kullanıcı kimliği
+				<input
+					className="kp-email-delivery__user-input"
+					value={userId}
+					onChange={(e) => setUserId(e.target.value)}
+					required
+					data-testid="email-delivery-mark-user"
+				/>
+			</label>
+			<label className="kp-email-delivery__field">
+				gerekçe
+				<textarea
+					className="kp-email-delivery__reason"
+					value={reason}
+					onChange={(e) => setReason(e.target.value)}
+					required
+					data-testid="email-delivery-mark-reason"
+				/>
+			</label>
+			<Button
+				variant="danger"
+				size="sm"
+				type="submit"
+				disabled={busy}
+				className="kp-email-delivery__btn"
+				data-testid="email-delivery-mark-button"
+			>
+				{busy ? "işaretleniyor…" : "işaretle"}
+			</Button>
+		</form>
+	);
+}
+
+function FailingList({
+	onResult,
+}: {
+	readonly onResult: (code: FateWireCode | null, ok: boolean) => void;
+}) {
+	const result = useRequest(
+		{"emailDelivery.failing": {list: FailingConnectionView}},
+		{mode: "network-only"},
+	);
+	const [items] = useListView(FailingConnectionView, result["emailDelivery.failing"]);
+
+	if (items.length === 0) {
+		return (
+			<p className="kp-email-delivery__empty" data-testid="email-delivery-empty">
+				şu an başarısız olan adres yok — kuyruk temiz.
+			</p>
+		);
+	}
+
+	return (
+		<table className="kp-email-delivery__table" data-testid="email-delivery-table">
+			<caption className="kp-email-delivery__caption">başarısız e-posta adresleri</caption>
+			<thead>
+				<tr>
+					<th scope="col">adres</th>
+					<th scope="col">hesap</th>
+					<th scope="col">gerekçe</th>
+					<th scope="col">başlangıç</th>
+					<th scope="col">işlem</th>
+				</tr>
+			</thead>
+			<tbody>
+				{items.map(({node}) => (
+					<FailingRow key={node.id} node={node} onResult={onResult} />
+				))}
+			</tbody>
+		</table>
+	);
+}
+
+function FailingRow({
+	node,
+	onResult,
+}: {
+	readonly node: ViewRef<"FailingAddress">;
+	readonly onResult: (code: FateWireCode | null, ok: boolean) => void;
+}) {
+	const data = useView(FailingRowView, node);
+	const fate = useFateClient();
+	const [busy, setBusy] = useState(false);
+
+	async function onClear() {
+		if (busy || data.userId === null) return;
+		setBusy(true);
+		try {
+			const {error} = await fate.mutations.emailDelivery.clear({
+				input: {userId: data.userId},
+				view: EmailDeliveryStateSelect,
+			});
+			onResult(error ? codeOf(error) : null, !error);
+		} catch (caught) {
+			onResult(codeOf(caught), false);
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	return (
+		<tr data-testid={`email-delivery-row-${data.id}`}>
+			<td className="kp-email-delivery__address">{data.address}</td>
+			<td>{resolvedUserLabel(data.userId)}</td>
+			<td>{reasonLabel(data.reason)}</td>
+			<td>{sinceLabel(data.since)}</td>
+			<td>
+				{data.userId !== null ? (
+					<Button
+						variant="secondary"
+						size="sm"
+						onClick={onClear}
+						disabled={busy}
+						className="kp-email-delivery__btn"
+						data-testid={`email-delivery-clear-${data.id}`}
+					>
+						{busy ? "temizleniyor…" : "temizle"}
+					</Button>
+				) : null}
+			</td>
+		</tr>
+	);
+}

--- a/apps/web/src/admin/email-delivery/email-delivery-module.test.ts
+++ b/apps/web/src/admin/email-delivery/email-delivery-module.test.ts
@@ -1,0 +1,24 @@
+/**
+ * The email-delivery module registers into the admin-console shell (#2732, epic #2687):
+ * importing the app-wide composition self-registers the `e-posta-teslimati` module as a nav
+ * entry with a Turkish label, and the shell's pure `selectActiveModule` resolves it —
+ * asserted DOM-free (the panel chunk is `React.lazy`, never evaluated here). Mirrors
+ * `flags-module.test.ts`; proves the console module contract (#2740) for this tenant.
+ */
+import {describe, expect, it} from "vitest";
+import {consoleRegistry} from "../app-modules";
+import {selectActiveModule} from "../module-registry";
+
+describe("email-delivery module registration", () => {
+	it("self-registers an `e-posta-teslimati` module with a Turkish nav label", () => {
+		const module = consoleRegistry.list().find((m) => m.id === "e-posta-teslimati");
+		expect(module).toBeDefined();
+		expect(module?.label).toBe("e-posta teslimatı");
+	});
+
+	it("is selectable as the active module (the shell renders its panel)", () => {
+		expect(selectActiveModule(consoleRegistry.list(), "e-posta-teslimati")?.id).toBe(
+			"e-posta-teslimati",
+		);
+	});
+});

--- a/apps/web/src/admin/email-delivery/email-delivery.test.ts
+++ b/apps/web/src/admin/email-delivery/email-delivery.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `email-delivery` pure-logic coverage (#2732) — the roll-up cell labels + the mark/clear
+ * outcome-message mapping, DOM-free (the `ban-controls.ts` idiom).
+ */
+import {describe, expect, it} from "vitest";
+import {
+	emailDeliveryOutcomeMessage,
+	reasonLabel,
+	resolvedUserLabel,
+	sinceLabel,
+} from "./email-delivery";
+
+describe("resolvedUserLabel", () => {
+	it("shows the user id when the address resolves to an account", () => {
+		expect(resolvedUserLabel("user_123")).toBe("user_123");
+	});
+	it("falls back to the no-account note when unresolved", () => {
+		expect(resolvedUserLabel(null)).toBe("hesap yok");
+	});
+});
+
+describe("reasonLabel", () => {
+	it("shows the reason when present", () => {
+		expect(reasonLabel("hard bounce")).toBe("hard bounce");
+	});
+	it("falls back to belirtilmemiş when absent", () => {
+		expect(reasonLabel(null)).toBe("belirtilmemiş");
+	});
+});
+
+describe("sinceLabel", () => {
+	it("renders the epoch-millis as a local date string", () => {
+		const label = sinceLabel(Date.UTC(2026, 0, 1));
+		expect(label).toBeTypeOf("string");
+		expect(label.length).toBeGreaterThan(0);
+	});
+});
+
+describe("emailDeliveryOutcomeMessage", () => {
+	it("success (null code) confirms the action per verb", () => {
+		expect(emailDeliveryOutcomeMessage("mark", null)).toBe("adres işaretlendi.");
+		expect(emailDeliveryOutcomeMessage("clear", null)).toBe("işaret temizlendi.");
+	});
+	it("an empty reason maps to the required message", () => {
+		expect(emailDeliveryOutcomeMessage("mark", "EMAIL_FAILING_REASON_REQUIRED")).toContain(
+			"gerekçe",
+		);
+	});
+	it("a denial maps to the no-authority message (both codes)", () => {
+		expect(emailDeliveryOutcomeMessage("mark", "UNAUTHORIZED")).toContain("yetkin yok");
+		expect(emailDeliveryOutcomeMessage("clear", "FORBIDDEN")).toContain("yetkin yok");
+	});
+	it("an unknown target maps to the not-found message", () => {
+		expect(emailDeliveryOutcomeMessage("clear", "USER_NOT_FOUND")).toContain("bulunamadı");
+	});
+	it("any other code maps to the generic retry message", () => {
+		expect(emailDeliveryOutcomeMessage("mark", "INTERNAL_SERVER_ERROR")).toContain("ters gitti");
+	});
+});

--- a/apps/web/src/admin/email-delivery/email-delivery.ts
+++ b/apps/web/src/admin/email-delivery/email-delivery.ts
@@ -1,0 +1,37 @@
+/**
+ * DOM-free render logic for the email-delivery admin module (#2732, email-bounce epic
+ * #2687) — the roll-up row labels + the mark/clear outcome-message mapping, pure so they
+ * are unit-testable without a DOM (the `ban-controls.ts` idiom). `EmailDeliveryPanel.tsx`
+ * is the thin shell.
+ */
+import type {FateWireCode} from "../../lib/fateWireCodes";
+
+/** The resolved-account cell — the user id, or the "no account row" note when unresolved. */
+export const resolvedUserLabel = (userId: string | null): string => userId ?? "hesap yok";
+
+/** The active-reason cell, falling back to the not-stated note (mirrors `banStatusLabel`). */
+export const reasonLabel = (reason: string | null): string => reason ?? "belirtilmemiş";
+
+/** The since cell — epoch-millis rendered as a local date/time (text, never color). */
+export const sinceLabel = (since: number): string => new Date(since).toLocaleString("tr-TR");
+
+/** Turkish feedback for a mark/clear mutation outcome, keyed on the wire code. */
+export const emailDeliveryOutcomeMessage = (
+	action: "mark" | "clear",
+	code: FateWireCode | null,
+): string => {
+	if (code === null) {
+		return action === "mark" ? "adres işaretlendi." : "işaret temizlendi.";
+	}
+	switch (code) {
+		case "EMAIL_FAILING_REASON_REQUIRED":
+			return "işaretleme gerekçesi zorunludur.";
+		case "UNAUTHORIZED":
+		case "FORBIDDEN":
+			return "bu işlem için yetkin yok.";
+		case "USER_NOT_FOUND":
+			return "kullanıcı bulunamadı.";
+		default:
+			return "bir şeyler ters gitti, lütfen tekrar dene.";
+	}
+};


### PR DESCRIPTION
Fixes #2732

## What

Adds the React consumer of the worker admin surface #2731 landed (child #2692, email-bounce epic #2687): an **admin-console module** that surfaces the failing-email-address state.

- Lists the currently-failing addresses off the `emailDelivery.failing` fate list root — **adres · hesap · gerekçe · başlangıç** (address, resolved account, reason, since).
- Offers **işaretle** (mark, required reason → surfaces `EMAIL_FAILING_REASON_REQUIRED` on an empty reason) and per-row **temizle** (clear), wired to the `emailDelivery.mark` / `emailDelivery.clear` mutations.
- Registered as one **appended** entry in the console module registry (`apps/web/src/admin/app-modules.ts`), mirroring the flags module (#2742) — the only shared file, appended not rewritten.

## Design / scope decisions (grounded in the merged worker surface)

- **Location: admin-console module, not a standalone `moderation/` control.** The issue body predates the admin console (#2740) and named the ban-controls shape; the console now exists and is the right host. The functional spec (list + mark/clear) and the design idiom (DOM-free logic + thin shell, role tokens, `role=\"status\"` outcome) are still mirrored from ban-controls.
- **Mark/clear are account-keyed (`userId`), by the merged worker contract (#2731).** So the **mark** affordance is a form taking a `userId` + required `gerekçe` (the honest shape — you mark a user not yet in the failing list), and **clear** is per-row but only for a row whose address resolves to an account. A failing address with **no** account (`userId: null`) shows in the roll-up but carries no clear affordance — there is nothing to target. This is a deliberate consequence of the userId-keyed mutations, not a data gap.

## Dark-ship

Ships **dark**. Gated behind the default-off `phoenix-email-delivery-admin` flag via `FlagGate` (the ban-controls stance) — with it off nothing renders and no roll-up request fires. It additionally lives inside the `/admin` console, itself behind default-off `phoenix-admin-console`. No new flag; rides the existing default-off flag declared in `apps/web/src/flags/keys.ts`. Inert until a human flips the flag at release (ADR 0083) — status stays awaiting-release semantics with no active-milestone urgency.

## Verification

- `pnpm typecheck` ✅ (panel chunk builds clean — no `never` regression on the `FailingAddress` / `EmailDeliveryState` client entities)
- `pnpm lint` ✅
- New unit tests ✅ — `email-delivery.test.ts` (labels + mark/clear outcome mapping, mirrors `ban-controls.test.ts`) and `email-delivery-module.test.ts` (registration, mirrors `flags-module.test.ts`); 12 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)