### PR TITLE
docs(cf-utils): deslop comments

### DIFF
--- a/packages/cf-utils/src/bin.ts
+++ b/packages/cf-utils/src/bin.ts
@@ -165,13 +165,9 @@ const resolveTarget = (
 	return Effect.fail(new FlagSetTargetInvalid({reason: "no target given"}));
 };
 
-// The lever's interactive confirm — the thin IO shell around the pure `decideLeverGuard` core. The
-// lever is agent-invokable (ADR 0134, supersedes 0133): humans-release is enforced at the /release
-// skill + the audit trail, NOT by a structural TTY refuse here. So a non-TTY caller (agent/CI)
-// PROCEEDS, logging the flip for the audit record; a TTY caller (a human at a terminal) is prompted
-// `flip <flag> live? [y/N]` as ergonomics and may decline. It runs ONLY on the `--execute` write
-// branch; the dry-run path never reaches it. See ADR 0134 (this behavior) and ADR 0083 (the
-// humans-release boundary, now enforced at the invocation layer).
+// The lever's interactive confirm — the thin IO shell around the pure `decideLeverGuard` core, which
+// owns the decision semantics (see ADR 0134). Prompts a TTY human `flip <flag> live? [y/N]`; a
+// non-TTY agent/CI caller proceeds. Reached ONLY on the `--execute` write branch.
 const guardLiveFlip = (
 	flagKey: string,
 ): Effect.Effect<void, LeverGuardRefused, Prompt.Environment> =>
@@ -228,9 +224,7 @@ const set = Command.make(
 			return;
 		}
 
-		// Lever confirm (ADR 0134): agent-invokable — a non-TTY caller proceeds (logged for audit);
-		// a TTY human is prompted to confirm. Runs ONLY here, on the changed `--execute` write branch
-		// (dry-run and no-op returned above are untouched).
+		// Lever confirm (ADR 0134) — reached ONLY here, on the changed `--execute` write branch.
 		yield* guardLiveFlip(key);
 
 		const write = yield* FlagshipWrite;

--- a/packages/cf-utils/src/flag.ts
+++ b/packages/cf-utils/src/flag.ts
@@ -228,12 +228,9 @@ export class FlagSetTargetInvalid extends Schema.TaggedErrorClass<FlagSetTargetI
 }
 
 /**
- * The interactive confirm's refusal — `flag set --execute` (the live-flip write branch ONLY)
- * declined because a human running the lever in a terminal did not affirm the `[y/N]` prompt.
- * Under ADR 0134 (supersedes 0133) the lever is agent-invokable: a non-TTY caller is NOT refused
- * (it proceeds, logged for the audit record), so this error surfaces ONLY on the TTY ergonomics
- * path — a human at a terminal who answered `n`/empty/EOF. The message names the recoverable fix
- * (re-run and answer the prompt affirmatively).
+ * The interactive confirm's refusal — `flag set --execute` declined because a human at a terminal
+ * did not affirm the `[y/N]` prompt. Surfaces ONLY on the TTY ergonomics path (`decideLeverGuard`,
+ * ADR 0134); a non-TTY agent/CI caller is never refused. The message names the recoverable fix.
  */
 export class LeverGuardRefused extends Schema.TaggedErrorClass<LeverGuardRefused>()(
 	"@kampus/cf-utils/LeverGuardRefused",

--- a/packages/cf-utils/src/flagship.ts
+++ b/packages/cf-utils/src/flagship.ts
@@ -65,8 +65,7 @@ const toRawFlag = (flag: {
 	enabled: flag.enabled,
 	defaultVariation: flag.defaultVariation,
 	variations: flag.variations,
-	// `rules` carries the no-match split — the actual release lever (#1726). Conditions stay
-	// opaque; the pure core only tests their presence and round-trips them verbatim.
+	// Conditions stay opaque — the pure core only tests their presence and round-trips them verbatim.
 	rules: flag.rules,
 });
 


### PR DESCRIPTION
Deslop the comments under `packages/cf-utils` per the `deslop-comments` skill. Comments-and-whitespace only — no code token, identifier, string, or behavior changed (`pnpm lint` + `pnpm typecheck` green).

## What changed

The cf-utils comments are largely load-bearing (they explain the #1726 no-match-split release lever, the ADR 0134/0083 humans-release boundary, ADR 0082 D1-SQLite grounding, and the destructive-ceremony invariants). The one clear #2179-class defect was the **ADR-0134 confirm rationale re-derived at three sites** while `decideLeverGuard`'s pure-core docblock already owns it in full. Collapsed the duplicates to pointers at that canonical home:

- `bin.ts` — `guardLiveFlip` docblock and the `set`-command inline confirm note: collapsed the ADR-0134 re-derivation to a `see ADR 0134` / `decideLeverGuard` pointer, keeping the IO-shell role + the "only on the `--execute` write branch" fact.
- `flag.ts` — `LeverGuardRefused` docblock: trimmed the ADR-0134 re-derivation to a `decideLeverGuard` pointer, keeping what the error *is* and its recoverable fix.
- `flagship.ts` — `toRawFlag` inner comment: dropped the `#1726` lever restatement already owned by the module docblock, keeping the load-bearing opaque-conditions / verbatim-round-trip note.

`decideLeverGuard`, the flag.ts and flagship.ts top-of-file docblocks (the canonical homes for the confirm semantics and the #1726 lever wire-shape), and every invariant/pragma note were left intact.

Fixes #2845

🤖 Generated with [Claude Code](https://claude.com/claude-code)