### PR TITLE
docs(authz): deslop comments

### DIFF
--- a/packages/authz/src/Actor.ts
+++ b/packages/authz/src/Actor.ts
@@ -10,46 +10,37 @@
  * adapters (`features/kunye`) build an `Actor` from the pasaport session.
  */
 
-/** An authenticated human principal — a bare account id. */
 export interface Human {
 	readonly _tag: "Human";
 	readonly id: string;
 }
 
-/** An authenticated agent principal, carrying the id of its human `root`. */
 export interface Agent {
 	readonly _tag: "Agent";
 	readonly id: string;
 	readonly root: string;
 }
 
-/** An authenticated principal — a human or an agent acting for a human root. */
 export type Principal = Human | Agent;
 
-/** Anonymous traffic — no principal. */
 export interface Unauthenticated {
 	readonly _tag: "Unauthenticated";
 }
 
-/** An authenticated request, carrying its {@link Principal}. */
 export interface Authenticated {
 	readonly _tag: "Authenticated";
 	readonly principal: Principal;
 }
 
-/** The actor behind a request. */
 export type Actor = Unauthenticated | Authenticated;
 
-/** The anonymous actor. */
 export const unauthenticated: Unauthenticated = {_tag: "Unauthenticated"};
 
-/** An authenticated human actor. */
 export const human = (id: string): Authenticated => ({
 	_tag: "Authenticated",
 	principal: {_tag: "Human", id},
 });
 
-/** An authenticated agent actor acting for human `root`. */
 export const agent = (id: string, root: string): Authenticated => ({
 	_tag: "Authenticated",
 	principal: {_tag: "Agent", id, root},

--- a/packages/authz/src/Capability.ts
+++ b/packages/authz/src/Capability.ts
@@ -54,14 +54,12 @@ export type CapabilityTag<Self, Id extends string> = Context.ServiceClass<Self, 
 		readonly key: Id;
 	};
 
-/** The generic base capability — discharged by a caller-supplied check. */
 export type ClassCapability<Self, Id extends string, DenyError> = CapabilityTag<Self, Id> & {
 	authorize<E, R>(
 		check: Effect.Effect<boolean, E, R>,
 	): Effect.Effect<Grant<Self>, DenyError | E, CurrentActor | R>;
 };
 
-/** A `Level`-axis capability — discharged by reading standing against a floor. */
 export type LevelCapability<
 	Self,
 	Id extends string,
@@ -76,19 +74,16 @@ export type LevelCapability<
 	>;
 };
 
-/** A `Relation`-axis capability — discharged over a resource's ancestry. */
 export type RelationCapability<Self, Id extends string, DenyError> = CapabilityTag<Self, Id> & {
 	over(
 		object: Resource,
 	): Effect.Effect<Grant<Self>, DenyError, CurrentActor | RelationStore | AgentAuthority>;
 };
 
-/** Config for {@link Class}. */
 export interface ClassConfig<DenyError> {
 	readonly deny: () => DenyError;
 }
 
-/** Config for {@link Level}. */
 export interface LevelConfig<Name extends string, DenyError, ReadError, ReadReqs> {
 	/** The ordered ladder the `min` floor is compared on. */
 	readonly scale: Scale<Name>;
@@ -99,7 +94,6 @@ export interface LevelConfig<Name extends string, DenyError, ReadError, ReadReqs
 	readonly deny: () => DenyError;
 }
 
-/** Config for {@link Relation}. */
 export interface RelationConfig<DenyError> {
 	/** The relation name (the ReBAC verb, e.g. `moderates`). */
 	readonly relation: string;

--- a/packages/authz/src/CurrentActor.ts
+++ b/packages/authz/src/CurrentActor.ts
@@ -7,7 +7,6 @@
 import {Context} from "effect";
 import type {Actor} from "./Actor.ts";
 
-/** The actor behind the current request. */
 export class CurrentActor extends Context.Service<
 	CurrentActor,
 	{


### PR DESCRIPTION
Deslop the comments across `packages/authz` per the `deslop-comments` skill. Comments-and-whitespace only — no code token changed (`git diff` is 16 pure comment-line deletions).

## What was cut
- **`Actor.ts`** — the wall of per-member one-line restater docblocks (Human, Agent, Principal, Unauthenticated, Authenticated, Actor, and the `unauthenticated`/`human`/`agent` constructors). The top-of-file docblock already states the three-armed structure + the dormant agent seam; each per-arm one-liner just restated its own type.
- **`Capability.ts`** — the three type-alias one-liners (`ClassCapability`/`LevelCapability`/`RelationCapability`) that verbatim-duplicated the header's three-builder bullet list, plus the three `Config for {@link X}` name-restaters.
- **`CurrentActor.ts`** — the class docblock restating the file header.

## What was kept (load-bearing)
All rationale that the code can't express: the seal derivations in `Grant.ts`, the `sealCapability` audited-coercion note + `CapabilityTag` #1483 brand rationale, the fresh-on-each-call `RelationStore` invariant, the `hasSubjects`/`subjectsOf` N+1/#1699 notes, the `Resource.key` seam-encoding note, the typetest R-channel assertions, and every top-of-file docblock (module + the one non-obvious thing). No unhomed rationale existed to migrate.

`pnpm lint` and `pnpm typecheck` both green (confirms no accidental code change).

Fixes #2842