### PR TITLE
refactor(lifecycle): export reusable sandboxArm builder + assert stats UNION structure

### DIFF
--- a/apps/web/worker/features/lifecycle/SandboxVisibility.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.ts
@@ -39,8 +39,9 @@ export interface SandboxColumns {
 }
 
 /**
- * The sandbox-dimension read arm each lifecycle state contributes for a **non-moderator**
- * viewer — the SQL half of that state's {@link lifecycleVisibilityRule}, keyed by the
+ * The reusable per-tag SQL arm builder {@link sandboxVisibleWhere} folds together — the
+ * sandbox-dimension read arm each lifecycle state contributes for a **non-moderator**
+ * viewer, the SQL half of that state's {@link lifecycleVisibilityRule}, keyed by the
  * closed {@link LifecycleTag} discriminant so the SQL encoding is tied to the SAME
  * exhaustive tag set the TS `isVisibleTo` uses (#2013). An exhaustive `switch`: a new
  * lifecycle tag has no case, so this **fails to compile** until its sandbox arm is
@@ -55,7 +56,7 @@ export interface SandboxColumns {
  *   `canSeeSandboxed` short-circuit in {@link sandboxVisibleWhere} (no restriction).
  * - `Removed` (`NoOne`) — `undefined`: not selected in the sandbox dimension.
  */
-const sandboxArm = (
+export const sandboxArm = (
 	tag: LifecycleTag,
 	cols: SandboxColumns,
 	viewer: SandboxViewer,

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
@@ -12,7 +12,12 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as L from "./EntityLifecycle.ts";
-import {ownSandboxed, publicLiveWhere, sandboxVisibleWhere} from "./SandboxVisibility.ts";
+import {
+	ownSandboxed,
+	publicLiveWhere,
+	sandboxArm,
+	sandboxVisibleWhere,
+} from "./SandboxVisibility.ts";
 
 const at = new Date("2026-06-25T00:00:00.000Z");
 const AUTHOR = "caylak-author";
@@ -81,6 +86,26 @@ describe("sandbox visibility matrix — Sandboxed content (the #1205 rule)", () 
 	it("an anonymous/public viewer NEVER sees sandboxed content", () => {
 		assert.isFalse(L.isVisibleTo(sandboxed, AUTHOR, viewers.anonymous));
 		assert.isFalse(L.isVisibleTo(sandboxed, OTHER, viewers.anonymous));
+	});
+});
+
+describe("sandboxArm — the exported reusable per-tag arm builder (#2031)", () => {
+	const cols = {sandboxedAt: {} as never, authorId: {} as never};
+
+	it("Live contributes an arm (the `sandboxed_at IS NULL` public base)", () => {
+		assert.isDefined(sandboxArm("Live", cols, viewers.anonymous));
+	});
+
+	it("Removed contributes no arm — undefined (the caller's removal guard filters it)", () => {
+		assert.isUndefined(sandboxArm("Removed", cols, viewers.caylakAuthor));
+	});
+
+	it("Sandboxed contributes the author arm for a signed-in viewer", () => {
+		assert.isDefined(sandboxArm("Sandboxed", cols, viewers.caylakAuthor));
+	});
+
+	it("Sandboxed contributes no arm for an anonymous viewer (no author to match)", () => {
+		assert.isUndefined(sandboxArm("Sandboxed", cols, viewers.anonymous));
 	});
 });
 

--- a/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
+++ b/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
@@ -111,3 +111,33 @@ describe("Stats.getLandingStats — public totalAuthors excludes sandbox-only/dr
 		}),
 	);
 });
+
+describe("Stats.getLandingStats — the author counter's UNION structure (#2031, AC4)", () => {
+	// Guards the query SHAPE the prior suite doesn't: three arms combined by `UNION`
+	// (deduplicating, not `UNION ALL`), one per record table in a fixed order, wrapped in
+	// a `COUNT(DISTINCT author_id)` subquery. Distinct from the rendered-string guard
+	// checks above (which assert the per-arm filters are wired): this asserts the arms
+	// compose into the intended set operation, so a regression that dropped an arm, split
+	// the count across separate reads, or swapped `UNION`→`UNION ALL` fails here.
+	const flatten = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
+
+	it.effect("three arms are joined by two deduplicating UNION operators (not UNION ALL)", () =>
+		Effect.gen(function* () {
+			const flat = flatten(yield* recordAuthorUnion);
+			const unions = flat.match(/\bunion\b(?!\s+all)/g) ?? [];
+			assert.strictEqual(unions.length, 2, "exactly two UNION operators join three arms");
+			assert.notMatch(flat, /\bunion\s+all\b/, "arms deduplicate with UNION, never UNION ALL");
+		}),
+	);
+
+	it.effect("the three record-table arms appear in order inside a COUNT(DISTINCT) subquery", () =>
+		Effect.gen(function* () {
+			const flat = flatten(yield* recordAuthorUnion);
+			assert.match(
+				flat,
+				/count\(distinct author_id\)[^(]*\(\s*select author_id from definition_record where .+ union select author_id from post_record where .+ union select author_id from comment_record where .+\)/,
+				"COUNT(DISTINCT author_id) over (definition_record UNION post_record UNION comment_record)",
+			);
+		}),
+	);
+});


### PR DESCRIPTION
## What

Closes AC2 + AC4 of #2031 — the two deferred, behavior-preserving hardening ACs from #2013 (the çaylak-sandbox cross-encoding leak-boundary, PR #2028). No observable behavior change.

**AC2 — `sandboxArm` promoted to a reusable exported builder.** The per-tag SQL arm-builder in `apps/web/worker/features/lifecycle/SandboxVisibility.ts` was already a module-scope named `const` as of #2028; the remaining "reusable builder" delta was making it part of the module surface. It is now `export const sandboxArm`, with its exhaustive-over-`LifecycleTag` `switch` preserved intact — a new lifecycle tag still fails to compile until its sandbox arm is stated. `sandboxVisibleWhere` and every caller behave identically. A focused unit test now exercises the exported builder's per-tag arms directly (`Live` → arm, `Removed` → none, `Sandboxed` → author arm for a signed-in viewer / none for anonymous).

**AC4 — explicit assertion over the landing-stats `UNION` structure.** `Stats.getLandingStats`'s distinct-author counter (`apps/web/worker/features/stats/Stats.ts`) had only a rendered-SQL string test asserting the per-arm filters are wired. Added a structural assertion in `landing-stats-authors-sandbox.unit.test.ts` over the `UNION` composition itself: three record-table arms joined by **two deduplicating `UNION` operators (never `UNION ALL`)**, in order, inside a `COUNT(DISTINCT author_id)` subquery. A regression that dropped an arm, split the count, or swapped `UNION`→`UNION ALL` now fails.

## Out of scope

**AC3 (real-D1 integration-tier cross-encoding proof) remains tracked and blocked** on a real-D1 integration harness that does not exist in the repo yet (ADR 0082 bans an in-process `node:sqlite` oracle as more permissive than real D1); the unit-tier drizzle-`{sql,params}` oracle stands in. Not built here per #2031's scope.

## Checks (local, green)

- `pnpm typecheck` — 29/29 packages pass
- affected unit tests — 34/34 pass (incl. 4 new `sandboxArm` + 2 new UNION-structure assertions)
- `pnpm lint` (biome) — clean

Fixes #2031