### PR TITLE
docs(gh-phoenix): deslop comments

### DIFF
--- a/packages/gh-phoenix/src/bin.ts
+++ b/packages/gh-phoenix/src/bin.ts
@@ -35,8 +35,6 @@ import {route} from "./router.ts";
 const FINDING_EXIT_CODE = 2;
 const ZERO_SCOPE_EXIT_CODE = 3;
 
-// ── The `gh` shim path (short-circuits before the Effect CLI) ──────────────────
-
 /**
  * Run the `gh` shim over `argv` (the args after the binary name). Execs the real
  * `gh` for passthrough/rewrite (inheriting stdio + exit code) or exits non-zero
@@ -72,8 +70,6 @@ const runShim = (argv: ReadonlyArray<string>): never => {
 	const result = spawnSync(realGh, [...decision.argv], {stdio: "inherit"});
 	process.exit(result.status ?? 1);
 };
-
-// ── The `lint-skills` subcommand (the Effect CLI surface) ──────────────────────
 
 class FindingsFound extends Schema.TaggedErrorClass<FindingsFound>()(
 	"@kampus/gh-phoenix/FindingsFound",


### PR DESCRIPTION
Runs the `deslop-comments` discipline over `packages/gh-phoenix`.

## What changed
Cut two box-drawing banner separators in `src/bin.ts`:
- `// ── The `gh` shim path (short-circuits before the Effect CLI) ──`
- `// ── The `lint-skills` subcommand (the Effect CLI surface) ──`

Both are pure section labels — their parenthetical notes are already stated in the top-of-file docblock (the shim path "short-circuits before the Effect CLI runtime") and in the adjacent function docblocks. They add visual noise without earning their place.

## What was kept (deliberately)
Everything else under `packages/gh-phoenix` is load-bearing and stays: the module-header docblocks (each states what the module is + the one non-obvious thing), the ADR 0092 zero-scope rationale, the #1766 frontmatter-defect explanation, the `g`-flagged shared-RegExp `lastIndex` reset gotcha, the self-recursion-guard notes, the "looks-wrong-but-deliberate" `i++` skip, and the RED/GREEN + macOS-realpath notes in the tests.

## Verification
- Diff is comments-and-whitespace only — no code token changed.
- `pnpm lint` and `pnpm typecheck` green.

Fixes #2855