### PR TITLE
fix(bildirim): popover renders the list — drop the byId-capable channel read (#2982)

### DIFF
--- a/apps/web/src/components/bildirim/BildirimList.test.tsx
+++ b/apps/web/src/components/bildirim/BildirimList.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Regression for #2982 (topbar popover "yüklenemedi"). The list's live-reconcile must
+ * read the viewer's unread count through the seed-gated, NON-suspending `useBildirimUnread`
+ * — NOT a suspending `useLiveView(channelRef)`. The suspending read's `readView` fires a
+ * `byId` against the loader-less `NotificationChannel` synthetic source on any cache miss,
+ * which 500s as `INTERNAL_ERROR` (#2206) and rendered the popover's generic error. These
+ * pin the byId-safe wiring: the count comes from `useBildirimUnread`, and an unread bump
+ * refetches the list (network-only) — the #1700 freshness behavior, preserved.
+ *
+ * `react-fate` and `useBildirimUnread` are mocked so this measures BildirimList's reconcile
+ * wiring, not the fate cache; the loader-less-source byId-safety of `useBildirimUnread`
+ * itself is pinned by its own suite (`useBildirimUnread.test.tsx`, #2206). Mocking
+ * `react-fate` WITHOUT a `useLiveView` export also fails the import outright if the
+ * suspending channel read is ever reintroduced here.
+ */
+import {render} from "@testing-library/react";
+import {afterEach, describe, expect, it, vi} from "vitest";
+
+const requestSpy = vi.fn(() => Promise.resolve({}));
+let sessionUserId: string | null = "user-1";
+let liveUnread = 0;
+
+vi.mock("../../auth/client", () => ({
+	useSession: () => ({data: sessionUserId ? {user: {id: sessionUserId}} : null}),
+}));
+
+vi.mock("./useBildirimUnread", () => ({
+	useBildirimUnread: vi.fn((_enabled: boolean, _userId: string | null) => liveUnread),
+}));
+
+vi.mock("react-fate", () => ({
+	// A view factory usable at module load: `view<T>()(selection)` → the selection object.
+	view: () => (selection: unknown) => selection,
+	useRequest: () => ({"bildirim.list": {}}),
+	// Empty connection → BildirimList renders its empty state (no rows, no useView needed).
+	useListView: () => [[], null],
+	useFateClient: () => ({request: requestSpy}),
+	useView: (_view: unknown, node: unknown) => node,
+	LoadMoreButton: () => null,
+}));
+
+import {BildirimList} from "./BildirimList";
+import {useBildirimUnread} from "./useBildirimUnread";
+
+afterEach(() => {
+	requestSpy.mockClear();
+	vi.mocked(useBildirimUnread).mockClear();
+	sessionUserId = "user-1";
+	liveUnread = 0;
+});
+
+describe("BildirimList live-reconcile — byId-safe (#2982 / #2206)", () => {
+	it("reads the live unread count via the seed-gated useBildirimUnread (never a suspending channel read)", () => {
+		liveUnread = 2;
+		render(<BildirimList />);
+		// Enabled when signed in, keyed by the viewer's id — the byId-safe path.
+		expect(useBildirimUnread).toHaveBeenCalledWith(true, "user-1");
+	});
+
+	it("refetches the list (network-only) when the live unread count bumps", () => {
+		liveUnread = 1;
+		const {rerender} = render(<BildirimList />);
+		expect(requestSpy).not.toHaveBeenCalled();
+
+		liveUnread = 3; // a recorded notification lands → count rises
+		rerender(<BildirimList />);
+
+		expect(requestSpy).toHaveBeenCalledTimes(1);
+		expect(requestSpy).toHaveBeenCalledWith(expect.anything(), {mode: "network-only"});
+	});
+
+	it("does not refetch when the count is unchanged or drops (mark-read lowers it)", () => {
+		liveUnread = 3;
+		const {rerender} = render(<BildirimList />);
+		liveUnread = 3;
+		rerender(<BildirimList />);
+		liveUnread = 1;
+		rerender(<BildirimList />);
+		expect(requestSpy).not.toHaveBeenCalled();
+	});
+
+	it("disables the live read when signed out (enabled=false, id=null)", () => {
+		sessionUserId = null;
+		render(<BildirimList />);
+		expect(useBildirimUnread).toHaveBeenCalledWith(false, null);
+	});
+});

--- a/apps/web/src/components/bildirim/BildirimList.tsx
+++ b/apps/web/src/components/bildirim/BildirimList.tsx
@@ -8,24 +8,13 @@
  * (`bildirimTarget`), never a broken link.
  */
 import {useEffect, useRef, useState} from "react";
-import {
-	useFateClient,
-	useListView,
-	useLiveView,
-	useRequest,
-	useView,
-	type ViewRef,
-	view,
-} from "react-fate";
+import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
-import type {
-	Notification,
-	NotificationChannel,
-	NotificationMarkReceipt,
-} from "../../../worker/features/fate/views";
+import type {Notification, NotificationMarkReceipt} from "../../../worker/features/fate/views";
 import {useSession} from "../../auth/client";
 import {LoadMoreButton} from "../../fate/wire";
 import {bildirimCopy, bildirimTarget, rowUnread, targetLinkLabel} from "./bildirim";
+import {useBildirimUnread} from "./useBildirimUnread";
 
 const PAGE_SIZE = 20;
 
@@ -46,24 +35,12 @@ const MarkReceiptView = view<NotificationMarkReceipt>()({
 	unreadCount: true,
 });
 
-const ChannelView = view<NotificationChannel>()({
-	id: true,
-	unreadCount: true,
-});
-
 const BildirimConnectionView = {
 	items: {node: BildirimRowView},
 } as const;
 
-// `bildirim.channel` rides the same request so `useLiveView(channelRef)` below reads a
-// HYDRATED cache instead of fetching a `byId` — `NotificationChannel` is a loader-less
-// `Fate.syntheticSource`, and a `byId` against it 500s through fate's capability-less arm
-// (#2206). `useRequest` suspends the component until this resolves, so the entity is in the
-// cache before `useLiveView`'s `readView` runs (a pure cache hit, no `byId`); the query
-// then reconciles live over `/fate/live` (seed-then-subscribe).
 const bildirimRequest = {
 	"bildirim.list": {list: BildirimConnectionView, args: {first: PAGE_SIZE}},
-	"bildirim.channel": {view: ChannelView},
 } as const;
 
 export function BildirimList() {
@@ -72,23 +49,29 @@ export function BildirimList() {
 	const fate = useFateClient();
 	const userId = useSession().data?.user?.id ?? null;
 
-	// Live-reconcile the center over `/fate/live` (#1700): subscribe the viewer's
-	// own `NotificationChannel` entity (recipient-scoped by construction — the id is
-	// the session user's), and when a recorded notification bumps its live unread
-	// count, refetch the list once (network-only) so the new row surfaces without a
-	// nav or refresh. `bildirim.list` has no per-node live topic; watching the
-	// per-recipient count is the coarse signal that a page re-read is due.
-	const channelRef = userId ? fate.ref("NotificationChannel", userId, ChannelView) : null;
-	const channel = useLiveView(ChannelView, channelRef);
+	// Live-reconcile the center over `/fate/live` (#1700): when a recorded notification
+	// bumps the viewer's live unread count, refetch the list once (network-only) so the
+	// new row surfaces without a nav or refresh. `bildirim.list` has no per-node live
+	// topic; the per-recipient count is the coarse signal that a re-read is due.
+	//
+	// The count comes from `useBildirimUnread` — the same seed-gated, NON-suspending live
+	// read the shell badge uses — NOT a `useLiveView(channelRef)`. `NotificationChannel` is
+	// a loader-less `Fate.syntheticSource`, so the suspending read's `readView` fires a
+	// `byId` on any cache miss, which 500s through fate's capability-less arm as an
+	// `INTERNAL_ERROR` (#2206). That surfaced as the popover's generic "yüklenemedi": the
+	// popover mounts this list from the shell where the co-bundled hydration isn't a hard
+	// guarantee, so the suspending read hit the `byId`. `useBildirimUnread` never issues a
+	// `byId` (it reads only once its own query seed has hydrated the cache), so the live
+	// count is byId-safe in every mount context (#2982).
+	const liveUnread = useBildirimUnread(userId != null, userId);
 	const lastUnread = useRef<number | null>(null);
 	useEffect(() => {
-		const next = channel?.unreadCount ?? null;
-		if (next == null) return;
-		if (lastUnread.current != null && next > lastUnread.current) {
+		if (userId == null) return;
+		if (lastUnread.current != null && liveUnread > lastUnread.current) {
 			void fate.request(bildirimRequest, {mode: "network-only"}).catch(() => {});
 		}
-		lastUnread.current = next;
-	}, [channel?.unreadCount, fate]);
+		lastUnread.current = liveUnread;
+	}, [liveUnread, userId, fate]);
 
 	// This session's mark state — the receipt confirms the write but doesn't
 	// rewrite the listed rows, so rows fold these into their unread reading.


### PR DESCRIPTION
Fixes #2982

## Diagnosis (DIAGNOSE→FIX, ADR 0070)

The topbar bildirim popover rendered the generic **"bildirimler yüklenemedi, tekrar dene."** while `/bildirimler` rendered the identical `BildirimList` fine.

**Observed error code: `INTERNAL_ERROR`** (fate's protocol fallback for an internal throw; the generic, non-auth branch of `<Screen error={({code})=>…}>`).

Chain of evidence, grounded in source + an empirical test:

1. `bildirim.list` (`apps/web/worker/features/bildirim/lists.ts`) only errors `Denied` → the **auth** copy ("giriş yapmalısın"), and signed-out degrades to an empty connection. So the generic branch is **not** the list.
2. The only `INTERNAL_ERROR` source in the whole surface is a **`byId` against the loader-less `NotificationChannel` `Fate.syntheticSource`** — `readView` on a cache miss calls `fetchByIdAndNormalize`, which 500s through fate's capability-less arm (#2206, documented in `apps/web/worker/features/bildirim/sources.ts`). Confirmed empirically against the real `@nkzw/fate@1.3.1` client: `readView` on an unhydrated `NotificationChannel` fires `fetchById` and throws; `Screen` forwards that as `INTERNAL_ERROR` (the fallback its own docblock calls out).
3. That `byId` was fired by `BildirimList`'s **suspending `useLiveView(ChannelView, channelRef)` → `useView` → `readView`**. The co-bundled `bildirim.channel` query was only *best-effort* hydration; from the popover's shell mount context it wasn't a hard guarantee, so the suspending read hit the `byId`. On the page the list stays mounted and the read never missed.

**Ruled out** the reporter's "mirror `useBildirimUnread` `enabled`-gating" hypothesis: `Topbar.tsx` already gates the popover on signed-in + `phoenix-bildirim`-on + unread>0 — the same preconditions the page gates on — so that fix was a no-op on the real cause.

## Fix

Drive `BildirimList`'s live-reconcile count through the seed-gated, **non-suspending `useBildirimUnread`** — the same byId-safe live read the shell badge already uses (its #2206 guarantee is pinned by `useBildirimUnread.test.tsx`). This removes the **only** byId-capable path in `BildirimList`, so the hazard can't fire in any mount context; the #1700 refetch-on-bump freshness is unchanged. `bildirim.channel` is dropped from the list's request bundle (no longer read there). Stays dark behind `phoenix-bildirim`.

## Tests

New `apps/web/src/components/bildirim/BildirimList.test.tsx` (4 cases) pins the byId-safe wiring: the count comes from `useBildirimUnread(enabled, userId)`, an unread bump refetches the list network-only, an unchanged/dropped count does not, and signed-out disables the read. The `react-fate` mock omits `useLiveView`, so reintroducing the suspending channel read fails the import — the regression is guarded.

- `pnpm lint` — clean
- `pnpm typecheck` — 30/30 successful
- `pnpm vitest --project client --project unit src/components/bildirim` — **25 passed** (new suite + the untouched popover shell + the #2206 badge pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)