### PR TITLE
test(integration): retry-wrap the two merge_group-flaky real-D1 suites (#3075)

### DIFF
--- a/apps/web/tests/integration/kunye-relation-store.test.ts
+++ b/apps/web/tests/integration/kunye-relation-store.test.ts
@@ -76,7 +76,14 @@ afterEach(async () => {
 	await remove(SUBJECT);
 });
 
-describe("RelationStoreLive.has on real D1 — resolves composite-PK tuple existence", () => {
+// #3075 stopgap (reversible): retry-wrap so a transient real-D1 flake in merge_group retries
+// instead of evicting clean, unrelated PRs from the merge queue. Retry, NOT skip — the real-D1
+// coverage stays. `mint()` is onConflictDoNothing (retry-idempotent) and uses no seedTerm, so
+// vitest.config's "no retry" seedTerm-dedup constraint isn't tripped here. Remove once #3075's
+// durable ci.yml worker-relevance filter lands.
+describe("RelationStoreLive.has on real D1 — resolves composite-PK tuple existence", {
+	retry: 2,
+}, () => {
 	it("a seeded tuple reads present; a non-matching tuple reads absent", async () => {
 		await mint(SUBJECT);
 

--- a/apps/web/tests/integration/search-error-vs-empty.test.ts
+++ b/apps/web/tests/integration/search-error-vs-empty.test.ts
@@ -40,7 +40,12 @@ beforeAll(async () => {
 	});
 });
 
-describe("search error-vs-empty (#549)", () => {
+// #3075 stopgap (reversible): retry-wrap so a transient real-CF/D1 flake in merge_group retries
+// instead of evicting clean, unrelated PRs from the merge queue. Retry, NOT skip — the real-D1
+// coverage stays. `seedTerm` runs in beforeAll (not re-entered by test retry) and the in-body op
+// is DROP TABLE IF EXISTS (idempotent), so vitest.config's "no retry" seedTerm-dedup constraint
+// isn't tripped here. Remove once #3075's durable ci.yml worker-relevance filter lands.
+describe("search error-vs-empty (#549)", {retry: 2}, () => {
 	it("a legitimate zero-match query succeeds with an empty connection (the 'sonuç yok' branch)", async () => {
 		// A well-formed query that matches nothing: `ok:true` with zero items. This is the
 		// SUCCESS path the page renders as "sonuç yok" — it must stay distinct from the

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -96,10 +96,14 @@ export default defineConfig({
 					// Each file's beforeAll(deploy(Stack)) provisions a real worker + D1
 					// under an isolated stage and seeds over the network, then asserts over
 					// HTTP — so a file's wall-clock is deploy + migrate + seed + assert.
-					// Generous timeouts cover that. NO Vitest `retry`: the harness owns
-					// per-request retries at the right layer, and a test-level retry would
+					// Generous timeouts cover that. No project-level Vitest `retry`: the harness
+					// owns per-request retries at the right layer, and a test-level retry would
 					// re-enter `seedTerm` whose process-level (slug, body) dedup then reports
 					// created:false / inserted:0 — breaking the seed assertions it retries.
+					// Exception: two files carry a file-local `describe(..., {retry: 2})` #3075
+					// stopgap (search-error-vs-empty, kunye-relation-store) — neither re-enters
+					// `seedTerm` on retry, so the dedup hazard above doesn't apply. Reversible;
+					// drops when #3075's durable ci.yml worker-relevance filter lands.
 					testTimeout: 120_000,
 					hookTimeout: 180_000,
 					pool: "forks",


### PR DESCRIPTION
## What

Adds a file-local `describe(..., { retry: 2 })` to the two real-D1 integration suites that intermittently flake under `merge_group` batch load — `kunye-relation-store` and `search-error-vs-empty` — so a transient flake **retries** instead of evicting clean, unrelated PRs from the merge queue.

## Why

Under concurrent-stage batch load the real-D1 suites hit transient failures (read-after-write races + CF API 429s) that fail the whole batch and evict green PRs (#3075). This is the reversible stopgap that stops the bleeding while the durable fixes land.

## Safety

- **Retry, not skip** — the real-D1 coverage is unchanged; a flake just gets another attempt.
- Neither suite re-enters `seedTerm` on retry, so the project-level "no retry" `seedTerm`-dedup constraint documented in `vitest.config.ts` isn't tripped: `mint()` is `onConflictDoNothing` (retry-idempotent) and `search`'s in-body op is `DROP TABLE IF EXISTS` (idempotent).

## Reversible

Remove the two file-local retries + the `vitest.config.ts` note once #3075's durable fixes land — the `merge_group` worker-relevance filter (#3083) and the two named de-flakes (#3078 kunye read-after-write, #3080 deploy-readiness).

Stopgap for #3075.
