### PR TITLE
feat(mute): mute.listMine — the manage-my-mutes read model (#3114)

### DIFF
--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -21,7 +21,7 @@ import type {
 import type {DivanBacklogItemView, DivanCaylakView, DivanVoteReceiptView} from "../divan/views.ts";
 import type {FunnelSummaryView} from "../funnel/views.ts";
 import type {MecmuaPostView, MecmuaSubscriptionReceiptView} from "../mecmua/views.ts";
-import type {MuteReceiptView} from "../mute/views.ts";
+import type {MutedMemberView, MuteReceiptView} from "../mute/views.ts";
 import type {CommentView, PostOverlayView, PostView, TagView} from "../pano/views.ts";
 import type {
 	AccountDeletionReceiptView,
@@ -69,8 +69,8 @@ export type {FunnelSummary} from "../funnel/views.ts";
 export {funnelSummaryDataView} from "../funnel/views.ts";
 export type {MecmuaPost, MecmuaSubscriptionReceipt} from "../mecmua/views.ts";
 export {mecmuaPostDataView, mecmuaSubscriptionReceiptDataView} from "../mecmua/views.ts";
-export type {MuteReceipt} from "../mute/views.ts";
-export {muteReceiptDataView} from "../mute/views.ts";
+export type {MutedMember, MuteReceipt} from "../mute/views.ts";
+export {mutedMemberDataView, muteReceiptDataView} from "../mute/views.ts";
 export type {Comment, Post, PostOverlay, Tag} from "../pano/views.ts";
 export {
 	commentDataView,
@@ -176,6 +176,7 @@ type _FateViewsFieldMapResolved = [
 		AssertFieldMapResolved<typeof MecmuaSubscriptionReceiptView>
 	>,
 	AssertResolved<typeof MuteReceiptView, AssertFieldMapResolved<typeof MuteReceiptView>>,
+	AssertResolved<typeof MutedMemberView, AssertFieldMapResolved<typeof MutedMemberView>>,
 	AssertResolved<typeof TagView, AssertFieldMapResolved<typeof TagView>>,
 	AssertResolved<typeof CommentView, AssertFieldMapResolved<typeof CommentView>>,
 	AssertResolved<typeof PostView, AssertFieldMapResolved<typeof PostView>>,

--- a/apps/web/worker/features/mute/Mute.ts
+++ b/apps/web/worker/features/mute/Mute.ts
@@ -17,12 +17,53 @@
  * Scope: storage + domain seam only. No fate/mutation exposure, no read-masking, no
  * UI, no *block* (mutual interaction-ban) semantics — those are siblings.
  */
-import {and, eq} from "drizzle-orm";
+import {and, desc, eq, type SQL} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
-import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
+import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import {
+	emptyKeysetPage,
+	forwardPage,
+	type KeysetPage,
+	keysetAfter,
+	resolveCursor,
+} from "../../db/keyset.ts";
 import {UserId} from "../../lib/ids.ts";
 import {SelfMuteRejected} from "./errors.ts";
+
+/** One entry of the viewer's own muted-members list — the muted member id (the row
+ * identity + keyset cursor) and when the mute was set (the newest-first order key).
+ * Hydrated with the muted member's profile handle in the `mute.listMine` resolver
+ * (the domain service stays over its own table; identity is joined at the fate seam). */
+export interface MutedMemberRow {
+	mutedId: string;
+	mutedAt: Date;
+}
+
+/** Options for {@link Mute.listMine} — `first` page size (clamped 1..100, default 20),
+ * `after` the opaque forward keyset cursor (a muted member id). */
+export interface MutedMemberListOpts {
+	first?: number | undefined;
+	after?: string | null | undefined;
+}
+
+/**
+ * The viewer's muted-members page read, scoped to `muter_id = muterId` and ordered
+ * newest-mute-first (`created_at desc`, `muted_id desc` as the stable tiebreaker).
+ * Exported pure so the ownership predicate is `.toSQL()`-inspectable with no engine
+ * (the `unreadCountQuery` idiom, ADR 0082): `muter_id` rides every read predicate, so
+ * "list someone else's mutes" matches zero rows by construction.
+ */
+export const mutedMembersQuery = (db: DrizzleDb, muterId: string, cursorPredicate?: SQL) =>
+	db
+		.select({mutedId: schema.userMute.mutedId, createdAt: schema.userMute.createdAt})
+		.from(schema.userMute)
+		.where(
+			cursorPredicate
+				? and(eq(schema.userMute.muterId, muterId), cursorPredicate)
+				: eq(schema.userMute.muterId, muterId),
+		)
+		.orderBy(desc(schema.userMute.createdAt), desc(schema.userMute.mutedId));
 
 export interface MuteSetInput {
 	muterId: string;
@@ -54,6 +95,18 @@ export class Mute extends Context.Service<
 		 * an N+1. Missing viewer short-circuits to an empty Set with no read.
 		 */
 		readonly readMutedIds: (viewerId: string | null | undefined) => Effect.Effect<Set<string>>;
+		/**
+		 * The viewer's own muted members, newest-mute-first, forward keyset-paginated
+		 * over the `(muter_id, muted_id)` PK's leading column. A missing viewer short-
+		 * circuits to the empty page with no read; a foreign/dead cursor is the shared
+		 * cursor-miss empty page (never a probe into another muter's rows). The muter
+		 * scope is structural — every read carries `muter_id`, so a member only ever
+		 * pages their own mutes.
+		 */
+		readonly listMine: (
+			viewerId: string | null | undefined,
+			opts?: MutedMemberListOpts,
+		) => Effect.Effect<KeysetPage<MutedMemberRow>>;
 	}
 >()("@kampus/mute/Mute") {}
 
@@ -76,8 +129,50 @@ export const MuteLive = Layer.effect(Mute)(
 			return new Set(rows.map((r) => r.mutedId));
 		});
 
+		const listMine = Effect.fn("Mute.listMine")(function* (
+			viewerId: string | null | undefined,
+			opts: MutedMemberListOpts = {},
+		) {
+			if (!viewerId) return emptyKeysetPage;
+			const first = Math.max(1, Math.min(opts.first ?? 20, 100));
+			const after = opts.after ?? null;
+
+			// The DB read is the port; `resolveCursor` is the pure cursor-miss decision
+			// (the bildirim idiom). The cursor is a muted member id, resolved to its
+			// `created_at` for the keyset tuple — muter-scoped, so a foreign cursor is a
+			// miss, not a probe into another muter's list.
+			const resolvedRow = after
+				? ((yield* run((db) =>
+						db
+							.select({createdAt: schema.userMute.createdAt})
+							.from(schema.userMute)
+							.where(and(eq(schema.userMute.muterId, viewerId), eq(schema.userMute.mutedId, after)))
+							.get(),
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor(after, resolvedRow);
+			if (cursor.kind === "miss") return emptyKeysetPage;
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
+
+			const cursorPredicate = keysetAfter([
+				{column: schema.userMute.createdAt, dir: "desc", value: cursorRow?.createdAt ?? null},
+				{column: schema.userMute.mutedId, dir: "desc", value: after},
+			]);
+
+			const fetched = yield* run((db) =>
+				mutedMembersQuery(db, viewerId, cursorPredicate).limit(first + 1),
+			);
+			return forwardPage<(typeof fetched)[number], MutedMemberRow>(
+				fetched,
+				first,
+				(row) => row.mutedId,
+				(row) => ({mutedId: row.mutedId, mutedAt: row.createdAt}),
+			);
+		});
+
 		return {
 			readMutedIds,
+			listMine,
 			set: Effect.fn("Mute.set")(function* (input: MuteSetInput) {
 				if (input.muterId === input.mutedId) {
 					return yield* new SelfMuteRejected({

--- a/apps/web/worker/features/mute/fate-module.ts
+++ b/apps/web/worker/features/mute/fate-module.ts
@@ -1,16 +1,28 @@
 /** mute's contribution to the one fate config. See `../fate/module.ts`. */
 import {Fate} from "@kampus/fate-effect";
-import type {FateModule} from "../fate/module.ts";
+import {list} from "@nkzw/fate/server";
+import type {FateModule, FateRootsRecord} from "../fate/module.ts";
+import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
-import {MuteReceiptView} from "./views.ts";
+import {MutedMemberView, MuteReceiptView, mutedMemberDataView} from "./views.ts";
 
-// `mute.set` / `mute.remove` return `MuteReceiptView` inline, so the entity needs a
-// source to be view-reachable in codegen. A `syntheticSource` (no by-id fetch path) is
-// the minimal footprint — the mutation delivers the receipt in its response (the mecmua
-// `MecmuaSubscriptionReceiptView` idiom).
+// Both mute entities are delivered inline (never read by id): `MuteReceipt` by the
+// `mute.set` / `mute.remove` mutations, `MutedMember` by the `mute.listMine` list root
+// (#3114). A `syntheticSource` (no by-id fetch path) makes each view-reachable in codegen
+// with zero capabilities — the mecmua `MecmuaSubscriptionReceiptView` / `ReportReceipt`
+// escape hatch (`.patterns/fate-effect-sources.md`).
 const muteReceiptSource = Fate.syntheticSource(MuteReceiptView);
+const mutedMemberSource = Fate.syntheticSource(MutedMemberView);
+
+const roots: FateRootsRecord = {
+	// The viewer's manage-my-mutes list (#3114) — a `CurrentUser`-gated, flag-dark list
+	// root; the `mute.listMine` resolver owns the newest-first keyset order + muter scoping.
+	"mute.listMine": list(mutedMemberDataView),
+};
 
 export const fateModule = {
+	lists,
 	mutations,
-	sources: [muteReceiptSource],
+	sources: [muteReceiptSource, mutedMemberSource],
+	roots,
 } satisfies FateModule;

--- a/apps/web/worker/features/mute/lists.ts
+++ b/apps/web/worker/features/mute/lists.ts
@@ -1,0 +1,84 @@
+/**
+ * `mute.listMine` — the manage-my-mutes read model (#3114, epic #2035): the viewer's
+ * own muted members, newest-mute-first, forward keyset-paginated. Gated on
+ * `CurrentUser` (an anonymous caller is rejected the invisible `Unauthorized` before
+ * any read) and behind the default-off `member-mute` flag (off ⇒ `MuteDisabled`, so
+ * the whole mute surface stays dark uniformly — the same containment the `mute.set` /
+ * `mute.remove` write path uses, see `errors.ts`).
+ *
+ * A member only ever pages their OWN mutes: the muter scope is structural in
+ * `Mute.listMine` (`muter_id` rides every predicate). Each row is hydrated with the
+ * muted member's profile handle joined from pasaport in ONE batched read (the divan
+ * roster idiom) — enough for a UI to render the row and offer a per-row unmute
+ * (`mute.remove` keyed on the row `id`). The read model only; the list UI + the
+ * unmute button are the reachability sibling, the unmute write is `mute.remove`.
+ */
+import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {MEMBER_MUTE} from "../../../src/flags/keys.ts";
+import {toConnection} from "../fate/connection.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
+import {Pasaport} from "../pasaport/Pasaport.ts";
+import {MuteDisabled} from "./errors.ts";
+import {Mute, type MutedMemberRow} from "./Mute.ts";
+import type {MutedMember} from "./views.ts";
+import {MutedMemberView} from "./views.ts";
+
+const ListMineArgs = Schema.Struct({
+	first: Schema.optional(Schema.Number),
+	after: Schema.optional(Schema.String),
+});
+
+/** Is the member-mute surface on for this request? Safe-default `false` (ships dark). */
+const memberMuteOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(MEMBER_MUTE, false).pipe(provideRequestFlags);
+});
+
+export const lists = {
+	"mute.listMine": Fate.list(
+		{
+			args: ListMineArgs,
+			type: MutedMemberView,
+			error: Schema.Union([Unauthorized, MuteDisabled]),
+		},
+		Effect.fn("mute.listMine")(function* ({args}) {
+			const user = yield* CurrentUser.required;
+			if (!(yield* memberMuteOn)) {
+				return yield* new MuteDisabled({message: "sustur şu an kapalı"});
+			}
+
+			const mute = yield* Mute;
+			const page = yield* mute.listMine(user.id, {
+				...(args.first !== undefined ? {first: args.first} : {}),
+				...(args.after !== undefined ? {after: args.after} : {}),
+			});
+
+			// One batched identity read for the whole page (never a per-row by-id): a
+			// member absent from `user_profile` simply has no entry and renders with a
+			// null handle client-side.
+			const pasaport = yield* Pasaport;
+			const identities = yield* pasaport.getProfileIdentitiesByIds(
+				page.rows.map((row) => row.mutedId),
+			);
+			const handles = new Map(identities.map((row) => [row.userId, row]));
+
+			return toConnection<MutedMemberRow, MutedMember>(
+				page,
+				(row) => row.mutedId,
+				(row) => {
+					const identity = handles.get(row.mutedId);
+					return {
+						__typename: "MutedMember",
+						id: row.mutedId,
+						username: identity?.username ?? null,
+						displayName: identity?.displayName ?? null,
+						mutedAt: row.mutedAt.toISOString(),
+					};
+				},
+			);
+		}),
+	),
+};

--- a/apps/web/worker/features/mute/mute-list.unit.test.ts
+++ b/apps/web/worker/features/mute/mute-list.unit.test.ts
@@ -1,0 +1,292 @@
+/**
+ * `mute.listMine` coverage (#3114, epic #2035) — the manage-my-mutes read model,
+ * split across the two seams the ACs live on (ADR 0082):
+ *
+ *   - **the domain read** (`Mute.listMine`) over the substituted `Drizzle` seam: the
+ *     muter-ownership predicate is asserted on the rendered SQL (`.toSQL()` over a
+ *     no-op D1 — the `Notification.unit.test.ts` idiom), so "list someone else's
+ *     mutes" carries `muter_id` by construction; the newest-first keyset paging folds
+ *     the `first + 1` probe into `{rows, hasNextPage, endCursor}`, and a foreign/dead
+ *     cursor is the shared cursor-miss empty page (never a probe into another muter's
+ *     rows). A null viewer short-circuits with no read.
+ *   - **the WIRE boundary** (the `mute.listMine` list resolver) through `resolveWire`
+ *     (decode → `encodeWireError`): an anonymous caller is rejected `UNAUTHORIZED`
+ *     before any read; with the `member-mute` flag OFF an authed caller is refused
+ *     `MUTE_DISABLED` (the dark-ship containment); with the flag ON the page is
+ *     hydrated with the muted member's profile handle in ONE batched pasaport read.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {drizzle} from "drizzle-orm/d1";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
+import type {ProfileIdentityRow} from "../pasaport/Pasaport.ts";
+import {lists} from "./lists.ts";
+import {Mute, MuteLive, mutedMembersQuery} from "./Mute.ts";
+
+// A real drizzle client over a no-op D1 — used ONLY to render `.toSQL()`; it never
+// executes (the `Notification.unit.test.ts` render seam).
+// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; nothing here executes against it.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {relations});
+
+// A `Drizzle` whose every call throws — any path that reaches the DB seam fails the
+// test, so a no-read short-circuit runs to completion against it (the "no read" proof).
+const throwingAccess: DrizzleAccess = {
+	run: () => Effect.die(new Error("Mute read the DB on a path that must short-circuit")),
+	batch: () => Effect.die(new Error("Mute wrote a batch on a path that must short-circuit")),
+};
+
+// A `Drizzle` seam that dispenses queued responses in order (the Funnel idiom).
+const scriptedSequence = (responses: ReadonlyArray<unknown>): DrizzleAccess => {
+	let call = 0;
+	return {
+		run: <A>(_fn: (db: DrizzleDb) => Promise<A>) => Effect.succeed(responses[call++] as A),
+		batch: () => Effect.die(new Error("Mute.listMine issues no batch")),
+	};
+};
+
+const muteLayer = (access: DrizzleAccess) =>
+	MuteLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+const muteRow = (mutedId: string, createdAt: Date) => ({mutedId, createdAt});
+
+describe("Mute.listMine — muter ownership scoping (rendered SQL, no engine)", () => {
+	it("every read predicate carries muter_id and orders newest-mute-first", () => {
+		const {sql, params} = mutedMembersQuery(renderDb, "me").toSQL();
+		assert.include(sql, '"muter_id" = ?');
+		assert.include(sql, "order by");
+		assert.include(sql, '"created_at" desc');
+		assert.include(sql, '"muted_id" desc');
+		assert.include(params, "me");
+	});
+});
+
+describe("Mute.listMine — no-read short-circuit", () => {
+	it.effect("a null viewer → empty page without touching the DB", () =>
+		Effect.gen(function* () {
+			const mute = yield* Mute;
+			const page = yield* mute.listMine(null);
+			assert.deepStrictEqual(page.rows, []);
+			assert.isFalse(page.hasNextPage);
+			assert.isNull(page.endCursor);
+		}).pipe(Effect.provide(muteLayer(throwingAccess))),
+	);
+});
+
+describe("Mute.listMine — newest-first keyset paging", () => {
+	it.effect("folds the first+1 probe into rows/hasNextPage/endCursor", () =>
+		Effect.gen(function* () {
+			const mute = yield* Mute;
+			const page = yield* mute.listMine("me", {first: 2});
+			assert.deepStrictEqual(
+				page.rows.map((r) => r.mutedId),
+				["u3", "u2"],
+			);
+			assert.isTrue(page.hasNextPage);
+			assert.strictEqual(page.endCursor, "u2");
+		}).pipe(
+			// One read (no cursor to resolve): the LIMIT 3 probe returns 3 rows.
+			Effect.provide(
+				muteLayer(
+					scriptedSequence([
+						[
+							muteRow("u3", new Date(3000)),
+							muteRow("u2", new Date(2000)),
+							muteRow("u1", new Date(1000)),
+						],
+					]),
+				),
+			),
+		),
+	);
+
+	it.effect("a cursor that resolves to no row (foreign or dead id) is the empty page", () =>
+		Effect.gen(function* () {
+			const mute = yield* Mute;
+			const page = yield* mute.listMine("me", {first: 2, after: "someone-elses"});
+			assert.deepStrictEqual(page.rows, []);
+			assert.isFalse(page.hasNextPage);
+			assert.isNull(page.endCursor);
+			// The cursor-resolve read returned no row → miss → no second read issued.
+		}).pipe(Effect.provide(muteLayer(scriptedSequence([undefined])))),
+	);
+
+	it.effect("a live cursor pages strictly after it (the second read is the keyset page)", () =>
+		Effect.gen(function* () {
+			const mute = yield* Mute;
+			const page = yield* mute.listMine("me", {first: 2, after: "u3"});
+			assert.deepStrictEqual(
+				page.rows.map((r) => r.mutedId),
+				["u2", "u1"],
+			);
+			assert.isFalse(page.hasNextPage);
+			assert.strictEqual(page.endCursor, "u1");
+		}).pipe(
+			// read #1 resolves the cursor to its created_at; read #2 is the keyset page.
+			Effect.provide(
+				muteLayer(
+					scriptedSequence([
+						{createdAt: new Date(3000)},
+						[muteRow("u2", new Date(2000)), muteRow("u1", new Date(1000))],
+					]),
+				),
+			),
+		),
+	);
+});
+
+// --- WIRE boundary: the `mute.listMine` list resolver through `resolveWire` ---
+
+const VIEWER = {id: "u-viewer", email: "kaan@example.com", name: "kaan"};
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "mute-list-test",
+	id: "mute-list-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(on),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service);
+
+type ListMine = (typeof Mute.Service)["listMine"];
+
+// A `Mute` whose `listMine` runs `impl` (or dies on contact) — a denied path that must
+// short-circuit before the read proves it by failing the fail-on-contact default.
+const muteStub = (impl?: ListMine) =>
+	Layer.succeed(Mute, {
+		listMine:
+			impl ??
+			((() => Effect.die("Mute.listMine reached on a path that must short-circuit")) as ListMine),
+		set: () => Effect.die("Mute.set not exercised"),
+		readMutedIds: () => Effect.die("Mute.readMutedIds not exercised"),
+	} as typeof Mute.Service);
+
+const pasaportStub = (rows: ReadonlyArray<ProfileIdentityRow>) =>
+	makePasaportStub({
+		getProfileIdentitiesByIds: (ids) => Effect.succeed(rows.filter((r) => ids.includes(r.userId))),
+	});
+
+const listMine = (user?: typeof VIEWER) =>
+	resolveWire(lists["mute.listMine"], {
+		args: {},
+		select: ["id", "username", "displayName", "mutedAt"],
+	}).pipe(
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+	);
+
+const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
+	const error = Cause.findErrorOption(cause);
+	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
+};
+
+describe("mute.listMine — CurrentUser gate + dark-ship (fail closed)", () => {
+	it.effect("an anonymous caller is rejected UNAUTHORIZED — and never reaches the read", () =>
+		Effect.gen(function* () {
+			const exit = yield* listMine().pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+		}).pipe(Effect.provide(Layer.mergeAll(flagsStub(true), muteStub(), pasaportStub([])))),
+	);
+
+	it.effect("with the flag OFF an authed caller is refused MUTE_DISABLED — no read", () =>
+		Effect.gen(function* () {
+			const exit = yield* listMine(VIEWER).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "MUTE_DISABLED");
+		}).pipe(Effect.provide(Layer.mergeAll(flagsStub(false), muteStub(), pasaportStub([])))),
+	);
+
+	it.effect("with the flag ON the page is hydrated with the muted member's handle", () =>
+		Effect.gen(function* () {
+			const connection = yield* listMine(VIEWER);
+			assert.strictEqual(connection.items.length, 1);
+			const [entry] = connection.items;
+			assert.strictEqual(entry?.cursor, "u-target");
+			assert.deepStrictEqual(entry?.node, {
+				__typename: "MutedMember",
+				id: "u-target",
+				username: "kaan",
+				displayName: "Kaan",
+				mutedAt: new Date(2000).toISOString(),
+			});
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					flagsStub(true),
+					muteStub((viewerId) => {
+						assert.strictEqual(viewerId, VIEWER.id, "the muter is the authed caller");
+						return Effect.succeed({
+							rows: [{mutedId: "u-target", mutedAt: new Date(2000)}],
+							hasNextPage: false,
+							endCursor: "u-target",
+						});
+					}),
+					pasaportStub([
+						{userId: "u-target", username: "kaan", displayName: "Kaan", totalKarma: 0},
+					]),
+				),
+			),
+		),
+	);
+
+	it.effect("a member absent from user_profile renders with a null handle", () =>
+		Effect.gen(function* () {
+			const connection = yield* listMine(VIEWER);
+			assert.deepStrictEqual(connection.items[0]?.node, {
+				__typename: "MutedMember",
+				id: "u-ghost",
+				username: null,
+				displayName: null,
+				mutedAt: new Date(1000).toISOString(),
+			});
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					flagsStub(true),
+					muteStub(() =>
+						Effect.succeed({
+							rows: [{mutedId: "u-ghost", mutedAt: new Date(1000)}],
+							hasNextPage: false,
+							endCursor: "u-ghost",
+						}),
+					),
+					pasaportStub([]),
+				),
+			),
+		),
+	);
+});

--- a/apps/web/worker/features/mute/mute-mutation.unit.test.ts
+++ b/apps/web/worker/features/mute/mute-mutation.unit.test.ts
@@ -51,6 +51,7 @@ const muteStub = (impl?: (input: MuteSetInput) => Effect.Effect<MuteSetResult, S
 	Layer.succeed(Mute, {
 		set: impl ?? (() => Effect.die("Mute.set reached on a path that must short-circuit")),
 		readMutedIds: () => Effect.die("Mute.readMutedIds not exercised"),
+		listMine: () => Effect.die("Mute.listMine not exercised"),
 	});
 
 const setMute = (mutedId: string, user?: typeof MUTER) =>

--- a/apps/web/worker/features/mute/views.ts
+++ b/apps/web/worker/features/mute/views.ts
@@ -26,3 +26,33 @@ export class MuteReceiptView extends FateDataView<MuteReceiptViewRow>()("MuteRec
 
 export const muteReceiptDataView = MuteReceiptView.view;
 export type MuteReceipt = WorkerEntity<typeof MuteReceiptView>;
+
+/**
+ * `MutedMember` — one entry of the viewer's own manage-my-mutes list (#3114),
+ * delivered inline by the `mute.listMine` list root (no by-id fetch path — a mute is
+ * the muter's private state). `id` is the muted member id (the row identity + the
+ * unmute target the UI passes to `mute.remove`); `username`/`displayName` are the
+ * profile handle joined at the resolver so a row renders + offers an unmute, both
+ * nullable for an un-bootstrapped member. `mutedAt` (ISO-8601) is the newest-first
+ * order key. See `.patterns/fate-effect-data-views.md`.
+ */
+export type MutedMemberViewRow = ViewRow<{
+	/** The muted member id — the row identity + the `mute.remove` unmute target. */
+	id: string;
+	/** The muted member's username (`null` for an un-bootstrapped member). */
+	username: string | null;
+	/** The muted member's display name (`null` when unset). */
+	displayName: string | null;
+	/** When the mute was set (ISO-8601) — the newest-first order key. */
+	mutedAt: string;
+}>;
+
+export class MutedMemberView extends FateDataView<MutedMemberViewRow>()("MutedMember")({
+	id: true,
+	username: true,
+	displayName: true,
+	mutedAt: true,
+} satisfies {[K in keyof MutedMemberViewRow]: true}) {}
+
+export const mutedMemberDataView = MutedMemberView.view;
+export type MutedMember = WorkerEntity<typeof MutedMemberView>;


### PR DESCRIPTION
## What

Adds `mute.listMine` — the manage-my-mutes read model (#3114, epic #2035): a fate list root over the viewer's own muted members, mirroring how `report` exposes `report.listOpen` as a gated list root.

- **`mute.listMine` list root** (`apps/web/worker/features/mute/lists.ts`) returns the viewer's muted members **newest-mute-first**, **forward keyset-paginated** over the `user_mute` reverse index (`Mute.listMine`, the `bildirim.list` keyset idiom).
- **Gated on `CurrentUser`** — an anonymous caller is rejected the invisible `UNAUTHORIZED` before any read; a member only ever pages their **own** mutes (the muter scope is structural in `Mute.listMine` — `muter_id` rides every read predicate, `.toSQL()`-asserted).
- **Hydrated** — each entry carries the muted member's profile handle (`username`/`displayName`), joined from pasaport in ONE batched read (the divan roster idiom), so a UI can render the row and offer a per-row unmute.
- **Behind the default-off `member-mute` flag** — off ⇒ `MUTE_DISABLED`, the same dark-ship containment the `mute.set`/`mute.remove` write path uses (`errors.ts`).

Out of scope (siblings): the list UI + unmute button (reachability child) and the unmute mutation itself (`mute.remove`). This slice is the read model for "my mutes".

## Acceptance criteria

- [x] `mute.listMine` fate list root exists, gated on `CurrentUser`; anonymous rejected, a member sees only their own mutes.
- [x] Returns the viewer's muted members newest-first, keyset-paginated, each hydrated with the profile fields a UI needs.
- [x] Behind the `member-mute` flag (off ⇒ the root is dark, `MUTE_DISABLED`).
- [x] Unit tests cover the gated read, the ownership scoping (rendered SQL), and pagination (`mute-list.unit.test.ts`).

## Testing

`pnpm --filter @kampus/web typecheck` and the `mute` unit suite (23 tests, incl. 9 new) pass; biome clean.

Fixes #3114