### PR TITLE
feat(web): attribute worker-tier Sentry errors to feature flags (#2895)

### DIFF
--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -13,6 +13,12 @@
  * 0118's and adjustable there.
  */
 import * as Sentry from "@sentry/react";
+import {flagTag} from "../../worker/features/flagship/flag-tag";
+
+// The `flag.<key>`:`on`/`off` naming contract now lives in one SDK-free module shared with the
+// worker tagger (`worker/lib/sentry.ts`), so both tiers stamp an identical shape and the #1822
+// graduation query reads uniformly across client + worker — see `flag-tag.ts` for the why (#1821).
+export {FLAG_TAG_PREFIX, flagTag} from "../../worker/features/flagship/flag-tag";
 
 /**
  * Whether a usable DSN is present — the single gate every Sentry path checks, so the
@@ -40,25 +46,6 @@ export function browserOptions(dsn: string): Sentry.BrowserOptions {
 			queryParams: false,
 		},
 	};
-}
-
-/**
- * Feature-flag attribution on captured errors (#1821). A flag the session resolves becomes the
- * Sentry tag `flag.<key>` with value `"on"`/`"off"`, so a single flag's on-path error rate is
- * isolable for the dark→release→burn-in→graduate gate the flag lifecycle depends on (#1822
- * consumes this). The graduation query is `flag.<key>:on` — e.g. `flag.phoenix-bildirim:on`
- * counts errors captured while `phoenix-bildirim` was on for the session, and `flag.<key>:off`
- * the comparison off-path. Keys are the `flags/keys.ts` constants (non-PII), so tagging is
- * orthogonal to the ADR 0118 `dataCollection` PII scrub and touches none of it.
- */
-export const FLAG_TAG_PREFIX = "flag.";
-
-/**
- * The `(tagKey, tagValue)` a resolved flag maps to — pure, so the tag-naming contract is
- * unit-testable without Sentry (the pure-core idiom of `browserOptions`).
- */
-export function flagTag(key: string, value: boolean): {tagKey: string; tagValue: "on" | "off"} {
-	return {tagKey: `${FLAG_TAG_PREFIX}${key}`, tagValue: value ? "on" : "off"};
 }
 
 const dsn = import.meta.env.VITE_SENTRY_DSN;

--- a/apps/web/worker/features/flagship/Flags.ts
+++ b/apps/web/worker/features/flagship/Flags.ts
@@ -23,6 +23,7 @@
  */
 import type {RuntimeContext} from "alchemy";
 import {type Cause, Context, Effect, Layer} from "effect";
+import {tagFlag} from "../../lib/sentry.ts";
 import {FlagsContext, toEvaluationContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
 
@@ -103,7 +104,18 @@ const buildRealFlags = (flagship: Flagship["Service"]): FlagsAccess => ({
 			return yield* flagship
 				.getBooleanValue(key, defaultValue, toEvaluationContext(context))
 				.pipe(swallowToDefault(key, defaultValue));
-		}),
+		}).pipe(
+			// Worker-tier feature-flag error attribution (#1821, the worker half of the SPA
+			// contract PR #2843 established). Stamp the effective gate value as the Sentry tag
+			// `flag.<key>`:`on`/`off` so a flag's worker-side error rate is isolable in the #1822
+			// graduation query, uniformly with the client tier. This is THE per-request boolean
+			// resolution choke point every worker flag gate flows through, so an error in any
+			// flag-gated worker path is attributed — not just the `/api/flags/evaluate` delivery
+			// seam. The tag is the resolved value the request actually saw (including a
+			// degrade-safe default). Inert when Sentry has no active client (`tagFlag` gates on
+			// `Sentry.isEnabled()`); non-PII, orthogonal to the ADR 0118 `dataCollection` scrub.
+			Effect.tap((value) => Effect.sync(() => tagFlag(key, value))),
+		),
 	getString: (key, defaultValue) =>
 		Effect.gen(function* () {
 			const context = yield* FlagsContext;

--- a/apps/web/worker/features/flagship/flag-tag.ts
+++ b/apps/web/worker/features/flagship/flag-tag.ts
@@ -1,0 +1,26 @@
+/**
+ * The Sentry feature-flag attribution contract (#1821), shared verbatim by BOTH tiers. A
+ * flag a request/session resolves becomes the Sentry tag `flag.<key>` with value
+ * `"on"`/`"off"`, so a single flag's on-path error rate is isolable for the
+ * dark→release→burn-in→graduate gate the flag lifecycle depends on (#1822 consumes this):
+ * the graduation query is `flag.<key>:on` — e.g. `flag.phoenix-bildirim:on` counts errors
+ * captured while `phoenix-bildirim` was on, and `flag.<key>:off` the comparison off-path.
+ *
+ * SDK-free on purpose. This pure naming contract is imported by the SPA tagger
+ * (`src/lib/sentry.ts`, `@sentry/react`) AND the worker tagger (`worker/lib/sentry.ts`,
+ * `@sentry/cloudflare`), so both tiers stamp an IDENTICAL `flag.<key>`:`on`/`off` shape and
+ * the #1822 graduation query reads uniformly across client and worker — one definition, no
+ * drift. Keys are the `flags/keys.ts` constants (non-PII), so tagging is orthogonal to the
+ * ADR 0118 `dataCollection` PII scrub and touches none of it.
+ */
+
+/** The tag-key namespace: a resolved flag `key` maps to `flag.<key>`. */
+export const FLAG_TAG_PREFIX = "flag.";
+
+/**
+ * The `(tagKey, tagValue)` a resolved flag maps to — pure, so the shared tag-naming contract
+ * is unit-testable without either Sentry SDK and both tiers provably agree on the shape.
+ */
+export function flagTag(key: string, value: boolean): {tagKey: string; tagValue: "on" | "off"} {
+	return {tagKey: `${FLAG_TAG_PREFIX}${key}`, tagValue: value ? "on" : "off"};
+}

--- a/apps/web/worker/features/flagship/flag-tag.unit.test.ts
+++ b/apps/web/worker/features/flagship/flag-tag.unit.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Pins the shared Sentry flag-attribution naming contract (#1821): a resolved flag maps to
+ * `flag.<key>` = `on`/`off`, so the #1822 graduation query is `flag.<key>:on`. One definition
+ * feeds both the SPA tagger (`src/lib/sentry.ts`) and the worker tagger (`worker/lib/sentry.ts`),
+ * so this is the single place the shape is proven — both tiers inherit it and cannot drift.
+ */
+import {describe, expect, it} from "vitest";
+import {FLAG_TAG_PREFIX, flagTag} from "./flag-tag.ts";
+
+describe("flagTag — the shared flag.<key>:on/off contract", () => {
+	it("maps a resolved-on flag to flag.<key> = on", () => {
+		expect(flagTag("phoenix-bildirim", true)).toEqual({
+			tagKey: "flag.phoenix-bildirim",
+			tagValue: "on",
+		});
+	});
+
+	it("maps a resolved-off flag to flag.<key> = off", () => {
+		expect(flagTag("pano-optimistic-comment-add", false)).toEqual({
+			tagKey: "flag.pano-optimistic-comment-add",
+			tagValue: "off",
+		});
+	});
+
+	it("namespaces every key under the flag. prefix", () => {
+		expect(FLAG_TAG_PREFIX).toBe("flag.");
+		expect(flagTag("any-key", true).tagKey.startsWith(FLAG_TAG_PREFIX)).toBe(true);
+	});
+});

--- a/apps/web/worker/lib/sentry.ts
+++ b/apps/web/worker/lib/sentry.ts
@@ -1,6 +1,6 @@
 /**
- * Worker-side Sentry options (ADR 0118). The worker copy of the SPA's
- * `src/lib/sentry.ts` — same options shape, but built on `@sentry/cloudflare`
+ * Worker-side Sentry options + the flag-attribution tagger (ADR 0118). The worker copy
+ * of the SPA's `src/lib/sentry.ts` — same options shape, but built on `@sentry/cloudflare`
  * (workerd/`nodejs_compat`) rather than `@sentry/react`.
  *
  * This module holds NO init: the client is created at the request seam in
@@ -8,9 +8,12 @@
  * workerd-safe init path for an Effect-`HttpRouter` worker (there is no
  * `ExportedHandler` in phoenix's source to wrap — ADR 0118 impl, issue #1502).
  * So "inert when no DSN" is structural: `index.ts` returns the base fetch effect
- * untouched, and nothing here ever runs.
+ * untouched, and `wrapRequestHandler` never runs, so no client is ever active —
+ * which is exactly what `tagFlag` gates on (`Sentry.isEnabled()`).
  */
 import type {CloudflareOptions} from "@sentry/cloudflare";
+import * as Sentry from "@sentry/cloudflare";
+import {flagTag} from "../features/flagship/flag-tag.ts";
 
 /**
  * Whether a usable DSN is present — the single gate the request seam checks, so
@@ -39,4 +42,25 @@ export function workerOptions(dsn: string): CloudflareOptions {
 			queryParams: false,
 		},
 	};
+}
+
+/**
+ * Stamp a resolved flag onto the request's Sentry scope as a queryable `flag.<key>`:`on`/`off`
+ * tag (#1821) — the worker half of the SPA `tagFlag` (`src/lib/sentry.ts`), over the shared
+ * `flagTag` naming contract so both tiers read uniformly in the #1822 graduation query. Called
+ * from the per-request flag-resolution seam (`Flags.getBoolean`), which runs inside the request's
+ * `wrapRequestHandler` scope (`index.ts`), so `setTag` lands on the isolation scope of every error
+ * subsequently captured for that request.
+ *
+ * `Sentry.isEnabled()` is the worker-tier inert gate mirroring the SPA's `sentryEnabled(dsn)`: with
+ * no DSN the request seam never calls `wrapRequestHandler`, so no client is active and this no-ops
+ * — no scope mutation, no work. Flag keys/values are non-PII, so tagging is orthogonal to the ADR
+ * 0118 `dataCollection` scrub and re-enables no PII collection.
+ */
+export function tagFlag(key: string, value: boolean): void {
+	if (!Sentry.isEnabled()) {
+		return;
+	}
+	const {tagKey, tagValue} = flagTag(key, value);
+	Sentry.setTag(tagKey, tagValue);
 }

--- a/apps/web/worker/lib/sentry.unit.test.ts
+++ b/apps/web/worker/lib/sentry.unit.test.ts
@@ -1,14 +1,30 @@
 /**
- * Pins ADR 0118's worker-tier invariant (issue #1502): the worker Sentry module is
- * pure options — no init, no client, no network. "Inert when no DSN" is enforced at
- * the request seam (`index.ts`) via the `sentryEnabled` gate this pins; the module
- * itself never touches `@sentry/cloudflare` at runtime. Mirrors the SPA's
- * `src/lib/sentry.unit.test.ts`. Also pins the DSN gate and the native-`dataCollection` shape.
+ * Pins ADR 0118's worker-tier invariant (issue #1502): the worker Sentry module ships pure
+ * options + the flag-attribution tagger — no init, no client of its own. "Inert when no DSN" is
+ * enforced at the request seam (`index.ts`), where `wrapRequestHandler` runs only with a DSN; the
+ * module's own `tagFlag` gates on `Sentry.isEnabled()`, which is false without an active client.
+ * Mirrors the SPA's `src/lib/sentry.unit.test.ts`. Also pins the DSN gate, the
+ * native-`dataCollection` shape, and the worker half of the #1821 `flag.<key>`:`on`/`off` tagging.
  */
 import * as Cause from "effect/Cause";
-import {describe, expect, it} from "vitest";
-import {sentryEnabled, workerOptions} from "./sentry.ts";
+import {afterEach, describe, expect, it, vi} from "vitest";
+
+// `@sentry/cloudflare` is stubbed so `tagFlag` can be driven across the inert (`isEnabled=false`)
+// and active (`isEnabled=true`) branches without a real client init — mirrors the SPA test's
+// `@sentry/react` mock. Hoisted so the module under test binds these fns at import.
+const {isEnabled, setTag} = vi.hoisted(() => ({
+	isEnabled: vi.fn(() => false),
+	setTag: vi.fn(),
+}));
+vi.mock("@sentry/cloudflare", () => ({isEnabled, setTag}));
+
+import {sentryEnabled, tagFlag, workerOptions} from "./sentry.ts";
 import {shouldCaptureCause} from "./sentry-capture.ts";
+
+afterEach(() => {
+	vi.clearAllMocks();
+	isEnabled.mockReturnValue(false);
+});
 
 describe("sentryEnabled — the inert gate", () => {
 	it("is false for absent/empty/whitespace DSN", () => {
@@ -36,6 +52,22 @@ describe("decided defaults (ADR 0118)", () => {
 			queryParams: false,
 		});
 		expect(opts.beforeSend).toBeUndefined();
+	});
+});
+
+describe("tagFlag — worker-tier flag attribution (#1821)", () => {
+	it("does not tag and does not throw when Sentry is inert (no active client)", () => {
+		isEnabled.mockReturnValue(false);
+		expect(() => tagFlag("phoenix-bildirim", true)).not.toThrow();
+		expect(setTag).not.toHaveBeenCalled();
+	});
+
+	it("sets flag.<key>=on/off on the scope when a client is active", () => {
+		isEnabled.mockReturnValue(true);
+		tagFlag("phoenix-bildirim", true);
+		expect(setTag).toHaveBeenCalledWith("flag.phoenix-bildirim", "on");
+		tagFlag("pano-optimistic-comment-add", false);
+		expect(setTag).toHaveBeenCalledWith("flag.pano-optimistic-comment-add", "off");
 	});
 });
 


### PR DESCRIPTION
## What & why

Fixes #2895 — the **worker half** of the flag/error-attribution ask (#1821). The SPA half merged in PR #2843; this mirrors its `flag.<key>`:`on`/`off` Sentry tag contract on the worker tier so a single flag's error rate is isolable across **both** tiers — the substrate the #1822 flag-graduation/burn-in query reads.

Before this, worker-tier Sentry capture (`@sentry/cloudflare`, ADR 0118) carried **zero** flag attribution: a flag could be error-clean on the client and quietly erroring in a worker gate, and the burn-in signal would miss it.

## Approach

- **Shared, drift-proof contract.** Extracted the `flag.<key>`:`on`/`off` naming into one SDK-free module — `apps/web/worker/features/flagship/flag-tag.ts` — imported by **both** the SPA tagger (`@sentry/react`) and the new worker tagger (`@sentry/cloudflare`). One definition means the two tiers stamp an identical shape and the graduation query reads uniformly across client + worker; they cannot drift (AC #2 is structural, not copied). The SPA `src/lib/sentry.ts` now re-exports from it, so its public surface and tests are unchanged.
- **Worker tagger.** `tagFlag` in `apps/web/worker/lib/sentry.ts` stamps `Sentry.setTag`, gated on `Sentry.isEnabled()` — the worker-tier inert mirror of the SPA's `sentryEnabled(dsn)`. With no DSN the request seam never runs `wrapRequestHandler`, so no client is active and tagging no-ops (AC #4).
- **Attribution seam.** The tag is stamped at `Flags.getBoolean` (the per-request boolean resolution choke point every worker flag gate flows through, `apps/web/worker/features/flagship/Flags.ts`). It runs inside the request's `wrapRequestHandler` scope, so an error in **any** flag-gated worker path is attributed — not just the `/api/flags/evaluate` delivery seam (AC #1).

## PII (ADR 0118)

Flag keys/values are non-PII, so tagging is orthogonal to the `dataCollection` suppression — **no PII collection is re-enabled** (AC #3). `workerOptions` / `browserOptions` are untouched.

## Acceptance criteria

- [x] Worker captures carry `flag.<key>`:`on`/`off` for each flag resolved during the request, at the `Flags` service seam.
- [x] Tag key/value shape matches PR #2843 exactly (shared module — cannot diverge).
- [x] ADR 0118 `dataCollection` PII suppression unchanged.
- [x] Inert when no DSN (`Sentry.isEnabled()` gate, no tag work).

## Verification

- `pnpm typecheck` — clean.
- `pnpm lint` (biome) — clean.
- `pnpm test:unit` — **2224 passed**, including new `worker/features/flagship/flag-tag.unit.test.ts` (shared contract) and `tagFlag` coverage in `worker/lib/sentry.unit.test.ts` (inert + active branches). Verified `@sentry/cloudflare` imports inertly in the node unit pool (`isEnabled()` false, `setTag` no-throw with no client).

## Notes

- Did **not** touch `apps/web/worker/features/flagship/resources.ts` (active in a sibling lane, PR #2896) — this change only reads flag state, it declares no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)