### PR TITLE
feat(pano): migrate PanoSubnavLayout onto SubnavShell (#2975)

### DIFF
--- a/apps/web/src/components/pano/PanoSubnavLayout.test.tsx
+++ b/apps/web/src/components/pano/PanoSubnavLayout.test.tsx
@@ -1,10 +1,13 @@
 /**
- * pano's persistent product Subnav zone (#2601, placement law #2587). Pins: (1) the zone is a
- * persistent layout — its `.kp-subnav` node survives a within-pano navigation (no remount);
- * (2) the routed feed's filters/meta publish UP into that one zone Subnav (the chip-bridge), so
- * there is a single Subnav, not a per-page second one; (3) the active site-filter folds into the
- * zone as a transient crumb with a working `× filtreyi kaldır` clear — and NO resting-chrome
- * `.kp-pano-crumb` strip is painted.
+ * pano's persistent product Subnav zone (#2601, placement law #2587), now composed through
+ * SubnavShell (#2975, ADR 0182). Pins: (1) the zone is a persistent layout — its `.kp-subnav`
+ * node survives a within-pano navigation (no remount); (2) the routed feed's filters/meta publish
+ * UP into that one zone Subnav (the chip-bridge), so there is a single Subnav, not a per-page
+ * second one; (3) the active site-filter folds into the zone as a transient crumb with a working
+ * `× filtreyi kaldır` clear — and NO resting-chrome `.kp-pano-crumb` strip is painted; (4) pano's
+ * content lands in the shell's typed zones — chips in `.kp-subnav__filters`, crumb in
+ * `.kp-subnav__leading`, CTA in `.kp-subnav__cta`, count in `.kp-subnav__meta` — with behavior
+ * unchanged from the pre-shell rendering.
  */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {useEffect} from "react";
@@ -62,7 +65,7 @@ function renderZone(leaf = <PublishingLeaf />) {
 	);
 }
 
-describe("PanoSubnavLayout — pano product Subnav zone (#2601)", () => {
+describe("PanoSubnavLayout — pano product Subnav zone through SubnavShell (#2975)", () => {
 	afterEach(() => {
 		signedIn = false;
 		vi.clearAllMocks();
@@ -79,6 +82,28 @@ describe("PanoSubnavLayout — pano product Subnav zone (#2601)", () => {
 		expect(screen.getByRole("button", {name: "sıcak"})).toBeTruthy();
 		expect(screen.getByRole("button", {name: "yeni"})).toBeTruthy();
 		expect(screen.getByText("3 başlık")).toBeTruthy();
+	});
+
+	it("lands pano's content in the shell's typed zones — chips in destinations, meta in signal", () => {
+		signedIn = true;
+		const {container} = renderZone(<PublishingLeaf host="foo.com" />);
+		const bar = container.querySelector(".kp-subnav");
+		// chips → destinations zone (the filters row inside the bar)
+		const filtersRow = bar?.querySelector(".kp-subnav__filters");
+		expect(filtersRow?.contains(screen.getByRole("button", {name: "sıcak"}))).toBe(true);
+		expect(filtersRow?.contains(screen.getByRole("button", {name: "yeni"}))).toBe(true);
+		// crumb → leading zone
+		expect(
+			bar?.querySelector(".kp-subnav__leading")?.contains(screen.getByText("site / foo.com")),
+		).toBe(true);
+		// CTA → primaryAction zone
+		expect(
+			bar
+				?.querySelector(".kp-subnav__cta")
+				?.contains(screen.getByRole("button", {name: "yeni gönderi"})),
+		).toBe(true);
+		// count → signal zone
+		expect(bar?.querySelector(".kp-subnav__meta")?.textContent).toContain("3 başlık");
 	});
 
 	it("signed in: the primary-action CTA fills the zone's CTA slot", () => {
@@ -109,7 +134,7 @@ describe("PanoSubnavLayout — pano product Subnav zone (#2601)", () => {
 
 	it("folds the active site-filter into the zone as a transient crumb with a working clear — no resting-chrome strip", () => {
 		const {container} = renderZone(<PublishingLeaf host="foo.com" />);
-		// Transient crumb paint in the Subnav (accent-faint pill), not the resting .kp-pano-crumb strip.
+		// Transient crumb paint in the Subnav, not the resting .kp-pano-crumb strip.
 		expect(container.querySelector(".kp-subnav__crumb")).toBeTruthy();
 		expect(container.querySelector(".kp-pano-crumb")).toBeNull();
 		expect(screen.getByText("site / foo.com")).toBeTruthy();

--- a/apps/web/src/components/pano/PanoSubnavLayout.tsx
+++ b/apps/web/src/components/pano/PanoSubnavLayout.tsx
@@ -1,6 +1,7 @@
 import {createContext, type ReactNode, useContext, useState} from "react";
 import {Outlet} from "react-router";
-import {Subnav, type SubnavFilter} from "../layout/Subnav";
+import type {SubnavFilter} from "../layout/Subnav";
+import {SubnavShell} from "../layout/SubnavShell";
 import {PanoSubnavCta} from "./PanoSubnavCta";
 
 /**
@@ -34,12 +35,60 @@ export function useSetPanoSubnavContent() {
 }
 
 /**
+ * pano's sort/filter chips, composed as one node for the shell's `destinations` zone. The consumer
+ * owns rendering its stateful buttons inside that single zone (ADR 0182) — the `kp-subnav__filter`
+ * class carries the shared tab treatment, `aria-pressed` marks the active subfeed.
+ */
+function PanoSubnavFilters({
+	filters,
+	activeFilter,
+	onFilterChange,
+}: {
+	filters: SubnavFilter[];
+	activeFilter: string;
+	onFilterChange: (id: string) => void;
+}) {
+	return (
+		<>
+			{filters.map((f) => (
+				<button
+					key={f.id}
+					type="button"
+					className="kp-subnav__filter"
+					aria-pressed={activeFilter === f.id}
+					onClick={() => onFilterChange(f.id)}
+				>
+					{f.label}
+				</button>
+			))}
+		</>
+	);
+}
+
+/**
+ * The active site-filter as a transient crumb for the shell's `leading` (context) zone — plain
+ * inline text + the `× filtreyi kaldır` clear, no resting-chrome pill (containment law, #2585).
+ */
+function PanoSubnavCrumb({crumb}: {crumb: {label: ReactNode; onClear: () => void}}) {
+	return (
+		<span className="kp-subnav__crumb">
+			{crumb.label}
+			<button type="button" className="kp-subnav__crumb-clear" onClick={crumb.onClear}>
+				× filtreyi kaldır
+			</button>
+		</span>
+	);
+}
+
+/**
  * pano's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
  * layout-route element that renders pano's Subnav once above the routed `<Outlet>`, so the zone
- * stays mounted across `/pano/*` (no per-page remount). Unlike mecmua's stable destination set,
- * pano's filters/meta/crumb are feed-scoped, so the routed feed publishes them UP via
- * {@link useSetPanoSubnavContent} (the same chip-bridge shape App.tsx uses for the topbar) and
- * this frame owns the state — keeping all feed logic (sort / startTransition / saved variant) in
+ * stays mounted across `/pano/*` (no per-page remount). Composes through {@link SubnavShell}
+ * (ADR 0182): pano's feed-scoped content maps onto the shell's typed zones — the crumb into
+ * `leading`, the sort/filter chips into `destinations`, `PanoSubnavCta` into `primaryAction`, and
+ * the count into `signal`. The routed feed publishes that content UP via
+ * {@link useSetPanoSubnavContent} (the same chip-bridge shape App.tsx uses for the topbar) and this
+ * frame owns the state — keeping all feed logic (sort / startTransition / saved variant) in
  * PanoFeed rather than duplicating it here. Mounted only behind the `phoenix-nav-ia` flag
  * (App.tsx); off ⇒ the router is flat and PanoFeed renders its own Subnav as today.
  */
@@ -47,13 +96,19 @@ export function PanoSubnavLayout() {
 	const [content, setContent] = useState<PanoSubnavContent | null>(null);
 	return (
 		<SetPanoSubnavContent.Provider value={setContent}>
-			<Subnav
-				filters={content?.filters}
-				activeFilter={content?.activeFilter}
-				onFilterChange={content?.onFilterChange}
-				crumb={content?.crumb}
-				meta={content?.meta}
-				cta={<PanoSubnavCta />}
+			<SubnavShell
+				leading={content?.crumb ? <PanoSubnavCrumb crumb={content.crumb} /> : undefined}
+				destinations={
+					content?.filters?.length ? (
+						<PanoSubnavFilters
+							filters={content.filters}
+							activeFilter={content.activeFilter}
+							onFilterChange={content.onFilterChange}
+						/>
+					) : undefined
+				}
+				primaryAction={<PanoSubnavCta />}
+				signal={content?.meta}
 			/>
 			<Outlet />
 		</SetPanoSubnavContent.Provider>


### PR DESCRIPTION
Fixes #2975

Phase 3 of epic #2954 (Migrate pano onto SubnavShell). Rebuilds pano's persistent product Subnav zone (`apps/web/src/components/pano/PanoSubnavLayout.tsx`) to compose through the `SubnavShell` recipe (ADR 0182) instead of driving the `Subnav` primitive's typed slots directly.

## What changed

Pano's feed-scoped publish-up content maps onto the shell's four typed zones:

| pano content | SubnavShell zone |
| --- | --- |
| site/host context crumb (`× filtreyi kaldır`) | `leading` |
| sort/filter chips (sıcak / yeni / kaydedilenler) | `destinations` |
| `PanoSubnavCta` (yeni gönderi) | `primaryAction` |
| `N başlık` count | `signal` |

Per ADR 0182's flat element-prop model, the chips and the crumb are composed as consumer-owned nodes (`PanoSubnavFilters` / `PanoSubnavCrumb`) rendered inside their zones — no consumer touches `Subnav`'s slots directly once migrated. There is no `utility` zone (deliberately omitted per ADR 0182).

## Preserved

- The `useSetPanoSubnavContent` publish-up bridge and `PanoSubnavContent` type are unchanged.
- The `phoenix-nav-ia` flag gating (App.tsx) and the flag-off fallback (PanoFeed renders its own Subnav) are untouched — behavior unchanged.
- Reuses existing token-based CSS classes (`kp-subnav__filter` / `kp-subnav__crumb` / `kp-subnav__leading` / `kp-subnav__meta` / `kp-subnav__cta`); no CSS change.

## Acceptance criteria

- [x] `PanoSubnavLayout` renders through `SubnavShell` with filters/meta/crumb/CTA in the correct typed zones.
- [x] The publish-up bridge and flag-off fallback behavior are preserved.
- [x] A test asserts pano's zones render through the shell with behavior unchanged (`PanoSubnavLayout.test.tsx`, incl. a new zone-placement assertion).

## Verification (local, at head)

- `pnpm typecheck` — 30/30 green
- `pnpm lint:worktree` — clean
- `pipeline-cli design-token-guard check` — pass (no CSS change; no regression)
- pano client tests — 9/9 green (`PanoSubnavLayout.test.tsx` + `PanoSubnavCta.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)