### PR TITLE
feat(pipeline-crew-mcp): patched MCP edge base — claude/channel capability + custom notification (#3053)

### DIFF
--- a/packages/pipeline-crew-mcp/src/edge/index.ts
+++ b/packages/pipeline-crew-mcp/src/edge/index.ts
@@ -2,4 +2,9 @@
  * edge/ — the MCP channel edge: exposes the substrate to an MCP client as channels.
  * Generic (crew-agnostic); see the boundary note in `../index.ts`.
  */
-export {};
+export {
+	CHANNEL_CAPABILITY,
+	CHANNEL_NOTIFICATION_METHOD,
+	type ChannelNotificationPayload,
+	channelExperimentalCapability,
+} from "./mcp-channel.ts";

--- a/packages/pipeline-crew-mcp/src/edge/mcp-channel.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/mcp-channel.test.ts
@@ -1,0 +1,125 @@
+// @patch-pin: effect@4.0.0-beta.92
+/**
+ * Two-layer behavior-pin drift guard for `patches/effect@4.0.0-beta.92.patch`
+ * (issue #3053, epic #3045; ADR 0038 pnpm-patch idiom). The patch adds, to effect's
+ * `effect/unstable/ai` MCP surface, the two things the fixed public API can't express:
+ *   - a `claude/channel` experimental-capability passthrough on `McpServer`, and
+ *   - a `notifications/claude/channel` custom notification on `ServerNotificationRpcs`.
+ *
+ * This IS the effect `@patch-pin` behavior-pin #3051's `patch-guard` convention
+ * requires (`.patterns/dependency-patch-behavior-pins.md`). Two layers:
+ *   1. SURFACE PIN — the upstream structures the patch grafts onto still exist at the
+ *      pin (the `experimental` capability slot, the notification RpcGroup, the
+ *      `layerHttp` factory). A sanctioned pin bump that moves them reds here, so the
+ *      patch can't rot silently under a bump (behavior-pinning, #3040).
+ *   2. BEHAVIOR PIN — the patch's added behavior: the server advertises the
+ *      `claude/channel` capability, and a `notifications/claude/channel` payload rides
+ *      the exact notification schema the server's run-loop encodes outgoing
+ *      notifications with.
+ *
+ * The advertise assertion drives a real in-memory MCP server (`McpServer.layerHttp` +
+ * `HttpRouter.toWebHandler` + a fetch shim), mirroring effect's own McpServer test.
+ * Retire when effect ships an `experimental`/custom-notification passthrough natively
+ * and the patch hunks are removed.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Schema} from "effect";
+import {McpSchema, McpServer} from "effect/unstable/ai";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import {RpcSerialization} from "effect/unstable/rpc";
+import * as RpcClient from "effect/unstable/rpc/RpcClient";
+import {
+	CHANNEL_CAPABILITY,
+	CHANNEL_NOTIFICATION_METHOD,
+	channelExperimentalCapability,
+} from "./mcp-channel.ts";
+
+class DisposeError extends Schema.TaggedErrorClass<DisposeError>()(
+	"@kampus/pipeline-crew-mcp/DisposeError",
+	{cause: Schema.Unknown},
+) {}
+
+const makeInitializedClient = Effect.gen(function* () {
+	const serverLayer = McpServer.layerHttp({
+		name: "ChannelEdgeTestServer",
+		version: "0.0.0",
+		path: "/mcp",
+		experimental: channelExperimentalCapability,
+	});
+	const {dispose, handler} = HttpRouter.toWebHandler(serverLayer, {disableLogger: true});
+	// Finalizer must be Effect<void, never>; a dispose rejection is irrelevant to
+	// teardown, so surface it as a typed failure and swallow it (never Effect.promise,
+	// whose rejection escapes as an uncatchable defect — .patterns/index.md, #2736).
+	yield* Effect.addFinalizer(() =>
+		Effect.tryPromise({try: () => dispose(), catch: (cause) => new DisposeError({cause})}).pipe(
+			Effect.ignore,
+		),
+	);
+
+	// The MCP session id is minted on initialize and required on every later request;
+	// replay it the way a real transport would so the second call isn't a 404.
+	let sessionId: string | null = null;
+	const customFetch: typeof fetch = async (input, init) => {
+		const request = input instanceof Request ? input : new Request(input, init);
+		if (sessionId) request.headers.set("Mcp-Session-Id", sessionId);
+		const response = await handler(request);
+		sessionId = response.headers.get("Mcp-Session-Id");
+		return response;
+	};
+
+	const clientLayer = RpcClient.layerProtocolHttp({url: "http://localhost/mcp"}).pipe(
+		Layer.provideMerge([FetchHttpClient.layer, RpcSerialization.layerJsonRpc()]),
+		Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch)),
+	);
+	return yield* RpcClient.make(McpSchema.ClientRpcs).pipe(Effect.provide(clientLayer));
+});
+
+describe("effect MCP edge patch — surface pin (upstream anchors the patch grafts onto)", () => {
+	it("ServerCapabilities carries the `experimental` capability slot", () => {
+		const decoded = Schema.decodeUnknownSync(McpSchema.ServerCapabilities)({
+			experimental: {[CHANNEL_CAPABILITY]: {}},
+		});
+		assert.deepEqual(decoded.experimental, {[CHANNEL_CAPABILITY]: {}});
+	});
+
+	it("ServerNotificationRpcs still carries the upstream notification members", () => {
+		const requests = McpSchema.ServerNotificationRpcs.requests;
+		assert.isTrue(requests.has("notifications/progress"));
+		assert.isTrue(requests.has("notifications/message"));
+	});
+
+	it("McpServer exposes the `layerHttp` factory the passthrough extends", () => {
+		assert.isFunction(McpServer.layerHttp);
+	});
+});
+
+describe("effect MCP edge patch — behavior pin (claude/channel capability + notification)", () => {
+	it.effect("the server advertises the claude/channel experimental capability", () =>
+		Effect.gen(function* () {
+			const client = yield* makeInitializedClient;
+			const result = yield* client.initialize({
+				protocolVersion: "9999-01-01",
+				capabilities: {},
+				clientInfo: {name: "TestClient", version: "0.0.0"},
+			});
+			assert.isDefined(result.capabilities.experimental);
+			assert.deepEqual(result.capabilities.experimental?.[CHANNEL_CAPABILITY], {});
+		}),
+	);
+
+	it("notifications/claude/channel is a member of the server notification union", () => {
+		assert.isTrue(McpSchema.ServerNotificationRpcs.requests.has(CHANNEL_NOTIFICATION_METHOD));
+	});
+
+	it("a channel payload encodes through the exact schema the run-loop uses", () => {
+		const rpc = McpSchema.ServerNotificationRpcs.requests.get(CHANNEL_NOTIFICATION_METHOD);
+		assert.isDefined(rpc);
+		const encoded = Schema.encodeUnknownSync(rpc!.payloadSchema)({
+			message: "wake",
+			_meta: {from: "a"},
+		}) as {message: string; _meta?: {from?: string}};
+		assert.strictEqual(encoded.message, "wake");
+		assert.strictEqual(encoded._meta?.from, "a");
+	});
+});

--- a/packages/pipeline-crew-mcp/src/edge/mcp-channel.ts
+++ b/packages/pipeline-crew-mcp/src/edge/mcp-channel.ts
@@ -1,0 +1,33 @@
+/**
+ * The patched MCP edge contract: the `claude/channel` experimental capability and
+ * the `notifications/claude/channel` custom server->client notification.
+ *
+ * effect's `effect/unstable/ai` `McpServer`/`McpSchema` fix the capability set and
+ * the `ServerNotificationRpcs` union, with no public way to advertise `claude/channel`
+ * or emit a custom notification. `patches/effect@4.0.0-beta.92.patch` (ADR 0038) adds
+ * both; this module names the wire contract so consumers reference these constants
+ * instead of magic strings, and the drift-guard test alongside pins the patch behavior.
+ *
+ * Generic (crew-agnostic): the wire contract only — no `crew/` coupling.
+ */
+
+export const CHANNEL_CAPABILITY = "claude/channel" as const;
+export const CHANNEL_NOTIFICATION_METHOD = "notifications/claude/channel" as const;
+
+/**
+ * The `experimental` capability object a channel-serving `McpServer` advertises —
+ * pass as `McpServer.layer*({ ..., experimental: channelExperimentalCapability })`.
+ */
+export const channelExperimentalCapability: Record<string, Record<string, never>> = {
+	[CHANNEL_CAPABILITY]: {},
+};
+
+/**
+ * Shape of a `notifications/claude/channel` payload. `_meta.from` carries the
+ * originating peer (the raw-SDK contract proven by spike #3034); `message` is the
+ * channel body.
+ */
+export interface ChannelNotificationPayload {
+	readonly message: string;
+	readonly _meta?: Record<string, unknown> & {readonly from?: string};
+}

--- a/patches/effect@4.0.0-beta.92.patch
+++ b/patches/effect@4.0.0-beta.92.patch
@@ -1,0 +1,99 @@
+diff --git a/dist/unstable/ai/McpSchema.d.ts b/dist/unstable/ai/McpSchema.d.ts
+index 06fff42d7f240698b9388524f874367c494242e6..8421cf06c7dee8215b690772df8a06a75284d679 100644
+--- a/dist/unstable/ai/McpSchema.d.ts
++++ b/dist/unstable/ai/McpSchema.d.ts
+@@ -3329,7 +3329,17 @@ export declare class ServerRequestRpcs extends ServerRequestRpcs_base {
+  * @since 4.0.0
+  */
+ export type ServerRequestEncoded = RequestEncoded<typeof ServerRequestRpcs>;
+-declare const ServerNotificationRpcs_base: RpcGroup.RpcGroup<typeof CancelledNotification | typeof ProgressNotification | typeof ResourceListChangedNotification | typeof ResourceUpdatedNotification | typeof PromptListChangedNotification | typeof ToolListChangedNotification | typeof LoggingMessageNotification>;
++declare const ChannelNotification_base: Rpc.Rpc<"notifications/claude/channel", Schema.Struct<{
++    message: Schema.String;
++    _meta: Schema.decodeTo<Schema.optional<Schema.$Record<Schema.String, Schema.Codec<Schema.Json, Schema.Json, never, never>>>, Schema.optionalKey<Schema.$Record<Schema.String, Schema.Codec<Schema.Json, Schema.Json, never, never>>>, never, never>;
++}>, Schema.Void, Schema.Never, never, never>;
++/**
++ * phoenix patch (#3053): custom, non-allowlisted server->client channel notification.
++ * See the `McpSchema.js` patch hunk for the rationale.
++ */
++export declare class ChannelNotification extends ChannelNotification_base {
++}
++declare const ServerNotificationRpcs_base: RpcGroup.RpcGroup<typeof CancelledNotification | typeof ProgressNotification | typeof ResourceListChangedNotification | typeof ResourceUpdatedNotification | typeof PromptListChangedNotification | typeof ToolListChangedNotification | typeof LoggingMessageNotification | typeof ChannelNotification>;
+ /**
+  * RPC group for notifications that an MCP server can send to a client,
+  * including cancellation, progress, logging, and list or resource update
+diff --git a/dist/unstable/ai/McpSchema.js b/dist/unstable/ai/McpSchema.js
+index 909ac602a249610fdd9a1f72ae207d8813ebc28a..3f8339d619cf06c6ec1c5686c701dfbb0dbdfdf4 100644
+--- a/dist/unstable/ai/McpSchema.js
++++ b/dist/unstable/ai/McpSchema.js
+@@ -1961,7 +1961,17 @@ export class ServerRequestRpcs extends /*#__PURE__*/RpcGroup.make(Ping, CreateMe
+  * @category protocols
+  * @since 4.0.0
+  */
+-export class ServerNotificationRpcs extends /*#__PURE__*/RpcGroup.make(CancelledNotification, ProgressNotification, LoggingMessageNotification, ResourceUpdatedNotification, ResourceListChangedNotification, ToolListChangedNotification, PromptListChangedNotification) {}
++// phoenix patch (#3053): custom, non-allowlisted server->client channel notification.
++// The MCP spec allows arbitrary `notifications/*` methods; upstream's ServerNotificationRpcs
++// union is fixed, so the run-loop's encode union (built from this group's payload schemas)
++// and the McpServer.notifications client both gain this member by adding it here.
++export class ChannelNotification extends /*#__PURE__*/Rpc.make("notifications/claude/channel", {
++  payload: {
++    ...NotificationMeta.fields,
++    message: Schema.String
++  }
++}) {}
++export class ServerNotificationRpcs extends /*#__PURE__*/RpcGroup.make(CancelledNotification, ProgressNotification, LoggingMessageNotification, ResourceUpdatedNotification, ResourceListChangedNotification, ToolListChangedNotification, PromptListChangedNotification, ChannelNotification) {}
+ const ParamSchemaTypeId = "~effect/ai/McpSchema/ParamSchema";
+ /**
+  * Returns `true` when a schema was created with `param` and therefore carries
+diff --git a/dist/unstable/ai/McpServer.d.ts b/dist/unstable/ai/McpServer.d.ts
+index 87a6f7acdd3d7f89b41fac68e575d80a09748f64..978ddb8206b27201c26fb2ff189dfad19d94f76b 100644
+--- a/dist/unstable/ai/McpServer.d.ts
++++ b/dist/unstable/ai/McpServer.d.ts
+@@ -150,6 +150,7 @@ export declare const run: (options: {
+     readonly name: string;
+     readonly version: string;
+     readonly extensions?: Record<`${string}/${string}`, unknown> | undefined;
++    readonly experimental?: Record<string, {}> | undefined;
+ }) => Effect.Effect<never, never, McpServer | RpcServer.Protocol>;
+ /**
+  * Creates a layer that starts an MCP server over an existing
+@@ -184,6 +185,7 @@ export declare const layer: (options: {
+     readonly name: string;
+     readonly version: string;
+     readonly extensions?: Record<`${string}/${string}`, unknown> | undefined;
++    readonly experimental?: Record<string, {}> | undefined;
+ }) => Layer.Layer<McpServer | McpServerClient, never, RpcServer.Protocol>;
+ /**
+  * Runs the McpServer, using stdio for input and output.
+@@ -247,6 +249,7 @@ export declare const layerStdio: (options: {
+     readonly name: string;
+     readonly version: string;
+     readonly extensions?: Record<`${string}/${string}`, unknown> | undefined;
++    readonly experimental?: Record<string, {}> | undefined;
+ }) => Layer.Layer<McpServer | McpServerClient, never, Stdio>;
+ /**
+  * Registers an HTTP POST JSON-RPC route at `options.path` on the current
+@@ -272,6 +275,7 @@ export declare const layerHttp: (options: {
+     readonly version: string;
+     readonly path: HttpRouter.PathInput;
+     readonly extensions?: Record<`${string}/${string}`, unknown> | undefined;
++    readonly experimental?: Record<string, {}> | undefined;
+ }) => Layer.Layer<McpServer | McpServerClient, never, HttpRouter.HttpRouter>;
+ /**
+  * Registers a `Toolkit` with the `McpServer`.
+diff --git a/dist/unstable/ai/McpServer.js b/dist/unstable/ai/McpServer.js
+index 4cb198b928a5538737af01c0d18a03c7d28eb445..d19e7f7992f437bec6a7b64ed512e3ae5bc90204 100644
+--- a/dist/unstable/ai/McpServer.js
++++ b/dist/unstable/ai/McpServer.js
+@@ -850,6 +850,12 @@ const layerHandlers = (serverInfo, options) => ClientRpcs.toLayer(Effect.gen(fun
+       if (serverInfo.extensions) {
+         capabilities.extensions = serverInfo.extensions;
+       }
++      // phoenix patch (#3053): advertise arbitrary experimental capabilities (e.g.
++      // { "claude/channel": {} }). Upstream wires only `extensions`; the `experimental`
++      // slot already exists on the ServerCapabilities schema but had no server passthrough.
++      if (serverInfo.experimental) {
++        capabilities.experimental = serverInfo.experimental;
++      }
+       return Effect.withFiber(fiber => {
+         const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest);
+         if (httpRequest) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ patchedDependencies:
   alchemy@2.0.0-beta.59:
     hash: f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1
     path: patches/alchemy@2.0.0-beta.59.patch
+  effect@4.0.0-beta.92:
+    hash: 3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade
+    path: patches/effect@4.0.0-beta.92.patch
   react-fate@1.3.1:
     hash: 6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b
     path: patches/react-fate@1.3.1.patch
@@ -216,28 +219,28 @@ importers:
     dependencies:
       '@alchemy.run/better-auth':
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(9fd2c81c842c11fbd7ee9b18e08fcdb8)
+        version: 2.0.0-beta.59(9a95b5cea7a55f9918de6e649971c2ea)
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))
+        version: 1.6.23(456558883cb20d24e53ea36eb8a82f55)
       '@better-auth/core':
         specifier: 'catalog:'
         version: 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@effect/sql-d1':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/sql-pg':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@kampus/authz':
         specifier: workspace:*
         version: link:../../packages/authz
@@ -252,13 +255,13 @@ importers:
         version: link:../../packages/fate-effect
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@sentry/cloudflare':
         specifier: 'catalog:'
         version: 10.62.0(@cloudflare/workers-types@4.20260629.1)
       '@sentry/effect':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92)
+        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@sentry/react':
         specifier: 'catalog:'
         version: 10.62.0(react@19.2.6)
@@ -267,19 +270,19 @@ importers:
         version: 0.2.0
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call:
         specifier: 'catalog:'
         version: 1.3.7(zod@4.4.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@19.2.6)
@@ -291,7 +294,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-fate:
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react-router:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -304,13 +307,13 @@ importers:
         version: 4.20260629.1
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@fontsource/ibm-plex-sans':
         specifier: 'catalog:'
         version: 5.2.8
@@ -376,10 +379,10 @@ importers:
     dependencies:
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -389,7 +392,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -407,19 +410,19 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))
+        version: 1.6.23(456558883cb20d24e53ea36eb8a82f55)
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -429,7 +432,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -447,10 +450,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -459,10 +462,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -472,7 +475,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -481,7 +484,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -493,7 +496,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/audit-stage':
         specifier: workspace:*
         version: link:../audit-stage
@@ -502,7 +505,7 @@ importers:
         version: link:../audit-verdict
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -512,7 +515,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -530,7 +533,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -542,7 +545,7 @@ importers:
         version: link:../preview-seed
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -552,7 +555,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -570,17 +573,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -598,7 +601,7 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -620,10 +623,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -633,7 +636,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -651,10 +654,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -666,10 +669,10 @@ importers:
         version: link:../db-schema
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -679,7 +682,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -700,7 +703,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -773,10 +776,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -786,7 +789,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -804,7 +807,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -826,17 +829,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -854,7 +857,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/depo':
         specifier: workspace:*
         version: link:../depo
@@ -863,14 +866,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -888,10 +891,10 @@ importers:
     dependencies:
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -913,17 +916,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -941,10 +944,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -953,10 +956,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -966,7 +969,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -975,7 +978,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -987,10 +990,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1002,10 +1005,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1015,7 +1018,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1033,10 +1036,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       yaml:
         specifier: 'catalog:'
         version: 2.9.0
@@ -1046,7 +1049,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1064,7 +1067,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/design-capture':
         specifier: workspace:*
         version: link:../design-capture
@@ -1073,14 +1076,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1098,17 +1101,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1126,19 +1129,19 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1148,7 +1151,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1157,7 +1160,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1169,20 +1172,20 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1200,7 +1203,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/ci-required':
         specifier: workspace:*
         version: link:../ci-required
@@ -1212,7 +1215,7 @@ importers:
         version: link:../primary-index-tripwire
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       fast-xml-parser:
         specifier: 'catalog:'
         version: 5.8.0
@@ -1225,7 +1228,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1243,17 +1246,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1271,10 +1274,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1286,10 +1289,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1299,7 +1302,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1308,7 +1311,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1320,17 +1323,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1351,7 +1354,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -4661,11 +4664,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@alchemy.run/better-auth@2.0.0-beta.59(9fd2c81c842c11fbd7ee9b18e08fcdb8)':
+  '@alchemy.run/better-auth@2.0.0-beta.59(9a95b5cea7a55f9918de6e649971c2ea)':
     dependencies:
-      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
-      effect: 4.0.0-beta.92
+      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     transitivePeerDependencies:
       - '@effect/platform-bun'
       - '@effect/platform-node'
@@ -4942,11 +4945,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))':
+  '@better-auth/api-key@1.6.23(456558883cb20d24e53ea36eb8a82f55)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -4965,12 +4968,12 @@ snapshots:
       '@cloudflare/workers-types': 4.20260629.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
 
   '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -5095,24 +5098,24 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92)':
+  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1053.0
       '@aws-sdk/types': 3.973.9
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@smithy/shared-ini-file-loader': 4.5.4
       '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.4.4
       aws4fetch: 1.0.20
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92)':
+  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
 
   '@distilled.cloud/cloudflare-rolldown-plugin@0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
     dependencies:
@@ -5125,74 +5128,74 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)':
+  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       workerd: 1.20260617.1
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92))(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(b7a52a79e2a9b18230ffd28d8c5f26e6)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
     transitivePeerDependencies:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92)':
+  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
 
-  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92)':
+  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
 
-  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92)':
+  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
 
-  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92)':
+  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
 
   '@drizzle-team/brocli@0.12.0': {}
 
   '@effect/language-service@0.85.1': {}
 
-  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92)':
+  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92)':
+  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.3.0
@@ -5200,14 +5203,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92)':
+  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
 
-  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92)':
+  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       pg: 8.21.0
       pg-connection-string: 2.12.0
       pg-cursor: 2.20.0(pg@8.21.0)
@@ -5247,9 +5250,9 @@ snapshots:
       '@effect/tsgo-win32-arm64': 0.5.2
       '@effect/tsgo-win32-x64': 0.5.2
 
-  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -5538,13 +5541,13 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
       superjson: 2.2.6
       zod: 4.4.3
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@noble/ciphers@2.2.0': {}
@@ -5794,12 +5797,12 @@ snapshots:
 
   '@sentry/core@10.62.0': {}
 
-  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92)':
+  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
       '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -6265,21 +6268,21 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0):
+  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1053.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92)
-      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92)
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)
-      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92))(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
-      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92)
-      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92)
-      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(b7a52a79e2a9b18230ffd28d8c5f26e6)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1
       '@octokit/webhooks': 14.2.0
@@ -6289,7 +6292,7 @@ snapshots:
       '@types/aws-lambda': 8.10.161
       aws4fetch: 1.0.20
       capnweb: 0.6.1
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       fast-glob: 3.3.3
       fast-xml-parser: 5.8.0
       ink: 6.8.0(@types/react@19.2.14)(react@19.2.6)
@@ -6305,11 +6308,11 @@ snapshots:
       undici: 7.24.8
       yaml: 2.9.0
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       ws: 8.21.0
     transitivePeerDependencies:
@@ -6350,10 +6353,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
+  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -6371,7 +6374,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       react: 19.2.6
@@ -6473,19 +6476,19 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92)
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@libsql/client': 0.17.3
       '@opentelemetry/api': 1.9.1
-      effect: 4.0.0-beta.92
+      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       zod: 4.4.3
 
-  effect@4.0.0-beta.92:
+  effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade):
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0
@@ -7227,9 +7230,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -126,7 +126,23 @@ onlyBuiltDependencies:
 #    `open`, so a feed load with N `useLiveView` mounts issued N single-op POSTs, each
 #    re-validating the session (~22 on an authed /pano load — #2273). Regression test:
 #    apps/web/src/fate/liveSubscribeBatch.test.ts. Not upstreamed in 1.3.1.
+#
+# effect — TWO hunks on 4.0.0-beta.92 (dist only; `effect/unstable/ai` resolves to
+# dist/*.js + dist/*.d.ts), giving the MCP channel edge the two things the fixed public
+# `McpServer`/`McpSchema` surface can't express (#3053, epic #3045):
+# 1. unstable/ai/McpServer.{js,d.ts} — an `experimental` capability passthrough in
+#    `layerHandlers` (+ the `experimental?` option on run/layer/layerStdio/layerHttp),
+#    so a server can advertise `experimental: { "claude/channel": {} }`. The
+#    `ServerCapabilities` schema already carries the slot; only the server wiring was
+#    missing.
+# 2. unstable/ai/McpSchema.{js,d.ts} — a `ChannelNotification`
+#    (`notifications/claude/channel`, `{ message, _meta }`) added to the fixed
+#    `ServerNotificationRpcs` union, so the run-loop's encode union and the
+#    `McpServer.notifications` client both gain the custom notification.
+# Behavior-pinned by packages/pipeline-crew-mcp/src/edge/mcp-channel.test.ts (the
+# `@patch-pin` guard, #3040/#3051). Retire when effect ships these natively.
 patchedDependencies:
   '@nkzw/fate@1.3.1': patches/@nkzw__fate@1.3.1.patch
   alchemy@2.0.0-beta.59: patches/alchemy@2.0.0-beta.59.patch
+  effect@4.0.0-beta.92: patches/effect@4.0.0-beta.92.patch
   react-fate@1.3.1: patches/react-fate@1.3.1.patch


### PR DESCRIPTION
## Summary

Establishes the **patched MCP edge base** the channel server (#3045 spine) builds on.

effect's `effect/unstable/ai` `McpServer`/`McpSchema` (pin `effect@4.0.0-beta.92`) fix
the capability set and the `ServerNotificationRpcs` union — there is no public way to
advertise an `experimental: { "claude/channel": {} }` capability or emit a custom
`notifications/claude/channel`. This PR adds an in-repo `pnpm patch` (ADR 0038) plus a
two-layer behavior-pinning drift guard.

## What's in it

- **`patches/effect@4.0.0-beta.92.patch`** (registered in `pnpm-workspace.yaml`
  `patchedDependencies`) — surgical, additive edits to the installed dist:
  - `McpServer.js`: an `experimental` capability passthrough in `layerHandlers`
    (upstream wired only `extensions`; the `experimental` slot already exists on the
    `ServerCapabilities` schema but had no server-side passthrough).
  - `McpServer.d.ts`: `experimental?` added to the `run`/`layer`/`layerStdio`/`layerHttp`
    option signatures, threaded through unchanged.
  - `McpSchema.js` + `McpSchema.d.ts`: a `ChannelNotification`
    (`notifications/claude/channel`, payload `{ message, _meta }`) added to
    `ServerNotificationRpcs`, so the run-loop's encode union and the
    `McpServer.notifications` client both gain the member.
- **`packages/pipeline-crew-mcp/src/edge/mcp-channel.ts`** — the generic (crew-agnostic)
  wire contract: `CHANNEL_CAPABILITY`, `CHANNEL_NOTIFICATION_METHOD`,
  `channelExperimentalCapability`, `ChannelNotificationPayload`. No `crew/` import.
- **`packages/pipeline-crew-mcp/src/edge/mcp-channel.test.ts`** — the two-layer
  drift guard, carrying the `// @patch-pin: effect@4.0.0-beta.92` marker:
  - **Surface pin:** the upstream anchors the patch grafts onto still exist at the pin
    (the `experimental` capability slot, the notification `RpcGroup`, `layerHttp`). A
    sanctioned pin bump that moves them reds here (behavior-pinning, #3040).
  - **Behavior pin:** a real in-memory MCP server (`McpServer.layerHttp` +
    `HttpRouter.toWebHandler`, mirroring effect's own McpServer test) advertises the
    `claude/channel` capability on `initialize`, and a channel payload encodes through
    the exact notification schema the server run-loop uses.

## Grounding

- The patched surface was re-verified against the installed dist at
  `effect@4.0.0-beta.92` (#3032/#3033 surface verification): `ServerCapabilities` already
  carries `experimental` (`McpSchema` L384); `ServerNotificationRpcs` is the fixed union
  (`McpSchema` L2396); `layerHandlers` wired only `serverInfo.extensions` (`McpServer`
  L1368). Resolution is `dist/*.js` + `dist/*.d.ts`, so the patch targets `dist/` only.
- The `notifications/claude/channel` payload (`{ message, _meta: { from } }`) matches the
  raw-SDK contract proven by spike #3034 (`spike/channel-mcp-server.mjs`); this is the
  effect-patched edge, not the raw SDK.

## Cross-epic (#3051 patch-guard)

The drift-guard test **is** the effect `@patch-pin` behavior-pin #3051's `patch-guard`
convention requires (`.patterns/dependency-patch-behavior-pins.md`): `effect@4.0.0-beta.92`
is registered in `patchedDependencies` and the test carries the exact
`// @patch-pin: effect@4.0.0-beta.92` marker, so #3051's guard covers the effect patch by
construction whether or not #3074 is on main yet.

## Verification

- `pnpm test` (package): 7 passed
- `pnpm typecheck` (package): clean
- `pnpm lint` (biome, incl. effect-error + promise plugins): clean, 0 warnings
- Patch applies cleanly to the worktree install; no other repo consumer of
  `effect/unstable/ai`, so the additive patch is isolated.

§CP: `packages/pipeline-crew-mcp/` is machine-§CP (#3072). Opened for the gate + banked
at cansirin — not shipped/enqueued.

Fixes #3053

🤖 Generated with [Claude Code](https://claude.com/claude-code)