### PR TITLE
fix(pipeline-cli): drive-letter carve-out for leak-guard macOS-home matcher (#3070)

### DIFF
--- a/packages/pipeline-cli/src/tools/leak-guard/crew-leak.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/crew-leak.ts
@@ -46,7 +46,9 @@ interface ClassPattern {
 const CLASS_PATTERNS: ReadonlyArray<ClassPattern> = [
 	{
 		class: "path",
-		pattern: /\/Users\/[A-Za-z0-9._-]+/g,
+		// Drive-letter carve-out — see leak-guard.ts LEAK_PATTERNS (#3070): exempts only a
+		// Windows `C:/Users/...` prefix, keeps the bare POSIX `/Users/<name>/` true positive.
+		pattern: /(?<![A-Za-z]:)\/Users\/[A-Za-z0-9._-]+/g,
 		reason: "absolute macOS home path (/Users/<name>/...)",
 	},
 	{

--- a/packages/pipeline-cli/src/tools/leak-guard/crew-leak.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/crew-leak.unit.test.ts
@@ -24,6 +24,11 @@ describe("findCrewLeaks — match classes", () => {
 			expect(classes(leaks)).toContain("path");
 			expect(matched(leaks)).toContain("/Users/alice");
 		});
+		// #3070 — the drive-letter carve-out drops the Windows-file-URL FP while keeping the
+		// bare POSIX `/Users/<name>/` true positive above.
+		it("does NOT flag a Windows drive-prefixed C:/Users/... file URL (#3070)", () => {
+			expect(findCrewLeaks("spawn from file:///C:/Users/ci/proj/alchemy.run.ts")).toEqual([]);
+		});
 		it("flags /home/<name>", () => {
 			expect(classes(findCrewLeaks("path /home/bob/.config"))).toContain("path");
 		});

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
@@ -66,7 +66,12 @@ interface LeakPattern {
 // Order = report order. Each `g` flag is required for the per-match scan in findLeaks.
 const LEAK_PATTERNS: ReadonlyArray<LeakPattern> = [
 	{
-		pattern: /\/Users\/[A-Za-z0-9._-]+/g,
+		// The `(?<![A-Za-z]:)` drive-letter carve-out keeps this a GENERIC structural check
+		// while dropping the Windows-file-URL false positive: a bare POSIX `/Users/<name>/`
+		// still matches (real macOS-home leak), but a drive-prefixed `C:/Users/...` (e.g.
+		// `file:///C:/Users/ci/...`) does not — that substring is not a macOS home path and
+		// carries no operator PII, yet its FP fail-closed-blocked legitimate PRs (#3070).
+		pattern: /(?<![A-Za-z]:)\/Users\/[A-Za-z0-9._-]+/g,
 		reason: "absolute macOS home path (/Users/<name>/...)",
 	},
 	{

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
@@ -58,6 +58,10 @@ describe("findLeaks — ALLOW matrix (legitimate content must NOT be flagged)", 
 		assert.isFalse(hasLeak("src/fixture.ts", 'const p = "/Users/foo/x"'));
 	});
 
+	it("allows a Windows drive-prefixed C:/Users/... path in a doc surface (#3070)", () => {
+		assert.isFalse(hasLeak("docs/notes.md", "on Windows the URL is file:///C:/Users/ci/proj/x"));
+	});
+
 	it("allows edits to a self-exempt skill (it names the tokens as patterns)", () => {
 		assert.isFalse(hasLeak("skills/report/SKILL.md", "never cite /Users/... or ~/.usirin paths"));
 	});
@@ -86,6 +90,13 @@ describe("findCommentLeaks — PR/issue comment body scan (#2796, stricter than 
 		assert.isTrue(hasCommentLeak("verdict staged at /tmp/review-code-verdict-12.md")));
 	it("blocks an absolute /Users/<name> path", () =>
 		assert.isTrue(hasCommentLeak("see /Users/foo/project/notes")));
+	// #3070 — the drive-letter carve-out: a Windows `C:/Users/...` file URL is not a macOS-home
+	// leak, so quoting one in a verdict comment must not fail-closed-block enqueue (the #3063 FP);
+	// a bare POSIX `/Users/<name>/` above still fires (true positive preserved).
+	it("allows a Windows drive-prefixed file:///C:/Users/... URL (#3070 FP dropped)", () =>
+		assert.isFalse(
+			hasCommentLeak("derivation-contract example: file:///C:/Users/ci/proj/alchemy.run.ts"),
+		));
 	it("blocks a temp path that sits in verdict PROSE, not a SHA field", () =>
 		assert.isTrue(hasCommentLeak(`review-code: advisory — see thread\n\nnotes at ${MKTEMP}`)));
 


### PR DESCRIPTION
Fixes #3070

## What

The macOS-home leak matcher `/\/Users\/[A-Za-z0-9._-]+/g` was un-anchored and duplicated in two copies. It matched the `/Users/<name>` substring **inside** a Windows file URL (`file:///C:/Users/ci/proj/alchemy.run.ts`), producing a spurious leak. Because ship-it Step 3.7's landed-comment scan is fail-closed (ADR 0092 / #3019), that false positive **hard-blocked merge-queue enqueue** of any PR whose comment or diff legitimately quoted a Windows user path — the #3063 block.

## Fix

Add a drive-letter negative lookbehind `(?<![A-Za-z]:)` to the `/Users/` pattern in **both** copies:

- `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts` (`LEAK_PATTERNS`) — consumed by `findLeaks` (doc surfaces) and `findCommentLeaks` (the PR/issue-comment scan that fired on #3063).
- `packages/pipeline-cli/src/tools/leak-guard/crew-leak.ts` (`CLASS_PATTERNS`) — consumed by `findCrewLeaks` (the pipeline-crew sanitization sweep).

A drive-prefixed `C:/Users/...` (Windows) no longer matches; a bare POSIX `/Users/<name>/` (the real macOS-home leak) still does. Kept **generic** — a structural drive-letter carve-out, not a named deny-list (leak-guards are generic pattern checks).

The `packages/leak-guard/` package named in triage's "check for a third copy" **does not exist on `main`** — that path only appears in unrelated in-flight worktree branches. There are exactly two copies on `main`, both fixed.

## Tests

Regression tests assert both directions across all three code paths:

- **Windows FP dropped:** `file:///C:/Users/ci/...` does NOT flag — added to `findLeaks` (doc), `findCommentLeaks` (the #3063 comment path), and `findCrewLeaks`.
- **POSIX true-positive preserved:** `/Users/<name>/...` still flags (existing assertions retained).

`pnpm vitest run src/tools/leak-guard/` → 69 passed. `pnpm typecheck` clean. Pre-commit leak-guard self-scan green.

## Provenance

§CP surface (`packages/pipeline-cli/`) — routes through the control-plane review lane. Unblocks the recurring alchemy `pathToFileURL` patch-pin lane (and PR #3063 specifically), whose subject matter routinely quotes Windows file URLs.