### PR TITLE
docs(web): retarget stale `__BOOT__.signedIn` comments to `__BOOT__.user` (#3042)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -221,9 +221,9 @@ function Layout() {
 						onLogout={onSignOut}
 						actions={
 							// giriş-yap rides the first-paint presence bit, not the settling session:
-							// `__BOOT__.signedIn` (via signedInAtFirstPaint) suppresses the CTA for a
+							// `__BOOT__.user != null` (via signedInAtFirstPaint) suppresses the CTA for a
 							// signed-in user from the first frame, so it never flashes then swaps out
-							// (#2933). Absent `__BOOT__` ⇒ this reduces to `isSignedIn`, today's split.
+							// (#2933, ADR 0185). Absent `__BOOT__` ⇒ this reduces to `isSignedIn`, today's split.
 							!signedInAtFirstPaint ? (
 								<button type="button" className="kp-topbar__btn" onClick={() => navigate("/auth")}>
 									giriş yap

--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -163,8 +163,8 @@
 /* Keyboard focus ring comes from the shared focus layer (global.css, #2169). */
 
 /* Reserved signed-in account slot (#2933, ADR 0179 §1) — a fixed-geometry stand-in for the
-   user-menu trigger, rendered from __BOOT__.signedIn while fate has yet to publish the real
-   chip. It reuses `.kp-topbar__user` (box: gap/padding/height) and, for the avatar, the real
+   user-menu trigger, driven by the typed __BOOT__.user object (ADR 0185) while fate has yet
+   to publish the real chip. It reuses `.kp-topbar__user` (box: gap/padding/height) and, for the avatar, the real
    `.kp-avatar` box primitive itself, so the swap to the real menu moves nothing — the placeholder
    avatar is pixel-identical to the Avatar it replaces. The cluster holds its final geometry from
    first paint (no giriş-yap↔cluster swap, no empty→pop); the value late-fills in place (#2160).


### PR DESCRIPTION
Fixes #3042

## What

Two load-bearing comments still referenced the `__BOOT__.signedIn` field that ADR 0185 (#3030) **removed** from `BOOT_MEMBER_KEYS`. Post-0185 the signed-in presence is derived from the typed `__BOOT__.user` object (`__BOOT__.user != null`). The **code was already correct** — this is comment-accuracy drift only.

## Changes (comment-only, zero behavior change)

- `apps/web/src/App.tsx` — the `actions` docblock now names `` `__BOOT__.user != null` `` (via `signedInAtFirstPaint`) instead of the removed `signedIn` field, and points at ADR 0185. Consistent with the ~line 163 note that already records `__BOOT__.user` as the first-paint identity source and the presence-only `signedIn` bit as superseded.
- `apps/web/src/components/layout/Topbar.css` — the reserved-slot comment now says the placeholder is driven by the typed `__BOOT__.user` object (ADR 0185) rather than `__BOOT__.signedIn`.

## Verification

- `git diff` is 4 comment lines across the two files — no code/logic/CSS-value change.
- `pnpm typecheck` green (31/31 tasks).
- `pnpm lint:worktree` green (2 files checked, no fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)