### PR TITLE
refactor(divan): compose DivanSubnavLayout through SubnavShell (#2977)

### DIFF
--- a/apps/web/src/components/divan/DivanSubnavLayout.test.tsx
+++ b/apps/web/src/components/divan/DivanSubnavLayout.test.tsx
@@ -6,7 +6,9 @@
  * resting boxed `.kp-divan__nav-tab` pill); (3) a switch click drives the published onFilterChange;
  * (4) a non-mod page (no second section) publishes null and the zone shows the bare substrate bar;
  * (5) with NO zone ancestor (flag off) the publish hook returns null — the signal DivanWorkspace
- * uses to keep painting its own in-page nav byte-identically as today.
+ * uses to keep painting its own in-page nav byte-identically as today; (6) the switcher renders
+ * through SubnavShell INSIDE the bar's `.kp-subnav__filters` row (ADR 0182 destinations zone),
+ * never a detached sibling.
  */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {useEffect, useState} from "react";
@@ -61,6 +63,14 @@ describe("DivanSubnavLayout — divan product Subnav zone (#2604)", () => {
 		expect(screen.getByRole("button", {name: "çaylaklar"})).toBeTruthy();
 		expect(screen.getByRole("button", {name: "raporlar"})).toBeTruthy();
 		expect(screen.getByTestId("divan-leaf")).toBeTruthy();
+	});
+
+	it("renders the switcher through SubnavShell INSIDE the bar's filters row, not a detached sibling (ADR 0182)", () => {
+		const {container} = renderZone();
+		// the destinations zone lives inside the shell's bar — the switcher buttons are descendants
+		// of `.kp-subnav > .kp-subnav__filters`, closing the orphaned-sibling composition class.
+		const inBar = container.querySelectorAll(".kp-subnav .kp-subnav__filters .kp-subnav__filter");
+		expect(inBar).toHaveLength(2);
 	});
 
 	it("carries the switchers as taxonomy filters — one taxonomy class, no resting boxed pill (#2586/#2590)", () => {

--- a/apps/web/src/components/divan/DivanSubnavLayout.tsx
+++ b/apps/web/src/components/divan/DivanSubnavLayout.tsx
@@ -1,6 +1,7 @@
 import {createContext, useContext, useState} from "react";
 import {Outlet} from "react-router";
-import {Subnav, type SubnavFilter} from "../layout/Subnav";
+import type {SubnavFilter} from "../layout/Subnav";
+import {SubnavShell} from "../layout/SubnavShell";
 
 /**
  * The section-switcher content the routed divan page publishes UP into its persistent Subnav
@@ -28,10 +29,34 @@ export function useSetDivanSubnavContent() {
 	return useContext(SetDivanSubnavContent);
 }
 
+// The switcher buttons carry the #2586 taxonomy filter treatment themselves (`.kp-subnav__filter`
+// + aria-pressed) — SubnavShell's `destinations` zone only positions them INSIDE the bar (ADR
+// 0182), never a detached sibling row. The shell exposes no typed filters array, so the consumer
+// composes the stateful buttons here.
+function DivanSectionSwitcher({filters, activeFilter, onFilterChange}: DivanSubnavContent) {
+	return (
+		<>
+			{filters.map((f) => (
+				<button
+					key={f.id}
+					type="button"
+					className="kp-subnav__filter"
+					aria-pressed={activeFilter === f.id}
+					onClick={() => onFilterChange(f.id)}
+				>
+					{f.label}
+				</button>
+			))}
+		</>
+	);
+}
+
 /**
  * divan's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
- * layout-route element that renders divan's Subnav once above the routed `<Outlet>`. divan's
- * section switch is page-local state, so the routed page publishes its switchers UP via
+ * layout-route element that renders divan's Subnav once above the routed `<Outlet>`. Composes
+ * through {@link SubnavShell} (ADR 0182): the section switch lands in the `destinations` zone
+ * inside the bar, and divan has no promoted verb, so `primaryAction` is absent by design.
+ * divan's section switch is page-local state, so the routed page publishes its switchers UP via
  * {@link useSetDivanSubnavContent} (the same publish-up shape pano uses) and this frame holds
  * the state. Mounted only behind the `phoenix-nav-ia` flag (App.tsx); off ⇒ the router is flat
  * and DivanWorkspace renders its own in-page section nav as today.
@@ -40,11 +65,7 @@ export function DivanSubnavLayout() {
 	const [content, setContent] = useState<DivanSubnavContent | null>(null);
 	return (
 		<SetDivanSubnavContent.Provider value={setContent}>
-			<Subnav
-				filters={content?.filters}
-				activeFilter={content?.activeFilter}
-				onFilterChange={content?.onFilterChange}
-			/>
+			<SubnavShell destinations={content ? <DivanSectionSwitcher {...content} /> : undefined} />
 			<Outlet />
 		</SetDivanSubnavContent.Provider>
 	);


### PR DESCRIPTION
Phase 3 of epic #2954 — migrate divan's persistent product Subnav zone onto `SubnavShell` (ADR 0182).

## What changed
`DivanSubnavLayout` now composes through `SubnavShell` instead of wiring the raw `Subnav` primitive directly. divan's publish-up section switcher (çaylaklar ↔ raporlar) is re-homed into the shell's `destinations` zone, so it renders **inside** the bar rather than as a detached sibling. divan has no promoted verb, so `primaryAction` is absent by design; there is no `utility` zone (ADR 0182 omits it).

Because `SubnavShell` exposes no typed filters array (only `ReactNode` zones), the consumer composes the stateful switcher buttons itself — a small `DivanSectionSwitcher` renders the `.kp-subnav__filter` buttons with `aria-pressed`, preserving the #2586 taxonomy treatment.

## Preserved (unchanged)
- The publish-up bridge (`useSetDivanSubnavContent`) — routed page pushes its switcher UP.
- Mod-gated raporlar visibility (a non-mod page publishes `null` → bare substrate bar).
- The `phoenix-nav-ia` flag gating (default-off) and flag-off in-page-nav fallback.
- Zone persistence across within-divan navigation (no remount).

## Acceptance criteria
- [x] `DivanSubnavLayout` renders through `SubnavShell` with the section-switcher in the destinations (filters) zone.
- [x] The publish-up bridge, mod-gating, and flag-off fallback are preserved.
- [x] A test asserts divan's switcher renders through the shell inside the bar's filters row (ADR 0182 orphan-fix), behavior unchanged.

## Verification (local, green)
- `test:client` divan — 7/7 pass
- `typecheck` — clean
- `lint:worktree` (biome) — clean
- `design-token-guard check` — pass (no CSS touched)

Fixes #2977