### PR TITLE
feat(pipeline-cli): roadmap-guard I5 — active↔done campaign lifecycle symmetry (#2660)

### DIFF
--- a/.github/workflows/roadmap-guard.yml
+++ b/.github/workflows/roadmap-guard.yml
@@ -4,10 +4,12 @@ name: roadmap-guard
 # `## Arcs`/`## Campaigns` tables and the GitHub milestone projection they pin to must
 # stay in sync — sync-drift diligence is load-bearing, so it is GUARDED fail-closed, not
 # left to vigilance. The tool parses ROADMAP.md (the sole parsed surface) and validates
-# I1–I4 against the live milestone REST projection:
+# I1–I5 against the live milestone REST projection:
 #   I1 arc/campaign pinned to an existing milestone by number (a queued arc may defer)
 #   I2 exactly one active arc  ·  I3 no unclaimed open milestone
 #   I4 fail-closed on zero scope (ADR 0092)
+#   I5 active↔done state symmetry — an active row's milestone is open, a done row's closed
+#      (the campaign lifecycle guard, #2660)
 # The check lives once in pipeline-cli (`roadmap-guard check`); this workflow only wires
 # it to the four triggers.
 on:

--- a/packages/pipeline-cli/src/tools/roadmap-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/command.ts
@@ -6,12 +6,14 @@
  * tables (the sole parsed surface) and validates them against the live milestone
  * projection, fail-closed:
  *
- *   pipeline-cli roadmap-guard check            # CI gate: exit non-zero on any I1–I4 drift
+ *   pipeline-cli roadmap-guard check            # CI gate: exit non-zero on any I1–I5 drift
  *   pipeline-cli roadmap-guard check --root <d> # point at a specific repo root (else: walk up)
  *
- * Invariants (I1–I4, extended to campaign rows; see `roadmap-guard.ts`): I1 arc/campaign
+ * Invariants (I1–I5, extended to campaign rows; see `roadmap-guard.ts`): I1 arc/campaign
  * pinned to an existing milestone by number (a queued arc may defer its pin); I2 exactly
- * one active arc; I3 no unclaimed open milestone; I4 fail-closed on zero scope (ADR 0092).
+ * one active arc; I3 no unclaimed open milestone; I4 fail-closed on zero scope (ADR 0092);
+ * I5 active↔done state symmetry — an active row's milestone is open, a done row's closed
+ * (the campaign lifecycle guard, #2660).
  *
  * The pure decision lives in `roadmap-guard.ts` (unit-tested exhaustively); the file read
  * + `gh api` milestone fetch in `gate.ts`/`github.ts`. `MilestonesLive` is baked in with
@@ -77,7 +79,7 @@ const check = Command.make(
 export const roadmapGuardCommand = Command.make("roadmap-guard").pipe(
 	Command.withSubcommands([check]),
 	Command.withDescription(
-		"Fail-closed gate: ROADMAP.md ↔ GitHub-milestone sync (I1–I4, #2620/#2632)",
+		"Fail-closed gate: ROADMAP.md ↔ GitHub-milestone sync (I1–I5, #2620/#2632/#2660)",
 	),
 	Command.provide(MilestonesLive),
 );

--- a/packages/pipeline-cli/src/tools/roadmap-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/gate.ts
@@ -40,8 +40,9 @@ const readRoadmap = (root: string): Effect.Effect<string, IoError> =>
 
 /**
  * The CI gate: parse `ROADMAP.md`'s `## Arcs`/`## Campaigns` tables, read the live
- * milestone projection, and judge I1–I4 (extended to campaign rows). Succeeds only on a
- * passing verdict; every non-pass — including zero-scope — is a `CheckFailed`.
+ * milestone projection, and judge I1–I5 (extended to campaign rows + the active↔done
+ * lifecycle symmetry, #2660). Succeeds only on a passing verdict; every non-pass —
+ * including zero-scope — is a `CheckFailed`.
  */
 export const checkRoadmap = (
 	root: string,

--- a/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.ts
@@ -7,7 +7,7 @@
  * fetch live in `gate.ts`/`github.ts`; this module never touches disk or the network.
  *
  * ROADMAP.md is the SOLE parsed surface; milestones are the projection validated
- * against it (#2630/#2632). The invariants (I1–I4, extended to campaign rows):
+ * against it (#2630/#2632). The invariants (I1–I5, extended to campaign rows):
  *   I1 — every row is pinned to its milestone BY NUMBER and that milestone exists.
  *        A QUEUED arc gets its milestone lazily on activation, so a queued arc with
  *        no pin is legal; every other row (active/done arc, any campaign) must pin.
@@ -16,6 +16,13 @@
  *   I3 — NO UNCLAIMED OPEN MILESTONE: every open milestone is claimed by some row.
  *   I4 — FAIL-CLOSED ON ZERO SCOPE (ADR 0092): zero arc rows or zero milestones ⇒
  *        a non-passing verdict, never a vacuous green (the readme-guard precedent).
+ *   I5 — STATE SYMMETRY (the active↔done campaign lifecycle, #2660): an `active` row's
+ *        milestone is OPEN and a `done` row's milestone is CLOSED — no active row over a
+ *        closed milestone, no done row over an open one. Applies to any row whose pin
+ *        resolves and whose state is active/done (arc or campaign); a queued arc is exempt
+ *        (its milestone opens lazily on activation, I1). This is the campaign guard's core:
+ *        it keeps ROADMAP.md's lifecycle cell and the milestone's open/closed reality from
+ *        silently disagreeing.
  */
 
 /** An arc is sequenced ahead (`queued`) then made current (`active`) and retired (`done`). */
@@ -56,7 +63,7 @@ const CAMPAIGN_STATES: ReadonlyArray<string> = ["active", "done"];
  * names the offending row/milestone so the report can print it on stderr (ADR 0092 §1).
  */
 export interface Violation {
-	readonly code: "I1" | "I2" | "I3" | "row-state";
+	readonly code: "I1" | "I2" | "I3" | "I5" | "row-state";
 	readonly message: string;
 }
 
@@ -98,7 +105,7 @@ const pinMayBeAbsent = (row: RoadmapRow): boolean => row.kind === "arc" && row.s
  *
  * Order: I4 (zero-scope) fails closed first — with no arcs or no milestones there is
  * nothing to meaningfully check, so refuse rather than pass vacuously. Otherwise every
- * violation is collected (row well-formedness, then I1, I2, I3) so one run names all
+ * violation is collected (row well-formedness, then I1, I2, I3, I5) so one run names all
  * drift, not just the first.
  */
 export const judge = (
@@ -174,6 +181,22 @@ export const judge = (
 		}
 	}
 
+	// I5 — state symmetry (the active↔done lifecycle, #2660): an active row's milestone is
+	// open, a done row's is closed. Only rows whose pin resolves are checked (an absent or
+	// dangling pin is already I1); a queued arc has no open/closed expectation (I1 lazy pin).
+	for (const row of rows) {
+		if (row.milestone === null) continue;
+		const m = byNumber.get(row.milestone);
+		if (m === undefined) continue; // dangling pin already reported by I1
+		const expected = row.state === "active" ? "open" : row.state === "done" ? "closed" : null;
+		if (expected !== null && m.state !== expected) {
+			violations.push({
+				code: "I5",
+				message: `${row.kind} row "${row.name}" is "${row.state}" but its milestone #${m.number} ("${m.title}") is ${m.state} — an active row needs an open milestone, a done row a closed one`,
+			});
+		}
+	}
+
 	if (violations.length > 0) {
 		return {pass: false, reason: "violations", violations};
 	}
@@ -190,7 +213,7 @@ export const renderReport = (verdict: RoadmapGuardVerdict): string => {
 	if (verdict.pass) {
 		return (
 			`roadmap-guard: in sync — ${verdict.arcCount} arc row(s) + ${verdict.campaignCount} campaign row(s) ` +
-			`validated against ${verdict.milestoneCount} milestone(s) (I1–I4 all green).`
+			`validated against ${verdict.milestoneCount} milestone(s) (I1–I5 all green).`
 		);
 	}
 	if (verdict.reason === "zero-scope") {
@@ -205,7 +228,7 @@ export const renderReport = (verdict: RoadmapGuardVerdict): string => {
 		`roadmap-guard: ${verdict.violations.length} ROADMAP.md ↔ milestone drift violation(s):\n` +
 		`${lines.join("\n")}\n\n` +
 		"ROADMAP.md's `## Arcs`/`## Campaigns` tables and the GitHub milestone projection have drifted.\n" +
-		"Reconcile the offending row(s)/milestone(s) above (roadmap map #2620; invariants I1–I4, #2632)."
+		"Reconcile the offending row(s)/milestone(s) above (roadmap map #2620; invariants I1–I5, #2632/#2660)."
 	);
 };
 

--- a/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/roadmap-guard.unit.test.ts
@@ -1,8 +1,9 @@
 /**
  * Pure-core tests for `roadmap-guard` (#2648, roadmap map #2620): the parse of
- * ROADMAP.md's `## Arcs`/`## Campaigns` tables and the I1–I4 verdict (each invariant's
- * pass + every failure mode, plus the zero-scope fail-closed of ADR 0092). No IO — the
- * `gh api`/filesystem seam is crossed in `gate.ts`/`github.ts`.
+ * ROADMAP.md's `## Arcs`/`## Campaigns` tables and the I1–I5 verdict (each invariant's
+ * pass + every failure mode, plus the zero-scope fail-closed of ADR 0092 and the
+ * active↔done state symmetry of #2660). No IO — the `gh api`/filesystem seam is crossed
+ * in `gate.ts`/`github.ts`.
  */
 import {describe, expect, it} from "@effect/vitest";
 import {
@@ -183,6 +184,91 @@ describe("judge — I3 no unclaimed open milestone", () => {
 			[ms(17, "open"), ms(27, "open")],
 		);
 		expect(v.pass).toBe(true);
+	});
+});
+
+describe("judge — I5 active↔done state symmetry (the campaign lifecycle, #2660)", () => {
+	it("PASSES an active campaign over an OPEN milestone (the Mentor Audit #27 validation case)", () => {
+		const v = judge(
+			[arc("Four Pillars", 17, "active")],
+			[campaign("Mentor Audit", 27, "active")],
+			[ms(17, "open"), ms(27, "open", "Mentor Audit campaign")],
+		);
+		expect(v.pass).toBe(true);
+	});
+
+	it("PASSES a done campaign over a CLOSED milestone", () => {
+		const v = judge(
+			[arc("Four Pillars", 17, "active")],
+			[campaign("Past Audit", 30, "done")],
+			[ms(17, "open"), ms(30, "closed")],
+		);
+		expect(v.pass).toBe(true);
+	});
+
+	it("FAILS I5 when an ACTIVE campaign sits over a CLOSED milestone", () => {
+		const v = judge(
+			[arc("Four Pillars", 17, "active")],
+			[campaign("Zombie", 27, "active")],
+			[ms(17, "open"), ms(27, "closed")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I5" && x.message.includes("Zombie"))).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("FAILS I5 when a DONE campaign sits over an OPEN milestone", () => {
+		const v = judge(
+			[arc("Four Pillars", 17, "active")],
+			[campaign("Premature", 27, "done")],
+			[ms(17, "open"), ms(27, "open")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I5" && x.message.includes("Premature"))).toBe(
+				true,
+			);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("applies symmetry to ARCS too: a done arc over an OPEN milestone FAILS I5", () => {
+		const v = judge(
+			[arc("Now", 17, "active"), arc("Shipped", 10, "done")],
+			[],
+			[ms(17, "open"), ms(10, "open")],
+		);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I5" && x.message.includes("Shipped"))).toBe(true);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
+	});
+
+	it("EXEMPTS a queued arc from symmetry (its milestone opens lazily on activation)", () => {
+		// A queued arc pinned to a still-closed milestone is legal — no active/done expectation.
+		const v = judge(
+			[arc("Now", 17, "active"), arc("Later", 24, "queued")],
+			[],
+			[ms(17, "open"), ms(24, "closed")],
+		);
+		expect(v.pass).toBe(true);
+	});
+
+	it("does NOT double-report I5 for a dangling pin (that is an I1, not an I5)", () => {
+		const v = judge([arc("Ghost", 99, "active")], [], [ms(17, "open")]);
+		expect(v.pass).toBe(false);
+		if (v.pass === false && v.reason === "violations") {
+			expect(v.violations.some((x) => x.code === "I1")).toBe(true);
+			expect(v.violations.some((x) => x.code === "I5")).toBe(false);
+		} else {
+			throw new Error("expected a violations verdict");
+		}
 	});
 });
 


### PR DESCRIPTION
## What

Roadmap unit 6d (epic #2652): the pipeline-cli **active↔done campaign lifecycle guard**. Extends the arc-level `roadmap-guard` (#2648) with a new invariant **I5 — state symmetry**: an `active` row's milestone must be OPEN and a `done` row's milestone must be CLOSED. No active row over a closed milestone, no done row over an open one.

Applies to any row whose milestone pin resolves and whose state is `active`/`done` (arc **or** campaign); a `queued` arc is exempt (its milestone opens lazily on activation — the existing I1 tolerance).

## Shape decision — extend roadmap-guard (not a standalone sibling)

The issue offered two shapes. Grounded in the landed code, I extended `roadmap-guard`:

- #2648 **has landed**, and its pure core already parses `## Campaigns` rows and carries the `CampaignState` type — the scaffolding explicitly anticipated this invariant.
- Its CI workflow (`roadmap-guard.yml`) already fires on **PR + `on:milestone` + `schedule` + `workflow_dispatch`** — exactly the triggers 6d asks for. No new job needed; the guard is already wired.
- One guard, one parsed surface (`ROADMAP.md`), one CI job — the least-duplication path the issue prefers when #2648 is present.

I1 (row→milestone-by-number), I3 (no unclaimed open milestone), and I4 (fail-closed on zero scope, ADR 0092) were **already** enforced; this PR closes only the state-symmetry gap.

## Changes

- `roadmap-guard.ts` — add `I5` to the `Violation` union and the symmetry check in `judge` (collected in the same all-violations pass); a dangling pin stays an I1, not a spurious I5.
- `roadmap-guard.unit.test.ts` — I5 fixtures: active-over-open PASS (the Mentor Audit #27 validation case), done-over-closed PASS, active-over-closed FAIL, done-over-open FAIL, arc symmetry FAIL, queued-arc exemption, and I1-not-I5 dangling-pin. **33 tests pass.**
- `gate.ts` / `command.ts` / `roadmap-guard.yml` — docblock + workflow-comment references bumped I1–I4 → I1–I5.

## Verification

- `pnpm -C packages/pipeline-cli typecheck` — clean.
- `vitest run roadmap-guard.unit.test.ts` — 33 passed.
- biome clean on changed code (the 2 `Data.TaggedError` warnings in `gate.ts` pre-exist on `main` and are untouched by this diff).
- **Live guard run** against real milestones: `roadmap-guard: in sync — 4 arc row(s) + 1 campaign row(s) validated against 23 milestone(s) (I1–I5 all green).` The live Mentor Audit campaign (#27, active/open) is the validation case and passes.

## §CP

`packages/pipeline-cli/` is a control-plane package and this is a fail-closed CI gate — **§CP**. This PR stops at reviewed-ready for cansirin's approval/merge; it does not auto-ship.

Fixes #2660

🤖 Generated with [Claude Code](https://claude.com/claude-code)