### PR TITLE
feat(pipeline): close the graduated source on both emission paths (#2988)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -950,6 +950,51 @@ exist and are linked, and every story maps to a child (the coverage invariant).
 
 ---
 
+## Step 6 — Close the graduated source investigation (close-on-graduation)
+
+An epic often **graduates from a resolved investigation**: the investigation's diagnosis is
+folded into an epic whose brief declares its provenance (e.g. `Emitted from resolved
+investigation #2570`). Once you've planned that epic, its work is carried forward by the epic +
+its children — so the **source investigation must be closed** as the durable "graduated into
+#EPIC" record, not left open as `status:triaged` looking pickable. Graduation had no
+close-on-source forcing function, so graduated investigations lingered open and inflated the
+backlog until a manual dedup sweep hand-closed them (#2988). plan-epic is the deterministic step
+that always touches a graduated epic, so it closes the source here rather than trusting a human to
+remember — the same enforce-at-the-path discipline the wayfinder emission close applies to maps.
+
+Scan the **brief** (the top section you read in Step 1) for the graduation-provenance marker and
+close each source it names — but only a genuine `type:investigation` source, idempotently:
+
+```bash
+# Extract every source the brief graduated from — tolerant of phrasing ("Emitted from resolved
+# investigation #N", "from resolved investigation #N"). The `resolved investigation` anchor is what
+# distinguishes a graduation provenance from an incidental `#N` cross-reference in the brief.
+SOURCES=$(grep -oiE 'resolved investigation #[0-9]+' /tmp/plan-epic-<EPIC>-current.md \
+  | grep -oE '[0-9]+' | sort -u)
+for SRC in $SOURCES; do
+  # Guard, fail-safe: close ONLY an open type:investigation — never a referenced epic/decision/bug,
+  # and never re-close a closed source (idempotent, so a re-plan run is a clean no-op). This is what
+  # keeps legitimately-open downstream artifacts (the epic itself, sibling epics) untouched.
+  read -r STATE TYPES < <(gh api repos/$REPO/issues/$SRC \
+    --jq '[.state, ([.labels[].name] | map(select(startswith("type:"))) | join(","))] | @tsv')
+  case "$STATE:$TYPES" in
+    open:*type:investigation*) ;;
+    *) echo "plan-epic: source #$SRC is $STATE ($TYPES) — not an open investigation, skipping close."; continue ;;
+  esac
+  # Audit trail (AC): a reason comment recording source → artifact, so a reader can trace the
+  # graduation, then close as completed (the work graduated, it wasn't abandoned).
+  gh api repos/$REPO/issues/$SRC/comments -f body="Graduated into epic #<EPIC> (planned by plan-epic) — closing this investigation as the durable \`graduated into #<EPIC>\` record. Its diagnosis is carried forward by the epic and its planned children." >/dev/null
+  gh api -X PATCH repos/$REPO/issues/$SRC -f state=closed -f state_reason=completed >/dev/null
+  echo "plan-epic: closed graduated source investigation #$SRC → epic #<EPIC>."
+done
+```
+
+Only the *source* that graduated is closed; the epic and every downstream artifact it links stay
+open (AC). If the brief carries no `resolved investigation #N` marker the loop no-ops — a
+plain-authored epic has no source to close.
+
+---
+
 ## Re-plan: reconciling a changed epic
 
 When you're re-run on an epic that already has a plan and children (the brief changed,
@@ -1052,8 +1097,8 @@ stories** / testing strategy) then engineering layer (Step 2), split into tracer
 children that each trace to a story — emitted idempotently (reconciled against the epic's existing
 children and the open backlog so a re-dispatch or overlap mints no duplicate) and transactionally
 (labels applied at create so a half-run leaves no pickable orphan) (Step 3), link them as native
-sub-issues (Step 4), and pin the full body with its `## Dependencies` topology (Step 5). Re-runs
-reconcile.
+sub-issues (Step 4), pin the full body with its `## Dependencies` topology (Step 5), and close the
+graduated source investigation when the epic declares one (Step 6). Re-runs reconcile.
 
 Acquire the `status:planning` epic-lock before you mutate (see [§Acquire the
 epic-lock](#acquire-the-epic-lock-before-you-mutate--release-it-on-every-exit)) and **release

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
@@ -338,13 +338,15 @@ reveals. The **only** difference from an investigation is *whose answer it is*: 
 was the founder's, never the agent's. wayfinder did the framing legwork, the founder made the call,
 and the map records it and moves on.
 
-## Emission — the cleared map emits triaged epics into the pipeline
+## Emission — the cleared map graduates into its durable artifact(s)
 
 This is the **handoff seam** where the ideation layer graduates into the execution pipeline: a
-map that has cleared enough fog emits one or more concrete epics/features into the **existing**
-`report` → `triage` → `plan-epic` → `write-code` funnel. Emission is **not a third mode with new
-machinery** — it is the terminal act of a map's life, reached from a WORK run whose
-graduation-readiness check finds the frontier cleared. Where CHART lays the frontier down and
+map that has cleared enough fog emits its **durable artifact(s)** — most often one or more concrete
+epics/features into the **existing** `report` → `triage` → `plan-epic` → `write-code` funnel, but a
+map whose destination was itself a decision graduates into an **ADR** (authored via `/adr`), and a
+map that charts strategic sequencing graduates into a **ROADMAP.md** entry. Emission is **not a
+third mode with new machinery** — it is the terminal act of a map's life, reached from a WORK run
+whose graduation-readiness check finds the frontier cleared. Where CHART lays the frontier down and
 WORK clears it one ticket at a time, emission is what a map *becomes* once its frontier holds no
 more answerable unknowns: the accreted plan, filed as intake the settled pipeline already knows
 how to drain. Nothing downstream is rebuilt — emission only feeds the funnel from its front.
@@ -431,28 +433,40 @@ EOF
   -f "labels[]=status:needs-triage"
 ```
 
-### Mark the map emitted — the traceable ideation→execution handoff
+### Close the map on graduation — the close-on-source forcing function
 
-Once the epics are filed, **mark the map as emitted** so the ideation→execution loop is traceable
-from both ends:
+Once the map's destination is fully realized in its durable artifact(s) — **whatever their kind:
+epic(s) filed into triage, an ADR authored via `/adr`, and/or a ROADMAP.md entry** — the map is
+**graduated**, and graduation **must close the map as part of the emission**, not leave it a step a
+human/agent remembers to run. A graduated-but-open map is indistinguishable from live ideation
+work: it looks pickable, inflates the backlog, and forces a manual dedup sweep to hand-close it
+(#2988 — maps #2583/#2829/#2467/#2620 all graduated but were closed only by hand; #2940 is the
+exemplar that *was* closed on graduation). The close is the durable "this map graduated into X"
+record; generalize the #2940 close across **every** graduation artifact, not epics alone.
 
-- Post a handoff comment on the map linking **every** emitted issue (`emitted #E1, #E2 → triage`),
-  so a reader of the map can follow it *forward* to the epics it became.
-- Each emitted issue already references the map (`Emitted from wayfinder:map #<MAP>` in its brief),
-  so a reader of any emitted epic can follow it *back* to the map that discovered it. The link is
-  **bidirectional** — that is what makes the ideation→execution handoff traceable.
-- **Close vs annotate.** A map whose buildable plan is **fully** emitted is **closed** — its
-  frontier is cleared and its purpose (charting the fog) is complete; it remains the durable record
-  of *how* the plan was discovered while the emitted issues carry it forward. A map that emits only
-  **part** of its plan (some destinations still fogged, or a fork still awaiting the founder) is
-  **annotated** with the emitted links but stays **open** for a future WORK run to clear the rest
-  and emit again.
+Make the ideation→execution handoff traceable from both ends, then close:
+
+- Post a handoff comment on the map naming **every** artifact it graduated into — emitted epics
+  (`#E1, #E2 → triage`), the ADR (`ADR NNNN`), the roadmap entry — so a reader can follow the map
+  *forward* to what it became. This comment **is** the audit trail; it records source → artifact.
+- Each emitted epic already references the map (`Emitted from wayfinder:map #<MAP>` in its brief),
+  and an ADR/roadmap entry graduated from a map cites it likewise, so a reader of the artifact can
+  follow it *back*. The link is **bidirectional** — that is what makes the handoff traceable.
+- **Close vs annotate.** A map whose destination is **fully** graduated (its whole buildable/decided
+  plan landed as artifacts) is **closed** — its frontier is cleared and its purpose (charting the
+  fog) is complete; it remains the durable record of *how* the plan was discovered while the
+  artifacts carry it forward. A map that graduates only **part** of its plan (some destinations
+  still fogged, or a fork still awaiting the founder) is **annotated** with the artifact links but
+  stays **open** for a future WORK run to clear the rest and graduate again. Only the *source map*
+  is closed; the emitted epics, the ADR, and the roadmap entry are legitimately-live artifacts and
+  stay as they are.
 
 ```bash
-# link the emitted epics on the map, then close it IFF the buildable plan is fully emitted
-BODY="Emitted into the pipeline: #$E1, #$E2 → triage → plan-epic → write-code. Frontier cleared."
+# Name every artifact the map graduated into (epics and/or ADR and/or roadmap), then close it
+# IFF the destination is FULLY graduated. A partial graduation is annotated but stays open.
+BODY="Graduated into: #$E1, #$E2 → triage → plan-epic → write-code; ADR 0176; ROADMAP.md v1. Frontier cleared — closing this map as the durable record of how the plan was discovered."
 gh api repos/$REPO/issues/$MAP/comments -f body="$BODY"
-gh api -X PATCH repos/$REPO/issues/$MAP -f state=closed   # fully-emitted only; a partial emit stays open
+gh api -X PATCH repos/$REPO/issues/$MAP -f state=closed -f state_reason=completed   # fully-graduated only; a partial graduation stays open
 ```
 
 ### What emission is not


### PR DESCRIPTION
## What

Graduation had no close-on-source forcing function, so graduated investigations and wayfinder maps lingered open — indistinguishable from live work, inflating the backlog until a manual dedup sweep hand-closed them (#2988). This is the cleanup-side pair of #2987 (creation-side).

Generalizes the working exemplar (map #2940, which the cartographer closed on graduation) into the two SKILL.md emission procedures. **SKILL.md-scoped only — no `packages/pipeline-cli/` change.**

### `plan-epic` — Step 6, close the graduated source investigation
When an epic declares its provenance in the brief (`Emitted from resolved investigation #N`), plan-epic — the deterministic step that always touches a graduated epic — closes the source investigation as part of planning:
- Detects the `resolved investigation #N` provenance marker in the brief.
- Guarded/fail-safe: closes **only** an open `type:investigation`, never a referenced epic/decision/bug; idempotent so a re-plan run is a clean no-op.
- Audit trail: a reason comment recording source → artifact, then `state=closed`, `state_reason=completed`.

### `wayfinder` — generalize the emission close across all graduation artifacts
The emission close was epic-only. Generalized so a map graduating into **any** durable artifact — epic(s), an ADR (via `/adr`), and/or a ROADMAP.md entry — is closed as a **mandatory** close-on-graduation step, with an audit comment naming source → artifact. Partial graduation still stays open.

## Acceptance criteria
- [x] **AC1** — plan-epic closes the source investigation an epic graduated from (`Emitted from resolved investigation #N`), no manual step (Step 6).
- [x] **AC2** — a `wayfinder:map` graduating by emitting its ADR/epic/roadmap is closed as part of emission, matching #2940's exemplar close.
- [x] **AC3** — the close carries an audit trail: a reason comment recording what the source graduated into (source → artifact).
- [x] **AC4** — enforced by the path itself (plan-epic's deterministic Step 6 + wayfinder's mandatory emission close), not left to memory.
- [x] **AC5** — only the *source* that graduated is closed; epics and other downstream artifacts (e.g. #2687/#2926/#2429) stay open — plan-epic's `type:investigation` guard and wayfinder's source-map-only close both enforce this.

Fixes #2988

🤖 Generated with [Claude Code](https://claude.com/claude-code)