### PR TITLE
docs(web): retarget stale nav-flag pop-in comments to the __BOOT__ synchronous first paint (#2828)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -145,32 +145,39 @@ vi.mock("./components/divan/useDivanAccess", () => ({useDivanAccess: () => false
 vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: () => 0}));
 
 // Controllable flag mock. The eager `/profile` Katkıların skeleton (#2188) is gated on
-// the authorship-loop flag, so its tests flip `flags.authorshipLoop`; the mecmua feed
-// (akış) nav entry (#2547) is gated on `mecmua-feed`, flipped via `flags.mecmuaFeed`.
-// Every other read (and other flag key) stays off, matching the default the shell
-// rendered under before.
+// the authorship-loop flag, so its tests flip `flags.authorshipLoop`; the mecmua nav entry
+// (#2512) on `mecmua-public-read` (`flags.mecmua`); the mecmua feed (akış) nav entry (#2547)
+// on `mecmua-feed` (`flags.mecmuaFeed`). Every other read (and other flag key) stays off,
+// matching the default the shell rendered under before. `loading: false` on every read models
+// the shell-key-manifest members' SYNCHRONOUS `__BOOT__` resolution (ADR 0179, #2828) — a member
+// carries its final value on the first render, no post-boot flip.
 // `signedIn` drives the mocked `readBootUser` (the `__BOOT__.user` edge identity, ADR 0185):
 // the shell frame reads it to reserve AND seed the signed-in account cluster before `useSession`
 // settles. Default false = `__BOOT__` absent, so the pre-existing shell tests see today's
 // signed-out first paint unchanged.
 const flags = vi.hoisted(() => ({
 	authorshipLoop: false,
+	mecmua: false,
 	mecmuaFeed: false,
 	navIa: false,
 	signedIn: false,
 }));
 vi.mock("./flags/useFlag", async () => {
-	const {PHOENIX_AUTHORSHIP_LOOP, MECMUA_FEED, PHOENIX_NAV_IA} = await import("./flags/keys");
+	const {PHOENIX_AUTHORSHIP_LOOP, MECMUA_PUBLIC_READ, MECMUA_FEED, PHOENIX_NAV_IA} = await import(
+		"./flags/keys"
+	);
 	return {
 		useFlag: (key: string) => ({
 			value:
 				key === PHOENIX_AUTHORSHIP_LOOP
 					? flags.authorshipLoop
-					: key === MECMUA_FEED
-						? flags.mecmuaFeed
-						: key === PHOENIX_NAV_IA
-							? flags.navIa
-							: false,
+					: key === MECMUA_PUBLIC_READ
+						? flags.mecmua
+						: key === MECMUA_FEED
+							? flags.mecmuaFeed
+							: key === PHOENIX_NAV_IA
+								? flags.navIa
+								: false,
 			loading: false,
 		}),
 	};
@@ -344,6 +351,50 @@ describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
 		expect(screen.queryByText("Elif")).toBeNull();
 		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
+	});
+});
+
+// The mecmua nav entry (#2828) gates on `mecmua-public-read`, a shell-key-manifest member —
+// so the unified `useFlag` resolves it synchronously from `__BOOT__` and the link is in its
+// final nav position on the FIRST paint (no false→true pop-in after sözlük/pano). These pin the
+// gating AND the first-paint geometry: on ⇒ mecmua present on the first render, in order after
+// pano; off ⇒ absent (the flag's dark-ship kill-switch is retained, ADR 0179).
+describe("mecmua nav entry (#2828) — resolves at first paint from __BOOT__, no pop-in", () => {
+	beforeEach(() => {
+		fateMounts.length = 0;
+		sessionState = {data: null, isPending: true};
+		flags.mecmua = false;
+	});
+	afterEach(() => {
+		flags.mecmua = false;
+		vi.clearAllMocks();
+	});
+
+	it("off: the kill-switch dark ⇒ no mecmua nav link (the route's dark-ship posture is preserved)", () => {
+		renderApp();
+		expect(screen.queryByRole("link", {name: "mecmua"})).toBeNull();
+		// sözlük/pano still paint — the ungated siblings are unaffected.
+		expect(screen.getByRole("link", {name: "sözlük"})).toBeTruthy();
+		expect(screen.getByRole("link", {name: "pano"})).toBeTruthy();
+	});
+
+	it("on: mecmua paints on the FIRST render (session still pending), in final position after pano", () => {
+		flags.mecmua = true;
+		renderApp();
+		// Present on the very first paint — no act()/settle needed: the member resolved
+		// synchronously, so there is no false→true flip that would inject it a tick later.
+		const mecmua = screen.getByRole("link", {name: "mecmua"});
+		expect(mecmua.getAttribute("href")).toBe("/mecmua");
+		// Final geometry: mecmua sits after pano, matching its ungated siblings' order.
+		const navLinks = ["sözlük", "pano", "mecmua"].map((label) =>
+			screen.getByRole("link", {name: label}),
+		);
+		const order = navLinks.map((el) =>
+			Array.prototype.indexOf.call(document.querySelectorAll("a"), el),
+		);
+		expect(order).toEqual([...order].sort((a, b) => a - b));
+		// Still fate-free at first paint — the nav geometry is final without a fate mount.
+		expect(fateMounts).toHaveLength(0);
 	});
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -102,22 +102,23 @@ function Layout() {
 	const location = useLocation();
 	const {toggle: toggleTheme, choice: themeChoice, setChoice: setThemeChoice} = useTheme();
 	const [chips, setChips] = useState<TopbarChips | null>(null);
-	// The mecmua nav entry (#2512), dark behind `mecmua-public-read` — the same seam the
-	// reader/index gate on. `useFlag` reads over `fetch` (no fate client), so it is safe in
-	// this always-painting shell frame: the entry simply appears once the flag resolves on,
-	// never blocking first paint (Pillar 1). Off ⇒ the nav is exactly as before.
+	// The three nav-shaping flags (mecmua-public-read, mecmua-feed, nav-IA) are shell-key-manifest
+	// members, so the unified `useFlag` resolves them SYNCHRONOUSLY from `window.__BOOT__` on the
+	// first render (loading:false, no fetch, no repaint): the nav paints its final geometry at first
+	// paint, killing the false→true pop-in these gates used to cost every load (#2828). Absent
+	// `__BOOT__` (flag off / the #2931 never-hang fallback) ⇒ the fetch fallback, exactly today's
+	// behavior. See ADR 0179.
+	//
+	// mecmua-public-read (#2512): the same seam the reader/index gate on; off ⇒ mecmua absent.
 	const {value: mecmuaOn} = useFlag(MECMUA_PUBLIC_READ, false);
-	// The mecmua feed (akış) nav entry (#2547), dark behind its own `mecmua-feed` seam —
-	// the SAME flag the `/mecmua/akis` route self-gates on (self-404 when off). Gating the
-	// link on the route's own seam is what keeps it from ever pointing at a dark 404: off ⇒
-	// no entry, so subscribing (also `mecmua-feed`) and its feed destination appear together.
-	// Under nav-IA (below) akış is a mecmua SUB-destination, so it moves out of this topbar
-	// product-noun row into the mecmua Subnav zone (#2603) — hence gated off here when navIaOn.
+	// mecmua-feed (akış, #2547): the SAME flag the `/mecmua/akis` route self-gates on (self-404 when
+	// off), so the link never points at a dark 404 — subscribing (also `mecmua-feed`) and its feed
+	// destination appear together. Under nav-IA akış is a mecmua SUB-destination, moving out of this
+	// topbar product-noun row into the mecmua Subnav zone (#2603) — hence gated off here when navIaOn.
 	const {value: feedOn} = useFlag(MECMUA_FEED, false);
-	// The nav-IA seam (#2600, epic #2596): with it on, pano's `+ gönderi` primary action
-	// lives in the pano Subnav CTA zone (placement law #2587), so the topbar no longer
-	// carries it — the eviction half of the atomic move. Off ⇒ the topbar is exactly as
-	// today. Same read as `App`'s zone-wrapping gate; `useFlag` is fate-free, safe here.
+	// nav-IA (#2600, epic #2596): with it on, pano's `+ gönderi` primary action lives in the pano
+	// Subnav CTA zone (placement law #2587), so the topbar drops it — the eviction half of the atomic
+	// move. Off ⇒ the topbar is exactly as today. Same read as `App`'s zone-wrapping gate below.
 	const {value: navIaOn} = useFlag(PHOENIX_NAV_IA, false);
 
 	// The two-tier fate provider's public first paint (ADR 0167). While `get-session`
@@ -391,7 +392,9 @@ export function App() {
 	// The per-product Subnav zones ride the shared nav-IA seam (#2598, epic #2596),
 	// default-off. With it off the router is flat (today's structure); with it on each
 	// product's routes mount under a pathless layout route rendering its persistent Subnav
-	// zone. `useFlag` reads over `fetch` (no fate client), safe above the providers.
+	// zone. As a shell-key-manifest member nav-IA resolves synchronously from `window.__BOOT__`
+	// (unified `useFlag`, ADR 0179), so the router shape is final at first paint — no restructure
+	// flip. Absent `__BOOT__` ⇒ the fetch fallback, exactly today's behavior.
 	const {value: navIaOn} = useFlag(PHOENIX_NAV_IA, false);
 	const panoRoutes = [
 		<Route key="pano" path="/pano" element={<PanoFeed />} />,


### PR DESCRIPTION
Fixes #2828

## Context — the epic subsumption

#2828 was re-planned as a child of epic #2926 (edge-resolved shell state, the `window.__BOOT__` contract, ADR 0179). Its standalone fix — "retire the vestigial client gate" — was **explicitly superseded** by the founder ruling that `mecmua-public-read` **stays** as a live kill-switch; the fix is render-layer, not flag removal.

That render-layer fix **already landed** with #2932 (unified `useFlag`): the three nav-shaping flags — `mecmua-public-read`, `mecmua-feed`, `phoenix-nav-ia` — are `SHELL_FLAG_KEYS` manifest members (`apps/web/src/flags/shell-keys.ts`), and the unified `useFlag` (`apps/web/src/flags/useFlag.ts`) resolves member keys **synchronously** from `window.__BOOT__` on the first render (`loading:false`, no fetch, no repaint). `apps/web/src/App.tsx` already imports and calls that unified hook, so **the mecmua link, akış entry, and nav-IA structure already paint in final geometry at first paint** — the false→true pop-in #2828 filed is gone whenever `__BOOT__` is present.

## What this PR does

The substantive behavior was subsumed by #2932; what remained was **stale narrative + missing test coverage** for the mecmua slot:

- **Retarget the stale nav-flag comments in `App.tsx`** (the `Layout` topbar spread ~L105–121 and the `App`-level nav-IA gate ~L391). They still narrated the old post-boot fetch flip ("`useFlag` reads over `fetch`… appears once the flag resolves on") — the pop-in that no longer happens on the `__BOOT__` path. Now they state the synchronous first-paint resolution once, with a `// See ADR 0179` pointer (per CLAUDE.md's comment-earns-its-place rule), keeping each flag's distinct fact. Mirrors #3042's retarget of the sibling signed-in-cluster comments after its `__BOOT__` migration.
- **Add `App.test.tsx` coverage** pinning the mecmua nav link at first paint: present on the first render (session still `isPending`, no `act()`/settle) in final position after `pano` when the member flag resolves on; absent when the kill-switch is dark. Complements `useFlag.test.ts`'s `resolveBootFlag` unit coverage of the synchronous `__BOOT__` path.

## Invariants held

- `mecmua-public-read` (and the sibling flags) **retained** as live kill-switches — no gate removed (AC: flag retained).
- `/mecmua` route **dark-ship self-404 posture unchanged** — render-layer only, no route touched.
- With `__BOOT__` absent (flag off / #2931 never-hang fallback) the topbar renders **exactly as today** (fetch fallback) — the off-path test pins it.

`pnpm typecheck` (32/32) · `pnpm biome check` (clean) · `pnpm vitest run --project client App.test` (34/34, incl. the two new #2828 tests) all green.