### PR TITLE
feat(pasaport): expose emailFailing on the me-read + declare the notice flag (#2730)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -45,6 +45,7 @@ import {
 	bildirimFlag,
 	demoTargetingFlag,
 	emailDeliveryAdminFlag,
+	emailDeliveryNoticeFlag,
 	Flagship,
 	funnelReadoutFlag,
 	karmaGatesFlag,
@@ -148,6 +149,9 @@ export default Alchemy.Stack(
 		// (#2692, epic #2687) — the single seam the emailDelivery.mark/clear mutations + the
 		// emailDelivery.failing admin roll-up gate behind until a human release.
 		yield* emailDeliveryAdminFlag(flagship.appId);
+		// The failing-email membrane notice dark-ship flag, default-off (#2693, epic #2687)
+		// — the seam the user-facing notice gates behind until a human release.
+		yield* emailDeliveryNoticeFlag(flagship.appId);
 		// The mecmua public-read dark-ship flag, default-off (#2498, epic #2467) — the
 		// single seam the anon GET route + reader page gate behind until a human release.
 		yield* mecmuaPublicReadFlag(flagship.appId);

--- a/apps/web/src/auth/useMe.ts
+++ b/apps/web/src/auth/useMe.ts
@@ -28,11 +28,13 @@ import {useSession} from "./client";
  * over the exact scalars `MeView` selects, never a hand-restated interface. `tier`
  * and `isModerator` are trusted account-level signals read server-side (the stored
  * column via `Kunye.tierOf` / the `moderates` relation), surfaced on the row, never
- * inferred from the session.
+ * inferred from the session. `emailFailing` is the SELF failing-delivery signal
+ * (#2693) the membrane notice reads via the `emailFailing?` seam — optional, so a
+ * non-self read (or the not-yet-wired worker) is treated as deliverable.
  */
 export type MeUser = Pick<
 	User,
-	"id" | "email" | "name" | "image" | "username" | "tier" | "isModerator"
+	"id" | "email" | "name" | "image" | "username" | "tier" | "isModerator" | "emailFailing"
 >;
 
 export type MeStatus = "idle" | "loading" | "ok" | "error";
@@ -45,6 +47,7 @@ const MeView = view<User>()({
 	username: true,
 	tier: true,
 	isModerator: true,
+	emailFailing: true,
 });
 
 export function useMe(): {

--- a/apps/web/worker/features/flagship/email-delivery-notice.invariant.test.ts
+++ b/apps/web/worker/features/flagship/email-delivery-notice.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the failing-email membrane notice
+ * (#2693, epic #2687). Inspected off the exported `EMAIL_DELIVERY_NOTICE_FLAG` record
+ * (the same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
+ * constructed — mirrors `email-delivery-admin.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_EMAIL_DELIVERY_NOTICE} from "../../../src/flags/keys.ts";
+import {EMAIL_DELIVERY_NOTICE_FLAG, emailDeliveryNoticeFlag} from "./resources.ts";
+
+describe("failing-email membrane notice — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.defaultVariation, "off");
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.variations.off, false);
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.variations.on, true);
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.key, "phoenix-email-delivery-notice");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(EMAIL_DELIVERY_NOTICE_FLAG.key, PHOENIX_EMAIL_DELIVERY_NOTICE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof emailDeliveryNoticeFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -25,6 +25,7 @@ import {
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_BILDIRIM,
 	PHOENIX_EMAIL_DELIVERY_ADMIN,
+	PHOENIX_EMAIL_DELIVERY_NOTICE,
 	PHOENIX_FUNNEL_READOUT,
 	PHOENIX_KARMA_GATES,
 	PHOENIX_MOD_QUEUE,
@@ -832,6 +833,37 @@ export const EMAIL_DELIVERY_ADMIN_FLAG = {
  */
 export const emailDeliveryAdminFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_email_delivery_admin", {appId, ...EMAIL_DELIVERY_ADMIN_FLAG});
+
+/**
+ * The failing-email membrane notice dark-ship flag config (#2693, email-bounce epic
+ * #2687). The seam the user-facing notice gates behind — with it off the membrane mount
+ * renders nothing, so the surface ships dark until a human flips it at release (ADR 0083).
+ * Its OWN key, not the admin seam (#2692): the user-facing notice is a distinct surface
+ * from the admin failing-address console, with its own release lifecycle.
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `EMAIL_DELIVERY_ADMIN_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           pasaport (the identity + email-delivery surface)
+ *   - originating:     #2693 (epic: email-bounce, #2687)
+ *   - removal trigger: once the notice graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline the membrane mount.
+ */
+export const EMAIL_DELIVERY_NOTICE_FLAG = {
+	key: PHOENIX_EMAIL_DELIVERY_NOTICE,
+	description:
+		"failing-email membrane notice dark-ship (#2693, epic #2687). owner: pasaport. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const emailDeliveryNoticeFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_email_delivery_notice", {appId, ...EMAIL_DELIVERY_NOTICE_FLAG});
 
 /**
  * The mecmua public-read dark-ship flag config (#2498, epic #2467). The SINGLE seam

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -62,27 +62,37 @@ export const queries = {
 			const user = yield* CurrentUser.required;
 			const pasaport = yield* Pasaport;
 			const fresh = yield* pasaport.getUserById(user.id);
-			// `toTrustedUser` resolves the trusted standing (tier via `Kunye.tierOf`,
-			// the moderator signal via the `moderates` tuple) — one shared home for the
-			// `User` shape `setUsername` and the by-id loader also build. The session
-			// supplies email/name/image; the canonical row, when present, overrides them
-			// so a fresh `username` round-trips before better-auth's session catches up.
-			if (!fresh) {
-				return yield* toTrustedUser({
-					id: user.id,
-					email: user.email,
-					name: user.name ?? null,
-					image: user.image ?? null,
-					username: null,
-				});
-			}
-			return yield* toTrustedUser({
-				id: fresh.id,
-				email: fresh.email,
-				name: fresh.name,
-				image: fresh.image,
-				username: fresh.username,
-			});
+			// The session supplies email/name/image; the canonical row, when present,
+			// overrides them so a fresh `username` round-trips before better-auth's
+			// session catches up.
+			const base = fresh
+				? {
+						id: fresh.id,
+						email: fresh.email,
+						name: fresh.name,
+						image: fresh.image,
+						username: fresh.username,
+					}
+				: {
+						id: user.id,
+						email: user.email,
+						name: user.name ?? null,
+						image: user.image ?? null,
+						username: null,
+					};
+			// The SELF failing-delivery signal (#2693): the reader’s own address projected
+			// through #2691’s `resolveEmailDeliveryState`. Stamped ONLY here (never on the
+			// by-id batch), so #2727’s membrane notice lights up for the current user without
+			// exposing any other account’s delivery-state. A row-missing principal has no
+			// events, so `UserNotFound` reads deliverable.
+			const emailFailing = yield* pasaport.getEmailDeliveryState(base.id).pipe(
+				Effect.map((r) => r.state.failing),
+				Effect.catchTag("pasaport/UserNotFound", () => Effect.succeed(false)),
+			);
+			// `toTrustedUser` resolves the trusted standing (tier via `Kunye.tierOf`, the
+			// moderator signal via the `moderates` tuple) — the one shared home for the
+			// `User` shape `setUsername` and the by-id loader also build.
+			return yield* toTrustedUser({...base, emailFailing});
 		}),
 	),
 	// `contributions` is delivered inline (not via a source `connection`

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -20,6 +20,8 @@ import {assert} from "vitest";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {Kunye, KunyeLive} from "../kunye/Kunye.ts";
 import type {StoredTier} from "../kunye/standing.ts";
+import {DELIVERABLE} from "./email-delivery.ts";
+import {UserNotFound} from "./errors.ts";
 import type {UserRow} from "./Pasaport.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {queries} from "./queries.ts";
@@ -61,8 +63,17 @@ const storedUser = (tier: StoredTier): UserRow => ({
 	tier,
 });
 
-const pasaportWithStoredTier = (tier: StoredTier) =>
-	({getUserById: () => Effect.succeed(storedUser(tier))}) as never;
+// The `me` resolver also reads the SELF failing-delivery signal (#2693) via
+// `getEmailDeliveryState`; deliverable by default so the tier/isModerator paths run
+// unaffected. `deliveryState` overrides it for the emailFailing coverage below.
+const pasaportWithStoredTier = (
+	tier: StoredTier,
+	deliveryState: {failing: boolean; reason: string | null} = DELIVERABLE,
+) =>
+	({
+		getUserById: () => Effect.succeed(storedUser(tier)),
+		getEmailDeliveryState: () => Effect.succeed({address: "u1@kamp.us", state: deliveryState}),
+	}) as never;
 
 // Drive `me` to the resolved wire object's `tier` scalar over the REAL `Kunye`
 // (KunyeLive) layered on a stored-tier Pasaport stub — exercising the trusted
@@ -153,8 +164,13 @@ it.effect("me ranks a row-missing principal as visitor (Kunye.tierOf fallback)",
 			image: null,
 		} satisfies CurrentUserInfo;
 		// No stored row → both the canonical read and Kunye.tierOf see null → visitor,
-		// the read-time rank the column can never store.
-		const noRowPasaport = {getUserById: () => Effect.succeed(null)} as never;
+		// the read-time rank the column can never store. `getEmailDeliveryState` fails
+		// `UserNotFound` for the row-missing address, which the `me` resolver catches to a
+		// deliverable signal (proving the catch keeps the read from crashing).
+		const noRowPasaport = {
+			getUserById: () => Effect.succeed(null),
+			getEmailDeliveryState: () => new UserNotFound({message: "kullanıcı bulunamadı"}),
+		} as never;
 		const tier = yield* resolveMeTier(user, noRowPasaport);
 		assert.strictEqual(tier, "visitor");
 	}),
@@ -196,5 +212,32 @@ it.effect("me carries isModerator false for a yazar who holds no moderates tuple
 			relationStoreReturning(false),
 		);
 		assert.strictEqual(isMod, false);
+	}),
+);
+
+// #2693 — the SELF failing-delivery signal the membrane notice reads. Stamped on the
+// `me` read from #2691's projection, self-scoped so it can only describe the reader.
+const resolveMeEmailFailing = (pasaport: never) =>
+	resolveWire(queries.me, {args: undefined, select: ["id", "emailFailing"]}).pipe(
+		Effect.provideService(CurrentUser, {user: u1}),
+		Effect.provide(KunyeLive),
+		Effect.provideService(Pasaport, pasaport),
+		Effect.provideService(RelationStore, relationStoreReturning(false)),
+		Effect.map((me) => (me as {emailFailing?: boolean}).emailFailing),
+	);
+
+it.effect("me stamps emailFailing true when the reader's own address is failing", () =>
+	Effect.gen(function* () {
+		const failing = yield* resolveMeEmailFailing(
+			pasaportWithStoredTier("yazar", {failing: true, reason: "hard-bounce"}),
+		);
+		assert.strictEqual(failing, true);
+	}),
+);
+
+it.effect("me stamps emailFailing false when the reader's own address is deliverable", () =>
+	Effect.gen(function* () {
+		const failing = yield* resolveMeEmailFailing(pasaportWithStoredTier("yazar"));
+		assert.strictEqual(failing, false);
 	}),
 );

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -24,6 +24,10 @@ import type {
 	User,
 } from "./views.ts";
 
+// `emailFailing` (#2693) rides here like the other resolver-stamped fields: truthful on
+// the self `me` read, a flat `false` on every other `User` (the by-id batch stamps it),
+// so a non-self row never carries another account's delivery-state. Its single home is
+// `user-fields.ts`'s `UserFields.emailFailing`.
 export const toUser = (r: UserFields): User => ({
 	__typename: "User",
 	id: r.id,
@@ -33,6 +37,7 @@ export const toUser = (r: UserFields): User => ({
 	username: r.username,
 	tier: r.tier,
 	isModerator: r.isModerator,
+	emailFailing: r.emailFailing,
 });
 
 // Stamps the client normalization key `id` === `userId` (a `Profile` is

--- a/apps/web/worker/features/pasaport/sources.unit.test.ts
+++ b/apps/web/worker/features/pasaport/sources.unit.test.ts
@@ -161,7 +161,9 @@ it.effect("userSource.byIds carries through the underlying row fields unchanged"
 			Effect.provideService(Pasaport, pasaportWithCorpus),
 			Effect.provideService(RelationStore, relationStoreFor(new Set())),
 		);
-		assert.deepStrictEqual(rows[0], {...storedUser("u1"), isModerator: false});
+		// The batch stamps `emailFailing: false` flat — it is the reader's OWN signal,
+		// resolved only on the self `me` read (#2693), never another account's here.
+		assert.deepStrictEqual(rows[0], {...storedUser("u1"), isModerator: false, emailFailing: false});
 	}),
 );
 

--- a/apps/web/worker/features/pasaport/trusted-user.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.ts
@@ -24,6 +24,10 @@ export interface TrustedUserBase {
 	name: string | null;
 	image: string | null;
 	username: string | null;
+	// The SELF failing-delivery signal (#2693). Only `queries.me` sets it (from #2691's
+	// projection); every other caller omits it and `toTrustedUser` defaults it `false`, so a
+	// non-self trusted `User` never carries real delivery-state (see `user-fields.ts`).
+	emailFailing?: boolean;
 }
 
 /**
@@ -39,7 +43,7 @@ export const toTrustedUser = (
 		const kunye = yield* Kunye;
 		const tier = yield* kunye.tierOf(base.id);
 		const isMod = yield* isModerator(base.id);
-		return toUser({...base, tier, isModerator: isMod});
+		return toUser({...base, tier, isModerator: isMod, emailFailing: base.emailFailing ?? false});
 	});
 
 /**
@@ -55,5 +59,7 @@ export const getUsersWithModerationByIds = (ids: ReadonlyArray<string>) =>
 		const pasaport = yield* Pasaport;
 		const rows = yield* pasaport.getUsersByIds(ids);
 		const mods = yield* moderatorsAmong(rows.map((row) => row.id));
-		return rows.map((row) => ({...row, isModerator: mods.has(row.id)}));
+		// `emailFailing` is a flat `false` on the by-id batch: it is the reader's OWN signal,
+		// resolved only on the self `me` read (#2693), never another account's delivery-state.
+		return rows.map((row) => ({...row, isModerator: mods.has(row.id), emailFailing: false}));
 	});

--- a/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
@@ -72,6 +72,9 @@ describe("toTrustedUser — the SELF trusted User shape", () => {
 				username: "u-one",
 				tier: "yazar",
 				isModerator: true,
+				// A base with no `emailFailing` defaults to `false` — the self signal is set
+				// only on the `me` read (#2693), never here.
+				emailFailing: false,
 			});
 		}),
 	);

--- a/apps/web/worker/features/pasaport/user-fields.ts
+++ b/apps/web/worker/features/pasaport/user-fields.ts
@@ -44,10 +44,19 @@ export type UserRow = {
  * the record-derived fields with `tier` widened to the read-time `Tier` and the
  * `isModerator` relation-tuple signal stamped by the resolver (`trusted-user.ts`),
  * never read from the record. Derived from `UserRow` so the field set can't drift.
+ *
+ * `emailFailing` is the SELF-scoped failing-delivery signal (#2693, epic #2687),
+ * stamped by the resolver like `tier`/`isModerator` and, like them, ALWAYS present:
+ * the `queries.me` resolver projects the reader's own state from #2691's
+ * `resolveEmailDeliveryState`, and every other `User` resolution (the by-id
+ * `userSource` batch) stamps a flat `false` — a non-self row never carries another
+ * account's real delivery-state, so nothing leaks. The client reads it through the
+ * `emailFailing?` seam (`emailDeliveryNoticeGate.ts`).
  */
 export interface UserFields extends Omit<UserRow, "tier"> {
 	tier: Tier;
 	isModerator: boolean;
+	emailFailing: boolean;
 }
 
 /**
@@ -65,6 +74,7 @@ export const userViewFields = {
 	username: true,
 	tier: true,
 	isModerator: true,
+	emailFailing: true,
 } as const satisfies Record<keyof UserFields, true>;
 
 /**


### PR DESCRIPTION
Worker-side enabler that lights up the (already-shipped, inert) #2693 membrane notice (PR #2727). Closes the AC1 worker gap so the notice reads a real signal, plus declares its release flag dark.

## What changed

**1 — `emailFailing` on the pasaport `User`/`me` read.**
- `emailFailing: boolean` joins `UserFields` (`user-fields.ts`) as a resolver-stamped, always-present trusted field, alongside `tier`/`isModerator`. `toUser` (`shapers.ts`) stamps it.
- The `queries.me` resolver projects the reader's OWN state from #2691's `resolveEmailDeliveryState` via the existing `Pasaport.getEmailDeliveryState(userId)` (`UserNotFound` for a row-missing principal reads deliverable).
- Every non-self `User` resolution — the by-id `userSource` batch (`trusted-user.ts` `getUsersWithModerationByIds`) — stamps a flat `false`, so a non-self row never carries another account's delivery-state. `setUsername`/`setDisplayName` default it `false` via `toTrustedUser`.
- `MeView` (`useMe.ts`) selects `emailFailing`, so #2727's notice lights up through the existing `readEmailFailing` seam — no further client change.

**2 — the `phoenix-email-delivery-notice` IaC flag.**
- Declared in `flagship/resources.ts` (`EMAIL_DELIVERY_NOTICE_FLAG` + `emailDeliveryNoticeFlag`) and wired into the stack (`alchemy.run.ts`). Default-off — deployed dark; a human flips the release (ADR 0083). The flag key + `DECLARED_FLAGS` entry + client `useFlag` wiring already existed (#2693).
- New default-off invariant test mirrors `email-delivery-admin.invariant.test.ts`.

## Acceptance criteria
- [x] `User`/`me` exposes an `emailFailing` boolean stamped from `resolveEmailDeliveryState` (#2691), field-map idiom in `pasaport/{views,shapers,user-fields}.ts`.
- [x] `MeView` (`useMe.ts`) selects `emailFailing`; #2727's notice lights up with no further client change.
- [x] `phoenix-email-delivery-notice` declared in `flagship/resources.ts`, deployed dark (default-off).
- [x] No fate-live fanout change — this adds a **read** field, not a mutation.

## Scope note (read-path expansion)
The clean fix needed the resolver stamp, so beyond the triage-named `{views,shapers,user-fields}.ts` this also touches read-path resolver files (`trusted-user.ts`, `queries.ts`) + the stack wiring (`alchemy.run.ts`) and their unit tests. It touches **none** of the sibling lane's write-path/schema files (`db/drizzle/schema.ts`, migrations, `pasaport/email-delivery.ts`).

## Verification
- `pnpm typecheck` clean, `pnpm lint` clean.
- Unit: `queries`/`trusted-user`/`sources`/notice-invariant + client `EmailDeliveryNotice`/`emailDeliveryNoticeGate` — all green (25 + 8 + 11).

Fixes #2730

🤖 Generated with [Claude Code](https://claude.com/claude-code)