### PR TITLE
docs(cf-credentials): deslop comments

### DIFF
--- a/packages/cf-credentials/src/auth.ts
+++ b/packages/cf-credentials/src/auth.ts
@@ -27,7 +27,6 @@ const accountIdPrompt = Prompt.text({
 			: Effect.fail("expected a 32-hex-char Cloudflare account id"),
 });
 
-// The pasted-token path (#1730): prompt for the token + account id, validate, store.
 const tokenPasteLogin = Effect.fn(function* () {
 	const token = yield* tokenPrompt;
 	const accountId = yield* accountIdPrompt;


### PR DESCRIPTION
Runs the `deslop-comments` discipline over `packages/cf-credentials` per the issue's dir scope.

## What changed
- `src/auth.ts`: cut one narration comment on `tokenPasteLogin` that restated the obvious prompt → validate → store flow in the lines below it and re-cited `#1730`, which the file's top docblock already carries.

The rest of the package is already deliberately curated — load-bearing notes were kept: the keychain-miss-as-normal-CI-path invariant (`keychain.ts` top docblock), the `security` exit -1 spawn-failure classification, the `args` deliberately-omits-`-w` secret-leak guard, the `errSecItemNotFound` (exit 44) magic-number gloss, the caching rationale in `credentials.ts`, and the "validate the ambient resolution so a green status proves flag commands authenticate" rationale.

## Verification
- Diff is comments-only — no code token, identifier, string, or behavior changed.
- `pnpm lint` green.
- `pnpm typecheck` green (29/29).

Fixes #2844