### PR TITLE
feat(anka-ops): report --name runner — generic AE-read + product-supplied catalog seam (#3134)

### DIFF
--- a/packages/anka-ops/package.json
+++ b/packages/anka-ops/package.json
@@ -14,6 +14,7 @@
 		"auth": "node src/bin.ts auth"
 	},
 	"dependencies": {
+		"@distilled.cloud/cloudflare": "catalog:",
 		"@effect/platform-node": "catalog:",
 		"@kampus/cf-credentials": "workspace:*",
 		"@kampus/cf-utils": "workspace:*",

--- a/packages/anka-ops/src/analytics.ts
+++ b/packages/anka-ops/src/analytics.ts
@@ -1,0 +1,124 @@
+/**
+ * The Analytics Engine read seam — the IO shell the `report` runner resolves its AE query through.
+ * ADR 0153 mandates reads go through the external AE SQL API (never from the worker); this is the
+ * operator-side client for exactly that. It rides the SAME ambient `Credentials | HttpClient` the
+ * cf-utils Flagship clients do (ADR 0045: one shared scoped operator credential), so `report`
+ * inherits the keychain-first least-privilege credential seam and rolls no second token store.
+ *
+ * The transport is the CF AE SQL endpoint `POST {apiBaseUrl}/accounts/{id}/analytics_engine/sql`
+ * with the raw SQL as the request body, returning a ClickHouse-style JSON envelope `{ data: [...] }`
+ * (Cloudflare AE SQL API: https://developers.cloudflare.com/analytics/analytics-engine/sql-api/).
+ * The query itself is rendered sampling-correct upstream in `report.ts`; this seam only executes it.
+ */
+
+import {Credentials, type ResolvedCredentials} from "@distilled.cloud/cloudflare/Credentials";
+import {Config, Context, Effect, Layer, Redacted} from "effect";
+import * as Schema from "effect/Schema";
+import type {HttpClient as HttpClientService} from "effect/unstable/http/HttpClient";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type {ReportRow} from "./report.ts";
+
+const accountId = Config.string("CLOUDFLARE_ACCOUNT_ID");
+
+/**
+ * Any failure of an AE read, collapsed to one typed `E`-channel fault carrying a human reason —
+ * a missing account id, an unresolvable credential, a transport error, a non-2xx from AE, or an
+ * unparseable body all surface here rather than a raw stack trace (rendered by `NodeRuntime.runMain`).
+ */
+export class AnalyticsReadError extends Schema.TaggedErrorClass<AnalyticsReadError>()(
+	"@kampus/anka-ops/AnalyticsReadError",
+	{reason: Schema.String},
+) {
+	override get message(): string {
+		return `analytics engine read failed: ${this.reason}`;
+	}
+}
+
+/** The `Authorization` header for the resolved credential — Bearer for token/oauth, X-Auth for API-key. */
+const authHeaders = (credentials: ResolvedCredentials): Record<string, string> => {
+	switch (credentials.type) {
+		case "apiToken":
+			return {authorization: `Bearer ${Redacted.value(credentials.apiToken)}`};
+		case "oauth":
+			return {authorization: `Bearer ${Redacted.value(credentials.accessToken)}`};
+		case "apiKey":
+			return {
+				"x-auth-email": credentials.email,
+				"x-auth-key": Redacted.value(credentials.apiKey),
+			};
+	}
+};
+
+/** Coerce AE's JSON `{ data: [row, …] }` envelope into typed rows, or fail if the shape is wrong. */
+const parseRows = (json: unknown): Effect.Effect<ReadonlyArray<ReportRow>, AnalyticsReadError> => {
+	if (
+		typeof json !== "object" ||
+		json === null ||
+		!Array.isArray((json as {data?: unknown}).data)
+	) {
+		return Effect.fail(
+			new AnalyticsReadError({
+				reason: "AE response missing a `data` array (unexpected SQL API shape)",
+			}),
+		);
+	}
+	const rows = (json as {data: ReadonlyArray<Record<string, unknown>>}).data.map((row) => {
+		const out: ReportRow = {};
+		for (const [key, value] of Object.entries(row)) {
+			out[key] =
+				value === null || typeof value === "string" || typeof value === "number"
+					? value
+					: String(value);
+		}
+		return out;
+	});
+	return Effect.succeed(rows);
+};
+
+/** `AnalyticsRead` — the injectable AE read seam. `query` runs one SQL read and returns decoded rows. */
+export class AnalyticsRead extends Context.Service<
+	AnalyticsRead,
+	{
+		readonly query: (sql: string) => Effect.Effect<ReadonlyArray<ReportRow>, AnalyticsReadError>;
+	}
+>()("@kampus/anka-ops/AnalyticsRead") {}
+
+export const AnalyticsReadLive: Layer.Layer<AnalyticsRead, never, Credentials | HttpClientService> =
+	Layer.effect(AnalyticsRead)(
+		Effect.gen(function* () {
+			// Capture the ambient credential + transport ONCE and re-provide into each read, so the
+			// public `query` carries `R = never` — the same shape FlagshipReadLive uses (ADR 0045).
+			const context = yield* Effect.context<Credentials | HttpClientService>();
+
+			const query = (sql: string) =>
+				Effect.gen(function* () {
+					const acct = yield* accountId;
+					const resolveCredentials = yield* Credentials;
+					const credentials = yield* resolveCredentials;
+					const url = `${credentials.apiBaseUrl}/accounts/${acct}/analytics_engine/sql`;
+					const request = HttpClientRequest.post(url).pipe(
+						HttpClientRequest.setHeaders(authHeaders(credentials)),
+						HttpClientRequest.bodyText(sql, "text/plain"),
+					);
+					const response = yield* HttpClient.execute(request);
+					if (response.status < 200 || response.status >= 300) {
+						const body = yield* response.text.pipe(Effect.orElseSucceed(() => ""));
+						return yield* new AnalyticsReadError({
+							reason: `AE SQL API returned HTTP ${response.status}: ${body.slice(0, 300)}`,
+						});
+					}
+					const json = yield* response.json;
+					return yield* parseRows(json);
+				}).pipe(
+					Effect.provide(context),
+					Effect.catch((error) =>
+						error instanceof AnalyticsReadError
+							? Effect.fail(error)
+							: Effect.fail(new AnalyticsReadError({reason: String(error)})),
+					),
+				);
+
+			return {query};
+		}),
+	);

--- a/packages/anka-ops/src/cli.ts
+++ b/packages/anka-ops/src/cli.ts
@@ -2,14 +2,15 @@
  * The `anka-ops` command tree + the shared operator-credential runtime layer.
  *
  * This is the framework-tier skeleton (epic #2089, ADR 0045): the root `anka-ops` command wires
- * the `auth` verb group — reused wholesale from `@kampus/cf-credentials`, so anka-ops rolls NO
- * second credential store — and leaves `VERB_GROUPS` as the single extension point children B
- * (`flag`, #3133) and C (`report`, #3134) fold their groups into. No product verb lands here.
+ * the `auth`, `flag`, and `report` verb groups — `auth` reused wholesale from `@kampus/cf-credentials`
+ * so anka-ops rolls NO second credential store — and leaves `VERB_GROUPS` as the single extension
+ * point children fold their groups into. No product verb (no flag, no report content) lands here.
  *
- * The runtime layer is the credential seam every later verb group resolves through: keychain-first
+ * The runtime layer is the credential seam every verb group resolves through: keychain-first
  * (`anka-ops auth login` → OS keychain), falling back to $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID
  * for CI (the byte-for-byte-unchanged env path). A missing/unauthorized credential surfaces a typed
  * error on the `E` channel, rendered by `NodeRuntime.runMain` in bin.ts — never a raw stack trace.
+ * `report` resolves the injected `ReportCatalog` (empty in the core) + the AE read client through it.
  */
 import {NodeServices} from "@effect/platform-node";
 import {
@@ -22,7 +23,11 @@ import {FlagshipReadLive, FlagshipWriteLive} from "@kampus/cf-utils";
 import {Layer} from "effect";
 import {Command} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {AnalyticsReadLive} from "./analytics.ts";
 import {flag} from "./flag-command.ts";
+import {makeReportCatalog} from "./report.ts";
+import {REPORT_CATALOG} from "./report-catalog.ts";
+import {report} from "./report-command.ts";
 
 /** A verb group folded under the root `anka-ops` command — the ops-language surface descriptor. */
 export interface VerbGroup {
@@ -32,8 +37,8 @@ export interface VerbGroup {
 
 /**
  * The registry of shipped verb groups — the single place a child extends the ops language.
- * `flag` folds the cf-utils Flagship core (#3133); `report` (#3134) appends its descriptor here
- * (and its `Command` into {@link ankaOps}'s `withSubcommands`) as it lands.
+ * `flag` folds the cf-utils Flagship core (#3133); `report` folds the generic AE-read runner over
+ * an injected report catalog (#3134). A new group touches both this registry and `withSubcommands`.
  */
 export const VERB_GROUPS: ReadonlyArray<VerbGroup> = [
 	{
@@ -44,11 +49,15 @@ export const VERB_GROUPS: ReadonlyArray<VerbGroup> = [
 		name: "flag",
 		summary: "Read and release Flagship flags — get/open/close/graduate over the cf-utils core",
 	},
+	{
+		name: "report",
+		summary: "Run named AE product-usage reports from an injected catalog (ADR 0153)",
+	},
 ];
 
-/** The root command. Extension point: child C adds its `Command` to `withSubcommands`. */
+/** The root command. Extension point: a new group adds its `Command` to `withSubcommands`. */
 export const ankaOps = Command.make("anka-ops").pipe(
-	Command.withSubcommands([auth, flag]),
+	Command.withSubcommands([auth, flag, report]),
 	Command.withDescription(
 		"Operator CLI for anka-built apps — scoped ops over hidden infra (epic #2089, ADR 0045)",
 	),
@@ -61,12 +70,18 @@ const CredentialLayer = Layer.mergeAll(CredentialsKeychainFirst, AccountIdKeycha
 	Layer.provideMerge(KeychainLive),
 );
 
-// The Flagship read/write clients the `flag` verb group resolves through — provided ON TOP of the
-// shared credential seam (ADR 0045: one credential), so the fold reuses cf-utils' clients as-is.
-const FlagshipClients = Layer.mergeAll(FlagshipReadLive, FlagshipWriteLive);
+// The per-verb-group clients, all provided ON TOP of the shared credential seam (ADR 0045: one
+// credential): cf-utils' Flagship read/write for `flag`, the AE read client for `report`, and the
+// injected report catalog (EMPTY in the core — product content is wired via REPORT_CATALOG, ADR 0153).
+const VerbGroupClients = Layer.mergeAll(
+	FlagshipReadLive,
+	FlagshipWriteLive,
+	AnalyticsReadLive,
+	makeReportCatalog(REPORT_CATALOG),
+);
 
 /** The runtime layer bin.ts provides to `anka-ops`; every verb group resolves through it. */
 export const AnkaOpsRuntimeLayer = Layer.provideMerge(
-	FlagshipClients,
+	VerbGroupClients,
 	CredentialLayer.pipe(Layer.provideMerge(Layer.merge(FetchHttpClient.layer, NodeServices.layer))),
 );

--- a/packages/anka-ops/src/cli.unit.test.ts
+++ b/packages/anka-ops/src/cli.unit.test.ts
@@ -1,9 +1,8 @@
 /**
  * Verb-wiring: the root `anka-ops` command exposes exactly the verb groups the `VERB_GROUPS`
  * registry advertises. The load-bearing assertion is that the registry and the actual
- * `withSubcommands` tree can't drift — when a child (B `flag` / C `report`) folds in a group it
- * must touch both, and this test reds if it touches only one. No IO: the command tree is a
- * pure value.
+ * `withSubcommands` tree can't drift — when a child folds in a group (`flag`, `report`) it must
+ * touch both, and this test reds if it touches only one. No IO: the command tree is a pure value.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {ankaOps, VERB_GROUPS} from "./cli.ts";
@@ -17,8 +16,8 @@ describe("ankaOps command tree", () => {
 		assert.strictEqual(ankaOps.name, "anka-ops");
 	});
 
-	it("wires the `auth` + `flag` verb groups", () => {
-		assert.deepStrictEqual(wiredSubcommandNames(), ["auth", "flag"]);
+	it("wires the `auth` + `flag` + `report` verb groups", () => {
+		assert.deepStrictEqual(wiredSubcommandNames(), ["auth", "flag", "report"]);
 	});
 
 	it("the registry advertises exactly the wired verb groups (no drift)", () => {

--- a/packages/anka-ops/src/index.ts
+++ b/packages/anka-ops/src/index.ts
@@ -1,3 +1,6 @@
+export * from "./analytics.ts";
 export * from "./cli.ts";
 export * from "./flag.ts";
 export * from "./posture.ts";
+export * from "./report.ts";
+export * from "./report-catalog.ts";

--- a/packages/anka-ops/src/report-catalog.ts
+++ b/packages/anka-ops/src/report-catalog.ts
@@ -1,0 +1,11 @@
+/**
+ * The product report registry — the single injection point for report *content*, wired into the
+ * runtime by `cli.ts`. The anka-ops core ships this EMPTY: it is the mechanism-vs-content boundary
+ * (ADR 0153) made concrete — the generic runner in `report.ts` carries no query, and a product adds
+ * its definitions here (the first, `votes-vs-reactions`, is a separate child). Until one is wired,
+ * `report --name <id>` fails loud listing an empty catalog rather than inventing a built-in report.
+ */
+
+import type {ReportDefinition} from "./report.ts";
+
+export const REPORT_CATALOG: ReadonlyArray<ReportDefinition> = [];

--- a/packages/anka-ops/src/report-command.ts
+++ b/packages/anka-ops/src/report-command.ts
@@ -1,0 +1,38 @@
+/**
+ * The `report` verb group's `effect/unstable/cli` wiring — the thin IO shell over the generic
+ * runner core (`report.ts` resolution + sampling-correct SQL rendering) and the AE read seam
+ * (`analytics.ts`). It holds no query and no report content: it resolves `--name` against the
+ * injected `ReportCatalog`, renders the resolved definition's query to sampling-correct SQL, runs
+ * it over the shared operator credential, and prints the result.
+ *
+ *   anka-ops report --name <id>     run a named AE report from the injected catalog
+ *
+ * A non-TTY caller proceeds and renders headless (a read has nothing to confirm — the ADR 0134
+ * posture only guards writes). An unknown `--name` fails loud with the known ids (`ReportNotFound`),
+ * never an empty result.
+ */
+
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {AnalyticsRead} from "./analytics.ts";
+import {ReportCatalog, renderReportResult, renderReportSql, resolveReport} from "./report.ts";
+
+const nameFlag = Flag.string("name").pipe(
+	Flag.withDescription("the report id to run — resolved against the injected catalog"),
+);
+
+export const report = Command.make(
+	"report",
+	{name: nameFlag},
+	Effect.fn(function* ({name}) {
+		const catalog = yield* ReportCatalog;
+		const definition = yield* resolveReport(catalog.entries, name);
+		const analytics = yield* AnalyticsRead;
+		const rows = yield* analytics.query(renderReportSql(definition.query));
+		yield* Console.log(renderReportResult(definition, rows));
+	}),
+).pipe(
+	Command.withDescription(
+		"Run a named AE product-usage report from the injected catalog — the generic runner over ADR 0153",
+	),
+);

--- a/packages/anka-ops/src/report.ts
+++ b/packages/anka-ops/src/report.ts
@@ -1,0 +1,168 @@
+/**
+ * The `report` verb group's mechanism core — framework-generic, product-content-free. This module
+ * is the load-bearing mechanism-vs-content seam (epic #2089, ADR 0153): it defines the shape a
+ * report *definition* satisfies, resolves one by name out of an injected catalog, and renders the
+ * catalog's structured query into sampling-correct AE SQL — but it names **no** concrete report and
+ * bakes **no** product-specific query. The first definition (`votes-vs-reactions`) is product content
+ * supplied by a separate child; the anka-ops core only carries this generic runner.
+ *
+ * Sampling-correctness is a MECHANISM guarantee, not left to product content: every measure a
+ * definition declares is rendered as `sumIf(_sample_interval, …)` — never `count()` — so a report
+ * can't accidentally bake in the count-vs-sample bug ADR 0153 warns about. The definition supplies
+ * *which* features to compare (content); this module supplies *how* the read is weighted (mechanism).
+ */
+
+import {Context, Effect, Layer} from "effect";
+import * as Schema from "effect/Schema";
+
+// The fixed `app_events` positional schema from ADR 0153: one index (the sampling/grouping key)
+// holds the feature-key, and reads weight by `_sample_interval` so per-feature counts stay exact
+// under sampling. These are schema constants of the seam, not a product query.
+const APP_EVENTS_DATASET = "app_events";
+const FEATURE_INDEX = "index1";
+const SAMPLE_INTERVAL = "_sample_interval";
+
+/**
+ * A single measured column of a report: a named count over one feature-key, resolved against the
+ * `index1` feature dimension. `feature` is the ADR-0153 feature-key (`vote`, `reaction`, …) — an
+ * English/technical identifier; `name` is the output column it renders under (`votes`, `reactions`).
+ */
+export interface FeatureMeasure {
+	readonly name: string;
+	readonly feature: string;
+}
+
+/**
+ * A report's query, encoded over the fixed positional schema (never raw SQL). The mechanism renders
+ * it sampling-correct; the product only declares the axes: which feature counts to compare, over how
+ * many trailing days, optionally bucketed per day. This is deliberately narrow — the counts-per-
+ * feature comparison ADR 0153's forcing question ("are reactions cannibalising votes") needs — and
+ * grows by extension as later reports need more, never by admitting a raw `count()`.
+ */
+export interface ReportQuery {
+	readonly measures: ReadonlyArray<FeatureMeasure>;
+	readonly windowDays: number;
+	readonly groupByDay: boolean;
+}
+
+/**
+ * A named, versioned report definition — the catalog-entry interface a product supplies. `version`
+ * is the definition's own revision (bump it when the query's shape changes so a cached/consuming
+ * surface can tell), `id` is the `--name` handle, `description` is the one-line operator summary.
+ */
+export interface ReportDefinition {
+	readonly id: string;
+	readonly version: number;
+	readonly description: string;
+	readonly query: ReportQuery;
+}
+
+/** A decoded AE result row — the positional-schema query returns named columns, values or null. */
+export type ReportRow = Record<string, string | number | null>;
+
+/**
+ * The injected report catalog — the product-supplied content the runner resolves `--name` against.
+ * A `Context.Service` so the anka-ops core stays query-free: the framework provides an EMPTY catalog,
+ * a product wires its definitions in. The runner never imports a definition; it only reads this seam.
+ */
+export class ReportCatalog extends Context.Service<
+	ReportCatalog,
+	{readonly entries: ReadonlyArray<ReportDefinition>}
+>()("@kampus/anka-ops/ReportCatalog") {}
+
+/** Wire a concrete catalog into the runtime — the single injection point for product report content. */
+export const makeReportCatalog = (
+	entries: ReadonlyArray<ReportDefinition>,
+): Layer.Layer<ReportCatalog> => Layer.succeed(ReportCatalog, {entries});
+
+/**
+ * An unknown `--name` — fail loud, listing the known ids so the operator can correct the typo rather
+ * than stare at an empty result. `knownIds` is empty when no product has wired any report yet (the
+ * bare framework), which the message states explicitly instead of an inscrutable blank list.
+ */
+export class ReportNotFound extends Schema.TaggedErrorClass<ReportNotFound>()(
+	"@kampus/anka-ops/ReportNotFound",
+	{
+		id: Schema.String,
+		knownIds: Schema.Array(Schema.String),
+	},
+) {
+	override get message(): string {
+		const known =
+			this.knownIds.length === 0
+				? "no reports are registered in the catalog"
+				: `known reports: ${this.knownIds.join(", ")}`;
+		return `unknown report "${this.id}" — ${known}`;
+	}
+}
+
+/** The catalog's ids, sorted — the operator-facing list `ReportNotFound` prints and `report list` uses. */
+export const knownReportIds = (catalog: ReadonlyArray<ReportDefinition>): ReadonlyArray<string> =>
+	catalog.map((entry) => entry.id).sort();
+
+/**
+ * Resolve a report id against the injected catalog. Succeeds with the definition; fails
+ * `ReportNotFound` (carrying the sorted known ids) on a miss — never returns an empty/blank result.
+ */
+export const resolveReport = (
+	catalog: ReadonlyArray<ReportDefinition>,
+	id: string,
+): Effect.Effect<ReportDefinition, ReportNotFound> => {
+	const found = catalog.find((entry) => entry.id === id);
+	return found === undefined
+		? Effect.fail(new ReportNotFound({id, knownIds: knownReportIds(catalog)}))
+		: Effect.succeed(found);
+};
+
+/**
+ * Render a report's structured query into sampling-correct AE SQL. Every measure becomes a
+ * `sumIf(_sample_interval, index1 = '<feature>')` weighting (ADR 0153 §"Reads are sampling-correct"
+ * — never `count()`), so sampling-correctness is guaranteed by construction, not by the product
+ * author remembering it. A `groupByDay` query buckets by `toStartOfDay(timestamp)` and orders by day.
+ */
+export const renderReportSql = (query: ReportQuery): string => {
+	const measureColumns = query.measures.map(
+		(measure) =>
+			`sumIf(${SAMPLE_INTERVAL}, ${FEATURE_INDEX} = '${measure.feature}') AS ${measure.name}`,
+	);
+	const selectColumns = query.groupByDay
+		? ["toStartOfDay(timestamp) AS day", ...measureColumns]
+		: measureColumns;
+	const lines = [
+		`SELECT ${selectColumns.join(",\n       ")}`,
+		`FROM ${APP_EVENTS_DATASET}`,
+		`WHERE timestamp > NOW() - INTERVAL '${query.windowDays}' DAY`,
+	];
+	if (query.groupByDay) {
+		lines.push("GROUP BY day", "ORDER BY day");
+	}
+	return lines.join("\n");
+};
+
+/** The columns a report renders, in order: the optional `day` bucket, then each measure. */
+const reportColumns = (definition: ReportDefinition): ReadonlyArray<string> => [
+	...(definition.query.groupByDay ? ["day"] : []),
+	...definition.query.measures.map((measure) => measure.name),
+];
+
+/**
+ * Render an AE result set as a headed text table — the operator-facing output of `report --name`.
+ * An empty result renders the header plus an explicit `(no rows in the window)` line rather than a
+ * blank, so "the report ran and found nothing" is never confused with "the report failed".
+ */
+export const renderReportResult = (
+	definition: ReportDefinition,
+	rows: ReadonlyArray<ReportRow>,
+): string => {
+	const columns = reportColumns(definition);
+	const header = `${definition.id} (v${definition.version}) — ${definition.description}`;
+	const cell = (value: string | number | null): string => (value === null ? "" : String(value));
+	const body =
+		rows.length === 0
+			? "  (no rows in the window)"
+			: [
+					columns.join("\t"),
+					...rows.map((row) => columns.map((column) => cell(row[column] ?? null)).join("\t")),
+				].join("\n");
+	return `${header}\n${body}`;
+};

--- a/packages/anka-ops/src/report.unit.test.ts
+++ b/packages/anka-ops/src/report.unit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The `report` runner's mechanism core: catalog resolution (known/unknown, with the catalog
+ * injected) and the sampling-correct SQL shaping. These are the two load-bearing guarantees of
+ * #3134 — the runner resolves a product-supplied definition by name and renders it into a read that
+ * weights by `_sample_interval` (ADR 0153), never `count()`. Pure transforms, no AE, no keychain.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {
+	knownReportIds,
+	type ReportDefinition,
+	ReportNotFound,
+	renderReportResult,
+	renderReportSql,
+	resolveReport,
+} from "./report.ts";
+
+// A fabricated catalog standing in for product content — the runner never carries its own.
+const votesVsReactions: ReportDefinition = {
+	id: "votes-vs-reactions",
+	version: 1,
+	description: "daily votes vs reactions",
+	query: {
+		measures: [
+			{name: "votes", feature: "vote"},
+			{name: "reactions", feature: "reaction"},
+		],
+		windowDays: 30,
+		groupByDay: true,
+	},
+};
+const catalog: ReadonlyArray<ReportDefinition> = [votesVsReactions];
+
+describe("resolveReport", () => {
+	it("resolves a known id against the injected catalog", () => {
+		const result = Effect.runSync(resolveReport(catalog, "votes-vs-reactions"));
+		assert.strictEqual(result, votesVsReactions);
+	});
+
+	it("fails ReportNotFound listing the known ids on an unknown id", () => {
+		const exit = Effect.runSyncExit(resolveReport(catalog, "nope"));
+		assert.isTrue(Exit.isFailure(exit));
+		const error = Effect.runSync(resolveReport(catalog, "nope").pipe(Effect.flip));
+		assert.instanceOf(error, ReportNotFound);
+		assert.deepStrictEqual(error.knownIds, ["votes-vs-reactions"]);
+		assert.include(error.message, "votes-vs-reactions");
+	});
+
+	it("names the empty catalog explicitly when nothing is registered", () => {
+		const error = Effect.runSync(resolveReport([], "anything").pipe(Effect.flip));
+		assert.deepStrictEqual(error.knownIds, []);
+		assert.include(error.message, "no reports are registered");
+	});
+});
+
+describe("knownReportIds", () => {
+	it("returns the catalog ids sorted", () => {
+		const many: ReadonlyArray<ReportDefinition> = [
+			{...votesVsReactions, id: "zeta"},
+			{...votesVsReactions, id: "alpha"},
+		];
+		assert.deepStrictEqual(knownReportIds(many), ["alpha", "zeta"]);
+	});
+});
+
+describe("renderReportSql — sampling-correct shaping", () => {
+	const sql = renderReportSql(votesVsReactions.query);
+
+	it("weights every measure by _sample_interval, never count()", () => {
+		assert.include(sql, "sumIf(_sample_interval, index1 = 'vote') AS votes");
+		assert.include(sql, "sumIf(_sample_interval, index1 = 'reaction') AS reactions");
+		assert.notMatch(sql, /count\s*\(/i);
+	});
+
+	it("reads the fixed app_events dataset over the trailing window", () => {
+		assert.include(sql, "FROM app_events");
+		assert.include(sql, "WHERE timestamp > NOW() - INTERVAL '30' DAY");
+	});
+
+	it("buckets and orders by day when groupByDay is set", () => {
+		assert.include(sql, "toStartOfDay(timestamp) AS day");
+		assert.include(sql, "GROUP BY day");
+		assert.include(sql, "ORDER BY day");
+	});
+
+	it("omits the day bucket for a non-grouped query", () => {
+		const flat = renderReportSql({
+			measures: [{name: "votes", feature: "vote"}],
+			windowDays: 7,
+			groupByDay: false,
+		});
+		assert.notInclude(flat, "toStartOfDay");
+		assert.notInclude(flat, "GROUP BY");
+		assert.include(flat, "sumIf(_sample_interval, index1 = 'vote') AS votes");
+	});
+});
+
+describe("renderReportResult", () => {
+	it("renders a headed table over the definition's columns", () => {
+		const out = renderReportResult(votesVsReactions, [{day: "2026-07-01", votes: 3, reactions: 5}]);
+		assert.include(out, "votes-vs-reactions (v1)");
+		assert.include(out, "day\tvotes\treactions");
+		assert.include(out, "2026-07-01\t3\t5");
+	});
+
+	it("renders an explicit no-rows line rather than a blank on an empty result", () => {
+		const out = renderReportResult(votesVsReactions, []);
+		assert.include(out, "(no rows in the window)");
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,6 +494,9 @@ importers:
 
   packages/anka-ops:
     dependencies:
+      '@distilled.cloud/cloudflare':
+        specifier: 'catalog:'
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)


### PR DESCRIPTION
Adds the framework-generic `report` verb group to `anka-ops`: an Analytics Engine read runner that resolves a **named report definition from an injected, product-supplied catalog** and executes its query against the AE telemetry seam (ADR 0153). This is the mechanism-vs-content seam — the runner is generic, the report definitions are product content (the first, `votes-vs-reactions`, lands in a separate child).

## What landed

- **`packages/anka-ops/src/report.ts`** — the mechanism core (framework-generic, query-free):
  - `ReportDefinition` — the versioned, named catalog-entry interface (id, version, description, a structured `ReportQuery` over the fixed `app_events` positional schema from ADR 0153).
  - `ReportCatalog` — the injectable `Context.Service` holding the product-supplied entries; `makeReportCatalog` wires a concrete catalog in.
  - `resolveReport` — resolves `--name`; fails typed `ReportNotFound` listing the known ids, never an empty/blank result.
  - `renderReportSql` — renders every measure as `sumIf(_sample_interval, index1 = '<feature>')` — **sampling-correctness is a mechanism guarantee, never `count()`** (ADR 0153 §"Reads are sampling-correct").
- **`packages/anka-ops/src/analytics.ts`** — the AE SQL read seam over the **same shared operator credential** (ADR 0045: keychain-first least-privilege, no second token store; #3171 seam inheritance kept least-privilege).
- **`packages/anka-ops/src/report-command.ts`** — the `anka-ops report --name <id>` IO shell.
- **`packages/anka-ops/src/report-catalog.ts`** — the product registry, **EMPTY in the core** (the anka-ops core carries no product-specific query).
- Wired into `cli.ts` `VERB_GROUPS` + `withSubcommands` + the runtime layer.

## Acceptance criteria

- [x] `anka-ops report --name <id>` resolves a named report from an injected catalog and executes its AE read against the ADR-0153 `app_events` seam — zero product query in the core.
- [x] The catalog-entry interface is a versioned, named report definition a product supplies; anka-ops resolves by name.
- [x] An unknown `--name` fails with a typed error listing the known report ids (verified via smoke test), never an empty result.
- [x] AE reads are sampling-correct (`sumIf(_sample_interval, …)` by construction).
- [x] Unit tests cover catalog resolution (known/unknown, injected) and the sampling-correct read shaping.

## Verification

`pnpm typecheck` clean · `pnpm test` 37 passed · biome clean · `catalog-guard` green. Smoke: `report --name nope` fails loud `unknown report "nope" — no reports are registered in the catalog`.

Out of scope (separate child): the `votes-vs-reactions` definition itself.

Fixes #3134

🤖 Generated with [Claude Code](https://claude.com/claude-code)