### PR TITLE
feat(pipeline-crew-mcp): edge/ channel server bridging peer inbox to notifications/claude/channel

### DIFF
--- a/packages/pipeline-crew-mcp/src/edge/boundary.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/boundary.test.ts
@@ -1,0 +1,21 @@
+/**
+ * The generic boundary (AC 4): no `edge/` source file imports from `crew/`. edge/ codes
+ * against the `peer/`+`protocol/` substrate and opaque role/peer parameters only — the
+ * concrete crew role catalog + wiring is the `crew/` composition root (#3059). Mirrors the
+ * same guard `peer/` and `protocol/` carry.
+ */
+import {readdirSync, readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+
+describe("edge/ generic boundary", () => {
+	it("no edge source file imports from crew/", () => {
+		const dir = fileURLToPath(new URL(".", import.meta.url));
+		const sources = readdirSync(dir).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+		assert.isAbove(sources.length, 0, "expected edge/ source files to scan");
+		for (const file of sources) {
+			const body = readFileSync(new URL(file, new URL(".", import.meta.url)), "utf8");
+			assert.isFalse(/from\s+["'][^"']*crew/.test(body), `${file} imports from crew/`);
+		}
+	});
+});

--- a/packages/pipeline-crew-mcp/src/edge/bridge.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/bridge.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Inbound bridge behavior (AC 2): a delivery to the channel-bridging `Inbox` wakes the
+ * session over the `ChannelSink`, carrying the message as a structured `<channel>` tag with
+ * the sender in `_meta.from`, and returns a delivered-to-inbox ack stamped by this edge peer.
+ * Driven against a capturing `ChannelSink`, so the bridge logic is under test without a live
+ * MCP transport (the real emit-through-the-patched-notification path is `channel-sink.test.ts`).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Ref} from "effect";
+import {Inbox, type InboxEnvelope} from "../peer/index.ts";
+import {channelInboxLayer, formatChannelTag} from "./bridge.ts";
+import {ChannelSink} from "./channel-sink.ts";
+import type {ChannelNotificationPayload} from "./mcp-channel.ts";
+
+const envelope = (over?: Partial<InboxEnvelope>): InboxEnvelope => ({
+	messageId: "msg-1",
+	from: "peer-a",
+	kind: "IntakePing",
+	body: {issue: "3057"},
+	at: "2026-07-16T10:00:00Z",
+	...over,
+});
+
+describe("edge/bridge — inbound peer-inbox message wakes the session (AC2)", () => {
+	it.effect("a delivery emits a channel wake with the message as a <channel> tag", () =>
+		Effect.gen(function* () {
+			const captured = yield* Ref.make<ReadonlyArray<ChannelNotificationPayload>>([]);
+			const CapturingSink = Layer.succeed(ChannelSink, {
+				wake: (payload) => Ref.update(captured, (xs) => [...xs, payload]),
+			});
+
+			yield* Effect.gen(function* () {
+				const inbox = yield* Inbox;
+				const ack = yield* inbox.deliver(envelope({messageId: "m-7"}));
+				// delivered-to-inbox, stamped by this edge peer — never seen-by-model (#3035).
+				assert.strictEqual(ack.messageId, "m-7");
+				assert.strictEqual(ack.by, "edge-a");
+
+				const wakes = yield* Ref.get(captured);
+				assert.strictEqual(wakes.length, 1);
+				assert.strictEqual(wakes[0]?.message, formatChannelTag(envelope({messageId: "m-7"})));
+				assert.strictEqual(wakes[0]?._meta?.from, "peer-a");
+			}).pipe(Effect.provide(channelInboxLayer("edge-a").pipe(Layer.provide(CapturingSink))));
+		}),
+	);
+
+	it("formatChannelTag renders sender + kind as attributes and the body as content", () => {
+		const tag = formatChannelTag(envelope());
+		assert.match(tag, /^<channel from="peer-a" kind="IntakePing">/);
+		assert.include(tag, '{"issue":"3057"}');
+	});
+});

--- a/packages/pipeline-crew-mcp/src/edge/bridge.ts
+++ b/packages/pipeline-crew-mcp/src/edge/bridge.ts
@@ -1,0 +1,48 @@
+/**
+ * edge/bridge — the inbound half of the channel edge: a peer-inbox delivery becomes a
+ * `notifications/claude/channel` wake carrying the message as a structured `<channel>`
+ * tag. Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ *
+ * The bridge IS the peer's `Inbox` service (`../peer`), so the peer inbox `RpcServer` fans
+ * a `Deliver` straight into a channel wake — no second delivery path. It emits through the
+ * `ChannelSink` port (`./channel-sink.ts`). The channel is 1:1 / wake-only / ack-less
+ * (`.patterns/mcp-channel-contract.md`), so this does last-mile delivery only; addressing
+ * and acks live in tracker/peer.
+ */
+import {Effect, Layer, Ref} from "effect";
+import {Inbox, type InboxAck, type InboxEnvelope} from "../peer/index.ts";
+import {ChannelSink} from "./channel-sink.ts";
+
+/**
+ * Render a delivered envelope as the `<channel>` tag the session reads: `from`/`kind` as
+ * attributes, the body as content. Identity rides in the tag because the channel carries
+ * no addressing (`_meta.from` on the notification is the wire-level echo of the same).
+ */
+export const formatChannelTag = (envelope: InboxEnvelope): string =>
+	`<channel from=${JSON.stringify(envelope.from)} kind=${JSON.stringify(envelope.kind)}>${JSON.stringify(envelope.body)}</channel>`;
+
+/**
+ * A channel-bridging `Inbox`: every delivery wakes the session over the `ChannelSink` and
+ * is recorded for `received`. The ack is stamped `by: self` — delivered-to-inbox, the peer
+ * inbox contract (#3035); it never means seen-by-model (the channel has no delivery acks).
+ */
+export const channelInboxLayer = (self: string): Layer.Layer<Inbox, never, ChannelSink> =>
+	Layer.effect(
+		Inbox,
+		Effect.gen(function* () {
+			const sink = yield* ChannelSink;
+			const log = yield* Ref.make<ReadonlyArray<InboxEnvelope>>([]);
+			return {
+				deliver: (envelope) =>
+					sink.wake({message: formatChannelTag(envelope), _meta: {from: envelope.from}}).pipe(
+						Effect.andThen(Ref.update(log, (xs) => [...xs, envelope])),
+						Effect.as<InboxAck>({
+							messageId: envelope.messageId,
+							by: self,
+							at: new Date().toISOString(),
+						}),
+					),
+				received: Ref.get(log),
+			};
+		}),
+	);

--- a/packages/pipeline-crew-mcp/src/edge/channel-sink.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/channel-sink.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Channel-sink emit against the patched base (AC 2): `layerFromMcpServer.wake` enqueues a
+ * `notifications/claude/channel` request onto the running `McpServer`'s outgoing-notification
+ * queue, carrying the `{message, _meta.from}` payload. The notification method is a
+ * `ServerNotificationRpcs` member ONLY under the effect patch (ADR 0038) — so emitting it
+ * through a real `McpServer` pins the bridge's last-mile emit to the actual patched wire
+ * contract, not a stub. No transport is installed, so the queue isn't drained and the emitted
+ * request is observable directly.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Queue} from "effect";
+import {McpServer} from "effect/unstable/ai";
+import {ChannelSink} from "./channel-sink.ts";
+import {CHANNEL_NOTIFICATION_METHOD} from "./mcp-channel.ts";
+
+// A live (transport-less) McpServer service — enough to observe its notification queue.
+const TestServer = Layer.effect(McpServer.McpServer, McpServer.McpServer.make);
+
+describe("edge/channel-sink — wake emits notifications/claude/channel (AC2, patched base)", () => {
+	it.effect("a wake enqueues a claude/channel notification carrying the payload", () =>
+		Effect.gen(function* () {
+			const message = '<channel from="peer-a" kind="IntakePing">{}</channel>';
+			const sink = yield* ChannelSink;
+			yield* sink.wake({message, _meta: {from: "peer-a"}});
+
+			const server = yield* McpServer.McpServer;
+			const request = yield* Queue.take(server.notificationsQueue);
+			assert.strictEqual(request.tag, CHANNEL_NOTIFICATION_METHOD);
+			const payload = request.payload as {message: string; _meta?: {from?: string}};
+			assert.strictEqual(payload.message, message);
+			assert.strictEqual(payload._meta?.from, "peer-a");
+		}).pipe(Effect.provide(ChannelSink.layerFromMcpServer.pipe(Layer.provideMerge(TestServer)))),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/edge/channel-sink.ts
+++ b/packages/pipeline-crew-mcp/src/edge/channel-sink.ts
@@ -1,0 +1,33 @@
+/**
+ * edge/channel-sink — the last-mile wake port: emit a `notifications/claude/channel` into
+ * the connected session. Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ *
+ * `ChannelSink` is the seam the inbox→channel bridge (`./bridge.ts`) delivers through, so
+ * the bridge logic is testable without a live MCP transport. `layerFromMcpServer` is the
+ * real implementation, emitting over the patched `notifications/claude/channel` member —
+ * which exists only under the effect patch (`.patterns/mcp-channel-contract.md`), so the
+ * wake is inert at a pin whose `patch-guard` is red.
+ */
+import {Context, Effect, Layer} from "effect";
+import {McpServer} from "effect/unstable/ai";
+import {CHANNEL_NOTIFICATION_METHOD, type ChannelNotificationPayload} from "./mcp-channel.ts";
+
+export class ChannelSink extends Context.Service<
+	ChannelSink,
+	{
+		readonly wake: (payload: ChannelNotificationPayload) => Effect.Effect<void>;
+	}
+>()("@kampus/pipeline-crew-mcp/edge/ChannelSink") {
+	/** Emit the wake through the running `McpServer`'s notification client. */
+	static readonly layerFromMcpServer: Layer.Layer<ChannelSink, never, McpServer.McpServer> =
+		Layer.effect(
+			ChannelSink,
+			Effect.gen(function* () {
+				const server = yield* McpServer.McpServer;
+				return {
+					wake: (payload) =>
+						server.notifications[CHANNEL_NOTIFICATION_METHOD](payload).pipe(Effect.asVoid),
+				};
+			}),
+		);
+}

--- a/packages/pipeline-crew-mcp/src/edge/index.ts
+++ b/packages/pipeline-crew-mcp/src/edge/index.ts
@@ -1,10 +1,21 @@
 /**
- * edge/ — the MCP channel edge: exposes the substrate to an MCP client as channels.
- * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ * edge/ — the MCP channel edge: bridges the peer inbox to a Claude Code session over the
+ * `claude/channel` capability. Generic (crew-agnostic); see the boundary note in
+ * `../index.ts`.
+ *
+ * Two directions, wired to a peer at the crew root (#3059):
+ *   - inbound  — `channelInboxLayer` is the peer's `Inbox`; each delivery `wake`s the
+ *     session via the `ChannelSink` as a structured `<channel>` tag,
+ *   - outbound — `channelServerLayer` serves the MCP server (capability + `channel_send`
+ *     tool), routing sends through the `ChannelSend` port.
  */
+export {channelInboxLayer, formatChannelTag} from "./bridge.ts";
+export {ChannelSink} from "./channel-sink.ts";
 export {
 	CHANNEL_CAPABILITY,
 	CHANNEL_NOTIFICATION_METHOD,
 	type ChannelNotificationPayload,
 	channelExperimentalCapability,
 } from "./mcp-channel.ts";
+export {ChannelSend, ChannelToolkit, channelToolHandlers, SendChannelMessage} from "./send-tool.ts";
+export {channelServerLayer} from "./server.ts";

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Outbound send tool (ACs 1, 3): the channel edge MCP server advertises the `claude/channel`
+ * capability, lists a `channel_send` tool, and a `tools/call` routes an outbound message
+ * through the `ChannelSend` port (the peer dialer — tracker lookup + dial + inbox-ack),
+ * returning the delivered-to-inbox ack; an offline role comes back as an error result, never
+ * a silent drop (#3035). Driven against a real in-memory `McpServer.layerHttp` +
+ * `HttpRouter.toWebHandler` + a session-replaying fetch shim (the `mcp-server-effect` harness).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Schema} from "effect";
+import {McpSchema, McpServer} from "effect/unstable/ai";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import {RpcSerialization} from "effect/unstable/rpc";
+import * as RpcClient from "effect/unstable/rpc/RpcClient";
+import {type InboxAck, PeerUnreachableError} from "../peer/index.ts";
+import {CHANNEL_CAPABILITY, channelExperimentalCapability} from "./mcp-channel.ts";
+import {ChannelSend, ChannelToolkit, channelToolHandlers} from "./send-tool.ts";
+
+class DisposeError extends Schema.TaggedErrorClass<DisposeError>()(
+	"@kampus/pipeline-crew-mcp/DisposeError",
+	{cause: Schema.Unknown},
+) {}
+
+// A ChannelSend standing in for the peer dialer: "reviewer" is live (acks by peer-b), any
+// other role is offline (a typed PeerUnreachableError, as the real tracker-lookup miss would be).
+const FakeSend = Layer.succeed(ChannelSend, {
+	send: (targetRole, _kind, _body) =>
+		targetRole === "reviewer"
+			? Effect.succeed<InboxAck>({messageId: "m-9", by: "peer-b", at: "2026-07-16T10:00:00Z"})
+			: Effect.fail(
+					new PeerUnreachableError({
+						target: targetRole,
+						reason: `no live peer for role "${targetRole}"`,
+					}),
+				),
+});
+
+const makeInitializedClient = Effect.gen(function* () {
+	const serverLayer = McpServer.toolkit(ChannelToolkit).pipe(
+		Layer.provide(channelToolHandlers),
+		Layer.provide(FakeSend),
+		Layer.provide(
+			McpServer.layerHttp({
+				name: "ChannelEdgeSendTestServer",
+				version: "0.0.0",
+				path: "/mcp",
+				experimental: channelExperimentalCapability,
+			}),
+		),
+	);
+	const {dispose, handler} = HttpRouter.toWebHandler(serverLayer, {disableLogger: true});
+	yield* Effect.addFinalizer(() =>
+		Effect.tryPromise({try: () => dispose(), catch: (cause) => new DisposeError({cause})}).pipe(
+			Effect.ignore,
+		),
+	);
+
+	let sessionId: string | null = null;
+	const customFetch: typeof fetch = async (input, init) => {
+		const request = input instanceof Request ? input : new Request(input, init);
+		if (sessionId) request.headers.set("Mcp-Session-Id", sessionId);
+		const response = await handler(request);
+		sessionId = response.headers.get("Mcp-Session-Id");
+		return response;
+	};
+
+	const clientLayer = RpcClient.layerProtocolHttp({url: "http://localhost/mcp"}).pipe(
+		Layer.provideMerge([FetchHttpClient.layer, RpcSerialization.layerJsonRpc()]),
+		Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch)),
+	);
+	const client = yield* RpcClient.make(McpSchema.ClientRpcs).pipe(Effect.provide(clientLayer));
+	const initialized = yield* client.initialize({
+		protocolVersion: "9999-01-01",
+		capabilities: {},
+		clientInfo: {name: "TestClient", version: "0.0.0"},
+	});
+	return {client, initialized};
+});
+
+describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
+	it.effect("advertises the claude/channel capability and lists the channel_send tool", () =>
+		Effect.gen(function* () {
+			const {client, initialized} = yield* makeInitializedClient;
+			assert.deepEqual(initialized.capabilities.experimental?.[CHANNEL_CAPABILITY], {});
+			const tools = yield* client["tools/list"]({});
+			assert.include(
+				tools.tools.map((t) => t.name),
+				"channel_send",
+			);
+		}),
+	);
+
+	it.effect("channel_send routes to the live peer and returns its delivered-to-inbox ack", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				arguments: {targetRole: "reviewer", kind: "IntakePing", body: {issue: "3057"}},
+			});
+			assert.isFalse(result.isError);
+			const ack = result.structuredContent as {by?: string; messageId?: string};
+			assert.strictEqual(ack.by, "peer-b");
+			assert.strictEqual(ack.messageId, "m-9");
+		}),
+	);
+
+	it.effect("channel_send to an offline role returns an error result (never a silent drop)", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				arguments: {targetRole: "ghost", kind: "IntakePing", body: {}},
+			});
+			assert.isTrue(result.isError);
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -1,0 +1,51 @@
+/**
+ * edge/send-tool — the outbound half of the channel edge: an MCP tool a session calls to
+ * send a typed message to a role, routed through the peer dialer (tracker lookup + dial +
+ * inbox-ack). Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ *
+ * The tool wraps the `ChannelSend` port — the peer's `send` capability (`../peer`) — so the
+ * edge never constructs a peer (the crew composition root does, #3059). A send to an
+ * offline role surfaces as `PeerUnreachableError`, which the tool returns as an error result
+ * to the caller — never a silent drop (#3035).
+ */
+import {Context, Effect, Schema} from "effect";
+import {Tool, Toolkit} from "effect/unstable/ai";
+import {type InboxAck, PeerUnreachableError} from "../peer/index.ts";
+import {Messages} from "../protocol/index.ts";
+
+/** The outbound send capability: dial the live peer serving `targetRole` and deliver `kind`/`body`. */
+export class ChannelSend extends Context.Service<
+	ChannelSend,
+	{
+		readonly send: (
+			targetRole: string,
+			kind: string,
+			body: unknown,
+		) => Effect.Effect<InboxAck, PeerUnreachableError>;
+	}
+>()("@kampus/pipeline-crew-mcp/edge/ChannelSend") {}
+
+/** The one send tool: `{targetRole, kind, body}` in, the delivered-to-inbox ack out. */
+export const SendChannelMessage = Tool.make("channel_send", {
+	description:
+		"Send a typed message to the live peer serving a role; returns the delivered-to-inbox ack.",
+	parameters: Schema.Struct({
+		targetRole: Schema.NonEmptyString,
+		kind: Schema.NonEmptyString,
+		body: Schema.Unknown,
+	}),
+	success: Messages.InboxAck,
+	failure: PeerUnreachableError,
+});
+
+export const ChannelToolkit = Toolkit.make(SendChannelMessage);
+
+/** The toolkit handler, routing each call through the `ChannelSend` port. */
+export const channelToolHandlers = ChannelToolkit.toLayer(
+	Effect.gen(function* () {
+		const sender = yield* ChannelSend;
+		return {
+			channel_send: ({body, kind, targetRole}) => sender.send(targetRole, kind, body),
+		};
+	}),
+);

--- a/packages/pipeline-crew-mcp/src/edge/server.ts
+++ b/packages/pipeline-crew-mcp/src/edge/server.ts
@@ -1,0 +1,27 @@
+/**
+ * edge/server — the channel-serving MCP server a crew session loads over stdio: it
+ * advertises the `claude/channel` capability and registers the outbound send tool.
+ * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ *
+ * Load path: a session starts Claude Code with `--dangerously-load-development-channels`
+ * (research preview) and this server as a stdio MCP server. The inbound wake path is the
+ * `channelInboxLayer` bridge (`./bridge.ts`), wired to the peer inbox at the crew root
+ * (#3059) — this layer requires the `ChannelSend` port (the peer's send capability) and
+ * the `Stdio` transport env, both supplied there.
+ */
+import {Layer} from "effect";
+import {McpServer} from "effect/unstable/ai";
+import {channelExperimentalCapability} from "./mcp-channel.ts";
+import {ChannelToolkit, channelToolHandlers} from "./send-tool.ts";
+
+export const channelServerLayer = (options: {readonly name: string; readonly version: string}) =>
+	McpServer.toolkit(ChannelToolkit).pipe(
+		Layer.provide(channelToolHandlers),
+		Layer.provide(
+			McpServer.layerStdio({
+				name: options.name,
+				version: options.version,
+				experimental: channelExperimentalCapability,
+			}),
+		),
+	);


### PR DESCRIPTION
Builds the `edge/` MCP channel server on the merged patched base (#3053/#3084), the protocol contract (#3087), and the peer inbox (#3056/#3128) — the generic, role-agnostic session↔peer bridge. Footprint is entirely `src/edge/` (no root barrel touched).

## What's here

- **`channel-sink.ts`** — `ChannelSink`, the last-mile wake port; `layerFromMcpServer` emits `notifications/claude/channel` through the running `McpServer`'s notification client (the patched member, ADR 0038). The port isolates the patched-notification coupling and makes the bridge unit-testable.
- **`bridge.ts`** — `channelInboxLayer`, a `ChannelSink`-backed peer `Inbox`: every inbox `Deliver` wakes the session with the message as a structured `<channel from=… kind=…>body</channel>` tag (sender echoed in `_meta.from`), returns a delivered-to-inbox ack. Last-mile delivery only — addressing/acks stay in tracker/peer (`.patterns/mcp-channel-contract.md`).
- **`send-tool.ts`** — the `channel_send` MCP tool + the `ChannelSend` port (the peer's `send` capability); the tool routes an outbound typed message through the peer dialer (tracker lookup + dial + inbox-ack) and returns the ack; an offline role comes back as an error result, never a silent drop (#3035).
- **`server.ts`** — `channelServerLayer`, the stdio channel server advertising the `claude/channel` capability + registering the send tool.

Roles/peers are opaque params — no baked-in crew nouns; the concrete crew catalog + wiring is #3059 (out of scope), and `edge/` imports no `crew/` (boundary test).

## Acceptance criteria

- [x] Edge MCP server declares the `claude/channel` capability and loads over stdio (`server.ts`; `send-tool.test.ts` asserts the advertised capability via the real in-memory `layerHttp` harness).
- [x] An inbound peer-inbox message emits `notifications/claude/channel` waking the session, payload as a `<channel>` tag (`bridge.test.ts`; `channel-sink.test.ts` pins the emit against the patched `ServerNotificationRpcs` member).
- [x] The `channel_send` tool routes an outbound message through the peer dialer and returns the ack (`send-tool.test.ts` drives `tools/call` through the real server).
- [x] `edge/` contains no import of `crew/` (`boundary.test.ts`).

## Verification

`pnpm exec tsgo -p tsconfig.json` clean, `pnpm vitest run` 49 pass (14 edge tests), `pnpm lint:worktree` clean.

Note for review: the `mcp-channel-contract.md` worked-example line "the edge module is small on purpose: constants + payload type" predates edge/ gaining behavior in this issue — flagging as minor doc staleness, left untouched to keep footprint in `src/edge/`.

Part of #3057
Epic: #3045