### PR TITLE
chore(fate-live): brand connectionId / entityId protocol id surfaces (#2724)

### DIFF
--- a/apps/web/worker/features/fate-live/protocol.ts
+++ b/apps/web/worker/features/fate-live/protocol.ts
@@ -18,6 +18,29 @@ import {
 } from "@nkzw/fate/server";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
+import {brandedId} from "../../lib/ids.ts";
+
+/**
+ * A LiveDO connection id — the client's stream identity the connection role is
+ * addressed by (`connection:<connectionId>`). Branded distinctly from {@link EntityId}
+ * so the two live-protocol ids can't be transposed at a call site (they are both bare
+ * strings on the wire, and the LiveDO plays both the connection and topic roles).
+ * Type-only, so the SSE wire form decodes byte-identically. Shared brand idiom + the
+ * cross-feature `UserId` live in `lib/ids.ts` (epic #2700); the two ids branded here are
+ * fate-live-owned, so they stay feature-local.
+ */
+export const ConnectionId = brandedId("ConnectionId");
+export type ConnectionId = typeof ConnectionId.Type;
+
+/**
+ * A fate protocol entity id — fate's `isProtocolId` admits a string OR a number, so the
+ * brand is applied to the *union* (not a branded string with a discarded number arm):
+ * `(string | number) & Brand<"EntityId">` keeps both wire arms while staying nominally
+ * distinct from {@link ConnectionId}. Brand is type-only, so the union decodes/serializes
+ * byte-identically.
+ */
+export const EntityId = Schema.Union([Schema.String, Schema.Number]).pipe(Schema.brand("EntityId"));
+export type EntityId = typeof EntityId.Type;
 
 /**
  * The ONE source of every live topic name: the string is
@@ -171,8 +194,7 @@ const SubscribeOp = Schema.Struct({
 	id: Schema.String,
 	kind: Schema.Literal("subscribe"),
 	type: Schema.String,
-	// fate's `isProtocolId`: a string or number entity id.
-	entityId: Schema.Union([Schema.String, Schema.Number]),
+	entityId: EntityId,
 	args: OptionalArgs,
 	lastEventId: Schema.optional(Schema.String),
 	select: Schema.Array(Schema.String),
@@ -203,7 +225,7 @@ const LiveControlOperationSchema = Schema.Union([
 
 const LiveControlRequestSchema = Schema.Struct({
 	version: Schema.Literal(1),
-	connectionId: Schema.String,
+	connectionId: ConnectionId,
 	operations: Schema.Array(LiveControlOperationSchema),
 });
 

--- a/apps/web/worker/features/fate-live/protocol.unit.test.ts
+++ b/apps/web/worker/features/fate-live/protocol.unit.test.ts
@@ -10,7 +10,15 @@
 
 import {assert, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {LiveTopic, parseLiveControlRequest} from "./protocol.ts";
+import {expectTypeOf, it as vit} from "vitest";
+import {
+	type ConnectionId,
+	type EntityId,
+	type LiveControlOperation,
+	type LiveControlRequest,
+	LiveTopic,
+	parseLiveControlRequest,
+} from "./protocol.ts";
 
 const subscribeConnectionRequest = (procedure: string) => ({
 	version: 1,
@@ -47,3 +55,22 @@ it.effect("rejects a subscribeConnection on an unregistered procedure with BAD_R
 		assert.strictEqual(error.code, "BAD_REQUEST");
 	}),
 );
+
+// A connectionId/entityId swap fails typecheck: the two live-protocol ids carry
+// distinct nominal brands, so neither is assignable to the other and the decoded
+// `LiveControlRequest`/subscribe-op surfaces expose the branded types. Pinned with
+// expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's TS377003 escapes the
+// directive (see vote-boundary.unit.test.ts). This is the type-level half of the guard;
+// the decode tests above cover the byte-identical runtime.
+vit("connectionId and entityId are distinct branded surfaces", () => {
+	// Each id is branded, not a bare string / bare union (the brand is what a swap trips).
+	expectTypeOf<ConnectionId>().not.toEqualTypeOf<string>();
+	expectTypeOf<EntityId>().not.toEqualTypeOf<string | number>();
+	// The two brands are distinct, so a connectionId can't stand in for an entityId.
+	expectTypeOf<ConnectionId>().not.toEqualTypeOf<EntityId>();
+	// The decoded protocol surfaces expose the branded types (not bare strings/unions).
+	expectTypeOf<LiveControlRequest["connectionId"]>().toEqualTypeOf<ConnectionId>();
+	expectTypeOf<
+		Extract<LiveControlOperation, {kind: "subscribe"}>["entityId"]
+	>().toEqualTypeOf<EntityId>();
+});


### PR DESCRIPTION
Fixes #2724 (epic #2700 — branded ID adoption).

## What

Adopt the branded-ID idiom across the fate-live protocol substrate ids in `apps/web/worker/features/fate-live/protocol.ts`:

- **`ConnectionId`** — the LiveDO connection identity (`connection:<connectionId>`), minted via the shared `brandedId` from `apps/web/worker/lib/ids.ts` (read-only consumer of the module landed in #2735).
- **`EntityId`** — branded on fate's `isProtocolId` union (`string | number`), **not** a branded string. Branding the union keeps both wire arms while the type stays nominally distinct from `ConnectionId`. Choice stated in the docblock.

The two schema fields now decode to the branded types:
- `LiveControlRequestSchema.connectionId`: `Schema.String` → `ConnectionId`
- `SubscribeOp.entityId`: bare `Schema.Union([String, Number])` → `EntityId`

## Why feature-local, not `lib/ids.ts`

`ConnectionId` / `EntityId` are fate-live-owned, so they live in the feature's schema file (`protocol.ts`) rather than the shared module — the shared module is imported read-only for `brandedId`, per the epic's placement convention (avoids append conflicts across sibling slices).

## Acceptance criteria

- [x] `connectionId` and `entityId` surfaces use branded schemas, not bare `Schema.String` / bare union.
- [x] A `connectionId`/`entityId` swap fails `pnpm typecheck` — pinned by an `expectTypeOf` type test in `protocol.unit.test.ts` (distinct brands, branded-not-bare, and the decoded surfaces expose the brands). Uses `expectTypeOf`, not `@ts-expect-error` (the effect LSP plugin's TS377003 escapes the directive).
- [x] The SSE wire form is byte-identical — the brand is type-only (`.make`/decode return the input unchanged); the existing `parseLiveControlRequest` decode tests still pass unchanged.
- [x] `pnpm typecheck` passes; all 2210 unit tests green; `biome check` clean.

Idiom grounded in effect-smol `SCHEMA.md` §Branding / §Branded Constructors (brand on a union produces `(string | number) & Brand<"EntityId">`; decode accepts unbranded input, so the untrusted-body decode path needs no `.make`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)