### PR TITLE
refactor(mecmua): brand the id surfaces (authorId / mecmua_post id) (#2722)

### DIFF
--- a/apps/web/worker/features/mecmua/Mecmua.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.ts
@@ -32,14 +32,19 @@ import {
 	resolveCursor,
 } from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
+import type {UserId} from "../../lib/ids.ts";
 import {MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.ts";
 import {selectMecmuaFeed} from "./feed-selection.ts";
+import type {MecmuaPostId} from "./ids.ts";
 import {anonymousMecmuaViewer, mecmuaPostVisibleWhere} from "./MecmuaPostVisibility.ts";
 import {MECMUA_FEED_ORDERING, MECMUA_MINE_ORDERING} from "./ordering.ts";
 import {type MecmuaPostRow, toMecmuaPostRow} from "./post-fields.ts";
 
+// The write-path input ids carry their brands (MecmuaPostId / UserId) so a
+// transposed `{id, authorId}` is a compile error at the resolver call site — the
+// brands are type-only, so the DB where/values still see plain strings (#2700).
 export interface SaveMecmuaDraftInput {
-	authorId: string;
+	authorId: UserId;
 	/** Optional on a draft — a half-filled form persists (empty ⇒ stored as ""). */
 	title?: string | null;
 	body?: string | null;
@@ -48,17 +53,17 @@ export interface SaveMecmuaDraftInput {
 
 export interface PublishMecmuaInput {
 	/** The draft to publish. */
-	id: string;
+	id: MecmuaPostId;
 	/** The caller — the write is scoped to their OWN draft. */
-	authorId: string;
+	authorId: UserId;
 }
 
 /** One reader→author subscription edge (#2500). */
 export interface MecmuaSubscriptionInput {
 	/** The reader who follows. */
-	subscriberId: string;
+	subscriberId: UserId;
 	/** The author followed. */
-	authorId: string;
+	authorId: UserId;
 }
 
 /** The subscribed-author feed page request — `subscriberId` + forward keyset window. */
@@ -102,7 +107,7 @@ export class Mecmua extends Context.Service<
 		) => Effect.Effect<ReadonlyArray<string>>;
 
 		/** Whether `subscriberId` follows `authorId` — the subscribe-affordance state read (#2527). */
-		readonly isSubscribed: (subscriberId: string, authorId: string) => Effect.Effect<boolean>;
+		readonly isSubscribed: (subscriberId: UserId, authorId: UserId) => Effect.Effect<boolean>;
 
 		/**
 		 * The subscribed-author time feed (#2500): a forward keyset page of PUBLISHED

--- a/apps/web/worker/features/mecmua/Mecmua.unit.test.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.unit.test.ts
@@ -11,7 +11,9 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import type * as schema from "../../db/drizzle/schema.ts";
+import {UserId} from "../../lib/ids.ts";
 import {MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.ts";
+import {MecmuaPostId} from "./ids.ts";
 import {Mecmua, MecmuaLive} from "./Mecmua.ts";
 
 type MecmuaRecord = typeof schema.mecmuaPost.$inferSelect;
@@ -47,7 +49,11 @@ describe("Mecmua.saveDraft — a private draft, multiple allowed", () => {
 	it.effect("writes a draft with publishedAt === null (private) and a mecmua_ id", () =>
 		Effect.gen(function* () {
 			const mecmua = yield* Mecmua;
-			const row = yield* mecmua.saveDraft({authorId: "cyl", title: " Taslak ", body: "içerik"});
+			const row = yield* mecmua.saveDraft({
+				authorId: UserId.make("cyl"),
+				title: " Taslak ",
+				body: "içerik",
+			});
 			assert.strictEqual(row.publishedAt, null);
 			assert.strictEqual(row.title, "Taslak");
 			assert.strictEqual(row.authorId, "cyl");
@@ -58,8 +64,8 @@ describe("Mecmua.saveDraft — a private draft, multiple allowed", () => {
 	it.effect("two saveDraft calls mint DISTINCT ids (multiple drafts, no upsert)", () =>
 		Effect.gen(function* () {
 			const mecmua = yield* Mecmua;
-			const a = yield* mecmua.saveDraft({authorId: "yzr", title: "A"});
-			const b = yield* mecmua.saveDraft({authorId: "yzr", title: "B"});
+			const a = yield* mecmua.saveDraft({authorId: UserId.make("yzr"), title: "A"});
+			const b = yield* mecmua.saveDraft({authorId: UserId.make("yzr"), title: "B"});
 			assert.notStrictEqual(a.id, b.id);
 		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([undefined, undefined])))),
 	);
@@ -69,7 +75,10 @@ describe("Mecmua.publish — stamps publishedAt on the caller's own draft", () =
 	it.effect("stamps a non-null publishedAt on a found, titled draft", () =>
 		Effect.gen(function* () {
 			const mecmua = yield* Mecmua;
-			const row = yield* mecmua.publish({id: "mecmua_existing", authorId: "yzr"});
+			const row = yield* mecmua.publish({
+				id: MecmuaPostId.make("mecmua_existing"),
+				authorId: UserId.make("yzr"),
+			});
 			assert.isNotNull(row.publishedAt);
 			assert.strictEqual(row.id, "mecmua_existing");
 		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([draft(), undefined])))),
@@ -79,7 +88,10 @@ describe("Mecmua.publish — stamps publishedAt on the caller's own draft", () =
 		Effect.gen(function* () {
 			const already = new Date("2026-06-01T00:00:00.000Z");
 			const mecmua = yield* Mecmua;
-			const row = yield* mecmua.publish({id: "mecmua_existing", authorId: "yzr"});
+			const row = yield* mecmua.publish({
+				id: MecmuaPostId.make("mecmua_existing"),
+				authorId: UserId.make("yzr"),
+			});
 			assert.strictEqual(row.publishedAt?.getTime(), already.getTime());
 		}).pipe(
 			Effect.provide(
@@ -93,7 +105,9 @@ describe("Mecmua.publish — stamps publishedAt on the caller's own draft", () =
 	it.effect("a foreign/absent id is refused MecmuaPostNotFound", () =>
 		Effect.gen(function* () {
 			const mecmua = yield* Mecmua;
-			const err = yield* mecmua.publish({id: "mecmua_missing", authorId: "yzr"}).pipe(Effect.flip);
+			const err = yield* mecmua
+				.publish({id: MecmuaPostId.make("mecmua_missing"), authorId: UserId.make("yzr")})
+				.pipe(Effect.flip);
 			assert.instanceOf(err, MecmuaPostNotFound);
 		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([undefined])))),
 	);
@@ -101,7 +115,9 @@ describe("Mecmua.publish — stamps publishedAt on the caller's own draft", () =
 	it.effect("an empty-title draft is refused MecmuaTitleRequired", () =>
 		Effect.gen(function* () {
 			const mecmua = yield* Mecmua;
-			const err = yield* mecmua.publish({id: "mecmua_existing", authorId: "yzr"}).pipe(Effect.flip);
+			const err = yield* mecmua
+				.publish({id: MecmuaPostId.make("mecmua_existing"), authorId: UserId.make("yzr")})
+				.pipe(Effect.flip);
 			assert.instanceOf(err, MecmuaTitleRequired);
 		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([draft({title: "   "})])))),
 	);

--- a/apps/web/worker/features/mecmua/ids.ts
+++ b/apps/web/worker/features/mecmua/ids.ts
@@ -1,0 +1,20 @@
+/**
+ * mecmua's feature-local branded id — `MecmuaPostId`, the nominal tag for a
+ * `mecmua_post` row's worker-private id (epic #2700). Lives here beside the
+ * feature rather than in the shared `lib/ids.ts` because it is mecmua's OWN
+ * entity, not a cross-feature id: `mecmua_post` is a distinct brand from pano's
+ * `PostId` (a `mecmua_post` id and a `pano_post` id are never interchangeable),
+ * and keeping it feature-local keeps sibling id slices from colliding on the
+ * shared module. The cross-feature `UserId` (a mecmua author IS a user) is
+ * imported read-only from `lib/ids.ts`; mecmua does not re-mint it.
+ *
+ * The brand is type-only (`brandedId` = effect-smol `SCHEMA.md` §Branding): it
+ * decodes byte-identically, so the D1/wire bytes are unchanged — only the type
+ * checker gains the nominal distinction that makes an `authorId`/`postId` swap a
+ * compile error.
+ */
+import {brandedId} from "../../lib/ids.ts";
+
+/** A `mecmua_post` row id — mecmua's own entity, distinct from pano's `PostId`. */
+export const MecmuaPostId = brandedId("MecmuaPostId");
+export type MecmuaPostId = typeof MecmuaPostId.Type;

--- a/apps/web/worker/features/mecmua/mecmua-feed.unit.test.ts
+++ b/apps/web/worker/features/mecmua/mecmua-feed.unit.test.ts
@@ -11,6 +11,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import type * as schema from "../../db/drizzle/schema.ts";
+import {UserId} from "../../lib/ids.ts";
 import {selectMecmuaFeed} from "./feed-selection.ts";
 import {Mecmua, MecmuaLive} from "./Mecmua.ts";
 import type {MecmuaPostRow} from "./post-fields.ts";
@@ -133,14 +134,14 @@ describe("Mecmua.isSubscribed — the subscribe-affordance state read (#2527)", 
 	it.effect("returns true when a (subscriber, author) edge row exists", () =>
 		Effect.gen(function* () {
 			const mecmua = yield* Mecmua;
-			assert.isTrue(yield* mecmua.isSubscribed("reader", "A"));
+			assert.isTrue(yield* mecmua.isSubscribed(UserId.make("reader"), UserId.make("A")));
 		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([[{authorId: "A"}]])))),
 	);
 
 	it.effect("returns false when no edge row matches", () =>
 		Effect.gen(function* () {
 			const mecmua = yield* Mecmua;
-			assert.isFalse(yield* mecmua.isSubscribed("reader", "A"));
+			assert.isFalse(yield* mecmua.isSubscribed(UserId.make("reader"), UserId.make("A")));
 		}).pipe(Effect.provide(mecmuaLayer(scriptedAccess([[]])))),
 	);
 });

--- a/apps/web/worker/features/mecmua/mutations.ts
+++ b/apps/web/worker/features/mecmua/mutations.ts
@@ -21,10 +21,12 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {MECMUA_FEED, MECMUA_WRITE} from "../../../src/flags/keys.ts";
+import {UserId} from "../../lib/ids.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {RequiresLevel} from "../kunye/errors.ts";
 import {MecmuaDisabled, MecmuaPostNotFound, MecmuaTitleRequired} from "./errors.ts";
+import {MecmuaPostId} from "./ids.ts";
 import {Mecmua} from "./Mecmua.ts";
 import {PublishMecmua, requirePublishMecmua} from "./PublishMecmua.ts";
 import type {MecmuaPostRow} from "./post-fields.ts";
@@ -48,7 +50,7 @@ const toMecmuaPost = (r: MecmuaPostRow): MecmuaPost => ({__typename: "MecmuaPost
 
 /** The subscribe/unsubscribe receipt shaper — the target author + the post-write edge state. */
 const toSubscriptionReceipt = (
-	authorId: string,
+	authorId: UserId,
 	subscribed: boolean,
 ): MecmuaSubscriptionReceipt => ({
 	__typename: "MecmuaSubscriptionReceipt",
@@ -56,8 +58,10 @@ const toSubscriptionReceipt = (
 	subscribed,
 });
 
+// Branded wire inputs (type-only, byte-identical decode): `authorId`/`id` arrive
+// tagged UserId / MecmuaPostId, so a transposed service call is a compile error (#2700).
 const SubscriptionInput = Schema.Struct({
-	authorId: Schema.String,
+	authorId: UserId,
 });
 
 const SaveDraftInput = Schema.Struct({
@@ -67,7 +71,7 @@ const SaveDraftInput = Schema.Struct({
 });
 
 const PublishInput = Schema.Struct({
-	id: Schema.String,
+	id: MecmuaPostId,
 });
 
 export const mutations = {
@@ -95,7 +99,7 @@ export const mutations = {
 				Effect.gen(function* () {
 					yield* PublishMecmua;
 					const mecmua = yield* Mecmua;
-					const row = yield* mecmua.publish({id: input.id, authorId: user.id});
+					const row = yield* mecmua.publish({id: input.id, authorId: UserId.make(user.id)});
 					return toMecmuaPost(row);
 				}),
 			);
@@ -114,7 +118,7 @@ export const mutations = {
 			}
 			const mecmua = yield* Mecmua;
 			const row = yield* mecmua.saveDraft({
-				authorId: user.id,
+				authorId: UserId.make(user.id),
 				...(input.title != null ? {title: input.title} : {}),
 				...(input.body != null ? {body: input.body} : {}),
 				...(input.slug != null ? {slug: input.slug} : {}),
@@ -132,7 +136,7 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			if (!(yield* feedOn)) return yield* new MecmuaDisabled({message: "mecmua şu an kapalı"});
 			const mecmua = yield* Mecmua;
-			yield* mecmua.subscribe({subscriberId: user.id, authorId: input.authorId});
+			yield* mecmua.subscribe({subscriberId: UserId.make(user.id), authorId: input.authorId});
 			return toSubscriptionReceipt(input.authorId, true);
 		}),
 	),
@@ -146,7 +150,7 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			if (!(yield* feedOn)) return yield* new MecmuaDisabled({message: "mecmua şu an kapalı"});
 			const mecmua = yield* Mecmua;
-			yield* mecmua.unsubscribe({subscriberId: user.id, authorId: input.authorId});
+			yield* mecmua.unsubscribe({subscriberId: UserId.make(user.id), authorId: input.authorId});
 			return toSubscriptionReceipt(input.authorId, false);
 		}),
 	),

--- a/apps/web/worker/features/mecmua/queries.ts
+++ b/apps/web/worker/features/mecmua/queries.ts
@@ -15,14 +15,17 @@ import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {MECMUA_FEED} from "../../../src/flags/keys.ts";
+import {UserId} from "../../lib/ids.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Mecmua} from "./Mecmua.ts";
 import type {MecmuaSubscriptionReceipt} from "./views.ts";
 import {MecmuaSubscriptionReceiptView} from "./views.ts";
 
+// `authorId` decodes byte-identically but arrives typed as UserId, so the
+// receipt + the `isSubscribed` read below carry the brand end-to-end (#2700).
 const SubscriptionStateArgs = Schema.Struct({
-	authorId: Schema.String,
+	authorId: UserId,
 });
 
 /** Is the mecmua feed on for this request? Safe-default `false` (ships dark). */
@@ -31,7 +34,7 @@ const feedOn = Effect.gen(function* () {
 	return yield* flags.getBoolean(MECMUA_FEED, false).pipe(provideRequestFlags);
 });
 
-const toReceipt = (authorId: string, subscribed: boolean): MecmuaSubscriptionReceipt => ({
+const toReceipt = (authorId: UserId, subscribed: boolean): MecmuaSubscriptionReceipt => ({
 	__typename: "MecmuaSubscriptionReceipt",
 	id: authorId,
 	subscribed,
@@ -44,7 +47,10 @@ export const queries = {
 			const {user} = yield* CurrentUser;
 			if (!user || !(yield* feedOn)) return toReceipt(args.authorId, false);
 			const mecmua = yield* Mecmua;
-			return toReceipt(args.authorId, yield* mecmua.isSubscribed(user.id, args.authorId));
+			return toReceipt(
+				args.authorId,
+				yield* mecmua.isSubscribed(UserId.make(user.id), args.authorId),
+			);
 		}),
 	),
 };


### PR DESCRIPTION
Fixes #2722 (epic #2700).

Adopts the branded-ID idiom across **mecmua** so an `authorId`/`postId` swap is a compile error while runtime stays byte-identical (the brands are type-only — decode/`.make` return the input unchanged, so wire + D1 bytes are identical).

## What changed
- **New feature-local brand** `MecmuaPostId` in `apps/web/worker/features/mecmua/ids.ts` — the worker-private `mecmua_post` id. Kept feature-local (not appended to the shared `lib/ids.ts`) to avoid append-conflicts with sibling id slices; it is mecmua's own entity, so it is a **distinct brand from pano's `PostId`** (AC #2). The cross-feature `UserId` is imported **read-only** from `lib/ids.ts` (landed via #2735) — never re-minted (AC #3).
- **`authorId` reuses the shared `UserId`** across `queries.ts`, `mutations.ts`, and the `Mecmua` service input types (`SaveMecmuaDraftInput`, `PublishMecmuaInput`, `MecmuaSubscriptionInput`, `isSubscribed`). The publish input `id` is `MecmuaPostId` (AC #1).
- **Threaded through the reader/writer call sites** — `UserId.make(user.id)` at the write boundaries in the resolvers; the in-scope unit tests construct branded ids.

## Grounding
Follows the sözlük tracer precedent (`features/sozluk`) and the effect-smol `SCHEMA.md` §Branding top-level `Schema.String.pipe(Schema.brand(...))` idiom via the shared `brandedId` helper.

## Verification
- `pnpm typecheck` — green.
- `biome check` (lint/format) — clean.
- `unit` project, `worker/features/mecmua` — 38 tests pass (runtime unchanged).

Scope: edits are confined to `apps/web/worker/features/mecmua/**`; `lib/ids.ts` is imported read-only, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)