### PR TITLE
feat(local-render): local render-and-capture harness over an alchemy dev build (#2963)

### DIFF
--- a/packages/design-capture/src/capture.ts
+++ b/packages/design-capture/src/capture.ts
@@ -41,11 +41,27 @@ export class CaptureError extends Schema.TaggedErrorClass<CaptureError>()(
 	},
 ) {}
 
+/** A cookie to seed into the capture browser context before navigation. */
+export interface CaptureCookie {
+	readonly name: string;
+	readonly value: string;
+	/** Either `url`, or both `domain` and `path`, per Playwright's `addCookies`. */
+	readonly url?: string;
+	readonly domain?: string;
+	readonly path?: string;
+}
+
 export interface CaptureOptions {
 	/** Per-navigation timeout in ms (default 30s). */
 	readonly navigationTimeoutMs?: number;
 	/** Full-page screenshot (default) vs. above-the-fold only. */
 	readonly fullPage?: boolean;
+	/**
+	 * Cookies seeded into every shot's browser context before navigation — how the
+	 * local render harness honors the `phoenix_flag_overrides` dev-override cookie so
+	 * flag-gated surfaces render under `alchemy dev` (#2963). Absent ⇒ no cookies.
+	 */
+	readonly cookies?: readonly CaptureCookie[];
 }
 
 /**
@@ -75,9 +91,19 @@ export const captureShots = (
 				(shot) =>
 					Effect.tryPromise({
 						try: async (): Promise<CapturedSurface> => {
-							const page = await browser.newPage({
+							// A context per shot (not `browser.newPage`) so a shot's `deviceScaleFactor`
+							// (the downscale lever) and the run's `cookies` (the dev-override cookie)
+							// can be seeded before navigation — both are context-level in Playwright.
+							const context = await browser.newContext({
 								viewport: {width: shot.viewport.width, height: shot.viewport.height},
+								...(shot.deviceScaleFactor === undefined
+									? {}
+									: {deviceScaleFactor: shot.deviceScaleFactor}),
 							});
+							if (options.cookies && options.cookies.length > 0) {
+								await context.addCookies(options.cookies);
+							}
+							const page = await context.newPage();
 							// Listen across the WHOLE navigation window (attached before goto), so a
 							// runtime error thrown during mount/init is caught even when the frame
 							// still renders acceptably (#2594). `networkidle` already settles past
@@ -91,7 +117,13 @@ export const captureShots = (
 							});
 							try {
 								await page.goto(shot.url, {waitUntil: "networkidle", timeout: navigationTimeoutMs});
-								const buffer = await page.screenshot({type: "png", fullPage});
+								// A clip crops to the changed region; Playwright rejects clip + fullPage
+								// together, so a clipped shot is never full-page.
+								const buffer = await page.screenshot(
+									shot.clip === undefined
+										? {type: "png", fullPage}
+										: {type: "png", clip: shot.clip},
+								);
 								const localPath = join(outDir, shot.fileName);
 								await writeFile(localPath, buffer);
 								return {
@@ -104,7 +136,7 @@ export const captureShots = (
 									pageErrors,
 								};
 							} finally {
-								await page.close();
+								await context.close();
 							}
 						},
 						catch: (cause) =>

--- a/packages/design-capture/src/index.ts
+++ b/packages/design-capture/src/index.ts
@@ -9,13 +9,13 @@
  * `resolvePreviewUrl` resolves the preview base from the sticky preview-deploy
  * comment, keyed off the per-app `<!-- preview-deploy:<app> -->` anchor.
  */
-export type {CapturedSurface, CaptureOptions} from "./capture.ts";
+export type {CaptureCookie, CapturedSurface, CaptureOptions} from "./capture.ts";
 export {CaptureError, captureShots} from "./capture.ts";
 export type {CaptureAndUploadRequest, CaptureRecord} from "./orchestrate.ts";
 export {captureAndUpload, hostedUrls, mergeRecord} from "./orchestrate.ts";
 export type {PageError, SurfacePageErrors} from "./page-errors.ts";
 export {isRenderCrash, renderCrashFailure, toPageError} from "./page-errors.ts";
-export type {Shot, Surface, Viewport} from "./plan.ts";
+export type {CaptureClip, Shot, Surface, Viewport} from "./plan.ts";
 export {
 	buildCapturePlan,
 	DEFAULT_VIEWPORT,

--- a/packages/design-capture/src/plan.ts
+++ b/packages/design-capture/src/plan.ts
@@ -56,6 +56,14 @@ export const DESKTOP_VIEWPORT: Viewport = {label: "desktop", width: 1280, height
 export const MOBILE_VIEWPORT: Viewport = {label: "mobile", width: 390, height: 844};
 export const DEFAULT_VIEWPORT: Viewport = DESKTOP_VIEWPORT;
 
+/** A crop rectangle in CSS pixels — the changed region the capture is narrowed to. */
+export interface CaptureClip {
+	readonly x: number;
+	readonly y: number;
+	readonly width: number;
+	readonly height: number;
+}
+
 /** One screenshot to take: an absolute URL at a viewport, written to `fileName`. */
 export interface Shot {
 	readonly surface: Surface;
@@ -64,6 +72,19 @@ export interface Shot {
 	readonly viewport: Viewport;
 	/** Filesystem-safe PNG file name (written under the capture out-dir). */
 	readonly fileName: string;
+	/**
+	 * Optional crop to the changed region (CSS px). When set, capture narrows to
+	 * this rectangle instead of the full page — the cost-control lever the local
+	 * render harness computes (#2963). Absent ⇒ the default full-page shot.
+	 */
+	readonly clip?: CaptureClip;
+	/**
+	 * Optional render device-pixel-ratio (`deviceScaleFactor`, per Playwright's
+	 * context option). A value < 1 renders fewer device pixels per CSS pixel — a
+	 * genuine raster downscale (device pixels = CSS pixels × dpr) — the budget
+	 * lever the local render harness computes (#2963). Absent ⇒ the default 1x.
+	 */
+	readonly deviceScaleFactor?: number;
 }
 
 /**

--- a/packages/local-render/README.md
+++ b/packages/local-render/README.md
@@ -1,0 +1,104 @@
+# @kampus/local-render
+
+The **local render-and-capture harness** — the root prerequisite of the write-code
+render-and-look inner loop ([epic #2953](https://github.com/kamp-us/phoenix/issues/2953),
+issue [#2963](https://github.com/kamp-us/phoenix/issues/2963)). It renders the **composed
+UI surface** of the app over a running local `alchemy dev` build and writes per-surface
+PNG(s) to disk, so a write-code agent can *see* the assembled page — not just the diff —
+before opening a UI PR.
+
+```
+running local build          this harness                      on disk
+(pnpm dev: Vite + alchemy) → resolve local base → build plan → captureShots → surface.png
+                             + dev-override cookie  + crop/downscale  (design-capture)
+```
+
+Neither [`@kampus/design-capture`](../design-capture/README.md) (shoots a *deployed*
+preview URL) nor `@kampus/audit-run` (a *deployed* stage) targets a local build — this adds
+that targeting on top of design-capture's plan/viewport/**capture** primitives. It does
+**not** re-implement browser capture: the Playwright leg is design-capture's `captureShots`.
+
+## What it renders — the composed surface over `alchemy dev`
+
+Under `pnpm dev` the composed page (chrome + shell — the composition-defect surface) is
+served by the **Vite dev origin** (`http://localhost:3000`), which serves the React SPA +
+HMR and proxies `/api` and `/fate` to the `alchemy dev` worker (vhost-routed at
+`http://phoenix.localhost:1337`). So the harness renders the Vite origin by default; point
+`--base` elsewhere if your build serves the composed surface at another localhost origin.
+`resolveLocalBase` refuses any non-loopback origin — a *local* render harness never renders
+(or seeds a dev-override cookie into) a remote/production origin.
+
+**Start the build first.** The harness renders a *running* build; run `pnpm dev` (or
+`pnpm dev:worker` + `pnpm dev:web`) before invoking it. A down server surfaces loudly as a
+`CaptureError` (the Playwright navigation fails).
+
+## The two decided local-render constraints
+
+- **Empty local D1, no seeding** (#2941). Composition is a property of the chrome/shell, and
+  designed-empty states are exactly the in-scope defect class. The harness adds nothing to
+  the local build — whatever the local worker serves is what renders. (No seeder is
+  rebuilt; that is a founder v1 non-goal + security guard.)
+- **Flag-gated UI via the existing dev-override cookie** (#2946). `--flag "<key>=on|off"`
+  seeds the `phoenix_flag_overrides` cookie (same name + URL-encoded-JSON wire format as the
+  worker's [`dev-override.ts`](../../apps/web/worker/features/flagship/dev-override.ts)) into
+  the capture context, so a flag-gated surface renders locally with no new mechanism.
+
+## Cost control — crop + downscale under a documented budget
+
+Vision loops run 10–20x cost unbudgeted (#2943), so captures are bounded two ways, both
+native to Playwright (no image dependency):
+
+- **Crop** to the changed region — `--region "<surface>=x,y,w,h"` (CSS px) narrows the shot
+  to that rectangle instead of the full page (the primary lever; drops the tall scroll).
+- **Downscale** — when a region's known longest edge exceeds the budget, the shot renders at
+  a `deviceScaleFactor` < 1 (device pixels = CSS pixels × dpr), bringing the raster longest
+  edge under budget.
+
+The budget is the longest edge in device px — **`LONGEST_EDGE_BUDGET = 1400`** by default,
+overridable with `--budget`. The crop/downscale plan (`planCaptureDirective`) is pure and
+unit-tested; the impure browser leg is injected.
+
+## Pure core + injected impure leg
+
+Same idiom design-capture follows: the pure selection logic (base resolution, cookie build,
+crop/downscale plan, CLI-token parsers — [`plan.ts`](./src/plan.ts)) is unit-tested, and the
+orchestration ([`render.ts`](./src/render.ts)) is parameterized over the capture leg
+(`CaptureLeg`, defaulting to `captureShots`) so the unit test injects a fake — no real
+browser, no local dev server in the tests.
+
+## Usage
+
+```
+# render two surfaces of the running local build to ./shots
+node packages/local-render/src/bin.ts render \
+  --surface "/sozluk" \
+  --surface "/pano:empty" \
+  --out ./shots
+
+# flag-gated surface + a cropped/downscaled region
+node packages/local-render/src/bin.ts render \
+  --surface "/pano" \
+  --flag "pano-draft-save=on" \
+  --region "/pano=0,0,1280,2600" \
+  --out ./shots
+```
+
+It prints a JSON array of per-surface records
+`{ surface, route, state, localPath, fileName }` on stdout — the `localPath` is the on-disk
+PNG the downstream evidence-attach step
+([#2964](https://github.com/kamp-us/phoenix/issues/2964)) uploads and attaches to the PR.
+
+## What downstream consumes
+
+- **#2964 (evidence-attach)** consumes each record's **`localPath`** (the on-disk PNG) — it
+  runs the harness for the before/after captures and uploads+attaches them per the SHA-bound
+  convention (reusing design-capture's `captureAndUpload`/`uploadAsset`).
+- **#2965 (§CP write-code loop)** invokes the `render` entry at its render→look→fix decision
+  points.
+
+## Commands
+
+```bash
+pnpm --filter @kampus/local-render test        # unit tier
+pnpm --filter @kampus/local-render typecheck
+```

--- a/packages/local-render/package.json
+++ b/packages/local-render/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@kampus/local-render",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Local render-and-capture harness (#2963, epic #2953) — renders the composed UI surface over a running local `alchemy dev` build and writes per-surface PNGs, honoring the dev-override cookie + an empty local D1, with capture-side crop/downscale under a documented budget. Reuses @kampus/design-capture's Playwright capture leg, adds local-build targeting on top.",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run --project unit",
+		"test:unit": "vitest run --project unit",
+		"render": "node src/bin.ts render"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"@kampus/design-capture": "workspace:*",
+		"@playwright/test": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/packages/local-render/src/bin.ts
+++ b/packages/local-render/src/bin.ts
@@ -1,0 +1,104 @@
+/**
+ * `local-render render` — the skill-/CLI-callable entry (#2963), driven by the
+ * write-code inner loop (#2965):
+ *
+ *   node packages/local-render/src/bin.ts render \
+ *     --surface "/sozluk" [--surface "/sozluk:empty" ...] \
+ *     --out <dir> \
+ *     [--base http://localhost:3000] \
+ *     [--flag "pano-draft-save=on" ...] \
+ *     [--region "/sozluk=0,0,1280,900" ...] \
+ *     [--budget 1400]
+ *
+ * Renders each composed surface over a running local `alchemy dev` build (start
+ * it first with `pnpm dev`), writes the PNG bytes under `--out`, and prints a JSON
+ * array of per-surface records `{ surface, route, state, localPath, fileName }` on
+ * stdout — the `localPath` the downstream evidence-attach step (#2964) uploads.
+ * Mechanical-tooling idiom (`effect/unstable/cli`, pure core + thin bin).
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {parseSurfaceSpec} from "@kampus/design-capture";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {DEFAULT_LOCAL_BASE, parseFlagOverride, parseRegionSpec} from "./plan.ts";
+import {renderLocal} from "./render.ts";
+
+const baseFlag = Flag.string("base").pipe(
+	Flag.withDefault(DEFAULT_LOCAL_BASE),
+	Flag.withDescription(
+		"the localhost base the composed dev build serves (default the Vite origin)",
+	),
+);
+
+const surfaceFlag = Flag.string("surface").pipe(
+	Flag.withDescription(
+		'a surface to render, "<route>[:state]" (repeatable), e.g. /sozluk or /sozluk:empty',
+	),
+	Flag.atLeast(1),
+);
+
+const outFlag = Flag.string("out").pipe(
+	Flag.withDescription("output directory for the captured PNG bytes"),
+);
+
+const flagFlag = Flag.string("flag").pipe(
+	Flag.withDescription(
+		'a dev-override flag, "<key>=on|off" (repeatable) — seeds the phoenix_flag_overrides cookie',
+	),
+	Flag.atLeast(0),
+);
+
+const regionFlag = Flag.string("region").pipe(
+	Flag.withDescription('a changed-region crop, "<surface>=x,y,w,h" in CSS px (repeatable)'),
+	Flag.atLeast(0),
+);
+
+const budgetFlag = Flag.integer("budget").pipe(
+	Flag.optional,
+	Flag.withDescription("longest-edge downscale budget in device px (default 1400)"),
+);
+
+const render = Command.make(
+	"render",
+	{
+		base: baseFlag,
+		surface: surfaceFlag,
+		out: outFlag,
+		flag: flagFlag,
+		region: regionFlag,
+		budget: budgetFlag,
+	},
+	Effect.fn(function* ({base, surface, out, flag, region, budget}) {
+		const overrides = Object.fromEntries(flag.map(parseFlagOverride));
+		const regions = Object.fromEntries(region.map(parseRegionSpec));
+		const captured = yield* renderLocal({
+			base,
+			surfaces: surface.map(parseSurfaceSpec),
+			outDir: out,
+			overrides,
+			regions,
+			...(Option.isSome(budget) ? {budget: budget.value} : {}),
+		});
+		const records = captured.map((c) => ({
+			surface: c.surface,
+			route: c.route,
+			state: c.state,
+			localPath: c.localPath,
+			fileName: c.fileName,
+		}));
+		yield* Console.log(JSON.stringify(records, null, 2));
+	}),
+).pipe(
+	Command.withDescription(
+		"Render the composed surfaces over a local alchemy dev build and write PNGs",
+	),
+);
+
+const cli = Command.make("local-render").pipe(
+	Command.withSubcommands([render]),
+	Command.withDescription(
+		"Local render-and-capture harness over an alchemy dev build (#2963, epic #2953)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/local-render/src/index.ts
+++ b/packages/local-render/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @kampus/local-render — the local render-and-capture harness (#2963, epic #2953).
+ *
+ * Renders the composed UI surface of the app over a running local `alchemy dev`
+ * build and writes per-surface PNG(s) to disk, honoring the dev-override cookie
+ * (flag-gated UI) and an empty local D1 (designed-empty states), with capture-side
+ * crop/downscale under a documented budget. Reuses `@kampus/design-capture`'s
+ * `captureShots`/`buildCapturePlan`/viewport primitives as the Playwright leg —
+ * it adds local-build targeting on top, it does not re-implement browser capture.
+ */
+export type {CaptureDirective, LocalShotOptions} from "./plan.ts";
+export {
+	buildLocalShots,
+	buildOverrideCookies,
+	DEFAULT_LOCAL_BASE,
+	FLAG_OVERRIDE_COOKIE,
+	LONGEST_EDGE_BUDGET,
+	normalizeClip,
+	planCaptureDirective,
+	resolveLocalBase,
+} from "./plan.ts";
+export type {CaptureLeg, LocalRenderDeps, LocalRenderRequest} from "./render.ts";
+export {renderLocal} from "./render.ts";

--- a/packages/local-render/src/plan.ts
+++ b/packages/local-render/src/plan.ts
@@ -1,0 +1,247 @@
+/**
+ * The pure core of the local render-and-capture harness (#2963, epic #2953):
+ * resolve the localhost base the running dev build serves, build the
+ * dev-override cookie that un-gates flag-gated surfaces locally, and compute the
+ * crop/downscale directive that keeps captured images under the vision-loop
+ * budget. No browser, no network — this is the unit-tested selection logic; the
+ * impure Playwright leg (`@kampus/design-capture`'s `captureShots`) is driven
+ * over the plan this produces (see `render.ts`).
+ *
+ * Local-build targeting, not preview targeting: `@kampus/design-capture` shoots
+ * a *deployed* preview URL and `@kampus/audit-run` a *deployed* stage — nothing
+ * targeted a local `alchemy dev` build. This adds that targeting on top of
+ * design-capture's plan/viewport/capture primitives without re-implementing
+ * browser capture.
+ */
+import {
+	buildCapturePlan,
+	type CaptureClip,
+	type CaptureCookie,
+	DEFAULT_VIEWPORT,
+	type Shot,
+	type Surface,
+	type Viewport,
+} from "@kampus/design-capture";
+
+/**
+ * The default localhost base the composed UI surface is served from under
+ * `pnpm dev`: the Vite dev server (`vite.config.ts` `server.port`), which serves
+ * the React SPA shell + HMR and proxies `/api` and `/fate` to the `alchemy dev`
+ * worker (vhost-routed at `http://phoenix.localhost:1337`). The *composed* page
+ * — chrome + shell, the composition defect surface — is the Vite origin, not the
+ * worker origin (the worker serves only the proxied data routes in the dev loop),
+ * so that is what the harness renders. Override with `--base` when a build serves
+ * the composed surface elsewhere.
+ */
+export const DEFAULT_LOCAL_BASE = "http://localhost:3000";
+
+/**
+ * The dev-override flag cookie honored under `alchemy dev` — same name + wire
+ * format as the worker's `apps/web/worker/features/flagship/dev-override.ts`
+ * (a URL-encoded JSON `{key: boolean}` map). Seeding it is how flag-gated UI
+ * renders locally with no new mechanism (#2946).
+ */
+export const FLAG_OVERRIDE_COOKIE = "phoenix_flag_overrides";
+
+/**
+ * The documented capture budget: the longest edge (in device px) a captured
+ * image is kept at or under, so the downstream vision loop stays cost-bounded
+ * (vision loops run 10–20x cost unbudgeted, #2943). A shot whose known CSS
+ * dimensions exceed this is downscaled (a `deviceScaleFactor` < 1); the crop to
+ * the changed region is the other, primary lever.
+ */
+export const LONGEST_EDGE_BUDGET = 1400;
+
+/** Loopback hostnames a local base is allowed to point at — never a remote host. */
+const isLoopbackHost = (host: string): boolean =>
+	host === "localhost" ||
+	host === "127.0.0.1" ||
+	host === "::1" ||
+	host === "[::1]" ||
+	host.endsWith(".localhost");
+
+/**
+ * Resolve + validate the local base URL: default to the Vite dev origin, and
+ * refuse anything that isn't an http(s) loopback URL. The refusal is the guard
+ * that a *local* render harness never accidentally renders (and seeds a
+ * dev-override cookie into) a remote/production origin.
+ */
+export const resolveLocalBase = (candidate?: string): string => {
+	const raw = candidate === undefined || candidate.length === 0 ? DEFAULT_LOCAL_BASE : candidate;
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		throw new Error(`local-render: base is not a valid absolute URL: ${raw}`);
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error(`local-render: base must be http(s), got ${url.protocol}`);
+	}
+	if (!isLoopbackHost(url.hostname)) {
+		throw new Error(
+			`local-render: base must be a loopback host (localhost/127.0.0.1/*.localhost) — refusing to render a non-local origin: ${raw}`,
+		);
+	}
+	return raw;
+};
+
+/**
+ * Build the dev-override cookie(s) to seed into the capture context, keyed to the
+ * local `base`. Returns `[]` for an empty override map (no cookie needed), else a
+ * single cookie whose value is the URL-encoded JSON map the worker's
+ * `parseOverrideCookie` decodes — the exact wire format of
+ * `encodeOverrideCookieValue` in the worker's `dev-override.ts`.
+ */
+export const buildOverrideCookies = (
+	base: string,
+	overrides: Readonly<Record<string, boolean>>,
+): readonly CaptureCookie[] => {
+	const keys = Object.keys(overrides);
+	if (keys.length === 0) return [];
+	return [
+		{
+			name: FLAG_OVERRIDE_COOKIE,
+			value: encodeURIComponent(JSON.stringify(overrides)),
+			url: base,
+		},
+	];
+};
+
+/**
+ * Normalize a changed-region clip against the viewport: clamp the origin to the
+ * page (x/y ≥ 0), clamp the width to the page width (there is no horizontal
+ * scroll), and leave the height unclamped (a full page scrolls vertically, so the
+ * region may sit below the fold). Refuses a non-positive or fully-off-page region
+ * — an empty clip is a caller bug, not a silent full-page fallback.
+ */
+export const normalizeClip = (region: CaptureClip, viewport: Viewport): CaptureClip => {
+	if (region.width <= 0 || region.height <= 0) {
+		throw new Error(
+			`local-render: clip region must have positive width/height, got ${region.width}x${region.height}`,
+		);
+	}
+	const x = Math.max(0, region.x);
+	const y = Math.max(0, region.y);
+	const width = Math.min(region.width, viewport.width - x);
+	if (width <= 0) {
+		throw new Error(
+			`local-render: clip region is off the page width (x=${region.x}, viewport width=${viewport.width})`,
+		);
+	}
+	return {x, y, width, height: region.height};
+};
+
+/** The crop + downscale a shot is captured under. `deviceScaleFactor` omitted ⇒ 1x (no downscale). */
+export interface CaptureDirective {
+	readonly clip?: CaptureClip;
+	readonly deviceScaleFactor?: number;
+}
+
+/**
+ * Compute the crop/downscale directive for one surface under the budget.
+ *
+ * Crop: when a changed `region` is given, narrow to it (the primary cost lever);
+ * else the default full-page shot. Downscale: the raster longest edge is the CSS
+ * longest edge × `deviceScaleFactor` (dpr), so to bring it under `budget` we set
+ * `deviceScaleFactor = budget / cssLongestEdge`, clamped to ≤ 1 (never upscale).
+ * The CSS longest edge is known only for a clipped region (`max(w, h)`) or, for a
+ * full-page shot, the viewport width (the page height is dynamic) — so a
+ * full-page desktop shot (1280 < 1400) needs no downscale, and the lever kicks in
+ * for a wide/tall clipped region.
+ */
+export const planCaptureDirective = (
+	viewport: Viewport,
+	opts: {readonly region?: CaptureClip; readonly budget?: number} = {},
+): CaptureDirective => {
+	const budget = opts.budget ?? LONGEST_EDGE_BUDGET;
+	if (budget <= 0) {
+		throw new Error(`local-render: budget must be positive, got ${budget}`);
+	}
+	const clip = opts.region === undefined ? undefined : normalizeClip(opts.region, viewport);
+	const cssLongestEdge = clip === undefined ? viewport.width : Math.max(clip.width, clip.height);
+	if (cssLongestEdge <= budget) {
+		return clip === undefined ? {} : {clip};
+	}
+	// Round to 4 dp so the factor is stable/reproducible across runs.
+	const deviceScaleFactor = Math.round((budget / cssLongestEdge) * 1e4) / 1e4;
+	return clip === undefined ? {deviceScaleFactor} : {clip, deviceScaleFactor};
+};
+
+/**
+ * Parse a `--flag "<key>=on|off"` token into a `[key, boolean]` override entry.
+ * `on`/`true`/`1` ⇒ true, `off`/`false`/`0` ⇒ false; anything else is a caller
+ * bug (a malformed override is refused, never silently dropped).
+ */
+export const parseFlagOverride = (token: string): readonly [string, boolean] => {
+	const eq = token.indexOf("=");
+	if (eq <= 0) {
+		throw new Error(`local-render: --flag must be "<key>=on|off", got: ${token}`);
+	}
+	const key = token.slice(0, eq).trim();
+	const raw = token
+		.slice(eq + 1)
+		.trim()
+		.toLowerCase();
+	if (key.length === 0) {
+		throw new Error(`local-render: --flag has an empty key: ${token}`);
+	}
+	if (raw === "on" || raw === "true" || raw === "1") return [key, true];
+	if (raw === "off" || raw === "false" || raw === "0") return [key, false];
+	throw new Error(`local-render: --flag value must be on/off, got: ${token}`);
+};
+
+/**
+ * Parse a `--region "<surface>=x,y,w,h"` token into a `[surface, clip]` entry —
+ * the changed-region crop for one surface. The four comma-separated numbers are
+ * CSS px; a malformed spec is refused.
+ */
+export const parseRegionSpec = (token: string): readonly [string, CaptureClip] => {
+	const eq = token.indexOf("=");
+	if (eq <= 0) {
+		throw new Error(`local-render: --region must be "<surface>=x,y,w,h", got: ${token}`);
+	}
+	const surface = token.slice(0, eq).trim();
+	if (surface.length === 0) {
+		throw new Error(`local-render: --region has an empty surface: ${token}`);
+	}
+	const parts = token
+		.slice(eq + 1)
+		.split(",")
+		.map((p) => Number(p.trim()));
+	if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) {
+		throw new Error(`local-render: --region rect must be four numbers "x,y,w,h", got: ${token}`);
+	}
+	const [x, y, width, height] = parts as [number, number, number, number];
+	return [surface, {x, y, width, height}];
+};
+
+/** Options for {@link buildLocalShots}: viewport, budget, and per-surface changed regions. */
+export interface LocalShotOptions {
+	readonly viewport?: Viewport;
+	readonly budget?: number;
+	/** Changed-region clips keyed by the surface token (`--surface`); a surface with no entry is shot full-page. */
+	readonly regions?: Readonly<Record<string, CaptureClip>>;
+}
+
+/**
+ * Build the local capture plan: reuse `@kampus/design-capture`'s `buildCapturePlan`
+ * (URL join, filesystem-safe name, empty/duplicate guards) over the local `base`,
+ * then attach each surface's crop/downscale directive. One {@link Shot} per surface.
+ */
+export const buildLocalShots = (
+	base: string,
+	surfaces: readonly Surface[],
+	opts: LocalShotOptions = {},
+): readonly Shot[] => {
+	const viewport = opts.viewport ?? DEFAULT_VIEWPORT;
+	const plan = buildCapturePlan(base, surfaces, viewport);
+	const regions = opts.regions ?? {};
+	return plan.map((shot) => {
+		const region = regions[shot.surface.surface];
+		const directive = planCaptureDirective(viewport, {
+			...(region === undefined ? {} : {region}),
+			...(opts.budget === undefined ? {} : {budget: opts.budget}),
+		});
+		return {...shot, ...directive};
+	});
+};

--- a/packages/local-render/src/plan.unit.test.ts
+++ b/packages/local-render/src/plan.unit.test.ts
@@ -1,0 +1,175 @@
+import {DESKTOP_VIEWPORT, MOBILE_VIEWPORT, parseSurfaceSpec} from "@kampus/design-capture";
+import {describe, expect, it} from "vitest";
+import {
+	buildLocalShots,
+	buildOverrideCookies,
+	DEFAULT_LOCAL_BASE,
+	FLAG_OVERRIDE_COOKIE,
+	LONGEST_EDGE_BUDGET,
+	normalizeClip,
+	parseFlagOverride,
+	parseRegionSpec,
+	planCaptureDirective,
+	resolveLocalBase,
+} from "./plan.ts";
+
+describe("resolveLocalBase", () => {
+	it("defaults to the Vite dev origin when omitted or empty", () => {
+		expect(resolveLocalBase()).toBe(DEFAULT_LOCAL_BASE);
+		expect(resolveLocalBase("")).toBe(DEFAULT_LOCAL_BASE);
+	});
+
+	it("accepts loopback origins", () => {
+		expect(resolveLocalBase("http://127.0.0.1:1337")).toBe("http://127.0.0.1:1337");
+		expect(resolveLocalBase("http://phoenix.localhost:1337")).toBe("http://phoenix.localhost:1337");
+	});
+
+	it("refuses a non-http(s) scheme", () => {
+		expect(() => resolveLocalBase("ftp://localhost")).toThrow(/http\(s\)/);
+	});
+
+	it("refuses a non-loopback host — a local harness never renders a remote origin", () => {
+		expect(() => resolveLocalBase("https://kamp.us")).toThrow(/loopback/);
+		expect(() => resolveLocalBase("http://example.com:3000")).toThrow(/loopback/);
+	});
+
+	it("refuses a malformed URL", () => {
+		expect(() => resolveLocalBase("not a url")).toThrow(/valid absolute URL/);
+	});
+});
+
+describe("buildOverrideCookies", () => {
+	it("returns no cookie for an empty override map", () => {
+		expect(buildOverrideCookies(DEFAULT_LOCAL_BASE, {})).toEqual([]);
+	});
+
+	it("encodes a URL-encoded JSON map the worker's parse decodes (roundtrip)", () => {
+		const overrides = {"pano-draft-save": true, "phoenix-flags-probe": false};
+		const cookie = buildOverrideCookies(DEFAULT_LOCAL_BASE, overrides)[0]!;
+		expect(cookie.name).toBe(FLAG_OVERRIDE_COOKIE);
+		expect(cookie.url).toBe(DEFAULT_LOCAL_BASE);
+		// mirrors apps/web/.../dev-override.ts decodeOverrides: JSON.parse(decodeURIComponent(value))
+		expect(JSON.parse(decodeURIComponent(cookie.value))).toEqual(overrides);
+	});
+});
+
+describe("normalizeClip", () => {
+	it("clamps the origin to the page and the width to the viewport", () => {
+		const clip = normalizeClip({x: -10, y: -5, width: 2000, height: 900}, DESKTOP_VIEWPORT);
+		expect(clip).toEqual({x: 0, y: 0, width: DESKTOP_VIEWPORT.width, height: 900});
+	});
+
+	it("leaves height unclamped — a full page scrolls vertically", () => {
+		const clip = normalizeClip({x: 0, y: 0, width: 100, height: 5000}, DESKTOP_VIEWPORT);
+		expect(clip.height).toBe(5000);
+	});
+
+	it("refuses a non-positive region", () => {
+		expect(() => normalizeClip({x: 0, y: 0, width: 0, height: 100}, DESKTOP_VIEWPORT)).toThrow(
+			/positive/,
+		);
+	});
+
+	it("refuses a region off the page width", () => {
+		expect(() => normalizeClip({x: 2000, y: 0, width: 100, height: 100}, DESKTOP_VIEWPORT)).toThrow(
+			/off the page width/,
+		);
+	});
+});
+
+describe("planCaptureDirective", () => {
+	it("no region, desktop viewport ⇒ no crop, no downscale (1280 < 1400 budget)", () => {
+		expect(planCaptureDirective(DESKTOP_VIEWPORT)).toEqual({});
+	});
+
+	it("a region under budget ⇒ crop, no downscale", () => {
+		const d = planCaptureDirective(DESKTOP_VIEWPORT, {
+			region: {x: 0, y: 0, width: 800, height: 600},
+		});
+		expect(d.clip).toEqual({x: 0, y: 0, width: 800, height: 600});
+		expect(d.deviceScaleFactor).toBeUndefined();
+	});
+
+	it("a region over budget ⇒ crop + downscale factor = budget / longest edge", () => {
+		const d = planCaptureDirective(DESKTOP_VIEWPORT, {
+			region: {x: 0, y: 0, width: 1000, height: 2800},
+		});
+		expect(d.clip).toEqual({x: 0, y: 0, width: 1000, height: 2800});
+		// longest edge 2800 > 1400 ⇒ 1400/2800 = 0.5
+		expect(d.deviceScaleFactor).toBe(0.5);
+	});
+
+	it("honors a custom budget", () => {
+		const d = planCaptureDirective(DESKTOP_VIEWPORT, {budget: 640});
+		// no region ⇒ css longest edge is the viewport width 1280 > 640 ⇒ 0.5
+		expect(d.deviceScaleFactor).toBe(0.5);
+	});
+
+	it("refuses a non-positive budget", () => {
+		expect(() => planCaptureDirective(DESKTOP_VIEWPORT, {budget: 0})).toThrow(/positive/);
+	});
+});
+
+describe("buildLocalShots", () => {
+	it("joins the local base into each shot URL and applies the crop directive", () => {
+		const shots = buildLocalShots(
+			DEFAULT_LOCAL_BASE,
+			[parseSurfaceSpec("/sozluk"), parseSurfaceSpec("/pano:empty")],
+			{regions: {"/sozluk": {x: 0, y: 0, width: 800, height: 600}}},
+		);
+		expect(shots.map((s) => s.url)).toEqual([
+			"http://localhost:3000/sozluk",
+			"http://localhost:3000/pano",
+		]);
+		expect(shots[0]!.clip).toEqual({x: 0, y: 0, width: 800, height: 600});
+		expect(shots[1]!.clip).toBeUndefined();
+	});
+
+	it("shoots at a supplied viewport (mobile)", () => {
+		const shots = buildLocalShots(DEFAULT_LOCAL_BASE, [parseSurfaceSpec("/sozluk")], {
+			viewport: MOBILE_VIEWPORT,
+		});
+		expect(shots[0]!.viewport).toEqual(MOBILE_VIEWPORT);
+	});
+
+	it("inherits design-capture's empty/duplicate guards", () => {
+		expect(() => buildLocalShots(DEFAULT_LOCAL_BASE, [])).toThrow(/no surfaces/);
+		expect(() =>
+			buildLocalShots(DEFAULT_LOCAL_BASE, [parseSurfaceSpec("/x"), parseSurfaceSpec("/x")]),
+		).toThrow(/duplicate/);
+	});
+});
+
+describe("parseFlagOverride", () => {
+	it("parses on/off (and synonyms) to booleans", () => {
+		expect(parseFlagOverride("pano-draft-save=on")).toEqual(["pano-draft-save", true]);
+		expect(parseFlagOverride("k=off")).toEqual(["k", false]);
+		expect(parseFlagOverride("k=true")).toEqual(["k", true]);
+		expect(parseFlagOverride("k=0")).toEqual(["k", false]);
+	});
+
+	it("refuses a malformed override", () => {
+		expect(() => parseFlagOverride("nokey")).toThrow(/on\|off/);
+		expect(() => parseFlagOverride("k=maybe")).toThrow(/on\/off/);
+		expect(() => parseFlagOverride("=on")).toThrow();
+	});
+});
+
+describe("parseRegionSpec", () => {
+	it("parses a surface=x,y,w,h token", () => {
+		expect(parseRegionSpec("/sozluk=0,10,800,600")).toEqual([
+			"/sozluk",
+			{x: 0, y: 10, width: 800, height: 600},
+		]);
+	});
+
+	it("refuses a malformed rect", () => {
+		expect(() => parseRegionSpec("/sozluk=0,10,800")).toThrow(/four numbers/);
+		expect(() => parseRegionSpec("/sozluk=a,b,c,d")).toThrow(/four numbers/);
+		expect(() => parseRegionSpec("noeq")).toThrow(/x,y,w,h/);
+	});
+});
+
+it("documents the default budget", () => {
+	expect(LONGEST_EDGE_BUDGET).toBe(1400);
+});

--- a/packages/local-render/src/render.ts
+++ b/packages/local-render/src/render.ts
@@ -1,0 +1,103 @@
+/**
+ * The thin orchestration of the local render-and-capture harness: resolve the
+ * local base, build the dev-override cookie + the crop/downscale plan (all pure,
+ * `plan.ts`), then drive the capture leg over it. The Playwright leg is the
+ * injected seam — `@kampus/design-capture`'s `captureShots` by default — so the
+ * orchestration is unit-tested with a fake leg (no real browser), the exact
+ * pure-core + injected-impure-leg idiom the capture package already follows.
+ *
+ * Rendered against an empty local D1 (no seeding — designed-empty states are the
+ * in-scope composition defect class, #2941): the harness targets a running
+ * `alchemy dev` build and adds nothing to it; whatever data the local worker
+ * serves is what renders.
+ */
+import {
+	type CapturedSurface,
+	CaptureError,
+	type CaptureOptions,
+	captureShots,
+	type Shot,
+	type Surface,
+} from "@kampus/design-capture";
+import {Effect} from "effect";
+import {buildLocalShots, buildOverrideCookies, resolveLocalBase} from "./plan.ts";
+
+/**
+ * The injected Playwright capture leg — the `captureShots` shape. Defaulted to
+ * `@kampus/design-capture`'s real leg; the unit test injects a fake to prove the
+ * orchestration without a browser.
+ */
+export type CaptureLeg = (
+	shots: readonly Shot[],
+	outDir: string,
+	options: CaptureOptions,
+) => Effect.Effect<readonly CapturedSurface[], CaptureError>;
+
+export interface LocalRenderRequest {
+	/** The composed UI surfaces to render, each a route + optional state variant. */
+	readonly surfaces: readonly Surface[];
+	/** Directory the per-surface PNG bytes are written to. */
+	readonly outDir: string;
+	/** The localhost base to render over (default: the Vite dev origin). */
+	readonly base?: string;
+	/** Flag keys to force on/off locally via the dev-override cookie (default: none). */
+	readonly overrides?: Readonly<Record<string, boolean>>;
+	/** Per-surface changed-region clips (keyed by surface token) for crop/downscale. */
+	readonly regions?: Readonly<Record<string, import("./plan.ts").CaptureDirective["clip"]>>;
+	/** Override the longest-edge downscale budget (default {@link LONGEST_EDGE_BUDGET}). */
+	readonly budget?: number;
+	/** Viewport to render each surface at (default desktop). */
+	readonly viewport?: import("@kampus/design-capture").Viewport;
+	/** Per-navigation timeout in ms, passed through to the capture leg. */
+	readonly navigationTimeoutMs?: number;
+}
+
+/** The seams the harness is parameterized over — the fake capture leg in the unit test. */
+export interface LocalRenderDeps {
+	readonly capture?: CaptureLeg;
+}
+
+/**
+ * Render the composed UI surfaces over a running local `alchemy dev` build and
+ * write per-surface PNG(s) to disk. Resolves + validates the local base, seeds
+ * the dev-override cookie so flag-gated surfaces render, computes the
+ * crop/downscale plan, and hands it to the capture leg. Returns one
+ * `CapturedSurface` per surface (its `localPath` is the on-disk PNG the
+ * downstream evidence-attach step, #2964, uploads).
+ */
+export const renderLocal = (
+	request: LocalRenderRequest,
+	deps: LocalRenderDeps = {},
+): Effect.Effect<readonly CapturedSurface[], CaptureError> => {
+	const capture = deps.capture ?? captureShots;
+	// The pure setup can throw (an invalid/non-loopback base, an empty/duplicate
+	// surface set, an off-page clip); wrap it so those surface as a CaptureError
+	// in-channel rather than escaping synchronously before the Effect is returned.
+	return Effect.try({
+		try: () => {
+			const base = resolveLocalBase(request.base);
+			const regions =
+				request.regions === undefined
+					? undefined
+					: Object.fromEntries(
+							Object.entries(request.regions).flatMap(([k, v]) =>
+								v === undefined ? [] : [[k, v]],
+							),
+						);
+			const shots = buildLocalShots(base, request.surfaces, {
+				...(request.viewport === undefined ? {} : {viewport: request.viewport}),
+				...(request.budget === undefined ? {} : {budget: request.budget}),
+				...(regions === undefined ? {} : {regions}),
+			});
+			const cookies = buildOverrideCookies(base, request.overrides ?? {});
+			const options: CaptureOptions = {
+				...(request.navigationTimeoutMs === undefined
+					? {}
+					: {navigationTimeoutMs: request.navigationTimeoutMs}),
+				...(cookies.length === 0 ? {} : {cookies}),
+			};
+			return {shots, options};
+		},
+		catch: (cause) => new CaptureError({message: "failed to build local render plan", cause}),
+	}).pipe(Effect.flatMap(({shots, options}) => capture(shots, request.outDir, options)));
+};

--- a/packages/local-render/src/render.unit.test.ts
+++ b/packages/local-render/src/render.unit.test.ts
@@ -1,0 +1,93 @@
+import type {CapturedSurface, CaptureOptions, Shot} from "@kampus/design-capture";
+import {parseSurfaceSpec} from "@kampus/design-capture";
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type CaptureLeg, renderLocal} from "./render.ts";
+
+/** A fake capture leg: records the plan + options it was handed, returns stub captures. */
+const recordingLeg = () => {
+	const calls: {shots: readonly Shot[]; outDir: string; options: CaptureOptions}[] = [];
+	const leg: CaptureLeg = (shots, outDir, options) => {
+		calls.push({shots, outDir, options});
+		return Effect.succeed(
+			shots.map(
+				(s): CapturedSurface => ({
+					surface: s.surface.surface,
+					route: s.surface.route,
+					state: s.surface.state,
+					localPath: `${outDir}/${s.fileName}`,
+					fileName: s.fileName,
+					pngBytes: new Uint8Array(),
+					pageErrors: [],
+				}),
+			),
+		);
+	};
+	return {leg, calls};
+};
+
+describe("renderLocal", () => {
+	it("drives the injected leg over the local plan and returns per-surface captures", async () => {
+		const {leg, calls} = recordingLeg();
+		const captured = await Effect.runPromise(
+			renderLocal({surfaces: [parseSurfaceSpec("/sozluk")], outDir: "/tmp/shots"}, {capture: leg}),
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]!.shots[0]!.url).toBe("http://localhost:3000/sozluk");
+		expect(captured[0]!.localPath).toBe("/tmp/shots/sozluk@desktop.png");
+	});
+
+	it("seeds the dev-override cookie only when overrides are given", async () => {
+		const {leg, calls} = recordingLeg();
+		await Effect.runPromise(
+			renderLocal(
+				{
+					surfaces: [parseSurfaceSpec("/sozluk")],
+					outDir: "/tmp/shots",
+					overrides: {"pano-draft-save": true},
+				},
+				{capture: leg},
+			),
+		);
+		const cookies = calls[0]!.options.cookies ?? [];
+		expect(cookies).toHaveLength(1);
+		expect(cookies[0]!.name).toBe("phoenix_flag_overrides");
+		expect(JSON.parse(decodeURIComponent(cookies[0]!.value))).toEqual({"pano-draft-save": true});
+	});
+
+	it("passes no cookie when no overrides are given", async () => {
+		const {leg, calls} = recordingLeg();
+		await Effect.runPromise(
+			renderLocal({surfaces: [parseSurfaceSpec("/sozluk")], outDir: "/tmp/shots"}, {capture: leg}),
+		);
+		expect(calls[0]!.options.cookies).toBeUndefined();
+	});
+
+	it("attaches the crop/downscale directive to the shot", async () => {
+		const {leg, calls} = recordingLeg();
+		await Effect.runPromise(
+			renderLocal(
+				{
+					surfaces: [parseSurfaceSpec("/sozluk")],
+					outDir: "/tmp/shots",
+					regions: {"/sozluk": {x: 0, y: 0, width: 1000, height: 2800}},
+				},
+				{capture: leg},
+			),
+		);
+		const shot = calls[0]!.shots[0]!;
+		expect(shot.clip).toEqual({x: 0, y: 0, width: 1000, height: 2800});
+		expect(shot.deviceScaleFactor).toBe(0.5);
+	});
+
+	it("fails in-channel (CaptureError) on a non-loopback base — never renders a remote origin", async () => {
+		const {leg} = recordingLeg();
+		const exit = await Effect.runPromiseExit(
+			renderLocal(
+				{surfaces: [parseSurfaceSpec("/sozluk")], outDir: "/tmp/shots", base: "https://kamp.us"},
+				{capture: leg},
+			),
+		);
+		expect(exit._tag).toBe("Failure");
+	});
+});

--- a/packages/local-render/tsconfig.json
+++ b/packages/local-render/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/local-render/vitest.config.ts
+++ b/packages/local-render/vitest.config.ts
@@ -1,0 +1,21 @@
+/**
+ * Vitest config — this package has a `unit` tier only. Its pure core (base
+ * resolution, override-cookie build, crop/downscale plan, CLI-token parsers) is
+ * DB-free and browser-free; the impure Playwright leg is `@kampus/design-capture`'s
+ * injected `captureShots`, so the orchestration is unit-covered with a fake leg
+ * (no real browser, no local dev server).
+ */
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		projects: [
+			{
+				test: {
+					name: "unit",
+					include: ["src/**/*.unit.test.ts"],
+				},
+			},
+		],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1057,6 +1057,40 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/local-render:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      '@kampus/design-capture':
+        specifier: workspace:*
+        version: link:../design-capture
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/migrations-guard:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
## What

Adds `@kampus/local-render` — the **local render-and-capture harness**, the root prerequisite (#2963) of the write-code render-and-look inner loop (epic #2953). A single `render` entry renders the composed UI surface of the app over a running local `alchemy dev` build and writes per-surface PNG(s) to disk.

Reuses `@kampus/design-capture`'s `captureShots` / `buildCapturePlan` / viewport primitives as the Playwright leg — it adds **local-build targeting** on top, it does **not** re-implement browser capture. Neither `packages/design-capture` (deployed preview URL) nor `packages/audit-run` (deployed stage) targeted a local build; this fills that gap.

## How it satisfies the ACs

- **Single entry over a local build → PNGs, reusing design-capture's leg.** `local-render render --surface … --out …` resolves the local base (the Vite dev origin `http://localhost:3000`, which composes the SPA + proxies `/api`,`/fate` to the `alchemy dev` worker), builds the plan via design-capture's `buildCapturePlan`, and drives `captureShots`. Refuses any non-loopback base.
- **Empty local D1 + dev-override cookie.** No seeding — the harness adds nothing to the local build (composition is a chrome/shell property; designed-empty states are the in-scope defect class, #2941). `--flag "<key>=on|off"` seeds the `phoenix_flag_overrides` cookie (same name + URL-encoded-JSON wire format as the worker's `apps/web/worker/features/flagship/dev-override.ts`) so flag-gated surfaces render locally with no new mechanism (#2946).
- **Crop/downscale under a documented budget, pure logic unit-tested with the browser leg injected.** Crop via Playwright `clip` (the changed region, `--region "<surface>=x,y,w,h"`); downscale via `deviceScaleFactor` (dpr — device px = CSS px × dpr, grounded in Playwright's own type doc) when a region's longest edge exceeds `LONGEST_EDGE_BUDGET` (1400px, `--budget` overridable). `planCaptureDirective` / `normalizeClip` / the CLI-token parsers are pure and unit-tested; `renderLocal` is parameterized over the capture leg (`CaptureLeg`) so the orchestration test injects a fake — no real browser.
- **README + no control-plane touch.** Carries a `README.md`; touches only `packages/local-render` and a backward-compatible extension of `packages/design-capture` — **not** `packages/pipeline-cli` or `packages/ci-required`.

## design-capture extension (backward-compatible)

Extends the capture leg so it can carry what local capture needs, without re-implementing it: optional `cookies` on `CaptureOptions`, optional per-shot `clip` / `deviceScaleFactor` on `Shot`, applied via a context-per-shot. When those are absent the behavior is byte-identical to before (full-page shot). design-capture's 46 unit tests + typecheck stay green.

## Scope

Root harness only. Out of scope by design: the PR-attach step (#2964, which consumes each record's `localPath`) and the write-code/SKILL.md loop wiring (#2965, §CP).

## Verification

- `pnpm --filter @kampus/local-render test` → 29 passing; typecheck clean.
- `pnpm --filter @kampus/design-capture test` → 46 passing (extension is backward-compatible); typecheck clean.
- `catalog-guard` / `readme-guard` green; biome + leak-guard green in pre-commit.

Fixes #2963

🤖 Generated with [Claude Code](https://claude.com/claude-code)