### PR TITLE
fix(integration): honor configured 180s deploy-hook ceiling + sub-ceiling readiness budget (#3146)

### DIFF
--- a/apps/web/tests/integration/_edge-ready.ts
+++ b/apps/web/tests/integration/_edge-ready.ts
@@ -40,6 +40,21 @@ export class CloudflarePlaceholder404Error extends Error {
 export const isCloudflarePlaceholder404Error = (e: unknown): e is CloudflarePlaceholder404Error =>
 	e instanceof CloudflarePlaceholder404Error;
 
+// The typed diagnostic the DEPLOY-time health gate (`awaitWorkerReady`) throws when a freshly-deployed
+// worker never serves a healthy `/api/health` within its readiness budget — a NAMED failure (not a bare
+// `Error`, not the opaque vitest "Hook timed out in 120000ms") so the eviction cause is greppable in CI.
+// Sized below the hook ceiling, this fires BEFORE the `beforeAll` guillotine, turning a nondeterministic
+// hook timeout that ejected clean product PRs from the merge queue into a deterministic diagnostic (#3146).
+export class WorkerNotReadyError extends Error {
+	readonly _tag = "WorkerNotReady";
+	constructor(url: string, detail: string) {
+		super(
+			`worker never served a healthy /api/health within the readiness window for ${url}: ${detail}`,
+		);
+		this.name = "WorkerNotReadyError";
+	}
+}
+
 // The generous cold-start budget the readiness poll defaults to. A cold dedicated stage's first
 // open can take many seconds to clear edge propagation + a cold DO / cold D1 replica; ~60s of
 // polls is generous enough to ride that out, and only delays — never hangs (the poll returns the
@@ -47,16 +62,32 @@ export const isCloudflarePlaceholder404Error = (e: unknown): e is CloudflarePlac
 export const EDGE_READY_DEADLINE_MS = 60_000;
 export const EDGE_READY_POLL_MS = 1_500;
 
-// The raised budget the DEPLOY-time worker-health gate (`awaitWorkerReady`) rides, distinct from the
-// per-probe `EDGE_READY_DEADLINE_MS` above. Under concurrent-stage batch load on the one shared
-// Cloudflare account, a fresh `*.workers.dev` /api/health route's edge propagation routinely overruns
-// the 60s per-probe budget — the module-top `beforeAll(deploy…)` then throws and fails the WHOLE
-// suite to load (#3080, #3075 Signature-A). vitest test-`retry` can't re-run a failed `beforeAll`, so
-// a bigger SINGLE budget — not a redeploy retry, which two deploy+readiness attempts couldn't fit —
-// is the lever. Doubled to 120s: it stays inside the integration `hookTimeout` (180s,
-// `vitest.config.ts`) with room for the deploy + trailing non-fatal warms, and never hangs (the poll
-// returns on the deadline), so a genuinely dead worker still fails fast within the bound.
+// The vitest `beforeAll` HOOK ceiling for the integration deploy hook — single-sourced here and
+// mirrored by `vitest.config.ts`'s `hookTimeout`. Load-bearing (#3146): alchemy `Test.make`'s
+// `beforeAll(eff, opts)` passes `timeoutOf(opts) ?? DEFAULT_TIMEOUT (120_000)` as vitest's EXPLICIT
+// per-hook timeout, and an explicit second arg to `vitest.beforeAll(fn, timeout)` OVERRIDES
+// `config.hookTimeout`. So a `beforeAll(deploy…)` registered with no opts is silently clamped to
+// alchemy's 120_000 and the configured 180s `hookTimeout` never applies — the #3085 mitigation was
+// sized against a 180s ceiling that never existed. Grounded in the active pin: alchemy@2.0.0-beta.59
+// `lib/Test/Vitest.js:7,70-72` (`timeoutOf` reads `.timeout`; `beforeAll` passes `?? DEFAULT_TIMEOUT`)
+// and `@vitest/runner@4.1.5` `beforeAll(fn, timeout = config.hookTimeout)`. `integrationStack` threads
+// `{timeout: HOOK_TIMEOUT_MS}` to UNDO that dependency-default override — restoring the already-declared
+// ceiling, NOT raising a working one.
+export const HOOK_TIMEOUT_MS = 180_000;
+
+// The DEPLOY-time worker-health readiness budget for the SHARED-stage (`_global-setup`) path —
+// UNCHANGED (no shared-path regression). The shared stage deploys once per run (low concurrency), is
+// not vitest-hook-bound (it runs in `globalSetup`, not a `beforeAll`), and was never the timeout, so it
+// keeps its generous single budget (#3080). The per-file, hook-bound path uses the smaller budget below.
 export const DEPLOY_HEALTH_DEADLINE_MS = 120_000;
+
+// The per-file readiness budget for the hook-bound `integrationStack` deploy `beforeAll` (#3146).
+// Sized STRICTLY BELOW `HOOK_TIMEOUT_MS` with headroom for the deploy-before (~40-60s under
+// concurrent-stage batch load) + the trailing non-fatal warms, so the poll GRACEFULLY bounded-returns
+// a typed `WorkerNotReadyError` diagnostic WELL before the vitest hook fires — a deterministic, named
+// failure instead of the opaque "Hook timed out" guillotine that evicted clean product PRs from the
+// merge queue: deploy(≤60) + readiness(100) = 160 < 180, so the typed throw wins the race every time.
+export const PER_FILE_HEALTH_DEADLINE_MS = 100_000;
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 

--- a/apps/web/tests/integration/_edge-ready.unit.test.ts
+++ b/apps/web/tests/integration/_edge-ready.unit.test.ts
@@ -24,10 +24,11 @@ import {
 	edgeFetch,
 	isCloudflarePlaceholder404,
 	isCloudflarePlaceholder404Error,
+	WorkerNotReadyError,
 } from "./_edge-ready.ts";
 import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
 import {harness} from "./_harness.ts";
-import {awaitAuthRouteReady} from "./_integration.ts";
+import {awaitAuthRouteReady, awaitWorkerReady} from "./_integration.ts";
 
 // A tiny budget so the tests drive the readiness logic in milliseconds, not the real 60s.
 const BUDGET = {deadlineMs: 120, pollMs: 5} as const;
@@ -187,6 +188,36 @@ describe("awaitAuthRouteReady — the bootstrap auth-route propagation gate (#24
 			Effect.runPromise(awaitAuthRouteReady("https://stage.example.workers.dev")),
 		).resolves.toBeUndefined();
 		expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+	});
+});
+
+// The DEPLOY-time worker-health gate turns a worker that never serves healthy JSON within its
+// readiness budget into a TYPED, greppable `WorkerNotReadyError` — and, sized below the hook ceiling
+// (`PER_FILE_HEALTH_DEADLINE_MS`), that throw fires before the vitest `beforeAll` guillotine so the
+// eviction cause is a named diagnostic, not the opaque "Hook timed out in 120000ms" (#3146).
+describe("awaitWorkerReady — typed readiness diagnostic (#3146)", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it("WorkerNotReadyError carries the url + detail in a named, greppable message", () => {
+		const e = new WorkerNotReadyError("https://stage.example.workers.dev", "last status 503");
+		expect(e).toBeInstanceOf(Error);
+		expect(e.name).toBe("WorkerNotReadyError");
+		expect(e._tag).toBe("WorkerNotReady");
+		expect(e.message).toContain("https://stage.example.workers.dev");
+		expect(e.message).toContain("last status 503");
+	});
+
+	it("a worker that never serves healthy JSON within the budget throws the typed diagnostic (not a bare Error, not a hook timeout)", async () => {
+		// A 200 whose body is never `{status:"ok"}` rides the readiness budget and never goes ready;
+		// on deadline `awaitEdgeReady` returns the last (still-not-ready) response, and the gate throws.
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(JSON.stringify({status: "warming"}), {status: 200})),
+		);
+		// A tiny per-call budget drives the exhaustion in milliseconds, not the real 100s.
+		await expect(
+			Effect.runPromise(awaitWorkerReady("https://stage.example.workers.dev", 40)),
+		).rejects.toThrow(/worker never served a healthy \/api\/health within the readiness window/);
 	});
 });
 

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -35,7 +35,14 @@ import * as Schedule from "effect/Schedule";
 import {inject} from "vitest";
 import Stack from "../../alchemy.run.ts";
 import {isTransientDeployError} from "./_deploy-transient.ts";
-import {awaitEdgeReady, DEPLOY_HEALTH_DEADLINE_MS, edgeFetch} from "./_edge-ready.ts";
+import {
+	awaitEdgeReady,
+	DEPLOY_HEALTH_DEADLINE_MS,
+	edgeFetch,
+	HOOK_TIMEOUT_MS,
+	PER_FILE_HEALTH_DEADLINE_MS,
+	WorkerNotReadyError,
+} from "./_edge-ready.ts";
 import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
 import {type Harness, harness} from "./_harness.ts";
 import {slugify, stageName} from "./_stage-name.ts";
@@ -304,24 +311,27 @@ export const deployTransientRetry = Effect.retry({
  * healthy JSON within the bound (60 × 2s) DIES with a clear message rather than hanging —
  * `Effect.promise` turns the thrown exhaustion error into a defect, the same hard failure the
  * retired `Effect.die` produced. ONE copy for both deploy paths (the per-file `integrationStack`
- * and the shared-stage `_global-setup.ts`).
- *
- * Rides the raised `DEPLOY_HEALTH_DEADLINE_MS` (see its rationale, #3080), not the 60s per-probe
- * default — the concurrent-stage load that overran 60s and died this `beforeAll` is why.
+ * and the shared-stage `_global-setup.ts`), each passing its OWN readiness budget: the shared path
+ * takes the default `DEPLOY_HEALTH_DEADLINE_MS`, the hook-bound per-file path passes the smaller
+ * `PER_FILE_HEALTH_DEADLINE_MS` so the typed throw beats the vitest hook ceiling (#3146; #3080).
  */
-export const awaitWorkerReady = (url: string): Effect.Effect<void, never, never> =>
+export const awaitWorkerReady = (
+	url: string,
+	deadlineMs: number = DEPLOY_HEALTH_DEADLINE_MS,
+): Effect.Effect<void, never, never> =>
 	Effect.promise(async () => {
 		const res = await awaitEdgeReady(() => edgeFetch(`${url}/api/health`), healthReady, {
 			pollMs: WARM_POLL_MS,
-			deadlineMs: DEPLOY_HEALTH_DEADLINE_MS,
+			deadlineMs,
 		});
 		// `awaitEdgeReady` returns the last response even when it never went ready (the #1060
-		// no-early-stop guarantee), so a worker that never served healthy JSON must be turned into
-		// a hard, clear failure here — the throw becomes an `Effect.promise` defect (die).
+		// no-early-stop guarantee), so a worker that never served healthy JSON must be turned into a
+		// hard, clear failure here — the throw becomes an `Effect.promise` defect (die). Thrown TYPED
+		// (`WorkerNotReadyError`, not a bare `Error`) so the diagnostic is greppable, and — with the
+		// per-file `deadlineMs` sized below the hook ceiling — it fires BEFORE the `beforeAll`
+		// guillotine rather than surfacing as the opaque "Hook timed out in 120000ms" (#3146).
 		if (!(await healthReady(res))) {
-			throw new Error(
-				`worker never served a healthy /api/health within the readiness window for ${url}: last status ${res.status}`,
-			);
+			throw new WorkerNotReadyError(url, `last status ${res.status}`);
 		}
 	});
 
@@ -400,12 +410,19 @@ export function integrationStack(metaUrl: string): Harness {
 						return yield* Effect.die(new Error("deploy returned no D1 databaseId"));
 					}
 					d1Target = {accountId: resolved.accountId, databaseId: resolved.databaseId};
-					yield* awaitWorkerReady(url);
+					// Per-file, hook-bound readiness budget (`PER_FILE_HEALTH_DEADLINE_MS`), sized
+					// below the restored hook ceiling so a slow/stuck edge fails as a typed diagnostic
+					// BEFORE the vitest guillotine — never the opaque "Hook timed out" (#3146).
+					yield* awaitWorkerReady(url, PER_FILE_HEALTH_DEADLINE_MS);
 					yield* warmLiveDO(url);
 					yield* warmFateRead(url);
 				}),
 			),
 		),
+		// Undo alchemy `Test.make`'s silent clamp of the deploy hook to its `DEFAULT_TIMEOUT` (120s):
+		// thread the already-configured `hookTimeout` so the hook honors 180s (see `HOOK_TIMEOUT_MS`).
+		// NOT a raised ceiling — a restored one; the readiness budget above stays well under it (#3146).
+		{timeout: HOOK_TIMEOUT_MS},
 	);
 
 	// Force vitest to await the deploy hook even though the harness reads the URL

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -22,6 +22,11 @@
  */
 import react from "@vitejs/plugin-react";
 import {defineConfig} from "vitest/config";
+// Single-source the integration hook ceiling (#3146). The value declared here is DEAD for every
+// `Test.make`-registered hook — alchemy passes an explicit per-hook timeout that overrides
+// `config.hookTimeout` (see `HOOK_TIMEOUT_MS`), so `integrationStack` must ALSO thread it. Importing
+// it here keeps the config and the threaded value provably equal (the module is import-side-effect free).
+import {HOOK_TIMEOUT_MS} from "./tests/integration/_edge-ready.ts";
 
 export default defineConfig({
 	// The `client` project below renders `*.test.tsx` through React's JSX runtime,
@@ -105,7 +110,10 @@ export default defineConfig({
 					// `seedTerm` on retry, so the dedup hazard above doesn't apply. Reversible;
 					// drops when #3075's durable ci.yml worker-relevance filter lands.
 					testTimeout: 120_000,
-					hookTimeout: 180_000,
+					// Silently overridden for `Test.make` hooks by alchemy's explicit per-hook timeout
+					// (`integrationStack` threads `{timeout: HOOK_TIMEOUT_MS}` to honor it); kept here,
+					// single-sourced, for any non-alchemy hook + to document the real ceiling (#3146).
+					hookTimeout: HOOK_TIMEOUT_MS,
 					pool: "forks",
 					// `isolate: false` shares one parsed JS module graph across the files
 					// that run in the same fork, so the phoenix worker barrel chain


### PR DESCRIPTION
Fixes #3146

## Pinned true limiter (source-verified)

The `Hook timed out in 120000ms` is **not** any of the three candidates as framed. It is the vitest `beforeAll` hook timeout set to **alchemy `Test.make`'s hardcoded `DEFAULT_TIMEOUT = 120_000`**, which silently overrides the project's configured `hookTimeout: 180_000`:

- `integrationStack()` (`_integration.ts`) registers the deploy hook via `beforeAll(deploy(...))` with **no second (timeout) arg**.
- Active pin `alchemy@2.0.0-beta.59` `lib/Test/Vitest.js:7,70-72`: `timeoutOf = (opts) => typeof opts === "number" ? opts : opts?.timeout`, and `beforeAll = (eff, opts) => vitestBeforeAll(fn, timeoutOf(opts) ?? DEFAULT_TIMEOUT)` with `DEFAULT_TIMEOUT = 120_000` → alchemy passes an **explicit** `120000`.
- `@vitest/runner@4.1.5` `chunk-artifact.js:668`: `function beforeAll(fn, timeout = getDefaultHookTimeout())` where the default is `config.hookTimeout`. An explicit second arg is used verbatim — so it **overrides** `config.hookTimeout: 180_000`.

Consequence: the configured 180s `hookTimeout` never applied to any `Test.make` hook. The #3085 comment sized `DEPLOY_HEALTH_DEADLINE_MS = 120_000` to "stay inside the 180s hookTimeout with room" — that headroom never existed; the readiness budget *equalled* the whole hook with zero room for the deploy-before + warms-after, so it guillotined at exactly 120000ms and ejected clean product PRs (`removed_from_merge_queue`, e.g. #3098).

## The fix (2 parts, confined to the integration harness — NON-§CP)

**Part 1 — config-override defect (the enabler).** `integrationStack` now threads `{timeout: HOOK_TIMEOUT_MS}` (180_000) through alchemy's `beforeAll`, so the hook honors its already-declared ceiling. This is **not** a raised wall-clock — it undoes a dependency-default override of an already-configured value. Single-sourced with `vitest.config.ts` (both import `HOOK_TIMEOUT_MS`), so the config and the threaded value can't drift.

**Part 2 — deterministic readiness gate (the real hardening).** The hook-bound per-file path now uses `PER_FILE_HEALTH_DEADLINE_MS = 100_000`, **strictly below** the 180s ceiling with headroom for deploy (≤60s under batch load) + trailing warms: `deploy(≤60) + readiness(100) = 160 < 180`. So a slow/stuck edge makes the poll **gracefully bounded-return a typed `WorkerNotReadyError`** *before* the vitest guillotine — a deterministic, named diagnostic instead of the opaque un-retryable "Hook timed out". The shared-stage budget (`DEPLOY_HEALTH_DEADLINE_MS = 120_000`, `_global-setup`) is **unchanged** — no shared-path regression (it isn't hook-bound and was never the timeout).

**Not** the redeploy-retry direction the triage floated: no source supports "a convergent redeploy makes CF edge propagation faster", and shortening the poll to fire an early redeploy could regress slow-but-ready routes (grounding-in-source rule). The determinism here comes from restored headroom + a clean typed failure, not an unsourced platform bet.

## One honest correction on the mechanism

A `beforeAll` failure — typed or not — is a suite-setup failure that vitest does **not** re-run via the file's `describe(..., {retry:2})` (per the in-repo #3085 finding: "vitest test-`retry` can't re-run a failed `beforeAll`"). So the win is (a) the restored 180s gives deploy+readiness real room to *succeed*, and (b) genuine failures surface as a clean typed diagnostic — **not** that `retry:2` catches it. Making readiness test-retryable would require moving it out of `beforeAll` into the harness client's first-request path (touches `_harness.ts`, out of this issue's confined scope) — noted as a possible follow-up.

## Files
- `apps/web/tests/integration/_edge-ready.ts` — `HOOK_TIMEOUT_MS`, `PER_FILE_HEALTH_DEADLINE_MS`, typed `WorkerNotReadyError`; `DEPLOY_HEALTH_DEADLINE_MS` unchanged.
- `apps/web/tests/integration/_integration.ts` — thread the hook timeout; `awaitWorkerReady(url, deadlineMs)` throws the typed error; per-file path passes the sub-ceiling budget.
- `apps/web/vitest.config.ts` — `hookTimeout` single-sourced from `HOOK_TIMEOUT_MS` + documents the clamp trap.
- `apps/web/tests/integration/_edge-ready.unit.test.ts` — 2 new tests for the typed diagnostic.

## Verification
- `pnpm typecheck` green (32/32). `pnpm lint` exit 0 (79 warnings = pre-existing baseline; no new `Effect.promise`). `_edge-ready.unit.test.ts` 27/27 (incl. the 2 new). Pre-push ran typecheck + full unit suite green.

## Follow-up (separate from this PR)
The root trap — alchemy@2.0.0-beta.59 `Test.make` hardcoding `DEFAULT_TIMEOUT=120_000` and ignoring `config.hookTimeout` — is a `pnpm patch` (ADR 0038) / upstream-fix candidate, to be filed via report→triage.
