### PR TITLE
feat(mute): mute.set/remove fate mutations behind a default-off flag (#3112)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -53,6 +53,7 @@ import {
 	mecmuaFeedFlag,
 	mecmuaPublicReadFlag,
 	mecmuaWriteFlag,
+	memberMuteFlag,
 	modQueueFlag,
 	navIaFlag,
 	optimisticDefinitionAddFlag,
@@ -188,6 +189,10 @@ export default Alchemy.Stack(
 		// mutation, and paint/save surface gate behind until a human release, so the whole
 		// profile-canvas feature ships dark.
 		yield* profileCanvasFlag(flagship.appId);
+		// The member-mute (sustur) write-path dark-ship flag, default-off (#3112, epic
+		// #2035) — the single seam `mute.set` / `mute.remove` gate behind until a human
+		// release, so the whole mute primitive ships dark.
+		yield* memberMuteFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -56,6 +56,8 @@ export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	EMAIL_FAILING_REASON_REQUIRED: "işaretleme gerekçesi zorunludur",
 	MECMUA_DISABLED: "mecmua şu an kapalı",
 	MECMUA_POST_NOT_FOUND: "yazı bulunamadı",
+	MUTE_DISABLED: "sustur şu an kapalı",
+	SELF_MUTE_REJECTED: "kendini susturamazsın",
 	BAD_REQUEST: "geçersiz istek",
 	INTERNAL_SERVER_ERROR: "bir şeyler ters gitti, lütfen tekrar dene",
 };

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -316,6 +316,17 @@ export const PHOENIX_EDGE_SHELL_BOOT = "phoenix-edge-shell-boot";
  */
 export const PROFILE_CANVAS = "profile-canvas";
 
+/**
+ * Member-mute (sustur) write-path dark-ship flag (#3112, epic #2035). The SINGLE seam
+ * the mute write path gates behind — the `mute.set` / `mute.remove` fate mutations fail
+ * closed (`MUTE_DISABLED`) with it off, so the whole primitive ships dark until a human
+ * flips it at release (ADR 0083): with it off no member can mute another even if a client
+ * bypasses the (not-yet-built) UI. Default-off, its own `member-` key scoped to the
+ * member-relation surface. The read-mask that consumes a mute (sibling) and the manage
+ * UI (reachability child) ship behind their own slices.
+ */
+export const MEMBER_MUTE = "member-mute";
+
 /** A declared flag paired with its default variation — the row the flags console lists (#2742). */
 export interface FlagDeclaration {
 	readonly key: string;
@@ -359,4 +370,5 @@ export const DECLARED_FLAGS: readonly FlagDeclaration[] = [
 	{key: PHOENIX_ADMIN_CONSOLE, defaultValue: false},
 	{key: PHOENIX_EDGE_SHELL_BOOT, defaultValue: false},
 	{key: PROFILE_CANVAS, defaultValue: false},
+	{key: MEMBER_MUTE, defaultValue: false},
 ];

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -96,6 +96,12 @@ export const FATE_WIRE_CODES = [
 	// A `mecmua.publish` target draft doesn't exist or isn't the caller's own
 	// (`mecmua/MecmuaPostNotFound`, #2497) — the ownership-scoped miss.
 	"MECMUA_POST_NOT_FOUND",
+	// member-mute write path is gated on the `member-mute` flag; the server raises this
+	// when `mute.set` / `mute.remove` run with the flag off (#3112).
+	"MUTE_DISABLED",
+	// A member tried to mute themselves (`mute/SelfMuteRejected`, #3112) — the domain
+	// refuses a self-mute before any write.
+	"SELF_MUTE_REJECTED",
 	"BAD_REQUEST",
 	"INTERNAL_SERVER_ERROR",
 ] as const;

--- a/apps/web/worker/features/fate-live/fanned-mutations.ts
+++ b/apps/web/worker/features/fate-live/fanned-mutations.ts
@@ -349,4 +349,23 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 		rationale:
 			"clears the caller's private reader→author subscription edge; per-viewer `mecmuaFeed` connection, same no-leak rationale as `mecmua.subscribe`",
 	},
+
+	// mute — member-mute (sustur) presence (#3112, epic #2035). A mute masks ONLY the
+	// muter's OWN reads (the read-mask is a sibling slice), so it writes no
+	// Post/Comment/Definition in a subscribed cross-client connection — and its own
+	// views (feed/thread/manage-mutes) are per-viewer, so a publish onto the login-blind
+	// shared topic would over-fan/leak to every viewer. The `post.save` / `mecmua.subscribe`
+	// per-viewer-private-relation precedent: no cross-viewer fan-out.
+	{
+		key: "mute.set",
+		fanned: false,
+		rationale:
+			"writes the caller's private (muter,muted) mute relation; a mute masks only the muter's OWN reads (the read-mask is a sibling), so it writes no fanned content entity — and its own views are per-viewer, so a publish onto the login-blind shared topic would over-fan/leak to all viewers (the post.save precedent). No cross-viewer fan-out",
+	},
+	{
+		key: "mute.remove",
+		fanned: false,
+		rationale:
+			"clears the caller's private (muter,muted) mute relation; per-viewer own-read mask, same no-fan rationale as `mute.set`",
+	},
 ];

--- a/apps/web/worker/features/fate/config.ts
+++ b/apps/web/worker/features/fate/config.ts
@@ -33,6 +33,7 @@ import {fateModule as divanModule} from "../divan/fate-module.ts";
 import {liveBusConfig} from "../fate-live/event-bus.ts";
 import {fateModule as funnelModule} from "../funnel/fate-module.ts";
 import {fateModule as mecmuaModule} from "../mecmua/fate-module.ts";
+import {fateModule as muteModule} from "../mute/fate-module.ts";
 import {fateModule as panoModule} from "../pano/fate-module.ts";
 import {fateModule as pasaportModule} from "../pasaport/fate-module.ts";
 import {fateModule as reportModule} from "../report/fate-module.ts";
@@ -56,6 +57,7 @@ export const modules = [
 	funnelModule,
 	bildirimModule,
 	mecmuaModule,
+	muteModule,
 ];
 
 export const fateConfig = FateServer.config({

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -31,6 +31,7 @@ import {RelationStoreLive} from "../kunye/RelationStore.ts";
 import {authorshipLadder} from "../kunye/standing.ts";
 import {VouchLedgerLive} from "../kunye/VouchLedger.ts";
 import {MecmuaLive} from "../mecmua/Mecmua.ts";
+import {MuteLive} from "../mute/Mute.ts";
 import {BookmarkLive} from "../pano/Bookmark.ts";
 import {PanoFeedCache} from "../pano/feed-cache.ts";
 import {PanoLive} from "../pano/Pano.ts";
@@ -243,6 +244,10 @@ export const makeFateLayer = Layer.mergeAll(
 	// other domain layers. The publish yazar-floor is discharged at the mutation via
 	// `PublishMecmua` (CurrentActor/AgentAuthority/Kunye already in this graph), not here.
 	MecmuaLive,
+	// The member-mute (sustur) write service (#3112, epic #2035) — the `mute.set` /
+	// `mute.remove` presence writes, depending only on `Drizzle` (discharged below), so
+	// it merges flat like the other domain layers.
+	MuteLive,
 	// The authz ports the moderation gate (`report.resolve`/`restore`/`listOpen`)
 	// discharges `Moderate.over(platform)` against: `RelationStoreLive` reads the
 	// `moderates` tuple off the same `Drizzle` seam (discharged below), and

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -21,6 +21,7 @@ import type {
 import type {DivanBacklogItemView, DivanCaylakView, DivanVoteReceiptView} from "../divan/views.ts";
 import type {FunnelSummaryView} from "../funnel/views.ts";
 import type {MecmuaPostView, MecmuaSubscriptionReceiptView} from "../mecmua/views.ts";
+import type {MuteReceiptView} from "../mute/views.ts";
 import type {CommentView, PostOverlayView, PostView, TagView} from "../pano/views.ts";
 import type {
 	AccountDeletionReceiptView,
@@ -68,6 +69,8 @@ export type {FunnelSummary} from "../funnel/views.ts";
 export {funnelSummaryDataView} from "../funnel/views.ts";
 export type {MecmuaPost, MecmuaSubscriptionReceipt} from "../mecmua/views.ts";
 export {mecmuaPostDataView, mecmuaSubscriptionReceiptDataView} from "../mecmua/views.ts";
+export type {MuteReceipt} from "../mute/views.ts";
+export {muteReceiptDataView} from "../mute/views.ts";
 export type {Comment, Post, PostOverlay, Tag} from "../pano/views.ts";
 export {
 	commentDataView,
@@ -172,6 +175,7 @@ type _FateViewsFieldMapResolved = [
 		typeof MecmuaSubscriptionReceiptView,
 		AssertFieldMapResolved<typeof MecmuaSubscriptionReceiptView>
 	>,
+	AssertResolved<typeof MuteReceiptView, AssertFieldMapResolved<typeof MuteReceiptView>>,
 	AssertResolved<typeof TagView, AssertFieldMapResolved<typeof TagView>>,
 	AssertResolved<typeof CommentView, AssertFieldMapResolved<typeof CommentView>>,
 	AssertResolved<typeof PostView, AssertFieldMapResolved<typeof PostView>>,

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -37,6 +37,7 @@ import {
 import {describe, expect, it} from "vitest";
 import {Denied, InsufficientKarma, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
 import {MecmuaDisabled, MecmuaPostNotFound, MecmuaTitleRequired} from "../mecmua/errors.ts";
+import {MuteDisabled, SelfMuteRejected} from "../mute/errors.ts";
 import {
 	CommentBodyRequired,
 	CommentBodyTooLong,
@@ -106,6 +107,10 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	[MecmuaDisabled, "MECMUA_DISABLED"],
 	[MecmuaPostNotFound, "MECMUA_POST_NOT_FOUND"],
 	[MecmuaTitleRequired, "TITLE_REQUIRED"],
+	// member-mute write path (#3112) — reachable from fateConfig via `mute.set` /
+	// `mute.remove`. Both message-only, so also round-trip representatives below.
+	[MuteDisabled, "MUTE_DISABLED"],
+	[SelfMuteRejected, "SELF_MUTE_REJECTED"],
 	// sozluk
 	[BodyRequired, "BODY_REQUIRED"],
 	[BodyTooLong, "BODY_TOO_LONG"],

--- a/apps/web/worker/features/flagship/member-mute.invariant.test.ts
+++ b/apps/web/worker/features/flagship/member-mute.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the member-mute (sustur) flag
+ * (#3112, epic #2035). Inspected off the exported `MEMBER_MUTE_FLAG` record (the same
+ * object the factory spreads into `FlagshipFlag`), so no alchemy resource is
+ * constructed — mirrors `mecmua-write.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {MEMBER_MUTE} from "../../../src/flags/keys.ts";
+import {MEMBER_MUTE_FLAG, memberMuteFlag} from "./resources.ts";
+
+describe("member-mute — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(MEMBER_MUTE_FLAG.defaultVariation, "off");
+		assert.strictEqual(MEMBER_MUTE_FLAG.variations.off, false);
+		assert.strictEqual(MEMBER_MUTE_FLAG.variations.on, true);
+		assert.strictEqual(MEMBER_MUTE_FLAG.key, "member-mute");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(MEMBER_MUTE_FLAG.key, MEMBER_MUTE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof memberMuteFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -14,6 +14,7 @@ import {
 	MECMUA_FEED,
 	MECMUA_PUBLIC_READ,
 	MECMUA_WRITE,
+	MEMBER_MUTE,
 	PANO_BASE_FEED,
 	PANO_DRAFT_SAVE,
 	PANO_FEED_EDGE_CACHE,
@@ -1093,3 +1094,34 @@ export const PROFILE_CANVAS_FLAG = {
  */
 export const profileCanvasFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("profile_canvas", {appId, ...PROFILE_CANVAS_FLAG});
+
+/**
+ * The member-mute (sustur) write-path dark-ship flag config (#3112, epic #2035). The
+ * SINGLE seam the mute write path gates behind — `mute.set` / `mute.remove` fail
+ * `MUTE_DISABLED` with it off, so the whole primitive reaches production dark; flipping
+ * it on is the human release act (ADR 0083). The read-mask (sibling) and the manage UI
+ * (reachability child) ship behind their own slices.
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `PROFILE_CANVAS_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           mute (the member-mute relation surface)
+ *   - originating:     #3112 (epic: free-paint canvas space / member-mute, #2035)
+ *   - removal trigger: once member-mute graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline the now-permanent path.
+ */
+export const MEMBER_MUTE_FLAG = {
+	key: MEMBER_MUTE,
+	description:
+		"member-mute (sustur) write path (mute.set / mute.remove) dark-ship (#3112, epic #2035). owner: mute. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const memberMuteFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("member_mute", {appId, ...MEMBER_MUTE_FLAG});

--- a/apps/web/worker/features/mute/errors.ts
+++ b/apps/web/worker/features/mute/errors.ts
@@ -1,12 +1,18 @@
 /**
- * Tagged errors raised by the Mute service layer.
+ * Tagged errors raised by the Mute service + its fate write path.
  *
  * `SelfMuteRejected` is the domain object refusing an invalid state — a member
  * muting themselves — at the write boundary (make-invalid-states-unrepresentable).
- * It carries no `FateWireCode`: a consuming service translates it at its own
- * boundary when the mutation surface lands (a sibling of this storage slice), so
- * the domain never asserts a wire code it doesn't yet have a wire for.
+ * It now carries its `FateWireCode` because the `mute.set` / `mute.remove` mutation
+ * surface (#3112) is the consuming boundary that landed: `encodeWireError` reads the
+ * annotation at the fate seam (`.patterns/fate-effect-wire-errors.md`), the same shape
+ * as pano's / mecmua's.
+ *
+ * `MuteDisabled` is the dark-ship containment (ADR 0083): with the `member-mute` flag
+ * off both mutations fail this before any read/write, so the primitive is unreachable
+ * even if a client bypasses the (not-yet-built) UI — mirrors `MecmuaDisabled`.
  */
+import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
 import {UserId} from "../../lib/ids.ts";
 
@@ -16,4 +22,11 @@ export class SelfMuteRejected extends Schema.TaggedErrorClass<SelfMuteRejected>(
 		memberId: UserId,
 		message: Schema.String,
 	},
+	{[FateWireCode]: "SELF_MUTE_REJECTED"},
+) {}
+
+export class MuteDisabled extends Schema.TaggedErrorClass<MuteDisabled>()(
+	"mute/MuteDisabled",
+	{message: Schema.String},
+	{[FateWireCode]: "MUTE_DISABLED"},
 ) {}

--- a/apps/web/worker/features/mute/fate-module.ts
+++ b/apps/web/worker/features/mute/fate-module.ts
@@ -1,0 +1,16 @@
+/** mute's contribution to the one fate config. See `../fate/module.ts`. */
+import {Fate} from "@kampus/fate-effect";
+import type {FateModule} from "../fate/module.ts";
+import {mutations} from "./mutations.ts";
+import {MuteReceiptView} from "./views.ts";
+
+// `mute.set` / `mute.remove` return `MuteReceiptView` inline, so the entity needs a
+// source to be view-reachable in codegen. A `syntheticSource` (no by-id fetch path) is
+// the minimal footprint — the mutation delivers the receipt in its response (the mecmua
+// `MecmuaSubscriptionReceiptView` idiom).
+const muteReceiptSource = Fate.syntheticSource(MuteReceiptView);
+
+export const fateModule = {
+	mutations,
+	sources: [muteReceiptSource],
+} satisfies FateModule;

--- a/apps/web/worker/features/mute/mutations.ts
+++ b/apps/web/worker/features/mute/mutations.ts
@@ -1,0 +1,81 @@
+/**
+ * Member-mute (sustur) write-path mutation resolvers (#3112, epic #2035) — the
+ * `mute.set` / `mute.remove` acts, gated behind the default-off `member-mute` flag
+ * (ADR 0083, the mecmua write-path dark-ship shape): with the flag off both fail
+ * {@link MuteDisabled}, so the write path is unreachable even if a client bypasses
+ * the (not-yet-built) UI. Domain validation + the DB write live in {@link Mute} (ADR
+ * 0013); this layer resolves the identity, the flag, and delegates to `Mute.set`.
+ *
+ * The muter is always the authenticated caller acting on themselves — `CurrentUser`
+ * is the muter (`muterId`), never a wire input, so a client cannot mute *on behalf
+ * of* another member. An anonymous caller is rejected `Unauthorized` before any read.
+ * `mute.set` mutes (`value: true`), `mute.remove` un-mutes (`value: false`); both are
+ * idempotent (a matching state is a `changed: false` no-op, decided in `Mute.set`).
+ *
+ * NOT fanned: a mute masks only the muter's OWN reads (the read-mask is a sibling
+ * slice), so it writes no Post/Comment/Definition in a subscribed cross-client
+ * connection and publishes no `/fate/live` invalidation — classified `fanned: false`
+ * with that rationale in `fate-live/fanned-mutations.ts` (the `post.save` per-viewer
+ * precedent). See ADR 0155.
+ */
+import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {MEMBER_MUTE} from "../../../src/flags/keys.ts";
+import {UserId} from "../../lib/ids.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
+import {MuteDisabled, SelfMuteRejected} from "./errors.ts";
+import {Mute, type MuteSetResult} from "./Mute.ts";
+import {type MuteReceipt, MuteReceiptView} from "./views.ts";
+
+/** Is the member-mute write path on for this request? Safe-default `false` (ships dark). */
+const memberMuteOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(MEMBER_MUTE, false).pipe(provideRequestFlags);
+});
+
+/** Stamp the wire `__typename` onto the service result — the one mute write-path shaper. */
+const toReceipt = (r: MuteSetResult): MuteReceipt => ({
+	__typename: "MuteReceipt",
+	id: r.mutedId,
+	isMuted: r.isMuted,
+	changed: r.changed,
+});
+
+// Branded wire input (type-only, byte-identical decode): `mutedId` arrives tagged
+// `UserId`, so a transposed service call is a compile error (the mecmua #2700 idiom).
+const MuteInput = Schema.Struct({
+	mutedId: UserId,
+});
+
+/** Resolve one mute presence write to `value`, shared by `mute.set` / `mute.remove`. */
+const setPresence = (value: boolean) =>
+	Effect.fn(value ? "mute.set" : "mute.remove")(function* ({input}: {input: {mutedId: UserId}}) {
+		const user = yield* CurrentUser.required;
+		if (!(yield* memberMuteOn)) {
+			return yield* new MuteDisabled({message: "sustur şu an kapalı"});
+		}
+		const mute = yield* Mute;
+		const result = yield* mute.set({muterId: user.id, mutedId: input.mutedId, value});
+		return toReceipt(result);
+	});
+
+export const mutations = {
+	"mute.set": Fate.mutation(
+		{
+			input: MuteInput,
+			type: MuteReceiptView,
+			error: Schema.Union([Unauthorized, MuteDisabled, SelfMuteRejected]),
+		},
+		setPresence(true),
+	),
+	"mute.remove": Fate.mutation(
+		{
+			input: MuteInput,
+			type: MuteReceiptView,
+			error: Schema.Union([Unauthorized, MuteDisabled, SelfMuteRejected]),
+		},
+		setPresence(false),
+	),
+};

--- a/apps/web/worker/features/mute/mute-fanout.unit.test.ts
+++ b/apps/web/worker/features/mute/mute-fanout.unit.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The live-invalidation classification for the member-mute mutations (#3112, ADR
+ * 0155). A mute masks only the muter's OWN reads (the read-mask is a sibling), so it
+ * writes no Post/Comment/Definition in a subscribed cross-client connection — it is
+ * `fanned: false`, the `post.save` per-viewer-private-relation precedent. This pins
+ * two things the classification asserts:
+ *
+ *   1. `mute.set` / `mute.remove` are declared in the manifest as `fanned: false`,
+ *      each with a rationale — so `fanout-guard`'s drift invariant passes and the
+ *      conscious not-fanned decision is recorded (`fanned-mutations.ts`).
+ *   2. The write path carries NO cross-viewer publish: the resolved mutation depends
+ *      on no `LivePublisher`, so muting/unmuting can never fan an invalidation to
+ *      another viewer's live view — exactly "the muter's own affected views, not a
+ *      cross-viewer fan". The muter's own live views re-mask once the read-mask
+ *      sibling lands; there is no subscribed connection to invalidate in this slice.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {FANNED_MUTATIONS} from "../fate-live/fanned-mutations.ts";
+import {mutations} from "./mutations.ts";
+
+const rowFor = (key: string) => FANNED_MUTATIONS.find((entry) => entry.key === key);
+
+describe("mute mutations — fanned classification (ADR 0155)", () => {
+	for (const key of ["mute.set", "mute.remove"] as const) {
+		it(`${key} is classified fanned: false with a rationale`, () => {
+			const row = rowFor(key);
+			assert.isDefined(row, `${key} must appear in the fanned-mutations manifest`);
+			assert.strictEqual(
+				row?.fanned,
+				false,
+				`${key} masks only the muter's own reads — not fanned`,
+			);
+			assert.isUndefined(row?.topics, `${key} declares no /fate/live topics (not fanned)`);
+			assert.isTrue((row?.rationale.length ?? 0) > 0, `${key} carries a rationale`);
+		});
+	}
+
+	it("every discovered mute mutation key has a manifest row (no drift)", () => {
+		for (const key of Object.keys(mutations)) {
+			assert.isDefined(rowFor(key), `mutation ${key} must be classified in fanned-mutations.ts`);
+		}
+	});
+});

--- a/apps/web/worker/features/mute/mute-mutation.unit.test.ts
+++ b/apps/web/worker/features/mute/mute-mutation.unit.test.ts
@@ -1,0 +1,159 @@
+/**
+ * `mute.set` / `mute.remove` WIRE-boundary coverage (#3112, epic #2035) — the
+ * decisions that are wrong-or-right with no database (ADR 0082), driven through the
+ * real external interface (`resolveWire`: decode + the `encodeWireError`
+ * class→wire-code seam), so a denial's wire `code` is what a client gets.
+ *
+ * The load-bearing ACs:
+ *   - gated on `CurrentUser`: an anonymous caller is rejected the invisible
+ *     `UNAUTHORIZED` before any read (the `Mute` stub is fail-on-contact);
+ *   - dark-ship: with the `member-mute` flag OFF both fail `MUTE_DISABLED` before the
+ *     write, so an unreleased mute never runs;
+ *   - with the flag ON an authed muter's set/remove reaches `Mute.set` and the receipt
+ *     carries the post-write presence; a self-mute surfaces `SELF_MUTE_REJECTED`.
+ *
+ * The real-D1 presence idempotency + set/readMutedIds round-trip live in
+ * `Mute.unit.test.ts` (the domain seam) and the integration tier once the read-mask +
+ * manage UI siblings wire an HTTP/fate surface to drive Mute black-box over.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {UserId} from "../../lib/ids.ts";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {SelfMuteRejected} from "./errors.ts";
+import {Mute, type MuteSetInput, type MuteSetResult} from "./Mute.ts";
+import {mutations} from "./mutations.ts";
+
+const MUTER = {id: "u-muter", email: "kaan@example.com", name: "kaan"};
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "mute-mutation-test",
+	id: "mute-mutation-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(on),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service);
+
+// A `Mute` whose `set` runs `impl` (or dies on contact) — so a denied path that must
+// short-circuit before the write proves it by failing the fail-on-contact default.
+const muteStub = (impl?: (input: MuteSetInput) => Effect.Effect<MuteSetResult, SelfMuteRejected>) =>
+	Layer.succeed(Mute, {
+		set: impl ?? (() => Effect.die("Mute.set reached on a path that must short-circuit")),
+		readMutedIds: () => Effect.die("Mute.readMutedIds not exercised"),
+	});
+
+const setMute = (mutedId: string, user?: typeof MUTER) =>
+	resolveWire(mutations["mute.set"], {input: {mutedId}, select: ["id", "isMuted", "changed"]}).pipe(
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+	);
+
+const removeMute = (mutedId: string, user?: typeof MUTER) =>
+	resolveWire(mutations["mute.remove"], {
+		input: {mutedId},
+		select: ["id", "isMuted", "changed"],
+	}).pipe(
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+	);
+
+const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
+	const error = Cause.findErrorOption(cause);
+	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
+};
+
+describe("mute.set / mute.remove — CurrentUser gate + dark-ship (fail closed)", () => {
+	it.effect("an anonymous caller is rejected UNAUTHORIZED — and never reaches the write", () =>
+		Effect.gen(function* () {
+			const exit = yield* setMute("u-target").pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+		}).pipe(Effect.provide(Layer.mergeAll(flagsStub(true), muteStub()))),
+	);
+
+	it.effect("with the flag OFF an authed muter is refused MUTE_DISABLED — no write", () =>
+		Effect.gen(function* () {
+			const exit = yield* setMute("u-target", MUTER).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "MUTE_DISABLED");
+		}).pipe(Effect.provide(Layer.mergeAll(flagsStub(false), muteStub()))),
+	);
+
+	it.effect("with the flag ON an authed muter mutes; the receipt reports the presence", () =>
+		Effect.gen(function* () {
+			const receipt = yield* setMute("u-target", MUTER);
+			assert.deepStrictEqual(receipt, {
+				__typename: "MuteReceipt",
+				id: "u-target",
+				isMuted: true,
+				changed: true,
+			});
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					flagsStub(true),
+					muteStub((input) => {
+						assert.strictEqual(input.muterId, MUTER.id, "the muter is the authed caller");
+						assert.strictEqual(input.value, true, "mute.set writes value=true");
+						return Effect.succeed({mutedId: input.mutedId, isMuted: true, changed: true});
+					}),
+				),
+			),
+		),
+	);
+
+	it.effect("with the flag ON mute.remove un-mutes; the receipt reports not-muted", () =>
+		Effect.gen(function* () {
+			const receipt = yield* removeMute("u-target", MUTER);
+			assert.deepStrictEqual(receipt, {
+				__typename: "MuteReceipt",
+				id: "u-target",
+				isMuted: false,
+				changed: true,
+			});
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					flagsStub(true),
+					muteStub((input) => {
+						assert.strictEqual(input.value, false, "mute.remove writes value=false");
+						return Effect.succeed({mutedId: input.mutedId, isMuted: false, changed: true});
+					}),
+				),
+			),
+		),
+	);
+
+	it.effect("a self-mute surfaces the SELF_MUTE_REJECTED wire code", () =>
+		Effect.gen(function* () {
+			const exit = yield* setMute(MUTER.id, MUTER).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "SELF_MUTE_REJECTED");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					flagsStub(true),
+					muteStub((input) =>
+						Effect.fail(
+							new SelfMuteRejected({
+								memberId: UserId.make(input.muterId),
+								message: "a member cannot mute themselves",
+							}),
+						),
+					),
+				),
+			),
+		),
+	);
+});

--- a/apps/web/worker/features/mute/views.ts
+++ b/apps/web/worker/features/mute/views.ts
@@ -1,0 +1,28 @@
+/**
+ * Mute fate data view (#3112) — the write receipt the `mute.set` / `mute.remove`
+ * mutations return inline (the mecmua `MecmuaSubscriptionReceiptView` idiom): a
+ * synthetic view with no fetch path, delivered by the mutation, never re-fetched.
+ * `id` is the muted member (the receipt's identity), `isMuted` the muter's presence
+ * over them AFTER the write, `changed` false on an idempotent no-op. Data views are
+ * the schema (ADR 0018); see `.patterns/fate-effect-data-views.md`.
+ */
+import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
+import type {ViewRow} from "../fate/view-types.ts";
+
+export type MuteReceiptViewRow = ViewRow<{
+	/** The muted member id — the receipt's identity. */
+	id: string;
+	/** The muter's mute presence over `id` after the write. */
+	isMuted: boolean;
+	/** `false` on an idempotent no-op (state already matched intent). */
+	changed: boolean;
+}>;
+
+export class MuteReceiptView extends FateDataView<MuteReceiptViewRow>()("MuteReceipt")({
+	id: true,
+	isMuted: true,
+	changed: true,
+} satisfies {[K in keyof MuteReceiptViewRow]: true}) {}
+
+export const muteReceiptDataView = MuteReceiptView.view;
+export type MuteReceipt = WorkerEntity<typeof MuteReceiptView>;


### PR DESCRIPTION
## What

The write-path + flag + live-classification slice of #3112: expose member-mute (sustur) as `mute.set` / `mute.remove` fate mutations, gated on `CurrentUser` and behind a new default-off `member-mute` Flagship flag, and classify them for the fanout-guard.

## Changes

- **Flag (dark-ship, ADR 0083).** `MEMBER_MUTE` (`"member-mute"`) key + `DECLARED_FLAGS` row (`apps/web/src/flags/keys.ts`), the `MEMBER_MUTE_FLAG` IaC config + `memberMuteFlag` factory (`worker/features/flagship/resources.ts`), registered in `alchemy.run.ts`. Default-off; with the flag off both mutations fail closed `MUTE_DISABLED`.
- **Mutations.** `mute.set` / `mute.remove` roots (`worker/features/mute/mutations.ts` + `fate-module.ts`, registered in `fate/config.ts`; `MuteLive` wired into `fate/layers.ts`). The muter is always the authed caller acting on themselves — an anonymous caller is rejected `UNAUTHORIZED`; a self-mute surfaces `SELF_MUTE_REJECTED`. Delegates to the existing `Mute.set` domain object.
- **Live classification (`fanned-mutations.ts`).** Both `fanned: false`. A mute masks only the muter's OWN reads (the read-mask is the out-of-scope sibling), so it writes no `Post`/`Comment`/`Definition` in a subscribed cross-client connection — and its own views are per-viewer, so a publish onto the login-blind shared topic would over-fan to every viewer. This is the exact `post.save` / `mecmua.subscribe` per-viewer-private-relation precedent. `fanout-guard check` passes (48 mutations classified).
- **Wire codes + view.** New `MUTE_DISABLED` / `SELF_MUTE_REJECTED` codes registered in the SPA list, messages, and per-class oracle; `MuteReceipt` view.

## Out of scope (per the issue)

The read-mask application (sibling) and the consuming/manage UI (reachability child). This slice is the write path only, so no subscribed entity is affected yet — hence the not-fanned classification.

## Tests

- `mute-mutation.unit.test.ts` — anon rejected `UNAUTHORIZED`, flag-off `MUTE_DISABLED` (no write), set/remove happy path + receipt, self-mute `SELF_MUTE_REJECTED` (wire-boundary).
- `member-mute.invariant.test.ts` — the default-off flag invariant.
- `mute-fanout.unit.test.ts` — the `fanned: false` classification + no-drift, proving no cross-viewer fan.

Typecheck, biome, `fanout-guard`, and `catalog-guard` all green.

Fixes #3112