### PR TITLE
feat(pipeline-cli): landed-comment leak scan + verdict-post self-verify (#3019)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1427,12 +1427,50 @@ run-evidence) and weakens none of them.
 
 ---
 
+## Step 3.7 — Landed-comment leak scan: refuse to enqueue a PR whose comments carry a machine-local path (guard 4)
+
+Every leak guard *before* this one is **emit-side** — a step the emitter (a `review-*` reviewer, a
+`write-code` progress comment, …) chooses to run: `verdict post`'s `emissionDefect`, its folded-in
+read-back, the `review-*` MANDATE blocks. That makes them all bypassable in one deviation: a reviewer
+who freelances a raw `gh api -f body=@$VERDICT_FILE` post skips the tool AND its verify in a single
+off-mandate step, landing a `/private/tmp/…`/`@filepath` body on a public PR and producing no valid
+marker — and **nothing off that reviewer's own transcript re-checks the comment that actually
+landed** (the #3018 / #3005 bypass; issue #3019). This step closes that structural gap by moving the
+one missing check to the gate **every** merge crosses, regardless of emit path.
+
+Before you enqueue, scan the PR's **landed** comments — the issue conversation (where verdict markers
+live) **and** the inline review comments — for a machine-local path leak, over the `gh api` REST
+boundary. Reuse the shared `findCommentLeaks` detector via the pipeline-cli verb (the same pure
+matcher `redact-leaks` and `verdict post` already consume — one detector, not a re-invented one):
+
+```bash
+# guard 4 — refuse the enqueue on ANY live leak in a landed comment (exit 2 = a leak; ADR 0092 fail-closed)
+pipeline-cli leak-guard scan-pr "$PR" || {
+  echo "ship-it: REFUSING to enqueue #$PR — a landed comment carries a machine-local path (issue #3019)." >&2
+  echo "  Remediate, then re-run ship-it:" >&2
+  echo "  1. redact each flagged comment body — pipeline-cli redact-leaks (the merged #3021 tool) preserves evidential shape;" >&2
+  echo "  2. re-post the redacted body (a verdict via 'pipeline-cli verdict post', which now self-verifies the landed comment, #3019);" >&2
+  echo "  3. the underlying issue is a bypassed emit path — route the PR back to repair so the leaking comment is re-emitted through the mandated choke point." >&2
+  exit 1
+}
+```
+
+Refuse **fail-closed**, exactly like the other pre-enqueue guards: a non-zero `scan-pr` (a live leak)
+STOPS the ship — you do not enqueue, you route to remediation (redact via `redact-leaks`, re-post
+through `verdict post`, and repair the bypass). This guard is **additive**: it layers a new
+pre-enqueue refusal on the existing sequence (Step 0 §CP approval, Step 2/2b current-head PASS, Step 3
+green CI, Step 3.5 run-evidence, Step 3.6 inline threads) and weakens none of them. It catches a
+leaked comment **regardless of how it was emitted** — the property no emit-side guard can offer.
+
+---
+
 ## Step 4 — Enqueue for squash-merge (auto-merge / merge queue)
 
 Every guard cleared: not a control-plane PR without a current-head team approval (Step 0), the
 required gates' latest verdicts are a current-head PASS (Step 2/2b), checks are green (Step 3),
-the run-evidence bundle is present, commit-bound, and all-`pass` (Step 3.5), and **no unresolved
-inline review thread is substantive** (Step 3.6, ADR 0158). **Enqueue** it for a squash merge — the
+the run-evidence bundle is present, commit-bound, and all-`pass` (Step 3.5), **no unresolved
+inline review thread is substantive** (Step 3.6, ADR 0158), and **no landed comment carries a
+machine-local path** (Step 3.7, issue #3019). **Enqueue** it for a squash merge — the
 merge queue owns the final merge, testing the prospective batched merge result against a fresh
 base before it lands (ADR
 [0132](https://github.com/kamp-us/phoenix/blob/main/.decisions/0132-merge-queue-for-base-freshness.md)):

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -104,8 +104,11 @@ semantics; it does **not** change what any gate verifies.
 - **`verdict post --pr N --gate <g> [--body-file <f>]`** — the ADR-0058 rule-2 **upsert**: read
   the composed verdict body (from `--body-file` or stdin), refuse fail-closed if its first line is
   not *this* gate's marker (the cross-namespace emission bug), then PATCH our own prior marker in
-  the namespace if one exists, else POST — exactly one verdict comment per (PR, gate). Prints
-  `patched <id>` / `posted <id>`.
+  the namespace if one exists, else POST — exactly one verdict comment per (PR, gate). It then
+  **re-fetches the landed comment and re-runs `emissionDefect` on its body** (the folded-in
+  self-verify, #3019): a body that passed the input gate but did not land as a clean in-namespace,
+  leak-free marker fails the post (non-zero) instead of reporting a false success — closing the
+  "called `post` but skipped the separate verify line" gap. Prints `patched <id>` / `posted <id>`.
 
 The pure match core (`verdict-match.ts`) is IO-free and unit-tested table-driven; `github.ts` is
 the REST-only `gh api` boundary (the `epic-lock` `github.ts` service pattern).
@@ -143,14 +146,26 @@ node packages/pipeline-cli/src/bin.ts intake-dedup check --query "retry helper s
 node packages/pipeline-cli/src/bin.ts intake-dedup check --query "<title + keywords>" --exclude 2802
 ```
 
-### `leak-guard` — personal-data leak gate for shared artifacts (#173, #2357)
+### `leak-guard` — personal-data leak gate for shared artifacts (#173, #2357, #2796, #3019)
 
-Two modes, one deny-list-per-mode core:
+Four verbs over the shared deny-list-per-surface core (`findLeaks` for doc files, the stricter
+`findCommentLeaks` for comment bodies):
 
 - **`leak-guard scan <file>…`** — the changed-file gate (#173): reports any user-local
   filesystem path (`/Users/<name>`, `~/.claude`, `~/code/…`, `/vault/…`) leaking into a
   shared **doc surface** (`.md`, `.decisions/`, `.patterns/`), exit 2 on a hit. CI hands it
   every changed file; the core (`findLeaks`) self-scopes to doc surfaces.
+- **`leak-guard scan-comment [--body-file <f>]`** — the pre-post net for a single PR/issue
+  **comment body** (stdin or `--body-file`, #2796): a comment is unconditionally a public
+  artifact, so `findCommentLeaks` runs with no doc-surface gate and the stricter temp-root
+  patterns (`/var/folders`, `/private/tmp`, `/tmp`) — exit 2 on a leak, run before a
+  `gh api …/comments` post.
+- **`leak-guard scan-pr <PR>`** — the **landed-comment** scan (#3019): fan `findCommentLeaks`
+  over a PR's already-posted comments — the issue conversation **and** the inline review
+  comments, fetched over `gh api` REST — reporting each leak as `<kind> comment <id>: <span>`,
+  exit 2 on a live leak. This is the check no emit-side guard can offer: it catches a leaked
+  comment **regardless of emit path** (a raw `gh api -f body=@$FILE` bypass, #3018/#3005), which
+  is why `ship-it` runs it as a pre-enqueue preflight (its Step 3.7) and refuses to merge on a hit.
 - **`leak-guard sweep [--dir <d>] [--root <r>]`** — the pipeline-crew sanitization sweep
   (#2357, crew epic #2342 Phase 4). The crew plugin ships **zero real operator data**, so
   its whole tree is swept by a **purely generic, pattern-based** personal-data detector —
@@ -169,6 +184,9 @@ Two modes, one deny-list-per-mode core:
 ```bash
 # changed-file doc-surface scan (exit 2 on a leak)
 node packages/pipeline-cli/src/bin.ts leak-guard scan path/to/file.md
+
+# scan a PR's landed comments (issue + review) — the ship-it pre-enqueue preflight (exit 2 on a leak)
+node packages/pipeline-cli/src/bin.ts leak-guard scan-pr 123
 
 # sweep the whole pipeline-crew tree (exit 1 on any hit or zero scope)
 node packages/pipeline-cli/src/bin.ts leak-guard sweep

--- a/packages/pipeline-cli/src/tools/leak-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.ts
@@ -30,7 +30,9 @@ import {Console, Data, Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, CREW_DIR, sweepCrew} from "./crew-gate.ts";
+import {PrComments, PrCommentsLive} from "./github.ts";
 import {findCommentLeaks, findLeaks, type Leak} from "./leak-guard.ts";
+import {scanPrComments} from "./scan-pr.ts";
 
 // 2 = a confirmed leak; any OTHER non-zero from this process means the scan
 // could not complete, which the pre-commit hook treats as warn-and-allow while
@@ -203,7 +205,50 @@ const scanComment = Command.make(
 	),
 );
 
+// The LANDED-comment scan (#3019). Where `scan-comment` nets a body BEFORE it is posted (an
+// emit-side step a bypass skips), `scan-pr` re-checks the comments that ALREADY landed on a PR —
+// the issue conversation + the inline review comments, straight off the REST boundary — so a leak
+// posted via a raw `gh api …/comments` that never touched the verdict tool is still caught. ship-it
+// runs this as a preflight before enqueue and refuses to merge on a live leak (route to redact-leaks
+// + repair). Exit 2 = a live leak (same LEAK_EXIT_CODE contract as `scan`), 0 = clean.
+const prArg = Argument.integer("pr").pipe(
+	Argument.withDescription("the pull request number whose landed comments to scan for leaks"),
+);
+
+const scanPr = Command.make(
+	"scan-pr",
+	{pr: prArg},
+	Effect.fn(function* ({pr}) {
+		const run = Effect.gen(function* () {
+			const comments = yield* (yield* PrComments).fetch(pr);
+			const leaks = scanPrComments(comments);
+			if (leaks.length === 0) {
+				yield* Console.log(
+					`leak-guard: clean — no machine-local paths in any landed comment on PR #${pr} (${comments.length} scanned)`,
+				);
+				return;
+			}
+			yield* Console.error(
+				`leak-guard: blocked — machine-local path(s) in landed comment(s) on PR #${pr} (issue #3019):`,
+			);
+			for (const {id, kind, leak} of leaks) {
+				yield* Console.error(`  ${kind} comment ${id}: ${leak.matched} — ${leak.reason}`);
+			}
+			yield* Console.error(
+				"Redact each flagged comment (pipeline-cli redact-leaks) and re-post it, then re-run — a merge must not carry a machine-local path in any comment.",
+			);
+			return yield* Effect.fail(new LeakFound({count: leaks.length}));
+		});
+		yield* run.pipe(Effect.catchTag("LeakFound", onLeakFound));
+	}),
+).pipe(
+	Command.withDescription(
+		"Scan a PR's landed comments (issue + review) for machine-local path leaks (exit 2 on a leak)",
+	),
+	Command.provide(PrCommentsLive),
+);
+
 export const leakGuardCommand = Command.make("leak-guard").pipe(
-	Command.withSubcommands([scan, sweep, scanComment]),
+	Command.withSubcommands([scan, sweep, scanComment, scanPr]),
 	Command.withDescription("Block user-local paths from entering shared-artifact doc surfaces"),
 );

--- a/packages/pipeline-cli/src/tools/leak-guard/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/github-service.unit.test.ts
@@ -1,0 +1,126 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {PrComments, PrCommentsLive, type RepoResolutionError} from "./github.ts";
+import {scanPrComments} from "./scan-pr.ts";
+
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+/** A `ChildProcessSpawner` answering `gh api` from a `GET <path>` fixture map (no `-X` here — reads only). */
+const mockSpawner = (
+	responses: Record<string, Response>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const rawPath =
+					args.find((a) => a.startsWith("repos/")) ??
+					(args[0] === "api" ? (args[1] ?? "") : args.slice(0, 2).join(" "));
+				const path = rawPath.replace(/\?.*$/, "");
+				const key = `GET ${path}`;
+				const canned =
+					key in responses
+						? normalize(responses[key]!)
+						: {stdout: "", exitCode: 1, stderr: `not found: ${key}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, PrComments>,
+	responses: Record<string, Response>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(PrCommentsLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const PR = 3018;
+const P = `repos/kamp-us/phoenix`;
+const ISSUE = `GET ${P}/issues/${PR}/comments`;
+const REVIEW = `GET ${P}/pulls/${PR}/comments`;
+
+describe("PrComments.fetch — read a PR's issue + review comments over a mock gh spawner (#3019)", () => {
+	it.effect("fetches BOTH surfaces and tags each comment's kind", () =>
+		Effect.gen(function* () {
+			const comments = yield* (yield* PrComments).fetch(PR);
+			assert.deepStrictEqual(
+				comments.map((c) => ({id: c.id, kind: c.kind})),
+				[
+					{id: 1, kind: "issue"},
+					{id: 2, kind: "review"},
+				],
+			);
+		}).pipe((effect) =>
+			provide(effect, {
+				[ISSUE]: JSON.stringify([{id: 1, body: "review-doc: PASS @ abc1234"}]),
+				[REVIEW]: JSON.stringify([{id: 2, body: "nit here"}]),
+			}),
+		),
+	);
+
+	it.effect(
+		"a leaked verdict comment (the #3018 bypass) is found by scanPrComments off the fetch",
+		() =>
+			Effect.gen(function* () {
+				const comments = yield* (yield* PrComments).fetch(PR);
+				const leaks = scanPrComments(comments);
+				assert.strictEqual(leaks.length, 1);
+				assert.strictEqual(leaks[0]?.id, 5);
+				assert.strictEqual(leaks[0]?.kind, "issue");
+				assert.include(leaks[0]?.leak.matched, "/private/tmp/review-doc-verdict.E2CYtu");
+			}).pipe((effect) =>
+				provide(effect, {
+					[ISSUE]: JSON.stringify([
+						{id: 5, body: "review-doc: FAIL — see /private/tmp/review-doc-verdict.E2CYtu"},
+					]),
+					[REVIEW]: JSON.stringify([]),
+				}),
+			),
+	);
+
+	it.effect("a null-body comment decodes to '' and is clean, not a crash", () =>
+		Effect.gen(function* () {
+			const comments = yield* (yield* PrComments).fetch(PR);
+			assert.deepStrictEqual(scanPrComments(comments), []);
+		}).pipe((effect) =>
+			provide(effect, {
+				[ISSUE]: JSON.stringify([{id: 9, body: null}]),
+				[REVIEW]: JSON.stringify([]),
+			}),
+		),
+	);
+});

--- a/packages/pipeline-cli/src/tools/leak-guard/github.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/github.ts
@@ -1,0 +1,190 @@
+/**
+ * The `gh api` REST boundary for `leak-guard scan-pr`: fetch a PR's landed comments — both the
+ * issue conversation (where `review-*` verdict markers live) AND the inline review comments — so the
+ * pure `scanPrComments` core can re-check them for machine-local path leaks. REST only (GraphQL is
+ * broken on the kamp-us org); untrusted REST JSON is Schema-decoded at the boundary into the domain
+ * `PrComment` the core scans. See issue #3019.
+ *
+ * Same service shape as `verdict`'s `Github` (a `Context.Service` on `ChildProcessSpawner`, repo
+ * resolved once per ADR 0062 §1, every infra fault a typed error) — a deliberately separate, minimal
+ * boundary: this tool only READS the two comment endpoints, it never posts.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {PrComment} from "./scan-pr.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/leak-guard/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/leak-guard/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/leak-guard/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const runGh = Effect.fn("LeakGuardGithub.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("LeakGuardGithub.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/** Resolve the target repo (`owner/name`) per ADR 0062 §1: env override → CI env → `gh repo view`. */
+const resolveRepo = Effect.fn("LeakGuardGithub.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/leak-guard/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// REST-only arg builders — never GraphQL. Issue comments carry the `review-*` verdict markers; the
+// inline review comments are the diff-anchored surface — both are public, both get scanned.
+const issueCommentsArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${pr}/comments?per_page=100`,
+];
+
+const reviewCommentsArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/pulls/${pr}/comments?per_page=100`,
+];
+
+/** A raw comment as either comments endpoint returns it; only these two fields are read. */
+const RawComment = Schema.Struct({
+	id: Schema.Number,
+	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+});
+const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+const fetchComments = Effect.fn("LeakGuardGithub.fetchComments")(function* (
+	args: ReadonlyArray<string>,
+	kind: PrComment["kind"],
+) {
+	const raw = yield* decodeComments(yield* json(args));
+	return raw.map((c): PrComment => ({id: c.id, kind, body: c.body ?? ""}));
+});
+
+/**
+ * `PrComments` — the IO shell over `gh api` REST that fetches a PR's issue + inline-review comments
+ * for `scanPrComments` to re-check. Built by `PrCommentsLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class PrComments extends Context.Service<
+	PrComments,
+	{
+		readonly fetch: (
+			pr: number,
+		) => Effect.Effect<
+			ReadonlyArray<PrComment>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/leak-guard/PrComments") {}
+
+/**
+ * The live `PrComments` layer. `ChildProcessSpawner` is captured once at construction and provided
+ * into each method, so the public method carries `R = never`. Repo resolution is deferred to first
+ * use (`Effect.cached`, ADR 0062 §1) — the layer build is side-effect-free.
+ */
+export const PrCommentsLive: Layer.Layer<
+	PrComments,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> = Layer.effect(PrComments)(
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const withSpawner = <A, E>(
+			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+		const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+		return {
+			fetch: (pr) =>
+				repo.pipe(
+					Effect.flatMap((r) =>
+						withSpawner(
+							Effect.gen(function* () {
+								const issue = yield* fetchComments(issueCommentsArgs(r, pr), "issue");
+								const review = yield* fetchComments(reviewCommentsArgs(r, pr), "review");
+								return [...issue, ...review];
+							}),
+						),
+					),
+				),
+		};
+	}),
+);

--- a/packages/pipeline-cli/src/tools/leak-guard/scan-pr.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/scan-pr.ts
@@ -1,0 +1,34 @@
+/**
+ * The pure core of `leak-guard scan-pr` — fan the shared `findCommentLeaks` detector over a PR's
+ * already-fetched comments (the issue conversation + the inline review comments) and report every
+ * live leak with the comment id + surface that carries it.
+ *
+ * This is the LANDED-comment re-check that no emit-side guard can provide: every existing leak guard
+ * (`emissionDefect`, `verdict post`'s read-back, the review-* MANDATE blocks) is a step the reviewer
+ * *chooses* to run, so a freelance raw `gh api -f body=@$FILE` verdict post bypasses all of them and
+ * leaks a machine-local path onto a public PR regardless of emit path (#3018/#3005). Re-scanning the
+ * comments straight off the REST boundary moves that one missing check off the reviewer's transcript
+ * to the ship-it preflight every merge crosses (issue #3019).
+ */
+import {findCommentLeaks, type Leak} from "./leak-guard.ts";
+
+/** Which surface a comment landed on — the PR's issue conversation, or an inline review comment. */
+export type PrCommentKind = "issue" | "review";
+
+/** A landed PR comment reduced to the fields the scan needs. */
+export interface PrComment {
+	readonly id: number;
+	readonly kind: PrCommentKind;
+	readonly body: string;
+}
+
+/** One machine-local path leak found in a landed comment — the comment id + surface + the leak. */
+export interface CommentLeak {
+	readonly id: number;
+	readonly kind: PrCommentKind;
+	readonly leak: Leak;
+}
+
+/** Every leak across all comments (report order = input order, then per-comment leak order). */
+export const scanPrComments = (comments: ReadonlyArray<PrComment>): ReadonlyArray<CommentLeak> =>
+	comments.flatMap((c) => findCommentLeaks(c.body).map((leak) => ({id: c.id, kind: c.kind, leak})));

--- a/packages/pipeline-cli/src/tools/leak-guard/scan-pr.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/scan-pr.unit.test.ts
@@ -1,0 +1,61 @@
+import {assert, describe, it} from "@effect/vitest";
+import {type PrComment, scanPrComments} from "./scan-pr.ts";
+
+describe("scanPrComments — fan findCommentLeaks over a PR's landed comments (#3019)", () => {
+	it("clean comments → no leaks", () => {
+		const comments: ReadonlyArray<PrComment> = [
+			{id: 1, kind: "issue", body: "review-code: PASS @ abc1234 — merge-ready"},
+			{id: 2, kind: "review", body: "see apps/web/worker for the handler"},
+		];
+		assert.deepStrictEqual(scanPrComments(comments), []);
+	});
+
+	it("a leaking issue comment → reports the comment id, surface, matched span", () => {
+		const comments: ReadonlyArray<PrComment> = [
+			{id: 42, kind: "issue", body: "review-doc: PASS — see /private/tmp/review-verdict.E2CYtu"},
+		];
+		const leaks = scanPrComments(comments);
+		assert.strictEqual(leaks.length, 1);
+		assert.strictEqual(leaks[0]?.id, 42);
+		assert.strictEqual(leaks[0]?.kind, "issue");
+		assert.include(leaks[0]?.leak.matched, "/private/tmp/review-verdict.E2CYtu");
+	});
+
+	it("a leaking inline review comment is scanned too (both surfaces)", () => {
+		const comments: ReadonlyArray<PrComment> = [
+			{id: 7, kind: "review", body: "nit: this path /Users/someone/x should be repo-relative"},
+		];
+		const leaks = scanPrComments(comments);
+		assert.strictEqual(leaks.length, 1);
+		assert.strictEqual(leaks[0]?.kind, "review");
+		assert.include(leaks[0]?.leak.matched, "/Users/someone");
+	});
+
+	it("the raw @filepath bypass shape (#3018/#3005) is caught wherever it landed", () => {
+		const comments: ReadonlyArray<PrComment> = [
+			{
+				id: 100,
+				kind: "issue",
+				body: "review-doc: FAIL @ deadbeef1234\n\n/var/folders/8f/abc/T/tmp.X",
+			},
+		];
+		const leaks = scanPrComments(comments);
+		assert.strictEqual(leaks.length, 1);
+		assert.strictEqual(leaks[0]?.id, 100);
+		assert.include(leaks[0]?.leak.matched, "/var/folders/8f/abc/T/tmp.X");
+	});
+
+	it("multiple leaks across multiple comments are each reported", () => {
+		const comments: ReadonlyArray<PrComment> = [
+			{id: 1, kind: "issue", body: "clean here"},
+			{id: 2, kind: "issue", body: "/tmp/a and /Users/b/c both leak"},
+			{id: 3, kind: "review", body: "/private/tmp/d"},
+		];
+		const leaks = scanPrComments(comments);
+		assert.strictEqual(leaks.length, 3);
+		assert.deepStrictEqual(
+			leaks.map((l) => l.id),
+			[2, 2, 3],
+		);
+	});
+});

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -15,7 +15,9 @@
  * rule 2): it reads the composed verdict body from `--body-file` (or stdin), refuses fail-closed
  * on any `emissionDefect` (wrong namespace, unbindable `@ <sha>`, or a non-full-40-hex/path-glued
  * SHA field), then PATCHes our own prior marker in the namespace if one exists, else POSTs —
- * exactly one verdict comment per (PR, gate). It prints `patched <id>` / `posted <id>` on stdout.
+ * exactly one verdict comment per (PR, gate). It then re-fetches the landed comment and re-runs
+ * `emissionDefect` on its body (the folded-in self-verify, #3019), failing non-zero if the marker
+ * didn't land clean rather than reporting a false success. It prints `patched <id>` / `posted <id>`.
  *
  * `validate --gate <g> [--body-file <f>]` runs that same `emissionDefect` gate WITHOUT posting —
  * the read-back assertion an emit path (review-code's native `APPROVE`) runs before a channel
@@ -124,9 +126,12 @@ const post = Command.make(
 				"empty verdict body — nothing to post (pass --body-file or pipe the body on stdin)",
 			);
 		}
-		const result = yield* (yield* Github)
-			.post(pr, g, body)
-			.pipe(Effect.catchTag("@kampus/verdict/VerdictInputError", (error) => fail(error.message)));
+		const result = yield* (yield* Github).post(pr, g, body).pipe(
+			Effect.catchTag("@kampus/verdict/VerdictInputError", (error) => fail(error.message)),
+			// The landed-comment self-verify (#3019): a body that passed the input gate but did not
+			// land as a clean in-namespace, leak-free marker fails the post — never a false success.
+			Effect.catchTag("@kampus/verdict/VerdictVerifyError", (error) => fail(error.message)),
+		);
 		yield* Console.log(`${result._tag} ${result.commentId}`);
 	}),
 ).pipe(

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -1,7 +1,13 @@
 import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
 import {Effect, Layer, Sink, Stream} from "effect";
 import {ChildProcessSpawner} from "effect/unstable/process";
-import {Github, GithubLive, type RepoResolutionError, VerdictInputError} from "./github.ts";
+import {
+	Github,
+	GithubLive,
+	type RepoResolutionError,
+	VerdictInputError,
+	VerdictVerifyError,
+} from "./github.ts";
 
 const PINNED_REPO = "kamp-us/phoenix";
 let savedEnv: string | undefined;
@@ -179,6 +185,8 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 					comment({id: 1, login: "someone", body: "just chatter"}),
 				]),
 				[`POST ${P}/issues/${PR}/comments`]: "999",
+				// the #3019 read-back: post re-fetches the landed comment and re-runs emissionDefect
+				[`GET ${P}/issues/comments/999`]: BODY,
 			}),
 		),
 	);
@@ -194,6 +202,7 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 					comment({id: 42, login: "usirin", body: `review-doc: FAIL @ ${OLD} — changes-requested`}),
 				]),
 				[`PATCH ${P}/issues/comments/42`]: "42",
+				[`GET ${P}/issues/comments/42`]: BODY,
 			}),
 		),
 	);
@@ -209,6 +218,7 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 					comment({id: 7, login: "cansirin", body: `review-doc: PASS @ ${OLD} — merge-ready`}),
 				]),
 				[`POST ${P}/issues/${PR}/comments`]: "1000",
+				[`GET ${P}/issues/comments/1000`]: BODY,
 			}),
 		),
 	);
@@ -266,6 +276,7 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
 				[`POST ${P}/issues/${PR}/comments`]: "777",
+				[`GET ${P}/issues/comments/777`]: `review-doc: PASS @ ${"a".repeat(40)}`,
 			}),
 		),
 	);
@@ -279,6 +290,7 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
 				[`POST ${P}/issues/${PR}/comments`]: "888",
+				[`GET ${P}/issues/comments/888`]: "review-doc: advisory — see thread",
 			}),
 		),
 	);
@@ -341,6 +353,79 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
 				[`POST ${P}/issues/${PR}/comments`]: "890",
+				[`GET ${P}/issues/comments/890`]: `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD40}`,
+			}),
+		),
+	);
+});
+
+// The #3019 defense-in-depth self-verify: after post writes the comment it re-fetches the LANDED body
+// and re-runs emissionDefect. A clean input that did NOT land as a clean in-namespace, leak-free marker
+// fails the post (VerdictVerifyError) instead of reporting a false success. The input here always passes
+// emissionDefect (a clean `PASS @ <40hex>`) so the write happens — the GET fixture models what landed.
+describe("Github.post — the folded-in landed-comment self-verify (#3019)", () => {
+	const CLEAN_INPUT = `review-doc: PASS @ ${"a".repeat(40)}`;
+
+	it.effect("the landed comment LEAKS a machine-local path → VerdictVerifyError, no success", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip((yield* Github).post(PR, "doc", CLEAN_INPUT));
+			assert.isTrue(error instanceof VerdictVerifyError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`POST ${P}/issues/${PR}/comments`]: "555",
+				[`GET ${P}/issues/comments/555`]: `review-doc: PASS @ ${"a".repeat(40)}\n\nsee /private/tmp/review-verdict.E2CYtu`,
+			}),
+		),
+	);
+
+	it.effect(
+		"the landed comment is a bare `@path` / non-marker first line → VerdictVerifyError",
+		() =>
+			Effect.gen(function* () {
+				const error = yield* Effect.flip((yield* Github).post(PR, "doc", CLEAN_INPUT));
+				assert.isTrue(error instanceof VerdictVerifyError);
+			}).pipe((effect) =>
+				provide(effect, {
+					"GET user": "usirin",
+					[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+					[`POST ${P}/issues/${PR}/comments`]: "556",
+					[`GET ${P}/issues/comments/556`]: "@/tmp/review-doc-verdict.E2CYtu",
+				}),
+			),
+	);
+
+	it.effect(
+		"the just-posted comment can't be re-fetched (missing/deleted) → VerdictVerifyError",
+		() =>
+			Effect.gen(function* () {
+				const error = yield* Effect.flip((yield* Github).post(PR, "doc", CLEAN_INPUT));
+				assert.isTrue(error instanceof VerdictVerifyError);
+			}).pipe((effect) =>
+				provide(effect, {
+					"GET user": "usirin",
+					[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+					[`POST ${P}/issues/${PR}/comments`]: "557",
+					[`GET ${P}/issues/comments/557`]: {
+						stdout: "",
+						exitCode: 1,
+						stderr: "HTTP 404: Not Found",
+					},
+				}),
+			),
+	);
+
+	it.effect("a clean marker that landed intact → success (the verify passes it through)", () =>
+		Effect.gen(function* () {
+			const result = yield* (yield* Github).post(PR, "doc", CLEAN_INPUT);
+			assert.deepStrictEqual(result, {_tag: "posted", commentId: 558});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`POST ${P}/issues/${PR}/comments`]: "558",
+				[`GET ${P}/issues/comments/558`]: CLEAN_INPUT,
 			}),
 		),
 	);

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -65,6 +65,20 @@ export class VerdictInputError extends Schema.TaggedErrorClass<VerdictInputError
 	},
 ) {}
 
+/**
+ * The LANDED verdict comment failed its post-write self-verify: after `post` wrote the comment it
+ * re-fetched it and the landed body is not a clean, in-namespace marker (a `@path`/non-marker first
+ * line, or a machine-local path anywhere in the body). This is the defense-in-depth read-back folded
+ * INTO `post` so the "called `post` but skipped the separate verify line" gap can't leak a bad
+ * marker (issue #3019). Non-recoverable: the tool exits non-zero rather than report a false success.
+ */
+export class VerdictVerifyError extends Schema.TaggedErrorClass<VerdictVerifyError>()(
+	"@kampus/verdict/VerdictVerifyError",
+	{
+		message: Schema.String,
+	},
+) {}
+
 /** The `read` verdict — the resolved outcome plus the head it was resolved against. */
 export interface ReadResult {
 	readonly outcome: VerdictOutcome;
@@ -206,6 +220,16 @@ const patchCommentArgs = (repo: string, id: number, body: string): ReadonlyArray
 	".id",
 ];
 
+// The read-back GET for the post self-verify (#3019): fetch the single comment we just upserted and
+// return its LANDED body, so `emissionDefect` re-checks the marker/leak-clean shape as it actually
+// landed — the same issues/comments/<id> endpoint PATCH targets.
+const getCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/comments/${id}`,
+	"--jq",
+	".body",
+];
+
 /** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
 const RawComment = Schema.Struct({
 	id: Schema.Number,
@@ -224,6 +248,36 @@ const toVerdictComment = (raw: (typeof RawComment)["Type"]): VerdictComment => (
 
 const currentHead = Effect.fn("Github.currentHead")(function* (repo: string, pr: number) {
 	return (yield* runGh(headShaArgs(repo, pr))).trim();
+});
+
+/**
+ * The post self-verify (#3019): re-fetch the comment `post` just upserted and assert its LANDED body
+ * passes the SAME `emissionDefect` gate the input passed — a marker on line one, a bindable `@ <sha>`,
+ * and no machine-local path anywhere. This is the read-back folded INTO `post` so a caller who calls
+ * `post` but skips the separate `validate`/read-back line still can't leave a `@path`/non-marker/leaking
+ * comment on a public PR reporting success. A failed re-fetch (a missing/deleted comment) is itself a
+ * verify failure. Fail-closed: only a clean landed body returns; anything else raises VerdictVerifyError.
+ */
+const verifyLanded = Effect.fn("Github.verifyLanded")(function* (
+	repo: string,
+	id: number,
+	gate: VerdictGate,
+) {
+	const landed = yield* runGh(getCommentArgs(repo, id)).pipe(
+		Effect.catchTag(
+			"@kampus/verdict/GhCommandError",
+			(cause) =>
+				new VerdictVerifyError({
+					message: `could not re-fetch the just-posted verdict comment #${id} to self-verify it (${cause.stderr.trim() || `exit ${cause.exitCode}`}) — refusing to report success on an unverifiable post (#3019)`,
+				}),
+		),
+	);
+	const defect = emissionDefect(landed, gate);
+	if (defect !== null) {
+		return yield* new VerdictVerifyError({
+			message: `the LANDED verdict comment #${id} failed self-verify: ${defect} — a bypassed/hand-rolled body reached GitHub; the post is rejected rather than reported as success (#3019)`,
+		});
+	}
 });
 
 const listComments = Effect.fn("Github.listComments")(function* (repo: string, pr: number) {
@@ -298,7 +352,9 @@ const read = Effect.fn("Github.read")(function* (
  * not a partial/non-hex/path-glued value (rejects the `mktemp`-path leak of #2683). An advisory
  * SHA-less first line stays postable. Then scan our OWN prior marker in the namespace (newest by
  * `(created_at, id)`) and PATCH it if present else POST a fresh one. The own-authored scope means
- * two reviewers never stomp each other's records.
+ * two reviewers never stomp each other's records. Finally, `verifyLanded` re-fetches the upserted
+ * comment and re-runs `emissionDefect` on its LANDED body — the defense-in-depth self-verify (#3019)
+ * that fails the post if the marker didn't land clean, rather than reporting a false success.
  */
 const post = Effect.fn("Github.post")(function* (
 	repo: string,
@@ -317,21 +373,25 @@ const post = Effect.fn("Github.post")(function* (
 		.filter((c) => c.author === me && re.test(c.body))
 		.sort((a, b) => (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id));
 	const priorId = mine[mine.length - 1]?.id;
-	if (priorId !== undefined) {
-		const decoded = yield* json(patchCommentArgs(repo, priorId, body));
-		return {
-			_tag: "patched",
-			commentId: typeof decoded === "number" ? decoded : priorId,
-		} satisfies PostResult;
-	}
-	const decoded = yield* json(postCommentArgs(repo, pr, body));
-	if (typeof decoded !== "number") {
-		return yield* new GhParseError({
-			args: postCommentArgs(repo, pr, "<body>"),
-			message: "comment POST did not return a numeric id",
-		});
-	}
-	return {_tag: "posted", commentId: decoded} satisfies PostResult;
+	const result: PostResult = yield* Effect.gen(function* () {
+		if (priorId !== undefined) {
+			const decoded = yield* json(patchCommentArgs(repo, priorId, body));
+			return {
+				_tag: "patched",
+				commentId: typeof decoded === "number" ? decoded : priorId,
+			} satisfies PostResult;
+		}
+		const decoded = yield* json(postCommentArgs(repo, pr, body));
+		if (typeof decoded !== "number") {
+			return yield* new GhParseError({
+				args: postCommentArgs(repo, pr, "<body>"),
+				message: "comment POST did not return a numeric id",
+			});
+		}
+		return {_tag: "posted", commentId: decoded} satisfies PostResult;
+	});
+	yield* verifyLanded(repo, result.commentId, gate);
+	return result;
 });
 
 /**
@@ -357,7 +417,12 @@ export class Github extends Context.Service<
 			body: string,
 		) => Effect.Effect<
 			PostResult,
-			RepoResolutionError | GhCommandError | GhParseError | VerdictInputError | Schema.SchemaError
+			| RepoResolutionError
+			| GhCommandError
+			| GhParseError
+			| VerdictInputError
+			| VerdictVerifyError
+			| Schema.SchemaError
 		>;
 	}
 >()("@kampus/verdict/Github") {}


### PR DESCRIPTION
Fixes #3019.

## Problem

Every leak guard in the pipeline is **emit-side** — a step the emitter chooses to run. A reviewer who freelanced a raw `gh api -f body=@$VERDICT_FILE` verdict post (on PRs #3018, #3005) skipped BOTH the mandated `verdict post` choke point AND its read-back in one deviation, landing a machine-local `/tmp` path on a public PR and producing no valid marker. All emit-side guards exist and are correct; the structural gap is that **nothing off the reviewer's own transcript re-checks a LANDED comment.**

Bounded two-part fix per the #3019 fork decision (no standalone ADR, per ADR 0070).

## Part 1 (primary) — ship-it-preflight landed-comment scan

- New `leak-guard scan-pr <PR>` verb (`packages/pipeline-cli/src/tools/leak-guard/`): fans the **existing** `findCommentLeaks` detector over a PR's landed comments — the issue conversation (where verdict markers live) **and** the inline review comments, fetched over `gh api` REST — reporting each leak as `<kind> comment <id>: <span>`, exit 2 on a live leak.
- Wired into `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` as a pre-enqueue preflight (**Step 3.7, guard 4**): ship-it runs `leak-guard scan-pr` before enqueue and, on a live leak, REFUSES to merge and routes to remediation (redact via `redact-leaks` + re-post + repair the bypass). Catches a leaked comment **regardless of emit path**, at the one gate every merge crosses.

## Part 2 (defense-in-depth) — verdict-post self-verify

- Folded the read-back INTO `verdict post` (`packages/pipeline-cli/src/tools/verdict/github.ts` + `command.ts`): after the upsert, re-fetch the landed comment and re-run `emissionDefect` on its body (marker on line one + leak-clean, reusing the existing gate). A `@path`/non-marker/leaking or **missing** landed comment fails the post non-zero instead of reporting a false success — closing the "called `post` but skipped the separate verify line" gap without changing the `review-*` SKILL mandates.

## Reuse

No detector or marker regex reinvented: `findCommentLeaks`, `emissionDefect`, and the `verdict` `github.ts` service pattern are sourced where they already live.

## Tests

- `scan-pr.unit.test.ts` — the pure core over clean / leaking-issue / leaking-review / raw-`@filepath`-shape / multi-leak comments.
- `leak-guard/github-service.unit.test.ts` — the fetch boundary (both surfaces, the #3018 bypass found off the fetch, null-body).
- `verdict/github-service.unit.test.ts` — the post self-verify against a **leaking** landed body, a **`@path`** landed body, a **valid** marker (passes through), and a **missing** comment (re-fetch 404 → fail); existing post tests updated with the read-back fixture.

`pnpm typecheck`, `pnpm lint:worktree`, and the full `pnpm --filter './packages/**' run test` (pipeline-cli: 1295 tests) green locally.

§CP throughout (pipeline-cli + ship-it/SKILL.md + verdict tool are gate-critical) — awaiting control-plane approval, does not self-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)