### PR TITLE
fix(pipeline): reclaim leaked review-head worktrees via worktree-sweep (#2785)

### DIFF
--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -240,16 +240,28 @@ pnpm pipeline-cli worktree-sweep            # dry-run: print the keep/remove pla
 pnpm pipeline-cli worktree-sweep --execute  # remove the clean+merged ones
 ```
 
-It is **safe by default** and mirrors the `@kampus/worktree-guard` reaper's rule
-(MEMORY "Safe worktree prune"): a worktree is removed **only** when it is CLEAN
-**and** its HEAD is already reachable from `origin/main` (its branch merged, or it
-sits detached at a merged commit). A **dirty** tree or an **unmerged** branch — e.g.
-a sibling agent's live, in-flight PR branch — is **KEPT**. It runs `git worktree
-remove` **without `--force`**, so git itself refuses any tree it judges unsafe and
-that refusal is reported as kept, never escalated. Draining the existing pile is the
-operator's explicit call; the command never force-discards unpushed work. The pure
-classifier (`packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts`) is
-unit-tested branch-by-branch.
+It sweeps **two leaked classes** (#2785):
+
+- **Build worktrees** under `.claude/worktrees/` — a harness-provisioned agent tree
+  carrying a real branch and possibly unpushed work. Removed **only** when it is CLEAN
+  **and** its HEAD is already reachable from `origin/main` (its branch merged, or it
+  sits detached at a merged commit — the squash case #1328 included). A **dirty** tree
+  or an **unmerged** branch — e.g. a sibling agent's live, in-flight PR branch — is **KEPT**.
+- **Review-head worktrees** — the `$TMPDIR`-rooted `review-head-*` / `review-doc-head-*`
+  / `review-skill-head-*` DETACHED checkouts the `review-*` gates materialize from a PR
+  head. These carry no branch and no unpushed work, so there is **no merge gate**: a leaked
+  one is reclaimed once it is CLEAN + idle + unlocked (an unmerged PR head is still reclaimed,
+  which the merge gate would strand for the PR's whole open life). Before this class they were
+  `not-managed` and never reaped, so they were the bulk of the 562-worktree leak.
+
+Both classes share the **#2240 liveness guard**: a **locked**, **recently-active** (mtime
+within the idle threshold), or (build class) **open-PR** tree is **KEPT**. It runs `git worktree
+remove` **without `--force`**, so git itself refuses any tree it judges unsafe and that refusal is
+reported as kept, never escalated (mirrors the `@kampus/worktree-guard` reaper's rule, MEMORY
+"Safe worktree prune"). Draining the pile is the operator's explicit call; the command never
+force-discards unpushed work. The pure classifier
+(`packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts`) is unit-tested branch-by-branch,
+and `command.hook.test.ts` proves both classes through the real-git command boundary.
 
 ## Why these constraints exist (and where the real fix lives)
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -358,6 +358,18 @@ pnpm -C "$REVIEW_WT" lint:worktree   # and/or the specific test the criterion na
 rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"   # tear the throwaway tree + ref down
 ```
 
+**Teardown runs on EVERY exit path — PASS, FAIL, or a mid-run error, not just the happy
+path.** The line above is the review's own `rm -rf` of a detached, already-pushed throwaway
+it materialized itself (safe — it holds no branch and no unpushed work), so run it even when
+the review is exiting `FAIL` or aborting after a typecheck/lint error; a leaked `review-head-*`
+tree accumulates on the shared primary otherwise (#2785). To catch a mid-block error inside a
+single Bash call, register it as a trap right after `git worktree add`:
+`trap 'rm -rf "$REVIEW_WT"; git worktree prune; git update-ref -d "$PR_REF"' EXIT`. And the
+standing net for the un-catchable case — a session-end abort *between* Bash calls, which no
+in-shell trap can reach — is `pipeline-cli worktree-sweep --execute` (#2785): it reclaims any
+leaked `review-head-*` tree that is clean + idle + unlocked, **without** `--force` (a dirty /
+active / locked one is KEPT — the #2240 liveness guard), so nothing accumulates unbounded.
+
 **The in-worktree typecheck is authoritative** (ADR
 [0067](https://github.com/kamp-us/phoenix/blob/main/.decisions/0067-sparse-typecheck-bootstrap.md),
 reversing ADR 0060's deferred-to-CI workaround). The cone-minus-denylist worktree carries

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -350,10 +350,20 @@ REVIEW_WT="$(mktemp -d)/review-doc-head-$PR"
 WT_FILE="$(mktemp /tmp/review-doc-wt.XXXXXX)"          # run-unique handle, never a fixed/PR-only path
 { echo "REVIEW_WT='$REVIEW_WT'"; echo "PR_REF='$PR_REF'"; } > "$WT_FILE"
 git worktree add "$REVIEW_WT" "$PR_REF"
+# Register teardown as a trap so a mid-block error still tears the throwaway tree down:
+trap 'rm -rf "$REVIEW_WT"; git worktree prune' EXIT
 # … later steps: `. "$WT_FILE"` re-sources $REVIEW_WT/$PR_REF after a between-call reset,
 # never re-deriving from the shared leaf name.
-rm -rf "$REVIEW_WT" && git worktree prune   # tear it down after
+rm -rf "$REVIEW_WT" && git worktree prune   # tear it down on EVERY exit path — PASS or FAIL
 ```
+
+**Teardown runs on both the success and the failure path**, not just when the check passed —
+run the `rm -rf` even when the review exits `FAIL` or aborts mid-run, so no `review-doc-head-*`
+tree leaks onto the shared primary (#2785). The `rm -rf` of the review's own detached, already-
+pushed throwaway is safe (it holds no branch/unpushed work). The standing net for a session-end
+abort between Bash calls (which no in-shell trap can reach) is `pipeline-cli worktree-sweep
+--execute` (#2785): it reclaims a leaked `review-doc-head-*` tree only when clean + idle +
+unlocked, **without** `--force` (dirty / active / locked is KEPT — the #2240 liveness guard).
 
 Never `git checkout` / `git switch` / `gh pr checkout` in the checkout you were launched in —
 not even `git -C`-scoped to your own worktree (the harness cwd-reset would still land a bare one

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -345,11 +345,22 @@ You're reading, not building — no `pnpm install`, no typecheck, no test suite.
 head's skill text in `$REVIEW_WT/skills/`, and the freshly-fetched `origin/$BASE_REF` for any
 shipped-state check are your whole evidence base.
 
-When you're done reading, tear the throwaway tree + ref down:
+Tear the throwaway tree + ref down on **every** exit path — PASS, FAIL, or a mid-run error,
+not only when you finish reading clean:
 
 ```bash
 rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"
 ```
+
+Run this even when the review is exiting `FAIL` or aborting mid-run, so no `review-skill-head-*`
+tree leaks onto the shared primary (#2785); the `rm -rf` of the review's own detached, already-
+pushed throwaway is safe (no branch/unpushed work). To catch a mid-block error, register it as a
+trap right after `git worktree add`:
+`trap 'rm -rf "$REVIEW_WT"; git worktree prune; git update-ref -d "$PR_REF"' EXIT`. The standing
+net for a session-end abort between Bash calls (no in-shell trap reaches it) is `pipeline-cli
+worktree-sweep --execute` (#2785): it reclaims a leaked `review-skill-head-*` tree only when
+clean + idle + unlocked, **without** `--force` (dirty / active / locked is KEPT — the #2240
+liveness guard).
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -850,7 +850,12 @@ docblocks in a file (the `coder.md` standing invariant is the source; #2186).
 > concurrent fallback runs collide on neither the branch nor the dir: `git fetch origin main;
 > WT="../wt-issue-<N>-$(uuidgen | head -c 8)"; git worktree add -b "$BRANCH" "$WT" FETCH_HEAD`,
 > then `cd "$WT"`. Branch off `FETCH_HEAD` (the just-fetched origin tip), **never** the possibly-stale
-> `origin/main` ref. When you're done, remove it with `git worktree remove "$WT"`. After the `cd "$WT"`, **re-run the Step 4 preflight** — the
+> `origin/main` ref. When you're done, remove it with `git worktree remove "$WT"` (never
+> `--force` — a dirty tree then errors out and is KEPT). A build worktree that made commits and
+> is *not* removed here (an aborted run, a fallback that never reached its done-step) does not
+> leak unbounded: it is backstopped by `pipeline-cli worktree-sweep --execute` (#1243/#2785),
+> which reclaims a `.claude/worktrees/` build tree only once it is clean + merged + idle +
+> unlocked with no open PR — the #2240 liveness guard, non-`--force`. After the `cd "$WT"`, **re-run the Step 4 preflight** — the
 > fresh worktree's git-dir now differs from the common dir, so the check passes and you may
 > mutate. This fallback is **only for the standalone (`isolation-expected=0`) path** — a run where
 > isolation was *expected* must NOT reach it: the preflight's loud branch (ADR 0172, #2443) hard-stops

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
@@ -43,6 +43,8 @@ const runSweep = (cwd: string, flags: ReadonlyArray<string>): Promise<RunResult>
 
 describe("worktree-sweep --execute — SessionStart cadence against a REAL git repo (#2238/#2240)", () => {
 	let mainRepo: string;
+	// $TMPDIR-shaped roots for review-head trees (removed in afterAll — any the sweep KEEPS must be cleaned).
+	const reviewRoots: Array<string> = [];
 	const git = (cwd: string, ...args: string[]) =>
 		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
 
@@ -71,6 +73,7 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 
 	afterAll(() => {
 		rmSync(mainRepo, {recursive: true, force: true});
+		for (const r of reviewRoots) rmSync(r, {recursive: true, force: true});
 	});
 
 	it("removes a CLEAN + IDLE + unlocked orphan, but KEEPS dirty / recently-active / locked (never --force)", async () => {
@@ -108,6 +111,33 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 
 		// unlock so afterAll's rmSync can tear the tree down cleanly.
 		git(mainRepo, "worktree", "unlock", lockedWt);
+	}, 30_000);
+
+	it("reclaims a leaked review-head detached checkout but KEEPS a dirty one (never --force) — #2785", async () => {
+		// The review gates root these under $TMPDIR (outside .claude/worktrees), so mirror that:
+		// a separate temp root, leaf `review-head-<PR>`, which `isReviewHeadWorktree` keys on.
+		const reviewRoot = mkdtempSync(join(tmpdir(), "wts-rev-"));
+		reviewRoots.push(reviewRoot);
+
+		// Clean + idle + unlocked leaked review head → reclaimed (no merge gate for this class).
+		const leakedReviewWt = join(reviewRoot, "review-head-8001");
+		git(mainRepo, "worktree", "add", "-q", "--detach", leakedReviewWt, "HEAD");
+		backdate(leakedReviewWt);
+
+		// Dirty review head → KEPT, its scratch file intact (proves the reclaim never --force-nukes).
+		const dirtyReviewWt = join(reviewRoot, "review-doc-head-8002");
+		git(mainRepo, "worktree", "add", "-q", "--detach", dirtyReviewWt, "HEAD");
+		writeFileSync(join(dirtyReviewWt, "scratch.txt"), "mid-review edit");
+		backdate(dirtyReviewWt);
+
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"]);
+		assert.strictEqual(code, 0, stdout);
+		assert.isFalse(existsSync(leakedReviewWt), "clean+idle leaked review-head must be reclaimed");
+		assert.isTrue(existsSync(dirtyReviewWt), "dirty review-head must be kept (no --force)");
+		assert.isTrue(
+			existsSync(join(dirtyReviewWt, "scratch.txt")),
+			"the dirty review-head's scratch file must survive — remove runs without --force",
+		);
 	}, 30_000);
 
 	it("dry-run (no --execute) touches nothing — even a clean+idle+unlocked orphan", async () => {

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -1,12 +1,14 @@
 /**
  * The `worktree-sweep` tool — `pipeline-cli worktree-sweep [--execute]`.
  *
- * The sanctioned, safe-by-default bulk drain for accumulated agent worktrees under
- * `.claude/worktrees/` (issue #1243). The harness does not auto-remove a worktree
- * that made commits, so they pile up without bound and slow every git op. This
- * command enumerates them, classifies each via the pure core (`worktree-sweep.ts`),
- * prints the plan, and — ONLY with `--execute` — runs `git worktree remove` (NEVER
- * `--force`) on the removable set.
+ * The sanctioned, safe-by-default bulk drain for accumulated agent worktrees (issue
+ * #1243). It sweeps two leaked classes (#2785): the harness-provisioned build trees under
+ * `.claude/worktrees/`, and the `$TMPDIR`-rooted `review-head-*` detached checkouts the
+ * review gates materialize. The harness does not auto-remove a build tree that made commits,
+ * and nothing at all reclaims a review-head tree, so both pile up without bound and slow every
+ * git op. This command enumerates them, classifies each via the pure core (`worktree-sweep.ts`),
+ * prints the plan, and — ONLY with `--execute` — runs `git worktree remove` (NEVER `--force`)
+ * on the removable set.
  *
  * Safe by construction (enforcement lines):
  *   1. The pure classifier only marks a worktree removable when it is CLEAN, reachable
@@ -32,6 +34,7 @@ import {Command, Flag} from "effect/unstable/cli";
 import {
 	computeWorktreeSweepPlan,
 	isManagedWorktree,
+	isReviewHeadWorktree,
 	parseWorktreeList,
 	type WorktreeRecord,
 } from "./worktree-sweep.ts";
@@ -200,14 +203,19 @@ const worktreeSweep = Command.make(
 			.filter((p) => !p.bare)
 			.map((p) => {
 				const managed = isManagedWorktree(p.path);
+				// A review-head tree is a swept candidate too (#2785), so its liveness (idle mtime)
+				// must be probed. Its detached HEAD carries no branch, so the open-PR probe below
+				// (branch-keyed) is N/A for it — the dirty/locked/idle triple carries its liveness.
+				const swept = managed || isReviewHeadWorktree(p.path);
 				const isDirty = worktreeIsDirty(p.path);
 				const reachable = reachableFromOriginMain(p.head);
 				// Only probe the costlier squash signal when ancestry already missed.
 				const squashMerged = reachable ? false : squashMergedToOriginMain(p.head);
-				const recentlyActive = managed ? worktreeRecentlyActive(p.path) : false;
-				// The network open-PR probe fires ONLY for a tree that would otherwise be swept —
+				const recentlyActive = swept ? worktreeRecentlyActive(p.path) : false;
+				// The network open-PR probe fires ONLY for a BUILD tree that would otherwise be swept —
 				// managed, clean, unlocked, idle, and content-merged — so SessionStart makes at most
-				// one gh call per reap candidate (usually zero), never one per worktree.
+				// one gh call per reap candidate (usually zero), never one per worktree. A review-head
+				// tree never enters here (no branch, and its classifier branch precedes the open-PR gate).
 				const wouldRemove =
 					managed && !isDirty && !p.locked && !recentlyActive && (reachable || squashMerged);
 				const hasOpenPr = wouldRemove ? branchHasOpenPr(p.branch) : false;
@@ -265,7 +273,7 @@ const worktreeSweep = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Safe bulk drain of accumulated .claude/worktrees/ agent worktrees — clean+merged only, never --force (#1243)",
+		"Safe bulk drain of accumulated agent build worktrees + leaked review-head checkouts — clean+idle only, never --force (#1243/#2785)",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
@@ -1,10 +1,20 @@
 /**
- * `worktree-sweep` pure core — classify each managed agent worktree under
- * `.claude/worktrees/` into KEEP or REMOVE with a reason, for the operator's
- * sanctioned bulk drain (issue #1243). IO-free and total: every decision is a
- * deterministic transform over already-gathered facts. The git boundary
- * (enumerate / status / ancestry / remove) lives in `command.ts`; this module
+ * `worktree-sweep` pure core — classify each swept worktree into KEEP or REMOVE with a
+ * reason, for the operator's sanctioned bulk drain (issue #1243). IO-free and total:
+ * every decision is a deterministic transform over already-gathered facts. The git
+ * boundary (enumerate / status / ancestry / remove) lives in `command.ts`; this module
  * never runs a command and never removes anything.
+ *
+ * Two swept classes (#2785):
+ *   - **Build worktrees** under `.claude/worktrees/` — a harness-provisioned agent tree
+ *     that carries a real branch and may hold unpushed work; removable ONLY when clean AND
+ *     its branch's content already landed on `origin/main` (the merge gate below).
+ *   - **Review-head worktrees** — the `$TMPDIR`-rooted `review-head-*` / `review-doc-head-*`
+ *     / `review-skill-head-*` DETACHED checkouts a review gate materializes from a PR head
+ *     (`isReviewHeadWorktree`). These are throwaway scratch trees of an already-pushed PR
+ *     head: they carry NO branch and no unpushed work, so they need no merge gate — a clean,
+ *     idle, unlocked one holds nothing recoverable. Without this class they were `not-managed`
+ *     and never reaped, so they leaked unbounded (562 accumulated before a manual sweep).
  *
  * The safety property is the whole point (MEMORY "Safe worktree prune", #1243 AC):
  * a worktree is removable ONLY when it is clean AND its branch's content has already
@@ -35,6 +45,23 @@ const MANAGED_SEGMENT = "/.claude/worktrees/";
 /** True when the path is a managed agent worktree — never the primary checkout, never a foreign tree. */
 export const isManagedWorktree = (path: string): boolean =>
 	path.replace(/\\/g, "/").includes(MANAGED_SEGMENT);
+
+/**
+ * The leaf-basename prefix of a `$TMPDIR`-rooted throwaway review checkout — `review-head-<PR>`
+ * (review-code), `review-doc-head-<PR>` (review-doc), `review-skill-head-<PR>` (review-skill).
+ * Anchored to the basename so a substring match on some parent dir can't misclassify a build tree.
+ */
+const REVIEW_HEAD_BASENAME = /^review-(doc-|skill-)?head-/;
+
+/** True when the path is a throwaway detached review-head checkout (a review gate's scratch tree, #2785). */
+export const isReviewHeadWorktree = (path: string): boolean => {
+	const norm = path.replace(/\\/g, "/");
+	return REVIEW_HEAD_BASENAME.test(norm.slice(norm.lastIndexOf("/") + 1));
+};
+
+/** True when the worktree is in scope for the sweep at all — either swept class. */
+export const isSweptWorktree = (path: string): boolean =>
+	isManagedWorktree(path) || isReviewHeadWorktree(path);
 
 /**
  * One worktree reduced to exactly the facts the decision needs. `branch` is the
@@ -71,7 +98,7 @@ export interface WorktreeRecord {
 
 /** Why a worktree is KEPT — the audit trail, so the plan is never an opaque list. */
 export type KeepReason =
-	/** Not under `.claude/worktrees/` — the primary checkout or a foreign tree; never touched. */
+	/** Neither swept class — the primary checkout, a foreign tree, or an unrelated worktree; never touched. */
 	| "not-managed"
 	/** Uncommitted/untracked changes present — keep, never `--force` (unpushed work is sacred). */
 	| "dirty"
@@ -84,14 +111,23 @@ export type KeepReason =
 	/** Branch not merged into `origin/main` (or detached HEAD not reachable) — live/unmerged work. */
 	| "unmerged";
 
-/** Why a worktree is REMOVABLE — clean AND its content already on `origin/main`. */
+/** Why a worktree is REMOVABLE — a build tree clean AND on `origin/main`, or an idle review-head tree. */
 export type RemoveReason =
 	/** Clean, on a branch whose tip is reachable from `origin/main` (merged). */
 	| "merged-clean"
 	/** Clean, detached at a commit reachable from `origin/main`. */
 	| "detached-reachable"
 	/** Clean; tip not an ancestor, but the branch's content squash-merged to `origin/main` (#1328). */
-	| "squash-merged-clean";
+	| "squash-merged-clean"
+	/**
+	 * A `review-head-*` throwaway detached checkout that is clean + unlocked + idle (#2785). No
+	 * merge gate: it holds a detached, already-pushed PR head and no branch/unpushed work, so once
+	 * it is clean, unlocked, and idle it is a pure leak — nothing to strand. Requiring merge here
+	 * would strand it for the PR's entire open life (a review is a bounded one-shot event, not tied
+	 * to PR lifetime), defeating the reclaim; the #2240 liveness triple (dirty/locked/recently-active)
+	 * still guards a live review.
+	 */
+	| "review-head-idle";
 
 export type SweepDecision =
 	| {readonly kind: "keep"; readonly reason: KeepReason}
@@ -115,24 +151,30 @@ export interface WorktreeSweepPlan {
 /**
  * Classify a single worktree. The order of checks IS the safety policy:
  *
- *   1. Not a managed worktree → KEEP (`not-managed`). The primary checkout and any
- *      foreign tree are never candidates, regardless of their other facts.
- *   2. Dirty → KEEP (`dirty`). Wins over every merge signal: a worktree with
- *      working-tree changes is never removed, even when its branch has merged.
- *   3. Liveness gates (#2240) — locked / recently-active / open-PR → KEEP. A clean+merged
- *      tree may still belong to a LIVE sibling lane (just committed+pushed, or PR just
- *      squash-merged mid-repair). These gates run BEFORE the remove branches, so each is a
- *      necessary condition on REMOVE: a tree is swept only when it clears all three.
- *   4. Ancestor-reachable from `origin/main` → REMOVE. `merged-clean` on a branch,
- *      `detached-reachable` when detached at a merged commit. Ancestry wins over the
- *      squash signal (a non-squash merge is the simpler, stronger fact).
- *   5. Else squash-merged to `origin/main` → REMOVE (`squash-merged-clean`). The
- *      #1328 case: a squash merge (ADR 0048) leaves the tip un-ancestored but lands
- *      the branch's content, so the worktree is done.
- *   6. Otherwise → KEEP (`unmerged`). Genuinely unmerged work.
+ *   1. Neither swept class → KEEP (`not-managed`). The primary checkout and any foreign
+ *      tree are never candidates, regardless of their other facts.
+ *   2. Dirty → KEEP (`dirty`). Wins over every other signal for BOTH classes: a worktree
+ *      with working-tree changes is never removed, even when its branch has merged.
+ *   3. Liveness gates (#2240) — locked / recently-active → KEEP, for BOTH classes. A clean
+ *      tree may still belong to a LIVE lane (a build tree just committed+pushed; a review
+ *      still running against its head). These run BEFORE any remove branch, so each is a
+ *      necessary condition on REMOVE.
+ *   4. Review-head tree → REMOVE (`review-head-idle`). Past the dirty+locked+recently-active
+ *      guards, a detached throwaway review checkout holds no branch and no unpushed work, so
+ *      it is a pure leak — no merge/open-PR gate applies (see `review-head-idle`). Returns here
+ *      before the build-tree merge gates so an unmerged PR head is still reclaimed.
+ *   5. (Build tree) open-PR → KEEP. A clean+merged build tree may still belong to a live sibling
+ *      lane whose branch has an open PR (#2240) — an open-PR review-head tree never reaches this
+ *      branch, and its detached HEAD has no branch to query anyway.
+ *   6. (Build tree) ancestor-reachable from `origin/main` → REMOVE — `merged-clean` on a branch,
+ *      `detached-reachable` when detached at a merged commit. Ancestry wins over the squash signal.
+ *   7. (Build tree) else squash-merged to `origin/main` → REMOVE (`squash-merged-clean`). The
+ *      #1328 case: a squash merge (ADR 0048) leaves the tip un-ancestored but lands the content.
+ *   8. Otherwise → KEEP (`unmerged`). Genuinely unmerged work.
  */
 export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
-	if (!isManagedWorktree(wt.path)) {
+	const reviewHead = isReviewHeadWorktree(wt.path);
+	if (!isManagedWorktree(wt.path) && !reviewHead) {
 		return {kind: "keep", reason: "not-managed"};
 	}
 	if (wt.isDirty) {
@@ -143,6 +185,9 @@ export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
 	}
 	if (wt.recentlyActive) {
 		return {kind: "keep", reason: "recently-active"};
+	}
+	if (reviewHead) {
+		return {kind: "remove", reason: "review-head-idle"};
 	}
 	if (wt.hasOpenPr) {
 		return {kind: "keep", reason: "open-pr"};

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
@@ -3,12 +3,30 @@ import {
 	classifyWorktree,
 	computeWorktreeSweepPlan,
 	isManagedWorktree,
+	isReviewHeadWorktree,
 	parseWorktreeList,
 	type WorktreeRecord,
 } from "./worktree-sweep.ts";
 
 const MAIN = "/Users/dev/phoenix";
 const wtPath = (id: string) => `${MAIN}/.claude/worktrees/${id}`;
+/** A $TMPDIR-rooted throwaway review checkout, as a review gate materializes it (#2785). */
+const reviewHeadPath = (leaf: string) => `/var/folders/8f/tmp.aBcD1234/${leaf}`;
+
+/** A review-head record: detached (no branch), clean, unlocked, idle — the leaked-and-reclaimable shape. */
+const reviewRecord = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
+	path: reviewHeadPath("review-head-2815"),
+	branch: null,
+	isDirty: false,
+	// A detached review head is often NOT reachable/merged (an open PR's head, pre-squash) — the
+	// leaked class the merge gate can't reclaim. These fields are moot for review-head classification.
+	reachableFromOriginMain: false,
+	squashMergedToOriginMain: false,
+	locked: false,
+	recentlyActive: false,
+	hasOpenPr: false,
+	...over,
+});
 
 const record = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	path: wtPath("agent-clean"),
@@ -37,6 +55,58 @@ describe("isManagedWorktree", () => {
 
 	it("normalizes backslash separators (windows-shaped path)", () => {
 		assert.isTrue(isManagedWorktree("C:\\Users\\dev\\phoenix\\.claude\\worktrees\\agent-a"));
+	});
+
+	it("does NOT classify a $TMPDIR review-head tree as a managed (.claude/worktrees) build tree", () => {
+		assert.isFalse(isManagedWorktree(reviewHeadPath("review-head-2815")));
+	});
+});
+
+describe("isReviewHeadWorktree", () => {
+	it("matches each review gate's leaf (review-code / review-doc / review-skill)", () => {
+		assert.isTrue(isReviewHeadWorktree(reviewHeadPath("review-head-2815")));
+		assert.isTrue(isReviewHeadWorktree(reviewHeadPath("review-doc-head-2815")));
+		assert.isTrue(isReviewHeadWorktree(reviewHeadPath("review-skill-head-2815")));
+	});
+
+	it("anchors to the BASENAME — a build tree under a review-head-named parent is not a review head", () => {
+		assert.isFalse(isReviewHeadWorktree(`${wtPath("review-head-2815")}/agent-x`));
+	});
+
+	it("rejects the primary checkout and a normal build worktree", () => {
+		assert.isFalse(isReviewHeadWorktree(MAIN));
+		assert.isFalse(isReviewHeadWorktree(wtPath("agent-a")));
+	});
+
+	it("normalizes backslash separators (windows-shaped path)", () => {
+		assert.isTrue(isReviewHeadWorktree("C:\\Users\\dev\\AppData\\Temp\\tmp.x\\review-head-9"));
+	});
+});
+
+describe("classifyWorktree — review-head trees (#2785)", () => {
+	it("RECLAIMS a leaked, idle, clean, unlocked review-head tree even though its head is unmerged", () => {
+		const d = classifyWorktree(reviewRecord());
+		assert.deepStrictEqual(d, {kind: "remove", reason: "review-head-idle"});
+	});
+
+	it("keeps a DIRTY review-head tree (liveness preserved — never nuke uncommitted work)", () => {
+		const d = classifyWorktree(reviewRecord({isDirty: true}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "dirty"});
+	});
+
+	it("keeps a LOCKED review-head tree (an operator/agent pinned it — #2240 liveness preserved)", () => {
+		const d = classifyWorktree(reviewRecord({locked: true}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "locked"});
+	});
+
+	it("keeps a RECENTLY-ACTIVE review-head tree (a review still running against the head — #2240)", () => {
+		const d = classifyWorktree(reviewRecord({recentlyActive: true}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "recently-active"});
+	});
+
+	it("dirty wins over the reclaim (still kept, reported as dirty) even for a review-head tree", () => {
+		const d = classifyWorktree(reviewRecord({isDirty: true, recentlyActive: false}));
+		assert.deepStrictEqual(d, {kind: "keep", reason: "dirty"});
 	});
 });
 
@@ -178,6 +248,28 @@ describe("computeWorktreeSweepPlan — partition", () => {
 		assert.strictEqual(keepReason(MAIN), "not-managed");
 		assert.strictEqual(keepReason(wtPath("b")), "dirty");
 		assert.strictEqual(keepReason(wtPath("c")), "unmerged");
+	});
+
+	it("partitions a mixed pile of build + review-head trees (both classes, liveness preserved)", () => {
+		const records: ReadonlyArray<WorktreeRecord> = [
+			record({path: wtPath("a"), branch: "umut/1-done"}), // build, merged-clean → remove
+			reviewRecord({path: reviewHeadPath("review-head-10")}), // leaked idle review head → remove
+			reviewRecord({path: reviewHeadPath("review-doc-head-11"), recentlyActive: true}), // live review → keep
+			reviewRecord({path: reviewHeadPath("review-skill-head-12"), isDirty: true}), // dirty review head → keep
+			reviewRecord({path: reviewHeadPath("review-head-13"), locked: true}), // locked review head → keep
+		];
+		const plan = computeWorktreeSweepPlan(records);
+		assert.deepStrictEqual(
+			new Set(plan.toRemove.map((p) => p.worktree.path)),
+			new Set([wtPath("a"), reviewHeadPath("review-head-10")]),
+		);
+		const removeReason = (path: string) =>
+			plan.toRemove.find((r) => r.worktree.path === path)?.reason;
+		assert.strictEqual(removeReason(reviewHeadPath("review-head-10")), "review-head-idle");
+		const keepReason = (path: string) => plan.kept.find((k) => k.worktree.path === path)?.reason;
+		assert.strictEqual(keepReason(reviewHeadPath("review-doc-head-11")), "recently-active");
+		assert.strictEqual(keepReason(reviewHeadPath("review-skill-head-12")), "dirty");
+		assert.strictEqual(keepReason(reviewHeadPath("review-head-13")), "locked");
 	});
 
 	it("an empty list yields an empty plan", () => {


### PR DESCRIPTION
## What & why

The `review-*` / `write-code` pipeline skills each materialize an ephemeral git worktree but teardown is not failure-safe, so an abort/error/session-end before the last line leaks the worktree onto the **shared primary checkout** — 562 accumulated before a manual sweep. `worktree-sweep` only enumerated `.claude/worktrees/` build trees, so the bulk leak — the `$TMPDIR`-rooted `review-head-*` detached checkouts — had no backstop.

Fixes #2785.

## Mechanism (sweep-extension)

Extend `worktree-sweep` to sweep a **second class**: the review gates' detached checkouts (`review-head-*` / `review-doc-head-*` / `review-skill-head-*`), keyed on **basename** via a new `isReviewHeadWorktree` (anchored to the leaf so a substring can't misclassify a build tree).

- A review-head tree is a **detached** throwaway of an already-pushed PR head — it carries **no branch and no unpushed work**, so there is **no merge gate**: a leaked one is reclaimed once it is **clean + idle + unlocked**. This is deliberate — an unmerged PR head is still reclaimed, which the build-tree merge gate would otherwise strand for the PR's whole open life (a review is a bounded one-shot event, not tied to PR lifetime). The classifier returns `review-head-idle` before the build-tree merge/open-PR branches.
- Build trees (`.claude/worktrees/`) are unchanged: clean + merged + idle + unlocked + no-open-PR.

## #2240 liveness guard preserved (for both classes)

`dirty` / `locked` / `recently-active` still force **KEEP** for the review-head class too (the open-PR guard remains the build-tree signal — a detached review head has no branch to query). Removal still runs `git worktree remove` **without `--force`** — git refuses a dirty/active/locked tree and that refusal is reported as KEPT, never escalated. **No blanket `--force`.**

## Per-skill teardown contract strengthened

`review-code` / `review-doc` / `review-skill`: teardown is now documented to run on **both the PASS and FAIL path** (with a `trap` idiom for the single-Bash-call case) and points to `worktree-sweep` as the standing net for the un-catchable between-call/session-end abort. `write-code`'s build-worktree teardown is documented as backstopped by the sweep (never `--force`). `.patterns/worktree-agent-constraints.md` updated to describe both swept classes.

## Tests

- Unit (`worktree-sweep.unit.test.ts`): `isReviewHeadWorktree` (each gate's leaf, basename-anchored, backslash-normalized); the review-head class is **reclaimed** when idle/clean/unlocked **even unmerged**, and **KEPT** when dirty/locked/recently-active; a mixed-pile partition across both classes.
- E2e (`command.hook.test.ts`): against a real git repo, `--execute` **reclaims** a clean+idle leaked review-head checkout while **keeping** a dirty one with its scratch file intact — proving the safe-prune invariant (no `--force`) through the command boundary.

`pnpm typecheck` clean; all 40 worktree-sweep tests pass.

## §CP

Touches `claude-plugins/kampus-pipeline/skills/` gate skills + `packages/pipeline-cli/` — control-plane, **human-merge-only (cansirin)**. Do not auto-merge/approve.

## Scope note

Distinct from #2801's `worktree-guard/reap.ts` — this touches only `worktree-sweep.ts` (the periodic sweep) + the skill/pattern docs, no shared file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
