### PR TITLE
docs(web): deslop comments

### DIFF
--- a/apps/web/src/components/divan/remove-the-wave.ts
+++ b/apps/web/src/components/divan/remove-the-wave.ts
@@ -77,7 +77,6 @@ export function toggleWaveRow(selected: ReadonlyArray<string>, key: string): Rea
 	return selected.includes(key) ? selected.filter((k) => k !== key) : [...selected, key];
 }
 
-/** Whether a row is currently selected. */
 export function isWaveSelected(selected: ReadonlyArray<string>, key: string): boolean {
 	return selected.includes(key);
 }

--- a/apps/web/src/components/reaction/ReactionGlyph.tsx
+++ b/apps/web/src/components/reaction/ReactionGlyph.tsx
@@ -47,7 +47,6 @@ function Glyph({children}: {children: ReactNode}) {
 	);
 }
 
-/** 👍 beğendim — thumbs-up. */
 function ThumbsUp() {
 	return (
 		<Glyph>
@@ -57,7 +56,6 @@ function ThumbsUp() {
 	);
 }
 
-/** ❤️ sevdim — heart. */
 function Heart() {
 	return (
 		<Glyph>
@@ -66,7 +64,6 @@ function Heart() {
 	);
 }
 
-/** 😂 güldüm — laughing face. */
 function Laughing() {
 	return (
 		<Glyph>
@@ -78,7 +75,6 @@ function Laughing() {
 	);
 }
 
-/** 🤔 düşündürdü — thinking face. */
 function Thinking() {
 	return (
 		<Glyph>
@@ -91,7 +87,6 @@ function Thinking() {
 	);
 }
 
-/** 😢 üzüldüm — crying face. */
 function Crying() {
 	return (
 		<Glyph>
@@ -104,7 +99,6 @@ function Crying() {
 	);
 }
 
-/** 🔥 efsane — flame. */
 function Flame() {
 	return (
 		<Glyph>


### PR DESCRIPTION
Deslops comments under `apps/web/src` per the [`deslop-comments`](.claude/skills/deslop-comments/SKILL.md) discipline. **Comments-and-whitespace only** — no code/logic change (`pnpm lint` + `pnpm typecheck` green, confirming no accidental token change).

## What was cut

- `apps/web/src/components/reaction/ReactionGlyph.tsx` — the six per-glyph docblocks (`/** 👍 beğendim — thumbs-up. */`, …). Each only restated the emoji + Turkish gloss already carried by the `GLYPHS` map and the top-of-file docblock's own six-member list — the near-identical per-item docblock wall (the #2179 reaction-surface duplication class). The load-bearing header (SVG-vs-OS-emoji rendering, `currentColor` token inheritance) and the `Glyph` helper's `aria-hidden` rationale are kept.
- `apps/web/src/components/divan/remove-the-wave.ts` — a one-line name-restater docblock over `isWaveSelected` (`/** Whether a row is currently selected. */`), which said nothing the signature + one-line body doesn't.

## What was deliberately kept

The rest of `apps/web/src` is already well-curated to the "comments earn their place" convention: the flag-registry docblocks in `flags/keys.ts` each carry distinct its-own-key-vs-shared-seam rationale (unhomed, load-bearing), the reaction-model / optimistic / Topbar / TriageLoop inline notes state invariants, fail-closed defaults, and byte-identical-to-today guards. Those were left intact — this pass is scoped to the genuine slop.

Fixes #2839