### PR TITLE
docs(orphan-sweep): deslop comments

### DIFF
--- a/packages/orphan-sweep/src/orphan-sweep.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.ts
@@ -34,9 +34,7 @@
  * so a flag's stage lives in its PARENT app's physical name (`appName`), never in `name`.
  */
 export type CfResource =
-	/** A Worker script; `name` is its physical name (carries the stage). */
 	| {readonly kind: "worker"; readonly name: string}
-	/** A D1 database; `name` is its physical name (carries the stage). */
 	| {readonly kind: "d1"; readonly name: string}
 	/** A Flagship app; `name` is its physical name (carries the stage), `appId` is the delete key (apps delete by server id, not name). */
 	| {readonly kind: "flagship-app"; readonly name: string; readonly appId: string}


### PR DESCRIPTION
Deslop pass over `packages/orphan-sweep` per the `deslop-comments` discipline. The package was already written close to the discipline — nearly every comment is load-bearing (invariants at their enforcement sites, the `-f`-absent / redaction / retry workaround rationale, the `biome-ignore` pragma note, headers that state what+the-one-non-obvious-thing). One clear named-category slop was found and cut:

- `packages/orphan-sweep/src/orphan-sweep.ts`: removed the two per-arm docblocks on the `CfResource` `worker` / `d1` union members. They restated what the type-header docblock already fully specifies ("Worker scripts and D1 databases leak by stage in their OWN physical name"). The `flagship-app` / `flagship-flag` arms keep their docblocks — those carry delete-key semantics (`appId` / `appName` delete paths) the header does not cover.

Diff is comments-only (two docblock lines removed); no code token changed. `pnpm lint` + `pnpm typecheck` green.

Fixes #2859