### PR TITLE
docs(db-schema): deslop comments

### DIFF
--- a/packages/db-schema/src/index.ts
+++ b/packages/db-schema/src/index.ts
@@ -40,10 +40,6 @@ import {index, integer, sqliteTable, text} from "drizzle-orm/sqlite-core";
 
 const timestamp = (name: string) => integer(name, {mode: "timestamp"});
 
-/**
- * One row per term, keyed by slug. Canonical store for sozluk terms under
- * d1-direct (ADR 0009) — the D1 row IS the term; deleting it destroys it.
- */
 export const termRecord = sqliteTable(
 	"term_record",
 	{
@@ -68,10 +64,8 @@ export const termRecord = sqliteTable(
 );
 
 /**
- * Per-definition row. Canonical store for sozluk definitions after d1-direct
- * (ADR 0009) — the per-term DO is no longer the source of truth. Denormalized
- * with term slug + title so the profile feed renders without joining
- * `term_record`; `body_excerpt` is a denormalized truncation for the feed card.
+ * Denormalized with term slug + title so the profile feed renders without
+ * joining `term_record`; `body_excerpt` is a truncation for the feed card.
  */
 export const definitionRecord = sqliteTable(
 	"definition_record",
@@ -112,10 +106,6 @@ export const definitionRecord = sqliteTable(
 	],
 );
 
-/**
- * One row per post. Canonical store for pano posts under d1-direct (ADR 0009) —
- * the per-post DO is no longer the source of truth; the D1 row IS the post.
- */
 export const postRecord = sqliteTable(
 	"post_record",
 	{
@@ -171,9 +161,8 @@ export const postRecord = sqliteTable(
 );
 
 /**
- * Per-comment row, denormalized with post id + title for the profile feed AND
- * the per-post thread reader. Canonical store for pano comments after d1-direct
- * (ADR 0009) — the per-post DO is no longer the source of truth.
+ * Denormalized with post id + title for the profile feed AND the per-post
+ * thread reader.
  *
  * A removed comment that still has live replies stays as a `Removed` row (its
  * canonical body kept for restore + moderator review); the `[silindi]` tombstone


### PR DESCRIPTION
Deslop-comments hygiene pass over `packages/db-schema` (comments-and-whitespace only — no code/logic change).

## What changed
Collapsed the four near-identical per-table docblocks in `src/index.ts` that each re-narrated the same ADR 0009 d1-direct "canonical store of record / the per-entity DO is no longer the source of truth" *why* — that rationale is already stated once in the top-of-file module docblock, so the per-table repeats were the #2179-class duplicated *why*. Each table's genuinely table-specific, load-bearing note is kept:
- `definition_record` / `comment_record`: the denormalization rationale (why author/term/post columns are stored) preserved.
- `term_record` / `post_record`: docblocks removed (pure name-restate + duplicated ADR re-derivation).

## What was kept (load-bearing)
- The top-of-file module docblock (what the leaf package is + the non-obvious leaf/scope constraints).
- Inline column notes (`first_letter`, `hot_score`, denormalized `url`/`host`/`tags`, etc.).
- The ADR 0096 removal-triad + çaylak sandbox (#1205/#1206) invariants, with their existing "see definition_record" pointers intact.
- Index WHERE-clause notes documenting the read each index serves.
- The test file's regression-guard docblock (#859 drift guard).

## Verification
- `git diff` is comments-and-whitespace only.
- `pnpm lint` clean, `pnpm typecheck` green (29/29) — confirms no accidental code change.

Fixes #2848