### PR TITLE
refactor(lifecycle): brand Moderated.reportId with report's ReportId (#2820)

### DIFF
--- a/apps/web/worker/features/lifecycle/EntityLifecycle.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.ts
@@ -18,6 +18,7 @@
 import * as Data from "effect/Data";
 import * as Match from "effect/Match";
 import * as Schema from "effect/Schema";
+import {ReportId} from "../report/ids.ts";
 
 /**
  * Why a piece of content was removed — the audit's "why". A `Schema.Union` of
@@ -36,14 +37,10 @@ export class Anonymized extends Schema.Class<Anonymized>("lifecycle/Anonymized")
 
 export class Moderated extends Schema.Class<Moderated>("lifecycle/Moderated")({
 	_tag: Schema.tag("Moderated"),
-	// Unbranded `Schema.String` (not report's `ReportId`) on purpose: this reason is
-	// constructed at each content feature's moderator-remove site — pano
-	// (`post-operations.ts`/`comment-operations.ts`) and sözlük (`Sozluk.ts`) — with a
-	// plain-string `reportId`, so a `ReportId` here would fail typecheck at those
-	// out-of-feature construction sites, which epic #2700's report slice (#2721) does not
-	// touch. Deferred to a follow-up that brands the content services' `moderateRemove*`
-	// reportId params (mirrors vote's deferred `SelfVoteNotAllowed.voterId`, #2723).
-	reportId: Schema.String,
+	// The originating report, branded (#2820, deferred slice of #2721): the content
+	// features mint it via `ReportId.make(...)` at the report→service boundary
+	// (`report/mutations.ts`), so a report/target/user id swap is a compile error here.
+	reportId: ReportId,
 }) {}
 
 export const RemovalReason = Schema.Union([AuthorDeletion, Anonymized, Moderated]);
@@ -349,7 +346,7 @@ export const reasonLabel: (reason: RemovalReason) => string = Match.type<Removal
 );
 
 /** The originating report of a `Moderated` removal, else null — `Match` exhaustive. */
-export const reasonReportId: (reason: RemovalReason) => string | null =
+export const reasonReportId: (reason: RemovalReason) => ReportId | null =
 	Match.type<RemovalReason>().pipe(
 		Match.tagsExhaustive({
 			AuthorDeletion: () => null,

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
@@ -7,6 +7,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {expectTypeOf} from "vitest";
+import {ReportId} from "../report/ids.ts";
 import * as L from "./EntityLifecycle.ts";
 
 const fixedNow = new Date("2026-06-20T12:00:00.000Z");
@@ -38,7 +39,7 @@ describe("EntityLifecycle — type transitions", () => {
 		const removed = L.remove({
 			removedAt: fixedNow,
 			removedBy: "user-1",
-			reason: new L.Moderated({reportId: "rep-9"}),
+			reason: new L.Moderated({reportId: ReportId.make("rep-9")}),
 			sandboxedAt: null,
 		});
 		const live = L.restore(removed);
@@ -245,7 +246,7 @@ describe("EntityLifecycle — exhaustive reason handling", () => {
 		assert.strictEqual(L.reasonLabel(new L.AuthorDeletion()), "yazar tarafından silindi");
 		assert.strictEqual(L.reasonLabel(new L.Anonymized()), "hesap silindiği için kaldırıldı");
 		assert.strictEqual(
-			L.reasonLabel(new L.Moderated({reportId: "rep-1"})),
+			L.reasonLabel(new L.Moderated({reportId: ReportId.make("rep-1")})),
 			"moderasyon kararıyla kaldırıldı",
 		);
 	});
@@ -253,6 +254,9 @@ describe("EntityLifecycle — exhaustive reason handling", () => {
 	it("reasonReportId extracts only the Moderated report id", () => {
 		assert.strictEqual(L.reasonReportId(new L.AuthorDeletion()), null);
 		assert.strictEqual(L.reasonReportId(new L.Anonymized()), null);
-		assert.strictEqual(L.reasonReportId(new L.Moderated({reportId: "rep-7"})), "rep-7");
+		assert.strictEqual(
+			L.reasonReportId(new L.Moderated({reportId: ReportId.make("rep-7")})),
+			"rep-7",
+		);
 	});
 });

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -27,6 +27,7 @@ import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import type * as Removal from "../lifecycle/removal.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Reaction} from "../reaction/Reaction.ts";
+import type {ReportId} from "../report/ids.ts";
 import type {SelfVoteNotAllowed, VoterNotEligible} from "../vote/errors.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
@@ -244,7 +245,7 @@ export class Pano extends Context.Service<
 		readonly moderateRemovePost: (input: {
 			postId: string;
 			resolverId: string;
-			reportId: string;
+			reportId: ReportId;
 		}) => Effect.Effect<{removed: boolean}>;
 
 		/**
@@ -304,7 +305,7 @@ export class Pano extends Context.Service<
 		readonly moderateRemoveComment: (input: {
 			commentId: string;
 			resolverId: string;
-			reportId: string;
+			reportId: ReportId;
 		}) => Effect.Effect<{removed: boolean}>;
 
 		/**

--- a/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
@@ -25,6 +25,7 @@ import {UserId} from "../../lib/ids.ts";
 import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import type * as Removal from "../lifecycle/removal.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
+import {ReportId} from "../report/ids.ts";
 import type {Vote} from "../vote/Vote.ts";
 import {type CommentOperationsDeps, makeCommentOperations} from "./comment-operations.ts";
 import {CommentId, PostId} from "./ids.ts";
@@ -230,7 +231,9 @@ const removedRow = (sandboxedAt: Date | null): CommentRow =>
 	commentRow({
 		removedAt: NOW,
 		removedBy: "u-mod",
-		removedReason: Lifecycle.encodeReason(new Lifecycle.Moderated({reportId: "rep_1"})),
+		removedReason: Lifecycle.encodeReason(
+			new Lifecycle.Moderated({reportId: ReportId.make("rep_1")}),
+		),
 		sandboxedAt,
 	});
 
@@ -247,7 +250,7 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 			const result = yield* ops.moderateRemoveComment({
 				commentId: "comm_1",
 				resolverId: "u-mod",
-				reportId: "rep_1",
+				reportId: ReportId.make("rep_1"),
 			});
 			assert.isTrue(result.removed, "the mod-remove still soft-removes the comment");
 			assert.strictEqual(
@@ -265,7 +268,7 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 			const result = yield* ops.moderateRemoveComment({
 				commentId: "comm_1",
 				resolverId: "u-mod",
-				reportId: "rep_1",
+				reportId: ReportId.make("rep_1"),
 			});
 			assert.isTrue(result.removed, "the mod-remove soft-removes the comment");
 			assert.strictEqual(captured.postCommentCount, 4, "a live comment's mod-remove decrements -1");
@@ -304,7 +307,7 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 			yield* opsRemove.moderateRemoveComment({
 				commentId: "comm_1",
 				resolverId: "u-mod",
-				reportId: "rep_1",
+				reportId: ReportId.make("rep_1"),
 			});
 			assert.strictEqual(remove.captured.postCommentCount, 5, "mod-remove of sandboxed is -0");
 
@@ -330,7 +333,7 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 				yield* opsRemove.moderateRemoveComment({
 					commentId: "comm_1",
 					resolverId: "u-mod",
-					reportId: "rep_1",
+					reportId: ReportId.make("rep_1"),
 				});
 				assert.strictEqual(remove.captured.postCommentCount, 5, "mod-remove of sandboxed is -0");
 

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -34,6 +34,7 @@ import {
 } from "../lifecycle/SandboxVisibility.ts";
 import type {ReactionTargetNotFound} from "../reaction/errors.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
+import type {ReportId} from "../report/ids.ts";
 import {SelfVoteNotAllowed} from "../vote/errors.ts";
 import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import type {Vote} from "../vote/Vote.ts";
@@ -736,7 +737,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 	const moderateRemoveComment = Effect.fn("Pano.moderateRemoveComment")(function* (input: {
 		commentId: string;
 		resolverId: string;
-		reportId: string;
+		reportId: ReportId;
 	}) {
 		const row = yield* run((db) =>
 			db.query.commentRecord.findFirst({where: {id: input.commentId}}),

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -41,6 +41,7 @@ import {
 } from "../lifecycle/SandboxVisibility.ts";
 import type {ReactionTargetNotFound} from "../reaction/errors.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
+import type {ReportId} from "../report/ids.ts";
 import {syncPostSearch} from "../search/fts-sync.ts";
 import {SelfVoteNotAllowed} from "../vote/errors.ts";
 import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
@@ -1114,7 +1115,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 	const moderateRemovePost = Effect.fn("Pano.moderateRemovePost")(function* (input: {
 		postId: string;
 		resolverId: string;
-		reportId: string;
+		reportId: ReportId;
 	}) {
 		const meta = yield* run((db) => db.query.postRecord.findFirst({where: {id: input.postId}}));
 		if (!meta) return {removed: false};

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -246,7 +246,9 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 	if (input.action === "remove" && wonTransition) {
 		// Act on the target via the 0096 substrate (reason `Moderated`), keyed to the
 		// first open report id captured above.
-		const reportId = firstOpenId ?? input.reportId ?? targetKey(target.targetKind, target.targetId);
+		const reportId = ReportId.make(
+			firstOpenId ?? input.reportId ?? targetKey(target.targetKind, target.targetId),
+		);
 		targetRemoved = yield* moderateRemove(target, moderatorId, reportId);
 		// The moderator-remove hides content that lives in the subscribed
 		// `posts` / `Post.comments` / `Term.definitions` connections; publish the
@@ -352,7 +354,7 @@ const restoreWaveGated = Effect.fn("report.restoreWaveGated")(function* (
 const moderateRemove = Effect.fn("report.moderateRemove")(function* (
 	target: {targetKind: TargetKind; targetId: string},
 	resolverId: string,
-	reportId: string,
+	reportId: ReportId,
 ) {
 	switch (target.targetKind) {
 		case "definition": {

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -32,6 +32,7 @@ import {
 } from "../lifecycle/SandboxVisibility.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Reaction} from "../reaction/Reaction.ts";
+import type {ReportId} from "../report/ids.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import {SelfVoteNotAllowed, type VoterNotEligible} from "../vote/errors.ts";
@@ -443,7 +444,7 @@ export class Sozluk extends Context.Service<
 		readonly moderateRemoveDefinition: (input: {
 			definitionId: string;
 			resolverId: string;
-			reportId: string;
+			reportId: ReportId;
 		}) => Effect.Effect<{removed: boolean}>;
 
 		/**
@@ -1242,7 +1243,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		});
 
 		const moderateRemoveDefinition = Effect.fn("Sozluk.moderateRemoveDefinition")(
-			function* (input: {definitionId: string; resolverId: string; reportId: string}) {
+			function* (input: {definitionId: string; resolverId: string; reportId: ReportId}) {
 				const definition = yield* run((db) =>
 					db.query.definitionRecord.findFirst({where: {id: input.definitionId}}),
 				);


### PR DESCRIPTION
Fixes #2820

Deferred moderation-id slice carved from epic #2700's report branding (#2721 landed the `ReportId` brand). Promotes the moderation lifecycle identifier `Moderated.reportId` from bare `Schema.String` to the branded `ReportId` — a compile-time type-safety change, **runtime byte-identical** (the brand is type-only; `.make`/decode return the input unchanged).

## What changed
- **`features/lifecycle/EntityLifecycle.ts`** — `Moderated.reportId` is now `ReportId` (imported from `features/report/ids.ts`, where #2721 owns it); `reasonReportId` returns `ReportId | null`. The stale "deferred, unbranded on purpose" note is collapsed to a one-line pointer to the mint boundary.
- **The three content services' `moderateRemove*` `reportId` params** (`Pano.moderateRemovePost` / `moderateRemoveComment` in `pano/post-operations.ts` + `pano/comment-operations.ts`; `Sozluk.moderateRemoveDefinition` in `sozluk/Sozluk.ts`) are branded, constructing `Removal.Moderated` without a cast. Their `Pano` / `Sozluk` service-interface declarations are branded to match.
- **`features/report/mutations.ts`** — `ReportId` is minted via `ReportId.make(...)` at the report→content-service call boundary in `moderateRemove` (the `firstOpenId ?? input.reportId ?? targetKey(...)` resolve).
- **Tests** (`EntityLifecycle.unit.test.ts`, `pano/comment-count-sandbox-gate.unit.test.ts`) mint the id via `ReportId.make(...)` at their `Moderated` constructions — the same test-fixup #2721 applied when it branded its own fields.

## Scope note — where `ReportId` lives
The issue's original AC anticipated *promoting* `ReportId` to shared `lib/ids.ts`. #2721 instead kept `ReportId` report-owned in `features/report/ids.ts` (documented there, to avoid sibling append-conflicts on the shared module), so this PR **imports it from there** rather than moving it — no redefinition, no `lib/ids.ts` edit. The lifecycle/pano/sozluk references are type-only imports of the report-owned brand.

## Verification
- `pnpm typecheck` — green. A `reportId`/other-id swap now fails to compile (the brand is nominal).
- `pnpm lint` — green.
- Affected unit suites (EntityLifecycle, comment-count-sandbox-gate, report-mutation, report-live-fanout) — 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)