### PR TITLE
feat(fate-effect): loud-fail guard for the field-map symbol slip (#2808)

### DIFF
--- a/packages/fate-effect/src/DataView.guard.test.ts
+++ b/packages/fate-effect/src/DataView.guard.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit — the loud-fail guard for the fate field-map symbol slip (#2808).
+ *
+ * The guarded failure (diagnosed in #2805): when a view's `dataViewFieldsKey`
+ * symbol recovery slips, fate's `ViewFieldConfig` misses its symbol branch and
+ * falls to the wide `V['fields']` fallback, dropping every literal field key —
+ * and the only downstream signal is a silent `never` at a far-away `view<>()`
+ * call, type-indistinguishable from a genuine under-typing defect.
+ *
+ * `AssertFieldMapResolved<typeof XView>` turns that silent `never` into the named
+ * `FieldMapRecoveryFailed` brand at the entity-definition site. This file proves
+ * both halves of the contract:
+ *
+ * 1. **Healthy → green.** The four #2805 comparands (`BanState`, `DivanCaylak`,
+ *    `EmailDeliveryState`, `FailingAddress`) — reproduced here at their exact
+ *    authoring shape — resolve to the view unchanged, and their downstream
+ *    `view<>()` selection still type-checks with every field (no `never`).
+ * 2. **Degraded → loud.** A synthetically-slipped view (its `.view` is a bare
+ *    `DataViewOf<Row>`, exactly what fate sees after a symbol slip) resolves to
+ *    the named `FieldMapRecoveryFailed` brand, and the mismatch is a real compile
+ *    error (the `@ts-expect-error` below), not a silent pass.
+ *
+ * Like `DataView.unit.test.ts`, the view classes + aliases are **exported** on
+ * purpose: the package tsconfig is `composite`, so tsgo runs the
+ * declaration-nameability checks (TS2883/TS4020) over the guard's exported
+ * surface — if the guard ever reintroduces a portability hazard, `pnpm typecheck`
+ * fails here.
+ */
+import {view} from "@nkzw/fate";
+import {describe, expect, expectTypeOf, it} from "vitest";
+import {
+	type AssertFieldMapResolved,
+	type DataViewOf,
+	type Entity,
+	FateDataView,
+	type FieldMapRecoveryFailed,
+	type FieldMapResolved,
+} from "./DataView.ts";
+
+// --- the four #2805 comparands, at their exact authoring shape --------------
+
+type BanStateRow = {id: string; reason: string; bannedAt: Date};
+type DivanCaylakRow = {id: string; handle: string; karma: number};
+type FailingAddressRow = {id: string; address: string; userId: string; reason: string; since: Date};
+type EmailDeliveryStateRow = {id: string; reason: string; failing: Array<FailingAddressRow>};
+
+export class BanStateView extends FateDataView<BanStateRow>()("BanState")({
+	id: true,
+	reason: true,
+	bannedAt: true,
+}) {}
+
+export class DivanCaylakView extends FateDataView<DivanCaylakRow>()("DivanCaylak")({
+	id: true,
+	handle: true,
+	karma: true,
+}) {}
+
+export class FailingAddressView extends FateDataView<FailingAddressRow>()("FailingAddress")({
+	id: true,
+	address: true,
+	userId: true,
+	reason: true,
+	since: true,
+}) {}
+
+// EmailDeliveryState is the #2805 mutation-return with a list relation — the
+// realistic roll-up shape, not just a flat scalar view.
+const failingField = FateDataView.list(FailingAddressView);
+
+export class EmailDeliveryStateView extends FateDataView<EmailDeliveryStateRow>()(
+	"EmailDeliveryState",
+)({
+	id: true,
+	reason: true,
+	failing: failingField,
+}) {}
+
+// --- the guard applied at each definition site (the load-bearing assertions) -
+
+export type BanStateAsserted = AssertFieldMapResolved<typeof BanStateView>;
+export type DivanCaylakAsserted = AssertFieldMapResolved<typeof DivanCaylakView>;
+export type FailingAddressAsserted = AssertFieldMapResolved<typeof FailingAddressView>;
+export type EmailDeliveryStateAsserted = AssertFieldMapResolved<typeof EmailDeliveryStateView>;
+
+// --- the synthetic slip: a view whose `.view` lost its symbol property -------
+// This is exactly what fate resolves after a `dataViewFieldsKey` identity slip —
+// a bare `DataView<Row>` with no field-map symbol, so `ViewFieldConfig` falls to
+// the wide `V['fields']`. It cannot be authored via `FateDataView` (which always
+// stamps the symbol), so it is spelled structurally.
+type SlippedFailingAddressView = {
+	readonly view: DataViewOf<FailingAddressRow>;
+	readonly typeName: "FailingAddress";
+};
+
+type FailingAddress = Entity<typeof FailingAddressView>;
+
+/**
+ * The "loud" half, as a compile-checked (never-run) proof: the guard's output is
+ * assignment-loud. Exported so tsgo runs its nameability checks over it and so it
+ * counts as used; the params carry real types (no `as`-assertion needed).
+ */
+export function loudFailProof(
+	healthyAssertion: AssertFieldMapResolved<typeof FailingAddressView>,
+	slippedAssertion: AssertFieldMapResolved<SlippedFailingAddressView>,
+): void {
+	// A healthy view's assertion IS the view — assignable, no error.
+	const healthy: typeof FailingAddressView = healthyAssertion;
+	void healthy;
+	// @ts-expect-error — the slipped assertion is the `FieldMapRecoveryFailed` brand,
+	// NOT the view: a slip is a real compile error here, at the entity-definition
+	// site, rather than a silent `never` at a far-away view<>() call. If the guard
+	// ever stopped firing, this directive would go unused and typecheck would fail.
+	const slipped: typeof FailingAddressView = slippedAssertion;
+	void slipped;
+}
+
+describe("AssertFieldMapResolved — healthy entities resolve to the view unchanged", () => {
+	it("the four #2805 comparands are all field-map-resolved (no false positive)", () => {
+		expectTypeOf<FieldMapResolved<typeof BanStateView>>().toEqualTypeOf<true>();
+		expectTypeOf<FieldMapResolved<typeof DivanCaylakView>>().toEqualTypeOf<true>();
+		expectTypeOf<FieldMapResolved<typeof FailingAddressView>>().toEqualTypeOf<true>();
+		expectTypeOf<FieldMapResolved<typeof EmailDeliveryStateView>>().toEqualTypeOf<true>();
+	});
+
+	it("the guard is the identity on a healthy view (resolves to the view type)", () => {
+		expectTypeOf<BanStateAsserted>().toEqualTypeOf<typeof BanStateView>();
+		expectTypeOf<DivanCaylakAsserted>().toEqualTypeOf<typeof DivanCaylakView>();
+		expectTypeOf<FailingAddressAsserted>().toEqualTypeOf<typeof FailingAddressView>();
+		expectTypeOf<EmailDeliveryStateAsserted>().toEqualTypeOf<typeof EmailDeliveryStateView>();
+	});
+
+	it("downstream view<>() still selects every field on a healthy entity (no never)", () => {
+		const selection = view<FailingAddress>()({
+			id: true,
+			address: true,
+			userId: true,
+			reason: true,
+			since: true,
+		});
+		// The runtime value is fate's selection object; the point is that the call
+		// type-checks — the field map is intact, so no field collapses to `never`.
+		expect(selection).toBeDefined();
+	});
+
+	it("the view<>() selection validator is still active (a bogus field is rejected)", () => {
+		// @ts-expect-error — `bogus` is not a FailingAddress field, so the selection
+		// validator collapses the parameter to `never`. This proves the validator is
+		// live: the healthy case above passes because the keys are present, not
+		// because validation is off.
+		view<FailingAddress>()({id: true, bogus: true});
+	});
+});
+
+describe("AssertFieldMapResolved — a symbol slip resolves to the named error brand", () => {
+	it("a slipped view is NOT field-map-resolved", () => {
+		expectTypeOf<FieldMapResolved<SlippedFailingAddressView>>().toEqualTypeOf<false>();
+	});
+
+	it("the guard names the failure (FieldMapRecoveryFailed) instead of a bare never", () => {
+		expectTypeOf<AssertFieldMapResolved<SlippedFailingAddressView>>().toEqualTypeOf<
+			FieldMapRecoveryFailed<"FailingAddress">
+		>();
+		// The named brand is distinguishable from both the healthy view AND a bare
+		// `never` — the whole point (a silent `never` is neither).
+		expectTypeOf<AssertFieldMapResolved<SlippedFailingAddressView>>().not.toEqualTypeOf<
+			typeof FailingAddressView
+		>();
+		expectTypeOf<AssertFieldMapResolved<SlippedFailingAddressView>>().not.toBeNever();
+	});
+
+	it("the loud-fail is a real compile error at the definition site (proven by loudFailProof)", () => {
+		// The compile-level proof is `loudFailProof` above: its @ts-expect-error only
+		// type-checks because the slipped assertion is unassignable to the view. This
+		// runtime case documents that the proof exists and is wired into the suite.
+		expect(loudFailProof).toBeTypeOf("function");
+	});
+});

--- a/packages/fate-effect/src/DataView.ts
+++ b/packages/fate-effect/src/DataView.ts
@@ -200,3 +200,62 @@ export type WorkerEntity<
 	DateKeys extends keyof WireResult<View> = never,
 	Override extends Record<string, unknown> = Record<never, never>,
 > = Entity<View, Omit<DateCorrection<View, DateKeys>, keyof Override> & Override>;
+
+// --- Loud-fail guard for the silent field-map symbol slip (#2808) -----------
+//
+// The forcing failure this guards: fate recovers a view's literal field map off
+// the `dataViewFieldsKey` symbol property `KernelDataView` stamps. When that
+// symbol identity slips (a cross-project dedup drift, or a stale TS incremental
+// artifact holding a mid-landing resolution — the #2805 transient), fate's
+// `ViewFieldConfig` misses its symbol branch and falls to the wide `V['fields']`
+// fallback (`Record<string, DataField>`). The entity loses every literal key, and
+// the ONLY downstream signal is a `never` at the far-away `view<>()` call — a
+// silent degrade indistinguishable from a genuine under-typing defect, which cost
+// a full investigation cycle (#2805). These types turn that silent `never` into a
+// named failure legible at the entity-definition site.
+
+/**
+ * The literal field map fate recovers for a view — mirrors the kernel's own
+ * `ViewFieldConfig<V> = V extends {[dataViewFieldsKey]: infer F} ? F : V['fields']`,
+ * spelled with this module's portable `DataViewFieldsKey`. A healthy recovery
+ * hits the symbol branch and yields the literal `{id: true, …}` config; a slip
+ * misses it and falls to the wide `V['fields']`.
+ */
+type RecoveredFieldConfig<View extends {readonly view: DataViewOf<AnyRow>}> = View["view"] extends {
+	readonly [K in DataViewFieldsKey]: infer Fields;
+}
+	? Fields
+	: View["view"]["fields"];
+
+/**
+ * True iff the field-map recovery kept its literal keys. The discriminator is
+ * `string extends keyof …`: a healthy recovery's keys are a literal field-name
+ * union (`"id" | "slug" | …`), of which `string` is never a subtype ⇒ `false`
+ * branch ⇒ `true`; the degraded `V['fields']` fallback keys as the wide `string`,
+ * so `string extends string` ⇒ the slip is caught. This is the whole
+ * false-positive-safety argument: a literal field-name union can never satisfy
+ * `string extends K` (no field is authored under an index signature), so the
+ * guard fires ONLY on the wide-fallback slip, never on a healthy entity.
+ */
+export type FieldMapResolved<View extends {readonly view: DataViewOf<AnyRow>}> =
+	string extends keyof RecoveredFieldConfig<View> ? false : true;
+
+/**
+ * The named, `@ts-expect-error`-detectable failure a degraded view resolves to —
+ * carrying its own name (and the view's type name) instead of a bare `never`, so
+ * a reader sees *why* at the definition site (see #2808).
+ */
+export interface FieldMapRecoveryFailed<Name extends string = string> {
+	readonly __fateError: "field-map symbol recovery slipped to the wide `V['fields']` fallback — `keyof ViewFieldConfig` degraded from the literal field union to `string`; every downstream `view<>()` selection would collapse to `never` (see #2808)";
+	readonly viewName: Name;
+}
+
+/**
+ * Loud-fail assertion: resolves to `View` on a healthy field-map recovery, or the
+ * named `FieldMapRecoveryFailed<name>` brand when the recovery slipped. Apply it at
+ * an entity/view definition site (`AssertFieldMapResolved<typeof XView>`) so a slip
+ * surfaces a legible, named error *there* rather than a distant `never` at `view<>()`.
+ */
+export type AssertFieldMapResolved<
+	View extends {readonly view: DataViewOf<AnyRow>; readonly typeName: string},
+> = FieldMapResolved<View> extends true ? View : FieldMapRecoveryFailed<View["typeName"]>;

--- a/packages/fate-effect/src/index.ts
+++ b/packages/fate-effect/src/index.ts
@@ -23,11 +23,14 @@ export type {
 export type {CompiledFateSources} from "./Compiled.ts";
 export {CurrentUser, type CurrentUserInfo, Unauthorized} from "./CurrentUser.ts";
 export {
+	type AssertFieldMapResolved,
 	type DataViewFieldsKey,
 	type DataViewOf,
 	type Entity,
 	FateDataView,
 	type FateDataViewClass,
+	type FieldMapRecoveryFailed,
+	type FieldMapResolved,
 	type FieldsConfigOf,
 	type KernelDataView,
 	type ListFieldOf,


### PR DESCRIPTION
Fixes #2808

## What & why

fate recovers a view's literal field map off the `dataViewFieldsKey` `unique symbol` that `KernelDataView` stamps (`packages/fate-effect/src/DataView.ts`). When that symbol identity slips — a cross-project dedup drift, or a stale TS incremental artifact holding a mid-landing resolution (the #2805 transient) — fate's `ViewFieldConfig<V>` misses its symbol branch and falls to the wide `V['fields']` fallback (`Record<string, DataField>`), dropping every literal field key. The only downstream signal was a **silent `never`** at a far-away `view<>()` call, type-indistinguishable from a genuine under-typing defect. That ambiguity cost the entire #2805 investigation cycle.

This turns the silent `never` into a **named, distinguishable failure legible at the entity-definition site.**

## Mechanism (candidate **(a)** — the false-positive-safe one)

Added to `packages/fate-effect/src/DataView.ts`:

- `FieldMapResolved<View>` — discriminates on `string extends keyof RecoveredFieldConfig<View>`. A healthy recovery keys as a literal field-name union (`"id" | "address" | …`), of which `string` is **never** a subtype ⇒ `true`; the degraded `V['fields']` fallback keys as the wide `string` ⇒ `string extends string` ⇒ `false`. `RecoveredFieldConfig` mirrors fate's own `ViewFieldConfig` spelled with this module's portable `DataViewFieldsKey`.
- `FieldMapRecoveryFailed<Name>` — the named, `@ts-expect-error`-detectable brand carrying its own message + the view's type name (not a bare `never`).
- `AssertFieldMapResolved<typeof XView>` — resolves to `View` on a healthy recovery, or `FieldMapRecoveryFailed<name>` on a slip. Applied at a definition site, a slip surfaces a legible named error *there*, not a distant `never`.

**False-positive safety is the whole argument:** a literal field-name union can never satisfy `string extends K` (fields are never authored under an index signature), so the guard fires **only** on the wide-fallback slip, never on a healthy entity.

## How the test proves it (`packages/fate-effect/src/DataView.guard.test.ts`)

- **Healthy → green (no false positive).** The four #2805 comparands — `BanState`, `DivanCaylak`, `EmailDeliveryState` (with its `failing` list relation), `FailingAddress` — reproduced at their exact `FateDataView<Row>()("Name")({…})` authoring shape, each asserted `FieldMapResolved = true` and `AssertFieldMapResolved = typeof XView` (identity). Downstream `view<FailingAddress>()({…all fields…})` still type-checks with every field (no `never`); a bogus-field probe (`@ts-expect-error`) confirms the selection validator is still active.
- **Degraded → loud.** A synthetically-slipped view (its `.view` is a bare `DataViewOf<Row>` with no symbol property — exactly what fate resolves after a symbol slip) asserts `FieldMapResolved = false`, `AssertFieldMapResolved = FieldMapRecoveryFailed<"FailingAddress">`, and `not.toBeNever()`. `loudFailProof` carries the load-bearing `@ts-expect-error`: the slipped assertion is unassignable to the view type, so if the guard ever stopped firing the directive would go unused and `pnpm typecheck` would fail.

## Portability / no regression

- `pnpm typecheck` (the `composite` package, which runs tsgo's declaration-nameability checks TS2883/TS4020 over the **exported** guard surface) exits **0** — no portability hazard reintroduced. The guard mirrors the existing portable `DataViewFieldsKey` / `KernelDataView` recovery rather than naming fate's non-exported `dataViewFieldsKey` / `ViewFieldConfig` directly.
- `pnpm exec vitest run` — all guard + existing DataView unit tests pass.
- `biome check` clean.
- Bounded to `packages/fate-effect`; additive exports only (no `@nkzw/fate` dep patch, no consumer break). No runtime behavior change — compile-time/type-level guard only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
