### PR TITLE
refactor(pipeline-cli): align guard command.ts to the github.ts service pattern

### DIFF
--- a/packages/pipeline-cli/src/tools/merge-queue-classify/command.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/command.ts
@@ -10,25 +10,22 @@
  * outcome is the value, read it from stdout. Step 5.5 shells out to this per poll and
  * branches on the printed word.
  *
- * The IO lives here (the thin bin), the decision in `merge-queue-classify.ts` (the pure
- * core). This bin reads the two authoritative ground-truth signals via `gh`:
- *   - PR `state` + `mergeStateStatus` from `gh pr view --json` (the same sanctioned
- *     PR-state read ship-it Step 2 uses — NOT a GraphQL intake query the org's
- *     Projects-classic integration breaks).
- *   - the LAST merge-queue timeline event (`added_to_merge_queue` /
- *     `removed_from_merge_queue`) from `gh api repos/<repo>/issues/<pr>/timeline` (REST,
- *     never GraphQL) — the authoritative queue-membership signal (GitHub "Managing a
- *     merge queue"), verified live on PR #1906.
+ * The IO lives in `github.ts` (the `Github` service — the `gh` REST boundary, ADR-0062 repo
+ * resolution, Schema-decoded PR-state + timeline reads); the decision in `merge-queue-classify.ts`
+ * (the pure core). This bin is the thin glue: read the ground-truth `MergeQueueSignals` via the
+ * service, hand them to `classify`, and print the word.
  *
- * Fail-closed away from a false ship: an unreadable PR state, an unreadable timeline, or
- * any ambiguity resolves to `pending` (still settling), never `merged` and never
- * `ejected` — a classifier miss can only ever keep polling within the bounded window, it
- * can neither report a false success nor trigger a false re-drive.
+ * Fail-closed away from a false ship (preserved through the #2738 idiom remediation): an
+ * unresolvable repo (`RepoResolutionError`) or an unreadable PR state (`GhCommandError` /
+ * `GhParseError` / `SchemaError`) resolves to `pending` (still settling), never `merged` and
+ * never `ejected` — the service already recovers an unreadable timeline to the settle window. A
+ * classifier miss can only ever keep polling within the bounded window; it can neither report a
+ * false success nor trigger a false re-drive.
  */
-import {execFileSync} from "node:child_process";
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {classify, lastMergeQueueEvent, type MergeQueueSignals} from "./merge-queue-classify.ts";
+import {Github, GithubLive} from "./github.ts";
+import {classify} from "./merge-queue-classify.ts";
 
 const prFlag = Flag.integer("pr").pipe(
 	Flag.withDescription("the PR number to classify the merge-queue state of"),
@@ -39,113 +36,33 @@ const repoFlag = Flag.string("repo").pipe(
 	Flag.withDescription("owner/repo (default: CLAUDE_PIPELINE_REPO / gh repo view)"),
 );
 
-/** Resolve owner/repo: `--repo`, else `CLAUDE_PIPELINE_REPO`, else `gh repo view`. null on failure. */
-const resolveRepo = (repo: Option.Option<string>): string | null => {
-	const explicit = Option.getOrUndefined(repo) ?? process.env.CLAUDE_PIPELINE_REPO;
-	if (explicit !== undefined && explicit.trim() !== "") return explicit.trim();
-	try {
-		return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], {
-			encoding: "utf8",
-		}).trim();
-	} catch {
-		return null;
-	}
-};
-
-/** The PR state read from `gh pr view` — merged/state/mergeStateStatus. null on any read failure. */
-interface PrState {
-	readonly merged: boolean;
-	readonly state: string;
-	readonly mergeStateStatus: string | undefined;
-}
-
-/**
- * Read the PR's `state` + `mergeStateStatus` via `gh pr view --json` — the working fields
- * (the old `merged` JSON field errors `Unknown JSON field` on this gh/repo, #1921); the
- * `merged` signal is derived from `state == MERGED`. Returns null on any read failure.
- */
-const readPrState = (repo: string, pr: number): PrState | null => {
-	try {
-		const raw = execFileSync(
-			"gh",
-			[
-				"pr",
-				"view",
-				String(pr),
-				"--repo",
-				repo,
-				"--json",
-				"state,mergeStateStatus",
-				"--jq",
-				"{state: .state, mergeStateStatus: .mergeStateStatus}",
-			],
-			{encoding: "utf8"},
-		);
-		const parsed = JSON.parse(raw) as {state?: unknown; mergeStateStatus?: unknown};
-		const state = typeof parsed.state === "string" ? parsed.state : "";
-		return {
-			merged: state === "MERGED",
-			state,
-			mergeStateStatus:
-				typeof parsed.mergeStateStatus === "string" ? parsed.mergeStateStatus : undefined,
-		};
-	} catch {
-		return null;
-	}
-};
-
-/**
- * Read the LAST merge-queue timeline event via the REST issue-timeline endpoint (never
- * GraphQL). Returns `null` on any read failure — the core then treats a missing event as
- * the settle window (`pending`), the fail-closed-away-from-a-false-ship posture.
- */
-const readLastMergeQueueEvent = (
-	repo: string,
-	pr: number,
-): "added_to_merge_queue" | "removed_from_merge_queue" | null => {
-	try {
-		const raw = execFileSync(
-			"gh",
-			["api", `repos/${repo}/issues/${pr}/timeline?per_page=100`, "--paginate"],
-			{encoding: "utf8"},
-		);
-		// `--paginate` concatenates JSON arrays; normalize `][` joins into one array.
-		const merged = raw.replace(/\]\s*\[/g, ",");
-		const timeline = JSON.parse(merged) as ReadonlyArray<{event?: string; created_at?: string}>;
-		return lastMergeQueueEvent(timeline);
-	} catch {
-		return null;
-	}
-};
+/** Emit the fail-closed `pending` verdict: the reason on stderr, the outcome word on stdout. */
+const pending = (reason: string): Effect.Effect<void> =>
+	Effect.sync(() => process.stderr.write(`merge-queue-classify: ${reason}\n`)).pipe(
+		Effect.andThen(Console.log("pending")),
+	);
 
 const classifyCmd = Command.make(
 	"classify",
 	{pr: prFlag, repo: repoFlag},
 	Effect.fn(function* ({pr, repo}) {
-		const resolvedRepo = resolveRepo(repo);
-		if (resolvedRepo === null) {
-			// No repo ⇒ cannot read ground truth ⇒ still settling (keep polling), never a false verdict.
-			yield* Effect.sync(() =>
-				process.stderr.write("merge-queue-classify: could not resolve repo — pending.\n"),
-			);
-			yield* Console.log("pending");
+		// null = a fail-closed branch already printed `pending`; every read fault folds to it, so
+		// an unresolvable repo / unreadable PR state can only ever keep the reconcile polling.
+		const signals = yield* (yield* Github).signals(pr, Option.getOrUndefined(repo)).pipe(
+			Effect.catchTag("@kampus/merge-queue-classify/RepoResolutionError", () =>
+				Effect.as(pending("could not resolve repo — pending."), null),
+			),
+			Effect.catchTags({
+				"@kampus/merge-queue-classify/GhCommandError": () =>
+					Effect.as(pending("could not read PR state — pending."), null),
+				"@kampus/merge-queue-classify/GhParseError": () =>
+					Effect.as(pending("could not read PR state — pending."), null),
+				SchemaError: () => Effect.as(pending("could not read PR state — pending."), null),
+			}),
+		);
+		if (signals === null) {
 			return;
 		}
-		const prState = readPrState(resolvedRepo, pr);
-		if (prState === null) {
-			yield* Effect.sync(() =>
-				process.stderr.write("merge-queue-classify: could not read PR state — pending.\n"),
-			);
-			yield* Console.log("pending");
-			return;
-		}
-		const lastEvent = readLastMergeQueueEvent(resolvedRepo, pr);
-		const signals: MergeQueueSignals = {
-			merged: prState.merged,
-			state: prState.state,
-			lastMergeQueueEvent: lastEvent,
-			mergeStateStatus: prState.mergeStateStatus,
-		};
 		const result = classify(signals);
 		yield* Effect.sync(() => process.stderr.write(`merge-queue-classify: ${result.reason}\n`));
 		yield* Console.log(result.outcome);
@@ -161,4 +78,5 @@ export const mergeQueueClassifyCommand = Command.make("merge-queue-classify").pi
 	Command.withDescription(
 		"Authoritative merge-queue-state classifier for ship-it Step 5.5's reconcile (#1921)",
 	),
+	Command.provide(GithubLive),
 );

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/github-service.unit.test.ts
@@ -1,0 +1,171 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {GhCommandError, Github, GithubLive, RepoResolutionError} from "./github.ts";
+import {classify} from "./merge-queue-classify.ts";
+
+// The live `Github` layer resolves its target repo lazily on first `signals` call (ADR 0062 §1):
+// the `--repo` override → `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`. These
+// tests clear the ambient env so the override / `gh repo view` branches are exercised explicitly
+// and no ambient var leaks in.
+let savedRepo: string | undefined;
+let savedGh: string | undefined;
+beforeAll(() => {
+	savedRepo = process.env.CLAUDE_PIPELINE_REPO;
+	savedGh = process.env.GITHUB_REPOSITORY;
+	delete process.env.CLAUDE_PIPELINE_REPO;
+	delete process.env.GITHUB_REPOSITORY;
+});
+afterAll(() => {
+	if (savedRepo === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedRepo;
+	if (savedGh === undefined) delete process.env.GITHUB_REPOSITORY;
+	else process.env.GITHUB_REPOSITORY = savedGh;
+});
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+/**
+ * A `ChildProcessSpawner` answering the two reads `signals` makes: `gh pr view … --json` from
+ * `prState`, and `gh api …/timeline` from `timeline`; plus `gh repo view` from `repoView`. An
+ * unprovided read exits 1 (the read-failure path the fail-closed posture recovers from).
+ */
+const mockSpawner = (fixture: {
+	readonly prState?: Response;
+	readonly timeline?: Response;
+	readonly repoView?: Response;
+}): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const isPrView = args[0] === "pr" && args[1] === "view";
+				const isRepoView = args[0] === "repo" && args[1] === "view";
+				const isTimeline = args.some((a) => a.includes("/timeline"));
+				const pick = (): Response | undefined =>
+					isPrView
+						? fixture.prState
+						: isRepoView
+							? fixture.repoView
+							: isTimeline
+								? fixture.timeline
+								: undefined;
+				const found = pick();
+				const canned = found ? normalize(found) : {stdout: "", exitCode: 1, stderr: "not found"};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	fixture: Parameters<typeof mockSpawner>[0],
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(fixture)))));
+
+const prView = (state: string, mergeStateStatus?: string): string =>
+	JSON.stringify({state, mergeStateStatus: mergeStateStatus ?? null});
+
+const timelineEvents = (...events: ReadonlyArray<string>): string =>
+	JSON.stringify(events.map((event, i) => ({event, created_at: `2026-01-01T00:0${i}:00Z`})));
+
+const REPO = "kamp-us/phoenix";
+
+describe("Github.signals — the ground-truth reads over a mock gh spawner (#2738)", () => {
+	it.effect("classifies `merged` from state==MERGED (the terminal-success read)", () =>
+		Effect.gen(function* () {
+			const signals = yield* (yield* Github).signals(1906, REPO);
+			assert.strictEqual(signals.merged, true);
+			assert.strictEqual(classify(signals).outcome, "merged");
+		}).pipe((effect) =>
+			provide(effect, {
+				prState: prView("MERGED"),
+				timeline: timelineEvents("added_to_merge_queue", "removed_from_merge_queue"),
+			}),
+		),
+	);
+
+	it.effect("classifies `queued` from the last timeline event added_to_merge_queue", () =>
+		Effect.gen(function* () {
+			const signals = yield* (yield* Github).signals(1906, REPO);
+			assert.strictEqual(signals.lastMergeQueueEvent, "added_to_merge_queue");
+			assert.strictEqual(classify(signals).outcome, "queued");
+		}).pipe((effect) =>
+			provide(effect, {
+				prState: prView("OPEN", "QUEUED"),
+				timeline: timelineEvents("added_to_merge_queue"),
+			}),
+		),
+	);
+
+	it.effect("classifies `ejected` from the last timeline event removed_from_merge_queue", () =>
+		Effect.gen(function* () {
+			const signals = yield* (yield* Github).signals(1906, REPO);
+			assert.strictEqual(classify(signals).outcome, "ejected");
+		}).pipe((effect) =>
+			provide(effect, {
+				prState: prView("OPEN"),
+				timeline: timelineEvents("added_to_merge_queue", "removed_from_merge_queue"),
+			}),
+		),
+	);
+
+	it.effect(
+		"classifies `pending` when OPEN with no merge-queue timeline event (the settle window)",
+		() =>
+			Effect.gen(function* () {
+				const signals = yield* (yield* Github).signals(1906, REPO);
+				assert.strictEqual(signals.lastMergeQueueEvent, null);
+				assert.strictEqual(classify(signals).outcome, "pending");
+			}).pipe((effect) => provide(effect, {prState: prView("OPEN", "CLEAN"), timeline: "[]"})),
+	);
+
+	it.effect(
+		"fail-closed: an unreadable timeline recovers to the settle window (null event), not an error",
+		() =>
+			Effect.gen(function* () {
+				// PR state reads clean; the timeline read exits 1 (unprovided). The deliberate
+				// recovery keeps the classifier polling — never a false `merged`/`ejected`.
+				const signals = yield* (yield* Github).signals(1906, REPO);
+				assert.strictEqual(signals.lastMergeQueueEvent, null);
+				assert.strictEqual(classify(signals).outcome, "pending");
+			}).pipe((effect) => provide(effect, {prState: prView("OPEN", "CLEAN")})),
+	);
+
+	it.effect("an unreadable PR state fails GhCommandError (the command maps it to pending)", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip((yield* Github).signals(1906, REPO));
+			assert.isTrue(error instanceof GhCommandError);
+		}).pipe((effect) => provide(effect, {timeline: timelineEvents("added_to_merge_queue")})),
+	);
+
+	it.effect("no --repo override and an unresolvable repo fails RepoResolutionError", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip((yield* Github).signals(1906));
+			assert.isTrue(error instanceof RepoResolutionError);
+		}).pipe((effect) => provide(effect, {prState: prView("OPEN")})),
+	);
+});

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/github.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/github.ts
@@ -1,0 +1,304 @@
+/**
+ * The GitHub boundary for `merge-queue-classify`: the live `Github` capability that reads
+ * the two authoritative ground-truth signals ship-it Step 5.5's reconcile classifies on
+ * (issue #1921), driving the IO-free `classify` core.
+ *
+ * Same service pattern as `verdict/github.ts` / `epic-ledger/github.ts`: a
+ * `Context.Service` on `ChildProcessSpawner` (`.patterns/effect-process-cli-shell.md`),
+ * `gh` REST only (GraphQL is broken on the kamp-us org), every infra failure a typed error
+ * in the `E` channel (`GhCommandError` / `GhParseError` / `RepoResolutionError`), and the
+ * untrusted `gh` JSON `Schema`-decoded at the boundary (`.patterns/effect-schema-validation.md`)
+ * before it reaches the pure classifier. This replaces the prior `execFileSync` + swallowing
+ * `catch { return null }` + unchecked `JSON.parse(...) as {…}` shell (#2738), so a fault surfaces
+ * as a typed `E` the command handles rather than an invisible defect.
+ *
+ * One verb, `signals(pr)`, resolves the whole `MergeQueueSignals` input: the PR `state` +
+ * `mergeStateStatus` from `gh pr view`, and the LAST merge-queue timeline event from
+ * `gh api .../timeline`. The fail-closed-away-from-a-false-ship posture is preserved exactly:
+ * an unreadable repo or PR state propagates as a typed error the command maps to `pending`, and
+ * an unreadable timeline is deliberately recovered to "no event yet" (the settle window) — a
+ * classifier miss can only ever keep polling, never report a false `merged`/`ejected`.
+ */
+import {Config, Context, Effect, Layer, Option, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {
+	type LastMergeQueueEvent,
+	lastMergeQueueEvent,
+	type MergeQueueSignals,
+} from "./merge-queue-classify.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/merge-queue-classify/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the reader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/merge-queue-classify/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/merge-queue-classify/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+// See `verdict/github.ts` `runGh` and `.patterns/effect-process-cli-shell.md`: spawn the handle
+// directly (not `ChildProcessSpawner.string`, which hides the exit code), lower a non-zero exit
+// into `GhCommandError`, and fold a spawn `PlatformError` (e.g. `gh` off PATH) into the same
+// typed error at exit `-1` — the `E` channel carries only this package's errors, never a throw.
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * The env half of repo resolution (ADR 0062 §1), read via `Config` rather than `process.env`
+ * (#2738): `CLAUDE_PIPELINE_REPO`, else `GITHUB_REPOSITORY` (CI). `Config.option` maps an unset
+ * var to `None` instead of a `ConfigError`, so absence is a clean fall-through to `gh repo view`,
+ * not a failure.
+ */
+const repoFromEnv = Config.string("CLAUDE_PIPELINE_REPO").pipe(
+	Config.orElse(() => Config.string("GITHUB_REPOSITORY")),
+	Config.option,
+);
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`. Never silently defaults —
+ * with no env and no resolvable current repo it fails `RepoResolutionError`. A broken config
+ * provider degrades to the same fall-through as an unset var (`orElseSucceed(None)`), so the
+ * method's `E` channel stays this package's own typed errors, never a `ConfigError`.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = yield* repoFromEnv.pipe(Effect.orElseSucceed(() => Option.none<string>()));
+	if (Option.isSome(fromEnv) && REPO_RE.test(fromEnv.value.trim())) {
+		return fromEnv.value.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/merge-queue-classify/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// --- REST arg builders (REST only, never GraphQL) --------------------------------
+
+/**
+ * `gh pr view --json` for the two working fields (the old `merged` field errors
+ * `Unknown JSON field` on this gh/repo, #1921); `merged` is derived from `state == MERGED`.
+ */
+const prStateArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"pr",
+	"view",
+	String(pr),
+	"--repo",
+	repo,
+	"--json",
+	"state,mergeStateStatus",
+	"--jq",
+	"{state: .state, mergeStateStatus: .mergeStateStatus}",
+];
+
+/** The REST issue-timeline endpoint (never GraphQL) — the authoritative queue-membership signal. */
+const timelineArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/${pr}/timeline?per_page=100`,
+	"--paginate",
+];
+
+// --- boundary decoders -----------------------------------------------------------
+
+/** The PR state as `gh pr view` returns it; `state`/`mergeStateStatus` may be absent or null. */
+const RawPrState = Schema.Struct({
+	state: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	mergeStateStatus: Schema.optionalKey(Schema.NullOr(Schema.String)),
+});
+const decodePrState = Schema.decodeUnknownEffect(RawPrState);
+
+/** A timeline entry as the issues/timeline endpoint returns it; only these fields are read. */
+const RawTimelineEntry = Schema.Struct({
+	event: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	created_at: Schema.optionalKey(Schema.NullOr(Schema.String)),
+});
+const decodeTimeline = Schema.decodeUnknownEffect(Schema.Array(RawTimelineEntry));
+
+/** The PR state read the classifier consumes — `merged` derived from `state == MERGED`. */
+interface PrState {
+	readonly merged: boolean;
+	readonly state: string;
+	readonly mergeStateStatus: string | undefined;
+}
+
+const toPrState = (raw: (typeof RawPrState)["Type"]): PrState => {
+	const state = raw.state ?? "";
+	return {
+		merged: state === "MERGED",
+		state,
+		mergeStateStatus: raw.mergeStateStatus ?? undefined,
+	};
+};
+
+// --- IO operations ---------------------------------------------------------------
+
+const readPrState = Effect.fn("Github.readPrState")(function* (repo: string, pr: number) {
+	const args = prStateArgs(repo, pr);
+	return toPrState(yield* decodePrState(yield* parseJson(args, yield* runGh(args))));
+});
+
+/**
+ * The LAST merge-queue timeline event, or `null` when the timeline carries none yet. An
+ * unreadable timeline is DELIBERATELY recovered to `null` here — the fail-closed-away-from-a-
+ * false-ship posture (#1921): a missing event reads as the enqueue-settle window (`pending`),
+ * so a `gh`/parse/shape fault on the timeline can only keep polling, never trigger a false
+ * ejection. The recovered errors are the typed `E` this read raises (not an untyped swallow):
+ * the recovery is scoped to exactly `GhCommandError`/`GhParseError`/`SchemaError` at this one site.
+ */
+const readLastMergeQueueEvent = Effect.fn("Github.readLastMergeQueueEvent")(
+	function* (repo: string, pr: number) {
+		const args = timelineArgs(repo, pr);
+		const raw = yield* runGh(args);
+		// `--paginate` concatenates JSON arrays; normalize `][` joins into one array before parsing.
+		const merged = raw.replace(/\]\s*\[/g, ",");
+		const entries = yield* decodeTimeline(yield* parseJson(args, merged));
+		// The core reads only `event` + `created_at`; project to its exact-optional shape, dropping
+		// a null/absent field to an omitted key rather than an explicit `undefined`.
+		return lastMergeQueueEvent(
+			entries.map((e) => {
+				const entry: {event?: string; created_at?: string} = {};
+				if (e.event != null) entry.event = e.event;
+				if (e.created_at != null) entry.created_at = e.created_at;
+				return entry;
+			}),
+		);
+	},
+	(effect) =>
+		effect.pipe(
+			Effect.catchTags({
+				"@kampus/merge-queue-classify/GhCommandError": () =>
+					Effect.succeed<LastMergeQueueEvent>(null),
+				"@kampus/merge-queue-classify/GhParseError": () =>
+					Effect.succeed<LastMergeQueueEvent>(null),
+				SchemaError: () => Effect.succeed<LastMergeQueueEvent>(null),
+			}),
+		),
+);
+
+const readSignals = Effect.fn("Github.signals")(function* (repo: string, pr: number) {
+	const prState = yield* readPrState(repo, pr);
+	const lastEvent = yield* readLastMergeQueueEvent(repo, pr);
+	return {
+		merged: prState.merged,
+		state: prState.state,
+		lastMergeQueueEvent: lastEvent,
+		mergeStateStatus: prState.mergeStateStatus,
+	} satisfies MergeQueueSignals;
+});
+
+/**
+ * `Github` — the IO shell over `gh` REST for the reconcile's ground-truth reads. `signals(pr,
+ * repoOverride?)` resolves the full `MergeQueueSignals` the pure `classify` consumes; a non-empty
+ * `repoOverride` (the CLI `--repo` flag, ADR 0062 §1's highest precedence) wins over the resolved
+ * repo, else the repo is resolved once (`RepoResolutionError`). An unreadable PR state propagates
+ * typed (the command maps it to `pending`); an unreadable timeline is recovered to the settle
+ * window. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly signals: (
+			pr: number,
+			repoOverride?: string,
+		) => Effect.Effect<
+			MergeQueueSignals,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/merge-queue-classify/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at construction
+ * and provided into each method body, so the public method carries `R = never`. Repo resolution
+ * is deferred to first use (`Effect.cached`, ADR 0062 §1): the layer build is side-effect-free,
+ * and `RepoResolutionError` lives in the method's `E` channel, raised only when `signals` reads —
+ * and never at all when a `--repo` override short-circuits the resolution.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				signals: (pr, repoOverride) => {
+					const resolved =
+						repoOverride !== undefined && repoOverride.trim() !== ""
+							? Effect.succeed(repoOverride.trim())
+							: repo;
+					return resolved.pipe(Effect.flatMap((r) => withSpawner(readSignals(r, pr))));
+				},
+			};
+		}),
+	);


### PR DESCRIPTION
## What & why

Remediates the `merge-queue-classify` tool's Effect-idiom "cosplay" (#2738) — the densest exemplar of the pipeline-cli guard-command debt the `packages/` audit found. The tool's IO was imperative sync (`execFileSync`, swallowing `catch { return null }`, unchecked `JSON.parse(...) as {…}`, `process.env`) wrapped in an Effect shell, so faults leaked as **defects** instead of typed `E`. This aligns it to the gold-standard sibling **`verdict/github.ts` / `epic-ledger/github.ts`** service pattern already in the same package. **No behavior change** (this is a chore).

This is the first of the ~8-tool sequence the issue scopes ("one PR per tool"), starting at the densest exemplar as triage directed. Scope is confined to the `merge-queue-classify/` folder only — no `router.ts` / `eval-harness/*` (that is #2752's scope).

## The transforms (each grounded in the reference + effect-smol `LLMS.md`)

- **`node:child_process` `execFileSync` (x3) → `ChildProcess.make` + `exitCode`** — spawn the handle directly (not `ChildProcessSpawner.string`, which hides the exit code), lower a non-zero exit and a spawn `PlatformError` into a typed `GhCommandError`. Mirrors `verdict/github.ts` `runGh`; grounds in `.patterns/effect-process-cli-shell.md` and `LLMS.md` §"Using Effect.fn" (the variadic `Effect.fn(gen, wrapper)` form).
- **Swallowing `catch { return null }` (x3) → typed `E`** — `RepoResolutionError` / `GhCommandError` / `GhParseError` / `SchemaError` (`LLMS.md` §Errors, `Schema.TaggedErrorClass`). The command maps them to the fail-closed `pending` verdict. The timeline read's null-on-failure is preserved as a **deliberate typed recovery** scoped to exactly those tags via `Effect.catchTags` (`LLMS.md` §"Catch multiple errors") — the documented settle-window posture (#1921), not an untyped swallow.
- **Unchecked `JSON.parse(...) as {…}` (x2) → `parseJson` (typed `GhParseError`) + `Schema.decodeUnknownEffect`** at the boundary for the PR state and timeline entries (`.patterns/effect-schema-validation.md`; CLAUDE.md trust-boundary mandate).
- **`process.env.CLAUDE_PIPELINE_REPO` → `Config`** — read via `Config.string(...).pipe(Config.orElse(...), Config.option)` (`Config` module; `Config<T> extends Effect<T, ConfigError>`, so `Config.option` maps an unset var to `None`, no `ConfigError` in the method channel). Resolution order per ADR 0062 §1: `--repo` → `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`. (This goes one step further than the reference `resolveRepo`, which still reads `process.env` — as the issue's env-axis AC requires.)

The IO moves into a new `Github` `Context.Service` (`github.ts`, `R = ChildProcessSpawner`), and `command.ts` becomes the thin bin consuming it via `Command.provide(GithubLive)` — exactly the `verdict` / `epic-ledger` shape.

## Fail-closed contract preserved

Any read fault resolves to `pending` (still settling), never a false `merged`/`ejected` — a classifier miss can only ever keep polling within the bounded window. The new `github-service.unit.test.ts` proves the classification paths (merged / queued / ejected / pending) **and** the fail-closed posture (unreadable timeline → settle window; unreadable PR state → `GhCommandError`; unresolvable repo → `RepoResolutionError`) over a mock spawner.

## Checks (local)

- `pnpm typecheck` (pipeline-cli `tsc --noEmit`): clean.
- `pnpm exec vitest run` (full pipeline-cli): **1236 passed / 89 files**; the new service test adds 7.
- `biome check` (incl. the Effect-v4 GritQL plugins: `no-context-tag`, `no-data-taggederror`, `no-effect-promise`, `no-raw-try-catch`, `no-type-assertions`): clean.
- pre-commit hooks (biome, leak-guard, primary-index-guard, ref-guard): green.

## ⚠️ Control-plane (§CP) — human-merge-only

Every path is under `packages/pipeline-cli/` (matches `^packages/pipeline-cli/`, ADR 0100/0103). `ship-it` will refuse to auto-merge; `review-code`'s PASS is the verdict a human reads, and **merge authority stops at cansirin**. Do not auto-ship.

Fixes #2738
