### PR TITLE
ci(deploy): force preview flags ON from preview-flag:<key> PR labels (#2951)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,6 +654,10 @@ jobs:
             // Match the web app's block in the sticky comment, capturing the URL
             // and the hidden d1 token deploy.yml emits for web only.
             const webRe = /<!-- preview-deploy:web -->\n[^\n]*?(https:\/\/[A-Za-z0-9.-]+\.workers\.dev)[^\n]*?<!-- d1:([0-9a-f-]+) -->/;
+            // Optional, independent of the required URL+D1 match: the forced preview-flag
+            // key set deploy.yml emits (issue #2951). Absent when no `preview-flag:<key>`
+            // label forced anything, so it never gates the poll — only enriches the run env.
+            const flagsRe = /<!-- preview-flags:([^>]*?) -->/;
             while (Date.now() < deadline) {
               const {data: comments} = await github.rest.issues.listComments({
                 ...context.repo, issue_number: context.issue.number, per_page: 100,
@@ -661,9 +665,12 @@ jobs:
               const c = comments.find((x) => x.body?.includes(marker));
               const m = c && c.body.match(webRe);
               if (m) {
+                const fm = c.body.match(flagsRe);
+                const flags = fm ? fm[1] : "";
                 core.setOutput("url", m[1]);
                 core.setOutput("db", m[2]);
-                core.info(`preview ready: ${m[1]} (D1 ${m[2]})`);
+                core.setOutput("flags", flags);
+                core.info(`preview ready: ${m[1]} (D1 ${m[2]})${flags ? ` forced flags: ${flags}` : ""}`);
                 return;
               }
               core.info("waiting for deploy.yml to post the web preview URL + D1 id…");
@@ -705,6 +712,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           E2E_D1_DATABASE_ID: ${{ steps.preview.outputs.db }}
+          # The forced preview-flag key set (comma-separated) deploy.yml forced ON in this
+          # preview's Flagship app (issue #2951). Darkship OFF-assertion specs read this to
+          # skip/invert against a forced-ON preview; empty when nothing was forced.
+          E2E_FORCED_FLAGS: ${{ steps.preview.outputs.flags }}
 
       # Upload the report whenever the run completed (pass or fail), so a red run's
       # traces survive for triage; `!cancelled()` keeps it from skipping on failure,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -418,6 +418,81 @@ jobs:
           fi
           echo "uuid=$uuid" >> "$GITHUB_OUTPUT"
 
+      # Force per-PR preview flags ON from `preview-flag:<key>` PR labels — deploy-time
+      # serving write (issue #2951; mechanism A2, decided in investigation #2946). A label
+      # `preview-flag:<key>` forces that flag key ON in THIS PR's own `pr-<n>` Flagship app,
+      # so the release-blocking flag-ON journey e2e (epic #2926) and a human clicking the
+      # preview link both see flag-gated UI in its ON state — previews are otherwise
+      # flag-dark (each stage's Flagship app mints at IaC defaults, all off). The write is
+      # CI-credentialed and direct-to-store via cf-utils' `setServing` seam (ADR 0134),
+      # with ZERO runtime surface in the worker bundle — the preview-seed idiom, the
+      # deliberate counter-shape of the deleted fail-open seeder (CLAUDE.md "Sözlük seed").
+      #
+      # PRODUCTION HARD-REFUSE — the load-bearing invariant this whole step exists to keep:
+      # forcing must NEVER reach the prod Flagship app. Two independent gates. (1) The step
+      # is `pull_request`-only, and prod deploys only on `push` (STAGE=prod), so it never
+      # runs on a prod deploy. (2) Inside the step, re-resolve `environmentForStage($STAGE)`
+      # from its single owner (apps/web/worker/environment.ts — only `prod` maps to
+      # `production`) and `exit 1` BEFORE any write when it is `production`. The in-step
+      # recompute is deliberately self-contained (not the earlier step's $ENVIRONMENT) so
+      # the guard can't be defeated by an upstream edit; it fails closed (ADR 0092) — the
+      # refusal aborts the step, never downgrades to a silent no-op.
+      #
+      # web-only: the Flagship app (`phoenix_flags`) lives in the web stack
+      # (apps/web/worker/features/flagship/resources.ts). Idempotent: cf-utils `flag set` is
+      # a converging upsert — a re-run on a later push writes nothing when already ON.
+      - name: Force preview flags ON from PR labels (${{ matrix.app }})
+        id: force-flags
+        if: github.event_name == 'pull_request' && matrix.app == 'web'
+        env:
+          # The store write is Cloudflare-credentialed, NOT GITHUB_TOKEN. Least privilege:
+          # the label read below uses the default job token, already scoped by the job's
+          # `permissions:` (contents: read, pull-requests: write — GitHub Actions scopes
+          # permissions per JOB, not per step); this step adds no GitHub token scope.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+
+          # GATE (structural production refuse): recompute the deploy class from the single
+          # owner of the stage→ENVIRONMENT map and abort before any write if it is
+          # production — belt-and-suspenders over the `pull_request`-only `if:` above.
+          ENVIRONMENT_FOR_STAGE="$(node --eval "import('./apps/web/worker/environment.ts').then((m) => process.stdout.write(m.environmentForStage(process.env.STAGE)))")"
+          if [ "$ENVIRONMENT_FOR_STAGE" = "production" ]; then
+            echo "::error::preview flag-forcing REFUSED — stage '$STAGE' resolves to ENVIRONMENT 'production'. This path must never touch the prod Flagship app (issue #2951; fail-closed, ADR 0092)."
+            exit 1
+          fi
+          echo "stage '$STAGE' → ENVIRONMENT '$ENVIRONMENT_FOR_STAGE' (non-prod) — preview flag-forcing permitted"
+
+          # Read the PR's `preview-flag:<key>` labels fresh from the API (so a label added
+          # after this deploy triggered is still honored on this run), stripping the prefix
+          # to the bare flag key.
+          keys="$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" \
+            --jq '.[].name | select(startswith("preview-flag:")) | sub("^preview-flag:"; "")')"
+
+          if [ -z "$keys" ]; then
+            echo "no preview-flag:<key> labels on PR #${PR_NUMBER} — nothing to force"
+            echo "forced=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Force each labeled key ON in THIS stage's Flagship app. `flag set <key> on
+          # --env <stage> --execute` resolves the app whose decoded stage == $STAGE
+          # (cf-utils decodeEnv/findAppForEnv) and serves on@100% via the no-match split.
+          # A `flag set` failure (unknown key, no app for the stage) aborts under `set -e`
+          # — fail-loud, never a silently-skipped force.
+          forced=""
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            echo "forcing flag '$key' ON in Flagship env '$STAGE'"
+            node packages/cf-utils/src/bin.ts flag set "$key" on --env "$STAGE" --execute
+            forced="${forced:+$forced,}$key"
+          done <<< "$keys"
+          echo "forced=$forced" >> "$GITHUB_OUTPUT"
+          echo "forced preview flags: ${forced:-none}"
+
       # Post (or update) a sticky comment carrying EVERY app's preview URL on PRs.
       # The outer `<!-- preview-deploy -->` marker makes the comment sticky; a
       # per-app `<!-- preview-deploy:<app> -->` line lets each matrix job upsert
@@ -433,20 +508,26 @@ jobs:
           STAGE_NAME: ${{ env.STAGE }}
           # web-only: the e2e job (ci.yml, #522) parses this token to seed the D1.
           DB_ID: ${{ steps.d1.outputs.uuid }}
+          # web-only: the forced preview-flag key set (issue #2951) the e2e run reads as
+          # E2E_FORCED_FLAGS, so darkship OFF-assertion specs can skip/invert against a
+          # forced-ON preview. Empty when no `preview-flag:<key>` labels forced anything.
+          FORCED_FLAGS: ${{ steps.force-flags.outputs.forced }}
         with:
           script: |
             const marker = "<!-- preview-deploy -->";
             const app = process.env.APP;
             const appMark = `<!-- preview-deploy:${app} -->`;
             const sha = context.sha.slice(0, 7);
-            // A hidden, machine-parseable token the e2e job reads (#522). Only web
-            // resolves a D1 id; other apps omit it. Kept in an HTML comment so it
-            // doesn't clutter the human-facing line.
+            // Hidden, machine-parseable tokens the e2e job reads. Only web resolves a D1 id
+            // (#522) and a forced-flag set (#2951); other apps omit both. Kept in HTML
+            // comments so they don't clutter the human-facing line.
             const dbId = process.env.DB_ID || "";
             const dbToken = dbId ? ` <!-- d1:${dbId} -->` : "";
+            const forcedFlags = process.env.FORCED_FLAGS || "";
+            const flagsToken = forcedFlags ? ` <!-- preview-flags:${forcedFlags} -->` : "";
             const appLine = `${appMark}\n`
               + `- **${app}** — Stage \`${process.env.STAGE_NAME}\` → ${process.env.PREVIEW_URL} `
-              + `<sub>(${sha})</sub>${dbToken}`;
+              + `<sub>(${sha})</sub>${dbToken}${flagsToken}`;
 
             // Replace this app's block in the body (or append it), preserving any
             // other app's block another matrix job may have already written.


### PR DESCRIPTION
Deploy-time preview flag-forcing — mechanism **A2** decided in investigation #2946, implemented as a post-deploy step in `.github/workflows/deploy.yml`. A `preview-flag:<key>` PR label forces that flag key ON in the PR's own `pr-<n>` Flagship app, so the release-blocking flag-ON journey e2e (epic #2926) and a human clicking the preview link both see flag-gated UI in its ON state. Previews are otherwise flag-dark (each stage's Flagship app mints at IaC defaults, all off).

## Preview-flag label contract
- Add a PR label `preview-flag:<key>` (e.g. `preview-flag:phoenix-nav-ia`). The post-deploy step strips the `preview-flag:` prefix and forces the bare `<key>` ON.
- Multiple labels force multiple keys. Labels are read **fresh from the API at step time** (`gh api repos/…/issues/<pr>/labels`), so a label added after the deploy triggered is still honored on that run.
- The write is via cf-utils' `setServing` seam (`node packages/cf-utils/src/bin.ts flag set <key> on --env <stage> --execute`, ADR 0134): it resolves the Flagship app whose decoded stage == `$STAGE` (`decodeEnv`/`findAppForEnv`) and serves `on@100%` via the no-match split. **Idempotent** — a converging upsert, so a re-run on a later push writes nothing when the key is already ON (AC: idempotent).
- **Security shape:** CI-credentialed, direct-to-store, **zero runtime surface in the worker bundle** — the `packages/preview-seed` idiom, the deliberate counter-shape of the deleted fail-open seeder (CLAUDE.md "Sözlük seed" guard). No worker/bundle code changes in this PR (AC: no runtime override surface).

## Production hard-refuse (load-bearing — verify this fast)
Forcing must **never** touch the prod Flagship app. Two independent gates:
1. **`pull_request`-only step.** The step's `if:` is `github.event_name == 'pull_request' && matrix.app == 'web'`. Prod deploys only on `push` (`STAGE=prod`), so the step never runs on a prod deploy.
2. **In-step structural refuse.** Before any write, the step re-resolves `environmentForStage($STAGE)` from its single owner (`apps/web/worker/environment.ts` — only `prod` maps to `production`) via `node --eval` and `exit 1`s with an `::error::` if the result is `production`. The recompute is deliberately self-contained (not the earlier `Resolve deploy ENVIRONMENT` step's `$ENVIRONMENT`) so an upstream edit can't defeat it. Fail-closed (ADR 0092): the refusal aborts the step, never downgrades to a no-op.

Verified locally against `apps/web/worker/environment.ts`: `prod → production` (would abort), `pr-2951 → preview` / `it-5 → preview` / `audit → audit` (permitted). Only `prod` maps to `production`, so no preview/integration/audit stage can reach the refuse branch, and no prod stage can reach the write.

## Least-privilege permissions
GitHub Actions scopes `permissions:` **per job, not per step**. The `deploy` job already declares explicit minimal `permissions: { contents: read, pull-requests: write }` (the `pull-requests: write` is for the existing preview-URL comment). The new step:
- Reads PR labels with the default `GITHUB_TOKEN` (`GH_TOKEN: ${{ github.token }}`), covered by the existing `pull-requests` scope — **adds no new GitHub token scope**.
- Performs the store write with the Cloudflare CI secrets (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`) — **not** `GITHUB_TOKEN`.

## Surfacing forced keys to the e2e run
`deploy.yml` emits a hidden `<!-- preview-flags:<csv> -->` token on the web preview-comment line (web-only, alongside the existing `<!-- d1:… -->` token). `ci.yml`'s e2e job reads it (independent, optional match — never gates the URL+D1 poll) and exports `E2E_FORCED_FLAGS` to the Playwright run, so darkship OFF-assertion specs can skip/invert against a forced-ON preview (AC: forced key set surfaced to e2e).

## Build-time `VITE_*` scope call (resolved)
Store-level forcing covers **runtime store flags only**. A `preview-flag:<key>` label targets a Flagship store flag key written via `setServing`; it does **not** cover build-time-baked `VITE_*` values (e.g. `VITE_SENTRY_DSN`, `VITE_FEED_SNAPSHOT`), which `deploy.yml` gates behind prod-only expressions and Vite bakes into the bundle at build time before any store write. So: **forced keys are runtime store flags (in scope); build-time `VITE_*` flags are out of A2's scope** — a label naming a build-time var has no effect on the served bundle. This is the deliberate boundary, called out per the issue's open scope question.

## §CP — control-plane
This lands in `.github/workflows/deploy.yml` (+ `ci.yml`), so it is **§CP** and stops **reviewed-ready for human merge** — it does not auto-ship.

`actionlint` clean on both workflows; `pnpm lint:worktree` clean-skips (YAML-only diff, no biome-handled files); no TypeScript changed.

Fixes #2951