### PR TITLE
fix(d1-rest): bounded read-your-writes poll for makeD1Rest read-after-write

### DIFF
--- a/apps/web/tests/integration/kunye-relation-store.test.ts
+++ b/apps/web/tests/integration/kunye-relation-store.test.ts
@@ -18,7 +18,7 @@
  */
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {type Relation, RelationStore, resource} from "@kampus/authz";
-import {makeD1Rest} from "@kampus/d1-rest";
+import {makeD1Rest, readYourWrite} from "@kampus/d1-rest";
 import {and, eq} from "drizzle-orm";
 import {Effect, Layer} from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
@@ -76,19 +76,26 @@ afterEach(async () => {
 	await remove(SUBJECT);
 });
 
-// #3075 stopgap (reversible): retry-wrap so a transient real-D1 flake in merge_group retries
-// instead of evicting clean, unrelated PRs from the merge queue. Retry, NOT skip — the real-D1
-// coverage stays. `mint()` is onConflictDoNothing (retry-idempotent) and uses no seedTerm, so
-// vitest.config's "no retry" seedTerm-dedup constraint isn't tripped here. Remove once #3075's
-// durable ci.yml worker-relevance filter lands.
-describe("RelationStoreLive.has on real D1 — resolves composite-PK tuple existence", {
-	retry: 2,
-}, () => {
+// The mint/remove writes and the `has` read all cross makeD1Rest's REST transport, which carries
+// no read-your-writes guarantee — the /query endpoint takes no D1 session bookmark (see
+// `readYourWrite`), so an immediate read after a write can observe the pre-write state until the
+// account's D1 fabric catches up (#3075 Signature B / #3078). Poll the read until it reflects the
+// just-written truth this test controls, so the read-after-write assertion is deterministic rather
+// than a stale coin-flip. `readYourWrite` returns the real read on exhaustion, so a genuinely-wrong
+// result still fails the assertion loudly — this waits out latency, it does not mask a bug.
+const hasWhen = (tuple: Relation, expected: boolean): Promise<boolean> =>
+	readYourWrite(
+		() => has(tuple),
+		(observed) => observed === expected,
+	);
+
+describe("RelationStoreLive.has on real D1 — resolves composite-PK tuple existence", () => {
 	it("a seeded tuple reads present; a non-matching tuple reads absent", async () => {
 		await mint(SUBJECT);
 
-		expect(await has({subject: SUBJECT, relation: RELATION, object})).toBe(true);
+		expect(await hasWhen({subject: SUBJECT, relation: RELATION, object}, true)).toBe(true);
 
+		// No write targets these keys, so their absence is stable — assert directly.
 		expect(await has({subject: `${NS}-rando`, relation: RELATION, object})).toBe(false);
 		expect(await has({subject: SUBJECT, relation: "admin", object})).toBe(false);
 		expect(
@@ -102,9 +109,9 @@ describe("RelationStoreLive.has on real D1 — resolves composite-PK tuple exist
 
 	it("a removed tuple is denied on the next call (fresh per call, no cached authority)", async () => {
 		await mint(SUBJECT);
-		expect(await has({subject: SUBJECT, relation: RELATION, object})).toBe(true);
+		expect(await hasWhen({subject: SUBJECT, relation: RELATION, object}, true)).toBe(true);
 
 		await remove(SUBJECT);
-		expect(await has({subject: SUBJECT, relation: RELATION, object})).toBe(false);
+		expect(await hasWhen({subject: SUBJECT, relation: RELATION, object}, false)).toBe(false);
 	});
 });

--- a/packages/d1-rest/README.md
+++ b/packages/d1-rest/README.md
@@ -39,7 +39,13 @@ acyclic.
   integration test both run the real direct-D1 work through.
 - `toRestParams` / `assertRestParam` — the REST-wire param transform and its strict-`string[]`
   null guard (#569).
-- `D1RestConfig` / `D1RestServices` types.
+- `readYourWrite(read, isConsistent, options?)` — a bounded read-your-writes poll for callers that
+  need read-after-write consistency over this transport. The REST `/query` endpoint carries no D1
+  session bookmark (that Sessions API primitive is Workers-binding-only), so an immediate read after
+  a write has no ordering guarantee; a caller that knows the post-write truth polls the read until it
+  reflects it. Returns the last read either way — it waits out latency, it never masks a wrong read
+  (#3075 / #3078).
+- `D1RestConfig` / `D1RestServices` / `ReadYourWriteOptions` types.
 
 ## Consumers
 
@@ -53,5 +59,7 @@ acyclic.
 
 The transport's contract is tested **once**, in `src/index.unit.test.ts` (no CF creds, no SQL
 engine — ADR 0082 unit tier): the `meta.changes` mapping (carried + defaulting to 0), the
-`toRestParams` null rejection (#569), and the batch single-POST contract. Each consumer's
-integration tier still exercises the real transport against real D1 end to end.
+`toRestParams` null rejection (#569), the batch single-POST contract, and `readYourWrite`'s
+read-your-writes poll (re-reads until consistent; returns the last value on exhaustion so a real
+absence is never masked). Each consumer's integration tier still exercises the real transport
+against real D1 end to end.

--- a/packages/d1-rest/src/index.ts
+++ b/packages/d1-rest/src/index.ts
@@ -159,3 +159,48 @@ export const d1RestLayerFromEnv: Layer.Layer<D1RestServices> = Layer.merge(
  */
 export const makeD1RestFromEnv = (target: {accountId: string; databaseId: string}): D1Database =>
 	makeD1Rest({...target, layer: d1RestLayerFromEnv});
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export interface ReadYourWriteOptions {
+	/** Max poll attempts, counting the first read (default 6). */
+	readonly maxAttempts?: number;
+	/** Base of the exponential backoff, in ms (default 100). */
+	readonly baseDelayMs?: number;
+	/** Injected for tests — real `setTimeout` sleep by default. */
+	readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Bounded read-your-writes poll for a read issued through {@link makeD1Rest}.
+ *
+ * The REST transport has NO read-your-writes guarantee: each statement is an independent
+ * `queryDatabase` POST to `/d1/database/<id>/query`, and that endpoint neither accepts nor
+ * returns a D1 session bookmark — `@distilled.cloud/cloudflare`'s `QueryDatabaseRequest` carries
+ * only `sql`/`params`/`batch` (verified against the pinned SDK schema, itself generated from
+ * Cloudflare's OpenAPI). D1's Sessions API commit token — the read-your-writes primitive — is
+ * reachable only through the Workers binding (`env.DB.withSession()`), not this REST path. So a
+ * REST read issued immediately after a REST write has no ordering against it and can observe the
+ * pre-write state until the account's D1 fabric catches up (the #3075 künye flake).
+ *
+ * A caller that KNOWS the post-write truth (a test that just minted a row) passes it as
+ * `isConsistent`; this re-reads with exponential backoff until the read reflects it or the attempt
+ * budget is spent, and returns the LAST value either way — it never throws and never fabricates a
+ * result, so the caller's own assertion on the returned value still fails loudly on a
+ * genuinely-wrong read and only a not-yet-visible write is waited out. The transport itself cannot
+ * do this: it cannot tell an absent row from a not-yet-visible one, so the expected state must come
+ * from the caller — which is why this is a caller-invoked helper, not a transport auto-retry.
+ */
+export const readYourWrite = async <T>(
+	read: () => Promise<T>,
+	isConsistent: (value: T) => boolean,
+	options: ReadYourWriteOptions = {},
+): Promise<T> => {
+	const {maxAttempts = 6, baseDelayMs = 100, sleep = defaultSleep} = options;
+	let value = await read();
+	for (let attempt = 1; attempt < maxAttempts && !isConsistent(value); attempt++) {
+		await sleep(baseDelayMs * 2 ** (attempt - 1));
+		value = await read();
+	}
+	return value;
+};

--- a/packages/d1-rest/src/index.unit.test.ts
+++ b/packages/d1-rest/src/index.unit.test.ts
@@ -12,7 +12,7 @@ import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
 import {assert, describe, it} from "@effect/vitest";
 import {Layer} from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
-import {assertRestParam, makeD1Rest, toRestParams} from "./index.ts";
+import {assertRestParam, makeD1Rest, readYourWrite, toRestParams} from "./index.ts";
 
 const restD1 = (fetch: typeof globalThis.fetch): D1Database =>
 	makeD1Rest({
@@ -105,5 +105,69 @@ describe("makeD1Rest — batch is one REST POST carrying every statement in orde
 		assert.deepStrictEqual(batch[0]!.params, ["sisli"]);
 		assert.strictEqual(batch[1]!.sql, "insert into t (slug, norm) values (?, ?)");
 		assert.deepStrictEqual(batch[1]!.params, ["sisli", "sisli"]);
+	});
+});
+
+// The REST /query endpoint carries no D1 session bookmark (verified against the pinned
+// `@distilled.cloud/cloudflare` `QueryDatabaseRequest` schema), so an immediate read after a
+// write has no read-your-writes guarantee — the #3075 künye flake. `readYourWrite` re-reads until
+// the caller's known post-write truth holds, and — load-bearing — returns the LAST value on
+// exhaustion so a genuinely-wrong read still fails the caller's assertion rather than being masked.
+describe("readYourWrite — bounded read-your-writes poll (#3075/#3078)", () => {
+	// A sleep double that resolves at once (no real timers) and records each backoff it was asked
+	// for, so the poll's cadence is asserted without waiting.
+	const recordingSleep = () => {
+		const delays: number[] = [];
+		return {delays, sleep: async (ms: number) => void delays.push(ms)};
+	};
+
+	it("returns the first read when it is already consistent (no sleep, no re-read)", async () => {
+		let reads = 0;
+		const {delays, sleep} = recordingSleep();
+		const value = await readYourWrite(
+			async () => {
+				reads++;
+				return true;
+			},
+			(v) => v === true,
+			{sleep},
+		);
+		assert.strictEqual(value, true);
+		assert.strictEqual(reads, 1);
+		assert.deepStrictEqual(delays, []);
+	});
+
+	it("re-reads until the write is observed, then returns the consistent value", async () => {
+		// The write becomes visible on the 3rd read (stale, stale, present).
+		const seq = [false, false, true];
+		let i = 0;
+		const {delays, sleep} = recordingSleep();
+		const value = await readYourWrite(
+			async () => seq[i++]!,
+			(v) => v === true,
+			{sleep, baseDelayMs: 100},
+		);
+		assert.strictEqual(value, true);
+		assert.strictEqual(i, 3);
+		// Two backoffs before the 2nd and 3rd reads, exponential from the base.
+		assert.deepStrictEqual(delays, [100, 200]);
+	});
+
+	it("returns the LAST value on budget exhaustion — a genuinely-absent write is not masked", async () => {
+		let reads = 0;
+		const {delays, sleep} = recordingSleep();
+		const value = await readYourWrite(
+			async () => {
+				reads++;
+				return false;
+			},
+			(v) => v === true,
+			{sleep, maxAttempts: 4, baseDelayMs: 50},
+		);
+		// Never became consistent → the real (false) read is returned so the caller's own assertion
+		// fails loudly; the poll never fabricates `true`.
+		assert.strictEqual(value, false);
+		assert.strictEqual(reads, 4);
+		assert.deepStrictEqual(delays, [50, 100, 200]);
 	});
 });


### PR DESCRIPTION
Fixes #3078

## Problem

`apps/web/tests/integration/kunye-relation-store.test.ts` intermittently flaked its mint→`has(...) === true` assertion (Signature B of #3075): an immediate REST read after a REST write, both through `makeD1Rest`, occasionally observed the pre-write state.

## Grounding — bookmark threading is not expressible through this transport

The issue's preferred fix is "thread the D1 session bookmark through `makeD1Rest`." Verified against source, that is **not achievable through the current REST transport**:

- `makeD1Rest` issues each statement as an independent `queryDatabase` POST to `/d1/database/<id>/query`. The pinned `@distilled.cloud/cloudflare@0.27.0` `QueryDatabaseRequest`/`QueryDatabaseResponse` schemas (generated from Cloudflare's OpenAPI) carry only `sql`/`params`/`batch` and `result[]` — **no session-bookmark field on the request or the response**. The only `bookmark` fields in the SDK are time-travel / import-export, unrelated to query read-your-writes.
- D1's **Sessions API commit token** (the read-your-writes primitive) is reachable only through the **Workers binding** (`env.DB.withSession()`), not the REST `/query` path this transport uses.

So a REST read issued immediately after a REST write has no ordering guarantee against it and can read stale until the account's D1 fabric catches up. Threading a bookmark would require replacing the SDK transport with a raw-fetch client and asserting an unverified header contract — out of proportion and ungrounded, so not taken.

## Fix — a sound, caller-driven read-your-writes poll

Add `readYourWrite(read, isConsistent, options?)` to `packages/d1-rest`: a caller that **knows** the post-write truth (a test that just minted a row) polls the read, with bounded exponential backoff, until it reflects that truth. It **returns the last read either way** — it never throws and never fabricates a result, so a genuinely-wrong read still fails the caller's own assertion loudly; only a not-yet-visible write is waited out.

A blanket auto-retry *inside* the transport would be unsound — `makeD1Rest` cannot tell an absent row from a not-yet-visible one — so the expected state must come from the caller. That is why this is a caller-invoked helper, not a transport-level retry.

Wired into the künye test's read-after-write assertions (`mint→has===true`, `remove→has===false`), replacing the coarse #3077 describe-level `retry: 2` stopgap this issue is the durable fix behind. The orthogonal 429 dimension is covered by the already-landed #3089 harness throttle.

## Acceptance criteria

- [x] `kunye-relation-store.test.ts`'s mint→`has(...) === true` (and remove→`has(...) === false`) are deterministic — the read-after-write poll waits out stale reads.
- [x] Confined to `apps/web/tests/integration/kunye-relation-store.test.ts` + `packages/d1-rest/`; no merge-gate / CI-workflow change.
- [x] `packages/d1-rest/src/index.unit.test.ts` covers the read-after-write contract (consistent-first, re-read-until-consistent cadence, last-value-on-exhaustion never masks a real absence).

## Verification

- `pnpm --filter @kampus/d1-rest test` — 8 passed (5 existing + 3 new).
- `pnpm --filter @kampus/d1-rest typecheck` and `pnpm --filter @kampus/web typecheck` — clean.
- `biome check` on all changed files — clean.
- The `kunye-relation-store.test.ts` integration change runs against real remote D1 in CI (no CF creds locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)