### PR TITLE
feat(web): worker-first HTML route + streaming HTMLRewriter __BOOT__ injection, dark behind phoenix-edge-shell-boot

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -178,8 +178,9 @@ export default Alchemy.Stack(
 		// behind until a human release, so the console ships dark (no chunk fetched).
 		yield* adminConsoleFlag(flagship.appId);
 		// The edge-resolved shell-boot dark-ship flag, default-off (#2928, epic #2926, ADR
-		// 0179) — the single seam the worker-first shell render + `window.__BOOT__` injection
-		// ships behind: off ⇒ edge-direct HTML byte-identical to today, until a human release.
+		// 0179) — the single seam the `window.__BOOT__` INJECTION ships behind (worker-first
+		// routing is unconditional): off ⇒ the worker returns the untransformed ASSETS bytes,
+		// byte-identical to today; on ⇒ `__BOOT__` injected, until a human release.
 		yield* edgeShellBootFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never

--- a/apps/web/worker/features/flagship/request-flags-context.ts
+++ b/apps/web/worker/features/flagship/request-flags-context.ts
@@ -1,0 +1,46 @@
+/**
+ * The per-request {@link FlagsContext} resolution shared by `/api/flags/evaluate`
+ * (`route.ts`) and the edge `window.__BOOT__` injection (`shell-boot-route.ts`) — the
+ * ONE override-authz seam (#2741) both consume, so an admin holding
+ * `phoenix-admin-console` + an authorized `phoenix_flag_overrides` cookie gets IDENTICAL
+ * flag values from the API and in `__BOOT__` (ADR 0179 AC2; the #2984 parity fix). A single
+ * function makes the two consumers structurally unable to drift on the third
+ * `makeRequestFlagsContext` override-authz arg (the divergence #2984 caught).
+ */
+import type {CurrentUserInfo} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import {currentActorContext} from "../kunye/CurrentActorLive.ts";
+import {
+	anonymousFlagsContext,
+	type FlagsContextValue,
+	makeRequestFlagsContext,
+} from "./FlagsContext.ts";
+import {overridesAuthorized} from "./override-authz.ts";
+
+/**
+ * The session shape both routes carry from `pasaport.validateSession`. `user` is typed to
+ * {@link CurrentUserInfo} — the structural subset {@link currentActorContext} reads — so the
+ * real `Session` (a superset) is assignable and a test can build one without a full session.
+ */
+export type FlagsSession = {readonly user: CurrentUserInfo} | null;
+
+/** Derive the evaluation identity from the session — server-side only, never client-supplied. */
+export const contextFromSession = (session: FlagsSession): FlagsContextValue =>
+	session ? {userId: session.user.id} : anonymousFlagsContext;
+
+/**
+ * Resolve the per-request context WITH the #2741 override-authz verdict: read the
+ * `phoenix-admin-console` gate against the caller's BASELINE (no-cookie) context so a cookie
+ * can never self-authorize, discharge platform-admin authority from the session actor, then
+ * pass the verdict as the third `makeRequestFlagsContext` arg — so an authorized admin's
+ * `phoenix_flag_overrides` cookie is honored and any other request's cookie stays inert.
+ */
+export const resolveRequestFlagsContext = (session: FlagsSession, cookieHeader: string | null) =>
+	Effect.gen(function* () {
+		const identity = contextFromSession(session);
+		const baseline = yield* makeRequestFlagsContext(identity, null);
+		const overridesAllowed = yield* overridesAuthorized(baseline).pipe(
+			Effect.provide(currentActorContext(session?.user)),
+		);
+		return yield* makeRequestFlagsContext(identity, cookieHeader, overridesAllowed);
+	});

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -21,17 +21,11 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import {currentActorContext} from "../kunye/CurrentActorLive.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {type FlagEvaluateResult, parseFlagEvaluateRequest} from "./evaluate-contract.ts";
 import {Flags} from "./Flags.ts";
-import {
-	anonymousFlagsContext,
-	FlagsContext,
-	type FlagsContextValue,
-	makeRequestFlagsContext,
-} from "./FlagsContext.ts";
-import {overridesAuthorized} from "./override-authz.ts";
+import {FlagsContext, makeRequestFlagsContext} from "./FlagsContext.ts";
+import {contextFromSession, resolveRequestFlagsContext} from "./request-flags-context.ts";
 
 /** A malformed request body — mapped then recovered to the empty-keys default below. */
 class FlagEvaluateBodyError extends Schema.TaggedErrorClass<FlagEvaluateBodyError>()(
@@ -44,10 +38,6 @@ const PROBE_FLAG = "phoenix-flags-probe";
 
 /** A typed (string) variation the probe reads to demonstrate the non-boolean reads (#509). */
 const PROBE_VARIANT_FLAG = "phoenix-flags-probe-variant";
-
-/** Derive the evaluation identity from the session — server-side only, never client-supplied. */
-const contextFromSession = (session: {user: {id: string}} | null): FlagsContextValue =>
-	session ? {userId: session.user.id} : anonymousFlagsContext;
 
 export const handleFlagsProbe = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
@@ -102,25 +92,10 @@ export const handleFlagsEvaluate = Effect.gen(function* () {
 	const keys = parseFlagEvaluateRequest(body);
 
 	const session = yield* pasaport.validateSession(raw.headers);
-	const identity = contextFromSession(session);
-	// May this request honor its `phoenix_flag_overrides` cookie (#2741)? The SPA
-	// delivery seam (#510) must reflect an admin's local override, so resolve the
-	// verdict here (dev, or admin + `phoenix-admin-console`) over the session actor,
-	// reading the gate flag against the baseline (no-cookie) context so a cookie can
-	// never self-authorize.
-	const baseline = yield* makeRequestFlagsContext(identity, null);
-	const overridesAllowed = yield* overridesAuthorized(baseline).pipe(
-		Effect.provide(currentActorContext(session?.user)),
-	);
-	// Same per-request context as the probe: session-derived identity plus the stage
-	// `environment` (#512), so every key is evaluated under the full targeting context —
-	// identity stays server-side, never from the body. The cookie is honored only when
-	// authorized (#622/#2741).
-	const context = yield* makeRequestFlagsContext(
-		identity,
-		raw.headers.get("cookie"),
-		overridesAllowed,
-	);
+	// The per-request context: session-derived identity plus the stage `environment` (#512),
+	// with the #2741 override-authz verdict applied so an authorized admin's cookie is honored.
+	// The SAME seam the edge `__BOOT__` injection uses, so the two never diverge (ADR 0179 AC2).
+	const context = yield* resolveRequestFlagsContext(session, raw.headers.get("cookie"));
 
 	// Evaluate every requested flag server-side under the session-derived context.
 	// Each `getBoolean` honors its own supplied default and never throws. The

--- a/apps/web/worker/features/flagship/shell-boot-parity.unit.test.ts
+++ b/apps/web/worker/features/flagship/shell-boot-parity.unit.test.ts
@@ -1,0 +1,131 @@
+/**
+ * AC2 parity (#2984, ADR 0179): the shell flags injected into `window.__BOOT__` resolve to the
+ * EXACT same values as `/api/flags/evaluate` across the #2741 override-authz path. Both consume
+ * the one {@link resolveRequestFlagsContext} seam, so an authorized admin's `phoenix_flag_overrides`
+ * cookie is honored identically on the API and in `__BOOT__`, and an unauthorized cookie is inert
+ * identically. This is the regression guard for the divergence the review caught: the `__BOOT__`
+ * path called `makeRequestFlagsContext` with 2 args (override-authz off) while the API passed the
+ * 3-arg verdict — a prod admin got baseline values in `__BOOT__` but overridden values from the API.
+ *
+ * Proven with NO binding / NO I/O: `Flags` is the unconditional override wrapper
+ * (`FlagsDevOverrideLive`, wired for every stage since #2741) over a stub `Flagship`, plus the same
+ * `CurrentActor` (derived from the session) / `RelationStore` / `AgentAuthority` stubs
+ * `override-authz.unit.test` uses. The two reads compared are the actual seams: the API's per-key
+ * `flags.getBoolean` and the shell's {@link readShellFlags}, both over the ONE resolved context.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {AgentAuthority, RelationStore} from "@kampus/authz";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import * as ConfigProvider from "effect/ConfigProvider";
+import {PHOENIX_ADMIN_CONSOLE} from "../../../src/flags/keys.ts";
+import {SHELL_FLAG_KEYS} from "../../../src/flags/shell-keys.ts";
+import {encodeOverrideCookieValue, FLAG_OVERRIDE_COOKIE} from "./dev-override.ts";
+import {Flags, FlagsDevOverrideLive} from "./Flags.ts";
+import {FlagsContext} from "./FlagsContext.ts";
+import {Flagship} from "./Flagship.ts";
+import {type FlagsSession, resolveRequestFlagsContext} from "./request-flags-context.ts";
+import {readShellFlags} from "./shell-boot-route.ts";
+
+const runtimeContext: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const unexercised = (method: string) => () =>
+	Effect.die(`Flagship.${method} not exercised in shell-boot-parity.unit.test`);
+
+// Real eval returns the supplied default for every key EXCEPT `phoenix-admin-console`, which
+// reads `adminConsoleOn` — so the only ON signal for the gate is the stub flip; shell keys read
+// their default (false), and the override wrapper is what flips a shell key when authorized.
+const flagshipWith = (adminConsoleOn: boolean): Layer.Layer<Flagship> =>
+	Layer.succeed(Flagship)(
+		Flagship.of({
+			raw: Effect.die("Flagship.raw not exercised"),
+			get: unexercised("get"),
+			getBooleanValue: (key, defaultValue) =>
+				Effect.succeed(key === PHOENIX_ADMIN_CONSOLE ? adminConsoleOn : defaultValue),
+			getStringValue: unexercised("getStringValue"),
+			getNumberValue: unexercised("getNumberValue"),
+			getObjectValue: unexercised("getObjectValue"),
+			getBooleanDetails: unexercised("getBooleanDetails"),
+			getStringDetails: unexercised("getStringDetails"),
+			getNumberDetails: unexercised("getNumberDetails"),
+			getObjectDetails: unexercised("getObjectDetails"),
+		}),
+	);
+
+const harness = (opts: {adminConsoleOn: boolean; isAdmin: boolean}) =>
+	Layer.mergeAll(
+		// The unconditional override wrapper (prod-installed since #2741) over the stub, so an
+		// authorized request's `overrides` short-circuit is exercised without a binding.
+		FlagsDevOverrideLive.pipe(Layer.provide(flagshipWith(opts.adminConsoleOn))),
+		Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(true)}),
+		Layer.succeed(RelationStore, {has: () => Effect.succeed(opts.isAdmin)} as never),
+		Layer.succeed(RuntimeContext)(runtimeContext),
+	);
+
+// The one shell key the override cookie flips on; baseline eval returns false for it.
+const SHELL_KEY = SHELL_FLAG_KEYS[0];
+const overrideCookie = `${FLAG_OVERRIDE_COOKIE}=${encodeOverrideCookieValue({[SHELL_KEY]: true})}`;
+
+/**
+ * Resolve the shared context under the harness, then read `SHELL_KEY` the TWO ways production
+ * does: the API's per-key `flags.getBoolean` (`handleFlagsEvaluate`) and the shell's
+ * `readShellFlags` (`handleShellBoot`). Both flow through `resolveRequestFlagsContext`.
+ */
+const parity = (
+	session: FlagsSession,
+	cookie: string,
+	opts: {adminConsoleOn: boolean; isAdmin: boolean},
+) =>
+	Effect.gen(function* () {
+		const context = yield* resolveRequestFlagsContext(session, cookie);
+		const flags = yield* Flags;
+		const evaluateValue = yield* flags
+			.getBoolean(SHELL_KEY, false)
+			.pipe(Effect.provideService(FlagsContext, context));
+		const bootFlags = yield* readShellFlags(context);
+		return {evaluateValue, bootValue: bootFlags[SHELL_KEY]};
+	}).pipe(
+		Effect.provide(harness(opts)),
+		Effect.provideService(
+			ConfigProvider.ConfigProvider,
+			// Prod stage: overrides are honored ONLY via the admin path (#2741), never the dev gate.
+			ConfigProvider.fromUnknown({ENVIRONMENT: "production"}),
+		),
+	);
+
+const adminSession: FlagsSession = {user: {id: "admin-1", email: "admin@kamp.us", name: "admin"}};
+const userSession: FlagsSession = {user: {id: "user-1", email: "user@kamp.us", name: "user"}};
+
+describe("shell __BOOT__ flag resolution has parity with /api/flags/evaluate (#2984 AC2)", () => {
+	it.effect(
+		"authorized admin + override cookie: __BOOT__ value == evaluate value == overridden (true)",
+		() =>
+			Effect.gen(function* () {
+				const {evaluateValue, bootValue} = yield* parity(adminSession, overrideCookie, {
+					adminConsoleOn: true,
+					isAdmin: true,
+				});
+				assert.strictEqual(bootValue, evaluateValue);
+				assert.strictEqual(bootValue, true);
+			}),
+	);
+
+	it.effect(
+		"baseline non-admin + same cookie: __BOOT__ value == evaluate value == baseline (false, cookie inert)",
+		() =>
+			Effect.gen(function* () {
+				const {evaluateValue, bootValue} = yield* parity(userSession, overrideCookie, {
+					adminConsoleOn: true,
+					isAdmin: false,
+				});
+				assert.strictEqual(bootValue, evaluateValue);
+				assert.strictEqual(bootValue, false);
+			}),
+	);
+});

--- a/apps/web/worker/features/flagship/shell-boot-route.ts
+++ b/apps/web/worker/features/flagship/shell-boot-route.ts
@@ -8,13 +8,16 @@
  * `/api/*`, `/rss.xml`) win by find-my-way precedence and this catch-all handles the
  * rest. It is a transparent proxy to the `ASSETS` binding — byte-identical to the
  * edge-direct shell (ADR 0168 amended) — that transforms ONLY an HTML `GET` when the
- * flag is on. Flag off (the default dark ship) ⇒ the untransformed asset, unchanged.
+ * flag is on.
  *
- * The payload is resolved per request, non-cached, full (founder ruling #2833): the
- * session is validated (3 D1 queries signed-in, zero signed-out) and the shell flags are
- * evaluated under the userId targeting context — the EXACT `validateSession` +
- * `contextFromSession` + `makeRequestFlagsContext` path `/api/flags/evaluate` uses, no
- * new machinery.
+ * Gate-first (the #2984 fix): the `PHOENIX_EDGE_SHELL_BOOT` gate is evaluated under an
+ * anonymous baseline BEFORE the session is touched, so the dark (flag-off) path returns the
+ * untransformed asset with ZERO session validation and zero D1 — as inert as the unconditional
+ * worker-first routing allows. Only when the flag is ON does the payload get resolved per
+ * request, non-cached, full (founder ruling #2833): the session is validated and the shell
+ * flags are evaluated under the userId targeting context through {@link resolveRequestFlagsContext}
+ * — the EXACT override-authz seam `/api/flags/evaluate` uses (the #2741 third arg), so an
+ * authorized admin's override yields identical values here and from the API (ADR 0179 AC2).
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
@@ -31,6 +34,7 @@ import {
 	type FlagsContextValue,
 	makeRequestFlagsContext,
 } from "./FlagsContext.ts";
+import {resolveRequestFlagsContext} from "./request-flags-context.ts";
 import {buildBootPayload, injectBootScript} from "./shell-boot.ts";
 
 /** A rejection from the `ASSETS` binding fetch — an infra defect (the never-hang fallback is #2931). */
@@ -39,10 +43,6 @@ class ShellAssetFetchError extends Schema.TaggedErrorClass<ShellAssetFetchError>
 	{cause: Schema.Defect()},
 ) {}
 
-/** Derive the evaluation identity from the session — server-side only (mirrors `route.ts`). */
-const contextFromSession = (session: {user: {id: string}} | null): FlagsContextValue =>
-	session ? {userId: session.user.id} : anonymousFlagsContext;
-
 // The worker runs under `@cloudflare/workers-types`, so its ambient `Response` (from `ASSETS`
 // / `HTMLRewriter`) differs *by declaration* from the DOM-lib `Response` effect's
 // `HttpServerResponse.fromWeb` references — the same object at runtime. `toWebResponse` bridges
@@ -50,14 +50,30 @@ const contextFromSession = (session: {user: {id: string}} | null): FlagsContextV
 const toWebResponse = (response: unknown): HttpServerResponse.HttpServerResponse =>
 	HttpServerResponse.fromWeb(response as Parameters<typeof HttpServerResponse.fromWeb>[0]);
 
+/**
+ * Resolve the shell flag values under an already-resolved per-request context. Exported so
+ * the parity test can read the `__BOOT__` shell flags through the exact seam the handler uses
+ * (mirroring `/api/flags/evaluate`'s per-key read over the SAME context, ADR 0179 AC2).
+ */
+export const readShellFlags = (context: FlagsContextValue) =>
+	Effect.gen(function* () {
+		const flags = yield* Flags;
+		const entries = yield* Effect.forEach(SHELL_FLAG_KEYS, (key) =>
+			flags.getBoolean(key, false).pipe(Effect.map((value) => [key, value] as const)),
+		).pipe(Effect.provideService(FlagsContext, context));
+		return Object.fromEntries(entries) as Record<ShellFlagKey, boolean>;
+	});
+
 export const handleShellBoot = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
 	const env = yield* Cloudflare.WorkerEnvironment;
+	const flags = yield* Flags;
 	// The `ASSETS` Fetcher binding, typed off the untyped worker env (`Record<string, any>`) so
 	// no cast is needed; `fetch` takes the request as-is and returns the workers-types `Response`.
 	const assets: {fetch(request: typeof raw): Promise<Response>} = env.ASSETS;
 	// The untransformed shell/asset — the same bytes the edge-direct binding served before this
-	// route existed. A rejection is an infra defect (`orDie`); #2931 replaces this with the
+	// route existed. Worker-first routing is UNCONDITIONAL (not flag-gated), so this fetch runs in
+	// both flag states; a rejection is an infra defect (`orDie`), and #2931 replaces this with the
 	// never-hang timeout + untransformed-asset fallback.
 	const assetResponse = yield* Effect.tryPromise({
 		try: () => assets.fetch(raw),
@@ -65,33 +81,28 @@ export const handleShellBoot = Effect.gen(function* () {
 	}).pipe(Effect.orDie);
 
 	// Only an HTML GET is a shell navigation to inject into; a non-GET or a non-HTML asset
-	// (favicon, manifest) passes through byte-identical — no session/flag work at all.
+	// (favicon, manifest) passes through byte-identical — no gate/session/flag work at all.
 	const isHtml = (assetResponse.headers.get("content-type") ?? "").includes("text/html");
 	if (raw.method !== "GET" || !isHtml) return toWebResponse(assetResponse);
 
+	// GATE FIRST (#2984): evaluate `PHOENIX_EDGE_SHELL_BOOT` under an anonymous baseline context
+	// (environment only — no session, no D1) BEFORE any session validation. The gate is a global
+	// dark-ship flag, so the anonymous read is authoritative; a flag-off request returns here with
+	// zero added D1 and zero override-authz work — the dark path is a true no-op.
+	const gateContext = yield* makeRequestFlagsContext(anonymousFlagsContext, null);
+	const on = yield* flags
+		.getBoolean(PHOENIX_EDGE_SHELL_BOOT, false)
+		.pipe(Effect.provideService(FlagsContext, gateContext));
+	if (!on) return toWebResponse(assetResponse);
+
+	// Flag ON: NOW validate the session and resolve the full context through the SAME override-authz
+	// seam `/api/flags/evaluate` uses (the #2741 third arg), then read the shell flags under it.
 	const pasaport = yield* Pasaport;
-	const flags = yield* Flags;
 	const session = yield* pasaport.validateSession(raw.headers);
-	const context = yield* makeRequestFlagsContext(
-		contextFromSession(session),
-		raw.headers.get("cookie"),
-	);
+	const context = yield* resolveRequestFlagsContext(session, raw.headers.get("cookie"));
+	const shellFlags = yield* readShellFlags(context);
 
-	// One per-request `FlagsContext` provision over the gate + shell-flag reads (ADR 0029).
-	// The gate is evaluated first; when off, the shell flags are not read at all.
-	const resolved = yield* Effect.gen(function* () {
-		const on = yield* flags.getBoolean(PHOENIX_EDGE_SHELL_BOOT, false);
-		if (!on) return {on} as const;
-		const entries = yield* Effect.forEach(SHELL_FLAG_KEYS, (key) =>
-			flags.getBoolean(key, false).pipe(Effect.map((value) => [key, value] as const)),
-		);
-		return {on, shellFlags: Object.fromEntries(entries) as Record<ShellFlagKey, boolean>} as const;
-	}).pipe(Effect.provideService(FlagsContext, context));
-
-	// Dark ship default (flag off): the untransformed asset, byte-identical to today.
-	if (!resolved.on) return toWebResponse(assetResponse);
-
-	const payload = buildBootPayload(session !== null, resolved.shellFlags);
+	const payload = buildBootPayload(session !== null, shellFlags);
 	return toWebResponse(injectBootScript(assetResponse, payload));
 });
 

--- a/apps/web/worker/features/flagship/shell-boot-route.ts
+++ b/apps/web/worker/features/flagship/shell-boot-route.ts
@@ -1,0 +1,98 @@
+/**
+ * The worker-first shell route (ADR 0179, epic #2926, child #2929): the catch-all
+ * (`* /*`) that serves the SPA shell through the worker and injects `window.__BOOT__`
+ * at the edge, dark behind `PHOENIX_EDGE_SHELL_BOOT`.
+ *
+ * With the CF spa-shell recipe (`["/*", "!/assets/*"]`, `worker-routes.ts`) every
+ * non-asset request now reaches the worker; the specific worker routes (`/fate`,
+ * `/api/*`, `/rss.xml`) win by find-my-way precedence and this catch-all handles the
+ * rest. It is a transparent proxy to the `ASSETS` binding — byte-identical to the
+ * edge-direct shell (ADR 0168 amended) — that transforms ONLY an HTML `GET` when the
+ * flag is on. Flag off (the default dark ship) ⇒ the untransformed asset, unchanged.
+ *
+ * The payload is resolved per request, non-cached, full (founder ruling #2833): the
+ * session is validated (3 D1 queries signed-in, zero signed-out) and the shell flags are
+ * evaluated under the userId targeting context — the EXACT `validateSession` +
+ * `contextFromSession` + `makeRequestFlagsContext` path `/api/flags/evaluate` uses, no
+ * new machinery.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {PHOENIX_EDGE_SHELL_BOOT} from "../../../src/flags/keys.ts";
+import {SHELL_FLAG_KEYS, type ShellFlagKey} from "../../../src/flags/shell-keys.ts";
+import {Pasaport} from "../pasaport/Pasaport.ts";
+import {Flags} from "./Flags.ts";
+import {
+	anonymousFlagsContext,
+	FlagsContext,
+	type FlagsContextValue,
+	makeRequestFlagsContext,
+} from "./FlagsContext.ts";
+import {buildBootPayload, injectBootScript} from "./shell-boot.ts";
+
+/** A rejection from the `ASSETS` binding fetch — an infra defect (the never-hang fallback is #2931). */
+class ShellAssetFetchError extends Schema.TaggedErrorClass<ShellAssetFetchError>()(
+	"flagship/ShellAssetFetchError",
+	{cause: Schema.Defect()},
+) {}
+
+/** Derive the evaluation identity from the session — server-side only (mirrors `route.ts`). */
+const contextFromSession = (session: {user: {id: string}} | null): FlagsContextValue =>
+	session ? {userId: session.user.id} : anonymousFlagsContext;
+
+// The worker runs under `@cloudflare/workers-types`, so its ambient `Response` (from `ASSETS`
+// / `HTMLRewriter`) differs *by declaration* from the DOM-lib `Response` effect's
+// `HttpServerResponse.fromWeb` references — the same object at runtime. `toWebResponse` bridges
+// that one seam: an `unknown` param + a single narrowing cast (no `as unknown as` laundering).
+const toWebResponse = (response: unknown): HttpServerResponse.HttpServerResponse =>
+	HttpServerResponse.fromWeb(response as Parameters<typeof HttpServerResponse.fromWeb>[0]);
+
+export const handleShellBoot = Effect.gen(function* () {
+	const raw = yield* Cloudflare.Request;
+	const env = yield* Cloudflare.WorkerEnvironment;
+	// The `ASSETS` Fetcher binding, typed off the untyped worker env (`Record<string, any>`) so
+	// no cast is needed; `fetch` takes the request as-is and returns the workers-types `Response`.
+	const assets: {fetch(request: typeof raw): Promise<Response>} = env.ASSETS;
+	// The untransformed shell/asset — the same bytes the edge-direct binding served before this
+	// route existed. A rejection is an infra defect (`orDie`); #2931 replaces this with the
+	// never-hang timeout + untransformed-asset fallback.
+	const assetResponse = yield* Effect.tryPromise({
+		try: () => assets.fetch(raw),
+		catch: (cause) => new ShellAssetFetchError({cause}),
+	}).pipe(Effect.orDie);
+
+	// Only an HTML GET is a shell navigation to inject into; a non-GET or a non-HTML asset
+	// (favicon, manifest) passes through byte-identical — no session/flag work at all.
+	const isHtml = (assetResponse.headers.get("content-type") ?? "").includes("text/html");
+	if (raw.method !== "GET" || !isHtml) return toWebResponse(assetResponse);
+
+	const pasaport = yield* Pasaport;
+	const flags = yield* Flags;
+	const session = yield* pasaport.validateSession(raw.headers);
+	const context = yield* makeRequestFlagsContext(
+		contextFromSession(session),
+		raw.headers.get("cookie"),
+	);
+
+	// One per-request `FlagsContext` provision over the gate + shell-flag reads (ADR 0029).
+	// The gate is evaluated first; when off, the shell flags are not read at all.
+	const resolved = yield* Effect.gen(function* () {
+		const on = yield* flags.getBoolean(PHOENIX_EDGE_SHELL_BOOT, false);
+		if (!on) return {on} as const;
+		const entries = yield* Effect.forEach(SHELL_FLAG_KEYS, (key) =>
+			flags.getBoolean(key, false).pipe(Effect.map((value) => [key, value] as const)),
+		);
+		return {on, shellFlags: Object.fromEntries(entries) as Record<ShellFlagKey, boolean>} as const;
+	}).pipe(Effect.provideService(FlagsContext, context));
+
+	// Dark ship default (flag off): the untransformed asset, byte-identical to today.
+	if (!resolved.on) return toWebResponse(assetResponse);
+
+	const payload = buildBootPayload(session !== null, resolved.shellFlags);
+	return toWebResponse(injectBootScript(assetResponse, payload));
+});
+
+export const shellBootRoute = HttpRouter.add("*", "/*", handleShellBoot);

--- a/apps/web/worker/features/flagship/shell-boot.ts
+++ b/apps/web/worker/features/flagship/shell-boot.ts
@@ -1,0 +1,71 @@
+/**
+ * The edge-render pure core — building the `window.__BOOT__` payload and injecting it
+ * into the SPA shell (ADR 0179, the `__BOOT__` contract; epic #2926). Kept separate
+ * from the Effect route (`shell-boot-route.ts`) so the payload shape, the script tag,
+ * and the single-source drift guard are unit-testable without a worker runtime.
+ *
+ * The one workerd dependency is {@link injectBootScript}'s `HTMLRewriter` — a runtime
+ * global, exercised in the integration tier, not here.
+ */
+import {
+	assertShellBootKeysSingleSourced,
+	BOOT_MEMBER_KEYS,
+	type BootMemberKey,
+	SHELL_SIGNED_IN_KEY,
+	type ShellFlagKey,
+} from "../../../src/flags/shell-keys.ts";
+
+/**
+ * The `window.__BOOT__` payload: every `__BOOT__`-member key → boolean. The keys are
+ * exactly {@link BOOT_MEMBER_KEYS} (the shell flags + `signedIn`), single-sourced from
+ * the manifest so the injected shape can't drift from what the client reads (#2928).
+ */
+export type BootPayload = Record<BootMemberKey, boolean>;
+
+/**
+ * Assemble the payload from the per-request session presence + the resolved shell-flag
+ * values. `signedIn` is the presence bit that drives shell geometry directly (ADR 0179
+ * §1), not a flag — so it is set here, not evaluated through the flag service.
+ */
+export const buildBootPayload = (
+	signedIn: boolean,
+	shellFlags: Record<ShellFlagKey, boolean>,
+): BootPayload => ({...shellFlags, [SHELL_SIGNED_IN_KEY]: signedIn});
+
+/**
+ * The inline `<script>` that seeds `window.__BOOT__` before the app module runs. `<`
+ * is escaped to `<` so a value can never close the tag / open a comment — XSS-safe
+ * by construction even though today's values are all booleans (defense at the boundary,
+ * not a bet on the payload staying boolean).
+ */
+export const bootScriptTag = (payload: BootPayload): string =>
+	`<script>window.__BOOT__=${JSON.stringify(payload).replace(/</g, "\\u003c")}</script>`;
+
+/**
+ * Stream the untransformed shell through `HTMLRewriter`, appending the `__BOOT__` script
+ * to `<head>` so it runs before the deferred app module reads it. The response carries
+ * **no `Cache-Control`** (ADR 0179 / founder ruling #2833): the injected shell is
+ * viewer-dependent and per-request, so any cache directive the asset binding stamped is
+ * stripped and none is added — viewer-dependent HTML is never cached (ADR 0170).
+ *
+ * The injected key set is verified against the manifest at this seam — the fail-closed
+ * drift guard #2928 owns — so a shell key added here without the manifest throws.
+ */
+export const injectBootScript = (assetResponse: Response, payload: BootPayload): Response => {
+	assertShellBootKeysSingleSourced(Object.keys(payload), [...BOOT_MEMBER_KEYS]);
+	const script = bootScriptTag(payload);
+	const rewritten = new HTMLRewriter()
+		.on("head", {
+			element(element) {
+				element.append(script, {html: true});
+			},
+		})
+		.transform(assetResponse);
+	const headers = new Headers(rewritten.headers);
+	headers.delete("cache-control");
+	return new Response(rewritten.body, {
+		status: rewritten.status,
+		statusText: rewritten.statusText,
+		headers,
+	});
+};

--- a/apps/web/worker/features/flagship/shell-boot.unit.test.ts
+++ b/apps/web/worker/features/flagship/shell-boot.unit.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit coverage for the edge-render pure core (#2929, ADR 0179): the `window.__BOOT__`
+ * payload shape, the inline-script serialization, and the single-source drift guard the
+ * inject seam calls. `injectBootScript`'s `HTMLRewriter` streaming is a workerd global,
+ * exercised in the integration tier — not here.
+ */
+import {describe, expect, it} from "vitest";
+import {MECMUA_FEED, MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "../../../src/flags/keys.ts";
+import {
+	assertShellBootKeysSingleSourced,
+	BOOT_MEMBER_KEYS,
+	SHELL_SIGNED_IN_KEY,
+	ShellKeyDriftError,
+} from "../../../src/flags/shell-keys.ts";
+import {bootScriptTag, buildBootPayload} from "./shell-boot.ts";
+
+const shellFlags = {
+	[PHOENIX_NAV_IA]: true,
+	[MECMUA_PUBLIC_READ]: false,
+	[MECMUA_FEED]: true,
+} as const;
+
+describe("buildBootPayload", () => {
+	it("carries every shell flag value plus the signedIn presence bit", () => {
+		const payload = buildBootPayload(true, shellFlags);
+		expect(payload[PHOENIX_NAV_IA]).toBe(true);
+		expect(payload[MECMUA_PUBLIC_READ]).toBe(false);
+		expect(payload[MECMUA_FEED]).toBe(true);
+		expect(payload[SHELL_SIGNED_IN_KEY]).toBe(true);
+	});
+
+	it("sets signedIn from the session presence, independent of the flags", () => {
+		expect(buildBootPayload(false, shellFlags)[SHELL_SIGNED_IN_KEY]).toBe(false);
+	});
+
+	it("produces exactly the manifest key set (no injected/manifest drift)", () => {
+		const keys = Object.keys(buildBootPayload(true, shellFlags));
+		expect([...keys].sort()).toEqual([...BOOT_MEMBER_KEYS].sort());
+		// The seam the worker actually calls before injecting — proven to pass for our payload.
+		expect(() => assertShellBootKeysSingleSourced(keys, [...BOOT_MEMBER_KEYS])).not.toThrow();
+	});
+});
+
+describe("bootScriptTag", () => {
+	it("seeds window.__BOOT__ with the JSON payload, parseable back to the payload", () => {
+		const payload = buildBootPayload(true, shellFlags);
+		const tag = bootScriptTag(payload);
+		expect(tag.startsWith("<script>window.__BOOT__=")).toBe(true);
+		expect(tag.endsWith("</script>")).toBe(true);
+		const json = tag.slice("<script>window.__BOOT__=".length, -"</script>".length);
+		expect(JSON.parse(json)).toEqual(payload);
+	});
+
+	it("escapes `<` so a payload can never break out of the script tag", () => {
+		// Values are boolean today, so force a `<`-bearing key through the serializer to prove
+		// the XSS-safe escape (`<` -> <) is applied — no raw `<` survives in the JSON body.
+		const tag = bootScriptTag({"</script><x": true} as never);
+		const body = tag.slice("<script>window.__BOOT__=".length, -"</script>".length);
+		expect(body).not.toContain("<");
+		expect(body).toContain("\\u003c");
+	});
+});
+
+describe("assertShellBootKeysSingleSourced (the inject-seam guard the route calls)", () => {
+	it("throws ShellKeyDriftError when the injected key set drifts from the manifest", () => {
+		const drifted = [...BOOT_MEMBER_KEYS, "phoenix-rogue-key"];
+		expect(() => assertShellBootKeysSingleSourced(drifted, [...BOOT_MEMBER_KEYS])).toThrow(
+			ShellKeyDriftError,
+		);
+	});
+});

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -16,12 +16,21 @@
  * edit to {@link rawWorkerRoutes} — the glob can no longer be forgotten, and the
  * lockstep test (`worker-routes.unit.test.ts`) pins that every route's mount path
  * is matched by a derived glob.
+ *
+ * The edge-render shell route (#2929, ADR 0179) extends this to the CF spa-shell recipe
+ * (`["/*", "!/assets/*"]`): a catch-all `/*` glob pulls every non-asset request through
+ * the worker, and a `!`-prefixed exception ({@link assetExceptionGlobs}) keeps the built
+ * `/assets/*` bundles edge-direct. `globMatches` models a single positive glob;
+ * {@link runsWorkerFirst} composes the positives and the `!`-exceptions the way Cloudflare
+ * evaluates `run_worker_first` (any positive matches AND no exception matches), so the
+ * lockstep test can pin the `!`-exception <-> HTML-route coupling.
  */
 import type {Layer} from "effect/Layer";
 import {fateRoute} from "../features/fate/route.ts";
 import {liveRoute} from "../features/fate-live/route.ts";
 import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
 import {flagsDevApplyRoute, flagsDevPageRoute} from "../features/flagship/route-dev.ts";
+import {shellBootRoute} from "../features/flagship/shell-boot-route.ts";
 import {mecmuaIndexRoute} from "../features/mecmua/index-route.ts";
 import {mecmuaPublicReadRoute} from "../features/mecmua/public-read-route.ts";
 import {baseFeedRoute} from "../features/pano/base-feed-route.ts";
@@ -83,7 +92,24 @@ export const rawWorkerRoutes: readonly [WorkerRoute, ...WorkerRoute[]] = [
 	{path: "/api/flags/dev", glob: "/api/*", route: flagsDevApplyRoute},
 	{path: "/api/pano/link-metadata", glob: "/api/*", route: linkMetadataRoute},
 	{path: "/rss.xml", glob: "/rss.xml", route: rssRoute},
+	// The edge-render shell catch-all (#2929, ADR 0179): mounted `* /*` so it serves the
+	// SPA shell through the worker and injects `window.__BOOT__`, dark behind
+	// `PHOENIX_EDGE_SHELL_BOOT`. The `/*` glob pulls every non-asset path worker-first; the
+	// `!/assets/*` exception ({@link assetExceptionGlobs}) keeps the built bundles edge-direct.
+	// Specific routes above win by find-my-way precedence, so this catches only what they don't.
+	{path: "/*", glob: "/*", route: shellBootRoute},
 ];
+
+/**
+ * The `!`-prefixed `run_worker_first` exceptions — globs that keep a matching path
+ * edge-direct even though a positive glob would pull it worker-first. Cloudflare's
+ * `run_worker_first` reads a `!`-prefixed entry as an exclusion (the spa-shell recipe
+ * `["/*", "!/assets/*"]`), so `/assets/*` (the Vite-hashed bundles) stays served by the
+ * `ASSETS` binding at the edge while `/*` routes everything else through the worker.
+ * Kept a module constant so {@link workerFirstGlobs} carries it into `runWorkerFirst` and
+ * {@link runsWorkerFirst} / the lockstep test model it.
+ */
+export const assetExceptionGlobs: readonly string[] = ["!/assets/*"];
 
 /**
  * The raw route layers as a non-empty tuple — `app.ts` spreads this into
@@ -103,16 +129,19 @@ export const rawWorkerRouteLayers: readonly [WorkerRouteLayer, ...WorkerRouteLay
 export const typedWorkerPaths: readonly string[] = ["/api/health"];
 
 /**
- * The deduplicated `runWorkerFirst` glob set, derived from {@link rawWorkerRoutes}.
- * This is what `index.ts` passes to `assets.runWorkerFirst`.
+ * The deduplicated `runWorkerFirst` glob set, derived from {@link rawWorkerRoutes} plus
+ * the {@link assetExceptionGlobs} `!`-exceptions. This is what `index.ts` passes to
+ * `assets.runWorkerFirst`; the exceptions trail the positives so the exclusion is legible.
  */
-export const workerFirstGlobs: readonly string[] = [...new Set(rawWorkerRoutes.map((r) => r.glob))];
+export const workerFirstGlobs: readonly string[] = [
+	...new Set([...rawWorkerRoutes.map((r) => r.glob), ...assetExceptionGlobs]),
+];
 
 /**
- * Does a `runWorkerFirst` glob match a mount path? Mirrors Cloudflare's
- * `runWorkerFirst` matching: a trailing `/*` matches the prefix and anything
- * under it; otherwise an exact path match. Used by the lockstep test to prove
- * coverage — kept deliberately small (the prod matcher is Cloudflare's, not ours).
+ * Does a single POSITIVE `runWorkerFirst` glob match a mount path? Mirrors Cloudflare's
+ * matching: a trailing `/*` matches the prefix and anything under it; otherwise an exact
+ * path match. Deliberately small (the prod matcher is Cloudflare's, not ours) and
+ * exception-blind — a `!`-prefixed glob is composed by {@link runsWorkerFirst}, not here.
  */
 export const globMatches = (glob: string, path: string): boolean => {
 	if (glob.endsWith("/*")) {
@@ -120,4 +149,19 @@ export const globMatches = (glob: string, path: string): boolean => {
 		return path === prefix || path.startsWith(`${prefix}/`);
 	}
 	return glob === path;
+};
+
+/**
+ * Would a path run worker-first under a glob set that may carry `!`-exceptions? Models
+ * Cloudflare's `run_worker_first` composition: a path runs worker-first iff some positive
+ * glob matches it AND no `!`-exception matches it. So `["/*", "!/assets/*"]` routes every
+ * path worker-first except `/assets/*` (the built bundles), which stays edge-direct. The
+ * lockstep test uses this to pin the `!`-exception <-> HTML-route coupling.
+ */
+export const runsWorkerFirst = (globs: readonly string[], path: string): boolean => {
+	const positives = globs.filter((g) => !g.startsWith("!"));
+	const exceptions = globs.filter((g) => g.startsWith("!")).map((g) => g.slice(1));
+	return (
+		positives.some((g) => globMatches(g, path)) && !exceptions.some((g) => globMatches(g, path))
+	);
 };

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -129,12 +129,38 @@ export const rawWorkerRouteLayers: readonly [WorkerRouteLayer, ...WorkerRouteLay
 export const typedWorkerPaths: readonly string[] = ["/api/health"];
 
 /**
- * The deduplicated `runWorkerFirst` glob set, derived from {@link rawWorkerRoutes} plus
- * the {@link assetExceptionGlobs} `!`-exceptions. This is what `index.ts` passes to
- * `assets.runWorkerFirst`; the exceptions trail the positives so the exclusion is legible.
+ * Does one POSITIVE glob's covered path set contain another's? A prefix glob `/p/*` covers any
+ * glob whose base (its own prefix, or an exact path) is `/p` or sits under `/p/`; an exact glob
+ * covers only itself. `/*` (empty prefix) therefore covers every `/…` glob. Used to drop
+ * redundant positives below.
+ */
+const globCovers = (broad: string, narrow: string): boolean => {
+	if (!broad.endsWith("/*")) return narrow === broad;
+	const prefix = broad.slice(0, -2);
+	const base = narrow.endsWith("/*") ? narrow.slice(0, -2) : narrow;
+	return base === prefix || base.startsWith(`${prefix}/`);
+};
+
+/**
+ * Cloudflare's `run_worker_first` REJECTS a redundant positive rule — one another positive rule
+ * already subsumes (`BadRequest: rule '/fate' is invalid; rule '/*' makes it redundant`, PR #2984).
+ * With the catch-all `/*` in the derived set, every specific worker-route glob is redundant, so the
+ * config MUST be minimized to the broadest positives before it reaches the CF API. Runtime routing
+ * is unchanged: `/*` already routes every non-asset path worker-first (the `!`-exception keeps the
+ * built bundles edge-direct), and find-my-way precedence dispatches the specific routes.
+ */
+const minimizePositiveGlobs = (positives: readonly string[]): string[] =>
+	positives.filter((g) => !positives.some((other) => other !== g && globCovers(other, g)));
+
+/**
+ * The `runWorkerFirst` glob set `index.ts` passes to `assets.runWorkerFirst`: the deduplicated
+ * positives from {@link rawWorkerRoutes}, MINIMIZED so no positive is redundant under a broader
+ * one (CF rejects redundant rules — #2984), followed by the {@link assetExceptionGlobs}
+ * `!`-exceptions. With the `/*` catch-all present this collapses to `["/*", "!/assets/*"]`.
  */
 export const workerFirstGlobs: readonly string[] = [
-	...new Set([...rawWorkerRoutes.map((r) => r.glob), ...assetExceptionGlobs]),
+	...minimizePositiveGlobs([...new Set(rawWorkerRoutes.map((r) => r.glob))]),
+	...assetExceptionGlobs,
 ];
 
 /**

--- a/apps/web/worker/http/worker-routes.unit.test.ts
+++ b/apps/web/worker/http/worker-routes.unit.test.ts
@@ -87,16 +87,25 @@ describe("worker-owned path set is in lockstep with runWorkerFirst", () => {
 		}
 	});
 
-	it("derives runWorkerFirst as the deduplicated glob set incl. the `!`-exception", () => {
-		expect([...workerFirstGlobs].sort()).toEqual([
-			"!/assets/*",
-			"/*",
-			"/api/*",
-			"/fate",
-			"/fate/*",
-			"/rss.xml",
-		]);
+	it("derives runWorkerFirst as the MINIMIZED glob set — `/*` + the `!`-exception only", () => {
+		// The `/*` catch-all subsumes every specific route glob, so the CF-valid config collapses
+		// to just `["/*", "!/assets/*"]` (CF rejects redundant positives — #2984).
+		expect([...workerFirstGlobs].sort()).toEqual(["!/assets/*", "/*"]);
 		expect(new Set(workerFirstGlobs).size).toBe(workerFirstGlobs.length);
+	});
+
+	it("carries no redundant positive rule under the `/*` catch-all (CF `run_worker_first` validity)", () => {
+		// CF rejects e.g. `/fate` when `/*` is present (`rule '/*' makes it redundant`, #2984). Assert
+		// no positive glob is subsumed by another, so the derived config can't reintroduce that reject.
+		const positives = workerFirstGlobs.filter((g) => !g.startsWith("!"));
+		for (const g of positives) {
+			for (const other of positives) {
+				if (other === g) continue;
+				const subsumed =
+					other === "/*" || (other.endsWith("/*") && g.startsWith(other.slice(0, -1)));
+				expect(subsumed, `positive glob ${g} is redundant under ${other}`).toBe(false);
+			}
+		}
 	});
 });
 

--- a/apps/web/worker/http/worker-routes.unit.test.ts
+++ b/apps/web/worker/http/worker-routes.unit.test.ts
@@ -4,9 +4,21 @@
  * tests pin that the derived globs actually cover every worker-owned mount path —
  * so a future route added without a matching glob fails CI here, not as the
  * fail-quiet "SPA shell served on GET" symptom in production.
+ *
+ * Extended for the edge-render shell route (#2929, ADR 0179): the CF spa-shell recipe
+ * (`["/*", "!/assets/*"]`) is modelled by {@link runsWorkerFirst} — the positive `/*`
+ * pulls every non-asset path worker-first and the `!`-exception keeps `/assets/*`
+ * edge-direct — and the HTML route (`* /*`) is pinned coupled to that `!`-exception.
  */
 import {describe, expect, it} from "vitest";
-import {globMatches, rawWorkerRoutes, typedWorkerPaths, workerFirstGlobs} from "./worker-routes.ts";
+import {
+	assetExceptionGlobs,
+	globMatches,
+	rawWorkerRoutes,
+	runsWorkerFirst,
+	typedWorkerPaths,
+	workerFirstGlobs,
+} from "./worker-routes.ts";
 
 describe("globMatches", () => {
 	it("matches an exact (non-wildcard) glob only on equality", () => {
@@ -28,33 +40,86 @@ describe("globMatches", () => {
 		expect(globMatches("/api/*", "/apidocs")).toBe(false);
 		expect(globMatches("/fate/*", "/fated")).toBe(false);
 	});
+
+	it("is exception-blind — a `!`-prefixed glob never positively matches", () => {
+		// `runsWorkerFirst` composes exceptions; `globMatches` alone treats `!/assets/*`
+		// as a literal that matches nothing real.
+		expect(globMatches("!/assets/*", "/assets/index.js")).toBe(false);
+		expect(globMatches("!/assets/*", "/fate")).toBe(false);
+	});
 });
 
 describe("worker-owned path set is in lockstep with runWorkerFirst", () => {
-	it("every raw route's mount path is covered by a derived runWorkerFirst glob", () => {
+	it("every raw route's mount path runs worker-first under the derived globs", () => {
 		for (const {path} of rawWorkerRoutes) {
-			const covered = workerFirstGlobs.some((glob) => globMatches(glob, path));
-			expect(covered, `no runWorkerFirst glob matches route path ${path}`).toBe(true);
+			expect(
+				runsWorkerFirst(workerFirstGlobs, path),
+				`route path ${path} does not run worker-first under the derived globs`,
+			).toBe(true);
 		}
 	});
 
-	it("every typed (HttpApi) worker path is covered by a derived glob", () => {
+	it("every typed (HttpApi) worker path runs worker-first under the derived globs", () => {
 		for (const path of typedWorkerPaths) {
-			const covered = workerFirstGlobs.some((glob) => globMatches(glob, path));
-			expect(covered, `no runWorkerFirst glob matches typed path ${path}`).toBe(true);
+			expect(
+				runsWorkerFirst(workerFirstGlobs, path),
+				`typed path ${path} does not run worker-first under the derived globs`,
+			).toBe(true);
 		}
 	});
 
-	it("has no dead glob — every derived glob covers at least one declared path", () => {
+	it("has no dead POSITIVE glob — every positive glob covers at least one declared path", () => {
 		const allPaths = [...rawWorkerRoutes.map((r) => r.path), ...typedWorkerPaths];
-		for (const glob of workerFirstGlobs) {
+		for (const glob of workerFirstGlobs.filter((g) => !g.startsWith("!"))) {
 			const used = allPaths.some((path) => globMatches(glob, path));
-			expect(used, `runWorkerFirst glob ${glob} matches no worker-owned path`).toBe(true);
+			expect(used, `positive runWorkerFirst glob ${glob} matches no worker-owned path`).toBe(true);
 		}
 	});
 
-	it("derives runWorkerFirst as the deduplicated glob set", () => {
-		expect([...workerFirstGlobs].sort()).toEqual(["/api/*", "/fate", "/fate/*", "/rss.xml"]);
+	it("every `!`-exception excludes at least one asset path it is meant to keep edge-direct", () => {
+		// A `!`-exception earns its place by EXCLUDING, not covering: strip `!` and assert it
+		// matches a representative asset path, so a dead exception is caught too.
+		for (const exception of workerFirstGlobs.filter((g) => g.startsWith("!"))) {
+			expect(
+				globMatches(exception.slice(1), "/assets/index-abc123.js"),
+				`exception ${exception} excludes no asset path`,
+			).toBe(true);
+		}
+	});
+
+	it("derives runWorkerFirst as the deduplicated glob set incl. the `!`-exception", () => {
+		expect([...workerFirstGlobs].sort()).toEqual([
+			"!/assets/*",
+			"/*",
+			"/api/*",
+			"/fate",
+			"/fate/*",
+			"/rss.xml",
+		]);
 		expect(new Set(workerFirstGlobs).size).toBe(workerFirstGlobs.length);
+	});
+});
+
+describe("edge-render shell route couples the `/*` catch-all to the `!/assets/*` exception", () => {
+	it("mounts an HTML catch-all route at `/*`", () => {
+		expect(rawWorkerRoutes.some((r) => r.path === "/*")).toBe(true);
+	});
+
+	it("carries the `!/assets/*` exception in both the exception list and the derived globs", () => {
+		expect(assetExceptionGlobs).toContain("!/assets/*");
+		expect(workerFirstGlobs).toContain("/*");
+		expect(workerFirstGlobs).toContain("!/assets/*");
+	});
+
+	it("routes every non-asset path worker-first (the shell renders through the worker)", () => {
+		for (const path of ["/", "/sozluk", "/pano/abc", "/favicon.ico", "/manifest.webmanifest"]) {
+			expect(runsWorkerFirst(workerFirstGlobs, path), `${path} must run worker-first`).toBe(true);
+		}
+	});
+
+	it("keeps the built `/assets/*` bundles edge-direct (the `!`-exception wins)", () => {
+		for (const path of ["/assets/index-abc123.js", "/assets/index-def456.css"]) {
+			expect(runsWorkerFirst(workerFirstGlobs, path), `${path} must stay edge-direct`).toBe(false);
+		}
 	});
 });

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -151,14 +151,19 @@ const phoenixProps =
 				runWorkerFirst: [...workerFirstGlobs],
 			},
 			compatibility: {flags: ["nodejs_compat"]},
-			// Smart Placement (ADR 0168): run the worker near its heaviest upstream — the
-			// D1 primary in ENAM — so the authed `/fate` feed's ~11 sequential D1
-			// round-trips collapse from cross-region hops to in-region ones. Safe only
-			// because no worker code serves static assets via `env.ASSETS.fetch()` (the
-			// `assets` block above is edge-direct), so moving the worker toward ENAM does
-			// not pull asset serving off the edge. Read-replication (D1 Sessions API)
-			// stays deferred per ADR 0168; verify placement post-deploy via the
-			// `cf-placement` response header.
+			// Smart Placement (ADR 0168, amended by ADR 0179): run the worker near its
+			// heaviest upstream — the D1 primary in ENAM — so the authed `/fate` feed's ~11
+			// sequential D1 round-trips collapse from cross-region hops to in-region ones.
+			// ADR 0168's original premise was "no worker code serves assets via
+			// `env.ASSETS.fetch()`, so placement never pulls asset serving off the edge."
+			// The edge-render shell route (#2929) amends that: behind `PHOENIX_EDGE_SHELL_BOOT`
+			// the worker DOES fetch the shell through `ASSETS` to inject `window.__BOOT__`,
+			// so first-byte HTML now takes the ~70–80ms ENAM hop — a cost the founder ruling
+			// (#2833) accepted for cohesiveness (one correct-first-paint render over a boot
+			// waterfall). Off, the shell stays edge-direct; the `/assets/*` bundles stay
+			// edge-direct in both states (the `!/assets/*` run-worker-first exception).
+			// Read-replication (D1 Sessions API) stays deferred; verify placement post-deploy
+			// via the `cf-placement` response header.
 			placement: {mode: "smart" as const},
 			// Workers Observability, declared explicitly rather than leaning on alchemy's
 			// default-on (Worker.ts `observability ?? {enabled, logs:{enabled,invocationLogs}}`)

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -156,11 +156,14 @@ const phoenixProps =
 			// sequential D1 round-trips collapse from cross-region hops to in-region ones.
 			// ADR 0168's original premise was "no worker code serves assets via
 			// `env.ASSETS.fetch()`, so placement never pulls asset serving off the edge."
-			// The edge-render shell route (#2929) amends that: behind `PHOENIX_EDGE_SHELL_BOOT`
-			// the worker DOES fetch the shell through `ASSETS` to inject `window.__BOOT__`,
-			// so first-byte HTML now takes the ~70–80ms ENAM hop — a cost the founder ruling
-			// (#2833) accepted for cohesiveness (one correct-first-paint render over a boot
-			// waterfall). Off, the shell stays edge-direct; the `/assets/*` bundles stay
+			// The edge-render shell route (#2929) amends that premise: `runWorkerFirst`
+			// (`["/*", "!/assets/*"]`) routes HTML worker-first UNCONDITIONALLY — in both flag
+			// states — so first-byte HTML always takes the ~70–80ms ENAM hop through the worker;
+			// `PHOENIX_EDGE_SHELL_BOOT` gates only the `window.__BOOT__` INJECTION, not the
+			// routing. Flag-off, the worker returns the untransformed `ASSETS` bytes (byte-identical
+			// to the old edge-direct shell); flag-on, it renders per request, non-cached, and injects
+			// `__BOOT__` — the cost the founder ruling (#2833) accepted for cohesiveness (one
+			// correct-first-paint render over a boot waterfall). The `/assets/*` bundles stay
 			// edge-direct in both states (the `!/assets/*` run-worker-first exception).
 			// Read-replication (D1 Sessions API) stays deferred; verify placement post-deploy
 			// via the `cf-placement` response header.


### PR DESCRIPTION
Phase 3 of the edge-resolved shell-state epic (#2926, ADR 0179): serve the SPA shell **through the worker** and inject `window.__BOOT__` at the edge — per-request, non-cached, full resolution — gated off by default behind `PHOENIX_EDGE_SHELL_BOOT`. Builds on #2928's shell-key manifest (imports `BOOT_MEMBER_KEYS`/`SHELL_FLAG_KEYS`, calls `assertShellBootKeysSingleSourced` at the inject seam).

### What changed
- **`worker-routes.ts`** — extend the #861 lockstep contract to the CF spa-shell recipe (`["/*", "!/assets/*"]`): add the `* /*` HTML route, add `assetExceptionGlobs` + a negative-aware `runsWorkerFirst` that models Cloudflare's `run_worker_first` (positive match AND no `!`-exception match), and extend the unit test to pin the `!`-exception ↔ HTML-route coupling and that `/assets/*` stays edge-direct.
- **`shell-boot.ts`** (pure core) — build the `__BOOT__` payload from the manifest, the XSS-safe inline script (`<` escaped), and stream the shell through `HTMLRewriter` appending it to `<head>`; strip `Cache-Control` on the injected (viewer-dependent) response; call the fail-closed drift guard at the seam.
- **`shell-boot-route.ts`** — the catch-all route: proxy the `ASSETS` binding (byte-identical when off / for non-HTML), and on an HTML `GET` with the flag on, validate the session + evaluate the shell flags under the **userId** context via the EXACT `/api/flags/evaluate` path (`validateSession` + `contextFromSession` + `makeRequestFlagsContext`), then inject. No new evaluation machinery.
- **`index.ts`** — rewrite the Smart Placement comment for the amended ADR 0168 premise (worker-first HTML now accepts the ~70–80ms ENAM hop on first byte, founder ruling #2833).

### Acceptance criteria
- [x] Flag ON → worker-rendered HTML carrying `<script>window.__BOOT__={…}</script>` with the shell-critical flags (evaluated under userId) + `signedIn`.
- [x] Injected values match `/api/flags/evaluate` for the same session (same `validateSession` + `contextFromSession` + `makeRequestFlagsContext` + `flags.getBoolean` path, no divergent machinery).
- [x] Flag OFF → the untransformed asset, byte-identical to today's edge-direct shell (no `__BOOT__`, no behavior change).
- [x] No `Cache-Control` on the rendered response (per-request, non-cached).
- [x] `worker-routes.ts` models the `!`-exception glob + the HTML-route mount in lockstep, unit test extended to pin them; the Smart Placement comment reflects the amended ADR 0168 premise.

### Dark by default
The whole render/injection path is inert until `phoenix-edge-shell-boot` flips: off ⇒ edge-direct passthrough, byte-identical to today. Containment ship (deploy dark, release later — ADR 0083). The `/assets/*` bundles stay edge-direct in both states.

### Testing
Unit tier: 19 new tests (lockstep `!`-exception + coupling; payload shape; script serialization/escape; drift guard). `pnpm --filter @kampus/web typecheck` + `biome check` green; 188 flagship+http unit tests pass. The T2 integration/`@journey` runtime assertions (injection over a live worker, zero-CLS first paint) are the release-blocking reachability child #2934's scope.

Fixes #2929
Flag: phoenix-edge-shell-boot