### PR TITLE
fix(ci): gate e2e on real preview API readiness, not the deploy-comment proxy (#3016)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,17 +648,30 @@ jobs:
 
       # deploy.yml runs as a SEPARATE workflow on the same PR event; there's no
       # cross-workflow `needs`, so synchronize on its artifact — the sticky
-      # comment. Poll until the web app's line carries both the preview URL and the
-      # `<!-- d1:<uuid> -->` token deploy.yml writes once its deploy + D1 resolve
-      # land. ~10 min budget covers a cold alchemy deploy; a stuck/failed deploy
-      # times out and fails this job (red `ci-required`), never hangs forever.
-      - name: Await preview URL + D1 id from deploy.yml
+      # comment. This step gates readiness in TWO phases inside one ~10-min budget
+      # (a cold alchemy deploy fits; a stuck/failed deploy times out → red
+      # `ci-required`, never hangs forever):
+      #   1. Discover the preview URL + `<!-- d1:<uuid> -->` token off the sticky
+      #      comment deploy.yml posts.
+      #   2. Health-probe that URL until the WORKER actually serves `/api/*`.
+      # Phase 2 exists because the comment is only a PROXY for "deploy started": it
+      # is posted ~43s before the worker goes live, so gating on the comment alone
+      # ran the suite against a preview whose `/api/*` still fell through to the SPA
+      # index → `sign-up/email failed: 404 <!DOCTYPE html>` → fixtures never seeded →
+      # false-red on green PRs (#3016, surfaced on #3014). `GET /api/health` (ADR
+      # 0156) is the readiness signal: the worker's typed-JSON endpoint answers with
+      # `content-type: application/json` + a `flagshipReachable` body on BOTH 200-ok
+      # and 503-degraded (Flagship unreachable is still the worker serving), whereas a
+      # not-live preview returns the `text/html` SPA index — so readiness keys on
+      # "the response came from the worker", not on a 2xx status.
+      - name: Await preview URL + D1 id + live /api from deploy.yml
         id: preview
         uses: actions/github-script@v7.0.1
         with:
           script: |
             const marker = "<!-- preview-deploy -->";
             const deadline = Date.now() + 10 * 60 * 1000;
+            const interval = 15000;
             // Match the web app's block in the sticky comment, capturing the URL
             // and the hidden d1 token deploy.yml emits for web only.
             const webRe = /<!-- preview-deploy:web -->\n[^\n]*?(https:\/\/[A-Za-z0-9.-]+\.workers\.dev)[^\n]*?<!-- d1:([0-9a-f-]+) -->/;
@@ -666,6 +679,10 @@ jobs:
             // key set deploy.yml emits (issue #2951). Absent when no `preview-flag:<key>`
             // label forced anything, so it never gates the poll — only enriches the run env.
             const flagsRe = /<!-- preview-flags:([^>]*?) -->/;
+            const sleep = () => new Promise((r) => setTimeout(r, interval));
+
+            // Phase 1 — discover the preview URL + D1 id from the sticky comment.
+            let url, db, flags = "";
             while (Date.now() < deadline) {
               const {data: comments} = await github.rest.issues.listComments({
                 ...context.repo, issue_number: context.issue.number, per_page: 100,
@@ -673,18 +690,47 @@ jobs:
               const c = comments.find((x) => x.body?.includes(marker));
               const m = c && c.body.match(webRe);
               if (m) {
+                url = m[1];
+                db = m[2];
                 const fm = c.body.match(flagsRe);
-                const flags = fm ? fm[1] : "";
-                core.setOutput("url", m[1]);
-                core.setOutput("db", m[2]);
-                core.setOutput("flags", flags);
-                core.info(`preview ready: ${m[1]} (D1 ${m[2]})${flags ? ` forced flags: ${flags}` : ""}`);
-                return;
+                flags = fm ? fm[1] : "";
+                core.info(`preview URL posted: ${url} (D1 ${db}) — now probing /api/health for real API readiness`);
+                break;
               }
               core.info("waiting for deploy.yml to post the web preview URL + D1 id…");
-              await new Promise((r) => setTimeout(r, 15000));
+              await sleep();
             }
-            core.setFailed("timed out waiting for the preview deploy (URL + D1 id) from deploy.yml");
+            if (!url) {
+              core.setFailed("timed out waiting for the preview deploy (URL + D1 id) from deploy.yml");
+              return;
+            }
+
+            // Phase 2 — probe /api/health until the worker serves it (not the SPA
+            // fallthrough), reusing the SAME deadline so total await stays ~10 min.
+            const healthUrl = `${url.replace(/\/$/, "")}/api/health`;
+            while (Date.now() < deadline) {
+              try {
+                const res = await fetch(healthUrl, {headers: {accept: "application/json"}});
+                const ct = res.headers.get("content-type") || "";
+                const body = await res.text();
+                // Worker-up iff a JSON body carrying the health shape; a text/html
+                // <!DOCTYPE html> (or a body without `flagshipReachable`) is the SPA
+                // index — deploy not live yet. 503-degraded still passes (worker serving).
+                if (ct.includes("application/json") && body.includes("flagshipReachable")) {
+                  core.info(`preview API live: GET ${healthUrl} → ${res.status} ${ct}`);
+                  core.setOutput("url", url);
+                  core.setOutput("db", db);
+                  core.setOutput("flags", flags);
+                  core.info(`preview ready: ${url} (D1 ${db})${flags ? ` forced flags: ${flags}` : ""}`);
+                  return;
+                }
+                core.info(`API not live yet: GET ${healthUrl} → ${res.status} ${ct || "(no content-type)"} — SPA-index fallthrough, backing off`);
+              } catch (e) {
+                core.info(`API probe errored (${e.message}) — deploy edge not up yet, backing off`);
+              }
+              await sleep();
+            }
+            core.setFailed(`preview URL ${url} was posted but GET ${healthUrl} never served the worker API (still SPA-index/unreachable) within the ~10-min budget — deploy is stuck or failed; refusing to run e2e against a not-live preview (#3016).`);
 
       # Seed the preview's (empty) D1 with the minimal sözlük + pano fixtures the
       # read specs assert on and the write/flow specs navigate from — e.g. the


### PR DESCRIPTION
## What this fixes

`Fixes #3016` — the required `e2e (reads + authed + flows, blocking)` gate went **false-RED pipeline-wide** because the e2e job's readiness gate keyed on a **proxy**, not on the API actually being live.

The e2e job (`.github/workflows/ci.yml`) can't use a cross-workflow `needs:` on `deploy.yml` (separate workflow, same PR event), so its **"Await preview URL + D1 id"** step polls the sticky `<!-- preview-deploy -->` comment for the preview URL + `<!-- d1:uuid -->` token. The defect: that comment is posted **~43s before the worker serves `/api/*`**. e2e then started against a preview where `/api/*` fell through to the SPA index → `sign-up/email failed: 404 Not Found <!DOCTYPE html>` → fixtures never seeded → downstream unauth specs asserted on empty state → **false-red on green PRs**.

Surfaced on #3014 (a flag-off `phoenix-nav-ia` change that cannot touch auth/seed/routing) — link, not cause; #3014 just needs an e2e re-run.

## The fix — gate on real API readiness

The Await step now runs **two phases inside the same ~10-min budget**:

1. **URL discovery (unchanged)** — poll the sticky comment for the web preview URL + D1 id. Still needed to know *where* to probe.
2. **API-readiness probe (new)** — poll `GET <url>/api/health` until the **worker** actually answers, then set the step outputs. Only then does Seed/Run proceed.

**Probe choice — `GET /api/health` (ADR 0156).** It's a core, always-present `/api/*` route (`apps/web/worker/http/health.ts`) whose typed-JSON handler responds with `content-type: application/json` and a body carrying `flagshipReachable` on **both** outcomes it can produce:
- `200 {status:"ok", flagshipReachable:true}` — Flagship reachable;
- `503 {status:"degraded", flagshipReachable:false}` — Flagship unreachable but **the worker is still serving `/api/*`**.

**Worker-up vs SPA-fallthrough distinguisher:** readiness = the response is `application/json` **and** its body contains `flagshipReachable`. A not-live preview returns the **SPA index** (`text/html`, `<!DOCTYPE html>`, no `flagshipReachable`), or the edge errors — both read as *not ready → back off + retry*. Readiness keys on "the response came from the worker", **not** on a 2xx status, so a legitimately-degraded (503) preview still counts as live.

If the API never becomes live within budget, the step **fails loud** with a clear message (`preview URL … was posted but GET …/api/health never served the worker API … deploy is stuck or failed`), so a genuinely-broken deploy still reds `ci-required` rather than hanging or silently passing.

## Acceptance criteria mapping

- e2e does not seed/run until `/api/*` serves as the worker → phase-2 probe gates the step outputs Seed/Run consume.
- A not-yet-live preview waits/retries within budget → phase-2 loops on the shared deadline, not run-then-fail.
- `sign-up/email` no longer intermittently 404s on green PRs → suite starts only after `/api/health` confirms the worker serves `/api/*`.
- The ~10-min budget and the `ci.yml`↔`deploy.yml` filter sync invariant (#2366) preserved → both phases share the one `deadline`; **no path filter touched** (path-filter-guard confirms the 12-glob `changes.e2e`↔`changes.deploy` sync still holds); timeout still `core.setFailed`s on a stuck deploy.
- Change confined to `.github/workflows/ci.yml` → only the e2e job's Await step changed; `deploy.yml`, `packages/preview-seed`, and the path filters are unchanged.

## Validation

- `python3 -c yaml.safe_load` → parses.
- Pinned **actionlint 1.7.12** (the exact CI-pinned version) on `ci.yml` → **exit 0**.
- Embedded github-script body → `node --check` clean (async-wrapped as github-script runs it).
- Readiness predicate dry-run against 6 up/down responses (200-json, 503-json, SPA-index HTML, edge-404 HTML, empty, wrong-json) → **6/6** correct.
- `pipeline-cli path-filter-guard check` → sync invariant holds.

## §CP — control-plane

This edits a gate-critical control-plane file (`.github/workflows/ci.yml`, the e2e job). Per the issue's §CP note, stopping **reviewed-ready** for human (EM + cansirin) merge — not auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)