### PR TITLE
refactor(web): brand moderation id surfaces — report/divan (Part of #2721)

### DIFF
--- a/apps/web/worker/features/divan/Divan.ts
+++ b/apps/web/worker/features/divan/Divan.ts
@@ -20,6 +20,7 @@
  *     #1290 detail view), newest first.
  */
 import {Context, Effect, Layer} from "effect";
+import {UserId} from "../../lib/ids.ts";
 import {Pano} from "../pano/Pano.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
@@ -34,7 +35,7 @@ export class Divan extends Context.Service<
 		/** The pending-çaylak roster: every çaylak with ≥1 sandboxed, not-removed item. */
 		readonly roster: () => Effect.Effect<ReadonlyArray<DivanRosterRow>>;
 		/** One çaylak's sandboxed backlog (newest first) — the detail-view items. */
-		readonly backlogOf: (authorId: string) => Effect.Effect<ReadonlyArray<DivanItem>>;
+		readonly backlogOf: (authorId: UserId) => Effect.Effect<ReadonlyArray<DivanItem>>;
 		/**
 		 * How many still-pending (sandboxed, not-removed) items one author has across
 		 * all three kinds — the mod-notification transition gate (#1699): a create path
@@ -42,6 +43,10 @@ export class Divan extends Context.Service<
 		 * right after a çaylak's item committed (their 0→1 entry onto the roster), so a
 		 * çaylak's second and later items don't re-page the team.
 		 */
+		// `authorId` stays unbranded `string` (unlike `backlogOf`'s `UserId`): the only
+		// caller is bildirim's `notifyCaylakEntersDivan` (`mod-emitters.ts`), which passes a
+		// plain-string author id — branding this param would fail typecheck in that
+		// out-of-feature site, which epic #2700's report slice (#2721) does not touch.
 		readonly pendingCountOf: (authorId: string) => Effect.Effect<number>;
 	}
 >()("divan/Divan") {}
@@ -69,7 +74,7 @@ export const DivanLive = Layer.effect(Divan)(
 					(d): DivanItem => ({
 						kind: "definition",
 						id: d.id,
-						authorId: d.authorId,
+						authorId: UserId.make(d.authorId),
 						createdAt: d.createdAt,
 						preview: preview(d.body),
 					}),
@@ -78,7 +83,7 @@ export const DivanLive = Layer.effect(Divan)(
 					(p): DivanItem => ({
 						kind: "post",
 						id: p.id,
-						authorId: p.authorId,
+						authorId: UserId.make(p.authorId),
 						createdAt: p.createdAt,
 						preview: preview(p.title),
 					}),
@@ -87,7 +92,7 @@ export const DivanLive = Layer.effect(Divan)(
 					(c): DivanItem => ({
 						kind: "comment",
 						id: c.id,
-						authorId: c.authorId,
+						authorId: UserId.make(c.authorId),
 						createdAt: c.createdAt,
 						preview: preview(c.body),
 					}),

--- a/apps/web/worker/features/divan/Divan.unit.test.ts
+++ b/apps/web/worker/features/divan/Divan.unit.test.ts
@@ -12,6 +12,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
+import {UserId} from "../../lib/ids.ts";
 import {type CommentRow, Pano, type PostSummaryRow} from "../pano/Pano.ts";
 import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
 import type {ProfileIdentityRow} from "../pasaport/Pasaport.ts";
@@ -204,7 +205,7 @@ describe("Divan.roster — person-grouped, removed & live excluded", () => {
 		const roster = run(Effect.flatMap(Divan, (d) => d.roster()));
 		assert.deepStrictEqual(roster, [
 			{
-				authorId: "cyl-a",
+				authorId: UserId.make("cyl-a"),
 				username: "ada",
 				displayName: "Ada Lovelace",
 				totalKarma: 7,
@@ -215,7 +216,7 @@ describe("Divan.roster — person-grouped, removed & live excluded", () => {
 			},
 			// cyl-b has no profile row → the join degrades to null handle + 0 karma.
 			{
-				authorId: "cyl-b",
+				authorId: UserId.make("cyl-b"),
 				username: null,
 				displayName: null,
 				totalKarma: 0,
@@ -251,7 +252,9 @@ describe("Divan preview — a short excerpt, never the full node", () => {
 
 	it("truncates a long body to the ellipsis excerpt form", () => {
 		const items = Effect.runSync(
-			Effect.flatMap(Divan, (d) => d.backlogOf("cyl-a")).pipe(Effect.provide(longLayer)),
+			Effect.flatMap(Divan, (d) => d.backlogOf(UserId.make("cyl-a"))).pipe(
+				Effect.provide(longLayer),
+			),
 		);
 		const item = items[0];
 		if (item === undefined) throw new Error("expected one backlog item");
@@ -263,7 +266,7 @@ describe("Divan preview — a short excerpt, never the full node", () => {
 
 describe("Divan.backlogOf — one çaylak's sandboxed backlog, newest first", () => {
 	it("returns only that author's sandboxed-not-removed items, newest first", () => {
-		const items = run(Effect.flatMap(Divan, (d) => d.backlogOf("cyl-a")));
+		const items = run(Effect.flatMap(Divan, (d) => d.backlogOf(UserId.make("cyl-a"))));
 		assert.deepStrictEqual(
 			items.map((i) => ({kind: i.kind, id: i.id})),
 			[
@@ -274,7 +277,7 @@ describe("Divan.backlogOf — one çaylak's sandboxed backlog, newest first", ()
 	});
 
 	it("excludes a removed item from the scoped backlog", () => {
-		const items = run(Effect.flatMap(Divan, (d) => d.backlogOf("cyl-b")));
+		const items = run(Effect.flatMap(Divan, (d) => d.backlogOf(UserId.make("cyl-b"))));
 		// cyl-b has c1 (06:00, sandboxed), c2 (07:00, REMOVED), d3 (03:00, sandboxed):
 		// the removed c2 is absent; the rest newest-first.
 		assert.deepStrictEqual(

--- a/apps/web/worker/features/divan/lists.ts
+++ b/apps/web/worker/features/divan/lists.ts
@@ -21,6 +21,7 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
 import {targetKey} from "../../db/target-kind.ts";
+import {UserId} from "../../lib/ids.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied} from "../kunye/errors.ts";
@@ -39,7 +40,7 @@ const RosterArgs = Schema.Struct({
 });
 
 const BacklogArgs = Schema.Struct({
-	authorId: Schema.String,
+	authorId: UserId,
 	first: Schema.optional(Schema.Number),
 });
 
@@ -94,7 +95,7 @@ const rosterGated = Effect.fn("divan.rosterGated")(function* () {
 	} satisfies ConnectionResult<DivanCaylak>;
 });
 
-const backlogGated = Effect.fn("divan.backlogGated")(function* (authorId: string) {
+const backlogGated = Effect.fn("divan.backlogGated")(function* (authorId: UserId) {
 	yield* ViewDivan;
 	const divan = yield* Divan;
 	const items = yield* divan.backlogOf(authorId);

--- a/apps/web/worker/features/divan/roster.ts
+++ b/apps/web/worker/features/divan/roster.ts
@@ -18,6 +18,7 @@
  */
 
 import type {TargetKind} from "../../db/target-kind.ts";
+import type {UserId} from "../../lib/ids.ts";
 
 /**
  * The content kind a sandboxed backlog item came from. Aliased to the shared
@@ -36,7 +37,7 @@ export type DivanItemKind = TargetKind;
 export interface DivanItem {
 	readonly kind: DivanItemKind;
 	readonly id: string;
-	readonly authorId: string;
+	readonly authorId: UserId;
 	readonly createdAt: Date;
 	/** A short text preview for the queue row (body / title), never the full node. */
 	readonly preview: string;
@@ -48,7 +49,7 @@ export interface DivanItem {
  * separately as that çaylak's backlog (`Divan.backlogOf`).
  */
 export interface DivanCaylakEntry {
-	readonly authorId: string;
+	readonly authorId: UserId;
 	readonly definitionCount: number;
 	readonly postCount: number;
 	readonly commentCount: number;
@@ -91,7 +92,7 @@ export type DivanRosterRow = DivanCaylakEntry & CaylakIdentityFields;
  * here.
  */
 export const buildRoster = (items: ReadonlyArray<DivanItem>): ReadonlyArray<DivanCaylakEntry> => {
-	const byAuthor = new Map<string, {definitions: number; posts: number; comments: number}>();
+	const byAuthor = new Map<UserId, {definitions: number; posts: number; comments: number}>();
 	for (const item of items) {
 		if (item.authorId === "") continue;
 		const counts = byAuthor.get(item.authorId) ?? {definitions: 0, posts: 0, comments: 0};

--- a/apps/web/worker/features/divan/roster.unit.test.ts
+++ b/apps/web/worker/features/divan/roster.unit.test.ts
@@ -5,12 +5,13 @@
  * blank-author (author-deleted placeholder) row is skipped.
  */
 import {assert, describe, it} from "@effect/vitest";
+import {UserId} from "../../lib/ids.ts";
 import {buildRoster, type DivanItem} from "./roster.ts";
 
 const item = (kind: DivanItem["kind"], id: string, authorId: string): DivanItem => ({
 	kind,
 	id,
-	authorId,
+	authorId: UserId.make(authorId),
 	createdAt: new Date("2026-06-25T00:00:00.000Z"),
 	preview: `${kind}:${id}`,
 });

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.ts
@@ -36,6 +36,13 @@ export class Anonymized extends Schema.Class<Anonymized>("lifecycle/Anonymized")
 
 export class Moderated extends Schema.Class<Moderated>("lifecycle/Moderated")({
 	_tag: Schema.tag("Moderated"),
+	// Unbranded `Schema.String` (not report's `ReportId`) on purpose: this reason is
+	// constructed at each content feature's moderator-remove site — pano
+	// (`post-operations.ts`/`comment-operations.ts`) and sözlük (`Sozluk.ts`) — with a
+	// plain-string `reportId`, so a `ReportId` here would fail typecheck at those
+	// out-of-feature construction sites, which epic #2700's report slice (#2721) does not
+	// touch. Deferred to a follow-up that brands the content services' `moderateRemove*`
+	// reportId params (mirrors vote's deferred `SelfVoteNotAllowed.voterId`, #2723).
 	reportId: Schema.String,
 }) {}
 

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -17,6 +17,7 @@ import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {type TargetKind, targetKey} from "../../db/target-kind.ts";
 import {targetTable} from "../../db/target-table.ts";
+import {TargetId} from "../../lib/ids.ts";
 import {ReportTargetNotFound} from "./errors.ts";
 import * as Resolution from "./resolution.ts";
 
@@ -284,7 +285,7 @@ export const ReportLive = Layer.effect(Report)(
 			if (!meta) {
 				return yield* new ReportTargetNotFound({
 					targetKind: kind,
-					targetId,
+					targetId: TargetId.make(targetId),
 					message: `report target ${kind} ${targetId} not found`,
 				});
 			}

--- a/apps/web/worker/features/report/errors.ts
+++ b/apps/web/worker/features/report/errors.ts
@@ -8,12 +8,13 @@
  */
 import * as Schema from "effect/Schema";
 import {TargetKindSchema} from "../../db/target-kind.ts";
+import {TargetId} from "../../lib/ids.ts";
 
 export class ReportTargetNotFound extends Schema.TaggedErrorClass<ReportTargetNotFound>()(
 	"report/ReportTargetNotFound",
 	{
 		targetKind: TargetKindSchema,
-		targetId: Schema.String,
+		targetId: TargetId,
 		message: Schema.String,
 	},
 ) {}

--- a/apps/web/worker/features/report/ids.ts
+++ b/apps/web/worker/features/report/ids.ts
@@ -1,0 +1,26 @@
+/**
+ * Report feature-local branded ids (epic #2700). The cross-feature polymorphic
+ * `TargetId` (a report's post/definition/comment target) is imported read-only from
+ * the shared `lib/ids.ts` (#2723/#2735); only the report-owned `ReportId` / `WaveId`
+ * are minted here, feature-locally, so sibling slices don't append-conflict on the
+ * shared module.
+ *
+ * Branding these distinctly from `TargetId` makes the moderation-flow triad
+ * type-distinct: a report id, a wave-grouping id, and a target id can no longer be
+ * transposed without a compile error, even though all three are plain strings at
+ * runtime. See `../../lib/ids.ts` for the branding idiom (effect-smol `SCHEMA.md`
+ * §Branding) — not re-derived here.
+ */
+import {brandedId} from "../../lib/ids.ts";
+
+/** A `content_report` row id — one filed report. */
+export const ReportId = brandedId("ReportId");
+export type ReportId = typeof ReportId.Type;
+
+/**
+ * A remove-the-wave grouping id (#1855, ADR 0138): the client stamps ONE per wave
+ * gesture and threads the same id through every fanned-out resolve, so the batch
+ * reopens/restores as a unit. Distinct from `ReportId` — a wave groups many reports.
+ */
+export const WaveId = brandedId("WaveId");
+export type WaveId = typeof WaveId.Type;

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -24,6 +24,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {type TargetKind, TargetKindSchema, targetKey} from "../../db/target-kind.ts";
+import {TargetId} from "../../lib/ids.ts";
 import {notifyReportFiled} from "../bildirim/mod-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Denied, InsufficientKarma} from "../kunye/errors.ts";
@@ -37,6 +38,7 @@ import {DefinitionNotFound} from "../sozluk/errors.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
 import {toDefinition} from "../sozluk/shapers.ts";
 import type {ReportTargetNotFound} from "./errors.ts";
+import {ReportId, WaveId} from "./ids.ts";
 import {reportLive} from "./live.ts";
 import {Report} from "./Report.ts";
 import {outcomeOf} from "./resolution.ts";
@@ -45,7 +47,7 @@ import {ReportReceiptView, ResolveReceiptView} from "./views.ts";
 
 const SubmitReportInput = Schema.Struct({
 	targetKind: TargetKindSchema,
-	targetId: Schema.String,
+	targetId: TargetId,
 	reason: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
@@ -53,26 +55,27 @@ const SubmitReportInput = Schema.Struct({
 // `targetId`), or pass a `reportId` and the resolve acts on its whole target group.
 // `waveId` is the remove-the-wave grouping id (#1855): the client generates ONE per
 // wave gesture and threads the SAME id through every fanned-out resolve, so the batch
-// reopens as a unit. Absent on a single-target resolve.
+// reopens as a unit. Absent on a single-target resolve. The three ids are distinct
+// brands (ReportId / TargetId / WaveId), so transposing them here is a compile error.
 const ResolveReportInput = Schema.Struct({
-	reportId: Schema.optional(Schema.String),
+	reportId: Schema.optional(ReportId),
 	targetKind: Schema.optional(TargetKindSchema),
-	targetId: Schema.optional(Schema.String),
+	targetId: Schema.optional(TargetId),
 	action: Schema.Literals(["remove", "dismiss"]),
-	waveId: Schema.optional(Schema.NullOr(Schema.String)),
+	waveId: Schema.optional(Schema.NullOr(WaveId)),
 });
 
 const RestoreReportInput = Schema.Struct({
-	reportId: Schema.optional(Schema.String),
+	reportId: Schema.optional(ReportId),
 	targetKind: Schema.optional(TargetKindSchema),
-	targetId: Schema.optional(Schema.String),
+	targetId: Schema.optional(TargetId),
 });
 
 // Restore a whole wave-removal (#1855) as a unit: the `waveId` names the one grouping id
 // the wave gesture stamped across its targets, so restore brings EVERY target in the batch
 // back live and reopens every report sharing the id together.
 const RestoreWaveReportInput = Schema.Struct({
-	waveId: Schema.String,
+	waveId: WaveId,
 });
 
 // Translate the service's kind-blind not-found into the feature-level error its

--- a/apps/web/worker/features/report/report-ids.typetest.ts
+++ b/apps/web/worker/features/report/report-ids.typetest.ts
@@ -1,0 +1,34 @@
+/**
+ * Type-level assertion (no runtime — checked by `tsgo`, not vitest): the moderation
+ * id surfaces `ReportId` (a filed report), `WaveId` (a remove-the-wave grouping), and
+ * the shared polymorphic `TargetId` (the report's post/definition/comment target) are
+ * nominally distinct, so transposing any two is a compile error (#2721 AC#4), while all
+ * three stay plain strings at runtime. Mirrors `../vote/vote-ids.typetest.ts`.
+ */
+import {expectTypeOf} from "vitest";
+import type {TargetId} from "../../lib/ids.ts";
+import type {ReportId, WaveId} from "./ids.ts";
+
+// All three brands erase to `string` at runtime — the brand is type-only (#2735).
+expectTypeOf<ReportId>().toMatchTypeOf<string>();
+expectTypeOf<WaveId>().toMatchTypeOf<string>();
+expectTypeOf<TargetId>().toMatchTypeOf<string>();
+
+// The distinctness that makes a reportId/targetId/waveId swap unrepresentable: no brand
+// is assignable to another, so a moderation flow can't confuse the three ids.
+expectTypeOf<ReportId>().not.toEqualTypeOf<TargetId>();
+expectTypeOf<ReportId>().not.toMatchTypeOf<TargetId>();
+expectTypeOf<TargetId>().not.toMatchTypeOf<ReportId>();
+expectTypeOf<ReportId>().not.toMatchTypeOf<WaveId>();
+expectTypeOf<WaveId>().not.toMatchTypeOf<ReportId>();
+
+declare const someReportId: ReportId;
+declare const someTargetId: TargetId;
+
+// The literal "a reportId/targetId swap fails pnpm typecheck" proof: were the two
+// interchangeable, these `@ts-expect-error` directives would themselves fail as unused
+// (TS2578).
+// @ts-expect-error a TargetId cannot stand in for a ReportId — the report/target swap is a compile error
+export const _targetAsReport: ReportId = someTargetId;
+// @ts-expect-error a ReportId cannot stand in for a TargetId — the report/target swap is a compile error
+export const _reportAsTarget: TargetId = someReportId;

--- a/apps/web/worker/features/report/report-live-fanout.unit.test.ts
+++ b/apps/web/worker/features/report/report-live-fanout.unit.test.ts
@@ -24,6 +24,7 @@ import {liveConnectionTopic, liveEntityTopic, liveGlobalConnectionTopic} from "@
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
+import {TargetId} from "../../lib/ids.ts";
 import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
 import {noopPanoFeedCache, noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
@@ -31,6 +32,7 @@ import {Flags} from "../flagship/Flags.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {Pano} from "../pano/Pano.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
+import {WaveId} from "./ids.ts";
 import {mutations} from "./mutations.ts";
 import {makeReportStub} from "./Report.testing.ts";
 
@@ -191,7 +193,7 @@ describe("report.resolve remove — publishes the content-topic invalidation", (
 		const {recorded, scheduled, layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			yield* mutations["report.resolve"].handler({
-				input: {targetKind: "post", targetId: "p1", action: "remove"},
+				input: {targetKind: "post", targetId: TargetId.make("p1"), action: "remove"},
 				select: ["id"],
 			});
 			yield* flush(scheduled);
@@ -202,7 +204,7 @@ describe("report.resolve remove — publishes the content-topic invalidation", (
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					reportStub({targetKind: "post", targetId: "p1"}),
+					reportStub({targetKind: "post", targetId: TargetId.make("p1")}),
 					Layer.succeed(
 						Pano,
 						panoStub({moderateRemovePost: () => Effect.succeed({removed: true})}),
@@ -221,7 +223,7 @@ describe("report.resolve remove — publishes the content-topic invalidation", (
 		const {recorded, scheduled, layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			yield* mutations["report.resolve"].handler({
-				input: {targetKind: "comment", targetId: "c1", action: "remove"},
+				input: {targetKind: "comment", targetId: TargetId.make("c1"), action: "remove"},
 				select: ["id"],
 			});
 			yield* flush(scheduled);
@@ -229,7 +231,7 @@ describe("report.resolve remove — publishes the content-topic invalidation", (
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					reportStub({targetKind: "comment", targetId: "c1"}),
+					reportStub({targetKind: "comment", targetId: TargetId.make("c1")}),
 					Layer.succeed(
 						Pano,
 						panoStub({
@@ -251,7 +253,7 @@ describe("report.resolve remove — publishes the content-topic invalidation", (
 		const {recorded, scheduled, layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			yield* mutations["report.resolve"].handler({
-				input: {targetKind: "definition", targetId: "d1", action: "remove"},
+				input: {targetKind: "definition", targetId: TargetId.make("d1"), action: "remove"},
 				select: ["id"],
 			});
 			yield* flush(scheduled);
@@ -262,7 +264,7 @@ describe("report.resolve remove — publishes the content-topic invalidation", (
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					reportStub({targetKind: "definition", targetId: "d1"}),
+					reportStub({targetKind: "definition", targetId: TargetId.make("d1")}),
 					Layer.succeed(Pano, panoStub({})),
 					Layer.succeed(
 						Sozluk,
@@ -284,7 +286,7 @@ describe("report.resolve remove — publishes the content-topic invalidation", (
 		const {recorded, scheduled, layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			yield* mutations["report.resolve"].handler({
-				input: {targetKind: "post", targetId: "p1", action: "remove"},
+				input: {targetKind: "post", targetId: TargetId.make("p1"), action: "remove"},
 				select: ["id"],
 			});
 			yield* flush(scheduled);
@@ -292,7 +294,7 @@ describe("report.resolve remove — publishes the content-topic invalidation", (
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					reportStub({targetKind: "post", targetId: "p1"}),
+					reportStub({targetKind: "post", targetId: TargetId.make("p1")}),
 					Layer.succeed(
 						Pano,
 						panoStub({moderateRemovePost: () => Effect.succeed({removed: false})}),
@@ -315,7 +317,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 			const {recorded, scheduled, layer} = recordingPublisher();
 			return Effect.gen(function* () {
 				yield* mutations["report.restore"].handler({
-					input: {targetKind: "post", targetId: "p1"},
+					input: {targetKind: "post", targetId: TargetId.make("p1")},
 					select: ["id"],
 				});
 				yield* flush(scheduled);
@@ -323,7 +325,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 			}).pipe(
 				Effect.provide(
 					Layer.mergeAll(
-						reportStub({targetKind: "post", targetId: "p1"}),
+						reportStub({targetKind: "post", targetId: TargetId.make("p1")}),
 						Layer.succeed(
 							Pano,
 							panoStub({
@@ -348,7 +350,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 			const {recorded, scheduled, layer} = recordingPublisher();
 			return Effect.gen(function* () {
 				yield* mutations["report.restore"].handler({
-					input: {targetKind: "post", targetId: "p1"},
+					input: {targetKind: "post", targetId: TargetId.make("p1")},
 					select: ["id"],
 				});
 				yield* flush(scheduled);
@@ -358,7 +360,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 			}).pipe(
 				Effect.provide(
 					Layer.mergeAll(
-						reportStub({targetKind: "post", targetId: "p1"}),
+						reportStub({targetKind: "post", targetId: TargetId.make("p1")}),
 						Layer.succeed(
 							Pano,
 							panoStub({
@@ -382,7 +384,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 		const {recorded, scheduled, layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			yield* mutations["report.restore"].handler({
-				input: {targetKind: "comment", targetId: "c1"},
+				input: {targetKind: "comment", targetId: TargetId.make("c1")},
 				select: ["id"],
 			});
 			yield* flush(scheduled);
@@ -390,7 +392,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					reportStub({targetKind: "comment", targetId: "c1"}),
+					reportStub({targetKind: "comment", targetId: TargetId.make("c1")}),
 					Layer.succeed(
 						Pano,
 						panoStub({
@@ -413,7 +415,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 		const {recorded, scheduled, layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			yield* mutations["report.restore"].handler({
-				input: {targetKind: "definition", targetId: "d1"},
+				input: {targetKind: "definition", targetId: TargetId.make("d1")},
 				select: ["id"],
 			});
 			yield* flush(scheduled);
@@ -421,7 +423,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					reportStub({targetKind: "definition", targetId: "d1"}),
+					reportStub({targetKind: "definition", targetId: TargetId.make("d1")}),
 					Layer.succeed(Pano, panoStub({})),
 					Layer.succeed(
 						Sozluk,
@@ -453,14 +455,14 @@ describe("fail-safe — a failed publish does not fail the moderation action", (
 			// The receipt still resolves even though every publish dies — the publisher's
 			// `never` error channel swallows the failure off the request path.
 			const receipt = yield* mutations["report.resolve"].handler({
-				input: {targetKind: "post", targetId: "p1", action: "remove"},
+				input: {targetKind: "post", targetId: TargetId.make("p1"), action: "remove"},
 				select: ["id", "targetRemoved"],
 			});
 			assert.strictEqual((receipt as {targetRemoved: boolean}).targetRemoved, true);
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					reportStub({targetKind: "post", targetId: "p1"}),
+					reportStub({targetKind: "post", targetId: TargetId.make("p1")}),
 					Layer.succeed(
 						Pano,
 						panoStub({moderateRemovePost: () => Effect.succeed({removed: true})}),
@@ -507,7 +509,12 @@ describe("report.resolve — threads the wave grouping id to resolveTarget (#185
 		const {layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			yield* mutations["report.resolve"].handler({
-				input: {targetKind: "post", targetId: "p1", action: "dismiss", waveId: "wave-1"},
+				input: {
+					targetKind: "post",
+					targetId: TargetId.make("p1"),
+					action: "dismiss",
+					waveId: WaveId.make("wave-1"),
+				},
 				select: ["id"],
 			});
 			assert.strictEqual(sink.waveId, "wave-1", "the shared wave id reaches resolveTarget");
@@ -519,7 +526,7 @@ describe("report.resolve — threads the wave grouping id to resolveTarget (#185
 		const {layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			yield* mutations["report.resolve"].handler({
-				input: {targetKind: "post", targetId: "p1", action: "dismiss"},
+				input: {targetKind: "post", targetId: TargetId.make("p1"), action: "dismiss"},
 				select: ["id"],
 			});
 			assert.strictEqual(sink.waveId, null, "a lone resolve carries no wave grouping");
@@ -545,7 +552,7 @@ describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () =
 		const {recorded, scheduled, layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			const receipt = yield* mutations["report.restoreWave"].handler({
-				input: {waveId: "wave-1"},
+				input: {waveId: WaveId.make("wave-1")},
 				select: ["id", "collapsed"],
 			});
 			yield* flush(scheduled);
@@ -560,8 +567,8 @@ describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () =
 			Effect.provide(
 				Layer.mergeAll(
 					waveReportStub([
-						{targetKind: "post", targetId: "p1"},
-						{targetKind: "definition", targetId: "d1"},
+						{targetKind: "post", targetId: TargetId.make("p1")},
+						{targetKind: "definition", targetId: TargetId.make("d1")},
 					]),
 					Layer.succeed(
 						Pano,
@@ -591,7 +598,7 @@ describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () =
 		const {recorded, scheduled, layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			const receipt = yield* mutations["report.restoreWave"].handler({
-				input: {waveId: "wave-gone"},
+				input: {waveId: WaveId.make("wave-gone")},
 				select: ["id", "collapsed"],
 			});
 			yield* flush(scheduled);
@@ -619,7 +626,10 @@ describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () =
 		const {layer} = recordingPublisher();
 		return Effect.gen(function* () {
 			const exit = yield* Effect.exit(
-				mutations["report.restoreWave"].handler({input: {waveId: "wave-1"}, select: ["id"]}),
+				mutations["report.restoreWave"].handler({
+					input: {waveId: WaveId.make("wave-1")},
+					select: ["id"],
+				}),
 			);
 			assert.isTrue(exit._tag === "Failure", "a non-moderator restoreWave is denied");
 			if (exit._tag === "Failure") {
@@ -656,7 +666,7 @@ describe("report.submit — the audit refuted submit; the CONTENT path fans out 
 				const {recorded, scheduled, layer} = recordingPublisher();
 				const receipt = yield* mutations["report.submit"]
 					.handler({
-						input: {targetKind: "post", targetId: "p1"},
+						input: {targetKind: "post", targetId: TargetId.make("p1")},
 						select: ["id", "created"],
 					})
 					.pipe(
@@ -664,7 +674,12 @@ describe("report.submit — the audit refuted submit; the CONTENT path fans out 
 						Effect.provide(
 							Layer.mergeAll(
 								makeReportStub({
-									submit: () => Effect.succeed({targetKind: "post", targetId: "p1", created: true}),
+									submit: () =>
+										Effect.succeed({
+											targetKind: "post",
+											targetId: TargetId.make("p1"),
+											created: true,
+										}),
 								}),
 								layer,
 								actorContext(human("u-reporter")),

--- a/apps/web/worker/features/report/report-mutation.unit.test.ts
+++ b/apps/web/worker/features/report/report-mutation.unit.test.ts
@@ -17,6 +17,7 @@ import {CurrentActor, human, RelationStore, unauthenticated} from "@kampus/authz
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, Effect, Layer} from "effect";
+import {TargetId} from "../../lib/ids.ts";
 import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
 import {noRequestFlagOverrides, resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
@@ -111,7 +112,7 @@ const notFound = (input: ReportInput): Effect.Effect<never, ReportTargetNotFound
 	Effect.fail(
 		new ReportTargetNotFound({
 			targetKind: input.targetKind,
-			targetId: input.targetId,
+			targetId: TargetId.make(input.targetId),
 			message: `report target ${input.targetKind} ${input.targetId} not found`,
 		}),
 	);


### PR DESCRIPTION
Adopt effect-smol's `Schema.brand` nominal-id idiom across the report + divan moderation surfaces (epic #2700, type-only, runtime byte-identical — a brand is a compile-time marker, `.make`/decode return the input unchanged).

## What changed
- **report** — feature-local `ReportId` / `WaveId` (`features/report/ids.ts`); the shared polymorphic `TargetId` imported from `lib/ids.ts` (#2723/#2735). Threaded through the `report.resolve` / `report.restore` / `report.restoreWave` / `report.submit` input schemas and the `ReportTargetNotFound` error. `features/report/report-ids.typetest.ts` pins that a reportId / targetId / waveId swap fails `pnpm typecheck` (AC#4).
- **divan** — `authorId` / roster id branded to the shared `UserId` (`DivanItem` / `DivanCaylakEntry` / `Divan.backlogOf` / the `divan.backlog` arg schema).

## Scope discipline (the #2723-surgical approach)
Branding stays at the schema/decode boundaries. Service-internal params that an **out-of-feature** caller passes as a plain string stay `string` — `Divan.pendingCountOf` (called by bildirim's `mod-emitters.ts`) — with an in-code note. No content-feature (pano/sozluk) or view/protocol file is touched.

## Deferred — lifecycle's `Moderated.reportId` → follow-up #2820
`Moderated.reportId` (`features/lifecycle/EntityLifecycle.ts`) stays bare `Schema.String`: it is constructed in pano + sozluk (`moderateRemove*` with plain-string `reportId`), so branding it would fail typecheck at those out-of-scope sites (mirrors vote's deferred `SelfVoteNotAllowed.voterId`, #2723). Captured as #2820. Because that lifecycle AC of #2721 is not delivered here, this PR uses `Part of` rather than a closing keyword.

Local `pnpm typecheck` + `pnpm lint:worktree` green. (Unit suite not run in-sandbox — the vitest bootstrap needs Cloudflare creds absent here; runtime is byte-identical by construction, so CI/review-code runs the suite.)

Part of #2721
Relates to #2700