### PR TITLE
feat(anka-ops): skeleton + scoped keychain operator credential (#3132)

### DIFF
--- a/packages/anka-ops/README.md
+++ b/packages/anka-ops/README.md
@@ -1,0 +1,68 @@
+# @kampus/anka-ops
+
+The **operator CLI for anka-built apps** — a framework-tier ops language over hidden infra
+(epic [#2089](https://github.com/kamp-us/phoenix/issues/2089), extending
+[ADR 0045](../../.decisions/0045-kampus-client-cli.md)).
+
+## What it is
+
+`anka-ops` is the single authenticated surface an operator (human or agent) uses to run
+scoped operations against the infra behind an anka-built app — the ops-language counterpart
+to the product-facing surfaces. It is a `packages/` Effect CLI per the repo's
+Node-over-Python convention (the `cf-utils` / `orphan-sweep` idiom): a pure, unit-tested core
+plus a thin `effect/unstable/cli` bin, run with `node src/bin.ts`.
+
+This package is the **framework-tier skeleton**. It ships:
+
+- the root `anka-ops` command and the verb-group extension point, and
+- the scoped, keychain-first **operator credential** every later verb group reuses.
+
+No product verb lands here. The `flag` verb group (fold cf-utils Flagship,
+[#3133](https://github.com/kamp-us/phoenix/issues/3133)) and the `report` verb group
+(generic AE-read + product-supplied catalog, [#3134](https://github.com/kamp-us/phoenix/issues/3134))
+build on this skeleton — the mechanism-vs-content seam keeps any product-specific query or
+catalog content out of this core.
+
+## The credential seam
+
+`anka-ops` rolls **no** new credential store. It reuses
+[`@kampus/cf-credentials`](../cf-credentials/README.md) — the shared macOS-Keychain
+Cloudflare-credential seam ([ADR 0045](../../.decisions/0045-kampus-client-cli.md), #1730) —
+so every CF operator CLI depends on one auth package:
+
+```bash
+node packages/anka-ops/src/bin.ts auth login    # paste a scoped operator token → OS keychain
+node packages/anka-ops/src/bin.ts auth status    # where credentials resolve from + do they authenticate
+node packages/anka-ops/src/bin.ts auth logout    # clear the stored credentials
+```
+
+Credentials resolve **keychain-first** (after `auth login`), falling back to
+`$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` — the env-var path CI keeps using,
+byte-for-byte unchanged. A missing or unauthorized credential surfaces a **typed error** on
+the Effect `E` channel, rendered by `NodeRuntime.runMain` — never a raw stack trace.
+
+## The non-TTY posture (ADR 0134)
+
+A write verb's confirmation is decided by the pure `decideConfirm` core (`src/posture.ts`):
+a **non-interactive** caller (agent/CI, no TTY) **proceeds without a prompt** and the action
+is logged for the audit record; an **interactive** human is prompted and only an affirmative
+answer proceeds. The humans-release boundary ([ADR 0083](../../.decisions/0083-agents-deploy-humans-release.md))
+lives at the audit trail, not as a structural TTY refuse — the same posture `cf-utils`
+already uses. Keeping the decision IO-free is what lets it be exhaustively unit-tested.
+
+## Shape
+
+- **`src/cli.ts`** — the root `anka-ops` command tree, the `VERB_GROUPS` registry (the single
+  extension point children B/C fold their groups into), and `AnkaOpsRuntimeLayer` (the shared
+  credential seam every verb group resolves through).
+- **`src/posture.ts`** — the pure ADR 0134 non-TTY decision core reused by write verbs.
+- **`src/bin.ts`** — the thin `effect/unstable/cli` shell: wire the command tree, provide the
+  runtime layer, run via `NodeRuntime.runMain`.
+- **`src/*.unit.test.ts`** — the pure cores' unit tests: the verb-wiring/registry-no-drift
+  contract and the non-TTY posture.
+
+## Testing
+
+```bash
+pnpm --filter @kampus/anka-ops test    # the unit tier — pure cores, no real keychain, no real CF
+```

--- a/packages/anka-ops/package.json
+++ b/packages/anka-ops/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@kampus/anka-ops",
+	"version": "0.0.0",
+	"private": true,
+	"description": "The operator CLI for anka-built apps — a framework-tier ops language over hidden infra (epic #2089, ADR 0045). This skeleton ships the scoped keychain-first operator credential every later verb group (flag, report) reuses; no product verb lands here.",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run --project unit",
+		"test:unit": "vitest run --project unit",
+		"auth": "node src/bin.ts auth"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"@kampus/cf-credentials": "workspace:*",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/anka-ops/src/bin.ts
+++ b/packages/anka-ops/src/bin.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * `anka-ops` — the operator CLI for anka-built apps (`effect/unstable/cli`, the same shell shape
+ * as `@kampus/cf-utils` / `@kampus/orphan-sweep`). The framework-tier skeleton (epic #2089,
+ * ADR 0045): only the `auth` verb group ships here.
+ *
+ *   node src/bin.ts auth login              paste a scoped operator token → OS keychain
+ *   node src/bin.ts auth status             report where credentials resolve from + whether they authenticate
+ *   node src/bin.ts auth logout             clear the stored credentials
+ *
+ * Credentials resolve keychain-first (`auth login`), falling back to $CLOUDFLARE_API_TOKEN /
+ * $CLOUDFLARE_ACCOUNT_ID — the env path CI keeps using. A missing/unauthorized credential
+ * surfaces a typed error on the `E` channel, rendered by `NodeRuntime.runMain` (never a raw
+ * stack trace). The command tree, the verb-group registry, and the credential seam live in
+ * `cli.ts`; this shell just runs them.
+ */
+import {NodeRuntime} from "@effect/platform-node";
+import {Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {AnkaOpsRuntimeLayer, ankaOps} from "./cli.ts";
+
+ankaOps.pipe(
+	Command.run({version: "0.0.0"}),
+	Effect.provide(AnkaOpsRuntimeLayer),
+	NodeRuntime.runMain,
+);

--- a/packages/anka-ops/src/cli.ts
+++ b/packages/anka-ops/src/cli.ts
@@ -1,0 +1,61 @@
+/**
+ * The `anka-ops` command tree + the shared operator-credential runtime layer.
+ *
+ * This is the framework-tier skeleton (epic #2089, ADR 0045): the root `anka-ops` command wires
+ * the `auth` verb group — reused wholesale from `@kampus/cf-credentials`, so anka-ops rolls NO
+ * second credential store — and leaves `VERB_GROUPS` as the single extension point children B
+ * (`flag`, #3133) and C (`report`, #3134) fold their groups into. No product verb lands here.
+ *
+ * The runtime layer is the credential seam every later verb group resolves through: keychain-first
+ * (`anka-ops auth login` → OS keychain), falling back to $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID
+ * for CI (the byte-for-byte-unchanged env path). A missing/unauthorized credential surfaces a typed
+ * error on the `E` channel, rendered by `NodeRuntime.runMain` in bin.ts — never a raw stack trace.
+ */
+import {NodeServices} from "@effect/platform-node";
+import {
+	AccountIdKeychainConfig,
+	auth,
+	CredentialsKeychainFirst,
+	KeychainLive,
+} from "@kampus/cf-credentials";
+import {Layer} from "effect";
+import {Command} from "effect/unstable/cli";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+/** A verb group folded under the root `anka-ops` command — the ops-language surface descriptor. */
+export interface VerbGroup {
+	readonly name: string;
+	readonly summary: string;
+}
+
+/**
+ * The registry of shipped verb groups — the single place a child extends the ops language.
+ * `auth` is the skeleton's only group today; `flag` (#3133) and `report` (#3134) append their
+ * descriptors here (and their `Command` into {@link ankaOps}'s `withSubcommands`) as they land.
+ */
+export const VERB_GROUPS: ReadonlyArray<VerbGroup> = [
+	{
+		name: "auth",
+		summary: "Persist the scoped operator credential (keychain-first) — login/status/logout",
+	},
+];
+
+/** The root command. Extension point: children B/C add their `Command` to `withSubcommands`. */
+export const ankaOps = Command.make("anka-ops").pipe(
+	Command.withSubcommands([auth]),
+	Command.withDescription(
+		"Operator CLI for anka-built apps — scoped ops over hidden infra (epic #2089, ADR 0045)",
+	),
+);
+
+// The keychain-first credential seam + its account-id ConfigProvider twin, with `KeychainLive`
+// underneath and a Node ChildProcessSpawner (for `security`) + Fetch HTTP client (for the
+// validating read) below — the SAME wiring shape cf-utils uses (ADR 0045: one shared credential).
+const CredentialLayer = Layer.mergeAll(CredentialsKeychainFirst, AccountIdKeychainConfig).pipe(
+	Layer.provideMerge(KeychainLive),
+);
+
+/** The runtime layer bin.ts provides to `anka-ops`; every verb group resolves credentials through it. */
+export const AnkaOpsRuntimeLayer = CredentialLayer.pipe(
+	Layer.provideMerge(Layer.merge(FetchHttpClient.layer, NodeServices.layer)),
+);

--- a/packages/anka-ops/src/cli.unit.test.ts
+++ b/packages/anka-ops/src/cli.unit.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Verb-wiring: the root `anka-ops` command exposes exactly the verb groups the `VERB_GROUPS`
+ * registry advertises. The load-bearing assertion is that the registry and the actual
+ * `withSubcommands` tree can't drift — when a child (B `flag` / C `report`) folds in a group it
+ * must touch both, and this test reds if it touches only one. No IO: the command tree is a
+ * pure value.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {ankaOps, VERB_GROUPS} from "./cli.ts";
+
+/** Flatten the wired subcommand names off the (group, commands) tree. */
+const wiredSubcommandNames = (): ReadonlyArray<string> =>
+	ankaOps.subcommands.flatMap((entry) => entry.commands.map((command) => command.name)).sort();
+
+describe("ankaOps command tree", () => {
+	it("is rooted at `anka-ops`", () => {
+		assert.strictEqual(ankaOps.name, "anka-ops");
+	});
+
+	it("wires the `auth` verb group (the skeleton's only shipped group)", () => {
+		assert.deepStrictEqual(wiredSubcommandNames(), ["auth"]);
+	});
+
+	it("the registry advertises exactly the wired verb groups (no drift)", () => {
+		const registered = VERB_GROUPS.map((group) => group.name).sort();
+		assert.deepStrictEqual(registered, wiredSubcommandNames());
+	});
+
+	it("every registry descriptor carries a non-empty summary", () => {
+		for (const group of VERB_GROUPS) {
+			assert.isAbove(group.summary.trim().length, 0);
+		}
+	});
+});

--- a/packages/anka-ops/src/index.ts
+++ b/packages/anka-ops/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./cli.ts";
+export * from "./posture.ts";

--- a/packages/anka-ops/src/posture.ts
+++ b/packages/anka-ops/src/posture.ts
@@ -1,0 +1,35 @@
+/**
+ * The ADR 0134 non-TTY posture as a pure decision core — the framework primitive every
+ * anka-ops write verb reuses so the humans-release boundary (ADR 0083) lives at the audit
+ * trail, not as a structural TTY refuse. A non-interactive caller (agent/CI, no TTY) PROCEEDS
+ * without a prompt (the action is logged for the audit record); an interactive human is asked
+ * to confirm and only an affirmative answer proceeds. Keeping the decision IO-free is what
+ * lets it be exhaustively unit-tested without a real terminal (mirrors cf-utils' decideLeverGuard).
+ */
+
+export interface ConfirmInput {
+	readonly isTTY: boolean;
+	/** The human's answer at the prompt; `undefined` for a non-TTY caller or an EOF/cancel. */
+	readonly confirmResponse: string | undefined;
+}
+
+export type ConfirmDecision =
+	| {readonly _tag: "Proceed"; readonly interactive: boolean}
+	| {readonly _tag: "Refuse"; readonly reason: string};
+
+const AFFIRMATIVE = new Set(["y", "yes"]);
+
+/**
+ * Decide whether a confirmation-guarded write proceeds. Non-TTY ⇒ always Proceed
+ * (`interactive: false`, the caller logs the action); TTY ⇒ Proceed only on an affirmative
+ * `y`/`yes`, else Refuse (a bare Enter, EOF, or any other answer is a decline).
+ */
+export const decideConfirm = (input: ConfirmInput): ConfirmDecision => {
+	if (!input.isTTY) {
+		return {_tag: "Proceed", interactive: false};
+	}
+	const answer = (input.confirmResponse ?? "").trim().toLowerCase();
+	return AFFIRMATIVE.has(answer)
+		? {_tag: "Proceed", interactive: true}
+		: {_tag: "Refuse", reason: "not confirmed at the interactive prompt"};
+};

--- a/packages/anka-ops/src/posture.unit.test.ts
+++ b/packages/anka-ops/src/posture.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * The ADR 0134 non-TTY posture, as a pure decision — no real terminal. Load-bearing contract:
+ * a non-interactive caller (agent/CI) ALWAYS proceeds without a prompt (the action is logged),
+ * and an interactive human proceeds only on an affirmative answer. Mirrors cf-utils'
+ * decideLeverGuard unit tests.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {decideConfirm} from "./posture.ts";
+
+describe("decideConfirm — the non-TTY posture (ADR 0134)", () => {
+	it("a non-TTY caller proceeds without a prompt (interactive: false)", () => {
+		const decision = decideConfirm({isTTY: false, confirmResponse: undefined});
+		assert.strictEqual(decision._tag, "Proceed");
+		assert.strictEqual(decision._tag === "Proceed" ? decision.interactive : null, false);
+	});
+
+	it("a non-TTY caller proceeds even if some stray response is present", () => {
+		const decision = decideConfirm({isTTY: false, confirmResponse: "n"});
+		assert.strictEqual(decision._tag, "Proceed");
+	});
+
+	for (const answer of ["y", "Y", "yes", "YES", " yes "]) {
+		it(`an interactive "${answer}" proceeds (interactive: true)`, () => {
+			const decision = decideConfirm({isTTY: true, confirmResponse: answer});
+			assert.strictEqual(decision._tag, "Proceed");
+			assert.strictEqual(decision._tag === "Proceed" ? decision.interactive : null, true);
+		});
+	}
+
+	for (const answer of ["n", "no", "", "maybe", undefined] as const) {
+		it(`an interactive ${JSON.stringify(answer)} refuses`, () => {
+			const decision = decideConfirm({isTTY: true, confirmResponse: answer});
+			assert.strictEqual(decision._tag, "Refuse");
+		});
+	}
+});

--- a/packages/anka-ops/tsconfig.json
+++ b/packages/anka-ops/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node", "@cloudflare/workers-types"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/anka-ops/vitest.config.ts
+++ b/packages/anka-ops/vitest.config.ts
@@ -1,0 +1,20 @@
+/**
+ * Vitest config — the unit tier only (ADR 0082's `unit`/`integration` split). The skeleton's
+ * pure cores (verb-group registry, the ADR 0134 non-TTY posture) are deterministic transforms
+ * with no real keychain or CF, so `*.unit.test.ts` is the whole surface today; a later verb
+ * group adds an `integration` project when a read is only-wrong-if-the-real-infra-differs.
+ */
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		projects: [
+			{
+				test: {
+					name: "unit",
+					include: ["src/**/*.unit.test.ts"],
+				},
+			},
+		],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,40 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/anka-ops:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+      '@kampus/cf-credentials':
+        specifier: workspace:*
+        version: link:../cf-credentials
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260629.1
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/audit-run:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
Fixes #3132

Phase 1 of epic #2089 — the framework-tier **anka-ops** skeleton + the scoped, keychain-first operator credential every later verb group reuses. No product verb lands here (children B #3133 `flag` / C #3134 `report` build on this).

## What this adds
- **`packages/anka-ops/`** — a new Effect `unstable/cli` package runnable via `node packages/anka-ops/src/bin.ts`, same shell shape as `cf-utils` / `orphan-sweep`. Every dep is `catalog:`/`workspace:` (catalog-guard passes) and it carries a `README.md` (readme-guard passes).
- **The credential seam** — reuses `@kampus/cf-credentials` wholesale (`CredentialsKeychainFirst` + `AccountIdKeychainConfig` + `KeychainLive` + the `auth` command): `auth login` pastes a scoped operator token into the OS keychain, `auth status` inspects it, `auth logout` clears it — keychain-first with the `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` env fallback CI uses. No second credential store (ADR 0045).
- **The extension point** — the root `anka-ops` command wires the `auth` group and exposes `VERB_GROUPS` as the single registry children B/C fold their `flag`/`report` groups into. A unit test pins the registry and the `withSubcommands` tree can't drift.
- **The ADR 0134 non-TTY posture** — `decideConfirm` (pure core): a non-interactive caller proceeds without a prompt (action logged); an interactive human is prompted where a write is involved.
- **Typed errors** ride the `E` channel, rendered by `NodeRuntime.runMain` — a missing/unauthorized credential surfaces a typed error, never a raw stack trace.

## Acceptance criteria
- [x] `packages/anka-ops/` runnable via `node packages/anka-ops/src/bin.ts`, with a `README.md`, all deps `catalog:`/`workspace:` (catalog-guard + readme-guard pass).
- [x] `auth login`/`status`/`logout` via `@kampus/cf-credentials`, `$CLOUDFLARE_API_TOKEN` env fallback preserved.
- [x] Non-TTY invocation proceeds without a prompt and logs; interactive one prompted where a write is involved (`decideConfirm`).
- [x] Missing/unauthorized credential surfaces a typed error, not a raw stack trace.
- [x] Unit tests cover the credential/verb-wiring pure cores (verb-wiring no-drift + non-TTY posture).

## Verification
- `pnpm --filter @kampus/anka-ops typecheck` — clean
- `pnpm --filter @kampus/anka-ops test` — 16 passed
- `biome check packages/anka-ops` — clean
- `pipeline-cli catalog-guard check` / `readme-guard check` — both green
- Smoke: `anka-ops --help` lists `auth`; `anka-ops auth status` resolves keychain-first and validates (no stack trace)

Out of scope: the `flag` and `report` verb groups (children B/C); any product-specific query or catalog content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)