### PR TITLE
refactor(web): compose ProductSubnavLayout through SubnavShell (#2978)

### DIFF
--- a/apps/web/src/components/layout/ProductSubnavLayout.test.tsx
+++ b/apps/web/src/components/layout/ProductSubnavLayout.test.tsx
@@ -1,14 +1,34 @@
 /**
- * The persistent product Subnav zone (#2598, placement law #2587). `ProductSubnavLayout`
- * is a pathless layout-route element that renders the product's Subnav above the routed
- * Outlet; React Router keeps that layout element mounted as the user moves within the
- * product's child routes — the "persistent zone, no remount" acceptance criterion. Proven
- * here by DOM-node identity: the `.kp-subnav` node survives a within-product navigation.
+ * The persistent product Subnav zone (#2598, placement law #2587), now composed through
+ * `SubnavShell` (#2978, ADR 0182). `ProductSubnavLayout` is a pathless layout-route element
+ * that renders the product's subnav above the routed Outlet; React Router keeps that layout
+ * element mounted as the user moves within the product's child routes — the "persistent zone,
+ * no remount" acceptance criterion, proven by DOM-node identity across a within-product nav.
+ * Two further properties are asserted: the substrate renders THROUGH `SubnavShell` (spied
+ * below — the shell receives the frame's `cta` as its `primaryAction` zone), and the `cta`
+ * contract is preserved unchanged (it still lands in the bar's `.kp-subnav__cta` slot).
  */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {Link, MemoryRouter, Route, Routes} from "react-router";
-import {describe, expect, it} from "vitest";
+import {beforeEach, describe, expect, it, vi} from "vitest";
 import {ProductSubnavLayout} from "./ProductSubnavLayout";
+import * as SubnavShellModule from "./SubnavShell";
+
+// Spy the real SubnavShell through a passthrough mock: the actual shell still renders (so the
+// DOM-level persistence + cta-contract assertions exercise real composition), while the spy
+// records the props the substrate handed it — that is how "renders through SubnavShell" is
+// asserted. Against the pre-refactor `<Subnav>` wiring this spy is never called, so those
+// assertions fail — the TDD guard on the refactor.
+vi.mock("./SubnavShell", async (importActual) => {
+	const actual = await importActual<typeof import("./SubnavShell")>();
+	return {...actual, SubnavShell: vi.fn(actual.SubnavShell)};
+});
+
+const subnavShellSpy = vi.mocked(SubnavShellModule.SubnavShell);
+
+beforeEach(() => {
+	subnavShellSpy.mockClear();
+});
 
 function ProductIndex() {
 	return (
@@ -58,5 +78,48 @@ describe("ProductSubnavLayout — persistent product Subnav zone (#2598)", () =>
 		// …but the layout's Subnav zone is the SAME DOM node — the persistent product zone
 		// stays mounted across the product's child routes (a remount would replace the node).
 		expect(container.querySelector(".kp-subnav")).toBe(before);
+	});
+});
+
+describe("ProductSubnavLayout — composes through SubnavShell (#2978, ADR 0182)", () => {
+	it("renders the substrate frame THROUGH SubnavShell", () => {
+		render(
+			<MemoryRouter initialEntries={["/pano"]}>
+				<Routes>
+					<Route element={<ProductSubnavLayout />}>
+						<Route path="/pano" element={<ProductIndex />} />
+					</Route>
+				</Routes>
+			</MemoryRouter>,
+		);
+		// The bar is emitted by the shell, not by a directly-wired <Subnav>.
+		expect(subnavShellSpy).toHaveBeenCalled();
+	});
+
+	it("preserves the cta contract — hands cta to the shell's primaryAction zone, rendered in .kp-subnav__cta", () => {
+		const {container} = render(
+			<MemoryRouter initialEntries={["/pano"]}>
+				<Routes>
+					<Route
+						element={
+							<ProductSubnavLayout
+								cta={
+									<button type="button" data-testid="cta">
+										yeni
+									</button>
+								}
+							/>
+						}
+					>
+						<Route path="/pano" element={<ProductIndex />} />
+					</Route>
+				</Routes>
+			</MemoryRouter>,
+		);
+		// The frame's cta is routed to the shell's primaryAction zone (ADR 0182's one promoted verb)…
+		expect(subnavShellSpy.mock.calls[0]?.[0]?.primaryAction).toBeTruthy();
+		// …and still lands in the bar's dedicated cta slot — the pre-refactor `cta` contract, unchanged.
+		const bar = container.querySelector(".kp-subnav");
+		expect(bar?.querySelector(".kp-subnav__cta")?.contains(screen.getByTestId("cta"))).toBe(true);
 	});
 });

--- a/apps/web/src/components/layout/ProductSubnavLayout.tsx
+++ b/apps/web/src/components/layout/ProductSubnavLayout.tsx
@@ -1,21 +1,21 @@
 import type * as React from "react";
 import {Outlet} from "react-router";
-import {Subnav} from "./Subnav";
+import {SubnavShell} from "./SubnavShell";
 
 /**
  * The persistent product Subnav zone (placement law #2587, epic #2596) — a pathless
- * layout-route element per product. It renders the product's `<Subnav>` once above the
+ * layout-route element per product. It renders the product's subnav bar once above the
  * routed `<Outlet>`, so the zone stays mounted as the user moves within `/<product>/*`
- * (no remount between that product's routes). The substrate (#2598) mounts an empty zone
- * frame; each per-product delta (#2600–#2604) fills its destinations / filters / CTA by
- * passing the matching `<Subnav>` slot here (the pano delta #2600 fills `cta`).
- * Mounted only behind the `phoenix-nav-ia` flag (App.tsx) — off ⇒ the router is flat, as
- * today.
+ * (no remount between that product's routes). It composes through `SubnavShell` (ADR 0182)
+ * rather than wiring `<Subnav>` directly, so any product on this generic frame inherits the
+ * shell's flat element-props and the orphan-as-type-error guarantee. The substrate's `cta`
+ * is the shell's `primaryAction` zone (the one promoted verb) — the pano delta #2600 fills it.
+ * Mounted only behind the `phoenix-nav-ia` flag (App.tsx) — off ⇒ the router is flat, as today.
  */
 export function ProductSubnavLayout({cta}: {cta?: React.ReactNode}) {
 	return (
 		<>
-			<Subnav cta={cta} />
+			<SubnavShell primaryAction={cta} />
 			<Outlet />
 		</>
 	);


### PR DESCRIPTION
## What

Rebuild the generic `apps/web/src/components/layout/ProductSubnavLayout.tsx` substrate (the empty/cta-only frame) to compose through the blessed `SubnavShell` (ADR 0182) instead of wiring `<Subnav>` directly — so any product on the generic frame inherits the shell's flat element-props and the unrepresentable-orphan guarantee.

## How

- `ProductSubnavLayout` now renders `<SubnavShell primaryAction={cta} />` above the routed `<Outlet>`.
- The frame's `cta` maps to the shell's `primaryAction` zone (ADR 0182's one promoted verb). Since `SubnavShell` maps `primaryAction` → the wrapped `Subnav`'s `cta` slot, the DOM output and the `cta` prop contract are **preserved exactly** — this is a behavior-preserving internal refactor.
- No `utility` prop introduced (deliberately omitted per ADR 0182). The `phoenix-nav-ia` flag is untouched (still default-off); no per-product layout (#2974–#2977) touched — those are separate in-flight migrations.

## Tests (TDD)

`ProductSubnavLayout.test.tsx` spies the real `SubnavShell` through a passthrough `vi.mock` (the actual shell still renders, so the DOM-level persistence + cta-contract assertions exercise the real composition), and asserts:
- the substrate renders **through** `SubnavShell` (the spy is called) — this fails against the pre-refactor `<Subnav>` wiring, the TDD guard;
- the `cta` is handed to the shell's `primaryAction` zone and still lands in the bar's `.kp-subnav__cta` slot — the `cta` contract, unchanged;
- the persistent-zone / no-remount behavior is preserved (same DOM node across a within-product navigation).

### Gate results

`pnpm vitest run --project client src/components/layout/ProductSubnavLayout`
```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

`pnpm typecheck` — `Tasks: 30 successful, 30 total`

`pnpm lint` — `Checked 2 files. No fixes applied.`

Fixes #2978