### PR TITLE
docs(design-manifest): promote the orphan-slot rule to nav IA law (#2980)

### DIFF
--- a/design-system-manifest.md
+++ b/design-system-manifest.md
@@ -354,6 +354,13 @@ lives as a contextual CTA in *that product's* Subnav — never as a global topba
 - **Never** place an element in a zone whose grammar does not admit its class (a product-scoped
   action or a sub-destination in the topbar; a global destination or the global primary action
   in a Subnav).
+- **Never** render a nav element as a **detached sibling of the bar** — a single orphan slot or
+  a detached filter-row floating *next to* the topbar / Subnav instead of *inside* a zone the
+  grammar admits. Every nav element lives inside a declared zone; an element rendered adjacent to
+  the bar with no structural home is the amateur-composition smell (the sözlük-alphabet-as-detached-sibling
+  shape, ADR [0182](https://github.com/kamp-us/phoenix/blob/main/.decisions/0182-subnavshell-pageshell-composition-api.md)).
+  This holds **even where a product has not yet adopted the shell** — the zone grammar governs the
+  render, not shell adoption, so the review-design gate flags the detached slot regardless.
 - **Never** promote more than one primary action per surface.
 
 ### Where the IA law is silent, surface the gap — do not fill it


### PR DESCRIPTION
## What

Promotes the single-orphan-slot / detached-filter-row composition class to an **enforced nav IA rule** at the review gate by adding a machine-checkable prohibition to the Navigation IA section of `design-system-manifest.md` — the agent-readable design law the `review-design` gate reads (ADR 0176 / ADR 0162).

## Why

ADR 0176 fixed the nav zone grammar (each element class lives in one zone); ADR 0182 recorded the **orphan-slot** smell — a nav element rendered as a *detached sibling next to the bar* with no structural home (the sözlük-alphabet-as-detached-sibling shape). That smell was only caught structurally in `SubnavShell` consumers. This promotes it to manifest law so a regression toward the amateur-composition class is flagged by the gate **even where a product has not yet adopted the shell** — the zone grammar governs the render, not shell adoption.

## Grounding

- ADR [0176](https://github.com/kamp-us/phoenix/blob/main/.decisions/0176-nav-ia-discipline.md) — the zone grammar the rule enforces.
- ADR [0182](https://github.com/kamp-us/phoenix/blob/main/.decisions/0182-subnavshell-pageshell-composition-api.md) — the orphan-slot / detached-filter-row composition class.
- ADR [0162](https://github.com/kamp-us/phoenix/blob/main/.decisions/0162-four-pillars-design-law.md) — the manifest mechanism.

## Scope

Confined to `design-system-manifest.md` (repo-root doc). No skill / control-plane surface touched — this child stays non-§CP. `pnpm lint` is a clean skip (pure `.md`).

Fixes #2980

🤖 Generated with [Claude Code](https://claude.com/claude-code)