### PR TITLE
fix(integration): bounded retry on the setup-only D1 REST 429 (#2915)

### DIFF
--- a/apps/web/tests/integration/_d1-rest-retry.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.ts
@@ -1,0 +1,62 @@
+/**
+ * Bounded retry for the setup-only D1 REST path against a transient CF rate-limit (HTTP 429).
+ *
+ * The per-file-stage integration model (ADR 0082) hammers ONE Cloudflare account's D1
+ * control-plane REST (`/d1/database/<id>/query`) from ~24 parallel stages. On a `merge_group`
+ * batch the combined load trips the account rate limit — HTTP 429, error code 971
+ * "TooManyRequests" — and a setup-only `execD1`/`setLastActivityAt` (`_harness.ts`) then throws,
+ * reddening `integration` on the batched ref and evicting clean bystander PRs (#2915). A 429 is
+ * the CF gateway REJECTING the request before it executes — no partial write — so replay is safe
+ * by construction; the same class is already treated transient-retryable at the DEPLOY layer
+ * (`_deploy-transient.ts`, `TooManyRequests`). This is the data-plane-setup counterpart.
+ *
+ * Scoped to 429 ONLY: a real SQL error surfaces as a 200-with-`errors[]` (classified by
+ * `runD1Query`), and a genuine API error as a non-429 4xx/5xx — neither is a 429, so neither is
+ * retried and a real failure still surfaces at once. A pure leaf (injectable `send`/`sleep`/
+ * `random`, no `fetch`/creds dependency) so the retry logic is unit-testable offline.
+ */
+
+export const CF_RATE_LIMIT_STATUS = 429;
+export const D1_REST_MAX_RETRIES = 5;
+export const D1_REST_BASE_DELAY_MS = 500;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export interface RateLimitRetryOptions {
+	/** Max retries AFTER the first attempt (default 5 → up to 6 sends). */
+	maxRetries?: number;
+	/** Base of the exponential backoff, in ms (default 500). */
+	baseDelayMs?: number;
+	/** Injected for tests — real sleep by default. */
+	sleep?: (ms: number) => Promise<void>;
+	/** Injected for tests — `Math.random` by default. */
+	random?: () => number;
+}
+
+/**
+ * Re-send `send()` while it answers HTTP 429, with **full-jitter** exponential backoff, up to
+ * `maxRetries` extra attempts. Returns the first non-429 `Response` (a success OR a real error
+ * the caller classifies), or the final 429 `Response` if the budget is exhausted — it never
+ * swallows a real failure and never throws of its own accord.
+ */
+export const cfFetchWithRateLimitRetry = async (
+	send: () => Promise<Response>,
+	{
+		maxRetries = D1_REST_MAX_RETRIES,
+		baseDelayMs = D1_REST_BASE_DELAY_MS,
+		sleep = defaultSleep,
+		random = Math.random,
+	}: RateLimitRetryOptions = {},
+): Promise<Response> => {
+	let res = await send();
+	for (let attempt = 0; attempt < maxRetries && res.status === CF_RATE_LIMIT_STATUS; attempt++) {
+		// Full-jitter backoff: the ~24 parallel stages that tripped the shared rate limit must
+		// not re-sync into a thundering herd on a fixed delay, so spread each retry uniformly
+		// over [0, base·2^attempt). Release the discarded 429 body before re-sending.
+		await res.body?.cancel().catch(() => {});
+		const ceil = baseDelayMs * 2 ** attempt;
+		await sleep(Math.floor(random() * ceil));
+		res = await send();
+	}
+	return res;
+};

--- a/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Pins that `cfFetchWithRateLimitRetry` retries ONLY the transient CF 429 (the #2915
+ * D1-429 batch flake) and never masks a real failure: a non-429 answer (success or a real
+ * error) is returned at once, a persistent 429 exhausts the bounded budget and surfaces the
+ * final 429, and the backoff stays within its full-jitter window. `sleep`/`random` are
+ * injected so the whole suite runs offline and instantly.
+ */
+
+import {describe, expect, it, vi} from "vitest";
+import {
+	CF_RATE_LIMIT_STATUS,
+	cfFetchWithRateLimitRetry,
+	D1_REST_BASE_DELAY_MS,
+} from "./_d1-rest-retry.ts";
+
+// A minimal `Response` stand-in — the retry only reads `.status` and cancels `.body`.
+const resp = (status: number): Response =>
+	new Response(status === CF_RATE_LIMIT_STATUS ? "429" : "ok", {status});
+
+// A `send` that yields the given statuses in order (last one repeats once exhausted).
+const sequence = (statuses: number[]) => {
+	let i = 0;
+	const send = vi.fn(async () => resp(statuses[Math.min(i++, statuses.length - 1)]!));
+	return send;
+};
+
+const noSleep = () => Promise.resolve();
+
+describe("cfFetchWithRateLimitRetry", () => {
+	it("returns the first non-429 response without retrying (no 429 → no sleep)", async () => {
+		const send = sequence([200]);
+		const sleep = vi.fn(noSleep);
+		const res = await cfFetchWithRateLimitRetry(send, {sleep});
+		expect(res.status).toBe(200);
+		expect(send).toHaveBeenCalledTimes(1);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("retries a 429 then returns the settled 200 (the #2915 recovery path)", async () => {
+		const send = sequence([429, 429, 200]);
+		const sleep = vi.fn(noSleep);
+		const res = await cfFetchWithRateLimitRetry(send, {sleep, random: () => 0.5});
+		expect(res.status).toBe(200);
+		expect(send).toHaveBeenCalledTimes(3); // initial + 2 retries
+		expect(sleep).toHaveBeenCalledTimes(2);
+	});
+
+	it("does NOT retry a non-429 error — a real failure surfaces at once", async () => {
+		const send = sequence([500]);
+		const sleep = vi.fn(noSleep);
+		const res = await cfFetchWithRateLimitRetry(send, {sleep});
+		expect(res.status).toBe(500);
+		expect(send).toHaveBeenCalledTimes(1);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("exhausts the bounded budget on a persistent 429 and returns the final 429", async () => {
+		const send = sequence([429]);
+		const sleep = vi.fn(noSleep);
+		const res = await cfFetchWithRateLimitRetry(send, {maxRetries: 5, sleep});
+		expect(res.status).toBe(429);
+		expect(send).toHaveBeenCalledTimes(6); // initial + 5 retries, then it stops
+		expect(sleep).toHaveBeenCalledTimes(5);
+	});
+
+	it("backs off with full jitter within [0, base·2^attempt) per retry", async () => {
+		const delays: number[] = [];
+		const sleep = vi.fn(async (ms: number) => {
+			delays.push(ms);
+		});
+		// random() = 1 - ε maximizes the delay; floor keeps it strictly below the ceiling.
+		await cfFetchWithRateLimitRetry(sequence([429]), {
+			maxRetries: 3,
+			baseDelayMs: D1_REST_BASE_DELAY_MS,
+			sleep,
+			random: () => 0.999999,
+		});
+		expect(delays).toHaveLength(3);
+		delays.forEach((ms, attempt) => {
+			const ceil = D1_REST_BASE_DELAY_MS * 2 ** attempt;
+			expect(ms).toBeGreaterThanOrEqual(0);
+			expect(ms).toBeLessThan(ceil);
+		});
+	});
+});

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -34,6 +34,7 @@
  *   - `h.openSse(...)` / `readFrame(...)` — live SSE transport helpers
  */
 
+import {cfFetchWithRateLimitRetry} from "./_d1-rest-retry.ts";
 import {
 	awaitEdgeReady,
 	CloudflarePlaceholder404Error,
@@ -237,15 +238,19 @@ const cloudflareApiToken = (): string => {
 
 // One authenticated request to the Cloudflare REST API; throws on a non-2xx with the
 // response body for diagnosis. Setup-only — never on a test's black-box assertion path.
+// A transient 429 (the shared-account D1 rate-limit that reds the batched ref, #2915) is
+// bounded-retried before the throw — see `_d1-rest-retry.ts` for why 429 is safe to replay.
 async function cloudflareApi(path: string, init?: RequestInit): Promise<Response> {
-	const res = await fetch(`${CLOUDFLARE_API_BASE}${path}`, {
-		...init,
-		headers: {
-			authorization: `Bearer ${cloudflareApiToken()}`,
-			"content-type": "application/json",
-			...init?.headers,
-		},
-	});
+	const res = await cfFetchWithRateLimitRetry(() =>
+		fetch(`${CLOUDFLARE_API_BASE}${path}`, {
+			...init,
+			headers: {
+				authorization: `Bearer ${cloudflareApiToken()}`,
+				"content-type": "application/json",
+				...init?.headers,
+			},
+		}),
+	);
 	if (!res.ok) {
 		throw new Error(
 			`Cloudflare API ${init?.method ?? "GET"} ${path} failed: ${res.status} ${await res.text()}`,


### PR DESCRIPTION
Fixes #2915

## Diagnosis (mechanism (b), non-§CP)

Ground-truthed against the failing `merge_group` run (29217721231, batch tipped by #2906). The exact failure:

```
content-removal-substrate.test.ts > removal substrate — definition remove → restore, karma kept
→ Cloudflare API POST /accounts/***/d1/database/.../query failed: 429
  {"success":false,"errors":[{"code":971,"message":"Please wait and consider throttling your request speed"}]...}
```

The D1-429 surfaces at the harness's **setup-only D1 REST path** — `cloudflareApi` in `apps/web/tests/integration/_harness.ts`, which POSTs to the Cloudflare D1 `/query` REST endpoint on behalf of `execD1` / `setLastActivityAt` / `promoteToYazar` (via `runD1Query`). `cloudflareApi` threw immediately on any non-2xx, with **no retry** on the 429.

**Why batch-only:** the per-file-stage model (ADR 0082) stands up ~24 parallel stages, each hammering the **one** shared Cloudflare account's D1 control-plane REST. A `merge_group` batch's combined load trips the account rate limit (HTTP 429 / code 971 `TooManyRequests`); a single-PR run's lighter load dodges it. It is **not** the worker's data-plane D1 — it is the harness's own REST helper.

## The fix

- New pure leaf `apps/web/tests/integration/_d1-rest-retry.ts` — `cfFetchWithRateLimitRetry`: bounded (5 retries), **full-jitter** exponential backoff, retrying **HTTP 429 only**. Injectable `send`/`sleep`/`random` so it is unit-testable offline.
- `cloudflareApi` now routes its fetch through it.

## Why the retry covers the 429 by construction (and can't mask a real failure)

- A **429 is the CF gateway rejecting the request before it executes** — no partial write — so a replay runs the statement exactly once. Safe by construction; the identical class is already treated transient-retryable at the deploy layer (`_deploy-transient.ts`, `TooManyRequests`).
- **Scoped to 429 only.** A real SQL error surfaces as a `200` with an `errors[]` body (classified separately by `runD1Query`); a real API error is a non-429 4xx/5xx. Neither is a 429, so neither is retried — a genuine failure still surfaces at once.
- **Full jitter** spreads the ~24 concurrent stages' retries so they don't re-sync into a second thundering herd on the shared limit.

## Tests

`_d1-rest-retry.unit.test.ts` (5 cases, runs in the `unit` tier, offline): no-429→no-retry; 429→recovers to 200; non-429 error surfaces immediately un-retried; persistent 429 exhausts the bounded budget and returns the final 429; backoff stays within `[0, base·2^attempt)`.

## Acceptance criteria

- Failing test identified: `content-removal-substrate.test.ts` (the `execD1`/substrate path), 429 / code-971 `TooManyRequests`.
- Root cause diagnosed: ~24 parallel stages on one account's D1 REST trip the account rate limit on the batched ref; `cloudflareApi` had no 429 retry.
- Mechanism chosen: (b), landing in `apps/web/tests/integration/**` (non-§CP). (a)/(c) live in `.github/**`/merge-queue config (§CP) and are unnecessary — the transient is retryable at the harness source.
- A clean bystander is no longer evicted by this co-batched flake: the transient 429 self-heals inside the harness rather than reddening `integration` on the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)