### PR TITLE
feat(mute): user_mute presence table + Mute domain service (#3110)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0031_user_mute.sql
+++ b/apps/web/worker/db/drizzle/migrations/0031_user_mute.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `user_mute` (
+	`muter_id` text NOT NULL,
+	`muted_id` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`muter_id`, `muted_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `user_mute_muted` ON `user_mute` (`muted_id`);

--- a/apps/web/worker/db/drizzle/migrations/meta/0031_user_mute_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0031_user_mute_snapshot.json
@@ -1,0 +1,2432 @@
+{
+ "version": "6",
+ "dialect": "sqlite",
+ "id": "585e46b7-0f90-4f55-96b4-6211b4b18794",
+ "prevId": "0efe67e8-dea6-4d7c-9c75-f93a2def2212",
+ "tables": {
+  "account": {
+   "name": "account",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "account_id": {
+     "name": "account_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "provider_id": {
+     "name": "provider_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "access_token": {
+     "name": "access_token",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "refresh_token": {
+     "name": "refresh_token",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "access_token_expires_at": {
+     "name": "access_token_expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "refresh_token_expires_at": {
+     "name": "refresh_token_expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "scope": {
+     "name": "scope",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "id_token": {
+     "name": "id_token",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "password": {
+     "name": "password",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {
+    "account_user_id_user_id_fk": {
+     "name": "account_user_id_user_id_fk",
+     "tableFrom": "account",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "apiKey": {
+   "name": "apiKey",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "config_id": {
+     "name": "config_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'default'"
+    },
+    "name": {
+     "name": "name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "start": {
+     "name": "start",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "prefix": {
+     "name": "prefix",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "key": {
+     "name": "key",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "refill_interval": {
+     "name": "refill_interval",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "refill_amount": {
+     "name": "refill_amount",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "last_refill_at": {
+     "name": "last_refill_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "enabled": {
+     "name": "enabled",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": true
+    },
+    "rate_limit_enabled": {
+     "name": "rate_limit_enabled",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": false
+    },
+    "rate_limit_time_window": {
+     "name": "rate_limit_time_window",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "rate_limit_max": {
+     "name": "rate_limit_max",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "request_count": {
+     "name": "request_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "remaining": {
+     "name": "remaining",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "last_request": {
+     "name": "last_request",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "expires_at": {
+     "name": "expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "permissions": {
+     "name": "permissions",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "metadata": {
+     "name": "metadata",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {
+    "apiKey_user_id_user_id_fk": {
+     "name": "apiKey_user_id_user_id_fk",
+     "tableFrom": "apiKey",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "comment_vote": {
+   "name": "comment_vote",
+   "columns": {
+    "comment_id": {
+     "name": "comment_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "voter_id": {
+     "name": "voter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "comment_vote_comment": {
+     "name": "comment_vote_comment",
+     "columns": [
+      "comment_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "comment_vote_comment_id_voter_id_pk": {
+     "columns": [
+      "comment_id",
+      "voter_id"
+     ],
+     "name": "comment_vote_comment_id_voter_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "definition_vote": {
+   "name": "definition_vote",
+   "columns": {
+    "definition_id": {
+     "name": "definition_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "voter_id": {
+     "name": "voter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "definition_vote_definition": {
+     "name": "definition_vote_definition",
+     "columns": [
+      "definition_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "definition_vote_definition_id_voter_id_pk": {
+     "columns": [
+      "definition_id",
+      "voter_id"
+     ],
+     "name": "definition_vote_definition_id_voter_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "pano_stats": {
+   "name": "pano_stats",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "integer",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 1
+    },
+    "total_posts": {
+     "name": "total_posts",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_comments": {
+     "name": "total_comments",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_authors": {
+     "name": "total_authors",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "post_record": {
+   "name": "post_record",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "slug": {
+     "name": "slug",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "title": {
+     "name": "title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "url": {
+     "name": "url",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "host": {
+     "name": "host",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "body": {
+     "name": "body",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "body_excerpt": {
+     "name": "body_excerpt",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_name": {
+     "name": "author_name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "tags": {
+     "name": "tags",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "score": {
+     "name": "score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "comment_count": {
+     "name": "comment_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "hot_score": {
+     "name": "hot_score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "last_activity_at": {
+     "name": "last_activity_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "is_draft": {
+     "name": "is_draft",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_at": {
+     "name": "removed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_by": {
+     "name": "removed_by",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_reason": {
+     "name": "removed_reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "sandboxed_at": {
+     "name": "sandboxed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "post_record_hot": {
+     "name": "post_record_hot",
+     "columns": [
+      "hot_score"
+     ],
+     "isUnique": false
+    },
+    "post_record_new": {
+     "name": "post_record_new",
+     "columns": [
+      "created_at"
+     ],
+     "isUnique": false
+    },
+    "post_record_top": {
+     "name": "post_record_top",
+     "columns": [
+      "score"
+     ],
+     "isUnique": false
+    },
+    "post_record_discuss": {
+     "name": "post_record_discuss",
+     "columns": [
+      "comment_count"
+     ],
+     "isUnique": false
+    },
+    "post_record_host": {
+     "name": "post_record_host",
+     "columns": [
+      "host"
+     ],
+     "isUnique": false
+    },
+    "post_record_author_created": {
+     "name": "post_record_author_created",
+     "columns": [
+      "author_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    },
+    "post_record_one_draft_per_author": {
+     "name": "post_record_one_draft_per_author",
+     "columns": [
+      "author_id"
+     ],
+     "isUnique": true,
+     "where": "`is_draft` = 1"
+    },
+    "post_record_sandboxed": {
+     "name": "post_record_sandboxed",
+     "columns": [
+      "sandboxed_at"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "post_vote": {
+   "name": "post_vote",
+   "columns": {
+    "post_id": {
+     "name": "post_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "voter_id": {
+     "name": "voter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "post_vote_post": {
+     "name": "post_vote_post",
+     "columns": [
+      "post_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "post_vote_post_id_voter_id_pk": {
+     "columns": [
+      "post_id",
+      "voter_id"
+     ],
+     "name": "post_vote_post_id_voter_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "session": {
+   "name": "session",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "expires_at": {
+     "name": "expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "token": {
+     "name": "token",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "ip_address": {
+     "name": "ip_address",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "user_agent": {
+     "name": "user_agent",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "session_token_unique": {
+     "name": "session_token_unique",
+     "columns": [
+      "token"
+     ],
+     "isUnique": true
+    }
+   },
+   "foreignKeys": {
+    "session_user_id_user_id_fk": {
+     "name": "session_user_id_user_id_fk",
+     "tableFrom": "session",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "sozluk_stats": {
+   "name": "sozluk_stats",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "integer",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 1
+    },
+    "total_definitions": {
+     "name": "total_definitions",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_terms": {
+     "name": "total_terms",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_authors": {
+     "name": "total_authors",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "term_record": {
+   "name": "term_record",
+   "columns": {
+    "slug": {
+     "name": "slug",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "title": {
+     "name": "title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "first_letter": {
+     "name": "first_letter",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "definition_count": {
+     "name": "definition_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_score": {
+     "name": "total_score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "excerpt": {
+     "name": "excerpt",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "top_definition_id": {
+     "name": "top_definition_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "first_at": {
+     "name": "first_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "last_activity_at": {
+     "name": "last_activity_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "last_edit_at": {
+     "name": "last_edit_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "term_record_recent": {
+     "name": "term_record_recent",
+     "columns": [
+      "last_activity_at"
+     ],
+     "isUnique": false
+    },
+    "term_record_popular": {
+     "name": "term_record_popular",
+     "columns": [
+      "total_score"
+     ],
+     "isUnique": false
+    },
+    "term_record_letter": {
+     "name": "term_record_letter",
+     "columns": [
+      "first_letter"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user": {
+   "name": "user",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "name": {
+     "name": "name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "email": {
+     "name": "email",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "image": {
+     "name": "image",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "type": {
+     "name": "type",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'human'"
+    },
+    "role": {
+     "name": "role",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'member'"
+    },
+    "tier": {
+     "name": "tier",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'\u00e7aylak'"
+    },
+    "promoted_at": {
+     "name": "promoted_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "email_verified": {
+     "name": "email_verified",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "username": {
+     "name": "username",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "deleted_at": {
+     "name": "deleted_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_username_unique": {
+     "name": "user_username_unique",
+     "columns": [
+      "username"
+     ],
+     "isUnique": true
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_profile": {
+   "name": "user_profile",
+   "columns": {
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "username": {
+     "name": "username",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "display_name": {
+     "name": "display_name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "image": {
+     "name": "image",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "total_karma": {
+     "name": "total_karma",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "definition_count": {
+     "name": "definition_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "post_count": {
+     "name": "post_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "comment_count": {
+     "name": "comment_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_profile_username_unique": {
+     "name": "user_profile_username_unique",
+     "columns": [
+      "username"
+     ],
+     "isUnique": true
+    },
+    "user_profile_username": {
+     "name": "user_profile_username",
+     "columns": [
+      "username"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_vote": {
+   "name": "user_vote",
+   "columns": {
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_kind": {
+     "name": "target_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_id": {
+     "name": "target_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_vote_target": {
+     "name": "user_vote_target",
+     "columns": [
+      "target_kind",
+      "target_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "user_vote_user_id_target_kind_target_id_pk": {
+     "columns": [
+      "user_id",
+      "target_kind",
+      "target_id"
+     ],
+     "name": "user_vote_user_id_target_kind_target_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "verification": {
+   "name": "verification",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "identifier": {
+     "name": "identifier",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "value": {
+     "name": "value",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "expires_at": {
+     "name": "expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "content_report": {
+   "name": "content_report",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "reporter_id": {
+     "name": "reporter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_kind": {
+     "name": "target_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_id": {
+     "name": "target_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "reason": {
+     "name": "reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "status": {
+     "name": "status",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'open'"
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "resolver_id": {
+     "name": "resolver_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "resolved_at": {
+     "name": "resolved_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "resolution": {
+     "name": "resolution",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "wave_id": {
+     "name": "wave_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "content_report_target": {
+     "name": "content_report_target",
+     "columns": [
+      "target_kind",
+      "target_id"
+     ],
+     "isUnique": false
+    },
+    "content_report_wave": {
+     "name": "content_report_wave",
+     "columns": [
+      "wave_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "content_report_pk": {
+     "name": "content_report_pk",
+     "columns": [
+      "reporter_id",
+      "target_kind",
+      "target_id"
+     ]
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "post_bookmark": {
+   "name": "post_bookmark",
+   "columns": {
+    "post_id": {
+     "name": "post_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "post_bookmark_user_created": {
+     "name": "post_bookmark_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "post_bookmark_pk": {
+     "name": "post_bookmark_pk",
+     "columns": [
+      "post_id",
+      "user_id"
+     ]
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "definition_record": {
+   "name": "definition_record",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_name": {
+     "name": "author_name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "term_slug": {
+     "name": "term_slug",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "term_title": {
+     "name": "term_title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "body": {
+     "name": "body",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "body_excerpt": {
+     "name": "body_excerpt",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "score": {
+     "name": "score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "removed_at": {
+     "name": "removed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_by": {
+     "name": "removed_by",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_reason": {
+     "name": "removed_reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "sandboxed_at": {
+     "name": "sandboxed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "definition_record_author_created": {
+     "name": "definition_record_author_created",
+     "columns": [
+      "author_id",
+      "created_at"
+     ],
+     "isUnique": false
+    },
+    "definition_record_term_score": {
+     "name": "definition_record_term_score",
+     "columns": [
+      "term_slug",
+      "score"
+     ],
+     "isUnique": false
+    },
+    "definition_record_sandboxed": {
+     "name": "definition_record_sandboxed",
+     "columns": [
+      "sandboxed_at"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "comment_record": {
+   "name": "comment_record",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_name": {
+     "name": "author_name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "post_id": {
+     "name": "post_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "post_title": {
+     "name": "post_title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "parent_id": {
+     "name": "parent_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "body": {
+     "name": "body",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "body_excerpt": {
+     "name": "body_excerpt",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "score": {
+     "name": "score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "removed_at": {
+     "name": "removed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_by": {
+     "name": "removed_by",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_reason": {
+     "name": "removed_reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "sandboxed_at": {
+     "name": "sandboxed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "comment_record_author_created": {
+     "name": "comment_record_author_created",
+     "columns": [
+      "author_id",
+      "created_at"
+     ],
+     "isUnique": false
+    },
+    "comment_record_post": {
+     "name": "comment_record_post",
+     "columns": [
+      "post_id"
+     ],
+     "isUnique": false
+    },
+    "comment_record_parent": {
+     "name": "comment_record_parent",
+     "columns": [
+      "parent_id"
+     ],
+     "isUnique": false
+    },
+    "comment_record_sandboxed": {
+     "name": "comment_record_sandboxed",
+     "columns": [
+      "sandboxed_at"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "relation_tuple": {
+   "name": "relation_tuple",
+   "columns": {
+    "subject": {
+     "name": "subject",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "relation": {
+     "name": "relation",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "object": {
+     "name": "object",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "relation_tuple_object": {
+     "name": "relation_tuple_object",
+     "columns": [
+      "object",
+      "relation"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "relation_tuple_subject_relation_object_pk": {
+     "name": "relation_tuple_subject_relation_object_pk",
+     "columns": [
+      "subject",
+      "relation",
+      "object"
+     ]
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "authorship_vouch": {
+   "name": "authorship_vouch",
+   "columns": {
+    "voucher_id": {
+     "name": "voucher_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "candidate_id": {
+     "name": "candidate_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "authorship_vouch_candidate": {
+     "name": "authorship_vouch_candidate",
+     "columns": [
+      "candidate_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "authorship_vouch_voucher_id_candidate_id_pk": {
+     "name": "authorship_vouch_voucher_id_candidate_id_pk",
+     "columns": [
+      "voucher_id",
+      "candidate_id"
+     ]
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "notification": {
+   "name": "notification",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "recipient_id": {
+     "name": "recipient_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "kind": {
+     "name": "kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_kind": {
+     "name": "target_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_id": {
+     "name": "target_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "actor_id": {
+     "name": "actor_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "count": {
+     "name": "count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 1
+    },
+    "read_at": {
+     "name": "read_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "notification_recipient_read": {
+     "name": "notification_recipient_read",
+     "columns": [
+      "recipient_id",
+      "read_at"
+     ],
+     "isUnique": false
+    },
+    "notification_recipient_created": {
+     "name": "notification_recipient_created",
+     "columns": [
+      "recipient_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_reaction": {
+   "name": "user_reaction",
+   "columns": {
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_kind": {
+     "name": "target_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_id": {
+     "name": "target_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "emoji": {
+     "name": "emoji",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_reaction_target": {
+     "name": "user_reaction_target",
+     "columns": [
+      "target_kind",
+      "target_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "user_reaction_user_id_target_kind_target_id_pk": {
+     "columns": [
+      "user_id",
+      "target_kind",
+      "target_id"
+     ],
+     "name": "user_reaction_user_id_target_kind_target_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_ban_event": {
+   "name": "user_ban_event",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "action": {
+     "name": "action",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "actor_id": {
+     "name": "actor_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "reason": {
+     "name": "reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "expires_at": {
+     "name": "expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_ban_event_user_created": {
+     "name": "user_ban_event_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {
+    "user_ban_event_user_id_user_id_fk": {
+     "name": "user_ban_event_user_id_user_id_fk",
+     "tableFrom": "user_ban_event",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "mecmua_post": {
+   "name": "mecmua_post",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "title": {
+     "name": "title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "body": {
+     "name": "body",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "slug": {
+     "name": "slug",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "published_at": {
+     "name": "published_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "mecmua_post_author_created": {
+     "name": "mecmua_post_author_created",
+     "columns": [
+      "author_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "mecmua_subscription": {
+   "name": "mecmua_subscription",
+   "columns": {
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "subscriber_id": {
+     "name": "subscriber_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "mecmua_subscription_subscriber": {
+     "name": "mecmua_subscription_subscriber",
+     "columns": [
+      "subscriber_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "mecmua_subscription_subscriber_id_author_id_pk": {
+     "columns": [
+      "subscriber_id",
+      "author_id"
+     ],
+     "name": "mecmua_subscription_subscriber_id_author_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "karma_event": {
+   "name": "karma_event",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "delta": {
+     "name": "delta",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "source_kind": {
+     "name": "source_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "source_id": {
+     "name": "source_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "reason": {
+     "name": "reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "karma_event_user_created": {
+     "name": "karma_event_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {
+    "karma_event_user_id_user_id_fk": {
+     "name": "karma_event_user_id_user_id_fk",
+     "tableFrom": "karma_event",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "email_delivery_event": {
+   "name": "email_delivery_event",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "address": {
+     "name": "address",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "action": {
+     "name": "action",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "actor_id": {
+     "name": "actor_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "reason": {
+     "name": "reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "email_delivery_event_address_created": {
+     "name": "email_delivery_event_address_created",
+     "columns": [
+      "address",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    },
+    "email_delivery_event_user_created": {
+     "name": "email_delivery_event_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {
+    "email_delivery_event_user_id_user_id_fk": {
+     "name": "email_delivery_event_user_id_user_id_fk",
+     "tableFrom": "email_delivery_event",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "set null",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_mute": {
+   "name": "user_mute",
+   "columns": {
+    "muter_id": {
+     "name": "muter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "muted_id": {
+     "name": "muted_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_mute_muted": {
+     "name": "user_mute_muted",
+     "columns": [
+      "muted_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "user_mute_muter_id_muted_id_pk": {
+     "columns": [
+      "muter_id",
+      "muted_id"
+     ],
+     "name": "user_mute_muter_id_muted_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  }
+ },
+ "views": {},
+ "enums": {},
+ "_meta": {
+  "schemas": {},
+  "tables": {},
+  "columns": {}
+ },
+ "internal": {
+  "indexes": {
+   "post_record_author_created": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   },
+   "user_ban_event_user_created": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   },
+   "mecmua_post_author_created": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   },
+   "mecmua_subscription_subscriber": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   }
+  }
+ }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
 			"when": 2396000000000,
 			"tag": "0030_api_key_plugin_fields",
 			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "6",
+			"when": 2496000000000,
+			"tag": "0031_user_mute",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -377,6 +377,25 @@ export const userReaction = sqliteTable(
 );
 
 /**
+ * One-directional member mute ("sustur") presence row: a row `(muter_id,
+ * muted_id)` means muter has muted muted, its absence means not. Pure presence in
+ * the `post_bookmark` shape — no value column — but keyed on two users rather than
+ * (user, target). The composite PK `(muter_id, muted_id)` is the cardinality-one
+ * constraint; the `muted_id` reverse index serves the batched viewer-side presence
+ * read (`Mute.readMutedIds`) so read-masking stamps without an N+1. Maintained
+ * inline by `Mute.set` (insert on mute, delete on un-mute; D1-direct, see ADR 0009).
+ */
+export const userMute = sqliteTable(
+	"user_mute",
+	{
+		muterId: text("muter_id").notNull(),
+		mutedId: text("muted_id").notNull(),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(t) => [primaryKey({columns: [t.muterId, t.mutedId]}), index("user_mute_muted").on(t.mutedId)],
+);
+
+/**
  * Per-user denormalized profile row. `total_karma` is the running sum of upvotes
  * received across all of this user's contributions, maintained inline by
  * `Vote.cast`'s atomic batch (D1-direct, see ADR 0009). Its provenance — one row

--- a/apps/web/worker/features/mute/Mute.ts
+++ b/apps/web/worker/features/mute/Mute.ts
@@ -1,0 +1,137 @@
+/**
+ * Mute — member-side mute ("sustur") service. Pure presence over a one-directional
+ * `(muter, muted)` relationship, the {@link ../pano/Bookmark Bookmark} shape keyed
+ * on two users instead of (user, post): a `user_mute` row means the muter has muted
+ * the muted member, its absence means not. No value column, no karma, no fanout.
+ *
+ * `set` is idempotent (probe-then-write, like `Bookmark.toggle`): re-muting an
+ * already-muted member — or un-muting an unmuted pair — is a no-op that writes
+ * nothing and returns `changed: false`. Self-mute is rejected in the domain object:
+ * a member cannot mute themselves (`SelfMuteRejected`, checked before any read).
+ *
+ * `readMutedIds` is the batched viewer-side read that downstream read-masking stamps
+ * from without an N+1: one query over the composite PK's leading `muter_id` column
+ * returns the whole set of ids the viewer has muted. A missing viewer short-circuits
+ * to an empty set with no read.
+ *
+ * Scope: storage + domain seam only. No fate/mutation exposure, no read-masking, no
+ * UI, no *block* (mutual interaction-ban) semantics — those are siblings.
+ */
+import {and, eq} from "drizzle-orm";
+import {Context, Effect, Layer} from "effect";
+import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {UserId} from "../../lib/ids.ts";
+import {SelfMuteRejected} from "./errors.ts";
+
+export interface MuteSetInput {
+	muterId: string;
+	mutedId: string;
+	/** Presence intent: `true` mutes, `false` un-mutes (mirrors `BookmarkToggleInput.value`). */
+	value: boolean;
+}
+
+export interface MuteSetResult {
+	mutedId: string;
+	/** The muter's mute presence over `mutedId` after the write. */
+	isMuted: boolean;
+	/** `false` on an idempotent no-op (state already matched intent). */
+	changed: boolean;
+}
+
+export class Mute extends Context.Service<
+	Mute,
+	{
+		/**
+		 * Set the muter's mute presence over `mutedId` to `value`, idempotently
+		 * (probe-then-write). A matching state is a no-op (`changed: false`, no
+		 * write). Self-mute (`muterId === mutedId`) is rejected before any read.
+		 */
+		readonly set: (input: MuteSetInput) => Effect.Effect<MuteSetResult, SelfMuteRejected>;
+		/**
+		 * The full set of member ids the viewer has muted, in one read over the
+		 * `(muter_id, muted_id)` PK's leading column so read-masking stamps without
+		 * an N+1. Missing viewer short-circuits to an empty Set with no read.
+		 */
+		readonly readMutedIds: (viewerId: string | null | undefined) => Effect.Effect<Set<string>>;
+	}
+>()("@kampus/mute/Mute") {}
+
+export const MuteLive = Layer.effect(Mute)(
+	Effect.gen(function* () {
+		// `orDieAccess`: DB failures are defects (domain-boundary rule), so the
+		// public signature carries `SelfMuteRejected` only and `R` stays `never`.
+		const {run, batch} = orDieAccess(yield* Drizzle);
+
+		const readMutedIds = Effect.fn("Mute.readMutedIds")(function* (
+			viewerId: string | null | undefined,
+		) {
+			if (!viewerId) return new Set<string>();
+			const rows = yield* run((db) =>
+				db
+					.select({mutedId: schema.userMute.mutedId})
+					.from(schema.userMute)
+					.where(eq(schema.userMute.muterId, viewerId)),
+			);
+			return new Set(rows.map((r) => r.mutedId));
+		});
+
+		return {
+			readMutedIds,
+			set: Effect.fn("Mute.set")(function* (input: MuteSetInput) {
+				if (input.muterId === input.mutedId) {
+					return yield* new SelfMuteRejected({
+						memberId: UserId.make(input.muterId),
+						message: "a member cannot mute themselves",
+					});
+				}
+
+				const existing = yield* run((db) =>
+					db.query.userMute.findFirst({
+						where: {muterId: input.muterId, mutedId: input.mutedId},
+						columns: {mutedId: true},
+					}),
+				);
+				const alreadyMuted = existing != null;
+
+				if (input.value === alreadyMuted) {
+					return {
+						mutedId: input.mutedId,
+						isMuted: alreadyMuted,
+						changed: false,
+					} satisfies MuteSetResult;
+				}
+
+				yield* batch((db) =>
+					input.value
+						? ([
+								db
+									.insert(schema.userMute)
+									.values({
+										muterId: input.muterId,
+										mutedId: input.mutedId,
+										createdAt: new Date(),
+									})
+									.onConflictDoNothing(),
+							] as const)
+						: ([
+								db
+									.delete(schema.userMute)
+									.where(
+										and(
+											eq(schema.userMute.muterId, input.muterId),
+											eq(schema.userMute.mutedId, input.mutedId),
+										),
+									),
+							] as const),
+				);
+
+				return {
+					mutedId: input.mutedId,
+					isMuted: input.value,
+					changed: true,
+				} satisfies MuteSetResult;
+			}),
+		};
+	}),
+);

--- a/apps/web/worker/features/mute/Mute.unit.test.ts
+++ b/apps/web/worker/features/mute/Mute.unit.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Mute unit coverage — the decisions that are wrong-or-right with no database
+ * (ADR 0082, the `Bookmark.unit.test.ts` idiom): the `Drizzle` seam is substituted
+ * directly. A `run`/`batch` that THROWS proves a short-circuit never touched the DB;
+ * a stubbed `run` feeds the pre-write decision its inputs without an engine.
+ *
+ * Mute's real-D1 fidelity — composite-PK presence idempotency, the set/readMutedIds
+ * round-trip over real rows — lands at the integration tier once a sibling wires the
+ * fate/mutation surface this storage slice intentionally omits (there is no HTTP/fate
+ * surface yet to drive Mute black-box over).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import {Mute, MuteLive} from "./Mute.ts";
+
+// A `Drizzle` whose every call throws — any path that actually reaches the DB seam
+// fails the test. A guard that short-circuits before reading runs to completion
+// against it, which is exactly the "no read" proof.
+const throwingAccess: DrizzleAccess = {
+	run: () => Effect.die(new Error("Mute read the DB on a path that must short-circuit")),
+	batch: () => Effect.die(new Error("Mute wrote a batch on a path that must short-circuit")),
+};
+
+// A `Drizzle` whose `run` replays a queued sequence of results and whose `batch`
+// throws — drives `set`'s pre-write presence probe while proving the idempotent
+// no-op never reaches `batch`.
+function scriptedAccess(results: ReadonlyArray<unknown>): {access: DrizzleAccess; runs: number} {
+	const state = {i: 0};
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			void fn;
+			const value = results[state.i++] as A;
+			return Effect.succeed(value);
+		},
+		batch: () => Effect.die(new Error("idempotent no-op set must not reach the batch")),
+	};
+	return {
+		access,
+		get runs() {
+			return state.i;
+		},
+	};
+}
+
+const muteLayer = (access: DrizzleAccess) =>
+	MuteLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+describe("Mute.set — self-mute rejection (mocked Drizzle seam)", () => {
+	it.effect("a member muting themselves is rejected before any read", () =>
+		Effect.gen(function* () {
+			const mute = yield* Mute;
+			const exit = yield* Effect.exit(mute.set({muterId: "u1", mutedId: "u1", value: true}));
+			assert.isTrue(exit._tag === "Failure", "self-mute fails");
+			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /SelfMuteRejected/);
+		}).pipe(Effect.provide(muteLayer(throwingAccess))),
+	);
+});
+
+describe("Mute.set — pre-write idempotency (mocked Drizzle seam)", () => {
+	it.effect("re-muting an already-muted member is an idempotent no-op — no batch", () => {
+		// run #1 presence probe → already muted. The `batch` stub throws, so reaching it fails.
+		const {access} = scriptedAccess([{mutedId: "u2"}]);
+		return Effect.gen(function* () {
+			const mute = yield* Mute;
+			const result = yield* mute.set({muterId: "u1", mutedId: "u2", value: true});
+			assert.isFalse(result.changed, "matching state is a no-op");
+			assert.isTrue(result.isMuted, "already-muted → isMuted true");
+			assert.strictEqual(result.mutedId, "u2");
+		}).pipe(Effect.provide(muteLayer(access)));
+	});
+
+	it.effect("un-muting a never-muted pair is an idempotent no-op — no batch", () => {
+		// run #1 presence probe → not muted.
+		const {access} = scriptedAccess([undefined]);
+		return Effect.gen(function* () {
+			const mute = yield* Mute;
+			const result = yield* mute.set({muterId: "u1", mutedId: "u2", value: false});
+			assert.isFalse(result.changed, "matching state is a no-op");
+			assert.isFalse(result.isMuted, "never-muted → isMuted false");
+			assert.strictEqual(result.mutedId, "u2");
+		}).pipe(Effect.provide(muteLayer(access)));
+	});
+});
+
+describe("Mute.readMutedIds — no-read short-circuit + batched read (mocked Drizzle seam)", () => {
+	it.effect("null viewer → empty Set without touching the DB", () =>
+		Effect.gen(function* () {
+			const mute = yield* Mute;
+			const muted = yield* mute.readMutedIds(null);
+			assert.strictEqual(muted.size, 0);
+		}).pipe(Effect.provide(muteLayer(throwingAccess))),
+	);
+
+	it.effect("undefined viewer → empty Set without touching the DB", () =>
+		Effect.gen(function* () {
+			const mute = yield* Mute;
+			const muted = yield* mute.readMutedIds(undefined);
+			assert.strictEqual(muted.size, 0);
+		}).pipe(Effect.provide(muteLayer(throwingAccess))),
+	);
+
+	it.effect("a viewer's muted ids come back as a Set from one batched read", () => {
+		// a single read returns the whole muted set for the viewer (keyed on muter_id).
+		const {access, runs} = ((): {access: DrizzleAccess; runs: () => number} => {
+			const state = {i: 0};
+			return {
+				access: {
+					run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+						void fn;
+						state.i++;
+						return Effect.succeed([{mutedId: "u2"}, {mutedId: "u3"}] as A);
+					},
+					batch: () => Effect.die(new Error("readMutedIds must not batch")),
+				},
+				runs: () => state.i,
+			};
+		})();
+		return Effect.gen(function* () {
+			const mute = yield* Mute;
+			const muted = yield* mute.readMutedIds("u1");
+			assert.strictEqual(muted.size, 2);
+			assert.isTrue(muted.has("u2") && muted.has("u3"));
+			assert.strictEqual(runs(), 1, "exactly one batched read, no N+1");
+		}).pipe(Effect.provide(muteLayer(access)));
+	});
+});

--- a/apps/web/worker/features/mute/errors.ts
+++ b/apps/web/worker/features/mute/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Tagged errors raised by the Mute service layer.
+ *
+ * `SelfMuteRejected` is the domain object refusing an invalid state — a member
+ * muting themselves — at the write boundary (make-invalid-states-unrepresentable).
+ * It carries no `FateWireCode`: a consuming service translates it at its own
+ * boundary when the mutation surface lands (a sibling of this storage slice), so
+ * the domain never asserts a wire code it doesn't yet have a wire for.
+ */
+import * as Schema from "effect/Schema";
+import {UserId} from "../../lib/ids.ts";
+
+export class SelfMuteRejected extends Schema.TaggedErrorClass<SelfMuteRejected>()(
+	"mute/SelfMuteRejected",
+	{
+		memberId: UserId,
+		message: Schema.String,
+	},
+) {}


### PR DESCRIPTION
Fixes #3110

## What

The storage + domain core of the member-side mute ("sustur") primitive: a one-directional `(muter, muted)` presence relationship on the pure-presence precedent of `post_bookmark` / `user_vote`, maintained D1-direct inline (ADR 0009).

- **`user_mute` table** — composite PK `(muter_id, muted_id)` (presence = muted, absence = not) plus a `muted_id` reverse index for the batched presence read. Generated migration `0031_user_mute` + snapshot + journal entry.
- **`Mute` domain service** (`apps/web/worker/features/mute/`, structured like `Bookmark`):
  - `set` — idempotent probe-then-write: re-muting an already-muted member, or un-muting an unmuted pair, writes nothing and returns `changed: false`.
  - `readMutedIds(viewerId)` — the viewer's full muted-id set in one read over the PK's leading `muter_id` column (no N+1); a missing viewer short-circuits to an empty set with no read.
  - Self-mute guard in the domain object (`SelfMuteRejected`, checked before any read) — make-invalid-states-unrepresentable.
- **Unit tests** (`Mute.unit.test.ts`) cover toggle idempotency, self-mute rejection, and the batched read against a mocked `Drizzle` seam (the `Bookmark.unit.test.ts` idiom, ADR 0082).

## Scope

Storage + domain seam only. Out of scope (siblings / decision child): fate/mutation exposure, read-masking, UI, and *block* (mutual interaction-ban) semantics.

## Acceptance criteria

- [x] `user_mute` table with composite PK `(muter_id, muted_id)` + `muted_id` reverse index + generated migration.
- [x] `Mute.set` idempotent: re-muting returns `changed: false` and writes nothing; un-muting an unmuted pair is a no-op.
- [x] Self-mute rejected in the domain object.
- [x] `Mute.readMutedIds(viewerId)` single batched read; missing/empty viewer short-circuits to an empty set with no read.
- [x] Unit tests cover toggle idempotency, self-mute rejection, and the batched read.

Local `pnpm typecheck`, `pnpm lint`, and the `Mute.unit.test.ts` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)