### PR TITLE
feat(web): reserve signed-in topbar cluster at first paint from __BOOT__.signedIn (#2933)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -149,7 +149,16 @@ vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: ()
 // (akış) nav entry (#2547) is gated on `mecmua-feed`, flipped via `flags.mecmuaFeed`.
 // Every other read (and other flag key) stays off, matching the default the shell
 // rendered under before.
-const flags = vi.hoisted(() => ({authorshipLoop: false, mecmuaFeed: false, navIa: false}));
+// `signedIn` drives the mocked `readSignedIn` (the `__BOOT__.signedIn` presence bit, #2933):
+// the shell frame reads it to reserve the signed-in account cluster before `useSession`
+// settles. Default false = `__BOOT__` absent, so the pre-existing shell tests see today's
+// signed-out first paint unchanged.
+const flags = vi.hoisted(() => ({
+	authorshipLoop: false,
+	mecmuaFeed: false,
+	navIa: false,
+	signedIn: false,
+}));
 vi.mock("./flags/useFlag", async () => {
 	const {PHOENIX_AUTHORSHIP_LOOP, MECMUA_FEED, PHOENIX_NAV_IA} = await import("./flags/keys");
 	return {
@@ -164,6 +173,7 @@ vi.mock("./flags/useFlag", async () => {
 							: false,
 			loading: false,
 		}),
+		readSignedIn: () => flags.signedIn,
 	};
 });
 
@@ -263,6 +273,55 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 
 		expect(fateMounts).toHaveLength(1);
 		expect(fateMounts[0]?.key).toBe("anon");
+	});
+});
+
+// Reserved signed-in cluster from __BOOT__.signedIn (#2933, ADR 0179 §1). The shell frame reads
+// the edge presence bit at first paint: signed-in ⇒ no giriş-yap CTA and a reserved account slot
+// BEFORE useSession settles, so the giriş-yap↔user-cluster swap + empty→pop never happen; absent
+// __BOOT__ ⇒ readSignedIn() false ⇒ today's session-gated render (the AC-3 no-op).
+describe("reserved signed-in cluster from __BOOT__.signedIn (#2933)", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		flags.signedIn = false;
+	});
+	afterEach(() => {
+		flags.signedIn = false;
+		vi.clearAllMocks();
+	});
+
+	it("__BOOT__ present + signedIn: first paint reserves the account slot — no giriş-yap flash, before the session settles", () => {
+		flags.signedIn = true;
+		renderApp();
+		// The session is still isPending (no fate, no chips), yet the shell already knows the
+		// user is signed in from the edge bit: the CTA is gone and the account slot is reserved.
+		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
+		expect(screen.getByTestId("topbar-user-placeholder")).toBeTruthy();
+		expect(fateMounts).toHaveLength(0);
+	});
+
+	it("__BOOT__ present + signedIn: no giriş-yap↔user-cluster swap when the session settles signed-in", () => {
+		flags.signedIn = true;
+		renderApp(FATE_FREE_ROUTE);
+		// Pre-settle: reserved placeholder, no CTA.
+		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
+		expect(screen.getByTestId("topbar-user-placeholder")).toBeTruthy();
+		act(() => {
+			setSession({
+				data: {user: {id: "user-42", name: "Elif", email: "elif@kamp.us"}},
+				isPending: false,
+			});
+		});
+		// Settled signed-in: still no CTA — the account cluster held its geometry across settle,
+		// never swapping giriş-yap in then out (the reported jank).
+		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
+	});
+
+	it("__BOOT__ absent (readSignedIn false): the shell is exactly as today — giriş-yap, no reserved slot (AC-3)", () => {
+		renderApp();
+		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
+		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
 	});
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -36,7 +36,7 @@ import {
 	PHOENIX_BILDIRIM,
 	PHOENIX_NAV_IA,
 } from "./flags/keys";
-import {useFlag} from "./flags/useFlag";
+import {readSignedIn, useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
 import {SAVED_HREF} from "./lib/panoNav";
 import {safeReturnTo} from "./lib/returnTo";
@@ -159,6 +159,17 @@ function Layout() {
 	}
 
 	const isSignedIn = !!session.data;
+	// First-paint shell geometry rides the edge-resolved presence bit (ADR 0179 §1, #2933):
+	// `__BOOT__.signedIn` tells us synchronously — before `useSession` settles — whether the
+	// account cluster should exist, so the giriş-yap↔user-cluster swap and the empty→pop never
+	// happen. Absent `__BOOT__` (flag off / the #2931 never-hang fallback) ⇒ `readSignedIn()`
+	// is false ⇒ the session-gated `isSignedIn` governs, exactly today's behavior.
+	const bootSignedIn = readSignedIn();
+	const signedInAtFirstPaint = bootSignedIn || isSignedIn;
+	// Reserve the account slot only while the edge said signed-in AND we haven't settled to a
+	// definitively signed-out session — so an absent `__BOOT__` never reserves (today's render)
+	// and a boot/session divergence collapses cleanly rather than stranding a phantom slot.
+	const reserveSignedInSlots = bootSignedIn && (session.isPending || isSignedIn);
 
 	return (
 		<TooltipProvider>
@@ -167,6 +178,7 @@ function Layout() {
 					<Topbar
 						brandName="kamp.us"
 						navIa={navIaOn}
+						reserveSignedInSlots={reserveSignedInSlots}
 						nav={[
 							{to: "/sozluk", label: "sözlük"},
 							{to: "/pano", label: "pano"},
@@ -193,7 +205,11 @@ function Layout() {
 						onThemeChange={setThemeChoice}
 						onLogout={onSignOut}
 						actions={
-							!isSignedIn ? (
+							// giriş-yap rides the first-paint presence bit, not the settling session:
+							// `__BOOT__.signedIn` (via signedInAtFirstPaint) suppresses the CTA for a
+							// signed-in user from the first frame, so it never flashes then swaps out
+							// (#2933). Absent `__BOOT__` ⇒ this reduces to `isSignedIn`, today's split.
+							!signedInAtFirstPaint ? (
 								<button type="button" className="kp-topbar__btn" onClick={() => navigate("/auth")}>
 									giriş yap
 								</button>

--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -162,6 +162,29 @@
 }
 /* Keyboard focus ring comes from the shared focus layer (global.css, #2169). */
 
+/* Reserved signed-in account slot (#2933, ADR 0179 §1) — a fixed-geometry stand-in for the
+   user-menu trigger, rendered from __BOOT__.signedIn while fate has yet to publish the real
+   chip. It reuses `.kp-topbar__user` so the box (gap/padding/height) matches, and the swap to
+   the real menu moves nothing: the cluster holds its final geometry from first paint (no
+   giriş-yap↔cluster swap, no empty→pop), the value late-fills in place (#2160). Quiet
+   `--surface-raised` blocks — decorative only, so a below-4.5:1 token is correct here. */
+.kp-topbar__user--placeholder {
+	cursor: default;
+}
+.kp-topbar__avatar-placeholder {
+	width: var(--avatar-size, 22px);
+	height: var(--avatar-size, 22px);
+	border-radius: var(--r-sm);
+	background: var(--surface-raised);
+	flex-shrink: 0;
+}
+.kp-topbar__name-placeholder {
+	width: 4.5rem;
+	height: 0.72em;
+	border-radius: var(--r-sm);
+	background: var(--surface-raised);
+}
+
 /* The ambient self-karma chip (#1208) — keep it centered in the topbar row. */
 .kp-topbar__karma {
 	align-self: center;

--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -164,19 +164,13 @@
 
 /* Reserved signed-in account slot (#2933, ADR 0179 §1) — a fixed-geometry stand-in for the
    user-menu trigger, rendered from __BOOT__.signedIn while fate has yet to publish the real
-   chip. It reuses `.kp-topbar__user` so the box (gap/padding/height) matches, and the swap to
-   the real menu moves nothing: the cluster holds its final geometry from first paint (no
-   giriş-yap↔cluster swap, no empty→pop), the value late-fills in place (#2160). Quiet
-   `--surface-raised` blocks — decorative only, so a below-4.5:1 token is correct here. */
+   chip. It reuses `.kp-topbar__user` (box: gap/padding/height) and, for the avatar, the real
+   `.kp-avatar` box primitive itself, so the swap to the real menu moves nothing — the placeholder
+   avatar is pixel-identical to the Avatar it replaces. The cluster holds its final geometry from
+   first paint (no giriş-yap↔cluster swap, no empty→pop); the value late-fills in place (#2160).
+   The quiet `--surface-raised` name block is decorative only, so a below-4.5:1 token is correct. */
 .kp-topbar__user--placeholder {
 	cursor: default;
-}
-.kp-topbar__avatar-placeholder {
-	width: var(--avatar-size, 22px);
-	height: var(--avatar-size, 22px);
-	border-radius: var(--r-sm);
-	background: var(--surface-raised);
-	flex-shrink: 0;
 }
 .kp-topbar__name-placeholder {
 	width: 4.5rem;

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -376,3 +376,58 @@ describe("Topbar tema toggle → theme picker (#2612)", () => {
 		expect(onThemeChange).toHaveBeenLastCalledWith("dark");
 	});
 });
+
+// Reserved signed-in account slot (#2933, ADR 0179 §1). `reserveSignedInSlots` (driven by
+// `__BOOT__.signedIn` in the shell frame) reserves the account cluster's geometry at first
+// paint: with no `user` yet it renders a fixed-geometry placeholder in the account slot, so
+// when fate publishes the real user menu it fills the same slot with zero cluster shift — no
+// giriş-yap↔user-cluster swap, no empty→pop. Off ⇒ the slot stays null (today's render).
+describe("Topbar reserved signed-in account slot (#2933)", () => {
+	function renderReserved(props: Partial<Parameters<typeof Topbar>[0]>) {
+		return render(
+			<MemoryRouter>
+				<Topbar nav={NAV} {...props} />
+			</MemoryRouter>,
+		);
+	}
+
+	it("reserve on, no user: renders a fixed-geometry account placeholder (inert, not a control)", () => {
+		renderReserved({reserveSignedInSlots: true});
+		const placeholder = screen.getByTestId("topbar-user-placeholder");
+		// Reuses the `.kp-topbar__user` box so the real menu swaps in with no geometry change.
+		expect(placeholder.classList.contains("kp-topbar__user")).toBe(true);
+		expect(placeholder.classList.contains("kp-topbar__user--placeholder")).toBe(true);
+		// A stand-in, never a control: not a button, hidden from assistive tech.
+		expect(placeholder.tagName).toBe("SPAN");
+		expect(placeholder.getAttribute("aria-hidden")).toBe("true");
+		expect(placeholder.closest("button")).toBeNull();
+		// No real user menu yet — the account cluster is reserved, not filled.
+		expect(screen.queryByRole("button", {name: /Elif/})).toBeNull();
+	});
+
+	it("reserve on → user arrives: the placeholder is replaced by the real menu in the SAME account slot (zero cluster shift)", () => {
+		const {container, rerender} = renderReserved({reserveSignedInSlots: true});
+		const header = container.querySelector(".kp-topbar");
+		// The account slot is the header's last child; before fate it holds the placeholder.
+		expect(header?.lastElementChild).toBe(screen.getByTestId("topbar-user-placeholder"));
+
+		// Fate publishes the real user: same reservation, now a real user prop.
+		rerender(
+			<MemoryRouter>
+				<Topbar nav={NAV} reserveSignedInSlots user={{name: "Elif", username: "elif"}} />
+			</MemoryRouter>,
+		);
+		// The placeholder is gone and the real menu trigger occupies the SAME last-child slot —
+		// content filled in place, the cluster position never moved (the AC-4 no-shift proof).
+		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
+		const trigger = container.querySelector(".kp-topbar__user");
+		expect(trigger?.textContent).toContain("Elif");
+		expect(header?.lastElementChild).toBe(trigger);
+	});
+
+	it("reserve off, no user: no placeholder — today's signed-out render (AC-3 no-op)", () => {
+		const {container} = renderReserved({reserveSignedInSlots: false});
+		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
+		expect(container.querySelector(".kp-topbar__user")).toBeNull();
+	});
+});

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -282,7 +282,7 @@ export function Topbar({
 				data-testid="topbar-user-placeholder"
 				aria-hidden="true"
 			>
-				<span className="kp-topbar__avatar-placeholder" />
+				<span className="kp-avatar" />
 				<span className="kp-topbar__name-placeholder" />
 			</span>
 		) : null);

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -31,6 +31,7 @@ export function Topbar({
 	onThemeChange,
 	onLogout,
 	navIa = false,
+	reserveSignedInSlots = false,
 }: {
 	brandName?: string;
 	brandTo?: string;
@@ -96,6 +97,16 @@ export function Topbar({
 	 * build on; it does no status-affordance rework of its own.
 	 */
 	navIa?: boolean;
+	/**
+	 * Reserve the signed-in account cluster's geometry at first paint (#2933, ADR 0179 §1).
+	 * Driven by `__BOOT__.signedIn` (`readSignedIn`) in the shell frame: when the edge
+	 * resolved a signed-in session, the account slot renders a fixed-geometry placeholder
+	 * before fate publishes the real `user` chip — so the cluster occupies its final geometry
+	 * from the first frame and the value late-fills in place (#2160), instead of the
+	 * giriş-yap↔user-cluster swap + empty→pop. False (absent `__BOOT__` / signed-out) ⇒ the
+	 * account slot stays null until `user` arrives — today's conditional render.
+	 */
+	reserveSignedInSlots?: boolean;
 }) {
 	const navigate = useNavigate();
 	const searchInputRef = useRef<HTMLInputElement>(null);
@@ -258,6 +269,23 @@ export function Topbar({
 			</Menu.Popup>
 		</Menu.Root>
 	) : null;
+	// The account slot: the real user menu once fate publishes it, else — when `__BOOT__`
+	// reserved a signed-in first paint — a fixed-geometry placeholder that holds the slot open
+	// so the menu late-fills in place with no shift (#2933). Mirrors `.kp-topbar__user`'s box
+	// (avatar + name) and is inert (aria-hidden, not a control). Signed-out / no reservation ⇒
+	// null, exactly today's render.
+	const accountSlot =
+		userMenu ??
+		(reserveSignedInSlots ? (
+			<span
+				className="kp-topbar__user kp-topbar__user--placeholder"
+				data-testid="topbar-user-placeholder"
+				aria-hidden="true"
+			>
+				<span className="kp-topbar__avatar-placeholder" />
+				<span className="kp-topbar__name-placeholder" />
+			</span>
+		) : null);
 
 	// Nav-IA zone grammar (#2611): every element is classed by the #2586 taxonomy and
 	// placed in its one lawful zone (#2587 Model-2). Zones carry a stable class +
@@ -301,7 +329,7 @@ export function Topbar({
 					{bildirimSignal}
 				</div>
 				{actions}
-				{userMenu}
+				{accountSlot}
 			</header>
 		);
 	}
@@ -322,7 +350,7 @@ export function Topbar({
 			{themeButton}
 			{actions}
 			{karmaChip}
-			{userMenu}
+			{accountSlot}
 		</header>
 	);
 }


### PR DESCRIPTION
The signed-in topbar right cluster renders empty at first paint, then pops karma/bell/avatar in after `useSession` settles — and the `giriş-yap` CTA flashes then swaps out. This is the geometry-law violation #2933 targets.

**The fix (ADR 0179 §1, geometry law).** The always-painting shell frame (`Layout` in `apps/web/src/App.tsx`) now reads `readSignedIn()` — the synchronous `__BOOT__.signedIn` presence bit landed by #2932 — at first paint:

- `giriş-yap` rides `signedInAtFirstPaint` (`readSignedIn() || isSignedIn`), so it never renders for a signed-in user and never swaps out on settle.
- `Topbar` gains `reserveSignedInSlots` (from the presence bit): while fate has yet to publish the real `user`, it renders a **fixed-geometry account placeholder** in the account slot. When the real user menu arrives it fills the **same** slot with zero cluster shift — the value late-fills into reserved geometry (#2160), geometry never moves.

**Dark-correct.** When `__BOOT__` is absent (flag off, or the #2931 never-hang fallback served an untransformed asset), `readSignedIn()` returns `false` ⇒ `reserveSignedInSlots` is `false` ⇒ the topbar renders exactly as today (session-gated). The whole path ships dark behind the prior-PR `phoenix-edge-shell-boot` flag (declared in #2928).

**Tests.** `Topbar.test.tsx` asserts the placeholder→real-menu swap holds the same account slot (zero cluster shift, AC-4) and that reserve-off is today's render (AC-3). `App.test.tsx` asserts the shell reserves the cluster with no `giriş-yap` flash pre-settle and no swap across a signed-in settle, and that absent `__BOOT__` is unchanged.

Out of scope: nav-IA topbar spread (#2828) and the chip fate value-loading (#2160), per the issue.

Fixes #2933
Flag: phoenix-edge-shell-boot