### PR TITLE
chore(pipeline): un-classify pipeline-crew-mcp from §CP (reverse #3072)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,4 +42,3 @@
 # stays standalone (ADR 0092) and keeps its own owner line.
 /packages/ci-required/          @kamp-us/control-plane
 /packages/pipeline-cli/         @kamp-us/control-plane
-/packages/pipeline-crew-mcp/    @kamp-us/control-plane

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1444,7 +1444,7 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^packages/pipeline-crew-mcp/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -43,7 +43,6 @@ describe("splitTopLevelBranches", () => {
 			"claude-plugins/kampus-pipeline/hooks(/|\\.json$)",
 			"packages/ci-required/",
 			"packages/pipeline-cli/",
-			"packages/pipeline-crew-mcp/",
 		]);
 	});
 });
@@ -111,7 +110,7 @@ describe("expandBranch", () => {
 });
 
 describe("cpPaths over the live regex", () => {
-	it("resolves the full §CP path set (21 paths: dirs, the two exact files, + the **/*.sh glob)", () => {
+	it("resolves the full §CP path set (20 paths: dirs, the two exact files, + the **/*.sh glob)", () => {
 		expect(cpPaths(LIVE_RE).map((p) => p.path)).toEqual([
 			".claude/",
 			".github/",
@@ -133,7 +132,6 @@ describe("cpPaths over the live regex", () => {
 			"claude-plugins/kampus-pipeline/hooks.json",
 			"packages/ci-required/",
 			"packages/pipeline-cli/",
-			"packages/pipeline-crew-mcp/",
 		]);
 	});
 
@@ -219,7 +217,6 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/hooks.json @usirin",
 			"/packages/ci-required/ @usirin",
 			"/packages/pipeline-cli/ @usirin",
-			"/packages/pipeline-crew-mcp/ @usirin",
 		].join("\n");
 		expect(findUncovered(paths, parseCodeownersPatterns(codeowners))).toEqual([]);
 	});
@@ -250,7 +247,6 @@ describe("findUncovered — the drift check", () => {
 			"claude-plugins/kampus-pipeline/hooks/",
 			"claude-plugins/kampus-pipeline/hooks.json",
 			"packages/pipeline-cli/",
-			"packages/pipeline-crew-mcp/",
 		]);
 	});
 });

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -31,7 +31,6 @@ const FULL_CODEOWNERS = [
 	"/claude-plugins/kampus-pipeline/hooks.json @usirin",
 	"/packages/ci-required/ @usirin",
 	"/packages/pipeline-cli/ @usirin",
-	"/packages/pipeline-crew-mcp/ @usirin",
 ].join("\n");
 
 /** A throwaway repo carrying just the two source files the gate reads. */

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -29,10 +29,6 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/doctor/doctor.sh")).toBe(true);
 		// depth is irrelevant — a hypothetical helper two levels deep is §CP too (no new anchoring accident).
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/report/lib/helper.sh")).toBe(true);
-		// pipeline-crew-mcp is a new control-plane package (epic #3045); registering its path makes
-		// every crew-mcp child PR classify §CP structurally (banks at cansirin), not auto-merge (#3069).
-		expect(isControlPlane("packages/pipeline-crew-mcp/src/index.ts")).toBe(true);
-		expect(isControlPlane("packages/pipeline-crew-mcp/package.json")).toBe(true);
 	});
 
 	it("does NOT classify the four deliberately-OUT skill dirs (operational, not gate-critical)", () => {
@@ -44,6 +40,11 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 	it("does NOT classify known non-§CP paths", () => {
 		expect(isControlPlane("apps/web/src/main.tsx")).toBe(false);
 		expect(isControlPlane("packages/some-other-pkg/src/index.ts")).toBe(false);
+		// pipeline-crew-mcp is crew-coordination tooling, NOT gate machinery — declassified from §CP
+		// (#3147, reverse of #3072). Its child PRs auto-merge on the normal review gates; only the
+		// surfaces that perform/enforce merges & reviews stay §CP.
+		expect(isControlPlane("packages/pipeline-crew-mcp/src/index.ts")).toBe(false);
+		expect(isControlPlane("packages/pipeline-crew-mcp/package.json")).toBe(false);
 		// Over-broadening guard (#2950): the any-depth clause matches `.sh` LEAVES only — a
 		// NON-`.sh` file in a non-gate skill's subdir stays non-§CP, so the broadening didn't
 		// silently swallow whole non-gate skill dirs (only their shell helpers).

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -33,4 +33,4 @@
  * runtime resolution off the origin/main read.
  */
 export const CONTROL_PLANE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^packages/pipeline-crew-mcp/";
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";


### PR DESCRIPTION
Fixes #3147

Reverse of #3072 — remove `packages/pipeline-crew-mcp/` from the §CP control-plane boundary. Crew-coordination tooling (tracker/peer/edge/protocol) gates no merge and touches no approval path, so it is not gate machinery; classifying it §CP in #3072 was over-broad.

## Changes (clean reverse of #3072)
- `packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts` — drop the trailing `|^packages/pipeline-crew-mcp/` clause from the single-source `CONTROL_PLANE_RE`.
- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` — drop the same clause from the byte-in-sync `CONTROL_PLANE_RE=` prose line (const↔formats drift-check stays green).
- `.github/CODEOWNERS` — remove the `/packages/pipeline-crew-mcp/  @kamp-us/control-plane` row.
- `control-plane-paths.unit.test.ts` — crew-mcp paths (`src/index.ts`, `package.json`) now asserted **NON-§CP**.
- `codeowners-cp.unit.test.ts` — drop crew-mcp from splitTopLevelBranches, the full §CP path set (21→20), and both CODEOWNERS fixtures.
- `gate.test.ts` — drop the crew-mcp row from `FULL_CODEOWNERS`.

Genuine §CP surfaces (ci-required, pipeline-cli, .claude, .github, skills, agents, hooks) are byte-identical.

## Verification
- Classifier: `packages/pipeline-crew-mcp/**` → NON-§CP; pipeline-cli / ci-required / .claude / .github / ship-it skill → still §CP.
- Live `codeowners-cp check` → `all 20 §CP path(s) covered` (was 21).
- `pnpm --filter @kampus/pipeline-cli test` — 1335 passed (97 files). Typecheck + biome clean.

## This PR is itself §CP
It edits the classifier + `.github/CODEOWNERS` + `gh-issue-intake-formats.md`, so the live gates classify it §CP against `origin/main`'s boundary (anti-self-authorization, ADR 0100/#981). It banks at cansirin for human merge — the founder ruling gets its sign-off at merge time, not auto-shipped.