### PR TITLE
feat(design-capture): blessing surface — bless/redline candidates into the golden set (#2962)

### DIFF
--- a/packages/design-capture/README.md
+++ b/packages/design-capture/README.md
@@ -210,6 +210,48 @@ state as provenance; this step **consumes** an already-flag-forced preview, it d
 force flags (that mechanism is emitted separately, #2955). The depo pasaport apiKey
 resolves via `--token`, else `KAMPUS_TOKEN`, else `~/.config/kampus/token` (ADR 0045).
 
+## The blessing surface (`golden-gallery` + `golden-bless-set`, #2962)
+
+The blessing surface is the **human-in-the-loop bless → commit path** on top of the
+candidate set (#2961) and the golden pointer (#2960) — epic #2955 stories 2/9, ADR
+0183 §5. The founder takes a candidate set, blesses/redlines it down to the small
+golden set (~5–8 screens), and the approved candidates are committed as golden
+baselines. It renders **no** new bytes: a bless is a **pointer move** to the exact
+`sha256` the founder saw in the gallery (the ADR 0183 §5 no-re-render guard).
+
+- **`blessing-surface.ts`** (pure) —
+  - `renderBlessingGallery(set)` emits the founder-facing GitHub gallery comment
+    (option a): one section per candidate in founder order, embedding the depo URL at
+    full resolution, plus a copy-paste **decision template** (`<surfaceId>
+    approve|redline` per line) the founder marks. The placeholder ships un-defaulted, so
+    a copy without editing fails loud rather than silently blessing.
+  - `parseBlessDecisions(text)` reads the filled-in template (ignoring blanks, `#`
+    comments, and ``` fences) into `{surfaceId, verdict}` decisions.
+  - `applyBlessing({set, decisions, blessedDate, pointer})` folds the verdicts into a
+    golden-pointer move: it blesses each **approved** surface to the `sha256` it carries
+    **in the set** (never a decision-supplied value — the no-re-render guard is
+    structural), leaves **redlined** ones out, and fails closed on an unaddressed
+    candidate, an unknown surface, or a duplicate decision. A re-bless (story 9) is the
+    same fold over the existing pointer — an explicit committed update to the new sha,
+    never a silent overwrite; a redline leaves an existing golden untouched (it is "not
+    re-blessed", not "removed").
+
+```bash
+# 1. render the gallery comment from a candidate set, post it on the PR for the founder:
+node packages/design-capture/src/bin.ts golden-gallery \
+  --set /tmp/candidates/candidate-set.json > gallery.md
+
+# 2. the founder copies the decision template, marks each surface approve|redline into
+#    decisions.txt, then commit the blessed set into the golden pointer:
+node packages/design-capture/src/bin.ts golden-bless-set \
+  --set /tmp/candidates/candidate-set.json \
+  --decisions decisions.txt
+```
+
+`golden-bless-set` writes `golden-pointer.json` (the `--pointer` default) — a one-line
+pointer move per approved surface, reviewable in a normal diff. It is the batch analogue
+of the single-surface `golden-bless`; both are pure + fs and never re-render bytes.
+
 ## The undocumented endpoint + the fallback (load-bearing)
 
 The upload POSTs the PNG bytes to

--- a/packages/design-capture/src/bin.ts
+++ b/packages/design-capture/src/bin.ts
@@ -18,15 +18,16 @@
  * `$GITHUB_TOKEN` (a user/GITHUB_TOKEN with write on the target repo) authorizes
  * the undocumented upload endpoint — read as a redacted Config, never a flag.
  */
-import {writeFileSync} from "node:fs";
+import {readFileSync, writeFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {DoormanClientLive, resolveApiKey} from "@kampus/depo";
 import {Config, Console, Effect, Layer, Redacted} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {applyBlessing, parseBlessDecisions, renderBlessingGallery} from "./blessing-surface.ts";
 import {renderCandidateSet} from "./candidate-render.ts";
-import {serializeCandidateSet} from "./candidate-set.ts";
+import {parseCandidateSet, serializeCandidateSet} from "./candidate-set.ts";
 import {loadGoldenPointer, serializeGoldenPointer} from "./golden-fs.ts";
 import {blessSurface} from "./golden-pointer.ts";
 import {storeGolden} from "./golden-store.ts";
@@ -216,8 +217,71 @@ const renderCandidates = Command.make(
 	),
 );
 
+// --- the blessing surface: gallery + bless-set (#2962) ---------------------------
+
+const setFlag = Flag.string("set").pipe(
+	Flag.withDescription("path to the serialized candidate set (render-candidates --emit output)"),
+);
+
+// golden-gallery: render the founder-facing GitHub gallery comment from a candidate set
+// (ADR 0183 §5, option a). Emits markdown on stdout for the operator to post on the PR;
+// the founder marks each surface approve/redline in the copied decision template.
+const gallery = Command.make(
+	"golden-gallery",
+	{set: setFlag},
+	Effect.fn(function* ({set}) {
+		const candidateSet = parseCandidateSet(readFileSync(set, "utf8"));
+		yield* Console.log(renderBlessingGallery(candidateSet));
+	}),
+).pipe(
+	Command.withDescription(
+		"Render the founder blessing gallery comment from a candidate set (#2962, ADR 0183)",
+	),
+);
+
+const decisionsFlag = Flag.string("decisions").pipe(
+	Flag.withDescription(
+		"path to the founder's filled-in decision block (one `<surfaceId> approve|redline` per line)",
+	),
+);
+
+// golden-bless-set: fold the founder's approve/redline verdicts into a golden-pointer
+// move — bless every approved candidate to the sha256 it carries in the SET (the ADR
+// 0183 §5 no-re-render guard: never a re-render, the committed sha is exactly what the
+// founder saw), leave redlined ones out, and write the committed pointer. A re-bless is
+// the same fold over the existing pointer (story 9's explicit committed update).
+const blessSet = Command.make(
+	"golden-bless-set",
+	{set: setFlag, decisions: decisionsFlag, pointer: pointerFlag},
+	Effect.fn(function* ({set, decisions, pointer}) {
+		const candidateSet = parseCandidateSet(readFileSync(set, "utf8"));
+		const founderDecisions = parseBlessDecisions(readFileSync(decisions, "utf8"));
+		const blessedDate = new Date().toISOString().slice(0, 10);
+		const result = applyBlessing({
+			set: candidateSet,
+			decisions: founderDecisions,
+			blessedDate,
+			pointer: loadGoldenPointer(pointer),
+		});
+		writeFileSync(pointer, serializeGoldenPointer(result.pointer));
+		for (const b of result.blessed) {
+			yield* Console.log(`design-capture: blessed ${b.surfaceId} → depo ${b.sha256}.png`);
+		}
+		for (const surfaceId of result.redlined) {
+			yield* Console.log(`design-capture: redlined ${surfaceId} (not blessed)`);
+		}
+		yield* Console.log(
+			`design-capture: committed ${result.blessed.length} golden(s) (${blessedDate}) → ${pointer}`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Commit the founder's blessed candidate set into the golden pointer (#2962, ADR 0183)",
+	),
+);
+
 const cli = Command.make("design-capture").pipe(
-	Command.withSubcommands([capture, bless, renderCandidates]),
+	Command.withSubcommands([capture, bless, renderCandidates, gallery, blessSet]),
 	Command.withDescription(
 		"Playwright-capture + golden-baseline (store/resolve/diff) for the review-design gate (ADR 0165/0183)",
 	),

--- a/packages/design-capture/src/blessing-surface.ts
+++ b/packages/design-capture/src/blessing-surface.ts
@@ -1,0 +1,200 @@
+/**
+ * The blessing surface (epic #2955 stories 2/9, issue #2962, ADR 0183 §5): the
+ * human-in-the-loop bless → commit path on top of the candidate set (#2961) and the
+ * golden pointer (#2960). It renders the founder-facing GitHub gallery comment from a
+ * candidate set, and folds the founder's per-surface approve/redline verdicts into a
+ * golden-pointer move — blessing the approved candidates, leaving the redlined ones out.
+ *
+ * Load-bearing guard (ADR 0183 §5, "commit the EXACT approved bytes — no re-render"):
+ * a bless is a POINTER MOVE, never a re-render. `applyBlessing` takes each blessed
+ * surface's `sha256` ONLY from the candidate set the founder saw in the gallery — the
+ * `BlessDecision` carries a verdict, never a sha — so the committed content-address is
+ * provably the one the founder approved. depo's write-once immutability is then the
+ * "explicit update, never silent overwrite" guarantee (story 9) for free.
+ *
+ * Pure + IO-free: gallery render, decision parse, and blessing fold are all
+ * deterministic (unit-tested — same inputs → same output). The fs/pointer boundary is
+ * `golden-fs.ts`; the depo boundary is `golden-store.ts`; this module touches neither.
+ */
+
+import type {CandidateScreen, CandidateSet} from "./candidate-set.ts";
+import {blessSurface, type GoldenPointer} from "./golden-pointer.ts";
+
+/** The founder's per-surface verdict: bless it into the golden set, or leave it out. */
+export type BlessVerdict = "approve" | "redline";
+
+/** One founder decision — which surface, and whether it is blessed. Carries NO sha. */
+export interface BlessDecision {
+	readonly surfaceId: string;
+	readonly verdict: BlessVerdict;
+}
+
+/** A surface that was blessed this session, with the exact sha the pointer moved to. */
+export interface BlessedSurface {
+	readonly surfaceId: string;
+	readonly sha256: string;
+}
+
+/** The outcome of a blessing session: the new pointer + what was blessed vs redlined. */
+export interface BlessingResult {
+	/** The golden pointer after moving each approved surface to its candidate sha. */
+	readonly pointer: GoldenPointer;
+	/** Surfaces blessed this session (approved), in candidate-set (founder) order. */
+	readonly blessed: readonly BlessedSurface[];
+	/** Surface-ids redlined this session (left out of the golden set), in order. */
+	readonly redlined: readonly string[];
+}
+
+/**
+ * Render the founder-facing blessing gallery — the GitHub comment (ADR 0183 §5,
+ * option a). One section per candidate in founder order, embedding the depo URL at
+ * full resolution, and a copy-paste decision template the operator marks and feeds
+ * back to `applyBlessing` (via `parseBlessDecisions`). Deterministic: forced-flag
+ * provenance is key-sorted so the same set always renders byte-identically.
+ */
+export const renderBlessingGallery = (set: CandidateSet): string => {
+	const flagKeys = Object.keys(set.forcedFlags).sort();
+	const flags =
+		flagKeys.length === 0
+			? "(none)"
+			: flagKeys.map((k) => `\`${k}=${set.forcedFlags[k] ? "on" : "off"}\``).join(", ");
+
+	const sections = set.screens.map((screen) => {
+		return [
+			`### ${screen.order}. ${screen.title}`,
+			`- surface: \`${screen.surfaceId}\``,
+			`- intent: ${screen.intent}`,
+			`- golden sha256: \`${screen.sha256}\``,
+			"",
+			`![${screen.title}](${screen.url})`,
+		].join("\n");
+	});
+
+	// The template intentionally ships the placeholder `approve|redline`, not a default:
+	// a copy-paste without editing fails loud in parseBlessDecisions, forcing a real
+	// per-surface decision rather than silently blessing (or dropping) a surface.
+	const template = set.screens.map((screen) => `${screen.surfaceId}	approve|redline`).join("\n");
+
+	return [
+		"## Golden blessing gallery",
+		"",
+		`Preview: ${set.previewUrl} · viewport: \`${set.viewport}\` · forced flags: ${flags}`,
+		`${set.screens.length} candidate surface(s) staged for blessing (ADR 0183 §5).`,
+		"",
+		"For each surface below, decide **approve** (bless into the golden set) or **redline** (leave it out). The blessed golden is committed at the exact `sha256` shown — no re-render between what you see and what is committed.",
+		"",
+		sections.join("\n\n"),
+		"",
+		"---",
+		"### Decision template",
+		"Copy the block, replace each `approve|redline` with your verdict, and feed it to `golden-bless-set --decisions`:",
+		"",
+		"```",
+		template,
+		"```",
+		"",
+	].join("\n");
+};
+
+const VERDICTS: Readonly<Record<string, BlessVerdict>> = {approve: "approve", redline: "redline"};
+
+/**
+ * Parse a founder decisions block (the filled-in gallery template) into decisions.
+ * Each meaningful line is `<surfaceId> <verdict>` (whitespace-separated); blank lines,
+ * `#` comments, and ``` fence lines are ignored so the raw copied template block parses
+ * as-is. A malformed line or an unrecognized verdict (e.g. the un-replaced
+ * `approve|redline` placeholder) fails loud — an ambiguous verdict must never silently
+ * bless or drop a surface.
+ */
+export const parseBlessDecisions = (text: string): readonly BlessDecision[] => {
+	const decisions: BlessDecision[] = [];
+	for (const rawLine of text.split("\n")) {
+		const line = rawLine.trim();
+		if (line.length === 0 || line.startsWith("#") || line.startsWith("```")) continue;
+		const tokens = line.split(/\s+/);
+		if (tokens.length !== 2) {
+			throw new Error(
+				`blessing-surface: decision line must be "<surfaceId> <approve|redline>", got: "${line}"`,
+			);
+		}
+		const [surfaceId, rawVerdict] = tokens as [string, string];
+		const verdict = VERDICTS[rawVerdict.toLowerCase()];
+		if (verdict === undefined) {
+			throw new Error(
+				`blessing-surface: verdict for "${surfaceId}" must be approve|redline, got: "${rawVerdict}"`,
+			);
+		}
+		decisions.push({surfaceId, verdict});
+	}
+	return decisions;
+};
+
+export interface ApplyBlessingInput {
+	readonly set: CandidateSet;
+	readonly decisions: readonly BlessDecision[];
+	/** ISO date (YYYY-MM-DD) stamped onto each blessed pointer entry. */
+	readonly blessedDate: string;
+	/** The current golden pointer a re-bless updates in place (empty on first bless). */
+	readonly pointer: GoldenPointer;
+}
+
+/**
+ * Fold the founder's verdicts into a golden-pointer move: bless (pointer-move) every
+ * approved surface to its candidate `sha256`, leave the redlined ones out, and return
+ * the new pointer. Every candidate must carry exactly one decision — an unaddressed
+ * candidate, a decision for a surface not in the set, and a duplicate decision all fail
+ * closed, so a partial/ambiguous blessing can never be committed.
+ *
+ * The blessed `sha256` and `intent` come from the candidate SCREEN, never from the
+ * decision — this is the ADR 0183 §5 no-re-render guard made structural: the pointer
+ * can only move to a content-address the founder actually saw in the gallery. A
+ * re-bless is exactly the same fold over a non-empty `pointer` (a redlined surface's
+ * existing golden is left untouched — a redline is "not re-blessed", not "removed").
+ */
+export const applyBlessing = (input: ApplyBlessingInput): BlessingResult => {
+	const screens = new Map<string, CandidateScreen>();
+	for (const screen of input.set.screens) {
+		screens.set(screen.surfaceId, screen);
+	}
+
+	const verdicts = new Map<string, BlessVerdict>();
+	for (const decision of input.decisions) {
+		if (!screens.has(decision.surfaceId)) {
+			throw new Error(
+				`blessing-surface: decision for "${decision.surfaceId}" — no such candidate in the set`,
+			);
+		}
+		if (verdicts.has(decision.surfaceId)) {
+			throw new Error(`blessing-surface: duplicate decision for "${decision.surfaceId}"`);
+		}
+		verdicts.set(decision.surfaceId, decision.verdict);
+	}
+
+	const unaddressed = input.set.screens
+		.filter((s) => !verdicts.has(s.surfaceId))
+		.map((s) => s.surfaceId);
+	if (unaddressed.length > 0) {
+		throw new Error(
+			`blessing-surface: every candidate needs an approve/redline verdict — missing: ${unaddressed.join(", ")}`,
+		);
+	}
+
+	let pointer = input.pointer;
+	const blessed: BlessedSurface[] = [];
+	const redlined: string[] = [];
+	for (const screen of input.set.screens) {
+		if (verdicts.get(screen.surfaceId) === "approve") {
+			pointer = blessSurface(pointer, {
+				surfaceId: screen.surfaceId,
+				sha256: screen.sha256,
+				blessedDate: input.blessedDate,
+				intent: screen.intent,
+			});
+			blessed.push({surfaceId: screen.surfaceId, sha256: screen.sha256});
+		} else {
+			redlined.push(screen.surfaceId);
+		}
+	}
+
+	return {pointer, blessed, redlined};
+};

--- a/packages/design-capture/src/blessing-surface.unit.test.ts
+++ b/packages/design-capture/src/blessing-surface.unit.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The blessing-surface pure core (issue #2962, ADR 0183 §5): render the founder
+ * gallery, parse decisions, and fold approve/redline verdicts into a golden-pointer
+ * move. Asserted with no fs, no network — the human-in-the-loop bless → commit path,
+ * including the no-re-render guard (blessed sha comes from the set, never a decision)
+ * and the re-bless update path (story 9).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {applyBlessing, parseBlessDecisions, renderBlessingGallery} from "./blessing-surface.ts";
+import type {CandidateSet} from "./candidate-set.ts";
+import type {GoldenPointer} from "./golden-pointer.ts";
+
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const SHA_C = "c".repeat(64);
+
+const set: CandidateSet = {
+	previewUrl: "https://pr-1.web.kamp.us",
+	viewport: "desktop",
+	forcedFlags: {"sozluk-nav-redesign": true, "pano-feed-v2": false},
+	screens: [
+		{
+			order: 1,
+			surfaceId: "/sozluk",
+			title: "Sözlük home",
+			intent: "sözlük home, seeded corpus",
+			sha256: SHA_A,
+			url: `https://depo.kamp.us/${SHA_A}.png`,
+			fileName: "sozluk.png",
+			localPath: "/tmp/shots/sozluk.png",
+		},
+		{
+			order: 2,
+			surfaceId: "/pano",
+			title: "Pano feed",
+			intent: "pano feed, seeded",
+			sha256: SHA_B,
+			url: `https://depo.kamp.us/${SHA_B}.png`,
+			fileName: "pano.png",
+			localPath: "/tmp/shots/pano.png",
+		},
+	],
+};
+
+describe("renderBlessingGallery", () => {
+	it("renders one section per candidate with the full-res depo embed + sha", () => {
+		const md = renderBlessingGallery(set);
+		assert.include(md, "### 1. Sözlük home");
+		assert.include(md, "### 2. Pano feed");
+		assert.include(md, "- surface: `/sozluk`");
+		assert.include(md, "- intent: pano feed, seeded");
+		assert.include(md, `- golden sha256: \`${SHA_A}\``);
+		assert.include(md, `![Sözlük home](https://depo.kamp.us/${SHA_A}.png)`);
+	});
+
+	it("renders forced-flag provenance key-sorted and a decision template per surface", () => {
+		const md = renderBlessingGallery(set);
+		assert.include(md, "`pano-feed-v2=off`, `sozluk-nav-redesign=on`");
+		// the template ships the placeholder (forces a real decision), one line per surface
+		assert.include(md, "/sozluk\tapprove|redline");
+		assert.include(md, "/pano\tapprove|redline");
+	});
+
+	it("is deterministic — same set renders byte-identically", () => {
+		assert.strictEqual(renderBlessingGallery(set), renderBlessingGallery(set));
+	});
+});
+
+describe("parseBlessDecisions", () => {
+	it("parses surfaceId + verdict lines, ignoring blanks, comments, and fences", () => {
+		const decisions = parseBlessDecisions(
+			["```", "# my picks", "/sozluk approve", "", "/pano redline", "```"].join("\n"),
+		);
+		assert.deepStrictEqual(decisions, [
+			{surfaceId: "/sozluk", verdict: "approve"},
+			{surfaceId: "/pano", verdict: "redline"},
+		]);
+	});
+
+	it("is case-insensitive on the verdict token", () => {
+		assert.deepStrictEqual(parseBlessDecisions("/sozluk APPROVE"), [
+			{surfaceId: "/sozluk", verdict: "approve"},
+		]);
+	});
+
+	it("rejects the un-replaced placeholder and any unknown verdict", () => {
+		assert.throws(() => parseBlessDecisions("/sozluk approve|redline"), /must be approve\|redline/);
+		assert.throws(() => parseBlessDecisions("/sozluk maybe"), /must be approve\|redline/);
+	});
+
+	it("rejects a malformed line (not exactly surfaceId + verdict)", () => {
+		assert.throws(() => parseBlessDecisions("/sozluk"), /<surfaceId> <approve\|redline>/);
+	});
+});
+
+describe("applyBlessing — the bless → pointer-move fold", () => {
+	const empty: GoldenPointer = {};
+
+	it("blesses approved surfaces to their candidate sha and leaves redlined ones out", () => {
+		const result = applyBlessing({
+			set,
+			decisions: [
+				{surfaceId: "/sozluk", verdict: "approve"},
+				{surfaceId: "/pano", verdict: "redline"},
+			],
+			blessedDate: "2026-07-14",
+			pointer: empty,
+		});
+		assert.deepStrictEqual(result.pointer["/sozluk"], {
+			sha256: SHA_A,
+			blessedDate: "2026-07-14",
+			intent: "sözlük home, seeded corpus",
+		});
+		assert.isUndefined(result.pointer["/pano"]);
+		assert.deepStrictEqual(result.blessed, [{surfaceId: "/sozluk", sha256: SHA_A}]);
+		assert.deepStrictEqual(result.redlined, ["/pano"]);
+	});
+
+	it("no-re-render: the committed sha is the SET's sha, not any decision-supplied value", () => {
+		// BlessDecision carries no sha by construction — the pointer can only move to a
+		// content-address that was in the candidate set the founder saw (ADR 0183 §5).
+		const result = applyBlessing({
+			set,
+			decisions: [
+				{surfaceId: "/sozluk", verdict: "approve"},
+				{surfaceId: "/pano", verdict: "approve"},
+			],
+			blessedDate: "2026-07-14",
+			pointer: empty,
+		});
+		assert.strictEqual(result.pointer["/sozluk"]?.sha256, SHA_A);
+		assert.strictEqual(result.pointer["/pano"]?.sha256, SHA_B);
+	});
+
+	it("re-bless (story 9): moves an existing golden to the new candidate sha, immutably", () => {
+		const existing: GoldenPointer = {
+			"/sozluk": {sha256: SHA_C, blessedDate: "2026-06-01", intent: "old sözlük home"},
+		};
+		const result = applyBlessing({
+			set,
+			decisions: [
+				{surfaceId: "/sozluk", verdict: "approve"},
+				{surfaceId: "/pano", verdict: "redline"},
+			],
+			blessedDate: "2026-07-14",
+			pointer: existing,
+		});
+		// the pointer moved to the new sha (explicit committed update, not a silent overwrite)
+		assert.strictEqual(result.pointer["/sozluk"]?.sha256, SHA_A);
+		assert.strictEqual(result.pointer["/sozluk"]?.blessedDate, "2026-07-14");
+		// input pointer untouched — the audited baseline can't be clobbered under a reader
+		assert.strictEqual(existing["/sozluk"]?.sha256, SHA_C);
+	});
+
+	it("a redline does NOT remove an existing golden — it is just not re-blessed", () => {
+		const existing: GoldenPointer = {
+			"/pano": {sha256: SHA_C, blessedDate: "2026-06-01", intent: "old pano"},
+		};
+		const result = applyBlessing({
+			set,
+			decisions: [
+				{surfaceId: "/sozluk", verdict: "approve"},
+				{surfaceId: "/pano", verdict: "redline"},
+			],
+			blessedDate: "2026-07-14",
+			pointer: existing,
+		});
+		assert.strictEqual(result.pointer["/pano"]?.sha256, SHA_C);
+	});
+
+	it("fails closed on an unaddressed candidate (every screen needs a verdict)", () => {
+		assert.throws(
+			() =>
+				applyBlessing({
+					set,
+					decisions: [{surfaceId: "/sozluk", verdict: "approve"}],
+					blessedDate: "2026-07-14",
+					pointer: empty,
+				}),
+			/missing: \/pano/,
+		);
+	});
+
+	it("fails closed on a decision for a surface not in the candidate set", () => {
+		assert.throws(
+			() =>
+				applyBlessing({
+					set,
+					decisions: [
+						{surfaceId: "/sozluk", verdict: "approve"},
+						{surfaceId: "/pano", verdict: "redline"},
+						{surfaceId: "/kunye", verdict: "approve"},
+					],
+					blessedDate: "2026-07-14",
+					pointer: empty,
+				}),
+			/no such candidate/,
+		);
+	});
+
+	it("fails closed on a duplicate decision for the same surface", () => {
+		assert.throws(
+			() =>
+				applyBlessing({
+					set,
+					decisions: [
+						{surfaceId: "/sozluk", verdict: "approve"},
+						{surfaceId: "/sozluk", verdict: "redline"},
+						{surfaceId: "/pano", verdict: "redline"},
+					],
+					blessedDate: "2026-07-14",
+					pointer: empty,
+				}),
+			/duplicate decision/,
+		);
+	});
+});

--- a/packages/design-capture/src/index.ts
+++ b/packages/design-capture/src/index.ts
@@ -10,6 +10,18 @@
  * comment, keyed off the per-app `<!-- preview-deploy:<app> -->` anchor.
  */
 
+// The blessing surface (ADR 0183 §5, epic #2955 stories 2/9, issue #2962): render the
+// founder gallery comment from a candidate set, parse the founder's verdicts, and fold
+// approve/redline into a golden-pointer move — the human-in-the-loop bless → commit path
+// (no re-render: the blessed sha comes from the set the founder saw).
+export type {
+	ApplyBlessingInput,
+	BlessDecision,
+	BlessedSurface,
+	BlessingResult,
+	BlessVerdict,
+} from "./blessing-surface.ts";
+export {applyBlessing, parseBlessDecisions, renderBlessingGallery} from "./blessing-surface.ts";
 // The candidate-render step (ADR 0183 §5, epic #2955 story 1): render the founder
 // priority surfaces over a flag-forced preview into a blessing candidate set, staged
 // for the founder's bless (#2962) — each candidate anchored to the exact depo sha256


### PR DESCRIPTION
Builds the **blessing surface** (epic #2955 stories 2/9, ADR 0183 §5): the human-in-the-loop bless → commit path on top of the candidate set (#2961) and golden pointer (#2960). The founder takes a candidate set, blesses/redlines it down to the small golden set (~5–8), and the approved candidates are committed as golden baselines — a **pointer move**, never a re-render.

## What changed
- `packages/design-capture/src/blessing-surface.ts` (pure core):
  - `renderBlessingGallery(set)` — the founder-facing GitHub gallery comment (ADR 0183 §5 option a): one section per candidate in founder order, embedding the depo URL at full resolution, plus a copy-paste `approve|redline` decision template (placeholder ships un-defaulted so a copy-without-editing fails loud).
  - `parseBlessDecisions(text)` — reads the filled template into `{surfaceId, verdict}` (ignoring blanks / `#` comments / ``` fences).
  - `applyBlessing({set, decisions, blessedDate, pointer})` — folds verdicts into a golden-pointer move: blesses each **approved** surface to the `sha256` it carries **in the set** (the ADR 0183 §5 no-re-render guard, made structural — `BlessDecision` carries no sha), leaves **redlined** ones out, fails closed on an unaddressed / unknown / duplicate decision.
- `golden-gallery` + `golden-bless-set` bin subcommands (pure + fs, reuse `blessSurface`; no depo, no re-render).
- `blessing-surface.unit.test.ts` — gallery render, decision parse, the bless fold, the **re-bless** update path (story 9), the no-re-render guard, and all fail-closed paths.
- README "The blessing surface" section; `index.ts` exports.

## Acceptance criteria
- Founder blesses/redlines a candidate set into a small golden set via the decided surface — the gallery comment + decision template + `applyBlessing`.
- Blessed screens committed as golden baselines via the golden-infra store (`blessSurface` pointer move), with surface identity + metadata (`blessedDate` + `intent`).
- Re-bless updates an existing baseline through an explicit committed update (not a silent overwrite); the moved pointer is what generation/review then anchor to (`resolveGoldenBytes`).

Non-control-plane (`packages/design-capture`). typecheck + lint:worktree + the full `packages/**` test surface pass locally.

Fixes #2962