### PR TITLE
feat(flags): declare default-off profile-canvas dark-ship flag (#3103)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -66,6 +66,7 @@ import {
 	panoOptimisticPostDeleteFlag,
 	panoOptimisticSubmitFlag,
 	panoStampWaveFlag,
+	profileCanvasFlag,
 	reactionsFlag,
 	sozlukStampWaveFlag,
 	userBanFlag,
@@ -182,6 +183,11 @@ export default Alchemy.Stack(
 		// routing is unconditional): off ⇒ the worker returns the untransformed ASSETS bytes,
 		// byte-identical to today; on ⇒ `__BOOT__` injected, until a human release.
 		yield* edgeShellBootFlag(flagship.appId);
+		// The profile free-paint canvas (duvar) dark-ship flag, default-off (#3103, epic
+		// #2035) — the single seam the fate read view + visitor render, owner enable/toggle
+		// mutation, and paint/save surface gate behind until a human release, so the whole
+		// profile-canvas feature ships dark.
+		yield* profileCanvasFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -306,6 +306,16 @@ export const PHOENIX_ADMIN_CONSOLE = "phoenix-admin-console";
  */
 export const PHOENIX_EDGE_SHELL_BOOT = "phoenix-edge-shell-boot";
 
+/**
+ * Profile free-paint canvas (duvar) dark-ship flag (#3103, epic #2035). The SINGLE seam
+ * the whole profile-canvas feature gates behind — the fate read view + visitor render
+ * (#3105), the owner enable/toggle mutation (#3108), and the paint/save surface (#3109)
+ * all key off this one string rather than minting per-child flags, so one human flip
+ * releases the mural as a unit. Default-off so the feature ships dark until a human flips
+ * it at release (ADR 0083). Its own `profile-` key, scoped to the profile surface.
+ */
+export const PROFILE_CANVAS = "profile-canvas";
+
 /** A declared flag paired with its default variation — the row the flags console lists (#2742). */
 export interface FlagDeclaration {
 	readonly key: string;
@@ -348,4 +358,5 @@ export const DECLARED_FLAGS: readonly FlagDeclaration[] = [
 	{key: PHOENIX_NAV_IA, defaultValue: false},
 	{key: PHOENIX_ADMIN_CONSOLE, defaultValue: false},
 	{key: PHOENIX_EDGE_SHELL_BOOT, defaultValue: false},
+	{key: PROFILE_CANVAS, defaultValue: false},
 ];

--- a/apps/web/worker/features/flagship/profile-canvas.invariant.test.ts
+++ b/apps/web/worker/features/flagship/profile-canvas.invariant.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the profile free-paint canvas (duvar)
+ * flag (#3103, epic #2035). Inspected off the exported `PROFILE_CANVAS_FLAG` record (the
+ * same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
+ * constructed — mirrors `edge-shell-boot.invariant.test.ts` (#2928). Off ⇒ the profile is
+ * exactly as today (no canvas surface, owner-only mutations denied).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PROFILE_CANVAS} from "../../../src/flags/keys.ts";
+import {PROFILE_CANVAS_FLAG, profileCanvasFlag} from "./resources.ts";
+
+describe("profile-canvas — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(PROFILE_CANVAS_FLAG.defaultVariation, "off");
+		assert.strictEqual(PROFILE_CANVAS_FLAG.variations.off, false);
+		assert.strictEqual(PROFILE_CANVAS_FLAG.variations.on, true);
+		assert.strictEqual(PROFILE_CANVAS_FLAG.key, "profile-canvas");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(PROFILE_CANVAS_FLAG.key, PROFILE_CANVAS);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof profileCanvasFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -38,6 +38,7 @@ import {
 	PHOENIX_REACTIONS,
 	PHOENIX_SOZLUK_STAMP_WAVE,
 	PHOENIX_USER_BAN,
+	PROFILE_CANVAS,
 } from "../../../src/flags/keys.ts";
 import {AUDIT_ENVIRONMENT} from "../../environment.ts";
 
@@ -1060,3 +1061,35 @@ export const EDGE_SHELL_BOOT_FLAG = {
  */
 export const edgeShellBootFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_edge_shell_boot", {appId, ...EDGE_SHELL_BOOT_FLAG});
+
+/**
+ * The profile free-paint canvas (duvar) dark-ship flag config (#3103, epic #2035). The
+ * SINGLE seam the whole profile-canvas feature gates behind — the fate read view + visitor
+ * render (#3105), the owner enable/toggle mutation (#3108), and the paint/save surface
+ * (#3109). Default-OFF so the whole feature reaches production dark: with it off no canvas
+ * surface renders and the owner-only mutations fail `CANVAS_DISABLED`, so the profile is
+ * exactly as today; flipping it on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `EDGE_SHELL_BOOT_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           pasaport (the profile surface)
+ *   - originating:     #3103 (epic: free-paint canvas space, #2035)
+ *   - removal trigger: once the profile canvas graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline the now-permanent path.
+ */
+export const PROFILE_CANVAS_FLAG = {
+	key: PROFILE_CANVAS,
+	description:
+		"profile free-paint canvas (duvar) dark-ship (#3103, epic #2035). owner: pasaport. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const profileCanvasFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("profile_canvas", {appId, ...PROFILE_CANVAS_FLAG});


### PR DESCRIPTION
## What

Declares the default-off dark-ship flag that gates the whole profile free-paint canvas feature (epic #2035), so the user-facing children (fate read view + visitor render #3105, owner enable/toggle #3108, paint/save #3109) gate behind one shared key from the start.

- `PROFILE_CANVAS = "profile-canvas"` key constant in `apps/web/src/flags/keys.ts` (the one-home-per-key module, no alchemy/React import), added to `DECLARED_FLAGS`.
- `PROFILE_CANVAS_FLAG` plain-object config + `profileCanvasFlag` factory in `apps/web/worker/features/flagship/resources.ts`, `defaultVariation: "off"`, following the `MECMUA_WRITE` / `edge-shell-boot` precedent, with per-flag metadata (owner: pasaport, originating #3103/epic #2035, removal trigger) per `.patterns/feature-flags-schema-lifecycle.md`.
- Yielded in `apps/web/alchemy.run.ts` so the flag is provisioned on deploy.
- `profile-canvas.invariant.test.ts` asserting the IaC default is the safe (off) state (mirrors `edge-shell-boot.invariant.test.ts`).

Out of scope: any consuming UI or read (the user-facing children); this slice only declares the key + IaC.

## Acceptance criteria

- [x] `PROFILE_CANVAS` constant exists in `apps/web/src/flags/keys.ts` with a docblock and no alchemy/React import.
- [x] The flag is declared default-off in the Flagship IaC (`flagship/resources.ts`).
- [x] `pnpm typecheck` and `pnpm lint` pass.

Fixes #3103