### PR TITLE
chore(web): remove dead ColorTheme accent-switcher from Controls.tsx

### DIFF
--- a/apps/web/src/components/controls/Controls.tsx
+++ b/apps/web/src/components/controls/Controls.tsx
@@ -4,32 +4,7 @@ import "./Controls.css";
 
 export type {Density};
 
-export type ColorTheme =
-	| "ember"
-	| "crimson"
-	| "amber"
-	| "jade"
-	| "teal"
-	| "cyan"
-	| "indigo"
-	| "iris"
-	| "plum"
-	| "mauve";
-
 export type Mode = "dark" | "light";
-
-const THEME_SWATCHES: Record<ColorTheme, string> = {
-	ember: "#e54d2e",
-	crimson: "#e93d82",
-	amber: "#ffc53d",
-	jade: "#29a383",
-	teal: "#12a594",
-	cyan: "#00a2c7",
-	indigo: "#3e63dd",
-	iris: "#5b5bd6",
-	plum: "#ab4aba",
-	mauve: "#7c7a85",
-};
 
 const DENSITY_LABELS: Record<Density, string> = {
 	compact: "sıkı",
@@ -41,30 +16,6 @@ const MODE_LABELS: Record<Mode, string> = {
 	dark: "koyu",
 	light: "açık",
 };
-
-export function ThemePicker({
-	value,
-	onChange,
-}: {
-	value: ColorTheme;
-	onChange: (v: ColorTheme) => void;
-}) {
-	return (
-		<div className="kp-controls__group">
-			<span className="kp-controls__label">renk</span>
-			<ToggleGroup.Root
-				variant="swatch"
-				value={[value]}
-				onValueChange={(v) => v[0] && onChange(v[0] as ColorTheme)}
-				aria-label="Renk teması"
-			>
-				{(Object.keys(THEME_SWATCHES) as ColorTheme[]).map((t) => (
-					<ToggleGroup.Item key={t} value={t} aria-label={t} swatchColor={THEME_SWATCHES[t]} />
-				))}
-			</ToggleGroup.Root>
-		</div>
-	);
-}
 
 export function DensityToggle({value, onChange}: {value: Density; onChange: (v: Density) => void}) {
 	return (
@@ -107,8 +58,6 @@ export function ModeToggle({value, onChange}: {value: Mode; onChange: (v: Mode) 
 }
 
 export function Controls(props: {
-	theme: ColorTheme;
-	onThemeChange: (v: ColorTheme) => void;
 	mode: Mode;
 	onModeChange: (v: Mode) => void;
 	density: Density;
@@ -116,7 +65,6 @@ export function Controls(props: {
 }) {
 	return (
 		<div className="kp-controls">
-			<ThemePicker value={props.theme} onChange={props.onThemeChange} />
 			<ModeToggle value={props.mode} onChange={props.onModeChange} />
 			<DensityToggle value={props.density} onChange={props.onDensityChange} />
 		</div>


### PR DESCRIPTION
## What & why

Removes the dead `ColorTheme` accent-switcher from `apps/web/src/components/controls/Controls.tsx`. The multi-accent color-theme picker was never wired to the DOM (nothing sets `data-color-theme`, and no module imports `Controls.tsx`), and manti (ADR 0162) collapses to a single neutral ramp with no multi-accent equivalent — so re-wiring would fight the established design direction. Deletion is the direction-consistent resolution. Pure dead-code cleanup, no observable behavior change.

## Changes

- Deleted the `ColorTheme` union type, the `THEME_SWATCHES` map, and the `ThemePicker` component.
- Dropped the `theme` / `onThemeChange` props from `Controls` and its `<ThemePicker>` render.
- `DensityToggle` and `ModeToggle` (and everything else in the module) are left untouched — they map to real mechanisms (density; `data-theme` light/dark).
- No imports became orphaned: `ThemePicker` shared `ToggleGroup` with the surviving toggles.

## Scope fences honored

- **`apps/web/src/styles/tokens.css` NOT touched** — its `[data-color-theme]` blocks are removed separately by the in-flight `phoenix-eats-manti` branch; not double-removed here.
- `ProfilePage.tsx` not touched; the whole panel delete-vs-mount question is out of scope.
- Only `Controls.tsx` changed (52 deletions, 1 file).

## Verification

- `pnpm typecheck` — 31/31 tasks successful.
- `pnpm lint` — 1 file checked, no fixes applied.
- No `Controls.tsx`-side dangling references to `ColorTheme` / `THEME_SWATCHES` / `data-color-theme` remain in `apps/web/src` (the only remaining `data-color-theme` refs are the out-of-scope `tokens.css` blocks).
- No `Controls.test.tsx` exists — no test to update.

Fixes #3028