### PR TITLE
fix(integration): raise dedicated-stage worker-readiness budget under concurrent load (#3080)

### DIFF
--- a/apps/web/tests/integration/_edge-ready.ts
+++ b/apps/web/tests/integration/_edge-ready.ts
@@ -47,6 +47,17 @@ export const isCloudflarePlaceholder404Error = (e: unknown): e is CloudflarePlac
 export const EDGE_READY_DEADLINE_MS = 60_000;
 export const EDGE_READY_POLL_MS = 1_500;
 
+// The raised budget the DEPLOY-time worker-health gate (`awaitWorkerReady`) rides, distinct from the
+// per-probe `EDGE_READY_DEADLINE_MS` above. Under concurrent-stage batch load on the one shared
+// Cloudflare account, a fresh `*.workers.dev` /api/health route's edge propagation routinely overruns
+// the 60s per-probe budget — the module-top `beforeAll(deploy…)` then throws and fails the WHOLE
+// suite to load (#3080, #3075 Signature-A). vitest test-`retry` can't re-run a failed `beforeAll`, so
+// a bigger SINGLE budget — not a redeploy retry, which two deploy+readiness attempts couldn't fit —
+// is the lever. Doubled to 120s: it stays inside the integration `hookTimeout` (180s,
+// `vitest.config.ts`) with room for the deploy + trailing non-fatal warms, and never hangs (the poll
+// returns on the deadline), so a genuinely dead worker still fails fast within the bound.
+export const DEPLOY_HEALTH_DEADLINE_MS = 120_000;
+
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 /**

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -35,7 +35,7 @@ import * as Schedule from "effect/Schedule";
 import {inject} from "vitest";
 import Stack from "../../alchemy.run.ts";
 import {isTransientDeployError} from "./_deploy-transient.ts";
-import {awaitEdgeReady, edgeFetch} from "./_edge-ready.ts";
+import {awaitEdgeReady, DEPLOY_HEALTH_DEADLINE_MS, edgeFetch} from "./_edge-ready.ts";
 import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
 import {type Harness, harness} from "./_harness.ts";
 import {slugify, stageName} from "./_stage-name.ts";
@@ -301,15 +301,19 @@ export const deployTransientRetry = Effect.retry({
  * workers.dev route 404s (the CF edge placeholder) for a few seconds while it propagates, so it
  * rides the shared readiness budget (`awaitEdgeReady` + `edgeFetch`, ADR 0127): the thrown
  * placeholder-404 AND any non-ready response retry until healthy. A worker that never serves
- * healthy JSON within the bound (30 × 2s) DIES with a clear message rather than hanging —
+ * healthy JSON within the bound (60 × 2s) DIES with a clear message rather than hanging —
  * `Effect.promise` turns the thrown exhaustion error into a defect, the same hard failure the
  * retired `Effect.die` produced. ONE copy for both deploy paths (the per-file `integrationStack`
  * and the shared-stage `_global-setup.ts`).
+ *
+ * Rides the raised `DEPLOY_HEALTH_DEADLINE_MS` (see its rationale, #3080), not the 60s per-probe
+ * default — the concurrent-stage load that overran 60s and died this `beforeAll` is why.
  */
 export const awaitWorkerReady = (url: string): Effect.Effect<void, never, never> =>
 	Effect.promise(async () => {
 		const res = await awaitEdgeReady(() => edgeFetch(`${url}/api/health`), healthReady, {
 			pollMs: WARM_POLL_MS,
+			deadlineMs: DEPLOY_HEALTH_DEADLINE_MS,
 		});
 		// `awaitEdgeReady` returns the last response even when it never went ready (the #1060
 		// no-early-stop guarantee), so a worker that never served healthy JSON must be turned into


### PR DESCRIPTION
Fixes #3080

## What

Raise the dedicated-stage deploy-time worker-readiness budget so a slow edge-propagation under concurrent-stage batch load is ridden out instead of dying the whole suite at load time. Signature A of the #3075 investigation — the live *unmitigated* half of the merge-queue flake on backend PRs (#3077's `{retry:2}` does not re-run a failed `beforeAll`).

## Root cause (pinned in #3075)

The module-top `integrationStack()` `beforeAll(deploy…)` in `apps/web/tests/integration/_integration.ts` deploys a fresh worker + D1, then probes `/api/health` via `awaitWorkerReady` on the **60s per-probe budget** (`EDGE_READY_DEADLINE_MS`). Under the load of many fresh dedicated stages hammering one eventually-consistent Cloudflare account, edge propagation of a fresh `*.workers.dev` /api/health route routinely overruns 60s → the probe throws → `Effect.promise` turns it into a defect → the **whole suite fails to load** (not a single assertion). `deployTransientRetry` never covers this: it wraps only the `deploy` step (piped before the readiness tap) and only self-heals 429/`WorkerNotFound`-class deploy errors — a readiness timeout is outside it.

## The fix — raise the readiness budget

- New dedicated `DEPLOY_HEALTH_DEADLINE_MS = 120_000` in `apps/web/tests/integration/_edge-ready.ts` (distinct from the 60s per-probe `EDGE_READY_DEADLINE_MS`), wired into `awaitWorkerReady`'s `awaitEdgeReady` call.
- 60s → 120s (a clean 2×) gives slow propagation room to ripen instead of dying.

### Why a bigger single budget, not a broadened redeploy-retry

The issue lists "broaden the transient-retry to cover readiness-timeout" and "raise the readiness budget" as `and/or` levers. The **180s integration `hookTimeout`** (`apps/web/vitest.config.ts`) is the deciding code constraint: the deploy+readiness runs *inside* the `beforeAll` hook, so two deploy+readiness attempts (a redeploy retry on a readiness timeout) cannot fit within 180s. A re-probe *without* a redeploy is equivalent to a larger single budget. So the raised single budget is the realizable form of "make the readiness path tolerate edge-not-ready" under the hook constraint. The 120s budget stays inside the 180s hook with room for the deploy + the trailing non-fatal warms in the recovery path.

## Readiness guarantee is NOT weakened

A genuinely broken worker still never serves healthy `/api/health` JSON and still **dies within the (now 120s) bound** — the poll returns on the deadline (never hangs), and `awaitWorkerReady` still turns exhaustion into a hard failure. Only a *transient* slow-propagation now rides out instead of dying at 60s; a real failure fails fast, just with a larger bound.

## Scope

- Confined to the integration harness: `apps/web/tests/integration/_edge-ready.ts` + `apps/web/tests/integration/_integration.ts`. **No** `.github/workflows/ci.yml` / merge-gate change (that is #3079 / Fix 1, out of scope).
- The dedicated stage stays dedicated (untouched — it must drop the `term_search` FTS5 table).
- The shared-stage path (`_global-setup.ts`) reuses `awaitWorkerReady`, so it gets the same more-tolerant budget — more-tolerant, not a regression.
- NON-§CP (`apps/web/tests/integration/**` is not in the control-plane surface).

## Validation

- `pnpm typecheck` — clean (32/32).
- `pnpm lint:worktree` — exit 0 (the 5 `Effect.promise`/`try-catch` plugin warnings in `_integration.ts` are **pre-existing on `main`**, not introduced by this diff).
- This is a real-CF/real-D1 harness path requiring CF creds, so full validation is the `integration` run itself (in `merge_group`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)