### PR TITLE
fix(pipeline): harden verdict-post seam + leak-guard over comment bodies (#2796)

### DIFF
--- a/packages/pipeline-cli/src/tools/leak-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.ts
@@ -4,7 +4,8 @@
  * The CI-callable scan for issue #173, moved into the pipeline-cli registry (epic
  * #994, Phase 2 / #999):
  *
- *   pipeline-cli leak-guard scan <file>...   # report user-local path leaks; exit 2 on a leak
+ *   pipeline-cli leak-guard scan <file>...        # report user-local path leaks in doc files; exit 2 on a leak
+ *   pipeline-cli leak-guard scan-comment          # scan a PR/issue comment body (stdin) before posting; exit 2 on a leak
  *
  * Reads each file, runs the pure `findLeaks` core, and reports
  * `<file>: <matched> — <reason>` lines on stderr. A missing/unreadable file is
@@ -29,7 +30,7 @@ import {Console, Data, Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, CREW_DIR, sweepCrew} from "./crew-gate.ts";
-import {findLeaks, type Leak} from "./leak-guard.ts";
+import {findCommentLeaks, findLeaks, type Leak} from "./leak-guard.ts";
 
 // 2 = a confirmed leak; any OTHER non-zero from this process means the scan
 // could not complete, which the pre-commit hook treats as warn-and-allow while
@@ -153,7 +154,56 @@ const sweep = Command.make(
 	),
 );
 
+// The pre-post net for a PR/issue COMMENT body (#2796). Where `scan` takes doc FILES and
+// `findLeaks` scopes to doc surfaces, this takes a single comment body on stdin/`--body-file`
+// and runs `findCommentLeaks` — which has no doc-surface gate (a comment is unconditionally a
+// public artifact) and the stricter temp-root patterns (`/var/folders`, `/private/tmp`, `/tmp`).
+// A `review-*` verdict-posting step runs it before `gh api …/comments` so a bypass of the
+// verdict-lib `post` seam can't silently land a scratchpad/@-filepath body on a public PR.
+const commentBodyFlag = Flag.string("body-file").pipe(
+	Flag.optional,
+	Flag.withDescription("path to the comment body to scan (default: read the body from stdin)"),
+);
+
+const readCommentBody = (bodyFile: Option.Option<string>): Effect.Effect<string> =>
+	Effect.sync(() =>
+		Option.match(bodyFile, {
+			onNone: () => readFileSync(0, "utf8"),
+			onSome: (path) => readFileSync(path, "utf8"),
+		}),
+	);
+
+const scanComment = Command.make(
+	"scan-comment",
+	{bodyFile: commentBodyFlag},
+	Effect.fn(function* ({bodyFile}) {
+		const run = Effect.gen(function* () {
+			const body = yield* readCommentBody(bodyFile);
+			const leaks = findCommentLeaks(body);
+			if (leaks.length === 0) {
+				yield* Console.log("leak-guard: clean — no machine-local paths in the comment body");
+				return;
+			}
+			yield* Console.error(
+				"leak-guard: blocked — machine-local path(s) in a PR/issue comment body (issue #2796):",
+			);
+			for (const leak of leaks) {
+				yield* Console.error(`  ${leak.matched} — ${leak.reason}`);
+			}
+			yield* Console.error(
+				"A verdict/PR comment must inline its TEXT with repo-relative paths only — never a scratchpad/@-filepath ref or a temp path. Post the verdict CONTENT, not a local path.",
+			);
+			return yield* Effect.fail(new LeakFound({count: leaks.length}));
+		});
+		yield* run.pipe(Effect.catchTag("LeakFound", onLeakFound));
+	}),
+).pipe(
+	Command.withDescription(
+		"Scan a PR/issue comment body for machine-local path leaks before posting (exit 2 on a leak)",
+	),
+);
+
 export const leakGuardCommand = Command.make("leak-guard").pipe(
-	Command.withSubcommands([scan, sweep]),
+	Command.withSubcommands([scan, sweep, scanComment]),
 	Command.withDescription("Block user-local paths from entering shared-artifact doc surfaces"),
 );

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
@@ -83,7 +83,46 @@ const LEAK_PATTERNS: ReadonlyArray<LeakPattern> = [
 	},
 ];
 
+// Machine-local temp/scratch roots — a PR/issue COMMENT (or verdict) body must never carry
+// one (the #2796/#2822 scratchpad-`@filepath` and #2683/#2772 mktemp-in-`@sha` leaks). This is
+// deliberately STRICTER than the doc-surface `findLeaks`, which carves out a bare `/tmp` for
+// illustrative examples in docs — a public PR comment has no such legitimate use, so these are
+// scanned by `findCommentLeaks` only, never by the file-surface path. Generic path shapes, NOT
+// a named deny-list (#2393): the macOS mktemp dirs and a bare `/tmp` scratch path. The
+// `(?<![\w.])` lookbehind stops a `/private/tmp/...` match from also double-firing the `/tmp/`
+// pattern (its preceding char is a word char), so each leak reports once.
+const TEMP_PATTERNS: ReadonlyArray<LeakPattern> = [
+	{
+		pattern: /(?<![\w.])\/var\/folders\/[A-Za-z0-9._/-]+/g,
+		reason: "macOS per-user mktemp dir (/var/folders/...)",
+	},
+	{
+		pattern: /(?<![\w.])\/private\/(?:tmp|var)\/[A-Za-z0-9._/-]+/g,
+		reason: "macOS resolved temp root (/private/tmp/..., /private/var/...)",
+	},
+	{
+		pattern: /(?<![\w.])\/tmp\/[A-Za-z0-9._/-]+/g,
+		reason: "machine-local temp/scratch path (/tmp/...)",
+	},
+];
+
 const normalize = (path: string): string => path.replace(/\\/g, "/");
+
+/** Every leak in `text` for `patterns`, deduped on matched+reason (report order = pattern order). */
+const scanPatterns = (text: string, patterns: ReadonlyArray<LeakPattern>): ReadonlyArray<Leak> => {
+	const seen = new Set<string>();
+	const leaks: Leak[] = [];
+	for (const {pattern, reason} of patterns) {
+		for (const match of text.matchAll(pattern)) {
+			const matched = match[0];
+			const key = `${matched}\t${reason}`;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			leaks.push({matched, reason});
+		}
+	}
+	return leaks;
+};
 
 export const isSharedArtifact = (path: string): boolean => {
 	const p = normalize(path);
@@ -106,17 +145,18 @@ export const findLeaks = (filePath: string, text: string): ReadonlyArray<Leak> =
 	if (!filePath || !text) return [];
 	if (!isSharedArtifact(filePath)) return [];
 	if (isSelfExempt(filePath)) return [];
+	return scanPatterns(text, LEAK_PATTERNS);
+};
 
-	const seen = new Set<string>();
-	const leaks: Leak[] = [];
-	for (const {pattern, reason} of LEAK_PATTERNS) {
-		for (const match of text.matchAll(pattern)) {
-			const matched = match[0];
-			const key = `${matched}\t${reason}`;
-			if (seen.has(key)) continue;
-			seen.add(key);
-			leaks.push({matched, reason});
-		}
-	}
-	return leaks;
+/**
+ * Every machine-local path leak in a PR/issue COMMENT body — the surface `findLeaks` never
+ * reaches (it scopes to doc *files*), the gap that let a `review-*` verdict comment carry a
+ * `/private/tmp/.../scratchpad/verdict.md` scratchpad ref and a `@/var/folders/.../tmp.XXXX`
+ * mktemp path onto public PRs (#2796/#2822/#2683/#2772). A comment body is UNCONDITIONALLY a
+ * shared public artifact, so there is no doc-surface gate and no self-exempt list — it scans
+ * the home-dir `LEAK_PATTERNS` AND the stricter `TEMP_PATTERNS`. Generic path shapes only (#2393).
+ */
+export const findCommentLeaks = (text: string): ReadonlyArray<Leak> => {
+	if (!text) return [];
+	return scanPatterns(text, [...LEAK_PATTERNS, ...TEMP_PATTERNS]);
 };

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
@@ -1,7 +1,8 @@
 import {assert, describe, it} from "@effect/vitest";
-import {findLeaks, isSelfExempt, isSharedArtifact} from "./leak-guard.ts";
+import {findCommentLeaks, findLeaks, isSelfExempt, isSharedArtifact} from "./leak-guard.ts";
 
 const hasLeak = (filePath: string, text: string): boolean => findLeaks(filePath, text).length > 0;
+const hasCommentLeak = (text: string): boolean => findCommentLeaks(text).length > 0;
 
 describe("findLeaks — BLOCK matrix (a real local path in a shared artifact)", () => {
 	it("blocks an absolute /Users/<name> path in a .md", () => {
@@ -68,6 +69,53 @@ describe("findLeaks — ALLOW matrix (legitimate content must NOT be flagged)", 
 	it("allows a clean shared artifact with no local paths", () => {
 		assert.isFalse(hasLeak("README.md", "this is ordinary prose with no paths at all"));
 	});
+});
+
+describe("findCommentLeaks — PR/issue comment body scan (#2796, stricter than the file surface)", () => {
+	const MKTEMP = "/var/folders/8f/r3k3t6817cgbsxsxvxk83q4c0000gn/T/tmp.TgExIt22qT";
+
+	it("blocks a /var/folders mktemp path (the #2816/#2818 @<sha>-field recurrence)", () => {
+		const leaks = findCommentLeaks(`review-code: PASS @${MKTEMP} — merge-ready`);
+		assert.isAbove(leaks.length, 0);
+	});
+	it("blocks a whole-body @filepath scratchpad ref (the #2789 case)", () =>
+		assert.isTrue(hasCommentLeak("@/private/tmp/claude-501/session/scratchpad/verdict.md")));
+	it("blocks a /private/tmp scratchpad path", () =>
+		assert.isTrue(hasCommentLeak("wrote it to /private/tmp/claude/scratchpad/verdict.md")));
+	it("blocks a bare /tmp scratch path (no doc carve-out on a public comment)", () =>
+		assert.isTrue(hasCommentLeak("verdict staged at /tmp/review-code-verdict-12.md")));
+	it("blocks an absolute /Users/<name> path", () =>
+		assert.isTrue(hasCommentLeak("see /Users/foo/project/notes")));
+	it("blocks a temp path that sits in verdict PROSE, not a SHA field", () =>
+		assert.isTrue(hasCommentLeak(`review-code: advisory — see thread\n\nnotes at ${MKTEMP}`)));
+
+	it("allows an inline verdict body with repo-relative paths and a real SHA", () =>
+		assert.isFalse(
+			hasCommentLeak(
+				`review-code: PASS @ ${"a".repeat(40)} — verified apps/web/worker and packages/pipeline-cli`,
+			),
+		));
+	it("allows a §CP advisory with a clean Reviewed-head anchor", () =>
+		assert.isFalse(
+			hasCommentLeak(
+				`review-code: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${"b".repeat(40)}`,
+			),
+		));
+	it("allows a GitHub PR URL (not a machine-local path)", () =>
+		assert.isFalse(
+			hasCommentLeak("cross-linked with https://github.com/kamp-us/phoenix/pull/2796"),
+		));
+	it("reports each leak once, no double-fire on /private/tmp vs /tmp", () => {
+		const leaks = findCommentLeaks("staged at /private/tmp/claude/scratchpad/verdict.md");
+		assert.strictEqual(leaks.length, 1);
+	});
+});
+
+describe("findLeaks — file surface keeps its /tmp carve-out (unchanged by the comment scan)", () => {
+	it("still allows a bare /tmp path in a doc surface", () =>
+		assert.isFalse(hasLeak("notes.md", "progress at /tmp/write-code-progress.md")));
+	it("still allows /var/folders in a doc surface (temp roots are comment-body-only)", () =>
+		assert.isFalse(hasLeak("notes.md", "ran under /var/folders/8f/T/tmp.abc")));
 });
 
 describe("surface predicates", () => {

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -15,6 +15,7 @@
  * exactly as `epic-lock`'s claim core takes it — a forged marker from a non-collaborator
  * never enters the candidate set, and an empty authorized set resolves NO verdict (fail-closed).
  */
+import {findCommentLeaks} from "../leak-guard/leak-guard.ts";
 
 /** The four PR-layer gate namespaces (ADR 0058 §Scope + ADR 0150/0162). */
 export type VerdictGate = "code" | "doc" | "skill" | "design";
@@ -269,18 +270,31 @@ export const malformedEmittedSha = (body: string, gate: VerdictGate): string | n
  * The single fail-closed gate every verdict EMISSION passes before it can reach GitHub — the one
  * source `Github.post` and `verdict validate` both consume so a raw-`gh api` skill and the tool
  * enforce identical rules. Returns the first structural defect (as a human-readable reason), or
- * null when the body is postable. Three ordered checks:
- *   1. cross-namespace — the first line must be *this* gate's marker (ADR 0058 §Scope);
+ * null when the body is postable. Four ordered checks:
+ *   1. cross-namespace — the first line must be *this* gate's marker (ADR 0058 §Scope); this also
+ *      refuses the whole-body bare `@filepath` case, whose first line is not a marker (#2796);
  *   2. unbound polarity — a PASS/FAIL first line must carry a bindable `@ <sha>` (the `@-` bug, #2646);
  *   3. malformed emitted SHA — every SHA field (first-line marker + `Reviewed-head:` anchor) must be
- *      a clean full 40-hex, never a partial/non-hex/path-glued value (the mktemp-path leak, #2683).
+ *      a clean full 40-hex, never a partial/non-hex/path-glued value (the mktemp-path leak, #2683/#2772);
+ *   4. body-wide leak — NO machine-local path (home / `/var/folders` mktemp / `/private/tmp` / `/tmp`)
+ *      anywhere in the body, closing the gap checks 1–3 miss: a temp path that sits in the verdict PROSE
+ *      rather than a SHA field (checks 3's field-scan skips it) or a whole-body scratchpad ref would
+ *      otherwise post a local path into a public comment (#2796/#2822). The verdict body must inline
+ *      verdict TEXT with repo-relative paths only.
  */
 export const emissionDefect = (body: string, gate: VerdictGate): string | null => {
 	if (!isNamespaceMarker(body, gate)) {
-		return `the body's first line is not a ${GATE_KEYWORD[gate]}: marker — a verdict must carry its own gate's marker on line one (the cross-namespace emission bug, ADR 0058 §Scope)`;
+		return `the body's first line is not a ${GATE_KEYWORD[gate]}: marker — a verdict must carry its own gate's marker on line one (the cross-namespace emission bug, ADR 0058 §Scope; also the whole-body bare @filepath case, #2796)`;
 	}
 	if (isUnboundPolarityMarker(body, gate)) {
 		return `a ${GATE_KEYWORD[gate]}: PASS/FAIL verdict must carry a well-formed '@ <sha>' (≥7 hex) — this polarity-bearing body has an empty/malformed SHA, which posts an unbindable marker the fail-closed read side refuses (the '@-' emission bug, ADR 0058, #2646)`;
 	}
-	return malformedEmittedSha(body, gate);
+	const shaDefect = malformedEmittedSha(body, gate);
+	if (shaDefect !== null) return shaDefect;
+	const leaks = findCommentLeaks(body);
+	if (leaks.length > 0) {
+		const leak = leaks[0];
+		return `the verdict body carries a machine-local path (${leak?.matched} — ${leak?.reason}) — a verdict comment must inline verdict TEXT with repo-relative paths only, never a scratchpad/@-filepath ref or a temp path (the silent-gate-loss + path-leak recurrence, #2796/#2822/#2683/#2772)`;
+	}
+	return null;
 };

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -360,11 +360,19 @@ describe("malformedEmittedSha — the post full-40-hex emission guard (#2683)", 
 		assert.isNull(malformedEmittedSha("review-code: advisory — see thread", "code")));
 });
 
-describe("emissionDefect — the one gate `post` and `validate` share (#2683)", () => {
+describe("emissionDefect — the one gate `post` and `validate` share (#2683/#2772/#2796)", () => {
 	const SHA40 = "a".repeat(40);
+	const MKTEMP = "/var/folders/8f/r3k3t6817cgbsxsxvxk83q4c0000gn/T/tmp.TgExIt22qT";
 
 	it("null (postable) for a clean full-40-hex PASS marker", () =>
 		assert.isNull(emissionDefect(`review-doc: PASS @ ${SHA40} — merge-ready`, "doc")));
+	it("null (postable) for a §CP advisory with an inline body + clean Reviewed-head", () =>
+		assert.isNull(
+			emissionDefect(
+				`review-doc: advisory — blocking-set PR (manual merge)\n\nverified apps/web and packages/pipeline-cli\n\nReviewed-head: @ ${SHA40}`,
+				"doc",
+			),
+		));
 	it("defect for a cross-namespace body (review-code on the doc gate)", () =>
 		assert.isNotNull(emissionDefect(`review-code: PASS @ ${SHA40} — merge-ready`, "doc")));
 	it("defect for an unbound `@-` polarity marker (the #2646 case)", () =>
@@ -372,5 +380,30 @@ describe("emissionDefect — the one gate `post` and `validate` share (#2683)", 
 	it("defect for a path-glued SHA field (the #2683 case)", () =>
 		assert.isNotNull(
 			emissionDefect("review-doc: PASS @ /var/folders/T/tmp.X — merge-ready", "doc"),
+		));
+
+	// The #2816/#2818 recurrence: a /var/folders mktemp path in the @<sha> field, refused loudly.
+	it("defect for a /var/folders mktemp path in the @<sha> field (#2772 variant, #2816/#2818)", () =>
+		assert.isNotNull(emissionDefect(`review-code: PASS @${MKTEMP} — merge-ready`, "code")));
+	it("defect for a /var/folders mktemp path in the Reviewed-head anchor", () =>
+		assert.isNotNull(
+			emissionDefect(`review-code: advisory — see thread\n\nReviewed-head: @${MKTEMP}`, "code"),
+		));
+	// The #2789 case: the whole body is a bare @filepath — its first line is not a marker.
+	it("defect for a whole-body bare @filepath scratchpad ref (#2789/#2796)", () =>
+		assert.isNotNull(
+			emissionDefect("@/private/tmp/claude-501/session/scratchpad/verdict.md", "code"),
+		));
+	// The hole checks 1–3 miss: a valid line-1 marker but a temp path in the PROSE tail.
+	it("defect for a temp path in verdict PROSE with an otherwise-valid marker (the prose hole)", () =>
+		assert.isNotNull(
+			emissionDefect(
+				`review-code: PASS @ ${SHA40}\n\nreviewed the diff staged at ${MKTEMP}`,
+				"code",
+			),
+		));
+	it("defect for a /Users home path in verdict prose", () =>
+		assert.isNotNull(
+			emissionDefect(`review-code: PASS @ ${SHA40}\n\nsee /Users/foo/scratch/notes`, "code"),
 		));
 });


### PR DESCRIPTION
Part of #2796

## The bug (now confirmed systemic)

A `review-*` verdict was posted as a bare `@filepath` reference / a shell-expanded mktemp path **instead of the verdict TEXT**, causing two failures at once:

1. **Silent gate-loss** — the intended `review-code: … @ <sha>` marker never landed as usable text, so ship-it's Step-2 verdict resolution found no marker and refused "unverified" even though the review PASSED. Silent: the reviewer believed it posted.
2. **Local-path leak** — the mangled body carried a `/private/tmp/…` / `/var/folders/…` absolute path into a public PR comment.

Recurred 3–4 times: §CP PR #2789 (whole-body `@filepath`), and PRs #2816 / #2818 with signature `@/var/folders/.../tmp.XXXX` in the marker's `@<sha>` field — both posted **after** #2772 (the #2683 mktemp-in-`@sha` guard) merged.

## Grounding — what #2772's guard already covers, and the gap

Empirically verified against the live `emissionDefect` guard (`verdict-match.ts`):

- `review-code: PASS @/var/folders/.../tmp.XXXX` in the `@<sha>` field → **already caught** (SHA-field defect).
- `Reviewed-head: @/var/folders/...` anchor → **already caught**.
- **Gap 1:** a valid line-1 marker with a temp/local path in the verdict **PROSE tail** → the field-scoped SHA checks skip it → `null` (postable). **HOLE.**
- **Gap 2:** the recurrence leaked because the emit path **bypassed** the verdict lib (hand-`gh api` raw comment), so no guard fired — the same bypass root as #2789. Code can't force a hand-post to route through the lib; the fix adds a pre-post leak-guard net the review step can call, plus closes the in-lib prose hole.

## Two hardening surfaces

**1. `emissionDefect` gains a fourth check — a body-wide leak scan** (`packages/pipeline-cli/src/tools/verdict/verdict-match.ts`). The one gate `Github.post` + `verdict validate` share now refuses ANY machine-local path (home / `/var/folders` mktemp / `/private/tmp` / `/tmp`) **anywhere** in the body — closing the prose hole and the whole-body `@filepath` case. So the invariant "a verdict body inlines TEXT with repo-relative paths only, `@<sha>` is a real 40-hex SHA" is enforced in every body position, refused loudly (`VerdictInputError`, non-zero) instead of silently posted.

**2. leak-guard reaches PR/issue COMMENT bodies** (`packages/pipeline-cli/src/tools/leak-guard/`). New `findCommentLeaks(text)` + a `pipeline-cli leak-guard scan-comment` subcommand (stdin / `--body-file`, exit 2 on a leak) — the pre-post net a `review-*` step runs before `gh api …/comments`, independent of whether the post routes through the verdict lib. A comment body is unconditionally a public artifact, so it has **no** doc-surface gate and **no** `/tmp` carve-out — the file-surface `findLeaks` is unchanged (its `/tmp` doc carve-out preserved). Generic path-shape patterns, **not** a named deny-list (per the #2393 ruling).

## Tests

- `verdict-match.unit.test.ts`: the `@/var/folders/.../tmp.XXXX` `@<sha>`-field and `Reviewed-head` variants (#2816/#2818), the whole-body `@filepath` (#2789), the temp-path-in-prose hole, and a `/Users` home path in prose are each REFUSED; a clean inline PASS marker and a §CP advisory with a clean `Reviewed-head` pass.
- `leak-guard.unit.test.ts`: `findCommentLeaks` blocks `/var/folders`, `/private/tmp`, bare `/tmp`, `/Users`, and a prose temp path; passes an inline verdict + a GitHub PR URL; reports each leak once; the file-surface `findLeaks` keeps its `/tmp` carve-out.

131 unit tests pass; typecheck + biome clean on the changed files.

## Coupling / scope notes

- The post-guard could also reject **non-canonical marker FORMS** (`review-<ns>: PASS/FAIL/advisory @ <40-hex>` per ADR 0111) at post time — a clean canonical-form check isn't a 1-liner here (advisory tails are freeform prose), so this is **left to #2773's emit-side canonicalization fix** (#2773 coupling noted, not solved here).
- Distinct-but-related: #2683 / #2772 (mktemp-in-`@sha` guard), #2822.
- **No #2800-open file is touched** — this lives entirely in the verdict lib + leak-guard core/command; #2800 edits the `review-*` SKILL.md, `gh-issue-intake-formats.md`, `control-plane-paths`, `codeowners-cp`, and `registry.ts`, none of which are modified here.

## §CP — do not merge

Gate-critical verdict/review seam + `pipeline-cli` → §CP, banked at cansirin. Do not merge, do not approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)