### PR TITLE
feat(pano): brand PostId / CommentId id surfaces (#2713)

### DIFF
--- a/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
+++ b/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
@@ -33,6 +33,7 @@ import {DefinitionId} from "../../lib/ids.ts";
 import {noopPanoFeedCache} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import type {CommentRow} from "../pano/comment-fields.ts";
+import {CommentId, PostId} from "../pano/ids.ts";
 import {mutations as panoMutations} from "../pano/mutations.ts";
 import {Pano, type PostPage} from "../pano/Pano.ts";
 import type {PostSummaryRow} from "../pano/post-fields.ts";
@@ -177,7 +178,7 @@ describe("çaylak sandbox-escape via delete→restore is structurally prevented 
 				getPostsByIds: () => Effect.succeed([postSummaryRow()]),
 			});
 			yield* panoMutations["post.restore"]
-				.handler({input: {id: "post-1"}, select: ["id"]})
+				.handler({input: {id: PostId.make("post-1")}, select: ["id"]})
 				.pipe(
 					Effect.provide(Layer.mergeAll(pano, layer)),
 					Effect.provideService(CurrentUser, {user: AUTHOR}),
@@ -226,7 +227,7 @@ describe("çaylak sandbox-escape via delete→restore is structurally prevented 
 				getPostsByIds: () => Effect.succeed([postSummaryRow()]),
 			});
 			yield* panoMutations["comment.restore"]
-				.handler({input: {id: "comment-1"}, select: ["id"]})
+				.handler({input: {id: CommentId.make("comment-1")}, select: ["id"]})
 				.pipe(
 					Effect.provide(Layer.mergeAll(pano, layer)),
 					Effect.provideService(CurrentUser, {user: AUTHOR}),

--- a/apps/web/worker/features/lifecycle/create-path-refresh-swallow.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/create-path-refresh-swallow.unit.test.ts
@@ -153,7 +153,7 @@ describe("submitPost — a post-commit refresh die cannot 500 a committed insert
 						body: "gövde",
 						url: undefined,
 						tags: [{kind: "soru"}],
-						authorId: "u1",
+						authorId: UserId.make("u1"),
 						authorName: "umut",
 					});
 				}).pipe(

--- a/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
@@ -21,13 +21,15 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
+import {UserId} from "../../lib/ids.ts";
 import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import type * as Removal from "../lifecycle/removal.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
 import type {Vote} from "../vote/Vote.ts";
 import {type CommentOperationsDeps, makeCommentOperations} from "./comment-operations.ts";
+import {CommentId, PostId} from "./ids.ts";
 
-const POST_ID = "post_1";
+const POST_ID = PostId.make("post_1");
 const NOW = new Date("2026-07-03T00:00:00.000Z");
 
 type CommentRow = {
@@ -136,7 +138,10 @@ describe("commentCount is sandbox-symmetric across create/delete (#1831)", () =>
 				startCount: 5,
 			});
 			const ops = makeCommentOperations(deps(runOverDb(db)));
-			const result = yield* ops.deleteComment({commentId: "comm_1", actorId: "u-author"});
+			const result = yield* ops.deleteComment({
+				commentId: CommentId.make("comm_1"),
+				actorId: UserId.make("u-author"),
+			});
 			assert.isTrue(result.deleted, "the delete still soft-removes the comment");
 			assert.strictEqual(
 				captured.postCommentCount,
@@ -153,7 +158,10 @@ describe("commentCount is sandbox-symmetric across create/delete (#1831)", () =>
 				startCount: 5,
 			});
 			const ops = makeCommentOperations(deps(runOverDb(db)));
-			const result = yield* ops.deleteComment({commentId: "comm_1", actorId: "u-author"});
+			const result = yield* ops.deleteComment({
+				commentId: CommentId.make("comm_1"),
+				actorId: UserId.make("u-author"),
+			});
 			assert.isTrue(result.deleted, "the delete soft-removes the comment");
 			assert.strictEqual(
 				captured.postCommentCount,
@@ -170,7 +178,10 @@ describe("commentCount is sandbox-symmetric across create/delete (#1831)", () =>
 				startCount: 0,
 			});
 			const ops = makeCommentOperations(deps(runOverDb(db)));
-			yield* ops.deleteComment({commentId: "comm_1", actorId: "u-author"});
+			yield* ops.deleteComment({
+				commentId: CommentId.make("comm_1"),
+				actorId: UserId.make("u-author"),
+			});
 			assert.strictEqual(
 				captured.postCommentCount,
 				0,
@@ -187,7 +198,7 @@ describe("commentCount is sandbox-symmetric across create/delete (#1831)", () =>
 			const ops = makeCommentOperations(deps(runOverDb(db)));
 			yield* ops.addComment({
 				postId: POST_ID,
-				authorId: "u-author",
+				authorId: UserId.make("u-author"),
 				authorName: "yazar",
 				body: "sandboxed",
 				sandboxedAt: NOW,
@@ -202,7 +213,7 @@ describe("commentCount is sandbox-symmetric across create/delete (#1831)", () =>
 			const ops = makeCommentOperations(deps(runOverDb(db)));
 			yield* ops.addComment({
 				postId: POST_ID,
-				authorId: "u-author",
+				authorId: UserId.make("u-author"),
 				authorName: "yazar",
 				body: "live",
 				sandboxedAt: null,
@@ -326,7 +337,10 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 				// author restoreComment of the removed-AND-sandboxed row: +0 (author-gated, #1811)
 				const restore = fakeDb({comment: removedRow(NOW), startCount: 5});
 				const opsRestore = makeCommentOperations(deps(runOverDb(restore.db)));
-				yield* opsRestore.restoreComment({commentId: "comm_1", actorId: "u-author"});
+				yield* opsRestore.restoreComment({
+					commentId: CommentId.make("comm_1"),
+					actorId: UserId.make("u-author"),
+				});
 				assert.strictEqual(
 					restore.captured.postCommentCount,
 					5,
@@ -345,7 +359,10 @@ describe("commentCount is sandbox-gated on the author restoreComment path (#1811
 		Effect.gen(function* () {
 			const {db, captured} = fakeDb({comment: removedRow(null), startCount: 5});
 			const ops = makeCommentOperations(deps(runOverDb(db)));
-			const result = yield* ops.restoreComment({commentId: "comm_1", actorId: "u-author"});
+			const result = yield* ops.restoreComment({
+				commentId: CommentId.make("comm_1"),
+				actorId: UserId.make("u-author"),
+			});
 			assert.isTrue(result.deleted, "the author-restore un-removes the comment");
 			assert.strictEqual(
 				captured.postCommentCount,

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -19,6 +19,7 @@ import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import type {UserId} from "../../lib/ids.ts";
 import {type ReadProfileIdentities, stampAuthorIdentity} from "../fate/author-identity.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {parallelStampWave} from "../fate/stamp-wave.ts";
@@ -46,6 +47,7 @@ import {
 	UnauthorizedCommentMutation,
 } from "./errors.ts";
 import {excerpt} from "./excerpt.ts";
+import type {CommentId, PostId} from "./ids.ts";
 import {COMMENT_ORDERING} from "./ordering.ts";
 import type {PersistPanoStats} from "./pano-stats.ts";
 
@@ -59,11 +61,11 @@ export const COMMENT_BODY_MAX = 5_000;
 export const SILINDI_PLACEHOLDER = "[silindi]";
 
 export interface AddCommentInput {
-	postId: string;
-	authorId: string;
+	postId: PostId;
+	authorId: UserId;
 	authorName: string;
 	body: string;
-	parentId?: string | null | undefined;
+	parentId?: CommentId | null | undefined;
 	/**
 	 * The çaylak mod-only sandbox stamp (#1205), decided by the resolver from the
 	 * authorship flag + author tier. `null`/absent ⇒ created live (today's behavior).
@@ -96,8 +98,8 @@ export interface AddCommentResult {
 }
 
 export interface VoteOnCommentInput {
-	commentId: string;
-	voterId: string;
+	commentId: CommentId;
+	voterId: UserId;
 }
 
 export interface VoteOnCommentResult {
@@ -114,8 +116,8 @@ export interface VoteOnCommentResult {
 }
 
 export interface ReactToCommentInput {
-	commentId: string;
-	userId: string;
+	commentId: CommentId;
+	userId: UserId;
 	/**
 	 * The reaction intent: a curated-palette member sets/changes the user's single
 	 * reaction; `null` retracts it (toggle off). Already decoded against
@@ -137,8 +139,8 @@ export interface ReactToCommentResult {
 }
 
 export interface EditCommentInput {
-	commentId: string;
-	actorId: string;
+	commentId: CommentId;
+	actorId: UserId;
 	body: string;
 }
 
@@ -155,8 +157,8 @@ export interface EditCommentResult {
 }
 
 export interface DeleteCommentInput {
-	commentId: string;
-	actorId: string;
+	commentId: CommentId;
+	actorId: UserId;
 	/** Why the comment is removed (ADR 0096). Defaults to `AuthorDeletion`. */
 	reason?: Removal.RemovalReason;
 }

--- a/apps/web/worker/features/pano/comment-self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-self-vote-guard.unit.test.ts
@@ -13,12 +13,14 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Cause, Effect, Exit} from "effect";
 import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
+import {UserId} from "../../lib/ids.ts";
 import type {Vote, VoteInput, VoteResult} from "../vote/Vote.ts";
 import {type CommentOperationsDeps, makeCommentOperations} from "./comment-operations.ts";
+import {CommentId} from "./ids.ts";
 
-const AUTHOR = "u-author";
-const OTHER = "u-other";
-const COMMENT_ID = "comment_1";
+const AUTHOR = UserId.make("u-author");
+const OTHER = UserId.make("u-other");
+const COMMENT_ID = CommentId.make("comment_1");
 
 // The `comment_record` the up-front load returns. Only `authorId` drives the guard; the
 // rest satisfy the fields the return projection reads.

--- a/apps/web/worker/features/pano/ids.ts
+++ b/apps/web/worker/features/pano/ids.ts
@@ -1,0 +1,16 @@
+/**
+ * Pano's feature-local branded id schemas (epic #2700). `PostId` / `CommentId`
+ * are nominal string tags minted from the shared `brandedId` factory, so a
+ * `postId`/`commentId` transposition at a write call site is a compile error
+ * while wire and D1 bytes stay identical (the brand is type-only — see
+ * `../../lib/ids.ts`). They live here, beside the pano feature, because only
+ * pano references them; the cross-feature `UserId` is imported read-only from
+ * the shared module. Idiom + tracer precedent: `features/sozluk` (#2712).
+ */
+import {brandedId} from "../../lib/ids.ts";
+
+export const PostId = brandedId("PostId");
+export type PostId = typeof PostId.Type;
+
+export const CommentId = brandedId("CommentId");
+export type CommentId = typeof CommentId.Type;

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -17,6 +17,7 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
 import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
+import {UserId} from "../../lib/ids.ts";
 import {notifyCommentReply} from "../bildirim/conversation-emitters.ts";
 import {notifyCaylakEntersDivan} from "../bildirim/mod-emitters.ts";
 import {notifyContentVote} from "../bildirim/vote-emitters.ts";
@@ -41,6 +42,7 @@ import {
 	UnauthorizedPostMutation,
 } from "./errors.ts";
 import {PanoFeedCache} from "./feed-cache.ts";
+import {CommentId, PostId} from "./ids.ts";
 import {panoLive} from "./live.ts";
 import {Pano} from "./Pano.ts";
 import {toComment, toPost, toPostFromPage} from "./shapers.ts";
@@ -76,7 +78,7 @@ const SaveDraftInput = Schema.Struct({
 const DiscardDraftInput = Schema.Struct({});
 
 const PostIdInput = Schema.Struct({
-	id: Schema.String,
+	id: PostId,
 });
 
 // `emoji` decodes against the curated `REACTION_EMOJI` palette (or `null` to
@@ -84,24 +86,24 @@ const PostIdInput = Schema.Struct({
 // bad emoji never reaches `Reaction.react` — the rejection is structural, not a
 // service error (the settled curated-fixed-palette model, #1859/#1863).
 const ReactToPostInput = Schema.Struct({
-	id: Schema.String,
+	id: PostId,
 	emoji: Schema.NullOr(ReactionEmojiSchema),
 });
 
 const EditPostInput = Schema.Struct({
-	id: Schema.String,
+	id: PostId,
 	title: Schema.optional(Schema.NullOr(Schema.String)),
 	body: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 const AddCommentInput = Schema.Struct({
-	postId: Schema.String,
-	parentId: Schema.optional(Schema.NullOr(Schema.String)),
+	postId: PostId,
+	parentId: Schema.optional(Schema.NullOr(CommentId)),
 	body: Schema.String,
 });
 
 const CommentIdInput = Schema.Struct({
-	id: Schema.String,
+	id: CommentId,
 });
 
 // `emoji` decodes against the curated `REACTION_EMOJI` palette (or `null` to
@@ -109,12 +111,12 @@ const CommentIdInput = Schema.Struct({
 // bad emoji never reaches `Reaction.react` — the rejection is structural, not a
 // service error (the settled curated-fixed-palette model, #1859/#1864).
 const ReactToCommentInput = Schema.Struct({
-	id: Schema.String,
+	id: CommentId,
 	emoji: Schema.NullOr(ReactionEmojiSchema),
 });
 
 const EditCommentInput = Schema.Struct({
-	id: Schema.String,
+	id: CommentId,
 	body: Schema.String,
 });
 
@@ -201,7 +203,7 @@ export const mutations = {
 					...(input.url ? {url: input.url} : {}),
 					...(input.body ? {body: input.body} : {}),
 					tags: input.tags.map((t) => ({kind: t.kind, ...(t.label ? {label: t.label} : {})})),
-					authorId: user.id,
+					authorId: UserId.make(user.id),
 					authorName: authorDisplayLabel(user),
 					sandboxedAt,
 				});
@@ -248,7 +250,7 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const r = yield* pano.saveDraft({
-				authorId: user.id,
+				authorId: UserId.make(user.id),
 				authorName: authorDisplayLabel(user),
 				...(input.title != null ? {title: input.title} : {}),
 				...(input.url != null ? {url: input.url} : {}),
@@ -280,7 +282,7 @@ export const mutations = {
 			}
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			const r = yield* pano.discardDraft({authorId: user.id});
+			const r = yield* pano.discardDraft({authorId: UserId.make(user.id)});
 			if (!r.postId) return null;
 			yield* live.post.delete(r.postId);
 			// Id-only eviction ref: the draft row is gone (see post.delete).
@@ -302,7 +304,7 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			const r = yield* pano.voteOnPost({postId: input.id, voterId: user.id});
+			const r = yield* pano.voteOnPost({postId: input.id, voterId: UserId.make(user.id)});
 			// Re-resolve the affected post via the same batched read `post.save`/`post.unsave`
 			// use, so the returned AND published projection carries the real `isSaved` + live
 			// author identity. The write result (`VoteOnPostResult`) has neither, and its
@@ -339,7 +341,7 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			yield* pano.retractPostVote({postId: input.id, voterId: user.id});
+			yield* pano.retractPostVote({postId: input.id, voterId: UserId.make(user.id)});
 			// Re-resolve like `post.vote` above so the returned/published projection keeps the
 			// real `isSaved` + author identity instead of the null-bearing write shape (#2213).
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
@@ -385,7 +387,11 @@ export const mutations = {
 				return toPost(current);
 			}
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			const r = yield* pano.reactToPost({postId: input.id, userId: user.id, emoji: input.emoji});
+			const r = yield* pano.reactToPost({
+				postId: input.id,
+				userId: UserId.make(user.id),
+				emoji: input.emoji,
+			});
 			const post = toPost(r.post);
 			yield* live.post.update(post.id, {changed: ["reactions"], data: post});
 			return post;
@@ -408,7 +414,7 @@ export const mutations = {
 			const pano = yield* Pano;
 			const bookmark = yield* Bookmark;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			yield* bookmark.toggle({userId: user.id, postId: input.id, value: true});
+			yield* bookmark.toggle({userId: UserId.make(user.id), postId: input.id, value: true});
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
 			if (!row) {
 				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
@@ -429,7 +435,7 @@ export const mutations = {
 			const pano = yield* Pano;
 			const bookmark = yield* Bookmark;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			yield* bookmark.toggle({userId: user.id, postId: input.id, value: false});
+			yield* bookmark.toggle({userId: UserId.make(user.id), postId: input.id, value: false});
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
 			if (!row) {
 				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
@@ -456,7 +462,7 @@ export const mutations = {
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const r = yield* pano.editPost({
 				postId: input.id,
-				actorId: user.id,
+				actorId: UserId.make(user.id),
 				...(input.title != null ? {title: input.title} : {}),
 				...(input.body != null ? {body: input.body} : {}),
 			});
@@ -483,7 +489,7 @@ export const mutations = {
 			// (#1639). Catch that defect into the declared, user-readable `PostDeleteFailed`;
 			// the typed `UnauthorizedPostMutation` (a failure, not a defect) passes through.
 			const r = yield* pano
-				.deletePost({postId: input.id, actorId: user.id})
+				.deletePost({postId: input.id, actorId: UserId.make(user.id)})
 				.pipe(
 					Effect.catchDefect(
 						() => new PostDeleteFailed({message: "Gönderi silinemedi. Lütfen tekrar deneyin."}),
@@ -508,7 +514,7 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			const restored = yield* pano.restorePost({postId: input.id, actorId: user.id});
+			const restored = yield* pano.restorePost({postId: input.id, actorId: UserId.make(user.id)});
 			const page = yield* pano.getPost(input.id);
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
@@ -551,7 +557,7 @@ export const mutations = {
 				const sandboxedAt = yield* sandboxedAtForAuthor(user.id, new Date());
 				const r = yield* pano.addComment({
 					postId: input.postId,
-					authorId: user.id,
+					authorId: UserId.make(user.id),
 					authorName: authorDisplayLabel(user),
 					body: input.body,
 					sandboxedAt,
@@ -597,7 +603,7 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			const r = yield* pano.voteOnComment({commentId: input.id, voterId: user.id});
+			const r = yield* pano.voteOnComment({commentId: input.id, voterId: UserId.make(user.id)});
 			const comment = shapeComment(r);
 			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
 			// Aggregated vote notification (#1698): see `post.vote` — a landed upvote
@@ -623,7 +629,10 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			const r = yield* pano.retractCommentVote({commentId: input.id, voterId: user.id});
+			const r = yield* pano.retractCommentVote({
+				commentId: input.id,
+				voterId: UserId.make(user.id),
+			});
 			const comment = shapeComment(r);
 			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
 			return comment;
@@ -670,7 +679,7 @@ export const mutations = {
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const r = yield* pano.reactToComment({
 				commentId: input.id,
-				userId: user.id,
+				userId: UserId.make(user.id),
 				emoji: input.emoji,
 			});
 			const comment = toComment(r.comment);
@@ -693,7 +702,11 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			const r = yield* pano.editComment({commentId: input.id, actorId: user.id, body: input.body});
+			const r = yield* pano.editComment({
+				commentId: input.id,
+				actorId: UserId.make(user.id),
+				body: input.body,
+			});
 			const [fresh] = yield* pano.getCommentsByIds([r.commentId], {viewerId: user.id});
 			const comment = shapeComment({...r, myVote: fresh?.myVote ?? null});
 			yield* live.comment.update(comment.id, {changed: ["body"], data: comment});
@@ -712,7 +725,10 @@ export const mutations = {
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			// Resolve the parent post id before the delete, while the row exists.
 			const postId = yield* pano.lookupCommentPostId(input.id);
-			const result = yield* pano.deleteComment({commentId: input.id, actorId: user.id});
+			const result = yield* pano.deleteComment({
+				commentId: input.id,
+				actorId: UserId.make(user.id),
+			});
 			if (!postId) return null;
 			const page = yield* pano.getPost(postId);
 			if (!page) return null;
@@ -761,7 +777,10 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const postId = yield* pano.lookupCommentPostId(input.id);
-			const restored = yield* pano.restoreComment({commentId: input.id, actorId: user.id});
+			const restored = yield* pano.restoreComment({
+				commentId: input.id,
+				actorId: UserId.make(user.id),
+			});
 			if (!postId) return null;
 			const [comment] = yield* pano.getCommentsByIds([input.id], {viewerId: user.id});
 			if (comment) {

--- a/apps/web/worker/features/pano/post-delete-undeclared-failure.unit.test.ts
+++ b/apps/web/worker/features/pano/post-delete-undeclared-failure.unit.test.ts
@@ -25,12 +25,14 @@ import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, type Context, Effect, Exit, Layer} from "effect";
 import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import {UserId} from "../../lib/ids.ts";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
+import {PostId} from "./ids.ts";
 import {mutations} from "./mutations.ts";
 import {Pano, PanoLive} from "./Pano.ts";
 
@@ -108,7 +110,7 @@ describe("post.delete — (a) no undeclared failure channel at the wire boundary
 });
 
 // The stamp batch commits (source of truth), then the post-commit stats refresh dies.
-const ownerId = AUTHOR.id;
+const ownerId = UserId.make(AUTHOR.id);
 const removalCommitsThenStatsDie = (): DrizzleAccess => {
 	let runs = 0;
 	return {
@@ -160,7 +162,9 @@ describe("post.delete — (b) a post-commit cache refresh cannot fail a committe
 		Effect.gen(function* () {
 			const exit = yield* Effect.gen(function* () {
 				const pano = yield* Pano;
-				return yield* pano.deletePost({postId: "post_1", actorId: ownerId}).pipe(Effect.exit);
+				return yield* pano
+					.deletePost({postId: PostId.make("post_1"), actorId: ownerId})
+					.pipe(Effect.exit);
 			}).pipe(Effect.provide(panoServiceLayer(removalCommitsThenStatsDie())));
 			assert.isTrue(
 				Exit.isSuccess(exit),

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -26,6 +26,7 @@ import {computeHotScore} from "../../db/hotScore.ts";
 import {decayHotScores, type HotDecayRow, type HotDecayUpdate} from "../../db/hotScoreDecay.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import type {UserId} from "../../lib/ids.ts";
 import {type ReadProfileIdentities, stampAuthorIdentity} from "../fate/author-identity.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
@@ -56,6 +57,7 @@ import {
 	UrlInvalid,
 } from "./errors.ts";
 import {excerpt} from "./excerpt.ts";
+import type {PostId} from "./ids.ts";
 import {isHttpUrl} from "./link-metadata.ts";
 import {postVisibleTo, postVisibleWhere} from "./PostVisibility.ts";
 import type {PersistPanoStats} from "./pano-stats.ts";
@@ -83,7 +85,7 @@ export interface SubmitPostInput {
 	url?: string | undefined;
 	body?: string | undefined;
 	tags: ReadonlyArray<{kind: string; label?: string | undefined}>;
-	authorId: string;
+	authorId: UserId;
 	authorName: string;
 	/**
 	 * The çaylak mod-only sandbox stamp (#1205), decided by the resolver from the
@@ -107,7 +109,7 @@ export interface SubmitPostResult {
 }
 
 export interface SaveDraftInput {
-	authorId: string;
+	authorId: UserId;
 	authorName: string;
 	title?: string | undefined;
 	url?: string | undefined;
@@ -121,7 +123,7 @@ export interface SaveDraftResult extends SubmitPostResult {
 }
 
 export interface DiscardDraftInput {
-	authorId: string;
+	authorId: UserId;
 }
 
 export interface DiscardDraftResult {
@@ -129,8 +131,8 @@ export interface DiscardDraftResult {
 }
 
 export interface VoteOnPostInput {
-	postId: string;
-	voterId: string;
+	postId: PostId;
+	voterId: UserId;
 }
 
 export interface VoteOnPostResult {
@@ -151,8 +153,8 @@ export interface VoteOnPostResult {
 }
 
 export interface ReactToPostInput {
-	postId: string;
-	userId: string;
+	postId: PostId;
+	userId: UserId;
 	/**
 	 * The reaction intent: a curated-palette member sets/changes the user's single
 	 * reaction; `null` retracts it (toggle off). Already decoded against
@@ -174,8 +176,8 @@ export interface ReactToPostResult {
 }
 
 export interface EditPostInput {
-	postId: string;
-	actorId: string;
+	postId: PostId;
+	actorId: UserId;
 	title?: string | undefined;
 	body?: string | undefined;
 }
@@ -197,8 +199,8 @@ export interface EditPostResult {
 }
 
 export interface DeletePostInput {
-	postId: string;
-	actorId: string;
+	postId: PostId;
+	actorId: UserId;
 	/** Why the post is removed (ADR 0096). Defaults to `AuthorDeletion`. */
 	reason?: Removal.RemovalReason;
 }

--- a/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
@@ -26,12 +26,14 @@ import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, Effect, Exit, Layer} from "effect";
+import {UserId} from "../../lib/ids.ts";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {EMPTY_REACTION_AGGREGATE, type ReactionAggregate} from "../reaction/Reaction.ts";
 import type {CommentRow} from "./comment-fields.ts";
 import type {ReactToCommentInput, ReactToCommentResult} from "./comment-operations.ts";
+import {CommentId} from "./ids.ts";
 import {mutations} from "./mutations.ts";
 import {Pano} from "./Pano.ts";
 
@@ -127,7 +129,9 @@ describe("comment.react — (1) flag ON delegates and echoes the aggregate", () 
 				true,
 				{id: "comment_1", emoji: "👍"},
 			);
-			assert.deepStrictEqual(calls, [{commentId: "comment_1", userId: CAYLAK.id, emoji: "👍"}]);
+			assert.deepStrictEqual(calls, [
+				{commentId: CommentId.make("comment_1"), userId: UserId.make(CAYLAK.id), emoji: "👍"},
+			]);
 			assert.deepStrictEqual((comment as {reactions?: unknown}).reactions, {
 				counts: [{emoji: "👍", count: 1}],
 				myReaction: "👍",

--- a/apps/web/worker/features/pano/self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/pano/self-vote-guard.unit.test.ts
@@ -13,12 +13,14 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Cause, Effect, Exit} from "effect";
 import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
+import {UserId} from "../../lib/ids.ts";
 import type {Vote, VoteInput, VoteResult} from "../vote/Vote.ts";
+import {PostId} from "./ids.ts";
 import {makePostOperations, type PostOperationsDeps} from "./post-operations.ts";
 
-const AUTHOR = "u-author";
-const OTHER = "u-other";
-const POST_ID = "post_1";
+const AUTHOR = UserId.make("u-author");
+const OTHER = UserId.make("u-other");
+const POST_ID = PostId.make("post_1");
 
 // The `post_record` the up-front load returns. Only `authorId` drives the guard; the
 // rest satisfy the row shape the return projection reads.

--- a/apps/web/worker/features/pano/submit-validation.unit.test.ts
+++ b/apps/web/worker/features/pano/submit-validation.unit.test.ts
@@ -27,10 +27,12 @@ import {it} from "@effect/vitest";
 import {Cause, type Context, Effect, Exit, Layer} from "effect";
 import {assert} from "vitest";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import {UserId} from "../../lib/ids.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Reaction} from "../reaction/Reaction.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
+import {type CommentId, PostId} from "./ids.ts";
 import {COMMENT_BODY_MAX, Pano, PanoLive, POST_BODY_MAX, POST_TITLE_MAX} from "./Pano.ts";
 
 // Every DB call dies, so any path that reaches the seam fails the test: the
@@ -107,7 +109,7 @@ const expectReachedDb = (exit: Exit.Exit<unknown, unknown>) => {
 	}
 };
 
-const ownerId = "u1";
+const ownerId = UserId.make("u1");
 
 const baseSubmit = {
 	title: "geçerli başlık",
@@ -250,11 +252,11 @@ it.effect("saveDraft: a tag outside the enum rejects with TagInvalid before any 
 );
 
 const baseComment = {
-	postId: "post_1",
+	postId: PostId.make("post_1"),
 	authorId: ownerId,
 	authorName: "umut",
 	body: "yorum",
-	parentId: null as string | null,
+	parentId: null as CommentId | null,
 };
 
 const runComment = (overrides: Partial<typeof baseComment>) =>
@@ -295,15 +297,20 @@ const ownedPostRow = {
 };
 
 const runEdit = (overrides: {
-	postId?: string;
-	actorId?: string;
+	postId?: PostId;
+	actorId?: UserId;
 	title?: string | undefined;
 	body?: string | undefined;
 }) =>
 	Effect.gen(function* () {
 		const pano = yield* Pano;
 		return yield* pano
-			.editPost({postId: "post_1", actorId: ownerId, title: "yeni başlık", ...overrides})
+			.editPost({
+				postId: PostId.make("post_1"),
+				actorId: ownerId,
+				title: "yeni başlık",
+				...overrides,
+			})
 			.pipe(Effect.exit);
 	}).pipe(Effect.provide(panoLayer(editPostReadThenDieAccess(ownedPostRow))));
 


### PR DESCRIPTION
Brands pano's id surfaces with feature-local `PostId` / `CommentId` nominal schemas (epic #2700), adopting the sözlük tracer idiom (#2712) so an id transposition at a write call site is a compile error while runtime stays byte-identical.

## What changed
- **`apps/web/worker/features/pano/ids.ts` (new)** — feature-local `PostId` / `CommentId`, minted from the shared `brandedId` factory. `UserId` is imported read-only from `lib/ids.ts` (already landed via #2735). The brands live beside the pano feature, not appended to the shared module (per the placement rule — only pano references them).
- **`mutations.ts`** — the mutation input schemas (`PostIdInput`, `ReactToPostInput`, `EditPostInput`, `AddCommentInput` incl. `parentId`, `CommentIdInput`, `ReactToCommentInput`, `EditCommentInput`) carry `PostId` / `CommentId`; author/voter/actor/reactor args are threaded as `UserId.make(user.id)` at each write boundary.
- **`post-operations.ts` / `comment-operations.ts`** — the `Pano` service write-method arg-structs carry the brands (`postId: PostId`, `commentId: CommentId`, `parentId: CommentId`, `authorId`/`voterId`/`actorId`/`userId: UserId`). This is what makes a `{postId, voterId}` transposition a compile error (the #2712 example).

## Scope notes (tracer precedent)
- Error-schema fields (`errors.ts`) and the id-or-slug query arg (`queries.ts` `idOrSlug`) stay `Schema.String`, exactly as the sözlük tracer left `definitionId` / `slug` unbranded — those carry server-derived output / an id-or-slug union, not a decoded id surface.
- Test call sites that construct the branded inputs directly wrap ids with `.make()`. Two of them are cross-feature handler tests (`flagship/sandbox-restore-escape.invariant.test.ts`, `lifecycle/create-path-refresh-swallow.unit.test.ts`) that exercise the pano service — the same cross-feature cascade the tracer absorbed (`.handler()` takes decoded input, unlike `resolveWire`).

## Verification
- `pnpm typecheck` — green (29/29, the exact CI command).
- `pnpm lint:worktree` — clean.
- Brand is type-only (decode/`.make` return the input unchanged, grounded in effect-smol `SCHEMA.md` §Branding), so wire/D1 bytes are unchanged.

Fixes #2713