### PR TITLE
feat(anka-ops): flag verb group — fold cf-utils Flagship (get/open/close/graduate)

### DIFF
--- a/packages/anka-ops/README.md
+++ b/packages/anka-ops/README.md
@@ -12,16 +12,16 @@ to the product-facing surfaces. It is a `packages/` Effect CLI per the repo's
 Node-over-Python convention (the `cf-utils` / `orphan-sweep` idiom): a pure, unit-tested core
 plus a thin `effect/unstable/cli` bin, run with `node src/bin.ts`.
 
-This package is the **framework-tier skeleton**. It ships:
+This package ships:
 
-- the root `anka-ops` command and the verb-group extension point, and
-- the scoped, keychain-first **operator credential** every later verb group reuses.
+- the root `anka-ops` command and the verb-group extension point,
+- the scoped, keychain-first **operator credential** every verb group reuses, and
+- the `flag` verb group ([#3133](https://github.com/kamp-us/phoenix/issues/3133)) — the
+  domain-language surface over Flagship, folding the `@kampus/cf-utils` core (see below).
 
-No product verb lands here. The `flag` verb group (fold cf-utils Flagship,
-[#3133](https://github.com/kamp-us/phoenix/issues/3133)) and the `report` verb group
-(generic AE-read + product-supplied catalog, [#3134](https://github.com/kamp-us/phoenix/issues/3134))
-build on this skeleton — the mechanism-vs-content seam keeps any product-specific query or
-catalog content out of this core.
+The `report` verb group (generic AE-read + product-supplied catalog,
+[#3134](https://github.com/kamp-us/phoenix/issues/3134)) builds on this skeleton next — the
+mechanism-vs-content seam keeps any product-specific query or catalog content out of this core.
 
 ## The credential seam
 
@@ -41,6 +41,31 @@ Credentials resolve **keychain-first** (after `auth login`), falling back to
 byte-for-byte unchanged. A missing or unauthorized credential surfaces a **typed error** on
 the Effect `E` channel, rendered by `NodeRuntime.runMain` — never a raw stack trace.
 
+## The `flag` verb group — fold cf-utils Flagship
+
+`anka-ops flag` is the operator-language surface over Flagship. It **folds** the
+[`@kampus/cf-utils`](../cf-utils/README.md) pure core (`flag.ts`'s no-match-split math +
+renderers, `flagship.ts`'s read/write clients, #1726) rather than re-implementing it — the only
+new logic is the operator-verb → cf-utils-lever mapping in `src/flag.ts`, fully unit-tested.
+
+```bash
+node packages/anka-ops/src/bin.ts flag get <key> [--env <env>]   # read a flag's live serving state
+node packages/anka-ops/src/bin.ts flag open <key> --env <env>    # release on (≡ cf-utils set on: 100% no-match split)
+node packages/anka-ops/src/bin.ts flag close <key> --env <env>   # kill (clear the split + default off)
+node packages/anka-ops/src/bin.ts flag graduate <key>            # verify fully open in prod, file the retirement chore
+```
+
+- **`open`** maps onto the cf-utils lever `set on` — the 100% no-match percentage split, never a
+  `defaultVariation` flip. **`close`** maps onto `set off` — the true kill switch (clear the split
+  *and* set the default off).
+- **`open`/`close` dry-run by default**; the live flip happens only under `--execute`. A non-TTY
+  caller proceeds (logged for the audit record), a TTY human is confirmed first (ADR 0134).
+- **`graduate`** never flips anything: it verifies the flag is fully open in prod (the retirement
+  trigger in [product-development-cycle.md](../../product-development-cycle.md) §Retirement — 100%
+  and stable for one release) and files the retirement chore via the `report` skill idiom
+  (`status:needs-triage`), so `write-code` drains the flag deletion. Dry-run by default,
+  `--execute` to file. An unknown key/env fails with a typed error listing the known keys/envs.
+
 ## The non-TTY posture (ADR 0134)
 
 A write verb's confirmation is decided by the pure `decideConfirm` core (`src/posture.ts`):
@@ -53,8 +78,12 @@ already uses. Keeping the decision IO-free is what lets it be exhaustively unit-
 ## Shape
 
 - **`src/cli.ts`** — the root `anka-ops` command tree, the `VERB_GROUPS` registry (the single
-  extension point children B/C fold their groups into), and `AnkaOpsRuntimeLayer` (the shared
-  credential seam every verb group resolves through).
+  extension point verb groups fold into), and `AnkaOpsRuntimeLayer` (the shared credential seam +
+  the cf-utils Flagship clients every verb group resolves through).
+- **`src/flag.ts`** — the pure `flag` adapter core: the operator-verb → cf-utils-lever mapping and
+  the graduate-eligibility decision. No serving-plan math (that stays in `@kampus/cf-utils`).
+- **`src/flag-command.ts`** — the thin `flag` verb-group IO shell wiring the pure adapter to the
+  cf-utils read/write clients.
 - **`src/posture.ts`** — the pure ADR 0134 non-TTY decision core reused by write verbs.
 - **`src/bin.ts`** — the thin `effect/unstable/cli` shell: wire the command tree, provide the
   runtime layer, run via `NodeRuntime.runMain`.

--- a/packages/anka-ops/package.json
+++ b/packages/anka-ops/package.json
@@ -16,6 +16,7 @@
 	"dependencies": {
 		"@effect/platform-node": "catalog:",
 		"@kampus/cf-credentials": "workspace:*",
+		"@kampus/cf-utils": "workspace:*",
 		"effect": "catalog:"
 	},
 	"devDependencies": {

--- a/packages/anka-ops/src/cli.ts
+++ b/packages/anka-ops/src/cli.ts
@@ -18,9 +18,11 @@ import {
 	CredentialsKeychainFirst,
 	KeychainLive,
 } from "@kampus/cf-credentials";
+import {FlagshipReadLive, FlagshipWriteLive} from "@kampus/cf-utils";
 import {Layer} from "effect";
 import {Command} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {flag} from "./flag-command.ts";
 
 /** A verb group folded under the root `anka-ops` command — the ops-language surface descriptor. */
 export interface VerbGroup {
@@ -30,19 +32,23 @@ export interface VerbGroup {
 
 /**
  * The registry of shipped verb groups — the single place a child extends the ops language.
- * `auth` is the skeleton's only group today; `flag` (#3133) and `report` (#3134) append their
- * descriptors here (and their `Command` into {@link ankaOps}'s `withSubcommands`) as they land.
+ * `flag` folds the cf-utils Flagship core (#3133); `report` (#3134) appends its descriptor here
+ * (and its `Command` into {@link ankaOps}'s `withSubcommands`) as it lands.
  */
 export const VERB_GROUPS: ReadonlyArray<VerbGroup> = [
 	{
 		name: "auth",
 		summary: "Persist the scoped operator credential (keychain-first) — login/status/logout",
 	},
+	{
+		name: "flag",
+		summary: "Read and release Flagship flags — get/open/close/graduate over the cf-utils core",
+	},
 ];
 
-/** The root command. Extension point: children B/C add their `Command` to `withSubcommands`. */
+/** The root command. Extension point: child C adds its `Command` to `withSubcommands`. */
 export const ankaOps = Command.make("anka-ops").pipe(
-	Command.withSubcommands([auth]),
+	Command.withSubcommands([auth, flag]),
 	Command.withDescription(
 		"Operator CLI for anka-built apps — scoped ops over hidden infra (epic #2089, ADR 0045)",
 	),
@@ -55,7 +61,12 @@ const CredentialLayer = Layer.mergeAll(CredentialsKeychainFirst, AccountIdKeycha
 	Layer.provideMerge(KeychainLive),
 );
 
-/** The runtime layer bin.ts provides to `anka-ops`; every verb group resolves credentials through it. */
-export const AnkaOpsRuntimeLayer = CredentialLayer.pipe(
-	Layer.provideMerge(Layer.merge(FetchHttpClient.layer, NodeServices.layer)),
+// The Flagship read/write clients the `flag` verb group resolves through — provided ON TOP of the
+// shared credential seam (ADR 0045: one credential), so the fold reuses cf-utils' clients as-is.
+const FlagshipClients = Layer.mergeAll(FlagshipReadLive, FlagshipWriteLive);
+
+/** The runtime layer bin.ts provides to `anka-ops`; every verb group resolves through it. */
+export const AnkaOpsRuntimeLayer = Layer.provideMerge(
+	FlagshipClients,
+	CredentialLayer.pipe(Layer.provideMerge(Layer.merge(FetchHttpClient.layer, NodeServices.layer))),
 );

--- a/packages/anka-ops/src/cli.unit.test.ts
+++ b/packages/anka-ops/src/cli.unit.test.ts
@@ -17,8 +17,8 @@ describe("ankaOps command tree", () => {
 		assert.strictEqual(ankaOps.name, "anka-ops");
 	});
 
-	it("wires the `auth` verb group (the skeleton's only shipped group)", () => {
-		assert.deepStrictEqual(wiredSubcommandNames(), ["auth"]);
+	it("wires the `auth` + `flag` verb groups", () => {
+		assert.deepStrictEqual(wiredSubcommandNames(), ["auth", "flag"]);
 	});
 
 	it("the registry advertises exactly the wired verb groups (no drift)", () => {

--- a/packages/anka-ops/src/flag-command.ts
+++ b/packages/anka-ops/src/flag-command.ts
@@ -1,0 +1,232 @@
+/**
+ * The `flag` verb group's `effect/unstable/cli` wiring — the thin IO shell folding the
+ * `@kampus/cf-utils` Flagship core (`flag.ts` pure math + renderers, `flagship.ts` read/write
+ * clients) into anka-ops operator verbs (#3133). No serving-plan math is re-implemented here: the
+ * operator-verb → lever mapping is the only new logic and lives in the pure `./flag.ts` adapter.
+ *
+ *   anka-ops flag get <key> [--env <env>]        read a flag's live serving state
+ *   anka-ops flag open <key> --env <env>          release on (≡ cf-utils set on: 100% no-match split)
+ *   anka-ops flag close <key> --env <env>         kill (clear the split + default off)
+ *   anka-ops flag graduate <key>                  verify fully open in prod, file the retirement chore
+ *
+ * `open`/`close` dry-run by default; the live flip happens only under `--execute`, and a TTY human
+ * is confirmed first (the ADR 0134 posture, `posture.ts`). `graduate` never flips — it verifies the
+ * flag is fully open and files a `report`-idiom chore (dry-run by default, `--execute` to file).
+ */
+
+import {execFileSync} from "node:child_process";
+import {
+	computeEffectiveServing,
+	computeServingPlan,
+	decodeEnv,
+	distinctKeys,
+	ENV_HELP,
+	FlagEnvNotFound,
+	FlagKeyNotFound,
+	FlagshipRead,
+	FlagshipWrite,
+	findAppForEnv,
+	renderEffectiveServing,
+	renderFlagDetail,
+	renderFlagTable,
+	renderServingPlan,
+	type ServeTarget,
+	selectStatesForKey,
+} from "@kampus/cf-utils";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {Argument, Command, Flag, Prompt} from "effect/unstable/cli";
+import {
+	decideGraduate,
+	FlagNotGraduable,
+	GRADUATE_ENV,
+	type ReleaseVerb,
+	releaseVerbToTarget,
+	renderRetirementChore,
+} from "./flag.ts";
+import {decideConfirm} from "./posture.ts";
+
+const keyArg = Argument.string("key").pipe(
+	Argument.withDescription("the flag key (e.g. authorship-loop)"),
+);
+const envFlag = Flag.string("env").pipe(Flag.withDescription(ENV_HELP));
+const getEnvFlag = Flag.string("env").pipe(
+	Flag.optional,
+	Flag.withDescription(`${ENV_HELP}; omit to read across every env`),
+);
+const executeFlag = Flag.boolean("execute").pipe(
+	Flag.withDescription(
+		"actually apply (default: dry-run — print what would happen, change nothing)",
+	),
+);
+
+/** Resolve the Flagship app for `env`, or fail `FlagEnvNotFound` listing the envs that DO resolve. */
+const resolveEnvApp = (env: string) =>
+	Effect.gen(function* () {
+		const read = yield* FlagshipRead;
+		const apps = yield* read.listApps();
+		const app = findAppForEnv(apps, env);
+		if (app === undefined) {
+			const knownEnvs = [
+				...new Set(apps.map((a) => decodeEnv(a.name)).filter((e): e is string => e !== undefined)),
+			].sort();
+			return yield* new FlagEnvNotFound({env, knownEnvs});
+		}
+		return app;
+	});
+
+const get = Command.make(
+	"get",
+	{key: keyArg, env: getEnvFlag},
+	Effect.fn(function* ({key, env}) {
+		const read = yield* FlagshipRead;
+		if (env._tag === "None") {
+			const rows = yield* read.listFlagStates();
+			const slice = selectStatesForKey(rows, key);
+			if (slice.length === 0) {
+				return yield* new FlagKeyNotFound({key, knownKeys: distinctKeys(rows)});
+			}
+			yield* Console.log(renderFlagTable(slice));
+			return;
+		}
+		const app = yield* resolveEnvApp(env.value);
+		const flag = yield* read.getAppFlag(app.id, key);
+		yield* Console.log(renderFlagDetail(env.value, flag));
+	}),
+).pipe(Command.withDescription("Read a flag's live serving state in an env (or across every env)"));
+
+/**
+ * The `--execute` live-flip confirm — the thin IO shell over the pure `decideConfirm` (ADR 0134).
+ * Non-TTY proceeds (logged for the audit record); a TTY human proceeds only on an affirmative
+ * `y`/`yes`. Reached only on the changed `--execute` write branch of open/close.
+ */
+export class FlagFlipRefused extends Schema.TaggedErrorClass<FlagFlipRefused>()(
+	"@kampus/anka-ops/FlagFlipRefused",
+	{reason: Schema.String},
+) {
+	override get message(): string {
+		return `flag flip refused: ${this.reason} — re-run in your terminal and answer the [y/N] confirm with y.`;
+	}
+}
+
+const confirmFlip = (key: string, env: string) =>
+	Effect.gen(function* () {
+		const isTTY = process.stdin.isTTY === true;
+		if (!isTTY) {
+			yield* Console.log("  live flip executed (non-interactive)");
+		}
+		const response = isTTY
+			? yield* Prompt.text({message: `flip ${key} @ ${env} live? [y/N]`}).pipe(
+					Effect.catchCause(() => Effect.succeed(undefined)),
+				)
+			: undefined;
+		const decision = decideConfirm({isTTY, confirmResponse: response});
+		if (decision._tag === "Refuse") {
+			return yield* new FlagFlipRefused({reason: decision.reason});
+		}
+	});
+
+/**
+ * Build the `open`/`close` release verb. The mapping (verb → cf-utils `ServeTarget` lever) is the
+ * pure adapter; the plan diff, the write, and the confirm are all reused cf-utils/posture pieces.
+ */
+const makeReleaseVerb = (verb: ReleaseVerb) =>
+	Command.make(
+		verb,
+		{key: keyArg, env: envFlag, execute: executeFlag},
+		Effect.fn(function* ({key, env, execute}) {
+			const target: ServeTarget = releaseVerbToTarget(verb);
+			const app = yield* resolveEnvApp(env);
+			const read = yield* FlagshipRead;
+			// Read-before-plan: an unknown key fails FlagshipFlagNotFound here, before any write.
+			const current = yield* read.getAppFlag(app.id, key);
+			const plan = computeServingPlan({key, env, flag: current, target});
+			yield* Console.log(renderServingPlan(plan));
+
+			if (!execute) {
+				yield* Console.log("  (dry-run — pass --execute to apply; the flag is unchanged)");
+				return;
+			}
+			if (!plan.changed) {
+				yield* Console.log("  (already at target — nothing to write)");
+				return;
+			}
+			yield* confirmFlip(key, env);
+			const write = yield* FlagshipWrite;
+			const updated = yield* write.setServing({appId: app.id, flagKey: key, target});
+			yield* Console.log(
+				`  applied — ${key} @ ${env} now serves ${renderEffectiveServing(computeEffectiveServing(updated))}`,
+			);
+		}),
+	).pipe(
+		Command.withDescription(
+			verb === "open"
+				? "Release a flag on via the 100% no-match split (≡ cf-utils set on; dry-run by default)"
+				: "Kill a flag — clear the no-match split and set the default off (dry-run by default)",
+		),
+	);
+
+/** File the retirement chore via the `report` skill's intake path (`gh`, `status:needs-triage`). */
+const fileRetirementChore = (title: string, body: string) =>
+	Effect.try({
+		try: () =>
+			execFileSync(
+				"gh",
+				["issue", "create", "--title", title, "--body", body, "--label", "status:needs-triage"],
+				{encoding: "utf8"},
+			).trim(),
+		catch: (cause) => new RetirementChoreFileFailed({cause: String(cause)}),
+	});
+
+export class RetirementChoreFileFailed extends Schema.TaggedErrorClass<RetirementChoreFileFailed>()(
+	"@kampus/anka-ops/RetirementChoreFileFailed",
+	{cause: Schema.String},
+) {
+	override get message(): string {
+		return `failed to file the retirement chore via gh: ${this.cause}`;
+	}
+}
+
+const graduate = Command.make(
+	"graduate",
+	{key: keyArg, execute: executeFlag},
+	Effect.fn(function* ({key, execute}) {
+		const read = yield* FlagshipRead;
+		const rows = yield* read.listFlagStates();
+		const slice = selectStatesForKey(rows, key);
+		if (slice.length === 0) {
+			return yield* new FlagKeyNotFound({key, knownKeys: distinctKeys(rows)});
+		}
+		const decision = decideGraduate({key, states: slice});
+		if (decision._tag === "Ineligible") {
+			return yield* new FlagNotGraduable({key, reason: decision.reason});
+		}
+
+		const prod = slice.find((s) => s.env === GRADUATE_ENV);
+		yield* Console.log(
+			`flag ${key} @ ${GRADUATE_ENV}: ${prod ? renderEffectiveServing(prod.serving) : "(unknown)"} — graduable`,
+		);
+		const chore = renderRetirementChore(key);
+		yield* Console.log(`  retirement chore: "${chore.title}"`);
+
+		if (!execute) {
+			yield* Console.log(
+				"  (dry-run — pass --execute to file the retirement chore; nothing filed)",
+			);
+			return;
+		}
+		const url = yield* fileRetirementChore(chore.title, chore.body);
+		yield* Console.log(`  filed retirement chore ${url}`);
+	}),
+).pipe(
+	Command.withDescription(
+		"Verify a flag is fully open in prod, then file its retirement chore (never flips; dry-run by default)",
+	),
+);
+
+export const flag = Command.make("flag").pipe(
+	Command.withSubcommands([get, makeReleaseVerb("open"), makeReleaseVerb("close"), graduate]),
+	Command.withDescription(
+		"Read and release Flagship flags — the domain-language surface over cf-utils",
+	),
+);

--- a/packages/anka-ops/src/flag.ts
+++ b/packages/anka-ops/src/flag.ts
@@ -1,0 +1,112 @@
+/**
+ * The `flag` verb group's pure adapter core — the operator-verb → cf-utils-lever mapping, and
+ * nothing else. The serving-plan math, the renderers, the read/write clients, and the typed
+ * not-found errors all live in `@kampus/cf-utils` (`flag.ts`/`flagship.ts`, #1726); this module
+ * only names the operator language over them (`open`/`close`/`graduate`) so the mapping is the
+ * one new, fully-unit-tested piece. It re-derives no split percentages.
+ */
+
+import type {FlagState, ServeTarget} from "@kampus/cf-utils";
+import * as Schema from "effect/Schema";
+
+/**
+ * The env graduation is evaluated against. Retirement is a prod fact — the cycle's trigger
+ * (`product-development-cycle.md` §Retirement) is "100% and stable for one release", which is
+ * about the real release surface, not a preview stage. So `graduate` reads the flag's prod row.
+ */
+export const GRADUATE_ENV = "prod";
+
+/**
+ * The two live-flip operator verbs and their cf-utils lever. `open` releases the flag on via the
+ * no-match 100% split (≡ cf-utils `set on`, never a `defaultVariation` flip — #1726); `close`
+ * kills it (clears the split AND sets the default off — the true kill switch, cf-utils `set off`).
+ */
+export type ReleaseVerb = "open" | "close";
+
+export const releaseVerbToTarget = (verb: ReleaseVerb): ServeTarget =>
+	verb === "open" ? {_tag: "Percent", percentage: 100} : {_tag: "Kill"};
+
+/**
+ * The graduate decision. `Eligible` ⇒ prod serves the flag fully open (`on@100%` split), so it is
+ * at the retirement trigger and the chore may be filed; `Ineligible` ⇒ not fully open (or absent
+ * in prod), carrying the reason so `graduate` refuses loudly rather than silently filing a chore
+ * for a flag that is still ramping. Stability-over-one-release is the operator's assertion (a
+ * single read can't observe it), so the machine check is "fully open in prod".
+ */
+export type GraduateDecision =
+	| {readonly _tag: "Eligible"; readonly key: string}
+	| {readonly _tag: "Ineligible"; readonly key: string; readonly reason: string};
+
+/**
+ * Decide graduation from the flag's per-env rows (the `selectStatesForKey` slice of `flag list`).
+ * Eligible only when the prod row exists and its effective serving is a full (100%) no-match split.
+ */
+export const decideGraduate = (input: {
+	readonly key: string;
+	readonly states: ReadonlyArray<FlagState>;
+}): GraduateDecision => {
+	const prod = input.states.find((s) => s.env === GRADUATE_ENV);
+	if (prod === undefined) {
+		return {
+			_tag: "Ineligible",
+			key: input.key,
+			reason: `not defined in "${GRADUATE_ENV}" — a flag graduates from its prod serving state`,
+		};
+	}
+	const serving = prod.serving;
+	if (serving._tag !== "Split" || serving.percentage < 100) {
+		const at =
+			serving._tag === "Split"
+				? `ramping at ${serving.percentage}%`
+				: `serving the default (${serving.variation})`;
+		return {
+			_tag: "Ineligible",
+			key: input.key,
+			reason: `${GRADUATE_ENV} is ${at}, not fully open — retire only a 100%-stable flag`,
+		};
+	}
+	return {_tag: "Eligible", key: input.key};
+};
+
+/**
+ * The retirement chore's title + body, filed via the `report` skill idiom (`status:needs-triage`,
+ * type-blind — triage classifies it `type:chore`). The body names the concrete removal work the
+ * cycle's §Retirement + step 7 of the feature-flags workflow prescribe, so `write-code` can drain
+ * it: delete the declaration, the `getBoolean` read + dead `else`, and inline the now-permanent path.
+ */
+export const renderRetirementChore = (
+	key: string,
+): {readonly title: string; readonly body: string} => ({
+	title: `retire the graduated \`${key}\` feature flag`,
+	body: [
+		`The \`${key}\` flag is fully open (100% no-match split) and stable — the retirement`,
+		`trigger in [product-development-cycle.md](product-development-cycle.md) §Retirement.`,
+		`Filed by \`anka-ops flag graduate ${key}\`.`,
+		"",
+		"Retire it per step 7 of",
+		"[.patterns/feature-flags-agent-workflow.md](.patterns/feature-flags-agent-workflow.md):",
+		"",
+		`- Delete the \`${key}\` flag declaration.`,
+		`- Delete its \`getBoolean\` read and the now-dead \`else\` branch.`,
+		"- Inline the now-permanent code path.",
+		"",
+		"Once merged, retire the live flag in Flagship (`anka-ops flag close` then delete).",
+	].join("\n"),
+});
+
+/**
+ * No Flagship serving state graduation could evaluate — `graduate` refuses fully-open verification.
+ * A typed `E`-channel fault so an ineligible flag exits loud with the reason, never silently files
+ * a chore or flips anything. (The unknown-key case reuses cf-utils' `FlagKeyNotFound` upstream.)
+ */
+export class FlagNotGraduable extends Schema.TaggedErrorClass<FlagNotGraduable>()(
+	"@kampus/anka-ops/FlagNotGraduable",
+	{
+		key: Schema.String,
+		reason: Schema.String,
+	},
+) {
+	override get message(): string {
+		return `flag "${this.key}" is not graduable: ${this.reason}`;
+	}
+}

--- a/packages/anka-ops/src/flag.unit.test.ts
+++ b/packages/anka-ops/src/flag.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The `flag` verb group's pure adapter — the operator-verb → cf-utils-lever mapping (#3133). The
+ * load-bearing contract: `open`/`close` map onto the EXACT cf-utils `ServeTarget` levers (100%
+ * no-match split / kill) so no serving-plan math is duplicated, and `graduate` only greenlights a
+ * flag fully open in prod. No IO: the mapping is a pure value, the graduate decision a pure fold
+ * over already-listed `FlagState` rows.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import type {EffectiveServing, FlagState} from "@kampus/cf-utils";
+import {
+	decideGraduate,
+	GRADUATE_ENV,
+	type ReleaseVerb,
+	releaseVerbToTarget,
+	renderRetirementChore,
+} from "./flag.ts";
+
+const split = (percentage: number): EffectiveServing => ({
+	_tag: "Split",
+	variation: "on",
+	percentage,
+	otherRules: 0,
+});
+const defaultServing = (variation: string): EffectiveServing => ({
+	_tag: "Default",
+	variation,
+	otherRules: 0,
+});
+
+const state = (env: string, serving: EffectiveServing): FlagState => ({
+	key: "authorship-loop",
+	env,
+	enabled: true,
+	defaultVariation: "off",
+	defaultValue: false,
+	serving,
+});
+
+describe("releaseVerbToTarget — verb → cf-utils lever", () => {
+	it("open maps onto the 100% no-match split (≡ cf-utils set on)", () => {
+		assert.deepStrictEqual(releaseVerbToTarget("open"), {_tag: "Percent", percentage: 100});
+	});
+
+	it("close maps onto the kill lever (clear the split + default off)", () => {
+		assert.deepStrictEqual(releaseVerbToTarget("close"), {_tag: "Kill"});
+	});
+
+	it("never emits a defaultVariation-flip lever — open is a Percent split, not a Default write", () => {
+		const openTarget = releaseVerbToTarget("open");
+		assert.strictEqual(openTarget._tag, "Percent");
+	});
+
+	for (const verb of ["open", "close"] as const satisfies ReadonlyArray<ReleaseVerb>) {
+		it(`${verb} yields a total ServeTarget the cf-utils core consumes`, () => {
+			const target = releaseVerbToTarget(verb);
+			assert.oneOf(target._tag, ["Percent", "Kill"]);
+		});
+	}
+});
+
+describe("decideGraduate — retirement-trigger eligibility (prod fully open)", () => {
+	it("is Eligible when prod serves a full 100% split", () => {
+		const decision = decideGraduate({
+			key: "authorship-loop",
+			states: [state("pr-42", split(100)), state(GRADUATE_ENV, split(100))],
+		});
+		assert.strictEqual(decision._tag, "Eligible");
+	});
+
+	it("is Ineligible when prod is still ramping (< 100%)", () => {
+		const decision = decideGraduate({
+			key: "authorship-loop",
+			states: [state(GRADUATE_ENV, split(50))],
+		});
+		assert.strictEqual(decision._tag, "Ineligible");
+		assert.include(decision._tag === "Ineligible" ? decision.reason : "", "ramping at 50%");
+	});
+
+	it("is Ineligible when prod serves the default (no split)", () => {
+		const decision = decideGraduate({
+			key: "authorship-loop",
+			states: [state(GRADUATE_ENV, defaultServing("off"))],
+		});
+		assert.strictEqual(decision._tag, "Ineligible");
+		assert.include(decision._tag === "Ineligible" ? decision.reason : "", "serving the default");
+	});
+
+	it("is Ineligible when the flag is not defined in prod (only previews)", () => {
+		const decision = decideGraduate({
+			key: "authorship-loop",
+			states: [state("pr-42", split(100))],
+		});
+		assert.strictEqual(decision._tag, "Ineligible");
+		assert.include(decision._tag === "Ineligible" ? decision.reason : "", GRADUATE_ENV);
+	});
+
+	it("graduates off prod alone — a preview still ramping does not block a prod-open flag", () => {
+		const decision = decideGraduate({
+			key: "authorship-loop",
+			states: [state("pr-42", split(10)), state(GRADUATE_ENV, split(100))],
+		});
+		assert.strictEqual(decision._tag, "Eligible");
+	});
+});
+
+describe("renderRetirementChore — the report-idiom chore payload", () => {
+	it("names the flag key in the title and the removal work in the body", () => {
+		const chore = renderRetirementChore("authorship-loop");
+		assert.include(chore.title, "authorship-loop");
+		assert.include(chore.body, "getBoolean");
+		assert.include(chore.body, "product-development-cycle.md");
+	});
+});

--- a/packages/anka-ops/src/index.ts
+++ b/packages/anka-ops/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./cli.ts";
+export * from "./flag.ts";
 export * from "./posture.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
+      '@kampus/cf-utils':
+        specifier: workspace:*
+        version: link:../cf-utils
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)


### PR DESCRIPTION
## What

Add the `flag` operator-verb group to `anka-ops` — the domain-language surface over Flagship — by **folding the existing `@kampus/cf-utils` Flagship core**, not re-implementing it. The only new logic is the operator-verb → cf-utils-lever mapping, kept as a thin pure adapter (`packages/anka-ops/src/flag.ts`) and fully unit-tested. No serving-plan math is duplicated.

Verbs (wired in `packages/anka-ops/src/flag-command.ts`, reusing the cf-utils `FlagshipRead`/`FlagshipWrite` clients + `flag.ts` renderers):

- `anka-ops flag get <key> [--env <env>]` — read a flag's live serving state (across every env when `--env` is omitted).
- `anka-ops flag open <key> --env <env>` — release on ≡ cf-utils `set on` (the 100% no-match percentage split, never `defaultVariation`).
- `anka-ops flag close <key> --env <env>` — kill ≡ cf-utils `set off` (clear the split **and** set the default off).
- `anka-ops flag graduate <key>` — verify the flag is fully open in prod (the retirement trigger, `product-development-cycle.md` §Retirement) and file the retirement chore via the `report` skill idiom, so `write-code` drains the flag deletion. Never flips anything.

## Behavior

- `open`/`close` **dry-run by default**; the live flip happens only under `--execute`, gated by the ADR 0134 non-TTY posture (`src/posture.ts`): a non-TTY caller proceeds and logs, a TTY human is prompted first.
- `graduate` refuses loudly (typed `FlagNotGraduable`) when prod isn't fully open, rather than silently filing a chore; dry-run by default, `--execute` to file.
- An unknown flag key or env fails with a typed, actionable error listing the known keys/envs (reusing cf-utils `FlagKeyNotFound`/`FlagEnvNotFound`), never an empty table or a stack trace.

## Tests

`packages/anka-ops/src/flag.unit.test.ts` covers the operator-verb → cf-utils-lever adapter for each verb (open→100% Percent split, close→Kill) and the graduate-eligibility decision (eligible only when prod serves a full 100% split; ineligible when ramping, serving the default, or absent in prod). `cli.unit.test.ts` updated for the added `flag` group (registry ⇄ wiring no-drift). `pnpm --filter @kampus/anka-ops typecheck && test` green; `biome check` clean.

## Notes

- The graduate chore is filed via the `report` skill idiom (`status:needs-triage`, type-blind) rather than hand-applying `type:chore` — triage classifies it, keeping the triage signal clean. The body names the concrete removal work per the cycle doc so it's classified instantly.
- The two `flag`-command error classes are exported so the depth-3 root command's declaration type stays nameable under `composite` (TS4023).

Fixes #3133