### PR TITLE
feat(web): never-hang boot timeout → untransformed-asset fallback; client __BOOT__ optional (#2931)

### DIFF
--- a/apps/web/src/flags/boot.test.ts
+++ b/apps/web/src/flags/boot.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The optional-`__BOOT__` client contract (#2931, ADR 0179 §4): the shell renders correctly when
+ * `window.__BOOT__` is ABSENT — the never-hang outage fallback or a flag-off render served the
+ * untransformed asset — by resolving to `undefined` so the caller falls back to its fetch path,
+ * never assuming injection happened. Runs in the node unit tier where `window` is undefined by
+ * default (the exact absence the contract must tolerate); the present-payload cases set a stub
+ * `window` and restore it.
+ */
+import {afterEach, describe, expect, it} from "vitest";
+import type {BootPayload} from "./boot.ts";
+import {readBoot, readBootMember} from "./boot.ts";
+import {MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "./keys.ts";
+import {SHELL_SIGNED_IN_KEY} from "./shell-keys.ts";
+
+const withBoot = (boot: unknown) => {
+	(globalThis as {window?: unknown}).window = {__BOOT__: boot};
+};
+
+afterEach(() => {
+	delete (globalThis as {window?: unknown}).window;
+});
+
+describe("readBoot — absent __BOOT__ is a first-class, non-error state", () => {
+	it("returns undefined when there is no window (outage fallback / flag off) — no throw", () => {
+		expect(readBoot()).toBeUndefined();
+	});
+
+	it("returns undefined when window exists but __BOOT__ was never injected", () => {
+		(globalThis as {window?: unknown}).window = {};
+		expect(readBoot()).toBeUndefined();
+	});
+
+	it("returns undefined when __BOOT__ is not a well-formed object", () => {
+		withBoot("not-an-object");
+		expect(readBoot()).toBeUndefined();
+		withBoot(null);
+		expect(readBoot()).toBeUndefined();
+	});
+
+	it("returns the injected payload when the edge injected a well-formed object", () => {
+		const payload: BootPayload = {[MECMUA_PUBLIC_READ]: true, [SHELL_SIGNED_IN_KEY]: false};
+		withBoot(payload);
+		expect(readBoot()).toEqual(payload);
+	});
+});
+
+describe("readBootMember — a member key falls back to the fetch path unless truly present", () => {
+	it("returns undefined for every member when __BOOT__ is absent (the fetch-fallback signal)", () => {
+		expect(readBootMember(MECMUA_PUBLIC_READ)).toBeUndefined();
+		expect(readBootMember(SHELL_SIGNED_IN_KEY)).toBeUndefined();
+	});
+
+	it("returns the injected boolean when the key is present", () => {
+		withBoot({[MECMUA_PUBLIC_READ]: true, [SHELL_SIGNED_IN_KEY]: true});
+		expect(readBootMember(MECMUA_PUBLIC_READ)).toBe(true);
+		expect(readBootMember(SHELL_SIGNED_IN_KEY)).toBe(true);
+	});
+
+	it("returns undefined for a key absent from an otherwise-present payload", () => {
+		withBoot({[MECMUA_PUBLIC_READ]: true});
+		expect(readBootMember(PHOENIX_NAV_IA)).toBeUndefined();
+	});
+
+	it("returns undefined for a non-boolean value rather than fabricating a gate", () => {
+		withBoot({[MECMUA_PUBLIC_READ]: "true"});
+		expect(readBootMember(MECMUA_PUBLIC_READ)).toBeUndefined();
+	});
+});

--- a/apps/web/src/flags/boot.ts
+++ b/apps/web/src/flags/boot.ts
@@ -1,0 +1,41 @@
+/**
+ * The client half of the `window.__BOOT__` contract, read as OPTIONAL (ADR 0179 §4, #2931).
+ *
+ * The edge injects `window.__BOOT__` only when the shell renders through the worker with the flag
+ * on AND the boot resolve succeeds within the never-hang bound. When it is ABSENT — the flag is
+ * off, or a Flagship/session outage tripped the never-hang fallback to the untransformed asset —
+ * these readers return `undefined` so the consumer resolves through its existing fetch path. A
+ * missing payload is a first-class, non-error state, never an assumption that injection happened;
+ * the unified `useFlag` (#2932) consumes this, so the optional contract lives here at its source.
+ */
+import type {BootMemberKey} from "./shell-keys.ts";
+
+/** The edge-injected payload as the client sees it: every member key MAY be present. */
+export type BootPayload = Partial<Record<BootMemberKey, boolean>>;
+
+declare global {
+	interface Window {
+		__BOOT__?: BootPayload;
+	}
+}
+
+/**
+ * Read `window.__BOOT__` when the edge injected a well-formed object, else `undefined`. Optional by
+ * construction: absence (outage fallback or flag off) is not an error — the caller falls back to
+ * its fetch path when this returns `undefined`.
+ */
+export function readBoot(): BootPayload | undefined {
+	if (typeof window === "undefined") return undefined;
+	const boot = window.__BOOT__;
+	return typeof boot === "object" && boot !== null ? boot : undefined;
+}
+
+/**
+ * Read a single `__BOOT__`-member key. Returns the injected boolean when present, else `undefined`
+ * — a missing payload, a missing key, or a non-boolean value all fall back rather than fabricate a
+ * value.
+ */
+export function readBootMember(key: BootMemberKey): boolean | undefined {
+	const value = readBoot()?.[key];
+	return typeof value === "boolean" ? value : undefined;
+}

--- a/apps/web/worker/features/flagship/shell-boot-never-hang.unit.test.ts
+++ b/apps/web/worker/features/flagship/shell-boot-never-hang.unit.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The never-hang / safe-default-on-outage invariant (#2931, epic #2926, ADR 0179 §4):
+ * `withNeverHangFallback` bounds the per-request boot resolve and degrades to the untransformed
+ * asset — never hanging, never 500-ing the shell. The three arms under test:
+ *
+ *   1. a resolve that never completes (a dead/slow Flagship or D1) is bounded by
+ *      SHELL_BOOT_READ_TIMEOUT and yields the untransformed asset;
+ *   2. a resolve that FAILS (a Flagship/D1 error) also degrades to the untransformed asset;
+ *   3. a resolve that succeeds passes its value straight through — the fallback is inert on the
+ *      healthy path.
+ *
+ * The bound is driven by `TestClock` (no real 1s sleep): a forked fiber runs the guarded resolve,
+ * the clock is adjusted past the timeout, then the exit is observed — the `cold-start-retry`
+ * idiom. Unit tier (ADR 0082): pure Effect logic, no deployed worker / platform fake.
+ */
+import {assert, it} from "@effect/vitest";
+import {Effect, Exit, Fiber} from "effect";
+import {TestClock} from "effect/testing";
+import {withNeverHangFallback} from "./shell-boot-route.ts";
+
+/** The untransformed asset stand-in — the byte-identical fallback the guard must degrade to. */
+const UNTRANSFORMED = "untransformed-asset";
+/** The injected shell stand-in — what a healthy resolve produces instead of the fallback. */
+const INJECTED = "injected-boot-shell";
+
+/** A tagged stand-in for a Flagship/D1 resolve failure — the `E`-channel value the guard degrades on. */
+class BootResolveError {
+	readonly _tag = "BootResolveError";
+}
+
+/**
+ * Run `effect` to its `Exit`, advancing the clock well past `SHELL_BOOT_READ_TIMEOUT` (1s) so a
+ * never-completing resolve is bounded and settles — the `cold-start-retry` TestClock idiom.
+ */
+const runPastTimeout = <A, E>(effect: Effect.Effect<A, E>) =>
+	Effect.gen(function* () {
+		const fiber = yield* Effect.forkChild(effect);
+		yield* TestClock.adjust("5 seconds");
+		return yield* Fiber.join(fiber).pipe(Effect.exit);
+	});
+
+it.effect("a resolve that never completes is bounded → the untransformed asset (never hangs)", () =>
+	Effect.gen(function* () {
+		const exit = yield* runPastTimeout(withNeverHangFallback(Effect.never, UNTRANSFORMED));
+		assert.deepStrictEqual(exit, Exit.succeed(UNTRANSFORMED));
+	}),
+);
+
+it.effect("a resolve that FAILS (Flagship/D1 error) → the untransformed asset (safe default)", () =>
+	Effect.gen(function* () {
+		const exit = yield* runPastTimeout(
+			withNeverHangFallback(Effect.fail(new BootResolveError()), UNTRANSFORMED),
+		);
+		assert.deepStrictEqual(exit, Exit.succeed(UNTRANSFORMED));
+	}),
+);
+
+it.effect("a healthy resolve passes straight through — the fallback is inert", () =>
+	Effect.gen(function* () {
+		const exit = yield* runPastTimeout(
+			withNeverHangFallback(Effect.succeed(INJECTED), UNTRANSFORMED),
+		);
+		assert.deepStrictEqual(exit, Exit.succeed(INJECTED));
+	}),
+);

--- a/apps/web/worker/features/flagship/shell-boot-route.ts
+++ b/apps/web/worker/features/flagship/shell-boot-route.ts
@@ -20,6 +20,7 @@
  * authorized admin's override yields identical values here and from the API (ADR 0179 AC2).
  */
 import * as Cloudflare from "alchemy/Cloudflare";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
@@ -64,6 +65,31 @@ export const readShellFlags = (context: FlagsContextValue) =>
 		return Object.fromEntries(entries) as Record<ShellFlagKey, boolean>;
 	});
 
+/**
+ * The never-hang ceiling on the per-request boot resolve — session validation (3 serial D1
+ * queries when signed in) + shell-flag evaluation (ADR 0179 §2). A healthy resolve is well
+ * under this; the cap bounds a slow or dead Flagship/D1 so the edge degrades rather than hangs.
+ * Tunable — the invariant is that a bound EXISTS, not its exact value.
+ */
+export const SHELL_BOOT_READ_TIMEOUT = Duration.seconds(1);
+
+/**
+ * The never-hang / safe-default-on-outage guard (ADR 0179 §4): bound the boot resolve with
+ * {@link SHELL_BOOT_READ_TIMEOUT} and, on timeout OR any Flagship/D1 failure, fall back to the
+ * untransformed asset — byte-identical to the flag-off / edge-direct shell, with no partial
+ * `__BOOT__`. Only expected failures (the `E` channel) + the timeout degrade; a genuine defect
+ * still propagates. Exported so the never-hang invariant is unit-testable (TestClock) without a
+ * deployed worker.
+ */
+export const withNeverHangFallback = <A, E, R>(
+	resolve: Effect.Effect<A, E, R>,
+	untransformed: A,
+): Effect.Effect<A, never, R> =>
+	resolve.pipe(
+		Effect.timeout(SHELL_BOOT_READ_TIMEOUT),
+		Effect.catch(() => Effect.succeed(untransformed)),
+	);
+
 export const handleShellBoot = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
 	const env = yield* Cloudflare.WorkerEnvironment;
@@ -72,9 +98,10 @@ export const handleShellBoot = Effect.gen(function* () {
 	// no cast is needed; `fetch` takes the request as-is and returns the workers-types `Response`.
 	const assets: {fetch(request: typeof raw): Promise<Response>} = env.ASSETS;
 	// The untransformed shell/asset — the same bytes the edge-direct binding served before this
-	// route existed. Worker-first routing is UNCONDITIONAL (not flag-gated), so this fetch runs in
-	// both flag states; a rejection is an infra defect (`orDie`), and #2931 replaces this with the
-	// never-hang timeout + untransformed-asset fallback.
+	// route existed, and the response the never-hang fallback degrades to (#2931). Worker-first
+	// routing is UNCONDITIONAL (not flag-gated), so this fetch runs in both flag states; a rejection
+	// stays an infra defect (`orDie`) — it is the fallback SOURCE, so if it fails there is nothing to
+	// serve. The never-hang timeout wraps the boot READS (session + flags) below, not this fetch.
 	const assetResponse = yield* Effect.tryPromise({
 		try: () => assets.fetch(raw),
 		catch: (cause) => new ShellAssetFetchError({cause}),
@@ -96,14 +123,21 @@ export const handleShellBoot = Effect.gen(function* () {
 	if (!on) return toWebResponse(assetResponse);
 
 	// Flag ON: NOW validate the session and resolve the full context through the SAME override-authz
-	// seam `/api/flags/evaluate` uses (the #2741 third arg), then read the shell flags under it.
-	const pasaport = yield* Pasaport;
-	const session = yield* pasaport.validateSession(raw.headers);
-	const context = yield* resolveRequestFlagsContext(session, raw.headers.get("cookie"));
-	const shellFlags = yield* readShellFlags(context);
+	// seam `/api/flags/evaluate` uses (the #2741 third arg), read the shell flags under it, and inject
+	// the payload. The whole resolve is wrapped in the never-hang guard: on a slow/dead Flagship or
+	// D1 (timeout) or any resolve failure it degrades to the untransformed asset — never a hung or
+	// 500-ing shell (ADR 0179 §4).
+	const resolveAndInject = Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+		const session = yield* pasaport.validateSession(raw.headers);
+		const context = yield* resolveRequestFlagsContext(session, raw.headers.get("cookie"));
+		const shellFlags = yield* readShellFlags(context);
+		const payload = buildBootPayload(session !== null, shellFlags);
+		return injectBootScript(assetResponse, payload);
+	});
 
-	const payload = buildBootPayload(session !== null, shellFlags);
-	return toWebResponse(injectBootScript(assetResponse, payload));
+	const response = yield* withNeverHangFallback(resolveAndInject, assetResponse);
+	return toWebResponse(response);
 });
 
 export const shellBootRoute = HttpRouter.add("*", "/*", handleShellBoot);


### PR DESCRIPTION
Fixes #2931 · child of epic #2926 (edge-resolved shell state, ADR 0179) · builds on #2929 (PR #2984, merged).

## What this does

The #2929 route already gates `PHOENIX_EDGE_SHELL_BOOT` first, then on flag-ON validates the session + evaluates the shell flags and injects `window.__BOOT__`. That flag-ON boot read had **no timeout** and the route could 500 on a resolve failure. This child adds the epic's non-negotiable **never-hang / safe-default-on-outage** invariant (ADR 0179 §4).

### Worker (`apps/web/worker/features/flagship/shell-boot-route.ts`)
- New `withNeverHangFallback` wraps the flag-ON boot resolve (session validation + shell-flag evaluation + inject) in `Effect.timeout(SHELL_BOOT_READ_TIMEOUT)` (1s) and, on **timeout OR any resolve failure** (`Effect.catch`), degrades to the **same untransformed asset** the flag-off path returns — byte-identical, no partial `__BOOT__`.
- The `ASSETS.fetch` stays `orDie`: it is the fallback **source**, so if it fails there is nothing to serve. The never-hang guard wraps only the boot **reads** (Flagship/D1), which are what can be slow/dead.
- Error channel collapses to `never`; a genuine defect still propagates.

### Client (`apps/web/src/flags/boot.ts`)
- `readBoot` / `readBootMember` read `window.__BOOT__` as **optional**: absence (outage fallback tripped, or flag off) → `undefined` → the caller resolves through its existing fetch path, never assuming injection happened. The unified `useFlag` (#2932, sibling) consumes this; the optional contract lives here at its source.

## Acceptance criteria
- [x] A simulated slow/dead flag-or-session path returns the untransformed asset within a bounded time (`Effect.timeout`), never hanging — unit-tested under `TestClock` (`shell-boot-never-hang.unit.test.ts`: never-completes → fallback; fails → fallback; succeeds → passthrough).
- [x] The outage-fallback response is byte-identical to today's edge-direct shell (the fallback IS the untransformed `assetResponse`, no injection).
- [x] The client renders correctly when `window.__BOOT__` is absent, resolving through the fetch path — unit-tested (`boot.test.ts`: absent/malformed/missing-key/non-boolean all → `undefined`).
- [x] A Flagship outage degrades to current behavior, proven by test — never a hung or errored shell.

## Grounding
- ADR 0179 §4 (the never-hang invariant); §2 (per-request full resolution — the 1s bound sits comfortably above a healthy 3-D1 + flag-eval resolve).
- `Effect.timeout` + `Effect.catch` idiom grounded in effect-smol (v4 `catch`, not v3 `catchAll`).

## Tests
`pnpm --filter @kampus/web vitest run --project unit shell-boot` → 19 passing (never-hang 3, optional-`__BOOT__` 8, existing shell-boot unit + parity intact). Typecheck + biome clean.

Stops at PR-open for the independent `review-code` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)