### PR TITLE
feat(pipeline-crew-mcp): protocol/ typed 7-message catalog as Effect RPC RpcGroup

### DIFF
--- a/packages/pipeline-crew-mcp/src/index.ts
+++ b/packages/pipeline-crew-mcp/src/index.ts
@@ -11,4 +11,5 @@
  * reverse. That one-way boundary is what keeps the substrate reusable — enforcing it
  * is the point of splitting these into directories.
  */
+export * as Protocol from "./protocol/index.ts";
 export {VERSION} from "./version.ts";

--- a/packages/pipeline-crew-mcp/src/protocol/group.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The catalog-shape guarantees: the `RpcGroup` covers all 7 kinds (acceptance criterion
+ * 1), the claim/collision-check kind is a request-response RPC with a typed reply rather
+ * than fire-and-forget (criterion 4), and the whole `protocol/` module imports nothing
+ * from `crew/` — the generic boundary holds (criterion 3).
+ */
+import {readdirSync, readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+import {Schema} from "effect";
+import {Rpc} from "effect/unstable/rpc";
+import {AnnouncePresence, Claim, CrewProtocol} from "./group.ts";
+
+describe("protocol/group catalog", () => {
+	it("covers all 7 message kinds (8 rpcs — presence is announce + lookup)", () => {
+		assert.deepStrictEqual([...CrewProtocol.requests.keys()].sort(), [
+			"AckInbox",
+			"AnnouncePresence",
+			"Claim",
+			"DrainProgress",
+			"EpicHandoff",
+			"Heartbeat",
+			"IntakePing",
+			"LookupRole",
+		]);
+	});
+
+	it("every rpc in the group is a real Rpc definition", () => {
+		for (const rpc of CrewProtocol.requests.values()) {
+			assert.isTrue(Rpc.isRpc(rpc));
+		}
+	});
+
+	it("claim/collision-check is a request-response RPC with a typed reply (not fire-and-forget)", () => {
+		// A fire-and-forget rpc's success defaults to Schema.Void; a non-void success schema
+		// that decodes a structured reply is what makes this kind request-response.
+		const reply = {
+			resource: "issue:3054",
+			granted: true,
+			collision: false,
+			owner: "peer-a",
+			since: "2026-07-16T10:00:00Z",
+		};
+		assert.deepStrictEqual(Schema.decodeUnknownSync(Claim.successSchema)(reply), reply);
+	});
+
+	it("a fire-and-forget kind carries no reply (success is Void)", () => {
+		assert.strictEqual(AnnouncePresence.successSchema, Schema.Void);
+	});
+
+	it("no protocol source file imports from crew/ (the generic boundary holds)", () => {
+		const dir = fileURLToPath(new URL(".", import.meta.url));
+		const sources = readdirSync(dir).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+		for (const file of sources) {
+			const body = readFileSync(new URL(file, new URL(".", import.meta.url)), "utf8");
+			assert.isFalse(/from\s+["'][^"']*crew/.test(body), `${file} imports from crew/`);
+		}
+	});
+});

--- a/packages/pipeline-crew-mcp/src/protocol/group.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.ts
@@ -1,0 +1,66 @@
+/**
+ * protocol/group — the 7 crew message kinds as one Effect `RpcGroup`.
+ *
+ * Generic (crew-agnostic); see the boundary note in `../index.ts`. Each kind is an
+ * `Rpc` carrying a Schema payload from `./schema.ts`. Kinds that expect an answer
+ * (claim/collision-check, role lookup) set a `success` schema — a typed reply the
+ * caller awaits; the fire-and-forget kinds leave `success` unset, so it defaults to
+ * `Schema.Void`. That success/void split is exactly what distinguishes a
+ * request-response kind from a fire-and-forget one on the wire.
+ */
+import {Rpc, RpcGroup} from "effect/unstable/rpc";
+import * as Messages from "./schema.ts";
+
+/** Kind 1 — synchronous claim/collision-check: a request that awaits a typed `ClaimReply`. */
+export const Claim = Rpc.make("Claim", {
+	payload: Messages.ClaimRequest,
+	success: Messages.ClaimReply,
+});
+
+/** Kind 2 — planned-epic handoff (EM → builder). */
+export const EpicHandoff = Rpc.make("EpicHandoff", {
+	payload: Messages.EpicHandoffNotice,
+});
+
+/** Kind 3 — drain-progress tally. */
+export const DrainProgress = Rpc.make("DrainProgress", {
+	payload: Messages.DrainProgressTally,
+});
+
+/** Kind 4 — intake ping. */
+export const IntakePing = Rpc.make("IntakePing", {
+	payload: Messages.IntakePing,
+});
+
+/** Kind 5a — role discovery/presence: announce (fire-and-forget). */
+export const AnnouncePresence = Rpc.make("AnnouncePresence", {
+	payload: Messages.PresenceAnnouncement,
+});
+
+/** Kind 5b — role discovery/presence: lookup, awaiting a typed `RoleLookupResult`. */
+export const LookupRole = Rpc.make("LookupRole", {
+	payload: Messages.RoleLookupQuery,
+	success: Messages.RoleLookupResult,
+});
+
+/** Kind 6 — heartbeat (presence TTL keepalive). */
+export const Heartbeat = Rpc.make("Heartbeat", {
+	payload: Messages.Heartbeat,
+});
+
+/** Kind 7 — inbox ack (delivery acknowledgement). */
+export const AckInbox = Rpc.make("AckInbox", {
+	payload: Messages.InboxAck,
+});
+
+/** The full crew message catalog — one transport-agnostic `RpcGroup` over all 7 kinds. */
+export const CrewProtocol = RpcGroup.make(
+	Claim,
+	EpicHandoff,
+	DrainProgress,
+	IntakePing,
+	AnnouncePresence,
+	LookupRole,
+	Heartbeat,
+	AckInbox,
+);

--- a/packages/pipeline-crew-mcp/src/protocol/index.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/index.ts
@@ -1,5 +1,18 @@
 /**
- * protocol/ — the wire format: message envelopes and the codec shared by every peer.
- * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ * protocol/ — the typed message catalog: the crew's 7 message kinds as an Effect
+ * `RpcGroup` with `effect/Schema` payloads, transport-agnostic. Generic (crew-agnostic);
+ * see the boundary note in `../index.ts`. This module defines the wire contract that
+ * tracker, peer, and edge all code against.
  */
-export {};
+export {
+	AckInbox,
+	AnnouncePresence,
+	Claim,
+	CrewProtocol,
+	DrainProgress,
+	EpicHandoff,
+	Heartbeat,
+	IntakePing,
+	LookupRole,
+} from "./group.ts";
+export * as Messages from "./schema.ts";

--- a/packages/pipeline-crew-mcp/src/protocol/schema.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Round-trip (encode → decode) coverage for every message kind's payload/reply schema:
+ * a decoded encoding must equal the original, proving each payload is a real
+ * `effect/Schema` codec (acceptance criterion 2). Kinds with a typed reply also
+ * round-trip their reply schema.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Schema} from "effect";
+import * as Messages from "./schema.ts";
+
+const roundTrips = <S extends Schema.Codec<any, any>>(schema: S, value: S["Type"]): void => {
+	const encoded = Schema.encodeSync(schema)(value);
+	const decoded = Schema.decodeUnknownSync(schema)(encoded);
+	assert.deepStrictEqual(decoded, value);
+};
+
+describe("protocol/schema round-trips", () => {
+	it("kind 1 — claim request + reply", () => {
+		roundTrips(Messages.ClaimRequest, {
+			resource: "issue:3054",
+			claimant: "peer-a",
+			role: "builder",
+			at: "2026-07-16T10:00:00Z",
+		});
+		roundTrips(Messages.ClaimReply, {
+			resource: "issue:3054",
+			granted: false,
+			collision: true,
+			owner: "peer-b",
+			since: "2026-07-16T09:59:00Z",
+		});
+	});
+
+	it("kind 2 — planned-epic handoff (with and without the optional summary)", () => {
+		roundTrips(Messages.EpicHandoffNotice, {
+			epic: "epic:3045",
+			child: "issue:3054",
+			from: "em",
+			to: "builder",
+			summary: "protocol/ is the foundation edge codes against",
+			at: "2026-07-16T10:01:00Z",
+		});
+		roundTrips(Messages.EpicHandoffNotice, {
+			epic: "epic:3045",
+			child: "issue:3054",
+			from: "em",
+			to: "builder",
+			at: "2026-07-16T10:01:00Z",
+		});
+	});
+
+	it("kind 3 — drain-progress tally", () => {
+		roundTrips(Messages.DrainProgressTally, {
+			scope: "milestone:crew-mcp",
+			completed: 3,
+			inFlight: 2,
+			total: 9,
+			reporter: "peer-em",
+			at: "2026-07-16T10:02:00Z",
+		});
+	});
+
+	it("kind 4 — intake ping (with and without the optional note)", () => {
+		roundTrips(Messages.IntakePing, {
+			issue: "issue:3100",
+			from: "triage",
+			note: "needs a second look",
+			at: "2026-07-16T10:03:00Z",
+		});
+		roundTrips(Messages.IntakePing, {
+			issue: "issue:3100",
+			from: "triage",
+			at: "2026-07-16T10:03:00Z",
+		});
+	});
+
+	it("kind 5 — presence announce + role lookup query/result", () => {
+		roundTrips(Messages.PresenceAnnouncement, {
+			peer: "peer-a",
+			role: "builder",
+			at: "2026-07-16T10:04:00Z",
+		});
+		roundTrips(Messages.RoleLookupQuery, {role: "builder"});
+		roundTrips(Messages.RoleLookupResult, {
+			role: "builder",
+			peers: [
+				{peer: "peer-a", role: "builder", lastSeen: "2026-07-16T10:04:00Z"},
+				{peer: "peer-b", role: "builder", lastSeen: "2026-07-16T10:04:30Z"},
+			],
+		});
+		roundTrips(Messages.RoleLookupResult, {role: "builder", peers: []});
+	});
+
+	it("kind 6 — heartbeat", () => {
+		roundTrips(Messages.Heartbeat, {
+			peer: "peer-a",
+			ttlSeconds: 30,
+			at: "2026-07-16T10:05:00Z",
+		});
+	});
+
+	it("kind 7 — inbox ack", () => {
+		roundTrips(Messages.InboxAck, {
+			messageId: "msg-1",
+			by: "peer-b",
+			at: "2026-07-16T10:06:00Z",
+		});
+	});
+});

--- a/packages/pipeline-crew-mcp/src/protocol/schema.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.ts
@@ -1,0 +1,115 @@
+/**
+ * protocol/schema — the Schema-typed payloads for every crew message kind.
+ *
+ * Generic (crew-agnostic); see the boundary note in `../index.ts`. The one non-obvious
+ * thing: a role is a `RoleId` *parameter* (an opaque non-empty string), never a baked-in
+ * crew noun — that is what lets tracker, peer, and edge code against this contract without
+ * pulling in `crew/`. Every payload is an `effect/Schema` type so the wire format is
+ * decode-checked at the boundary rather than trusted as an untyped bag.
+ */
+import {Schema} from "effect";
+
+/** An opaque role identifier — a parameter, never a concrete crew role noun (see the module note). */
+export const RoleId = Schema.NonEmptyString;
+
+/** An opaque participant identifier — a peer/session on the substrate. */
+export const PeerId = Schema.NonEmptyString;
+
+/** An opaque message identifier, used to correlate an ack back to its delivery. */
+export const MessageId = Schema.NonEmptyString;
+
+/** An ISO-8601 UTC instant, kept as a string so the wire format stays transport-agnostic + JSON-safe. */
+export const Timestamp = Schema.String;
+
+// Kind 1 — synchronous claim / collision-check (request → typed reply).
+
+/** A sender's request to claim a resource; answered by a `ClaimReply` (not fire-and-forget). */
+export const ClaimRequest = Schema.Struct({
+	resource: Schema.NonEmptyString,
+	claimant: PeerId,
+	role: RoleId,
+	at: Timestamp,
+});
+
+/** The typed answer to a `ClaimRequest`: whether it was granted, and who currently owns it. */
+export const ClaimReply = Schema.Struct({
+	resource: Schema.NonEmptyString,
+	granted: Schema.Boolean,
+	collision: Schema.Boolean,
+	owner: PeerId,
+	since: Timestamp,
+});
+
+// Kind 2 — planned-epic handoff (EM → builder).
+
+export const EpicHandoffNotice = Schema.Struct({
+	epic: Schema.NonEmptyString,
+	child: Schema.NonEmptyString,
+	from: RoleId,
+	to: RoleId,
+	summary: Schema.optionalKey(Schema.String),
+	at: Timestamp,
+});
+
+// Kind 3 — drain-progress tally.
+
+export const DrainProgressTally = Schema.Struct({
+	scope: Schema.NonEmptyString,
+	completed: Schema.Int,
+	inFlight: Schema.Int,
+	total: Schema.Int,
+	reporter: PeerId,
+	at: Timestamp,
+});
+
+// Kind 4 — intake ping.
+
+export const IntakePing = Schema.Struct({
+	issue: Schema.NonEmptyString,
+	from: RoleId,
+	note: Schema.optionalKey(Schema.String),
+	at: Timestamp,
+});
+
+// Kind 5 — role discovery / presence (announce + lookup).
+
+/** One presence record: a peer, the role it serves, and when it was last seen. */
+export const PresenceEntry = Schema.Struct({
+	peer: PeerId,
+	role: RoleId,
+	lastSeen: Timestamp,
+});
+
+/** A peer announcing that it serves a role (fire-and-forget). */
+export const PresenceAnnouncement = Schema.Struct({
+	peer: PeerId,
+	role: RoleId,
+	at: Timestamp,
+});
+
+/** A lookup query for peers serving a role; answered by a `RoleLookupResult`. */
+export const RoleLookupQuery = Schema.Struct({
+	role: RoleId,
+});
+
+/** The typed answer to a `RoleLookupQuery`: the peers currently present for the role. */
+export const RoleLookupResult = Schema.Struct({
+	role: RoleId,
+	peers: Schema.Array(PresenceEntry),
+});
+
+// Kind 6 — heartbeat (presence TTL keepalive).
+
+export const Heartbeat = Schema.Struct({
+	peer: PeerId,
+	ttlSeconds: Schema.Int,
+	at: Timestamp,
+});
+
+// Kind 7 — inbox ack (delivery acknowledgement).
+
+export const InboxAck = Schema.Struct({
+	messageId: MessageId,
+	by: PeerId,
+	at: Timestamp,
+});


### PR DESCRIPTION
Part of #3054 — a spine child of epic #3045.

## What this delivers
The generic `protocol/` module in `packages/pipeline-crew-mcp`: the crew's typed message catalog as **Effect RPC**, Schema-defined, transport-agnostic. It's the foundation edge/tracker/peer code against — it depends on nothing from those siblings.

- **`protocol/schema.ts`** — an `effect/Schema` payload/reply type for every message kind. Roles are opaque `RoleId` parameters (a `NonEmptyString`), never baked-in crew nouns.
- **`protocol/group.ts`** — the `CrewProtocol` `RpcGroup` over 8 `Rpc`s covering the 7 kinds:
  1. `Claim` — synchronous claim/collision-check, an **RPC with a typed reply** (`ClaimReply` success schema), not fire-and-forget.
  2. `EpicHandoff` — planned-epic handoff (EM → builder).
  3. `DrainProgress` — drain-progress tally.
  4. `IntakePing` — intake ping.
  5. `AnnouncePresence` + `LookupRole` — role discovery/presence (announce is fire-and-forget; lookup carries a typed `RoleLookupResult` reply).
  6. `Heartbeat` — presence TTL keepalive.
  7. `AckInbox` — inbox delivery acknowledgement.
- **`protocol/index.ts`** + package barrel re-export the catalog as `Protocol`.

Fire-and-forget kinds leave `success` unset, so it defaults to `Schema.Void`; the request-response kinds (claim, lookup) set an explicit success schema. That split is what distinguishes a typed reply from a fire-and-forget on the wire.

Grounded in effect-smol's `effect/unstable/rpc` (`Rpc.make` / `RpcGroup.make`) at the phoenix pin (`effect@4.0.0-beta.92`).

## Acceptance criteria
- [x] `protocol/` exports an `RpcGroup` covering all 7 message kinds, each with an `effect/Schema` payload.
- [x] Schema round-trip (encode/decode) tests pass for each message kind's payload (`schema.test.ts`).
- [x] `protocol/` contains no import of `crew/` — asserted by a source-scan boundary test (`group.test.ts`).
- [x] The claim/collision-check kind is an RPC with a typed reply, not fire-and-forget.

## Verification
- `pnpm --filter @kampus/pipeline-crew-mcp test` — 13 passed (round-trips, catalog coverage, typed-reply shape, no-crew boundary).
- `pnpm typecheck` — clean (full workspace, `tsgo`).
- `pnpm lint:worktree` — clean.

## Scope
Out of scope (separate children): tracker registry logic, peer inbox/dialer runtime, the concrete crew role catalog.
