### PR TITLE
docs(fts-backfill): deslop comments

### DIFF
--- a/packages/fts-backfill/src/backfill.ts
+++ b/packages/fts-backfill/src/backfill.ts
@@ -1,26 +1,17 @@
 /**
- * The FTS backfill core (issue #534): re-index the existing `term_record` /
- * `post_record` rows into the FTS5 `term_search` / `post_search` tables by
- * replaying the ADR-0080 dual-write sync over every source row.
- *
- * Root cause it fixes: the FTS tables are populated ONLY by the application
- * dual-write on new writes (`syncTermSearch` / `syncPostSearch`, ADR 0080) —
- * rows written before that sync existed in the summary tables but were never
- * indexed, so search returns empty for all pre-existing content. This is the
- * one-time backfill CLAUDE.md's "Sözlük seed" section mandates: a direct-D1
- * script, not a worker route, not a `.sql` migration (a migration can't run the
- * app-side Turkish fold the FTS `norm` column needs).
+ * The FTS backfill core (#534): re-index existing `term_record` / `post_record`
+ * rows into the FTS5 `term_search` / `post_search` tables by replaying the
+ * ADR-0080 dual-write over every source row — the one-time backfill CLAUDE.md's
+ * "Sözlük seed" section mandates (a direct-D1 script, not a route/migration).
  *
  * Reuses the worker's OWN sync builders (`@kampus/web/features/search/fts-sync`),
- * NOT a reimplementation — so the indexed `norm` is byte-identical to the
- * dual-write's (issue #534's hard constraint: identical normalization, or the
- * backfilled rows won't match queries). Each builder is a delete-then-insert
- * upsert keyed on slug/id, so the backfill is idempotent: re-running it replaces
- * the same FTS rows rather than duplicating them.
+ * so the indexed `norm` is byte-identical to the dual-write's — #534's hard
+ * constraint: identical normalization, or backfilled rows won't match queries.
+ * The builders are delete-then-insert upserts keyed on slug/id, so the backfill
+ * is idempotent.
  *
- * Posts are filtered to live (`removed_at IS NULL`) rows — the search resolver
- * only hydrates non-removed posts and the dual-write removes a removed post's
- * FTS row, so a removed post must not be searchable.
+ * Posts are filtered to live (`removed_at IS NULL`) rows: the dual-write removes
+ * a removed post's FTS row, so a removed post must not be searchable.
  */
 import type {FtsSyncDb, Stmt} from "@kampus/web/db/Drizzle";
 import {syncPostSearch, syncTermSearch} from "@kampus/web/features/search/fts-sync";

--- a/packages/fts-backfill/src/bin.ts
+++ b/packages/fts-backfill/src/bin.ts
@@ -1,19 +1,9 @@
 /**
- * `fts-backfill run` — the one-time, direct-D1 FTS backfill for issue #534.
- *
- * Re-indexes every existing `term_record` / `post_record` row into the FTS5
- * `term_search` / `post_search` tables through the worker's own ADR-0080 sync
- * builders, so search works for content written before the dual-write existed.
- * This is the direct-D1 script CLAUDE.md's "Sözlük seed" mandates — NOT a worker
- * route, NOT a `.sql` migration (a migration can't run the app-side Turkish fold
- * the `norm` column needs), and NOT Python (the `effect/unstable/cli` idiom,
- * mirroring `@kampus/preview-seed` / `@kampus/leak-guard`). Idempotent: safe to
- * re-run.
- *
- * Transport: a `D1Database` adapter (`makeD1Rest`) over the Cloudflare D1 REST
- * query API via alchemy's already-installed `@distilled.cloud/cloudflare` (zero
- * new deps) — so the bin runs the SAME `backfill(d1)` path the unit test exercises
- * against an in-memory fake, no workerd binding needed.
+ * `fts-backfill run` — the one-time, direct-D1 FTS backfill for #534 (see
+ * backfill.ts for the why). A thin `effect/unstable/cli` bin over `backfill(d1)`
+ * with a `D1Database` adapter (`makeD1RestFromEnv`) speaking the Cloudflare D1
+ * REST query API, so the bin runs the SAME path the unit test exercises against
+ * an in-memory fake. Idempotent: safe to re-run.
  *
  * Parameterized on the TARGET stage's D1 (never prod-hardcoded):
  *   --database-id  the stage's D1 UUID (from the alchemy state store / `getDatabase`)

--- a/packages/fts-backfill/src/schema.ts
+++ b/packages/fts-backfill/src/schema.ts
@@ -1,18 +1,10 @@
 /**
  * The read-side slice of the phoenix D1 schema this backfill scans —
- * `term_record` / `post_record`. These come from the `@kampus/db-schema` leaf
- * (the single canonical declaration the worker also re-exports), so this copy can
- * never drift from the real schema again (issue #859; the `deleted_at →
- * removed_at` rename that broke the old hand-copy now arrives by construction).
- * The backfill reads only a projection (`.slug`/`.id`/`.title`/`.removedAt`), but
- * importing the full canonical tables is the point — there is one declaration.
- * The leaf is a true leaf (only `drizzle-orm`), so depending on it adds no cycle
- * even though this package already prod-depends on `@kampus/web`.
- *
- * The *write* side is NOT here — the FTS upsert SQL is the worker's own
- * `syncTermSearch` / `syncPostSearch` (imported from `@kampus/web`), so the
- * indexed `norm` is byte-identical to the dual-write (issue #534's hard
- * constraint: same normalization, or backfilled rows won't match queries).
+ * `term_record` / `post_record`, imported from the canonical `@kampus/db-schema`
+ * leaf so this copy can never drift from the real schema again (#859: the
+ * `deleted_at → removed_at` rename that broke the old hand-copy now arrives by
+ * construction). The leaf depends only on `drizzle-orm`, so importing it adds no
+ * cycle.
  */
 import {postRecord, termRecord} from "@kampus/db-schema";
 


### PR DESCRIPTION
Runs the `deslop-comments` discipline over `packages/fts-backfill/src` (issue scope). Collapses the essay-style top-of-file docblocks in `backfill.ts`, `bin.ts`, and `schema.ts` that re-derived #534 / ADR 0080 / #859 at length down to what each module is plus its one non-obvious constraint (norm byte-identity, idempotency, removed-post filter, no-cycle leaf import), pointing to the homed issue/ADR for the full why.

Comments-only: the diff touches only leading `/** … */` docblocks — no code token, identifier, string, or behavior changed. Load-bearing inline notes (the RQB-v2 `defineRelations` rationale, the #863 batch-safety guard, the pragma justifications in the tests) were left intact. `pnpm lint` + `pnpm typecheck` green.

Fixes #2853