### PR TITLE
docs(glossary): land recipe/shell architecture terms (ADR 0182)

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -253,6 +253,30 @@ calls *unrepresentable*; 0037 reunified them into a single class (the split's tw
 motivations — a mutual-DO Layer cycle and a SQLite registry — both went away), where a
 misroute now no-ops at runtime (role-guarded) rather than failing to compile.
 
+### The composition shell / recipe
+
+A **shell** wraps a nav/page **primitive** and owns a whole zone, exposing it to the page
+as **flat element-props — one `ReactNode` prop per zone** — so an element not assigned to a
+declared zone is a *type* error, not a lint finding. The **recipe** is the composition idiom
+a shell is built on. (ADR
+[0182](../.decisions/0182-subnavshell-pageshell-composition-api.md) — *SubnavShell / PageShell
+composition API — flat element-props*, which coins both terms; it builds on ADR
+[0176](../.decisions/0176-nav-ia-discipline.md)'s nav element taxonomy. The `SubnavShell` /
+`PageShell` source is defined by that ADR — the term is grounded in the ADR until the shells
+land in [`apps/web/src/components/layout/`](../apps/web/src/components/layout/).)
+
+- **`recipe`** — the composition-primitive idiom: **one flat element-prop per zone**,
+  orphan-as-type-error. NOT a zones-object, NOT compound components
+  (`<Shell.Destinations>…`) — a compound API leaves an *orphan slot* (an element rendered
+  but placed nowhere) that only a lint pass catches; flat element-props make that
+  unrepresentable, because an element with no declared zone prop has nowhere to compile in.
+- **`shell`** — the layout-composition wrapper (`SubnavShell` / `PageShell`) that **names a
+  page's zone-plus-content shape once** and hands each zone to the consumer as one prop.
+  `SubnavShell` composes the per-product [`Subnav`](../apps/web/src/components/layout/Subnav.tsx)
+  primitive (wrapping it, not replacing it); `PageShell` composes `SubnavShell` plus the routed
+  page content below it. A shell sits *between* a **primitive** and the page — distinct from a
+  **primitive**, which owns no zone and exposes raw slots.
+
 ### The three senses of "phoenix"
 
 "phoenix" carries **three distinct meanings**, each with a graduation name —


### PR DESCRIPTION
Adds the two architecture-vocabulary terms ADR 0182 coins — `recipe` and `shell` — to `.glossary/LANGUAGE.md` Section 2 (phoenix structural terms), each anchored to ADR 0182.

## What
- **`recipe`** — the composition-primitive idiom: one flat element-prop per zone, orphan-as-type-error.
- **`shell`** — the layout-composition wrapper (`SubnavShell` / `PageShell`) that names a page's zone-plus-content shape once and hands each zone to the consumer as one prop.

Both entries use the existing Section-2 `### The X` heading + prose + bullets shape (new `### The composition shell / recipe` subsection placed before "The three senses of phoenix"), disambiguated against the near-neighbor `primitive` (a shell sits *between* a primitive and the page). No surrounding terms reflowed; no new top-level section.

## Grounding
Grounded in ADR 0182 (`.decisions/0182-subnavshell-pageshell-composition-api.md`, on main). The `SubnavShell` / `PageShell` source is not built yet, so the entry states the term is defined by the ADR until the shells land in `apps/web/src/components/layout/`.

## Acceptance criteria (from #2999)
- [x] Section 2 has a one-line canonical def for `recipe`, anchored to ADR 0182.
- [x] Section 2 has a one-line canonical def for `shell`, anchored to ADR 0182.
- [x] Both use the existing Section-2 entry shape (no new section, no reflow).
- [x] The ADR 0182 anchor resolves (0182 merged on main).

## Gating
`.glossary/**` is CODE-class → gates on `review-code`, not `review-doc`. This PR carries linked issue #2999 so `review-code` can run. Not §CP.

Closes #2999