### PR TITLE
chore(pipeline): deslop comments in kampus-pipeline shell scripts (#2879)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/report/footer.sh
+++ b/claude-plugins/kampus-pipeline/skills/report/footer.sh
@@ -10,13 +10,11 @@ set -euo pipefail
 
 parts=("Filed by an agent")
 
-# Session id — Claude Code exposes it in the environment when running.
 session="${CLAUDE_CODE_SESSION_ID:-}"
 if [[ -n "$session" ]]; then
 	parts+=("session \`${session}\`")
 fi
 
-# Model — env var if present, else nothing (never guess).
 model="${ANTHROPIC_MODEL:-${CLAUDE_MODEL:-}}"
 if [[ -n "$model" ]]; then
 	parts+=("model \`${model}\`")


### PR DESCRIPTION
Deslop-comments pass across every source file under `claude-plugins/kampus-pipeline/`.

Fixes #2879

## Scope of the pass
The plugin's code files are the **10 shell scripts** (hooks + skill validators + doctor/footer). The one `.js` (`skills/rite-audit/dimensions/vendor/axe.min.js`) is vendored/minified third-party and was left untouched; the `.md` skill/agent files are prose (no code/comment separation), so the "comments-and-whitespace-only, zero code change" mandate does not apply to them.

All 10 shell scripts were read and assessed against the CUT/COLLAPSE/MIGRATE/KEEP taxonomy:

- **No banners/separators, no commented-out code, no `TODO`/`FIXME`/`HACK`.**
- The hook scripts (`create-worktree.sh`, `guard.sh`, `install.sh`, `resolve-data-dir.sh`) and the validators (`validate-*.sh`, `doctor.sh`) are **already tightly curated** to the CLAUDE.md comment discipline — their comments are load-bearing: workarounds + forcing constraints (PATH-stripping, verbatim `settings.json` `env` semantics, bash-3.2 gotchas), ADR/issue pointers, invariants at their enforcement sites, and hook-contract docs. Nothing there was cruft, so those files are unchanged (manufacturing cuts would violate the skill's KEEP mandate).

## Change
`skills/report/footer.sh`: cut two per-field comments that purely restate the adjacent code —
- `# Session id — Claude Code exposes it in the environment when running.` (the `${CLAUDE_CODE_SESSION_ID:-}` read + `if [[ -n ]]` guard already say this)
- `# Model — env var if present, else nothing (never guess).` (the `${A:-${B:-}}` fallback chain already enforces this)

**Kept** the two load-bearing field notes: the branch/path note (`a branch name is not a filesystem path` — justifies the privacy contract) and the timestamp note (explains the deliberate absence of a presence guard). The `PRIVACY CONTRACT` docblock is untouched.

## No migration needed
No orphaned load-bearing rationale — nothing was deleted that lacked a home. No ADR/`.patterns/` change, so the PR stays inside the `claude-plugins/kampus-pipeline/` scope fence.

## Verification
- `git diff` = **comments-only**, 2 comment lines removed, programmatically confirmed no non-comment/non-blank line changed.
- `pnpm lint` → clean skip (no biome-handled files changed).
- `pnpm typecheck` → **29/29 successful** (FULL TURBO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)