### PR TITLE
docs(adr): 0182 SubnavShell/PageShell composition API — flat element-props

### DIFF
--- a/.decisions/0182-subnavshell-pageshell-composition-api.md
+++ b/.decisions/0182-subnavshell-pageshell-composition-api.md
@@ -1,0 +1,134 @@
+---
+id: 0182
+title: SubnavShell / PageShell composition API — flat element-props (one prop per zone), orphan-slot as a type error
+status: accepted
+date: 2026-07-14
+tags: [design, frontend, navigation, composition, information-architecture]
+---
+
+# 0182 — SubnavShell / PageShell composition API — flat element-props
+
+## Context
+
+This is a **conversation-authored** decision, authored directly (not via report → triage)
+and merged issueless on the doc lane per ADR [0075](0075-issueless-doc-pr-merge-seam.md). It
+transcribes a founder ruling ([#2971](https://github.com/kamp-us/phoenix/issues/2971)) faithfully:
+it is the law the ten children of epic [#2954](https://github.com/kamp-us/phoenix/issues/2954)
+build against, so precision matters more than prose.
+
+ADR [0176](0176-nav-ia-discipline.md) fixed the nav **information architecture** — the closed
+element taxonomy (destination / primary action / utility / signal) and the placement law (which
+class lives in which zone), with the per-product **Subnav** as the product zone. What 0176 did
+*not* fix is the **composition API** of that Subnav: how a product surface hands its elements to
+the bar. That gap is what let the shape drift.
+
+A live audit of the five real subnav consumers grounded this decision:
+
+- **mecmua** — sub-destination tabs (`akış` / `yazılarım`) + a promoted `yaz` CTA.
+- **pano** — sort/filter chips + a site/host context crumb + a `N başlık` count + a `yeni` CTA.
+- **divan** — reviewer sections, no promoted verb (its subnav has no CTA and that is correct).
+- **sözlük** — an alphabet strip + a go-to-or-create box, no promoted verb.
+- the **shared `Subnav` primitive** ([`apps/web/src/components/layout/Subnav.tsx`](../apps/web/src/components/layout/Subnav.tsx))
+  every one of them wraps, whose slot list had sprawled to `title` / `count` / `filters` / `links`
+  / `crumb` / `input` / `meta` / `cta`.
+
+Two smells fell out of the audit. First, the primitive carried redundant slots — `title` is
+chrome that maps to no 0176 zone, and `count` and `meta` are the same read-only `span` treatment
+under two names. Second, and load-bearing: sözlük's alphabet rendered as a **detached sibling**
+next to the bar rather than inside it — an orphaned slot with no structural home, the kind of
+gap a compound-component API leaves undetectable except by lint.
+
+## Decision
+
+Faithful transcription of the founder ruling on #2971. This ADR **builds on** ADR
+[0176](0176-nav-ia-discipline.md)'s element taxonomy — it does not amend or supersede it; 0176's
+four-class taxonomy and placement law stand unchanged and are the ground this API stands on.
+
+### Flat element-props — ONE prop per zone
+
+`SubnavShell` takes **flat element-props: one `ReactNode` prop per zone.** NOT a zones-object,
+NOT compound components (`<SubnavShell.Destinations>…`). The rationale is
+make-invalid-states-unrepresentable: a compound-component API leaves an **orphan slot** — an
+element rendered but placed nowhere — detectable only by a lint pass. Flat element-props make an
+orphaned slot a **TYPE error** instead: an element that isn't assigned to a declared zone prop
+simply has nowhere to go and won't compile in. The zones below are grounded in ADR 0176's real
+element taxonomy — they are not invented here.
+
+`SubnavShell` props (the law, exactly):
+
+- **`leading?: ReactNode`** — context / crumb (e.g. pano's site/host crumb).
+- **`destinations?: ReactNode`** — **ONE** slot; the route-links OR stateful buttons are composed
+  *inside* it by the consumer (mecmua tabs / pano chips / divan sections / sözlük alphabet). The
+  shell does not enumerate destinations — it hands the consumer one zone and the consumer fills it.
+- **`primaryAction?: ReactNode`** — the ONE promoted verb (mecmua / pano). **ABSENT for divan and
+  sözlük is normal, not a gap** — a subnav with no promoted verb is a valid subnav.
+- **`signal?: ReactNode`** — meta / count (e.g. pano's `N başlık`).
+
+### `utility` is deferred by YAGNI — sanctioned, deliberately not slotted
+
+The `utility` zone is **OMITTED**. Its only real consumer today was sözlük's go-to-or-create box
+(the primitive's current `input` slot), which the founder is folding into the global `⌘K` search
+(a separate follow-up). `utility` is a **sanctioned ADR-0176 element class** — it is not being
+denied legitimacy; it is **deliberately not slotted** into `SubnavShell` until a real consumer
+needs it. Adding a `utility?` prop later is a **deliberate law change, NOT drift**: the next
+author who wants it makes an explicit amendment, they do not quietly discover a gap and fill it.
+
+### PageShell composes SubnavShell
+
+**`PageShell`** composes `SubnavShell` as its top zone plus the routed page content below it. A
+product page is a `PageShell` — the subnav-plus-content shape is named once, not rebuilt per
+surface.
+
+### Wrap the existing `Subnav` primitive — do NOT replace it
+
+`SubnavShell` **wraps** the existing `Subnav` primitive
+([`apps/web/src/components/layout/Subnav.tsx`](../apps/web/src/components/layout/Subnav.tsx)); it
+does not reimplement or replace it. Wrapping is where the slot-sprawl is collapsed:
+
+- **DROP `title`** — chrome that maps to no 0176 zone.
+- **MERGE `count` → `signal`** — `count` and `meta` are the identical read-only `span` treatment
+  today; they collapse into the single `signal` zone.
+
+### The orphan smell dies structurally
+
+sözlük's alphabet becomes **`destinations={<SozlukAlphabet/>}`** — rendered *inside* the bar, with
+no detached sibling. This holds in **both** flag states (behind the existing `phoenix-nav-ia`
+flag). The structural change is the fix: the orphan is not linted away, it is made unrepresentable
+because there is no "next to the bar" slot to render into — only the `destinations` zone inside it.
+
+## Consequences
+
+- **Orphan-as-type-error.** An element not assigned to a declared zone prop cannot be rendered by
+  the shell — the compound-component orphan-slot class (detectable only by lint) is closed at the
+  type level. This is the make-invalid-states-unrepresentable payoff over a zones-object or
+  compound API.
+- **`utility` is deferred, not dropped.** It remains a legitimate ADR-0176 class; re-introducing a
+  `utility?` prop is a sanctioned, explicit law change when a real consumer arrives — never a
+  silent fill-in. This ADR is the record that its absence is deliberate.
+- **`Subnav` is wrapped, not replaced.** The primitive keeps rendering; `SubnavShell` narrows its
+  surface (drop `title`, merge `count` → `signal`). No consumer touches `Subnav`'s slots directly
+  once migrated — they go through the shell's four zones.
+- **Migration lands behind `phoenix-nav-ia`.** The ten children of #2954 migrate the five consumers
+  onto `SubnavShell` / `PageShell` behind the existing `phoenix-nav-ia` flag; the sözlük-alphabet
+  fix holds in both flag states.
+- **Coupled vocabulary.** This ADR coins `recipe` and `shell` as architecture terms; their
+  canonical one-line definitions land in [`.glossary/LANGUAGE.md`](../.glossary/LANGUAGE.md) in the
+  same PR (see Vocabulary impact below).
+- This ADR **builds on** ADR [0176](0176-nav-ia-discipline.md)'s taxonomy and **does not amend or
+  supersede** it. It adds a composition-API law where 0176 was silent; it relaxes no existing guard.
+
+### Vocabulary impact
+
+Two terms coined, both routed to [`.glossary/LANGUAGE.md`](../.glossary/LANGUAGE.md) in this PR:
+
+- **`recipe`** — the composition-primitive idiom (one flat element-prop per zone, orphan-as-type-error).
+- **`shell`** — the layout-composition wrapper (`SubnavShell` / `PageShell`) that names a
+  page's zone-plus-content shape once.
+
+### References
+
+- Founder ruling [#2971](https://github.com/kamp-us/phoenix/issues/2971) — the decision this ADR transcribes.
+- Epic [#2954](https://github.com/kamp-us/phoenix/issues/2954) — the ten children this law unblocks.
+- ADR [0176](0176-nav-ia-discipline.md) — the nav IA taxonomy + placement law this API builds on.
+- ADR [0075](0075-issueless-doc-pr-merge-seam.md) — the issueless conversation-authored doc lane this PR ships on.
+</content>

--- a/.decisions/0182-subnavshell-pageshell-composition-api.md
+++ b/.decisions/0182-subnavshell-pageshell-composition-api.md
@@ -137,4 +137,3 @@ by this change set:
 - Epic [#2954](https://github.com/kamp-us/phoenix/issues/2954) — the ten children this law unblocks.
 - ADR [0176](0176-nav-ia-discipline.md) — the nav IA taxonomy + placement law this API builds on.
 - ADR [0075](0075-issueless-doc-pr-merge-seam.md) — the issueless conversation-authored doc lane this PR ships on.
-</content>

--- a/.decisions/0182-subnavshell-pageshell-composition-api.md
+++ b/.decisions/0182-subnavshell-pageshell-composition-api.md
@@ -112,14 +112,20 @@ because there is no "next to the bar" slot to render into — only the `destinat
   onto `SubnavShell` / `PageShell` behind the existing `phoenix-nav-ia` flag; the sözlük-alphabet
   fix holds in both flag states.
 - **Coupled vocabulary.** This ADR coins `recipe` and `shell` as architecture terms; their
-  canonical one-line definitions land in [`.glossary/LANGUAGE.md`](../.glossary/LANGUAGE.md) in the
-  same PR (see Vocabulary impact below).
+  canonical one-line definitions are routed to [`.glossary/LANGUAGE.md`](../.glossary/LANGUAGE.md)
+  via a separate follow-up ([#2999](https://github.com/kamp-us/phoenix/issues/2999), triage's
+  canon/glossary lane), gated on this ADR landing — **not** shipped in this PR, which stays
+  `.decisions`-only (see Vocabulary impact below).
 - This ADR **builds on** ADR [0176](0176-nav-ia-discipline.md)'s taxonomy and **does not amend or
   supersede** it. It adds a composition-API law where 0176 was silent; it relaxes no existing guard.
 
 ### Vocabulary impact
 
-Two terms coined, both routed to [`.glossary/LANGUAGE.md`](../.glossary/LANGUAGE.md) in this PR:
+Two terms coined, both routed to [`.glossary/LANGUAGE.md`](../.glossary/LANGUAGE.md) via a
+separate follow-up ([#2999](https://github.com/kamp-us/phoenix/issues/2999), triage's canon/glossary
+lane) gated on this ADR landing — not in this PR. This PR stays `.decisions`-only; #2971's AC3
+("terms `recipe`/`shell` defined in `.glossary/LANGUAGE.md`") is satisfied by that follow-up, not
+by this change set:
 
 - **`recipe`** — the composition-primitive idiom (one flat element-prop per zone, orphan-as-type-error).
 - **`shell`** — the layout-composition wrapper (`SubnavShell` / `PageShell`) that names a

--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -253,6 +253,41 @@ calls *unrepresentable*; 0037 reunified them into a single class (the split's tw
 motivations — a mutual-DO Layer cycle and a SQLite registry — both went away), where a
 misroute now no-ops at runtime (role-guarded) rather than failing to compile.
 
+### Recipe / shell (frontend composition primitives)
+
+Two names for phoenix's frontend layout-composition idiom. (ADR
+[0182](../.decisions/0182-subnavshell-pageshell-composition-api.md) — *SubnavShell / PageShell
+composition API*, building on ADR [0176](../.decisions/0176-nav-ia-discipline.md)'s nav element
+taxonomy.)
+
+**Recipe**
+The composition-primitive idiom: a component that takes **one flat element-prop (a `ReactNode`)
+per zone** rather than a zones-object or compound children, so an element assigned to no declared
+zone is a **type error** (orphan-as-type-error), not a lint-only smell.
+
+**Shell**
+A layout-composition wrapper that names a page's zone-plus-content shape once — `SubnavShell`
+(the per-product subnav zones) and `PageShell` (a subnav shell plus routed content). A shell is a
+recipe: it exposes flat per-zone element-props and wraps the underlying primitive rather than
+replacing it.
+
+### Recipe and shell (the composition primitives)
+
+Two named UI-composition idioms, coined by ADR
+[0182](../.decisions/0182-subnavshell-pageshell-composition-api.md).
+
+**Recipe**
+The composition-primitive idiom: a component that takes **one flat element-prop per zone**
+(not a zones-object, not compound children), so an element unassigned to a declared zone is a
+**type error**, not a lint-caught orphan slot — make-invalid-states-unrepresentable applied to
+layout composition.
+
+**Shell**
+A layout-composition wrapper built as a recipe, naming a surface's zone-plus-content shape once:
+`SubnavShell` (the per-product subnav zones — `leading` / `destinations` / `primaryAction` /
+`signal`) and `PageShell` (a `SubnavShell` plus routed content). A shell wraps an underlying
+primitive (the `Subnav` primitive) rather than replacing it.
+
 ### The three senses of "phoenix"
 
 "phoenix" carries **three distinct meanings**, each with a graduation name —

--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -253,41 +253,6 @@ calls *unrepresentable*; 0037 reunified them into a single class (the split's tw
 motivations — a mutual-DO Layer cycle and a SQLite registry — both went away), where a
 misroute now no-ops at runtime (role-guarded) rather than failing to compile.
 
-### Recipe / shell (frontend composition primitives)
-
-Two names for phoenix's frontend layout-composition idiom. (ADR
-[0182](../.decisions/0182-subnavshell-pageshell-composition-api.md) — *SubnavShell / PageShell
-composition API*, building on ADR [0176](../.decisions/0176-nav-ia-discipline.md)'s nav element
-taxonomy.)
-
-**Recipe**
-The composition-primitive idiom: a component that takes **one flat element-prop (a `ReactNode`)
-per zone** rather than a zones-object or compound children, so an element assigned to no declared
-zone is a **type error** (orphan-as-type-error), not a lint-only smell.
-
-**Shell**
-A layout-composition wrapper that names a page's zone-plus-content shape once — `SubnavShell`
-(the per-product subnav zones) and `PageShell` (a subnav shell plus routed content). A shell is a
-recipe: it exposes flat per-zone element-props and wraps the underlying primitive rather than
-replacing it.
-
-### Recipe and shell (the composition primitives)
-
-Two named UI-composition idioms, coined by ADR
-[0182](../.decisions/0182-subnavshell-pageshell-composition-api.md).
-
-**Recipe**
-The composition-primitive idiom: a component that takes **one flat element-prop per zone**
-(not a zones-object, not compound children), so an element unassigned to a declared zone is a
-**type error**, not a lint-caught orphan slot — make-invalid-states-unrepresentable applied to
-layout composition.
-
-**Shell**
-A layout-composition wrapper built as a recipe, naming a surface's zone-plus-content shape once:
-`SubnavShell` (the per-product subnav zones — `leading` / `destinations` / `primaryAction` /
-`signal`) and `PageShell` (a `SubnavShell` plus routed content). A shell wraps an underlying
-primitive (the `Subnav` primitive) rather than replacing it.
-
 ### The three senses of "phoenix"
 
 "phoenix" carries **three distinct meanings**, each with a graduation name —


### PR DESCRIPTION
Conversation-authored ADR (ADR 0075 doc lane — exempt from triage) recording the founder ruling on #2971 for the SubnavShell/PageShell composition API. Unblocks epic #2954 (its ten children build against this law).

## What it decides (faithful transcription of #2971)

- **Flat element-props — ONE `ReactNode` prop per zone.** NOT a zones-object, NOT compound components. An orphaned slot becomes a **type error** (make-invalid-states-unrepresentable) instead of a lint-only smell.
- **SubnavShell zones** (grounded in ADR 0176's element taxonomy): `leading?` (context/crumb), `destinations?` (one slot, links-or-buttons composed inside), `primaryAction?` (the one promoted verb; absent for divan/sözlük is normal), `signal?` (meta/count).
- **`utility` deferred by YAGNI** — a sanctioned ADR-0176 element class deliberately not slotted until a real consumer needs it (its only consumer, sözlük's go-to-or-create box, folds into global ⌘K). Adding it later is a deliberate law change, not drift.
- **PageShell** composes SubnavShell + routed content.
- **Wrap the existing `Subnav` primitive, do not replace it** — collapse slot-sprawl: drop `title`, merge `count`→`signal`.
- The orphan smell dies structurally: sözlük alphabet becomes `destinations={<SozlukAlphabet/>}` inside the bar, in both `phoenix-nav-ia` flag states.

Builds **on** ADR 0176's taxonomy — does not amend or supersede it.

## Coupled vocabulary (routed separately via #2999)

The ADR coins `recipe` (composition-primitive idiom) and `shell` (SubnavShell/PageShell layout-composition); their canonical one-line `.glossary/LANGUAGE.md` defs land in a separate PR, #2999. This PR is `.decisions/`-only.

## Number claim (in-flight reservation lock, ADR 0074)

- Merged max: **0180** (`decisions-index next` → 0181 against fresh origin/main).
- In-flight set: **{0181}** — claimed by open PR #2994 (REST enumeration, no GraphQL).
- Took `max(union) + 1` = **0182**.

Additive-only doc PR: adds `.decisions/0182-subnavshell-pageshell-composition-api.md` only — `.decisions/`-only, the LANGUAGE.md vocab edit routes via #2999. Does NOT Fixes-close #2971 (EA closes it pointing at the ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)