### PR TITLE
feat(web): SubnavShell recipe — the shell owning the whole subnav bar (#2972)

### DIFF
--- a/apps/web/src/components/layout/Subnav.css
+++ b/apps/web/src/components/layout/Subnav.css
@@ -51,6 +51,13 @@
 	color: var(--text-primary);
 }
 
+/* Leading zone wrapper (SubnavShell recipe, ADR 0182) — positions only; the consumer's
+   composed context/crumb node carries its own treatment. */
+.kp-subnav__leading {
+	display: inline-flex;
+	align-items: center;
+}
+
 .kp-subnav__spacer {
 	flex: 1;
 }

--- a/apps/web/src/components/layout/Subnav.tsx
+++ b/apps/web/src/components/layout/Subnav.tsx
@@ -18,6 +18,8 @@ export function Subnav({
 	activeFilter,
 	onFilterChange,
 	links,
+	leading,
+	destinations,
 	crumb,
 	input,
 	meta,
@@ -29,6 +31,14 @@ export function Subnav({
 	activeFilter?: string;
 	onFilterChange?: (id: string) => void;
 	links?: SubnavLink[];
+	// Zone slots for the SubnavShell recipe (ADR 0182): `leading` is the context/crumb zone
+	// and `destinations` is the single sub-destinations/filters zone the consumer composes
+	// its route-links or stateful buttons inside. `destinations` renders INSIDE the bar's
+	// filters row — the structural fix for sözlük's orphaned alphabet, which had rendered as
+	// a detached sibling of the bar. Additive over the older typed `filters`/`links` arrays;
+	// the #2973–#2978 migration moves consumers onto these zones.
+	leading?: React.ReactNode;
+	destinations?: React.ReactNode;
 	crumb?: {label: React.ReactNode; onClear?: () => void};
 	// The input slot (#2602): a product-scoped on-demand utility control — sözlük's
 	// go-to-or-create box (distinct from the topbar `ara`, #1669). Left-anchored in the
@@ -47,7 +57,7 @@ export function Subnav({
 }) {
 	return (
 		<div className="kp-subnav">
-			{filters?.length || links?.length ? (
+			{filters?.length || links?.length || destinations ? (
 				<div className="kp-subnav__filters">
 					{filters?.map((f) => (
 						<button
@@ -66,8 +76,10 @@ export function Subnav({
 							{l.label}
 						</NavLink>
 					))}
+					{destinations}
 				</div>
 			) : null}
+			{leading ? <span className="kp-subnav__leading">{leading}</span> : null}
 			{title ? <span className="kp-subnav__title">{title}</span> : null}
 			{crumb ? (
 				<span className="kp-subnav__crumb">

--- a/apps/web/src/components/layout/SubnavShell.test.tsx
+++ b/apps/web/src/components/layout/SubnavShell.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * SubnavShell recipe (#2972, ADR 0182) — the shell owns the whole bar, filters row included.
+ * Two properties are load-bearing: (1) the sub-destinations zone renders INSIDE the bar (no
+ * detached sibling row — the structural fix for sözlük's orphaned alphabet), and (2) the flat
+ * element-props make a single-orphan-slot composition a TYPE error, not a lint finding.
+ */
+import {render, screen} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {SubnavShell} from "./SubnavShell";
+
+describe("SubnavShell — the shell owning the whole bar (#2972)", () => {
+	it("renders the destinations zone INSIDE the bar, in the filters row — no detached sibling", () => {
+		const {container} = render(
+			<SubnavShell
+				destinations={
+					<button type="button" data-testid="alphabet">
+						A
+					</button>
+				}
+			/>,
+		);
+		const bar = container.querySelector(".kp-subnav");
+		const alphabet = screen.getByTestId("alphabet");
+		expect(bar).toBeTruthy();
+		// The composed destinations node lives INSIDE the bar (a detached sibling would fail this)…
+		expect(bar?.contains(alphabet)).toBe(true);
+		// …specifically inside the filters row, where the sub-destinations zone belongs.
+		expect(bar?.querySelector(".kp-subnav__filters")?.contains(alphabet)).toBe(true);
+		// It is not the shell's direct sibling — there is no "next to the bar" row to orphan into.
+		expect(container.firstElementChild).toBe(bar);
+	});
+
+	it("maps the four zones onto the bar — leading / primaryAction / signal all render inside it", () => {
+		const {container} = render(
+			<SubnavShell
+				leading={<span data-testid="crumb">pano</span>}
+				primaryAction={
+					<button type="button" data-testid="cta">
+						yeni
+					</button>
+				}
+				signal={<span data-testid="signal">3 başlık</span>}
+			/>,
+		);
+		const bar = container.querySelector(".kp-subnav");
+		expect(bar?.contains(screen.getByTestId("crumb"))).toBe(true);
+		expect(bar?.querySelector(".kp-subnav__cta")?.contains(screen.getByTestId("cta"))).toBe(true);
+		expect(bar?.querySelector(".kp-subnav__meta")?.contains(screen.getByTestId("signal"))).toBe(
+			true,
+		);
+	});
+
+	it("makes a single-orphan-slot composition a TYPE error — an undeclared zone won't compile in", () => {
+		// @ts-expect-error — `utility` is deliberately OMITTED (ADR 0182 YAGNI). An element assigned
+		// to no declared zone prop has nowhere to go, so the orphan-slot composition is a TYPE error,
+		// not a lint finding. If this ever compiles, the flat-props invariant has regressed.
+		const orphan = <SubnavShell utility={<span data-testid="orphan">orphan</span>} />;
+		// The extra prop is ignored at runtime (never spread to the DOM); the assertion above is the
+		// point — the @ts-expect-error fails typecheck the moment an orphan zone becomes expressible.
+		expect(orphan).toBeTruthy();
+	});
+});

--- a/apps/web/src/components/layout/SubnavShell.tsx
+++ b/apps/web/src/components/layout/SubnavShell.tsx
@@ -1,0 +1,38 @@
+import type * as React from "react";
+import {Subnav} from "./Subnav";
+
+/**
+ * SubnavShell — the blessed shell that owns the whole subnav bar, filters row included.
+ *
+ * A `recipe` over the `Subnav` primitive that exposes ADR 0176's nav-zone grammar as
+ * flat element-props — ONE `ReactNode` prop per zone (ADR 0182). The flat shape is the
+ * make-invalid-states-unrepresentable payoff: an element assigned to no declared zone has
+ * nowhere to go and is a TYPE error, closing the compound-component orphan-slot class (an
+ * element rendered but placed nowhere, detectable only by lint) at the type level — sözlük's
+ * alphabet becomes `destinations={…}` inside the bar, never a detached sibling of it.
+ *
+ * `utility` is deliberately OMITTED (ADR 0182, YAGNI) — re-introducing it is an explicit law
+ * change, never a quietly-discovered gap.
+ */
+export type SubnavShellProps = {
+	/** Context / crumb zone (e.g. pano's site/host crumb). */
+	leading?: React.ReactNode;
+	/**
+	 * The single sub-destinations zone. The consumer composes the route-links OR stateful
+	 * buttons (mecmua tabs / pano chips / divan sections / sözlük alphabet) inside this one
+	 * node; the shell renders it INSIDE the bar, so there is no "next to the bar" slot to
+	 * orphan into.
+	 */
+	destinations?: React.ReactNode;
+	/** The ONE promoted verb (mecmua / pano). Absent for divan and sözlük is normal, not a gap. */
+	primaryAction?: React.ReactNode;
+	/** Meta / count zone (e.g. pano's `N başlık`). */
+	signal?: React.ReactNode;
+};
+
+export function SubnavShell({leading, destinations, primaryAction, signal}: SubnavShellProps) {
+	// Map the four zones onto the wrapped primitive's slots — `primaryAction`→`cta`,
+	// `signal`→`meta` (ADR 0182's count→signal merge). No consumer touches `Subnav`'s slots
+	// directly; they go through these four zones.
+	return <Subnav leading={leading} destinations={destinations} cta={primaryAction} meta={signal} />;
+}


### PR DESCRIPTION
Builds `SubnavShell`, the blessed shell that owns the whole subnav bar (filters row included), per ADR 0182 — the root of the #2954 composition-shell epic.

## What changed
- **`apps/web/src/components/layout/SubnavShell.tsx`** — the recipe over the `Subnav` primitive. Exposes ADR 0176's nav-zone grammar as **flat element-props, one `ReactNode` per zone**: `leading?` (context/crumb), `destinations?` (the single sub-destinations/filters zone the consumer composes inside), `primaryAction?` (the one promoted verb), `signal?` (meta/count). `utility` is deliberately **omitted** (ADR 0182 YAGNI). Maps `primaryAction`→`cta` and `signal`→`meta` (the ADR's count→signal merge).
- **`apps/web/src/components/layout/Subnav.tsx` / `.css`** — additively extend the wrapped primitive with `leading?` / `destinations?` `ReactNode` zone slots; `destinations` renders **inside** the bar's filters row so a filters row (e.g. sözlük's alphabet) can no longer be an orphaned detached sibling. Existing typed `filters`/`links`/`crumb`/`cta`/`meta` slots and their consumers are untouched — the #2973–#2978 migration narrows the surface later.
- **`apps/web/src/components/layout/SubnavShell.test.tsx`** — asserts (1) the destinations zone renders inside `.kp-subnav`/`.kp-subnav__filters` (no detached sibling), (2) the four zones map onto the bar, and (3) a single-orphan-slot composition is a **TYPE error** — a `@ts-expect-error` on an undeclared zone (`utility`) that `pnpm typecheck` validates as a genuine error.

## Design/quality
- Reuses existing design tokens only; `design-token-guard` clean (no raw hex/px).
- Flat element-props make the orphan-slot class unrepresentable at the type level (make-invalid-states-unrepresentable), not lint-detectable.

## Gates run locally (in the worktree)
- `pnpm typecheck` — 30/30 (validates the orphan-as-type-error contract)
- `pnpm lint:worktree` — clean
- `design-token-guard check` — clean
- vitest (client project) — SubnavShell 3/3, Subnav + ProductSubnavLayout still green

Out of scope (separate children): migrating any product onto the shell, and PageShell (#2973).

Fixes #2972