### PR TITLE
feat(fate): adopt AssertFieldMapResolved onto the live worker entity views (#2811)

### DIFF
--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -7,6 +7,40 @@
  * `.patterns/fate-data-views.md`, `.patterns/per-feature-fate-aggregators.md`.
  */
 
+import type {AssertFieldMapResolved} from "@kampus/fate-effect";
+// Every client-facing entity's View class, imported (type-only) so the loud-fail
+// field-map guard can be asserted over the full shipping surface at the bottom of
+// this file. See the `AssertFieldMapResolved` block below (#2808/#2811).
+import type {AdminProbeView} from "../admin-console/probe-view.ts";
+import type {
+	NotificationChannelView,
+	NotificationMarkReceiptView,
+	NotificationUnreadView,
+	NotificationView,
+} from "../bildirim/views.ts";
+import type {DivanBacklogItemView, DivanCaylakView, DivanVoteReceiptView} from "../divan/views.ts";
+import type {FunnelSummaryView} from "../funnel/views.ts";
+import type {MecmuaPostView, MecmuaSubscriptionReceiptView} from "../mecmua/views.ts";
+import type {CommentView, PostOverlayView, PostView, TagView} from "../pano/views.ts";
+import type {
+	AccountDeletionReceiptView,
+	AuthorshipStandingView,
+	BanStateView,
+	ContributionView,
+	EmailDeliveryStateView,
+	FailingAddressView,
+	ProfileView,
+	PromotionReceiptView,
+	UserView,
+} from "../pasaport/views.ts";
+import type {
+	OpenReportView,
+	ReportReceiptView,
+	ResolvedReportView,
+	ResolveReceiptView,
+} from "../report/views.ts";
+import type {DefinitionView, TermView} from "../sozluk/views.ts";
+import type {LandingStatsView} from "../stats/views.ts";
 import {modules} from "./config.ts";
 import {mergeFateRoots} from "./module.ts";
 
@@ -96,3 +130,75 @@ export {landingStatsDataView} from "../stats/views.ts";
  * inspects this value at runtime.
  */
 export const Root: Record<string, unknown> = mergeFateRoots(modules);
+
+// --- Loud-fail field-map guard, adopted onto every shipping entity (#2808/#2811) ---
+//
+// `AssertFieldMapResolved<typeof XView>` (the #2810 machinery) resolves to the view
+// itself when fate's `dataViewFieldsKey` symbol recovery is healthy, or to the named
+// `FieldMapRecoveryFailed<Name>` brand when the symbol identity slips and the field map
+// degrades to the wide `Record<string, DataField>` fallback (the #2805 failure). The
+// `Guarded extends Resolved` slot below makes that brand a NAMED compile error HERE, at
+// the barrel next to the entity — instead of a silent `never` at a far-away `view<>()`
+// selection, which is exactly the silent degrade that cost the #2805 investigation cycle.
+//
+// This is intentionally NOT exported: surfacing fate's internal `DataView` types on this
+// composite worker project's declaration boundary would trip the TS2883/TS4020 nameability
+// checks (the same portability cost that keeps `Root` above annotated `Record<string,
+// unknown>`). Kept local, the assertions type-check without emitting any declaration.
+type AssertResolved<Resolved, Guarded extends Resolved> = Guarded;
+
+// One entry per client-exposed entity; a slip on any one fails this list loudly.
+type _FateViewsFieldMapResolved = [
+	AssertResolved<typeof AdminProbeView, AssertFieldMapResolved<typeof AdminProbeView>>,
+	AssertResolved<typeof NotificationView, AssertFieldMapResolved<typeof NotificationView>>,
+	AssertResolved<
+		typeof NotificationUnreadView,
+		AssertFieldMapResolved<typeof NotificationUnreadView>
+	>,
+	AssertResolved<
+		typeof NotificationChannelView,
+		AssertFieldMapResolved<typeof NotificationChannelView>
+	>,
+	AssertResolved<
+		typeof NotificationMarkReceiptView,
+		AssertFieldMapResolved<typeof NotificationMarkReceiptView>
+	>,
+	AssertResolved<typeof DivanCaylakView, AssertFieldMapResolved<typeof DivanCaylakView>>,
+	AssertResolved<typeof DivanBacklogItemView, AssertFieldMapResolved<typeof DivanBacklogItemView>>,
+	AssertResolved<typeof DivanVoteReceiptView, AssertFieldMapResolved<typeof DivanVoteReceiptView>>,
+	AssertResolved<typeof FunnelSummaryView, AssertFieldMapResolved<typeof FunnelSummaryView>>,
+	AssertResolved<typeof MecmuaPostView, AssertFieldMapResolved<typeof MecmuaPostView>>,
+	AssertResolved<
+		typeof MecmuaSubscriptionReceiptView,
+		AssertFieldMapResolved<typeof MecmuaSubscriptionReceiptView>
+	>,
+	AssertResolved<typeof TagView, AssertFieldMapResolved<typeof TagView>>,
+	AssertResolved<typeof CommentView, AssertFieldMapResolved<typeof CommentView>>,
+	AssertResolved<typeof PostView, AssertFieldMapResolved<typeof PostView>>,
+	AssertResolved<typeof PostOverlayView, AssertFieldMapResolved<typeof PostOverlayView>>,
+	AssertResolved<typeof UserView, AssertFieldMapResolved<typeof UserView>>,
+	AssertResolved<typeof ContributionView, AssertFieldMapResolved<typeof ContributionView>>,
+	AssertResolved<typeof ProfileView, AssertFieldMapResolved<typeof ProfileView>>,
+	AssertResolved<
+		typeof AccountDeletionReceiptView,
+		AssertFieldMapResolved<typeof AccountDeletionReceiptView>
+	>,
+	AssertResolved<typeof PromotionReceiptView, AssertFieldMapResolved<typeof PromotionReceiptView>>,
+	AssertResolved<typeof BanStateView, AssertFieldMapResolved<typeof BanStateView>>,
+	AssertResolved<
+		typeof EmailDeliveryStateView,
+		AssertFieldMapResolved<typeof EmailDeliveryStateView>
+	>,
+	AssertResolved<typeof FailingAddressView, AssertFieldMapResolved<typeof FailingAddressView>>,
+	AssertResolved<
+		typeof AuthorshipStandingView,
+		AssertFieldMapResolved<typeof AuthorshipStandingView>
+	>,
+	AssertResolved<typeof OpenReportView, AssertFieldMapResolved<typeof OpenReportView>>,
+	AssertResolved<typeof ReportReceiptView, AssertFieldMapResolved<typeof ReportReceiptView>>,
+	AssertResolved<typeof ResolvedReportView, AssertFieldMapResolved<typeof ResolvedReportView>>,
+	AssertResolved<typeof ResolveReceiptView, AssertFieldMapResolved<typeof ResolveReceiptView>>,
+	AssertResolved<typeof DefinitionView, AssertFieldMapResolved<typeof DefinitionView>>,
+	AssertResolved<typeof TermView, AssertFieldMapResolved<typeof TermView>>,
+	AssertResolved<typeof LandingStatsView, AssertFieldMapResolved<typeof LandingStatsView>>,
+];


### PR DESCRIPTION
Fixes #2811.

## What

Adopts the #2810 loud-fail field-map guard (`AssertFieldMapResolved`) onto every client-exposed fate entity, at the `apps/web/worker/features/fate/views.ts` barrel. This is the adoption half that fully realizes #2808's defense-in-depth — #2810 landed the machinery bounded to `packages/fate-effect`; nothing on the worker asserted through it yet.

A healthy entity resolves the guard to the view itself (identity, no-op). A real `dataViewFieldsKey` symbol slip degrades the field map to the wide `Record<string, DataField>` fallback and resolves the guard to the named `FieldMapRecoveryFailed<Name>` brand — which the `Guarded extends Resolved` slot turns into a **named compile error at the barrel, next to the entity**, instead of a silent `never` at a far-away `view<>()` selection (the #2805 failure mode that cost a full investigation cycle).

31 client-exposed entity views are asserted: `AdminProbe`; the `Notification*` set; `DivanCaylak`/`DivanBacklogItem`/`DivanVoteReceipt`; `FunnelSummary`; `MecmuaPost`/`MecmuaSubscriptionReceipt`; `Tag`/`Comment`/`Post`/`PostOverlay`; `User`/`Contribution`/`Profile`/`AccountDeletionReceipt`/`PromotionReceipt`/`BanState`/`EmailDeliveryState`/`FailingAddress`/`AuthorshipStanding`; `OpenReport`/`ReportReceipt`/`ResolvedReport`/`ResolveReceipt`; `Definition`/`Term`; `LandingStats`.

## Nameability (the first-class AC)

The assertions are **non-exported**. Surfacing fate's internal `DataView` types on the composite worker project's declaration boundary would trip the TS2883/TS4020 nameability checks — the exact portability cost #2808 deliberately bounded out of #2810, and the same reason `Root` stays annotated `Record<string, unknown>`. Kept local, the guard type-checks without emitting any declaration.

**Validated:** `pnpm --filter @kampus/web typecheck` (the composite/`tsgo` declaration-emit path: `tsgo -b tsconfig.worker.json tsconfig.node.json && tsgo -p tsconfig.app.json`) exits 0 with **zero TS2883 / TS4020** and zero TS errors introduced.

## Loud-fail proof

A temporary probe fed a structurally-slipped view (a bare `DataViewOf<Row>` with no field-map symbol — what fate resolves after a symbol slip) through the same assertion on a real barrel entity. It tripped:

```
error TS2739: Type 'FieldMapRecoveryFailed<"BanState">' is missing the following properties from type 'SlippedBanStateView': view, typeName
```

— the named brand, at the assertion site — while the healthy entry stayed green. Probe removed before commit; the standing regression proof also lives in `packages/fate-effect/src/DataView.guard.test.ts`.

## Scope

- Compile-time / type-level only — **no runtime behavior change**.
- One file: `apps/web/worker/features/fate/views.ts`.
- Non-§CP (app code; no `.claude/`, `.github/`, `pipeline-cli`, `ci-required`, or hook path touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)