### PR TITLE
chore(pipeline-cli): deslop-comments over packages/pipeline-cli (#2871)

### DIFF
--- a/packages/pipeline-cli/src/tools/campaign/github.ts
+++ b/packages/pipeline-cli/src/tools/campaign/github.ts
@@ -128,7 +128,7 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 	});
 });
 
-// --- REST arg builders (REST only, never GraphQL) --------------------------------
+// REST-only arg builders — never GraphQL.
 
 // `-X GET -f k=v` sends query params (with encoding), so a wave label with special chars is safe.
 const clusterArgs = (repo: string, waveLabel: string): ReadonlyArray<string> => [
@@ -151,8 +151,6 @@ const commentsArgs = (repo: string, issue: number): ReadonlyArray<string> => [
 	`repos/${repo}/issues/${issue}/comments?per_page=100`,
 ];
 
-// --- boundary decoders -----------------------------------------------------------
-
 /** A raw issue as the issues endpoint returns it; `pull_request` present ⇒ it's a PR, filtered out. */
 const RawIssue = Schema.Struct({
 	number: Schema.Number,
@@ -168,8 +166,6 @@ const RawComment = Schema.Struct({
 	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
 });
 const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
-
-// --- IO operations ---------------------------------------------------------------
 
 /** The issue numbers carrying the wave label (PRs filtered out — the label binds to issues). */
 const clusterIssues = Effect.fn("Github.clusterIssues")(function* (

--- a/packages/pipeline-cli/src/tools/decisions-index/decisions-index.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/decisions-index.ts
@@ -1,40 +1,19 @@
 /**
- * `@kampus/decisions-index` core — the pure, IO-free derivation of the ADR map(s)
- * from the ADR files.
+ * `@kampus/decisions-index` core — pure, IO-free derivation of the ADR map(s) from the
+ * `.decisions/NNNN-*.md` files. Each file's YAML front-matter (`id`/`title`/`status`/`date`)
+ * is the single source of truth; the compact ambient map (`renderCompact`, ADR 0126) and the
+ * legacy markdown table (`renderIndex`) are derived, ordered by `id` ascending. There is no
+ * committed `index.md` (ADR 0126, supersedes 0066's storage half); the legacy builders are
+ * retained only for the `generate`/`check` surfaces.
  *
- * The single source of truth is each `.decisions/NNNN-*.md` file's YAML
- * front-matter (`id`, `title`, `status`, `date`); both the compact ambient map
- * (`renderCompact` — one line per ADR, the ADR 0126 surface) and the legacy markdown
- * table (`renderIndex`) are *derived* output, deterministically ordered by `id`
- * ascending. There is no committed `index.md` anymore (ADR 0126, supersedes 0066's
- * storage half); discovery is ambient. `renderIndex`/`buildIndex` are retained only
- * for the legacy `generate`/`check` CLI surfaces.
- *
- * `buildIndex` folds the sibling problem in: a **duplicate `id`** across files is
- * a `DuplicateIdError`, so the same gate that catches a stale index catches two
- * same-numbered ADR files coexisting on `main`.
- *
- * The ADR number lives on **two axes** that must agree: the filename `NNNN[a]`
- * prefix (what `/adr` allocates and what humans/git key on) and the front-matter
- * `id`. `parseAdrFile` enforces filename-prefix == `id` (`NumberMismatchError`), so
- * the two can never drift. That single invariant upgrades the front-matter-keyed
- * `findDuplicateId` into a **filename-NNNN** duplicate guard for free: two files
- * sharing a `0114-*.md` prefix necessarily share `id: 0114` (or one mismatches its
- * own filename and is rejected first), so the collision the ledger's filename
- * primary key suffers is caught at `check` time. This is the within-tree half of
- * the #1471 fix; the residual it does NOT catch is two *stale* concurrent PR
- * branches that each add a `0114-*.md` the other can't see — that only becomes a
- * single-tree duplicate once both land on `main`, where the next `check` then fails
- * loudly (a cross-open-PR pre-merge guard is out of scope; see ADR 0066 / #1471).
- *
- * Two non-obvious points, both load-bearing and pinned by the unit tests:
- *  - `title`/`status` render **verbatim** from front-matter — they may carry
- *    inline markdown (a linked `superseded by [0009](…)`), so the front-matter is
- *    the curated display text, not just a bare keyword. Make the file right; the
- *    table mirrors it.
- *  - ordering is numeric-then-suffix so a lettered id like `0034a` sorts between
- *    `0034` and `0035` (a plain string sort would too here, but the explicit
- *    numeric compare keeps it correct if ids ever stop being zero-padded).
+ * Two load-bearing points, both pinned by the unit tests:
+ *  - `title`/`status` render VERBATIM — they may carry inline markdown (a linked
+ *    `superseded by [0009](…)`), so the front-matter is the curated display text.
+ *  - The ADR number lives on two axes that must agree — the filename `NNNN[a]` prefix and
+ *    the front-matter `id`. `parseAdrFile` enforces prefix == `id` (`NumberMismatchError`),
+ *    which for free upgrades the id-keyed `findDuplicateId` into a filename-collision guard
+ *    at `check` time. This is the within-tree half of #1471; two stale concurrent PR branches
+ *    each adding `0114-*.md` are out of scope until both land on `main` (see ADR 0066 / #1471).
  */
 
 export interface AdrEntry {
@@ -198,21 +177,12 @@ const idSortKey = (id: string): [number, string] => {
 export const ADR_ID_WIDTH = 4;
 
 /**
- * The next free ADR number as a zero-padded string — `max(numeric id) + 1`, padded
- * to {@link ADR_ID_WIDTH} (`[…, 0151] → "0152"`, empty set → `0001`). The
- * deterministic allocator that replaces eyeballing `.decisions/` — which goes stale
- * between a local checkout and origin/main, or races two simultaneous authors onto
- * the same guess (#2064). A pure derivation over the parsed entries, reading the same
- * `id` axis the index/validate surfaces read, so the number it hands out is exactly
- * the one `validate` guards.
- *
- * A **lettered** id (`0034a`, a supersede-in-place variant) shares its base numeric
- * with `0034`, so it never advances the allocation past `0035` — the letter suffix is
- * deliberately ignored, only the numeric axis allocates. This is an allocator, **not**
- * a collision guard: the rare two-authors-at-once collision is still caught fail-closed
- * by `validate` (`findDuplicateId`) on merge. `next` kills the stale-guess case,
- * `validate` backs the simultaneous case — the two together are collision-proof without
- * a date-slug rename (#2064, supersedes #2058).
+ * The next free ADR number, zero-padded to {@link ADR_ID_WIDTH} — `max(numeric id) + 1`
+ * (empty set → `0001`). The deterministic allocator replacing an eyeballed `.decisions/`,
+ * which goes stale or races two authors onto the same guess (#2064). A lettered id (`0034a`,
+ * a supersede-in-place variant) shares its base numeric, so it never advances allocation. This
+ * is an allocator, NOT a collision guard: the rare simultaneous collision is still caught by
+ * `validate` (`findDuplicateId`) on merge — the two together are collision-proof (#2064).
  */
 export const nextAdrNumber = (entries: ReadonlyArray<AdrEntry>): string => {
 	let max = 0;
@@ -298,11 +268,10 @@ export const renderIndex = (entries: ReadonlyArray<AdrEntry>): string => {
 };
 
 /**
- * Render the ambient compact ADR map: one line per ADR, `id · title · status`,
- * sorted ascending by id (ADR 0126). This is the map the SessionStart hook injects
- * (#1728) — no table, no links, no committed file; a dense line per ADR the loader
- * surfaces into context the way the skills catalog does. `title`/`status` render
- * verbatim from front-matter, the same source-of-truth as the table rows.
+ * Render the ambient compact ADR map: one line per ADR, `id · title · status`, sorted
+ * ascending by id (ADR 0126). No table, links, or committed file — surfaced on demand via
+ * `pipeline-cli decisions-index compact` (ADR 0129 dropped the SessionStart hook).
+ * `title`/`status` render verbatim, the same source-of-truth as the table rows.
  */
 export const renderCompact = (entries: ReadonlyArray<AdrEntry>): string =>
 	sortEntries(entries)

--- a/packages/pipeline-cli/src/tools/epic-lock/github.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/github.ts
@@ -153,7 +153,7 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 	});
 });
 
-// --- REST arg builders (REST only, never GraphQL) --------------------------------
+// REST-only arg builders — never GraphQL.
 
 const issueArgs = (repo: string, epic: number): ReadonlyArray<string> => [
 	"api",
@@ -209,8 +209,6 @@ const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
 	".permission",
 ];
 
-// --- boundary decoders -----------------------------------------------------------
-
 /** The issue-label array `[.labels[].name]` returns. */
 const decodeLabels = Schema.decodeUnknownEffect(Schema.Array(Schema.String));
 
@@ -232,8 +230,6 @@ const toClaimComment = (raw: (typeof RawComment)["Type"]): ClaimComment => ({
 
 /** A clean 404 — the only `gh` failure that means "already gone / not found". */
 const is404 = (stderr: string): boolean => /404|not found/i.test(stderr);
-
-// --- IO operations ---------------------------------------------------------------
 
 const labelHeld = Effect.fn("Github.labelHeld")(function* (repo: string, epic: number) {
 	const args = issueArgs(repo, epic);

--- a/packages/pipeline-cli/src/tools/eval-harness/report.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/report.ts
@@ -331,11 +331,9 @@ export const renderTable = (scorecard: Scorecard): string => {
 	return lines.join("\n");
 };
 
-// --- The report's on-disk input: a serialized array of runner rows (`RunRow[]`) --------------
-//
-// The report command reads the runner's graded rows from a JSON file — the array `collectRuns`
-// produces, serialized. These schemas decode that file totally: a malformed body or a shape
-// mismatch returns a typed `Result` failure, never a throw (mirrors `decodeManifest`).
+// On-disk input: a serialized array of runner rows (`RunRow[]`) — the array `collectRuns`
+// produces. These schemas decode it totally: a malformed body or shape mismatch returns a
+// typed `Result` failure, never a throw (mirrors `decodeManifest`).
 
 const StageSpendSchema = Schema.Struct({
 	input: Schema.Finite,

--- a/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/main-sync.ts
@@ -1,86 +1,43 @@
 /**
- * `main-sync` pure core — decide how the orchestrator should sync the shared
- * primary checkout to `origin/main`, auto-reattaching a detached HEAD first
- * (issue #1573, Unit C of the #1494 diagnosis). IO-free and total: every decision
- * is a deterministic transform over already-gathered git facts. The git boundary
- * (branch probe / dirty probe / fetch / checkout / merge) lives in `command.ts`;
- * this module never runs a command.
+ * `main-sync` pure core — decide how the orchestrator should sync the shared primary
+ * checkout to `origin/main`. IO-free and total: a deterministic transform over
+ * already-gathered git facts; the git boundary (probes / fetch / checkout / merge)
+ * lives in `command.ts`. See #1494 (drain-sync reattach), #2056 (post-merge refresh),
+ * #2784/#2778 (mass-deletion refusal).
  *
- * The problem it codifies (#1494 root cause): the hand-run orchestrator main-sync —
- * `git fetch origin main && git merge --ff-only origin/main` on the primary checkout —
- * lives only in operator memory. During a heavy parallel drain a primary-sharing
- * process can detach that primary HEAD onto a non-`main` commit, and the next
- * `merge --ff-only` then fails with "Not possible to fast-forward", silently wedging
- * sync until a human runs `git checkout main && git merge --ff-only origin/main` by
- * hand. This core encodes that recovery as a decision so the orchestrator runs it
- * before/after a drain instead of a human noticing.
- *
- * The safety property (the whole point, #1494 AC #3): a reattach `git checkout main`
- * is a HEAD-moving op, so it must never run when it could lose work. The #1494
- * incidents all had a CLEAN tree — so a reattach is authorized ONLY on a clean tree;
- * a dirty primary tree DETECTS-AND-SURFACES (refuse to reattach, report the dirt)
- * rather than blindly `checkout`-ing and discarding the operator's changes.
- *
- * A SECOND, gentler policy lives beside the drain-sync above: `decideMainRefresh`, the
- * post-merge refresh (#2056). Under the merge queue (ADR 0132) a PR lands GitHub-side with
- * no local `git merge` on the primary, so the owner's checkout silently drifts behind
- * `origin/main` and any read of the local tree (next-free ADR number, "does X exist yet")
- * is made against stale state. The refresh is invoked by a pipeline step that KNOWS a merge
- * landed (ship-it / the orchestrator) and passively fast-forwards the primary — but, unlike
- * the drain-sync, it NEVER moves HEAD: on a non-`main` branch or a tree with tracked
- * modifications it LEAVES THE CHECKOUT ALONE and exits cleanly (a stale checkout is no worse
- * than today; yanking the owner off their feature branch or clobbering their tracked work is).
- * It ff's through untracked-only dirt, which a fast-forward never touches (see
- * `decideMainRefresh`, #2455). Failing-to-refresh is acceptable; failing-loudly or clobbering is not.
- *
- * A THIRD guard, orthogonal to both above (#2784): an EXPLICIT refusal on the #2778
- * mass-staged-deletion signature. The #2778 incident was caught only INCIDENTALLY — the mass of
- * staged deletions happened to trip `hasTrackedModifications`, so `decideMainRefresh` left the tree
- * alone. That is not a guarantee: it is a side-effect of one dirt probe, and a future variant (e.g.
- * a mass deletion already committed, or a config where the incidental gate doesn't fire) could slip
- * through. So both decide functions now check the mass-deletion signature FIRST and refuse it by
- * NAME — a guaranteed, LOUD fail-closed refusal keyed on the same signature the §CP
- * `primary-index-guard` blocks at pre-commit, not a byproduct of the generic dirty check. The
- * signature count is classified with `@kampus/primary-index-tripwire`'s detection at the git
- * boundary (single source of "what is a #2778 mass deletion"); this core reads the resulting count.
+ * The load-bearing safety policy, in order:
+ *  - A `#2778` mass control-plane staged deletion is refused BY NAME, first, in both
+ *    decide functions — a guaranteed LOUD refusal keyed on the same signature §CP
+ *    `primary-index-guard` blocks, not the incidental dirt-probe side-effect it was (#2784).
+ *  - The drain-sync reattach (`decideMainSync`) moves HEAD, so it is authorized ONLY on a
+ *    clean tree; a dirty tree detects-and-surfaces rather than discarding operator work.
+ *  - The post-merge refresh (`decideMainRefresh`) NEVER moves HEAD: off-`main` or
+ *    tracked-modified → leave-alone; it ff's through untracked-only dirt (#2455).
  */
 
 /**
- * The primary checkout's HEAD state, reduced to exactly the facts the decision needs.
- * Gathered at the git boundary (`command.ts`); both fields fail-safe toward refusing
- * to mutate — an indeterminate branch probe reads detached, an indeterminate status
- * probe reads dirty.
+ * The primary checkout's HEAD state, reduced to the facts the decision needs. Gathered
+ * at the git boundary; every field fail-safes toward refusing to mutate (an
+ * indeterminate probe reads detached / dirty).
  */
 export interface HeadState {
-	/**
-	 * The short branch name the primary HEAD points at, or `null` for a detached HEAD
-	 * (`git rev-parse --abbrev-ref HEAD` resolved to the literal `HEAD`, or the probe
-	 * was indeterminate). `"main"` is the healthy state; any other branch or `null`
-	 * needs attention.
-	 */
+	/** Short branch name, or `null` for a detached HEAD. `"main"` is the healthy state. */
 	readonly branch: string | null;
 	/**
-	 * The working tree has uncommitted/untracked changes (`git status --porcelain`
-	 * non-empty, or the probe was indeterminate). A dirty tree blocks a reattach —
-	 * a `git checkout main` from a detached HEAD with local changes could lose them.
-	 * This is the coarse dirty signal the drain-sync reattach consults; the post-merge
-	 * refresh consults the finer `hasTrackedModifications` instead (see #2455).
+	 * Working tree has any uncommitted/untracked changes. The coarse signal the drain-sync
+	 * reattach gates on; the refresh gates on the finer `hasTrackedModifications` (#2455).
 	 */
 	readonly isDirty: boolean;
 	/**
-	 * The tree has TRACKED modifications — staged or unstaged changes to tracked files
-	 * (`git status --porcelain -uno` non-empty, or the probe was indeterminate),
-	 * EXCLUDING untracked files. This is the only dirt a `merge --ff-only` could clobber;
-	 * git fast-forwards straight through untracked files without touching them. The
-	 * post-merge refresh gates on THIS, not `isDirty`, so an untracked-only tree ff's
-	 * through (see #2455). Implies `isDirty` (tracked dirt is a subset of all dirt).
+	 * Staged/unstaged changes to TRACKED files, excluding untracked — the only dirt a
+	 * `merge --ff-only` could clobber (it ff's straight through untracked files). Implies
+	 * `isDirty`. The post-merge refresh gates on this, not `isDirty` (#2455).
 	 */
 	readonly hasTrackedModifications: boolean;
 	/**
-	 * The count of staged deletions under the instruction-trust prefixes (`.claude/**`,
-	 * `.decisions/**`, …) — the #2778 signature, classified at the git boundary with
-	 * `@kampus/primary-index-tripwire`'s detection. Its own value is what makes the catch a
-	 * GUARANTEE rather than the incidental `hasTrackedModifications` side-effect it was (#2784).
+	 * Count of staged deletions under the instruction-trust prefixes (`.claude/**`,
+	 * `.decisions/**`, …) — the #2778 signature, classified at the git boundary. Reading
+	 * its own value is what makes the catch a guarantee, not an incidental side-effect (#2784).
 	 */
 	readonly stagedControlPlaneDeletionCount: number;
 }
@@ -88,8 +45,8 @@ export interface HeadState {
 /** The name of the branch the primary checkout must be attached to for a clean main-sync. */
 export const MAIN_BRANCH = "main";
 
-// Re-exported single source: main-sync refuses at the SAME "mass" threshold the §CP
-// `primary-index-guard` blocks at, so the sync-path refusal and the pre-commit block agree.
+// Re-exported single source: main-sync refuses at the SAME threshold §CP
+// `primary-index-guard` blocks at, so sync-path refusal and pre-commit block agree.
 export {MASS_DELETION_BLOCK_THRESHOLD} from "@kampus/primary-index-tripwire";
 
 import {MASS_DELETION_BLOCK_THRESHOLD} from "@kampus/primary-index-tripwire";
@@ -99,62 +56,28 @@ export const isMassControlPlaneDeletion = (head: HeadState): boolean =>
 	head.stagedControlPlaneDeletionCount >= MASS_DELETION_BLOCK_THRESHOLD;
 
 /**
- * What the orchestrator should do to bring the primary checkout to a state where
- * `git merge --ff-only origin/main` can run. The order of the checks below IS the
- * safety policy.
+ * What the orchestrator should do to reach a state where `merge --ff-only origin/main`
+ * can run. The order of the checks below IS the safety policy (see module docblock).
  */
 export type MainSyncPlan =
-	/**
-	 * The primary index carries a #2778 mass control-plane staged deletion — REFUSE, by name,
-	 * before any other consideration (#2784). This is the guaranteed catch: the orchestrator must
-	 * NOT sync a primary in the loaded-gun state; a human resolves the staged deletion first.
-	 */
+	// #2778 mass staged deletion — refused by name, before any other check (#2784).
 	| {readonly action: "blocked-mass-deletion"; readonly count: number}
-	/**
-	 * HEAD is already on `main` — no reattach needed. The orchestrator proceeds
-	 * straight to `fetch` + `merge --ff-only`. This is the healthy steady state.
-	 */
+	// Already on `main` — sync proceeds straight to fetch + merge --ff-only.
 	| {readonly action: "already-on-main"; readonly branch: string}
-	/**
-	 * HEAD is detached (or on a non-`main` branch) AND the tree is clean — the #1494
-	 * recoverable case. A reattach `git checkout main` is authorized; the
-	 * orchestrator runs it, then `fetch` + `merge --ff-only`.
-	 */
+	// Off-`main` AND clean — the #1494 recoverable case; reattach is authorized.
 	| {readonly action: "reattach"; readonly from: string}
-	/**
-	 * HEAD needs reattaching BUT the tree is dirty — DETECT-AND-SURFACE. A reattach
-	 * here could discard the operator's uncommitted work, so the tool refuses to
-	 * `checkout` and surfaces the dirt for a human, consistent with the #1494
-	 * incidents (which were always clean). The orchestrator must NOT force it.
-	 */
+	// Off-`main` BUT dirty — detect-and-surface; refuse to reattach, never discard work.
 	| {readonly action: "blocked-dirty"; readonly from: string};
 
-/**
- * A `null` branch (detached HEAD) renders as this stable label in a plan's `from`
- * field, so the report reads "reattach from detached-HEAD" rather than an empty string.
- */
+// Stable label so a detached HEAD (`branch === null`) reports as "detached-HEAD", not "".
 export const DETACHED_LABEL = "detached-HEAD";
 
 const fromLabel = (branch: string | null): string => branch ?? DETACHED_LABEL;
 
 /**
- * Decide the main-sync plan from the primary checkout's HEAD state:
- *
- *   0. #2778 mass control-plane staged deletion present → `blocked-mass-deletion`. Checked FIRST,
- *      by name — the guaranteed catch (#2784), not the incidental dirt gate. Refuse to sync a
- *      primary in the loaded-gun state regardless of branch/dirt.
- *   1. On `main` → `already-on-main`. No HEAD move needed; sync can proceed. The
- *      dirty flag is irrelevant here — `merge --ff-only` fails safe on its own if
- *      the tree conflicts, and this tool never touches a tree that is already on the
- *      right branch.
- *   2. Not on `main` AND dirty → `blocked-dirty`. Detect-and-surface: a reattach
- *      would risk the operator's uncommitted work, so refuse (never blindly discard).
- *   3. Not on `main` AND clean → `reattach`. The #1494 recoverable case: authorize
- *      `git checkout main` before the merge.
- *
- * Total over every `HeadState`; the dirty check is ONLY consulted on the off-`main`
- * path, so a clean-but-detached HEAD reattaches and a dirty-but-detached HEAD is
- * surfaced, never checked out.
+ * Decide the drain-sync plan. Total over every `HeadState`; the dirty check is consulted
+ * ONLY on the off-`main` path, so a clean detached HEAD reattaches and a dirty one is
+ * surfaced, never checked out. See the module docblock for the ordering rationale.
  */
 export const decideMainSync = (head: HeadState): MainSyncPlan => {
 	if (isMassControlPlaneDeletion(head)) {
@@ -170,35 +93,18 @@ export const decideMainSync = (head: HeadState): MainSyncPlan => {
 };
 
 /**
- * What the post-merge refresh should do to bring the primary checkout up to
- * `origin/main` — the gentle, HEAD-preserving counterpart to `MainSyncPlan`. It has
- * exactly two outcomes because the refresh never moves HEAD (see the module docblock,
- * #2056): either a fast-forward is safe, or the checkout is left exactly as it is.
+ * What the post-merge refresh should do — the HEAD-preserving counterpart to
+ * `MainSyncPlan` (#2056). Either a fast-forward is safe, or the checkout is left as-is;
+ * the refresh never moves HEAD.
  */
 export type MainRefreshPlan =
-	/**
-	 * The primary index carries a #2778 mass control-plane staged deletion — a LOUD fail-closed
-	 * REFUSAL (#2784), distinct from the silent `leave-alone` no-op below. The refresh's normal
-	 * failure mode is "do nothing quietly", but the loaded-gun state must SURFACE, not be silently
-	 * skipped — so this exits non-zero at the command boundary, unlike every other refresh outcome.
-	 */
+	// #2778 mass staged deletion — a LOUD fail-closed refusal (exits non-zero), NOT the
+	// silent `leave-alone` no-op; the loaded-gun state must surface (#2784).
 	| {readonly action: "refuse-mass-deletion"; readonly count: number}
-	/**
-	 * HEAD is on `main` AND free of tracked modifications — the state in which a `git merge
-	 * --ff-only origin/main` is both possible and non-destructive (untracked-only dirt is
-	 * fine; a fast-forward passes straight through it, #2455). The refresh runs
-	 * `fetch` + `merge --ff-only`; ff-only never creates a merge commit and aborts on any
-	 * divergence, so the worst case is a no-op, never a clobber.
-	 */
+	// On `main`, no tracked modifications — ff is safe (passes through untracked-only dirt, #2455).
 	| {readonly action: "fast-forward"; readonly branch: string}
-	/**
-	 * The refresh is a deliberate NO-OP — HEAD is not on `main`, or the tree has tracked
-	 * modifications. It exits cleanly (never an error): a fast-forward of `main` can't advance
-	 * a checked-out feature branch, and tracked modifications could be clobbered, so the
-	 * refresh leaves the checkout untouched. `reason` records which condition held for the
-	 * report (`dirty` means tracked-modified, #2455); `branch` is the current branch (or
-	 * `detached-HEAD`).
-	 */
+	// Deliberate no-op: off-`main` (ff can't advance a feature branch) or tracked-modified
+	// (ff could clobber). `reason` `dirty` means tracked-modified (#2455).
 	| {
 			readonly action: "leave-alone";
 			readonly reason: "off-main" | "dirty";
@@ -206,31 +112,13 @@ export type MainRefreshPlan =
 	  };
 
 /**
- * Decide the post-merge refresh plan from the primary checkout's HEAD state (#2056):
+ * Decide the post-merge refresh plan (#2056). Total over every `HeadState`. The branch
+ * check precedes the tracked-dirt check on purpose: off-`main` is the binding reason the ff
+ * can't run regardless of tree state, so it is reported even when also dirty.
  *
- *   0. #2778 mass control-plane staged deletion present → `refuse-mass-deletion`. Checked FIRST,
- *      by name — a LOUD fail-closed refusal (#2784), NOT the silent `leave-alone` no-op. The
- *      incidental `hasTrackedModifications` gate below would also skip the ff, but silently; the
- *      loaded-gun state must surface loudly instead.
- *   1. Not on `main` → `leave-alone` (reason `off-main`). The owner is on their own
- *      feature branch (or detached); a fast-forward of `main` cannot advance it, and
- *      yanking them onto `main` is exactly the disruption the refresh must avoid. No-op.
- *   2. On `main` with TRACKED modifications → `leave-alone` (reason `dirty`). A fast-forward
- *      could clobber the owner's uncommitted tracked work, and a stale-but-clobber-free
- *      checkout is acceptable — failing-to-refresh beats touching tracked work. No-op.
- *   3. On `main` AND free of tracked modifications → `fast-forward`. Safe to advance —
- *      including when the tree carries untracked-only dirt (see the untracked note below).
- *
- * The branch check precedes the tracked-dirt check on purpose — off-`main` is reported even
- * when also dirty, because the branch is the binding reason the ff can't run (it can't
- * advance a checked-out feature branch regardless of tree state). Total over every `HeadState`.
- *
- * The tracked-vs-untracked distinction (#2455): the ff-blocking guard consults
- * `hasTrackedModifications`, NOT `isDirty`. `merge --ff-only` fast-forwards straight through
- * untracked files without touching them, so untracked-only dirt buys no safety by blocking —
- * gating on `isDirty` instead pinned the primary STALE session-long (the #2453 detached-HEAD
- * corruption root cause: stale on-disk skills). This matches the drain-sync path, which never
- * consults dirt once already on `main`.
+ * The ff-blocking guard consults `hasTrackedModifications`, NOT `isDirty` (#2455): a ff passes
+ * straight through untracked files, so gating on `isDirty` bought no safety and pinned the
+ * primary stale session-long (the #2453 detached-HEAD corruption root cause).
  */
 export const decideMainRefresh = (head: HeadState): MainRefreshPlan => {
 	if (isMassControlPlaneDeletion(head)) {

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/github.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/github.ts
@@ -142,7 +142,7 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 	});
 });
 
-// --- REST arg builders (REST only, never GraphQL) --------------------------------
+// REST-only arg builders — never GraphQL.
 
 /**
  * `gh pr view --json` for the two working fields (the old `merged` field errors
@@ -166,8 +166,6 @@ const timelineArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 	`repos/${repo}/issues/${pr}/timeline?per_page=100`,
 	"--paginate",
 ];
-
-// --- boundary decoders -----------------------------------------------------------
 
 /** The PR state as `gh pr view` returns it; `state`/`mergeStateStatus` may be absent or null. */
 const RawPrState = Schema.Struct({
@@ -198,8 +196,6 @@ const toPrState = (raw: (typeof RawPrState)["Type"]): PrState => {
 		mergeStateStatus: raw.mergeStateStatus ?? undefined,
 	};
 };
-
-// --- IO operations ---------------------------------------------------------------
 
 const readPrState = Effect.fn("Github.readPrState")(function* (repo: string, pr: number) {
 	const args = prStateArgs(repo, pr);

--- a/packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/ref-guard.ts
@@ -6,27 +6,18 @@
  * resolve `origin/main`, run `merge-base --is-ancestor`) lives in `command.ts`; this
  * module never runs a command.
  *
- * The problem it codifies (#2143 root cause): the orchestrator/PULLER role force-moved
- * the shared primary checkout's `main` ref off the merge seam — a bare
- * `branch -f main` / `checkout -B main` / `update-ref refs/heads/main` / `push HEAD:main`
- * that landed `main` on a stranding commit DIVERGED from `origin/main` (not a
- * fast-forward), with a ~13.5k-line deletion staged — a "one `git push -f` clobbers
- * `origin/main`" loaded gun. The #1571 `worktree-guard` bash-pin can't reach this
- * class on three counts (the offender has no `$WORKTREE_ROOT`; a ref force-move is not
- * in its `HEAD_MOVING` set; the keystroke is outside the agent Bash tool-call path).
- * A `reference-transaction` hook sits at git's OWN ref boundary, so it catches ANY
- * caller — agent Bash, harness worktree machinery, a manually-run command, or another
- * git hook — which a `PreToolUse` Bash hook cannot.
+ * Why at git's ref boundary (#2143 root cause): the PULLER role force-moved the primary's
+ * `main` off the merge seam onto a diverged commit — a "one `git push -f` clobbers
+ * `origin/main`" loaded gun. The #1571 `worktree-guard` bash-pin can't reach this class (the
+ * offender has no `$WORKTREE_ROOT`; a ref force-move isn't in its `HEAD_MOVING` set; the
+ * keystroke is off the agent Bash path). A `reference-transaction` hook sits at git's OWN ref
+ * boundary, so it catches ANY caller a `PreToolUse` Bash hook can't.
  *
- * The safety property (#2143 AC): a `refs/heads/main` update that would make local
- * `main` a NON-fast-forward of `origin/main` (a divergence) is REFUSED; the legitimate
- * PULLER flow — `checkout main` reattach (no ref move on `main`) + `merge --ff-only
- * origin/main` (a fast-forward ⇒ `origin/main` is an ancestor of the new tip) — is
- * ALLOWED. The core refuses only the diverging move, never the sync.
- *
- * Fail-safe posture (fail-closed on the guarded ref, fail-open off it): every
- * indeterminate fact the git boundary can't resolve is passed as a discriminated flag
- * so the decision is explicit, never a silent allow of a `main` divergence.
+ * Safety property (#2143): a `refs/heads/main` update that would make local `main` a
+ * NON-fast-forward of `origin/main` is REFUSED; the legitimate PULLER flow (reattach +
+ * `merge --ff-only`, both fast-forwards) is ALLOWED — refuse the diverging move, never the sync.
+ * Fail-safe posture: fail-closed on the guarded ref, fail-open off it — every indeterminate
+ * fact is a discriminated flag so a `main` divergence is never a silent allow.
  *
  * A second, orthogonal concern lives here too (#2270, the mechanical half): `decideHeadDetach`
  * refuses a bare HEAD-detaching checkout on the shared PRIMARY checkout — a distinct hazard from
@@ -103,29 +94,12 @@ export type RefDecision =
 	| {readonly kind: "refuse"; readonly reason: string};
 
 /**
- * Decide whether a queued `reference-transaction` update is safe:
- *
- *   1. NOT `refs/heads/main` → `allow`. The guard is scoped to the one shared-primary ref;
- *      every feature branch, tag, and `origin/*` update passes untouched. (Worktree agents
- *      only ever move their OWN branch refs, so they never reach the guarded path.)
- *   2. `refs/heads/main` DELETE (`newOid` all-zeroes) → `refuse`. Deleting the primary's
- *      `main` is never a legitimate PULLER op and is a divergence in the extreme.
- *   3. `refs/heads/main`, `origin/main` unresolvable → `allow`. With no `origin/main` there
- *      is nothing to diverge from (a fresh clone before the first fetch); refusing here would
- *      wedge legitimate setup. This is the ONE fail-OPEN on the guarded ref, safe precisely
- *      because the divergence the guard exists to catch is undefined without an origin.
- *   4. `refs/heads/main`, new tip == `origin/main` → `allow`. In-sync (e.g. a reset/reattach
- *      landing exactly on `origin/main`); trivially a fast-forward.
- *   5. `refs/heads/main`, `origin/main` IS an ancestor of the new tip → `allow`. A
- *      fast-forward-ahead: the legitimate `merge --ff-only origin/main` and any `main` advance
- *      that carries `origin/main`'s history forward.
- *   6. `refs/heads/main`, `origin/main` is NOT an ancestor of the new tip → `refuse`. The
- *      #2143 non-fast-forward divergence: `main` would leave `origin/main`'s history, the exact
- *      loaded-gun state. Fail-closed.
- *
- * Total over every `RefUpdate` × `OriginFacts`. The order above is the policy: the ref-scope
- * check gates first (off-`main` never touches origin facts), then delete, then the origin-absent
- * fail-open, then the two fast-forward allows, then the divergence refuse.
+ * Decide whether a queued `reference-transaction` update is safe. Total over every
+ * `RefUpdate` × `OriginFacts`; each branch's `reason` string carries its own why. The
+ * check order IS the policy: ref-scope first (off-`main` never touches origin facts), then
+ * delete-refuse, then the one fail-OPEN on an unresolvable `origin/main` (no origin ⇒ no
+ * divergence to guard — a fresh clone before first fetch), then the two fast-forward allows,
+ * then the #2143 divergence refuse (fail-closed).
  */
 export const decideRefUpdate = (update: RefUpdate, facts: OriginFacts): RefDecision => {
 	if (update.refName !== GUARDED_REF) {

--- a/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.ts
@@ -209,8 +209,6 @@ export const renderReport = (verdict: RoadmapGuardVerdict): string => {
 	);
 };
 
-// --- ROADMAP.md parsing (pure over the file text) --------------------------------
-
 /** Resolve a `## <heading>` markdown table's milestone cell (`#17`) to its number, else null. */
 export const parseMilestoneCell = (cell: string): number | null => {
 	const m = cell.match(/#(\d+)/);

--- a/packages/pipeline-cli/src/tools/roadmap/github.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/github.ts
@@ -124,7 +124,7 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 	});
 });
 
-// --- REST arg builders (REST only, never GraphQL) --------------------------------
+// REST-only arg builders — never GraphQL.
 
 // `state=all` so I can resolve a done arc's CLOSED milestone by number; `--paginate` for >100.
 const milestonesArgs = (repo: string): ReadonlyArray<string> => [
@@ -171,8 +171,6 @@ const openPullsArgs = (repo: string): ReadonlyArray<string> => [
 	"--paginate",
 ];
 
-// --- boundary decoders -----------------------------------------------------------
-
 /** A raw issue as the issues endpoint returns it; `pull_request` present ⇒ it's a PR, filtered out. */
 const RawIssue = Schema.Struct({
 	number: Schema.Number,
@@ -208,8 +206,6 @@ const RawPull = Schema.Struct({
 	head: Schema.Struct({ref: Schema.String}),
 });
 const decodePulls = Schema.decodeUnknownEffect(Schema.Array(RawPull));
-
-// --- IO operations ---------------------------------------------------------------
 
 const toIssue = (
 	raw: {

--- a/packages/pipeline-cli/src/tools/roadmap/roadmap.ts
+++ b/packages/pipeline-cli/src/tools/roadmap/roadmap.ts
@@ -89,8 +89,6 @@ export const parseLinkedIssues = (body: string, branch: string): ReadonlyArray<n
 	return [...nums];
 };
 
-// --- view model -------------------------------------------------------------------
-
 /** One epic and its sub-issue children (both states shown; a puller wants the whole tree). */
 export interface EpicNode {
 	readonly epic: Issue;
@@ -208,8 +206,6 @@ export const buildView = (
 		staleP1s: deriveStaleP1s(facts.issues, activeMilestone),
 	};
 };
-
-// --- rendering (pure over the view model) -----------------------------------------
 
 const issueLine = (i: Issue): string => {
 	const prio = i.priority ? ` ${i.priority}` : "";

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -160,7 +160,7 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 	});
 });
 
-// --- REST arg builders (REST only, never GraphQL) --------------------------------
+// REST-only arg builders — never GraphQL.
 
 const headShaArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 	"api",
@@ -206,8 +206,6 @@ const patchCommentArgs = (repo: string, id: number, body: string): ReadonlyArray
 	".id",
 ];
 
-// --- boundary decoders -----------------------------------------------------------
-
 /** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
 const RawComment = Schema.Struct({
 	id: Schema.Number,
@@ -223,8 +221,6 @@ const toVerdictComment = (raw: (typeof RawComment)["Type"]): VerdictComment => (
 	createdAt: raw.created_at,
 	body: raw.body ?? "",
 });
-
-// --- IO operations ---------------------------------------------------------------
 
 const currentHead = Effect.fn("Github.currentHead")(function* (repo: string, pr: number) {
 	return (yield* runGh(headShaArgs(repo, pr))).trim();


### PR DESCRIPTION
Fixes #2871.

Ran `deslop-comments` across every source file under `packages/pipeline-cli`. **Comments-and-whitespace only — `git diff` shows zero code/logic change.**

## What changed (11 files)

**CUT — section-banner separators** (the pure-separator class):
- `// --- boundary decoders ---`, `// --- IO operations ---`, and the view-model / rendering / `ROADMAP.md`-parsing / report-input banners across the `github.ts` family (campaign, epic-lock, merge-queue-classify, roadmap, verdict) and roadmap/roadmap-guard/report modules.
- The `// --- REST arg builders (REST only, never GraphQL) ---` banner keeps its load-bearing invariant as a plain `// REST-only arg builders — never GraphQL.` line (the org's Projects-classic/GraphQL constraint), just without the banner decoration.

**COLLAPSE — over-derived docblocks to what-it-is + pointers:**
- `main-sync/main-sync.ts` — the four-paragraph module essay re-deriving #1494/#2056/#2784/#2778 and the per-union-member / per-field re-narrations collapsed, keeping the load-bearing safety policy (reattach-only-on-clean, refresh-never-moves-HEAD, mass-deletion-refused-by-name).
- `ref-guard/ref-guard.ts` — the `decideRefUpdate` numbered if-ladder re-narration collapsed (each branch's `reason` string already carries its why) and the module header tightened. **Kept** the git-version-grounded `reference-transaction` detach measurement (2.40 vs 2.55) verbatim — that is exactly the "ground platform behavior in source" note CLAUDE.md requires.
- `decisions-index/decisions-index.ts` — module essay + `nextAdrNumber` essay collapsed; also **fixed a stale claim** — the compact ADR map is surfaced on demand via `pipeline-cli decisions-index compact`, not a SessionStart hook (ADR 0129 dropped it).

**KEPT untouched — already curated, load-bearing:** `bash-pin`, `verdict-match`, `class-probe`, `worktree-sweep`, `fanout-guard` and the rest — fail-closed invariants at their enforcement sites, ReDoS workarounds + forcing constraints (CodeQL), deliberate-looking-wrong guards, and incident-specific edge cases. An honest yield; no manufactured cuts.

No new ADR/pattern doc was needed — every rationale collapsed to an existing issue/ADR pointer, so nothing was migrated outside the scope fence. No `TODO`/`FIXME`/`HACK`, license header, shebang, or pragma was touched.

## Verification
- `pnpm typecheck` — **pass** (30/30 tasks successful).
- `pnpm lint` — **pass** (11 changed files checked, no fixes/errors).
- `pnpm --filter @kampus/pipeline-cli test` — **pass** (90 test files, 1255 tests). Behavior untouched. (The `does-not-exist/bin.ts` line in test output is a ref-guard test deliberately exercising a missing-module path — captured subprocess stderr, not a failure.)
- Diff-scope guard: every change is within `packages/pipeline-cli`; a filter for non-comment changed lines returns none.

§CP — human-merge via cansirin after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)