### PR TITLE
revert(pipeline): drop the #2925 WorktreeCreate hook registration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,17 +52,6 @@
 				]
 			}
 		],
-		"WorktreeCreate": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/create-worktree.sh\"",
-						"timeout": 600
-					}
-				]
-			}
-		],
 		"SessionStart": [
 			{
 				"matcher": "startup|resume",

--- a/claude-plugins/kampus-pipeline/hooks.json
+++ b/claude-plugins/kampus-pipeline/hooks.json
@@ -69,17 +69,6 @@
 					}
 				]
 			}
-		],
-		"WorktreeCreate": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/create-worktree.sh",
-						"timeout": 600
-					}
-				]
-			}
 		]
 	}
 }


### PR DESCRIPTION
## Emergency revert

This reverts **only** the #2925 `WorktreeCreate` hook *registration* to restore default `isolation:worktree` provisioning.

### Why
The hook registered in #2925 was built to a wrong inferred payload contract. The real `WorktreeCreate` payload has **no `worktree_path`** field, so the handler fail-closed and **blocked worktree creation on every `isolation:worktree` spawn crew-wide** — halting the whole pipeline.

### What this changes
- `.claude/settings.json` — removed the `WorktreeCreate` hook array (command `create-worktree.sh`, timeout 600).
- `claude-plugins/kampus-pipeline/hooks.json` — removed the mirrored `WorktreeCreate` array (and fixed the trailing comma so the JSON stays valid).

Minimal diff: 2 files, 22 deletions. Nothing else in either file was reformatted or reordered. Both files validate as JSON and pass Biome.

### What this deliberately keeps (inert, as the base for the corrected re-attempt)
Left unchanged in-tree so the fix-forward has a foundation:
- `claude-plugins/kampus-pipeline/hooks/create-worktree.sh`
- `packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts`
- `.decisions/0178-worktreecreate-hook-provisioning.md`

The corrected re-attempt (construct the worktree path from the real payload's `name` + `cwd`) is tracked under #2936 and gated on the #2935 golden-real-payload-fixture harness.

### Issue linkage
- Reverts the registration from #2925.
- Fix-forward gated on #2935 (golden-real-payload fixture) and re-attempt #2936.
- **Does not close #2924** — the provisioning goal is being properly re-solved under #2935/#2936; referenced, not closed.