### PR TITLE
test(integration): 429-retry the kunye restLayer data-plane calls (#3099)

### DIFF
--- a/apps/web/tests/integration/_d1-rest-retry.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.ts
@@ -60,3 +60,23 @@ export const cfFetchWithRateLimitRetry = async (
 	}
 	return res;
 };
+
+/**
+ * A `fetch` that funnels every send through {@link cfFetchWithRateLimitRetry}, so the SAME 429
+ * discipline the setup path has (#2915/#3089) also covers a test's DATA-PLANE D1 REST calls issued
+ * over `makeD1Rest`'s `restLayer`. Inject it as the `FetchHttpClient.Fetch` reference the rest layer
+ * reads (`Layer.succeed(FetchHttpClient.Fetch, rateLimitRetryingFetch(fetch))`).
+ *
+ * Why this seam and not a per-call catch: `fetch` RESOLVES a 429 as a `Response` (an HTTP status is
+ * not a network error, so it never rejects), so the retry inspects `.status` and re-sends BEFORE
+ * `queryDatabase` maps a settled 429 body to a thrown error. A 429 therefore never surfaces as a
+ * thrown error to drizzle or to `readYourWrite`'s poll — one seam covers every data-plane call
+ * (`has`/`mint`/`remove`), the polled and the direct reads alike, reusing #3089's wrapper unchanged
+ * rather than growing a second retry path (#3099).
+ */
+export const rateLimitRetryingFetch = (
+	base: typeof globalThis.fetch,
+	options: RateLimitRetryOptions = {},
+): typeof globalThis.fetch =>
+	((input: Parameters<typeof globalThis.fetch>[0], init?: Parameters<typeof globalThis.fetch>[1]) =>
+		cfFetchWithRateLimitRetry(() => base(input, init), options)) as typeof globalThis.fetch;

--- a/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
@@ -6,11 +6,16 @@
  * injected so the whole suite runs offline and instantly.
  */
 
+import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
+import {makeD1Rest} from "@kampus/d1-rest";
+import {Layer} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {describe, expect, it, vi} from "vitest";
 import {
 	CF_RATE_LIMIT_STATUS,
 	cfFetchWithRateLimitRetry,
 	D1_REST_BASE_DELAY_MS,
+	rateLimitRetryingFetch,
 } from "./_d1-rest-retry.ts";
 
 // A minimal `Response` stand-in — the retry only reads `.status` and cancels `.body`.
@@ -81,5 +86,55 @@ describe("cfFetchWithRateLimitRetry", () => {
 			expect(ms).toBeGreaterThanOrEqual(0);
 			expect(ms).toBeLessThan(ceil);
 		});
+	});
+});
+
+// The data-plane fix (#3099): the `restLayer` transport's fetch is wrapped so a data-plane D1 REST
+// call retries a 429 at the transport, before `queryDatabase` maps a settled 429 to a thrown error.
+describe("rateLimitRetryingFetch — 429-resilient restLayer transport", () => {
+	// A base fetch yielding the given statuses in order (last repeats); a 200 carries a valid
+	// D1 REST body so `makeD1Rest` can parse it. Records how many sends the wrapper made.
+	const baseFetch = (statuses: number[]) => {
+		let i = 0;
+		return vi.fn(async () => {
+			const status = statuses[Math.min(i++, statuses.length - 1)]!;
+			if (status === CF_RATE_LIMIT_STATUS) return new Response("429", {status});
+			return new Response(
+				JSON.stringify({result: [{meta: {changes: 1}, results: [], success: true}]}),
+				{
+					status,
+					headers: {"content-type": "application/json"},
+				},
+			);
+		});
+	};
+
+	it("resends a data-plane 429 through the base fetch until it settles 200", async () => {
+		const base = baseFetch([429, 429, 200]);
+		const res = await rateLimitRetryingFetch(base, {sleep: noSleep, random: () => 0.5})(
+			"https://example.test/query",
+		);
+		expect(res.status).toBe(200);
+		expect(base).toHaveBeenCalledTimes(3); // initial + 2 retries
+	});
+
+	it("drives a makeD1Rest query through a 429→200 fetch WITHOUT throwing (the #3099 hard-fail)", async () => {
+		const base = baseFetch([429, 200]);
+		const db = makeD1Rest({
+			accountId: "acc",
+			databaseId: "db",
+			layer: Layer.mergeAll(
+				FetchHttpClient.layer.pipe(
+					Layer.provide(
+						Layer.succeed(FetchHttpClient.Fetch, rateLimitRetryingFetch(base, {sleep: noSleep})),
+					),
+				),
+				fromApiToken({apiToken: "test-token"}),
+			),
+		});
+		// Without the wrapper the 429 would surface as a thrown error and reject this run.
+		const res = await db.prepare("update x set y = ? where z = ?").bind("a", "b").run();
+		expect(res.meta.changes).toBe(1);
+		expect(base).toHaveBeenCalledTimes(2); // 429 retried, then the settled 200
 	});
 });

--- a/apps/web/tests/integration/kunye-relation-store.test.ts
+++ b/apps/web/tests/integration/kunye-relation-store.test.ts
@@ -26,13 +26,27 @@ import {afterEach, beforeAll, describe, expect, it} from "vitest";
 import {createDrizzle, type DrizzleDb, makeDrizzleLayer} from "../../worker/db/Drizzle.ts";
 import * as schema from "../../worker/db/drizzle/schema.ts";
 import {objectKey, RelationStoreLive} from "../../worker/features/kunye/RelationStore.ts";
+import {rateLimitRetryingFetch} from "./_d1-rest-retry.ts";
 import {sharedStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
 
 const h = sharedStack();
 const NS = nsToken(import.meta.url);
 
-const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+// Data-plane `has`/`mint`/`remove` cross this REST transport, so its `fetch` carries the same
+// 429-retry the setup path has (#3089): a transient CF 429 (code 971) under merge_group load is
+// re-sent with full-jitter backoff at the transport, not thrown into drizzle/`readYourWrite` (#3099).
+const restLayer = Layer.merge(
+	CredentialsFromEnv,
+	FetchHttpClient.layer.pipe(
+		Layer.provide(
+			Layer.succeed(
+				FetchHttpClient.Fetch,
+				rateLimitRetryingFetch((input, init) => fetch(input, init)),
+			),
+		),
+	),
+);
 
 const object = resource("platform", NS);
 const SUBJECT = `${NS}-alice`;


### PR DESCRIPTION
Fixes #3099

## What

The real-D1 integration suite `apps/web/tests/integration/kunye-relation-store.test.ts` runs its data-plane `has()` / `mint()` / `remove()` calls over a plain `restLayer` (`makeD1Rest` + `FetchHttpClient`). That transport carried **no 429 resilience**. With #3090 (merged) removing the `retry: 2` block-level stopgap, a transient CF 429 (code 971) on one of those calls would **hard-fail** the test where `retry: 2` used to transparently re-run it.

## How — reuse #3089's wrapper at the transport seam (no parallel retry path)

Wrap the `restLayer`'s `FetchHttpClient.Fetch` reference with the **same** `cfFetchWithRateLimitRetry` (from `_d1-rest-retry.ts`, the #2915/#3089 setup-path 429 retry), exposed as a new `rateLimitRetryingFetch(base)` helper in that same file:

```ts
const restLayer = Layer.merge(
  CredentialsFromEnv,
  FetchHttpClient.layer.pipe(
    Layer.provide(
      Layer.succeed(FetchHttpClient.Fetch, rateLimitRetryingFetch((input, init) => fetch(input, init))),
    ),
  ),
);
```

`FetchHttpClient.Fetch` is a `Context.Reference<typeof globalThis.fetch>` (verified against effect-smol `unstable/http/FetchHttpClient.ts` — the `Fetch` reference the fetch client reads per request), and `fetch` **resolves** a 429 as a `Response` (an HTTP status is not a network error, so `fetch` never rejects). So `cfFetchWithRateLimitRetry` inspects `.status` and re-sends with full-jitter backoff **before** `queryDatabase` maps a settled 429 body to a thrown error.

### Why the transport seam covers the whole acceptance surface

- **AC1 — data-plane calls 429-resilient via the #3089 discipline:** every call over `restLayer` (`has`/`mint`/`remove`) now funnels through `cfFetchWithRateLimitRetry` (429-only, full-jitter backoff), reused unchanged.
- **AC2 — no thrown 429 reaches `readYourWrite`'s poll:** because the 429 is retried one layer down (at the fetch `Response`), it never surfaces as a thrown error to drizzle **or** to `readYourWrite`'s `read()` poll — the exact hard-fail AC2 names is eliminated at the source, and it covers the *direct* `has()` reads too (the ones not wrapped in `readYourWrite`), which a `readYourWrite`-only catch would miss. `readYourWrite` (in shared `packages/d1-rest`) is intentionally left untouched — the fix stays confined to the integration harness.
- **AC3 — coverage unchanged:** no `skip`, no weakened assertions; only transport resilience added. The `hasWhen`/`has` assertions are identical.
- **AC4 — sequenced with #3090:** built on fresh `origin/main` (both #3089 and #3090 merged); the `retry: 2` stopgap is already gone.

## Tests

Added two unit tests to `_d1-rest-retry.unit.test.ts`:
- `rateLimitRetryingFetch` resends a data-plane 429 through the base fetch until it settles 200.
- Driving a real `makeD1Rest` query through a 429→200 fetch returns a parsed result **without throwing** (the #3099 hard-fail path, now retried).

`pnpm -C apps/web typecheck` clean · `biome check` clean · unit suite green (7/7).