### PR TITLE
feat(ship-it): deterministic §CP team-cardinality discharge check (ADR 0175)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -365,17 +365,17 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
   #2191; its `review-doc` verdict routing is unchanged, only merge-authority moves) → the PR is
   **§CP: APPROVAL-GATED** (not a blanket refuse — ADR
   [0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md),
-  amending 0053's merge model). Check for a **current-head `@kamp-us/control-plane` team approval**
-  (the [§CP approval gate](#step-0-cp-approval-gate) below):
-  - **present** → the human-judgment gate is satisfied; **carry on** into Step 2's normal machine
+  amending 0053's merge model). Run the **deterministic §CP cardinality check** (the
+  [§CP approval gate](#step-0-cp-approval-gate) below, ADR 0175):
+  - **discharge** → the human-judgment gate is satisfied; **carry on** into Step 2's normal machine
     gates (matching-gate SHA-bound PASS, CI green, run-evidence). Once those pass, ENQUEUE exactly
     like a non-§CP PR (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method;
     QUEUED → auto-merges on green; §CP PRs now
     enter the ADR 0132 queue too). §CP carries **one extra** gate — the team approval — layered on
     the same machine gates every PR clears.
-  - **absent** (or only a stale-head approval) → **STOP.** Report `awaiting control-plane approval`
-    and stop; do **not** enqueue. A `@kamp-us/control-plane` member must APPROVE the PR at its
-    current head. This **replaces** the old blanket refuse.
+  - **stop** (the cardinality branch's required current-head signal is absent, or the team is
+    empty) → **STOP.** Report `awaiting control-plane approval` and stop; do **not** enqueue. This
+    **replaces** the old blanket refuse.
 
   This holds even if the rest of the diff is clean code/docs/skills — a mixed PR that touches the
   control plane needs the team approval for the whole PR, and should be split so the non-§CP half
@@ -387,40 +387,88 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
   auto-merges on a PASS with no team approval.
 
   <a id="step-0-cp-approval-gate"></a>
-  **The §CP approval gate — a current-head team approval, resolved over `gh api` REST.** An approval
-  counts only when it is (a) authored by a `@kamp-us/control-plane` team member and (b) **bound to
-  the PR's current head** — the review's `commit_id` (the commit the review was submitted against,
-  per the [GitHub REST reviews resource](https://docs.github.com/rest/pulls/reviews)) equals the PR
-  head SHA. A stale approval on a superseded head **does not count** — this mirrors ADR
+  **The §CP approval gate — a deterministic team-cardinality check, resolved over `gh api` REST
+  (ADR [0175](https://github.com/kamp-us/phoenix/blob/main/.decisions/0175-cp-self-approval-cardinality-check.md)).**
+  The discharge is a **function of `@kamp-us/control-plane` team shape**, never agent judgment — the
+  same §CP conditions produce the same verdict across agents (killing the #2435 non-determinism where
+  identical single-owner PRs merged in one run and were refused in another). The branch keys on `N`,
+  the count of present, active, human control-plane members, exactly as ADR 0175's `case "$N"`
+  reference specifies:
+  - **`N == 0`** (empty team) → **STOP, fail closed** — no accountable human to discharge the boundary.
+  - **`N == 1`, sole owner *is* the PR author** → a current-head **self-approval marker** by the sole
+    owner discharges (the single-owner degenerate case; GitHub blocks native self-approval, so the
+    signal is a marker comment — ADR 0135/0175).
+  - **`N == 1`, sole member *is not* the author** → that member's current-head **approval** discharges.
+  - **`N >= 2`** (ADR 0135's two-person control, unchanged) → a current-head **APPROVED review by a
+    control-plane member who is NOT the author** discharges; a self-approval never does.
+
+  Every discharge signal is **bound to the PR's current head** — a review's `commit_id` (the commit
+  it was submitted against, per the [GitHub REST reviews resource](https://docs.github.com/rest/pulls/reviews))
+  or the self-approval marker's `@ <sha>` equals the PR head SHA. A stale signal on a superseded head
+  **does not count** — this retains ADR
   [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md)'s
-  SHA-staleness rule for machine verdicts (and the `dismiss_stale_reviews_on_push` the Phase-3
-  ruleset sets, which dismisses an approval on any post-approval push). Resolve it via REST, never
-  GraphQL:
+  SHA-staleness rule (and the `dismiss_stale_reviews_on_push` the Phase-3 ruleset sets). The branch
+  itself lives in the pure, unit-tested `cp-cardinality` core (`packages/pipeline-cli`) — the single
+  source ship-it runs, so the verdict cannot drift across shippers (the class-probe/control-plane-paths
+  precedent). Resolve the roster + the two signals over REST, never GraphQL, then decide:
 
   ```bash
+  # ADR 0175: DETERMINISTIC §CP discharge keyed on control-plane team cardinality, not judgment.
   ORG="${REPO%%/*}"                                            # owner half of owner/repo
-  HEAD="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"    # the SHA the approval must bind to
-  # latest review per author, keep APPROVED ones whose commit_id == the current head (SHA-bound)
+  # N = present, active, human control-plane members (REST, never GraphQL — ADR 0135/0175)
+  MEMBERS="$(gh api --paginate "orgs/$ORG/teams/control-plane/members?per_page=100" --jq '.[].login')"
+  AUTHOR="$(gh api "repos/$REPO/pulls/$PR" --jq '.user.login')"
+  HEAD="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"    # every signal binds THIS head (ADR 0058)
+  sha_binds_head() { [ -n "$1" ] || return 1; case "$HEAD" in "$1"*) return 0;; esac; case "$1" in "$HEAD"*) return 0;; esac; return 1; }
+
+  # Signal 1 — a current-head APPROVED review by a control-plane member who is NOT the author
+  # (the N>=2 and N==1-sole!=author discharge). Latest review per author, APPROVED, commit_id == HEAD.
+  NON_AUTHOR_APPROVAL_AT_HEAD=false
   CURRENT_APPROVERS="$(gh api --paginate "repos/$REPO/pulls/$PR/reviews?per_page=100" \
     --jq "group_by(.user.login) | map(max_by(.submitted_at))
           | map(select(.state == \"APPROVED\" and .commit_id == \"$HEAD\") | .user.login) | .[]")"
-  # is any current-head approver a @kamp-us/control-plane MEMBER? membership via REST (active state)
-  CP_OK=""
   while IFS= read -r u; do
     [ -z "$u" ] && continue
+    [ "$u" = "$AUTHOR" ] && continue                          # self-approval never counts here (ADR 0175)
     st="$(gh api "orgs/$ORG/teams/control-plane/memberships/$u" --jq '.state' 2>/dev/null)"
-    [ "$st" = "active" ] && { CP_OK=1; break; }
+    [ "$st" = "active" ] && { NON_AUTHOR_APPROVAL_AT_HEAD=true; break; }
   done <<<"$CURRENT_APPROVERS"
-  [ -n "$CP_OK" ] && echo "§CP approval: current-head team approval present → carry on to machine gates" \
-                  || echo "§CP approval: absent → STOP (awaiting control-plane approval)"
+
+  # Signal 2 — a deliberate current-head self-approval MARKER by the sole owner (the ONLY N==1
+  # sole-owner discharge). GitHub records no native self-approval, so the signal is a marker comment:
+  # first line `control-plane-self-approval @ <sha>` — a DISTINCT token from the review-* markers, so
+  # it can never leak a §CP PR into the auto-merge namespace (ADR 0111) — authored by the sole owner
+  # and SHA-bound to the current head. The sole owner posts it to consciously self-approve their own
+  # §CP PR; it is inert unless N==1 and they are the author (cp-cardinality ignores it otherwise).
+  SELF_APPROVAL_AT_HEAD=false
+  SELF_SHA="$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
+    --jq "[.[] | select(.user.login == \"$AUTHOR\")
+               | select(.body | test(\"(?i)^\\\\s*\\\\**\\\\s*control-plane-self-approval\\\\b\"))]
+          | last | .body // \"\"" \
+    | grep -ioE 'control-plane-self-approval[[:space:]]*@?[[:space:]]*[0-9a-f]{7,40}' \
+    | grep -ioE '[0-9a-f]{7,40}' | head -n1)"
+  sha_binds_head "$SELF_SHA" && SELF_APPROVAL_AT_HEAD=true
+
+  # The DETERMINISTIC decision — the whole ADR-0175 `case "$N"` branch lives in the tested pure core.
+  # discharge → carry on to the machine gates; stop → STOP (fail closed). Pass a signal flag only when
+  # that signal is present at head; cp-cardinality selects which signal the branch actually requires.
+  if printf '%s\n' "$MEMBERS" | pipeline-cli cp-cardinality decide \
+       --author "$AUTHOR" \
+       $([ "$NON_AUTHOR_APPROVAL_AT_HEAD" = true ] && printf -- '--non-author-approval-at-head') \
+       $([ "$SELF_APPROVAL_AT_HEAD" = true ] && printf -- '--self-approval-at-head'); then
+    echo "§CP approval: discharged deterministically (ADR 0175) → carry on to machine gates"
+  else
+    echo "§CP approval: STOP (awaiting control-plane approval) — cardinality branch not satisfied (ADR 0175)"
+  fi
   ```
 
   This is **only** the §CP unblock — it does not weaken any other guard. The SHA-bound gate verdict
   (Step 2/2b), CI-green (Step 3), the run-evidence bundle (Step 3.5), and single-merge-authority
-  (ADR 0048) all still apply to a §CP PR exactly as to a non-§CP one; the team approval is an
-  **additional** requirement, never a substitute. Note a team member cannot approve their **own**
-  §CP PR (GitHub blocks self-approval) — a §CP change needs the OTHER team member (the deliberate
-  two-person control, ADR 0135).
+  (ADR 0048) all still apply to a §CP PR exactly as to a non-§CP one; the cardinality discharge is an
+  **additional** requirement, never a substitute. The two-person control is preserved exactly where it
+  exists (`N >= 2`): GitHub blocks a member approving their **own** §CP PR, so a §CP change needs the
+  OTHER team member (ADR 0135). Adding a second control-plane member automatically re-tightens the
+  gate to that two-person control with no further edit — the branch keys on live cardinality (ADR 0175).
 - Otherwise, note which **artifact classes are present** (skills, code, docs, or a mix) **and
   whether the diff is UI-affecting** (`has-ui`). Step 2 requires the matching gate's latest
   verdict = PASS for **each class present**: skills → `review-skill` PASS; code → `review-code`

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {ciRequiredCommand} from "./tools/ci-required/command.ts";
 import {classProbeCommand} from "./tools/class-probe/command.ts";
 import {codeownersCpCommand} from "./tools/codeowners-cp/command.ts";
 import {controlPlanePathsCommand} from "./tools/control-plane-paths/command.ts";
+import {cpCardinalityCommand} from "./tools/cp-cardinality/command.ts";
 import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {designTokenGuardCommand} from "./tools/design-token-guard/command.ts";
@@ -112,6 +113,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	worktreeSweepCommand,
 	codeownersCpCommand,
 	controlPlanePathsCommand,
+	cpCardinalityCommand,
 	tokenSpendCommand,
 	trivialDiffCommand,
 	classProbeCommand,

--- a/packages/pipeline-cli/src/tools/cp-cardinality/README.md
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/README.md
@@ -1,0 +1,62 @@
+# cp-cardinality
+
+`pipeline-cli cp-cardinality decide` — the deterministic §CP discharge decision
+**ship-it's control-plane approval gate** runs, keyed on `@kamp-us/control-plane` team
+cardinality (ADR
+[0175](https://github.com/kamp-us/phoenix/blob/main/.decisions/0175-cp-self-approval-cardinality-check.md),
+enforcing decision #2435 / issue
+[#2541](https://github.com/kamp-us/phoenix/issues/2541)).
+
+## Why it exists
+
+The §CP gate (ADR
+[0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md))
+models the control-plane team as exactly two humans and requires the *other* member's
+approval. It never specified the degenerate shapes — one present member, or zero — so
+agents resolved them by **judgment**, and the same conditions produced opposite verdicts
+across runs (`#2655`/`#2658`/`#217` merged vs `#44` refused under identical single-owner
+conditions — the #2435 non-determinism). A gate whose verdict depends on which agent ran
+it is not a gate.
+
+ADR 0175 makes the discharge a pure function of team shape. This tool is that function,
+unit-tested at every boundary, so ship-it's gate is reproducible: same inputs → same
+decision.
+
+## The branch (ADR 0175's `case "$N"`, transcribed)
+
+`N` = count of distinct, active, human `@kamp-us/control-plane` members.
+
+| Shape | Discharge signal |
+| --- | --- |
+| `N == 0` (empty team) | **none** — STOP, fail closed (no accountable human) |
+| `N == 1`, sole owner **is** the PR author | a current-head **self-approval marker** by the sole owner |
+| `N == 1`, sole member **is not** the author | that member's current-head **approval** |
+| `N >= 2` (ADR 0135 two-person control) | a current-head **APPROVED review by a different** control-plane member; a self-approval never counts |
+
+A self-approval discharges **only** in the `N == 1` sole-owner case — never when `N >= 2`
+(ADR 0175 Banned), and every stale (non-current-head) signal is excluded upstream by
+ship-it's SHA-binding (ADR 0058), never regressed here.
+
+## Split of concerns
+
+IO in the thin bin (`command.ts`), the whole policy in the pure core
+(`cp-cardinality.ts`) — the same split `class-probe` uses for ship-it Step 0. **ship-it**
+owns the `gh api` REST resolution (the member roster, the PR author/head SHA, and the two
+current-head signals — a different-member APPROVED review and the sole-owner self-approval
+marker); this tool owns the branch. It never calls the network.
+
+## Usage
+
+```bash
+# ship-it's §CP gate resolves the roster + signals over REST, then decides deterministically:
+ORG="${REPO%%/*}"
+MEMBERS="$(gh api --paginate "orgs/$ORG/teams/control-plane/members?per_page=100" --jq '.[].login')"
+printf '%s\n' "$MEMBERS" | pipeline-cli cp-cardinality decide \
+  --author "$AUTHOR" \
+  --non-author-approval-at-head \   # pass iff a current-head APPROVED review by a member != author exists
+  --self-approval-at-head           # pass iff a current-head self-approval marker by the sole owner exists
+```
+
+The decision word (`discharge` | `stop`) goes to **stdout**; a human reason goes to
+**stderr**. Exit is **0 on `discharge`, 1 on `stop`**, so the gate bash fails closed with
+`… && carry-on || STOP`.

--- a/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
@@ -1,0 +1,89 @@
+/**
+ * The `cp-cardinality` tool — `pipeline-cli cp-cardinality decide [flags]` (issue #2541).
+ *
+ *   printf '%s\n' "$MEMBERS" | pipeline-cli cp-cardinality decide \
+ *     --author "$AUTHOR" [--non-author-approval-at-head] [--self-approval-at-head]
+ *
+ * The deterministic §CP discharge decision ship-it's control-plane approval gate runs
+ * (ADR 0175, enforcing decision #2435). Reads the active `@kamp-us/control-plane` member
+ * logins from stdin (one per line, like class-probe reads changed files), takes the PR
+ * author and the two current-head approval signals as flags, and prints the decision word
+ * (`discharge` | `stop`) to **stdout** — the token ship-it branches on. A human reason goes
+ * to **stderr**. Exit code mirrors the decision: 0 on `discharge`, 1 on `stop`, so the gate
+ * bash can `pipeline-cli cp-cardinality decide … && carry-on || STOP` and fail closed.
+ *
+ * IO here (the thin bin); the whole ADR-0175 branch lives in `cp-cardinality.ts` (the pure,
+ * unit-tested core). ship-it owns the `gh api` REST resolution of the members roster, the PR
+ * author/head, and the two SHA-bound signals — the integration half this tool never touches.
+ */
+import {readFileSync} from "node:fs";
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {type CpCardinalityInput, decideCpCardinality} from "./cp-cardinality.ts";
+
+const authorFlag = Flag.string("author").pipe(
+	Flag.withDescription("the PR author login (keys the single-owner branch)"),
+);
+
+const nonAuthorApprovalFlag = Flag.boolean("non-author-approval-at-head").pipe(
+	Flag.withDescription(
+		"a current-head APPROVED review by a control-plane member who is NOT the author exists",
+	),
+);
+
+const selfApprovalFlag = Flag.boolean("self-approval-at-head").pipe(
+	Flag.withDescription(
+		"a current-head self-approval marker authored by the sole owner exists (N==1 discharge signal)",
+	),
+);
+
+/** Read the control-plane member logins from stdin; empty/failed read ⇒ N==0 (fail closed). */
+const readMembers = (): ReadonlyArray<string> => {
+	let raw: string;
+	try {
+		raw = readFileSync(0, "utf8");
+	} catch {
+		return [];
+	}
+	return raw
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+};
+
+const decideCmd = Command.make(
+	"decide",
+	{
+		author: authorFlag,
+		nonAuthorApproval: nonAuthorApprovalFlag,
+		selfApproval: selfApprovalFlag,
+	},
+	Effect.fn(function* ({author, nonAuthorApproval, selfApproval}) {
+		const input: CpCardinalityInput = {
+			members: readMembers(),
+			author,
+			nonAuthorApprovalAtHead: nonAuthorApproval,
+			selfApprovalAtHead: selfApproval,
+		};
+		const verdict = decideCpCardinality(input);
+		yield* Effect.sync(() =>
+			process.stderr.write(
+				`cp-cardinality: N=${verdict.n} branch=${verdict.branch} — ${verdict.reason}\n`,
+			),
+		);
+		yield* Console.log(verdict.decision);
+		// Exit code mirrors the decision so the gate bash fails closed on `stop` (ADR 0175).
+		if (verdict.decision === "stop") return yield* Effect.sync(() => process.exit(1));
+	}),
+).pipe(
+	Command.withDescription(
+		"Decide the §CP discharge deterministically from control-plane team cardinality (ADR 0175, #2541)",
+	),
+);
+
+export const cpCardinalityCommand = Command.make("cp-cardinality").pipe(
+	Command.withSubcommands([decideCmd]),
+	Command.withDescription(
+		"Deterministic §CP team-cardinality discharge check ship-it's control-plane gate runs (ADR 0175, #2541)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/cp-cardinality/cp-cardinality.ts
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/cp-cardinality.ts
@@ -1,0 +1,151 @@
+/**
+ * `cp-cardinality` pure core — the deterministic §CP discharge decision ship-it runs at
+ * its control-plane approval gate, keyed on `@kamp-us/control-plane` team cardinality
+ * (ADR 0175, enforcing decision #2435 / issue #2541).
+ *
+ * The gate used to resolve the degenerate team shapes (one present member, or zero) by
+ * agent judgment, and the same conditions produced opposite verdicts across runs — the
+ * #2435 non-determinism. This core makes the whole discharge policy a pure function of
+ * data the ship-it bash resolves over `gh api` REST (team members, PR author, and the two
+ * current-head approval signals), so the verdict is reproducible: same inputs → same
+ * decision. ship-it does the REST IO and marker matching (the integration half); this core
+ * owns the branch (the tested half), the same split class-probe uses for ship-it Step 0.
+ *
+ * The branch transcribes ADR 0175's `case "$N"` reference exactly:
+ *   N == 0                 → STOP, fail closed (no accountable human).
+ *   N == 1, sole == author → a current-head self-approval marker by the sole owner discharges.
+ *   N == 1, sole != author → the single member's current-head approval discharges.
+ *   N >= 2                 → ADR 0135 holds: a current-head APPROVED review by a DIFFERENT
+ *                            control-plane member discharges; a self-approval never does.
+ */
+
+/** The gate outcome ship-it acts on: enqueue-eligible, or STOP at `awaiting control-plane approval`. */
+export type CpDecision = "discharge" | "stop";
+
+/** Which ADR-0175 cardinality branch produced the decision — surfaced for the human reason line. */
+export type CpBranch = "empty" | "single-owner-self" | "single-owner-other" | "multi-member";
+
+/**
+ * The resolved gate state, all as data so the decision is pure. `members` is the active,
+ * human `@kamp-us/control-plane` roster; the two `*AtHead` flags are the SHA-bound signals
+ * ship-it resolves against the PR's current head (ADR 0058), never a stale-head signal.
+ */
+export interface CpCardinalityInput {
+	/** Active human control-plane team logins (the core dedupes and drops blanks). */
+	readonly members: ReadonlyArray<string>;
+	/** The PR author login. */
+	readonly author: string;
+	/** A current-head APPROVED review by a control-plane member who is NOT the author exists. */
+	readonly nonAuthorApprovalAtHead: boolean;
+	/** A current-head self-approval marker authored by the sole owner exists (N==1 discharge signal). */
+	readonly selfApprovalAtHead: boolean;
+}
+
+export interface CpVerdict {
+	readonly decision: CpDecision;
+	/** Count of distinct present control-plane members — the `N` of ADR 0175's `case "$N"`. */
+	readonly n: number;
+	readonly branch: CpBranch;
+	/** Human-readable justification, cites the governing ADR branch. */
+	readonly reason: string;
+}
+
+/** Distinct, non-blank logins — trims and dedupes so a whitespace/duplicate roster line can't skew `N`. */
+const distinctMembers = (members: ReadonlyArray<string>): ReadonlyArray<string> => {
+	const seen = new Set<string>();
+	for (const raw of members) {
+		const login = raw.trim();
+		if (login.length > 0) seen.add(login);
+	}
+	return [...seen];
+};
+
+/**
+ * Decide whether the §CP gate discharges, per ADR 0175's cardinality branch. Pure and total:
+ * every shape resolves to `discharge` or `stop` with a reason — there is no path that defers
+ * to judgment, which is the whole point (kill the #2435 non-determinism). Fail-closed by
+ * construction: only positive evidence of the branch's required current-head signal discharges;
+ * an empty roster, an unresolvable author, or a missing signal all STOP.
+ */
+export const decideCpCardinality = (input: CpCardinalityInput): CpVerdict => {
+	const members = distinctMembers(input.members);
+	const n = members.length;
+	const author = input.author.trim();
+
+	// An unresolvable author cannot be matched against the roster — fail closed rather than
+	// guess the single-owner-self branch (which would let a missing author self-discharge).
+	if (author.length === 0) {
+		return {
+			decision: "stop",
+			n,
+			branch: n === 1 ? "single-owner-self" : n >= 2 ? "multi-member" : "empty",
+			reason:
+				"§CP: PR author could not be resolved — cannot key the cardinality branch, fail closed (ADR 0175).",
+		};
+	}
+
+	if (n === 0) {
+		return {
+			decision: "stop",
+			n,
+			branch: "empty",
+			reason:
+				"§CP N==0: the @kamp-us/control-plane team is empty — no accountable human to discharge the boundary, fail closed (ADR 0175).",
+		};
+	}
+
+	if (n === 1) {
+		const soleIsAuthor = members[0] === author;
+		if (soleIsAuthor) {
+			// The sole owner IS the team; GitHub blocks their native self-approval, so a deliberate
+			// current-head self-approval marker is the only discharge signal (ADR 0175 N==1). A
+			// self-approval never discharges when N>=2 — this branch is the sole place it counts.
+			return input.selfApprovalAtHead
+				? {
+						decision: "discharge",
+						n,
+						branch: "single-owner-self",
+						reason:
+							"§CP N==1 (sole owner == author): a current-head self-approval marker by the sole owner discharges §CP (ADR 0175).",
+					}
+				: {
+						decision: "stop",
+						n,
+						branch: "single-owner-self",
+						reason:
+							"§CP N==1 (sole owner == author): no current-head self-approval marker by the sole owner — STOP (ADR 0175).",
+					};
+		}
+		return input.nonAuthorApprovalAtHead
+			? {
+					decision: "discharge",
+					n,
+					branch: "single-owner-other",
+					reason:
+						"§CP N==1 (sole member != author): the sole control-plane member's current-head approval discharges §CP (ADR 0175).",
+				}
+			: {
+					decision: "stop",
+					n,
+					branch: "single-owner-other",
+					reason:
+						"§CP N==1 (sole member != author): no current-head approval by the sole control-plane member — STOP (ADR 0175).",
+				};
+	}
+
+	// N >= 2: ADR 0135's two-person control, unchanged. A self-approval is explicitly not a
+	// discharge here (ADR 0175 Banned) — only a different member's current-head approval counts.
+	return input.nonAuthorApprovalAtHead
+		? {
+				decision: "discharge",
+				n,
+				branch: "multi-member",
+				reason: `§CP N>=2 (N=${n}): a current-head APPROVED review by a different control-plane member discharges §CP (ADR 0135/0175).`,
+			}
+		: {
+				decision: "stop",
+				n,
+				branch: "multi-member",
+				reason: `§CP N>=2 (N=${n}): no current-head APPROVED review by a control-plane member other than the author — STOP (ADR 0135/0175).`,
+			};
+};

--- a/packages/pipeline-cli/src/tools/cp-cardinality/cp-cardinality.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/cp-cardinality.unit.test.ts
@@ -1,0 +1,169 @@
+import {describe, expect, it} from "vitest";
+import {type CpCardinalityInput, decideCpCardinality} from "./cp-cardinality.ts";
+
+/** Build an input with fail-closed defaults (no signals present), overriding only what a case exercises. */
+const input = (over: Partial<CpCardinalityInput> = {}): CpCardinalityInput => ({
+	members: [],
+	author: "usirin",
+	nonAuthorApprovalAtHead: false,
+	selfApprovalAtHead: false,
+	...over,
+});
+
+describe("decideCpCardinality — ADR 0175 §CP team-cardinality branch (#2541)", () => {
+	describe("N == 0 (empty team) — fail closed", () => {
+		it("STOPs with no members, regardless of any signal", () => {
+			const v = decideCpCardinality(
+				input({members: [], nonAuthorApprovalAtHead: true, selfApprovalAtHead: true}),
+			);
+			expect(v.decision).toBe("stop");
+			expect(v.n).toBe(0);
+			expect(v.branch).toBe("empty");
+		});
+	});
+
+	describe("N == 1, sole owner == author (single-owner degenerate case)", () => {
+		it("discharges on a current-head self-approval marker", () => {
+			const v = decideCpCardinality(
+				input({members: ["usirin"], author: "usirin", selfApprovalAtHead: true}),
+			);
+			expect(v.decision).toBe("discharge");
+			expect(v.n).toBe(1);
+			expect(v.branch).toBe("single-owner-self");
+		});
+
+		it("STOPs with no self-approval marker", () => {
+			const v = decideCpCardinality(
+				input({members: ["usirin"], author: "usirin", selfApprovalAtHead: false}),
+			);
+			expect(v.decision).toBe("stop");
+			expect(v.branch).toBe("single-owner-self");
+		});
+
+		it("does NOT discharge on a non-author approval signal (there is no other member to give it)", () => {
+			// The only discharge signal for a sole owner IS the self-approval marker; a stray
+			// non-author-approval flag must never substitute for it.
+			const v = decideCpCardinality(
+				input({
+					members: ["usirin"],
+					author: "usirin",
+					nonAuthorApprovalAtHead: true,
+					selfApprovalAtHead: false,
+				}),
+			);
+			expect(v.decision).toBe("stop");
+		});
+	});
+
+	describe("N == 1, sole member != author", () => {
+		it("discharges on the sole member's current-head approval", () => {
+			const v = decideCpCardinality(
+				input({members: ["cansirin"], author: "usirin", nonAuthorApprovalAtHead: true}),
+			);
+			expect(v.decision).toBe("discharge");
+			expect(v.branch).toBe("single-owner-other");
+		});
+
+		it("STOPs without that member's current-head approval", () => {
+			const v = decideCpCardinality(
+				input({members: ["cansirin"], author: "usirin", nonAuthorApprovalAtHead: false}),
+			);
+			expect(v.decision).toBe("stop");
+			expect(v.branch).toBe("single-owner-other");
+		});
+
+		it("a self-approval marker does NOT discharge when the sole member is not the author", () => {
+			const v = decideCpCardinality(
+				input({members: ["cansirin"], author: "usirin", selfApprovalAtHead: true}),
+			);
+			expect(v.decision).toBe("stop");
+		});
+	});
+
+	describe("N == 2 (exactly-N, ADR 0135 two-person control) — unchanged", () => {
+		it("discharges on a current-head approval by a DIFFERENT control-plane member", () => {
+			const v = decideCpCardinality(
+				input({members: ["usirin", "cansirin"], author: "usirin", nonAuthorApprovalAtHead: true}),
+			);
+			expect(v.decision).toBe("discharge");
+			expect(v.n).toBe(2);
+			expect(v.branch).toBe("multi-member");
+		});
+
+		it("STOPs without a different-member current-head approval", () => {
+			const v = decideCpCardinality(
+				input({members: ["usirin", "cansirin"], author: "usirin", nonAuthorApprovalAtHead: false}),
+			);
+			expect(v.decision).toBe("stop");
+			expect(v.branch).toBe("multi-member");
+		});
+
+		it("self-approval is EXCLUDED — a self-approval marker never discharges when N>=2 (ADR 0175 Banned)", () => {
+			const v = decideCpCardinality(
+				input({
+					members: ["usirin", "cansirin"],
+					author: "usirin",
+					nonAuthorApprovalAtHead: false,
+					selfApprovalAtHead: true,
+				}),
+			);
+			expect(v.decision).toBe("stop");
+		});
+	});
+
+	describe("N == 3 (N+1 boundary) — same multi-member rule", () => {
+		it("discharges on a different-member current-head approval", () => {
+			const v = decideCpCardinality(
+				input({
+					members: ["usirin", "cansirin", "third"],
+					author: "usirin",
+					nonAuthorApprovalAtHead: true,
+				}),
+			);
+			expect(v.decision).toBe("discharge");
+			expect(v.n).toBe(3);
+			expect(v.branch).toBe("multi-member");
+		});
+
+		it("STOPs without one", () => {
+			const v = decideCpCardinality(
+				input({members: ["usirin", "cansirin", "third"], author: "usirin"}),
+			);
+			expect(v.decision).toBe("stop");
+		});
+	});
+
+	describe("roster hygiene — N is a count of DISTINCT, non-blank logins", () => {
+		it("dedupes duplicate logins (a doubled roster line does not inflate N to the multi-member branch)", () => {
+			const v = decideCpCardinality(
+				input({members: ["usirin", "usirin"], author: "usirin", selfApprovalAtHead: true}),
+			);
+			expect(v.n).toBe(1);
+			expect(v.branch).toBe("single-owner-self");
+			expect(v.decision).toBe("discharge");
+		});
+
+		it("ignores blank/whitespace roster lines", () => {
+			const v = decideCpCardinality(input({members: ["", "  ", "cansirin"], author: "usirin"}));
+			expect(v.n).toBe(1);
+			expect(v.branch).toBe("single-owner-other");
+		});
+
+		it("trims logins before matching the author", () => {
+			const v = decideCpCardinality(
+				input({members: ["  usirin  "], author: "usirin", selfApprovalAtHead: true}),
+			);
+			expect(v.branch).toBe("single-owner-self");
+			expect(v.decision).toBe("discharge");
+		});
+	});
+
+	describe("unresolvable author — fail closed", () => {
+		it("STOPs when the author is empty even with a single self-owner member", () => {
+			const v = decideCpCardinality(
+				input({members: ["usirin"], author: "", selfApprovalAtHead: true}),
+			);
+			expect(v.decision).toBe("stop");
+		});
+	});
+});


### PR DESCRIPTION
Replaces the judgment-based §CP approval discharge (the `CURRENT_APPROVERS` → `CP_OK` loop) in the ship-it gate with the **deterministic team-cardinality branch** ADR 0175 specifies, so the same §CP conditions produce the same verdict across agents — killing the #2435 non-determinism (identical single-owner PRs that merged in one run and were refused in another). Enforcement half of decision #2435.

## What changed

**`packages/pipeline-cli/src/tools/cp-cardinality/`** (new) — a pure, unit-tested core (`cp-cardinality.ts`) + thin Effect bin (`command.ts`) that owns ADR 0175's `case "$N"` branch, the single source ship-it runs. Follows the `class-probe` / `control-plane-paths` precedent (deterministic gate logic ship-it calls, so the verdict can't drift across shippers). `N` = distinct present active human `@kamp-us/control-plane` members:

- `N == 0` → STOP, fail closed (no accountable human).
- `N == 1`, sole owner **is** the author → a current-head **self-approval marker** by the sole owner discharges.
- `N == 1`, sole member **is not** the author → that member's current-head **approval** discharges.
- `N >= 2` → ADR 0135's two-person control, unchanged: a current-head APPROVED review by a **different** control-plane member discharges; a self-approval never does.

**`claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`** — the §CP approval gate now resolves the member roster via `GET /orgs/{org}/teams/control-plane/members` (REST, never GraphQL), resolves the two SHA-bound current-head signals (a different-member APPROVED review; the sole-owner self-approval marker `control-plane-self-approval @ <sha>`), and decides via `pipeline-cli cp-cardinality decide`. The ADR 0058 SHA-binding is retained (stale signals never count); the judgment-based `CURRENT_APPROVERS` → `CP_OK` loop is fully removed.

## Tests

`cp-cardinality.unit.test.ts` — 16 cases covering every boundary: `N==0`, `N==1` (self / other, present / absent signal), `N==2` (exactly-N, self-approval **excluded**), `N==3` (N+1), roster dedup/trim/blank hygiene, and unresolvable-author fail-closed. `pnpm typecheck` + `pnpm lint:worktree` + full pipeline-cli suite (1335) green.

## Routing

§CP / control-plane (edits a gate-critical skill + `packages/pipeline-cli/`). Stops at reviewed-ready — needs a current-head `review-skill` PASS (skill) and `review-code` PASS (the new tool), then merges via the human/cansirin §CP approval path (ADR 0135 two-person control / ADR 0048 single merge authority), not autonomous ship.

Fixes #2541