### PR TITLE
feat(pipeline-cli): unified intake-dedup tool wired at report + triage seams (ADR 0181)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/report/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/report/SKILL.md
@@ -84,21 +84,24 @@ REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOw
    concurrently (several people run them at once), so the same observation may have
    been filed minutes ago. Run this check *after* composing the body, as the final
    action before the create call — composing first keeps the window between check
-   and create as small as possible:
+   and create as small as possible. Run the shared **intake-dedup tool** (ADR 0181):
+   one tested implementation of the "is there already an open issue for this?" query,
+   fed your title plus a few keywords:
 
    ```bash
-   gh api 'repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100' \
-     --jq '.[] | "#\(.number) \(.title)"'
-   gh api 'search/issues?q=repo:$REPO+is:issue+is:open+<keywords>' \
-     --jq '.items[] | "#\(.number) \(.title)"'
+   node packages/pipeline-cli/src/bin.ts intake-dedup check \
+     --query "<the title + a few distinguishing keywords>"
    ```
 
-   The two commands guard different failure modes — don't drop either: the label
-   list is read-after-write consistent and catches an issue filed seconds ago, while
-   the search runs against GitHub's eventually-consistent index (fresh issues can
-   lag out of it) but covers older open issues that already left the queue. Join
-   keywords with `+` (e.g. `…+is:open+retry+abort`) — raw spaces inside the quoted
-   URL produce a malformed query.
+   It prints one `#<n>\t<title>` line per candidate duplicate to stdout (empty output
+   ⇒ no likely match) and the candidate count on stderr. Under the hood it runs the
+   same two sources this check always used and fuses them — the label list is
+   read-after-write consistent and catches an issue filed seconds ago, while the
+   search runs against GitHub's eventually-consistent index (fresh issues can lag out
+   of it) but covers older open issues that already left the queue. Keyword joining
+   and query-shape are the tool's job now — you pass free text, not a hand-built
+   `q=` string. It resolves the target repo itself per ADR 0062 §1 (`$CLAUDE_PIPELINE_REPO`
+   → `$GITHUB_REPOSITORY` → the current repo), so it needs no `$REPO`.
 
    If an existing issue covers the same observation, don't file a twin — add anything
    you know that it lacks as a comment there, and return to your task.
@@ -146,4 +149,4 @@ The body never lands on disk under a shared name and never round-trips through a
 This skill is one of a suite that turns GitHub issues into an agent-operable pipeline; the shared formats and label semantics are documented in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) (the report template here is its own type-blind thing, but the label dimensions and progress/handoff formats live there).
 
 - One observation, one issue. If you noticed two genuinely separate things, file two — don't bundle. (Triage can split bundles, but clean intake saves it the work.)
-- The pre-filing re-query (step 3 above) is mandatory, but it's a search, not an oracle: when the results are genuinely ambiguous, file — a duplicate is cheap for triage to close, a lost observation is gone. (Use the REST search shown in step 3, never `gh issue list --search` — that goes through GraphQL, which this org breaks.)
+- The pre-filing re-query (step 3 above) is mandatory, but it's a search, not an oracle: when the results are genuinely ambiguous, file — a duplicate is cheap for triage to close, a lost observation is gone. (Use the `intake-dedup` tool shown in step 3 — it queries via `gh api` REST, never `gh issue list --search`, which goes through GraphQL that this org breaks.)

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -127,6 +127,38 @@ pick a real priority; a triage that skips the codebase produces labels nobody do
 can trust. Note **who filed it** and **what shape it's in** — both feed the human-vs-agent
 judgment (Step 5) and the classification (Step 2).
 
+### Intake dedup — is this issue itself a duplicate? (ADR 0181)
+
+You board-read every intake issue anyway, so this is the **zero-new-surface enforcement
+point** for the human path: a UI/hand-filed issue never ran `report`'s pre-file dedup check
+(the #2802 class), so triage is where a human-filed duplicate is caught. Run the same shared
+**intake-dedup tool** the `report` skill uses (ADR 0181), on *this* issue's own title +
+keywords, excluding itself so it never flags itself:
+
+```bash
+node packages/pipeline-cli/src/bin.ts intake-dedup check \
+  --query "<this issue's title + a few distinguishing keywords>" \
+  --exclude <N>
+```
+
+It prints one `#<n>\t<title>` line per candidate open issue that may already cover this
+observation (empty output ⇒ no likely duplicate), fusing the read-after-write `needs-triage`
+queue with the eventually-consistent search index — the two sources this skill used to query
+by hand. It resolves the target repo itself (ADR 0062 §1), so it needs no `$REPO`.
+
+Read the candidates — it's a search, not an oracle. If one genuinely covers the same thing:
+
+- **Agent-filed duplicate** → it is close-eligible. Fold anything this issue adds into the
+  original as a comment, then close this one not-planned as a duplicate via the Step-6 close
+  path ([`close-not-planned.md`](./close-not-planned.md) — the duplicate-content-preservation
+  step is exactly this case).
+- **Human-filed duplicate** → **never auto-closed** (Step 5). Comment linking the original
+  (`duplicate of #M`) and apply `status:needs-info`, or triage it normally with a triage-note
+  cross-link — the human decides whether to close their own. The dedup surfaces it; it does
+  not close it.
+
+An empty result is the common case — proceed to classify.
+
 ---
 
 ## Step 2 — Classify into exactly ONE of six types
@@ -202,22 +234,21 @@ How to split:
 2. **Re-query before you create.** Report agents run concurrently with your sweep
    (several people run them, from their own accounts), so the queue you listed at
    the start is already stale. Immediately before creating *any* new issue — a
-   split child or a follow-up you spotted while triaging — re-list
-   `status:needs-triage` and keyword-search open issues for the same observation:
+   split child or a follow-up you spotted while triaging — run the same shared
+   **intake-dedup tool** (ADR 0181; the one Step 1 and the `report` skill use) on the
+   new unit's title + keywords:
 
    ```bash
-   gh api "repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100" \
-     --jq '.[] | "#\(.number) \(.title)"'
-   gh api "search/issues?q=repo:$REPO+is:issue+is:open+<keywords>" \
-     --jq '.items[] | "#\(.number) \(.title)"'
+   node packages/pipeline-cli/src/bin.ts intake-dedup check \
+     --query "<the new unit's title + a few distinguishing keywords>"
    ```
 
-   The two commands guard different failure modes — don't drop either: the label
-   list is read-after-write consistent and catches an issue filed seconds ago; the
-   search runs against GitHub's eventually-consistent index but covers older open
-   issues that already left the queue. Join keywords with `+`
-   (e.g. `…+is:open+retry+abort`) — raw spaces inside the quoted URL produce a
-   malformed query.
+   It fuses the two sources this check always used — the label list is
+   read-after-write consistent and catches an issue filed seconds ago; the search
+   runs against GitHub's eventually-consistent index but covers older open issues
+   that already left the queue. Keyword joining and query shape are the tool's job
+   now — you pass free text, not a hand-built `q=` string; it resolves the repo
+   itself (ADR 0062 §1), so it needs no `$REPO`.
 
    If an existing issue already covers it, enrich/triage that one instead of filing
    a twin. (This rule exists because a triage run once filed a duplicate of an issue

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -117,6 +117,32 @@ node packages/pipeline-cli/src/bin.ts verdict read --pr 123 --gate doc && echo "
 node packages/pipeline-cli/src/bin.ts verdict post --pr 123 --gate doc --body-file "$VERDICT_FILE"
 ```
 
+### `intake-dedup` — the ADR-0181 unified intake-dedup check (#2992)
+
+The "is there already an open issue for this?" query the `report` (pre-file) and `triage`
+(intake board-read + split-pre-create) skills each used to hand-maintain inline, extracted
+into one deterministic, unit-tested tool wired at both intake seams — so the agent path and
+the human path share one implementation and cannot drift. The **pure core**
+(`dedup-match.ts`) is IO-free: `tokenize` + `searchQuery` shape free text into a deterministic
+GitHub search, and `rankCandidates` fuses the two result sources (the read-after-write
+`needs-triage` queue + the eventually-consistent search index) into one deduped,
+title-overlap-ranked candidate list. `github.ts` is the REST-only `gh api` boundary (the
+`verdict`/`epic-lock` `github.ts` service pattern).
+
+- **`intake-dedup check --query "<text>" [--exclude N] [--label L] [--limit N]`** — prints one
+  `#<n>\t<title>` line per candidate duplicate to stdout (empty ⇒ no likely match) and the
+  count on stderr. Advisory, not an oracle (a duplicate is cheap to close, a lost observation
+  is gone): **always exits 0**. `--exclude` omits an issue number (the one being deduped at the
+  triage seam, so it never flags itself); `--label` overrides the intake-queue label
+  (default `status:needs-triage`). It resolves the target repo itself (ADR 0062 §1).
+
+```bash
+# pre-file check (report seam) — pass the title + a few keywords, not a hand-built query
+node packages/pipeline-cli/src/bin.ts intake-dedup check --query "retry helper swallows abort reason"
+# triage intake check — dedup the issue against the board, excluding itself
+node packages/pipeline-cli/src/bin.ts intake-dedup check --query "<title + keywords>" --exclude 2802
+```
+
 ### `leak-guard` — personal-data leak gate for shared artifacts (#173, #2357)
 
 Two modes, one deny-list-per-mode core:

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -29,6 +29,7 @@ import {failureClassifierCommand} from "./tools/failure-classifier/command.ts";
 import {fanoutGuardCommand} from "./tools/fanout-guard/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
+import {intakeDedupCommand} from "./tools/intake-dedup/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {mainSyncCommand} from "./tools/main-sync/command.ts";
 import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
@@ -128,4 +129,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	verdictCommand,
 	campaignCommand,
 	catalogGuardCommand,
+	intakeDedupCommand,
 ];

--- a/packages/pipeline-cli/src/tools/intake-dedup/command.ts
+++ b/packages/pipeline-cli/src/tools/intake-dedup/command.ts
@@ -1,0 +1,86 @@
+/**
+ * The `intake-dedup` tool — `pipeline-cli intake-dedup check --query "<text>"`.
+ *
+ * The ADR-0181 "is there already an open issue for this?" check, extracted from the inline
+ * dual `gh api` query the `report` (pre-file) and `triage` (intake / split-pre-create) skills
+ * each hand-maintained. One tested implementation wired at both intake seams — no drift.
+ *
+ * `check` fuses the two sources the skills ran by hand — the read-after-write `needs-triage`
+ * queue + the eventually-consistent search index — into one deduped, title-overlap-ranked
+ * candidate list, printed one `#<n>\t<title>` line per candidate to stdout (empty output = no
+ * likely duplicate). It is advisory, not an oracle (ADR 0181; a duplicate is cheap to close, a
+ * lost observation is gone), so it exits 0 whether or not it finds candidates; the count and any
+ * refusal go to stderr. `GithubLive` is baked in with `Command.provide(...)` so the registered
+ * command's residual requirement is the Node platform union (the registry seam, epic #994).
+ */
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {rankCandidates, tokenize} from "./dedup-match.ts";
+import {Github, GithubLive} from "./github.ts";
+
+const DEFAULT_LABEL = "status:needs-triage";
+const DEFAULT_LIMIT = 20;
+
+const queryFlag = Flag.string("query").pipe(
+	Flag.withDescription(
+		"the observation text (title + keywords) to check for an existing open issue",
+	),
+);
+
+const labelFlag = Flag.string("label").pipe(
+	Flag.withDefault(DEFAULT_LABEL),
+	Flag.withDescription(`the intake-queue label to list (default: ${DEFAULT_LABEL})`),
+);
+
+const limitFlag = Flag.integer("limit").pipe(
+	Flag.withDefault(DEFAULT_LIMIT),
+	Flag.withDescription(`max candidates to print (default: ${DEFAULT_LIMIT})`),
+);
+
+const excludeFlag = Flag.integer("exclude").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"an issue number to omit from results — the issue being deduped, so it never flags itself",
+	),
+);
+
+const check = Command.make(
+	"check",
+	{query: queryFlag, label: labelFlag, limit: limitFlag, exclude: excludeFlag},
+	Effect.fn(function* ({query, label, limit, exclude}) {
+		const tokens = tokenize(query);
+		// No usable keywords ⇒ the search half would match everything and the queue half nothing;
+		// there is no meaningful dedup to run, so surface that on stderr and exit clean (advisory).
+		if (tokens.length === 0) {
+			process.stderr.write("intake-dedup: no usable keywords in --query — nothing to check\n");
+			return;
+		}
+		const gh = yield* Github;
+		const [queue, search] = yield* Effect.all([gh.queue(label), gh.search(tokens)], {
+			concurrency: "unbounded",
+		});
+		const candidates = rankCandidates({
+			queue,
+			search,
+			tokens,
+			exclude: Option.getOrUndefined(exclude),
+			limit,
+		});
+		for (const c of candidates) yield* Console.log(`#${c.number}\t${c.title}`);
+		process.stderr.write(
+			`intake-dedup: ${candidates.length} candidate duplicate(s) for [${tokens.join(" ")}]\n`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"List open issues that may already cover an observation (the ADR-0181 pre-file / intake dedup check)",
+	),
+);
+
+export const intakeDedupCommand = Command.make("intake-dedup").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"The ADR-0181 unified intake-dedup check — one tested query shared by the report + triage seams",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/intake-dedup/dedup-match.ts
+++ b/packages/pipeline-cli/src/tools/intake-dedup/dedup-match.ts
@@ -1,0 +1,170 @@
+/**
+ * The pure match core for `intake-dedup` (ADR 0181): the "is there already an open
+ * issue for this?" heuristic the `report` and `triage` skills used to each hand-maintain
+ * inline. One tested implementation — no drift between the two intake seams.
+ *
+ * IO-free by construction: `tokenize` + `searchQuery` shape the free-text observation into
+ * a deterministic GitHub search, and `rankCandidates` fuses the two result sources (the
+ * read-after-write `needs-triage` queue + the eventually-consistent search index) into one
+ * deduped, title-overlap-ranked candidate list. The `github.ts` shell feeds it raw REST rows.
+ */
+
+/** A minimal open-issue row — the only two fields either seam consumed from the old queries. */
+export interface IssueRef {
+	readonly number: number;
+	readonly title: string;
+}
+
+/** Which source(s) surfaced a candidate — `both` is the strongest duplicate signal. */
+export type CandidateSource = "queue" | "search" | "both";
+
+/** A ranked duplicate candidate: an open issue that may already cover the observation. */
+export interface Candidate {
+	readonly number: number;
+	readonly title: string;
+	readonly source: CandidateSource;
+	/** Query-token overlap with the candidate's title — the rank key, higher = stronger. */
+	readonly score: number;
+}
+
+/**
+ * English function words + report-template scaffolding nouns that carry no dedup signal.
+ * Kept deliberately small: the goal is to drop pure noise ("the", "when", "issue"), not to
+ * stem — an over-eager stoplist silently starves the search of real keywords.
+ */
+const STOPWORDS: ReadonlySet<string> = new Set([
+	"the",
+	"and",
+	"for",
+	"are",
+	"was",
+	"were",
+	"with",
+	"that",
+	"this",
+	"then",
+	"than",
+	"from",
+	"into",
+	"when",
+	"what",
+	"which",
+	"where",
+	"while",
+	"have",
+	"has",
+	"had",
+	"not",
+	"but",
+	"you",
+	"your",
+	"our",
+	"its",
+	"it's",
+	"they",
+	"them",
+	"their",
+	"there",
+	"here",
+	"can",
+	"cant",
+	"will",
+	"would",
+	"should",
+	"could",
+	"issue",
+	"issues",
+	"bug",
+	"report",
+	"todo",
+]);
+
+/** Tokens shorter than this carry no discriminating signal (`a`, `to`, `id`). */
+const MIN_TOKEN_LENGTH = 3;
+
+/**
+ * Cap on keyword count in the built query. A GitHub search AND-joins its terms, so an
+ * over-long query from a whole paragraph matches nothing; the first N high-signal tokens
+ * (insertion order, so the title/lead words win) keep the query usefully broad.
+ */
+const MAX_QUERY_TOKENS = 12;
+
+/**
+ * Split free text into the deterministic keyword set the search half runs on: lowercase,
+ * break on any non-alphanumeric run, drop stopwords and sub-`MIN_TOKEN_LENGTH` tokens,
+ * dedupe preserving first-seen order, cap at `MAX_QUERY_TOKENS`.
+ */
+export const tokenize = (text: string): ReadonlyArray<string> => {
+	const seen = new Set<string>();
+	const out: Array<string> = [];
+	for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+		if (raw.length < MIN_TOKEN_LENGTH || STOPWORDS.has(raw) || seen.has(raw)) continue;
+		seen.add(raw);
+		out.push(raw);
+		if (out.length >= MAX_QUERY_TOKENS) break;
+	}
+	return out;
+};
+
+/**
+ * The GitHub `search/issues` `q` value for `repo`'s open issues over `tokens`: the
+ * `repo:` / `is:issue` / `is:open` qualifiers plus the space-joined keywords. Space-joined
+ * (not `+`-joined) because the caller passes this through `gh api -f q=…`, which URL-encodes
+ * the field — so no raw-space-in-URL hazard the hand-written queries had to `+`-guard against.
+ */
+export const searchQuery = (repo: string, tokens: ReadonlyArray<string>): string =>
+	[`repo:${repo}`, "is:issue", "is:open", ...tokens].join(" ");
+
+/** Count how many of `tokens` appear as a token of `title` — the title-overlap rank score. */
+export const titleScore = (title: string, tokens: ReadonlyArray<string>): number => {
+	if (tokens.length === 0) return 0;
+	const titleTokens = new Set(tokenize(title));
+	let score = 0;
+	for (const t of tokens) if (titleTokens.has(t)) score += 1;
+	return score;
+};
+
+export interface RankInput {
+	readonly queue: ReadonlyArray<IssueRef>;
+	readonly search: ReadonlyArray<IssueRef>;
+	readonly tokens: ReadonlyArray<string>;
+	/** Issue number to omit — the very issue being deduped, so it never flags itself (triage seam). */
+	readonly exclude?: number | undefined;
+	readonly limit: number;
+}
+
+/**
+ * Fuse the two result sources into one ranked candidate list. The `needs-triage` queue is
+ * unfiltered server-side, so a queue row is kept only when its title shares a query token
+ * (score > 0); a search row already matched server-side (title *or* body), so it is kept
+ * regardless of title overlap. A number seen in both sources upgrades to `source: "both"` —
+ * the strongest duplicate signal — and takes the higher score. Ranked by score desc, then
+ * newer (higher number) first; capped at `limit`.
+ */
+export const rankCandidates = (input: RankInput): ReadonlyArray<Candidate> => {
+	const {queue, search, tokens, exclude, limit} = input;
+	const byNumber = new Map<number, Candidate>();
+
+	const add = (ref: IssueRef, source: "queue" | "search", keepZero: boolean): void => {
+		if (ref.number === exclude) return;
+		const score = titleScore(ref.title, tokens);
+		if (!keepZero && score === 0) return;
+		const prior = byNumber.get(ref.number);
+		if (prior === undefined) {
+			byNumber.set(ref.number, {number: ref.number, title: ref.title, source, score});
+			return;
+		}
+		byNumber.set(ref.number, {
+			...prior,
+			source: "both",
+			score: Math.max(prior.score, score),
+		});
+	};
+
+	for (const ref of queue) add(ref, "queue", false);
+	for (const ref of search) add(ref, "search", true);
+
+	return [...byNumber.values()]
+		.sort((a, b) => (b.score !== a.score ? b.score - a.score : b.number - a.number))
+		.slice(0, limit);
+};

--- a/packages/pipeline-cli/src/tools/intake-dedup/dedup-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/intake-dedup/dedup-match.unit.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the `intake-dedup` pure core (ADR 0181): tokenization, query building,
+ * title scoring, and the two-source rank/fuse. IO-free — no `gh` boundary here.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	type Candidate,
+	type IssueRef,
+	rankCandidates,
+	searchQuery,
+	titleScore,
+	tokenize,
+} from "./dedup-match.ts";
+
+describe("tokenize", () => {
+	it("lowercases and splits on non-alphanumeric runs", () => {
+		expect(tokenize("Retry-helper swallows Abort")).toEqual([
+			"retry",
+			"helper",
+			"swallows",
+			"abort",
+		]);
+	});
+
+	it("drops stopwords and sub-3-char tokens", () => {
+		// "the"/"in"/"a" are noise; "id" is < 3 chars; "worker" survives.
+		expect(tokenize("the id in a worker")).toEqual(["worker"]);
+	});
+
+	it("dedupes preserving first-seen order", () => {
+		expect(tokenize("cache cache Cache invalidation cache")).toEqual(["cache", "invalidation"]);
+	});
+
+	it("drops the report-scaffolding nouns (issue/bug/report)", () => {
+		expect(tokenize("bug report: issue with pagination")).toEqual(["pagination"]);
+	});
+
+	it("caps at 12 tokens", () => {
+		const many = tokenize(
+			"alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november",
+		);
+		expect(many.length).toBe(12);
+		expect(many[0]).toBe("alpha");
+	});
+
+	it("returns empty for all-noise text", () => {
+		expect(tokenize("the and for a to")).toEqual([]);
+	});
+});
+
+describe("searchQuery", () => {
+	it("prepends the repo/is:issue/is:open qualifiers, space-joined", () => {
+		expect(searchQuery("kamp-us/phoenix", ["retry", "abort"])).toBe(
+			"repo:kamp-us/phoenix is:issue is:open retry abort",
+		);
+	});
+
+	it("emits qualifiers-only when there are no tokens (no trailing raw space)", () => {
+		expect(searchQuery("kamp-us/phoenix", [])).toBe("repo:kamp-us/phoenix is:issue is:open");
+	});
+});
+
+describe("titleScore", () => {
+	it("counts query tokens present in the title", () => {
+		expect(
+			titleScore("Retry helper swallows the abort reason", ["retry", "abort", "missing"]),
+		).toBe(2);
+	});
+
+	it("is zero when nothing overlaps", () => {
+		expect(titleScore("Unrelated pagination fix", ["retry", "abort"])).toBe(0);
+	});
+
+	it("is zero for an empty token set", () => {
+		expect(titleScore("anything", [])).toBe(0);
+	});
+});
+
+describe("rankCandidates", () => {
+	const q = (n: number, title: string): IssueRef => ({number: n, title});
+	const bare = (c: Candidate) => ({number: c.number, source: c.source, score: c.score});
+
+	it("drops queue rows with no title overlap, keeps search rows regardless", () => {
+		const out = rankCandidates({
+			queue: [q(10, "retry helper abort"), q(11, "totally unrelated")],
+			// a search row that matched server-side on the BODY has no title overlap — still kept.
+			search: [q(12, "no shared words at all")],
+			tokens: ["retry", "abort"],
+			limit: 20,
+		});
+		expect(out.map((c) => c.number).sort((a, b) => a - b)).toEqual([10, 12]);
+	});
+
+	it("upgrades a number seen in both sources to source:both with the higher score", () => {
+		const out = rankCandidates({
+			queue: [q(10, "retry abort helper")],
+			search: [q(10, "retry abort helper")],
+			tokens: ["retry", "abort", "helper"],
+			limit: 20,
+		});
+		expect(out).toHaveLength(1);
+		expect(bare(out[0]!)).toEqual({number: 10, source: "both", score: 3});
+	});
+
+	it("ranks by score desc, then newer (higher number) first", () => {
+		const out = rankCandidates({
+			queue: [q(5, "retry abort helper"), q(9, "retry only"), q(8, "retry only")],
+			search: [],
+			tokens: ["retry", "abort", "helper"],
+			limit: 20,
+		});
+		expect(out.map((c) => c.number)).toEqual([5, 9, 8]);
+	});
+
+	it("excludes the issue being deduped so it never flags itself", () => {
+		const out = rankCandidates({
+			queue: [q(42, "retry abort helper"), q(43, "retry abort helper")],
+			search: [],
+			tokens: ["retry", "abort"],
+			exclude: 42,
+			limit: 20,
+		});
+		expect(out.map((c) => c.number)).toEqual([43]);
+	});
+
+	it("caps the result at limit", () => {
+		const out = rankCandidates({
+			queue: [q(1, "retry a"), q(2, "retry b"), q(3, "retry c")],
+			search: [],
+			tokens: ["retry"],
+			limit: 2,
+		});
+		expect(out).toHaveLength(2);
+	});
+});

--- a/packages/pipeline-cli/src/tools/intake-dedup/github.ts
+++ b/packages/pipeline-cli/src/tools/intake-dedup/github.ts
@@ -1,0 +1,220 @@
+/**
+ * The GitHub boundary for `intake-dedup`: the live `Github` capability that fetches the two
+ * intake-dedup result sources over `gh api` REST, feeding the IO-free `dedup-match.ts` core.
+ *
+ * Same service pattern as the `verdict` / `epic-lock` template children (epic #994): a
+ * `Context.Service` on `ChildProcessSpawner`, REST only (GraphQL is broken on the kamp-us
+ * org), every infra failure a typed error in the `E` channel, untrusted REST JSON
+ * Schema-decoded at the boundary into `IssueRef`s the core ranks over.
+ *
+ * Two reads, mirroring the pair the report/triage skills hand-ran:
+ *  - `queue(label)` — open issues carrying `label` (`status:needs-triage`), read-after-write
+ *    consistent (catches an issue filed seconds ago); PR rows are dropped (the issues
+ *    endpoint returns both, but a PR is never an intake duplicate).
+ *  - `search(tokens)` — the `search/issues` index over the query the core builds; covers
+ *    older open issues that have already left the needs-triage queue.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {type IssueRef, searchQuery} from "./dedup-match.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/intake-dedup/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/intake-dedup/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/intake-dedup/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the same
+ * direct-spawn shape `verdict`/`epic-lock` use so a non-zero exit + stderr lower into a typed
+ * error rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` not on PATH) folds in as exit `-1`.
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently defaults —
+ * with no env and no resolvable current repo it fails `RepoResolutionError`.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/intake-dedup/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// REST-only arg builders — never GraphQL.
+
+const queueArgs = (repo: string, label: string): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues?state=open&labels=${label}&per_page=100`,
+];
+
+const searchArgs = (query: string): ReadonlyArray<string> => [
+	"api",
+	"--method",
+	"GET",
+	"search/issues",
+	"-f",
+	`q=${query}`,
+	"-F",
+	"per_page=100",
+];
+
+/**
+ * A raw issue row from the issues endpoint; `pull_request` present ⇒ it is a PR, which the
+ * issues endpoint returns alongside issues and which is never an intake duplicate — so it's dropped.
+ */
+const RawIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	pull_request: Schema.optionalKey(Schema.Unknown),
+});
+const decodeQueue = Schema.decodeUnknownEffect(Schema.Array(RawIssue));
+
+/** The `search/issues` envelope; only `items[].{number,title}` are read (PRs never match `is:issue`). */
+const SearchResult = Schema.Struct({
+	items: Schema.Array(Schema.Struct({number: Schema.Number, title: Schema.String})),
+});
+const decodeSearch = Schema.decodeUnknownEffect(SearchResult);
+
+const queue = Effect.fn("Github.queue")(function* (repo: string, label: string) {
+	const args = queueArgs(repo, label);
+	const rows = yield* decodeQueue(yield* json(args));
+	return rows
+		.filter((r) => r.pull_request === undefined)
+		.map((r): IssueRef => ({number: r.number, title: r.title}));
+});
+
+const search = Effect.fn("Github.search")(function* (repo: string, tokens: ReadonlyArray<string>) {
+	const args = searchArgs(searchQuery(repo, tokens));
+	const {items} = yield* decodeSearch(yield* json(args));
+	return items.map((i): IssueRef => ({number: i.number, title: i.title}));
+});
+
+/**
+ * `Github` — the IO shell over `gh api` REST for the two intake-dedup sources. `queue`
+ * lists the `needs-triage` queue (read-after-write), `search` runs the built query against
+ * the search index. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly queue: (
+			label: string,
+		) => Effect.Effect<
+			ReadonlyArray<IssueRef>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+		readonly search: (
+			tokens: ReadonlyArray<string>,
+		) => Effect.Effect<
+			ReadonlyArray<IssueRef>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/intake-dedup/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at
+ * construction and provided into each method body, so the public methods carry `R = never`.
+ * Repo resolution is deferred to first use (`Effect.cached`, ADR 0062 §1): the layer build is
+ * side-effect-free, and `RepoResolutionError` lives in each method's `E`, raised only on a real read.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				queue: (label) => repo.pipe(Effect.flatMap((r) => withSpawner(queue(r, label)))),
+				search: (tokens) => repo.pipe(Effect.flatMap((r) => withSpawner(search(r, tokens)))),
+			};
+		}),
+	);


### PR DESCRIPTION
Implements **ADR 0181** — the unified intake-dedup mechanism. Extracts the "is there already an open issue for this?" dedup query (which the `report` and `triage` skills each hand-maintained inline) into one tested, deterministic `pipeline-cli` tool, wired at both intake seams so the agent path and the human path share one implementation and cannot drift.

Fixes #2992

## What landed

**New `intake-dedup` tool** (`packages/pipeline-cli/src/tools/intake-dedup/`):
- `dedup-match.ts` — the pure, IO-free core: `tokenize` + `searchQuery` shape free text into a deterministic GitHub search; `rankCandidates` fuses the two result sources (the read-after-write `needs-triage` queue + the eventually-consistent search index) into one deduped, title-overlap-ranked candidate list. Unit-tested (`dedup-match.unit.test.ts`, 16 cases).
- `github.ts` — the REST-only `gh api` boundary (the `verdict`/`epic-lock` `github.ts` service pattern; never GraphQL), decoding untrusted REST JSON at the edge and dropping PR rows.
- `command.ts` — the thin Effect bin: `intake-dedup check --query "<text>" [--exclude N] [--label L] [--limit N]`. Advisory, not an oracle (a duplicate is cheap to close, a lost observation is gone) — **always exits 0**; prints `#<n>\t<title>` per candidate to stdout, the count to stderr.
- Registered in `registry.ts`; documented in the package README.

**Both seams wired to the one tool:**
- **Report seam** (`skills/report/SKILL.md`, Step 3): pre-file check re-pointed at the tool — no inline hand-built query left.
- **Triage seam** (`skills/triage/SKILL.md`): a **NEW** Step-1 board-read intake dedup check (the zero-new-surface human-path enforcement point that catches UI-filed duplicates, the #2802 class), plus the Step-3 split-pre-create re-query re-pointed at the same tool.

## Per-AC

- [x] ADR 0181 on `main` before pickup (confirmed `.decisions/0181-*.md` present on the branch base).
- [x] New dedup subcommand: pure unit-tested core + thin Effect bin; the query logic is unit-tested.
- [x] Report Step-3 check re-pointed at the tool (no remaining inline query).
- [x] Triage gains a triage-time intake dedup check at the existing board-read point (no new surface).
- [x] Both seams invoke one shared implementation — the query is not duplicated across the two skills.
- [x] Package guards pass (`readme-guard`, `catalog-guard`); no new deps added (all `effect`/platform already present, so nothing to catalog).

## Verification
- `pnpm typecheck` clean; full pipeline-cli suite `1271 passed`.
- Live smoke against `kamp-us/phoenix`: `intake-dedup check --query "intake dedup"` matches raw `gh api search/issues` exactly (including a body-only match kept via the search source); the all-noise-query guard path exits clean.
- `biome check` clean; `leak-guard scan` clean on the changed skills + README.

## §CP — stop reviewed-ready
Edits `packages/pipeline-cli` **and** two pipeline skills (`report`, `triage`) — all control-plane. **No auto-ship**: stop reviewed-ready for human (EM + cansirin bank) merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)