### PR TITLE
fix(pipeline): carve src-colocated test/spec out of the class-probe UI gate (#3071)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -195,11 +195,14 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   dispatch, fail-closed to **has-ui** (dispatch `review-design`) if that line is unreadable — never
   fail-open to skip it (#2341, the #981 `?ref=main` idiom):
   ```bash
-  UI_RE='^apps/web/src/'   # fail-closed reference; the live line below is authoritative (#2470: scope is apps/web/src ONLY — a non-web .tsx/.css has no rendered surface, not design-gate work)
-  UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
+  UI_RE='^apps/web/src/'   # fail-closed reference; the live lines below are authoritative (#2470: scope is apps/web/src ONLY — a non-web .tsx/.css has no rendered surface, not design-gate work)
+  UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'   # #3071: a src-colocated *.test.tsx/*.spec.ts renders no surface — carve it out (mirrors §CLASS has-docs carve-then-test; ERE has no lookahead, hence the exclude pair)
+  UI_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+  UI_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_RE=' | head -n1 || true)"; UX_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_EXCLUDE_RE=' | head -n1 || true)"
   if [ -n "$UI_LIVE" ]; then UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"; else UI_RE='.'; fi   # unreadable ⇒ '.' ⇒ every path is UI-affecting ⇒ dispatch review-design (never silently drop it)
+  if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")"; else UI_EXCLUDE_RE='$^'; fi   # unreadable ⇒ '$^' never-match ⇒ carve nothing ⇒ dispatch review-design for every src path (fail-closed)
   CHANGED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"
-  echo "$CHANGED" | grep -Eq "$UI_RE" && echo "UI-affecting → dispatch review-design alongside the class gate"
+  echo "$CHANGED" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "UI-affecting → dispatch review-design alongside the class gate"
   ```
   Because all sides resolve the identical live `UI_RE`, `required-gate == dispatched-gate ==
   satisfiable-gate` holds by construction, not by hand-syncing aging copies — the exact staleness

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -195,10 +195,13 @@ PR=<pr number>
 # ship-it requires on and reviewer.md dispatches on, so require == dispatch == off-ramp by
 # construction (#2470). The literal is the fail-closed REFERENCE, not the live decision source.
 UI_RE='^apps/web/src/'
-UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
+UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'   # #3071: carve src-colocated test/spec out (no rendered surface); mirrors §CLASS has-docs carve-then-test — ERE has no lookahead, hence the exclude pair
+UI_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+UI_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_RE=' | head -n1 || true)"; UX_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_EXCLUDE_RE=' | head -n1 || true)"
 if [ -n "$UI_LIVE" ]; then UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"; else UI_RE='.'; fi   # unreadable ⇒ '.' ⇒ every path is UI-affecting ⇒ proceed & verdict (never silently off-ramp)
+if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")"; else UI_EXCLUDE_RE='$^'; fi   # unreadable ⇒ '$^' never-match ⇒ carve nothing ⇒ proceed & verdict (fail-closed)
 UI_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '.[].filename' | grep -E "$UI_RE" || true)"
+  --jq '.[].filename' | grep -Ev "$UI_EXCLUDE_RE" | grep -E "$UI_RE" || true)"
 ```
 
 - **Empty** (the diff changes no `apps/web/src/**` surface — a pure backend / infra / docs / skill

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -339,14 +339,21 @@ echo "$FILES" | grep -Ev "$HAS_DOCS_EXCLUDE_RE" | grep -Eq "$HAS_DOCS_RE" && ech
 # made the *require* predicate a superset of review-design's own dispatch/off-ramp predicate
 # (`^apps/web/src/`): a non-web `.tsx` was required-but-unroutable — the dispatched review-design run
 # off-ramped with no marker and ship-it deadlocked on a review-design PASS no run could produce.
+# IN-SRC TEST CARVE-OUT (#3071): a change whose apps/web/src paths are ALL test/spec files renders no
+# surface, so it must NOT mint a required review-design either — the src-colocated `*.test.tsx` next to
+# a component (the established sibling-colocation convention) stalled #3046/#3047 at ship on a gate no
+# run could satisfy. ERE (grep -E) has no negative lookahead, so a single UI_RE can't express "under
+# src, but not a test" — mirror §CLASS's has-docs carve-then-test: strip test/spec files FIRST, THEN
+# test for a UI path. A real component (apps/web/src/**/*.tsx non-test) or a mixed component+test diff
+# survives the carve and STILL gates; only an all-test/spec src diff is exempted.
 UI_RE='^apps/web/src/'
-UI_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^UI_RE=' | head -n1 || true)"
-if [ -n "$UI_LIVE" ]; then
-  UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"   # UI-gating tracks origin/main, not the snapshot's age (#2341)
-else
-  UI_RE='.'   # FAIL CLOSED: can't read origin/main's UI_RE ⇒ treat EVERY path as UI-affecting ⇒ REQUIRE review-design, never silently skip the gate (the safe default is demand-the-gate)
-fi
-echo "$FILES" | grep -Eq "$UI_RE" && echo "has-ui"   # UI-affecting → require review-design ALONGSIDE the class gate(s)
+UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'
+UI_RAW="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
+UI_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_RE=' | head -n1 || true)"
+UX_LIVE="$(printf '%s\n' "$UI_RAW" | grep '^UI_EXCLUDE_RE=' | head -n1 || true)"
+if [ -n "$UI_LIVE" ]; then UI_RE="$(printf '%s' "$UI_LIVE" | sed "s/^UI_RE='//; s/'$//")"; else UI_RE='.'; fi   # FAIL CLOSED: can't read origin/main's UI_RE ⇒ '.' ⇒ every path UI-affecting ⇒ REQUIRE review-design, never silently skip (#2341)
+if [ -n "$UX_LIVE" ]; then UI_EXCLUDE_RE="$(printf '%s' "$UX_LIVE" | sed "s/^UI_EXCLUDE_RE='//; s/'$//")"; else UI_EXCLUDE_RE='$^'; fi   # FAIL CLOSED: unreadable ⇒ '$^' never-match ⇒ carve out NOTHING ⇒ every apps/web/src path (incl. tests) gates review-design
+echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"   # carve test/spec first, THEN require review-design ALONGSIDE the class gate(s)
 ```
 
 **Routing:**

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
@@ -152,22 +152,45 @@ export const DESIGN_NAMESPACE = "review-design" as const;
 export const FAILCLOSED_UI_RE = ".";
 
 /**
- * Parse the canonical `UI_RE='…'` line out of `ship-it/SKILL.md` — the single source for the
- * additive has-ui/review-design gate (§CLASS keeps `UI_RE` in ship-it, not in §CLASS itself).
- * A missing line falls back to the fail-closed default; the source is single, so this only
- * bites on a truncated read.
+ * Fail-closed UI carve-out: `$^` (end-anchor before start-anchor ⇒ never matches) ⇒ carve out
+ * NOTHING, so an unreadable/incomplete `UI_EXCLUDE_RE` leaves every apps/web/src path (tests
+ * included) reaching the UI test ⇒ demand review-design. Mirrors §CLASS's `HAS_DOCS_EXCLUDE_RE`
+ * fail-closed sentinel — the safe direction is over-gate, never silently exempt.
+ */
+export const FAILCLOSED_UI_EXCLUDE_RE = "$^";
+
+/**
+ * Parse the canonical `UI_RE='…'` / `UI_EXCLUDE_RE='…'` lines out of `ship-it/SKILL.md` — the
+ * single source for the additive has-ui/review-design gate (§CLASS keeps both in ship-it, not in
+ * §CLASS itself). A missing line falls back to its fail-closed default; the source is single, so
+ * this only bites on a truncated read. (`^UI_RE=` does not match the `UI_EXCLUDE_RE=` line — the
+ * fourth char diverges — so the two never cross-capture.)
  */
 export const parseUiProbe = (shipItText: string): string =>
 	shipItText.match(/^UI_RE='([^']*)'/m)?.[1] ?? FAILCLOSED_UI_RE;
 
+export const parseUiExclude = (shipItText: string): string =>
+	shipItText.match(/^UI_EXCLUDE_RE='([^']*)'/m)?.[1] ?? FAILCLOSED_UI_EXCLUDE_RE;
+
 /**
- * Is the diff UI-affecting (has-ui)? A non-visual `apps/web/src/*.ts` still matches `UI_RE`
- * (`^apps/web/src/`) — that is deliberate here, not a bug to eyeball away: ship-it requires
+ * Is the diff UI-affecting (has-ui)? Carve-then-test, mirroring §CLASS's has-docs probe: a file
+ * counts only if it is NOT a test/spec (`UI_EXCLUDE_RE`) AND matches `UI_RE`. A non-visual
+ * `apps/web/src/*.ts` still counts — deliberate, not a bug to eyeball away: ship-it requires
  * review-design on exactly this predicate, so the fan must dispatch it on exactly this predicate
- * or the PR deadlocks on a phantom-empty review-design namespace (#2485/#2483). Conversely a
- * `.tsx`/`.css` OUTSIDE apps/web/src is NOT has-ui — the scope is `^apps/web/src/` only, so the
- * require predicate never exceeds review-design's dispatch/off-ramp (#2470). Fail-closed: an
- * uncompilable probe matches every path ⇒ has-ui.
+ * or the PR deadlocks on a phantom-empty review-design namespace (#2485/#2483). A `.tsx`/`.css`
+ * OUTSIDE apps/web/src is not has-ui — the scope is `^apps/web/src/` only, so the require predicate
+ * never exceeds review-design's dispatch/off-ramp (#2470). The carve-out (#3071) exempts an
+ * all-test/spec src diff — `*.test.tsx` / `*.spec.ts` render no surface, so a required review-design
+ * on them could only ever no-op PASS (the #3046/#3047 ship stall); a real component or a mixed
+ * component+test diff survives the carve and STILL gates. Fail-closed: an uncompilable UI_RE matches
+ * every path ⇒ has-ui; an uncompilable exclude carves nothing ⇒ still has-ui.
  */
-export const isUiAffecting = (files: ReadonlyArray<string>, uiRe: string): boolean =>
-	files.some(matcher(uiRe, () => true));
+export const isUiAffecting = (
+	files: ReadonlyArray<string>,
+	uiRe: string,
+	uiExclude: string,
+): boolean => {
+	const isUi = matcher(uiRe, () => true);
+	const isTestOrSpec = matcher(uiExclude, () => false);
+	return files.some((f) => !isTestOrSpec(f) && isUi(f));
+};

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
@@ -5,9 +5,11 @@ import {describe, expect, it} from "vitest";
 import {
 	classify,
 	FAILCLOSED_PROBES,
+	FAILCLOSED_UI_EXCLUDE_RE,
 	FAILCLOSED_UI_RE,
 	isUiAffecting,
 	parseClassProbes,
+	parseUiExclude,
 	parseUiProbe,
 	requiredNamespaces,
 } from "./class-probe.ts";
@@ -21,9 +23,11 @@ const FORMATS_PATH = join(
 	"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
 );
 const LIVE_PROBES = parseClassProbes(readFileSync(FORMATS_PATH, "utf8"));
-// The additive UI_RE off its live single source (ship-it/SKILL.md) — same discipline.
+// The additive UI_RE + its in-src test carve-out off their live single source (ship-it/SKILL.md).
 const SHIP_IT_PATH = join(REPO_ROOT, "claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md");
-const LIVE_UI_RE = parseUiProbe(readFileSync(SHIP_IT_PATH, "utf8"));
+const SHIP_IT_TEXT = readFileSync(SHIP_IT_PATH, "utf8");
+const LIVE_UI_RE = parseUiProbe(SHIP_IT_TEXT);
+const LIVE_UI_EXCLUDE = parseUiExclude(SHIP_IT_TEXT);
 
 describe("parseClassProbes", () => {
 	it("extracts the four single-quoted §CLASS probes off the live contract", () => {
@@ -160,7 +164,7 @@ describe("classify — fail-closed on an unreadable source over-dispatches, neve
 	});
 });
 
-describe("parseUiProbe — the additive UI_RE off its single source (ship-it/SKILL.md)", () => {
+describe("parseUiProbe / parseUiExclude — the additive UI gate off its single source (ship-it/SKILL.md)", () => {
 	it("extracts the live single-quoted UI_RE line", () => {
 		// #2470: scope is `^apps/web/src/` ONLY. The old `|\.tsx$|\.css$` branches made the require
 		// predicate a superset of review-design's own dispatch/off-ramp (`^apps/web/src/`), so a
@@ -168,9 +172,21 @@ describe("parseUiProbe — the additive UI_RE off its single source (ship-it/SKI
 		expect(LIVE_UI_RE).toBe("^apps/web/src/");
 	});
 
-	it("falls back to the fail-closed UI_RE for a missing/truncated source", () => {
+	it("extracts the live single-quoted UI_EXCLUDE_RE line (#3071 in-src test carve-out)", () => {
+		expect(LIVE_UI_EXCLUDE).toBe("\\.(test|spec)\\.tsx?$");
+	});
+
+	it("does not cross-capture UI_EXCLUDE_RE as UI_RE (nor vice-versa)", () => {
+		// `^UI_RE=` and `^UI_EXCLUDE_RE=` are distinct line prefixes; parsing must keep them apart.
+		expect(parseUiProbe("UI_EXCLUDE_RE='\\.(test|spec)\\.tsx?$'\n")).toBe(FAILCLOSED_UI_RE);
+		expect(parseUiExclude("UI_RE='^apps/web/src/'\n")).toBe(FAILCLOSED_UI_EXCLUDE_RE);
+	});
+
+	it("falls back to the fail-closed defaults for a missing/truncated source", () => {
 		expect(parseUiProbe("")).toBe(FAILCLOSED_UI_RE);
 		expect(FAILCLOSED_UI_RE).toBe(".");
+		expect(parseUiExclude("")).toBe(FAILCLOSED_UI_EXCLUDE_RE);
+		expect(FAILCLOSED_UI_EXCLUDE_RE).toBe("$^");
 	});
 });
 
@@ -183,7 +199,7 @@ describe("isUiAffecting — review-design reaches a marker, never a phantom-empt
 	const nonVisualSrcTs = ["apps/web/src/fate/wireMessages.ts", "apps/web/src/lib/fateWireCodes.ts"];
 
 	it("classes a non-visual apps/web/src/*.ts diff has-ui (the #2483 files)", () => {
-		expect(isUiAffecting(nonVisualSrcTs, LIVE_UI_RE)).toBe(true);
+		expect(isUiAffecting(nonVisualSrcTs, LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(true);
 	});
 
 	it("the same diff is also has-code — fan must dispatch BOTH review-code AND review-design", () => {
@@ -192,30 +208,42 @@ describe("isUiAffecting — review-design reaches a marker, never a phantom-empt
 		// The lockstep contract: what ship-it requires (has-code + has-ui) == what the fan
 		// dispatches. The additive review-design rides on top of the class namespace(s).
 		expect(requiredNamespaces(classes)).toEqual(["review-code"]);
-		expect(isUiAffecting(nonVisualSrcTs, LIVE_UI_RE)).toBe(true);
+		expect(isUiAffecting(nonVisualSrcTs, LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(true);
 	});
 
 	it("fires on visual surfaces under apps/web/src (*.tsx, *.css) via the prefix", () => {
-		expect(isUiAffecting(["apps/web/src/App.tsx"], LIVE_UI_RE)).toBe(true);
-		expect(isUiAffecting(["apps/web/src/styles/theme.css"], LIVE_UI_RE)).toBe(true);
+		expect(isUiAffecting(["apps/web/src/App.tsx"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(true);
+		expect(isUiAffecting(["apps/web/src/styles/theme.css"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(
+			true,
+		);
 	});
 
 	it("does not fire on a non-UI diff — no phantom review-design on a docs/skill-only PR", () => {
-		expect(isUiAffecting([".decisions/0173-x.md"], LIVE_UI_RE)).toBe(false);
+		expect(isUiAffecting([".decisions/0173-x.md"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(false);
 		expect(
-			isUiAffecting(["claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md"], LIVE_UI_RE),
+			isUiAffecting(
+				["claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md"],
+				LIVE_UI_RE,
+				LIVE_UI_EXCLUDE,
+			),
 		).toBe(false);
 	});
 
 	it("an empty diff is never UI-affecting (no review-design required)", () => {
-		expect(isUiAffecting([], LIVE_UI_RE)).toBe(false);
-		expect(isUiAffecting([], FAILCLOSED_UI_RE)).toBe(false);
+		expect(isUiAffecting([], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(false);
+		expect(isUiAffecting([], FAILCLOSED_UI_RE, FAILCLOSED_UI_EXCLUDE_RE)).toBe(false);
 	});
 
 	it("fail-closed: an unreadable UI_RE treats every changed path as UI-affecting", () => {
 		// Mirrors ship-it Step 0 / the reviewer's fail-closed `has-ui` — demand the gate, never
-		// silently drop it. Empty diff stays empty (nothing to gate).
-		expect(isUiAffecting(["packages/pipeline-cli/src/bin.ts"], FAILCLOSED_UI_RE)).toBe(true);
+		// silently drop it. The fail-closed exclude (`$^`) carves nothing, so the demand stands.
+		expect(
+			isUiAffecting(
+				["packages/pipeline-cli/src/bin.ts"],
+				FAILCLOSED_UI_RE,
+				FAILCLOSED_UI_EXCLUDE_RE,
+			),
+		).toBe(true);
 	});
 });
 
@@ -234,15 +262,77 @@ describe("isUiAffecting — a non-web .tsx/.css mints NO phantom review-design (
 
 	it("a non-apps/web/src .tsx/.css is NOT has-ui — no required/dispatched review-design", () => {
 		for (const f of nonWebUi) {
-			expect(isUiAffecting([f], LIVE_UI_RE)).toBe(false);
+			expect(isUiAffecting([f], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(false);
 		}
-		expect(isUiAffecting(nonWebUi, LIVE_UI_RE)).toBe(false);
+		expect(isUiAffecting(nonWebUi, LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(false);
 	});
 
 	it("a real apps/web/src UI file STILL is has-ui — the gate holds for rendered surfaces", () => {
-		expect(isUiAffecting(["apps/web/src/App.tsx"], LIVE_UI_RE)).toBe(true);
-		expect(isUiAffecting(["apps/web/src/styles/theme.css"], LIVE_UI_RE)).toBe(true);
+		expect(isUiAffecting(["apps/web/src/App.tsx"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(true);
+		expect(isUiAffecting(["apps/web/src/styles/theme.css"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(
+			true,
+		);
 		// and the #2485 non-visual apps/web/src/*.ts stays has-ui via the same prefix branch
-		expect(isUiAffecting(["apps/web/src/fate/wireMessages.ts"], LIVE_UI_RE)).toBe(true);
+		expect(isUiAffecting(["apps/web/src/fate/wireMessages.ts"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(
+			true,
+		);
+	});
+});
+
+describe("isUiAffecting — a src-colocated *.test.ts[x] / *.spec.* mints NO review-design (#3071)", () => {
+	// The #3071 stall: a test file colocated under apps/web/src (the sibling-colocation convention,
+	// e.g. next to a component) matched `^apps/web/src/` and minted a REQUIRED review-design gate —
+	// but a test fixture renders no surface, so that gate could only ever no-op PASS. It stalled the
+	// test-only PRs #3046/#3047 at ship. The carve-out exempts an ALL-test/spec src diff; a real
+	// component or a mixed component+test diff STILL gates (the fail-closed direction: exempt only
+	// what provably renders nothing).
+	const srcTestOnly = [
+		"apps/web/src/Foo.test.tsx",
+		"apps/web/src/Foo.test.ts",
+		"apps/web/src/fate/liveSubscribeBatch.spec.ts",
+		"apps/web/src/lib/util.spec.tsx",
+	];
+
+	it("(a) a diff of ONLY src-colocated test/spec files is NOT has-ui", () => {
+		for (const f of srcTestOnly) {
+			expect(isUiAffecting([f], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(false);
+		}
+		expect(isUiAffecting(srcTestOnly, LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(false);
+	});
+
+	it("(b) a real src component (non-test .tsx / .ts / .css) STILL is has-ui — the gate holds", () => {
+		expect(isUiAffecting(["apps/web/src/Foo.tsx"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(true);
+		expect(isUiAffecting(["apps/web/src/fate/wireMessages.ts"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(
+			true,
+		);
+		expect(isUiAffecting(["apps/web/src/styles/theme.css"], LIVE_UI_RE, LIVE_UI_EXCLUDE)).toBe(
+			true,
+		);
+	});
+
+	it("(c) a MIXED diff (component + its colocated test) STILL is has-ui — the component gates", () => {
+		expect(
+			isUiAffecting(
+				["apps/web/src/Foo.tsx", "apps/web/src/Foo.test.tsx"],
+				LIVE_UI_RE,
+				LIVE_UI_EXCLUDE,
+			),
+		).toBe(true);
+	});
+
+	it("classes the test-only diff as has-code (review-code) — it is gated, just not review-design", () => {
+		// The carve-out removes ONLY the phantom review-design, never the real review-code gate:
+		// a src `.test.ts[x]` is still `apps/web/**` → has-code, so the test change is reviewed.
+		const classes = classify(srcTestOnly, LIVE_PROBES);
+		expect(classes).toEqual(["has-code"]);
+		expect(requiredNamespaces(classes)).toEqual(["review-code"]);
+	});
+
+	it("fail-closed: an unreadable UI_EXCLUDE_RE carves nothing ⇒ a src test still demands review-design", () => {
+		// Safe direction: if the carve-out source can't be read, over-gate rather than silently
+		// exempt. `$^` never matches, so the test file falls through to the UI_RE test.
+		expect(isUiAffecting(["apps/web/src/Foo.test.tsx"], LIVE_UI_RE, FAILCLOSED_UI_EXCLUDE_RE)).toBe(
+			true,
+		);
 	});
 });

--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -35,6 +35,7 @@ import {
 	DESIGN_NAMESPACE,
 	isUiAffecting,
 	parseClassProbes,
+	parseUiExclude,
 	parseUiProbe,
 	requiredNamespaces,
 } from "./class-probe.ts";
@@ -114,9 +115,10 @@ const classifyCmd = Command.make(
 		const probes = parseClassProbes(formats ?? "");
 		const shipIt = readShipIt(rootDir);
 		const uiRe = parseUiProbe(shipIt ?? "");
+		const uiExclude = parseUiExclude(shipIt ?? "");
 		const files = readFiles(filesFrom);
 		const classes = classify(files, probes);
-		const uiAffecting = isUiAffecting(files, uiRe);
+		const uiAffecting = isUiAffecting(files, uiRe, uiExclude);
 
 		if (formats === null) {
 			yield* Effect.sync(() =>


### PR DESCRIPTION
Fixes #3071

## Problem

`UI_RE='^apps/web/src/'` (single source in `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`, parsed by `class-probe` via a plain `compiled.test`) prefix-matched **any** path under `apps/web/src/` — including `*.test.ts` / `*.test.tsx` / `*.spec.*`. So a test-only diff minted a **required** `review-design` gate that can never be satisfied (a test fixture renders no surface), stalling the test-only PRs #3046/#3047 at ship. #2470 narrowed `UI_RE` to `^apps/web/src/` but added no in-src test carve-out.

## Fix — the carve-then-test exclude pair (mirrors §CLASS's has-docs idiom)

ERE (`grep -E`, used by every side that re-resolves the live gate) has **no negative lookahead**, so a single `UI_RE` cannot express "under src, but not a test". Instead of inventing a new shape, this mirrors the established `HAS_DOCS_EXCLUDE_RE` + `HAS_DOCS_RE` carve-then-test already in this exact code (`grep -Ev exclude | grep -Eq include`, and `!isExcluded(f) && isDocPath(f)` in the core):

- Add a `UI_EXCLUDE_RE='\.(test|spec)\.tsx?$'` single-source line **alongside** `UI_RE` in `ship-it/SKILL.md`.
- Strip test/spec files **first**, **then** test for a UI path — on every side, so `required == dispatched == satisfiable` holds by construction: ship-it Step 0 (the single source), the reviewer fan's `ui_reresolve` reference, review-design's Step 0 off-ramp, and `class-probe`'s `isUiAffecting` (+ new `parseUiExclude`).

A real component (`apps/web/src/**/*.tsx` non-test) or a **mixed** component+test diff survives the carve and **still** gates. A test-only diff still rides `has-code` (`review-code`) — the carve-out removes **only** the phantom `review-design`, never the real logic gate. **Fail-closed:** an unreadable `UI_EXCLUDE_RE` (`$^`, never-match) carves nothing ⇒ every src path still demands `review-design`.

## Tests (class-probe unit)

Added a `#3071` describe block pinning the exact regression:
- **(a)** ONLY `apps/web/src/Foo.test.tsx` / `.test.ts` / `.spec.ts` / `.spec.tsx` → **NOT** has-ui (no review-design).
- **(b)** a real `apps/web/src/Foo.tsx` (and non-visual `.ts`, `.css`) → **STILL** has-ui.
- **(c)** a mixed component+test diff → **STILL** has-ui.
- Plus: test-only diff still classes `has-code`/`review-code`; fail-closed exclude still demands the gate; `UI_RE` ⁄ `UI_EXCLUDE_RE` never cross-capture.

All existing `isUiAffecting` cases threaded through the new exclude arg. 35 tests pass; `pnpm typecheck` clean.

## §CP

Edits a gate-critical skill (`ship-it/SKILL.md`) + `packages/pipeline-cli/` → mechanically §CP. Opened for the §CP merge path; not shipped/enqueued.