### PR TITLE
docs(ci-required): deslop comments

### DIFF
--- a/packages/ci-required/src/bin.ts
+++ b/packages/ci-required/src/bin.ts
@@ -1,19 +1,14 @@
 /**
- * `ci-required` assertion bin — the CI-callable surface for issue #786.
- *
- * Reads the gating jobs' `needs.*.result` + the single-sourced `*_required`
- * booleans from `process.env` (the `ci-required` step's `env:` block in ci.yml),
- * runs the pure `judge` core, prints the per-job verdicts (ADR 0092 §1
- * "emit what you scanned"), and exits 0 on PASS / 1 on FAIL.
+ * `ci-required` assertion bin — the CI-callable IO shell for the pure `judge`
+ * core (issue #786, ADR 0092): read the gating jobs' `needs.*.result` + the
+ * `*_required` booleans from `process.env`, print the per-job verdicts (ADR 0092
+ * §1 "emit what you scanned"), exit 0 on PASS / 1 on FAIL.
  *
  * ZERO runtime dependencies on purpose: the `ci-required` gate job runs only
- * `actions/checkout` + `node packages/ci-required/src/bin.ts` — no `pnpm install`,
- * so the always-on aggregator stays fast. This file is plain Node (no Effect
- * import) for the same reason; the repo's Effect-CLI idiom would pull
- * `@effect/platform-node` + `effect` into the gate's install path, which the
- * pure-node form avoids. The pure core (`inputFromEnv` + `judge`) is the
- * unit-tested module per the repo "pure core + thin bin" convention; this bin is
- * the IO shell — read env, print, exit.
+ * `actions/checkout` + `node packages/ci-required/src/bin.ts` — no `pnpm install`
+ * — so the always-on aggregator stays fast. Plain Node (no Effect import) for the
+ * same reason: the Effect-CLI idiom would pull `@effect/platform-node` + `effect`
+ * into the gate's install path.
  */
 import {inputFromEnv, judge} from "./ci-required.ts";
 

--- a/packages/ci-required/src/ci-required.ts
+++ b/packages/ci-required/src/ci-required.ts
@@ -12,10 +12,8 @@
  * The required-ness inputs are single-sourced: the `changes` job emits one
  * `*_required` boolean per gating job, derived from the SAME expression that
  * gates that job's own `if:` (see ci.yml `changes` outputs), so run-ness and
- * required-ness can't drift (#375/#738). This module is the behavioral half that
- * was previously an untested inline bash loop: it takes those booleans + each
- * job's `result` + the `changes` job's own result and returns a deterministic
- * verdict. No IO — `bin.ts` reads the GHA `env:` and prints; this decides.
+ * required-ness can't drift (#375/#738). No IO — `bin.ts` reads the GHA `env:`
+ * and prints; this decides.
  */
 
 /**
@@ -26,7 +24,6 @@
  */
 export type JobResult = "success" | "skipped" | "failure" | "cancelled" | "" | (string & {});
 
-/** One gating job's required-ness + observed result, the per-job verdict input. */
 export interface JobInput {
 	readonly name: string;
 	/** Did this job's single-sourced `*_required` predicate say it should run? */
@@ -57,7 +54,6 @@ export interface CiRequiredVerdict {
 	readonly changesReport: JobReport | null;
 }
 
-/** The verdict for one gating job, given its required-ness and observed result. */
 export const judgeJob = (job: JobInput): JobReport => {
 	if (job.required) {
 		// should_run=true ⇒ result MUST be success; a skip (or any non-success) is

--- a/packages/ci-required/src/index.ts
+++ b/packages/ci-required/src/index.ts
@@ -1,10 +1,4 @@
-/**
- * `@kampus/ci-required` — the pure verdict for the `ci-required` CI aggregator
- * (issue #786, ADR 0092). The core (`judge`/`judgeJob`/`inputFromEnv`) is a pure,
- * IO-free, zero-runtime-dependency matcher; `bin.ts` is the thin Node shell that
- * reads the gate job's `env:` and exits 0/1. This replaces the untested inline
- * bash assertion loop in `.github/workflows/ci.yml`.
- */
+/** `@kampus/ci-required` — public surface of the pure `ci-required` CI-aggregator verdict core (see `ci-required.ts`; issue #786, ADR 0092). */
 export {
 	type CiRequiredInput,
 	type CiRequiredVerdict,


### PR DESCRIPTION
Deslop-comments pass over `packages/ci-required/src` (issue scope: `packages/ci-required` only).

## What changed
- `ci-required.ts`: cut the module-docblock paragraph that re-narrated "the behavioral half that was previously an untested inline bash loop"; cut two signature-restater JSDoc lines (over `JobInput` and `judgeJob`).
- `bin.ts`: trimmed the header's convention-restating / "read env, print, exit" narration tail — kept the load-bearing ZERO-runtime-dependency + plain-Node rationale.
- `index.ts`: collapsed the barrel header (which re-derived the two module headers) to a one-line what-it-is + ADR pointer.

## Kept (load-bearing)
ADR 0092 pointers, the fail-closed invariant comments at their enforcement sites in `judgeJob`, the `*_required`-only-`"true"` parsing note, the GHA env-mapping field docs, and the gating-expression comments in the test file (they map each scenario to ci.yml).

## Guarantees
- Diff is **comments-and-whitespace only** — no code/identifier/string/logic token changed (`git diff` verifiable).
- No `TODO`/`FIXME`/`HACK`, license header, shebang, or pragma touched.
- `pnpm lint` and `pnpm typecheck` green.
- No file edited outside `packages/ci-required`.

§CP (control-plane) — human-merge (EM + cansirin); do not auto-ship.

Fixes #2873