### PR TITLE
feat(design-capture): candidate-render step for the priority surfaces (#2961)

### DIFF
--- a/packages/design-capture/README.md
+++ b/packages/design-capture/README.md
@@ -169,6 +169,47 @@ it records the **approved** sha into the committed pointer — it never re-rende
 re-stores bytes, so "what the founder saw" and "what gets committed" are provably the
 same content address (ADR 0183 §5).
 
+## The candidate-render step (`render-candidates`, #2961)
+
+The candidate-render step produces the small set of candidate screens the founder
+blesses in one sitting (epic #2955 story 1, ADR 0183 §5). It renders the
+**founder-decided priority surfaces, in order** — global shell + product subnav
+(`/sozluk`), sözlük term page (`/sozluk/:slug`), pano feed (`/pano`) — over a
+**flag-forced preview deploy**, PUTs each candidate's bytes to depo, and emits a
+**candidate set** staged for blessing. It does **not** bless — blessing is the
+founder's step (#2962); this step stops at "a deterministic candidate set exists."
+
+- **`priority-surfaces.ts`** (pure) — `PRIORITY_SURFACES` is the ordered founder set;
+  `resolvePrioritySurfaces({termSlug})` substitutes the term route's `:slug` and
+  yields concrete capture surfaces in order, failing closed on an unfilled param,
+  non-contiguous order, or a duplicate surface-id.
+- **`candidate-set.ts`** (pure) — `assembleCandidateSet` folds the resolved surfaces
+  against their rendered-and-stored artifacts into the `CandidateSet` the blessing
+  surface consumes; `serializeCandidateSet` / `parseCandidateSet` are its JSON
+  boundary. Each `CandidateScreen` carries its surface-id (the golden-pointer key) +
+  the **exact depo `sha256`** of the rendered bytes — the ADR 0183 §5 no-re-render
+  anchor: the bless later moves the pointer to that same `sha256`, no re-render.
+- **`candidate-render.ts`** (thin Effect) — `renderCandidateSet` drives the reused
+  capture leg (the same flake canon `review-design` uses) + the depo store leg over
+  the priority set. Both impure legs are injected seams, so the whole orchestration is
+  unit-tested with fakes — no browser, no depo.
+
+```bash
+# render the priority surfaces over a flag-forced preview into a candidate set:
+KAMPUS_TOKEN=<pasaport apiKey> node packages/design-capture/src/bin.ts render-candidates \
+  --preview-url https://pr-123.web.kamp.us \
+  --term-slug amortisman \
+  --out /tmp/candidates \
+  --flag "golden-screens=on" \
+  --emit /tmp/candidates/candidate-set.json
+```
+
+Prints the serialized candidate set on stdout (and to `--emit` if given) — the input
+the blessing surface (#2962) consumes. `--flag "<key>=on|off"` records the forced flag
+state as provenance; this step **consumes** an already-flag-forced preview, it does not
+force flags (that mechanism is emitted separately, #2955). The depo pasaport apiKey
+resolves via `--token`, else `KAMPUS_TOKEN`, else `~/.config/kampus/token` (ADR 0045).
+
 ## The undocumented endpoint + the fallback (load-bearing)
 
 The upload POSTs the PNG bytes to

--- a/packages/design-capture/src/bin.ts
+++ b/packages/design-capture/src/bin.ts
@@ -21,11 +21,15 @@
 import {writeFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Config, Console, Effect, Redacted} from "effect";
+import {DoormanClientLive, resolveApiKey} from "@kampus/depo";
+import {Config, Console, Effect, Layer, Redacted} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {renderCandidateSet} from "./candidate-render.ts";
+import {serializeCandidateSet} from "./candidate-set.ts";
 import {loadGoldenPointer, serializeGoldenPointer} from "./golden-fs.ts";
 import {blessSurface} from "./golden-pointer.ts";
+import {storeGolden} from "./golden-store.ts";
 import {captureAndUpload} from "./orchestrate.ts";
 import {renderCrashFailure} from "./page-errors.ts";
 import {parseSurfaceSpec} from "./plan.ts";
@@ -127,8 +131,93 @@ const bless = Command.make(
 	),
 );
 
+// --- render-candidates: the candidate-render step (#2961) ------------------------
+
+const termSlugFlag = Flag.string("term-slug").pipe(
+	Flag.withDescription(
+		"the seeded sözlük term slug to render the term page at (a real term on the preview)",
+	),
+);
+
+const forcedFlagFlag = Flag.string("flag").pipe(
+	Flag.withDescription(
+		'the forced flag state the preview is rendered under, "<key>=on|off" (repeatable) — recorded as candidate-set provenance',
+	),
+	Flag.atLeast(0),
+);
+
+const tokenFlag = Flag.string("token").pipe(
+	Flag.withDefault(""),
+	Flag.withDescription(
+		"depo pasaport apiKey (else KAMPUS_TOKEN or ~/.config/kampus/token, ADR 0045)",
+	),
+);
+
+const emitFlag = Flag.string("emit").pipe(
+	Flag.withDefault(""),
+	Flag.withDescription(
+		"also write the serialized candidate set to this path (stdout gets it either way)",
+	),
+);
+
+/** Parse a `<key>=on|off` provenance flag token; a malformed token is a caller bug. */
+const parseForcedFlag = (token: string): readonly [string, boolean] => {
+	const eq = token.indexOf("=");
+	const key = eq <= 0 ? "" : token.slice(0, eq).trim();
+	const raw =
+		eq <= 0
+			? ""
+			: token
+					.slice(eq + 1)
+					.trim()
+					.toLowerCase();
+	if (key.length === 0) {
+		throw new Error(`design-capture: --flag must be "<key>=on|off", got: ${token}`);
+	}
+	if (raw === "on" || raw === "true" || raw === "1") return [key, true];
+	if (raw === "off" || raw === "false" || raw === "0") return [key, false];
+	throw new Error(`design-capture: --flag value must be on/off, got: ${token}`);
+};
+
+// The depo write layer for the store leg — DoormanClientLive over fetch. Golden bytes
+// go to the content-addressed store the pointer references (ADR 0183 §1), so a
+// candidate's emitted sha256 IS what a later bless commits (§5 no-re-render guard).
+const DepoLive = DoormanClientLive.pipe(Layer.provide(FetchHttpClient.layer));
+
+const renderCandidates = Command.make(
+	"render-candidates",
+	{
+		previewUrl: previewUrlFlag,
+		termSlug: termSlugFlag,
+		out: outFlag,
+		flag: forcedFlagFlag,
+		token: tokenFlag,
+		emit: emitFlag,
+	},
+	Effect.fn(function* ({previewUrl, termSlug, out, flag, token, emit}) {
+		const apiKey = yield* resolveApiKey(token.length === 0 ? undefined : token);
+		const forcedFlags = Object.fromEntries(flag.map(parseForcedFlag));
+		const set = yield* renderCandidateSet(
+			{previewUrl, params: {termSlug}, outDir: out, forcedFlags},
+			{
+				store: (pngBytes) => storeGolden({apiKey, pngBytes}).pipe(Effect.provide(DepoLive)),
+			},
+		);
+		const serialized = serializeCandidateSet(set);
+		if (emit.length > 0) {
+			writeFileSync(emit, serialized);
+		}
+		// stdout is the candidate set — the input the blessing surface (#2962) consumes.
+		yield* Console.log(serialized);
+	}),
+).pipe(
+	Command.withDescription(
+		"Render the founder priority surfaces over a flag-forced preview into a blessing candidate set (#2961)",
+	),
+);
+
 const cli = Command.make("design-capture").pipe(
-	Command.withSubcommands([capture, bless]),
+	Command.withSubcommands([capture, bless, renderCandidates]),
 	Command.withDescription(
 		"Playwright-capture + golden-baseline (store/resolve/diff) for the review-design gate (ADR 0165/0183)",
 	),

--- a/packages/design-capture/src/candidate-render.ts
+++ b/packages/design-capture/src/candidate-render.ts
@@ -1,0 +1,131 @@
+/**
+ * The candidate-render step (epic #2955 story 1, issue #2961): render the founder's
+ * priority surfaces over a flag-forced preview into a deterministic candidate set
+ * staged for blessing — it does NOT bless (that is the founder's step, #2962).
+ *
+ * Thin orchestration over pure cores: resolve the priority surfaces
+ * (`priority-surfaces.ts`), shoot them over the preview via the reused capture leg
+ * (`capture.ts` — the same flake canon the review-design gate uses), PUT each
+ * candidate's bytes to depo up front (so the emitted `sha256` IS what a later bless
+ * commits — ADR 0183 §5 no-re-render guard), and fold the results into the candidate
+ * set (`candidate-set.ts`). Both impure legs are injected seams — the unit test
+ * drives the whole orchestration with fakes, no browser and no depo (the
+ * pure-core + injected-impure-leg idiom `renderLocal`/`captureAndUpload` already use).
+ */
+import {Effect} from "effect";
+import {assembleCandidateSet, type CandidateSet, type RenderedCandidate} from "./candidate-set.ts";
+import {type CapturedSurface, CaptureError, type CaptureOptions, captureShots} from "./capture.ts";
+import type {StoredGolden} from "./golden-store.ts";
+import {buildCapturePlan, DEFAULT_VIEWPORT, type Shot, type Viewport} from "./plan.ts";
+import {
+	type PrioritySurfaceParams,
+	type PrioritySurfaceSpec,
+	resolvePrioritySurfaces,
+} from "./priority-surfaces.ts";
+
+/**
+ * The injected Playwright capture leg — `captureShots`' shape. Defaulted to the real
+ * leg; the unit test injects a fake to prove the orchestration without a browser.
+ */
+export type CaptureLeg = (
+	shots: readonly Shot[],
+	outDir: string,
+	options: CaptureOptions,
+) => Effect.Effect<readonly CapturedSurface[], CaptureError>;
+
+/**
+ * The injected depo store leg — PUT candidate bytes, get back `{ sha256, url }`. Its
+ * error/requirement channels are the caller's (the bin provides the real
+ * `storeGolden` + depo layer; the test injects a fake with neither), so this module's
+ * `renderCandidateSet` stays parametric over both and needs no service at its edge.
+ */
+export type StoreLeg<E = never, R = never> = (
+	pngBytes: Uint8Array,
+) => Effect.Effect<StoredGolden, E, R>;
+
+export interface RenderCandidateSetRequest {
+	/** The flag-forced preview base URL to render the candidates over. */
+	readonly previewUrl: string;
+	/** Concrete data the priority routes need — the seeded sözlük term slug. */
+	readonly params: PrioritySurfaceParams;
+	/** Directory the per-candidate PNG bytes are written to. */
+	readonly outDir: string;
+	/**
+	 * The forced flag state the preview is rendered under (flag key → on/off),
+	 * recorded on the set as provenance. This step consumes an already-forced
+	 * preview; it does not force flags (#2955).
+	 */
+	readonly forcedFlags?: Readonly<Record<string, boolean>>;
+	/** Viewport to shoot each candidate at (default desktop). */
+	readonly viewport?: Viewport;
+	/** Passed through to the capture leg (timeout, full-page). */
+	readonly captureOptions?: CaptureOptions;
+	/** Override the priority set (test seam); defaults to the founder set. */
+	readonly specs?: readonly PrioritySurfaceSpec[];
+}
+
+export interface RenderCandidateSetDeps<E = never, R = never> {
+	readonly capture?: CaptureLeg;
+	/** REQUIRED — the depo store leg (there is no browser-free default that PUTs bytes). */
+	readonly store: StoreLeg<E, R>;
+}
+
+/**
+ * Render the priority surfaces into a candidate set. Resolves the founder-ordered
+ * surfaces, shoots them over the preview, stores each candidate's bytes to depo, and
+ * assembles the set — one candidate screen per priority surface, in founder order,
+ * each anchored to the exact `sha256` a later bless commits. A capture failure
+ * short-circuits (nothing to bless from a broken render); a store failure propagates
+ * in the leg's own error channel.
+ */
+export const renderCandidateSet = <E = never, R = never>(
+	request: RenderCandidateSetRequest,
+	deps: RenderCandidateSetDeps<E, R>,
+): Effect.Effect<CandidateSet, CaptureError | E, R> => {
+	const capture = deps.capture ?? captureShots;
+	const viewport = request.viewport ?? DEFAULT_VIEWPORT;
+	return Effect.try({
+		try: () => {
+			const surfaces = resolvePrioritySurfaces(request.params, request.specs);
+			const plan = buildCapturePlan(
+				request.previewUrl,
+				surfaces.map((s) => s.surface),
+				viewport,
+			);
+			return {surfaces, plan};
+		},
+		catch: (cause) => new CaptureError({message: "failed to build candidate-render plan", cause}),
+	}).pipe(
+		Effect.flatMap(({surfaces, plan}) =>
+			capture(plan, request.outDir, request.captureOptions ?? {}).pipe(
+				Effect.flatMap((captured) =>
+					Effect.forEach(
+						captured,
+						(shot): Effect.Effect<RenderedCandidate, E, R> =>
+							deps.store(shot.pngBytes).pipe(
+								Effect.map(
+									(stored): RenderedCandidate => ({
+										surfaceId: shot.surface,
+										sha256: stored.sha256,
+										url: stored.url,
+										fileName: shot.fileName,
+										localPath: shot.localPath,
+									}),
+								),
+							),
+						{concurrency: 1},
+					),
+				),
+				Effect.map((rendered) =>
+					assembleCandidateSet({
+						previewUrl: request.previewUrl,
+						viewport: viewport.label,
+						forcedFlags: request.forcedFlags ?? {},
+						surfaces,
+						rendered,
+					}),
+				),
+			),
+		),
+	);
+};

--- a/packages/design-capture/src/candidate-render.unit.test.ts
+++ b/packages/design-capture/src/candidate-render.unit.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The candidate-render orchestration (issue #2961 AC 1/2): drive the injected
+ * capture + depo-store legs over the founder priority set and fold the results into a
+ * candidate set — no browser, no depo. Proves the surfaces are shot in founder order
+ * over the flag-forced preview, each candidate's emitted sha256 IS the stored one
+ * (the ADR 0183 §5 no-re-render anchor), and the forced-flag state is recorded.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {type CaptureLeg, renderCandidateSet, type StoreLeg} from "./candidate-render.ts";
+import {type CapturedSurface, CaptureError, type CaptureOptions} from "./capture.ts";
+import type {StoredGolden} from "./golden-store.ts";
+import type {Shot} from "./plan.ts";
+
+/** A fake capture leg: returns stub captures with per-surface deterministic bytes. */
+const fakeCapture = (): {leg: CaptureLeg; calls: {shots: readonly Shot[]}[]} => {
+	const calls: {shots: readonly Shot[]}[] = [];
+	const leg: CaptureLeg = (shots, outDir, _options: CaptureOptions) => {
+		calls.push({shots});
+		return Effect.succeed(
+			shots.map(
+				(s, i): CapturedSurface => ({
+					surface: s.surface.surface,
+					route: s.surface.route,
+					state: s.surface.state,
+					localPath: `${outDir}/${s.fileName}`,
+					fileName: s.fileName,
+					// distinct bytes per surface so the store leg yields a distinct sha per surface
+					pngBytes: new Uint8Array([i + 1]),
+					pageErrors: [],
+				}),
+			),
+		);
+	};
+	return {leg, calls};
+};
+
+/** A fake depo store leg: content-address is a deterministic 64-hex from the first byte. */
+const fakeStore = (): StoreLeg => (pngBytes) => {
+	const stem = String(pngBytes[0] ?? 0).padStart(64, "0");
+	return Effect.succeed<StoredGolden>({sha256: stem, url: `https://depo.kamp.us/${stem}.png`});
+};
+
+describe("renderCandidateSet", () => {
+	it("renders the priority surfaces over the preview in founder order and stores each", async () => {
+		const {leg, calls} = fakeCapture();
+		const set = await Effect.runPromise(
+			renderCandidateSet(
+				{
+					previewUrl: "https://pr-1.workers.dev",
+					params: {termSlug: "amortisman"},
+					outDir: "/out",
+					forcedFlags: {"golden-screens": true},
+				},
+				{capture: leg, store: fakeStore()},
+			),
+		);
+		// shot over the preview, in founder order
+		assert.deepStrictEqual(
+			calls[0]?.shots.map((s) => s.url),
+			[
+				"https://pr-1.workers.dev/sozluk",
+				"https://pr-1.workers.dev/sozluk/amortisman",
+				"https://pr-1.workers.dev/pano",
+			],
+		);
+		assert.deepStrictEqual(
+			set.screens.map((s) => [s.order, s.surfaceId]),
+			[
+				[1, "/sozluk"],
+				[2, "/sozluk/amortisman"],
+				[3, "/pano"],
+			],
+		);
+	});
+
+	it("emits the EXACT stored sha256 per candidate (the no-re-render anchor, ADR 0183 §5)", async () => {
+		const {leg} = fakeCapture();
+		const set = await Effect.runPromise(
+			renderCandidateSet(
+				{previewUrl: "https://pr-1.workers.dev", params: {termSlug: "x"}, outDir: "/out"},
+				{capture: leg, store: fakeStore()},
+			),
+		);
+		// bytes were [1],[2],[3] → stems "…001","…002","…003" → matching urls
+		assert.deepStrictEqual(
+			set.screens.map((s) => s.sha256),
+			[String(1).padStart(64, "0"), String(2).padStart(64, "0"), String(3).padStart(64, "0")],
+		);
+		for (const s of set.screens) {
+			assert.strictEqual(s.url, `https://depo.kamp.us/${s.sha256}.png`);
+		}
+	});
+
+	it("records the forced-flag state + viewport as provenance", async () => {
+		const {leg} = fakeCapture();
+		const set = await Effect.runPromise(
+			renderCandidateSet(
+				{
+					previewUrl: "https://pr-1.workers.dev",
+					params: {termSlug: "x"},
+					outDir: "/out",
+					forcedFlags: {"golden-screens": true},
+				},
+				{capture: leg, store: fakeStore()},
+			),
+		);
+		assert.deepStrictEqual(set.forcedFlags, {"golden-screens": true});
+		assert.strictEqual(set.viewport, "desktop");
+		assert.strictEqual(set.previewUrl, "https://pr-1.workers.dev");
+	});
+
+	it("short-circuits a capture failure (nothing to bless from a broken render)", async () => {
+		const failing: CaptureLeg = () => Effect.fail(new CaptureError({message: "boom"}));
+		const exit = await Effect.runPromiseExit(
+			renderCandidateSet(
+				{previewUrl: "https://pr-1.workers.dev", params: {termSlug: "x"}, outDir: "/out"},
+				{capture: failing, store: fakeStore()},
+			),
+		);
+		assert.isTrue(exit._tag === "Failure");
+	});
+
+	it("wraps a plan-build failure (unfilled term slug) as a CaptureError in-channel", async () => {
+		const {leg} = fakeCapture();
+		const exit = await Effect.runPromiseExit(
+			renderCandidateSet(
+				// empty termSlug ⇒ resolvePrioritySurfaces throws on the :slug route
+				{previewUrl: "https://pr-1.workers.dev", params: {termSlug: ""}, outDir: "/out"},
+				{capture: leg, store: fakeStore()},
+			),
+		);
+		assert.isTrue(exit._tag === "Failure");
+	});
+});

--- a/packages/design-capture/src/candidate-set.ts
+++ b/packages/design-capture/src/candidate-set.ts
@@ -1,0 +1,204 @@
+/**
+ * The candidate-set contract (epic #2955 story 1 → 2, ADR 0183 §5): the pure
+ * assembly + (de)serialization of the SET the blessing surface (#2962) consumes.
+ *
+ * A candidate SET is the input to the founder's one blessing session: one candidate
+ * SCREEN per priority surface, each carrying its surface identity + the depo
+ * content-address of the exact rendered bytes (`sha256` + immutable `url`). That
+ * `sha256` is load-bearing — it is the byte-faithfulness anchor of ADR 0183 §5's
+ * no-re-render guard: the blessing surface embeds `url` in the gallery comment at
+ * full resolution, the founder approves it, and the blessed pointer moves to THIS
+ * `sha256` — never a re-render. So the render step (this package) PUTs each candidate
+ * to depo up front and emits its `sha256` here, and the bless commits exactly it.
+ *
+ * Pure + IO-free: `assembleCandidateSet` folds resolved priority surfaces against
+ * their rendered+stored artifacts (unit-tested — same inputs → same set), and
+ * `serialize`/`parse` are the JSON boundary the blessing surface decodes. Hand-
+ * validated (the `golden-fs.ts` idiom) so a malformed set fails loud, never as a
+ * half-filled set a bless would mis-read.
+ */
+
+import {isSha256Hex} from "./golden-pointer.ts";
+import type {ResolvedPrioritySurface} from "./priority-surfaces.ts";
+
+/** One rendered-and-stored candidate screen — a blessing-gallery entry. */
+export interface CandidateScreen {
+	/** 1-based founder-decided blessing order (#2944). */
+	readonly order: number;
+	/** The `<route>[:state]` surface-id — the golden-pointer key a bless moves. */
+	readonly surfaceId: string;
+	/** Human label shown in the gallery. */
+	readonly title: string;
+	/** The bless intent recorded on the pointer when this candidate is blessed. */
+	readonly intent: string;
+	/** 64-hex depo content-address of the EXACT rendered bytes (the no-re-render anchor). */
+	readonly sha256: string;
+	/** Immutable `depo.kamp.us/<sha256>.png` URL — the full-res gallery embed. */
+	readonly url: string;
+	/** Filesystem-safe PNG name (basename of `localPath`). */
+	readonly fileName: string;
+	/** On-disk PNG path the render wrote — the operator's local copy of the candidate. */
+	readonly localPath: string;
+}
+
+/** The whole candidate set staged for one blessing session. */
+export interface CandidateSet {
+	/** The flag-forced preview base the candidates were rendered over. */
+	readonly previewUrl: string;
+	/** The viewport label every candidate was shot at. */
+	readonly viewport: string;
+	/**
+	 * The forced flag state the preview was rendered under (flag key → on/off).
+	 * Recorded as metadata for provenance — this step CONSUMES a flag-forced preview,
+	 * it does not force flags (the forcing mechanism is emitted separately, #2955).
+	 */
+	readonly forcedFlags: Readonly<Record<string, boolean>>;
+	/** The candidate screens, in founder order. */
+	readonly screens: readonly CandidateScreen[];
+}
+
+/** A rendered-and-stored artifact for one surface — the impure legs' output, joined by surface-id. */
+export interface RenderedCandidate {
+	readonly surfaceId: string;
+	readonly sha256: string;
+	readonly url: string;
+	readonly fileName: string;
+	readonly localPath: string;
+}
+
+export interface AssembleCandidateSetInput {
+	readonly previewUrl: string;
+	readonly viewport: string;
+	readonly forcedFlags: Readonly<Record<string, boolean>>;
+	readonly surfaces: readonly ResolvedPrioritySurface[];
+	readonly rendered: readonly RenderedCandidate[];
+}
+
+/**
+ * Assemble the candidate set: join each resolved priority surface to its rendered
+ * artifact by surface-id, preserving founder order. Fail-closed on a mismatch —
+ * every priority surface must have exactly one rendered candidate and vice-versa (a
+ * missing or extra render means the capture leg silently dropped/duplicated a
+ * surface, which must never reach the founder as a partial gallery). Rejects a
+ * non-sha256 content-address (a `.png` or URL slipped in where the stem belongs).
+ */
+export const assembleCandidateSet = (input: AssembleCandidateSetInput): CandidateSet => {
+	const byId = new Map<string, RenderedCandidate>();
+	for (const r of input.rendered) {
+		if (byId.has(r.surfaceId)) {
+			throw new Error(`candidate-set: duplicate rendered candidate for ${r.surfaceId}`);
+		}
+		byId.set(r.surfaceId, r);
+	}
+	if (byId.size !== input.surfaces.length) {
+		throw new Error(
+			`candidate-set: rendered count (${byId.size}) != priority-surface count (${input.surfaces.length}) — refusing a partial candidate set`,
+		);
+	}
+	const screens = input.surfaces.map((surface): CandidateScreen => {
+		const surfaceId = surface.surface.surface;
+		const r = byId.get(surfaceId);
+		if (r === undefined) {
+			throw new Error(`candidate-set: no rendered candidate for priority surface ${surfaceId}`);
+		}
+		if (!isSha256Hex(r.sha256)) {
+			throw new Error(
+				`candidate-set: ${surfaceId} content-address must be a 64-hex sha256 stem (no ".png"/URL), got "${r.sha256}"`,
+			);
+		}
+		return {
+			order: surface.order,
+			surfaceId,
+			title: surface.title,
+			intent: surface.intent,
+			sha256: r.sha256,
+			url: r.url,
+			fileName: r.fileName,
+			localPath: r.localPath,
+		};
+	});
+	return {
+		previewUrl: input.previewUrl,
+		viewport: input.viewport,
+		forcedFlags: input.forcedFlags,
+		screens,
+	};
+};
+
+/**
+ * Serialize the set to the JSON the blessing surface consumes — tab-indented +
+ * trailing newline, matching the repo's committed-JSON convention. Deterministic:
+ * screens stay in founder order, and flag keys are sorted so the same set always
+ * serializes byte-identically (a stable operator artifact / diff).
+ */
+export const serializeCandidateSet = (set: CandidateSet): string => {
+	const forcedFlags: Record<string, boolean> = {};
+	for (const key of Object.keys(set.forcedFlags).sort()) {
+		forcedFlags[key] = set.forcedFlags[key] as boolean;
+	}
+	return `${JSON.stringify({...set, forcedFlags}, null, "\t")}\n`;
+};
+
+interface RawCandidateSet {
+	readonly previewUrl?: unknown;
+	readonly viewport?: unknown;
+	readonly forcedFlags?: unknown;
+	readonly screens?: unknown;
+}
+
+const isStringRecordOfBoolean = (value: unknown): value is Record<string, boolean> =>
+	typeof value === "object" &&
+	value !== null &&
+	Object.values(value).every((v) => typeof v === "boolean");
+
+/**
+ * Parse + validate a serialized candidate set (the blessing surface's decode
+ * boundary). Every field is checked so a malformed set fails loud here, not later as
+ * a half-filled set a bless mis-reads — the `golden-fs.ts` hand-validation idiom.
+ */
+export const parseCandidateSet = (text: string): CandidateSet => {
+	const raw = JSON.parse(text) as RawCandidateSet;
+	if (typeof raw.previewUrl !== "string" || typeof raw.viewport !== "string") {
+		throw new Error("candidate-set: malformed set (needs string previewUrl/viewport)");
+	}
+	if (!isStringRecordOfBoolean(raw.forcedFlags)) {
+		throw new Error("candidate-set: malformed forcedFlags (needs a {string: boolean} map)");
+	}
+	if (!Array.isArray(raw.screens)) {
+		throw new Error("candidate-set: malformed set (screens must be an array)");
+	}
+	const screens = raw.screens.map((entry, index): CandidateScreen => {
+		const s = entry as Partial<CandidateScreen>;
+		if (
+			typeof s.order !== "number" ||
+			typeof s.surfaceId !== "string" ||
+			typeof s.title !== "string" ||
+			typeof s.intent !== "string" ||
+			typeof s.sha256 !== "string" ||
+			typeof s.url !== "string" ||
+			typeof s.fileName !== "string" ||
+			typeof s.localPath !== "string"
+		) {
+			throw new Error(`candidate-set: screen[${index}] is malformed`);
+		}
+		if (!isSha256Hex(s.sha256)) {
+			throw new Error(`candidate-set: screen[${index}] sha256 is not a 64-hex stem: "${s.sha256}"`);
+		}
+		return {
+			order: s.order,
+			surfaceId: s.surfaceId,
+			title: s.title,
+			intent: s.intent,
+			sha256: s.sha256,
+			url: s.url,
+			fileName: s.fileName,
+			localPath: s.localPath,
+		};
+	});
+	return {
+		previewUrl: raw.previewUrl,
+		viewport: raw.viewport,
+		forcedFlags: raw.forcedFlags,
+		screens,
+	};
+};

--- a/packages/design-capture/src/candidate-set.unit.test.ts
+++ b/packages/design-capture/src/candidate-set.unit.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The candidate-set assembly + (de)serialize core (issue #2961 AC 2/3): the set is
+ * assembled in founder order with the exact depo sha256 per surface (ADR 0183 §5's
+ * no-re-render anchor), serialized deterministically, and round-trips through parse;
+ * a partial/mismatched render fails closed.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	assembleCandidateSet,
+	parseCandidateSet,
+	type RenderedCandidate,
+	serializeCandidateSet,
+} from "./candidate-set.ts";
+import {parseSurfaceSpec} from "./plan.ts";
+import type {ResolvedPrioritySurface} from "./priority-surfaces.ts";
+
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+
+const surfaces: readonly ResolvedPrioritySurface[] = [
+	{
+		order: 1,
+		key: "global-shell-subnav",
+		title: "Global shell + product subnav",
+		intent: "shell",
+		surface: parseSurfaceSpec("/sozluk"),
+	},
+	{
+		order: 2,
+		key: "pano-feed",
+		title: "Pano feed",
+		intent: "feed",
+		surface: parseSurfaceSpec("/pano"),
+	},
+];
+
+const rendered: readonly RenderedCandidate[] = [
+	{
+		surfaceId: "/pano",
+		sha256: SHA_B,
+		url: `https://depo.kamp.us/${SHA_B}.png`,
+		fileName: "pano@desktop.png",
+		localPath: "/out/pano@desktop.png",
+	},
+	{
+		surfaceId: "/sozluk",
+		sha256: SHA_A,
+		url: `https://depo.kamp.us/${SHA_A}.png`,
+		fileName: "sozluk@desktop.png",
+		localPath: "/out/sozluk@desktop.png",
+	},
+];
+
+describe("assembleCandidateSet", () => {
+	it("joins by surface-id and preserves founder order (not render order)", () => {
+		const set = assembleCandidateSet({
+			previewUrl: "https://pr-1.workers.dev",
+			viewport: "desktop",
+			forcedFlags: {"golden-screens": true},
+			surfaces,
+			rendered,
+		});
+		assert.deepStrictEqual(
+			set.screens.map((s) => [s.order, s.surfaceId, s.sha256]),
+			[
+				[1, "/sozluk", SHA_A],
+				[2, "/pano", SHA_B],
+			],
+		);
+	});
+
+	it("carries the bless intent + full-res depo url per candidate", () => {
+		const set = assembleCandidateSet({
+			previewUrl: "https://pr-1.workers.dev",
+			viewport: "desktop",
+			forcedFlags: {},
+			surfaces,
+			rendered,
+		});
+		assert.strictEqual(set.screens[0]?.intent, "shell");
+		assert.strictEqual(set.screens[0]?.url, `https://depo.kamp.us/${SHA_A}.png`);
+	});
+
+	it("fails closed when a priority surface has no rendered candidate", () => {
+		assert.throws(
+			() =>
+				assembleCandidateSet({
+					previewUrl: "https://pr-1.workers.dev",
+					viewport: "desktop",
+					forcedFlags: {},
+					surfaces,
+					rendered: [rendered[1] as RenderedCandidate], // only /sozluk
+				}),
+			/count.*!=.*priority-surface count/,
+		);
+	});
+
+	it("fails closed on a duplicate rendered candidate", () => {
+		assert.throws(
+			() =>
+				assembleCandidateSet({
+					previewUrl: "https://pr-1.workers.dev",
+					viewport: "desktop",
+					forcedFlags: {},
+					surfaces,
+					rendered: [rendered[1] as RenderedCandidate, rendered[1] as RenderedCandidate],
+				}),
+			/duplicate rendered candidate/,
+		);
+	});
+
+	it("rejects a non-sha256 content-address (a .png/URL slipped in)", () => {
+		assert.throws(
+			() =>
+				assembleCandidateSet({
+					previewUrl: "https://pr-1.workers.dev",
+					viewport: "desktop",
+					forcedFlags: {},
+					surfaces: [surfaces[0] as ResolvedPrioritySurface],
+					rendered: [
+						{...(rendered[1] as RenderedCandidate), surfaceId: "/sozluk", sha256: `${SHA_A}.png`},
+					],
+				}),
+			/64-hex sha256 stem/,
+		);
+	});
+});
+
+describe("serializeCandidateSet / parseCandidateSet", () => {
+	const set = assembleCandidateSet({
+		previewUrl: "https://pr-1.workers.dev",
+		viewport: "desktop",
+		forcedFlags: {"golden-screens": true, "pano-draft": false},
+		surfaces,
+		rendered,
+	});
+
+	it("round-trips through serialize → parse", () => {
+		assert.deepStrictEqual(parseCandidateSet(serializeCandidateSet(set)), set);
+	});
+
+	it("serializes deterministically (sorted flag keys, trailing newline)", () => {
+		const text = serializeCandidateSet(set);
+		assert.strictEqual(serializeCandidateSet(set), text);
+		assert.isTrue(text.endsWith("\n"));
+		assert.isBelow(text.indexOf("golden-screens"), text.indexOf("pano-draft"));
+	});
+
+	it("parse fails closed on a malformed screen", () => {
+		assert.throws(
+			() =>
+				parseCandidateSet(
+					'{"previewUrl":"x","viewport":"d","forcedFlags":{},"screens":[{"order":1}]}',
+				),
+			/screen\[0\] is malformed/,
+		);
+	});
+
+	it("parse fails closed on a bad sha256 in a screen", () => {
+		const bad = JSON.stringify({
+			previewUrl: "x",
+			viewport: "d",
+			forcedFlags: {},
+			screens: [
+				{
+					order: 1,
+					surfaceId: "/sozluk",
+					title: "t",
+					intent: "i",
+					sha256: "nope",
+					url: "u",
+					fileName: "f",
+					localPath: "l",
+				},
+			],
+		});
+		assert.throws(() => parseCandidateSet(bad), /not a 64-hex stem/);
+	});
+});

--- a/packages/design-capture/src/index.ts
+++ b/packages/design-capture/src/index.ts
@@ -9,6 +9,25 @@
  * `resolvePreviewUrl` resolves the preview base from the sticky preview-deploy
  * comment, keyed off the per-app `<!-- preview-deploy:<app> -->` anchor.
  */
+
+// The candidate-render step (ADR 0183 §5, epic #2955 story 1): render the founder
+// priority surfaces over a flag-forced preview into a blessing candidate set, staged
+// for the founder's bless (#2962) — each candidate anchored to the exact depo sha256
+// a later bless commits (the no-re-render guard).
+export type {
+	CaptureLeg as CandidateCaptureLeg,
+	RenderCandidateSetDeps,
+	RenderCandidateSetRequest,
+	StoreLeg,
+} from "./candidate-render.ts";
+export {renderCandidateSet} from "./candidate-render.ts";
+export type {
+	AssembleCandidateSetInput,
+	CandidateScreen,
+	CandidateSet,
+	RenderedCandidate,
+} from "./candidate-set.ts";
+export {assembleCandidateSet, parseCandidateSet, serializeCandidateSet} from "./candidate-set.ts";
 export type {CaptureCookie, CapturedSurface, CaptureOptions} from "./capture.ts";
 export {CaptureError, captureShots} from "./capture.ts";
 // The golden-baseline seam (ADR 0183): bytes in depo, the current-golden pointer in
@@ -46,6 +65,17 @@ export {
 	parseSurfaceSpec,
 	surfaceFileName,
 } from "./plan.ts";
+export type {
+	PrioritySurfaceKey,
+	PrioritySurfaceParams,
+	PrioritySurfaceSpec,
+	ResolvedPrioritySurface,
+} from "./priority-surfaces.ts";
+export {
+	PRIORITY_SURFACES,
+	resolvePrioritySurfaces,
+	substituteRouteParams,
+} from "./priority-surfaces.ts";
 export {resolvePreviewUrl} from "./resolve.ts";
 export type {RawUploadResponse, UploadAssetOptions, UploadOutcome} from "./upload.ts";
 export {parseUploadResponse, uploadAsset, uploadEndpoint} from "./upload.ts";

--- a/packages/design-capture/src/priority-surfaces.ts
+++ b/packages/design-capture/src/priority-surfaces.ts
@@ -1,0 +1,165 @@
+/**
+ * The pure priority-surface core (epic #2955 story 1, ADR 0183 §2/§5): the small,
+ * founder-decided, ORDERED set of surfaces the candidate-render step shoots for the
+ * one blessing session. The order is the founder's (#2944) — global shell + product
+ * subnav, then sözlük term page, then pano feed — and is load-bearing: the blessing
+ * gallery is presented in this order, so the list is ordered data, never an
+ * incidental array.
+ *
+ * A surface's identity is the `<route>[:state]` capture spec keyed exactly the way
+ * the golden pointer is (ADR 0183 §2: `surface-id -> { sha256, blessed-date,
+ * intent }`), so a blessed candidate's surface-id IS the pointer key — no second
+ * identity scheme. Route and state are carried as SEPARATE fields (not one
+ * colon-joined string) because a route TEMPLATE also uses `:` for params
+ * (`/sozluk/:slug`); keeping them apart makes param substitution unambiguous, and the
+ * concrete surface-id is assembled only after the term slug is filled (a template
+ * can't be captured — a real term must be named).
+ *
+ * Pure + IO-free: this is the unit-tested selection logic; the impure capture/store
+ * legs run over the surfaces it resolves (see `candidate-render.ts`).
+ */
+import {parseSurfaceSpec, type Surface} from "./plan.ts";
+
+/** A stable key for one priority surface — the founder's three deliberate screens. */
+export type PrioritySurfaceKey = "global-shell-subnav" | "sozluk-term" | "pano-feed";
+
+/** One priority surface: its founder-order rank, its route (+ optional state), its bless intent. */
+export interface PrioritySurfaceSpec {
+	/** 1-based rank in the founder-decided blessing order (#2944). */
+	readonly order: number;
+	readonly key: PrioritySurfaceKey;
+	/** Human label shown in the blessing gallery. */
+	readonly title: string;
+	/**
+	 * The route path, possibly a template with `:param` segments (e.g.
+	 * `/sozluk/:slug`) the resolve step fills with concrete data. Never carries a
+	 * `:state` suffix — state is the separate field below.
+	 */
+	readonly route: string;
+	/** The capture state variant (`empty`, `focus-visible`, …), or omitted for the default render. */
+	readonly state?: string;
+	/** The bless intent recorded on the golden pointer — what this golden captures / why. */
+	readonly intent: string;
+}
+
+/**
+ * The founder-decided priority set, in blessing order (#2944; the epic #2955 story-1
+ * order). `/sozluk` is the shell + product-subnav chrome reference (the composition
+ * the sozluk-subnav defect class, #2587/#2602/#2790, kept getting wrong); `/sozluk/:slug`
+ * is the term page; `/pano` is the feed. The intents express the taste north star —
+ * ekşi sözlük spirit in a Discord-grade modern/a11y body (map #2940).
+ */
+export const PRIORITY_SURFACES: readonly PrioritySurfaceSpec[] = [
+	{
+		order: 1,
+		key: "global-shell-subnav",
+		title: "Global shell + product subnav",
+		route: "/sozluk",
+		intent:
+			"Global app shell + product subnav chrome — the composition reference the shell/subnav defect class must converge to.",
+	},
+	{
+		order: 2,
+		key: "sozluk-term",
+		title: "Sözlük term page",
+		route: "/sozluk/:slug",
+		intent: "Sözlük term page — ekşi-spirit entry reading surface in a modern, a11y body.",
+	},
+	{
+		order: 3,
+		key: "pano-feed",
+		title: "Pano feed",
+		route: "/pano",
+		intent: "Pano feed — the link-aggregator feed composition reference.",
+	},
+];
+
+/** A resolved priority surface: the concrete capture Surface + its order/title/intent. */
+export interface ResolvedPrioritySurface {
+	readonly order: number;
+	readonly key: PrioritySurfaceKey;
+	readonly title: string;
+	readonly intent: string;
+	/** The concrete surface (route + optional state), route params substituted. */
+	readonly surface: Surface;
+}
+
+/** The concrete data a priority surface's route template needs (e.g. the term slug). */
+export interface PrioritySurfaceParams {
+	/** The seeded term slug substituted into `/sozluk/:slug` — a real term on the preview. */
+	readonly termSlug: string;
+}
+
+const PARAM_SEGMENT = /^:([A-Za-z][A-Za-z0-9_]*)$/;
+
+/**
+ * Substitute `:param` path segments in a ROUTE template from a params map. Operates
+ * on the route only (state is separate), so no colon ambiguity. Fails closed on an
+ * unfilled param — a `/sozluk/:slug` left with a live `:slug` would capture a 404,
+ * so an absent param is a caller bug, never a silent bad shot.
+ */
+export const substituteRouteParams = (
+	route: string,
+	params: Readonly<Record<string, string>>,
+): string =>
+	route
+		.split("/")
+		.map((segment) => {
+			const match = PARAM_SEGMENT.exec(segment);
+			if (match === null) return segment;
+			const name = match[1] as string;
+			const value = params[name];
+			if (value === undefined || value.length === 0) {
+				throw new Error(
+					`priority-surfaces: route param ":${name}" in "${route}" has no value — cannot render an unfilled route`,
+				);
+			}
+			return encodeURIComponent(value);
+		})
+		.join("/");
+
+/**
+ * Resolve the priority set into concrete capture surfaces, in founder order.
+ * Substitutes each route's params (the sözlük term slug), assembles the `<route>[:state]`
+ * surface-id, parses it into a {@link Surface}, and asserts the set is well-formed:
+ * contiguous 1-based order and unique surface-ids (a duplicate would collide two
+ * candidates onto one pointer key). Fail-closed — an ill-formed priority set is a
+ * bug, not a partial set.
+ */
+export const resolvePrioritySurfaces = (
+	params: PrioritySurfaceParams,
+	specs: readonly PrioritySurfaceSpec[] = PRIORITY_SURFACES,
+): readonly ResolvedPrioritySurface[] => {
+	if (specs.length === 0) {
+		throw new Error("priority-surfaces: empty priority set — nothing to render");
+	}
+	const ordered = [...specs].sort((a, b) => a.order - b.order);
+	ordered.forEach((spec, index) => {
+		if (spec.order !== index + 1) {
+			throw new Error(
+				`priority-surfaces: order must be contiguous 1..${ordered.length}; got ${spec.order} at rank ${index + 1}`,
+			);
+		}
+	});
+	// The sözlük term route names its param `:slug`; the priority-surface params supply
+	// it as `termSlug` (the one concrete datum the founder set needs).
+	const routeParams = {slug: params.termSlug};
+	const seen = new Set<string>();
+	return ordered.map((spec) => {
+		const route = substituteRouteParams(spec.route, routeParams);
+		const surfaceId = spec.state === undefined ? route : `${route}:${spec.state}`;
+		if (seen.has(surfaceId)) {
+			throw new Error(
+				`priority-surfaces: duplicate surface-id ${surfaceId} — surfaces must be unique`,
+			);
+		}
+		seen.add(surfaceId);
+		return {
+			order: spec.order,
+			key: spec.key,
+			title: spec.title,
+			intent: spec.intent,
+			surface: parseSurfaceSpec(surfaceId),
+		};
+	});
+};

--- a/packages/design-capture/src/priority-surfaces.unit.test.ts
+++ b/packages/design-capture/src/priority-surfaces.unit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The priority-surface selection core (issue #2961 AC 3): the founder-decided set
+ * resolves to concrete capture surfaces in order, route params are substituted, and
+ * an ill-formed set (unfilled param, bad order, duplicate) fails closed.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	PRIORITY_SURFACES,
+	resolvePrioritySurfaces,
+	substituteRouteParams,
+} from "./priority-surfaces.ts";
+
+describe("PRIORITY_SURFACES — the founder-decided set (#2944)", () => {
+	it("is the three surfaces in the founder order: shell+subnav, sözlük term, pano feed", () => {
+		assert.deepStrictEqual(
+			PRIORITY_SURFACES.map((s) => [s.order, s.key]),
+			[
+				[1, "global-shell-subnav"],
+				[2, "sozluk-term"],
+				[3, "pano-feed"],
+			],
+		);
+	});
+
+	it("every surface carries a non-empty bless intent (the pointer records it)", () => {
+		for (const s of PRIORITY_SURFACES) {
+			assert.isAbove(s.intent.trim().length, 0);
+		}
+	});
+});
+
+describe("substituteRouteParams", () => {
+	it("substitutes a :param path segment", () => {
+		assert.strictEqual(
+			substituteRouteParams("/sozluk/:slug", {slug: "amortisman"}),
+			"/sozluk/amortisman",
+		);
+	});
+
+	it("leaves a param-free route untouched", () => {
+		assert.strictEqual(substituteRouteParams("/pano", {}), "/pano");
+	});
+
+	it("url-encodes the substituted value", () => {
+		assert.strictEqual(substituteRouteParams("/sozluk/:slug", {slug: "a b"}), "/sozluk/a%20b");
+	});
+
+	it("fails closed on an unfilled param — never renders a live :param route", () => {
+		assert.throws(() => substituteRouteParams("/sozluk/:slug", {}), /route param ":slug"/);
+	});
+});
+
+describe("resolvePrioritySurfaces", () => {
+	it("resolves the founder set to concrete surfaces in order, term slug filled", () => {
+		const resolved = resolvePrioritySurfaces({termSlug: "amortisman"});
+		assert.deepStrictEqual(
+			resolved.map((r) => [r.order, r.surface.surface]),
+			[
+				[1, "/sozluk"],
+				[2, "/sozluk/amortisman"],
+				[3, "/pano"],
+			],
+		);
+	});
+
+	it("carries order/title/intent onto each resolved surface", () => {
+		const [first] = resolvePrioritySurfaces({termSlug: "x"});
+		assert.strictEqual(first?.key, "global-shell-subnav");
+		assert.strictEqual(first?.title, "Global shell + product subnav");
+		assert.isAbove((first?.intent ?? "").length, 0);
+	});
+
+	it("assembles a :state suffix onto the surface-id", () => {
+		const resolved = resolvePrioritySurfaces({termSlug: "x"}, [
+			{
+				order: 1,
+				key: "sozluk-term",
+				title: "T",
+				route: "/sozluk/:slug",
+				state: "empty",
+				intent: "t",
+			},
+		]);
+		assert.strictEqual(resolved[0]?.surface.surface, "/sozluk/x:empty");
+		assert.strictEqual(resolved[0]?.surface.route, "/sozluk/x");
+		assert.strictEqual(resolved[0]?.surface.state, "empty");
+	});
+
+	it("sorts by order before validating (input order-independent)", () => {
+		const resolved = resolvePrioritySurfaces({termSlug: "x"}, [
+			{order: 2, key: "pano-feed", title: "B", route: "/pano", intent: "b"},
+			{order: 1, key: "global-shell-subnav", title: "A", route: "/sozluk", intent: "a"},
+		]);
+		assert.deepStrictEqual(
+			resolved.map((r) => r.order),
+			[1, 2],
+		);
+	});
+
+	it("fails closed on a non-contiguous order", () => {
+		assert.throws(
+			() =>
+				resolvePrioritySurfaces({termSlug: "x"}, [
+					{order: 1, key: "global-shell-subnav", title: "A", route: "/sozluk", intent: "a"},
+					{order: 3, key: "pano-feed", title: "C", route: "/pano", intent: "c"},
+				]),
+			/contiguous/,
+		);
+	});
+
+	it("fails closed on a duplicate surface-id", () => {
+		assert.throws(
+			() =>
+				resolvePrioritySurfaces({termSlug: "x"}, [
+					{order: 1, key: "global-shell-subnav", title: "A", route: "/pano", intent: "a"},
+					{order: 2, key: "pano-feed", title: "B", route: "/pano", intent: "b"},
+				]),
+			/duplicate surface-id/,
+		);
+	});
+
+	it("fails closed on an empty priority set", () => {
+		assert.throws(() => resolvePrioritySurfaces({termSlug: "x"}, []), /empty priority set/);
+	});
+});


### PR DESCRIPTION
Fixes #2961 — Phase 3 of the golden-screens epic #2955, on the #2960 golden infra + ADR 0183.

## What this builds
The **candidate-render step**: render the founder-decided priority surfaces, **in order** (#2944) — global shell + product subnav (`/sozluk`), sözlük term page (`/sozluk/:slug`), pano feed (`/pano`) — over a **flag-forced preview** into a **blessing candidate set**, staged for the founder's bless (#2962). It does **not** bless — this child stops at "a deterministic candidate set exists."

Each candidate carries its surface-id (the golden-pointer key) + the **exact depo `sha256`** of the rendered bytes: the render step PUTs each candidate to depo up front, so the emitted `sha256` **is** what a later bless commits — ADR 0183 §5's no-re-render guard, structural rather than procedural.

## Files (`packages/design-capture/src/`)
- **`priority-surfaces.ts`** (pure) — `PRIORITY_SURFACES` (the ordered founder set) + `resolvePrioritySurfaces` (route-param substitution → concrete capture surfaces); fail-closed on unfilled param, non-contiguous order, or duplicate surface-id.
- **`candidate-set.ts`** (pure) — `assembleCandidateSet` folds resolved surfaces against rendered+stored artifacts into the `CandidateSet` the blessing surface consumes (join-by-surface-id, founder order, fail-closed on partial/mismatched render); `serializeCandidateSet`/`parseCandidateSet` are the hand-validated JSON boundary.
- **`candidate-render.ts`** (thin Effect) — `renderCandidateSet` drives the reused capture leg (same flake canon `review-design` uses) + the depo store leg over the priority set; both impure legs are injected seams, so the whole orchestration is unit-tested with fakes — no browser, no depo.
- **`bin.ts`** — `render-candidates` subcommand (emits the candidate set on stdout / `--emit`); **`README.md`** — a candidate-render section; **`index.ts`** — new exports.

## Acceptance criteria
- [x] A candidate-render step renders the three priority surfaces over a flag-forced preview into deterministic PNGs under the flake canon (reuses `captureShots`/`buildCapturePlan`).
- [x] The candidate set is emitted in the schema the blessing surface consumes (surface identity + metadata per ADR 0183; each screen carries the depo `sha256`/`url` + bless intent).
- [x] Pure cores (surface selection, candidate-set assembly) unit-tested per `.patterns/effect-testing.md`.

## Verification (local, in an isolated worktree)
- `turbo typecheck` — 31/31 tasks pass.
- `lint:worktree` — clean.
- Full packages test surface (`pnpm --filter './packages/**' run test`) — green; design-capture 96 tests (26 new).

NON-control-plane (normal package work, not §CP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)