### PR TITLE
fix(pipeline): mandate the guarded verdict-emit path across review-* skills (#2824)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1152,6 +1152,42 @@ branches runs, call `verdict_post_verify "$PR" <gate> "$HEAD_SHA" || exit 1`. On
 between post and verify the head advanced *during* review — re-resolve the head, re-verify against it
 (the gate is stateless), and re-post; never loosen the match to paper over a moved head.
 
+### The guarded emit path is MANDATORY — never hand-post a verdict marker off the guard
+
+`verdict_post_verify` above is the *read-back*: it re-scans PR state **after** a post and fails loud
+on a marker that landed broken or leaking. But a read-back cannot police a post it never sees. An
+agent that **hand-posts** the verdict marker with a raw `gh api …/comments` or `gh pr comment` call
+bypasses the verdict lib entirely, so `emissionDefect` never fires — and, worse, the marker often
+never resolves through `verdict_post_verify`'s re-scan either, so nothing catches it. That is the
+**emit-side hole** the recurrences rode: #2789 (the whole body was an `@filepath`), #2816 / #2818 (a
+`/var/folders` mktemp path glued into the `@ <sha>` field) — each leaked because the marker was
+hand-posted off the verdict lib, not because the lib's guard was wrong. Code cannot force a hand-post
+through a guard the reviewer never invokes; the **emit path itself** must be mandated, not just
+described.
+
+So for **all four PR gates** — `review-code`, `review-doc`, `review-skill`, `review-design` — routing
+every verdict-marker post through the guarded path is a **hard invariant, not a suggestion**:
+
+- **MUST** post every verdict marker through `pipeline-cli verdict post` — the single marker-emit
+  choke point that runs `emissionDefect` (the body-wide machine-local-path scan added by #2823, plus
+  the 40-hex `@ <sha>` field guards, #2683) and **refuses fail-closed** on a leaking or malformed
+  body. For the native `APPROVE` review body (which `verdict post` cannot emit), run the **same** gate
+  as an explicit read-back assertion — `verdict validate` — **before** the `APPROVE`, so a
+  malformed/leaking marker fails loud rather than landing in a public review body.
+- **FORBIDDEN:** a bare `gh api …/comments` / `gh pr comment` hand-post of a verdict marker that skips
+  the guard. The guarded tool is the **only** sanctioned emit path; a free-form raw post is a bypass,
+  never an equivalent — a reviewer must not free-form the marker even when the body "looks clean."
+- **The one escape hatch, itself guarded:** if a raw post is genuinely unavoidable, the body **MUST**
+  first pass `pipeline-cli leak-guard scan-comment` (the standalone pre-post net #2823 added — reads
+  the body on stdin / `--body-file`, exits non-zero on a machine-local path) **before** the post. A
+  raw post whose body was never scanned is the forbidden case; a scanned one is the escape hatch.
+
+This is the **enforcement complement** to #2823: #2823 hardened the guard *code* (`emissionDefect`'s
+body-wide scan + the `leak-guard scan-comment` CLI); this mandate closes the emit-side hole by
+forbidding the reviewer from routing around it — the two together are what actually close #2796. Each
+review gate **references this rule as the single source** (it does not re-derive the *why* per skill).
+Per #2393 the guard stays generic path-shape patterns, never a named-path deny-list.
+
 ---
 
 ## 3. Progress-comment format

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1243,6 +1243,15 @@ native `APPROVE` path (which posts a review, not a comment `verdict post` can gu
 **same** gate as an explicit read-back assertion first — `verdict validate` — so a malformed
 marker fails loud **before** the APPROVE, never landing in a public review body.
 
+**MANDATE (hard invariant, not a suggestion):** the guarded path is the **only** permitted way to
+emit this verdict marker — `$VERDICT post` for the comment, or the `verdict validate` read-back
+before the native `APPROVE`. A bare `gh api …/comments` / `gh pr comment` hand-post of the marker
+that skips the guard is **FORBIDDEN** (it is the emit-side hole #2789 / #2816 / #2818 rode:
+hand-posting off the verdict lib means `emissionDefect` never runs). If a raw post is ever
+genuinely unavoidable, the body **MUST** first pass `pipeline-cli leak-guard scan-comment` (the
+#2823 pre-post net) before the post. This is the single-source rule in
+[gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
+
 ```bash
 # resolve the verdict CLI once — in-repo-first, published-fallback (ADR 0062/0064; epic #994)
 if [ -f packages/pipeline-cli/src/bin.ts ]; then

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -413,6 +413,15 @@ closing the mktemp-path leak where a scratch path bled into the `@ <sha>` field 
 a comment, never a native review** (ADR 0058 rule 4): a native review can't carry the `@ <sha>` in
 the shape this contract controls, so the comment is the single carrier.
 
+**MANDATE (hard invariant, not a suggestion):** `$VERDICT post` (here via the `upsert` wrapper
+below) is the **only** permitted way to emit this verdict marker. A bare `gh api …/comments` /
+`gh pr comment` hand-post of the marker that skips the guard is **FORBIDDEN** (it is the emit-side
+hole #2789 / #2816 / #2818 rode: hand-posting off the verdict lib means `emissionDefect` never
+runs). If a raw post is ever genuinely unavoidable, the body **MUST** first pass
+`pipeline-cli leak-guard scan-comment` (the #2823 pre-post net) before the post. This is the
+single-source rule in
+[gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
+
 The SHA in the first line is **load-bearing**: `ship-it` refuses any verdict not bound to the PR's
 current head (ADR 0058). **Token order is fixed** (§5): `@ <HEAD_SHA>` comes **immediately after**
 `PASS`/`FAIL`, **before** `— merge-ready`/`— changes-requested` — never a trailing `@ <sha>` (that

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -602,6 +602,14 @@ SHA-refuses any marker without an `@ <sha>` on the current head (Step 2b). It al
 fail-closed if the body's first line is not a `review-doc:` marker — the cross-namespace
 emission guard (§the never-a-`review-code`-marker invariant) enforced by the tool, not by care.
 
+**MANDATE (hard invariant, not a suggestion):** `$VERDICT post` is the **only** permitted way to
+emit this verdict marker. A bare `gh api …/comments` / `gh pr comment` hand-post of the marker that
+skips the guard is **FORBIDDEN** (it is the emit-side hole #2789 / #2816 / #2818 rode: hand-posting
+off the verdict lib means `emissionDefect` never runs). If a raw post is ever genuinely unavoidable,
+the body **MUST** first pass `pipeline-cli leak-guard scan-comment` (the #2823 pre-post net) before
+the post. This is the single-source rule in
+[gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
+
 Resolve the tool once — in-repo first, published fallback (ADR 0062/0064; epic #994) — and pass
 your composed verdict body by file:
 

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -192,6 +192,12 @@ Given an epic number it fetches the `EpicLedger` via the `Github` capability, ru
 FAIL verdict and flips **nothing**. It returns a structured `GateVerdict`
 (`{_tag: "pass", flipped}` or `{_tag: "fail", defects, signature}`).
 
+**Guarded-emit scope note (the emit-side mandate, gh-issue-intake-formats.md).** Unlike the four
+PR gates, `review-plan` **never hand-posts** its verdict comment: `runGate` emits it deterministically
+through the `epic-ledger` action's `Github` capability, so there is no free-form `gh api …/comments` /
+`gh pr comment` marker post to route through the guard. That structural non-hand-post *is* the
+mandate for this gate — never bypass `runGate` to hand-post a `review-plan` verdict comment yourself.
+
 Invoke it through the package's CLI (the `bin.ts` entry, wired over `NodeRuntime.runMain` +
 `NodeServices.layer` — you run the binary, you don't re-implement the floor in prose). Which
 binary — the in-repo `packages/pipeline-cli/src/bin.ts epic-ledger` or the published

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -535,6 +535,14 @@ the marker-emit choke point:** it refuses fail-closed unless every SHA field (th
 the mktemp-path leak (#2683), the empty-`@-` case (#2646), and any cross-namespace body. Resolve
 the tool once — in-repo first, published fallback (ADR 0062/0064; epic #994):
 
+**MANDATE (hard invariant, not a suggestion):** `$VERDICT post` is the **only** permitted way to
+emit this verdict marker. A bare `gh api …/comments` / `gh pr comment` hand-post of the marker that
+skips the guard is **FORBIDDEN** (it is the emit-side hole #2789 / #2816 / #2818 rode: hand-posting
+off the verdict lib means `emissionDefect` never runs). If a raw post is ever genuinely unavoidable,
+the body **MUST** first pass `pipeline-cli leak-guard scan-comment` (the #2823 pre-post net) before
+the post. This is the single-source rule in
+[gh-issue-intake-formats.md](../gh-issue-intake-formats.md#the-guarded-emit-path-is-mandatory--never-hand-post-a-verdict-marker-off-the-guard) — the *why* lives there, not re-derived here.
+
 ```bash
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin


### PR DESCRIPTION
Closes the **emit-side** hole behind the verdict-post local-path-leak / silent-gate-loss bug — the enforcement half of #2796 (#2823 is the tooling half).

## Problem
Reviewer subagents could hand-post a verdict marker via a raw `gh api …/comments` / `gh pr comment` call, bypassing the verdict lib entirely so `emissionDefect` never ran and no guard fired. The four PR-gate skills only *described* the guarded `pipeline-cli verdict post` path — none *mandated* it or *forbade* the bare hand-post. That soft framing is the bypass the recurrences (#2789 / #2816 / #2818) rode. Code cannot force a hand-post through a guard the reviewer never invokes, so the emit path itself has to be mandated.

## What this does
- **`gh-issue-intake-formats.md`** — new single-source rule *"The guarded emit path is MANDATORY — never hand-post a verdict marker off the guard"*, placed beside `verdict_post_verify` (its read-back complement). It states the hard invariant, forbids the bare `gh api`/`gh pr comment` hand-post, and requires `pipeline-cli leak-guard scan-comment` on the body for any unavoidable raw post. The *why* (the recurrence narrative) lives here **once**, per the no-duplication convention — the skills point at it rather than re-deriving it.
- **`review-code` / `review-doc` / `review-skill` / `review-design`** — each verdict-post step now carries a terse **MANDATE + FORBID + fallback** invariant:
  - MUST post the marker through `$VERDICT post` (or `verdict validate` before the native `APPROVE` in `review-code`).
  - A bare `gh api …/comments` / `gh pr comment` hand-post that skips the guard is **FORBIDDEN**.
  - `pipeline-cli leak-guard scan-comment` (the #2823 pre-post net) is the required fallback for any unavoidable raw post.
- **`review-plan`** — one-line scope note: its verdict emits deterministically through the `epic-ledger` action's `Github` capability, so there is no free-form hand-post to guard; that structural non-hand-post *is* its mandate.

## How the mandate forbids the bypass
Each gate now states the guarded tool is the **only** permitted emit path (a hard invariant, not a suggestion) and names the exact forbidden call shapes (`gh api …/comments`, `gh pr comment`). The soft "posts via `verdict post`" framing an agent could satisfy with a raw comment is replaced by an explicit prohibition plus the single guarded escape hatch (`leak-guard scan-comment`-then-post).

## Sequencing (verified this run — please honor at §CP merge)
- Built on **#2800's merged** `CONTROL_PLANE_RE` single-source (base = `9f74c66e`); no conflict with #2800's edits.
- **#2823 is NOT yet merged** — it is still open on `umut/2796-verdict-post-leak-guard`, contrary to the "already merged" premise in my task brief (verified via `gh api` — my tool result is ground truth). The `leak-guard scan-comment` command and the body-wide `emissionDefect` scan this PR's prose references land **with #2823**. So **merge #2823 before this PR** so the mandate points at live tooling.

## §CP
The review-* `SKILL.md` files (and `gh-issue-intake-formats.md`) match `CONTROL_PLANE_RE` — this is control-plane. Do **not** auto-merge; human-merge at cansirin. Guard stays generic path-shape patterns, no named deny-list (#2393).

Refs #2824 · #2823 · #2789 · #2816 · #2818

Fixes #2796

🤖 Generated with [Claude Code](https://claude.com/claude-code)