### PR TITLE
feat(local-render): attach before/after local captures to the UI PR as SHA-bound evidence (#2964)

### DIFF
--- a/packages/local-render/README.md
+++ b/packages/local-render/README.md
@@ -2,10 +2,12 @@
 
 The **local render-and-capture harness** — the root prerequisite of the write-code
 render-and-look inner loop ([epic #2953](https://github.com/kamp-us/phoenix/issues/2953),
-issue [#2963](https://github.com/kamp-us/phoenix/issues/2963)). It renders the **composed
+issues [#2963](https://github.com/kamp-us/phoenix/issues/2963) +
+[#2964](https://github.com/kamp-us/phoenix/issues/2964)). It renders the **composed
 UI surface** of the app over a running local `alchemy dev` build and writes per-surface
 PNG(s) to disk, so a write-code agent can *see* the assembled page — not just the diff —
-before opening a UI PR.
+before opening a UI PR, then **attaches the before/after captures to that PR as SHA-bound
+evidence** so a reviewer sees the composed delta without re-running anything.
 
 ```
 running local build          this harness                      on disk
@@ -85,16 +87,38 @@ node packages/local-render/src/bin.ts render \
 
 It prints a JSON array of per-surface records
 `{ surface, route, state, localPath, fileName }` on stdout — the `localPath` is the on-disk
-PNG the downstream evidence-attach step
-([#2964](https://github.com/kamp-us/phoenix/issues/2964)) uploads and attaches to the PR.
+PNG the evidence-attach step (`attachLocalEvidence`, below) uploads and attaches to the PR.
+
+## Attaching before/after evidence to the PR (#2964)
+
+`attachLocalEvidence` ([`attach.ts`](./src/attach.ts)) turns two render passes into
+**SHA-bound PR evidence**: hand it the before (pre-edit baseline) and after (post-edit
+result) `CapturedSurface[]` from two `renderLocal` runs plus the PR head SHA, and it uploads
+each PNG through design-capture's upload leg and renders the PR-attachment markdown — one
+before/after block per surface, bound to the head via a `Captured-head: @ <sha>` anchor.
+
+- **SHA-bound** (ADR 0058): the markdown refuses to render unless `headSha` is a full 40-hex
+  SHA, and it carries a `Captured-head:` anchor distinct from review-design's `Reviewed-head:`
+  — this is generation evidence, not a merge-authorizing verdict, so it stays out of
+  `ship-it`'s PASS namespace.
+- **Upload is display-only** (ADR 0165): the injected leg is design-capture's `uploadAsset`,
+  whose error channel is `never` — a failed upload degrades one embed to its `uploadError`
+  diagnostic, it never loses the paired evidence and never fails the effect.
+- **New/removed surfaces** are tolerated: a surface present in only one pass renders a
+  `not captured this pass` slot on the missing side.
+- **Pure core + injected leg**: `pairSurfaces` and `renderEvidenceMarkdown` are pure and
+  unit-tested; the upload leg is injected, so the orchestration is proven with a fake — no
+  live network. The caller (the write-code loop, #2965) wires the real `uploadAsset`.
+
+> **Depo dependency — none here.** This capability uploads to GitHub user-attachments via
+> design-capture's `uploadAsset` (the same undocumented endpoint the review-design gate uses),
+> **not** to depo. It does not depend on the depo write-host (ADR 0083/0144) being deployed —
+> the golden-baseline depo path (ADR 0183) is a separate design-capture concern.
 
 ## What downstream consumes
 
-- **#2964 (evidence-attach)** consumes each record's **`localPath`** (the on-disk PNG) — it
-  runs the harness for the before/after captures and uploads+attaches them per the SHA-bound
-  convention (reusing design-capture's `captureAndUpload`/`uploadAsset`).
 - **#2965 (§CP write-code loop)** invokes the `render` entry at its render→look→fix decision
-  points.
+  points and calls `attachLocalEvidence` at PR-open time to attach the composed before/after.
 
 ## Commands
 

--- a/packages/local-render/src/attach.ts
+++ b/packages/local-render/src/attach.ts
@@ -1,0 +1,215 @@
+/**
+ * Attach before/after local captures to a UI PR as SHA-bound evidence (#2964).
+ *
+ * The render→look→fix inner loop (#2965) runs two capture passes over the local
+ * `alchemy dev` build — a pre-edit baseline and the post-edit result (renderLocal,
+ * #2963). This entry pairs those passes by surface, uploads each PNG through the
+ * design-capture upload leg, and renders the PR-attachment markdown bound to the PR
+ * head SHA — the same SHA-bound, hosted-evidence convention review-design emits
+ * (ADR 0058 SHA-binding, ADR 0165 evidence-hosting).
+ *
+ * Pure core + injected impure leg (the orchestrate.ts idiom): the before/after
+ * pairing and the markdown render are pure and unit-tested; the only impure leg —
+ * the GitHub user-attachments upload — is injected, so the orchestration is proven
+ * with a fake leg and no live network. The upload is display-only and out of the
+ * decision path: a failed upload degrades one embed to its `uploadError` diagnostic,
+ * it never loses the paired evidence and never fails the effect.
+ */
+import type {CapturedSurface, UploadAssetOptions, UploadOutcome} from "@kampus/design-capture";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+
+/**
+ * The injected upload leg — `uploadAsset`'s shape. Its error/requirement channels
+ * are the caller's: the bin wires the real `@kampus/design-capture` `uploadAsset`
+ * (`E = never`, `R = HttpClient`), the unit test injects a fake with neither, so
+ * this module stays parametric over both and needs no service at its edge (the same
+ * `StoreLeg` seam candidate-render uses).
+ */
+export type UploadLeg<E = never, R = never> = (
+	opts: UploadAssetOptions,
+) => Effect.Effect<UploadOutcome, E, R>;
+
+/** Fail-closed when a head SHA is malformed — evidence must never be bound to a non-SHA. */
+export class AttachEvidenceError extends Schema.TaggedErrorClass<AttachEvidenceError>()(
+	"AttachEvidenceError",
+	{
+		message: Schema.String,
+		cause: Schema.optional(Schema.Unknown),
+	},
+) {}
+
+/** One surface's paired evidence: the before/after upload outcome, either side possibly absent. */
+export interface SurfaceEvidence {
+	readonly surface: string;
+	readonly route: string | null;
+	readonly state: string | null;
+	/** The before pass's upload outcome, or `null` when the surface is new (after only). */
+	readonly before: UploadOutcome | null;
+	/** The after pass's upload outcome, or `null` when the surface was removed (before only). */
+	readonly after: UploadOutcome | null;
+}
+
+export interface AttachEvidenceRequest {
+	/** The pre-edit baseline captures (a renderLocal pass over the surfaces before the change). */
+	readonly before: readonly CapturedSurface[];
+	/** The post-edit result captures (a renderLocal pass over the surfaces after the change). */
+	readonly after: readonly CapturedSurface[];
+	/** The PR head commit the evidence binds to — a full 40-hex git SHA (ADR 0058). */
+	readonly headSha: string;
+	/** The target repo's numeric id (`gh api repos/OWNER/REPO --jq .id`). */
+	readonly repositoryId: number;
+	/** A GitHub token with write access to the target repo. */
+	readonly token: string;
+}
+
+export interface AttachEvidenceResult {
+	/** One paired record per surface, in before-then-new-surface order. */
+	readonly records: readonly SurfaceEvidence[];
+	/** The PR-attachment markdown, bound to `headSha`, ready to embed in the PR body/comment. */
+	readonly markdown: string;
+}
+
+/** A full-length lowercase git SHA — the head an evidence block may bind to. */
+export const isHeadSha = (value: string): boolean => /^[0-9a-f]{40}$/.test(value);
+
+/** A paired surface across the two passes — either slot possibly absent (new/removed surface). */
+interface PairedSurface {
+	readonly surface: string;
+	readonly route: string | null;
+	readonly state: string | null;
+	readonly before: CapturedSurface | null;
+	readonly after: CapturedSurface | null;
+}
+
+/**
+ * PURE: pair two capture passes by surface token into before/after slots. A surface
+ * present in both is a changed surface (both slots); one present in only the after
+ * pass is new (before `null`); only in the before pass is removed (after `null`).
+ * Order is before-pass order, then any after-only surfaces appended in their order.
+ */
+export const pairSurfaces = (
+	before: readonly CapturedSurface[],
+	after: readonly CapturedSurface[],
+): readonly PairedSurface[] => {
+	const afterBySurface = new Map(after.map((s) => [s.surface, s]));
+	const seen = new Set<string>();
+	const paired = before.map((b): PairedSurface => {
+		seen.add(b.surface);
+		return {
+			surface: b.surface,
+			route: b.route,
+			state: b.state,
+			before: b,
+			after: afterBySurface.get(b.surface) ?? null,
+		};
+	});
+	const afterOnly = after
+		.filter((a) => !seen.has(a.surface))
+		.map(
+			(a): PairedSurface => ({
+				surface: a.surface,
+				route: a.route,
+				state: a.state,
+				before: null,
+				after: a,
+			}),
+		);
+	return [...paired, ...afterOnly];
+};
+
+/** One side of the before/after embed: the image, its fallback diagnostic, or "not captured". */
+const embed = (label: string, outcome: UploadOutcome | null): string => {
+	if (outcome === null) return `${label} — _not captured this pass_`;
+	if (outcome.hostedUrl !== null) return `${label} — ![${label}](${outcome.hostedUrl})`;
+	return `${label} — _upload failed: ${outcome.uploadError ?? "unknown error"}_`;
+};
+
+/**
+ * PURE: render the SHA-bound before/after evidence markdown. The `Captured-head:`
+ * anchor binds every embed to the exact PR head the captures were shot at — a
+ * distinct anchor from review-design's `Reviewed-head:`, since this is generation
+ * evidence, not a merge-authorizing verdict (it stays out of ship-it's namespace).
+ * Throws on a malformed head SHA — the orchestration lifts that into the E channel;
+ * emitting evidence bound to a non-SHA would break the binding contract (ADR 0058).
+ */
+export const renderEvidenceMarkdown = (
+	records: readonly SurfaceEvidence[],
+	headSha: string,
+): string => {
+	if (!isHeadSha(headSha)) {
+		throw new Error(
+			`refusing to render evidence bound to a malformed head SHA (expected 40-hex): ${JSON.stringify(headSha)}`,
+		);
+	}
+	const lines = [
+		"**Composed-surface evidence** (before/after)",
+		"",
+		"Local captures of the changed UI surfaces over the `alchemy dev` build, bound to the PR head.",
+		"",
+		`Captured-head: @ ${headSha}`,
+		"",
+	];
+	if (records.length === 0) {
+		lines.push("_No composed surfaces captured for this change._");
+		return lines.join("\n");
+	}
+	for (const r of records) {
+		const title = r.state === null ? r.surface : `${r.surface}:${r.state}`;
+		lines.push(`- ${title}`, `  - ${embed("before", r.before)}`, `  - ${embed("after", r.after)}`);
+	}
+	return lines.join("\n");
+};
+
+/**
+ * Upload the before/after captures and render the SHA-bound PR-attachment markdown.
+ * Pairs the two passes (pure), uploads each side through the injected leg
+ * (concurrency 1 — the undocumented endpoint is gentle-only), folds the outcomes
+ * into per-surface records, and renders the markdown. A malformed head SHA
+ * fail-closes into `AttachEvidenceError`; the upload leg's own error channel is
+ * whatever the caller wires (`never` for the real `uploadAsset`).
+ */
+export const attachLocalEvidence = <E = never, R = never>(
+	request: AttachEvidenceRequest,
+	upload: UploadLeg<E, R>,
+): Effect.Effect<AttachEvidenceResult, AttachEvidenceError | E, R> => {
+	if (!isHeadSha(request.headSha)) {
+		return Effect.fail(
+			new AttachEvidenceError({
+				message: `refusing to attach evidence bound to a malformed head SHA (expected 40-hex): ${JSON.stringify(request.headSha)}`,
+			}),
+		);
+	}
+	const paired = pairSurfaces(request.before, request.after);
+	const uploadSide = (
+		captured: CapturedSurface | null,
+		suffix: string,
+	): Effect.Effect<UploadOutcome | null, E, R> =>
+		captured === null
+			? Effect.succeed(null)
+			: upload({
+					pngBytes: captured.pngBytes,
+					repositoryId: request.repositoryId,
+					token: request.token,
+					fileName: `${suffix}-${captured.fileName}`,
+				});
+	return Effect.forEach(
+		paired,
+		(p): Effect.Effect<SurfaceEvidence, E, R> =>
+			Effect.all([uploadSide(p.before, "before"), uploadSide(p.after, "after")]).pipe(
+				Effect.map(([before, after]) => ({
+					surface: p.surface,
+					route: p.route,
+					state: p.state,
+					before,
+					after,
+				})),
+			),
+		{concurrency: 1},
+	).pipe(
+		Effect.map((records) => ({
+			records,
+			markdown: renderEvidenceMarkdown(records, request.headSha),
+		})),
+	);
+};

--- a/packages/local-render/src/attach.unit.test.ts
+++ b/packages/local-render/src/attach.unit.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The evidence-attach orchestration + its pure cores (#2964). The load-bearing
+ * invariants: (a) the markdown is BOUND to the PR head SHA and refuses a non-SHA;
+ * (b) before/after are paired by surface, tolerating new/removed surfaces; (c) an
+ * upload fallback (endpoint down) degrades one embed to its diagnostic, never loses
+ * the paired evidence and never fails the effect. The impure upload leg is injected
+ * — no live network.
+ */
+import type {CapturedSurface, UploadAssetOptions, UploadOutcome} from "@kampus/design-capture";
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {
+	AttachEvidenceError,
+	attachLocalEvidence,
+	isHeadSha,
+	pairSurfaces,
+	renderEvidenceMarkdown,
+	type SurfaceEvidence,
+	type UploadLeg,
+} from "./attach.ts";
+
+const SHA = "a".repeat(40);
+
+const captured = (surface: string, state: string | null, byte: number): CapturedSurface => ({
+	surface,
+	route: surface.replace(/:.*$/, ""),
+	state,
+	localPath: `/tmp/out/${surface}.png`,
+	fileName: `${surface.replace(/[/:]/g, "-")}.png`,
+	pngBytes: new Uint8Array([byte]),
+	pageErrors: [],
+});
+
+/** A fake upload leg: records the files it was handed, returns a hosted URL per call (no network). */
+const recordingUpload = () => {
+	const calls: UploadAssetOptions[] = [];
+	const leg: UploadLeg = (opts) => {
+		calls.push(opts);
+		return Effect.succeed<UploadOutcome>({
+			hostedUrl: `https://github.com/user-attachments/assets/${opts.fileName}`,
+			uploadError: null,
+		});
+	};
+	return {leg, calls};
+};
+
+describe("isHeadSha", () => {
+	it("accepts a full 40-hex lowercase SHA and rejects everything else", () => {
+		expect(isHeadSha(SHA)).toBe(true);
+		expect(isHeadSha("abc123")).toBe(false); // too short
+		expect(isHeadSha(SHA.toUpperCase())).toBe(false); // uppercase
+		expect(isHeadSha(`${SHA}0`)).toBe(false); // too long
+		expect(isHeadSha("")).toBe(false);
+	});
+});
+
+describe("pairSurfaces", () => {
+	it("pairs a changed surface into both slots", () => {
+		const paired = pairSurfaces([captured("/sozluk", null, 1)], [captured("/sozluk", null, 2)]);
+		expect(paired).toHaveLength(1);
+		expect(paired[0]?.before?.pngBytes).toEqual(new Uint8Array([1]));
+		expect(paired[0]?.after?.pngBytes).toEqual(new Uint8Array([2]));
+	});
+
+	it("marks an after-only surface new (before null) and a before-only surface removed (after null)", () => {
+		const paired = pairSurfaces([captured("/removed", null, 1)], [captured("/added", null, 2)]);
+		const removed = paired.find((p) => p.surface === "/removed");
+		const added = paired.find((p) => p.surface === "/added");
+		expect(removed?.after).toBeNull();
+		expect(added?.before).toBeNull();
+		// before-pass surfaces come first, after-only appended
+		expect(paired.map((p) => p.surface)).toEqual(["/removed", "/added"]);
+	});
+});
+
+describe("renderEvidenceMarkdown", () => {
+	const evidence = (over: Partial<SurfaceEvidence> = {}): SurfaceEvidence => ({
+		surface: "/sozluk",
+		route: "/sozluk",
+		state: null,
+		before: {hostedUrl: "https://github.com/user-attachments/assets/before", uploadError: null},
+		after: {hostedUrl: "https://github.com/user-attachments/assets/after", uploadError: null},
+		...over,
+	});
+
+	it("binds the markdown to the head SHA and embeds both images", () => {
+		const md = renderEvidenceMarkdown([evidence()], SHA);
+		expect(md).toContain(`Captured-head: @ ${SHA}`);
+		expect(md).toContain("![before](https://github.com/user-attachments/assets/before)");
+		expect(md).toContain("![after](https://github.com/user-attachments/assets/after)");
+	});
+
+	it("does NOT emit review-design's Reviewed-head anchor (stays out of ship-it's namespace)", () => {
+		expect(renderEvidenceMarkdown([evidence()], SHA)).not.toContain("Reviewed-head:");
+	});
+
+	it("degrades a failed-upload side to its diagnostic, keeping the other embed", () => {
+		const md = renderEvidenceMarkdown(
+			[evidence({before: {hostedUrl: null, uploadError: "HTTP 500: boom"}})],
+			SHA,
+		);
+		expect(md).toContain("_upload failed: HTTP 500: boom_");
+		expect(md).toContain("![after](https://github.com/user-attachments/assets/after)");
+	});
+
+	it("renders a not-captured slot for a new/removed surface", () => {
+		const md = renderEvidenceMarkdown([evidence({before: null})], SHA);
+		expect(md).toContain("_not captured this pass_");
+	});
+
+	it("qualifies a stated surface title with its state", () => {
+		const md = renderEvidenceMarkdown([evidence({surface: "/sozluk", state: "empty"})], SHA);
+		expect(md).toContain("- /sozluk:empty");
+	});
+
+	it("emits an explicit no-surfaces note rather than a bare header", () => {
+		expect(renderEvidenceMarkdown([], SHA)).toContain("_No composed surfaces captured");
+	});
+
+	it("throws on a malformed head SHA", () => {
+		expect(() => renderEvidenceMarkdown([evidence()], "not-a-sha")).toThrow(/malformed head SHA/);
+	});
+});
+
+describe("attachLocalEvidence", () => {
+	it("uploads before+after per surface through the injected leg and binds the markdown", async () => {
+		const {leg, calls} = recordingUpload();
+		const result = await Effect.runPromise(
+			attachLocalEvidence(
+				{
+					before: [captured("/sozluk", null, 1)],
+					after: [captured("/sozluk", null, 2)],
+					headSha: SHA,
+					repositoryId: 42,
+					token: "gh-token",
+				},
+				leg,
+			),
+		);
+		// two uploads (before + after), each prefixed so the two passes don't collide by name
+		expect(calls.map((c) => c.fileName)).toEqual(["before--sozluk.png", "after--sozluk.png"]);
+		expect(calls.every((c) => c.repositoryId === 42 && c.token === "gh-token")).toBe(true);
+		expect(result.records).toHaveLength(1);
+		expect(result.markdown).toContain(`Captured-head: @ ${SHA}`);
+	});
+
+	it("skips the upload for an absent side (new/removed surface) and marks it not-captured", async () => {
+		const {leg, calls} = recordingUpload();
+		const result = await Effect.runPromise(
+			attachLocalEvidence(
+				{
+					before: [],
+					after: [captured("/added", null, 2)],
+					headSha: SHA,
+					repositoryId: 1,
+					token: "t",
+				},
+				leg,
+			),
+		);
+		// only the after side uploads; the absent before side is never sent to the leg
+		expect(calls.map((c) => c.fileName)).toEqual(["after--added.png"]);
+		expect(result.records[0]?.before).toBeNull();
+		expect(result.markdown).toContain("_not captured this pass_");
+	});
+
+	it("fail-closes into AttachEvidenceError on a malformed head SHA before uploading", async () => {
+		const {leg, calls} = recordingUpload();
+		const exit = await Effect.runPromiseExit(
+			attachLocalEvidence(
+				{
+					before: [captured("/x", null, 1)],
+					after: [],
+					headSha: "nope",
+					repositoryId: 1,
+					token: "t",
+				},
+				leg,
+			),
+		);
+		expect(exit._tag).toBe("Failure");
+		// no upload attempted once the SHA is rejected
+		expect(calls).toHaveLength(0);
+		if (exit._tag === "Failure") {
+			const err = exit.cause;
+			expect(JSON.stringify(err)).toContain("AttachEvidenceError");
+		}
+	});
+
+	it("propagates an upload fallback into the record without failing the effect", async () => {
+		const failing: UploadLeg = () =>
+			Effect.succeed<UploadOutcome>({hostedUrl: null, uploadError: "endpoint down"});
+		const result = await Effect.runPromise(
+			attachLocalEvidence(
+				{
+					before: [captured("/sozluk", null, 1)],
+					after: [captured("/sozluk", null, 2)],
+					headSha: SHA,
+					repositoryId: 1,
+					token: "t",
+				},
+				failing,
+			),
+		);
+		expect(result.records[0]?.before?.uploadError).toBe("endpoint down");
+		expect(result.markdown).toContain("_upload failed: endpoint down_");
+	});
+});
+
+// keep AttachEvidenceError import load-bearing (asserted by tag string above)
+void AttachEvidenceError;

--- a/packages/local-render/src/index.ts
+++ b/packages/local-render/src/index.ts
@@ -7,7 +7,24 @@
  * crop/downscale under a documented budget. Reuses `@kampus/design-capture`'s
  * `captureShots`/`buildCapturePlan`/viewport primitives as the Playwright leg —
  * it adds local-build targeting on top, it does not re-implement browser capture.
+ *
+ * On top of render, it attaches the before/after captures to a UI PR as SHA-bound
+ * evidence (#2964): two renderLocal passes → uploaded via design-capture's upload
+ * leg → PR-attachment markdown bound to the PR head SHA.
  */
+export type {
+	AttachEvidenceRequest,
+	AttachEvidenceResult,
+	SurfaceEvidence,
+	UploadLeg,
+} from "./attach.ts";
+export {
+	AttachEvidenceError,
+	attachLocalEvidence,
+	isHeadSha,
+	pairSurfaces,
+	renderEvidenceMarkdown,
+} from "./attach.ts";
 export type {CaptureDirective, LocalShotOptions} from "./plan.ts";
 export {
 	buildLocalShots,


### PR DESCRIPTION
Fixes #2964

## What

Adds `attachLocalEvidence` to `@kampus/local-render` — the reusable capability that
attaches **before/after local UI captures to a PR as SHA-bound evidence**, part of epic
#2953 (the render→look→fix inner loop). It consumes child #2963's `renderLocal` output
contract (two capture passes: pre-edit baseline + post-edit result) and reuses
`@kampus/design-capture`'s `uploadAsset` leg as-is.

## How

- **Pure cores (unit-tested):** `pairSurfaces` pairs the two passes by surface (tolerating
  new/removed surfaces); `renderEvidenceMarkdown` renders the PR-attachment markdown bound
  to the PR head via a `Captured-head: @ <sha>` anchor.
- **Thin orchestration:** `attachLocalEvidence` uploads each PNG through the **injected**
  upload leg (`concurrency: 1`), folds the outcomes into per-surface records, and renders the
  markdown — the `orchestrate.ts` idiom (pure core + injected impure leg), so the whole thing
  is proven with a fake leg and **no live network** in unit tests.

## SHA-bound + fail-closed (ADR 0058 / 0165)

- Refuses to render evidence bound to anything but a full 40-hex head SHA (`AttachEvidenceError`).
- Uses `Captured-head:` (distinct from review-design's `Reviewed-head:`) so this **generation
  evidence** stays out of `ship-it`'s PASS namespace — it authorizes no merge.
- Upload is display-only: a failed upload degrades one embed to its `uploadError` diagnostic,
  never loses the paired evidence, never fails the effect.

## Scope

Reusable capability **only**. It does **not** edit the `write-code` skill, the self-critique
loop, or `packages/pipeline-cli` / `packages/ci-required` — child #2965 wires the call into
the write-code inner loop at PR-open time (kept isolated as §CP).

**No depo dependency:** uploads to GitHub user-attachments via `uploadAsset` (the same
undocumented endpoint review-design uses), **not** the depo write-host (ADR 0083/0144). The
golden-baseline depo path (ADR 0183) is a separate `@kampus/design-capture` concern.

## Acceptance criteria

- [x] An entry takes before/after local captures (over the child-#2963 harness), uploads them
      via the design-capture upload leg, and emits SHA-bound PR-attachment markdown.
- [x] The upload/attachment orchestration is unit-tested with the impure upload leg injected
      (the `orchestrate.ts` idiom); no live network in unit tests.
- [x] The capability is importable by a caller and does not edit the write-code skill or touch
      `packages/pipeline-cli` / `packages/ci-required`.

## Verification

- `pnpm typecheck` (local-render): clean
- `pnpm test` (local-render): 43 passed (11 new in `attach.unit.test.ts`)
- `pnpm lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
