### PR TITLE
fix(flags): single Flags build — raw routes read the fate-runtime instance (#1438)

### DIFF
--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -18,7 +18,6 @@ import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import type {WorkerFateServices} from "../features/fate/layers.ts";
 import type {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
-import {FlagsDevOverrideLive} from "../features/flagship/Flags.ts";
 import type {Flagship} from "../features/flagship/Flagship.ts";
 import {healthApiLayer} from "./health.ts";
 import {rawWorkerRouteLayers} from "./worker-routes.ts";
@@ -65,17 +64,14 @@ export const makeAppLive = (options: {
 	// (its `ConfigProvider` is auto-wired at worker scope); discharge it here.
 	const typedJson = healthApiLayer.pipe(Layer.provide(options.flagshipLayer));
 
-	// The `Flags` domain service over the init-resolved `Flagship` client (#508):
-	// isolate-level, so it's built once here from `flagshipLayer` and provided into
-	// the per-request set. The probe route reads it; `getBoolean`'s `FlagsContext`
-	// is supplied inline by the handler from the session, so it isn't wired here.
-	// The local-override wrapper is installed UNCONDITIONALLY (#2741): it is a no-op
-	// unless the per-request `FlagsContext.overrides` is populated, which
-	// `makeRequestFlagsContext` does only when the request is authorized (dev, or an
-	// admin with `phoenix-admin-console` on) — so a deployed non-admin read is
-	// byte-identical to the plain `FlagsLive`.
-	const flagsLayer = FlagsDevOverrideLive.pipe(Layer.provide(options.flagshipLayer));
-
+	// `Flags` is NOT built a second time here (#1438): the raw flag routes resolve it
+	// from `options.fateLayer`, which already exports the ONE `Flags` build the fate
+	// resolvers read — `FateFlagsLive` in `makeFateLayer`, memoized once per isolate by
+	// `makeFateRuntime` (the #622 override wrapper, unconditional since #2741). A separate
+	// `FlagsDevOverrideLive` build here would be a redundant second singleton the raw
+	// routes read instead of the fate one, so the local flag-flip cookie could diverge
+	// between the two consumer sets — the exact duplicated-wiring smell #1438 removes.
+	//
 	// `provideRequest` discharges the route-requirement markers `HttpRouter.add`
 	// lifts (plain `Layer.provide` does not). All provided layers are
 	// dependency-free (`R = never`), so they merge flat.
@@ -85,7 +81,6 @@ export const makeAppLive = (options: {
 				options.fateLayer,
 				options.liveLayer,
 				options.betterAuthLayer,
-				flagsLayer,
 				Layer.succeed(RuntimeContext)(options.runtimeContext),
 			),
 		),


### PR DESCRIPTION
## What & why

`Flags` was composed at two sites and built twice:

- **(a) fate path** — `FateFlagsLive` in `makeFateLayer` (`features/fate/layers.ts`), the instance fate resolvers/mutations read, memoized once per isolate by `makeFateRuntime`.
- **(b) raw-route path** — a **second** `FlagsDevOverrideLive` built in `makeAppLive` (`http/app.ts`) and provided into the raw-route `HttpRouter.provideRequest` set.

Both build the #622 override wrapper (unconditional since #2741) over the same init-resolved `Flagship` client, so site (b) was a redundant second singleton the raw flag routes (`/api/flags/probe`, `/api/flags/evaluate`, `/api/flags/dev`) read instead of the fate one — the duplicated-wiring smell #1438 names.

## The fix (the deletion test #1438 spells out)

Drop the `app.ts` build. `options.fateLayer` already exports `Flags` via `WorkerFateServices`, so the raw routes' `provideRequest` set discharges the `Flags` marker from that **one** build. Net: one `Flags` build remains, read by both consumer sets.

The **type system is the regression guard** — removing the local `flagsLayer` only typechecks because `fateLayer` supplies `Flags`; reintroducing a divergent second build would surface as an unmet route marker or a duplicate provider.

## On the acceptance criteria (the issue predates #2741)

- **AC #1 (one build)** — delivered here.
- **AC #2 / #4 (fate-resolver read honors an override; a test asserts it)** — already delivered by #1868/#2741, guarded by `apps/web/worker/features/fate/fate-flags-dev-override.unit.test.ts`. The original "`PANO_DRAFT_SAVE` unflippable in dev" behavior bug was fixed there when `makeFateLayer` switched from plain `FlagsLive` to the override wrapper.
- **AC #3 (override branch never built on a deployed stage)** — **superseded by #2741**, which deliberately builds the wrapper *unconditionally* and gates *honoring* an override per request via `overridesAuthorized` (dev, or an admin with `phoenix-admin-console` on). The prod fail-closed invariant ("a non-admin's cookie is inert") now lives in `override-authz.unit.test.ts`, not in a build-time env branch. This PR does not reintroduce the retired env branch.

## Verification

- `pnpm typecheck` — green (the dedup's structural guard).
- `pnpm vitest run --project unit worker/features/flagship worker/features/fate/fate-flags-dev-override.unit.test.ts worker/http/worker-routes.unit.test.ts` — 162 passed.
- `pnpm lint` — clean.

Fixes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)