### PR TITLE
docs(primary-index-tripwire): deslop comments

### DIFF
--- a/packages/primary-index-tripwire/src/bash-attribution.ts
+++ b/packages/primary-index-tripwire/src/bash-attribution.ts
@@ -2,19 +2,16 @@
  * Run-time (pre-Bash) attribution for the #2778 corruption — the complement to the pre-commit
  * {@link import("./tripwire.ts").decideTripwire} core.
  *
- * The pre-commit tripwire sees only the POST-HOC index state (a mass of staged deletions), which
- * cannot say WHICH command produced it (staging leaves no reflog trace, #2778). This core runs at
- * the `PreToolUse` Bash boundary instead, where the offending staging COMMAND string + cwd + agent
- * are still in hand — so wiring it into the `worktree-guard pre-bash` hook captures the actor at
- * the moment a bulk-staging op is issued, closing the "which command staged it?" ambiguity for the
- * primary-operator surface the pre-commit leg is blind to.
+ * The pre-commit tripwire sees only the POST-HOC index state, which cannot say WHICH command produced
+ * it (staging leaves no reflog trace, #2778). This core runs at the `PreToolUse` Bash boundary, where
+ * the staging COMMAND string + cwd + agent are still in hand — wiring it into `worktree-guard
+ * pre-bash` captures the actor at the moment a bulk-staging op is issued.
  *
- * RECORD-ONLY, like the pre-commit tripwire: this decides only whether to WRITE an attribution
- * record; it never blocks a command (blocking is the §CP guard on the pre-commit/sync path). It is
- * scoped to the HIGH-SIGNAL bulk-staging shapes that stage deletions EN MASSE — a stage-everything
- * (`git add -A/--all/.`, `git commit -a`), or an index removal (`git rm --cached`, the literal
- * `git rm -r --cached`-class the #2778 signature names). A plain `git add <one-path>` of a
- * modification is deliberately NOT recorded — it is low-signal and would drown the log.
+ * RECORD-ONLY, like the pre-commit tripwire (blocking is the §CP guard on the pre-commit/sync path).
+ * Scoped to the HIGH-SIGNAL shapes that stage deletions EN MASSE — a stage-everything (`git add
+ * -A/--all/.`, `git commit -a`) or an index removal (`git rm --cached`, the literal `git rm -r
+ * --cached`-class #2778 names); a plain `git add <one-path>` is deliberately NOT recorded (low-signal,
+ * would drown the log).
  */
 import {CONTROL_PLANE_DELETION_PREFIXES, isControlPlaneDeletion} from "./tripwire.ts";
 

--- a/packages/primary-index-tripwire/src/bin.ts
+++ b/packages/primary-index-tripwire/src/bin.ts
@@ -2,18 +2,15 @@
 /**
  * `primary-index-tripwire record` — the read-only attribution leg for the #2778 corruption.
  *
- * Gathers git facts with READ-ONLY plumbing (`git-io.ts`), reads the agent-identity env, runs the
- * pure {@link decideTripwire} core, and — on a trip — appends a JSON attribution record to a log path
- * and prints a LOUD stderr warning. It NEVER blocks and NEVER mutates git or the working tree: the
- * exit code is always 0, so wiring it into a `pre-commit` hook (see `lefthook.yml`) records the actor
- * about to commit a mass control-plane deletion without ever preventing a legitimate commit.
- * Prevention/blocking is the §CP hardening fix, out of scope here
+ * Gathers git facts with READ-ONLY plumbing (`git-io.ts`), runs the pure {@link decideTripwire} core,
+ * and on a trip appends a JSON attribution record to a log path and prints a LOUD stderr warning. It
+ * NEVER blocks and NEVER mutates git: the exit code is always 0, so a `pre-commit` hook (`lefthook.yml`)
+ * records the actor without preventing a legitimate commit. Blocking is the §CP fix, out of scope
  * (`ops/incidents/2778-primary-index-mass-staged-deletion.md`).
  *
  * The log path is `$PRIMARY_INDEX_TRIPWIRE_LOG`, else `${TMPDIR:-/tmp}/primary-index-tripwire.jsonl`
  * — an OUT-OF-REPO path so recording never dirties the tree it observes. Wired per effect-smol's CLI
- * guidance (mirrors `@kampus/orphan-sweep`): `effect/unstable/cli` for typed flags over
- * `NodeServices.layer`, run via `NodeRuntime.runMain`; the read-only git/log IO lives in `git-io.ts`.
+ * guidance: `effect/unstable/cli` typed flags over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Effect, Option} from "effect";

--- a/packages/primary-index-tripwire/src/tripwire.ts
+++ b/packages/primary-index-tripwire/src/tripwire.ts
@@ -1,21 +1,13 @@
 /**
  * `@kampus/primary-index-tripwire` pure core — decide whether a to-be-committed staged fileset
- * carries the signature of the #2778 corruption (a mass staged-deletion of the instruction-trust
- * set against the PRIMARY index) and build an attribution record naming WHO/WHERE is about to
- * commit it.
+ * carries the #2778 corruption signature (a mass staged-deletion of the instruction-trust set) and
+ * build an attribution record naming WHO/WHERE is about to commit it.
  *
- * DETECTION + ATTRIBUTION ONLY. This core never blocks a commit and never mutates git — it emits a
- * record so the *next* occurrence is attributable (which actor, on which checkout, from which cwd).
- * Preventing the staging (scoping worktree git ops, guarding the primary index) and *blocking* the
- * dangerous commit are the §CP hardening fix tracked separately — see
- * `ops/incidents/2778-primary-index-mass-staged-deletion.md`. Read-only by construction: the caller
- * (`bin.ts`) gathers git facts with read-only plumbing and this module is IO-free and total.
- *
- * The #2778 signature (from the incident, verbatim): the primary index held 248 staged deletions of
- * tracked files under `.claude/**`, `.decisions/**`, and more — 0 unstaged modifications, 0 commits
- * ahead, a reflog of only clean fast-forward merges. Staging leaves no reflog trace, so the resulting
- * index state alone cannot say *which* actor ran the staging; the record this core builds captures the
- * identity/cwd context at the one caller-agnostic choke point that git itself fires — `pre-commit`.
+ * DETECTION + ATTRIBUTION ONLY, IO-free and total: this core never blocks a commit and never mutates
+ * git — it emits a record so the *next* occurrence is attributable. Staging leaves no reflog trace, so
+ * the index state alone cannot name the actor; the record captures the identity/cwd context at the
+ * caller-agnostic choke point git itself fires (`pre-commit`). Prevention/blocking is the §CP
+ * hardening fix, tracked separately — see `ops/incidents/2778-primary-index-mass-staged-deletion.md`.
  */
 
 /** One `git diff --cached --name-status` row: the status letter plus the path. */
@@ -42,7 +34,6 @@ export const CONTROL_PLANE_DELETION_PREFIXES: readonly string[] = [
 	"claude-plugins/",
 ];
 
-/** True when a path falls under one of the instruction-trust prefixes above. */
 export const isControlPlaneDeletion = (path: string): boolean =>
 	CONTROL_PLANE_DELETION_PREFIXES.some((p) => path.startsWith(p));
 


### PR DESCRIPTION
Deslop the comments under `packages/primary-index-tripwire` per the `deslop-comments` discipline. Comments-and-whitespace only — no code token changed.

## What changed
- Collapsed the three top-of-file docblocks (`tripwire.ts`, `bash-attribution.ts`, `bin.ts`) that re-derived the #2778 incident *why* down to a concise what-it-is + the one non-obvious note, pointing at the homed source (`ops/incidents/2778-primary-index-mass-staged-deletion.md`) rather than re-narrating the verbatim 248-deletion signature and caller wiring.
- Cut one name-restater one-liner over `isControlPlaneDeletion`.

## Kept (load-bearing)
- The ReDoS/CodeQL rationale on the flag-predicate regexes and `stripTrailingSlashes`.
- The checkout-severity note, the `MASS_DELETION_BLOCK_THRESHOLD` value rationale, and the `git-io.ts` try/catch-separation rationale.

## Verification
- `git diff` is comments-and-whitespace only.
- `pnpm lint` and `pnpm typecheck` pass.

Fixes #2861

🤖 Generated with [Claude Code](https://claude.com/claude-code)