### PR TITLE
docs(depo): deslop comments

### DIFF
--- a/packages/depo/src/client.ts
+++ b/packages/depo/src/client.ts
@@ -8,10 +8,7 @@
  *
  * `putBytes` is the seam-testable core (bytes in); `put(path)` is the fs-reading
  * wrapper the bin calls. The mapping from the doorman's HTTP status to a typed
- * failure is the acceptance contract (#1970):
- *   201/200 → success (created / benign idempotent re-PUT), URL returned
- *   401 → Unauthorized   415 → UnsupportedMediaType
- *   413 → PayloadTooLarge   409 → ContentAddressConflict   else → UploadFailed
+ * failure is the acceptance contract (#1970); it lives in `putBytes` below.
  */
 import {readFile} from "node:fs/promises";
 import * as Context from "effect/Context";

--- a/packages/depo/src/client.unit.test.ts
+++ b/packages/depo/src/client.unit.test.ts
@@ -2,11 +2,8 @@
  * Unit tests for the client core (`putBytes`) with the doorman behind the
  * `DoormanClient` seam — no live worker (`.patterns/effect-testing.md` unit tier).
  * These assert the acceptance contract: the content-addressed request the client
- * SENDS, and the mapping from each doorman status to a typed outcome.
- *
- *   201/200 → the public URL      401 → Unauthorized
- *   415 → UnsupportedMediaType     413 → PayloadTooLarge
- *   409 → ContentAddressConflict   500/other → UploadFailed
+ * SENDS, and the mapping from each doorman status to a typed outcome (a case per
+ * status below).
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as Effect from "effect/Effect";

--- a/packages/depo/src/errors.ts
+++ b/packages/depo/src/errors.ts
@@ -4,16 +4,9 @@
  * `Schema.TaggedErrorClass` (the repo-wide error constructor — #2736). These are
  * CLI-only and never reach the fate wire, so they carry no `FateWireCode`
  * annotation. The set is the client-side image of the doorman's HTTP contract
- * (#1970): every 4xx the doorman can return maps to exactly one error here, so a
- * caller `catch`es a typed failure rather than parsing a status code.
- *
- *   doorman 401 → Unauthorized          doorman 415 → UnsupportedMediaType
- *   doorman 413 → PayloadTooLarge        doorman 409 → ContentAddressConflict
- *
- * Plus the client-local faults with no server counterpart: `MissingCredential`
- * (no apiKey resolved before any request), `FileReadError` (the local file could
- * not be read), `DigestError` (the SHA-256 content address could not be computed),
- * and `UploadFailed` (transport failure or an unmapped status).
+ * (#1970): every 4xx the doorman can return maps to exactly one error here (each
+ * class documents its own status below), so a caller `catch`es a typed failure
+ * rather than parsing a status code.
  */
 import * as Schema from "effect/Schema";
 


### PR DESCRIPTION
Deslop the comments under `packages/depo` (issue scope). Comments-and-whitespace only — no code token changed.

The doorman-status → outcome mapping table was re-derived in three files (`errors.ts`, `client.ts`, `client.unit.test.ts`). Each error class documents its own status at its enforcement site, `putBytes` is the mapping code, and each test case names its own status — so the header tables were duplicated *why*. Collapsed each to a pointer at the single source ("each class documents its own status below" / "it lives in `putBytes` below" / "a case per status below").

Load-bearing notes kept as-is: the `biome-ignore` rationale on `parseSuccess`, the `crypto.subtle.digest`/`.slice()` `BufferSource` gotcha in `domain.ts`, the ADR/issue pointers, and each file's top-of-file docblock (what the module is + the one non-obvious thing).

`pnpm lint` + `pnpm typecheck` green (confirms no accidental code change).

Fixes #2849

🤖 Generated with [Claude Code](https://claude.com/claude-code)