### PR TITLE
refactor(pasaport): brand identity/vouch id surfaces (userId / CandidateId)

### DIFF
--- a/apps/web/worker/features/pasaport/ids.ts
+++ b/apps/web/worker/features/pasaport/ids.ts
@@ -1,0 +1,18 @@
+/**
+ * Pasaport feature-local branded ids (epic #2700). The cross-feature `UserId` is
+ * imported read-only from the shared `lib/ids.ts` (the #2735 tracer module); only
+ * the pasaport-owned `CandidateId` is minted here, feature-locally, so sibling
+ * slices don't append-conflict on the shared module.
+ *
+ * `CandidateId` is a user account id in the vouch (kefil) *candidate* role — the
+ * çaylak being vouched. It is a plain string at runtime, but branding it distinctly
+ * from `UserId` makes the vouch-flow pairing type-distinct: the acting user's id and
+ * the candidate's id can no longer be transposed without a compile error, even though
+ * both are user ids. See `../../lib/ids.ts` for the branding idiom (effect-smol
+ * `SCHEMA.md` §Branding) — not re-derived here.
+ */
+import {brandedId} from "../../lib/ids.ts";
+
+/** A vouch candidate's account id — a user id in the candidate (vouched çaylak) role. */
+export const CandidateId = brandedId("CandidateId");
+export type CandidateId = typeof CandidateId.Type;

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -14,6 +14,7 @@ import {
 	PHOENIX_EMAIL_DELIVERY_ADMIN,
 	PHOENIX_USER_BAN,
 } from "../../../src/flags/keys.ts";
+import {UserId} from "../../lib/ids.ts";
 import {notifyKefil, notifyPromotion} from "../bildirim/rite-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
@@ -33,6 +34,7 @@ import {
 	UsernameInvalidErrors,
 	UsernameTaken,
 } from "./errors.ts";
+import {CandidateId} from "./ids.ts";
 import {pasaportLive} from "./live.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {publishPromotion} from "./promote-live.ts";
@@ -110,17 +112,17 @@ const DeleteAccountInput = Schema.Struct({
 // so a client can never request a target tier — `yazar` is the only destination the
 // server writes (#1203), and the path is the only writer.
 const PromoteInput = Schema.Struct({
-	userId: Schema.String,
+	userId: UserId,
 });
 
 const VouchInput = Schema.Struct({
-	candidateId: Schema.String,
+	candidateId: CandidateId,
 });
 
 // Withdraw names the same target as a vouch — the voucher is the discharged-`Vouch`
 // actor, never an arg, so a yazar can only withdraw their OWN vouch for `candidateId`.
 const WithdrawVouchInput = Schema.Struct({
-	candidateId: Schema.String,
+	candidateId: CandidateId,
 });
 
 // Ban a target account by id: a `reason` (required — enforced non-empty in the gated
@@ -128,13 +130,13 @@ const WithdrawVouchInput = Schema.Struct({
 // permanent). No `actor` arg — the acting admin is the discharged `Admin` grant's id,
 // never client-supplied, so a ban is always audited against its real author.
 const BanUserInput = Schema.Struct({
-	userId: Schema.String,
+	userId: UserId,
 	reason: Schema.String,
 	expiresAt: Schema.optional(Schema.NullOr(Schema.Number)),
 });
 
 const UnbanUserInput = Schema.Struct({
-	userId: Schema.String,
+	userId: UserId,
 });
 
 // Mark a target account's address as failing: a `reason` (required — enforced non-empty
@@ -142,12 +144,12 @@ const UnbanUserInput = Schema.Struct({
 // is named by id and its address is server-resolved, so an admin can't mark an arbitrary
 // address, and the acting admin is the discharged `Admin` grant (never client-supplied).
 const MarkEmailFailingInput = Schema.Struct({
-	userId: Schema.String,
+	userId: UserId,
 	reason: Schema.String,
 });
 
 const ClearEmailFailingInput = Schema.Struct({
-	userId: Schema.String,
+	userId: UserId,
 });
 
 export const mutations = {

--- a/apps/web/worker/features/pasaport/pasaport-ids.typetest.ts
+++ b/apps/web/worker/features/pasaport/pasaport-ids.typetest.ts
@@ -1,0 +1,29 @@
+/**
+ * Type-level assertion (no runtime — checked by `tsgo`, not vitest): the pasaport
+ * vouch-flow ids `UserId` and `CandidateId` are nominally distinct, so transposing
+ * the acting user's id and the vouch candidate's id is a compile error (#2714 AC#2),
+ * while both stay plain strings at runtime. Mirrors `../kunye/admin.typetest.ts`.
+ */
+import {expectTypeOf} from "vitest";
+import type {UserId} from "../../lib/ids.ts";
+import type {CandidateId} from "./ids.ts";
+
+// Both brands erase to `string` at runtime — the brand is type-only (#2735).
+expectTypeOf<UserId>().toMatchTypeOf<string>();
+expectTypeOf<CandidateId>().toMatchTypeOf<string>();
+
+// The distinctness that makes a userId/candidateId swap unrepresentable: neither
+// brand is assignable to the other, so the vouch pairing can't be transposed.
+expectTypeOf<UserId>().not.toEqualTypeOf<CandidateId>();
+expectTypeOf<UserId>().not.toMatchTypeOf<CandidateId>();
+expectTypeOf<CandidateId>().not.toMatchTypeOf<UserId>();
+
+declare const someUserId: UserId;
+declare const someCandidateId: CandidateId;
+
+// The literal "a swap fails pnpm typecheck" proof: were the two interchangeable,
+// these `@ts-expect-error` directives would themselves fail as unused (TS2578).
+// @ts-expect-error a CandidateId cannot stand in for a UserId — the vouch-flow swap is a compile error
+export const _candidateAsUser: UserId = someCandidateId;
+// @ts-expect-error a UserId cannot stand in for a CandidateId — the vouch-flow swap is a compile error
+export const _userAsCandidate: CandidateId = someUserId;

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -11,6 +11,7 @@ import {hasNestedSelection} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_USER_BAN} from "../../../src/flags/keys.ts";
+import {UserId} from "../../lib/ids.ts";
 import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
@@ -41,7 +42,7 @@ const userBanOn = Effect.gen(function* () {
 });
 
 const BanStateArgs = Schema.Struct({
-	userId: Schema.String,
+	userId: UserId,
 });
 
 // Nested connection args are scoped under the field path
@@ -179,7 +180,7 @@ export const queries = {
 // The post-gate ban-state read — runnable only with an `Admin` `Grant` in R
 // (`requireAdmin` provides it); `yield* Admin` requires the proof, so reading an
 // account's ban-state without a discharged grant is a compile error (ADR 0107).
-const banStateGated = Effect.fn("user.banStateGated")(function* (userId: string) {
+const banStateGated = Effect.fn("user.banStateGated")(function* (userId: UserId) {
 	yield* Admin;
 	const pasaport = yield* Pasaport;
 	return toBanState(userId, yield* pasaport.getBanState(userId));


### PR DESCRIPTION
Brands pasaport's `userId` and `candidateId` surfaces with the effect-smol Brand vocabulary (epic #2700), so the id types are nominal instead of interchangeable bare strings. Runtime is byte-identical — the brand is type-only.

## What changed
- **`queries.ts` / `mutations.ts`** — every `userId` input surface (`BanStateArgs`, `PromoteInput`, `BanUserInput`, `UnbanUserInput`, `MarkEmailFailingInput`, `ClearEmailFailingInput`) and the `banStateGated` param now use the shared `UserId` brand instead of `Schema.String`; the vouch surfaces (`VouchInput`, `WithdrawVouchInput`) use `CandidateId`.
- **`features/pasaport/ids.ts`** (new) — mints the feature-local `CandidateId` brand. Placed feature-locally (not appended to the shared `lib/ids.ts`) to avoid append conflicts with sibling epic-#2700 slices; imports `brandedId` + reuses `UserId` from `lib/ids.ts` read-only.
- **`features/pasaport/pasaport-ids.typetest.ts`** (new) — type-level proof (checked by `tsgo`) that `UserId` and `CandidateId` are non-interchangeable, so a userId/candidateId swap in the vouch flow fails `pnpm typecheck`.

## Design decision — distinct `CandidateId`
A vouch candidate *is* a user account at runtime, but the vouch flow pairs two user-role ids: the voucher (actor, from the discharged `Vouch` grant) and the candidate (target). Branding the candidate role distinctly makes that pairing type-distinct — the acting user's id can no longer be transposed with the candidate's — which is the "make invalid states unrepresentable" idiom the AC asks for. The distinctness is proven falsifiably in the typetest (two `@ts-expect-error` swap lines).

## Acceptance criteria
- [x] pasaport's `userId` and `candidateId` surfaces use branded schemas, not bare `Schema.String`.
- [x] The vouch-flow id pairing is type-distinct (a swap fails `pnpm typecheck`) — see `pasaport-ids.typetest.ts`.
- [x] pasaport reuses the shared `UserId`.
- [x] `pnpm typecheck` passes; runtime behavior unchanged (brand is type-only).

`pnpm typecheck` (29/29) and `pnpm lint:worktree` green.

Fixes #2714