### PR TITLE
feat(web): unified useFlag — __BOOT__-member keys resolve synchronously, expose signedIn presence (#2932)

### DIFF
--- a/apps/web/src/flags/useFlag.test.ts
+++ b/apps/web/src/flags/useFlag.test.ts
@@ -1,16 +1,22 @@
 /**
- * The `useFlag` response-wiring contract (#1111) — covers the SPA call-site
- * wiring of `resolveFlag` that, before this, only one e2e touched. The pure
- * `resolveFlagResponse` is the load-bearing edge: a hook that forgot to route the
- * server JSON through `resolveFlag`, or dropped the non-2xx guard, ships green
- * past everything but the e2e and would fail here instead.
+ * The `useFlag` resolution cores — the two pure edges the render-only hook is built on
+ * (`apps/web/src` has no jsdom/testing-library, so the hook itself is exercised e2e; these
+ * cover the wiring that would otherwise ship green past everything but the e2e).
+ *
+ * - `resolveFlagResponse` (#1111): the fetch-path safe-default wiring of `resolveFlag` — a
+ *   hook that forgot to route the server JSON through `resolveFlag`, or dropped the non-2xx
+ *   guard, fails here.
+ * - `resolveBootFlag` / `readSignedIn` (#2932, ADR 0179): the synchronous `__BOOT__` member
+ *   path — member keys resolve from the injected payload with no fetch, a non-member or an
+ *   absent `__BOOT__` returns `undefined` so the hook falls back to fetch, and the `signedIn`
+ *   presence bit reads safe-default `false` when `__BOOT__` is absent.
  *
  * Node-tested with no DOM/`fetch`, per the repo's pure-extraction idiom
- * (`toProfileStatsState` / `useToggleAction.test.ts`); `apps/web/src` has no
- * jsdom/testing-library.
+ * (`toProfileStatsState` / `useToggleAction.test.ts`).
  */
-import {describe, expect, it} from "vitest";
-import {resolveFlagResponse} from "./useFlag";
+import {afterEach, describe, expect, it} from "vitest";
+import {MECMUA_FEED, MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "./keys";
+import {readSignedIn, resolveBootFlag, resolveFlagResponse} from "./useFlag";
 
 describe("resolveFlagResponse — useFlag's safe-default wiring of resolveFlag", () => {
 	it("returns the server value when the response is 2xx and the flag is on (the gated path)", () => {
@@ -38,5 +44,59 @@ describe("resolveFlagResponse — useFlag's safe-default wiring of resolveFlag",
 		// The body is untrusted JSON; the resolveFlag guard, not a cast, rejects it.
 		expect(resolveFlagResponse(true, null, "new-ui", false)).toBe(false);
 		expect(resolveFlagResponse(true, {flags: {"new-ui": "yes"}}, "new-ui", false)).toBe(false);
+	});
+});
+
+describe("resolveBootFlag — the synchronous __BOOT__ member resolution", () => {
+	it("returns the injected value for a shell-key-manifest member (no fetch, loading:false)", () => {
+		// A member key present in __BOOT__ resolves to its edge-injected value on first render.
+		expect(resolveBootFlag({[PHOENIX_NAV_IA]: true}, PHOENIX_NAV_IA)).toBe(true);
+		expect(resolveBootFlag({[MECMUA_PUBLIC_READ]: false}, MECMUA_PUBLIC_READ)).toBe(false);
+		expect(resolveBootFlag({[MECMUA_FEED]: true}, MECMUA_FEED)).toBe(true);
+	});
+
+	it("returns undefined for a member when __BOOT__ is absent (the fetch fallback signal)", () => {
+		// The never-hang fallback serves an untransformed asset with no __BOOT__ — the hook must
+		// fall back to fetch, so resolution is undefined rather than a crash or a false default.
+		expect(resolveBootFlag(undefined, PHOENIX_NAV_IA)).toBeUndefined();
+	});
+
+	it("returns undefined for a member key missing from a present __BOOT__ (partial payload)", () => {
+		expect(resolveBootFlag({[MECMUA_FEED]: true}, PHOENIX_NAV_IA)).toBeUndefined();
+	});
+
+	it("returns undefined for a member whose __BOOT__ value is non-boolean (malformed)", () => {
+		expect(resolveBootFlag({[PHOENIX_NAV_IA]: "yes"} as never, PHOENIX_NAV_IA)).toBeUndefined();
+	});
+
+	it("returns undefined for a non-member key regardless of __BOOT__ (always the fetch path)", () => {
+		// A non-member key never resolves synchronously even if __BOOT__ happens to carry it.
+		expect(resolveBootFlag({"pano-draft-save": true} as never, "pano-draft-save")).toBeUndefined();
+		expect(resolveBootFlag(undefined, "pano-draft-save")).toBeUndefined();
+	});
+});
+
+describe("readSignedIn — the synchronous signed-in presence bit", () => {
+	afterEach(() => {
+		delete (globalThis as {window?: unknown}).window;
+	});
+
+	it("reads true from window.__BOOT__.signedIn when signed in", () => {
+		(globalThis as {window?: unknown}).window = {__BOOT__: {signedIn: true}};
+		expect(readSignedIn()).toBe(true);
+	});
+
+	it("reads false from window.__BOOT__.signedIn when signed out", () => {
+		(globalThis as {window?: unknown}).window = {__BOOT__: {signedIn: false}};
+		expect(readSignedIn()).toBe(false);
+	});
+
+	it("safe-defaults to false when __BOOT__ is absent (never-hang fallback / flag off)", () => {
+		(globalThis as {window?: unknown}).window = {};
+		expect(readSignedIn()).toBe(false);
+	});
+
+	it("safe-defaults to false when there is no window at all (never throws)", () => {
+		expect(readSignedIn()).toBe(false);
 	});
 });

--- a/apps/web/src/flags/useFlag.ts
+++ b/apps/web/src/flags/useFlag.ts
@@ -3,19 +3,27 @@
  * single boolean flag's **server-evaluated** value to a React 19 component, so a
  * screen can render a gated UI path without re-implementing evaluation.
  *
- * Evaluation is server-side, by design. The hook POSTs the flag key + its
- * default to `/api/flags/evaluate`; the Worker evaluates it through the `Flags`
- * service under the **session-derived** targeting context and returns the
- * resolved boolean. The targeting context (user identity) is never sent from the
- * browser — the request carries only `{key, default}`, and no Flagship binding or
- * flag config ships to the client. The hook consumes a resolved value, nothing
- * more.
+ * Two resolution paths, one hook (the unified flag surface, ADR 0179, epic #2926):
+ *
+ * - **Shell-key-manifest member** ({@link BOOT_MEMBER_KEYS}): resolved SYNCHRONOUSLY from
+ *   `window.__BOOT__` on the **first render** — `{value, loading: false}`, no `useEffect`
+ *   fetch and no post-boot repaint. The worker resolved it at the edge under the full
+ *   session context and injected it, so the shell paints its final geometry immediately.
+ *   If `__BOOT__` is absent (flag off / the never-hang outage fallback serves an
+ *   untransformed asset), the member falls back to the fetch path unchanged — the
+ *   optional-`__BOOT__` contract.
+ * - **Non-member key**: the fetch path below, exactly as before — the value POSTs the flag
+ *   key + its default to `/api/flags/evaluate`, the Worker evaluates it under the
+ *   session-derived targeting context, and the hook consumes the resolved boolean.
+ *
+ * The targeting context (user identity) is never sent from the browser — the request
+ * carries only `{key, default}`, and no Flagship binding or flag config ships to the client.
  *
  * Safe-default, always. The returned `value` starts at `defaultValue` and stays
- * there unless the server returns a genuine boolean for the key; any fetch error,
- * non-2xx response, or missing key leaves it at the default ({@link resolveFlag}).
- * The hook never throws — a Flagship outage degrades the gated UI to its off/old
- * path rather than breaking the screen.
+ * there unless a genuine boolean resolves for the key — from `__BOOT__` or the server;
+ * any fetch error, non-2xx response, missing key, or absent `__BOOT__` leaves it at the
+ * default ({@link resolveFlag}). The hook never throws — a Flagship outage or a missing
+ * `__BOOT__` degrades the gated UI to its off/old path rather than breaking the screen.
  *
  * Imperative (`fetch` in an effect), not a suspending fate read: a flag gate can
  * sit anywhere in the tree, including above a `<Screen>` Suspense boundary, so it
@@ -28,6 +36,12 @@ import {
 	resolveFlag,
 } from "../../worker/features/flagship/evaluate-contract";
 import {tagFlag} from "../lib/sentry";
+import {
+	assertShellBootKeysSingleSourced,
+	BOOT_MEMBER_KEYS,
+	type BootMemberKey,
+	SHELL_SIGNED_IN_KEY,
+} from "./shell-keys.ts";
 
 /** A flag read: its current value plus whether the server result is in yet. */
 export interface FlagState {
@@ -35,6 +49,61 @@ export interface FlagState {
 	readonly value: boolean;
 	/** `true` while the evaluate request is in flight (the value is still the default). */
 	readonly loading: boolean;
+}
+
+/**
+ * The client view of `window.__BOOT__`: each manifest member key → boolean, every key
+ * optional so a partial or absent payload cleanly falls back to fetch. Mirrors the worker's
+ * injected payload (`worker/features/flagship/shell-boot.ts`); both sides derive their key
+ * set from the one manifest ({@link BOOT_MEMBER_KEYS}), so the shapes can't drift.
+ */
+export type BootPayload = Partial<Record<BootMemberKey, boolean>>;
+
+/**
+ * The `__BOOT__`-member key set `useFlag` resolves synchronously — the shell flags plus the
+ * `signedIn` presence bit — single-sourced from the one manifest ({@link BOOT_MEMBER_KEYS}),
+ * never re-listed here. The consume-side drift guard (ADR 0179 §3) runs once at module load:
+ * it proves the key set the client reads derives from the manifest, the same fail-closed
+ * check the worker runs at injection. A static self-check only — the never-throw runtime
+ * paths below read this set, they never re-assert against live `__BOOT__` data (a drift throw
+ * on untrusted per-request data would violate the never-throw contract).
+ */
+const BOOT_MEMBER_KEY_SET: ReadonlySet<string> = ((): ReadonlySet<string> => {
+	const consumed = [...BOOT_MEMBER_KEYS];
+	assertShellBootKeysSingleSourced(consumed, consumed);
+	return new Set(consumed);
+})();
+
+/** Read `window.__BOOT__` defensively — absent/non-object ⇒ `undefined` ⇒ the fetch fallback. */
+function readBoot(): BootPayload | undefined {
+	if (typeof window === "undefined") return undefined;
+	const boot = (window as {__BOOT__?: unknown}).__BOOT__;
+	return typeof boot === "object" && boot !== null ? (boot as BootPayload) : undefined;
+}
+
+/**
+ * The synchronous `__BOOT__` resolution for a member key, factored out pure (takes the
+ * payload explicitly) so the member-sync / absent-fallback contract is unit-testable without
+ * a DOM. Returns the boot value only when the key is a manifest member AND `boot` carries a
+ * boolean for it; `undefined` otherwise (non-member key, absent `__BOOT__`, or a
+ * missing/malformed value) — the signal `useFlag` reads to fall back to the fetch path.
+ */
+export function resolveBootFlag(boot: BootPayload | undefined, key: string): boolean | undefined {
+	if (!BOOT_MEMBER_KEY_SET.has(key)) return undefined;
+	if (boot === undefined) return undefined;
+	const value = (boot as Record<string, unknown>)[key];
+	return typeof value === "boolean" ? value : undefined;
+}
+
+/**
+ * The synchronous signed-in presence bit from `window.__BOOT__` (ADR 0179 §1) — the shell
+ * frame reads it to reserve the signed-in cluster's geometry while `useSession` is still
+ * settling, rather than swapping in the cluster on a post-settle repaint. Absent `__BOOT__`
+ * (flag off / the never-hang fallback) ⇒ `false`: the shell renders its signed-out geometry,
+ * the safe default. Never throws.
+ */
+export function readSignedIn(): boolean {
+	return resolveBootFlag(readBoot(), SHELL_SIGNED_IN_KEY) ?? false;
 }
 
 async function fetchFlag(key: string, defaultValue: boolean): Promise<boolean> {
@@ -70,20 +139,35 @@ export function resolveFlagResponse(
 }
 
 export function useFlag(key: string, defaultValue: boolean): FlagState {
-	const [value, setValue] = useState(defaultValue);
-	const [loading, setLoading] = useState(true);
+	// Member keys resolve synchronously from __BOOT__ in the initializer so the very first
+	// render carries {value, loading:false} — no effect, no post-boot repaint. `undefined`
+	// (non-member, or __BOOT__ absent) starts the fetch path at the loading default.
+	const [state, setState] = useState<FlagState>(() => {
+		const booted = resolveBootFlag(readBoot(), key);
+		return booted === undefined
+			? {value: defaultValue, loading: true}
+			: {value: booted, loading: false};
+	});
 
 	useEffect(() => {
+		const booted = resolveBootFlag(readBoot(), key);
+		if (booted !== undefined) {
+			// Member key: the value came synchronously from __BOOT__. Re-sync only on a key
+			// change (the initializer runs once); returning `prev` when unchanged makes React
+			// bail out of the re-render, so a member never repaints and never fetches.
+			setState((prev) =>
+				prev.value === booted && !prev.loading ? prev : {value: booted, loading: false},
+			);
+			return;
+		}
 		let active = true;
-		setLoading(true);
-		// Reset to the default before each read so a key change can't briefly show
+		// Reset to the loading default before each read so a key change can't briefly show
 		// the previous key's value.
-		setValue(defaultValue);
+		setState({value: defaultValue, loading: true});
 		fetchFlag(key, defaultValue)
 			.then((resolved) => {
 				if (!active) return;
-				setValue(resolved);
-				setLoading(false);
+				setState({value: resolved, loading: false});
 				// Attribute captured errors to this flag's resolved state (#1821): once the
 				// server resolves the flag it becomes a queryable Sentry `flag.<key>` tag on the
 				// scope, so a graduation query can isolate its on-path error rate. Inert when
@@ -94,13 +178,12 @@ export function useFlag(key: string, defaultValue: boolean): FlagState {
 			.catch(() => {
 				// Any failure stays at the default — the off/old/safe path (#488).
 				if (!active) return;
-				setValue(defaultValue);
-				setLoading(false);
+				setState({value: defaultValue, loading: false});
 			});
 		return () => {
 			active = false;
 		};
 	}, [key, defaultValue]);
 
-	return {value, loading};
+	return state;
 }


### PR DESCRIPTION
Fixes #2932

## What

Unifies the client flag surface (`apps/web/src/flags/useFlag.ts`) on the edge-resolved shell contract (ADR 0179, epic #2926), building on #2928's shell-key manifest and the #2984 worker `window.__BOOT__` injection.

- **Shell-key-manifest member** (a key in `BOOT_MEMBER_KEYS`): resolves SYNCHRONOUSLY from `window.__BOOT__` in the `useState` initializer — `{value, loading: false}` on the first render, no `useEffect` fetch and no post-boot repaint. The worker already resolved it at the edge under the full session context.
- **Missing `__BOOT__`** (flag off / the #2931 never-hang fallback serves an untransformed asset with no `__BOOT__`): the member falls back to the existing fetch path unchanged — the optional-`__BOOT__` contract, never a crash.
- **Non-member key**: behavior is byte-for-byte today's — fetch-in-`useEffect`, `loading:true` first, safe-default.
- **`readSignedIn()`**: the synchronous signed-in presence bit from `__BOOT__.signedIn` (ADR 0179 §1) the shell frame reads while `useSession` settles; absent `__BOOT__` ⇒ `false` (safe default, never throws). The topbar (#2933) consumes this.
- Consume-side `assertShellBootKeysSingleSourced` runs once at module load, proving the client key set derives from the one manifest (ADR 0179 §3). It is a static self-check — the never-throw runtime paths never re-assert against live per-request `__BOOT__` data.

## Acceptance criteria

- [x] Member key with `__BOOT__` present ⇒ `{value: <boot value>, loading: false}` on first render, no fetch, no repaint (the initializer computes it; effect bails out via `prev`-return).
- [x] Member key with `__BOOT__` absent ⇒ falls back to the existing fetch path unchanged.
- [x] Non-member key ⇒ byte-for-byte today's fetch / `loading:true` / safe-default path.
- [x] Synchronous `signedIn` presence signal available while `useSession` is pending (`readSignedIn()`).
- [x] Safe-default-on-error / never-throw holds on every path (absent window, absent `__BOOT__`, malformed value, non-2xx fetch).

## Tests

`apps/web/src/flags/useFlag.test.ts` — the pure resolution cores (`apps/web/src` has no jsdom, so the hook is exercised e2e; these cover the wiring): `resolveBootFlag` (member-sync / absent-fallback / partial / malformed / non-member) and `readSignedIn` (present/absent/no-window). 23 unit tests pass; typecheck + biome clean.

## Scope

Client-side only (`useFlag` + the `signedIn` presence reader). Does NOT build #2931 (never-hang, worker-side) or #2933 (topbar chip slots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)