### PR TITLE
feat(web): PageShell recipe — encode the page zone-stack as slots (#2973)

### DIFF
--- a/apps/web/src/components/layout/PageShell.css
+++ b/apps/web/src/components/layout/PageShell.css
@@ -1,0 +1,9 @@
+/* PageShell — the page zone-stack: the persistent Subnav zone on top, the routed content
+   below (ADR 0182). Column flow makes the vertical anatomy explicit; content grows so a
+   short page fills the frame rather than jamming the subnav against the content. */
+.kp-page-shell {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-width: 0;
+}

--- a/apps/web/src/components/layout/PageShell.test.tsx
+++ b/apps/web/src/components/layout/PageShell.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * PageShell recipe (#2973, ADR 0182) — the shell names a product page's vertical zone-stack
+ * once: the persistent Subnav zone on top, the routed content below. Two properties are
+ * load-bearing: (1) the zones render in structural order (subnav ABOVE content) through the
+ * shell, and (2) the flat element-props make an undeclared page zone a TYPE error, not a lint
+ * finding — the same orphan-as-type-error guarantee SubnavShell has.
+ */
+import {render, screen} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {PageShell} from "./PageShell";
+import {SubnavShell} from "./SubnavShell";
+
+describe("PageShell — the page zone-stack recipe (#2973)", () => {
+	it("renders the zone-stack in structural order — the subnav zone ABOVE the content", () => {
+		const {container} = render(
+			<PageShell
+				subnav={<nav data-testid="subnav">bar</nav>}
+				content={<main data-testid="content">page</main>}
+			/>,
+		);
+		const shell = container.querySelector(".kp-page-shell");
+		const subnav = screen.getByTestId("subnav");
+		const content = screen.getByTestId("content");
+		expect(shell).toBeTruthy();
+		// Both zones live inside the shell…
+		expect(shell?.contains(subnav)).toBe(true);
+		expect(shell?.contains(content)).toBe(true);
+		// …and the subnav zone precedes the content zone in DOM order — the page anatomy is the
+		// persistent bar on top, the routed content below (DOCUMENT_POSITION_FOLLOWING = 4).
+		const order = subnav.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING;
+		expect(order).toBeTruthy();
+	});
+
+	it("composes SubnavShell as its top zone (ADR 0182) — the bar renders inside the subnav zone", () => {
+		const {container} = render(
+			<PageShell
+				subnav={
+					<SubnavShell
+						primaryAction={
+							<button type="button" data-testid="cta">
+								yeni
+							</button>
+						}
+					/>
+				}
+				content={<div data-testid="content">page</div>}
+			/>,
+		);
+		const shell = container.querySelector(".kp-page-shell");
+		// The composed SubnavShell's bar is the top zone, inside the shell.
+		expect(shell?.querySelector(".kp-subnav")).toBeTruthy();
+		expect(shell?.querySelector(".kp-subnav__cta")?.contains(screen.getByTestId("cta"))).toBe(true);
+	});
+
+	it("makes an undeclared page zone a TYPE error — an orphan zone won't compile in", () => {
+		// The page zone-stack is exactly {subnav, content} (ADR 0182). A `header` (or any undeclared)
+		// zone has nowhere to go, so the orphan-slot composition is a TYPE error, not a lint finding —
+		// if the @ts-expect-error below ever goes unused, the flat-props invariant has regressed.
+		// @ts-expect-error — `header` is not a declared PageShell zone; an orphan zone won't compile in.
+		const orphan = <PageShell header={<div data-testid="orphan">orphan</div>} />;
+		// The extra prop is ignored at runtime; the suppressed compile error above is the point —
+		// it fails typecheck the moment an orphan zone becomes expressible.
+		expect(orphan).toBeTruthy();
+	});
+});

--- a/apps/web/src/components/layout/PageShell.tsx
+++ b/apps/web/src/components/layout/PageShell.tsx
@@ -1,0 +1,30 @@
+import type * as React from "react";
+import "./PageShell.css";
+
+/**
+ * PageShell — the recipe that names a product page's vertical zone-stack once (ADR 0182):
+ * the persistent Subnav zone on top, the routed page content below. A product page is a
+ * PageShell, so the subnav-plus-content shape is named once, not rebuilt as ad-hoc JSX per
+ * surface. It composes `SubnavShell` as that top zone — PageShell owns the page's VERTICAL
+ * anatomy (subnav above content); SubnavShell owns the bar's horizontal zones and composes
+ * into the `subnav` slot.
+ *
+ * Same flat element-props idiom as SubnavShell — ONE `ReactNode` prop per zone — so an element
+ * assigned to no declared zone has nowhere to go and is a TYPE error, closing the
+ * compound-component orphan-slot class at the type level.
+ */
+export type PageShellProps = {
+	/** The persistent Subnav zone on top — a `SubnavShell` composes here (ADR 0182). */
+	subnav?: React.ReactNode;
+	/** The routed page content below the subnav (typically the router `<Outlet>`). */
+	content?: React.ReactNode;
+};
+
+export function PageShell({subnav, content}: PageShellProps) {
+	return (
+		<div className="kp-page-shell">
+			{subnav}
+			{content}
+		</div>
+	);
+}


### PR DESCRIPTION
## What

Adds the **PageShell** recipe — phase 3 of epic #2954 (the composition-shell recipe layer), the last unbuilt child. Binding spec is **ADR 0182** (SubnavShell / PageShell composition API).

PageShell names a product page's **vertical zone-stack** once: the persistent Subnav zone on top, the routed page content below. It composes `SubnavShell` as that top zone (per ADR 0182) — PageShell owns the page's *vertical* anatomy, SubnavShell owns the subnav bar's *horizontal* zones and composes into the `subnav` slot.

Same flat element-props idiom as the landed SubnavShell (#2972): **one `ReactNode` prop per zone** (`subnav`, `content`). An element assigned to no declared zone has nowhere to go and is a **TYPE error** — the compound-component orphan-slot class is closed at the type level, not by a lint pass (make-invalid-states-unrepresentable).

Establishes the shell only — product adoption of the Subnav zone is the migration children's job (out of scope here per the issue).

## Files

- `apps/web/src/components/layout/PageShell.tsx` — the recipe (flat `subnav` / `content` slots).
- `apps/web/src/components/layout/PageShell.css` — the column zone-stack container (`.kp-page-shell`; distinct from AppShell's `.kp-page` page-wrapper). Design tokens only — no raw hex/px.
- `apps/web/src/components/layout/PageShell.test.tsx` — asserts (1) the zones render in structural order (subnav above content) through the shell, (2) a composed `SubnavShell` renders inside the subnav zone, and (3) an undeclared zone is a `@ts-expect-error` compile error (the orphan-as-type-error guarantee).

## Acceptance criteria

- [x] `PageShell` exists and exposes the decided page zone-stack slots (persistent Subnav zone + content).
- [x] A test asserts the zone-stack renders in the correct structural order through the shell.
- [x] `pnpm typecheck` and `pnpm lint` pass.

## Local gates (green)

- typecheck: clean
- client tests: 249 passed (incl. 3 new PageShell tests)
- design-token-guard: 63 CSS files, 1784 refs — no raw hex/px, all refs resolve
- lint:worktree: 3 files clean

Fixes #2973

🤖 Generated with [Claude Code](https://claude.com/claude-code)