### PR TITLE
feat(pipeline-crew-mcp): package scaffold + module skeleton (#3052)

### DIFF
--- a/packages/pipeline-crew-mcp/README.md
+++ b/packages/pipeline-crew-mcp/README.md
@@ -1,0 +1,45 @@
+# @kampus/pipeline-crew-mcp
+
+The crew's channels-backed messaging substrate — the peer-to-peer transport the pipeline
+crew (EM, triage, coder, reviewer, shipper) talk over, exposed to each agent as MCP
+channels (epic #3045).
+
+## What it is
+
+A small, layered substrate split into a **generic core** and one **crew-coupled** module:
+
+- **`src/protocol/`** — the wire format: message envelopes and the codec every peer shares.
+- **`src/tracker/`** — the rendezvous registry where peers announce and discover each other.
+- **`src/peer/`** — a p2p participant: dials, holds connections, relays messages over the protocol.
+- **`src/edge/`** — the MCP channel edge: exposes the substrate to an MCP client as channels.
+- **`src/crew/`** — the only crew-coupled module: the Role catalog and the wiring that binds
+  the generic substrate to concrete crew roles.
+
+**The load-bearing boundary:** `protocol/`, `tracker/`, `peer/`, and `edge/` are the reusable
+channels substrate and never import `crew/`; `crew/` depends inward on the generic core, never
+the reverse. That one-way dependency is what keeps the substrate reusable beyond the crew — it
+is the reason the modules are split into directories rather than a flat file.
+
+## Why it exists
+
+The crew is a set of independent agent sessions that today coordinate through out-of-band
+surfaces (filed issues, tmux relays). This package gives them a first-class, in-process
+messaging substrate — a generic p2p tracker + peers underneath, an MCP channel edge on top —
+so an agent joins a channel and sends/receives crew messages through its MCP client rather than
+a bespoke relay. It is internal pipeline tooling, on no kamp.us user surface.
+
+## Status
+
+Scaffold only (issue #3052): the package shape, the module skeleton, and a thin Effect bin.
+No seam behavior is wired yet — each module is filled by its own child of epic #3045.
+
+## Usage
+
+Built on Effect + `effect/unstable/cli`, run from source with Node's TypeScript loader (the
+pipeline-tooling idiom, mirroring `@kampus/pipeline-cli`):
+
+```bash
+pnpm --filter @kampus/pipeline-crew-mcp cli        # run the (scaffold-only) root command
+pnpm --filter @kampus/pipeline-crew-mcp typecheck  # tsgo typecheck
+pnpm --filter @kampus/pipeline-crew-mcp test       # @effect/vitest suite
+```

--- a/packages/pipeline-crew-mcp/package.json
+++ b/packages/pipeline-crew-mcp/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@kampus/pipeline-crew-mcp",
+	"version": "0.0.0",
+	"private": true,
+	"description": "pipeline-crew-mcp — the crew's channels-backed messaging substrate: a generic tracker + p2p peers + MCP channel edge, with a thin crew consumer module (epic #3045)",
+	"type": "module",
+	"bin": {
+		"pipeline-crew-mcp": "./src/bin.ts"
+	},
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"cli": "node src/bin.ts"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * `pipeline-crew-mcp` — the substrate's entry bin (epic #3045, scaffold #3052).
+ *
+ *   node src/bin.ts            # run the (scaffold-only) root command
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/pipeline-cli`'s bin):
+ * `effect/unstable/cli` for the typed command, the Node platform over
+ * `NodeServices.layer`, run via `NodeRuntime.runMain`. Scaffold-only today — the
+ * root command just reports that no seam behavior is wired yet; children add
+ * subcommands as the tracker/peer/edge/crew modules land.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+
+import {VERSION} from "./version.ts";
+
+const cli = Command.make(
+	"pipeline-crew-mcp",
+	{},
+	Effect.fn(function* () {
+		yield* Console.log(
+			`pipeline-crew-mcp ${VERSION} — scaffold; no seam behavior wired yet (epic #3045)`,
+		);
+	}),
+).pipe(Command.withDescription("The crew's channels-backed messaging substrate (epic #3045)"));
+
+cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -1,0 +1,6 @@
+/**
+ * crew/ — the only crew-coupled module: the Role catalog and the wiring that binds the
+ * generic substrate to concrete crew roles. Depends inward on protocol/tracker/peer/edge;
+ * the generic core never depends back on it (see the boundary note in `../index.ts`).
+ */
+export {};

--- a/packages/pipeline-crew-mcp/src/edge/index.ts
+++ b/packages/pipeline-crew-mcp/src/edge/index.ts
@@ -1,0 +1,5 @@
+/**
+ * edge/ — the MCP channel edge: exposes the substrate to an MCP client as channels.
+ * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ */
+export {};

--- a/packages/pipeline-crew-mcp/src/index.ts
+++ b/packages/pipeline-crew-mcp/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @kampus/pipeline-crew-mcp — the crew's channels-backed messaging substrate (epic #3045).
+ *
+ * This scaffold (issue #3052) lands the package shape and the module skeleton only; no
+ * seam behavior yet — each module below is filled by its own child.
+ *
+ * The one structural invariant the skeleton exists to hold: the generic core is
+ * crew-agnostic. `protocol/`, `tracker/`, `peer/`, and `edge/` are the reusable
+ * channels substrate and MUST NOT import `crew/`; `crew/` is the sole crew-coupled
+ * module (Role catalog + wiring) and depends inward on the generic core, never the
+ * reverse. That one-way boundary is what keeps the substrate reusable — enforcing it
+ * is the point of splitting these into directories.
+ */
+export {VERSION} from "./version.ts";

--- a/packages/pipeline-crew-mcp/src/peer/index.ts
+++ b/packages/pipeline-crew-mcp/src/peer/index.ts
@@ -1,0 +1,5 @@
+/**
+ * peer/ — a p2p participant: dials, holds connections, and relays messages over the protocol.
+ * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ */
+export {};

--- a/packages/pipeline-crew-mcp/src/protocol/index.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/index.ts
@@ -1,0 +1,5 @@
+/**
+ * protocol/ — the wire format: message envelopes and the codec shared by every peer.
+ * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ */
+export {};

--- a/packages/pipeline-crew-mcp/src/tracker/index.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/index.ts
@@ -1,0 +1,5 @@
+/**
+ * tracker/ — the rendezvous registry: peers announce and discover each other here.
+ * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ */
+export {};

--- a/packages/pipeline-crew-mcp/src/version.ts
+++ b/packages/pipeline-crew-mcp/src/version.ts
@@ -1,0 +1,2 @@
+/** The pipeline-crew-mcp version string, surfaced at the bin's root `--version` and handler. */
+export const VERSION = "0.0.0";

--- a/packages/pipeline-crew-mcp/src/version.unit.test.ts
+++ b/packages/pipeline-crew-mcp/src/version.unit.test.ts
@@ -1,0 +1,13 @@
+/**
+ * The scaffold's tracer test — wires the `@effect/vitest` harness end to end so the
+ * package's `test` script runs something real (issue #3052). Replaced by the modules'
+ * own tests as they land.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {VERSION} from "./version.ts";
+
+describe("pipeline-crew-mcp scaffold", () => {
+	it("exposes a version string", () => {
+		assert.strictEqual(VERSION, "0.0.0");
+	});
+});

--- a/packages/pipeline-crew-mcp/tsconfig.json
+++ b/packages/pipeline-crew-mcp/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/pipeline-crew-mcp/vitest.config.ts
+++ b/packages/pipeline-crew-mcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1239,6 +1239,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/pipeline-crew-mcp:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/preview-seed:
     dependencies:
       '@distilled.cloud/cloudflare':


### PR DESCRIPTION
Scaffolds the workspace package `packages/pipeline-crew-mcp` — the crew's channels-backed messaging substrate (epic #3045, graduated from map #3031). Empty-but-well-structured: the package shape and the generic/crew module boundary, no seam behavior yet.

## What landed
- **`package.json`** — private workspace member; every dep on `catalog:` (`effect`, `@effect/platform-node`). Mirrors the `@kampus/gh-phoenix` source-run idiom (no `dist`/build). No `pnpm-workspace.yaml` change was needed — `@effect/platform-node` (`4.0.0-beta.92`) is already cataloged in the `effect` pin family — so this PR does not touch the catalog block (leaving `patchedDependencies` untouched for the sibling PR #3053).
- **`README.md`** — what/why/how (readme-guard).
- **`tsconfig.json`, `vitest.config.ts`, `src/bin.ts`** — a thin `effect/unstable/cli` bin run via `NodeRuntime`, mirroring `pipeline-cli`. `@effect/vitest` harness wired with a tracer test.
- **Module skeleton** — `src/protocol/`, `src/tracker/`, `src/peer/`, `src/edge/` (generic — none import `crew/`) + `src/crew/` (the sole crew-coupled module). The one-way boundary is documented once in `src/index.ts`.

## Verification (local)
- `pnpm typecheck` — clean
- `pnpm lint` (biome) — clean
- `pnpm test` (@effect/vitest) — 1 passed
- `pipeline-cli catalog-guard check` — pass (all deps catalog:/workspace:)
- `pipeline-cli readme-guard check` — pass
- generic dirs contain zero `crew/` imports (only the word "crew-agnostic" in prose)

## §CP
This is a control-plane item — opened for human approval, not auto-shipped.

Fixes #3052

🤖 Generated with [Claude Code](https://claude.com/claude-code)