### PR TITLE
docs(migrations-guard): deslop comments

### DIFF
--- a/packages/migrations-guard/src/bin.ts
+++ b/packages/migrations-guard/src/bin.ts
@@ -9,8 +9,8 @@
  *               a DELIBERATE, audited re-baseline (e.g. the #1306 flat→per-dir cutover). Writing
  *               the baseline is a human-reviewed control-plane act, not something CI does.
  *
- * The pure core (`migrations-guard.ts`) decides; this bin is the thin `effect/unstable/cli`
- * shell over the `fs.ts` disk boundary (same idiom as `@kampus/flake-rate`).
+ * The thin `effect/unstable/cli` shell over the core + `fs.ts` boundary (same idiom as
+ * `@kampus/flake-rate`).
  */
 import {writeFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";

--- a/packages/migrations-guard/src/fs.ts
+++ b/packages/migrations-guard/src/fs.ts
@@ -1,7 +1,6 @@
 /**
  * The filesystem boundary: load a `MigrationTree` from the flat migrations directory and read
- * the committed immutability baseline. The pure core (`migrations-guard.ts`) decides; this
- * module is the only place that touches disk, so it stays thin and the decision stays testable.
+ * the committed immutability baseline. The only module that touches disk, keeping the core pure.
  */
 import {createHash} from "node:crypto";
 import {readdirSync, readFileSync} from "node:fs";

--- a/packages/migrations-guard/src/migrations-guard.ts
+++ b/packages/migrations-guard/src/migrations-guard.ts
@@ -10,8 +10,8 @@
  *                      content hash (an edit to journaled history is caught; a *new* trailing
  *                      migration absent from the baseline passes).
  *
- * It never touches the filesystem; the `fs.ts` boundary loads the `MigrationTree` and the
- * baseline, this core decides. Total over the loaded input, so every branch is unit-testable.
+ * It never touches the filesystem and is total over the loaded input, so every branch is
+ * unit-testable.
  */
 
 // A journal entry as drizzle-kit writes it into meta/_journal.json.


### PR DESCRIPTION
Fixes #2857

Deslop-comments sweep over `packages/migrations-guard`, comments-only.

The core/boundary/bin architecture rationale ("pure core decides / fs boundary loads / thin bin wires") was re-derived across all four source top docblocks — the "state a why once" anti-pattern. Collapsed it to its single home in `src/index.ts` (the package front door); `src/migrations-guard.ts`, `src/fs.ts`, and `src/bin.ts` now keep only a one-line statement of their own module's role.

Everything genuinely load-bearing is kept intact: the three-property check spec, the per-check property docblocks, the `#1435`/`ADR 0108`/`#1306` pointers, the bare-vs-tagged snapshot note, the immutability/trailing-migration invariant, and the field-level context comments.

- Diff is comments-only — `git diff` shows no code/logic/token change.
- `pnpm lint` and `pnpm typecheck` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)