### PR TITLE
feat(web): carry the current user in __BOOT__ for synchronous first paint (#3030)

### DIFF
--- a/.decisions/0185-boot-user-object.md
+++ b/.decisions/0185-boot-user-object.md
@@ -1,0 +1,81 @@
+---
+id: 0185
+title: "`window.__BOOT__` carries the current user object — the boolean-only boot payload gains a typed `user: User | null` field so first-paint surfaces read identity synchronously (supersedes #2933's presence-only `signedIn` bit); amends ADR 0179"
+status: accepted
+date: 2026-07-16
+tags: [frontend, performance, session, flags]
+---
+
+# 0185 — `window.__BOOT__` carries the current user object
+
+Amends ADR [0179](0179-edge-resolved-shell-state-boot-contract.md) (the `window.__BOOT__`
+edge-resolved shell-state contract). It records the founder ruling on
+[#3030](https://github.com/kamp-us/phoenix/issues/3030), part of the edge-shell epic
+[#2926](https://github.com/kamp-us/phoenix/issues/2926).
+
+## Context
+
+Under ADR 0179 the worker resolves shell state at the edge and injects `window.__BOOT__` so the
+initial paint is already correct. Its payload was **boolean-only**: a `Record<BootMemberKey, boolean>`
+of the three shell flag keys plus a `signedIn` presence bit (#2933). That presence bit is enough to
+reserve the signed-in cluster's *geometry* and suppress the signed-out CTA, but the user's actual
+*content* — name, handle, avatar, standing — still resolved asynchronously through `useMe`
+(`apps/web/src/auth/useMe.ts`, a `/fate` `me` read). So even with `phoenix-edge-shell-boot` on, the
+navbar cluster still soft-swapped its content in and pano's new-post CTA still popped in when the
+session settled.
+
+The remaining gap is specifically the **user object**. Flags already resolve synchronously (#2932);
+`signedIn` already resolves synchronously (#2933). What first paint lacks is *who* the signed-in user
+is, as a value it can read on frame one.
+
+## Decision
+
+`window.__BOOT__` carries the full current user as a typed field:
+
+- The payload shape changes from boolean-only to `Record<ShellFlagKey, boolean> & { user: BootUser | null }`.
+  `BootUser` is the wire `User` minus fate's transport-only `__typename` — the exact shape `useMe`
+  exposes as `MeUser` — single-sourced in `apps/web/src/flags/shell-keys.ts` so the worker-injected
+  object and the client-consumed object stay one type.
+- The worker edge-injects the resolved user through the **same session→user resolution the `/fate`
+  `me` view uses**. That resolution is factored into one shared `resolveMeUser`
+  (`apps/web/worker/features/pasaport/trusted-user.ts`) that both the `me` query resolver and the
+  shell-boot route call, so the boot payload and the `me` read can never describe the same user
+  differently.
+- The client reads it synchronously: `readBootUser()` (`apps/web/src/flags/boot.ts`) returns the
+  user or `null`. `useMe` seeds its first-paint value from it and reconciles on session change; the
+  navbar cluster (`apps/web/src/App.tsx`) and the pano CTA (`PanoSubnavCta`) read it directly, so
+  identity renders on the first frame with no async read on the critical path.
+
+### Scope is the user object only
+
+The founder ruling bounds this deliberately: `__BOOT__` gains the **current user and nothing else**
+— the one thing every first paint needs. No flag payloads are inlined, no below-the-fold data is
+added. `user` is the single new field.
+
+### `signedIn` is superseded by `user != null`
+
+This supersedes #2933's presence-only `signedIn` boolean. The signed-in state is now derived from
+`user != null`, so `signedIn` is removed from the boot member key set rather than kept as a second,
+redundant source of the same fact. `BOOT_MEMBER_KEYS` is now exactly the shell flag keys; `user` is a
+distinct typed field alongside them. The single-source drift check (ADR 0179 §3) continues to cover
+the boolean flag keys — `user` is single-typed via `BootUser`, so it needs no key-set membership.
+
+### The absent-`__BOOT__` fallback is unchanged
+
+The optional-`__BOOT__` contract (ADR 0179 §4, #2931) carries forward as-is: when `__BOOT__` is
+absent — the flag is off, or the never-hang fallback served the untransformed asset — `readBootUser()`
+returns `null`, so `useMe` falls back to its async read and the surfaces render exactly as they do
+today. The extra per-request user resolution sits inside the existing never-hang bound, so a slow or
+failed resolve degrades to the untransformed asset rather than a hung or partial shell.
+
+## Consequences
+
+- First-paint identity is correct and content-complete for signed-in users: the navbar cluster and
+  pano CTA no longer swap or pop in with the flag on.
+- The `me` session→user resolution has one home (`resolveMeUser`), consumed by both the `/fate` query
+  and the edge injection — the boot user and the reconciled `me` can't drift.
+- The per-request boot resolve does more work (the user's canonical row + trusted standing reads) than
+  the boolean-only version. It stays within the never-hang bound, which degrades to the untransformed
+  asset on a slow resolve, so the worst case is the flag-off experience, not a regression.
+- `MeUser` is now defined as `BootUser`, so the async `me` read and the synchronous boot seed carry
+  identical fields by construction.

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -149,8 +149,8 @@ vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: ()
 // (akış) nav entry (#2547) is gated on `mecmua-feed`, flipped via `flags.mecmuaFeed`.
 // Every other read (and other flag key) stays off, matching the default the shell
 // rendered under before.
-// `signedIn` drives the mocked `readSignedIn` (the `__BOOT__.signedIn` presence bit, #2933):
-// the shell frame reads it to reserve the signed-in account cluster before `useSession`
+// `signedIn` drives the mocked `readBootUser` (the `__BOOT__.user` edge identity, ADR 0185):
+// the shell frame reads it to reserve AND seed the signed-in account cluster before `useSession`
 // settles. Default false = `__BOOT__` absent, so the pre-existing shell tests see today's
 // signed-out first paint unchanged.
 const flags = vi.hoisted(() => ({
@@ -173,9 +173,28 @@ vi.mock("./flags/useFlag", async () => {
 							: false,
 			loading: false,
 		}),
-		readSignedIn: () => flags.signedIn,
 	};
 });
+// The edge-resolved `__BOOT__.user` (ADR 0185): when `flags.signedIn`, the shell reads the full
+// identity synchronously — the account cluster paints its name (`Elif`) on the first frame, before
+// the session settles. Absent (default) ⇒ null ⇒ the signed-out first paint. `importActual` keeps
+// the real `readBoot`/`readBootMember`; only the user read is faked.
+vi.mock("./flags/boot", async (importActual) => ({
+	...(await importActual<typeof import("./flags/boot")>()),
+	readBootUser: () =>
+		flags.signedIn
+			? {
+					id: "user-42",
+					email: "elif@kamp.us",
+					name: "Elif",
+					image: null,
+					username: "elif",
+					tier: "yazar" as const,
+					isModerator: false,
+					emailFailing: false,
+				}
+			: null,
+}));
 
 // Render the real App at a chosen route. Invariant 2's tests settle the session, which
 // commits FateProvider and mounts the routed page BELOW it — so they route to a
@@ -276,11 +295,12 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 	});
 });
 
-// Reserved signed-in cluster from __BOOT__.signedIn (#2933, ADR 0179 §1). The shell frame reads
-// the edge presence bit at first paint: signed-in ⇒ no giriş-yap CTA and a reserved account slot
-// BEFORE useSession settles, so the giriş-yap↔user-cluster swap + empty→pop never happen; absent
-// __BOOT__ ⇒ readSignedIn() false ⇒ today's session-gated render (the AC-3 no-op).
-describe("reserved signed-in cluster from __BOOT__.signedIn (#2933)", () => {
+// Signed-in cluster seeded from __BOOT__.user (ADR 0185, superseding #2933's presence-only bit).
+// The shell frame reads the edge identity at first paint: signed-in ⇒ no giriş-yap CTA and the
+// account cluster's CONTENT (the name) rendered synchronously BEFORE useSession settles, so the
+// giriş-yap↔user-cluster swap + the name content pop-in never happen; absent __BOOT__ ⇒
+// readBootUser() null ⇒ today's session-gated render (the AC-3 no-op).
+describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
 		sessionState = {data: null, isPending: true};
@@ -291,36 +311,38 @@ describe("reserved signed-in cluster from __BOOT__.signedIn (#2933)", () => {
 		vi.clearAllMocks();
 	});
 
-	it("__BOOT__ present + signedIn: first paint reserves the account slot — no giriş-yap flash, before the session settles", () => {
+	it("__BOOT__ present + user: first paint renders the account name — no giriş-yap flash, before the session settles", () => {
 		flags.signedIn = true;
 		renderApp();
-		// The session is still isPending (no fate, no chips), yet the shell already knows the
-		// user is signed in from the edge bit: the CTA is gone and the account slot is reserved.
+		// The session is still isPending (no fate, no chips), yet the shell already knows WHO is
+		// signed in from the edge user object: the CTA is gone and the name renders synchronously.
 		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
-		expect(screen.getByTestId("topbar-user-placeholder")).toBeTruthy();
+		expect(screen.getByText("Elif")).toBeTruthy();
 		expect(fateMounts).toHaveLength(0);
 	});
 
-	it("__BOOT__ present + signedIn: no giriş-yap↔user-cluster swap when the session settles signed-in", () => {
+	it("__BOOT__ present + user: no content swap when the session settles signed-in", () => {
 		flags.signedIn = true;
 		renderApp(FATE_FREE_ROUTE);
-		// Pre-settle: reserved placeholder, no CTA.
+		// Pre-settle: the signed-in name is already painted, no CTA.
 		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
-		expect(screen.getByTestId("topbar-user-placeholder")).toBeTruthy();
+		expect(screen.getByText("Elif")).toBeTruthy();
 		act(() => {
 			setSession({
 				data: {user: {id: "user-42", name: "Elif", email: "elif@kamp.us"}},
 				isPending: false,
 			});
 		});
-		// Settled signed-in: still no CTA — the account cluster held its geometry across settle,
-		// never swapping giriş-yap in then out (the reported jank).
+		// Settled signed-in: still no CTA and the same name — the account cluster held its content
+		// across settle, never swapping giriş-yap in then out nor popping the name in (the jank).
 		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
+		expect(screen.getByText("Elif")).toBeTruthy();
 	});
 
-	it("__BOOT__ absent (readSignedIn false): the shell is exactly as today — giriş-yap, no reserved slot (AC-3)", () => {
+	it("__BOOT__ absent (readBootUser null): the shell is exactly as today — giriş-yap, no account cluster (AC-3)", () => {
 		renderApp();
 		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
+		expect(screen.queryByText("Elif")).toBeNull();
 		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
 	});
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {FateProvider, PublicFateProvider} from "./fate/FateProvider";
 import {teardownAuthedSnapshot} from "./fate/snapshot";
+import {readBootUser} from "./flags/boot";
 import {
 	MECMUA_FEED,
 	MECMUA_PUBLIC_READ,
@@ -36,7 +37,7 @@ import {
 	PHOENIX_BILDIRIM,
 	PHOENIX_NAV_IA,
 } from "./flags/keys";
-import {readSignedIn, useFlag} from "./flags/useFlag";
+import {useFlag} from "./flags/useFlag";
 import {DensityProvider} from "./lib/density";
 import {SAVED_HREF} from "./lib/panoNav";
 import {safeReturnTo} from "./lib/returnTo";
@@ -159,17 +160,31 @@ function Layout() {
 	}
 
 	const isSignedIn = !!session.data;
-	// First-paint shell geometry rides the edge-resolved presence bit (ADR 0179 §1, #2933):
-	// `__BOOT__.signedIn` tells us synchronously — before `useSession` settles — whether the
-	// account cluster should exist, so the giriş-yap↔user-cluster swap and the empty→pop never
-	// happen. Absent `__BOOT__` (flag off / the #2931 never-hang fallback) ⇒ `readSignedIn()`
-	// is false ⇒ the session-gated `isSignedIn` governs, exactly today's behavior.
-	const bootSignedIn = readSignedIn();
+	// First-paint identity rides the edge-resolved `__BOOT__.user` (ADR 0185, superseding #2933's
+	// presence-only `signedIn` bit): the full user is known synchronously — before `useSession`
+	// settles — so the account cluster both exists AND carries its name/handle from the first
+	// frame, killing the giriş-yap↔user-cluster swap and the name content pop-in. Absent `__BOOT__`
+	// (flag off / the #2931 never-hang fallback) ⇒ `readBootUser()` is null ⇒ the session-gated
+	// `isSignedIn` governs, exactly today's behavior.
+	const bootUser = readBootUser();
+	const bootSignedIn = bootUser != null;
 	const signedInAtFirstPaint = bootSignedIn || isSignedIn;
 	// Reserve the account slot only while the edge said signed-in AND we haven't settled to a
 	// definitively signed-out session — so an absent `__BOOT__` never reserves (today's render)
 	// and a boot/session divergence collapses cleanly rather than stranding a phantom slot.
 	const reserveSignedInSlots = bootSignedIn && (session.isPending || isSignedIn);
+	// Seed the topbar identity synchronously from `__BOOT__.user` so the name/handle render on the
+	// first frame, before `FateProvider`/`LayoutContent` publish the fate-derived chips below. Once
+	// those chips arrive (session settled) they take over — the same resolved value, so no visible
+	// swap. Absent `__BOOT__` ⇒ `{}` ⇒ the chips-only path, exactly today's render.
+	const bootUserProps = bootUser
+		? {
+				user: {
+					name: actorLabel(bootUser.name, bootUser.username, "kullanıcı"),
+					username: bootUser.username,
+				},
+			}
+		: {};
 
 	return (
 		<TooltipProvider>
@@ -189,7 +204,7 @@ function Layout() {
 							...(feedOn && !navIaOn ? [{to: "/mecmua/akis", label: "akış"}] : []),
 						]}
 						divanTo={chips?.divanTo}
-						{...(chips?.userProps ?? {})}
+						{...(chips?.userProps ?? bootUserProps)}
 						karma={chips?.karma}
 						{...(chips?.bildirim ? {bildirim: chips.bildirim} : {})}
 						searchQuery={searchQuery}

--- a/apps/web/src/auth/useMe.ts
+++ b/apps/web/src/auth/useMe.ts
@@ -21,21 +21,19 @@ import {useRef} from "react";
 import {view} from "react-fate";
 import type {User} from "../../worker/features/fate/views";
 import {useImperativeView} from "../fate/useImperativeView";
+import {readBootUser} from "../flags/boot";
+import type {BootUser} from "../flags/shell-keys";
 import {useSession} from "./client";
 
 /**
- * The `me` shape, derived from the codegen'd `User` Entity (ADR 0022) — a `Pick`
- * over the exact scalars `MeView` selects, never a hand-restated interface. `tier`
- * and `isModerator` are trusted account-level signals read server-side (the stored
- * column via `Kunye.tierOf` / the `moderates` relation), surfaced on the row, never
- * inferred from the session. `emailFailing` is the SELF failing-delivery signal
- * (#2693) the membrane notice reads via the `emailFailing?` seam — optional, so a
- * non-self read (or the not-yet-wired worker) is treated as deliverable.
+ * The `me` shape — the client identity, single-sourced as {@link BootUser} (the wire `User`
+ * minus fate's `__typename`, ADR 0185) so the async `me` read and the synchronous `__BOOT__.user`
+ * seed carry the EXACT same fields. `tier` and `isModerator` are trusted account-level signals
+ * read server-side (the stored column via `Kunye.tierOf` / the `moderates` relation), never
+ * inferred from the session. `emailFailing` is the SELF failing-delivery signal (#2693) the
+ * membrane notice reads via the `emailFailing?` seam — a non-self read is treated as deliverable.
  */
-export type MeUser = Pick<
-	User,
-	"id" | "email" | "name" | "image" | "username" | "tier" | "isModerator" | "emailFailing"
->;
+export type MeUser = BootUser;
 
 export type MeStatus = "idle" | "loading" | "ok" | "error";
 
@@ -64,12 +62,16 @@ export function useMe(): {
 		deps: [session.data],
 	});
 
-	// `me` persists across a `loading` refetch; cleared only when signed out (idle)
-	// or on a read error, mirroring the pre-helper behavior (no flash to null).
-	const meRef = useRef<MeUser | null>(null);
+	// Seed first paint from the edge-resolved `__BOOT__.user` (ADR 0185): the identity renders
+	// synchronously so the signed-in surfaces never swap in content while the async `me` read
+	// settles. The fate read reconciles on session change; absent `__BOOT__` ⇒ null ⇒ today's
+	// async-only behavior. `me` persists across a `loading` refetch and while the session is still
+	// settling (so the seed survives first paint), cleared only on a read error OR a definitively
+	// signed-out session — never a flash to null.
+	const meRef = useRef<MeUser | null>(readBootUser());
 	if (state.status === "ok") {
 		meRef.current = state.data;
-	} else if (state.status !== "loading") {
+	} else if (state.status === "error" || (!session.isPending && !session.data)) {
 		meRef.current = null;
 	}
 

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -378,8 +378,8 @@ describe("Topbar tema toggle → theme picker (#2612)", () => {
 });
 
 // Reserved signed-in account slot (#2933, ADR 0179 §1). `reserveSignedInSlots` (driven by
-// `__BOOT__.signedIn` in the shell frame) reserves the account cluster's geometry at first
-// paint: with no `user` yet it renders a fixed-geometry placeholder in the account slot, so
+// `__BOOT__.user != null` in the shell frame, ADR 0185) reserves the account cluster's geometry at
+// first paint: with no `user` yet it renders a fixed-geometry placeholder in the account slot, so
 // when fate publishes the real user menu it fills the same slot with zero cluster shift — no
 // giriş-yap↔user-cluster swap, no empty→pop. Off ⇒ the slot stays null (today's render).
 describe("Topbar reserved signed-in account slot (#2933)", () => {

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -99,12 +99,12 @@ export function Topbar({
 	navIa?: boolean;
 	/**
 	 * Reserve the signed-in account cluster's geometry at first paint (#2933, ADR 0179 §1).
-	 * Driven by `__BOOT__.signedIn` (`readSignedIn`) in the shell frame: when the edge
-	 * resolved a signed-in session, the account slot renders a fixed-geometry placeholder
-	 * before fate publishes the real `user` chip — so the cluster occupies its final geometry
-	 * from the first frame and the value late-fills in place (#2160), instead of the
-	 * giriş-yap↔user-cluster swap + empty→pop. False (absent `__BOOT__` / signed-out) ⇒ the
-	 * account slot stays null until `user` arrives — today's conditional render.
+	 * Driven by `__BOOT__.user != null` (`readBootUser`, ADR 0185) in the shell frame: when the
+	 * edge resolved a signed-in session, the account slot holds its geometry from the first frame.
+	 * With `__BOOT__.user` present the shell also seeds the real `user` chip synchronously, so the
+	 * cluster paints its content immediately rather than a placeholder; this placeholder covers the
+	 * residual reserve-without-content window (a boot/session divergence). False (absent `__BOOT__`
+	 * / signed-out) ⇒ the account slot stays null until `user` arrives — today's conditional render.
 	 */
 	reserveSignedInSlots?: boolean;
 }) {

--- a/apps/web/src/components/pano/PanoSubnavCta.tsx
+++ b/apps/web/src/components/pano/PanoSubnavCta.tsx
@@ -1,5 +1,6 @@
 import {useNavigate} from "react-router";
 import {useSession} from "../../auth/client";
+import {readBootUser} from "../../flags/boot";
 import {Button} from "../ui/Button";
 
 /**
@@ -9,11 +10,15 @@ import {Button} from "../ui/Button";
  * one-for-one, so a signed-out visitor still reaches auth via the topbar `giriş yap` and
  * sees no CTA. Renders the sanctioned primary-action treatment (`Button` `primary`
  * variant, #2586 taxonomy), never the utility filter/tab styling.
+ *
+ * The signed-in gate reads the edge-resolved `__BOOT__.user` FIRST (ADR 0185) so the CTA
+ * renders on the first frame instead of popping in when the session settles; it falls back to
+ * the settling session when `__BOOT__` is absent (flag off / the #2931 never-hang fallback).
  */
 export function PanoSubnavCta() {
 	const session = useSession();
 	const navigate = useNavigate();
-	if (!session.data) return null;
+	if (readBootUser() == null && !session.data) return null;
 	return (
 		<Button variant="primary" onClick={() => navigate("/pano/yeni")}>
 			yeni gönderi

--- a/apps/web/src/flags/boot.test.ts
+++ b/apps/web/src/flags/boot.test.ts
@@ -8,9 +8,9 @@
  */
 import {afterEach, describe, expect, it} from "vitest";
 import type {BootPayload} from "./boot.ts";
-import {readBoot, readBootMember} from "./boot.ts";
-import {MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "./keys.ts";
-import {SHELL_SIGNED_IN_KEY} from "./shell-keys.ts";
+import {readBoot, readBootMember, readBootUser} from "./boot.ts";
+import {MECMUA_FEED, MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "./keys.ts";
+import type {BootUser} from "./shell-keys.ts";
 
 const withBoot = (boot: unknown) => {
 	(globalThis as {window?: unknown}).window = {__BOOT__: boot};
@@ -38,7 +38,7 @@ describe("readBoot — absent __BOOT__ is a first-class, non-error state", () =>
 	});
 
 	it("returns the injected payload when the edge injected a well-formed object", () => {
-		const payload: BootPayload = {[MECMUA_PUBLIC_READ]: true, [SHELL_SIGNED_IN_KEY]: false};
+		const payload: BootPayload = {[MECMUA_PUBLIC_READ]: true, [MECMUA_FEED]: false};
 		withBoot(payload);
 		expect(readBoot()).toEqual(payload);
 	});
@@ -47,13 +47,13 @@ describe("readBoot — absent __BOOT__ is a first-class, non-error state", () =>
 describe("readBootMember — a member key falls back to the fetch path unless truly present", () => {
 	it("returns undefined for every member when __BOOT__ is absent (the fetch-fallback signal)", () => {
 		expect(readBootMember(MECMUA_PUBLIC_READ)).toBeUndefined();
-		expect(readBootMember(SHELL_SIGNED_IN_KEY)).toBeUndefined();
+		expect(readBootMember(MECMUA_FEED)).toBeUndefined();
 	});
 
 	it("returns the injected boolean when the key is present", () => {
-		withBoot({[MECMUA_PUBLIC_READ]: true, [SHELL_SIGNED_IN_KEY]: true});
+		withBoot({[MECMUA_PUBLIC_READ]: true, [MECMUA_FEED]: true});
 		expect(readBootMember(MECMUA_PUBLIC_READ)).toBe(true);
-		expect(readBootMember(SHELL_SIGNED_IN_KEY)).toBe(true);
+		expect(readBootMember(MECMUA_FEED)).toBe(true);
 	});
 
 	it("returns undefined for a key absent from an otherwise-present payload", () => {
@@ -64,5 +64,34 @@ describe("readBootMember — a member key falls back to the fetch path unless tr
 	it("returns undefined for a non-boolean value rather than fabricating a gate", () => {
 		withBoot({[MECMUA_PUBLIC_READ]: "true"});
 		expect(readBootMember(MECMUA_PUBLIC_READ)).toBeUndefined();
+	});
+});
+
+describe("readBootUser — the synchronous first-paint identity (ADR 0185)", () => {
+	const bootUser: BootUser = {
+		id: "user-42",
+		email: "elif@kamp.us",
+		name: "Elif",
+		image: null,
+		username: "elif",
+		tier: "yazar",
+		isModerator: false,
+		emailFailing: false,
+	};
+
+	it("returns the injected user object when the edge resolved a signed-in viewer", () => {
+		withBoot({[MECMUA_PUBLIC_READ]: true, user: bootUser});
+		expect(readBootUser()).toEqual(bootUser);
+	});
+
+	it("returns null for a signed-out viewer (user explicitly null)", () => {
+		withBoot({[MECMUA_PUBLIC_READ]: true, user: null});
+		expect(readBootUser()).toBeNull();
+	});
+
+	it("returns null when __BOOT__ is absent (never-hang fallback / flag off) — the async fallback", () => {
+		expect(readBootUser()).toBeNull();
+		withBoot({[MECMUA_PUBLIC_READ]: true});
+		expect(readBootUser()).toBeNull();
 	});
 });

--- a/apps/web/src/flags/boot.ts
+++ b/apps/web/src/flags/boot.ts
@@ -8,10 +8,14 @@
  * missing payload is a first-class, non-error state, never an assumption that injection happened;
  * the unified `useFlag` (#2932) consumes this, so the optional contract lives here at its source.
  */
-import type {BootMemberKey} from "./shell-keys.ts";
+import type {BootMemberKey, BootUser} from "./shell-keys.ts";
 
-/** The edge-injected payload as the client sees it: every member key MAY be present. */
-export type BootPayload = Partial<Record<BootMemberKey, boolean>>;
+/**
+ * The edge-injected payload as the client sees it: every boolean member key MAY be present, plus
+ * the edge-resolved current `user` (ADR 0185) — absent/`null` for a signed-out viewer or the
+ * absent-`__BOOT__` fallback.
+ */
+export type BootPayload = Partial<Record<BootMemberKey, boolean>> & {user?: BootUser | null};
 
 declare global {
 	interface Window {
@@ -38,4 +42,16 @@ export function readBoot(): BootPayload | undefined {
 export function readBootMember(key: BootMemberKey): boolean | undefined {
 	const value = readBoot()?.[key];
 	return typeof value === "boolean" ? value : undefined;
+}
+
+/**
+ * Read the edge-resolved current user from `window.__BOOT__.user` (ADR 0185, amending 0179):
+ * the full identity, so first-paint surfaces (the navbar cluster, the pano CTA, `useMe`'s seed)
+ * render the signed-in state SYNCHRONOUSLY instead of the async `useMe` fetch. Returns `null`
+ * for a signed-out viewer AND for the absent-`__BOOT__` fallback (flag off / the #2931 never-hang
+ * outage) — the caller then resolves through its async path, never assuming injection happened.
+ */
+export function readBootUser(): BootUser | null {
+	const user = readBoot()?.user;
+	return typeof user === "object" && user !== null ? user : null;
 }

--- a/apps/web/src/flags/shell-keys.test.ts
+++ b/apps/web/src/flags/shell-keys.test.ts
@@ -10,7 +10,6 @@ import {
 	assertShellBootKeysSingleSourced,
 	BOOT_MEMBER_KEYS,
 	SHELL_FLAG_KEYS,
-	SHELL_SIGNED_IN_KEY,
 	ShellKeyDriftError,
 } from "./shell-keys";
 
@@ -20,13 +19,12 @@ describe("shell-key manifest — the geometry-law member set", () => {
 		expect([...SHELL_FLAG_KEYS]).toEqual(["phoenix-nav-ia", "mecmua-public-read", "mecmua-feed"]);
 	});
 
-	it("the __BOOT__ shape is the flag keys plus the signedIn presence bit", () => {
-		expect(SHELL_SIGNED_IN_KEY).toBe("signedIn");
-		expect([...BOOT_MEMBER_KEYS]).toEqual([...SHELL_FLAG_KEYS, "signedIn"]);
-	});
-
-	it("signedIn is part of the __BOOT__ shape but is NOT a flag key", () => {
-		expect([...SHELL_FLAG_KEYS]).not.toContain(SHELL_SIGNED_IN_KEY);
+	it("the __BOOT__ boolean-member keys are exactly the flag keys — the user is not a member key", () => {
+		// ADR 0185 superseded #2933's `signedIn` presence bit with the typed `user` object, so the
+		// boolean member set carries the shell flags and nothing else; `user` is a distinct field.
+		expect([...BOOT_MEMBER_KEYS]).toEqual([...SHELL_FLAG_KEYS]);
+		expect([...BOOT_MEMBER_KEYS]).not.toContain("signedIn");
+		expect([...BOOT_MEMBER_KEYS]).not.toContain("user");
 	});
 });
 
@@ -59,9 +57,9 @@ describe("assertShellBootKeysSingleSourced — fail-closed single-source guard",
 		);
 	});
 
-	it("FAILS when the client omits the signedIn presence bit (the non-flag member still drifts)", () => {
-		const consumedMissingSignedIn = canonical.filter((k) => k !== SHELL_SIGNED_IN_KEY);
-		expect(() => assertShellBootKeysSingleSourced(canonical, consumedMissingSignedIn)).toThrow(
+	it("FAILS when the client omits a manifest flag key (client-side drift)", () => {
+		const consumedMissingFeed = canonical.filter((k) => k !== MECMUA_FEED);
+		expect(() => assertShellBootKeysSingleSourced(canonical, consumedMissingFeed)).toThrow(
 			ShellKeyDriftError,
 		);
 	});

--- a/apps/web/src/flags/shell-keys.ts
+++ b/apps/web/src/flags/shell-keys.ts
@@ -19,6 +19,7 @@
  * Inert until the edge-render children consume it (#2929 worker injection, #2932 unified
  * `useFlag`): this module introduces no runtime behavior on its own.
  */
+import type {User} from "../../worker/features/fate/views.ts";
 import {MECMUA_FEED, MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "./keys.ts";
 
 /**
@@ -31,18 +32,27 @@ export const SHELL_FLAG_KEYS = [PHOENIX_NAV_IA, MECMUA_PUBLIC_READ, MECMUA_FEED]
 export type ShellFlagKey = (typeof SHELL_FLAG_KEYS)[number];
 
 /**
- * The session-presence bit. Part of the `__BOOT__` shape but NOT a flag key — it drives
- * shell geometry directly (signed-in ⇒ reserved chip slots, ADR 0179 §1) while `useSession`
- * settles, rather than resolving through the flag evaluator.
+ * The edge-resolved current user carried in `window.__BOOT__.user` (ADR 0185, amending 0179):
+ * the full identity, so first-paint surfaces read "who is signed in" SYNCHRONOUSLY instead of
+ * the async `useMe`. This supersedes #2933's presence-only `signedIn` boolean — the signed-in
+ * state is now `user != null`, and the name/handle/avatar/standing ride the object itself, so
+ * the navbar cluster and pano CTA render their final content on the first frame.
+ *
+ * It is the wire `User` minus fate's `__typename` — the exact shape `useMe` exposes as `MeUser`
+ * — single-sourced here so the worker-injected object and the client-consumed object can't
+ * drift. `null` for a signed-out viewer, and the absent-`__BOOT__` fallback resolves to `null`
+ * too (flag off / the #2931 never-hang outage ⇒ today's async `useMe` path).
  */
-export const SHELL_SIGNED_IN_KEY = "signedIn" as const;
+export type BootUser = Omit<User, "__typename">;
 
 /**
- * The full `__BOOT__` member key set — the shell flag keys plus the presence bit. This is
- * the shape the worker injects and the client reads; both sides derive from this one array,
- * enforced by {@link assertShellBootKeysSingleSourced}.
+ * The `__BOOT__` boolean-member key set — the shell flag keys the client resolves synchronously
+ * (`useFlag`). The worker injection and the client consumption both derive from this one array,
+ * enforced by {@link assertShellBootKeysSingleSourced}. The signed-in state is NOT a member key:
+ * it is carried by the typed {@link BootUser} `user` field (ADR 0185, superseding #2933's
+ * presence-only `signedIn` bit), derivable as `user != null`.
  */
-export const BOOT_MEMBER_KEYS = [...SHELL_FLAG_KEYS, SHELL_SIGNED_IN_KEY] as const;
+export const BOOT_MEMBER_KEYS = [...SHELL_FLAG_KEYS] as const;
 
 export type BootMemberKey = (typeof BOOT_MEMBER_KEYS)[number];
 

--- a/apps/web/src/flags/useFlag.test.ts
+++ b/apps/web/src/flags/useFlag.test.ts
@@ -6,17 +6,17 @@
  * - `resolveFlagResponse` (#1111): the fetch-path safe-default wiring of `resolveFlag` — a
  *   hook that forgot to route the server JSON through `resolveFlag`, or dropped the non-2xx
  *   guard, fails here.
- * - `resolveBootFlag` / `readSignedIn` (#2932, ADR 0179): the synchronous `__BOOT__` member
- *   path — member keys resolve from the injected payload with no fetch, a non-member or an
- *   absent `__BOOT__` returns `undefined` so the hook falls back to fetch, and the `signedIn`
- *   presence bit reads safe-default `false` when `__BOOT__` is absent.
+ * - `resolveBootFlag` (#2932, ADR 0179): the synchronous `__BOOT__` member path — member keys
+ *   resolve from the injected payload with no fetch, a non-member or an absent `__BOOT__` returns
+ *   `undefined` so the hook falls back to fetch. (The signed-in identity moved to the typed
+ *   `__BOOT__.user` object, `readBootUser` in `boot.ts`, covered by `boot.test.ts` — ADR 0185.)
  *
  * Node-tested with no DOM/`fetch`, per the repo's pure-extraction idiom
  * (`toProfileStatsState` / `useToggleAction.test.ts`).
  */
-import {afterEach, describe, expect, it} from "vitest";
+import {describe, expect, it} from "vitest";
 import {MECMUA_FEED, MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "./keys";
-import {readSignedIn, resolveBootFlag, resolveFlagResponse} from "./useFlag";
+import {resolveBootFlag, resolveFlagResponse} from "./useFlag";
 
 describe("resolveFlagResponse — useFlag's safe-default wiring of resolveFlag", () => {
 	it("returns the server value when the response is 2xx and the flag is on (the gated path)", () => {
@@ -73,30 +73,5 @@ describe("resolveBootFlag — the synchronous __BOOT__ member resolution", () =>
 		// A non-member key never resolves synchronously even if __BOOT__ happens to carry it.
 		expect(resolveBootFlag({"pano-draft-save": true} as never, "pano-draft-save")).toBeUndefined();
 		expect(resolveBootFlag(undefined, "pano-draft-save")).toBeUndefined();
-	});
-});
-
-describe("readSignedIn — the synchronous signed-in presence bit", () => {
-	afterEach(() => {
-		delete (globalThis as {window?: unknown}).window;
-	});
-
-	it("reads true from window.__BOOT__.signedIn when signed in", () => {
-		(globalThis as {window?: unknown}).window = {__BOOT__: {signedIn: true}};
-		expect(readSignedIn()).toBe(true);
-	});
-
-	it("reads false from window.__BOOT__.signedIn when signed out", () => {
-		(globalThis as {window?: unknown}).window = {__BOOT__: {signedIn: false}};
-		expect(readSignedIn()).toBe(false);
-	});
-
-	it("safe-defaults to false when __BOOT__ is absent (never-hang fallback / flag off)", () => {
-		(globalThis as {window?: unknown}).window = {};
-		expect(readSignedIn()).toBe(false);
-	});
-
-	it("safe-defaults to false when there is no window at all (never throws)", () => {
-		expect(readSignedIn()).toBe(false);
 	});
 });

--- a/apps/web/src/flags/useFlag.ts
+++ b/apps/web/src/flags/useFlag.ts
@@ -40,7 +40,6 @@ import {
 	assertShellBootKeysSingleSourced,
 	BOOT_MEMBER_KEYS,
 	type BootMemberKey,
-	SHELL_SIGNED_IN_KEY,
 } from "./shell-keys.ts";
 
 /** A flag read: its current value plus whether the server result is in yet. */
@@ -60,9 +59,10 @@ export interface FlagState {
 export type BootPayload = Partial<Record<BootMemberKey, boolean>>;
 
 /**
- * The `__BOOT__`-member key set `useFlag` resolves synchronously — the shell flags plus the
- * `signedIn` presence bit — single-sourced from the one manifest ({@link BOOT_MEMBER_KEYS}),
- * never re-listed here. The consume-side drift guard (ADR 0179 §3) runs once at module load:
+ * The `__BOOT__`-member key set `useFlag` resolves synchronously — the shell flag keys —
+ * single-sourced from the one manifest ({@link BOOT_MEMBER_KEYS}), never re-listed here. (The
+ * signed-in identity is the typed `__BOOT__.user` object, read by `boot.ts`, not a member key —
+ * ADR 0185.) The consume-side drift guard (ADR 0179 §3) runs once at module load:
  * it proves the key set the client reads derives from the manifest, the same fail-closed
  * check the worker runs at injection. A static self-check only — the never-throw runtime
  * paths below read this set, they never re-assert against live `__BOOT__` data (a drift throw
@@ -93,17 +93,6 @@ export function resolveBootFlag(boot: BootPayload | undefined, key: string): boo
 	if (boot === undefined) return undefined;
 	const value = (boot as Record<string, unknown>)[key];
 	return typeof value === "boolean" ? value : undefined;
-}
-
-/**
- * The synchronous signed-in presence bit from `window.__BOOT__` (ADR 0179 §1) — the shell
- * frame reads it to reserve the signed-in cluster's geometry while `useSession` is still
- * settling, rather than swapping in the cluster on a post-settle repaint. Absent `__BOOT__`
- * (flag off / the never-hang fallback) ⇒ `false`: the shell renders its signed-out geometry,
- * the safe default. Never throws.
- */
-export function readSignedIn(): boolean {
-	return resolveBootFlag(readBoot(), SHELL_SIGNED_IN_KEY) ?? false;
 }
 
 async function fetchFlag(key: string, defaultValue: boolean): Promise<boolean> {

--- a/apps/web/worker/features/flagship/shell-boot-route.ts
+++ b/apps/web/worker/features/flagship/shell-boot-route.ts
@@ -26,8 +26,10 @@ import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {PHOENIX_EDGE_SHELL_BOOT} from "../../../src/flags/keys.ts";
-import {SHELL_FLAG_KEYS, type ShellFlagKey} from "../../../src/flags/shell-keys.ts";
+import {type BootUser, SHELL_FLAG_KEYS, type ShellFlagKey} from "../../../src/flags/shell-keys.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
+import {resolveMeUser} from "../pasaport/trusted-user.ts";
+import type {User} from "../pasaport/views.ts";
 import {Flags} from "./Flags.ts";
 import {
 	anonymousFlagsContext,
@@ -50,6 +52,22 @@ class ShellAssetFetchError extends Schema.TaggedErrorClass<ShellAssetFetchError>
 // that one seam: an `unknown` param + a single narrowing cast (no `as unknown as` laundering).
 const toWebResponse = (response: unknown): HttpServerResponse.HttpServerResponse =>
 	HttpServerResponse.fromWeb(response as Parameters<typeof HttpServerResponse.fromWeb>[0]);
+
+/**
+ * Project the wire `User` down to the client `BootUser` for `__BOOT__.user` — the same fields
+ * `useMe` exposes as `MeUser`, minus fate's transport-only `__typename` (ADR 0185). An explicit
+ * field list (not an `Omit` spread) so a wire-shape change surfaces here as a compile error.
+ */
+const toBootUser = (user: User): BootUser => ({
+	id: user.id,
+	email: user.email,
+	name: user.name,
+	image: user.image,
+	username: user.username,
+	tier: user.tier,
+	isModerator: user.isModerator,
+	emailFailing: user.emailFailing,
+});
 
 /**
  * Resolve the shell flag values under an already-resolved per-request context. Exported so
@@ -132,7 +150,13 @@ export const handleShellBoot = Effect.gen(function* () {
 		const session = yield* pasaport.validateSession(raw.headers);
 		const context = yield* resolveRequestFlagsContext(session, raw.headers.get("cookie"));
 		const shellFlags = yield* readShellFlags(context);
-		const payload = buildBootPayload(session !== null, shellFlags);
+		// Edge-resolve the current user through the SAME session→user seam the `/fate` `me` view
+		// uses (ADR 0185), so first-paint surfaces read identity synchronously off `__BOOT__.user`
+		// instead of the async `useMe`; `null` when signed out. Projected off the wire `User` (drop
+		// fate's `__typename`) to the client `BootUser` shape. These extra D1 reads sit inside the
+		// never-hang guard below, so a slow/dead resolve degrades to the untransformed asset (#2931).
+		const user = session ? toBootUser(yield* resolveMeUser(session.user)) : null;
+		const payload = buildBootPayload(user, shellFlags);
 		return injectBootScript(assetResponse, payload);
 	});
 

--- a/apps/web/worker/features/flagship/shell-boot.ts
+++ b/apps/web/worker/features/flagship/shell-boot.ts
@@ -10,33 +10,36 @@
 import {
 	assertShellBootKeysSingleSourced,
 	BOOT_MEMBER_KEYS,
-	type BootMemberKey,
-	SHELL_SIGNED_IN_KEY,
+	type BootUser,
 	type ShellFlagKey,
 } from "../../../src/flags/shell-keys.ts";
 
 /**
- * The `window.__BOOT__` payload: every `__BOOT__`-member key → boolean. The keys are
- * exactly {@link BOOT_MEMBER_KEYS} (the shell flags + `signedIn`), single-sourced from
- * the manifest so the injected shape can't drift from what the client reads (#2928).
+ * The `window.__BOOT__` payload: the shell flag keys → boolean, plus the edge-resolved current
+ * `user` (`BootUser | null`) carried for synchronous first-paint identity (ADR 0185, amending
+ * 0179 — supersedes #2933's presence-only `signedIn` boolean). The boolean member keys are
+ * exactly {@link BOOT_MEMBER_KEYS}, single-sourced from the manifest so the injected boolean
+ * shape can't drift from what the client reads (#2928); `user` is a distinct typed field,
+ * single-sourced via {@link BootUser}.
  */
-export type BootPayload = Record<BootMemberKey, boolean>;
+export type BootPayload = Record<ShellFlagKey, boolean> & {user: BootUser | null};
 
 /**
- * Assemble the payload from the per-request session presence + the resolved shell-flag
- * values. `signedIn` is the presence bit that drives shell geometry directly (ADR 0179
- * §1), not a flag — so it is set here, not evaluated through the flag service.
+ * Assemble the payload from the edge-resolved current user + the resolved shell-flag values.
+ * `user` is the per-request identity (`null` when signed out), resolved through the SAME
+ * session→user seam the `/fate` `me` view uses, not evaluated through the flag service.
  */
 export const buildBootPayload = (
-	signedIn: boolean,
+	user: BootUser | null,
 	shellFlags: Record<ShellFlagKey, boolean>,
-): BootPayload => ({...shellFlags, [SHELL_SIGNED_IN_KEY]: signedIn});
+): BootPayload => ({...shellFlags, user});
 
 /**
  * The inline `<script>` that seeds `window.__BOOT__` before the app module runs. `<`
  * is escaped to `<` so a value can never close the tag / open a comment — XSS-safe
- * by construction even though today's values are all booleans (defense at the boundary,
- * not a bet on the payload staying boolean).
+ * by construction. Load-bearing now that the payload carries the `user` object's strings
+ * (name/handle/email), not only booleans: a `<` in any user-controlled field can never break
+ * out of the tag.
  */
 export const bootScriptTag = (payload: BootPayload): string =>
 	`<script>window.__BOOT__=${JSON.stringify(payload).replace(/</g, "\\u003c")}</script>`;
@@ -52,7 +55,10 @@ export const bootScriptTag = (payload: BootPayload): string =>
  * drift guard #2928 owns — so a shell key added here without the manifest throws.
  */
 export const injectBootScript = (assetResponse: Response, payload: BootPayload): Response => {
-	assertShellBootKeysSingleSourced(Object.keys(payload), [...BOOT_MEMBER_KEYS]);
+	// The single-source drift guard covers the boolean flag members only; `user` is a distinct
+	// typed field (ADR 0185), not a manifest member key, so it is excluded from the key-set check.
+	const flagKeys = Object.keys(payload).filter((key) => key !== "user");
+	assertShellBootKeysSingleSourced(flagKeys, [...BOOT_MEMBER_KEYS]);
 	const script = bootScriptTag(payload);
 	const rewritten = new HTMLRewriter()
 		.on("head", {

--- a/apps/web/worker/features/flagship/shell-boot.unit.test.ts
+++ b/apps/web/worker/features/flagship/shell-boot.unit.test.ts
@@ -1,15 +1,15 @@
 /**
- * Unit coverage for the edge-render pure core (#2929, ADR 0179): the `window.__BOOT__`
- * payload shape, the inline-script serialization, and the single-source drift guard the
- * inject seam calls. `injectBootScript`'s `HTMLRewriter` streaming is a workerd global,
- * exercised in the integration tier — not here.
+ * Unit coverage for the edge-render pure core (#2929, ADR 0179; #3030/ADR 0185 for the `user`
+ * field): the `window.__BOOT__` payload shape, the inline-script serialization, and the
+ * single-source drift guard the inject seam calls. `injectBootScript`'s `HTMLRewriter` streaming
+ * is a workerd global, exercised in the integration tier — not here.
  */
 import {describe, expect, it} from "vitest";
 import {MECMUA_FEED, MECMUA_PUBLIC_READ, PHOENIX_NAV_IA} from "../../../src/flags/keys.ts";
 import {
 	assertShellBootKeysSingleSourced,
 	BOOT_MEMBER_KEYS,
-	SHELL_SIGNED_IN_KEY,
+	type BootUser,
 	ShellKeyDriftError,
 } from "../../../src/flags/shell-keys.ts";
 import {bootScriptTag, buildBootPayload} from "./shell-boot.ts";
@@ -20,41 +20,60 @@ const shellFlags = {
 	[MECMUA_FEED]: true,
 } as const;
 
+// The edge-resolved current user (`__BOOT__.user`, ADR 0185) — the exact `BootUser` shape the
+// client `useMe` seeds from, carrying the trusted tier + moderator standing.
+const bootUser: BootUser = {
+	id: "user-42",
+	email: "elif@kamp.us",
+	name: "Elif",
+	image: null,
+	username: "elif",
+	tier: "yazar",
+	isModerator: false,
+	emailFailing: false,
+};
+
 describe("buildBootPayload", () => {
-	it("carries every shell flag value plus the signedIn presence bit", () => {
-		const payload = buildBootPayload(true, shellFlags);
+	it("carries every shell flag value plus the edge-resolved user object", () => {
+		const payload = buildBootPayload(bootUser, shellFlags);
 		expect(payload[PHOENIX_NAV_IA]).toBe(true);
 		expect(payload[MECMUA_PUBLIC_READ]).toBe(false);
 		expect(payload[MECMUA_FEED]).toBe(true);
-		expect(payload[SHELL_SIGNED_IN_KEY]).toBe(true);
+		expect(payload.user).toEqual(bootUser);
 	});
 
-	it("sets signedIn from the session presence, independent of the flags", () => {
-		expect(buildBootPayload(false, shellFlags)[SHELL_SIGNED_IN_KEY]).toBe(false);
+	it("sets user to null for a signed-out viewer, independent of the flags", () => {
+		expect(buildBootPayload(null, shellFlags).user).toBeNull();
 	});
 
-	it("produces exactly the manifest key set (no injected/manifest drift)", () => {
-		const keys = Object.keys(buildBootPayload(true, shellFlags));
-		expect([...keys].sort()).toEqual([...BOOT_MEMBER_KEYS].sort());
-		// The seam the worker actually calls before injecting — proven to pass for our payload.
-		expect(() => assertShellBootKeysSingleSourced(keys, [...BOOT_MEMBER_KEYS])).not.toThrow();
+	it("the boolean flag members are exactly the manifest key set — `user` is not a member key", () => {
+		const flagKeys = Object.keys(buildBootPayload(bootUser, shellFlags)).filter(
+			(k) => k !== "user",
+		);
+		expect([...flagKeys].sort()).toEqual([...BOOT_MEMBER_KEYS].sort());
+		expect(BOOT_MEMBER_KEYS).not.toContain("user");
+		// The seam the worker actually calls before injecting — proven to pass for our flag keys.
+		expect(() => assertShellBootKeysSingleSourced(flagKeys, [...BOOT_MEMBER_KEYS])).not.toThrow();
 	});
 });
 
 describe("bootScriptTag", () => {
-	it("seeds window.__BOOT__ with the JSON payload, parseable back to the payload", () => {
-		const payload = buildBootPayload(true, shellFlags);
+	it("seeds window.__BOOT__ with the JSON payload (flags + user), parseable back to the payload", () => {
+		const payload = buildBootPayload(bootUser, shellFlags);
 		const tag = bootScriptTag(payload);
 		expect(tag.startsWith("<script>window.__BOOT__=")).toBe(true);
 		expect(tag.endsWith("</script>")).toBe(true);
 		const json = tag.slice("<script>window.__BOOT__=".length, -"</script>".length);
 		expect(JSON.parse(json)).toEqual(payload);
+		expect(JSON.parse(json).user).toEqual(bootUser);
 	});
 
 	it("escapes `<` so a payload can never break out of the script tag", () => {
-		// Values are boolean today, so force a `<`-bearing key through the serializer to prove
-		// the XSS-safe escape (`<` -> <) is applied — no raw `<` survives in the JSON body.
-		const tag = bootScriptTag({"</script><x": true} as never);
+		// A `<`-bearing user field (e.g. an attacker display name) must not survive raw in the JSON
+		// body — the escape (`<` -> <) is what keeps the injected object XSS-safe.
+		const tag = bootScriptTag(
+			buildBootPayload({...bootUser, name: "</script><script>evil"}, shellFlags),
+		);
 		const body = tag.slice("<script>window.__BOOT__=".length, -"</script>".length);
 		expect(body).not.toContain("<");
 		expect(body).toContain("\\u003c");

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -23,7 +23,7 @@ import {promotionBarFor} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {toAuthorshipStanding, toBanState, toContributionRow, toProfile} from "./shapers.ts";
-import {toTrustedUser} from "./trusted-user.ts";
+import {resolveMeUser} from "./trusted-user.ts";
 import type {Contribution} from "./views.ts";
 import {AuthorshipStandingView, BanStateView, ProfileView, UserView} from "./views.ts";
 
@@ -55,44 +55,13 @@ const ProfileArgs = Schema.Struct({
 export const queries = {
 	me: Fate.query(
 		{type: UserView, error: Unauthorized},
-		// Reads the canonical row (not the session) so a fresh `username`
-		// round-trips right after `setUsername` — better-auth's session inference
-		// lags. Falls back to the session user when the row isn't found.
+		// The current user, resolved through the shared {@link resolveMeUser} seam (ADR 0185):
+		// the canonical row read fresh (so a just-set `username` round-trips before better-auth's
+		// session inference), the SELF failing-delivery signal (#2693), and the trusted tier +
+		// moderator standing — the SAME resolution the edge `__BOOT__.user` injection reuses.
 		Effect.fn("me")(function* () {
 			const user = yield* CurrentUser.required;
-			const pasaport = yield* Pasaport;
-			const fresh = yield* pasaport.getUserById(user.id);
-			// The session supplies email/name/image; the canonical row, when present,
-			// overrides them so a fresh `username` round-trips before better-auth's
-			// session catches up.
-			const base = fresh
-				? {
-						id: fresh.id,
-						email: fresh.email,
-						name: fresh.name,
-						image: fresh.image,
-						username: fresh.username,
-					}
-				: {
-						id: user.id,
-						email: user.email,
-						name: user.name ?? null,
-						image: user.image ?? null,
-						username: null,
-					};
-			// The SELF failing-delivery signal (#2693): the reader’s own address projected
-			// through #2691’s `resolveEmailDeliveryState`. Stamped ONLY here (never on the
-			// by-id batch), so #2727’s membrane notice lights up for the current user without
-			// exposing any other account’s delivery-state. A row-missing principal has no
-			// events, so `UserNotFound` reads deliverable.
-			const emailFailing = yield* pasaport.getEmailDeliveryState(base.id).pipe(
-				Effect.map((r) => r.state.failing),
-				Effect.catchTag("pasaport/UserNotFound", () => Effect.succeed(false)),
-			);
-			// `toTrustedUser` resolves the trusted standing (tier via `Kunye.tierOf`, the
-			// moderator signal via the `moderates` tuple) — the one shared home for the
-			// `User` shape `setUsername` and the by-id loader also build.
-			return yield* toTrustedUser({...base, emailFailing});
+			return yield* resolveMeUser(user);
 		}),
 	),
 	// `contributions` is delivered inline (not via a source `connection`

--- a/apps/web/worker/features/pasaport/trusted-user.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.ts
@@ -46,6 +46,50 @@ export const toTrustedUser = (
 		return toUser({...base, tier, isModerator: isMod, emailFailing: base.emailFailing ?? false});
 	});
 
+/** The validated session identity {@link resolveMeUser} resolves the trusted `User` from. */
+export interface MeSessionUser {
+	id: string;
+	email: string;
+	name?: string | null | undefined;
+	image?: string | null | undefined;
+}
+
+/**
+ * The ONE session→user resolution shared by the `/fate` `me` query and the edge
+ * `__BOOT__.user` injection (ADR 0185), so both read the same canonical row + trusted
+ * standing. Reads the canonical `user` row fresh (so a just-set `username` round-trips before
+ * better-auth's session inference catches up), falling back to the session identity when the
+ * row is absent; projects the SELF failing-delivery signal (#2693); then attaches the trusted
+ * tier + moderator standing via {@link toTrustedUser}.
+ */
+export const resolveMeUser = (
+	sessionUser: MeSessionUser,
+): Effect.Effect<User, never, Pasaport | Kunye | RelationStore> =>
+	Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+		const fresh = yield* pasaport.getUserById(sessionUser.id);
+		const base = fresh
+			? {
+					id: fresh.id,
+					email: fresh.email,
+					name: fresh.name,
+					image: fresh.image,
+					username: fresh.username,
+				}
+			: {
+					id: sessionUser.id,
+					email: sessionUser.email,
+					name: sessionUser.name ?? null,
+					image: sessionUser.image ?? null,
+					username: null,
+				};
+		const emailFailing = yield* pasaport.getEmailDeliveryState(base.id).pipe(
+			Effect.map((r) => r.state.failing),
+			Effect.catchTag("pasaport/UserNotFound", () => Effect.succeed(false)),
+		);
+		return yield* toTrustedUser({...base, emailFailing});
+	});
+
 /**
  * The BATCHED by-id user rows with moderator standing joined on: fetch the user
  * rows, then ONE `RelationStore` set-membership read (`moderatorsAmong`) decides


### PR DESCRIPTION
Fixes #3030

Extends the `window.__BOOT__` edge-shell payload with the full current user (`user | null`) so first-paint-critical surfaces read identity **synchronously** instead of the async `useMe` — killing the residual signed-in content swap in the navbar cluster and the pano new-post CTA pop-in that persist even with `phoenix-edge-shell-boot` on.

Scope held tight to the founder ruling: **the user object only**, no other `__BOOT__` payload expansion.

## What changed

- **Contract shape (`shell-boot.ts` / `shell-keys.ts`).** `BootPayload` gains a typed `user: BootUser | null` field (`BootUser` = the wire `User` minus fate's `__typename`, single-sourced so it can't drift from the client's `MeUser`). `signedIn` is **superseded by `user != null`** and removed from the boolean member-key set; the single-source drift check still covers the flag keys, and `user` is single-typed via `BootUser`.
- **Worker injection (`shell-boot-route.ts`).** The edge resolves the user through the **same session→user resolution the `/fate` `me` view uses**, factored into one shared `resolveMeUser` (`pasaport/trusted-user.ts`) consumed by both the `me` query resolver and the shell-boot route — so the boot user and the reconciled `me` can't describe the same user differently. The resolve sits inside the existing never-hang bound.
- **Client consumers.** `useMe` seeds first paint from `__BOOT__.user` and reconciles on session change (the seed survives while the session settles); `App.tsx` seeds the navbar identity synchronously; `PanoSubnavCta` reads it first. Absent `__BOOT__` (flag off / the #2931 never-hang fallback) ⇒ `user = null` ⇒ today's async path, unchanged.
- **ADR 0185** amends [0179](https://github.com/kamp-us/phoenix/blob/main/.decisions/0179-edge-resolved-shell-state-boot-contract.md), recording the boolean-only → `user`-carrying shape change and the supersession of #2933's presence-only `signedIn` bit.

## Acceptance criteria

- [x] `__BOOT__.user` carries the resolved current user (`user | null`), edge-injected, reusing the `/fate` `me` session→user resolution (`resolveMeUser`).
- [x] Boot contract type extended to `user: User | null`; user-only change, no other payload expansion.
- [x] `useMe` seeds first paint from `__BOOT__.user` and reconciles on session change; no async fetch on the first-paint identity path.
- [x] Navbar signed-in cluster + pano new-post CTA render correct signed-in state on first paint — no swap/pop-in with the flag on (App.test.tsx covers this).
- [x] Absent `__BOOT__` degrades to `user = null` and today's async behavior (no hang).
- [x] Recorded as an ADR amending 0179 (0185).
- [x] `shell-boot.unit.test.ts` + `boot.test.ts` cover the `user` payload and the absent-`__BOOT__` fallback.

## Verification (local)

`pnpm typecheck` green; `lint:worktree` green; `design-token-guard check` green; touched worker/client tests green (`shell-boot*`, `shell-keys`, `boot`, `useFlag`, `App`, `PanoSubnavCta`, `Topbar`, pasaport unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)