### PR TITLE
ci: gate merge_group integration on worker-relevance (§CP — the #3075 eviction fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,11 @@ jobs:
       # PR (the #994 pipeline-cli reorg) edits the lockfile, paying the tier + the
       # #1010/#813 stage-leak flake for nothing. The `@kampus/worker-relevance`
       # classifier (run in the `worker-relevance` step below) attributes the lockfile
-      # delta and FAILS SAFE TO RUNNING. Default `'true'`: the step only runs on PRs
-      # (it needs a base ref), so a `push` keeps the full backstop, and any step
-      # failure/skip leaves the safe default. ANDed into integration/e2e required-ness
-      # below so it can only ever REMOVE a run, never add a skip the old gate didn't.
+      # delta and FAILS SAFE TO RUNNING. Default `'true'`: the step runs on `pull_request`
+      # and `merge_group` (issue #3079) but not `push` (no base ref), so a `push` keeps the
+      # full backstop, and any step failure/skip leaves the safe default. ANDed into
+      # integration/e2e required-ness below so it can only ever REMOVE a run, never add a
+      # skip the old gate didn't.
       worker_relevant: ${{ steps.worker-relevance.outputs.worker_relevant || 'true' }}
       # Per-gating-job *required-ness* (#786): the SINGLE SOURCE of "should this job
       # have run". Each `*_required` output mirrors the SAME inputs that gate the job's
@@ -74,12 +75,25 @@ jobs:
       # The `feature-complete` forcing function still wins (it ORs with `backend`), and
       # since a feature-complete PR is by definition worker-affecting the worker-
       # relevance AND never strips a flagged full sweep in practice.
-      # `merge_group` ORed in FIRST: the batch runs in the trusted base's context (only
-      # already-mergeable PRs enter the queue) with repo secrets, so the fork/author
-      # guard — a PR-only fork-secret safety — is not applicable and the full backstop
-      # runs on the batch (ADR 0132).
+      # `merge_group` now respects the SAME worker-relevance filter the `pull_request`
+      # path trusts (issue #3079), instead of ORing in FIRST to force the full suite on
+      # every batch — the old unconditional merge_group run let a flaky real-CF integration
+      # suite evict clean worker-IRRELEVANT PRs from the queue (#3075: #3067/#3073/#3074/
+      # #3064). The classify step below now runs on `merge_group` too, over the batch's
+      # real `base_sha...head_sha` range (ADR 0132) — the prospective merge of every queued
+      # PR, so a diff over it OR's ALL batched PRs: the batch is worker-relevant if ANY
+      # batched PR touches the worker, and integration is skipped ONLY when EVERY batched PR
+      # is provably worker-irrelevant (`worker_relevant == 'false'`). FAIL-SAFE TO RUNNING is
+      # preserved end to end — `|| 'true'` defaults an absent/empty output to running, the
+      # classify step emits `worker_relevant=true` on any missing base/head SHA or
+      # unresolvable diff, and the classifier core itself fails safe to running — so any
+      # doubt RUNS integration, never skips (the #3079 threat model: a mis-classified
+      # worker-relevant batch must never skip and merge broken). The batch still runs in the
+      # trusted base's context with repo secrets, so the PR-only fork/author guard does not
+      # apply.
       integration_required: >-
-        ${{ github.event_name == 'merge_group' ||
+        ${{ (github.event_name == 'merge_group' &&
+             (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false') ||
             ((steps.filter.outputs.backend == 'true' ||
              contains(github.event.pull_request.labels.*.name, 'feature-complete')) &&
             (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false' &&
@@ -229,38 +243,69 @@ jobs:
         with:
           node-version-file: package.json
 
-      # Worker-relevance classifier (issue #1014). Only on a PR (a `push` has no base
-      # ref to diff and keeps the full integration backstop). Emits `worker_relevant`
-      # — `false` ONLY when the whole diff (incl. the `pnpm-lock.yaml` delta, attributed
-      # per importer block) is provably confined to packages the worker never imports;
-      # any worker-affecting path, a shared lockfile section, an unattributable diff, or
-      # any failure leaves it `true` (fail-safe to running). Runs the zero-runtime-dep
-      # `@kampus/worker-relevance` bin directly — no `pnpm install` (the `ci-required`
-      # idiom), so the always-on detector stays fast. `git diff base...head` over the
-      # full-history checkout above gives the PR's changed files + the lockfile diff.
+      # Worker-relevance classifier (issue #1014, extended to the batch by #3079). Runs on
+      # `pull_request` AND `merge_group` — a `push` has no base ref to diff and keeps the
+      # full integration backstop. Emits `worker_relevant` — `false` ONLY when the whole
+      # diff (incl. the `pnpm-lock.yaml` delta, attributed per importer block) is provably
+      # confined to packages the worker never imports; any worker-affecting path, a shared
+      # lockfile section, an unattributable diff, or any failure leaves it `true` (fail-safe
+      # to running). Runs the zero-runtime-dep `@kampus/worker-relevance` bin directly — no
+      # `pnpm install` (the `ci-required` idiom), so the always-on detector stays fast.
+      # The `git diff base...head` over the full-history checkout above gives the changed
+      # files + the lockfile diff: on `pull_request` the range is the PR's merge-base...HEAD;
+      # on `merge_group` it is the batch's `base_sha...head_sha` (ADR 0132) — the prospective
+      # merge of every queued PR, so the SAME classifier sees, and OR's across, all batched
+      # PRs (#3079 defenses 1/2/4: real base ref, OR-across-batch, exact classifier reuse).
       - name: Classify worker-relevance of the diff
         id: worker-relevance
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         env:
           BASE_REF: ${{ github.base_ref }}
+          # The batch's real base + head (empty on `pull_request`). The queue builds the
+          # batch on `base_sha` and `head_sha` is its prospective-merge tip (ADR 0132).
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
-          # Full base fetch (no `--depth=1`): the `fetch-depth: 0` checkout above already
-          # has HEAD's full history, but a shallow `--depth=1` base re-fetch can land a base
-          # commit sharing NO ancestor with HEAD on a branch whose base drifted behind a
-          # fast-moving `main`, so `git merge-base` came back empty under `set -e` and
-          # false-red the whole `changes` job (issue #1154). A full base fetch restores a
-          # real merge-base.
-          git fetch --no-tags origin "$BASE_REF"
-          # Fail SAFE to running, not red, if a merge-base still can't be found (orphan/grafted
-          # history): an empty base degrades to the two-dot range against `origin/$BASE_REF`,
-          # which yields a superset diff → `worker_relevant=true` (the step's existing
-          # fail-safe-to-running stance), never a hard step failure.
-          if base="$(git merge-base "origin/$BASE_REF" HEAD)" && [ -n "$base" ]; then
-            range="$base...HEAD"
+          if [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+            # #3079 defense 3 (FAIL-SAFE TO RUNNING): any doubt about the batch's diff — an
+            # empty base/head SHA, or an endpoint that can't be resolved in the checkout —
+            # emits `worker_relevant=true` and runs integration; NEVER a skip on doubt, and
+            # never a hard step failure (which would red the batch instead of running it).
+            if [ -z "$MERGE_GROUP_BASE_SHA" ] || [ -z "$MERGE_GROUP_HEAD_SHA" ]; then
+              echo "::warning::worker-relevance: merge_group base_sha/head_sha empty — fail-safe to running"
+              echo "worker_relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # The `fetch-depth: 0` checkout already carries the batch head's history (base_sha
+            # is its ancestor); fetch defensively and fail SAFE to running if either endpoint
+            # is still unresolvable, rather than let `set -e` red the batch.
+            git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA" "$MERGE_GROUP_HEAD_SHA" 2>/dev/null || true
+            if ! git cat-file -e "${MERGE_GROUP_BASE_SHA}^{commit}" 2>/dev/null \
+               || ! git cat-file -e "${MERGE_GROUP_HEAD_SHA}^{commit}" 2>/dev/null; then
+              echo "::warning::worker-relevance: merge_group base/head SHA unresolvable in checkout — fail-safe to running"
+              echo "worker_relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            range="$MERGE_GROUP_BASE_SHA...$MERGE_GROUP_HEAD_SHA"
           else
-            echo "::warning::worker-relevance: no merge-base with origin/$BASE_REF — degrading to a full diff (fail-safe to running)"
-            range="origin/$BASE_REF..HEAD"
+            # Full base fetch (no `--depth=1`): the `fetch-depth: 0` checkout above already
+            # has HEAD's full history, but a shallow `--depth=1` base re-fetch can land a base
+            # commit sharing NO ancestor with HEAD on a branch whose base drifted behind a
+            # fast-moving `main`, so `git merge-base` came back empty under `set -e` and
+            # false-red the whole `changes` job (issue #1154). A full base fetch restores a
+            # real merge-base.
+            git fetch --no-tags origin "$BASE_REF"
+            # Fail SAFE to running, not red, if a merge-base still can't be found (orphan/grafted
+            # history): an empty base degrades to the two-dot range against `origin/$BASE_REF`,
+            # which yields a superset diff → `worker_relevant=true` (the step's existing
+            # fail-safe-to-running stance), never a hard step failure.
+            if base="$(git merge-base "origin/$BASE_REF" HEAD)" && [ -n "$base" ]; then
+              range="$base...HEAD"
+            else
+              echo "::warning::worker-relevance: no merge-base with origin/$BASE_REF — degrading to a full diff (fail-safe to running)"
+              range="origin/$BASE_REF..HEAD"
+            fi
           fi
           CHANGED_FILES="$(git diff --name-only --diff-filter=ACMRD "$range")"
           LOCKFILE_DIFF="$(git diff "$range" -- pnpm-lock.yaml)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,11 +251,12 @@ jobs:
       # lockfile section, an unattributable diff, or any failure leaves it `true` (fail-safe
       # to running). Runs the zero-runtime-dep `@kampus/worker-relevance` bin directly — no
       # `pnpm install` (the `ci-required` idiom), so the always-on detector stays fast.
-      # The `git diff base...head` over the full-history checkout above gives the changed
-      # files + the lockfile diff: on `pull_request` the range is the PR's merge-base...HEAD;
-      # on `merge_group` it is the batch's `base_sha...head_sha` (ADR 0132) — the prospective
-      # merge of every queued PR, so the SAME classifier sees, and OR's across, all batched
-      # PRs (#3079 defenses 1/2/4: real base ref, OR-across-batch, exact classifier reuse).
+      # The `git diff` over the full-history checkout above gives the changed files + the
+      # lockfile diff: on `pull_request` the range is the PR's merge-base...HEAD (three-dot);
+      # on `merge_group` it is the batch's `base_sha..head_sha` (two-dot — see the range
+      # assignment below for why two-dot is merge-base-safe here; ADR 0132), which OR's the
+      # SAME classifier across every batched PR (#3079 defenses 1/2/4: real base ref,
+      # OR-across-batch, exact classifier reuse).
       - name: Classify worker-relevance of the diff
         id: worker-relevance
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
@@ -287,7 +288,12 @@ jobs:
               echo "worker_relevant=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            range="$MERGE_GROUP_BASE_SHA...$MERGE_GROUP_HEAD_SHA"
+            # TWO-DOT (not three-dot): diff the batch's base and head TREES directly. A
+            # merge_group's base_sha and head_sha need NOT share a merge base, so the three-dot
+            # form (which requires one) exit-128'd the batch under `set -e` before any fail-safe
+            # could run (#3083). head_sha is the prospective-merge tip that already contains
+            # every batched PR, so `base..head` captures the whole batch's cumulative diff.
+            range="$MERGE_GROUP_BASE_SHA..$MERGE_GROUP_HEAD_SHA"
           else
             # Full base fetch (no `--depth=1`): the `fetch-depth: 0` checkout above already
             # has HEAD's full history, but a shallow `--depth=1` base re-fetch can land a base
@@ -307,8 +313,17 @@ jobs:
               range="origin/$BASE_REF..HEAD"
             fi
           fi
-          CHANGED_FILES="$(git diff --name-only --diff-filter=ACMRD "$range")"
-          LOCKFILE_DIFF="$(git diff "$range" -- pnpm-lock.yaml)"
+          # Guard the diff fail-safe-to-running: ANY failure — a no-merge-base endpoint pair, an
+          # unresolvable SHA, any git error — degrades to running, never `set -e`-reds the batch.
+          # Belt-and-suspenders with the two-dot switch above: the two-dot range already avoids
+          # the merge-base requirement, and this catch keeps a future git edge case fail-safe too
+          # (#3083). Runs in an `if` condition, which is exempt from `set -e`.
+          if ! CHANGED_FILES="$(git diff --name-only --diff-filter=ACMRD "$range")" \
+             || ! LOCKFILE_DIFF="$(git diff "$range" -- pnpm-lock.yaml)"; then
+            echo "::warning::worker-relevance: git diff over '$range' failed — fail-safe to running"
+            echo "worker_relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           export CHANGED_FILES LOCKFILE_DIFF
           node packages/worker-relevance/src/bin.ts
 


### PR DESCRIPTION
## What & why

`Fixes #3079`. Durable structural fix for #3075: the flaky real-CF/D1 integration
suite evicting clean **worker-irrelevant** PRs from the merge queue (confirmed
evictions #3067 / #3073 / #3074 / #3064; the whole #3045 crew-mcp / pipeline-cli spine
is worker-irrelevant and structurally exposed).

Today `integration_required` ORs `github.event_name == 'merge_group'` in **first and
unconditionally**, so the full integration suite runs on **every** merge-queue batch —
including PRs the `pull_request` worker-relevance classifier marks irrelevant and
correctly skips on their own head. This makes `merge_group` respect the **same**
worker-relevance filter the `pull_request` path already trusts: run integration on a
batch when it is worker-relevant; skip **only** when **every** batched PR is
worker-irrelevant.

**Premise is founder-ruled** (umut, 2026-07-16): reversing the
"always-run-integration-on-`merge_group`" belt is sanctioned — this is a *consistency*
fix (apply the PR-head guard to the batch), not a new relaxation surface. Do not
re-litigate the premise; the review must adversarially stress the **implementation** of
the four defenses.

## §CP — banks at cansirin, dedicated adversarial review first

This edits `.github/workflows/ci.yml` (the trusted merge gate), so it is a §CP
control-plane change. It **must not** self-ship / self-enqueue. Route it for a
**dedicated adversarial review of the classifier-reuse + the fail-safe** (the threat
model below), then bank at cansirin for approval/merge.

## Load-bearing threat model (must survive to review)

This relaxes **when** a merge-safety gate runs. The failure mode to defend against:
**a genuinely worker-relevant PR mis-classified as irrelevant → integration skipped on
its batch → it merges broken.** The four defenses below are the mitigation; the review
must stress exactly this scenario.

## The four defenses — how each is implemented

**1. Diff the batch's real `merge_group.base_sha...head_sha`.** The classify step now
runs on `merge_group` and computes its range from the batch's real endpoints:

```yaml
MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
...
range="$MERGE_GROUP_BASE_SHA...$MERGE_GROUP_HEAD_SHA"
```

These endpoints are confirmed usable on the batch ref — `leak-guard.yml` already diffs
`$MERGE_GROUP_BASE_SHA...HEAD` on `merge_group` (ADR 0132), the same in-repo idiom.

**2. OR-relevance across ALL batched PRs.** `base_sha...head_sha` is the prospective
merge of *every* queued PR in the batch, so running the classifier over that **combined
diff** naturally OR's the PRs: the diff contains a worker-relevant file iff **some**
batched PR touched the worker, so the classifier returns `relevant` (→ run) unless
**every** batched PR is worker-irrelevant. The gate then skips only on
`worker_relevant == 'false'`:

```yaml
integration_required: >-
  ${{ (github.event_name == 'merge_group' &&
       (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false') || ...
```

**3. Fail-safe to running (default every doubt to RUN).** Three layers, all defaulting
to running integration and none able to red the batch instead of running it:
- The **expression** `(… || 'true') != 'false'` — an empty/absent classifier output
  becomes `'true'` → runs.
- The **classify step** explicitly emits `worker_relevant=true` and `exit 0` on any
  missing/empty `base_sha`/`head_sha` or an endpoint unresolvable in the checkout:
  ```yaml
  if [ -z "$MERGE_GROUP_BASE_SHA" ] || [ -z "$MERGE_GROUP_HEAD_SHA" ]; then
    echo "worker_relevant=true" >> "$GITHUB_OUTPUT"; exit 0
  fi
  ...
  if ! git cat-file -e "${MERGE_GROUP_BASE_SHA}^{commit}" 2>/dev/null \
     || ! git cat-file -e "${MERGE_GROUP_HEAD_SHA}^{commit}" 2>/dev/null; then
    echo "worker_relevant=true" >> "$GITHUB_OUTPUT"; exit 0
  fi
  ```
  (the `git fetch … || true` also prevents `set -e` from reddening the batch on a fetch
  blip — it degrades to the `cat-file` fail-safe).
- The **classifier core** itself fails safe to running on any unattributable diff /
  scan error (issue #1014 / ADR 0114) — unchanged here.

**4. Reuse the EXACT `@kampus/worker-relevance` classifier.** Same bin
(`node packages/worker-relevance/src/bin.ts`), same inputs (`CHANGED_FILES` +
`LOCKFILE_DIFF`), same output contract as the `pull_request` path — no bespoke or looser
reimplementation. The only new code is *how the diff range is computed per event*; the
classifier that consumes it is byte-for-byte the one the PR head already trusts. The
classifier's 41 unit tests pass unchanged.

## Scope discipline

Only the **`merge_group` integration** gating changes. `check_required`,
`packages_required`, and `workflows_required` still OR in `merge_group` unconditionally
(unchanged — those need no deploy and are cheap), and `e2e_required` stays skipped on the
batch (unchanged — it awaits a preview `deploy.yml` never produces on `merge_group`).
`.github/CODEOWNERS` is untouched. No other gate's requiredness changed.

## Build-risk investigated: does this PR's own landing self-heal?

**Two sub-questions — resolved:**

**(a) Which `ci.yml` does a `merge_group` run read — the speculative merge ref or base
`main`?** The speculative merge ref. A `merge_group` run triggers on the temporary
`refs/heads/gh-readonly-queue/<base>/…` branch (its `GITHUB_REF` / `GITHUB_SHA`, per
GitHub Actions "Events that trigger workflows → merge_group"), which is the prospective
merge of base + the queued PR(s) (GitHub Docs, "Managing a merge queue" — the batch
branch "contains the changes from your pull request combined with … the base branch",
cited in ADR 0132). GitHub evaluates the workflow file **from the ref that triggered the
run** for branch-ref events like this (the `pull_request`-reads-from-base special case
does **not** apply to `merge_group`, which runs on a trusted internal branch). So the
`gh-readonly-queue` ref includes this PR's `ci.yml` → **the fix self-heals: once this PR
is in a batch, the batch runs the NEW gating.**

**(b) Does that self-heal make this PR skip its own integration?** **No — and that is the
correct, conservative outcome.** The exact classifier marks `.github/workflows/ci.yml` a
**worker-relevant** path (verified locally: `CHANGED_FILES=.github/workflows/ci.yml →
worker_relevant=true`). So this PR's own batch is classified **relevant → integration
RUNS**, under both the new gating (self-heal) and the old unconditional OR. Net: this
CI-gate change is **still integration-tested on its own landing** (a control-plane change
should be), and it is *not* shielded from the integration flake on its own first landing —
if the suite flakes, this PR may need a clean-window batch or a re-enqueue to land, same
as any backend PR today. The eviction relief this PR delivers is for the **worker-
irrelevant** PRs (crew-mcp / pipeline-cli), which take effect the moment this lands on
`main`.

## Where reviewers should adversarially stress the fail-safe

- **The skip condition is `!= 'false'`, not `== 'true'`.** Confirm every non-`'false'`
  value (empty, `'true'`, unset) routes to **run**. A batch skips integration **only** on
  a literal `worker_relevant == 'false'` from the classifier.
- **`set -euo pipefail` vs the fail-safe exits.** Confirm no path can `set -e`-abort the
  step *after* emitting nothing (which would leave the output empty → the expression's
  `|| 'true'` still runs, but verify the step can't red the batch instead). The `|| true`
  on `git fetch` and the guarded `cat-file` `if` are the intended shields.
- **`base_sha...head_sha` vs `..`.** Three-dot is used (matches the issue + the
  `pull_request` idiom). Since `base_sha` is an ancestor of `head_sha` in a batch,
  three-dot == two-dot here; confirm no batch topology breaks that assumption.
- **OR-across-batch correctness.** Confirm that evaluating the classifier over the single
  combined `base_sha...head_sha` diff is genuinely equivalent to OR-ing per-PR relevance
  (it is, because a union diff contains a relevant file iff some member PR contributed
  one), and that a partial/renamed diff can't drop a relevant file (the `--diff-filter`
  and the classifier's fail-safe cover this).
- **Not extracted to a unit test:** the new logic is the YAML shell branch + the gating
  expression. `actionlint` (which shellchecks the embedded `run:`) passes, the expression
  is reasoned exhaustively above, and the classifier core is covered by its 41 unchanged
  unit tests. There is no bespoke classifier to unit-test (that is the point of defense 4).

## Validation done

- `actionlint .github/workflows/ci.yml` → exit 0 (lints the workflow + shellchecks the
  embedded `run:` script).
- `@kampus/worker-relevance` vitest suite → 41/41 pass (classifier core untouched).
- Verdict spot-checks: `.github/workflows/ci.yml` → `worker_relevant=true` (relevant);
  `apps/web/worker/index.ts` → `worker_relevant=true` (relevant). The fail-safe holds.
