### PR TITLE
refactor(vote): brand cross-cutting vote/reaction id surfaces (voterId / polymorphic TargetId) (#2723)

### DIFF
--- a/apps/web/worker/features/reaction/Reaction.ts
+++ b/apps/web/worker/features/reaction/Reaction.ts
@@ -38,6 +38,7 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {REACTION_EMOJI, type ReactionEmoji} from "../../db/reaction-emoji.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {targetTable} from "../../db/target-table.ts";
+import {TargetId} from "../../lib/ids.ts";
 import {Telemetry} from "../telemetry/Telemetry.ts";
 import {ReactionTargetNotFound} from "./errors.ts";
 
@@ -179,7 +180,7 @@ export const ReactionLive = Layer.effect(Reaction)(
 			if (!meta) {
 				return yield* new ReactionTargetNotFound({
 					targetKind: kind,
-					targetId,
+					targetId: TargetId.make(targetId),
 					message: `reaction target ${kind} ${targetId} not found`,
 				});
 			}

--- a/apps/web/worker/features/reaction/errors.ts
+++ b/apps/web/worker/features/reaction/errors.ts
@@ -15,12 +15,13 @@
  */
 import * as Schema from "effect/Schema";
 import {TargetKindSchema} from "../../db/target-kind.ts";
+import {TargetId} from "../../lib/ids.ts";
 
 export class ReactionTargetNotFound extends Schema.TaggedErrorClass<ReactionTargetNotFound>()(
 	"reaction/ReactionTargetNotFound",
 	{
 		targetKind: TargetKindSchema,
-		targetId: Schema.String,
+		targetId: TargetId,
 		message: Schema.String,
 	},
 ) {}

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -23,6 +23,7 @@ import * as schema from "../../db/drizzle/schema.ts";
 import type {KarmaEventReason} from "../../db/karma-event.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {type TargetRecordMeta, targetTable} from "../../db/target-table.ts";
+import {TargetId, UserId} from "../../lib/ids.ts";
 import {Telemetry} from "../telemetry/Telemetry.ts";
 import {
 	VOTE_REQUIRED_TIER,
@@ -204,7 +205,7 @@ export const VoteLive = Layer.effect(Vote)(
 			if (!meta) {
 				return yield* new VoteTargetNotFound({
 					targetKind: kind,
-					targetId,
+					targetId: TargetId.make(targetId),
 					message: `vote target ${kind} ${targetId} not found`,
 				});
 			}
@@ -274,7 +275,7 @@ export const VoteLive = Layer.effect(Vote)(
 				const eligible = yield* voterStanding.isAboveNewcomer(input.userId);
 				if (!eligible) {
 					return yield* new VoterNotEligible({
-						voterId: input.userId,
+						voterId: UserId.make(input.userId),
 						need: VOTE_REQUIRED_TIER,
 						message: `voter ${input.userId} is below the vote-eligibility floor (must be promoted above çaylak)`,
 					});
@@ -286,7 +287,7 @@ export const VoteLive = Layer.effect(Vote)(
 			if (meta.sandboxed && !allowSandboxed) {
 				return yield* new VoteTargetSandboxed({
 					targetKind: input.targetKind,
-					targetId: input.targetId,
+					targetId: TargetId.make(input.targetId),
 					message: `vote target ${input.targetKind} ${input.targetId} is sandboxed`,
 				});
 			}

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -16,6 +16,7 @@ import {wireCodeOfClass} from "@kampus/fate-effect";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {TARGET_KINDS} from "../../db/target-kind.ts";
+import {UserId} from "../../lib/ids.ts";
 import type {TelemetryEvent} from "../telemetry/schema.ts";
 import {Telemetry} from "../telemetry/Telemetry.ts";
 import {VOTE_ELIGIBILITY_WIRE_CODE, VOTE_REQUIRED_TIER, VoterNotEligible} from "./errors.ts";
@@ -375,7 +376,11 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 	it("VoterNotEligible.need + its wire code are single-sourced from VOTE_REQUIRED_TIER (#2021)", () => {
 		// The tier name and the wire code are ONE fact: the error's `need` is `VOTE_REQUIRED_TIER`
 		// and its `FateWireCode` is derived from it, so a ladder move can't drift them apart.
-		const err = new VoterNotEligible({voterId: "u1", need: VOTE_REQUIRED_TIER, message: "x"});
+		const err = new VoterNotEligible({
+			voterId: UserId.make("u1"),
+			need: VOTE_REQUIRED_TIER,
+			message: "x",
+		});
 		assert.strictEqual(err.need, VOTE_REQUIRED_TIER);
 		assert.strictEqual(
 			VOTE_ELIGIBILITY_WIRE_CODE,

--- a/apps/web/worker/features/vote/errors.ts
+++ b/apps/web/worker/features/vote/errors.ts
@@ -9,12 +9,13 @@
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
 import {TargetKindSchema} from "../../db/target-kind.ts";
+import {TargetId, UserId} from "../../lib/ids.ts";
 
 export class VoteTargetNotFound extends Schema.TaggedErrorClass<VoteTargetNotFound>()(
 	"vote/VoteTargetNotFound",
 	{
 		targetKind: TargetKindSchema,
-		targetId: Schema.String,
+		targetId: TargetId,
 		message: Schema.String,
 	},
 ) {}
@@ -32,7 +33,7 @@ export class VoteTargetSandboxed extends Schema.TaggedErrorClass<VoteTargetSandb
 	"vote/VoteTargetSandboxed",
 	{
 		targetKind: TargetKindSchema,
-		targetId: Schema.String,
+		targetId: TargetId,
 		message: Schema.String,
 	},
 ) {}
@@ -76,7 +77,7 @@ export const VOTE_ELIGIBILITY_WIRE_CODE =
 export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>()(
 	"vote/VoterNotEligible",
 	{
-		voterId: Schema.String,
+		voterId: UserId,
 		need: Schema.String,
 		message: Schema.String,
 	},
@@ -97,6 +98,11 @@ export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>(
 export class SelfVoteNotAllowed extends Schema.TaggedErrorClass<SelfVoteNotAllowed>()(
 	"vote/SelfVoteNotAllowed",
 	{
+		// Unbranded `Schema.String` (unlike VoterNotEligible's `UserId`) on purpose:
+		// this error is constructed at each feature's own self-vote guard — pano
+		// (post/comment) and sözlük — not inside Vote. Until those features brand
+		// their voter id (pano #2713), a `UserId` here would fail repo-wide typecheck
+		// at the pano call sites, which the epic #2700 forbids (#2723 stays vote-local).
 		voterId: Schema.String,
 		message: Schema.String,
 	},

--- a/apps/web/worker/features/vote/translate-vote-miss.unit.test.ts
+++ b/apps/web/worker/features/vote/translate-vote-miss.unit.test.ts
@@ -8,6 +8,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {TargetId} from "../../lib/ids.ts";
 import {VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
 import {translateVoteMiss} from "./translate-vote-miss.ts";
 
@@ -20,12 +21,12 @@ const makeNotFound = () => new FeatureNotFound({id: "x", message: "x not found"}
 
 const notFound = new VoteTargetNotFound({
 	targetKind: "post",
-	targetId: "x",
+	targetId: TargetId.make("x"),
 	message: "gone",
 });
 const sandboxed = new VoteTargetSandboxed({
 	targetKind: "post",
-	targetId: "x",
+	targetId: TargetId.make("x"),
 	message: "sandboxed",
 });
 

--- a/apps/web/worker/features/vote/vote-ids.typetest.ts
+++ b/apps/web/worker/features/vote/vote-ids.typetest.ts
@@ -1,0 +1,30 @@
+/**
+ * Type-level assertion (no runtime — checked by `tsgo`, not vitest): the vote /
+ * reaction id surfaces `UserId` (the voter) and `TargetId` (the polymorphic vote /
+ * reaction target) are nominally distinct, so transposing a voter id and a target id
+ * is a compile error (#2723 AC#3), while both stay plain strings at runtime. Mirrors
+ * `../pasaport/pasaport-ids.typetest.ts`.
+ */
+import {expectTypeOf} from "vitest";
+import type {TargetId, UserId} from "../../lib/ids.ts";
+
+// Both brands erase to `string` at runtime — the brand is type-only (#2735).
+expectTypeOf<UserId>().toMatchTypeOf<string>();
+expectTypeOf<TargetId>().toMatchTypeOf<string>();
+
+// The distinctness that makes a voterId/targetId swap unrepresentable: neither brand
+// is assignable to the other, so a vote/reaction can't be misrouted across the roles.
+expectTypeOf<UserId>().not.toEqualTypeOf<TargetId>();
+expectTypeOf<UserId>().not.toMatchTypeOf<TargetId>();
+expectTypeOf<TargetId>().not.toMatchTypeOf<UserId>();
+
+declare const someUserId: UserId;
+declare const someTargetId: TargetId;
+
+// The literal "a voterId/targetId swap fails pnpm typecheck" proof: were the two
+// interchangeable, these `@ts-expect-error` directives would themselves fail as
+// unused (TS2578).
+// @ts-expect-error a TargetId cannot stand in for a UserId — the voter/target swap is a compile error
+export const _targetAsVoter: UserId = someTargetId;
+// @ts-expect-error a UserId cannot stand in for a TargetId — the voter/target swap is a compile error
+export const _voterAsTarget: TargetId = someUserId;

--- a/apps/web/worker/lib/ids.ts
+++ b/apps/web/worker/lib/ids.ts
@@ -42,3 +42,16 @@ export type DefinitionId = typeof DefinitionId.Type;
 /** A sözlük term (başlık) slug — the başlık's stable identifier. */
 export const TermSlug = brandedId("TermSlug");
 export type TermSlug = typeof TermSlug.Type;
+
+/**
+ * A vote/reaction/report **target** id — the row id of the entity being scored or
+ * flagged. Cross-feature (vote, reaction, and the moderation surfaces all reference
+ * it), so it lives here rather than in one feature. It is *polymorphic* over the
+ * `TargetKind` set (`definition` | `post` | `comment`, `db/target-kind.ts`): one broad
+ * brand tags the raw id, and the accompanying `targetKind` carries the discriminator —
+ * the same (kind, id) pairing already threaded through every target surface. The brand
+ * only stops a `TargetId` being confused with a `UserId` (a voter/target swap), not one
+ * target kind for another; the kind guard is `TargetKind`'s job.
+ */
+export const TargetId = brandedId("TargetId");
+export type TargetId = typeof TargetId.Type;


### PR DESCRIPTION
## What & why

Brands the cross-cutting **vote / reaction** id surfaces with the effect-smol Brand vocabulary (epic #2700), so a `voterId`/`targetId` swap becomes a compile error instead of a silent wrong-row write. Runtime is byte-identical — the brand is type-only.

Grounded in effect-smol `SCHEMA.md` §Branding (`Schema.String.pipe(Schema.brand(...))`, via `lib/ids.ts`'s `brandedId`), following the sözlük tracer's precedent (#2712/#2735).

## Changes

- **`lib/ids.ts` — DEFINE the cross-feature `TargetId`.** It is genuinely cross-feature (vote, reaction, and the moderation surfaces all reference it), so it belongs in the shared module — #2723 is its natural definer so moderation (#2721) can import it. It is *polymorphic* over the `TargetKind` set (`definition | post | comment`): one broad brand tags the raw id, with `targetKind` carrying the discriminator — the same `(kind, id)` pairing already threaded through every target surface. Matches the tracer's resolved broad-brand approach.
- **`features/vote/errors.ts`** — `VoteTargetNotFound.targetId`, `VoteTargetSandboxed.targetId` → `TargetId`; `VoterNotEligible.voterId` → shared `UserId`. Construction sites in `Vote.ts` mint the brand at the boundary (`TargetId.make` / `UserId.make`).
- **`features/reaction/errors.ts`** — `ReactionTargetNotFound.targetId` → `TargetId` (minted in `Reaction.ts`).
- **`features/vote/vote-ids.typetest.ts`** — compile-level proof that a `voterId`/`targetId` swap fails `pnpm typecheck` (mirrors `pasaport-ids.typetest.ts`).

## Scope note (deliberate deferral)

`SelfVoteNotAllowed.voterId` stays `Schema.String` **on purpose**: unlike `VoterNotEligible`, this error is constructed at each feature's own self-vote guard — pano (post/comment) and sözlük — not inside Vote. Branding it to `UserId` would fail repo-wide `pnpm typecheck` at pano's still-unbranded call sites (pano #2713), which is outside #2723's vote-local scope and would violate the "typecheck passes overall" AC. A load-bearing note at the field records this; pano's slice will brand it when pano's ids land.

## Acceptance criteria

- [x] vote's `voterId` uses the shared `UserId` and reaction/vote `targetId` uses the branded `TargetId`, not bare `Schema.String` (except the cross-feature-constructed `SelfVoteNotAllowed.voterId`, deferred per scope note above).
- [x] The polymorphic `targetId` treatment matches the tracer's resolved approach (broad brand + `TargetKind` discriminator), consistent with the moderation child.
- [x] A `voterId`/`targetId` swap fails `pnpm typecheck` (`vote-ids.typetest.ts`); `pnpm typecheck` passes overall; runtime unchanged (61 vote/reaction unit tests pass).

Fixes #2723

🤖 Generated with [Claude Code](https://claude.com/claude-code)