### PR TITLE
feat(flags): shell-key manifest + phoenix-edge-shell-boot flag + fail-closed drift check (#2928)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -44,6 +44,7 @@ import {
 	authorshipLoopFlag,
 	bildirimFlag,
 	demoTargetingFlag,
+	edgeShellBootFlag,
 	emailDeliveryAdminFlag,
 	emailDeliveryNoticeFlag,
 	Flagship,
@@ -176,6 +177,10 @@ export default Alchemy.Stack(
 		// single seam the /admin route + client probe + worker `admin.probe` read gate
 		// behind until a human release, so the console ships dark (no chunk fetched).
 		yield* adminConsoleFlag(flagship.appId);
+		// The edge-resolved shell-boot dark-ship flag, default-off (#2928, epic #2926, ADR
+		// 0179) — the single seam the worker-first shell render + `window.__BOOT__` injection
+		// ships behind: off ⇒ edge-direct HTML byte-identical to today, until a human release.
+		yield* edgeShellBootFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -294,6 +294,18 @@ export const PHOENIX_NAV_IA = "phoenix-nav-ia";
  */
 export const PHOENIX_ADMIN_CONSOLE = "phoenix-admin-console";
 
+/**
+ * Edge-resolved shell-boot containment flag (#2928, epic #2926, ADR 0179). The SINGLE seam
+ * the whole worker-first shell render ships behind — with it OFF the SPA HTML stays
+ * edge-direct byte-identical to today (the `assets` binding serves it, the worker never
+ * touches it); with it ON the worker renders the shell per request and injects
+ * `window.__BOOT__` (the shell-key manifest flags under full-session userId context +
+ * `signedIn`). Default-off so the whole edge-render path reaches production dark until a
+ * human flips it at release (ADR 0083). Its own cross-cutting (`phoenix`) key — the render
+ * path spans every product's shell geometry.
+ */
+export const PHOENIX_EDGE_SHELL_BOOT = "phoenix-edge-shell-boot";
+
 /** A declared flag paired with its default variation — the row the flags console lists (#2742). */
 export interface FlagDeclaration {
 	readonly key: string;
@@ -335,4 +347,5 @@ export const DECLARED_FLAGS: readonly FlagDeclaration[] = [
 	{key: PHOENIX_EMAIL_DELIVERY_NOTICE, defaultValue: false},
 	{key: PHOENIX_NAV_IA, defaultValue: false},
 	{key: PHOENIX_ADMIN_CONSOLE, defaultValue: false},
+	{key: PHOENIX_EDGE_SHELL_BOOT, defaultValue: false},
 ];

--- a/apps/web/src/flags/shell-keys.test.ts
+++ b/apps/web/src/flags/shell-keys.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The fail-closed drift check for the shell-key manifest (#2928, ADR 0179 §3): the worker
+ * injects `window.__BOOT__` and the client reads it, and this proves BOTH key sets derive
+ * from the one manifest — a divergence throws. Deliberately an in-app unit test, NOT a
+ * `pipeline-cli` CI guard, so this slice stays NON-§CP (#2928).
+ */
+import {describe, expect, it} from "vitest";
+import {MECMUA_FEED, MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "./keys";
+import {
+	assertShellBootKeysSingleSourced,
+	BOOT_MEMBER_KEYS,
+	SHELL_FLAG_KEYS,
+	SHELL_SIGNED_IN_KEY,
+	ShellKeyDriftError,
+} from "./shell-keys";
+
+describe("shell-key manifest — the geometry-law member set", () => {
+	it("names exactly the three shell-critical flag keys", () => {
+		expect([...SHELL_FLAG_KEYS]).toEqual([PHOENIX_NAV_IA, MECMUA_PUBLIC_READ, MECMUA_FEED]);
+		expect([...SHELL_FLAG_KEYS]).toEqual(["phoenix-nav-ia", "mecmua-public-read", "mecmua-feed"]);
+	});
+
+	it("the __BOOT__ shape is the flag keys plus the signedIn presence bit", () => {
+		expect(SHELL_SIGNED_IN_KEY).toBe("signedIn");
+		expect([...BOOT_MEMBER_KEYS]).toEqual([...SHELL_FLAG_KEYS, "signedIn"]);
+	});
+
+	it("signedIn is part of the __BOOT__ shape but is NOT a flag key", () => {
+		expect([...SHELL_FLAG_KEYS]).not.toContain(SHELL_SIGNED_IN_KEY);
+	});
+});
+
+describe("assertShellBootKeysSingleSourced — fail-closed single-source guard", () => {
+	// The seam both sides derive from the manifest: the worker injects BOOT_MEMBER_KEYS, the
+	// client reads BOOT_MEMBER_KEYS — the shared-source case the guard must accept.
+	const canonical = [...BOOT_MEMBER_KEYS];
+
+	it("accepts when the worker-injected and client-consumed sets both derive from the manifest", () => {
+		expect(() => assertShellBootKeysSingleSourced(canonical, canonical)).not.toThrow();
+	});
+
+	it("accepts regardless of key ordering (a set, not a sequence)", () => {
+		expect(() =>
+			assertShellBootKeysSingleSourced(canonical, [...canonical].reverse()),
+		).not.toThrow();
+	});
+
+	it("FAILS when the worker injection omits a manifest key (worker-side drift)", () => {
+		const injectedMissingFeed = canonical.filter((k) => k !== MECMUA_FEED);
+		expect(() => assertShellBootKeysSingleSourced(injectedMissingFeed, canonical)).toThrow(
+			ShellKeyDriftError,
+		);
+	});
+
+	it("FAILS when the client consumption adds a key the manifest does not name (client-side drift)", () => {
+		const consumedWithExtra = [...canonical, "phoenix-not-a-shell-key"];
+		expect(() => assertShellBootKeysSingleSourced(canonical, consumedWithExtra)).toThrow(
+			ShellKeyDriftError,
+		);
+	});
+
+	it("FAILS when the client omits the signedIn presence bit (the non-flag member still drifts)", () => {
+		const consumedMissingSignedIn = canonical.filter((k) => k !== SHELL_SIGNED_IN_KEY);
+		expect(() => assertShellBootKeysSingleSourced(canonical, consumedMissingSignedIn)).toThrow(
+			ShellKeyDriftError,
+		);
+	});
+
+	it("names the drifting side and the missing/extra keys in the error", () => {
+		try {
+			assertShellBootKeysSingleSourced(
+				canonical.filter((k) => k !== PHOENIX_NAV_IA),
+				canonical,
+			);
+			expect.unreachable("expected a ShellKeyDriftError");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ShellKeyDriftError);
+			const drift = err as ShellKeyDriftError;
+			expect(drift.side).toContain("worker");
+			expect(drift.missing).toContain(PHOENIX_NAV_IA);
+			expect(drift.extra).toEqual([]);
+		}
+	});
+});

--- a/apps/web/src/flags/shell-keys.ts
+++ b/apps/web/src/flags/shell-keys.ts
@@ -1,0 +1,98 @@
+/**
+ * The shell-key manifest — the single declared source of the shell-critical flag keys
+ * that the worker resolves at the edge and injects into `window.__BOOT__`, consumed
+ * synchronously by the client (ADR 0179, the `__BOOT__` contract). The same
+ * single-source idiom as the fanned-mutations classifier (ADR 0155): ONE declared list
+ * both bundles import, so the injected key set and the consumed key set can never drift.
+ *
+ * A plain-string module (no alchemy/React import) so it is safe in the worker bundle AND
+ * the SPA bundle, mirroring the sibling {@link file://./keys.ts} and `src/lib/fateWireCodes.ts`.
+ * The key *strings* are single-homed in `keys.ts`; this manifest names the subset that is
+ * shell-critical, so it can never name a string the flag registry doesn't declare.
+ *
+ * The fail-closed drift guard is {@link assertShellBootKeysSingleSourced}. It is a pure,
+ * in-app unit-tested check that lives in the same bundle as the manifest — deliberately
+ * NOT a `pipeline-cli` CI guard (#2928): a CI guard would touch `packages/pipeline-cli/**`
+ * and flip this slice §CP-blocking-for-merge. If a CI-level guard is wanted later it is its
+ * own §CP child.
+ *
+ * Inert until the edge-render children consume it (#2929 worker injection, #2932 unified
+ * `useFlag`): this module introduces no runtime behavior on its own.
+ */
+import {MECMUA_FEED, MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "./keys.ts";
+
+/**
+ * The shell-critical flag keys — the `__BOOT__`-member flags whose wrong value moves
+ * geometry at first paint (ADR 0179 §1, the geometry law). Exactly the three nav-shaping
+ * flags and nothing else; below-fold flags stay on the client fetch path.
+ */
+export const SHELL_FLAG_KEYS = [PHOENIX_NAV_IA, MECMUA_PUBLIC_READ, MECMUA_FEED] as const;
+
+export type ShellFlagKey = (typeof SHELL_FLAG_KEYS)[number];
+
+/**
+ * The session-presence bit. Part of the `__BOOT__` shape but NOT a flag key — it drives
+ * shell geometry directly (signed-in ⇒ reserved chip slots, ADR 0179 §1) while `useSession`
+ * settles, rather than resolving through the flag evaluator.
+ */
+export const SHELL_SIGNED_IN_KEY = "signedIn" as const;
+
+/**
+ * The full `__BOOT__` member key set — the shell flag keys plus the presence bit. This is
+ * the shape the worker injects and the client reads; both sides derive from this one array,
+ * enforced by {@link assertShellBootKeysSingleSourced}.
+ */
+export const BOOT_MEMBER_KEYS = [...SHELL_FLAG_KEYS, SHELL_SIGNED_IN_KEY] as const;
+
+export type BootMemberKey = (typeof BOOT_MEMBER_KEYS)[number];
+
+/** A drift between a bundle's `__BOOT__` key set and the manifest — the fail-closed signal. */
+export class ShellKeyDriftError extends Error {
+	readonly side: string;
+	readonly missing: readonly string[];
+	readonly extra: readonly string[];
+
+	constructor(side: string, missing: readonly string[], extra: readonly string[]) {
+		super(
+			`shell-key manifest drift on the ${side} side: ` +
+				`missing [${missing.join(", ")}] extra [${extra.join(", ")}] ` +
+				`— the injected and consumed __BOOT__ key sets MUST both derive from BOOT_MEMBER_KEYS (ADR 0179 §3).`,
+		);
+		this.name = "ShellKeyDriftError";
+		this.side = side;
+		this.missing = missing;
+		this.extra = extra;
+	}
+}
+
+/**
+ * Fail-closed: assert a candidate `__BOOT__` key set is EXACTLY the manifest's — any missing
+ * or extra key throws {@link ShellKeyDriftError}. `side` names the seam for the error message.
+ */
+function assertKeySetIsManifest(side: string, candidate: readonly string[]): void {
+	const canonical = new Set<string>(BOOT_MEMBER_KEYS);
+	const seen = new Set<string>(candidate);
+	const missing = [...canonical].filter((k) => !seen.has(k));
+	const extra = [...seen].filter((k) => !canonical.has(k));
+	if (missing.length > 0 || extra.length > 0) {
+		throw new ShellKeyDriftError(side, missing, extra);
+	}
+}
+
+/**
+ * The single-source drift guard (ADR 0179 §3, fanned-mutations idiom of ADR 0155): assert
+ * BOTH the worker-injected `__BOOT__` key set and the client-consumed key set derive from the
+ * one manifest. A divergence on either seam throws — so a shell key added/removed on one side
+ * without the other is caught, fail-closed, before it can staleness-break the shell.
+ *
+ * Both sides pass the keys they actually inject / read; each is checked against
+ * {@link BOOT_MEMBER_KEYS}. Called at each seam by the consuming children AND unit-tested here,
+ * so the invariant holds at authoring time and at runtime.
+ */
+export function assertShellBootKeysSingleSourced(
+	injected: readonly string[],
+	consumed: readonly string[],
+): void {
+	assertKeySetIsManifest("worker __BOOT__ injection", injected);
+	assertKeySetIsManifest("client __BOOT__ consumption", consumed);
+}

--- a/apps/web/tsconfig.worker.json
+++ b/apps/web/tsconfig.worker.json
@@ -19,6 +19,7 @@
 		"src/lib/panoTags.ts",
 		"src/lib/panoFeedSort.ts",
 		"src/flags/keys.ts",
+		"src/flags/shell-keys.ts",
 		"alchemy.run.ts",
 		// The black-box integration suite (Vitest node pool → HTTP against the
 		// deployed worker) belongs to the worker project: it needs the same `.ts`

--- a/apps/web/worker/features/flagship/edge-shell-boot.invariant.test.ts
+++ b/apps/web/worker/features/flagship/edge-shell-boot.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the edge-resolved shell-boot flag (#2928,
+ * epic #2926, ADR 0179). Inspected off the exported `EDGE_SHELL_BOOT_FLAG` record (the same
+ * object the factory spreads into `FlagshipFlag`), so no alchemy resource is constructed —
+ * mirrors `nav-ia.invariant.test.ts` (#2598). Off ⇒ the SPA HTML stays edge-direct today.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_EDGE_SHELL_BOOT} from "../../../src/flags/keys.ts";
+import {EDGE_SHELL_BOOT_FLAG, edgeShellBootFlag} from "./resources.ts";
+
+describe("edge-resolved shell-boot — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(EDGE_SHELL_BOOT_FLAG.defaultVariation, "off");
+		assert.strictEqual(EDGE_SHELL_BOOT_FLAG.variations.off, false);
+		assert.strictEqual(EDGE_SHELL_BOOT_FLAG.variations.on, true);
+		assert.strictEqual(EDGE_SHELL_BOOT_FLAG.key, "phoenix-edge-shell-boot");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(EDGE_SHELL_BOOT_FLAG.key, PHOENIX_EDGE_SHELL_BOOT);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof edgeShellBootFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -24,6 +24,7 @@ import {
 	PHOENIX_ADMIN_CONSOLE,
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_BILDIRIM,
+	PHOENIX_EDGE_SHELL_BOOT,
 	PHOENIX_EMAIL_DELIVERY_ADMIN,
 	PHOENIX_EMAIL_DELIVERY_NOTICE,
 	PHOENIX_FUNNEL_READOUT,
@@ -1027,3 +1028,35 @@ export const ADMIN_CONSOLE_FLAG = {
  */
 export const adminConsoleFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_admin_console", {appId, ...ADMIN_CONSOLE_FLAG});
+
+/**
+ * The edge-resolved shell-boot containment flag config (#2928, epic #2926, ADR 0179). The
+ * SINGLE seam the whole worker-first shell render ships behind. Default-OFF so the edge-render
+ * path reaches production dark: with it off the SPA HTML stays edge-direct byte-identical to
+ * today (the `assets` binding serves it, the worker never touches HTML); flipping it on has the
+ * worker render the shell per request and inject `window.__BOOT__`. Flipping it on is the human
+ * release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable WITHOUT
+ * constructing the alchemy resource (mirrors `NAV_IA_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           edge-shell (the worker-first shell render, epic #2926)
+ *   - originating:     #2928 (epic: edge-resolved shell state, #2926)
+ *   - removal trigger: once the edge shell render graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline the worker-first render.
+ */
+export const EDGE_SHELL_BOOT_FLAG = {
+	key: PHOENIX_EDGE_SHELL_BOOT,
+	description:
+		"edge-resolved shell-boot (worker-first shell render + __BOOT__ injection) dark-ship (#2928, epic #2926, ADR 0179). owner: edge-shell. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const edgeShellBootFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_edge_shell_boot", {appId, ...EDGE_SHELL_BOOT_FLAG});


### PR DESCRIPTION
The shared substrate the edge-resolved shell-state epic (#2926, ADR 0179 — the `window.__BOOT__` contract) builds against. Phase-2 child; the ADR (#2927 / ADR 0179) has landed.

## What this adds
- **Shell-key manifest** (`apps/web/src/flags/shell-keys.ts`) — the single declared source of the shell-critical `__BOOT__`-member flag keys (`PHOENIX_NAV_IA`, `MECMUA_PUBLIC_READ`, `MECMUA_FEED`) plus the `signedIn` presence bit (part of the `__BOOT__` shape, not a flag key). A plain-string module importable from **both** the worker and SPA bundles (added to `tsconfig.worker.json`'s cross-include), following the fanned-mutations single-source idiom (ADR 0155). One list, both sides — the key strings stay single-homed in `keys.ts`.
- **Fail-closed drift guard** — `assertShellBootKeysSingleSourced(injected, consumed)` asserts the worker-injected `__BOOT__` key set and the client-consumed key set both derive from the one manifest (`BOOT_MEMBER_KEYS`); any missing/extra key on either seam throws `ShellKeyDriftError`.
- **`PHOENIX_EDGE_SHELL_BOOT = "phoenix-edge-shell-boot"`** containment flag, default-off: `keys.ts` constant + `DECLARED_FLAGS` row, `worker/features/flagship/resources.ts` config (`EDGE_SHELL_BOOT_FLAG`) + factory (`edgeShellBootFlag`), and `alchemy.run.ts` wiring. With it off the SPA HTML stays edge-direct byte-identical to today.

## The §CP boundary (deliberate)
The drift check is an **in-app unit test** (`apps/web/src/flags/shell-keys.test.ts`), **not** a `pipeline-cli` CI guard. A pipeline-cli guard would touch `packages/pipeline-cli/**` and flip this slice §CP-blocking-for-merge — out of scope by #2928's hard boundary. If a CI-level guard is wanted later it is its own §CP child.

## Acceptance criteria
- [x] Shell-key manifest module, importable from both worker + SPA bundle, enumerating exactly the shell-critical `__BOOT__`-member flag keys.
- [x] `PHOENIX_EDGE_SHELL_BOOT = "phoenix-edge-shell-boot"` declared in `keys.ts` with a default-off `DECLARED_FLAGS` row and a matching `resources.ts` declaration.
- [x] Unit-tested fail-closed check proves the worker-injected key set and client-consumed key set both derive from the one manifest (divergence fails the test).
- [x] Inert at runtime on its own — no behavior change until the worker-injection child (#2929) consumes it.

## Verification
- `pnpm typecheck` clean (full workspace, `tsgo`).
- `pnpm lint:worktree` clean.
- New tests green: `shell-keys.test.ts` (9), `edge-shell-boot.invariant.test.ts` (3), `flags-module.test.ts` (unchanged, DECLARED_FLAGS still unique).

Fixes #2928
Flag: phoenix-edge-shell-boot