### PR TITLE
feat(web): migrate mecmua Subnav onto SubnavShell (#2976)

### DIFF
--- a/apps/web/src/components/mecmua/MecmuaSubnavLayout.test.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavLayout.test.tsx
@@ -1,9 +1,11 @@
 /**
- * mecmua's persistent product Subnav zone (#2603, placement law #2587). Pins two things:
+ * mecmua's persistent product Subnav zone (#2603, placement law #2587). Pins three things:
  * (1) the zone is a persistent layout — its `.kp-subnav` node survives a within-mecmua
  * navigation (no remount); (2) each destination is flag-composed on the SAME seam its
  * route self-gates on, so a link never points at a dark 404 — keşfet on mecmua-public-read,
- * akış on mecmua-feed, yazılarım on the write path (yazar-gated, #2579's missing home).
+ * akış on mecmua-feed, yazılarım on the write path (yazar-gated, #2579's missing home);
+ * (3) after the SubnavShell migration (ADR 0182), the destinations render INSIDE the bar's
+ * sub-destinations zone and the CTA inside the primary-action zone — behavior unchanged.
  */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {Link, MemoryRouter, Route, Routes} from "react-router";
@@ -121,5 +123,24 @@ describe("MecmuaSubnavLayout — mecmua product Subnav zone (#2603)", () => {
 		meTier = "caylak";
 		renderZone();
 		expect(screen.queryByRole("link", {name: "yazılarım"})).toBeNull();
+	});
+
+	// Zone-through-shell (ADR 0182): the destinations fill the shell's one sub-destinations
+	// zone (inside the bar, never a detached sibling) and the CTA fills the primary-action zone.
+	it("renders the destinations INSIDE the shell's sub-destinations zone — no detached sibling", () => {
+		flags.read = true;
+		const {container} = renderZone();
+		const kesfet = screen.getByRole("link", {name: "keşfet"});
+		const filters = container.querySelector(".kp-subnav__filters");
+		expect(filters?.contains(kesfet)).toBe(true);
+	});
+
+	it("renders the CTA in the shell's primary-action zone when the author can write", () => {
+		flags.write = true;
+		signedIn = true;
+		meTier = "yazar";
+		const {container} = renderZone();
+		const cta = screen.getByRole("button", {name: "yeni yazı"});
+		expect(container.querySelector(".kp-subnav__cta")?.contains(cta)).toBe(true);
 	});
 });

--- a/apps/web/src/components/mecmua/MecmuaSubnavLayout.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavLayout.tsx
@@ -1,10 +1,11 @@
-import {Outlet} from "react-router";
+import {NavLink, Outlet} from "react-router";
 import {useSession} from "../../auth/client";
 import {useMe} from "../../auth/useMe";
 import {MECMUA_FEED, MECMUA_PUBLIC_READ, MECMUA_WRITE} from "../../flags/keys";
 import {useFlag} from "../../flags/useFlag";
 import {shouldShowMecmuaWriteCta} from "../../pages/mecmua-write-gate";
-import {Subnav, type SubnavLink} from "../layout/Subnav";
+import type {SubnavLink} from "../layout/Subnav";
+import {SubnavShell} from "../layout/SubnavShell";
 import {MecmuaSubnavCta} from "./MecmuaSubnavCta";
 
 /**
@@ -12,7 +13,8 @@ import {MecmuaSubnavCta} from "./MecmuaSubnavCta";
  * layout-route element that hosts mecmua's product destinations + its primary action, so
  * they live in the product zone instead of leaking into the global topbar (#2603). Mounted
  * only behind the `phoenix-nav-ia` flag (App.tsx); off ⇒ the router is flat, exactly as
- * today.
+ * today. Composes through `SubnavShell` (ADR 0182): the destination links fill the one
+ * `destinations` zone, the CTA the `primaryAction` zone.
  *
  * Each destination is composed on the SAME flag its route/page self-gates on, so a link
  * never points at a dark 404 (the #2547 "never a dead link" rule): keşfet (the public index)
@@ -35,7 +37,20 @@ export function MecmuaSubnavLayout() {
 	];
 	return (
 		<>
-			<Subnav links={links} cta={<MecmuaSubnavCta />} />
+			<SubnavShell
+				destinations={
+					links.length
+						? links.map((l) => (
+								// NavLink sets aria-current="page" on the active route; the filter treatment is
+								// the utility tab styling (#2586 taxonomy), never the primary-action treatment.
+								<NavLink key={l.to} to={l.to} end={l.end} className="kp-subnav__filter">
+									{l.label}
+								</NavLink>
+							))
+						: null
+				}
+				primaryAction={<MecmuaSubnavCta />}
+			/>
 			<Outlet />
 		</>
 	);


### PR DESCRIPTION
Phase 3 of epic #2954 — migrates mecmua's product Subnav onto the `SubnavShell` recipe (ADR 0182), the third-phase sibling of the sözlük/pano/divan migrations.

## What changed
`MecmuaSubnavLayout` now composes through `SubnavShell` (`apps/web/src/components/layout/SubnavShell.tsx`) instead of the raw `Subnav` primitive:

- The flag-gated destination links (keşfet / akış / yazılarım) are composed as `NavLink`s inside the shell's single `destinations` zone — the sub-destinations zone that renders inside the bar, never a detached sibling.
- `MecmuaSubnavCta` (already the sanctioned #2586 primary-action treatment) maps to the shell's `primaryAction` zone.
- No `utility` prop is used — ADR 0182 deliberately omits it (re-adding is a compile error), and mecmua has no utility element.

## Preserved (behavior unchanged)
- Per-link flag gating: each destination is composed on the SAME flag its route self-gates on (keşfet on `mecmua-public-read`, akış on `mecmua-feed`, yazılarım on the write path), so a link never points at a dark 404.
- `shouldShowMecmuaWriteCta` gate parity: yazılarım and the CTA ride the same yazar + write-live gate.
- The whole surface stays dark behind the existing `phoenix-nav-ia` flag (no new flag). The rendered DOM is equivalent to the pre-migration primitive, so behavior is unchanged.

## Acceptance criteria
- [x] `MecmuaSubnavLayout` renders through `SubnavShell` with its destination links and CTA in the correct typed zones.
- [x] Per-link flag gating and CTA gate parity are preserved.
- [x] A test asserts mecmua's zones render through the shell with behavior unchanged (destinations inside `.kp-subnav__filters`, CTA inside `.kp-subnav__cta`).

## Local gates (green)
- mecmua client tests: 16 passed (incl. 2 new zone-through-shell assertions)
- typecheck (`@kampus/web`): clean
- biome lint: clean
- `pipeline-cli design-token-guard check`: pass (TSX-only change, no CSS/token deltas)

Fixes #2976

🤖 Generated with [Claude Code](https://claude.com/claude-code)