### PR TITLE
feat(pipeline): WorktreeCreate hook provisions isolation:worktree with a 600s budget (#2924)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,17 @@
 				]
 			}
 		],
+		"WorktreeCreate": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/create-worktree.sh\"",
+						"timeout": 600
+					}
+				]
+			}
+		],
 		"SessionStart": [
 			{
 				"matcher": "startup|resume",

--- a/.decisions/0178-worktreecreate-hook-provisioning.md
+++ b/.decisions/0178-worktreecreate-hook-provisioning.md
@@ -1,0 +1,112 @@
+---
+id: 0178
+title: A WorktreeCreate Hook Provisions isolation:worktree, Giving the Deps Install a 600s Budget Instead of Racing the Default-Path Timeout
+status: accepted
+date: 2026-07-12
+tags: [pipeline, worktree, tooling, harness]
+---
+
+# 0178 — A `WorktreeCreate` Hook Provisions `isolation:worktree`, Giving the Deps Install a 600s Budget Instead of Racing the Default-Path Timeout
+
+## Context
+
+This extends ADR [0109](0109-worktree-deps-provision-not-share.md). 0109 fixed *what* a
+worktree's deps are (a real `pnpm install`, never a filesystem share) and made the lefthook
+`post-checkout` `bootstrap-deps` hook the correct, version-pinned install that fires on
+`git worktree add`. What 0109 left harness-owned was the *when*: it recommended the harness
+invoke provisioning "once, post-`git worktree add`, with a full PATH." The harness did wire a
+default worktree provisioning path — but that path has an **undocumented readiness timeout**,
+and `isolation:worktree` spawns began non-deterministically **falling back to the primary
+checkout** (a coder/reviewer/shipper that expected a linked worktree lands on primary and
+fail-closes at the Step-4 preflight — the #2924/#2923 lane-down class).
+
+**Measured root cause (grounded, not intuition — per CLAUDE.md's falsifiable-claims rule).**
+The fall-back is a **race**, not disk pressure:
+
+- The `bootstrap-deps` `pnpm install` the default provisioning fires measures **13.4–13.7s**
+  (disk-independent — reproduced across volumes; a warm-store install of the full workspace).
+- The harness default-worktree-path has an **undocumented ~13s readiness limit**. When the
+  install runs long (essentially every time, since 13.4s > ~13s), the default path times out
+  and the harness abandons the worktree, dropping the agent onto primary.
+
+So the two numbers straddle the timeout: a **correct** install (0109's, which we must keep)
+is *just over* the budget the default path allows. #2923 was resolved operationally (a pool
+prune bought margin), but pruning only moves install cost around the ~13s line — it does not
+remove the race. The durable fix is to stop running the install under the racy budget.
+
+## Decision
+
+**Provision `isolation:worktree` via a Claude Code `WorktreeCreate` hook** —
+`claude-plugins/kampus-pipeline/hooks/create-worktree.sh`, registered in `.claude/settings.json`
+(mirrored in the plugin's `hooks.json`) under a `WorktreeCreate` array with `"timeout": 600`.
+The hook **replaces** the harness's default worktree provisioning: it reads the payload's
+`worktree_path` + `base_ref` from stdin, runs `git worktree add --detach "$worktree_path"
+"$base_ref"` itself, and prints only the resulting path to stdout on success. Because the hook
+carries a **600s timeout**, the same 0109 `post-checkout` install (which `git worktree add`
+still fires — we **reuse** it, never reimplement it) now runs inside a generous budget instead
+of racing the ~13s default-path limit. The 13.4s install against a 600s budget has ~44x margin.
+
+**Why this over decoupling the lefthook `post-checkout` install.** The alternative — move the
+install off `post-checkout` so `git worktree add` returns fast, then install separately — would
+change 0109's install contract (the single choke point where a worktree's deps are provisioned
+correctly, `--ignore-scripts` and all) and risk re-opening the shared-`.git/hooks` and
+provision-not-share subtleties 0109 closed. The `WorktreeCreate` hook is **less invasive**: it
+changes *who triggers provisioning and with what timeout*, not *how deps are installed*. 0109's
+`post-checkout` install is preserved verbatim.
+
+**`--detach` deliberately.** A linked worktree cannot check out a `base_ref` that is a *local*
+branch already checked out in the primary (`git worktree add <p> main` fatals with `'main' is
+already checked out`). The coder re-branches off `origin/main` in its Step-4 preflight
+regardless, so the base HEAD is throwaway — a detached checkout at `base_ref`'s commit sidesteps
+the collision and still fires `post-checkout`.
+
+### Documented vs undocumented platform facts
+
+Grounding the mechanism honestly (which parts are contract, which are defended-against guesses):
+
+- **Documented** (Claude Code `WorktreeCreate` mechanism): the hook **replaces** default git
+  provisioning; honors a per-hook `timeout` (here 600s); a **non-zero exit blocks** worktree
+  creation; stdin carries the JSON payload with `worktree_path` + `base_ref`; stdout's path is
+  adopted as the worktree.
+- **Undocumented** (handled defensively, never relied on):
+  - **The hook exec env's PATH.** The sibling harness `git worktree add` strips PATH to
+    `/usr/bin` (#787/ADR 0109); whether the `WorktreeCreate` hook env is stripped too is
+    undocumented. If it were, `bootstrap-deps` would find no pnpm/corepack and clean-SKIP,
+    leaving a **dep-less, useless** worktree. The script therefore **parses first under the
+    inherited PATH**, then prepends the standard toolchain dirs (Homebrew, `/usr/local`,
+    system, `~/.local`) while preserving the inherited PATH — OS/standard dirs only, never a
+    per-machine volta/fnm shim (0109's prohibition).
+  - **The default-path fallback trigger** — the ~13s readiness limit itself is undocumented;
+    it was measured empirically (#2924). The 600s budget is sized to dominate it by a wide
+    margin rather than to a documented number.
+
+### Fail-closed safety
+
+Every failure path in the script exits **non-zero**, and a non-zero `WorktreeCreate` **blocks
+creation** — so the coder lands on the Step-4 worktree preflight and fail-closes there (ADR
+0092). That is **no worse than today's** fall-back-to-primary, and strictly better than the
+silent alternative: the script never emits a path for a worktree it couldn't fully create, so
+there is never a dep-less worktree presented as ready. An absent `worktree_path`, a failed
+`git worktree add`, all refuse loudly.
+
+## Consequences
+
+- **The provisioning race is removed by construction** — the correct 0109 install runs under a
+  600s budget, not the racy ~13s default-path limit, so `isolation:worktree` spawns stop
+  non-deterministically dropping to primary.
+- **0109 is preserved unchanged** — `git worktree add` still fires the same `post-checkout`
+  `bootstrap-deps`; this ADR changes only the trigger + timeout, not the install.
+- **Validation happens on settings reload, post-merge (the one honest caveat).** A
+  `WorktreeCreate` hook takes effect only when Claude Code loads the updated `.claude/settings.json`
+  — i.e. the **live crew sessions must reload/restart after this merges** for the hook to fire.
+  It **cannot be end-to-end validated in a unit test** (that needs a real harness spawn against
+  the reloaded settings); the committed unit test
+  (`packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts`) covers the
+  script's pure logic — stdin parse (jq and jq-less fallback) → the `git worktree add` it runs →
+  the stdout-path contract → the fail-closed exits — against a real throwaway repo, and the live
+  firing is verified on reload.
+- **§CP / control-plane.** This touches `.claude/settings.json` and `packages/pipeline-cli/`,
+  so it is human-merged (cansirin), never auto-shipped.
+- Sibling context: ADR 0109 (the install this reuses), #2924 (this durable fix), #2923 (the
+  acute incident + empirical 13s measurement), #787/#788/#789 (the PATH-strip class defended
+  against here).

--- a/claude-plugins/kampus-pipeline/hooks.json
+++ b/claude-plugins/kampus-pipeline/hooks.json
@@ -69,6 +69,17 @@
 					}
 				]
 			}
+		],
+		"WorktreeCreate": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/create-worktree.sh",
+						"timeout": 600
+					}
+				]
+			}
 		]
 	}
 }

--- a/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
+++ b/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# WorktreeCreate hook: provision an isolation:worktree by running `git worktree add`
+# OURSELVES, so the ~13s bootstrap-deps `pnpm install` gets the hook's 600s timeout
+# budget instead of racing the harness default-worktree-path's ~13s readiness limit
+# (the non-deterministic fall-back-to-primary of #2924/#2923). See ADR 0178.
+#
+# Contract (Claude Code WorktreeCreate mechanism):
+#  * stdin  — a JSON payload carrying `worktree_path` (where to create the tree) and
+#             `base_ref` (the ref to check out). Parsed with jq when present, else a
+#             dependency-free grep/sed fallback (a hook may fire before the CLI/toolchain
+#             is warm, so it must not hard-depend on jq — mirrors guard.sh's fail-soft).
+#  * stdout — ON SUCCESS, ONLY the resulting worktree path (Claude Code adopts it).
+#  * exit   — 0 on success; NON-ZERO on ANY failure. A non-zero WorktreeCreate blocks
+#             creation, so the coder fail-closes on the Step-4 preflight — no worse than
+#             today's fall-back-to-primary, and never a silently dep-less worktree.
+#
+# `git worktree add` fires the existing lefthook post-checkout `bootstrap-deps` install
+# (ADR 0109) — we REUSE it, never reimplement it, so 0109's provision-not-share
+# correctness is preserved unchanged.
+
+set -u
+
+# Parse the payload FIRST, under the inherited PATH — before the defensive toolchain PATH
+# below. Parsing needs only jq-or-coreutils, and keeping it ahead of the toolchain prepend
+# is what lets the jq-vs-fallback branch be forced under a controlled PATH (the unit test's
+# `env -i`), rather than always resolving jq from a hardcoded standard dir.
+payload="$(cat)"
+
+# Extract a scalar field from the JSON payload — jq when available, else a robust
+# grep/sed fallback for the flat `"key": "value"` shape WorktreeCreate emits (a hook may
+# fire before the toolchain is warm, so it must not hard-depend on jq — like guard.sh).
+extract() {
+	local key="$1"
+	if command -v jq >/dev/null 2>&1; then
+		printf '%s' "$payload" | jq -r --arg k "$key" '.[$k] // empty'
+	else
+		printf '%s' "$payload" \
+			| grep -o "\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+			| head -n1 \
+			| sed -E "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"([^\"]*)\".*/\1/"
+	fi
+}
+
+worktree_path="$(extract worktree_path)"
+base_ref="$(extract base_ref)"
+
+# worktree_path is mandatory — with no destination there is nothing to create.
+if [ -z "$worktree_path" ]; then
+	echo "create-worktree: no worktree_path in the WorktreeCreate payload — cannot provision." >&2
+	exit 1
+fi
+
+# base_ref may be absent; fall back to origin/main (the default base every coder branches
+# from) so a payload that omits it still yields a usable tree rather than a hard failure.
+if [ -z "$base_ref" ]; then
+	base_ref="origin/main"
+fi
+
+# NOW ensure a full PATH for git + the post-checkout `pnpm install` it fires. The hook exec
+# env's PATH handling is UNDOCUMENTED (the sibling harness `git worktree add` strips PATH to
+# /usr/bin — #787/ADR 0109); if that stripping applies here too, `bootstrap-deps` finds no
+# pnpm/corepack and clean-SKIPs, leaving the tree dep-less and useless. Prepend the standard
+# toolchain locations (Homebrew, /usr/local, system, ~/.local) while PRESERVING the inherited
+# PATH (kept last) — OS/standard dirs only, never a per-machine volta/fnm shim (ADR 0109).
+export PATH="/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin:${HOME:-}/.local/bin:${PATH:-}"
+
+# `--detach` deliberately: a linked worktree can't check out a base_ref that is a LOCAL
+# branch already checked out in the primary (`git worktree add <p> main` fatals with
+# 'main is already checked out') — and the coder re-branches off origin/main in its Step-4
+# preflight regardless, so the base HEAD is throwaway. A detached checkout at base_ref's
+# commit sidesteps the collision and still fires post-checkout (ADR 0109 provisioning).
+if ! git worktree add --detach "$worktree_path" "$base_ref" >&2; then
+	echo "create-worktree: git worktree add --detach '$worktree_path' '$base_ref' failed — refusing (fail-closed)." >&2
+	exit 1
+fi
+
+# Success: emit ONLY the path on stdout (all git/install chatter went to stderr above).
+printf '%s\n' "$worktree_path"

--- a/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit guard for the WorktreeCreate hook script (create-worktree.sh, #2924/ADR 0178):
+ * the script parses a WorktreeCreate JSON payload from stdin, runs `git worktree add`,
+ * and prints ONLY the resulting path to stdout on success (non-zero on any failure).
+ *
+ * This drives the REAL script against a REAL throwaway git repo — the same
+ * against-a-real-repo idiom as command.hook.test.ts. The temp repo has NO lefthook
+ * config, so `git worktree add` here does NOT fire the phoenix post-checkout
+ * `bootstrap-deps` install (that ~13s install, and the live 600s-budgeted harness
+ * firing that motivates the whole hook, cannot be reproduced in a unit test — it only
+ * fires on a real harness spawn after a settings reload). What IS unit-testable, and is
+ * what this asserts, is the script's PURE decision logic: stdin JSON parse → the git
+ * command it runs → the stdout path contract → the fail-closed exit on bad input.
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, mkdtempSync, rmSync, symlinkSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+const SCRIPT = fileURLToPath(
+	new URL(
+		"../../../../../claude-plugins/kampus-pipeline/hooks/create-worktree.sh",
+		import.meta.url,
+	),
+);
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+describe("create-worktree.sh — WorktreeCreate hook against a REAL git repo (#2924)", () => {
+	let mainRepo: string;
+	const git = (cwd: string, ...args: string[]) =>
+		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
+
+	// Run the hook script with `payload` on stdin, cwd inside the repo — exactly as
+	// Claude Code fires it. Never throws: a non-zero exit is captured, not raised.
+	const run = (cwd: string, payload: string): RunResult => {
+		try {
+			const stdout = execFileSync("bash", [SCRIPT], {cwd, input: payload, encoding: "utf8"});
+			return {code: 0, stdout, stderr: ""};
+		} catch (e) {
+			const err = e as {status?: number; stdout?: string; stderr?: string};
+			return {code: err.status ?? 1, stdout: err.stdout ?? "", stderr: err.stderr ?? ""};
+		}
+	};
+
+	beforeAll(() => {
+		mainRepo = mkdtempSync(join(tmpdir(), "wtc-main-"));
+		git(mainRepo, "init", "-q", "-b", "main");
+		git(mainRepo, "config", "user.email", "t@t.t");
+		git(mainRepo, "config", "user.name", "t");
+		writeFileSync(join(mainRepo, "README.md"), "x");
+		git(mainRepo, "add", ".");
+		git(mainRepo, "commit", "-q", "-m", "init");
+	});
+
+	afterAll(() => rmSync(mainRepo, {recursive: true, force: true}));
+
+	it("creates the worktree at worktree_path from base_ref and prints ONLY that path", () => {
+		const wt = join(mainRepo, ".claude", "worktrees", "wtc_ok");
+		const payload = JSON.stringify({worktree_path: wt, base_ref: "main"});
+		const {code, stdout} = run(mainRepo, payload);
+		assert.strictEqual(code, 0);
+		assert.strictEqual(stdout.trim(), wt, "stdout must be ONLY the resulting worktree path");
+		assert.isTrue(existsSync(wt), "the worktree must actually be created");
+		assert.isTrue(existsSync(join(wt, "README.md")), "base_ref's tree must be checked out");
+	});
+
+	it("defaults base_ref to origin/main when the payload omits it", () => {
+		// Point origin at self so origin/main resolves inside the throwaway repo.
+		git(mainRepo, "remote", "add", "origin", mainRepo);
+		git(mainRepo, "fetch", "-q", "origin");
+		const wt = join(mainRepo, ".claude", "worktrees", "wtc_default");
+		const {code, stdout} = run(mainRepo, JSON.stringify({worktree_path: wt}));
+		assert.strictEqual(code, 0, "a payload without base_ref still provisions from origin/main");
+		assert.strictEqual(stdout.trim(), wt);
+		assert.isTrue(existsSync(wt));
+	});
+
+	it("parses correctly without jq (grep/sed fallback) — the same result", () => {
+		// Force the jq-less branch deterministically across OSes: run under `env -i` with a
+		// PATH pointing at a bindir that has ONLY the tools the parse needs (bash + coreutils),
+		// and crucially NO jq. The script parses under this PATH before it prepends the standard
+		// toolchain dirs, so `command -v jq` genuinely misses and the grep/sed fallback runs.
+		const bindir = mkdtempSync(join(tmpdir(), "wtc-nojq-bin-"));
+		const which = (tool: string) =>
+			execFileSync("bash", ["-lc", `command -v ${tool}`], {encoding: "utf8"}).trim();
+		for (const tool of ["bash", "cat", "grep", "sed", "head", "git", "printf"]) {
+			try {
+				symlinkSync(which(tool), join(bindir, tool));
+			} catch {
+				/* printf is often a shell builtin with no binary — the parse still works without it */
+			}
+		}
+		const wt = join(mainRepo, ".claude", "worktrees", "wtc_nojq");
+		const payload = JSON.stringify({worktree_path: wt, base_ref: "main"});
+		let stdout = "";
+		let code = 0;
+		try {
+			stdout = execFileSync("bash", [SCRIPT], {
+				cwd: mainRepo,
+				input: payload,
+				encoding: "utf8",
+				// env -i: PATH=bindir ONLY (jq-free — no /usr/bin, which carries jq on Linux) so
+				// the parse deterministically takes the fallback; the script re-adds the standard
+				// toolchain dirs AFTER parsing, so git still resolves for `worktree add`.
+				env: {PATH: bindir, HOME: mainRepo},
+			});
+		} catch (e) {
+			const err = e as {status?: number; stdout?: string};
+			code = err.status ?? 1;
+			stdout = err.stdout ?? "";
+		} finally {
+			rmSync(bindir, {recursive: true, force: true});
+		}
+		assert.strictEqual(code, 0);
+		assert.strictEqual(stdout.trim(), wt, "the jq-less fallback must extract the same path");
+		assert.isTrue(existsSync(wt));
+	});
+
+	it("fail-closes (non-zero) when worktree_path is absent — never a silent no-op", () => {
+		const {code} = run(mainRepo, JSON.stringify({base_ref: "main"}));
+		assert.notStrictEqual(code, 0, "a payload with no worktree_path must be rejected");
+	});
+
+	it("fail-closes (non-zero) when git worktree add fails (bad base_ref)", () => {
+		const wt = join(mainRepo, ".claude", "worktrees", "wtc_badref");
+		const {code} = run(mainRepo, JSON.stringify({worktree_path: wt, base_ref: "no-such-ref"}));
+		assert.notStrictEqual(code, 0, "a non-existent base_ref must fail-close, blocking creation");
+		assert.isFalse(existsSync(wt), "no partial worktree should be left behind");
+	});
+});


### PR DESCRIPTION
Fixes #2924

## What this is — §CP / harness-critical

Every `isolation:worktree` spawn was provisioned via the harness **default worktree path**, whose **undocumented ~13s readiness limit** races the `bootstrap-deps` `pnpm install` (measured **13.4–13.7s**, disk-independent — #2924/#2923). The two numbers straddle: a *correct* install (ADR 0109's) is *just over* the default-path budget, so the harness abandons the worktree and the agent falls back to primary and fail-closes. #2923 was resolved operationally (a pool prune bought margin); this is the **durable** fix — stop running the install under the racy budget.

This adds a Claude Code **`WorktreeCreate` hook** (`claude-plugins/kampus-pipeline/hooks/create-worktree.sh`) that **replaces** the default provisioning: reads `worktree_path` + `base_ref` from stdin, runs `git worktree add --detach` itself (which still fires the **existing ADR 0109 `post-checkout` install — reused, not reimplemented**), and prints only the resulting path on success. Registered in `.claude/settings.json` and mirrored in `hooks.json` with **`"timeout": 600`**, so the 13s install runs inside a ~44x-margin budget instead of racing the ~13s limit.

**Direction note:** issue #2924's body proposed pool-bounding GC; the EM redirected to this `WorktreeCreate`-hook approach, which removes the provisioning *race* at the root (GC only moves install cost around the ~13s line, it doesn't remove the race). ADR 0178 records the reasoning.

## Undocumented risks + how the script defends

- **PATH-stripping (undocumented).** The sibling harness `git worktree add` strips PATH to `/usr/bin` (#787/ADR 0109); whether the `WorktreeCreate` env is stripped too is undocumented. If it were, `bootstrap-deps` finds no pnpm/corepack and clean-SKIPs → a dep-less, useless worktree. The script **parses the payload first under the inherited PATH**, then **prepends the standard toolchain dirs** (Homebrew, `/usr/local`, system, `~/.local`) preserving the inherited PATH — OS/standard dirs only, never a per-machine volta/fnm shim (ADR 0109's prohibition). This is load-bearing: no PATH, no install, no usable tree.
- **Default-path fallback trigger (undocumented).** The ~13s limit itself is undocumented; it was measured empirically. The 600s budget is sized to dominate it, not to a documented number.
- **`--detach` deliberately.** A linked worktree can't check out a `base_ref` that is a local branch already checked out in primary (`'main' is already checked out`). The coder re-branches off `origin/main` in its Step-4 preflight anyway, so a detached base sidesteps the collision and still fires `post-checkout`.

## Fail-closed safety

Every failure path exits **non-zero**, and a non-zero `WorktreeCreate` **blocks creation** — so the coder lands on the Step-4 worktree preflight and fail-closes there (no worse than today's fall-back-to-primary, and strictly better than a silent dep-less worktree, which never happens: no path is emitted for a tree that wasn't fully created).

## Documented `WorktreeCreate` facts relied on

Replaces default provisioning · honors per-hook `timeout` (600s) · non-zero exit blocks creation · stdin carries `worktree_path` + `base_ref` · stdout path is adopted.

## Testing + the validation caveat

- Unit test (`packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts`) drives the **real script against a real throwaway repo**, asserting the pure logic: stdin JSON parse (jq **and** the jq-less grep/sed fallback, forced deterministically via `env -i`) → the `git worktree add` it runs → the stdout-path contract → the fail-closed exits on absent `worktree_path` / bad `base_ref`. Full pipeline-cli suite green (1246 tests).
- **End-to-end validation happens on settings reload, post-merge.** A `WorktreeCreate` hook takes effect only when Claude Code reloads `.claude/settings.json` — the live crew sessions must **reload/restart after this merges** for the hook to fire. It cannot be end-to-end tested here (that needs a real harness spawn against reloaded settings).

## §CP

Touches `.claude/settings.json` + `packages/pipeline-cli/` → control-plane, human-merged (cansirin), not auto-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)