### PR TITLE
refactor(pipeline-cli): remediate residual Effect-v4 idioms in tool modules (#2922)

### DIFF
--- a/packages/pipeline-cli/src/tools/changelog-derive/command.ts
+++ b/packages/pipeline-cli/src/tools/changelog-derive/command.ts
@@ -18,15 +18,15 @@
  * `runMain` wiring is dropped — the shared `pipeline-cli` bin owns the run boundary.
  */
 import {readFileSync, writeFileSync} from "node:fs";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
 import {type ChangelogEntry, deriveChangelog, type ReleaseMeta} from "./changelog.ts";
 
-class EntriesReadError extends Data.TaggedError("EntriesReadError")<{
-	readonly file: string;
-	readonly cause: unknown;
-}> {}
+class EntriesReadError extends Schema.TaggedErrorClass<EntriesReadError>()("EntriesReadError", {
+	file: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** One entry as the gathered JSON carries it; decoded at this boundary. */
 const EntrySchema = Schema.Struct({

--- a/packages/pipeline-cli/src/tools/gh-phoenix/command.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/command.ts
@@ -29,22 +29,23 @@
  */
 import {readFileSync} from "node:fs";
 import {isZeroScope, type LintResult, lintCorpus, type ScanFile} from "@kampus/gh-phoenix";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect, Result} from "effect";
+import * as Schema from "effect/Schema";
 import {Argument, Command} from "effect/unstable/cli";
 
 const FINDING_EXIT_CODE = 2;
 const ZERO_SCOPE_EXIT_CODE = 3;
 
-class FindingsFound extends Data.TaggedError("FindingsFound")<{readonly count: number}> {}
-class ZeroScope extends Data.TaggedError("ZeroScope")<{}> {}
+class FindingsFound extends Schema.TaggedErrorClass<FindingsFound>()("FindingsFound", {
+	count: Schema.Number,
+}) {}
+class ZeroScope extends Schema.TaggedErrorClass<ZeroScope>()("ZeroScope", {}) {}
 
-const readFileOrSkip = (file: string): string | null => {
-	try {
-		return readFileSync(file, "utf8");
-	} catch {
-		return null;
-	}
-};
+const readFileOrSkip = (file: string): string | null =>
+	Result.getOrElse(
+		Result.try(() => readFileSync(file, "utf8")),
+		() => null,
+	);
 
 const fileArg = Argument.string("file").pipe(
 	Argument.atLeast(1),

--- a/packages/pipeline-cli/src/tools/glossary-drift/command.ts
+++ b/packages/pipeline-cli/src/tools/glossary-drift/command.ts
@@ -27,7 +27,8 @@
 import {execFileSync} from "node:child_process";
 import {existsSync, readFileSync} from "node:fs";
 import {dirname, join, resolve} from "node:path";
-import {Console, Data, Effect, Option} from "effect";
+import {Console, Effect, Option} from "effect";
+import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
 import {findDrift, parseKnownTerms, renderIssueBody, renderReport} from "./drift.ts";
@@ -37,10 +38,10 @@ const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 const DEFAULT_WINDOW = 25;
 
 /** A shell-out (git/gh) or file-read failure — the run couldn't complete (non-zero exit). */
-class SweepIoError extends Data.TaggedError("SweepIoError")<{
-	readonly step: string;
-	readonly cause: unknown;
-}> {}
+class SweepIoError extends Schema.TaggedErrorClass<SweepIoError>()("SweepIoError", {
+	step: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 const defaultRoot = (from: string = process.cwd()): string => {
 	const start = resolve(from);

--- a/packages/pipeline-cli/src/tools/roadmap/view.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/view.ts
@@ -8,17 +8,17 @@
  */
 import {existsSync, readFileSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
-import type * as Schema from "effect/Schema";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {Github} from "./github.ts";
 import {buildView, parseRoadmap, renderView} from "./roadmap.ts";
 
 /** Couldn't read `ROADMAP.md` (absent or unreadable). */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 const ROADMAP_FILE = "ROADMAP.md";
 

--- a/packages/pipeline-cli/src/tools/ship-digest/command.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/command.ts
@@ -16,15 +16,15 @@
  * JSON is the `/what-shipped` skill's job, not this tool.
  */
 import {readFileSync, writeFileSync} from "node:fs";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
 import {type DigestWindow, deriveShipDigest, type ShipEntry} from "./digest.ts";
 
-class EntriesReadError extends Data.TaggedError("EntriesReadError")<{
-	readonly file: string;
-	readonly cause: unknown;
-}> {}
+class EntriesReadError extends Schema.TaggedErrorClass<EntriesReadError>()("EntriesReadError", {
+	file: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** One entry as the gathered JSON carries it; decoded at this boundary. */
 const EntrySchema = Schema.Struct({

--- a/packages/pipeline-cli/src/tools/token-spend/command.ts
+++ b/packages/pipeline-cli/src/tools/token-spend/command.ts
@@ -14,14 +14,18 @@
  * scan — a bad path is an error, not a silent empty report).
  */
 import {readFileSync} from "node:fs";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {Argument, Command} from "effect/unstable/cli";
 import {formatStageSpend, reconstructSpend} from "./token-spend.ts";
 
 // A named transcript path that could not be read — a hard error (exit 1), not a skip.
-class TranscriptUnreadable extends Data.TaggedError("TranscriptUnreadable")<{
-	readonly path: string;
-}> {}
+class TranscriptUnreadable extends Schema.TaggedErrorClass<TranscriptUnreadable>()(
+	"TranscriptUnreadable",
+	{
+		path: Schema.String,
+	},
+) {}
 
 const transcriptArg = Argument.string("transcript").pipe(
 	Argument.withDescription(


### PR DESCRIPTION
## What

Remediate the six residual Effect-v4 `Data.TaggedError` sites in `packages/pipeline-cli/` tool modules — the sites outside #2752 (router/eval-harness) and #2738 (guard) scopes. Same mechanical, behavior-preserving recipe as siblings #2752/#2738/#2751 (Rules 1/2 of the #2736 Effect-v4 migration).

## Sites remediated (9 → 0 GritQL warnings)

| File | Error class(es) | Also |
| --- | --- | --- |
| `tools/changelog-derive/command.ts` | `EntriesReadError` | |
| `tools/gh-phoenix/command.ts` | `FindingsFound`, `ZeroScope` | co-located raw `try/catch` in `readFileOrSkip` (no-raw-try-catch) → `Result.try` + `Result.getOrElse` |
| `tools/glossary-drift/command.ts` | `SweepIoError` | |
| `tools/ship-digest/command.ts` | `EntriesReadError` | |
| `tools/token-spend/command.ts` | `TranscriptUnreadable` | |
| `tools/roadmap/view.ts` | `IoError` | `Schema` import promoted from type-only to value |

Each error class goes from `Data.TaggedError("X")<{...}>` to `Schema.TaggedErrorClass<X>()("X", {...})`. **Tag strings preserved byte-for-byte** — the `Effect.catchTag` sites (`ZeroScope`, `FindingsFound`, `SweepIoError`, `TranscriptUnreadable`) depend on the bare `_tag`, so any rename would silently break error routing. `cause: unknown` → `cause: Schema.Unknown`; no `FateWireCode` annotation (CLI-only errors, mirroring the in-package gold standard `epic-ledger/github.ts`).

## Grounding

`Schema.TaggedErrorClass` idiom grounded in effect-smol `LLMS.md` (Error handling basics, line 46: `Schema.TaggedErrorClass<X>()("Tag", { fields })`); the sync-skip `Result.try(() => …)` single-arg form grounded in `Result.ts` (`try_` doc). Shape mirrored precisely from the already-merged sibling #2920 and the in-package gold standard `epic-ledger/github.ts`.

## Scope fence

Touches **only** the six files above. No file owned by #2752 (`router.ts`, `eval-harness/*`) or #2738 (guard/merge-queue-classify `command.ts` set).

## Verification

- `pnpm typecheck` — clean (pipeline-cli built fresh, 29/29 tasks pass).
- `pnpm lint` — clean (6 changed files, 0 warnings; the four Effect-v4 GritQL rules all clear at these sites — baseline was 9 warnings).
- `pnpm --filter @kampus/pipeline-cli test` — **1253 tests / 90 files pass** (behavior preserved; the bare-`_tag` `catchTag` assertions still hold).

Behavior-preserving — only the Effect-v4 API migration, no functional change.

Fixes #2922