### PR TITLE
feat(atolye): /lab/atolye/:exhibit detail route + knob-state deep-linking (#3093)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -39,6 +39,7 @@ import {
 	PHOENIX_NAV_IA,
 } from "./flags/keys";
 import {useFlag} from "./flags/useFlag";
+import {AtolyeExhibitPage} from "./lab/atolye/AtolyeExhibitPage";
 import {AtolyeIndexPage} from "./lab/atolye/AtolyeIndexPage";
 import {DensityProvider} from "./lib/density";
 import {SAVED_HREF} from "./lib/panoNav";
@@ -520,6 +521,11 @@ export function App() {
 						    ASCII route slug (routes-are-English); reachable by URL only, no nav entry,
 						    matching the /lab/composer precedent. */}
 						<Route path="/lab/atolye" element={<AtolyeIndexPage />} />
+						{/* /lab/atolye/:exhibit — the exhibit detail route (#3093): resolves the slug
+						    against the registry, renders it through the knobs harness with knob state
+						    deep-linked into the URL, and self-renders an atölye-scoped not-found on an
+						    unknown slug (never the global 404). ASCII route slug. */}
+						<Route path="/lab/atolye/:exhibit" element={<AtolyeExhibitPage />} />
 						<Route path="/profile" element={<ProfilePage />} />
 						<Route path="/u/:username" element={<UserProfilePage />} />
 						{/* The admin console (#2740, epic #2711) — the route element self-gates on

--- a/apps/web/src/lab/atolye/AtolyeExhibitPage.css
+++ b/apps/web/src/lab/atolye/AtolyeExhibitPage.css
@@ -1,0 +1,25 @@
+/* /lab/atolye/:exhibit detail (#3093). Role tokens only — atölye dogfoods the ADR-0162 design
+   law it showcases. Shares the .kp-atolye__inner/title/lead frame with the index. */
+
+.kp-atolye-detail__masthead {
+	padding: var(--s-2) 0 var(--s-4);
+	margin-bottom: var(--s-4);
+	border-bottom: 1px solid var(--border);
+}
+
+.kp-atolye-detail__back {
+	display: inline-block;
+	font: var(--t-meta);
+	color: var(--link);
+	text-decoration: none;
+	margin-bottom: var(--s-2);
+}
+
+.kp-atolye-detail__back:hover {
+	text-decoration: underline;
+}
+
+.kp-atolye-detail__slug {
+	font-family: var(--font-mono);
+	color: var(--text-primary);
+}

--- a/apps/web/src/lab/atolye/AtolyeExhibitPage.test.tsx
+++ b/apps/web/src/lab/atolye/AtolyeExhibitPage.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * The /lab/atolye/:exhibit detail route (#3093): slug resolution against the registry, the
+ * knob-state ↔ URL round-trip (a shareable/landable component state), and the graceful
+ * atölye-scoped not-found on an unknown slug — never the global 404, never a crash.
+ */
+import {fireEvent, render, screen} from "@testing-library/react";
+import {MemoryRouter, Route, Routes, useLocation} from "react-router";
+import {describe, expect, it} from "vitest";
+import {AtolyeExhibitPage} from "./AtolyeExhibitPage";
+import {listExhibits} from "./registry";
+
+// jsdom ships no `PointerEvent`; base-ui's click handlers read it (mirrors ExhibitStage.test).
+if (typeof globalThis.PointerEvent === "undefined") {
+	class PointerEventShim extends MouseEvent {}
+	globalThis.PointerEvent = PointerEventShim as typeof PointerEvent;
+}
+
+// Surfaces the live URL search string so the round-trip assertions can read what a knob wrote.
+function LocationProbe() {
+	const location = useLocation();
+	return <output data-testid="search">{location.search}</output>;
+}
+
+function renderAt(path: string) {
+	return render(
+		<MemoryRouter initialEntries={[path]}>
+			<Routes>
+				<Route path="/lab/atolye/:exhibit" element={<AtolyeExhibitPage />} />
+			</Routes>
+			<LocationProbe />
+		</MemoryRouter>,
+	);
+}
+
+describe("AtolyeExhibitPage — /lab/atolye/:exhibit detail route (#3093)", () => {
+	it("resolves a known slug and renders it through the knobs harness", () => {
+		renderAt("/lab/atolye/button");
+		expect(screen.getByTestId("lab-atolye-detail")).toBeTruthy();
+		expect(screen.getByTestId("exhibit-stage")).toBeTruthy();
+		// the exhibit's own component is mounted (the Button host)
+		expect(screen.getByTestId("lab-atolye-detail").querySelector(".kp-btn")).not.toBeNull();
+	});
+
+	it("renders the atölye-scoped not-found for an unknown slug — not the global 404", () => {
+		renderAt("/lab/atolye/does-not-exist");
+		expect(screen.getByTestId("lab-atolye-not-found")).toBeTruthy();
+		expect(screen.queryByTestId("not-found-page")).toBeNull();
+		expect(screen.queryByTestId("exhibit-stage")).toBeNull();
+	});
+
+	it("reflects a knob change into the URL (deep-link out)", () => {
+		const {container} = renderAt("/lab/atolye/button");
+		// default variant is primary → no param until it diverges
+		expect(screen.getByTestId("search").textContent).toBe("");
+		const host = container.querySelector(".kp-btn")!;
+		expect(host.classList.contains("kp-btn--lg")).toBe(false);
+
+		fireEvent.click(screen.getByText("Büyük")); // size → lg
+
+		expect(new URLSearchParams(screen.getByTestId("search").textContent ?? "").get("size")).toBe(
+			"lg",
+		);
+		expect(host.classList.contains("kp-btn--lg")).toBe(true);
+	});
+
+	it("restores knob state from URL params on load (deep-link in)", () => {
+		const {container} = renderAt("/lab/atolye/button?size=lg&loading=true");
+		const host = container.querySelector(".kp-btn")!;
+		expect(host.classList.contains("kp-btn--lg")).toBe(true);
+		expect(host.getAttribute("aria-busy")).toBe("true");
+	});
+
+	it("drops a param when a knob returns to its default (clean URL round-trip)", () => {
+		renderAt("/lab/atolye/button?size=lg");
+		expect(new URLSearchParams(screen.getByTestId("search").textContent ?? "").get("size")).toBe(
+			"lg",
+		);
+
+		fireEvent.click(screen.getByText("Orta")); // size → md, the default
+
+		expect(new URLSearchParams(screen.getByTestId("search").textContent ?? "").has("size")).toBe(
+			false,
+		);
+	});
+
+	it("only exposes real registry slugs — every listed exhibit resolves", () => {
+		for (const exhibit of listExhibits()) {
+			const {unmount} = renderAt(`/lab/atolye/${exhibit.id}`);
+			expect(screen.getByTestId("lab-atolye-detail")).toBeTruthy();
+			unmount();
+		}
+	});
+});

--- a/apps/web/src/lab/atolye/AtolyeExhibitPage.tsx
+++ b/apps/web/src/lab/atolye/AtolyeExhibitPage.tsx
@@ -1,0 +1,63 @@
+/**
+ * `/lab/atolye/:exhibit` — the exhibit detail route (#3093). Resolves the slug against the
+ * headless registry and renders that exhibit through the knobs harness, with knob state reflected
+ * into the URL so a specific component state is shareable (story 6). An unknown/stale slug renders
+ * a graceful atölye-scoped not-found — in-page, never the global 404 — so a dead deep-link can't
+ * crash the harness (story 8).
+ *
+ * Route/slug are ASCII English (`/lab/atolye/:exhibit`, matching the dir + routes-are-English
+ * convention); the visible brand copy stays Turkish (`atölye`, with the ö).
+ */
+
+import {Link, useParams} from "react-router";
+import {ExhibitStage} from "./ExhibitStage";
+import type {AnyExhibit} from "./exhibit";
+import {getExhibit} from "./registry";
+import {useUrlKnobs} from "./useUrlKnobs";
+import "./AtolyeExhibitPage.css";
+
+export function AtolyeExhibitPage() {
+	const {exhibit: slug} = useParams<{exhibit: string}>();
+	const exhibit = slug ? getExhibit(slug) : undefined;
+	if (!exhibit) return <ExhibitNotFound slug={slug} />;
+	return <ExhibitDetail exhibit={exhibit} />;
+}
+
+// A distinct component so the knob hooks only run on the resolved-exhibit branch — never
+// conditionally, and never against a missing schema on the not-found branch.
+function ExhibitDetail({exhibit}: {exhibit: AnyExhibit}) {
+	const knobs = useUrlKnobs(exhibit.knobs);
+	return (
+		<main className="kp-atolye" data-testid="lab-atolye-detail">
+			<div className="kp-atolye__inner">
+				<header className="kp-atolye-detail__masthead">
+					<Link to="/lab/atolye" className="kp-atolye-detail__back">
+						← atölye
+					</Link>
+					<h1 className="kp-atolye__title">{exhibit.title}</h1>
+					{exhibit.summary ? <p className="kp-atolye__lead">{exhibit.summary}</p> : null}
+				</header>
+				<ExhibitStage exhibit={exhibit} knobs={knobs} />
+			</div>
+		</main>
+	);
+}
+
+function ExhibitNotFound({slug}: {slug?: string}) {
+	return (
+		<main className="kp-atolye" data-testid="lab-atolye-not-found">
+			<div className="kp-atolye__inner">
+				<header className="kp-atolye-detail__masthead">
+					<Link to="/lab/atolye" className="kp-atolye-detail__back">
+						← atölye
+					</Link>
+					<h1 className="kp-atolye__title">sergi bulunamadı</h1>
+					<p className="kp-atolye__lead">
+						{slug ? <code className="kp-atolye-detail__slug">{slug}</code> : "bu"} diye bir sergi
+						yok. Vitrindeki parçalara göz atmak ister misin?
+					</p>
+				</header>
+			</div>
+		</main>
+	);
+}

--- a/apps/web/src/lab/atolye/ExhibitStage.tsx
+++ b/apps/web/src/lab/atolye/ExhibitStage.tsx
@@ -2,7 +2,7 @@ import {Surface} from "../../components/ui/Card";
 import type {AnyExhibit} from "./exhibit";
 import {PropKnobs} from "./PropKnobs";
 import "./ExhibitStage.css";
-import {useKnobs} from "./useKnobs";
+import {type KnobState, useKnobs} from "./useKnobs";
 
 const styles = {
 	root: "kp-exhibit-stage",
@@ -13,6 +13,11 @@ const styles = {
 
 export interface ExhibitStageProps {
 	readonly exhibit: AnyExhibit;
+	/**
+	 * Controlled knob state. Omit for a self-contained stage (its own in-memory knobs); the
+	 * detail route passes a URL-backed state (`useUrlKnobs`) so knob twiddling deep-links (#3093).
+	 */
+	readonly knobs?: KnobState;
 }
 
 /**
@@ -20,8 +25,11 @@ export interface ExhibitStageProps {
  * so a knob change re-renders the component with the new prop. The knob-value → props seam is
  * a single spread — `{...fixedProps, ...values}` — over the current knob state.
  */
-export function ExhibitStage({exhibit}: ExhibitStageProps) {
-	const {values, setKnob} = useKnobs(exhibit.knobs);
+export function ExhibitStage({exhibit, knobs}: ExhibitStageProps) {
+	// The uncontrolled fallback is always instantiated (hooks run unconditionally) but goes
+	// unused when a controlled `knobs` state is supplied.
+	const internal = useKnobs(exhibit.knobs);
+	const {values, setKnob} = knobs ?? internal;
 	const Component = exhibit.component;
 	const props = {...exhibit.fixedProps, ...values};
 	return (

--- a/apps/web/src/lab/atolye/index.ts
+++ b/apps/web/src/lab/atolye/index.ts
@@ -26,3 +26,4 @@ export {PropKnobs} from "./PropKnobs";
 export {getExhibit, listExhibits} from "./registry";
 export type {KnobState} from "./useKnobs";
 export {useKnobs} from "./useKnobs";
+export {useUrlKnobs} from "./useUrlKnobs";

--- a/apps/web/src/lab/atolye/useUrlKnobs.ts
+++ b/apps/web/src/lab/atolye/useUrlKnobs.ts
@@ -1,0 +1,86 @@
+import {useCallback, useMemo} from "react";
+import {useSearchParams} from "react-router";
+import {type AnyKnob, type AnyKnobSchema, type KnobValue, resolveKnobDefaults} from "./knob";
+import type {KnobState} from "./useKnobs";
+
+/**
+ * The URL-backed knob state (#3093): the query string IS the source of truth, so a specific
+ * exhibit state is shareable and landable. One source, not two synced ones — reading a URL and
+ * reflecting a knob change are the same round-trip, so there is no state↔URL drift to race.
+ *
+ * Only knobs that differ from their schema default are written, keeping a pristine exhibit's URL
+ * param-free; a default-valued knob drops its param. History is `replace`d — twiddling a knob
+ * refines the current entry rather than stacking a back-button trap.
+ */
+export function useUrlKnobs(schema: AnyKnobSchema): KnobState {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const defaults = useMemo(() => resolveKnobDefaults(schema), [schema]);
+
+	const values = useMemo(() => {
+		const resolved: Record<string, KnobValue> = {...defaults};
+		for (const [key, knob] of Object.entries(schema)) {
+			const raw = searchParams.get(key);
+			if (raw == null) continue;
+			const parsed = parseKnobValue(knob, raw);
+			if (parsed !== undefined) resolved[key] = parsed;
+		}
+		return resolved;
+	}, [schema, defaults, searchParams]);
+
+	const setKnob = useCallback(
+		(key: string, value: KnobValue) => {
+			setSearchParams(
+				(prev) => {
+					const next = new URLSearchParams(prev);
+					const knob = schema[key];
+					if (knob && sameKnobValue(value, knob.default)) next.delete(key);
+					else next.set(key, serializeKnobValue(value));
+					return next;
+				},
+				{replace: true},
+			);
+		},
+		[schema, setSearchParams],
+	);
+
+	const reset = useCallback(() => {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				for (const key of Object.keys(schema)) next.delete(key);
+				return next;
+			},
+			{replace: true},
+		);
+	}, [schema, setSearchParams]);
+
+	return {values, setKnob, reset};
+}
+
+function serializeKnobValue(value: KnobValue): string {
+	return String(value);
+}
+
+/** Coerce a raw query-param string back to the knob's typed value, or `undefined` if it doesn't fit. */
+function parseKnobValue(knob: AnyKnob, raw: string): KnobValue | undefined {
+	switch (knob.kind) {
+		case "string":
+			return raw;
+		case "number": {
+			const n = Number(raw);
+			return Number.isNaN(n) ? undefined : n;
+		}
+		case "boolean":
+			return raw === "true" ? true : raw === "false" ? false : undefined;
+		case "enum": {
+			// enum values may be non-string (a number literal), so match on the serialized form
+			// and hand back the real option value — never the raw string.
+			const option = knob.options.find((o) => serializeKnobValue(o.value) === raw);
+			return option?.value;
+		}
+	}
+}
+
+function sameKnobValue(a: KnobValue, b: KnobValue): boolean {
+	return serializeKnobValue(a) === serializeKnobValue(b);
+}


### PR DESCRIPTION
Fixes #3093

## What

The **exhibit detail route** for atölye (epic #2473), off the merged index route + registry (#3092): `/lab/atolye/:exhibit` resolves a slug against the C1 registry and renders that exhibit through the prop-knobs harness, with knob state round-tripped through the URL.

- **Slug resolution** — `getExhibit(slug)` off the headless registry; a known slug renders `<ExhibitStage exhibit={…} knobs={urlKnobs} />`.
- **Knob-state ↔ URL deep-linking** (story 6) — new `useUrlKnobs(schema)` makes the query string the single source of truth (one source, no state↔URL race). Changing a knob reflects into the URL; landing a URL with knob params restores that state. Only non-default knobs write a param (a pristine exhibit URL stays param-free), enum/number/boolean values coerce back to their typed form on read, and history is `replace`d so twiddling doesn't stack back-button traps.
- **Graceful not-found** (story 8) — an unknown/stale slug renders an atölye-scoped in-page not-found (`data-testid="lab-atolye-not-found"`), never the global `NotFoundPage`, never a crash.

`ExhibitStage` gains an optional controlled `knobs` prop; its uncontrolled path (own in-memory knobs) is unchanged.

## Scope

Route work only — does **not** append `registry.ts` (that is #3094's catalog lane). Registry untouched.

**Route slug is ASCII** `/lab/atolye/:exhibit` per the founder ruling (routes-are-English, #2469 convention); only brand/display copy stays Turkish (`atölye`).

## Tests (TDD)

New `AtolyeExhibitPage.test.tsx` covers slug resolution, the knob-state ↔ URL round-trip (deep-link out, deep-link in, default-drops-param), and the unknown-slug not-found branch. `pnpm typecheck`, `pnpm lint`, and the atölye client suite (12 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)