### PR TITLE
feat(pipeline-crew-mcp): crew/ — Role enum + catalog + wiring (5-role flat-topology composition root) (#3059)

### DIFF
--- a/packages/pipeline-crew-mcp/README.md
+++ b/packages/pipeline-crew-mcp/README.md
@@ -1,8 +1,9 @@
 # @kampus/pipeline-crew-mcp
 
 The crew's channels-backed messaging substrate — the peer-to-peer transport the pipeline
-crew (EM, triage, coder, reviewer, shipper) talk over, exposed to each agent as MCP
-channels (epic #3045).
+crew talk over, exposed to each agent as MCP channels (epic #3045). The crew is a flat
+topology of five standing roles: `ea-chief-of-staff`, `engineering-manager`, `triage-guy`,
+`junior-engineer`, `cartographer` (the canonical agent-type slugs).
 
 ## What it is
 
@@ -12,8 +13,12 @@ A small, layered substrate split into a **generic core** and one **crew-coupled*
 - **`src/tracker/`** — the rendezvous registry where peers announce and discover each other.
 - **`src/peer/`** — a p2p participant: dials, holds connections, relays messages over the protocol.
 - **`src/edge/`** — the MCP channel edge: exposes the substrate to an MCP client as channels.
-- **`src/crew/`** — the only crew-coupled module: the Role catalog and the wiring that binds
-  the generic substrate to concrete crew roles.
+- **`src/crew/`** — the only crew-coupled module and the composition root: the Role enum
+  (the five-role flat topology, a single swap-in roster seam), the seam catalog (each role's
+  crew interactions mapped over `protocol/` — claim/collision-check, role-uniqueness lease,
+  epic handoff, drain tally, intake ping, discovery/presence), and the wiring that composes
+  tracker + peer + edge into a per-role channel server (enforcing the role-uniqueness lease
+  the generic peer does not).
 
 **The load-bearing boundary:** `protocol/`, `tracker/`, `peer/`, and `edge/` are the reusable
 channels substrate and never import `crew/`; `crew/` depends inward on the generic core, never
@@ -30,8 +35,10 @@ a bespoke relay. It is internal pipeline tooling, on no kamp.us user surface.
 
 ## Status
 
-Scaffold only (issue #3052): the package shape, the module skeleton, and a thin Effect bin.
-No seam behavior is wired yet — each module is filled by its own child of epic #3045.
+The generic substrate (`protocol`/`tracker`/`peer`/`edge`) and the `crew/` composition root
+(Role enum + catalog + wiring) are landed. The runnable stdio entry that binds a live crew
+session's MCP server to the composition — and the retirement of the tmux relay convention —
+is the cutover (#3062), sequenced after this. The `bin` remains scaffold-only until then.
 
 ## Usage
 

--- a/packages/pipeline-crew-mcp/src/crew/boundary.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/boundary.test.ts
@@ -1,0 +1,32 @@
+/**
+ * The one-way boundary (AC 4): the generic substrate never imports the crew composition root.
+ * `protocol/`, `tracker/`, `peer/`, and `edge/` are the reusable channels substrate and must
+ * contain no import of `crew/`; only `crew/` imports them. Each generic module carries its own
+ * mirror of this guard — this test asserts the whole boundary from the crew side, so the
+ * disjointness is a checked fact, not a convention.
+ */
+import {readdirSync, readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+
+const GENERIC_MODULES = ["protocol", "tracker", "peer", "edge"] as const;
+
+describe("crew/ composition-root boundary", () => {
+	it("no generic module source imports from crew/", () => {
+		const srcDir = fileURLToPath(new URL("..", import.meta.url));
+		let scanned = 0;
+		for (const mod of GENERIC_MODULES) {
+			const dir = new URL(`../${mod}/`, import.meta.url);
+			const files = readdirSync(fileURLToPath(dir)).filter(
+				(f) => f.endsWith(".ts") && !f.endsWith(".test.ts"),
+			);
+			assert.isAbove(files.length, 0, `expected ${mod}/ source files to scan`);
+			for (const file of files) {
+				scanned += 1;
+				const body = readFileSync(new URL(file, dir), "utf8");
+				assert.isFalse(/from\s+["'][^"']*crew/.test(body), `${mod}/${file} imports from crew/`);
+			}
+		}
+		assert.isAbove(scanned, 0, `expected generic sources under ${srcDir} to scan`);
+	});
+});

--- a/packages/pipeline-crew-mcp/src/crew/catalog.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/catalog.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The crew catalog (AC 1): a total map from each standing role to its seams over `protocol/`,
+ * covering the six required crew interactions, with the two `Claim`-based seams named apart.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {ALL_SEAMS, CrewCatalogGroup, CrewSeams, crewCatalog} from "./catalog.ts";
+import {CREW_ROLES} from "./roles.ts";
+
+describe("crew/catalog — roles mapped to seams over protocol/", () => {
+	it("maps every standing role (a total map, no missing entry)", () => {
+		for (const role of CREW_ROLES) {
+			const entry = crewCatalog.get(role);
+			assert.isDefined(entry);
+			assert.strictEqual(entry?.role, role);
+			assert.deepStrictEqual([...(entry?.seams ?? [])], [...ALL_SEAMS]);
+		}
+		assert.strictEqual(crewCatalog.size, CREW_ROLES.length);
+	});
+
+	it("names the six required crew seams over the protocol kinds", () => {
+		// claim/collision-check, role-uniqueness lease, epic handoff, drain tally, intake ping,
+		// role discovery/presence (announce + lookup) — the seams the ticket enumerates.
+		for (const seam of [
+			"claimCollisionCheck",
+			"roleUniquenessLease",
+			"epicHandoff",
+			"drainTally",
+			"intakePing",
+			"announcePresence",
+			"lookupRole",
+		] as const) {
+			assert.isDefined(CrewSeams[seam]);
+		}
+	});
+
+	it("names the two distinct crew uses of the one Claim kind apart", () => {
+		// both ride Claim on the wire (resource vs role), so the catalog distinguishes them.
+		assert.strictEqual(CrewSeams.claimCollisionCheck, CrewSeams.roleUniquenessLease);
+	});
+
+	it("exposes the crew catalog group as the full protocol catalog", () => {
+		assert.deepStrictEqual([...CrewCatalogGroup.requests.keys()].sort(), [
+			"AckInbox",
+			"AnnouncePresence",
+			"Claim",
+			"DrainProgress",
+			"EpicHandoff",
+			"Heartbeat",
+			"IntakePing",
+			"LookupRole",
+		]);
+	});
+});

--- a/packages/pipeline-crew-mcp/src/crew/catalog.ts
+++ b/packages/pipeline-crew-mcp/src/crew/catalog.ts
@@ -1,0 +1,62 @@
+/**
+ * crew/catalog — where the abstract protocol message kinds (`../protocol/`) become the
+ * concrete crew seams, and each role is mapped to the seams it is a party to.
+ *
+ * The value-add over the raw protocol: the two distinct crew uses of the one `Claim` kind
+ * are named apart — `claimCollisionCheck` (an agent claiming an issue before picking it up)
+ * and `roleUniquenessLease` (a session claiming its ROLE so only one holds it) both ride
+ * `Claim` on the wire, keyed by resource vs role respectively. Flat topology: every role is
+ * a party to every seam, so the catalog is a total map over `CREW_ROLES` — swap the roster
+ * and the catalog follows, no per-role special-casing to update.
+ */
+import {
+	AckInbox,
+	AnnouncePresence,
+	Claim,
+	CrewProtocol,
+	DrainProgress,
+	EpicHandoff,
+	Heartbeat,
+	IntakePing,
+	LookupRole,
+} from "../protocol/index.ts";
+import {CREW_ROLES, type CrewRole} from "./roles.ts";
+
+/**
+ * The named crew seams, each mapped to the protocol `Rpc` it rides. `claimCollisionCheck`
+ * and `roleUniquenessLease` deliberately share `Claim` — same wire kind, two crew meanings.
+ */
+export const CrewSeams = {
+	claimCollisionCheck: Claim,
+	roleUniquenessLease: Claim,
+	epicHandoff: EpicHandoff,
+	drainTally: DrainProgress,
+	intakePing: IntakePing,
+	announcePresence: AnnouncePresence,
+	lookupRole: LookupRole,
+	heartbeat: Heartbeat,
+	inboxAck: AckInbox,
+} as const;
+
+export type CrewSeamName = keyof typeof CrewSeams;
+
+/** Every named crew seam — the seam set every role is a party to under the flat topology. */
+export const ALL_SEAMS = Object.keys(CrewSeams) as ReadonlyArray<CrewSeamName>;
+
+/** The `RpcGroup` a crew peer speaks — the full protocol catalog the crew composes over. */
+export const CrewCatalogGroup = CrewProtocol;
+
+export interface CrewCatalogEntry {
+	readonly role: CrewRole;
+	/** The crew seams this role is a party to (flat topology ⇒ all of them). */
+	readonly seams: ReadonlyArray<CrewSeamName>;
+}
+
+/** The catalog: a total map from each standing role to the seams it participates in. */
+export const crewCatalog: ReadonlyMap<CrewRole, CrewCatalogEntry> = new Map(
+	CREW_ROLES.map((role): readonly [CrewRole, CrewCatalogEntry] => [role, {role, seams: ALL_SEAMS}]),
+);
+
+/** The seams a role is a party to — total over the roster (never a missing entry). */
+export const seamsFor = (role: CrewRole): ReadonlyArray<CrewSeamName> =>
+	crewCatalog.get(role)?.seams ?? ALL_SEAMS;

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The composition root end to end (ACs 2 + 3), driven fully in-memory: an `RpcTest` client of
+ * the real `TrackerRegistry` (backed by `RegistryLive`) IS the crew tracker, so every announce /
+ * discover / claim / role-lease runs through the real registry semantics — no socket opened.
+ *
+ *   - AC 2: two roles stand up (tracker + peer + edge composed), announce, discover each other,
+ *     and exchange a claim/collision-check with a typed reply; a peer-to-peer intake ping wakes
+ *     the receiver's edge channel sink and returns its inbox-ack (peer + edge in the loop).
+ *   - AC 3: the role-uniqueness lease rejects a second live session for a held role, across all
+ *     five standing roles.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Option, Ref} from "effect";
+import {RpcTest} from "effect/unstable/rpc";
+import {ChannelSink, channelInboxLayer} from "../edge/index.ts";
+import {
+	type Connect,
+	Dialer,
+	Inbox,
+	inboxHandlers,
+	PeerInbox,
+	PeerUnreachableError,
+} from "../peer/index.ts";
+import {TrackerRegistry} from "../tracker/group.ts";
+import {TrackerHandlers} from "../tracker/handlers.ts";
+import {RegistryLive} from "../tracker/registry.ts";
+import {makeCrewChannel} from "./channel-server.ts";
+import {RoleUniquenessError} from "./errors.ts";
+import {CREW_ROLES} from "./roles.ts";
+import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
+
+const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+
+// A dialer that always fails — used where the peer-to-peer send is not the thing under test.
+const alwaysUnreachable = Dialer.layerFromConnect((address) =>
+	Effect.fail(new PeerUnreachableError({target: address, reason: "no route"})),
+);
+
+// The per-channel substrate over a shared CrewTracker: the peer Tracker port + a local inbox +
+// a dialer. Sharing the tracker layer keeps every channel on ONE registry (so they discover
+// each other); the inbox/dialer vary per channel identity.
+const channelLayers = (
+	tracker: Layer.Layer<CrewTracker>,
+	address: string,
+	dialer: Layer.Layer<Dialer>,
+) =>
+	Layer.mergeAll(
+		tracker,
+		peerTrackerLayer.pipe(Layer.provide(tracker)),
+		Inbox.layer(address),
+		dialer,
+	);
+
+describe("crew/channel-server — announce, discover, claim/collision-check (AC 2)", () => {
+	it.effect("two roles announce, discover each other, and exchange a typed claim reply", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const tracker = CrewTracker.fromClient(client);
+			const [roleA, roleB] = [CREW_ROLES[0], CREW_ROLES[1]];
+
+			const a = yield* makeCrewChannel({role: roleA, address: "inbox://a"}).pipe(
+				Effect.provide(channelLayers(tracker, "inbox://a", alwaysUnreachable)),
+			);
+			const b = yield* makeCrewChannel({role: roleB, address: "inbox://b"}).pipe(
+				Effect.provide(channelLayers(tracker, "inbox://b", alwaysUnreachable)),
+			);
+
+			// discover each other across the flat topology
+			const aFindsB = yield* a.discover(roleB);
+			const bFindsA = yield* b.discover(roleA);
+			assert.isTrue(Option.isSome(aFindsB));
+			assert.strictEqual(Option.getOrThrow(aFindsB).address, "inbox://b");
+			assert.isTrue(Option.isSome(bFindsA));
+			assert.strictEqual(Option.getOrThrow(bFindsA).address, "inbox://a");
+
+			// a synchronous claim/collision-check with a typed reply: A grants, B collides
+			const granted = yield* a.claim("issue-3059");
+			assert.isTrue(granted.granted);
+			assert.isFalse(granted.collision);
+			assert.strictEqual(granted.owner, "inbox://a");
+
+			const collided = yield* b.claim("issue-3059");
+			assert.isFalse(collided.granted);
+			assert.isTrue(collided.collision);
+			assert.strictEqual(collided.owner, "inbox://a", "the incumbent keeps the resource");
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect("an intake ping reaches the receiver's edge channel + returns its inbox-ack", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const tracker = CrewTracker.fromClient(client);
+			const [roleA, roleB] = [CREW_ROLES[0], CREW_ROLES[1]];
+
+			// The receiver's edge: a channel-bridging inbox whose ChannelSink records each wake,
+			// proving the peer→edge last-mile fires. Reachable as an in-memory PeerInbox client.
+			const wakes = yield* Ref.make<ReadonlyArray<unknown>>([]);
+			const recordingSink = Layer.succeed(ChannelSink, {
+				wake: (payload) => Ref.update(wakes, (xs) => [...xs, payload]),
+			});
+			const bInbox = yield* RpcTest.makeClient(PeerInbox).pipe(
+				Effect.provide(
+					Layer.provideMerge(
+						inboxHandlers,
+						channelInboxLayer("inbox://b").pipe(Layer.provide(recordingSink)),
+					),
+				),
+			);
+			const connect: Connect = (address) =>
+				address === "inbox://b"
+					? Effect.succeed(bInbox)
+					: Effect.fail(new PeerUnreachableError({target: address, reason: "no route"}));
+
+			// announce B directly on the registry (it is a bare inbox here, not a full channel),
+			// then stand up A as a full channel that dials B.
+			yield* client.AnnouncePresence({
+				peer: "inbox://b",
+				role: roleB,
+				at: new Date().toISOString(),
+			});
+			const a = yield* makeCrewChannel({role: roleA, address: "inbox://a"}).pipe(
+				Effect.provide(channelLayers(tracker, "inbox://a", Dialer.layerFromConnect(connect))),
+			);
+
+			const ack = yield* a.peer.send(roleB, "IntakePing", {issue: "3059", from: roleA});
+			assert.strictEqual(ack.by, "inbox://b", "acked by B's inbox ⇒ it went straight to B");
+			const recorded = yield* Ref.get(wakes);
+			assert.lengthOf(recorded, 1);
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+});
+
+describe("crew/channel-server — role-uniqueness lease (AC 3)", () => {
+	it.effect("a second live session for a held role is rejected, across all five roles", () =>
+		Effect.gen(function* () {
+			for (const role of CREW_ROLES) {
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				const tracker = CrewTracker.fromClient(client);
+
+				// first session for the role acquires the lease
+				const first = yield* makeCrewChannel({role, address: `inbox://${role}-1`}).pipe(
+					Effect.provide(channelLayers(tracker, `inbox://${role}-1`, alwaysUnreachable)),
+				);
+				assert.strictEqual(first.role, role);
+
+				// a second session (a DIFFERENT peer) for the same held role is rejected, not shared
+				const rejection = yield* makeCrewChannel({role, address: `inbox://${role}-2`}).pipe(
+					Effect.provide(channelLayers(tracker, `inbox://${role}-2`, alwaysUnreachable)),
+					Effect.flip,
+				);
+				assert.instanceOf(rejection, RoleUniquenessError);
+				assert.strictEqual(rejection.role, role);
+				assert.strictEqual(rejection.heldBy, `inbox://${role}-1`);
+			}
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect(
+		"all five distinct roles hold their leases simultaneously (uniqueness is per role)",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				const tracker = CrewTracker.fromClient(client);
+				for (const role of CREW_ROLES) {
+					const channel = yield* makeCrewChannel({role, address: `inbox://${role}`}).pipe(
+						Effect.provide(channelLayers(tracker, `inbox://${role}`, alwaysUnreachable)),
+					);
+					assert.strictEqual(channel.role, role);
+				}
+				// every role is independently discoverable — five distinct leases coexist
+				for (const role of CREW_ROLES) {
+					const result = yield* client.LookupRole({role});
+					assert.lengthOf(result.peers, 1, `${role} should be present`);
+				}
+			}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.ts
@@ -1,0 +1,138 @@
+/**
+ * crew/channel-server — the wiring: compose the generic substrate (tracker + peer + edge)
+ * into a per-role channel server for one crew role. This is the composition root the whole
+ * package builds toward — `crew/` imports the generic modules; they never import back (the
+ * one-way boundary in `../index.ts`).
+ *
+ * The shape is transport-injected on purpose: `makeCrewChannel` needs only the abstract seams
+ * (`CrewTracker`, the peer `Inbox`/`Dialer`/`Tracker` ports) in context, so the tests drive it
+ * fully in-memory (`RpcTest` client + an in-memory connect) while production supplies the socket
+ * bindings below. The one crew-specific rule the wiring enforces that the generic peer does not:
+ * the role-uniqueness lease — a session claims its ROLE up front, and a second live session for a
+ * held role is rejected (`RoleUniquenessError`), never allowed to co-occupy it.
+ *
+ * The runnable stdio entry (the edge MCP server + `ChannelSink.layerFromMcpServer` + the send
+ * tool's `ChannelSend` bound to this session's peer) is assembled by the bin/cutover (#3062,
+ * out of scope here); this module lands the composition + the socket transport bindings it needs.
+ */
+import {createHash} from "node:crypto";
+import {NodeSocket, NodeSocketServer} from "@effect/platform-node";
+import {Effect, Layer, type Option} from "effect";
+import {RpcClient, RpcSerialization, RpcServer} from "effect/unstable/rpc";
+import {type ChannelSink, channelInboxLayer} from "../edge/index.ts";
+import {
+	Dialer,
+	inboxHandlers,
+	make as makePeer,
+	type Peer,
+	PeerInbox,
+	PeerUnreachableError,
+	type RolePresence,
+} from "../peer/index.ts";
+import {RoleUniquenessError} from "./errors.ts";
+import type {CrewRole} from "./roles.ts";
+import {type ClaimReply, CrewTracker} from "./tracker.ts";
+
+export interface CrewChannelConfig {
+	readonly role: CrewRole;
+	/** This session's dialable inbox address; the crew binds peer-id ≡ inbox-address. */
+	readonly address: string;
+}
+
+export interface CrewChannel {
+	readonly role: CrewRole;
+	readonly address: string;
+	/** The composed peer: its inbox (`received`) + its direct peer-to-peer `send`. */
+	readonly peer: Peer;
+	/** Role discovery: the live holder of `role` across the flat topology, or `None`. */
+	readonly discover: (role: CrewRole) => Effect.Effect<Option.Option<RolePresence>>;
+	/** A claim/collision-check on a resource (e.g. an issue) — the typed granted/collision reply. */
+	readonly claim: (resource: string) => Effect.Effect<ClaimReply>;
+}
+
+/**
+ * Stand up a crew channel for one role: acquire the role-uniqueness lease, then compose the
+ * peer (which announces its presence for the connection lifetime). Requires the substrate
+ * seams — `CrewTracker`, the peer `Tracker`/`Inbox`/`Dialer` ports — in context.
+ *
+ * The role-uniqueness lease is the one crew-specific rule the generic peer does not enforce:
+ * a session claims its ROLE and is REJECTED (not co-occupied) when a different live session
+ * already holds it. A resource collision is a value; a role collision is a rejection — that
+ * asymmetry is the whole point of the lease (see `./errors.ts`).
+ */
+export const makeCrewChannel = Effect.fn("crew.makeCrewChannel")(function* (
+	config: CrewChannelConfig,
+) {
+	const tracker = yield* CrewTracker;
+	const lease = yield* tracker.claim({
+		resource: config.role,
+		claimant: config.address,
+		role: config.role,
+	});
+	if (lease.collision) {
+		return yield* new RoleUniquenessError({role: config.role, heldBy: lease.owner});
+	}
+	const peer = yield* makePeer({
+		self: config.address,
+		role: config.role,
+		address: config.address,
+	});
+	return {
+		role: config.role,
+		address: config.address,
+		peer,
+		discover: (role: CrewRole) => tracker.lookup(role),
+		claim: (resource: string) =>
+			tracker.claim({resource, claimant: config.address, role: config.role}),
+	} satisfies CrewChannel;
+});
+
+/** A per-address unix socket path for a peer inbox — deterministic, collision-free, short. */
+export const inboxSocketPathFor = (address: string): string => {
+	const digest = createHash("sha256").update(address).digest("hex").slice(0, 16);
+	return `/tmp/kampus-crew-inbox-${digest}.sock`;
+};
+
+/**
+ * The real socket `Dialer`: dial a target peer's inbox socket, `Deliver`, ack — all inside one
+ * scope so the connection lives across the delivery, then closes. Every unreachable path (bad
+ * socket, decode error) collapses to `PeerUnreachableError`, never a silent drop (#3035).
+ */
+export const crewSocketDialerLayer: Layer.Layer<Dialer> = Layer.succeed(Dialer, {
+	send: (address, envelope) =>
+		Effect.scoped(
+			RpcClient.make(PeerInbox).pipe(
+				Effect.flatMap((client) => client.Deliver(envelope)),
+				Effect.provide(
+					RpcClient.layerProtocolSocket().pipe(
+						Layer.provide([
+							NodeSocket.layerNet({path: inboxSocketPathFor(address)}),
+							RpcSerialization.layerNdjson,
+						]),
+					),
+				),
+			),
+		).pipe(
+			Effect.mapError(
+				(cause) => new PeerUnreachableError({target: address, reason: String(cause)}),
+			),
+		),
+});
+
+/**
+ * The peer-inbox `RpcServer` over a unix socket at `address`, serving `PeerInbox` with the
+ * channel-bridging inbox (`edge`) so each delivery wakes the session — mirrors the tracker's
+ * socket server. Requires a `ChannelSink` (the edge's last-mile wake port).
+ */
+export const inboxServerSocketLayer = (address: string): Layer.Layer<never, unknown, ChannelSink> =>
+	RpcServer.layer(PeerInbox).pipe(
+		Layer.provide(inboxHandlers.pipe(Layer.provide(channelInboxLayer(address)))),
+		Layer.provide(
+			RpcServer.layerProtocolSocketServer.pipe(
+				Layer.provide([
+					RpcSerialization.layerNdjson,
+					NodeSocketServer.layer({path: inboxSocketPathFor(address)}),
+				]),
+			),
+		),
+	);

--- a/packages/pipeline-crew-mcp/src/crew/errors.ts
+++ b/packages/pipeline-crew-mcp/src/crew/errors.ts
@@ -1,0 +1,17 @@
+/**
+ * crew/errors — the typed failures the crew composition root raises. The one non-obvious
+ * thing: a role-uniqueness collision is a REJECTION (a typed error), not a value — a second
+ * live session for a held role must not silently co-occupy it, so the wiring fails loudly.
+ * A resource claim/collision-check, by contrast, answers with a value (`ClaimReply`), never
+ * this error — that collision is a normal answer, not a rejection.
+ */
+import {Schema} from "effect";
+
+/** A second live session tried to hold a role another session already holds — rejected, not shared. */
+export class RoleUniquenessError extends Schema.TaggedErrorClass<RoleUniquenessError>()(
+	"@kampus/pipeline-crew-mcp/crew/RoleUniquenessError",
+	{
+		role: Schema.String,
+		heldBy: Schema.String,
+	},
+) {}

--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -1,6 +1,32 @@
 /**
- * crew/ — the only crew-coupled module: the Role catalog and the wiring that binds the
- * generic substrate to concrete crew roles. Depends inward on protocol/tracker/peer/edge;
- * the generic core never depends back on it (see the boundary note in `../index.ts`).
+ * crew/ — the only crew-coupled module: the Role enum, the seam catalog, and the wiring that
+ * binds the generic substrate (`protocol`/`tracker`/`peer`/`edge`) to the concrete crew
+ * topology. Depends inward on the generic modules; the generic core never depends back on it
+ * (the one-way boundary in `../index.ts`, guarded by `./boundary.test.ts`).
  */
-export {};
+export {
+	ALL_SEAMS,
+	type CrewCatalogEntry,
+	CrewCatalogGroup,
+	type CrewSeamName,
+	CrewSeams,
+	crewCatalog,
+	seamsFor,
+} from "./catalog.ts";
+export {
+	type CrewChannel,
+	type CrewChannelConfig,
+	crewSocketDialerLayer,
+	inboxServerSocketLayer,
+	inboxSocketPathFor,
+	makeCrewChannel,
+} from "./channel-server.ts";
+export {RoleUniquenessError} from "./errors.ts";
+export {CREW_ROLES, CrewRole, isCrewRole} from "./roles.ts";
+export {
+	type ClaimReply,
+	CrewTracker,
+	crewTrackerSocketLayer,
+	peerTrackerLayer,
+	type TrackerRegistryClient,
+} from "./tracker.ts";

--- a/packages/pipeline-crew-mcp/src/crew/roles.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/roles.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The Role enum (AC 1): the five standing crew roles, the canonical agent-type slugs, and
+ * that the enum decode-checks a role (accepts a member, rejects a non-role). The roster is a
+ * single seam — this test pins the confirmed set so a stale/short list can't slip through.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Schema} from "effect";
+import {CREW_ROLES, CrewRole, isCrewRole} from "./roles.ts";
+
+describe("crew/roles — the five standing roles", () => {
+	it("is exactly the confirmed five-role roster", () => {
+		assert.deepStrictEqual(
+			[...CREW_ROLES],
+			["ea-chief-of-staff", "engineering-manager", "triage-guy", "junior-engineer", "cartographer"],
+		);
+	});
+
+	it("has five distinct roles (no duplicate slug)", () => {
+		assert.strictEqual(new Set(CREW_ROLES).size, 5);
+	});
+
+	it("decodes a member and rejects a non-role", () => {
+		for (const role of CREW_ROLES) {
+			assert.strictEqual(Schema.decodeUnknownSync(CrewRole)(role), role);
+			assert.isTrue(isCrewRole(role));
+		}
+		assert.isFalse(isCrewRole("reviewer"));
+		assert.isFalse(isCrewRole("builder"));
+	});
+});

--- a/packages/pipeline-crew-mcp/src/crew/roles.ts
+++ b/packages/pipeline-crew-mcp/src/crew/roles.ts
@@ -1,0 +1,30 @@
+/**
+ * crew/roles — the crew's flat-topology Role enum: the ONE place the concrete role roster
+ * is named, so the catalog, the wiring, and the tests reference `CrewRole` / `CREW_ROLES`
+ * and never a role string literal. The roster below is the single swap-in seam — nothing
+ * else in `crew/` hardcodes a role, so the set can change without reworking anything.
+ *
+ * The roster is a founder ruling (five standing roles, not four); the slugs are the repo's
+ * canonical agent-type identifiers, so a crew role maps 1:1 to the agent-type that fills it.
+ */
+import {Schema} from "effect";
+
+/**
+ * The five standing crew roles, canonical agent-type slugs. Flat topology: every role is a
+ * symmetric peer on the substrate — any role may claim, hand off, tally, ping, and discover
+ * any other. This tuple is the roster seam; see the module note.
+ */
+export const CREW_ROLES = [
+	"ea-chief-of-staff",
+	"engineering-manager",
+	"triage-guy",
+	"junior-engineer",
+	"cartographer",
+] as const;
+
+/** The Role enum as an `effect/Schema` literal union — decode-checks a role at the wire boundary. */
+export const CrewRole = Schema.Literals(CREW_ROLES);
+export type CrewRole = typeof CrewRole.Type;
+
+/** A total refinement: is `value` one of the standing crew roles? */
+export const isCrewRole = Schema.is(CrewRole);

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -1,0 +1,109 @@
+/**
+ * crew/tracker — the crew's live tracker seam: the `CrewTracker` service that speaks the
+ * control-plane registry (`../tracker/`) over an `RpcClient(TrackerRegistry)`, and the
+ * `peerTrackerLayer` that derives the generic `peer/Tracker` port from it so `Peer.make`
+ * can announce + look up without knowing the transport.
+ *
+ * Two design choices worth stating once:
+ *   - A tracker transport failure is unrecoverable for a session, so the registry client's
+ *     transport errors are collapsed with `Effect.orDie` — the service's own error channel
+ *     stays clean (only a resource collision, which is a VALUE in `ClaimReply`, crosses it).
+ *   - The crew binds peer-id ≡ inbox-address: the registry stores one `peer` field per
+ *     presence, so the announced `peer` IS the dialable inbox address, and a lookup recovers
+ *     that address back out (matching the `inbox://…` convention the tracker socket test uses).
+ */
+import {NodeSocket} from "@effect/platform-node";
+import {Context, Effect, Layer, Option, type Scope} from "effect";
+import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
+import {type RolePresence, Tracker} from "../peer/index.ts";
+import type * as Schema from "../protocol/schema.ts";
+import {TrackerRegistry} from "../tracker/index.ts";
+
+/** The typed answer to a claim/collision-check — re-exported so consumers name one type. */
+export type ClaimReply = typeof Schema.ClaimReply.Type;
+type ClaimRequest = typeof Schema.ClaimRequest.Type;
+type PresenceAnnouncement = typeof Schema.PresenceAnnouncement.Type;
+type RoleLookupQuery = typeof Schema.RoleLookupQuery.Type;
+type RoleLookupResult = typeof Schema.RoleLookupResult.Type;
+
+/**
+ * The structural shape of the registry client the crew depends on — the three registry
+ * kinds it drives. Any `RpcClient(TrackerRegistry)` satisfies it (the real socket client,
+ * or an in-memory `RpcTest` client in tests); the error channel is `unknown` because it is
+ * `orDie`'d at the seam.
+ */
+export interface TrackerRegistryClient {
+	readonly Claim: (payload: ClaimRequest) => Effect.Effect<ClaimReply, unknown>;
+	readonly AnnouncePresence: (payload: PresenceAnnouncement) => Effect.Effect<void, unknown>;
+	readonly LookupRole: (payload: RoleLookupQuery) => Effect.Effect<RoleLookupResult, unknown>;
+}
+
+const now = (): string => new Date().toISOString();
+
+export class CrewTracker extends Context.Service<
+	CrewTracker,
+	{
+		/** A named claim/collision-check: granted vs collision is a VALUE in the reply, never a failure. */
+		readonly claim: (input: {
+			readonly resource: string;
+			readonly claimant: string;
+			readonly role: string;
+		}) => Effect.Effect<ClaimReply>;
+		/** Soft presence announce, held for the enclosing scope (connection-is-lease). */
+		readonly announce: (presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>;
+		/** The live holder of `role`, or `None` when absent/expired — the explicit not-present result. */
+		readonly lookup: (role: string) => Effect.Effect<Option.Option<RolePresence>>;
+	}
+>()("@kampus/pipeline-crew-mcp/crew/CrewTracker") {
+	/** Build the service from a live registry client (real socket or in-memory `RpcTest`). */
+	static readonly fromClient = (client: TrackerRegistryClient): Layer.Layer<CrewTracker> =>
+		Layer.succeed(CrewTracker, {
+			claim: ({resource, claimant, role}) =>
+				client.Claim({resource, claimant, role, at: now()}).pipe(Effect.orDie),
+			announce: (presence) =>
+				Effect.acquireRelease(
+					// peer-id ≡ inbox-address: announce the dialable address so a lookup can dial it back.
+					client
+						.AnnouncePresence({peer: presence.address, role: presence.role, at: now()})
+						.pipe(Effect.orDie),
+					// The release rides the socket lifecycle (a dropped connection ages/frees the lease);
+					// there is no wire release kind, so scope close is a no-op on the client side.
+					() => Effect.void,
+				),
+			lookup: (role) =>
+				client.LookupRole({role}).pipe(
+					Effect.orDie,
+					Effect.map((result) => {
+						const first = result.peers[0];
+						return first
+							? Option.some<RolePresence>({role: first.role, peer: first.peer, address: first.peer})
+							: Option.none<RolePresence>();
+					}),
+				),
+		});
+}
+
+/** The generic `peer/Tracker` port, derived from `CrewTracker` — what `Peer.make` consumes. */
+export const peerTrackerLayer: Layer.Layer<Tracker, never, CrewTracker> = Layer.effect(
+	Tracker,
+	Effect.gen(function* () {
+		const tracker = yield* CrewTracker;
+		return {announce: tracker.announce, lookup: tracker.lookup};
+	}),
+);
+
+/** The registry client's socket protocol for `socketPath` — the per-project tracker rendezvous. */
+const trackerClientSocketProtocol = (socketPath: string) =>
+	RpcClient.layerProtocolSocket().pipe(
+		Layer.provide([NodeSocket.layerNet({path: socketPath}), RpcSerialization.layerNdjson]),
+	);
+
+/**
+ * A socket-backed `CrewTracker` for the tracker at `socketPath` — the production binding a
+ * runnable crew session uses (the in-memory tests supply `CrewTracker.fromClient` with an
+ * `RpcTest` client instead).
+ */
+export const crewTrackerSocketLayer = (socketPath: string) =>
+	Layer.unwrap(RpcClient.make(TrackerRegistry).pipe(Effect.map(CrewTracker.fromClient))).pipe(
+		Layer.provide(trackerClientSocketProtocol(socketPath)),
+	);


### PR DESCRIPTION
Fixes #3059

The **composition root** of the crew-mcp spine (epic #3045, P5): `crew/` imports the generic substrate (`protocol`/`tracker`/`peer`/`edge`) and binds it to the concrete crew topology; the generic core never imports back.

## Roster (founder ruling, umut)
The `4-role` wording in the ticket is **superseded** — the enum is exactly the **five standing roles** (canonical agent-type slugs): `ea-chief-of-staff`, `engineering-manager`, `triage-guy`, `junior-engineer`, `cartographer`. The roster is a single swap-in seam (`crew/roles.ts`); nothing else hardcodes a role, so #3062's cutover inherits the same five.

## What landed (`src/crew/`)
- **`roles.ts`** — the `CrewRole` enum: the five-role flat topology as one `Schema.Literals` union; the sole place the roster is named.
- **`catalog.ts`** — each role's crew seams mapped over `protocol/`; the two `Claim`-based seams (`claimCollisionCheck`, `roleUniquenessLease`) are named apart (same wire kind, keyed by resource vs role). A total map over the roster.
- **`tracker.ts`** — `CrewTracker` over an `RpcClient(TrackerRegistry)` (transport errors `orDie`'d; a resource collision stays a value) + the derived `peer/Tracker` port + a socket binding.
- **`channel-server.ts`** — `makeCrewChannel` composes tracker + peer + edge into a per-role channel server, enforcing the **role-uniqueness lease** the generic peer does not (a second live session for a held role is *rejected* with `RoleUniquenessError`, never co-occupied). Transport-injected, plus the real socket dialer + peer-inbox server bindings.
- **`errors.ts`** — `RoleUniquenessError` (a role collision is a rejection, not a value).

## Acceptance criteria → test coverage
- **AC1** (Role enum + catalog mapping roles→seams over `protocol/`): `roles.test.ts` (pins the exact five slugs, decode-checks), `catalog.test.ts` (total map over the roster, the six named seams, the two Claim seams named apart, the group = full protocol catalog).
- **AC2** (per-role server composes tracker+peer+edge; two roles announce, discover each other, exchange a claim/collision-check with a typed reply): `channel-server.test.ts` › *"two roles announce, discover each other, and exchange a typed claim reply"* + *"an intake ping reaches the receiver's edge channel + returns its inbox-ack"* (peer→edge last-mile via a recording `ChannelSink`).
- **AC3** (role-uniqueness lease enforced; a second session for a held role rejected): `channel-server.test.ts` › *"a second live session for a held role is rejected, across all five roles"* + *"all five distinct roles hold their leases simultaneously"*.
- **AC4** (generic modules contain no import of `crew/`; only `crew/` imports them): `boundary.test.ts` scans `protocol`/`tracker`/`peer`/`edge` for any `crew` import (verified by grep: none; `crew/` imports all four).

## Verification
`pnpm -C packages/pipeline-crew-mcp typecheck` clean · `biome check` clean · 61 tests pass (12 new crew tests) · deps unchanged (all `catalog:`) · README updated.

## Out of scope
The runnable stdio entry (edge MCP server + `ChannelSink.layerFromMcpServer` + the send tool's `ChannelSend` bound to the live peer) and the tmux-relay retirement are the **cutover (#3062)**, sequenced after this. The root `src/index.ts` barrel is intentionally untouched to keep #3062 disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)