### PR TITLE
fix(integration): shared CF-API throttle to smooth setup-side 429 pressure (#3081)

### DIFF
--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -125,6 +125,35 @@ create/destroy surface every CF flake class scales with (#1010 / #1019 /
 #1020), which also retired the fork cap: the integration project runs uncapped
 `fileParallelism: true`.
 
+## CF API rate-limit discipline — two complementary halves
+
+The harness's setup-only Cloudflare REST path (`cloudflareApi` → `runD1Query` in
+`_harness.ts`; `setLastActivityAt` / `execD1` / `promoteToYazar`) hits ONE
+account's D1 control-plane, which trips the account-global rate limit (HTTP 429,
+code 971 "TooManyRequests") under concurrent-stage batch load. Two wrappers guard
+it, and a call funnels through both:
+
+- **Reactive per-call retry** — `cfFetchWithRateLimitRetry` (`_d1-rest-retry.ts`):
+  after a 429 fires, replay the one call with full-jitter exponential backoff
+  (429 is a pre-execution reject, so replay is safe; #2915). Bounded — a
+  persistent 429 exhausts the budget and surfaces.
+- **Proactive shared throttle** — `cfApiThrottle` (`_cf-api-throttle.ts`, #3081):
+  a concurrency cap + jittered start-pacing every harness CF REST call funnels
+  through, so fewer 429s fire in the first place. `cloudflareApi` composes it
+  AROUND the retry (`throttle.run(() => cfFetchWithRateLimitRetry(send))`), so
+  each logical call — retries included — is one throttled unit. Both knobs are
+  env-tunable (`CF_API_MAX_CONCURRENT` / `CF_API_MIN_SPACING_MS`).
+
+**Ceiling (why this isn't the whole 429 story):** the throttle is an in-process
+singleton — under `isolate:false` it is shared across files in the same fork, but
+it does NOT reach across forks or across separate CI runs. The observed
+"~24 concurrent" 429 pressure is a CROSS-run aggregate (~4 overlapping
+`merge_group` runs on the one account), and the dominant 429 fires inside
+alchemy's OWN deploy path, which the harness can't wrap. Those need the
+out-of-harness levers named in #3081 (a CI `concurrency:` group; 429 backoff in
+alchemy's deploy path via `pnpm patch`, ADR 0038). This throttle is the
+run-agnostic backoff on the slice the harness owns.
+
 ## Teardown is best-effort — leaked stages are a known class
 
 Both destroy paths (`afterAll` per-file, the globalSetup teardown) are

--- a/apps/web/tests/integration/_cf-api-throttle.ts
+++ b/apps/web/tests/integration/_cf-api-throttle.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared harness-level throttle for the setup-side Cloudflare API surface — a concurrency
+ * cap + full-jitter minimum spacing that every harness-initiated CF REST call funnels
+ * through, so the harness's OWN aggregate CF API pressure stays smoothed under the
+ * account-global rate limit (HTTP 429, error code 971 "TooManyRequests"; #3081).
+ *
+ * Relationship to the existing per-call retry (`cfFetchWithRateLimitRetry`, `_d1-rest-retry.ts`):
+ * that wrapper reacts to a 429 AFTER it fires, replaying one call with backoff. This throttle
+ * is the complementary PROACTIVE half — it bounds how many CF calls the harness launches at
+ * once and paces their starts, so fewer 429s fire in the first place. It COMPOSES AROUND the
+ * per-call retry (`throttle.run(() => cfFetchWithRateLimitRetry(send))`), never replacing it —
+ * each logical CF call, retries included, counts as one throttled unit.
+ *
+ * Scope ceiling (deliberate, per #3081's "confined to the integration harness" constraint):
+ * the limiter is an in-process singleton, so under `isolate:false` (`vitest.config.ts`) it is
+ * shared across every file that runs in the SAME fork and genuinely paces their combined setup
+ * D1 REST burst. It does NOT coordinate across forks or across separate CI runs — the observed
+ * "~24 concurrent" pressure is a CROSS-run aggregate (~4 overlapping `merge_group` runs on the
+ * one account, #3081 evidence), which no in-harness code can reach. The cross-run levers named
+ * in #3081 live outside this harness: a GitHub Actions `concurrency:` group (a workflow change)
+ * and 429 backoff inside alchemy's own deploy path (a `pnpm patch`, ADR 0038). This throttle is
+ * the run-agnostic backoff applied to the slice the harness DOES own — its own D1 REST calls.
+ *
+ * A pure leaf: `sleep` / `now` / `random` are injectable, no `fetch`/creds dependency, so the
+ * pacing logic is unit-testable offline (matches `_d1-rest-retry.ts` / `_deploy-transient.ts`).
+ */
+
+/** Max CF API calls this throttle keeps in flight at once (tunable via env). */
+export const CF_API_MAX_CONCURRENT = 4;
+/** Minimum full-jitter gap between successive CF API call starts, ms (tunable via env). */
+export const CF_API_MIN_SPACING_MS = 100;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export interface CfApiThrottleOptions {
+	/** Cap on concurrently in-flight calls (default {@link CF_API_MAX_CONCURRENT}). */
+	maxConcurrent?: number;
+	/** Minimum spacing between call starts, ms (default {@link CF_API_MIN_SPACING_MS}). */
+	minSpacingMs?: number;
+	/** Injected for tests — real sleep by default. */
+	sleep?: (ms: number) => Promise<void>;
+	/** Injected for tests — `Date.now` by default. */
+	now?: () => number;
+	/** Injected for tests — `Math.random` by default. */
+	random?: () => number;
+}
+
+export interface CfApiThrottle {
+	/** Run `op` under the concurrency cap + start-pacing; resolves/rejects with `op`'s result. */
+	run<T>(op: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Build a throttle enforcing (1) a max in-flight count and (2) a minimum full-jitter gap
+ * between call starts. Both knobs are independently disable-able: `maxConcurrent = Infinity`
+ * drops the cap, `minSpacingMs = 0` drops the pacing.
+ */
+export const createCfApiThrottle = ({
+	maxConcurrent = CF_API_MAX_CONCURRENT,
+	minSpacingMs = CF_API_MIN_SPACING_MS,
+	sleep = defaultSleep,
+	now = () => Date.now(),
+	random = Math.random,
+}: CfApiThrottleOptions = {}): CfApiThrottle => {
+	let inFlight = 0;
+	const waiters: Array<() => void> = [];
+	// Earliest timestamp the NEXT call may start — advanced synchronously as each call
+	// reserves its slot, so staggered runners de-sync instead of firing as one packet.
+	let nextStartFloor = 0;
+
+	const acquireSlot = async (): Promise<void> => {
+		if (inFlight >= maxConcurrent) await new Promise<void>((resolve) => waiters.push(resolve));
+		inFlight++;
+	};
+	const releaseSlot = (): void => {
+		inFlight--;
+		waiters.shift()?.();
+	};
+
+	// Full-jitter start pacing: reserve a start no earlier than `minSpacingMs` past the prior
+	// reservation, plus a uniform jitter in [0, minSpacingMs). The reservation (reading `now`,
+	// bumping `nextStartFloor`) is synchronous, so concurrent runners each claim a distinct,
+	// monotonically-spaced start before any of them awaits — the same anti-thundering-herd
+	// discipline `cfFetchWithRateLimitRetry`'s retry jitter applies, here to first attempts.
+	const pace = async (): Promise<void> => {
+		if (minSpacingMs <= 0) return;
+		const start = Math.max(nextStartFloor, now()) + Math.floor(random() * minSpacingMs);
+		nextStartFloor = start + minSpacingMs;
+		const wait = start - now();
+		if (wait > 0) await sleep(wait);
+	};
+
+	return {
+		async run<T>(op: () => Promise<T>): Promise<T> {
+			await acquireSlot();
+			try {
+				await pace();
+				return await op();
+			} finally {
+				releaseSlot();
+			}
+		},
+	};
+};
+
+// Read a positive numeric tunable from the env, else the default — lets an operator widen or
+// tighten the harness's self-imposed CF-API ceiling without a code change (the single-account
+// budget is a fixed ceiling to MANAGE, not a stopgap; #3081 founder constraint).
+const envNumber = (name: string, fallback: number): number => {
+	const raw = process.env[name];
+	if (raw === undefined) return fallback;
+	const n = Number(raw);
+	return Number.isFinite(n) && n >= 0 ? n : fallback;
+};
+
+/**
+ * The process-wide shared throttle every harness CF REST call funnels through
+ * (`_harness.ts`'s `cloudflareApi`). One instance per fork under `isolate:false`, so all
+ * files sharing a fork share this limiter's state.
+ */
+export const cfApiThrottle: CfApiThrottle = createCfApiThrottle({
+	maxConcurrent: envNumber("CF_API_MAX_CONCURRENT", CF_API_MAX_CONCURRENT),
+	minSpacingMs: envNumber("CF_API_MIN_SPACING_MS", CF_API_MIN_SPACING_MS),
+});

--- a/apps/web/tests/integration/_cf-api-throttle.unit.test.ts
+++ b/apps/web/tests/integration/_cf-api-throttle.unit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Pins the harness CF-API throttle (#3081): it caps concurrent in-flight calls, never runs
+ * more than `maxConcurrent` at once, paces call starts by at least `minSpacingMs` with full
+ * jitter, propagates results/errors transparently, and always releases its slot (even when
+ * `op` throws) so one failure can't wedge the limiter. `sleep`/`now`/`random` are injected so
+ * the suite runs offline and deterministically.
+ */
+
+import {describe, expect, it, vi} from "vitest";
+import {
+	CF_API_MAX_CONCURRENT,
+	CF_API_MIN_SPACING_MS,
+	createCfApiThrottle,
+} from "./_cf-api-throttle.ts";
+
+// A deferred promise + its resolver, to hold `op` open and observe in-flight concurrency.
+const deferred = <T>() => {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return {promise, resolve};
+};
+
+const noSleep = () => Promise.resolve();
+
+// Drain the microtask queue so every `run`'s synchronous prelude (acquire → pace → op)
+// settles — one `await Promise.resolve()` clears a single tick, not the 2–3 an async
+// `run` chains before `op` executes.
+const flush = async (): Promise<void> => {
+	for (let i = 0; i < 20; i++) await Promise.resolve();
+};
+
+describe("createCfApiThrottle", () => {
+	it("returns op's value and does not pace when spacing is disabled", async () => {
+		const sleep = vi.fn(noSleep);
+		const throttle = createCfApiThrottle({minSpacingMs: 0, sleep});
+		await expect(throttle.run(async () => 42)).resolves.toBe(42);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("propagates a rejection and still releases the slot", async () => {
+		const throttle = createCfApiThrottle({maxConcurrent: 1, minSpacingMs: 0});
+		await expect(throttle.run(async () => Promise.reject(new Error("boom")))).rejects.toThrow(
+			"boom",
+		);
+		// If the failed call had leaked its slot, this second call would never acquire one.
+		await expect(throttle.run(async () => "recovered")).resolves.toBe("recovered");
+	});
+
+	it("never runs more than maxConcurrent ops at once", async () => {
+		const throttle = createCfApiThrottle({maxConcurrent: 2, minSpacingMs: 0});
+		let active = 0;
+		let peak = 0;
+		const gates = [deferred<void>(), deferred<void>(), deferred<void>(), deferred<void>()];
+		const runs = gates.map((g) =>
+			throttle.run(async () => {
+				active++;
+				peak = Math.max(peak, active);
+				await g.promise;
+				active--;
+			}),
+		);
+		// Let the first wave acquire slots, then release them one at a time.
+		await flush();
+		expect(active).toBe(2); // only two admitted; the other two are queued
+		for (const g of gates) {
+			g.resolve();
+			await flush();
+		}
+		await Promise.all(runs);
+		expect(peak).toBe(2);
+	});
+
+	it("admits a queued op only after a slot frees", async () => {
+		const throttle = createCfApiThrottle({maxConcurrent: 1, minSpacingMs: 0});
+		const first = deferred<void>();
+		let secondStarted = false;
+		const r1 = throttle.run(async () => {
+			await first.promise;
+		});
+		const r2 = throttle.run(async () => {
+			secondStarted = true;
+		});
+		await flush();
+		expect(secondStarted).toBe(false); // blocked behind the single slot
+		first.resolve();
+		await Promise.all([r1, r2]);
+		expect(secondStarted).toBe(true);
+	});
+
+	it("spaces successive starts by >= minSpacingMs of jittered wait", async () => {
+		const waits: number[] = [];
+		let clock = 0;
+		const sleep = vi.fn(async (ms: number) => {
+			waits.push(ms);
+			clock += ms; // advance the injected clock by exactly the slept time
+		});
+		const throttle = createCfApiThrottle({
+			maxConcurrent: 10, // cap out of the way — isolate the pacing knob
+			minSpacingMs: 100,
+			sleep,
+			now: () => clock,
+			random: () => 0.999999, // maximize jitter → widest wait, still < 2·spacing
+		});
+		// Fire three back-to-back; each reserves a start floor spaced by minSpacingMs.
+		await Promise.all([
+			throttle.run(async () => {}),
+			throttle.run(async () => {}),
+			throttle.run(async () => {}),
+		]);
+		// First call starts immediately (only jitter); the next two wait at least one spacing.
+		const paced = waits.filter((w) => w > 0);
+		expect(paced.length).toBeGreaterThanOrEqual(2);
+		for (const w of paced) {
+			expect(w).toBeGreaterThan(0);
+			expect(w).toBeLessThan(2 * 100); // start floor + jitter, both bounded by spacing
+		}
+	});
+
+	it("exports sane default knobs", () => {
+		expect(CF_API_MAX_CONCURRENT).toBeGreaterThan(0);
+		expect(CF_API_MIN_SPACING_MS).toBeGreaterThanOrEqual(0);
+	});
+});

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -34,6 +34,7 @@
  *   - `h.openSse(...)` / `readFrame(...)` — live SSE transport helpers
  */
 
+import {cfApiThrottle} from "./_cf-api-throttle.ts";
 import {cfFetchWithRateLimitRetry} from "./_d1-rest-retry.ts";
 import {
 	awaitEdgeReady,
@@ -240,16 +241,21 @@ const cloudflareApiToken = (): string => {
 // response body for diagnosis. Setup-only — never on a test's black-box assertion path.
 // A transient 429 (the shared-account D1 rate-limit that reds the batched ref, #2915) is
 // bounded-retried before the throw — see `_d1-rest-retry.ts` for why 429 is safe to replay.
+// The whole call funnels through the shared `cfApiThrottle` (proactive concurrency cap +
+// jittered start-pacing, #3081) so the harness's own aggregate CF-API burst stays gentler on
+// the account-global limit; the throttle composes AROUND the per-call retry, not over it.
 async function cloudflareApi(path: string, init?: RequestInit): Promise<Response> {
-	const res = await cfFetchWithRateLimitRetry(() =>
-		fetch(`${CLOUDFLARE_API_BASE}${path}`, {
-			...init,
-			headers: {
-				authorization: `Bearer ${cloudflareApiToken()}`,
-				"content-type": "application/json",
-				...init?.headers,
-			},
-		}),
+	const res = await cfApiThrottle.run(() =>
+		cfFetchWithRateLimitRetry(() =>
+			fetch(`${CLOUDFLARE_API_BASE}${path}`, {
+				...init,
+				headers: {
+					authorization: `Bearer ${cloudflareApiToken()}`,
+					"content-type": "application/json",
+					...init?.headers,
+				},
+			}),
+		),
 	);
 	if (!res.ok) {
 		throw new Error(


### PR DESCRIPTION
## What

Adds a shared harness-level throttle for the setup-side Cloudflare API surface so the integration harness's own aggregate CF-API pressure stays smoothed under the account-global rate limit (HTTP 429, error code 971 `TooManyRequests`).

- **New** `apps/web/tests/integration/_cf-api-throttle.ts` — `cfApiThrottle`, a shared in-process limiter: a concurrency cap plus full-jitter minimum start-pacing. A pure leaf (injectable `sleep`/`now`/`random`), unit-tested offline like `_d1-rest-retry.ts` / `_deploy-transient.ts`. Both knobs are env-tunable (`CF_API_MAX_CONCURRENT` / `CF_API_MIN_SPACING_MS`).
- **Wired** at the single setup-only CF REST choke point `cloudflareApi` in `_harness.ts` (drives `runD1Query` → `setLastActivityAt` / `execD1` / `promoteToYazar`). The throttle composes **around** the existing per-call retry: `cfApiThrottle.run(() => cfFetchWithRateLimitRetry(send))`, so each logical call — retries included — is one throttled unit.
- **Docs** — extends `.patterns/alchemy-test-harness.md` with the two-halves CF-API rate-limit discipline (reactive per-call retry + proactive shared throttle) and its ceiling.

## Why this shape

`cfFetchWithRateLimitRetry` reacts to a 429 *after* it fires (bounded jittered backoff, safe replay — 429 is a pre-execution reject; #2915). This PR adds the **proactive** complement — bounding how many CF calls the harness launches at once and pacing their starts — so fewer 429s fire in the first place. The two are composed, not swapped, so per-call retry behavior is preserved (AC3).

Grounding: code 971 → `TooManyRequests` and its retryable classification are already decoded/cited in `_deploy-transient.ts` (`@distilled.cloud/cloudflare` `GLOBAL_ERROR_CODE_MAP[971]`); this PR reuses that discipline rather than re-asserting the CF error shape.

## Scope ceiling (deliberate, honest)

Per the issue's "confined to the integration harness, no CI change" constraint, this is the harness-owned slice only. The limiter is an in-process singleton: under `isolate:false` it is shared across files in the **same fork** and genuinely paces their combined setup D1 burst, but it does **not** coordinate across forks or across separate CI runs. The observed "~24 concurrent" 429 pressure is a **cross-run** aggregate (~4 overlapping `merge_group` runs on the one account), and the dominant 429 fires inside alchemy's own deploy path — neither is reachable from in-harness code. Those need the out-of-harness levers named in the issue and its founder comments: a GitHub Actions `concurrency:` group (workflow change) and 429 backoff inside alchemy's deploy path (a `pnpm patch`, ADR 0038). This PR is the run-agnostic backoff applied where the harness has reach.

## Acceptance criteria

- [x] Aggregate CF API pressure is throttled (shared rate-limiter: concurrency cap + jittered start-pacing) for the harness-owned CF REST surface.
- [x] Confined to `apps/web/tests/integration/` (+ its patterns doc); no merge-gate / CI-workflow change.
- [x] Existing per-call retry (`cfFetchWithRateLimitRetry` / `runD1Query`) preserved — composed around, not replaced.

## Verification

- `pnpm --filter @kampus/web typecheck` — green
- `biome check` on all touched files — clean
- `vitest run --project unit _cf-api-throttle.unit.test.ts` — 6/6 pass (concurrency cap, queue-admits-after-free, jittered spacing, slot-release-on-throw, result/error propagation)

Fixes #3081