### PR TITLE
docs(decisions): ADR 0148 — record the 2026-07-16 reverts-to-çaylak clarification (#144)

### DIFF
--- a/.decisions/0148-kunye-ban-vouch-graph-semantics.md
+++ b/.decisions/0148-kunye-ban-vouch-graph-semantics.md
@@ -42,9 +42,11 @@ designed.
 
 ## Decision
 
-The founder ruling (2026-07-04) **adopts the founder-leaning proposal as-is,
-without amendment**. Four rules govern a ban's effect on the released vouch/kefil
-graph:
+This is an **evaluate-then-adopt** decision: the founder-leaning proposal (#144's
+body) was evaluated explicitly and **adopted as-is with one clarification**. The
+2026-07-04 ruling adopted the four rules below unchanged; the 2026-07-16 ruling
+re-affirmed them and added the single clarification recorded as rule 5. Five rules
+govern a ban's effect on the released vouch/kefil graph:
 
 1. **A banned yazar's outstanding pre-promotion vouches → revoked; each affected
    çaylak's tandem check re-runs.** A vouch given by a now-banned yazar is no
@@ -72,9 +74,20 @@ graph:
    human moderator judgment**: the mod sees the cluster (rule 3) and acts case by
    case, rather than the system auto-penalizing every account the sponsor touched.
 
+5. **A çaylak who drops below the promotion threshold after the rule-1 tandem
+   re-run reverts to çaylak — re-vouchable, no penalty, not limbo** (clarification,
+   2026-07-16 ruling). Revoking the banned yazar's vouch (rule 1) can leave a
+   not-yet-promoted çaylak short of the tandem bar. That çaylak is simply a çaylak
+   again: they may receive a fresh vouch from any other yazar and re-run tandem
+   normally, they carry **no** mark or penalty from the revoked vouch, and they are
+   **not** placed in a distinct suspended/quarantined state. This is the
+   already-implied behavior of an active-by-existence `VouchLedger` (a revoked
+   vouch is indistinguishable from one never given) stated explicitly, so the
+   mod-UI never invents a limbo status for these çaylaks.
+
 ## Consequences
 
-- **Feeds mod-UI ban controls before they are designed.** These four rules are the
+- **Feeds mod-UI ban controls before they are designed.** These five rules are the
   settled graph semantics that
   [#1665](https://github.com/kamp-us/phoenix/issues/1665) (moderator-UI planning)
   and [#970](https://github.com/kamp-us/phoenix/issues/970) (ban / unban a user


### PR DESCRIPTION
Fixes #144

## What

Amends **ADR 0148 — künye ban vouch/kefil-graph semantics** to close out the re-typed #144 deliverable.

ADR 0148 (authored 2026-07-04 via PR #1999 for this same issue) already recorded the four adopted ban semantics. #144 was then re-typed `type:decision` → `type:chore` on 2026-07-16, and the founder ruling gained **one clarification** that the ADR predated. This PR records it:

- Reframes the Decision as an explicit **evaluate-then-adopt** outcome: the founder-leaning proposal was evaluated and **adopted as-is with one clarification**.
- Adds **rule 5** (the 2026-07-16 clarification): a çaylak who drops below the promotion threshold after the rule-1 tandem re-run **reverts to çaylak — re-vouchable, no penalty, not limbo**.

The four prior semantics are unchanged: (1) outstanding pre-promotion vouches revoked + tandem re-run; (2) promoted vouchees keep yazar, no cascade demotion; (3) kefil provenance stays moderator-visible; (4) sponsor liability social, not mechanical, in v1.

## Acceptance criteria

- [x] ADR authored as an **evaluate-then-adopt** decision — proposal evaluated, adopted as-is with one clarification.
- [x] All four adopted semantics recorded (rules 1–4).
- [x] Clarification recorded (rule 5 — reverts to çaylak, re-vouchable, no penalty, not limbo).
- [x] Fed into moderator-UI ban-control planning: the ADR's Consequences cite the mod-UI ban-control consumers (#1665, #970). Both are now `closed` with no open successor planning issue, so the durable ADR cross-reference is the feed; the ADR lands before any future ban-control design.

## Scope note

Kept strictly to the re-typed #144 unit: a `.decisions/` doc write. Per the issue body, the künye/moderation **code** that implements these semantics is separate downstream `apps/web` work, not this unit — so no worker/DO code changes here. Amends the existing ADR 0148 (the record for this decision) rather than opening a duplicate ADR for the same decision.