### PR TITLE
refactor(pipeline-cli): remediate Effect-v4 idioms in non-guard modules

### DIFF
--- a/packages/pipeline-cli/src/router.ts
+++ b/packages/pipeline-cli/src/router.ts
@@ -11,23 +11,27 @@
  * (ADR 0082). The router is closed for modification: new tools arrive only
  * via `registry.ts`, never by editing this file.
  */
-import {Data, Result} from "effect";
+import {Result} from "effect";
+import * as Schema from "effect/Schema";
 import type {RegisteredTool} from "./registry.ts";
 
 /** The first argv token named no registered tool. Carries the offender + the known set. */
-export class UnknownToolError extends Data.TaggedError("UnknownToolError")<{
-	readonly tool: string;
-	readonly known: ReadonlyArray<string>;
-}> {
+export class UnknownToolError extends Schema.TaggedErrorClass<UnknownToolError>()(
+	"UnknownToolError",
+	{
+		tool: Schema.String,
+		known: Schema.Array(Schema.String),
+	},
+) {
 	override get message(): string {
 		return `unknown tool "${this.tool}" — known tools: ${this.known.join(", ") || "(none)"}`;
 	}
 }
 
 /** No argv token at all (`pipeline-cli` with no subcommand) — the help/usage case. */
-export class NoToolError extends Data.TaggedError("NoToolError")<{
-	readonly known: ReadonlyArray<string>;
-}> {
+export class NoToolError extends Schema.TaggedErrorClass<NoToolError>()("NoToolError", {
+	known: Schema.Array(Schema.String),
+}) {
 	override get message(): string {
 		return `no tool given — known tools: ${this.known.join(", ") || "(none)"}`;
 	}

--- a/packages/pipeline-cli/src/tools/eval-harness/command.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/command.ts
@@ -17,7 +17,8 @@
  * decode, render. An unreadable path and a malformed/mismatched input both exit non-zero.
  */
 import {readFileSync} from "node:fs";
-import {Console, Data, Effect, Result} from "effect";
+import {Console, Effect, Result} from "effect";
+import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {decodeManifest, STAGES} from "./corpus.ts";
 import {
@@ -31,9 +32,12 @@ import {
 const GATE_FAIL_EXIT_CODE = 1;
 
 // A named manifest path that could not be read — a hard error (exit 1), not a skip.
-class ManifestUnreadable extends Data.TaggedError("ManifestUnreadable")<{
-	readonly path: string;
-}> {}
+class ManifestUnreadable extends Schema.TaggedErrorClass<ManifestUnreadable>()(
+	"ManifestUnreadable",
+	{
+		path: Schema.String,
+	},
+) {}
 
 const manifestArg = Argument.string("manifest").pipe(
 	Argument.withDescription("path to a corpus manifest JSON file to validate against the schema"),
@@ -73,9 +77,9 @@ const check = Command.make(
 );
 
 // A named report-input path that could not be read — a hard error (exit 1), not a skip.
-class RowsUnreadable extends Data.TaggedError("RowsUnreadable")<{
-	readonly path: string;
-}> {}
+class RowsUnreadable extends Schema.TaggedErrorClass<RowsUnreadable>()("RowsUnreadable", {
+	path: Schema.String,
+}) {}
 
 const rowsArg = Argument.string("rows").pipe(
 	Argument.withDescription(

--- a/packages/pipeline-cli/src/tools/eval-harness/corpus.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/corpus.ts
@@ -18,7 +18,7 @@
  * `decodeManifest` is total — it returns a typed `Result` failure on malformed JSON or a
  * schema mismatch, never a throw.
  */
-import {Data, Result} from "effect";
+import {Result} from "effect";
 import * as Schema from "effect/Schema";
 
 /** The five graded pipeline stages a corpus entry can label. */
@@ -118,10 +118,13 @@ export const CorpusManifest = Schema.Struct({
 export type CorpusManifest = typeof CorpusManifest.Type;
 
 /** A typed manifest decode failure — malformed JSON, or a shape that doesn't match the schema. */
-export class ManifestDecodeError extends Data.TaggedError("ManifestDecodeError")<{
-	readonly reason: "malformed-json" | "schema-mismatch";
-	readonly message: string;
-}> {}
+export class ManifestDecodeError extends Schema.TaggedErrorClass<ManifestDecodeError>()(
+	"ManifestDecodeError",
+	{
+		reason: Schema.Literals(["malformed-json", "schema-mismatch"]),
+		message: Schema.String,
+	},
+) {}
 
 const decodeUnknownManifest = Schema.decodeUnknownResult(CorpusManifest);
 const encodeManifest_ = Schema.encodeSync(CorpusManifest);
@@ -130,26 +133,23 @@ const encodeManifest_ = Schema.encodeSync(CorpusManifest);
  * Decode a manifest from its on-disk text. Total — a non-JSON body or a schema mismatch
  * both return a typed `Result` failure, never a throw.
  */
-export const decodeManifest = (
-	text: string,
-): Result.Result<CorpusManifest, ManifestDecodeError> => {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(text);
-	} catch (cause) {
-		return Result.fail(
+export const decodeManifest = (text: string): Result.Result<CorpusManifest, ManifestDecodeError> =>
+	Result.try({
+		try: (): unknown => JSON.parse(text),
+		catch: (cause) =>
 			new ManifestDecodeError({
 				reason: "malformed-json",
 				message: cause instanceof Error ? cause.message : String(cause),
 			}),
-		);
-	}
-	return decodeUnknownManifest(parsed).pipe(
-		Result.mapError(
-			(error) => new ManifestDecodeError({reason: "schema-mismatch", message: error.message}),
+	}).pipe(
+		Result.flatMap((parsed) =>
+			decodeUnknownManifest(parsed).pipe(
+				Result.mapError(
+					(error) => new ManifestDecodeError({reason: "schema-mismatch", message: error.message}),
+				),
+			),
 		),
 	);
-};
 
 /** Serialize a valid manifest to its canonical on-disk text (round-trips with `decodeManifest`). */
 export const encodeManifest = (manifest: CorpusManifest): string =>

--- a/packages/pipeline-cli/src/tools/eval-harness/repair-churn.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/repair-churn.ts
@@ -26,7 +26,7 @@
  * the four-`usage`-component offline sum), reused read-only via `tokensFromTranscript` below;
  * this core never mints a second token meter.
  */
-import {Data, Result} from "effect";
+import {Result} from "effect";
 import * as Schema from "effect/Schema";
 import {reconstructSpend} from "../token-spend/token-spend.ts";
 
@@ -52,9 +52,12 @@ export const RepairChurnInput = Schema.Struct({
 export type RepairChurnInput = typeof RepairChurnInput.Type;
 
 /** A typed input-validation failure — an out-of-range `passRate` or a negative token count. */
-export class RepairChurnInputError extends Data.TaggedError("RepairChurnInputError")<{
-	readonly message: string;
-}> {}
+export class RepairChurnInputError extends Schema.TaggedErrorClass<RepairChurnInputError>()(
+	"RepairChurnInputError",
+	{
+		message: Schema.String,
+	},
+) {}
 
 /** The priced churn for one (stage × model), derived from a validated `RepairChurnInput`. */
 export interface RepairChurnCost {

--- a/packages/pipeline-cli/src/tools/eval-harness/report.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/report.ts
@@ -22,7 +22,7 @@
  * — a cell's spend is the mean over its reconstructed runs, and a cell with zero reconstructed
  * spends reports a null token axis rather than a fabricated zero.
  */
-import {Data, Result} from "effect";
+import {Result} from "effect";
 import * as Schema from "effect/Schema";
 import {CorpusEntry} from "./corpus.ts";
 import {priceModelSwap, repairChurnCost} from "./repair-churn.ts";
@@ -381,10 +381,13 @@ export const ReportInput = Schema.Array(RunRowSchema);
 export type ReportInput = typeof ReportInput.Type;
 
 /** A typed report-input decode failure — malformed JSON, or a shape that doesn't match the rows schema. */
-export class ReportInputError extends Data.TaggedError("ReportInputError")<{
-	readonly reason: "malformed-json" | "schema-mismatch";
-	readonly message: string;
-}> {}
+export class ReportInputError extends Schema.TaggedErrorClass<ReportInputError>()(
+	"ReportInputError",
+	{
+		reason: Schema.Literals(["malformed-json", "schema-mismatch"]),
+		message: Schema.String,
+	},
+) {}
 
 const decodeUnknownReportInput = Schema.decodeUnknownResult(ReportInput);
 
@@ -392,21 +395,20 @@ const decodeUnknownReportInput = Schema.decodeUnknownResult(ReportInput);
  * Decode the report's input (a serialized `RunRow[]`) from its on-disk text. Total — a non-JSON
  * body or a schema mismatch both return a typed `Result` failure, never a throw.
  */
-export const decodeReportInput = (text: string): Result.Result<ReportInput, ReportInputError> => {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(text);
-	} catch (cause) {
-		return Result.fail(
+export const decodeReportInput = (text: string): Result.Result<ReportInput, ReportInputError> =>
+	Result.try({
+		try: (): unknown => JSON.parse(text),
+		catch: (cause) =>
 			new ReportInputError({
 				reason: "malformed-json",
 				message: cause instanceof Error ? cause.message : String(cause),
 			}),
-		);
-	}
-	return decodeUnknownReportInput(parsed).pipe(
-		Result.mapError(
-			(error) => new ReportInputError({reason: "schema-mismatch", message: error.message}),
+	}).pipe(
+		Result.flatMap((parsed) =>
+			decodeUnknownReportInput(parsed).pipe(
+				Result.mapError(
+					(error) => new ReportInputError({reason: "schema-mismatch", message: error.message}),
+				),
+			),
 		),
 	);
-};

--- a/packages/pipeline-cli/src/tools/eval-harness/runner.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/runner.ts
@@ -21,7 +21,7 @@
  * counts the run with an explicit `TranscriptMissing` spend rather than crashing, and a
  * malformed artifact grades `fail` through the oracle — never a throw.
  */
-import {Data, Result} from "effect";
+import {Result} from "effect";
 import * as Schema from "effect/Schema";
 import {reconstructSpend, type StageSpend} from "../token-spend/token-spend.ts";
 import {type CorpusEntry, type CorpusManifest, STAGES} from "./corpus.ts";
@@ -101,10 +101,13 @@ export const CaptureManifest = Schema.Struct({
 export type CaptureManifest = typeof CaptureManifest.Type;
 
 /** A typed capture-manifest decode failure — malformed JSON, or a shape that doesn't match the schema. */
-export class CaptureDecodeError extends Data.TaggedError("CaptureDecodeError")<{
-	readonly reason: "malformed-json" | "schema-mismatch";
-	readonly message: string;
-}> {}
+export class CaptureDecodeError extends Schema.TaggedErrorClass<CaptureDecodeError>()(
+	"CaptureDecodeError",
+	{
+		reason: Schema.Literals(["malformed-json", "schema-mismatch"]),
+		message: Schema.String,
+	},
+) {}
 
 const decodeUnknownCapture = Schema.decodeUnknownResult(CaptureManifest);
 
@@ -114,24 +117,23 @@ const decodeUnknownCapture = Schema.decodeUnknownResult(CaptureManifest);
  */
 export const decodeCaptureManifest = (
 	text: string,
-): Result.Result<CaptureManifest, CaptureDecodeError> => {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(text);
-	} catch (cause) {
-		return Result.fail(
+): Result.Result<CaptureManifest, CaptureDecodeError> =>
+	Result.try({
+		try: (): unknown => JSON.parse(text),
+		catch: (cause) =>
 			new CaptureDecodeError({
 				reason: "malformed-json",
 				message: cause instanceof Error ? cause.message : String(cause),
 			}),
-		);
-	}
-	return decodeUnknownCapture(parsed).pipe(
-		Result.mapError(
-			(error) => new CaptureDecodeError({reason: "schema-mismatch", message: error.message}),
+	}).pipe(
+		Result.flatMap((parsed) =>
+			decodeUnknownCapture(parsed).pipe(
+				Result.mapError(
+					(error) => new CaptureDecodeError({reason: "schema-mismatch", message: error.message}),
+				),
+			),
 		),
 	);
-};
 
 /**
  * Load a transcript's raw text for a path, or `null` when it is absent/unreadable. The runner core


### PR DESCRIPTION
Fixes #2752

## What

Remediates the Effect-v4 idiom violations (Rules 3/4 of #2736) in the pipeline-cli **non-guard** modules — the sites outside #2738's guard `command.ts`/`gate.ts` scope. Mechanical idiom application, behavior preserved.

### Files changed
- `packages/pipeline-cli/src/router.ts` — `UnknownToolError`, `NoToolError`: `Data.TaggedError` → `Schema.TaggedErrorClass` (the `override get message()` getter is kept on the subclass body).
- `packages/pipeline-cli/src/tools/eval-harness/command.ts` — `ManifestUnreadable`, `RowsUnreadable` → `Schema.TaggedErrorClass` (adds the `effect/Schema` import; the existing `Effect.try` shells are untouched).
- `packages/pipeline-cli/src/tools/eval-harness/corpus.ts` — `ManifestDecodeError` → `Schema.TaggedErrorClass`; `decodeManifest`'s raw `try { JSON.parse }` → `Result.try({ try, catch })`.
- `packages/pipeline-cli/src/tools/eval-harness/report.ts` — `ReportInputError` → `Schema.TaggedErrorClass`; `decodeReportInput`'s `try/catch` → `Result.try`.
- `packages/pipeline-cli/src/tools/eval-harness/runner.ts` — `CaptureDecodeError` → `Schema.TaggedErrorClass`; `decodeCaptureManifest`'s `try/catch` → `Result.try`.
- `packages/pipeline-cli/src/tools/eval-harness/repair-churn.ts` — `RepairChurnInputError` → `Schema.TaggedErrorClass`.

### Idiom grounding (effect-smol)
- `Schema.TaggedErrorClass<Self>()("Tag", { ...fields })` — the documented error idiom (effect-smol `LLMS.md` "Error handling basics" and "Using Effect.fn"); copied from the in-package gold standard `packages/pipeline-cli/src/tools/epic-ledger/github.ts`.
- The `try/catch` sites return a `Result`, not an `Effect`, so the behavior-preserving equivalent is **`Result.try({ try, catch })`** (effect-smol `Result.ts` `try`, whose docstring shows the exact `JSON.parse` use) — not `Effect.try`, which would change the return type and break callers/tests. No type assertion introduced (`try: (): unknown => JSON.parse(text)` uses a return-type annotation).
- **Tag strings preserved exactly** (`ManifestDecodeError`, `CaptureDecodeError`, `RepairChurnInputError`, …) — tests assert bare `_tag` values and `command.ts` catches by tag, so namespacing them would be a behavior change.

## Scope fence
Touches **no** file #2738 owns (guard `command.ts`/`gate.ts`). The remaining `Data.TaggedError` sites in pipeline-cli are the guard `gate.ts`/`command.ts` files (#2738's scope) plus a handful of other non-guard command/view tools **not named in this issue's build list** (`changelog-derive`, `gh-phoenix`, `glossary-drift`, `ship-digest`, `token-spend`, `roadmap/view.ts`) — left untouched to respect the fence. The AC "zero Phase-1 findings across `packages/pipeline-cli/**`" is explicitly gated on #2738 having merged (still open); that whole-tree sweep is a follow-up once #2738 lands.

## Verification (local, all green)
- `pnpm typecheck` — pass
- pipeline-cli unit tests (`router` + `eval-harness/`) — 65 pass
- `pnpm lint` (biome + GritQL plugins `no-data-taggederror` / `no-raw-try-catch` / `no-effect-promise`) — clean on all changed files; pre-commit and pre-push hooks green

## §CP — human-merge-only
Every path is under `packages/pipeline-cli/` (matches `CONTROL_PLANE_RE`). Routed to human merge (EM + cansirin); not auto-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)