### PR TITLE
feat(atolye): /lab/atölye public exhibit index route (#3092)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -380,6 +380,11 @@ const LabComposerPage = lazy(() =>
 const MecmuaEditorPage = lazy(() =>
 	import("./pages/MecmuaEditorPage").then((m) => ({default: m.MecmuaEditorPage})),
 );
+// atölye's exhibit catalog (#2473) grows over time and is imported by no other route, so
+// lazy-loading its index keeps that payload out of the entry chunk every public route pays for.
+const AtolyeIndexPage = lazy(() =>
+	import("./lab/atolye/AtolyeIndexPage").then((m) => ({default: m.AtolyeIndexPage})),
+);
 
 function ComposerRouteFallback() {
 	return (
@@ -512,6 +517,16 @@ export function App() {
 							element={
 								<Suspense fallback={<ComposerRouteFallback />}>
 									<LabComposerPage />
+								</Suspense>
+							}
+						/>
+						{/* /lab/atölye — the public exhibit index (#3092, epic #2473), reachable by URL
+						    only, no nav entry (matching the /lab/composer precedent). */}
+						<Route
+							path="/lab/atölye"
+							element={
+								<Suspense fallback={<ComposerRouteFallback />}>
+									<AtolyeIndexPage />
 								</Suspense>
 							}
 						/>

--- a/apps/web/src/lab/atolye/AtolyeIndexPage.css
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.css
@@ -1,0 +1,62 @@
+/* /lab/atölye index (#3092). Role tokens only — atölye dogfoods the ADR-0162 design law it
+   showcases. */
+
+.kp-atolye__inner {
+	max-width: var(--content-w);
+	margin: 0 auto;
+	padding: var(--s-4) var(--s-3) var(--s-8);
+}
+
+.kp-atolye__masthead {
+	padding: var(--s-2) 0 var(--s-4);
+	border-bottom: 1px solid var(--border);
+}
+
+.kp-atolye__title {
+	font: var(--t-h-feed);
+	font-weight: 700;
+	margin: 0;
+	color: var(--text-primary);
+}
+
+.kp-atolye__lead {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	margin: var(--s-2) 0 0;
+	max-width: 60ch;
+}
+
+.kp-atolye__list {
+	list-style: none;
+	margin: var(--s-4) 0 0;
+	padding: 0;
+	display: grid;
+	gap: var(--s-2);
+}
+
+.kp-atolye__card {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	padding: var(--s-3);
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+	background: var(--surface);
+	text-decoration: none;
+}
+
+.kp-atolye__card:hover {
+	border-color: var(--border-strong);
+	background: var(--surface-raised);
+}
+
+.kp-atolye__card-title {
+	font: var(--t-body);
+	font-weight: 600;
+	color: var(--link);
+}
+
+.kp-atolye__card-summary {
+	font: var(--t-meta);
+	color: var(--text-secondary);
+}

--- a/apps/web/src/lab/atolye/AtolyeIndexPage.test.tsx
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * The /lab/atölye index lists exactly what the headless registry enumerates and deep-links each
+ * row to its detail route (#3092). The registry is the seam: the page holds no exhibit list of its
+ * own, so it can never drift from `listExhibits()`.
+ */
+import {render, screen, within} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {describe, expect, it} from "vitest";
+import {AtolyeIndexPage} from "./AtolyeIndexPage";
+import {listExhibits} from "./registry";
+
+function renderPage() {
+	return render(
+		<MemoryRouter initialEntries={["/lab/atölye"]}>
+			<AtolyeIndexPage />
+		</MemoryRouter>,
+	);
+}
+
+describe("AtolyeIndexPage — /lab/atölye index (#3092)", () => {
+	it("renders one row per registered exhibit, sourced from listExhibits()", () => {
+		renderPage();
+		const list = screen.getByRole("list", {name: "sergiler"});
+		expect(within(list).getAllByRole("listitem")).toHaveLength(listExhibits().length);
+	});
+
+	it("links each exhibit to its /lab/atölye/:exhibit detail path", () => {
+		renderPage();
+		for (const exhibit of listExhibits()) {
+			const link = screen.getByRole("link", {name: new RegExp(exhibit.title)});
+			// `\S*` tolerates whether react-router keeps the `ö` literal or percent-encodes it in
+			// the href attribute; the load-bearing assertion is the deep-link's exhibit-id segment.
+			expect(link.getAttribute("href")).toMatch(new RegExp(`/lab/at\\S*/${exhibit.id}$`));
+		}
+	});
+});

--- a/apps/web/src/lab/atolye/AtolyeIndexPage.tsx
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.tsx
@@ -1,0 +1,40 @@
+/**
+ * `/lab/atölye` — the public index of atölye, the in-product museum of craft (epic #2473).
+ * Lists every exhibit the headless registry enumerates; each row deep-links to that exhibit's
+ * detail route (#3093). The registry is the seam (`.patterns/atolye-exhibit-harness.md`) — a new
+ * exhibit appears here by landing one `*.exhibit.tsx` + one registry line, never a route edit.
+ */
+
+import {Link} from "react-router";
+import {listExhibits} from "./registry";
+import "./AtolyeIndexPage.css";
+
+export function AtolyeIndexPage() {
+	const exhibits = listExhibits();
+	return (
+		<main className="kp-atolye" data-testid="lab-atolye-index">
+			<div className="kp-atolye__inner">
+				<header className="kp-atolye__masthead">
+					<h1 className="kp-atolye__title">atölye</h1>
+					<p className="kp-atolye__lead">
+						Tasarım sistemimizin canlı vitrini — her parça, kendi prop-düğmeleriyle yaşayan bir
+						sergi. Bir sergiye tıkla, varyantlarını canlı kurcala.
+					</p>
+				</header>
+
+				<ul className="kp-atolye__list" aria-label="sergiler">
+					{exhibits.map((exhibit) => (
+						<li key={exhibit.id} className="kp-atolye__item">
+							<Link to={`/lab/atölye/${exhibit.id}`} className="kp-atolye__card">
+								<span className="kp-atolye__card-title">{exhibit.title}</span>
+								{exhibit.summary ? (
+									<span className="kp-atolye__card-summary">{exhibit.summary}</span>
+								) : null}
+							</Link>
+						</li>
+					))}
+				</ul>
+			</div>
+		</main>
+	);
+}


### PR DESCRIPTION
Fixes #3092

## What

Builds the public **atölye index** route — `/lab/atölye` — the listing page for the in-product museum of craft (epic #2473). Wires it into the react-router 7 route tree in `apps/web/src/App.tsx` under the `/lab/*` public convention, alongside the existing `/lab/composer` route (reachable by URL only, no nav entry).

The page lists every exhibit the headless C1 registry enumerates via `listExhibits()`, and deep-links each row to its `/lab/atölye/:exhibit` detail path (built in #3093). The registry is the seam (`.patterns/atolye-exhibit-harness.md`): adding an exhibit appears here by landing one `*.exhibit.tsx` module plus one registry line — no index edit. This PR consumes `listExhibits()`; it does not touch the exhibit catalog contents (that is #3094's lane).

## Acceptance criteria

- [x] `/lab/atölye` renders a public page listing every registered exhibit, sourced from the C1 registry (a new registry exhibit appears with no index edit — the page holds no list of its own).
- [x] Route wired into `apps/web/src/App.tsx` under `/lab/*`; public, no auth gate.
- [x] Each listed exhibit links to its `/lab/atölye/:exhibit` detail path.
- [x] Role-token / four-pillar styling (ADR 0162) — role tokens only, no raw/scale colors, no external storybook dep; `ul`/`li` list semantics with an `aria-label` (pillar 4).

## Scope

Index page + route wiring only. Out of scope (per the child): the detail/deep-link route + not-found (#3093), the exhibit catalog fill (#3094).

## Verification

- `pnpm typecheck` — green
- `pnpm lint` — clean (4 changed files)
- `pnpm --filter @kampus/web test:client` — 259 passed, including the 2 new `AtolyeIndexPage` tests (row-count from `listExhibits()`, per-exhibit deep-link href)

Lazy-loaded like `/lab/composer` so the growing exhibit catalog stays out of the entry chunk every public route pays for (performance pillar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)