### PR TITLE
fix(triage): redact leak-containing originals before verbatim-preserve (#3021)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -334,10 +334,28 @@ record and the reporter's unedited words. If the body has its own triple-backtic
 code fences, the `<details>` block still nests them fine; don't re-indent or reflow
 the original.
 
-To get the original verbatim:
+**But the leak invariant outranks verbatim-fidelity when the verbatim content is itself a
+leak.** The no-machine-local-paths rule above governs the *whole* body — the enrichment you
+write **and** the original you preserve. "Preserve byte-for-byte" fails *toward* exposure when
+the original itself contains a machine-local path (a `/var/folders/…<user-hash>…` temp path, a
+home path, an absolute `/Users/…`): a naive verbatim re-emit re-commits that leak into a public
+issue (the #2393-class violation; the concrete re-leak was #3019). So **before** the original
+goes into the `<details>` block, run it through the shared `pipeline-cli` leak matcher and
+**redact** any matched local path — REDACT, not strip: the redaction preserves evidential shape
+(`@/var/folders/<redacted>` still documents "a temp path was posted as the whole body") while
+removing the identifying segments (user-hash, temp filename, home path). This reuses the existing
+leak matcher (`findCommentLeaks`, `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts`) via
+the `redact-leaks` tool — it is **not** a second, divergent leak-pattern definition. A leak-free
+original is passed through byte-for-byte unchanged, exactly as before.
+
+To get the original and redact any leak before preserving it:
 
 ```bash
 gh api "repos/$REPO/issues/<N>" --jq '.body' > /tmp/triage-original-<N>.md
+# redact any machine-local path leak in the ORIGINAL before it goes into <details>; leak-free
+# originals pass through byte-for-byte. Reuses the shared leak matcher — no divergent patterns.
+pipeline-cli redact-leaks --body-file /tmp/triage-original-<N>.md > /tmp/triage-original-<N>.redacted.md
+# assemble the <details> block from the REDACTED original, never the raw one
 ```
 
 Assemble the new body in a temp file and read it into `$BODY` so multi-line markdown,
@@ -369,10 +387,15 @@ prioritize, optionally add a short triage note as a comment, then shape the body
 </details>
 ```
 
+The same leak-outranks-fidelity rule applies to this wrap-in-place preserve: run the epic's
+original brief through `pipeline-cli redact-leaks` before it goes into the `<details>` block, so
+a leak-containing brief can't re-leak. A leak-free brief passes through byte-for-byte — the
+common case, and the exact bytes `plan-epic` splices are then unchanged.
+
 This is a *collapse in place*, not the Step-4 rewrite-on-top: nothing sits above the
 `<details>` but the one-line typed header (so a pre-plan epic body leads with the epic,
-not a bare collapsed element), and the brief inside is verbatim — so the exact bytes
-`plan-epic` splices are unchanged. The `<summary>` is the epic variant of the other
+not a bare collapsed element), and the brief inside is verbatim (post-redaction) — so the
+exact bytes `plan-epic` splices are unchanged for any leak-free brief. The `<summary>` is the epic variant of the other
 types' `Original report (verbatim)` — `Original brief` names an epic's original as its
 *brief* (Step 2's tell), the same verbatim-provenance guarantee. (If an epic was filed
 truly threadbare, prefer `status:needs-info` over mangling it.)

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -38,6 +38,7 @@ import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {primaryIndexGuardCommand} from "./tools/primary-index-guard/command.ts";
 import {reachabilityGuardCommand} from "./tools/reachability-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
+import {redactLeaksCommand} from "./tools/redact-leaks/command.ts";
 import {refGuardCommand} from "./tools/ref-guard/command.ts";
 import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
 import {roadmapCommand} from "./tools/roadmap/command.ts";
@@ -130,4 +131,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	campaignCommand,
 	catalogGuardCommand,
 	intakeDedupCommand,
+	redactLeaksCommand,
 ];

--- a/packages/pipeline-cli/src/tools/redact-leaks/command.ts
+++ b/packages/pipeline-cli/src/tools/redact-leaks/command.ts
@@ -1,0 +1,47 @@
+/**
+ * The `redact-leaks` tool — `pipeline-cli redact-leaks [--body-file <path>]`.
+ *
+ * Reads a body (stdin, or `--body-file <path>`), redacts every machine-local path leak while
+ * preserving evidential shape, and writes the redacted body to STDOUT. Detection is the shared
+ * leak-guard matcher (`findCommentLeaks`); this tool only masks (issue #3021). Triage's Step-4
+ * verbatim-preserve step pipes an original through this before nesting it in `<details>`, so a
+ * leak-containing original cannot re-leak into the enriched issue body.
+ *
+ * NOT a gate — always exits 0 and emits the (possibly unchanged) body so it composes in a
+ * shell pipeline; each redaction is reported on stderr for observability. `process.stdout.write`
+ * (not `Console.log`) so a leak-free body is emitted byte-for-byte, no appended newline (#3021 AC5).
+ */
+import {readFileSync} from "node:fs";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findCommentLeaks} from "../leak-guard/leak-guard.ts";
+import {redactLeaks} from "./redact-leaks.ts";
+
+const bodyFileFlag = Flag.string("body-file").pipe(
+	Flag.optional,
+	Flag.withDescription("path to the body to redact (default: read the body from stdin)"),
+);
+
+const readBody = (bodyFile: Option.Option<string>): Effect.Effect<string> =>
+	Effect.sync(() =>
+		Option.match(bodyFile, {
+			onNone: () => readFileSync(0, "utf8"),
+			onSome: (path) => readFileSync(path, "utf8"),
+		}),
+	);
+
+export const redactLeaksCommand = Command.make(
+	"redact-leaks",
+	{bodyFile: bodyFileFlag},
+	Effect.fn(function* ({bodyFile}) {
+		const body = yield* readBody(bodyFile);
+		for (const leak of findCommentLeaks(body)) {
+			yield* Console.error(`redact-leaks: redacted ${leak.matched} — ${leak.reason}`);
+		}
+		yield* Effect.sync(() => process.stdout.write(redactLeaks(body)));
+	}),
+).pipe(
+	Command.withDescription(
+		"Redact machine-local path leaks in a body, preserving evidential shape (issue #3021)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/redact-leaks/redact-leaks.ts
+++ b/packages/pipeline-cli/src/tools/redact-leaks/redact-leaks.ts
@@ -1,0 +1,63 @@
+/**
+ * `redact-leaks` core — the pure, IO-free transform that MASKS an already-detected
+ * machine-local path leak while preserving its evidential shape (issue #3021).
+ *
+ * Detection is NOT re-implemented here: `redactLeaks` consumes `findCommentLeaks`
+ * (../leak-guard/leak-guard.ts) as the single leak-pattern source (#3021 AC3) and only
+ * decides how to MASK each hit — never a second, divergent pattern definition. The mask
+ * keeps the class-root that documents "a machine-local path of this kind was here"
+ * (`/var/folders`, `/Users`, `~`, …) and replaces the identifying remainder (user-hash,
+ * temp filename, home segment) with `<redacted>`: REDACT, not strip — `@/var/folders/<redacted>`
+ * still reads as evidence without exposing the user-hash. This is the transform triage's
+ * Step-4 verbatim-preserve step runs over an original before nesting it in `<details>`, so
+ * the no-local-paths leak invariant OUTRANKS verbatim-fidelity when the verbatim content is
+ * itself a leak (#2393-class).
+ */
+import {findCommentLeaks} from "../leak-guard/leak-guard.ts";
+
+const REDACTED = "<redacted>";
+
+// [matched-prefix, class-root to keep], longest-prefix-first. The kept root is the
+// non-identifying token that names the leak CLASS (the evidential shape); everything after
+// it is the identifying remainder the mask drops. Keyed off the matcher's own matched
+// string, so this is post-classification of findCommentLeaks output — NOT a second
+// leak-pattern definition (detection stays single-sourced in leak-guard). A `~/.claude`
+// tool dir and a `/vault/` mount are themselves identifying, so their kept root drops to
+// `~` / `` (bare slash) — the shape survives, the identity does not.
+const REDACTION_ROOTS: ReadonlyArray<readonly [prefix: string, keep: string]> = [
+	["/var/folders", "/var/folders"],
+	["/private/tmp", "/private/tmp"],
+	["/private/var", "/private/var"],
+	["/Users", "/Users"],
+	["/tmp", "/tmp"],
+	["~/.claude", "~"],
+	["~/.usirin", "~"],
+	["~/.agent", "~"],
+	["~/code", "~"],
+	["/vault", ""],
+];
+
+/** Mask one matched leak: keep its class-root, redact the identifying remainder, keep a trailing slash. */
+const redactMatch = (matched: string): string => {
+	const root = REDACTION_ROOTS.find(([prefix]) => matched.startsWith(prefix));
+	const keep = root ? root[1] : "";
+	const trailing = matched.endsWith("/") ? "/" : "";
+	return `${keep}/${REDACTED}${trailing}`;
+};
+
+/**
+ * Redact every machine-local path leak in `text`, preserving evidential shape. Leak-free
+ * text is returned byte-for-byte unchanged (#3021 AC5). Longest matches are replaced first
+ * so a shorter match can't corrupt a longer overlapping one (`/Users/foo` vs `/Users/foobar`).
+ */
+export const redactLeaks = (text: string): string => {
+	if (!text) return text;
+	const matches = [...new Set(findCommentLeaks(text).map((leak) => leak.matched))].sort(
+		(a, b) => b.length - a.length,
+	);
+	let out = text;
+	for (const matched of matches) {
+		out = out.split(matched).join(redactMatch(matched));
+	}
+	return out;
+};

--- a/packages/pipeline-cli/src/tools/redact-leaks/redact-leaks.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/redact-leaks/redact-leaks.unit.test.ts
@@ -1,0 +1,85 @@
+import {assert, describe, it} from "@effect/vitest";
+import {findCommentLeaks} from "../leak-guard/leak-guard.ts";
+import {redactLeaks} from "./redact-leaks.ts";
+
+// The invariant the whole tool serves: a redacted body carries NO leak the shared matcher
+// (its single source) would still flag — REDACT to the point of clean, never leave a partial.
+const isClean = (text: string): boolean => findCommentLeaks(text).length === 0;
+
+describe("redactLeaks — REDACT matched leaks, preserving evidential shape (#3021 AC2)", () => {
+	it("redacts a /var/folders mktemp path to its class-root, dropping the user-hash/temp-filename", () => {
+		const out = redactLeaks("posted as the body: @/var/folders/zz/9abc1x/T/tmp.Qk29Vd");
+		assert.strictEqual(out, "posted as the body: @/var/folders/<redacted>");
+		// evidential shape survives (still shows a temp path was here), and it is clean
+		assert.include(out, "/var/folders/");
+		assert.isTrue(isClean(out));
+	});
+
+	it("redacts an absolute /Users/<name> home path, keeping the /Users root", () => {
+		const out = redactLeaks("see /Users/umut/code/phoenix/apps/web for the seam");
+		assert.strictEqual(out, "see /Users/<redacted>/code/phoenix/apps/web for the seam");
+		assert.isTrue(isClean(out));
+	});
+
+	it("redacts a /private/tmp resolved temp root, keeping /private/tmp", () => {
+		const out = redactLeaks("wrote /private/tmp/claude-501/scratch/verdict.md");
+		assert.strictEqual(out, "wrote /private/tmp/<redacted>");
+		assert.isTrue(isClean(out));
+	});
+
+	it("redacts a bare /tmp scratch path, keeping /tmp", () => {
+		const out = redactLeaks("scratch at /tmp/triage-original-3019.md here");
+		assert.strictEqual(out, "scratch at /tmp/<redacted> here");
+		assert.isTrue(isClean(out));
+	});
+
+	it("redacts an agent/tool home dir (~/.claude) down to ~, dropping the tool name", () => {
+		const out = redactLeaks("edit ~/.claude/settings.json please");
+		assert.strictEqual(out, "edit ~/<redacted>/settings.json please");
+		assert.isTrue(isClean(out));
+	});
+
+	it("redacts a ~/code sibling-repo clone, keeping the trailing slash", () => {
+		const out = redactLeaks("rebuilt from ~/code/github.com/kamp-us/kampus");
+		assert.strictEqual(out, "rebuilt from ~/<redacted>/github.com/kamp-us/kampus");
+		assert.isTrue(isClean(out));
+	});
+
+	it("redacts a /vault path", () => {
+		const out = redactLeaks("stored under /vault/secrets/key");
+		assert.strictEqual(out, "stored under /<redacted>/secrets/key");
+		assert.isTrue(isClean(out));
+	});
+});
+
+describe("redactLeaks — no regression for leak-free text (#3021 AC5)", () => {
+	it("returns leak-free text byte-for-byte unchanged", () => {
+		const original =
+			"See apps/web/worker and .claude/skills/report. A bare /tmp mention with no path is fine, and ~/.config passes.";
+		assert.strictEqual(redactLeaks(original), original);
+	});
+
+	it("preserves an empty string", () => {
+		assert.strictEqual(redactLeaks(""), "");
+	});
+
+	it("leaves a leak-free multi-line body with code fences byte-for-byte", () => {
+		const body =
+			"## Report\n\n```ts\nconst x = 1;\n```\n\nRepo-relative: packages/pipeline-cli/src.\n";
+		assert.strictEqual(redactLeaks(body), body);
+	});
+});
+
+describe("redactLeaks — multiple + overlapping leaks", () => {
+	it("redacts every distinct leak in one body", () => {
+		const out = redactLeaks("temp @/var/folders/zz/T/tmp.AB and home /Users/umut/x");
+		assert.strictEqual(out, "temp @/var/folders/<redacted> and home /Users/<redacted>/x");
+		assert.isTrue(isClean(out));
+	});
+
+	it("does not let a shorter match corrupt a longer overlapping one (/Users/foo vs /Users/foobar)", () => {
+		const out = redactLeaks("/Users/foo and /Users/foobar");
+		assert.strictEqual(out, "/Users/<redacted> and /Users/<redacted>");
+		assert.isTrue(isClean(out));
+	});
+});


### PR DESCRIPTION
Fixes #3021

## What & why

Triage's Step-4 **rewrite-on-top** enrichment (and the **epic wrap-in-place** variant) preserved the original issue body byte-for-byte in a `<details>` block with **no leak scan**. When the original itself carried a machine-local path (a temp path with a user-hash segment, a home path, an absolute `/Users/…`), the protocol faithfully **re-committed the leak** into the enriched public body — the #2393-class no-local-paths violation, concretely #3019's `/var/folders` re-leak. Verbatim-fidelity and the leak invariant collide exactly when the verbatim content *is* the leak, and fidelity was silently winning.

## The fix

- **New `pipeline-cli redact-leaks` tool** (`packages/pipeline-cli/src/tools/redact-leaks/`) — reads a body (stdin or `--body-file`), runs it through the **shared** leak matcher `findCommentLeaks` (imported read-only from `leak-guard/leak-guard.ts`), and **redacts** each matched path while preserving evidential shape: `@/var/folders/<redacted>` still documents "a temp path was posted as the whole body" without exposing the user-hash / temp-filename / home segment. REDACT, not strip. Leak-free bodies pass through byte-for-byte.
- **Triage skill** (`claude-plugins/kampus-pipeline/skills/triage/SKILL.md`) — both verbatim-preserve steps (rewrite-on-top `<details>` and epic wrap-in-place `<details>`) now run the original through `redact-leaks` before it goes into the block. The skill text states the governing rule explicitly: **the leak invariant outranks verbatim-fidelity when the verbatim content is itself a leak.**

## Acceptance criteria

- [x] Step-4 verbatim-preserve (both `<details>` steps) runs the preserved original through the existing `pipeline-cli` leak matcher before emitting the body.
- [x] Matched local path is **redacted, not stripped** — evidential shape preserved (`@/var/folders/<redacted>`), identifying segments (user-hash, temp filename, home path) removed.
- [x] Reuses the existing `leak-guard/` matcher (`findCommentLeaks`) read-only — **no** second, divergent leak-pattern definition.
- [x] Skill text states the precedence rule explicitly.
- [x] No regression for leak-free originals — passed through byte-for-byte (unit-tested).

## Collision safety (#3019 tripwire)

Sibling issue #3019 owns `packages/pipeline-cli/src/tools/leak-guard/`. This PR **adds no file and modifies no file under `leak-guard/`** — it only *imports* `findCommentLeaks` read-only. The redact transform lives in a **new** tool dir `packages/pipeline-cli/src/tools/redact-leaks/`, plus the one-line registry append and the skill edit.

## Gates

- `pnpm --filter @kampus/pipeline-cli test` — **92 files, 1283 tests passed** (10 new redact-leaks unit tests: each leak class redacted-with-shape, leak-free text unchanged, overlapping-match safety).
- `pnpm typecheck` — **31/31 successful.**
- `pnpm lint` — **clean.**
- Smoke: `printf '…@/var/folders/…/T/tmp.Qk29 and /Users/umut/code/x…' | pipeline-cli redact-leaks` → `…@/var/folders/<redacted> and /Users/<redacted>/code/x…`, repo-relative paths untouched.

## §CP — control-plane

Edits a pipeline skill + `pipeline-cli`. Must stop **reviewed-ready** for human merge (EM + cansirin at the bank), **not** auto-ship.