### PR TITLE
fix(pipeline-cli): §CP regex covers skill-subdir .sh helpers at any depth (#2950)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,10 +21,12 @@
 /claude-plugins/kampus-pipeline/skills/plan-epic/                  @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/release/                    @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/review-trivial/             @kamp-us/control-plane
-# Control-plane: the bare gate-critical *.sh guards directly under skills/ (validate-*.sh) — the
-# §CP `skills/[^/]+\.sh$` branch (ADR 0174, #2576). `*.sh` matches a within-segment name only, so
-# it owns the loose scripts without swallowing the skill dirs already owned above.
-/claude-plugins/kampus-pipeline/skills/*.sh                        @kamp-us/control-plane
+# Control-plane: every skill shell helper, at ANY depth under skills/ — the top-level
+# gate guards (validate-*.sh) AND a subdir helper (report/footer.sh, doctor/doctor.sh). The
+# §CP `skills/([^/]+/)*[^/]+\.sh$` branch (ADR 0174, #2576/#2950). `**/*.sh` matches zero-or-more
+# dirs then a `.sh` name, so it owns the loose scripts and subdir helpers without swallowing the
+# skill dirs already owned above.
+/claude-plugins/kampus-pipeline/skills/**/*.sh                     @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md  @kamp-us/control-plane
 # Control-plane: the pipeline agent definitions — the behavior of the very agents that run the
 # pipeline, including shipper.md (merge authority) and reviewer.md (verdict gate). §CP-blocking

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1346,12 +1346,16 @@ closing the #375 drift class).
   - `claude-plugins/kampus-pipeline/skills/write-code/**`
   - `claude-plugins/kampus-pipeline/skills/plan-epic/**`
   - `claude-plugins/kampus-pipeline/skills/release/**` — the release machinery (ADR 0174, #2679).
-  - `claude-plugins/kampus-pipeline/skills/*.sh` — the bare gate-critical guard scripts directly
-    under `skills/` (`validate-gate-path-drift.sh`, `validate-skills.sh`, `validate-cycle-*.sh`):
-    executable enforcement that runs the gates, control-plane *by nature* like the guard packages.
-    The `^claude-plugins/kampus-pipeline/skills/[^/]+\.sh$` branch classifies them (ADR
-    [0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md), #2576);
-    the `[^/]+` matches a bare filename only, so it never reaches into the skill *dirs* above.
+  - `claude-plugins/kampus-pipeline/skills/**/*.sh` — every skill shell helper, at **any depth**
+    under `skills/`: the bare gate-critical guard scripts directly under `skills/`
+    (`validate-gate-path-drift.sh`, `validate-skills.sh`, `validate-cycle-*.sh`) **and** a helper
+    nested in a skill subdir (`report/footer.sh` — its `Filed by an agent` provenance marker feeds
+    triage's ADR-0159 auto-close eligibility; `doctor/doctor.sh`): executable enforcement that
+    feeds or runs the gates, control-plane *by nature* like the guard packages. The
+    `^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$` branch classifies them (ADR
+    [0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md), #2576/#2950);
+    the leaf `[^/]+\.sh$` matches a `.sh` filename and `([^/]+/)*` the intervening dirs, so it owns
+    a shell helper wherever it sits without reaching the non-`.sh` files in the skill *dirs* above.
   - `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (this file)
 
   **Deliberately OUT of §CP** (recorded so their absence is a decision, not an oversight): the
@@ -1440,7 +1444,7 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
@@ -68,10 +68,16 @@ export const splitTopLevelBranches = (re: string): ReadonlyArray<string> =>
  * `…/hooks(/|\.json$)`. We cartesian-expand every `(…)` group, then normalize each
  * expansion to a path: unescape `\.`→`.` and drop a regex `$` end-anchor. A trailing
  * `/` ⇒ a directory prefix; a `[^/]+` within-segment class ⇒ a `glob` (translated to a
- * gitignore `*`, e.g. `.../skills/[^/]+\.sh$` → `.../skills/*.sh`); otherwise an exact
- * file (the `$`-anchored leaf).
+ * gitignore `*`, and the any-depth `([^/]+/)*` prefix to a gitignore double-star, so the
+ * skill-`.sh` branch resolves to an any-depth `.sh` glob under `skills/`); otherwise an
+ * exact file (the `$`-anchored leaf).
  */
 export const expandBranch = (branch: string): ReadonlyArray<CpPath> => {
+	// `([^/]+/)*` is the any-depth segment prefix (the skill-`.sh` clause, #2950) — a
+	// quantified group the alternation loop below cannot expand (the trailing `*` isn't an
+	// alternation). Translate it up front to a gitignore/CODEOWNERS `**/` any-depth glob so
+	// the branch normalizes to a real ownable pattern (`…/skills/**/*.sh`).
+	const anyDepth = branch.replace(/\(\[\^\/\]\+\/\)\*/g, "**/");
 	const normalize = (s: string): CpPath => {
 		const base = s.replace(/\$/g, "").replace(/\\\./g, ".");
 		// `[^/]+` (one-or-more non-slash) is a within-segment regex wildcard; gitignore's
@@ -85,7 +91,7 @@ export const expandBranch = (branch: string): ReadonlyArray<CpPath> => {
 	// Cartesian-expand each `(alt|alt|…)` group, left to right. The regex only ever
 	// carries one group per branch, but expanding all groups keeps this robust to a
 	// future multi-group branch.
-	let forms: string[] = [branch];
+	let forms: string[] = [anyDepth];
 	const groupRe = /\(([^()]*)\)/;
 	for (let guard = 0; guard < 16; guard++) {
 		const next: string[] = [];

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -37,7 +37,7 @@ describe("splitTopLevelBranches", () => {
 		expect(branches).toEqual([
 			"(\\.claude|\\.github)/",
 			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/",
-			"claude-plugins/kampus-pipeline/skills/[^/]+\\.sh$",
+			"claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$",
 			"claude-plugins/kampus-pipeline/agents/",
 			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$",
 			"claude-plugins/kampus-pipeline/hooks(/|\\.json$)",
@@ -75,9 +75,9 @@ describe("expandBranch", () => {
 		expect(out.every((p) => p.kind === "dir")).toBe(true);
 	});
 
-	it("expands the bare `[^/]+\\.sh$` branch to a `*.sh` glob path", () => {
-		expect(expandBranch("claude-plugins/kampus-pipeline/skills/[^/]+\\.sh$")).toEqual([
-			{path: "claude-plugins/kampus-pipeline/skills/*.sh", kind: "glob"},
+	it("expands the any-depth `([^/]+/)*[^/]+\\.sh$` skill-`.sh` branch to a `**/*.sh` glob path (#2950)", () => {
+		expect(expandBranch("claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$")).toEqual([
+			{path: "claude-plugins/kampus-pipeline/skills/**/*.sh", kind: "glob"},
 		]);
 	});
 
@@ -110,7 +110,7 @@ describe("expandBranch", () => {
 });
 
 describe("cpPaths over the live regex", () => {
-	it("resolves the full §CP path set (20 paths: dirs, the two exact files, + the *.sh glob)", () => {
+	it("resolves the full §CP path set (20 paths: dirs, the two exact files, + the **/*.sh glob)", () => {
 		expect(cpPaths(LIVE_RE).map((p) => p.path)).toEqual([
 			".claude/",
 			".github/",
@@ -125,7 +125,7 @@ describe("cpPaths over the live regex", () => {
 			"claude-plugins/kampus-pipeline/skills/plan-epic/",
 			"claude-plugins/kampus-pipeline/skills/release/",
 			"claude-plugins/kampus-pipeline/skills/review-trivial/",
-			"claude-plugins/kampus-pipeline/skills/*.sh",
+			"claude-plugins/kampus-pipeline/skills/**/*.sh",
 			"claude-plugins/kampus-pipeline/agents/",
 			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
 			"claude-plugins/kampus-pipeline/hooks/",
@@ -186,8 +186,8 @@ describe("covers", () => {
 		).toBe(true);
 	});
 	it("a glob §CP path is covered by an identical `*`-glob row, not a mismatched literal", () => {
-		const glob: CpPath = {path: "claude-plugins/kampus-pipeline/skills/*.sh", kind: "glob"};
-		expect(covers(dir("claude-plugins/kampus-pipeline/skills/*.sh"), glob)).toBe(true);
+		const glob: CpPath = {path: "claude-plugins/kampus-pipeline/skills/**/*.sh", kind: "glob"};
+		expect(covers(dir("claude-plugins/kampus-pipeline/skills/**/*.sh"), glob)).toBe(true);
 		expect(covers(dir("claude-plugins/kampus-pipeline/skills/ship-it/"), glob)).toBe(false);
 	});
 });
@@ -210,7 +210,7 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/skills/plan-epic/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/release/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-trivial/ @usirin",
-			"/claude-plugins/kampus-pipeline/skills/*.sh @usirin",
+			"/claude-plugins/kampus-pipeline/skills/**/*.sh @usirin",
 			"/claude-plugins/kampus-pipeline/agents/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 			"/claude-plugins/kampus-pipeline/hooks/ @usirin",
@@ -237,7 +237,7 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/skills/plan-epic/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/release/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/review-trivial/ @usirin",
-			"/claude-plugins/kampus-pipeline/skills/*.sh @usirin",
+			"/claude-plugins/kampus-pipeline/skills/**/*.sh @usirin",
 			"/claude-plugins/kampus-pipeline/agents/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 			"/packages/ci-required/ @usirin",

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -24,7 +24,7 @@ const FULL_CODEOWNERS = [
 	"/claude-plugins/kampus-pipeline/skills/plan-epic/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/release/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/review-trivial/ @usirin",
-	"/claude-plugins/kampus-pipeline/skills/*.sh @usirin",
+	"/claude-plugins/kampus-pipeline/skills/**/*.sh @usirin",
 	"/claude-plugins/kampus-pipeline/agents/ @usirin",
 	"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 	"/claude-plugins/kampus-pipeline/hooks/ @usirin",

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -21,6 +21,14 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md")).toBe(
 			true,
 		);
+		// a `.sh` helper in a NON-gate skill's SUBDIR (#2950) — the escape set the any-depth
+		// `([^/]+/)*[^/]+\.sh$` clause closes. `report/footer.sh` emits the filing-provenance
+		// marker triage keys ADR-0159 auto-close eligibility on, so it feeds a gate decision yet
+		// escaped §CP under the old top-level-only `[^/]+\.sh$` anchoring — could auto-merge.
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/report/footer.sh")).toBe(true);
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/doctor/doctor.sh")).toBe(true);
+		// depth is irrelevant — a hypothetical helper two levels deep is §CP too (no new anchoring accident).
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/report/lib/helper.sh")).toBe(true);
 	});
 
 	it("does NOT classify the four deliberately-OUT skill dirs (operational, not gate-critical)", () => {
@@ -32,9 +40,13 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 	it("does NOT classify known non-§CP paths", () => {
 		expect(isControlPlane("apps/web/src/main.tsx")).toBe(false);
 		expect(isControlPlane("packages/some-other-pkg/src/index.ts")).toBe(false);
-		// a nested `.sh` UNDER a non-§CP skill dir is not the bare-guard branch (that requires the
-		// script sit directly under skills/, matched by `[^/]+\.sh$`).
-		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/heal-ci/helper.sh")).toBe(false);
+		// Over-broadening guard (#2950): the any-depth clause matches `.sh` LEAVES only — a
+		// NON-`.sh` file in a non-gate skill's subdir stays non-§CP, so the broadening didn't
+		// silently swallow whole non-gate skill dirs (only their shell helpers).
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/heal-ci/helper.md")).toBe(false);
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/doctor/notes.txt")).toBe(false);
+		// a `.sh`-suffixed name that is NOT a `.sh` file (no such extension boundary) also stays out
+		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/doctor/doctor.shell")).toBe(false);
 	});
 
 	it("still classifies every PRE-EXISTING §CP path (no branch dropped)", () => {

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -14,7 +14,17 @@
  *
  * The runtime value (what `pipeline-cli control-plane-paths` prints) is the POSIX-ERE
  * grep/jq form the gates match against; the doubled backslashes here are TS string
- * escapes, so `\\.` is the value `\.` and `[^/]+\\.sh$` is the value `[^/]+\.sh$`.
+ * escapes, so `\\.` is the value `\.` and `([^/]+/)*[^/]+\\.sh$` is the value
+ * `([^/]+/)*[^/]+\.sh$`.
+ *
+ * The skill-`.sh` clause is depth-agnostic on purpose (#2950): `([^/]+/)*[^/]+\.sh$`
+ * matches a shell helper at ANY depth under `skills/` — a top-level `skills/<name>.sh`
+ * (the `validate-*.sh` gate guards, zero dir segments) AND a subdir helper
+ * `skills/<skill>/<helper>.sh` (e.g. `report/footer.sh`, whose provenance marker feeds
+ * triage's ADR-0159 auto-close eligibility). The prior `[^/]+\.sh$` matched top-level
+ * only, so a subdir helper escaped §CP and could auto-merge without control-plane
+ * sign-off. Anchoring to one depth was an accident, not a "subdir helpers are safe"
+ * carve-out — a skill's shell helper is control-plane wherever it sits.
  *
  * Anti-self-authorization is preserved (#981): the live merge-deciding gates still
  * re-resolve the boundary from the formats doc on `origin/main` at run time, so a
@@ -23,4 +33,4 @@
  * runtime resolution off the origin/main read.
  */
 export const CONTROL_PLANE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";


### PR DESCRIPTION
Broadens the §CP control-plane classifier's skill-`.sh` clause so a shell helper nested in a skill **subdirectory** is classified control-plane. Closes a latent fail-open: `CONTROL_PLANE_RE`'s clause was `skills/[^/]+\.sh$`, matching only a **top-level** `skills/<name>.sh`. A `.sh` one level deeper (`skills/<skill>/<helper>.sh`) matched neither that clause nor a gate-skill dir, so a PR touching only it classified NON-§CP and could auto-merge without human control-plane sign-off (surfaced on PR #2949).

## The escape set this closes (verified by scanning today's tree)

- `claude-plugins/kampus-pipeline/skills/report/footer.sh` — emits the `Filed by an agent` provenance marker; triage keys its human-vs-agent auto-close eligibility on that marker (ADR 0159), so it demonstrably feeds a gate decision yet was NON-§CP.
- `claude-plugins/kampus-pipeline/skills/doctor/doctor.sh` — the other currently-escaping subdir helper.

(Top-level `skills/validate-*.sh` were already covered; gate-skill dirs are covered by the dir clause — neither regresses.)

## The change

- **`control-plane-re.ts`** (single source, #2761): the skill-`.sh` clause becomes `skills/([^/]+/)*[^/]+\.sh$` — a `.sh` at **any depth** under `skills/`. This **subsumes** the old top-level clause rather than adding a second depth-specific anchor, so there is no new depth-anchoring accident of the same class the issue flags.
- **`gh-issue-intake-formats.md`** mirror: the `CONTROL_PLANE_RE=` line is kept **byte-in-sync** with the const; the `codeowners-cp` and `validate-gate-path-drift.sh` drift guards both pass (verified locally: `codeowners-cp: all 20 §CP path(s) covered`; `validate-gate-path-drift: OK — 18 checks`).
- **`codeowners-cp.ts`**: the branch-expander gains a `([^/]+/)*`→`**/` translation so the any-depth branch resolves to the ownable glob `skills/**/*.sh`; `.github/CODEOWNERS` owns it (replacing the old `skills/*.sh` row, which `**/*.sh` subsumes).
- **`control-plane-paths.unit.test.ts`**: fixtures lock `report/footer.sh` + `doctor/doctor.sh` (and a deeper helper) as §CP, keep top-level §CP, and **guard against over-broadening** (a non-`.sh` file in a non-gate skill subdir stays non-§CP). `codeowners-cp.unit.test.ts` / `gate.test.ts` updated for the new glob.

## §CP — reviewed-ready only, human merge

This edits `CONTROL_PLANE_RE` (in `control-plane-re.ts`, its formats-doc mirror, and `packages/pipeline-cli/**` tests) — all §CP-class paths. **Do not auto-merge; stop at reviewed-ready for human §CP sign-off.** Anti-self-authorization holds: the live gates classify this PR against `origin/main`'s boundary, not its own edit.

## Open questions for the §CP owner to adjudicate (per triage's ruling — decided at this gate)

1. **Is top-level-only INTENTIONAL, or a gap?** The reporter raised this; triage ruled it is adjudicated here, at the §CP merge gate. This PR **broadens the §CP boundary to include skill-subdir `.sh`** — newly-covered today: `skills/report/footer.sh`, `skills/doctor/doctor.sh`. If top-level-only was a considered "subdir helpers are safe" carve-out, **reject-with-rationale** and I'll revert; nothing in `control-plane-re.ts`'s docblock justified the old anchoring, which is why I read it as an accident.
2. **Depth: any-depth (`([^/]+/)*`) vs exactly-one-level (`*/*.sh`).** I chose any-depth on the principle "a skill's shell helper is control-plane wherever it sits" — encoding a specific depth would re-introduce the same anchoring-accident class. The demonstrated escape set is depth-1 only (skills are structurally flat), so if you prefer confining to one level, say so.

Fixes #2950