### PR TITLE
fix(pipeline): register pipeline-crew-mcp in the §CP path classifier (#3069)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,3 +42,4 @@
 # stays standalone (ADR 0092) and keeps its own owner line.
 /packages/ci-required/          @kamp-us/control-plane
 /packages/pipeline-cli/         @kamp-us/control-plane
+/packages/pipeline-crew-mcp/    @kamp-us/control-plane

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1444,7 +1444,7 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^packages/pipeline-crew-mcp/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -43,6 +43,7 @@ describe("splitTopLevelBranches", () => {
 			"claude-plugins/kampus-pipeline/hooks(/|\\.json$)",
 			"packages/ci-required/",
 			"packages/pipeline-cli/",
+			"packages/pipeline-crew-mcp/",
 		]);
 	});
 });
@@ -110,7 +111,7 @@ describe("expandBranch", () => {
 });
 
 describe("cpPaths over the live regex", () => {
-	it("resolves the full §CP path set (20 paths: dirs, the two exact files, + the **/*.sh glob)", () => {
+	it("resolves the full §CP path set (21 paths: dirs, the two exact files, + the **/*.sh glob)", () => {
 		expect(cpPaths(LIVE_RE).map((p) => p.path)).toEqual([
 			".claude/",
 			".github/",
@@ -132,6 +133,7 @@ describe("cpPaths over the live regex", () => {
 			"claude-plugins/kampus-pipeline/hooks.json",
 			"packages/ci-required/",
 			"packages/pipeline-cli/",
+			"packages/pipeline-crew-mcp/",
 		]);
 	});
 
@@ -217,6 +219,7 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/hooks.json @usirin",
 			"/packages/ci-required/ @usirin",
 			"/packages/pipeline-cli/ @usirin",
+			"/packages/pipeline-crew-mcp/ @usirin",
 		].join("\n");
 		expect(findUncovered(paths, parseCodeownersPatterns(codeowners))).toEqual([]);
 	});
@@ -247,6 +250,7 @@ describe("findUncovered — the drift check", () => {
 			"claude-plugins/kampus-pipeline/hooks/",
 			"claude-plugins/kampus-pipeline/hooks.json",
 			"packages/pipeline-cli/",
+			"packages/pipeline-crew-mcp/",
 		]);
 	});
 });

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -31,6 +31,7 @@ const FULL_CODEOWNERS = [
 	"/claude-plugins/kampus-pipeline/hooks.json @usirin",
 	"/packages/ci-required/ @usirin",
 	"/packages/pipeline-cli/ @usirin",
+	"/packages/pipeline-crew-mcp/ @usirin",
 ].join("\n");
 
 /** A throwaway repo carrying just the two source files the gate reads. */

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -29,6 +29,10 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/doctor/doctor.sh")).toBe(true);
 		// depth is irrelevant — a hypothetical helper two levels deep is §CP too (no new anchoring accident).
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/report/lib/helper.sh")).toBe(true);
+		// pipeline-crew-mcp is a new control-plane package (epic #3045); registering its path makes
+		// every crew-mcp child PR classify §CP structurally (banks at cansirin), not auto-merge (#3069).
+		expect(isControlPlane("packages/pipeline-crew-mcp/src/index.ts")).toBe(true);
+		expect(isControlPlane("packages/pipeline-crew-mcp/package.json")).toBe(true);
 	});
 
 	it("does NOT classify the four deliberately-OUT skill dirs (operational, not gate-critical)", () => {

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -33,4 +33,4 @@
  * runtime resolution off the origin/main read.
  */
 export const CONTROL_PLANE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^packages/pipeline-crew-mcp/";


### PR DESCRIPTION
Fixes #3069

## The gap

`packages/pipeline-crew-mcp/` is declared §CP by the epic #3045 plan (all children bank at cansirin approval, never auto-ship), but it was **absent from the single-source §CP boundary**. So a crew-mcp child PR classified as ordinary autonomous `packages/**` code, earned a bindable `PASS @ <sha>`, and would **auto-merge past the cansirin control-plane gate** (ADR 0053/0135). Enforcement rested entirely on the EM hand-invoking the ADR-0111 advisory form per child PR — discipline, not structural teeth.

## The fix — register the package at its single source (no duplicated regex)

Registered `^packages/pipeline-crew-mcp/` in lockstep across the three surfaces that resolve from ONE source (`CONTROL_PLANE_RE`, #2761):

1. **`packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts`** — the single-source `CONTROL_PLANE_RE` const (every importable surface imports this).
2. **`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`** — the drift-guarded `CONTROL_PLANE_RE=` prose line the live gates re-resolve from `origin/main`, kept byte-in-sync with the const.
3. **`.github/CODEOWNERS`** — a `/packages/pipeline-crew-mcp/  @kamp-us/control-plane` row mirroring the existing `ci-required` / `pipeline-cli` rows, so `codeowners-cp` stays green.

No second literal was introduced — every consumer reads the single const/formats-line pair.

After this, every crew-mcp child PR classifies §CP structurally → reviewer emits the ADR-0111 advisory (SHA-less) form → ship-it refuses auto-merge → banks at cansirin. Removes the reliance on manual per-PR holding.

## Tests

- `control-plane-paths.unit.test.ts` — asserts `packages/pipeline-crew-mcp/src/index.ts` and `package.json` now classify §CP (was: `has-code` → auto-merge-eligible), and the existing `packages/some-other-pkg/...` → non-§CP assertion stays green (no over-broadening).
- `codeowners-cp.unit.test.ts` / `gate.test.ts` — the derived §CP path set (now 21), the split-branches list, the drift-check fixtures, and the FULL_CODEOWNERS fixture all extended to carry the new path so the const↔formats↔CODEOWNERS lockstep guards stay green.

Behavioral confirmation: `pipeline-cli control-plane-paths` regex now matches a crew-mcp path (§CP) and still rejects a generic `packages/some-other-pkg/` path; `codeowners-cp check` → "all 21 §CP path(s) covered".

## Scope decision — the 3 canon `.patterns` children are deliberately NOT covered (option a)

Scope: this registers the crew-mcp **PACKAGE path** → structurally covers the 8 code children (#3052–#3057, #3059, #3062, all under the package). The 3 canon `.patterns` children (#3058/#3060/#3061) keep a manual/advisory §CP hold by EM discipline (a doc is not a gate — the author≠approver invariant targets gate-critical control plane). Deliberately **NOT** broadening §CP to all of `.patterns/**` (too broad — it would gate every future pattern doc through cansirin) and **NOT** hardcoding three not-yet-existing doc paths (brittle).

## This PR is itself §CP

It edits `packages/pipeline-cli/**`, `.github/**`, and `gh-issue-intake-formats.md` — all §CP MATCH — so it banks at cansirin approval (never auto-ship). Per ADR 0100/#981 anti-self-authorization, the live gates classify this boundary-editing PR against `origin/main`'s boundary, not its own edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)