### PR TITLE
feat(pasaport): enable @better-auth/api-key plugin + reachable create-apiKey (#108)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
 	"dependencies": {
 		"@alchemy.run/better-auth": "catalog:",
 		"@base-ui/react": "catalog:",
+		"@better-auth/api-key": "catalog:",
 		"@better-auth/core": "catalog:",
 		"@effect/platform-bun": "catalog:",
 		"@effect/platform-node": "catalog:",

--- a/apps/web/src/auth/client.ts
+++ b/apps/web/src/auth/client.ts
@@ -1,6 +1,7 @@
 // Re-anchor transitive type specifiers away from `.pnpm/<hash>/...` paths
 // so tsgo can portably name plugin types under composite project refs.
 // Mirrors worker/features/pasaport/better-auth-live.ts.
+import {apiKeyClient} from "@better-auth/api-key/client";
 import type {} from "@better-auth/core";
 import type {} from "better-auth/client";
 import {inferAdditionalFields} from "better-auth/client/plugins";
@@ -21,7 +22,15 @@ export const authClient = createAuthClient({
 	// keeps the worker auth instance out of the SPA bundle. `username` is immutable
 	// once set, so this session value equals `me.username` — see `useMe` for the one
 	// transient (right after a `setUsername` write) where the canonical row still wins.
-	plugins: [inferAdditionalFields({user: {username: {type: "string", required: false}}})],
+	// `apiKeyClient` surfaces the minimal documented mint path for a logged-in human to
+	// obtain a durable agent credential (ADR 0044 Decision 3, #108): a session can mint +
+	// copy a key with `await authClient.apiKey.create({name})`, reading the one-time
+	// plaintext off `res.data.key` to hand to an agent (which then sends it as the
+	// `x-api-key` header). The full `kampus auth` PAT UX is the separate CLI epic (#113).
+	plugins: [
+		inferAdditionalFields({user: {username: {type: "string", required: false}}}),
+		apiKeyClient(),
+	],
 	fetchOptions: {
 		auth: {
 			type: "Bearer",

--- a/apps/web/tests/integration/pasaport-api-key.test.ts
+++ b/apps/web/tests/integration/pasaport-api-key.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Agent-credential enabler (ADR 0044 Decision 3, #108) — black-box against the
+ * deployed worker's `/api/auth/*` + `/fate` routes on real remote D1 (ADR 0082
+ * integration tier). Proves the end-to-end apiKey contract a substituted seam can't
+ * reach:
+ *
+ *   - **A logged-in session mints a key.** `POST /api/auth/api-key/create` under a
+ *     session cookie returns the one-time plaintext `key`.
+ *   - **The key authenticates as the SAME pasaport user.** A later `me` read carrying
+ *     only the `x-api-key` header (no cookie) resolves the identical `user.id` — the
+ *     apiKey plugin mock-resolves the session through the same `getSession` path
+ *     `Pasaport.validateSession` reads.
+ *   - **Create is session-gated (no fail-open).** An unauthenticated create is
+ *     rejected, so the mint endpoint never issues a credential to an anonymous caller.
+ *
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7). Every email is `NS`-prefixed
+ * (this file's deterministic `nsToken`) so its rows can't collide with a sibling file's.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
+
+const h = sharedStack();
+const NS = nsToken(import.meta.url);
+
+// Mint an apiKey under a session cookie; return the one-time plaintext `key`.
+async function createApiKey(cookie: string, name: string): Promise<string> {
+	const res = await h.req(
+		"/api/auth/api-key/create",
+		{
+			method: "POST",
+			headers: {"content-type": "application/json", origin: "http://localhost:3000", cookie},
+			body: JSON.stringify({name}),
+		},
+		{timeoutMs: 30_000},
+	);
+	expect(res.ok).toBe(true);
+	const body = (await res.json()) as {key?: string};
+	expect(typeof body.key).toBe("string");
+	return body.key!;
+}
+
+// Read the `me` query carrying ONLY the `x-api-key` header (no session cookie), so a
+// pass proves the key alone authenticated the request.
+async function meViaApiKey(key: string): Promise<{ok: boolean; id?: string; code?: string}> {
+	const res = await h.req(
+		"/fate",
+		{
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				origin: "http://localhost:3000",
+				"x-api-key": key,
+			},
+			body: JSON.stringify({
+				version: 1,
+				operations: [{id: "1", kind: "query", name: "me", select: ["id"]}],
+			}),
+		},
+		{timeoutMs: 30_000},
+	);
+	const parsed = (await res.json()) as {
+		results: Array<{ok: true; data: {id: string}} | {ok: false; error: {code: string}}>;
+	};
+	const r = parsed.results[0]!;
+	return r.ok ? {ok: true, id: r.data.id} : {ok: false, code: r.error.code};
+}
+
+beforeAll(() => {
+	expect(typeof h.url()).toBe("string");
+});
+
+describe("pasaport apiKey — durable agent credentials", () => {
+	it("a session mints a key that authenticates a later request as the same user", async () => {
+		const owner = await h.signUp(`${NS}-agent-owner@test.local`, "hunter2hunter2", "Agent Owner");
+
+		const key = await createApiKey(owner.cookie, `${NS}-agent-key`);
+
+		const me = await meViaApiKey(key);
+		expect(me.ok).toBe(true);
+		expect(me.id).toBe(owner.userId);
+	});
+
+	it("rejects an unauthenticated create (no fail-open mint)", async () => {
+		const res = await h.req(
+			"/api/auth/api-key/create",
+			{
+				method: "POST",
+				headers: {"content-type": "application/json", origin: "http://localhost:3000"},
+				body: JSON.stringify({name: `${NS}-anon-key`}),
+			},
+			{timeoutMs: 30_000},
+		);
+		expect(res.ok).toBe(false);
+		expect(res.status).toBe(401);
+	});
+});

--- a/apps/web/worker/db/drizzle/migrations/0030_api_key_plugin_fields.sql
+++ b/apps/web/worker/db/drizzle/migrations/0030_api_key_plugin_fields.sql
@@ -1,0 +1,8 @@
+-- #108 — align the `apiKey` table with the pinned @better-auth/api-key plugin's declared
+-- schema. The plugin's `apikey` model requires a `configId` field (default 'default'); its
+-- drizzle adapter's `checkMissingFields` indexes the table by the plugin's field names on
+-- every create, so a key mint 500s without this column. `reference_id` needs no rename: the
+-- plugin field `referenceId` maps to the existing `user_id` column at the drizzle-property
+-- level (default user-references config → the reference IS the user id).
+
+ALTER TABLE `apiKey` ADD `config_id` text DEFAULT 'default' NOT NULL;

--- a/apps/web/worker/db/drizzle/migrations/meta/0030_api_key_plugin_fields_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0030_api_key_plugin_fields_snapshot.json
@@ -1,0 +1,2385 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "0efe67e8-dea6-4d7c-9c75-f93a2def2212",
+	"prevId": "5676c862-8d82-4c4f-a9b0-e8b16d3c5e66",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"apiKey": {
+			"name": "apiKey",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"config_id": {
+					"name": "config_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'default'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"start": {
+					"name": "start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prefix": {
+					"name": "prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"refill_interval": {
+					"name": "refill_interval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refill_amount": {
+					"name": "refill_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_refill_at": {
+					"name": "last_refill_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"rate_limit_enabled": {
+					"name": "rate_limit_enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"rate_limit_time_window": {
+					"name": "rate_limit_time_window",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rate_limit_max": {
+					"name": "rate_limit_max",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"request_count": {
+					"name": "request_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"remaining": {
+					"name": "remaining",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_request": {
+					"name": "last_request",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"permissions": {
+					"name": "permissions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"apiKey_user_id_user_id_fk": {
+					"name": "apiKey_user_id_user_id_fk",
+					"tableFrom": "apiKey",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_vote": {
+			"name": "comment_vote",
+			"columns": {
+				"comment_id": {
+					"name": "comment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"comment_vote_comment": {
+					"name": "comment_vote_comment",
+					"columns": [
+						"comment_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comment_vote_comment_id_voter_id_pk": {
+					"columns": [
+						"comment_id",
+						"voter_id"
+					],
+					"name": "comment_vote_comment_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"definition_vote": {
+			"name": "definition_vote",
+			"columns": {
+				"definition_id": {
+					"name": "definition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"definition_vote_definition": {
+					"name": "definition_vote_definition",
+					"columns": [
+						"definition_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"definition_vote_definition_id_voter_id_pk": {
+					"columns": [
+						"definition_id",
+						"voter_id"
+					],
+					"name": "definition_vote_definition_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"pano_stats": {
+			"name": "pano_stats",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"total_posts": {
+					"name": "total_posts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_comments": {
+					"name": "total_comments",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_authors": {
+					"name": "total_authors",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_record": {
+			"name": "post_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"host": {
+					"name": "host",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"comment_count": {
+					"name": "comment_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"hot_score": {
+					"name": "hot_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_draft": {
+					"name": "is_draft",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_record_hot": {
+					"name": "post_record_hot",
+					"columns": [
+						"hot_score"
+					],
+					"isUnique": false
+				},
+				"post_record_new": {
+					"name": "post_record_new",
+					"columns": [
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"post_record_top": {
+					"name": "post_record_top",
+					"columns": [
+						"score"
+					],
+					"isUnique": false
+				},
+				"post_record_discuss": {
+					"name": "post_record_discuss",
+					"columns": [
+						"comment_count"
+					],
+					"isUnique": false
+				},
+				"post_record_host": {
+					"name": "post_record_host",
+					"columns": [
+						"host"
+					],
+					"isUnique": false
+				},
+				"post_record_author_created": {
+					"name": "post_record_author_created",
+					"columns": [
+						"author_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				},
+				"post_record_one_draft_per_author": {
+					"name": "post_record_one_draft_per_author",
+					"columns": [
+						"author_id"
+					],
+					"isUnique": true,
+					"where": "`is_draft` = 1"
+				},
+				"post_record_sandboxed": {
+					"name": "post_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_vote": {
+			"name": "post_vote",
+			"columns": {
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_vote_post": {
+					"name": "post_vote_post",
+					"columns": [
+						"post_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"post_vote_post_id_voter_id_pk": {
+					"columns": [
+						"post_id",
+						"voter_id"
+					],
+					"name": "post_vote_post_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": [
+						"token"
+					],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"sozluk_stats": {
+			"name": "sozluk_stats",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"total_definitions": {
+					"name": "total_definitions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_terms": {
+					"name": "total_terms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_authors": {
+					"name": "total_authors",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"term_record": {
+			"name": "term_record",
+			"columns": {
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"first_letter": {
+					"name": "first_letter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"definition_count": {
+					"name": "definition_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_score": {
+					"name": "total_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"excerpt": {
+					"name": "excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"top_definition_id": {
+					"name": "top_definition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"first_at": {
+					"name": "first_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_edit_at": {
+					"name": "last_edit_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"term_record_recent": {
+					"name": "term_record_recent",
+					"columns": [
+						"last_activity_at"
+					],
+					"isUnique": false
+				},
+				"term_record_popular": {
+					"name": "term_record_popular",
+					"columns": [
+						"total_score"
+					],
+					"isUnique": false
+				},
+				"term_record_letter": {
+					"name": "term_record_letter",
+					"columns": [
+						"first_letter"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'human'"
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\u00e7aylak'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_username_unique": {
+					"name": "user_username_unique",
+					"columns": [
+						"username"
+					],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_profile": {
+			"name": "user_profile",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"total_karma": {
+					"name": "total_karma",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"definition_count": {
+					"name": "definition_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"post_count": {
+					"name": "post_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"comment_count": {
+					"name": "comment_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_profile_username_unique": {
+					"name": "user_profile_username_unique",
+					"columns": [
+						"username"
+					],
+					"isUnique": true
+				},
+				"user_profile_username": {
+					"name": "user_profile_username",
+					"columns": [
+						"username"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_vote": {
+			"name": "user_vote",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_vote_target": {
+					"name": "user_vote_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"user_vote_user_id_target_kind_target_id_pk": {
+					"columns": [
+						"user_id",
+						"target_kind",
+						"target_id"
+					],
+					"name": "user_vote_user_id_target_kind_target_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"content_report": {
+			"name": "content_report",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reporter_id": {
+					"name": "reporter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'open'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"resolver_id": {
+					"name": "resolver_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolution": {
+					"name": "resolution",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"wave_id": {
+					"name": "wave_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"content_report_target": {
+					"name": "content_report_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				},
+				"content_report_wave": {
+					"name": "content_report_wave",
+					"columns": [
+						"wave_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"content_report_pk": {
+					"name": "content_report_pk",
+					"columns": [
+						"reporter_id",
+						"target_kind",
+						"target_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_bookmark": {
+			"name": "post_bookmark",
+			"columns": {
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_bookmark_user_created": {
+					"name": "post_bookmark_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"post_bookmark_pk": {
+					"name": "post_bookmark_pk",
+					"columns": [
+						"post_id",
+						"user_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"definition_record": {
+			"name": "definition_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"term_slug": {
+					"name": "term_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"term_title": {
+					"name": "term_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"definition_record_author_created": {
+					"name": "definition_record_author_created",
+					"columns": [
+						"author_id",
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"definition_record_term_score": {
+					"name": "definition_record_term_score",
+					"columns": [
+						"term_slug",
+						"score"
+					],
+					"isUnique": false
+				},
+				"definition_record_sandboxed": {
+					"name": "definition_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_record": {
+			"name": "comment_record",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"post_title": {
+					"name": "post_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandboxed_at": {
+					"name": "sandboxed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"comment_record_author_created": {
+					"name": "comment_record_author_created",
+					"columns": [
+						"author_id",
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"comment_record_post": {
+					"name": "comment_record_post",
+					"columns": [
+						"post_id"
+					],
+					"isUnique": false
+				},
+				"comment_record_parent": {
+					"name": "comment_record_parent",
+					"columns": [
+						"parent_id"
+					],
+					"isUnique": false
+				},
+				"comment_record_sandboxed": {
+					"name": "comment_record_sandboxed",
+					"columns": [
+						"sandboxed_at"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"relation_tuple": {
+			"name": "relation_tuple",
+			"columns": {
+				"subject": {
+					"name": "subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"relation": {
+					"name": "relation",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"object": {
+					"name": "object",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"relation_tuple_object": {
+					"name": "relation_tuple_object",
+					"columns": [
+						"object",
+						"relation"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"relation_tuple_subject_relation_object_pk": {
+					"name": "relation_tuple_subject_relation_object_pk",
+					"columns": [
+						"subject",
+						"relation",
+						"object"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"authorship_vouch": {
+			"name": "authorship_vouch",
+			"columns": {
+				"voucher_id": {
+					"name": "voucher_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"candidate_id": {
+					"name": "candidate_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"authorship_vouch_candidate": {
+					"name": "authorship_vouch_candidate",
+					"columns": [
+						"candidate_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"authorship_vouch_voucher_id_candidate_id_pk": {
+					"name": "authorship_vouch_voucher_id_candidate_id_pk",
+					"columns": [
+						"voucher_id",
+						"candidate_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification": {
+			"name": "notification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipient_id": {
+					"name": "recipient_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"count": {
+					"name": "count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"read_at": {
+					"name": "read_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"notification_recipient_read": {
+					"name": "notification_recipient_read",
+					"columns": [
+						"recipient_id",
+						"read_at"
+					],
+					"isUnique": false
+				},
+				"notification_recipient_created": {
+					"name": "notification_recipient_created",
+					"columns": [
+						"recipient_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_reaction": {
+			"name": "user_reaction",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emoji": {
+					"name": "emoji",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_reaction_target": {
+					"name": "user_reaction_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"user_reaction_user_id_target_kind_target_id_pk": {
+					"columns": [
+						"user_id",
+						"target_kind",
+						"target_id"
+					],
+					"name": "user_reaction_user_id_target_kind_target_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_ban_event": {
+			"name": "user_ban_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_ban_event_user_created": {
+					"name": "user_ban_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"user_ban_event_user_id_user_id_fk": {
+					"name": "user_ban_event_user_id_user_id_fk",
+					"tableFrom": "user_ban_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mecmua_post": {
+			"name": "mecmua_post",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"published_at": {
+					"name": "published_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mecmua_post_author_created": {
+					"name": "mecmua_post_author_created",
+					"columns": [
+						"author_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mecmua_subscription": {
+			"name": "mecmua_subscription",
+			"columns": {
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subscriber_id": {
+					"name": "subscriber_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mecmua_subscription_subscriber": {
+					"name": "mecmua_subscription_subscriber",
+					"columns": [
+						"subscriber_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"mecmua_subscription_subscriber_id_author_id_pk": {
+					"columns": [
+						"subscriber_id",
+						"author_id"
+					],
+					"name": "mecmua_subscription_subscriber_id_author_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"karma_event": {
+			"name": "karma_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"delta": {
+					"name": "delta",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_kind": {
+					"name": "source_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"karma_event_user_created": {
+					"name": "karma_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"karma_event_user_id_user_id_fk": {
+					"name": "karma_event_user_id_user_id_fk",
+					"tableFrom": "karma_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"email_delivery_event": {
+			"name": "email_delivery_event",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"email_delivery_event_address_created": {
+					"name": "email_delivery_event_address_created",
+					"columns": [
+						"address",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				},
+				"email_delivery_event_user_created": {
+					"name": "email_delivery_event_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"email_delivery_event_user_id_user_id_fk": {
+					"name": "email_delivery_event_user_id_user_id_fk",
+					"tableFrom": "email_delivery_event",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {
+			"post_record_author_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"user_ban_event_user_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"mecmua_post_author_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"mecmua_subscription_subscriber": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
 			"when": 2296000000000,
 			"tag": "0029_email_delivery_event_actor_id",
 			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "6",
+			"when": 2396000000000,
+			"tag": "0030_api_key_plugin_fields",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -124,11 +124,19 @@ export const verification = sqliteTable("verification", {
 
 export const apikey = sqliteTable("apiKey", {
 	id: text("id").primaryKey(),
+	// `configId` + `referenceId` are the property names the pinned @better-auth/api-key
+	// plugin resolves against (its declared `apikey` schema names them, with no
+	// `fieldName` override) — the drizzle adapter's `checkMissingFields` indexes the
+	// table object by those exact keys on every create, so a mismatch 500s the mint
+	// (#108). `referenceId` keeps the SQL column `user_id`: with the plugin's default
+	// user-references config the reference IS the user id, so the column name stays
+	// accurate and no destructive column-rename migration is needed.
+	configId: text("config_id").notNull().default("default"),
 	name: text("name"),
 	start: text("start"),
 	prefix: text("prefix"),
 	key: text("key").notNull(),
-	userId: text("user_id")
+	referenceId: text("user_id")
 		.notNull()
 		.references(() => user.id, {onDelete: "cascade"}),
 	refillInterval: integer("refill_interval"),

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -1213,7 +1213,7 @@ function buildAnonymizeStatements(db: DrizzleDb, userId: string, email: string |
 
 	const dropSessions = db.delete(schema.session).where(eq(schema.session.userId, userId));
 	const dropAccounts = db.delete(schema.account).where(eq(schema.account.userId, userId));
-	const dropApikeys = db.delete(schema.apikey).where(eq(schema.apikey.userId, userId));
+	const dropApikeys = db.delete(schema.apikey).where(eq(schema.apikey.referenceId, userId));
 
 	const scrubUser = db
 		.update(schema.user)

--- a/apps/web/worker/features/pasaport/api-key-rate-limit.unit.test.ts
+++ b/apps/web/worker/features/pasaport/api-key-rate-limit.unit.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The apiKey plugin's per-key `rateLimit` (ADR 0044 Decision 3, #108) — the agent
+ * half of the rate mechanism. Asserting the declared config directly is how the
+ * "bounded independently" invariant is verified without firing thousands of requests:
+ * the shape is the proof. It must be ENABLED with a finite window + max, so a single
+ * key's velocity is capped rather than unbounded (a disabled or absent bound would let
+ * one runaway key issue without limit). Kept in step with #110's per-user backstop.
+ */
+import {describe, expect, it} from "vitest";
+import {apiKeyRateLimit} from "./better-auth-live.ts";
+
+describe("apiKeyRateLimit — a per-key velocity bound is enabled and finite", () => {
+	it("is enabled (a key is rate-limited, never unbounded)", () => {
+		expect(apiKeyRateLimit.enabled).toBe(true);
+	});
+
+	it("caps requests to a finite positive maximum per window", () => {
+		expect(apiKeyRateLimit.maxRequests).toBeGreaterThan(0);
+		expect(Number.isFinite(apiKeyRateLimit.maxRequests)).toBe(true);
+	});
+
+	it("bounds the window to a finite positive duration", () => {
+		expect(apiKeyRateLimit.timeWindow).toBeGreaterThan(0);
+		expect(Number.isFinite(apiKeyRateLimit.timeWindow)).toBe(true);
+	});
+});

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -223,11 +223,16 @@ export const BetterAuthLive = Layer.effect(
 					}),
 					// Durable agent credentials (ADR 0044 Decision 3). Exposes the
 					// session-authenticated create endpoint under `/api/auth/api-key/create`
-					// and mock-resolves a session for any request carrying the `x-api-key`
-					// header — so a minted key authenticates as its owning pasaport user
-					// through the same `getSession` path `validateSession` reads. The apikey
-					// table is already migrated (`schema.ts`). Rate limit: `apiKeyRateLimit`.
-					apiKey({rateLimit: apiKeyRateLimit}),
+					// and, with `enableSessionForAPIKeys`, resolves a session for any request
+					// carrying the `x-api-key` header — so a minted key authenticates as its
+					// owning pasaport user through the same `getSession` path `validateSession`
+					// reads. The flag is load-bearing, not decorative: it defaults `false`, and
+					// the plugin's session-from-key before-hook only registers a matcher for a
+					// config with the flag on (`findApiKeyAndConfig` skips flag-off configs), so
+					// without it an `x-api-key` header never mints a session and every key-auth'd
+					// read resolves anonymous. The apikey table is migrated (`schema.ts`). Rate
+					// limit: `apiKeyRateLimit`.
+					apiKey({rateLimit: apiKeyRateLimit, enableSessionForAPIKeys: true}),
 				],
 			} satisfies BetterAuthOptions);
 		}).pipe(Effect.cached);

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -14,6 +14,7 @@
  */
 
 import * as BetterAuth from "@alchemy.run/better-auth";
+import {apiKey} from "@better-auth/api-key";
 // Re-anchor transitive type specifiers away from `.pnpm/<hash>/...` paths so
 // tsgo can portably name plugin types under composite project refs.
 // See microsoft/typescript-go#1034 and better-auth#5666 for context.
@@ -80,6 +81,21 @@ export const additionalUserFields = {
 	tier: {type: "string", required: false, input: false},
 	promotedAt: {type: "date", required: false, input: false, returned: false},
 } satisfies AdditionalUserFields;
+
+/**
+ * The apiKey plugin's built-in per-key rate limit — the agent half of the rate
+ * mechanism (ADR 0044 Decision 3). Each agent credential's request velocity is
+ * bounded *independently* on its own rolling window, so one runaway key can't starve
+ * the others. Kept deliberately generous — comfortably above a normal agent burst
+ * (e.g. a multi-screenshot report) — and coupled to the per-user session-path backstop
+ * in #110; keep the two in step. Extracted as a pure value so the numbers are
+ * unit-assertable and the test layer (`better-auth.testing.ts`) shares the exact shape.
+ */
+export const apiKeyRateLimit = {
+	enabled: true,
+	timeWindow: 1000 * 60 * 60, // 1 hour
+	maxRequests: 1000,
+} as const;
 
 /**
  * The better-auth origin/cookie config for one deploy class (ADR 0088). Pure over
@@ -205,6 +221,13 @@ export const BetterAuthLive = Layer.effect(
 							await sendEmail(magicLinkEmail(email, url));
 						},
 					}),
+					// Durable agent credentials (ADR 0044 Decision 3). Exposes the
+					// session-authenticated create endpoint under `/api/auth/api-key/create`
+					// and mock-resolves a session for any request carrying the `x-api-key`
+					// header — so a minted key authenticates as its owning pasaport user
+					// through the same `getSession` path `validateSession` reads. The apikey
+					// table is already migrated (`schema.ts`). Rate limit: `apiKeyRateLimit`.
+					apiKey({rateLimit: apiKeyRateLimit}),
 				],
 			} satisfies BetterAuthOptions);
 		}).pipe(Effect.cached);

--- a/apps/web/worker/features/pasaport/better-auth.testing.ts
+++ b/apps/web/worker/features/pasaport/better-auth.testing.ts
@@ -8,6 +8,7 @@
  * A **factory, not a shared instance** (`.patterns/effect-testing.md`).
  */
 import * as BetterAuth from "@alchemy.run/better-auth";
+import {apiKey} from "@better-auth/api-key";
 import {type Auth, type BetterAuthOptions, betterAuth as makeBetterAuth} from "better-auth";
 import {drizzleAdapter} from "better-auth/adapters/drizzle";
 import {bearer} from "better-auth/plugins";
@@ -18,7 +19,7 @@ import * as Layer from "effect/Layer";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import * as schema from "../../db/drizzle/schema.ts";
-import {BetterAuthHandlerError} from "./better-auth-live.ts";
+import {apiKeyRateLimit, BetterAuthHandlerError} from "./better-auth-live.ts";
 
 /**
  * A REAL better-auth instance over a test `D1Database` handle, reproducing
@@ -26,9 +27,9 @@ import {BetterAuthHandlerError} from "./better-auth-live.ts";
  * stack the node test pool lacks.
  *
  * MUST stay in lockstep with `BetterAuthLive` (same `emailAndPassword`,
- * `drizzleAdapter`, `bearer()`, `additionalFields.username`) — if they drift the
- * guard suites silently test a different shape than production. Test-only diffs,
- * immaterial to the shape under test: literal `secret`/`baseURL`/`trustedOrigins`
+ * `drizzleAdapter`, `bearer()`, `apiKey()`, `additionalFields.username`) — if they
+ * drift the guard suites silently test a different shape than production. Test-only
+ * diffs, immaterial to the shape under test: literal `secret`/`baseURL`/`trustedOrigins`
  * and no `magicLink` plugin.
  *
  * Returns a concrete `Auth<{…}>`; callers widen to the generic `Auth` (see {@link layerTest}).
@@ -46,7 +47,7 @@ export function makeRealAuthForTest(d1: D1Database) {
 				username: {type: "string", required: false, input: false},
 			},
 		},
-		plugins: [bearer()],
+		plugins: [bearer(), apiKey({rateLimit: apiKeyRateLimit})],
 	} satisfies BetterAuthOptions);
 }
 

--- a/apps/web/worker/features/pasaport/better-auth.testing.ts
+++ b/apps/web/worker/features/pasaport/better-auth.testing.ts
@@ -47,7 +47,7 @@ export function makeRealAuthForTest(d1: D1Database) {
 				username: {type: "string", required: false, input: false},
 			},
 		},
-		plugins: [bearer(), apiKey({rateLimit: apiKeyRateLimit})],
+		plugins: [bearer(), apiKey({rateLimit: apiKeyRateLimit, enableSessionForAPIKeys: true})],
 	} satisfies BetterAuthOptions);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ catalogs:
       specifier: ^1.4.1
       version: 1.4.1
     '@better-auth/api-key':
-      specifier: 1.6.10
-      version: 1.6.10
+      specifier: 1.6.23
+      version: 1.6.23
     '@better-auth/core':
-      specifier: 1.6.10
-      version: 1.6.10
+      specifier: 1.6.23
+      version: 1.6.23
     '@biomejs/biome':
       specifier: ^2.4.15
       version: 2.4.15
@@ -118,8 +118,8 @@ catalogs:
       specifier: ^1.6.13
       version: 1.6.23
     better-call:
-      specifier: 1.3.5
-      version: 1.3.5
+      specifier: 1.3.7
+      version: 1.3.7
     drizzle-kit:
       specifier: 1.0.0-rc.4
       version: 1.0.0-rc.4
@@ -220,9 +220,12 @@ importers:
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@better-auth/api-key':
+        specifier: 'catalog:'
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/core':
         specifier: 'catalog:'
-        version: 1.6.10(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+        version: 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92)
@@ -270,7 +273,7 @@ importers:
         version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call:
         specifier: 'catalog:'
-        version: 1.3.5(zod@4.4.3)
+        version: 1.3.7(zod@4.4.3)
       drizzle-orm:
         specifier: 'catalog:'
         version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
@@ -404,7 +407,7 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.10(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))
       alchemy:
         specifier: 'catalog:'
         version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
@@ -1446,29 +1449,13 @@ packages:
       '@types/react':
         optional: true
 
-  '@better-auth/api-key@1.6.10':
-    resolution: {integrity: sha512-oUJgDaDYLaDpYHhm/adNXD/FeXhG9CMrotadIXLiAsyae4nXYAVNin22sdSGmUVYsX84HXLaPnM3a5rgqnxkuw==}
+  '@better-auth/api-key@1.6.23':
+    resolution: {integrity: sha512-HQMTv1GkY5FzE8BlUXdNhuKPBPUvusBYlAtIQElQjfsmGiPiBie7BdzuhcbXhAqJerunU299yvEge2WlZusp+Q==}
     peerDependencies:
-      '@better-auth/core': ^1.6.10
-      '@better-auth/utils': 0.4.0
-      better-auth: ^1.6.10
-
-  '@better-auth/core@1.6.10':
-    resolution: {integrity: sha512-13h/rfSGMLl7zwyOb1BSlxAQZs2nQqn/xFI/bxB7zQuS95hVgTmNbKqhHtJYkNDtuJCcjEf1sNtLBHkvaPT/vw==}
-    peerDependencies:
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
-      '@cloudflare/workers-types': '>=4'
-      '@opentelemetry/api': ^1.9.0
-      better-call: 1.3.5
-      jose: ^6.1.0
-      kysely: ^0.28.5
-      nanostores: ^1.0.1
-    peerDependenciesMeta:
-      '@cloudflare/workers-types':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      better-auth: ^1.6.23
+      better-call: 1.3.7
 
   '@better-auth/core@1.6.23':
     resolution: {integrity: sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==}
@@ -1543,14 +1530,8 @@ packages:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
-  '@better-auth/utils@0.4.0':
-    resolution: {integrity: sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==}
-
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
-
-  '@better-fetch/fetch@1.1.21':
-    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
@@ -3232,14 +3213,6 @@ packages:
       vue:
         optional: true
 
-  better-call@1.3.5:
-    resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
-    peerDependencies:
-      zod: ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
   better-call@1.3.7:
     resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
     peerDependencies:
@@ -4904,27 +4877,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.6.10(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))':
+  '@better-auth/api-key@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
-
-  '@better-auth/core@1.6.10(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
-    dependencies:
-      '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@standard-schema/spec': 1.1.0
-      better-call: 1.3.5(zod@4.4.3)
-      jose: 6.2.3
-      kysely: 0.28.17
-      nanostores: 1.3.0
-      zod: 4.4.3
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260629.1
-      '@opentelemetry/api': 1.9.1
 
   '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
@@ -4976,15 +4935,9 @@ snapshots:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
-  '@better-auth/utils@0.4.0':
-    dependencies:
-      '@noble/hashes': 2.2.0
-
   '@better-auth/utils@0.4.2':
     dependencies:
       '@noble/hashes': 2.2.0
-
-  '@better-fetch/fetch@1.1.21': {}
 
   '@better-fetch/fetch@1.3.1': {}
 
@@ -6362,15 +6315,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.5(zod@4.4.3):
-    dependencies:
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 4.4.3
 
   better-call@1.3.7(zod@4.4.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,14 @@ packages:
 catalog:
   '@alchemy.run/better-auth': 2.0.0-beta.59
   '@base-ui/react': ^1.4.1
-  '@better-auth/api-key': 1.6.10
-  '@better-auth/core': 1.6.10
+  # Lockstep with better-auth 1.6.23 (the `^1.6.13` catalog pin resolves there):
+  # api-key + core pinned to the EXACT version better-auth links transitively, so ONE
+  # `@better-auth/core` lives in the tree. A stale `core: 1.6.10` left apps/web's direct
+  # (type-anchor) core a version behind the transitive 1.6.23 the apiKey plugin's hook
+  # types are built against — two `HookEndpointContext` types → TS2322 in the plugins
+  # array (#108, the CLAUDE.md "don't introduce a second version" catalog invariant).
+  '@better-auth/api-key': 1.6.23
+  '@better-auth/core': 1.6.23
   '@biomejs/biome': ^2.4.15
   '@cloudflare/workers-types': ^4.20260629.1
   '@distilled.cloud/cloudflare': 0.27.0
@@ -46,7 +52,11 @@ catalog:
   # by that incompatibility — don't assume a bump makes them join-compatible (no RQB-v2 adapter
   # release exists yet). See #2286 (guard) / #2291 (re-enable joins via pnpm patch).
   better-auth: ^1.6.13
-  better-call: 1.3.5
+  # better-call's EXACT-pinned peer of `@better-auth/core@1.6.23` (`better-call: 1.3.7`),
+  # also what better-auth 1.6.23 links transitively. A stale 1.3.5 split core@1.6.23 into
+  # two peer-hash instances (one per better-call), re-surfacing the two-`HookEndpointContext`
+  # TS2322 — pinned to 1.3.7 so ONE core/better-call pair lives in the tree (#108).
+  better-call: 1.3.7
   drizzle-kit: 1.0.0-rc.4
   drizzle-orm: 1.0.0-rc.4
   effect: 4.0.0-beta.92


### PR DESCRIPTION
Fixes #108

Enables durable agent credentials by registering better-auth's `apiKey` plugin against the pasaport user (ADR 0044 Decision 3). The `apikey` table was already migrated; this is the dependency-add + register + reachable-create-endpoint half.

## What changed

- **`apiKey()` registered** in `apps/web/worker/features/pasaport/better-auth-live.ts`, beside `bearer()`/`magicLink()`. The plugin auto-exposes `POST /api/auth/api-key/create` under the existing `/api/auth/*` route, and mock-resolves a session for any request carrying the `x-api-key` header — through the same `getSession` path `Pasaport.validateSession` reads, so a minted key authenticates as its owning pasaport user.
- **Per-key `rateLimit`** configured via the plugin's built-in mechanism (extracted as the pure, unit-asserted `apiKeyRateLimit`: enabled, 1h window, 1000 max) so each agent key's velocity is bounded *independently* — the agent half of the rate mechanism, kept in step with #110's per-user backstop.
- **Minimal documented mint path**: `apiKeyClient()` added to the SPA `authClient`, so a logged-in human mints + copies a key with `await authClient.apiKey.create({name})` (reads the one-time plaintext off `res.data.key`). Full `kampus auth` PAT UX stays in #113.
- **Catalog alignment (no second version).** `better-auth` resolves to **1.6.23**, but the catalog had stale `@better-auth/core: 1.6.10` + `better-call: 1.3.5`. Because the apiKey plugin's hook types are built against core `1.6.23`, that skew split `HookEndpointContext` into two incompatible types (TS2322 in the plugins array). Pinned `@better-auth/api-key` + `@better-auth/core` to `1.6.23` and `better-call` to `1.3.7` (core@1.6.23's exact peer) so ONE core/better-call pair lives in the tree — the CLAUDE.md "don't introduce a second version" invariant.

## Tests

- `apps/web/tests/integration/pasaport-api-key.test.ts` — black-box on real remote D1: a session mints a key, and a later `me` read carrying **only** `x-api-key` resolves the same `user.id`; an unauthenticated create is rejected (401, no fail-open mint).
- `apps/web/worker/features/pasaport/api-key-rate-limit.unit.test.ts` — asserts the per-key bound is enabled + finite.

## Gates (local)

- `pnpm typecheck` — 29/29 packages pass
- `pnpm lint` — clean
- `pnpm --filter @kampus/web test:unit` — 2213 pass
- `pipeline-cli catalog-guard check` — pass

Integration test runs against real Cloudflare in CI (needs deploy creds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)