### PR TITLE
docs(composer): deslop comments

### DIFF
--- a/packages/composer/src/ReadOnlyComposer.render.test.tsx
+++ b/packages/composer/src/ReadOnlyComposer.render.test.tsx
@@ -42,7 +42,6 @@ Bir paragraf **kalın** ve *italik* içerir. [kamp.us](https://kamp.us) bağlant
 
 describe("ReadOnlyComposer render path (#2581)", () => {
 	it("renders composer-authored markdown as rich read-only DOM (no raw ## / \\[ \\] / &nbsp;)", async () => {
-		// The real reader flow: author via composer → the stored markdown → render read-only.
 		const stored = await authorAndStore(SAMPLE);
 		const {container} = render(<ReadOnlyComposer content={stored} />);
 		const el = await surface(container);
@@ -105,7 +104,6 @@ describe("ReadOnlyComposer render path (#2581)", () => {
 		const {container} = render(<ReadOnlyComposer content={payload} />);
 		const el = await surface(container);
 
-		// No script node, no surviving event-handler attribute, no javascript: href.
 		expect(container.querySelectorAll("script").length).toBe(0);
 		expect(el.querySelector("[onerror]")).toBeNull();
 		for (const a of el.querySelectorAll("a")) {

--- a/packages/composer/src/public-surface.unit.test.ts
+++ b/packages/composer/src/public-surface.unit.test.ts
@@ -28,7 +28,6 @@ describe("public export surface", () => {
 		// The read-only render mode (#2581) is part of the public surface — a consumer (mecmua
 		// reader) renders through it without importing tiptap or reaching a deep path.
 		expect(typeof composer.ReadOnlyComposer).toBe("function");
-		// No deep-path import is required of a consumer: everything above resolves from the root.
 	});
 });
 

--- a/packages/composer/src/renderTestMarkdown.render.test.tsx
+++ b/packages/composer/src/renderTestMarkdown.render.test.tsx
@@ -46,7 +46,6 @@ describe("renderTestMarkdown through useComposerEditor (render path)", () => {
 		act(() => handle.setContent(renderTestMarkdown));
 		const out = handle.getMarkdown();
 
-		// Every block + inline element the fixture claims survives the round-trip.
 		expect(out).toContain("# Composer render testi");
 		expect(out).toContain("###### Altıncı seviye başlık");
 		expect(out).toContain("**kalın**");


### PR DESCRIPTION
Deslop-comments pass over `packages/composer` (the issue's dir scope).

## What changed
Cut four narration/restater comments in the composer test files — each duplicated its own `it()` title or an adjacent comment, so a reader pattern-matched them as boilerplate:

- `ReadOnlyComposer.render.test.tsx` — dropped a flow-narration line above `authorAndStore` and a comment restating the three XSS asserts (already covered by the `it()` title).
- `renderTestMarkdown.render.test.tsx` — dropped a comment restating the round-trip `it()` title.
- `public-surface.unit.test.ts` — dropped a trailing comment restating the adjacent read-only-mode note.

The rest of the package's comments carry load-bearing issue-number pointers, invariants (the `setContent` teardown guard #2593), and workaround rationale — kept as-is.

## Scope
- Comments-and-whitespace only — `git diff` shows no code/logic change (4 deletions, all comment lines).
- Scoped to `packages/composer` only.
- `pnpm lint` and `pnpm typecheck` pass.

Fixes #2846