### PR TITLE
feat(pipeline-crew-mcp): cut crew seams over to the channels protocol — the stdio session entry (#3062)

### DIFF
--- a/packages/pipeline-crew-mcp/README.md
+++ b/packages/pipeline-crew-mcp/README.md
@@ -16,9 +16,11 @@ A small, layered substrate split into a **generic core** and one **crew-coupled*
 - **`src/crew/`** — the only crew-coupled module and the composition root: the Role enum
   (the five-role flat topology, a single swap-in roster seam), the seam catalog (each role's
   crew interactions mapped over `protocol/` — claim/collision-check, role-uniqueness lease,
-  epic handoff, drain tally, intake ping, discovery/presence), and the wiring that composes
+  epic handoff, drain tally, intake ping, discovery/presence), the wiring that composes
   tracker + peer + edge into a per-role channel server (enforcing the role-uniqueness lease
-  the generic peer does not).
+  the generic peer does not), and — the cutover (#3062) — the **runnable stdio session entry**
+  (`crew/session.ts`): one live session's stdio `McpServer` + `ChannelSend`-from-peer, driving
+  both channel edges (outbound `channel_send` tool, inbound inbox→channel wake) off one server.
 
 **The load-bearing boundary:** `protocol/`, `tracker/`, `peer/`, and `edge/` are the reusable
 channels substrate and never import `crew/`; `crew/` depends inward on the generic core, never
@@ -27,18 +29,23 @@ is the reason the modules are split into directories rather than a flat file.
 
 ## Why it exists
 
-The crew is a set of independent agent sessions that today coordinate through out-of-band
-surfaces (filed issues, tmux relays). This package gives them a first-class, in-process
-messaging substrate — a generic p2p tracker + peers underneath, an MCP channel edge on top —
-so an agent joins a channel and sends/receives crew messages through its MCP client rather than
-a bespoke relay. It is internal pipeline tooling, on no kamp.us user surface.
+The crew is a set of independent agent sessions that previously coordinated through out-of-band
+surfaces — filed issues plus a tmux relay convention (buffer-paste + staggered-submit, pane-title
+discovery, capture-pane identity verification). This package gives them a first-class, in-process
+messaging substrate — a generic p2p tracker + peers underneath, an MCP channel edge on top — so an
+agent joins a channel and sends/receives crew messages through its MCP client rather than a bespoke
+relay. It is internal pipeline tooling, on no kamp.us user surface. tmux is retained only as session
+host / stand-up topology; the seams no longer ride it.
 
 ## Status
 
-The generic substrate (`protocol`/`tracker`/`peer`/`edge`) and the `crew/` composition root
-(Role enum + catalog + wiring) are landed. The runnable stdio entry that binds a live crew
-session's MCP server to the composition — and the retirement of the tmux relay convention —
-is the cutover (#3062), sequenced after this. The `bin` remains scaffold-only until then.
+The generic substrate (`protocol`/`tracker`/`peer`/`edge`), the `crew/` composition root (Role enum
++ catalog + wiring), and the **cutover** (#3062) are landed: `crew/session.ts` binds the runnable
+stdio session entry, and the root barrel (`src/index.ts`) exposes the whole substrate onto the
+`crew/` composition. Every inter-session seam (claim/collision-check, planned-epic handoff, drain
+tally, intake pings, role discovery/presence, the role-uniqueness lease) routes over the channels
+protocol. Out of v1: the EA→operator human-notification channel (deferred) and removing tmux as
+session host.
 
 ## Usage
 
@@ -46,7 +53,12 @@ Built on Effect + `effect/unstable/cli`, run from source with Node's TypeScript 
 pipeline-tooling idiom, mirroring `@kampus/pipeline-cli`):
 
 ```bash
-pnpm --filter @kampus/pipeline-crew-mcp cli        # run the (scaffold-only) root command
+# run one live crew session (stdio MCP server + channel peer) for a standing role
+pnpm --filter @kampus/pipeline-crew-mcp cli session --role engineering-manager
 pnpm --filter @kampus/pipeline-crew-mcp typecheck  # tsgo typecheck
 pnpm --filter @kampus/pipeline-crew-mcp test       # @effect/vitest suite
 ```
+
+The `--role` is one of the five standing `CREW_ROLES` (`ea-chief-of-staff`, `engineering-manager`,
+`triage-guy`, `junior-engineer`, `cartographer`); the session joins the per-project tracker under
+`--project-root` (default: cwd) and runs until interrupted.

--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -1,29 +1,67 @@
 #!/usr/bin/env node
 /**
- * `pipeline-crew-mcp` — the substrate's entry bin (epic #3045, scaffold #3052).
+ * `pipeline-crew-mcp` — the substrate's entry bin (epic #3045, scaffold #3052; cutover #3062).
  *
- *   node src/bin.ts            # run the (scaffold-only) root command
+ *   node src/bin.ts                                  # the root command (no seam wired)
+ *   node src/bin.ts session --role <role>            # run one live crew session (stdio MCP)
  *
- * Wired per effect-smol's CLI guidance (mirrors `@kampus/pipeline-cli`'s bin):
- * `effect/unstable/cli` for the typed command, the Node platform over
- * `NodeServices.layer`, run via `NodeRuntime.runMain`. Scaffold-only today — the
- * root command just reports that no seam behavior is wired yet; children add
- * subcommands as the tracker/peer/edge/crew modules land.
+ * The `session` subcommand is the runnable stdio MCP entry (#3062): it stands up one live crew
+ * session's `McpServer` over stdio + its channel peer, so the crew's inter-session seams run over
+ * the channels protocol. `--role` is one of the five standing `CREW_ROLES` (the roster is the
+ * single source — the flag chooses from it, never a re-declared list); the session joins the
+ * per-project tracker at `--project-root` (default: cwd). It runs until interrupted.
+ *
+ * NB: an MCP stdio server owns stdout for JSON-RPC, so the one startup line goes to STDERR — a
+ * log on stdout would corrupt the protocol stream.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/pipeline-cli`'s bin): `effect/unstable/cli`
+ * for the typed command, the Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Effect} from "effect";
-import {Command} from "effect/unstable/cli";
+import {Command, Flag} from "effect/unstable/cli";
 
+import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
 import {VERSION} from "./version.ts";
+
+const roleFlag = Flag.choice("role", CREW_ROLES).pipe(
+	Flag.withDescription("the standing crew role this session serves (one of the five CREW_ROLES)"),
+);
+const projectRootFlag = Flag.string("project-root").pipe(
+	Flag.withDefault(process.cwd()),
+	Flag.withDescription("the project root whose per-project tracker socket this session joins"),
+);
+
+const session = Command.make(
+	"session",
+	{projectRoot: projectRootFlag, role: roleFlag},
+	Effect.fn(function* ({projectRoot, role}) {
+		yield* Console.error(
+			`pipeline-crew-mcp ${VERSION} — crew session for role "${role}" (project ${projectRoot})`,
+		);
+		return yield* runCrewSession({projectRoot, role}).pipe(
+			Effect.catch((error: unknown) =>
+				Console.error(
+					error instanceof RoleUniquenessError
+						? `refusing to start: role "${error.role}" is already held by ${error.heldBy} (role-uniqueness lease)`
+						: `crew session failed to start: ${String(error)}`,
+				).pipe(Effect.andThen(Effect.sync(() => process.exit(1)))),
+			),
+		);
+	}),
+).pipe(Command.withDescription("Run one live crew session: stdio MCP server + channel peer"));
 
 const cli = Command.make(
 	"pipeline-crew-mcp",
 	{},
 	Effect.fn(function* () {
-		yield* Console.log(
-			`pipeline-crew-mcp ${VERSION} — scaffold; no seam behavior wired yet (epic #3045)`,
+		yield* Console.error(
+			`pipeline-crew-mcp ${VERSION} — run \`session --role <role>\` to start a live crew session`,
 		);
 	}),
-).pipe(Command.withDescription("The crew's channels-backed messaging substrate (epic #3045)"));
+).pipe(
+	Command.withDescription("The crew's channels-backed messaging substrate (epic #3045)"),
+	Command.withSubcommands([session]),
+);
 
 cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -24,6 +24,15 @@ export {
 export {RoleUniquenessError} from "./errors.ts";
 export {CREW_ROLES, CrewRole, isCrewRole} from "./roles.ts";
 export {
+	type CrewSessionConfig,
+	channelSendFromPeer,
+	crewSessionLayer,
+	inboxAddressFor,
+	inboxSocketFor,
+	runCrewSession,
+	SESSION_SERVER_NAME,
+} from "./session.ts";
+export {
 	type ClaimReply,
 	CrewTracker,
 	crewTrackerSocketLayer,

--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The cutover end to end (#3062): the live session's `ChannelSend`-from-peer binding stands up and
+ * a crew seam round-trips over the channels protocol — proving the seams left the tmux relay.
+ *
+ * Driven fully in-memory (an `RpcTest` client of the real `TrackerRegistry` + an in-memory peer
+ * `Connect`), the same transport-free idiom `channel-server.test.ts` uses — the one seam not
+ * exercised here is the stdio `McpServer` wake, which needs a live MCP client. What IS exercised is
+ * the exact `ChannelSend` the `channel_send` MCP tool routes through:
+ *   - an intake ping sent through `channelSendFromPeer`'s `ChannelSend` reaches the receiver's
+ *     channel edge (its recorded `ChannelSink` wake) and returns its delivered-to-inbox ack,
+ *   - `inboxAddressFor` addresses all five standing roles distinctly (no role orphaned — the
+ *     cartographer included).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Ref} from "effect";
+import {RpcTest} from "effect/unstable/rpc";
+import type {ChannelNotificationPayload} from "../edge/index.ts";
+import {ChannelSend, ChannelSink, channelInboxLayer} from "../edge/index.ts";
+import {
+	type Connect,
+	Dialer,
+	Inbox,
+	inboxHandlers,
+	PeerInbox,
+	PeerUnreachableError,
+} from "../peer/index.ts";
+import {TrackerRegistry} from "../tracker/group.ts";
+import {TrackerHandlers} from "../tracker/handlers.ts";
+import {RegistryLive} from "../tracker/registry.ts";
+import {CREW_ROLES} from "./roles.ts";
+import {channelSendFromPeer, inboxAddressFor} from "./session.ts";
+import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
+
+const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+
+// The sender's substrate over one shared CrewTracker: the peer Tracker port + a local inbox + the
+// injected dialer — the in-memory stand-in for `peerSocketSubstrate` (session.ts).
+const substrate = (
+	tracker: Layer.Layer<CrewTracker>,
+	address: string,
+	dialer: Layer.Layer<Dialer>,
+) =>
+	Layer.mergeAll(
+		tracker,
+		peerTrackerLayer.pipe(Layer.provide(tracker)),
+		Inbox.layer(address),
+		dialer,
+	);
+
+describe("crew/session — cutover: the ChannelSend-from-peer binding round-trips a seam", () => {
+	it.effect("an intake ping sent through ChannelSend wakes the receiver's channel edge", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const tracker = CrewTracker.fromClient(client);
+			const [senderRole, receiverRole] = [CREW_ROLES[0], CREW_ROLES[1]];
+			const receiverAddress = inboxAddressFor(receiverRole);
+
+			// The receiver's channel edge: a channel-bridging inbox recording each wake, reachable as
+			// an in-memory PeerInbox client. This is what a live receiver's inbox socket server hosts.
+			const wakes = yield* Ref.make<ReadonlyArray<ChannelNotificationPayload>>([]);
+			const recordingSink = Layer.succeed(ChannelSink, {
+				wake: (payload) => Ref.update(wakes, (xs) => [...xs, payload]),
+			});
+			const receiverInbox = yield* RpcTest.makeClient(PeerInbox).pipe(
+				Effect.provide(
+					Layer.provideMerge(
+						inboxHandlers,
+						channelInboxLayer(receiverAddress).pipe(Layer.provide(recordingSink)),
+					),
+				),
+			);
+			const connect: Connect = (address) =>
+				address === receiverAddress
+					? Effect.succeed(receiverInbox)
+					: Effect.fail(new PeerUnreachableError({target: address, reason: "no route"}));
+
+			// Announce the receiver on the registry (a bare inbox here), so the sender can discover it.
+			yield* client.AnnouncePresence({
+				peer: receiverAddress,
+				role: receiverRole,
+				at: new Date().toISOString(),
+			});
+
+			// The sender's real ChannelSend-from-peer binding (the cutover) — the port channel_send uses.
+			const ack = yield* Effect.gen(function* () {
+				const sender = yield* ChannelSend;
+				return yield* sender.send(receiverRole, "IntakePing", {issue: "3062", from: senderRole});
+			}).pipe(
+				Effect.provide(
+					channelSendFromPeer(senderRole).pipe(
+						Layer.provide(
+							substrate(tracker, inboxAddressFor(senderRole), Dialer.layerFromConnect(connect)),
+						),
+					),
+				),
+			);
+
+			// Delivered straight to the receiver's inbox (peer→peer, the tracker never relays).
+			assert.strictEqual(ack.by, receiverAddress, "acked by the receiver's inbox ⇒ it went to it");
+			const recorded = yield* Ref.get(wakes);
+			assert.lengthOf(recorded, 1);
+			assert.match(recorded[0]?.message ?? "", /IntakePing/, "the seam rode a channel wake");
+			assert.strictEqual(recorded[0]?._meta?.from, inboxAddressFor(senderRole));
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect("a send to an offline role surfaces as a typed unreachable, never a silent drop", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const tracker = CrewTracker.fromClient(client);
+			const [senderRole, offlineRole] = [CREW_ROLES[0], CREW_ROLES[2]];
+			const alwaysUnreachable = Dialer.layerFromConnect((address) =>
+				Effect.fail(new PeerUnreachableError({target: address, reason: "no route"})),
+			);
+
+			const failure = yield* Effect.gen(function* () {
+				const sender = yield* ChannelSend;
+				return yield* sender.send(offlineRole, "IntakePing", {});
+			}).pipe(
+				Effect.provide(
+					channelSendFromPeer(senderRole).pipe(
+						Layer.provide(substrate(tracker, inboxAddressFor(senderRole), alwaysUnreachable)),
+					),
+				),
+				Effect.flip,
+			);
+			assert.instanceOf(failure, PeerUnreachableError);
+			assert.strictEqual(failure.target, offlineRole);
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+});
+
+describe("crew/session — the five-role roster is intact (no role orphaned)", () => {
+	it("inboxAddressFor addresses all five standing roles distinctly", () => {
+		const addresses = CREW_ROLES.map(inboxAddressFor);
+		assert.lengthOf(addresses, 5, "the roster is exactly five roles (the cartographer included)");
+		assert.strictEqual(new Set(addresses).size, 5, "every role maps to a distinct inbox address");
+		assert.include(addresses, "inbox://cartographer", "the cartographer must have an address");
+	});
+});

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -1,0 +1,151 @@
+/**
+ * crew/session — THE runnable stdio entry the cutover binds (#3062): stand up one live crew
+ * session's `McpServer` over stdio + its channel peer, so every inter-session seam that used to
+ * ride the tmux relay convention (claim/collision-check, planned-epic handoff, drain tally,
+ * intake pings, role discovery/presence, the role-uniqueness lease) now runs over the channels
+ * protocol instead of buffer-paste + staggered-submit + pane-title discovery + capture-pane
+ * identity verification.
+ *
+ * #3059 built the composition (`makeCrewChannel`) but deliberately left this live entry out; this
+ * module binds it. The ONE running stdio `McpServer` drives BOTH edges of the channel:
+ *   - outbound — the `channel_send` toolkit, its `ChannelSend` port bound to THIS session's peer,
+ *     so a role addresses a peer by role (never a tmux window/pane) and the send dials it directly,
+ *   - inbound  — the peer-inbox socket server whose deliveries wake the session through
+ *     `ChannelSink.layerFromMcpServer` (the same running server), rendered as a `<channel>` tag.
+ * Both edges share one `McpServer` instance by layer memoization (the shared `server` value), so
+ * the toolkit registers on, and the sink wakes through, the exact transport serving stdio — the
+ * same memoization the edge server (#3162) relies on when it provides `layerStdio` to the toolkit.
+ *
+ * The role-uniqueness lease + presence announce ride the peer's scope (`makeCrewChannel`): a
+ * second live session for a held role fails the build with `RoleUniquenessError`, and presence
+ * frees on teardown (connection-is-lease, #3035). The address is keyed on the role because the
+ * lease guarantees one live session per role, so discovery→dial is deterministic.
+ *
+ * The binding is transport-injected: `channelSendFromPeer` takes the peer substrate as a
+ * requirement (production supplies `peerSocketSubstrate` over unix sockets), so `session.test.ts`
+ * drives the exact `ChannelSend`-from-peer binding fully in-memory (an `RpcTest` `CrewTracker` + an
+ * in-memory `Connect`) — the same transport-free idiom `channel-server.test.ts` uses. The one seam
+ * not exercised without a live MCP client is the stdio `McpServer` wake itself.
+ */
+import {NodeStdio} from "@effect/platform-node";
+import {Effect, Layer} from "effect";
+import {McpServer} from "effect/unstable/ai";
+import {
+	ChannelSend,
+	ChannelSink,
+	ChannelToolkit,
+	channelExperimentalCapability,
+	channelToolHandlers,
+} from "../edge/index.ts";
+import {type Dialer, Inbox, type Tracker} from "../peer/index.ts";
+import {socketPathFor} from "../tracker/index.ts";
+import {VERSION} from "../version.ts";
+import {
+	crewSocketDialerLayer,
+	inboxServerSocketLayer,
+	inboxSocketPathFor,
+	makeCrewChannel,
+} from "./channel-server.ts";
+import type {RoleUniquenessError} from "./errors.ts";
+import type {CrewRole} from "./roles.ts";
+import {type CrewTracker, crewTrackerSocketLayer, peerTrackerLayer} from "./tracker.ts";
+
+/** The MCP server identity a crew session advertises over stdio when none is configured. */
+export const SESSION_SERVER_NAME = "@kampus/pipeline-crew-mcp" as const;
+
+export interface CrewSessionConfig {
+	readonly role: CrewRole;
+	/** The project root whose per-project tracker socket this session rendezvous on. */
+	readonly projectRoot: string;
+	/** The MCP server name advertised over stdio (defaults to the package name). */
+	readonly name?: string;
+	/** The MCP server version advertised over stdio (defaults to the package `VERSION`). */
+	readonly version?: string;
+}
+
+/**
+ * This session's dialable inbox address. The crew binds peer-id ≡ inbox-address, and the
+ * role-uniqueness lease guarantees one live session per role, so keying the address on the role
+ * makes discovery→dial deterministic: any peer that discovers `role` dials this exact address
+ * (`inboxSocketPathFor` maps it to the unix socket the inbound server binds).
+ */
+export const inboxAddressFor = (role: CrewRole): string => `inbox://${role}`;
+
+/** The unix socket this session's peer inbox is served on — the address resolved to a socket path. */
+export const inboxSocketFor = (role: CrewRole): string => inboxSocketPathFor(inboxAddressFor(role));
+
+/**
+ * The peer substrate over real unix sockets: the socket `CrewTracker`, the peer `Tracker` port
+ * derived from it (one shared tracker client), this peer's local inbox log, and the socket dialer.
+ * The production substrate `channelSendFromPeer` runs on; the tests inject an in-memory one
+ * (an `RpcTest` `CrewTracker` + an in-memory `Dialer`) to drive the same binding transport-free.
+ */
+export const peerSocketSubstrate = (
+	config: CrewSessionConfig,
+): Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown> => {
+	const crewTracker = crewTrackerSocketLayer(socketPathFor(config.projectRoot));
+	return Layer.mergeAll(
+		peerTrackerLayer.pipe(Layer.provideMerge(crewTracker)),
+		Inbox.layer(inboxAddressFor(config.role)),
+		crewSocketDialerLayer,
+	);
+};
+
+/**
+ * The outbound binding: `ChannelSend` resolved to THIS session's peer `send` (`makeCrewChannel`).
+ * Building the layer acquires the role-uniqueness lease and announces presence for the layer's
+ * scope; a second live session for a held role fails the build with `RoleUniquenessError`. This is
+ * the exact `ChannelSend` the `channel_send` MCP tool routes through — the tests drive it directly.
+ *
+ * The peer substrate (`CrewTracker` + the peer ports) is a REQUIREMENT, not baked in, so the binding
+ * is transport-injected: production supplies `peerSocketSubstrate`, the tests an in-memory substrate.
+ */
+export const channelSendFromPeer = (
+	role: CrewRole,
+): Layer.Layer<ChannelSend, RoleUniquenessError, CrewTracker | Tracker | Inbox | Dialer> =>
+	Layer.effect(
+		ChannelSend,
+		Effect.gen(function* () {
+			const channel = yield* makeCrewChannel({role, address: inboxAddressFor(role)});
+			return {send: channel.peer.send};
+		}),
+	);
+
+/**
+ * The full runnable session layer: launch it (`Layer.launch`) to run one live crew session. The
+ * one stdio `McpServer` (`server`) is provided to BOTH edges — the toolkit registers on it, the
+ * inbound socket server's `ChannelSink` wakes through it — memoized to a single running transport.
+ */
+export const crewSessionLayer = (config: CrewSessionConfig) => {
+	const address = inboxAddressFor(config.role);
+	// The one running stdio McpServer + its channel capability; shared across both channel edges.
+	const server = McpServer.layerStdio({
+		name: config.name ?? SESSION_SERVER_NAME,
+		version: config.version ?? VERSION,
+		experimental: channelExperimentalCapability,
+	}).pipe(Layer.provide(NodeStdio.layer));
+
+	// outbound: the channel_send toolkit, its ChannelSend bound to this session's peer.
+	const outbound = McpServer.toolkit(ChannelToolkit).pipe(
+		Layer.provide(channelToolHandlers),
+		Layer.provide(
+			channelSendFromPeer(config.role).pipe(Layer.provide(peerSocketSubstrate(config))),
+		),
+		Layer.provide(server),
+	);
+
+	// inbound: the peer-inbox socket server, its deliveries waking THIS running server.
+	const inbound = inboxServerSocketLayer(address).pipe(
+		Layer.provide(ChannelSink.layerFromMcpServer),
+		Layer.provide(server),
+	);
+
+	return Layer.mergeAll(outbound, inbound);
+};
+
+/**
+ * Run one live crew session until interrupted — the stdio MCP entry the bin's `session` subcommand
+ * drives. Blocks on `Layer.launch` (the stdio server + inbox socket server run on scoped fibers,
+ * the role lease + presence held for the process lifetime); teardown frees the lease.
+ */
+export const runCrewSession = (config: CrewSessionConfig) => Layer.launch(crewSessionLayer(config));

--- a/packages/pipeline-crew-mcp/src/index.ts
+++ b/packages/pipeline-crew-mcp/src/index.ts
@@ -1,15 +1,23 @@
 /**
  * @kampus/pipeline-crew-mcp — the crew's channels-backed messaging substrate (epic #3045).
  *
- * This scaffold (issue #3052) lands the package shape and the module skeleton only; no
- * seam behavior yet — each module below is filled by its own child.
+ * The cutover (#3062) binds the substrate into a runnable crew: `Crew.runCrewSession` /
+ * `Crew.crewSessionLayer` stand up one live session's stdio `McpServer` + `ChannelSend`-from-peer,
+ * so every inter-session seam (claim/collision-check, planned-epic handoff, drain tally, intake
+ * pings, role discovery/presence, the role-uniqueness lease) runs over the channels protocol
+ * instead of the retired tmux relay convention. `Crew.CREW_ROLES` is the single five-role roster
+ * every binding consumes — never a re-declared or short list (a four-role list orphans the
+ * cartographer, the failure this cutover exists to prevent).
  *
- * The one structural invariant the skeleton exists to hold: the generic core is
- * crew-agnostic. `protocol/`, `tracker/`, `peer/`, and `edge/` are the reusable
- * channels substrate and MUST NOT import `crew/`; `crew/` is the sole crew-coupled
- * module (Role catalog + wiring) and depends inward on the generic core, never the
- * reverse. That one-way boundary is what keeps the substrate reusable — enforcing it
- * is the point of splitting these into directories.
+ * The one structural invariant the module boundary holds: the generic core is crew-agnostic.
+ * `Protocol`, `Tracker`, `Peer`, and `Edge` are the reusable channels substrate and MUST NOT
+ * import `Crew`; `Crew` is the sole crew-coupled module (Role catalog + wiring + the session
+ * entry) and depends inward on the generic core, never the reverse. That one-way boundary is what
+ * keeps the substrate reusable — enforcing it is the point of splitting these into directories.
  */
+export * as Crew from "./crew/index.ts";
+export * as Edge from "./edge/index.ts";
+export * as Peer from "./peer/index.ts";
 export * as Protocol from "./protocol/index.ts";
+export * as Tracker from "./tracker/index.ts";
 export {VERSION} from "./version.ts";


### PR DESCRIPTION
Fixes #3062

## The cutover

The P6 final child of the crew-mcp spine (#3045): binds the runnable stdio MCP entry #3059 deliberately left out of scope, and cuts every crew inter-session seam from the tmux relay convention onto the channels protocol (v1, all seams together).

### What the root barrel binds onto crew/

- **`src/crew/session.ts`** — the live session entry. `crewSessionLayer(config)` / `runCrewSession(config)` stand up **one** stdio `McpServer` (`McpServer.layerStdio` + `channelExperimentalCapability`, matching the edge server #3162) that drives **both** channel edges off a single memoized server instance:
  - **outbound** — `McpServer.toolkit(ChannelToolkit)` registered on the server, its `ChannelSend` port bound to this session's peer (`channelSendFromPeer` → `makeCrewChannel(...).peer.send`), so a role addresses a peer **by role**, never a tmux window/pane;
  - **inbound** — the peer-inbox socket server (`inboxServerSocketLayer`) whose deliveries wake the session through `ChannelSink.layerFromMcpServer` (the same running server), rendered as a `<channel>` tag.
  - The single-server sharing is the same layer memoization the edge server relies on when it provides `layerStdio` to the toolkit — `server` is provided to both edges.
- **`src/index.ts`** — the root barrel now exposes the whole substrate onto the composition: `Crew` (incl. `crewSessionLayer` / `runCrewSession` / `channelSendFromPeer` / `CREW_ROLES` / the catalog), plus `Edge` / `Peer` / `Protocol` / `Tracker`. The one-way boundary (generic core never imports `crew/`) is preserved.
- **`src/bin.ts`** — a `session --role <role> [--project-root <path>]` subcommand launches one live session; `--role` is a `Flag.choice` over `CREW_ROLES`.

### The 5-role roster (consumed, never re-declared)

Every binding consumes `CREW_ROLES` from the merged `crew/roles.ts` — `ea-chief-of-staff`, `engineering-manager`, `triage-guy`, `junior-engineer`, `cartographer`. `inboxAddressFor` addresses all five distinctly (a test asserts exactly five + the cartographer's address), so no live session — the cartographer included — is orphaned.

### Seams routed over channels

claim/collision-check, planned-epic handoff, drain tally, intake pings, role discovery/presence, and the role-uniqueness lease all ride the peer/tracker/edge substrate. tmux is retained only as session host / stand-up topology (no relay prose). The EA→operator human-notification channel stays **out of v1** (deferred).

### Testing

`channelSendFromPeer` takes the peer substrate as a **requirement** (transport-injected), so `crew/session.test.ts` drives the exact `ChannelSend`-from-peer binding **in-memory** (an `RpcTest` `CrewTracker` + an in-memory `Connect`) — the same idiom `channel-server.test.ts` uses. An intake ping sent through `ChannelSend` reaches the receiver's channel edge (recorded `ChannelSink` wake) and returns its delivered-to-inbox ack; an offline role surfaces a typed `PeerUnreachableError`, never a silent drop. Production supplies `peerSocketSubstrate` over unix sockets; the stdio `McpServer` wake is the one seam a live MCP client owns.

## Verification

- `pnpm -C packages/pipeline-crew-mcp typecheck` — clean
- `pnpm -C packages/pipeline-crew-mcp test` — 64 passing (19 files)
- biome check — clean
- `pipeline-cli readme-guard check` / `catalog-guard check` — pass (README updated; no new deps)

Diff confined to `packages/pipeline-crew-mcp/**` (this child legitimately touches the root `src/index.ts` barrel — its job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)