### PR TITLE
docs(worker-relevance): deslop comments

### DIFF
--- a/packages/worker-relevance/src/index.ts
+++ b/packages/worker-relevance/src/index.ts
@@ -1,10 +1,7 @@
 /**
- * `@kampus/worker-relevance` — the pure verdict for whether a PR's diff can affect
- * the `apps/web` worker (issue #1014). The core (`classify`/`inputFromEnv`) is a
- * pure, IO-free, zero-runtime-dependency classifier; `bin.ts` is the thin Node shell
- * the `changes` job runs to gate the worker `integration`/`e2e` tiers off a diff
- * confined to worker-irrelevant packages — including a `pnpm-lock.yaml` delta
- * confined to their importer blocks — fail-safe to running.
+ * `@kampus/worker-relevance` — public barrel. The pure verdict for whether a PR's
+ * diff can affect the `apps/web` worker (issue #1014); the core + its fail-safe
+ * design live in `./worker-relevance.ts`, the CI shell in `./bin.ts`.
  */
 export {
 	type ClassifyInput,


### PR DESCRIPTION
Deslop the comments in `packages/worker-relevance` per the `deslop-comments` skill.

The package is already tightly commented — most docblocks carry genuinely load-bearing, non-obvious rationale (the fail-safe-to-running invariant, the pnpm-lockfile-diff attribution logic, the grounded worker-import closure) that the code itself can't express, so those stay untouched.

The one clear hit: `src/index.ts`'s barrel docblock re-derived the entire core+bin design essay that `worker-relevance.ts` and `bin.ts` already own. Collapsed it to a what-it-is line plus a pointer to the two source-of-truth modules (state a *why* once).

- Diff is **comments-only** — no code token, identifier, string, or behavior changed.
- `pnpm lint` and `pnpm typecheck` both green.

Fixes #2863