### PR TITLE
feat(web): tag SPA Sentry errors with active feature-flag context (#1821)

### DIFF
--- a/apps/web/src/flags/useFlag.ts
+++ b/apps/web/src/flags/useFlag.ts
@@ -27,6 +27,7 @@ import {
 	type FlagEvaluateRequest,
 	resolveFlag,
 } from "../../worker/features/flagship/evaluate-contract";
+import {tagFlag} from "../lib/sentry";
 
 /** A flag read: its current value plus whether the server result is in yet. */
 export interface FlagState {
@@ -83,6 +84,12 @@ export function useFlag(key: string, defaultValue: boolean): FlagState {
 				if (!active) return;
 				setValue(resolved);
 				setLoading(false);
+				// Attribute captured errors to this flag's resolved state (#1821): once the
+				// server resolves the flag it becomes a queryable Sentry `flag.<key>` tag on the
+				// scope, so a graduation query can isolate its on-path error rate. Inert when
+				// Sentry has no DSN. Only on a genuine server resolution — the catch below holds
+				// the default without a server answer, so nothing is attributed there.
+				tagFlag(key, resolved);
 			})
 			.catch(() => {
 				// Any failure stays at the default — the off/old/safe path (#488).

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -42,6 +42,25 @@ export function browserOptions(dsn: string): Sentry.BrowserOptions {
 	};
 }
 
+/**
+ * Feature-flag attribution on captured errors (#1821). A flag the session resolves becomes the
+ * Sentry tag `flag.<key>` with value `"on"`/`"off"`, so a single flag's on-path error rate is
+ * isolable for the dark→release→burn-in→graduate gate the flag lifecycle depends on (#1822
+ * consumes this). The graduation query is `flag.<key>:on` — e.g. `flag.phoenix-bildirim:on`
+ * counts errors captured while `phoenix-bildirim` was on for the session, and `flag.<key>:off`
+ * the comparison off-path. Keys are the `flags/keys.ts` constants (non-PII), so tagging is
+ * orthogonal to the ADR 0118 `dataCollection` PII scrub and touches none of it.
+ */
+export const FLAG_TAG_PREFIX = "flag.";
+
+/**
+ * The `(tagKey, tagValue)` a resolved flag maps to — pure, so the tag-naming contract is
+ * unit-testable without Sentry (the pure-core idiom of `browserOptions`).
+ */
+export function flagTag(key: string, value: boolean): {tagKey: string; tagValue: "on" | "off"} {
+	return {tagKey: `${FLAG_TAG_PREFIX}${key}`, tagValue: value ? "on" : "off"};
+}
+
 const dsn = import.meta.env.VITE_SENTRY_DSN;
 
 /** Initialize Sentry for the SPA — a no-op when no DSN is provisioned (inert). */
@@ -64,4 +83,17 @@ export function captureBoundaryError(error: unknown, componentStack?: string | n
 		error,
 		componentStack ? {contexts: {react: {componentStack}}} : undefined,
 	);
+}
+
+/**
+ * Record a resolved flag on the global Sentry scope so subsequently-captured errors carry its
+ * state as a queryable `flag.<key>` tag (#1821). No-ops when inert (no DSN) — no scope mutation,
+ * no network, mirroring init/capture — so tagging adds nothing while Sentry is off.
+ */
+export function tagFlag(key: string, value: boolean): void {
+	if (!sentryEnabled(dsn)) {
+		return;
+	}
+	const {tagKey, tagValue} = flagTag(key, value);
+	Sentry.setTag(tagKey, tagValue);
 }

--- a/apps/web/src/lib/sentry.unit.test.ts
+++ b/apps/web/src/lib/sentry.unit.test.ts
@@ -8,12 +8,16 @@
  */
 import {afterEach, describe, expect, it, vi} from "vitest";
 
-const {init, captureException} = vi.hoisted(() => ({init: vi.fn(), captureException: vi.fn()}));
-vi.mock("@sentry/react", () => ({init, captureException}));
+const {init, captureException, setTag} = vi.hoisted(() => ({
+	init: vi.fn(),
+	captureException: vi.fn(),
+	setTag: vi.fn(),
+}));
+vi.mock("@sentry/react", () => ({init, captureException, setTag}));
 
-// The inert block imports `initSentry`/`captureBoundaryError` dynamically (after stubbing the
-// DSN), so only the DSN-independent helpers are imported statically here.
-import {browserOptions, sentryEnabled} from "./sentry";
+// The inert block imports `initSentry`/`captureBoundaryError`/`tagFlag` dynamically (after stubbing
+// the DSN), so only the DSN-independent helpers are imported statically here.
+import {browserOptions, flagTag, sentryEnabled} from "./sentry";
 
 afterEach(() => {
 	vi.clearAllMocks();
@@ -57,6 +61,42 @@ describe("inert without a DSN (the whole point of ADR 0118's parked-provisioning
 		const {captureBoundaryError} = await loadInert();
 		expect(() => captureBoundaryError(new Error("boom"), "  at X")).not.toThrow();
 		expect(captureException).not.toHaveBeenCalled();
+	});
+
+	it("tagFlag does not tag and does not throw (no scope mutation while inert)", async () => {
+		const {tagFlag} = await loadInert();
+		expect(() => tagFlag("phoenix-bildirim", true)).not.toThrow();
+		expect(setTag).not.toHaveBeenCalled();
+	});
+});
+
+describe("flag attribution — the tag-naming contract (#1821)", () => {
+	// The DSN-independent naming: `flag.<key>` = `on|off`, so a graduation query is `flag.<key>:on`.
+	it("flagTag maps a resolved flag to a queryable flag.<key> tag", () => {
+		expect(flagTag("phoenix-bildirim", true)).toEqual({
+			tagKey: "flag.phoenix-bildirim",
+			tagValue: "on",
+		});
+		expect(flagTag("pano-optimistic-comment-add", false)).toEqual({
+			tagKey: "flag.pano-optimistic-comment-add",
+			tagValue: "off",
+		});
+	});
+
+	// With a DSN, a resolved flag lands on the global Sentry scope as a queryable tag. The loader
+	// stubs a real DSN + re-imports so `tagFlag` reads the enabled gate (mirrors `loadInert`).
+	const loadEnabled = async () => {
+		vi.stubEnv("VITE_SENTRY_DSN", "https://abc@o0.ingest.de.sentry.io/1");
+		vi.resetModules();
+		return import("./sentry");
+	};
+
+	it("tagFlag sets flag.<key>=on/off on the scope when a DSN is provisioned", async () => {
+		const {tagFlag} = await loadEnabled();
+		tagFlag("phoenix-bildirim", true);
+		expect(setTag).toHaveBeenCalledWith("flag.phoenix-bildirim", "on");
+		tagFlag("pano-optimistic-comment-add", false);
+		expect(setTag).toHaveBeenCalledWith("flag.pano-optimistic-comment-add", "off");
 	});
 });
 


### PR DESCRIPTION
Fixes #1821

## What & why

Captured SPA errors landed in one undifferentiated firehose — there was no way to isolate a single feature-flag's on-path error rate, blocking the flag lifecycle's graduation gate (dark → release → burn-in → **graduate**). This adds per-flag attribution to captured Sentry errors so a flag's on-path error rate becomes queryable. **Scoped to the SPA tier only** — the worker `@sentry/cloudflare` tier defers to #1502/#1671 (not merged), per the issue's scope.

## Approach

The SPA has no synchronous "active flag set": flags resolve individually and asynchronously at the `useFlag` seam (`POST /api/flags/evaluate`, server-evaluated under the session-derived targeting context). So attribution is recorded **at that seam** — when the server resolves a flag, `tagFlag(key, value)` sets the global Sentry scope tag `flag.<key>` = `"on"`/`"off"`, and every subsequently-captured error carries it.

- **Tag naming (for the graduation query, AC 4):** `flag.<key>` = `on`/`off`, keyed off the `apps/web/src/flags/keys.ts` constants. A graduation query is then `flag.<key>:on` — e.g. `flag.phoenix-bildirim:on` counts errors captured while `phoenix-bildirim` was on for the session; `flag.<key>:off` is the comparison off-path. Documented in the `FLAG_TAG_PREFIX` / `tagFlag` docblocks in `apps/web/src/lib/sentry.ts`. This is the substrate #1822 consumes.
- **PII scrub preserved (AC 2):** flag keys are non-PII, so tagging is orthogonal to the ADR 0118 `dataCollection` scrub and touches none of it. (Note: the actual `sentry.ts` uses native `dataCollection` PII suppression, not the older hand-rolled `beforeSend`/`scrubPii` the issue body referenced — the equivalent scrub is left intact.)
- **Inert-when-no-DSN preserved (AC 3):** `tagFlag` short-circuits on the same `sentryEnabled` gate as init/capture — no scope mutation, no capture, no network while Sentry is off.

## Changes

- `apps/web/src/lib/sentry.ts` — add `FLAG_TAG_PREFIX`, the pure `flagTag(key, value)` naming mapper, and `tagFlag(key, value)` (inert-gated `Sentry.setTag`).
- `apps/web/src/flags/useFlag.ts` — call `tagFlag(key, resolved)` on genuine server resolution (not the safe-default catch path).
- `apps/web/src/lib/sentry.unit.test.ts` — cover the pure naming contract, the enabled-tag path, and the inert (no scope mutation) path.

## Acceptance criteria

- [x] Captured SPA errors carry a queryable `flag:<key>`-style tag (`flag.<key>` = `on`/`off`) sourced from `flags/keys.ts` constants, reflecting flags resolved for the session/render.
- [x] The ADR 0118 PII scrub (native `dataCollection`) remains applied — no PII regression.
- [x] Stays inert when no DSN is provisioned (the `sentryEnabled` gate still short-circuits).
- [x] Tag naming documented enough to write a graduation query against (the `flag.<key>:on` form) — the dependency #1822 consumes.
- [x] Worker tier: deferred to #1502/#1671 (the `@sentry/cloudflare` tier isn't merged); ships SPA-only per issue scope.

## Verification

- `vitest run --project unit src/lib/sentry.unit.test.ts src/flags/useFlag.test.ts` → 13 passed.
- `pnpm --filter @kampus/web typecheck` → clean.
- `biome check` on the changed files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)