### PR TITLE
feat(atolye): /lab/atolye public exhibit index route (#3092)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -39,6 +39,7 @@ import {
 	PHOENIX_NAV_IA,
 } from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
+import {AtolyeIndexPage} from "./lab/atolye/AtolyeIndexPage";
 import {DensityProvider} from "./lib/density";
 import {SAVED_HREF} from "./lib/panoNav";
 import {safeReturnTo} from "./lib/returnTo";
@@ -515,6 +516,10 @@ export function App() {
 								</Suspense>
 							}
 						/>
+						{/* /lab/atolye — public index of atölye, the museum of craft (epic #2473, #3092).
+						    ASCII route slug (routes-are-English); reachable by URL only, no nav entry,
+						    matching the /lab/composer precedent. */}
+						<Route path="/lab/atolye" element={<AtolyeIndexPage />} />
 						<Route path="/profile" element={<ProfilePage />} />
 						<Route path="/u/:username" element={<UserProfilePage />} />
 						{/* The admin console (#2740, epic #2711) — the route element self-gates on

--- a/apps/web/src/lab/atolye/AtolyeIndexPage.css
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.css
@@ -1,0 +1,62 @@
+/* /lab/atolye index (#3092). Role tokens only — atölye dogfoods the ADR-0162 design law it
+   showcases. */
+
+.kp-atolye__inner {
+	max-width: var(--content-w);
+	margin: 0 auto;
+	padding: var(--s-4) var(--s-3) var(--s-8);
+}
+
+.kp-atolye__masthead {
+	padding: var(--s-2) 0 var(--s-4);
+	border-bottom: 1px solid var(--border);
+}
+
+.kp-atolye__title {
+	font: var(--t-h-feed);
+	font-weight: 700;
+	margin: 0;
+	color: var(--text-primary);
+}
+
+.kp-atolye__lead {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	margin: var(--s-2) 0 0;
+	max-width: 60ch;
+}
+
+.kp-atolye__list {
+	list-style: none;
+	margin: var(--s-4) 0 0;
+	padding: 0;
+	display: grid;
+	gap: var(--s-2);
+}
+
+.kp-atolye__card {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	padding: var(--s-3);
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+	background: var(--surface);
+	text-decoration: none;
+}
+
+.kp-atolye__card:hover {
+	border-color: var(--border-strong);
+	background: var(--surface-raised);
+}
+
+.kp-atolye__card-title {
+	font: var(--t-body);
+	font-weight: 600;
+	color: var(--link);
+}
+
+.kp-atolye__card-summary {
+	font: var(--t-meta);
+	color: var(--text-secondary);
+}

--- a/apps/web/src/lab/atolye/AtolyeIndexPage.test.tsx
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * The /lab/atolye index lists exactly what the headless registry enumerates and deep-links each
+ * row to its detail route (#3092). The registry is the seam: the page holds no exhibit list of its
+ * own, so it can never drift from `listExhibits()`.
+ */
+import {render, screen, within} from "@testing-library/react";
+import {MemoryRouter} from "react-router";
+import {describe, expect, it} from "vitest";
+import {AtolyeIndexPage} from "./AtolyeIndexPage";
+import {listExhibits} from "./registry";
+
+function renderPage() {
+	return render(
+		<MemoryRouter initialEntries={["/lab/atolye"]}>
+			<AtolyeIndexPage />
+		</MemoryRouter>,
+	);
+}
+
+describe("AtolyeIndexPage — /lab/atolye index (#3092)", () => {
+	it("renders one row per registered exhibit, sourced from listExhibits()", () => {
+		renderPage();
+		const list = screen.getByRole("list", {name: "sergiler"});
+		expect(within(list).getAllByRole("listitem")).toHaveLength(listExhibits().length);
+	});
+
+	it("links each exhibit to its ASCII /lab/atolye/:exhibit detail path", () => {
+		renderPage();
+		for (const exhibit of listExhibits()) {
+			const link = screen.getByRole("link", {name: new RegExp(exhibit.title)});
+			expect(link.getAttribute("href")).toBe(`/lab/atolye/${exhibit.id}`);
+		}
+	});
+});

--- a/apps/web/src/lab/atolye/AtolyeIndexPage.tsx
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.tsx
@@ -1,0 +1,43 @@
+/**
+ * `/lab/atolye` — the public index of atölye, the in-product museum of craft (epic #2473).
+ * Lists every exhibit the headless registry enumerates; each row deep-links to that exhibit's
+ * detail route (#3093). The registry is the seam (`.patterns/atolye-exhibit-harness.md`) — a new
+ * exhibit appears here by landing one `*.exhibit.tsx` + one registry line, never a route edit.
+ *
+ * Route/slug are ASCII English (`/lab/atolye`, matching this dir + the routes-are-English
+ * convention); the visible brand copy stays Turkish (`atölye`, with the ö).
+ */
+
+import {Link} from "react-router";
+import {listExhibits} from "./registry";
+import "./AtolyeIndexPage.css";
+
+export function AtolyeIndexPage() {
+	const exhibits = listExhibits();
+	return (
+		<main className="kp-atolye" data-testid="lab-atolye-index">
+			<div className="kp-atolye__inner">
+				<header className="kp-atolye__masthead">
+					<h1 className="kp-atolye__title">atölye</h1>
+					<p className="kp-atolye__lead">
+						Tasarım sistemimizin canlı vitrini — her parça, kendi prop-düğmeleriyle yaşayan bir
+						sergi. Bir sergiye tıkla, varyantlarını canlı kurcala.
+					</p>
+				</header>
+
+				<ul className="kp-atolye__list" aria-label="sergiler">
+					{exhibits.map((exhibit) => (
+						<li key={exhibit.id} className="kp-atolye__item">
+							<Link to={`/lab/atolye/${exhibit.id}`} className="kp-atolye__card">
+								<span className="kp-atolye__card-title">{exhibit.title}</span>
+								{exhibit.summary ? (
+									<span className="kp-atolye__card-summary">{exhibit.summary}</span>
+								) : null}
+							</Link>
+						</li>
+					))}
+				</ul>
+			</div>
+		</main>
+	);
+}


### PR DESCRIPTION
Fixes #3092

## What

Builds the public **atölye index** route — `/lab/atolye` — the listing page for the in-product museum of craft (epic #2473). Wires it into the react-router 7 route tree in `apps/web/src/App.tsx` alongside `/lab/composer`, under the public `/lab/*` convention (#2469). Reachable by URL only, no nav entry, no auth gate.

## Route slug — ASCII (founder ruling)

The URL segment is ASCII English **`/lab/atolye`** (matching the already-ASCII `apps/web/src/lab/atolye/` dir + the routes-are-English convention), not `/lab/atölye`. The visible brand/display copy stays Turkish `atölye` (with the ö). This corrects the closed PR #3177, which used the non-ASCII route slug and was closed by the founder to rebuild clean.

## How

- `AtolyeIndexPage` sources its rows from the headless registry via `listExhibits()` — the page holds no exhibit list of its own, so adding an exhibit to the registry makes it appear here with **no index edit** (the registry seam, `.patterns/atolye-exhibit-harness.md`). Appending exhibits is out of scope (that is #3094).
- Each row is a `Link` deep-linking to that exhibit's `/lab/atolye/:exhibit` detail path (built in #3093).
- Role-token / ADR-0162 four-pillar styling (no raw hex/px, no external storybook dep); semantic list + labelled links (pillar-4 a11y). Turkish product copy for the visible title + lead.

## Scope

Index page + route wiring only. Out of scope: the detail/deep-link route + not-found (#3093), the exhibit catalog fill (#3094).

## Test

`AtolyeIndexPage.test.tsx` asserts one row per registered exhibit (sourced from `listExhibits()`, so it can't drift) and that each row deep-links to the ASCII `/lab/atolye/:exhibit` path.

Local: `pnpm typecheck` ✓, `pnpm lint` ✓, client tests (AtolyeIndexPage + App) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)