### PR TITLE
feat(sozluk): migrate SozlukSubnavLayout onto SubnavShell — kill the orphan alphabet row

### DIFF
--- a/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
@@ -1,10 +1,12 @@
 /**
- * sözlük's persistent product Subnav zone (#2602, placement law #2587). Pins: (1) the zone is a
- * persistent layout — its `.kp-subnav` node survives a within-sozluk navigation (no remount);
- * (2) the go-to-or-create box lives in the zone's `input` slot and performs a term-to-term
- * jump-or-create mid-browse from a term page (not just the home), distinct from the topbar `ara`;
- * (3) the alphabet filter row sits in the zone with its active-letter accent left as-is; (4) the
- * input box carries the `.kp-subnav__input` taxonomy class, never a filter/CTA treatment (#2586/#2590).
+ * sözlük's persistent product Subnav zone, composed through `SubnavShell` (#2974, on the
+ * #2602 zone / #2587 placement law). Pins: (1) the zone is a persistent layout — its
+ * `.kp-subnav` node survives a within-sozluk navigation (no remount); (2) the go-to-or-create
+ * box fills the shell's leading zone and performs a term-to-term jump-or-create mid-browse from
+ * a term page (not just the home), distinct from the topbar `ara`; (3) the alphabet fills the
+ * shell's `destinations` zone so it renders INSIDE the bar's filters row — never the detached
+ * sibling it was before #2974 (the orphan-row regression this file pins closed); (4) the input
+ * box carries the `.kp-subnav__input` taxonomy class, never a filter/CTA treatment (#2586/#2590).
  */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {Link, MemoryRouter, Route, Routes, useParams} from "react-router";
@@ -34,15 +36,32 @@ function renderZone(initial = "/sozluk") {
 	);
 }
 
-describe("SozlukSubnavLayout — sözlük product Subnav zone (#2602)", () => {
+describe("SozlukSubnavLayout — sözlük product Subnav zone through SubnavShell (#2974)", () => {
 	it("renders one persistent Subnav zone with the go-to-or-create box + alphabet above the Outlet", () => {
 		const {container} = renderZone();
 		expect(container.querySelectorAll(".kp-subnav")).toHaveLength(1);
 		expect(container.querySelector(".kp-subnav__input")).toBeTruthy();
 		expect(screen.getByLabelText("Terime git ya da oluştur")).toBeTruthy();
-		// the alphabet filter row is present in the zone (a couple of populated letters)
 		expect(container.querySelector(".kp-sozluk-alphabet")).toBeTruthy();
 		expect(screen.getByTestId("home-leaf")).toBeTruthy();
+	});
+
+	it("renders the alphabet INSIDE the shell's filters zone — not a detached sibling of the bar (#2974)", () => {
+		const {container} = renderZone();
+		const bar = container.querySelector(".kp-subnav");
+		const alphabet = container.querySelector(".kp-sozluk-alphabet");
+		expect(bar).toBeTruthy();
+		expect(alphabet).toBeTruthy();
+		// the orphan-row regression: the alphabet must live inside the bar, not beside it
+		expect(bar?.contains(alphabet ?? null)).toBe(true);
+		expect(container.querySelector(".kp-subnav__filters .kp-sozluk-alphabet")).toBeTruthy();
+	});
+
+	it("preserves the ?harf= URL-driven active letter on the alphabet", () => {
+		const {container} = renderZone("/sozluk?harf=a");
+		const active = container.querySelector(".kp-sozluk-alphabet__letter.is-active");
+		expect(active?.textContent).toBe("a");
+		expect(active?.getAttribute("aria-current")).toBe("page");
 	});
 
 	it("go-to-or-create performs a term-to-term jump-or-create mid-browse from a term page", () => {

--- a/apps/web/src/components/sozluk/SozlukSubnavLayout.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavLayout.tsx
@@ -1,6 +1,6 @@
 import {createContext, useContext, useState} from "react";
 import {Outlet, useSearchParams} from "react-router";
-import {Subnav} from "../layout/Subnav";
+import {SubnavShell} from "../layout/SubnavShell";
 import {SozlukAlphabet} from "./index";
 import {SozlukGoToCreate} from "./SozlukGoToCreate";
 
@@ -22,14 +22,15 @@ export function useSozlukSubnavQuery() {
 }
 
 /**
- * sözlük's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
- * layout-route element that renders sözlük's Subnav once above the routed `<Outlet>`, so the
- * zone stays mounted across `/sozluk/*` (no per-page remount). The go-to-or-create box (a
- * product-scoped utility, #2586 taxonomy — distinct from the topbar `ara`, #1669) fills the
- * Subnav's `input` slot; the URL-driven alphabet (`?harf=<letter>`) is the filters row, its
- * active-letter accent legal transient state paint left as-is. Mounted only behind the
- * `phoenix-nav-ia` flag (App.tsx); off ⇒ the router is flat and SozlukHome renders its own
- * masthead box + alphabet as today.
+ * sözlük's persistent product Subnav zone (placement law #2587, epic #2596), composed through
+ * the blessed `SubnavShell` recipe (ADR 0182, #2974) — the pathless layout-route element that
+ * renders sözlük's Subnav once above the routed `<Outlet>`, so the zone stays mounted across
+ * `/sozluk/*` (no per-page remount). The go-to-or-create box (a product-scoped utility, #2586
+ * taxonomy — distinct from the topbar `ara`, #1669) fills the shell's `leading` zone; the
+ * URL-driven alphabet (`?harf=<letter>`) fills the `destinations` zone so it renders INSIDE the
+ * bar's filters row — not the detached sibling it was before #2974 — its active-letter accent
+ * left as-is. Mounted only behind the `phoenix-nav-ia` flag (App.tsx); off ⇒ the router is flat
+ * and SozlukHome renders its own masthead box + alphabet as today.
  */
 export function SozlukSubnavLayout() {
 	const [query, setQuery] = useState("");
@@ -37,10 +38,12 @@ export function SozlukSubnavLayout() {
 	const letter = params.get("harf") ?? undefined;
 	return (
 		<SozlukSubnavQuery.Provider value={{query, setQuery}}>
-			<Subnav
-				input={<SozlukGoToCreate className="kp-subnav__input" query={query} setQuery={setQuery} />}
+			<SubnavShell
+				leading={
+					<SozlukGoToCreate className="kp-subnav__input" query={query} setQuery={setQuery} />
+				}
+				destinations={<SozlukAlphabet value={letter} />}
 			/>
-			<SozlukAlphabet value={letter} />
 			<Outlet />
 		</SozlukSubnavQuery.Provider>
 	);


### PR DESCRIPTION
## What

Migrate sözlük's persistent Subnav zone onto the blessed `SubnavShell` recipe (ADR 0182, Phase 3 of epic #2954) and **kill the orphan alphabet row** — the canonical-defect migration.

`SozlukSubnavLayout` previously rendered `<SozlukAlphabet>` as a **detached sibling of `<Subnav>`**, so the alphabet painted as its own row beside the bar instead of inside it. Rebuilt to compose through `SubnavShell`:

- `SozlukGoToCreate` (the go-to-create box) → the shell's **`leading`** zone.
- `SozlukAlphabet` (the `?harf=`-driven alphabet) → the shell's **`destinations`** zone, so it renders **inside** the bar's filters row — closing the orphan-row defect.

## Zone constraint (ADR 0182)

`SubnavShell`'s only zones are `leading` / `destinations` / `primaryAction` / `signal` — there is **no `utility` prop** (deliberately omitted). The go-to-create box maps to `leading`; the alphabet maps to `destinations` (the single sub-destinations/filters zone rendered inside the bar).

## Preserved

- The `phoenix-nav-ia` flag gating (default-off; flag-off fallback path in `SozlukHome` untouched).
- The `SozlukSubnavQuery` context (query provided down to `SozlukHome`).
- The `?harf=` URL-driven active-letter behavior.

## Scope fence

This PR does **not** implement #2995's reconciliation (delete `SozlukGoToCreate` / add a "+ yeni tanım" primaryAction / route search→⌘K) — that is a separate later change held on #2412. `SozlukGoToCreate` is preserved here in the `leading` zone.

## Tests (TDD)

Updated `SozlukSubnavLayout.test.tsx`:
- New test pins the alphabet **inside** the shell's `.kp-subnav__filters` zone — the orphan-row regression is closed (`bar.contains(alphabet)`).
- New test pins `?harf=` preservation (active letter carries `is-active` + `aria-current="page"`).
- Existing pins (persistent zone / no-remount / go-to-or-create jump / input taxonomy class) retained.

Green locally: the sözlük client tests, `pnpm typecheck`, `pnpm lint:worktree`, `design-token-guard` (diff touches no CSS).

Fixes #2974