### PR TITLE
docs(pipeline): deslop comments

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
+++ b/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
@@ -21,12 +21,10 @@ say()  { printf '  %s %s\n' "$1" "$2"; }
 fix()  { printf '      ↳ fix: %s\n' "$1"; }
 hdr()  { printf '\n%s\n' "$1"; }
 
-# ── Target repo resolution (the one snippet every parameterized skill uses) ──
 REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)}"
 
 printf 'kampus-pipeline doctor — target repo: %s\n' "${REPO:-<unresolved>}"
 
-# ── Tier 1 — load-bearing ───────────────────────────────────────────────────
 hdr "Tier 1 — load-bearing (first run fails without these)"
 
 # 1a. gh authenticated
@@ -93,7 +91,6 @@ else
 	fails=$((fails + 1))
 fi
 
-# ── Tier 2 — gating ─────────────────────────────────────────────────────────
 hdr "Tier 2 — gating (a stage fails deep without these)"
 
 # 2a. target repo resolves
@@ -118,7 +115,6 @@ else
 	fails=$((fails + 1))
 fi
 
-# ── Tier 3 — optional (absence degrades a stage, never breaks the pipeline) ──
 hdr "Tier 3 — optional (degrades a stage; pipeline still runs)"
 
 # 3a. the consolidated `pnpm dlx` package adr / review-plan reach for (epic #994:
@@ -148,7 +144,6 @@ else
 	fix "optional: ship .github/workflows/run-evidence.yml + packages/pipeline-cli/src/tools/crabbox-manifest for SHA-bound evidence"
 fi
 
-# ── Verdict ─────────────────────────────────────────────────────────────────
 hdr "Verdict"
 if [ "$fails" -eq 0 ]; then
 	printf '  %s pipeline-ready: all Tier-1 and Tier-2 checks passed.\n' "$PASS"

--- a/claude-plugins/kampus-pipeline/skills/report/footer.sh
+++ b/claude-plugins/kampus-pipeline/skills/report/footer.sh
@@ -31,7 +31,6 @@ fi
 # Timestamp — always available, UTC ISO-8601.
 parts+=("$(date -u +"%Y-%m-%dT%H:%M:%SZ")")
 
-# Join with " · ".
 line=""
 for p in "${parts[@]}"; do
 	if [[ -z "$line" ]]; then line="$p"; else line="$line · $p"; fi

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
@@ -48,7 +48,7 @@ checks=0
 fail() { echo "FAIL: $*"; errors=$((errors + 1)); }
 ok() { echo "ok: $*"; checks=$((checks + 1)); }
 
-# ── Layer 1: static wiring ───────────────────────────────────────────────────
+# Layer 1: static wiring.
 # Every cycle-aware skill must (a) cite the single canonical probe path and (b) pair it
 # with an absent⇒no-op branch. Proves AC: "the canonical absence-probe is the one each
 # skill branches on — no skill hardcodes flags or assumes the doc exists."
@@ -88,7 +88,7 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 	fi
 done
 
-# ── Layer 2: hermetic runtime walkthrough ────────────────────────────────────
+# Layer 2: hermetic runtime walkthrough.
 # Execute the canonical working-tree form of the probe (formats §1: a skill on a local tree
 # may substitute `test -f product-development-cycle.md` for the gh api read — same probe,
 # same well-known path, same absent⇒no-op rule) against a synthetic repo root that has NO
@@ -166,7 +166,6 @@ else
 	fail "ship-it surfaced a release queue on an absent cycle doc"
 fi
 
-# ── Verdict ──────────────────────────────────────────────────────────────────
 if [ "$errors" -gt 0 ]; then
 	echo "validate-cycle-absence: FAILED — $errors error(s); the graceful-absence guarantee (ADR 0062 / 0083) is broken"
 	exit 1

--- a/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
@@ -60,7 +60,7 @@ declare -a scanned_paths=()
 fail() { echo "FAIL: $*"; errors=$((errors + 1)); }
 ok() { echo "ok: $*"; checks=$((checks + 1)); }
 
-# ── Layer 1: static wiring (present branch) ──────────────────────────────────
+# Layer 1: static wiring (present branch).
 # Every cycle-aware skill must (a) cite the canonical probe path, (b) resolve it to `present`
 # somewhere, and (c) carry the present-path ACTION the cycle requires of it. This is what proves
 # the present branch is real wiring and not dead prose; if a future edit drops a skill's
@@ -97,7 +97,7 @@ for entry in "${CYCLE_SKILLS[@]}"; do
 	fi
 done
 
-# ── Layer 2: hermetic runtime walkthrough (present branch) ───────────────────
+# Layer 2: hermetic runtime walkthrough (present branch).
 # Execute the canonical working-tree form of the probe (formats §1) against a synthetic repo
 # root that HAS a cycle doc, then walk the four present-path decisions exactly as each skill's
 # cycle-step does. This is the doc-present scenario actually run — the inverse of the absence
@@ -157,7 +157,7 @@ else
 	fail "ship-it surfaced no release queue on a present cycle doc + flag containment"
 fi
 
-# ── Zero-scope guard (ADR 0092): the present path MUST actually be exercised ──
+# Zero-scope guard (ADR 0092): the present path MUST actually be exercised.
 # Two ways this gate could scan nothing and pass vacuously, both FAIL CLOSED:
 #   1. The static scope matched zero skills (a moved/renamed skills dir).
 #   2. phoenix's real cycle doc is missing — then the present path is never exercised here,
@@ -172,10 +172,9 @@ else
 	ok "phoenix's real cycle doc is present at $CYCLE_DOC_PATH (present path is live)"
 fi
 
-# ── Emitted scope (ADR 0092): every run states what it looked at ─────────────
+# Emitted scope (ADR 0092): every run states what it looked at.
 echo "scanned scope: ${scanned_skills} cycle-aware skill(s) [${scanned_paths[*]}]; phoenix cycle doc: $([ -f "$repo_root/$CYCLE_DOC_PATH" ] && echo present || echo MISSING)"
 
-# ── Verdict ──────────────────────────────────────────────────────────────────
 if [ "$errors" -gt 0 ]; then
 	echo "validate-cycle-presence: FAILED — $errors error(s); phoenix's present cycle-doc path is not real (a present-branch action is missing, or the gate scanned zero scope — ADR 0091/0092)"
 	exit 1

--- a/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
@@ -36,7 +36,7 @@ checks=0
 fail() { echo "FAIL: $*"; errors=$((errors + 1)); }
 ok()   { echo "ok: $*";   checks=$((checks + 1)); }
 
-# ── Invariant 1: formats-doc CONTROL_PLANE_RE matches the single-source const ─
+# Invariant 1: formats-doc CONTROL_PLANE_RE matches the single-source const.
 #
 # The §CP boundary is single-sourced in packages/pipeline-cli (#2761), emitted by
 # `pipeline-cli control-plane-paths`. Read it from THERE (not a byte-compare of N
@@ -73,7 +73,7 @@ else
   formats: $FORMATS_RE"
 fi
 
-# ── Invariant 1b: GUARD_ADR_RE copy matches §CP (ADR 0164) ──────────────────
+# Invariant 1b: GUARD_ADR_RE copy matches §CP (ADR 0164).
 #
 # The guard-touching-ADR content predicate (ADR 0164, #2191) is single-sourced in §CP the
 # same way CONTROL_PLANE_RE is: one canonical GUARD_ADR_RE= line in gh-issue-intake-formats.md,
@@ -106,7 +106,7 @@ else
 	fi
 fi
 
-# ── Invariant 1c: HAS_*_RE class-fan copies match §CP (issue #2488) ──────────
+# Invariant 1c: HAS_*_RE class-fan copies match §CP (issue #2488).
 #
 # The four class-classification probes — HAS_CODE_RE / HAS_SKILLS_RE /
 # HAS_DOCS_EXCLUDE_RE / HAS_DOCS_RE — are single-sourced as canonical HAS_*_RE='…'
@@ -166,7 +166,7 @@ for name in $HAS_NAMES; do
 	done
 done
 
-# ── Invariant 2: .claude/skills symlink agrees with marketplace source ───────
+# Invariant 2: .claude/skills symlink agrees with marketplace source.
 #
 # .claude/skills -> ../claude-plugins/kampus-pipeline/skills
 # marketplace.json source -> ./claude-plugins/kampus-pipeline
@@ -208,7 +208,6 @@ else
 	fi
 fi
 
-# ── Verdict ──────────────────────────────────────────────────────────────────
 if [ "$errors" -gt 0 ]; then
 	echo "validate-gate-path-drift: FAILED — $errors error(s); gate-path invariants are broken (issue #720)"
 	exit 1


### PR DESCRIPTION
Refs #2879

Deslop pass over `claude-plugins/kampus-pipeline/` (§CP, gate-critical — human-merge, cansirin), **excluding `skills/ship-it/SKILL.md`** which is owned by an in-flight collision lane.

### What changed
Comments-and-whitespace only — `git diff` shows no code/logic change (verified: no non-comment, non-blank line added or removed).

The cuttable comment slop across this surface is confined to the shell scripts; the markdown skills/agents/`gh-issue-intake-formats.md` are prose instructions (not code comments) and their HTML `<!-- ... -->` markers are load-bearing marker/AC grammar, so they are untouched.

- **Removed decorative box-drawing section-separator banners** (`# ── … ──`) across the four pipeline shell scripts:
  - `skills/doctor/doctor.sh` — Tier/Verdict/target-repo banners that merely restated the adjacent `hdr`/`REPO=` line → deleted.
  - `skills/validate-cycle-absence.sh`, `skills/validate-cycle-presence.sh`, `skills/validate-gate-path-drift.sh` — `Verdict` banners restated by the adjacent `echo` → deleted; `Layer`/`Invariant`/`Zero-scope`/`Emitted scope` banners (the sole carrier of a section label) → kept as plain `#` comments, decoration stripped.
- **Cut one obvious-control-flow narration** (`# Join with " · ".`) in `skills/report/footer.sh`.

### Preserved (load-bearing, per the deslop KEEP rule)
All invariant docblocks and platform-gotcha notes: the guard.sh/install.sh/resolve-data-dir.sh fail-open + verbatim-settings-env invariants, footer.sh's privacy contract, the doctor tier taxonomy, and every ADR/issue reference.

### Verification
- `pnpm lint` — clean (no biome-handled files changed).
- `pnpm typecheck` — 29/29 successful.
- `bash -n` parses all five scripts.

### Scope
`skills/ship-it/SKILL.md` deliberately left untouched (separate later pass). This is a §CP PR — stops at PR-open; §CP merge is EM + cansirin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)