### PR TITLE
refactor(kunye): retire hand-rolled PublishDecisionBrand for effect-smol Brand; brand actor ids (#2715)

### DIFF
--- a/apps/web/worker/features/kunye/admin.ts
+++ b/apps/web/worker/features/kunye/admin.ts
@@ -15,6 +15,7 @@
  */
 import {Capability, Grant, matchActor, platform} from "@kampus/authz";
 import {Effect} from "effect";
+import {UserId} from "../../lib/ids.ts";
 import {Denied} from "./errors.ts";
 
 export class Admin extends Capability.Relation<Admin>()("kunye/Admin", {
@@ -37,16 +38,17 @@ export const requireAdmin = <A, E, R>(body: Effect.Effect<A, E, Admin | R>) =>
 
 /**
  * The admin's account id from a discharged `Admin` grant — the authority-checked
- * identity an admin write stamps. A discharged grant is never anonymous
- * (`Admin.over` fails `Denied` on the `Unauthenticated` arm before minting), so the
- * anonymous arm is unreachable and dies as the defect it would be.
+ * identity an admin write stamps, minted as the shared branded {@link UserId} (see
+ * `lib/ids.ts`). A discharged grant is never anonymous (`Admin.over` fails `Denied`
+ * on the `Unauthenticated` arm before minting), so the anonymous arm is unreachable
+ * and dies as the defect it would be.
  */
-export const adminOf = (grant: Grant<Admin>): Effect.Effect<string> =>
+export const adminOf = (grant: Grant<Admin>): Effect.Effect<UserId> =>
 	matchActor(grant.actor, {
 		onUnauthenticated: () =>
 			Effect.die(
 				new Error("Admin grant carried an unauthenticated actor — Admin.over denies anonymous"),
 			),
-		onHuman: (subject) => Effect.succeed(subject.id),
-		onAgent: (acting) => Effect.succeed(acting.id),
+		onHuman: (subject) => Effect.succeed(UserId.make(subject.id)),
+		onAgent: (acting) => Effect.succeed(UserId.make(acting.id)),
 	});

--- a/apps/web/worker/features/kunye/id-brand.typetest.ts
+++ b/apps/web/worker/features/kunye/id-brand.typetest.ts
@@ -1,0 +1,38 @@
+/**
+ * Type-level assertions (no runtime — checked by `tsgo`, not vitest) for the #2715
+ * branding slice (epic #2700):
+ *
+ *   1. `PublishDecision` is nominally branded via effect-smol's `Brand` vocabulary —
+ *      a bare `{broadcast}` struct is NOT assignable to it, so the value is
+ *      unconstructible outside `sandbox.ts` (only {@link decidePublish} /
+ *      {@link alwaysLive} mint one). This is the #1280 guarantee, now carried by
+ *      `Brand.Branded` instead of a hand-rolled `unique symbol`.
+ *   2. The künye actor-id producers (`adminOf` / `moderatorOf` / `voucherOf`) yield
+ *      the shared branded {@link UserId}, not a bare `string`.
+ *
+ * Falsifiable: revert `PublishDecision` to a plain interface and assertion (1) fails;
+ * drop a `UserId.make` wrap and assertion (2) fails.
+ */
+import type {Effect} from "effect";
+import {expectTypeOf} from "vitest";
+import type {UserId} from "../../lib/ids.ts";
+import type {adminOf} from "./admin.ts";
+import type {moderatorOf} from "./moderate.ts";
+import {alwaysLive, decidePublish, type PublishDecision} from "./sandbox.ts";
+import type {voucherOf} from "./vouch.ts";
+
+/** The success (A) channel of an effect type. */
+type SuccessOf<T> = [T] extends [Effect.Effect<infer A, unknown, unknown>] ? A : never;
+
+// (1) The two exported constructors mint a `PublishDecision`…
+expectTypeOf(decidePublish(null)).toEqualTypeOf<PublishDecision>();
+expectTypeOf(alwaysLive).toEqualTypeOf<PublishDecision>();
+
+// …but a bare struct with the same shape is NOT — the brand keeps it unconstructible
+// outside the module (the #1280 guarantee, now via `Brand.Branded`).
+expectTypeOf<{readonly broadcast: boolean}>().not.toMatchTypeOf<PublishDecision>();
+
+// (2) The grant-derived actor ids are the shared branded `UserId`, not bare `string`.
+expectTypeOf<SuccessOf<ReturnType<typeof adminOf>>>().toEqualTypeOf<UserId>();
+expectTypeOf<SuccessOf<ReturnType<typeof moderatorOf>>>().toEqualTypeOf<UserId>();
+expectTypeOf<SuccessOf<ReturnType<typeof voucherOf>>>().toEqualTypeOf<UserId>();

--- a/apps/web/worker/features/kunye/moderate.ts
+++ b/apps/web/worker/features/kunye/moderate.ts
@@ -13,6 +13,7 @@
  */
 import {Capability, Grant, matchActor, platform, RelationStore} from "@kampus/authz";
 import {Effect} from "effect";
+import {UserId} from "../../lib/ids.ts";
 import {Denied} from "./errors.ts";
 
 export class Moderate extends Capability.Relation<Moderate>()("kunye/Moderate", {
@@ -85,11 +86,12 @@ export const requireModeration = <A, E, R>(body: Effect.Effect<A, E, Moderate | 
 /**
  * The moderator's account id from a discharged `Moderate` grant — the
  * authority-checked identity a moderation write stamps as `resolver_id` /
- * `removed_by`. A discharged grant is never anonymous (`Moderate.over` fails
- * `Denied` on the `Unauthenticated` arm before minting), so the anonymous arm is
- * unreachable and dies as the defect it would be.
+ * `removed_by`, minted as the shared branded {@link UserId} (see `lib/ids.ts`). A
+ * discharged grant is never anonymous (`Moderate.over` fails `Denied` on the
+ * `Unauthenticated` arm before minting), so the anonymous arm is unreachable and
+ * dies as the defect it would be.
  */
-export const moderatorOf = (grant: Grant<Moderate>): Effect.Effect<string> =>
+export const moderatorOf = (grant: Grant<Moderate>): Effect.Effect<UserId> =>
 	matchActor(grant.actor, {
 		onUnauthenticated: () =>
 			Effect.die(
@@ -97,6 +99,6 @@ export const moderatorOf = (grant: Grant<Moderate>): Effect.Effect<string> =>
 					"Moderate grant carried an unauthenticated actor — Moderate.over denies anonymous",
 				),
 			),
-		onHuman: (subject) => Effect.succeed(subject.id),
-		onAgent: (acting) => Effect.succeed(acting.id),
+		onHuman: (subject) => Effect.succeed(UserId.make(subject.id)),
+		onAgent: (acting) => Effect.succeed(UserId.make(acting.id)),
 	});

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -22,7 +22,7 @@
 
 import {CurrentUser} from "@kampus/fate-effect";
 import type {RuntimeContext} from "alchemy";
-import {Effect} from "effect";
+import {Brand, Effect} from "effect";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags, type RequestFlagOverrides} from "../flagship/FlagsContext.ts";
@@ -75,13 +75,6 @@ export const currentSandboxViewer = Effect.gen(function* () {
 	return {viewerId: user?.id ?? null, canSeeSandboxed} satisfies SandboxViewer;
 });
 
-// The brand makes `PublishDecision` opaque: a value with the phantom `never`
-// property is unconstructible outside this module, so the only way to obtain one is
-// `decidePublish` or `alwaysLive` below. A node-broadcasting publish requires one
-// (`live.ts`), so omitting the sandbox check is a missing-argument compile error,
-// not a code-review catch — the #1280 hardening.
-declare const PublishDecisionBrand: unique symbol;
-
 /**
  * Whether a brand-new content node may be broadcast to a public (viewer-blind)
  * fate-live topic. The type-level form of the #1205 gate: every node-broadcasting
@@ -89,14 +82,22 @@ declare const PublishDecisionBrand: unique symbol;
  * it is constructible ONLY from {@link decidePublish} (the sandbox-gated create path)
  * or {@link alwaysLive} (the explicit always-Live escape hatch). So a future create
  * mutation cannot broadcast a node without first discharging the sandbox check —
- * ADR 0107's make-the-mistake-untypeable, applied here.
+ * ADR 0107's make-the-mistake-untypeable, applied here (the #1280 hardening).
+ *
+ * Branded via effect-smol's standard `Brand` vocabulary (`Brand.Branded`, grounded
+ * in effect-smol `Brand.ts`) — NOT a hand-rolled `unique symbol` phantom. The brand
+ * is type-only: a `PublishDecision` is byte-identical to `{broadcast}` at runtime,
+ * nominal only at the type level. Unconstructibility rests on the private
+ * {@link makePublishDecision} constructor below staying module-local, so
+ * {@link decidePublish} / {@link alwaysLive} remain the only exported constructors.
  */
-export interface PublishDecision {
-	readonly broadcast: boolean;
-	readonly [PublishDecisionBrand]: never;
-}
+export type PublishDecision = Brand.Branded<{readonly broadcast: boolean}, "PublishDecision">;
 
-const branded = (broadcast: boolean): PublishDecision => ({broadcast}) as PublishDecision;
+// `Brand.nominal` is the type-only constructor, kept PRIVATE so the module retains the
+// only two exported ways to mint a `PublishDecision` (decidePublish / alwaysLive). It
+// applies no runtime check (per effect-smol `Brand.ts`) — it returns its input.
+const makePublishDecision = Brand.nominal<PublishDecision>();
+const branded = (broadcast: boolean): PublishDecision => makePublishDecision({broadcast});
 
 /**
  * The sandbox-gated decision a create path discharges: broadcast iff the new row is

--- a/apps/web/worker/features/kunye/vouch.ts
+++ b/apps/web/worker/features/kunye/vouch.ts
@@ -16,6 +16,7 @@
  */
 import {Capability, Grant, matchActor, type Principal} from "@kampus/authz";
 import {Effect} from "effect";
+import {UserId} from "../../lib/ids.ts";
 import {RequiresLevel} from "./errors.ts";
 import {authorshipLadder, Kunye} from "./Kunye.ts";
 
@@ -44,16 +45,17 @@ export const requireVouch = <A, E, R>(body: Effect.Effect<A, E, Vouch | R>) =>
 
 /**
  * The voucher's account id from a discharged `Vouch` grant — the vouching actor the
- * vouch record preserves. A discharged grant is never anonymous (`Vouch.require`
- * fails on the `Unauthenticated` arm before minting), so the anonymous arm is
- * unreachable and dies as the defect it would be.
+ * vouch record preserves, minted as the shared branded {@link UserId} (see
+ * `lib/ids.ts`). A discharged grant is never anonymous (`Vouch.require` fails on the
+ * `Unauthenticated` arm before minting), so the anonymous arm is unreachable and
+ * dies as the defect it would be.
  */
-export const voucherOf = (grant: Grant<Vouch>): Effect.Effect<string> =>
+export const voucherOf = (grant: Grant<Vouch>): Effect.Effect<UserId> =>
 	matchActor(grant.actor, {
 		onUnauthenticated: () =>
 			Effect.die(
 				new Error("Vouch grant carried an unauthenticated actor — Vouch.require denies anonymous"),
 			),
-		onHuman: (subject) => Effect.succeed(subject.id),
-		onAgent: (acting) => Effect.succeed(acting.id),
+		onHuman: (subject) => Effect.succeed(UserId.make(subject.id)),
+		onAgent: (acting) => Effect.succeed(UserId.make(acting.id)),
 	});


### PR DESCRIPTION
## What

Retires künye's hand-rolled `PublishDecisionBrand` phantom for effect-smol's standard `Brand` vocabulary, and brands künye's own actor-id surface with the shared `UserId`. Phase-2 child of epic #2700; the opaque-struct branding slice (distinct from the sözlük string-id tracer #2735).

### `PublishDecision` — the opaque-struct brand (AC#1, AC#2)
- `sandbox.ts`'s `declare const PublishDecisionBrand: unique symbol` phantom is gone. `PublishDecision` is now `Brand.Branded<{readonly broadcast: boolean}, "PublishDecision">`, minted through a **module-private** `Brand.nominal` constructor (grounded in effect-smol `Brand.ts`; `nominal` applies no runtime check, so the value is byte-identical to `{broadcast}` at runtime).
- `decidePublish` / `alwaysLive` remain the **only exported constructors**, so a `PublishDecision` stays unconstructible outside the module and a node-broadcasting publish still requires one — the #1280 hardening holds unchanged.

### Actor-id surface — the shared `UserId` (AC#3)
- `adminOf` / `moderatorOf` / `voucherOf` now yield `Effect<UserId>` (imported read-only from `lib/ids.ts`) instead of a bare `string`, minting via `UserId.make(...)`. `UserId` is `string & Brand`, so every external caller sits in a covariant `string` position and is unaffected — the change is fully contained in `features/kunye/**` with no ripple into pasaport/report/etc.
- Note: `tierOf` / `karmaOf` / `castVouch` **parameters** stay `string` deliberately — branding an input would force `.make` at every cross-feature callsite (pasaport, divan, vote, fate, report, bildirim, mecmua), outside this slice's scope. Return-type branding is the applicable, non-rippling win.

### Test (AC#4)
- New `id-brand.typetest.ts` asserts the brand teeth: a bare `{broadcast}` struct is **not** assignable to `PublishDecision`, and the three producers return `UserId`.
- `pnpm typecheck` green (29/29); `pnpm lint:worktree` clean; the existing `sandbox-publish.unit.test.ts` (the #1280 runtime gate) still passes — runtime behavior unchanged.

Fixes #2715