### PR TITLE
docs(design-capture): deslop comments

### DIFF
--- a/packages/design-capture/src/capture.ts
+++ b/packages/design-capture/src/capture.ts
@@ -5,18 +5,10 @@
  * (`upload.ts`) hold the unit-tested logic; this file launches a browser, visits
  * each `Shot.url` at its viewport, screenshots it, and persists it.
  *
- * `localPath` is the PRIMARY judged artifact (ADR 0165): the review-design gate
- * reads the local PNG bytes to reach its verdict, decoupled from whether the
- * upload later succeeds. So capture ALWAYS produces `localPath` on success —
- * losing it is never acceptable.
- *
- * Captures over the EXISTING per-PR preview deploy (#2247): the caller passes
- * URLs already rooted at the preview the `preview-deploy` bot stood up — this
- * helper never serves the app itself.
- *
- * Each capture also collects the runtime errors thrown into the page during the
- * render (`pageErrors`) — the crash signal the gate fails on when a mount/init
- * race throws on a bad tick (see `page-errors.ts`, #2594).
+ * `localPath` is the PRIMARY judged artifact (ADR 0165), so capture ALWAYS
+ * produces it on success — losing it is never acceptable. Each capture also
+ * collects the runtime errors thrown into the page during the render
+ * (`pageErrors`) — the crash signal the gate fails on (see `page-errors.ts`, #2594).
  */
 import {mkdir, writeFile} from "node:fs/promises";
 import {join} from "node:path";

--- a/packages/design-capture/src/orchestrate.ts
+++ b/packages/design-capture/src/orchestrate.ts
@@ -58,10 +58,8 @@ export interface CaptureAndUploadRequest {
 }
 
 /**
- * PURE: fold an upload outcome onto a captured surface. The judged image
- * (`localPath`) is copied straight through from the capture and is NEVER
- * conditional on the upload — a fallback (`hostedUrl: null`) still yields a
- * record carrying `localPath`, so the gate always has bytes to judge (ADR 0165).
+ * PURE: fold an upload outcome onto a captured surface. `localPath` is copied
+ * straight through and is never conditional on the upload (ADR 0165).
  */
 export const mergeRecord = (captured: CapturedSurface, outcome: UploadOutcome): CaptureRecord => ({
 	surface: captured.surface,

--- a/packages/design-capture/src/page-errors.ts
+++ b/packages/design-capture/src/page-errors.ts
@@ -42,7 +42,6 @@ export const toPageError = (kind: PageError["kind"], text: string): PageError =>
 	return {kind, text: trimmed.length === 0 ? "(no message)" : trimmed};
 };
 
-/** Only an uncaught exception hard-fails the gate; console.error rides advisory. */
 export const isRenderCrash = (error: PageError): boolean => error.kind === "pageerror";
 
 /**


### PR DESCRIPTION
Deslop the comments in `packages/design-capture` per the `deslop-comments` discipline.

The package was already well-tended, so this is a light-touch pass targeting the one genuine defect: the ADR-0165 *why* (`localPath` is the primary judged artifact, decoupled from the display-only upload) was re-derived in full across `capture.ts` and `orchestrate.ts`, and the pageerror-vs-console.error rationale was stated three times in `page-errors.ts` (the duplicated-*why* class CLAUDE.md flags — state a why once, collapse the rest to a pointer).

Changes (comments-only):
- `capture.ts` — collapse the top-docblock ADR-0165 re-derivation to a pointer; drop the `#2247` preview-deploy narration (owned by `bin.ts`); keep the local `localPath`-always invariant.
- `orchestrate.ts` — trim the `mergeRecord` docblock (third in-file restatement) to a one-line `(ADR 0165)` pointer.
- `page-errors.ts` — drop the one-line restater on `isRenderCrash` (the top docblock is the single home for that why).

Kept every load-bearing note: the ReDoS/CodeQL workaround in `plan.ts`, the undocumented-endpoint LOAD-BEARING NOTE + `biome-ignore` rationale in `upload.ts`, the inline listener-window note in `capture.ts`, and all test-scenario notes.

The diff is comments-only — no code token, identifier, string, or behavior changed. `pnpm lint` and `pnpm typecheck` are green.

Fixes #2850