### PR TITLE
feat(pipeline-crew-mcp): tracker/ — control-plane registry (announce/lookup, heartbeat TTL, role leases, per-project socket)

### DIFF
--- a/packages/pipeline-crew-mcp/src/tracker/group.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/group.ts
@@ -1,0 +1,17 @@
+/**
+ * tracker/group — the registry `RpcGroup` the tracker actually serves: a control-plane-only
+ * SUBSET of the crew protocol (`../protocol/`).
+ *
+ * The tracker serves exactly the four registry kinds — `Claim` (the request/reply lease
+ * acquire), `AnnouncePresence` (soft presence), `LookupRole` (discovery), `Heartbeat` (TTL
+ * keepalive). It deliberately does NOT serve the four message-relay kinds (`EpicHandoff`,
+ * `DrainProgress`, `IntakePing`, `AckInbox`): those payloads travel peer-to-peer on the data
+ * plane, never through the registry. This exclusion IS the "no message-relay path" invariant —
+ * the tracker cannot relay a message it has no handler for. It reuses the protocol's Rpc
+ * definitions verbatim; it never redefines a message type.
+ */
+import {RpcGroup} from "effect/unstable/rpc";
+import {AnnouncePresence, Claim, Heartbeat, LookupRole} from "../protocol/index.ts";
+
+/** The control-plane registry surface — presence + role leases only, no relay kinds. */
+export const TrackerRegistry = RpcGroup.make(Claim, AnnouncePresence, LookupRole, Heartbeat);

--- a/packages/pipeline-crew-mcp/src/tracker/handlers.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/handlers.ts
@@ -1,0 +1,59 @@
+/**
+ * tracker/handlers — the `TrackerRegistry` handlers, mapping each registry Rpc onto the
+ * `Registry` service. The lease name (the registry key) is the role string: `AnnouncePresence`
+ * and `LookupRole` key on `role`, `Claim` keys on `resource` (the named lease it acquires).
+ *
+ * `lastSeen`/`since`/`at` cross the wire as ISO-8601 strings (the protocol `Timestamp`), but the
+ * registry reasons in epoch millis against its own clock — the conversion happens here at the
+ * boundary. `Claim` is the only reply-carrying kind (granted/collision/owner); the rest are
+ * fire-and-forget.
+ */
+import {Effect} from "effect";
+import {TrackerRegistry} from "./group.ts";
+import {Registry} from "./registry.ts";
+import {DEFAULT_TTL_SECONDS} from "./registry-core.ts";
+
+const iso = (millis: number): string => new Date(millis).toISOString();
+
+export const TrackerHandlers = TrackerRegistry.toLayer(
+	Effect.gen(function* () {
+		const registry = yield* Registry;
+		return {
+			Claim: (payload) =>
+				registry
+					.acquire({
+						role: payload.resource,
+						peer: payload.claimant,
+						ttlSeconds: DEFAULT_TTL_SECONDS,
+					})
+					.pipe(
+						Effect.map((outcome) => ({
+							resource: payload.resource,
+							granted: outcome._tag === "Granted",
+							collision: outcome._tag === "Collision",
+							owner: outcome.owner,
+							since: iso(outcome.sinceMillis),
+						})),
+					),
+			AnnouncePresence: (payload) =>
+				registry.announce({
+					role: payload.role,
+					peer: payload.peer,
+					ttlSeconds: DEFAULT_TTL_SECONDS,
+				}),
+			LookupRole: (payload) =>
+				registry.lookup(payload.role).pipe(
+					Effect.map((records) => ({
+						role: payload.role,
+						peers: records.map((r) => ({
+							peer: r.peer,
+							role: r.role,
+							lastSeen: iso(r.lastSeenMillis),
+						})),
+					})),
+				),
+			Heartbeat: (payload) =>
+				registry.heartbeat({peer: payload.peer, ttlSeconds: payload.ttlSeconds}),
+		};
+	}),
+);

--- a/packages/pipeline-crew-mcp/src/tracker/index.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/index.ts
@@ -1,5 +1,17 @@
 /**
- * tracker/ — the rendezvous registry: peers announce and discover each other here.
- * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ * tracker/ — the control-plane registry: a standing `RpcServer` over a per-project unix socket
+ * where peers announce their role + inbox, look each other up, and hold named role leases, all as
+ * soft state that ages out on missed heartbeats. Registry only — it NEVER relays a message (that
+ * is the peer/data-plane's job). Generic (crew-agnostic); see the boundary note in `../index.ts`.
  */
-export {};
+export {TrackerRegistry} from "./group.ts";
+export {TrackerHandlers} from "./handlers.ts";
+export {type AnnounceInput, Registry, RegistryLive} from "./registry.ts";
+export {
+	type AcquireOutcome,
+	DEFAULT_TTL_SECONDS,
+	type Lease,
+	type PresenceRecord,
+	type RegistryState,
+} from "./registry-core.ts";
+export {launchTracker, socketPathFor, trackerServerLayer} from "./server.ts";

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The soft-state registry semantics, tested in isolation from any transport: announce/lookup
+ * round-trip, heartbeat-driven TTL aging, connection-is-lease role uniqueness + release, and the
+ * explicit not-present result. These are the four acceptance criteria at the domain level.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as Core from "./registry-core.ts";
+
+const T0 = 1_000_000; // an arbitrary epoch-millis baseline
+const secs = (n: number) => n * 1000;
+
+describe("registry-core — announce / lookup", () => {
+	it("announce then lookup round-trips the peer for its role", () => {
+		const {state} = Core.acquire(Core.empty(), {
+			role: "builder",
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		});
+		const found = Core.lookup(state, "builder", T0);
+		assert.deepStrictEqual(found, [{peer: "peer-a", role: "builder", lastSeenMillis: T0}]);
+	});
+
+	it("a lookup of an absent role returns an explicit empty result (never a silent drop)", () => {
+		assert.deepStrictEqual(Core.lookup(Core.empty(), "nobody", T0), []);
+	});
+});
+
+describe("registry-core — heartbeat TTL aging", () => {
+	it("a peer that stops heart-beating ages out of lookups past its TTL", () => {
+		const {state} = Core.acquire(Core.empty(), {
+			role: "builder",
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		});
+		assert.lengthOf(Core.lookup(state, "builder", T0 + secs(29)), 1, "still live before TTL");
+		assert.lengthOf(Core.lookup(state, "builder", T0 + secs(31)), 0, "aged out after TTL");
+	});
+
+	it("a heartbeat refreshes the window, keeping the peer discoverable", () => {
+		const acquired = Core.acquire(Core.empty(), {
+			role: "builder",
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		}).state;
+		const beat = Core.heartbeat(acquired, {
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0 + secs(20),
+		});
+		// Without the heartbeat this instant (T0+40s) would be expired; the beat at T0+20s carries it.
+		assert.lengthOf(Core.lookup(beat, "builder", T0 + secs(40)), 1);
+	});
+});
+
+describe("registry-core — connection-is-lease role uniqueness", () => {
+	it("a second live acquire of a held role collides and does not steal the lease", () => {
+		const held = Core.acquire(Core.empty(), {
+			role: "builder",
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		}).state;
+		const {state, outcome} = Core.acquire(held, {
+			role: "builder",
+			peer: "peer-b",
+			ttlSeconds: 30,
+			nowMillis: T0 + secs(1),
+		});
+		assert.deepStrictEqual(outcome, {_tag: "Collision", owner: "peer-a", sinceMillis: T0});
+		assert.deepStrictEqual(Core.lookup(state, "builder", T0 + secs(1)), [
+			{peer: "peer-a", role: "builder", lastSeenMillis: T0},
+		]);
+	});
+
+	it("releasing the connection frees the lease for another peer", () => {
+		const held = Core.acquire(Core.empty(), {
+			role: "builder",
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		}).state;
+		const freed = Core.release(held, "peer-a");
+		assert.deepStrictEqual(Core.lookup(freed, "builder", T0), []);
+		const {outcome} = Core.acquire(freed, {
+			role: "builder",
+			peer: "peer-b",
+			ttlSeconds: 30,
+			nowMillis: T0 + secs(1),
+		});
+		assert.deepStrictEqual(outcome, {_tag: "Granted", owner: "peer-b", sinceMillis: T0 + secs(1)});
+	});
+
+	it("an expired holder frees the lease — a later acquire is granted, not a collision", () => {
+		const held = Core.acquire(Core.empty(), {
+			role: "builder",
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		}).state;
+		const {outcome} = Core.acquire(held, {
+			role: "builder",
+			peer: "peer-b",
+			ttlSeconds: 30,
+			nowMillis: T0 + secs(31),
+		});
+		assert.strictEqual(outcome._tag, "Granted");
+	});
+
+	it("a re-acquire by the same peer keeps its original `since`", () => {
+		const held = Core.acquire(Core.empty(), {
+			role: "builder",
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		}).state;
+		const {outcome} = Core.acquire(held, {
+			role: "builder",
+			peer: "peer-a",
+			ttlSeconds: 30,
+			nowMillis: T0 + secs(5),
+		});
+		assert.deepStrictEqual(outcome, {_tag: "Granted", owner: "peer-a", sinceMillis: T0});
+	});
+});

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.ts
@@ -1,0 +1,129 @@
+/**
+ * tracker/registry-core — the soft-state presence registry as a pure data structure.
+ *
+ * No Effect, no IO: state transitions only, so the announce / lookup / heartbeat-TTL /
+ * role-lease semantics are unit-testable in isolation from the socket transport. The
+ * service (`./registry.ts`) holds one of these in a `Ref` and supplies the clock.
+ *
+ * The two non-obvious model choices:
+ *   - A role maps to at MOST ONE live lease (`RegistryState` is keyed by role) — that is
+ *     how "named leases for role uniqueness" is made unrepresentable-otherwise rather than
+ *     checked after the fact: you cannot store two live holders of one role.
+ *   - "Connection-is-lease" is modelled by the peer id being the connection identity, and
+ *     liveness being measured against the tracker's own clock (never the client-supplied
+ *     `at`): a peer that stops heart-beating ages past its TTL and its lease frees, and an
+ *     explicit `release` (a graceful connection close) frees it immediately. A client can't
+ *     extend its own liveness by lying about `at`.
+ */
+
+/** The default presence TTL applied on acquire, until the first `heartbeat` sets a real one. */
+export const DEFAULT_TTL_SECONDS = 30;
+
+/** One role lease: who holds the role, when they took it, and their soft-state liveness window. */
+export interface Lease {
+	readonly role: string;
+	readonly peer: string;
+	readonly ttlSeconds: number;
+	readonly leasedAtMillis: number;
+	readonly lastSeenMillis: number;
+}
+
+/** The whole registry: one live lease per role (role uniqueness is structural). */
+export type RegistryState = ReadonlyMap<string, Lease>;
+
+/** A present peer for a role, as the pure core reports it (millis; the handler formats the ISO). */
+export interface PresenceRecord {
+	readonly peer: string;
+	readonly role: string;
+	readonly lastSeenMillis: number;
+}
+
+/**
+ * The result of an acquire: `Granted` when the caller now holds the role, `Collision` when a
+ * different live peer already holds it (the lease is NOT stolen — the incumbent keeps it).
+ */
+export type AcquireOutcome =
+	| {readonly _tag: "Granted"; readonly owner: string; readonly sinceMillis: number}
+	| {readonly _tag: "Collision"; readonly owner: string; readonly sinceMillis: number};
+
+/** A fresh, empty registry. */
+export const empty = (): RegistryState => new Map();
+
+const isLive = (lease: Lease, nowMillis: number): boolean =>
+	nowMillis <= lease.lastSeenMillis + lease.ttlSeconds * 1000;
+
+/**
+ * Acquire the lease for `role` on behalf of `peer`. Granted when the role is free, held by an
+ * expired peer, or already held by `peer` itself (re-announce refreshes without moving `since`);
+ * a Collision — leaving state untouched — when a *different* live peer holds it.
+ */
+export const acquire = (
+	state: RegistryState,
+	input: {
+		readonly role: string;
+		readonly peer: string;
+		readonly ttlSeconds: number;
+		readonly nowMillis: number;
+	},
+): {readonly state: RegistryState; readonly outcome: AcquireOutcome} => {
+	const {role, peer, ttlSeconds, nowMillis} = input;
+	const existing = state.get(role);
+	if (existing && existing.peer !== peer && isLive(existing, nowMillis)) {
+		return {
+			state,
+			outcome: {_tag: "Collision", owner: existing.peer, sinceMillis: existing.leasedAtMillis},
+		};
+	}
+	const leasedAtMillis = existing && existing.peer === peer ? existing.leasedAtMillis : nowMillis;
+	const lease: Lease = {role, peer, ttlSeconds, leasedAtMillis, lastSeenMillis: nowMillis};
+	const next = new Map(state);
+	next.set(role, lease);
+	return {state: next, outcome: {_tag: "Granted", owner: peer, sinceMillis: leasedAtMillis}};
+};
+
+/** Refresh every lease held by `peer`: bump `lastSeen` to now and adopt the heartbeat's TTL. */
+export const heartbeat = (
+	state: RegistryState,
+	input: {readonly peer: string; readonly ttlSeconds: number; readonly nowMillis: number},
+): RegistryState => {
+	const {peer, ttlSeconds, nowMillis} = input;
+	const next = new Map(state);
+	for (const [role, lease] of state) {
+		if (lease.peer === peer) {
+			next.set(role, {...lease, ttlSeconds, lastSeenMillis: nowMillis});
+		}
+	}
+	return next;
+};
+
+/**
+ * The present holders of `role` — the single live lease, or `[]` when the role is absent or its
+ * holder has aged out. An empty array is the explicit not-present result (never a silent drop).
+ */
+export const lookup = (
+	state: RegistryState,
+	role: string,
+	nowMillis: number,
+): ReadonlyArray<PresenceRecord> => {
+	const lease = state.get(role);
+	if (!lease || !isLive(lease, nowMillis)) return [];
+	return [{peer: lease.peer, role: lease.role, lastSeenMillis: lease.lastSeenMillis}];
+};
+
+/** Free every lease held by `peer` — a graceful connection close (connection-is-lease). */
+export const release = (state: RegistryState, peer: string): RegistryState => {
+	const next = new Map(state);
+	for (const [role, lease] of state) {
+		if (lease.peer === peer) next.delete(role);
+	}
+	return next;
+};
+
+/** Housekeeping: drop every lease that has aged past its TTL as of `nowMillis`. */
+export const prune = (state: RegistryState, nowMillis: number): RegistryState => {
+	const next = new Map(state);
+	for (const [role, lease] of state) {
+		if (!isLive(lease, nowMillis)) next.delete(role);
+	}
+	return next;
+};

--- a/packages/pipeline-crew-mcp/src/tracker/registry.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The registry over the real RPC machinery, in-memory: `RpcTest.makeClient` drives the
+ * `TrackerRegistry` handlers (backed by `RegistryLive`) through the same client/server path a
+ * socket transport would, without opening a socket. Proves announce/lookup round-trips, the
+ * `Claim` lease acquire's granted/collision reply, and the explicit not-present lookup — all end
+ * to end through decode/encode.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {RpcTest} from "effect/unstable/rpc";
+import {TrackerRegistry} from "./group.ts";
+import {TrackerHandlers} from "./handlers.ts";
+import {RegistryLive} from "./registry.ts";
+
+const handlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+const at = "2026-07-16T10:00:00Z";
+
+describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
+	it.effect("announce then lookup round-trips a peer's role + inbox address", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			yield* client.AnnouncePresence({peer: "inbox://peer-a", role: "builder", at});
+			const result = yield* client.LookupRole({role: "builder"});
+			assert.strictEqual(result.role, "builder");
+			assert.lengthOf(result.peers, 1);
+			assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
+			assert.strictEqual(result.peers[0]?.role, "builder");
+		}).pipe(Effect.scoped, Effect.provide(handlers)),
+	);
+
+	it.effect("a lookup of an absent role returns an explicit empty result", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const result = yield* client.LookupRole({role: "nobody"});
+			assert.deepStrictEqual(result, {role: "nobody", peers: []});
+		}).pipe(Effect.scoped, Effect.provide(handlers)),
+	);
+
+	it.effect("Claim grants a free role lease and collides on a second live acquire", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const first = yield* client.Claim({
+				resource: "builder",
+				claimant: "peer-a",
+				role: "builder",
+				at,
+			});
+			assert.isTrue(first.granted);
+			assert.isFalse(first.collision);
+			assert.strictEqual(first.owner, "peer-a");
+
+			const second = yield* client.Claim({
+				resource: "builder",
+				claimant: "peer-b",
+				role: "builder",
+				at,
+			});
+			assert.isFalse(second.granted);
+			assert.isTrue(second.collision);
+			assert.strictEqual(second.owner, "peer-a", "the incumbent keeps the lease");
+		}).pipe(Effect.scoped, Effect.provide(handlers)),
+	);
+
+	it.effect("a heartbeat is accepted for a live peer", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			yield* client.AnnouncePresence({peer: "inbox://peer-a", role: "builder", at});
+			yield* client.Heartbeat({peer: "inbox://peer-a", ttlSeconds: 60, at});
+			const result = yield* client.LookupRole({role: "builder"});
+			assert.lengthOf(result.peers, 1);
+		}).pipe(Effect.scoped, Effect.provide(handlers)),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/tracker/registry.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry.ts
@@ -1,0 +1,68 @@
+/**
+ * tracker/registry — the `Registry` service: the soft-state core (`./registry-core.ts`) held
+ * in a `Ref`, with the tracker's own `Clock` as the sole authority on "now".
+ *
+ * Every liveness decision (acquire collision, lookup aging, heartbeat freshness) is measured
+ * against `Clock.currentTimeMillis`, never a client-supplied `at` — presence is soft state the
+ * tracker owns, so a client can't extend its own lease by lying about the time. The service is
+ * transport-agnostic: the socket wiring (`./server.ts`) and the RPC handlers (`./handlers.ts`)
+ * depend on it, never the reverse.
+ */
+import {Clock, Context, Effect, Layer, Ref} from "effect";
+import * as Core from "./registry-core.ts";
+
+export interface AnnounceInput {
+	readonly role: string;
+	readonly peer: string;
+	readonly ttlSeconds: number;
+}
+
+export class Registry extends Context.Service<
+	Registry,
+	{
+		/** Acquire `role` for `peer`, returning whether it was granted or collided with a live holder. */
+		readonly acquire: (input: AnnounceInput) => Effect.Effect<Core.AcquireOutcome>;
+		/** Soft presence announce — acquire and discard the outcome (the fire-and-forget wire kind). */
+		readonly announce: (input: AnnounceInput) => Effect.Effect<void>;
+		/** Refresh the TTL window for every lease `peer` holds. */
+		readonly heartbeat: (input: {
+			readonly peer: string;
+			readonly ttlSeconds: number;
+		}) => Effect.Effect<void>;
+		/** The present holders of `role` (empty ⇒ absent/expired — the explicit not-present result). */
+		readonly lookup: (role: string) => Effect.Effect<ReadonlyArray<Core.PresenceRecord>>;
+		/** Free every lease `peer` holds — a connection close (connection-is-lease). */
+		readonly release: (peer: string) => Effect.Effect<void>;
+	}
+>()("@kampus/pipeline-crew-mcp/tracker/Registry") {}
+
+export const RegistryLive: Layer.Layer<Registry> = Layer.effect(Registry)(
+	Effect.gen(function* () {
+		const ref = yield* Ref.make(Core.empty());
+		const acquire = (input: AnnounceInput) =>
+			Effect.gen(function* () {
+				const nowMillis = yield* Clock.currentTimeMillis;
+				return yield* Ref.modify(ref, (state) => {
+					const {state: next, outcome} = Core.acquire(state, {...input, nowMillis});
+					return [outcome, next];
+				});
+			});
+		return {
+			acquire,
+			announce: (input) => Effect.asVoid(acquire(input)),
+			heartbeat: (input) =>
+				Clock.currentTimeMillis.pipe(
+					Effect.flatMap((nowMillis) =>
+						Ref.update(ref, (state) => Core.heartbeat(state, {...input, nowMillis})),
+					),
+				),
+			lookup: (role) =>
+				Effect.gen(function* () {
+					const nowMillis = yield* Clock.currentTimeMillis;
+					const state = yield* Ref.get(ref);
+					return Core.lookup(state, role, nowMillis);
+				}),
+			release: (peer) => Ref.update(ref, (state) => Core.release(state, peer)),
+		};
+	}),
+);

--- a/packages/pipeline-crew-mcp/src/tracker/server.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The socket transport: the per-project socket path derivation, the control-plane-only served
+ * surface (no relay kinds), and a real unix-socket announce→lookup round-trip proving the tracker
+ * runs as an `RpcServer` over `layerProtocolSocketServer`.
+ */
+import {randomUUID} from "node:crypto";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeSocket} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
+import {TrackerRegistry} from "./group.ts";
+import {socketPathFor, trackerServerLayer} from "./server.ts";
+
+describe("tracker socket path — per-project derivation", () => {
+	it("is deterministic and normalizes the root", () => {
+		assert.strictEqual(socketPathFor("/some/project"), socketPathFor("/some/project/"));
+	});
+	it("differs across projects and is a well-formed .sock path", () => {
+		assert.notStrictEqual(socketPathFor("/project/a"), socketPathFor("/project/b"));
+		assert.match(socketPathFor("/project/a"), /kampus-crew-[0-9a-f]{16}\.sock$/);
+	});
+});
+
+describe("tracker served surface — control-plane only", () => {
+	it("serves exactly the four registry kinds and no message-relay kind", () => {
+		assert.deepStrictEqual([...TrackerRegistry.requests.keys()].sort(), [
+			"AnnouncePresence",
+			"Claim",
+			"Heartbeat",
+			"LookupRole",
+		]);
+		for (const relay of ["AckInbox", "DrainProgress", "EpicHandoff", "IntakePing"]) {
+			assert.isFalse(
+				TrackerRegistry.requests.has(relay),
+				`tracker must not serve relay kind ${relay}`,
+			);
+		}
+	});
+});
+
+describe("tracker over a unix socket — RpcServer round-trip", () => {
+	it.effect("announce then lookup round-trips over layerProtocolSocketServer", () => {
+		const socketPath = join(tmpdir(), `crew-test-${randomUUID().slice(0, 8)}.sock`);
+		const clientLayer = RpcClient.layerProtocolSocket().pipe(
+			Layer.provide([NodeSocket.layerNet({path: socketPath}), RpcSerialization.layerNdjson]),
+		);
+		return Effect.gen(function* () {
+			const client = yield* RpcClient.make(TrackerRegistry);
+			yield* client.AnnouncePresence({
+				peer: "inbox://peer-a",
+				role: "builder",
+				at: "2026-07-16T10:00:00Z",
+			});
+			const result = yield* client.LookupRole({role: "builder"});
+			assert.strictEqual(result.role, "builder");
+			assert.lengthOf(result.peers, 1);
+			assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
+		}).pipe(
+			Effect.provide(Layer.mergeAll(clientLayer, trackerServerLayer(socketPath))),
+			Effect.scoped,
+		);
+	});
+});

--- a/packages/pipeline-crew-mcp/src/tracker/server.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.ts
@@ -1,0 +1,58 @@
+/**
+ * tracker/server — the standing registry `RpcServer` over a per-project unix socket, and the
+ * first-peer-spawn launch entry.
+ *
+ * The socket path is derived deterministically from the project root (`socketPathFor`), so every
+ * peer of one project rendezvous on the same socket while different projects stay isolated — the
+ * "per-project socket". The tracker is brought up by whichever peer needs it first (first-peer-
+ * spawn): the first bind wins the socket; a later peer's bind gets `EADDRINUSE`, the signal that a
+ * tracker is already serving this project, and it connects as a client instead.
+ *
+ * The served surface is `TrackerRegistry` — registry kinds only (see `./group.ts`); the tracker
+ * has no handler for any message-relay kind, so it structurally cannot relay a message.
+ */
+import {createHash} from "node:crypto";
+import {tmpdir} from "node:os";
+import {join, resolve} from "node:path";
+import {NodeSocketServer} from "@effect/platform-node";
+import {type Effect, Layer} from "effect";
+import {RpcSerialization, RpcServer} from "effect/unstable/rpc";
+import {TrackerRegistry} from "./group.ts";
+import {TrackerHandlers} from "./handlers.ts";
+import {RegistryLive} from "./registry.ts";
+
+/**
+ * The per-project unix socket path for `projectRoot`. Deterministic (same project ⇒ same socket)
+ * yet collision-free across projects, and short enough to stay under the ~104-char unix socket
+ * path limit by hashing the root rather than embedding it. Honors `XDG_RUNTIME_DIR` when set,
+ * falling back to the OS temp dir.
+ */
+export const socketPathFor = (projectRoot: string): string => {
+	const digest = createHash("sha256").update(resolve(projectRoot)).digest("hex").slice(0, 16);
+	const base = process.env.XDG_RUNTIME_DIR ?? tmpdir();
+	return join(base, `kampus-crew-${digest}.sock`);
+};
+
+/**
+ * The composed tracker server layer: the registry `RpcServer` (its handlers over `RegistryLive`)
+ * bound to a unix `SocketServer` at `socketPath`, NDJSON-framed. Building the layer starts the
+ * server listening on a scoped fiber; closing the scope stops it. Its error channel carries the
+ * `SocketServerError` a failed bind (e.g. `EADDRINUSE`) raises.
+ */
+export const trackerServerLayer = (socketPath: string) =>
+	RpcServer.layer(TrackerRegistry).pipe(
+		Layer.provide(TrackerHandlers.pipe(Layer.provide(RegistryLive))),
+		Layer.provide(
+			RpcServer.layerProtocolSocketServer.pipe(
+				Layer.provide([RpcSerialization.layerNdjson, NodeSocketServer.layer({path: socketPath})]),
+			),
+		),
+	);
+
+/**
+ * First-peer-spawn entry: launch the tracker for `projectRoot` and keep it running until
+ * interrupted (`Layer.launch` builds the server layer and blocks, closing it on teardown). A
+ * `SocketServerError` from an already-bound socket means a tracker is already up for this project.
+ */
+export const launchTracker = (projectRoot: string): Effect.Effect<never, unknown> =>
+	Layer.launch(trackerServerLayer(socketPathFor(projectRoot)));


### PR DESCRIPTION
Part of #3055 (epic #3045, P3 spine child).

## What this builds
The generic `tracker/` control-plane registry: a standing `RpcServer` over a per-project unix socket (`RpcServer.layerProtocolSocketServer` at the `effect@4.0.0-beta.92` pin), brought up first-peer-spawn. Its whole job is presence + role bookkeeping — it **never** relays a message.

- **announce / lookup** — a peer announces its role + inbox address (`AnnouncePresence`); any peer looks up who serves a role (`LookupRole`). The opaque `PeerId` doubles as the addressable inbox.
- **heartbeat TTL** — presence is soft state measured against the tracker's *own* clock (never a client-supplied `at`); a peer that stops heart-beating ages out of lookups. This is the reliability story that replaces capture-pane liveness checks.
- **named role leases (connection-is-lease)** — a role maps to at most one live lease (structural uniqueness); a second live acquire collides and does not steal the incumbent's lease; releasing the connection (or aging out) frees it.
- **offline-receiver contract** — a lookup of an absent/expired role returns an explicit empty result, never a silent success.

## Control-plane only (AC #4)
The tracker serves a **subset** of the crew protocol — exactly the four registry kinds (`Claim`, `AnnouncePresence`, `LookupRole`, `Heartbeat`). The four message-relay kinds (`EpicHandoff`, `DrainProgress`, `IntakePing`, `AckInbox`) are deliberately unhandled, so the tracker structurally *cannot* relay a message (asserted in a test). It reuses the protocol's `Rpc` definitions verbatim (from #3054 / #3087) — no message type is redefined.

## Design
- `registry-core.ts` — a pure soft-state data structure (announce/lookup/heartbeat/release/prune); no Effect, no IO, fully unit-tested.
- `registry.ts` — the `Registry` service: the core in a `Ref`, `Clock` as the sole "now" authority.
- `group.ts` / `handlers.ts` — the served registry `RpcGroup` + handlers mapping onto `Registry`.
- `server.ts` — deterministic per-project `socketPathFor`, the composed socket-server layer, and the `launchTracker` first-peer-spawn entry.

Built on the just-merged protocol contract (#3054 → #3087) and patched MCP edge base (#3053 → #3084). Grounded in effect-smol `RpcServer` / `RpcTest` / `NodeSocketServer` at the pin.

## Verification
- `pnpm typecheck` clean, `pnpm test` 35/35 green (7 files), biome lint clean on the new files.
- Tests: pure-core behavior (all four ACs at the domain level), in-memory wire round-trips via `RpcTest.makeClient` (announce/lookup/Claim collision/heartbeat), and a **real unix-socket** announce→lookup round-trip over `layerProtocolSocketServer`.

§CP — control-plane (`packages/pipeline-crew-mcp/**`, machine-§CP via #3072). Banks at cansirin.

Footprint: only `packages/pipeline-crew-mcp/src/tracker/**` (+ its own module barrel `src/tracker/index.ts`) — the shared root `src/index.ts` barrel is untouched (the cutover child #3062 wires it), keeping this disjoint from the parallel peer/ PR #3056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)