### PR TITLE
docs(ci-credentials): deslop comments

### DIFF
--- a/infra/ci-credentials/github.ts
+++ b/infra/ci-credentials/github.ts
@@ -4,9 +4,6 @@
  * run `alchemy deploy` (Part 5 of the alchemy tutorial, adapted to phoenix:
  * pnpm + node, not bun; `kamp-us/phoenix`).
  *
- * Authored by Can Sirin (@cansirin) in #19; brought into #12 to land the
- * self-provisioning CI credential flow with the framework foundation.
- *
  * Why a separate stack from `alchemy.run.ts`: the app stack only needs enough
  * Cloudflare permission to deploy the worker. THIS stack *mints a brand-new,
  * scoped Cloudflare API token* (which requires the elevated `API Tokens > Write`


### PR DESCRIPTION
Runs the `deslop-comments` discipline over `infra/` (ci-credentials + depo swept together per the issue).

## What changed
- `infra/ci-credentials/github.ts` — cut the authorship / PR-history attribution paragraph from the module docblock. Provenance is carried by git blame, not a docblock, and the stale `#19`/`#12` PR references are narration a reader does not need.

## What was deliberately left intact
The rest of `infra/` (both stacks) was already at the deslop standard, so no other file changed:
- Module docblocks state what the module is + the one non-obvious thing (KEEP).
- Invariants sit at their enforcement sites (e.g. `errors.ts` HTTP-status mapping, `upload.ts` write-once ordering, `index.ts` "never leak detail").
- ADR *why* is already collapsed to pointers (ADR 0144 / 0057 / 0028 / 0124).
- Seam rationale (`storage.ts`, `verifier.ts`) and the canonical `#1432` CI-secret roster are load-bearing.

## Guarantees
- Diff is **comments-only** — no code token, identifier, string, or behavior changed (`git diff` = 3 deleted comment lines).
- `pnpm lint` and `pnpm typecheck` both green.

Fixes #2841