### PR TITLE
feat(mute): read-mask muted members across pano feed/threads + sözlük (#3113)

### DIFF
--- a/apps/web/worker/features/mute/read-mask.ts
+++ b/apps/web/worker/features/mute/read-mask.ts
@@ -1,0 +1,69 @@
+/**
+ * Mute read-mask (#3113) — the seam that makes a muted member's content disappear
+ * from the muter's reads across pano + sözlük, the mute analogue of the çaylak
+ * sandbox's viewer-scoped read filter (`SandboxVisibility.sandboxVisibleWhere`,
+ * #1205). Three pieces, all viewer-scoped and off-by-default:
+ *
+ *   - {@link mutedAuthorsWhere} — the SQL read arm the connection/by-id reads `and()`
+ *     beside their existing sandbox + removal guards: `author_id NOT IN (:muted)`.
+ *     An empty/absent set contributes NO clause, so a flag-off read is byte-for-byte
+ *     today's read.
+ *   - {@link isMutedAuthor} — the in-memory dual for the single-row reads (`getPost`)
+ *     that decide visibility after fetching one record.
+ *   - {@link currentMutedIds} — the resolver-level read that resolves the muter's
+ *     muted-id set once per request, gated behind the default-off `member-mute` flag
+ *     (ADR 0083): off ⇒ the empty set ⇒ no mask. The mask is fully hidden, not a
+ *     "muted" placeholder — matching the sandbox filter's hide (the issue's stated
+ *     mask-vs-collapse choice).
+ */
+import {CurrentUser} from "@kampus/fate-effect";
+import type {RuntimeContext} from "alchemy";
+import {notInArray, type SQL, type SQLWrapper} from "drizzle-orm";
+import {Effect} from "effect";
+import {MEMBER_MUTE} from "../../../src/flags/keys.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags, type RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import {Mute} from "./Mute.ts";
+
+/**
+ * The read arm masking a muted member's rows: `author_id NOT IN (:muted)`, or
+ * `undefined` when nothing is muted so drizzle's `and()` drops the term and the
+ * read is unchanged. Kept beside the caller's own sandbox/removal guards, never
+ * folded into them (the mute dimension is orthogonal, like the removal guard).
+ */
+export const mutedAuthorsWhere = (
+	authorId: SQLWrapper,
+	mutedIds: ReadonlySet<string> | undefined,
+): SQL | undefined =>
+	mutedIds && mutedIds.size > 0 ? notInArray(authorId, [...mutedIds]) : undefined;
+
+/**
+ * The in-memory dual of {@link mutedAuthorsWhere} for a read that has already
+ * fetched one record (`getPost`): `true` iff the row's author is in the muter's
+ * muted set, so the caller masks it to not-found.
+ */
+export const isMutedAuthor = (
+	authorId: string,
+	mutedIds: ReadonlySet<string> | undefined,
+): boolean => mutedIds != null && mutedIds.has(authorId);
+
+/**
+ * The muter's muted-id set for this request — the viewer-scoped mask the content
+ * resolvers thread into their reads. Gated behind the default-off `member-mute`
+ * flag (safe-default: a Flagship outage or the unflipped default both read `false`,
+ * so reads are exactly as today). An anonymous viewer (no `CurrentUser`) has no
+ * mutes, short-circuiting to the empty set with no DB read.
+ */
+export const currentMutedIds: Effect.Effect<
+	Set<string>,
+	never,
+	Flags | RuntimeContext | RequestFlagOverrides | CurrentUser | Mute
+> = Effect.gen(function* () {
+	const flags = yield* Flags;
+	const on = yield* flags.getBoolean(MEMBER_MUTE, false).pipe(provideRequestFlags);
+	if (!on) return new Set<string>();
+	const {user} = yield* CurrentUser;
+	if (!user?.id) return new Set<string>();
+	const mute = yield* Mute;
+	return yield* mute.readMutedIds(user.id);
+});

--- a/apps/web/worker/features/mute/read-mask.unit.test.ts
+++ b/apps/web/worker/features/mute/read-mask.unit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Mute read-mask (#3113) — the decisions that are wrong-or-right with no database
+ * (ADR 0082): the SQL arm {@link mutedAuthorsWhere} folds beside a read's existing
+ * guards, the in-memory {@link isMutedAuthor} dual, and the {@link currentMutedIds}
+ * flag gate. Row-level EXCLUSION against real D1 (each content surface actually
+ * hiding a muted author's rows) is the integration tier's job, like the sandbox
+ * filter (`SandboxVisibility.agreement` leaves execution to integration).
+ *
+ * The masked-read coverage per surface (present-without-mute / absent-with-mute /
+ * flag-off-unchanged) is anchored on the two invariants those reds reduce to:
+ *   - the arm is `undefined` (no clause) exactly when nothing is muted — so a
+ *     flag-off read (empty set) is byte-for-byte today's read on every surface;
+ *   - the arm is `author_id NOT IN (…)` when the muter has mutes — the one predicate
+ *     the pano feed, pano thread, and sözlük definition reads all `and()` in.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {SQLiteDialect, sqliteTable, text} from "drizzle-orm/sqlite-core";
+import {Effect, Layer} from "effect";
+import {Flags} from "../flagship/Flags.ts";
+import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import {Mute} from "./Mute.ts";
+import {currentMutedIds, isMutedAuthor, mutedAuthorsWhere} from "./read-mask.ts";
+
+// A throwaway table carrying the one column the mask reads, for a stable rendered name.
+const content = sqliteTable("content", {
+	id: text("id").primaryKey(),
+	authorId: text("author_id").notNull(),
+});
+const dialect = new SQLiteDialect();
+
+describe("mutedAuthorsWhere — the SQL read arm (no clause unless something is muted)", () => {
+	it("no mask when the set is undefined", () => {
+		assert.strictEqual(mutedAuthorsWhere(content.authorId, undefined), undefined);
+	});
+
+	it("no mask when the set is empty (the flag-off / nothing-muted read is unchanged)", () => {
+		assert.strictEqual(mutedAuthorsWhere(content.authorId, new Set()), undefined);
+	});
+
+	it("a non-empty set renders `author_id not in (…)` over the muted ids", () => {
+		const where = mutedAuthorsWhere(content.authorId, new Set(["u-a", "u-b"]));
+		assert.isDefined(where);
+		const {sql, params} = dialect.sqlToQuery(where!);
+		assert.match(sql, /"content"\."author_id" not in \(\?, \?\)/);
+		assert.deepStrictEqual(params, ["u-a", "u-b"]);
+	});
+});
+
+describe("isMutedAuthor — the in-memory dual for single-row reads", () => {
+	it("false when there is no muted set", () => {
+		assert.isFalse(isMutedAuthor("u-a", undefined));
+	});
+	it("false for an author the muter has not muted", () => {
+		assert.isFalse(isMutedAuthor("u-a", new Set(["u-b"])));
+	});
+	it("true for a muted author", () => {
+		assert.isTrue(isMutedAuthor("u-a", new Set(["u-a", "u-b"])));
+	});
+});
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "mute-read-mask-test",
+	id: "mute-read-mask-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(on),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service);
+
+// `Mute` whose `readMutedIds` returns a fixed set — or dies on contact, proving a
+// path that must short-circuit before the read (flag off / anonymous) never reaches it.
+const muteStub = (
+	readMutedIds?: (viewerId: string | null | undefined) => Effect.Effect<Set<string>>,
+) =>
+	Layer.succeed(Mute, {
+		set: () => Effect.die("Mute.set not exercised"),
+		listMine: () => Effect.die("Mute.listMine not exercised"),
+		readMutedIds:
+			readMutedIds ??
+			(() => Effect.die("Mute.readMutedIds reached on a path that must short-circuit")),
+	});
+
+const resolve = (opts: {
+	on: boolean;
+	user?: {id: string} | undefined;
+	mute: ReturnType<typeof muteStub>;
+}) =>
+	currentMutedIds.pipe(
+		Effect.provideService(CurrentUser, {user: opts.user}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+		Effect.provideService(RequestFlagOverrides, {cookieHeader: null, overridesAllowed: false}),
+		Effect.provide(Layer.mergeAll(flagsStub(opts.on), opts.mute)),
+	);
+
+describe("currentMutedIds — flag-gated, viewer-scoped", () => {
+	it.effect("flag OFF ⇒ the empty set, and Mute is never read (byte-for-byte today)", () =>
+		Effect.gen(function* () {
+			const ids = yield* resolve({on: false, user: {id: "u-muter"}, mute: muteStub()});
+			assert.strictEqual(ids.size, 0);
+		}),
+	);
+
+	it.effect("flag ON + anonymous ⇒ the empty set, Mute unread (no viewer to scope to)", () =>
+		Effect.gen(function* () {
+			const ids = yield* resolve({on: true, user: undefined, mute: muteStub()});
+			assert.strictEqual(ids.size, 0);
+		}),
+	);
+
+	it.effect("flag ON + signed-in ⇒ the muter's OWN muted set (viewer-scoped)", () =>
+		Effect.gen(function* () {
+			const ids = yield* resolve({
+				on: true,
+				user: {id: "u-muter"},
+				mute: muteStub((viewerId) => {
+					assert.strictEqual(
+						viewerId,
+						"u-muter",
+						"reads the current viewer's mutes, not another's",
+					);
+					return Effect.succeed(new Set(["u-target"]));
+				}),
+			});
+			assert.deepStrictEqual([...ids], ["u-target"]);
+		}),
+	);
+});

--- a/apps/web/worker/features/pano/Pano.connection.unit.test.ts
+++ b/apps/web/worker/features/pano/Pano.connection.unit.test.ts
@@ -466,3 +466,48 @@ describe("Pano — authed feed: parallelized listPostsConnection composes with t
 		},
 	);
 });
+
+// Mute read-mask (#3113): the muted-author SQL arm is `and()`ed into the pano feed +
+// thread fetch. Rendered over the same `.toSQL()` seam — present-with-mute emits
+// `author_id not in (…)`, absent/off emits nothing (byte-for-byte today's read).
+describe("Pano feed + thread — mute read-mask (author_id NOT IN …)", () => {
+	it.effect("listPostsConnection masks a muted author when `mutedIds` is non-empty", () => {
+		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.listPostsConnection({sort: "new", first: 10, mutedIds: new Set(["u-muted"])});
+			const {sql, params} = fetchQuery(queries);
+			assert.match(sql, /"post_record"\."author_id" not in \(\?\)/, "muted author excluded");
+			assert.include(params, "u-muted");
+		}).pipe(Effect.provide(panoLayer(access)));
+	});
+
+	it.effect("listPostsConnection is unchanged with no `mutedIds` (no NOT IN clause)", () => {
+		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.listPostsConnection({sort: "new", first: 10});
+			assert.notMatch(fetchQuery(queries).sql, /not in/, "no mask ⇒ byte-for-byte today's feed");
+		}).pipe(Effect.provide(panoLayer(access)));
+	});
+
+	it.effect("listCommentsKeyset masks a muted author when `mutedIds` is non-empty", () => {
+		const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.listCommentsKeyset("post-1", {first: 10, mutedIds: new Set(["u-muted"])});
+			const {sql, params} = fetchQuery(queries);
+			assert.match(sql, /"comment_record"\."author_id" not in \(\?\)/, "muted author excluded");
+			assert.include(params, "u-muted");
+		}).pipe(Effect.provide(panoLayer(access)));
+	});
+
+	it.effect("listCommentsKeyset is unchanged with no `mutedIds` (no NOT IN clause)", () => {
+		const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.listCommentsKeyset("post-1", {first: 10});
+			assert.notMatch(fetchQuery(queries).sql, /not in/, "no mask ⇒ byte-for-byte today's thread");
+		}).pipe(Effect.provide(panoLayer(access)));
+	});
+});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -138,7 +138,12 @@ export class Pano extends Context.Service<
 	{
 		readonly getPost: (
 			postId: string,
-			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
+			opts?: {
+				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
+				/** Mute read-mask (#3113): a muted author's post reads as not-found. */
+				mutedIds?: ReadonlySet<string> | undefined;
+			},
 		) => Effect.Effect<PostPage | null>;
 
 		readonly listPostsConnection: (opts?: {
@@ -147,6 +152,8 @@ export class Pano extends Context.Service<
 			after?: string | null;
 			host?: string | null;
 			sandboxViewer?: SandboxViewer | undefined;
+			/** Mute read-mask (#3113): the muter's muted authors, hidden from the feed. */
+			mutedIds?: ReadonlySet<string> | undefined;
 		}) => Effect.Effect<PostConnectionPage>;
 
 		/**
@@ -161,6 +168,8 @@ export class Pano extends Context.Service<
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				/** Mute read-mask (#3113): muted authors' comments hidden from the thread. */
+				mutedIds?: ReadonlySet<string> | undefined;
 				/** Collapse the finalize stamps into one concurrent wave (#2710). Default off. */
 				parallelStamps?: boolean | undefined;
 			},
@@ -169,7 +178,12 @@ export class Pano extends Context.Service<
 		/** Post source `byIds` — batched read avoiding the relation N+1. */
 		readonly getPostsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
+			opts?: {
+				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
+				/** Mute read-mask (#3113): muted authors' posts dropped from the batch. */
+				mutedIds?: ReadonlySet<string> | undefined;
+			},
 		) => Effect.Effect<ReadonlyArray<PostSummaryRow>>;
 
 		/**
@@ -191,6 +205,8 @@ export class Pano extends Context.Service<
 			opts?: {
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				/** Mute read-mask (#3113): muted authors' comments dropped from the batch. */
+				mutedIds?: ReadonlySet<string> | undefined;
 				/** Collapse the finalize stamps into one concurrent wave (#2710). Default off. */
 				parallelStamps?: boolean | undefined;
 			},

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -32,6 +32,7 @@ import {
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
+import {mutedAuthorsWhere} from "../mute/read-mask.ts";
 import type {ReactionTargetNotFound} from "../reaction/errors.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
 import type {ReportId} from "../report/ids.ts";
@@ -323,6 +324,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			after?: string | null | undefined;
 			viewerId?: string | null | undefined;
 			sandboxViewer?: SandboxViewer | undefined;
+			mutedIds?: ReadonlySet<string> | undefined;
 			/**
 			 * Route the finalize stamps through the concurrent {@link parallelStampWave}
 			 * instead of the serial chain (#2710). Default/off ⇒ the wave runs at
@@ -347,7 +349,14 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			{sandboxedAt: schema.commentRecord.sandboxedAt, authorId: schema.commentRecord.authorId},
 			resolveSandboxViewer(opts),
 		);
-		const baseWhere = and(eq(schema.commentRecord.postId, postId), visible, sandboxClause);
+		// Mute read-mask (#3113): hide muted authors' comments from the muter's thread.
+		const muteClause = mutedAuthorsWhere(schema.commentRecord.authorId, opts.mutedIds);
+		const baseWhere = and(
+			eq(schema.commentRecord.postId, postId),
+			visible,
+			sandboxClause,
+			muteClause,
+		);
 		const totalCount = yield* run((db) =>
 			db
 				.select({n: sql<number>`count(*)`})
@@ -406,6 +415,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		opts: {
 			viewerId?: string | null | undefined;
 			sandboxViewer?: SandboxViewer | undefined;
+			mutedIds?: ReadonlySet<string> | undefined;
 			/** See `listCommentsKeyset`'s `parallelStamps` (#2710). */
 			parallelStamps?: boolean | undefined;
 		} = {},
@@ -426,6 +436,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 							},
 							resolveSandboxViewer(opts),
 						),
+						// Mute read-mask (#3113): drop muted authors' comments from the batch.
+						mutedAuthorsWhere(schema.commentRecord.authorId, opts.mutedIds),
 					),
 				),
 		);

--- a/apps/web/worker/features/pano/lists.ts
+++ b/apps/web/worker/features/pano/lists.ts
@@ -22,6 +22,7 @@ import {emptyKeysetPage} from "../../db/keyset.ts";
 import {toConnection} from "../fate/connection.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
+import {currentMutedIds} from "../mute/read-mask.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {Pano, type PostSummaryRow} from "./Pano.ts";
 import {toPost} from "./shapers.ts";
@@ -72,6 +73,9 @@ export const lists = {
 			// hides çaylak-sandboxed posts from anyone but their author + a mod (#1205).
 			const sandboxViewer = yield* currentSandboxViewer;
 			const viewerId = sandboxViewer.viewerId;
+			// Mute read-mask (#3113): the muter's muted authors, gated behind the
+			// default-off `member-mute` flag (empty set off ⇒ today's feed unchanged).
+			const mutedIds = yield* currentMutedIds;
 			const pano = yield* Pano;
 			const page = yield* pano.listPostsConnection({
 				sort: toPostSort(args.sort),
@@ -79,6 +83,7 @@ export const lists = {
 				...(args.after !== undefined ? {after: args.after} : {}),
 				...(args.host !== undefined && args.host.length > 0 ? {host: args.host} : {}),
 				sandboxViewer,
+				mutedIds,
 			});
 
 			// Signed-out: serve the keyset page as-is (neutral `myVote`/`isSaved`).

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -39,6 +39,7 @@ import {
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
+import {isMutedAuthor, mutedAuthorsWhere} from "../mute/read-mask.ts";
 import type {ReactionTargetNotFound} from "../reaction/errors.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
 import type {ReportId} from "../report/ids.ts";
@@ -532,7 +533,11 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 
 	const getPost = Effect.fn("Pano.getPost")(function* (
 		postId: string,
-		opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
+		opts: {
+			viewerId?: string | null | undefined;
+			sandboxViewer?: SandboxViewer | undefined;
+			mutedIds?: ReadonlySet<string> | undefined;
+		} = {},
 	) {
 		const meta = yield* run((db) =>
 			db.query.postRecord.findFirst({
@@ -540,6 +545,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			}),
 		);
 		if (!meta) return null;
+		// Mute read-mask (#3113): a muted author's post reads as not-found for the
+		// muter, the in-memory dual of the feed's `mutedAuthorsWhere` SQL arm.
+		if (isMutedAuthor(meta.authorId, opts.mutedIds)) return null;
 		// The in-memory visibility decision via the ADR 0113 seam (`postVisibleTo`) —
 		// the mirror of the SQL `postVisibleWhere` the batch read uses, applied here
 		// because this single-row read uses the relational query builder. It composes
@@ -565,6 +573,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			after?: string | null;
 			host?: string | null;
 			sandboxViewer?: SandboxViewer | undefined;
+			mutedIds?: ReadonlySet<string> | undefined;
 		} = {},
 	) {
 		const sort = opts.sort ?? "hot";
@@ -585,6 +594,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			resolveSandboxViewer(opts),
 		);
 		if (sandboxClause) baseConditions.push(sandboxClause);
+		// Mute read-mask (#3113): hide muted authors' posts from the muter's feed.
+		const muteClause = mutedAuthorsWhere(schema.postRecord.authorId, opts.mutedIds);
+		if (muteClause) baseConditions.push(muteClause);
 
 		type CursorRow = {
 			id: string;
@@ -715,7 +727,11 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 
 	const getPostsByIds = Effect.fn("Pano.getPostsByIds")(function* (
 		ids: ReadonlyArray<string>,
-		opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
+		opts: {
+			viewerId?: string | null | undefined;
+			sandboxViewer?: SandboxViewer | undefined;
+			mutedIds?: ReadonlySet<string> | undefined;
+		} = {},
 	) {
 		if (ids.length === 0) return [];
 		const viewerId = opts.viewerId ?? null;
@@ -735,6 +751,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 							},
 							resolveSandboxViewer(opts),
 						),
+						// Mute read-mask (#3113): drop muted authors' posts from the muter's batch.
+						mutedAuthorsWhere(schema.postRecord.authorId, opts.mutedIds),
 					),
 				),
 		);

--- a/apps/web/worker/features/pano/queries.ts
+++ b/apps/web/worker/features/pano/queries.ts
@@ -15,6 +15,7 @@ import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
+import {currentMutedIds} from "../mute/read-mask.ts";
 import {Pano} from "./Pano.ts";
 import {toComment, toPostFromPage} from "./shapers.ts";
 import type {Comment} from "./views.ts";
@@ -38,12 +39,15 @@ export const queries = {
 			// sandboxed post is hidden from anyone but its author + a moderator (#1205).
 			const sandboxViewer = yield* currentSandboxViewer;
 			const viewerId = sandboxViewer.viewerId;
-			const page = yield* pano.getPost(args.idOrSlug, {sandboxViewer});
+			// Mute read-mask (#3113): a muted author's post + its thread read as
+			// not-found for the muter (default-off `member-mute` ⇒ empty set ⇒ unchanged).
+			const mutedIds = yield* currentMutedIds;
+			const page = yield* pano.getPost(args.idOrSlug, {sandboxViewer, mutedIds});
 			if (!page) return null;
 
 			// Stamp `myVote` + `isSaved` by batching the single post through the same
 			// `user_vote` / `post_bookmark` read — no per-row resolver.
-			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId, sandboxViewer});
+			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId, sandboxViewer, mutedIds});
 
 			const base = toPostFromPage(
 				page,
@@ -75,6 +79,7 @@ export const queries = {
 				...keysetInput(args.comments, COMMENTS_PAGE_SIZE),
 				viewerId,
 				sandboxViewer,
+				mutedIds,
 				parallelStamps,
 			});
 			const comments = toConnection<(typeof connection.rows)[number], Comment>(

--- a/apps/web/worker/features/pano/sources.ts
+++ b/apps/web/worker/features/pano/sources.ts
@@ -11,6 +11,7 @@ import {PANO_BASE_FEED, PHOENIX_PANO_STAMP_WAVE} from "../../../src/flags/keys.t
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
+import {currentMutedIds} from "../mute/read-mask.ts";
 import {Pano, tagLabel} from "./Pano.ts";
 import {CommentView, PostOverlayView, PostView, TagView} from "./views.ts";
 
@@ -21,7 +22,12 @@ export const postSource = Fate.source(
 		byIds: function* (ids) {
 			const pano = yield* Pano;
 			const sandboxViewer = yield* currentSandboxViewer;
-			return yield* pano.getPostsByIds(ids, {viewerId: sandboxViewer.viewerId, sandboxViewer});
+			const mutedIds = yield* currentMutedIds;
+			return yield* pano.getPostsByIds(ids, {
+				viewerId: sandboxViewer.viewerId,
+				sandboxViewer,
+				mutedIds,
+			});
 		},
 	},
 );
@@ -60,6 +66,7 @@ export const commentSource = Fate.source(
 		byIds: function* (ids) {
 			const pano = yield* Pano;
 			const sandboxViewer = yield* currentSandboxViewer;
+			const mutedIds = yield* currentMutedIds;
 			// The read-path collapse is contained behind its default-off flag (#2710): off ⇒
 			// the stamps run serially (today), on ⇒ one concurrent wave. Same wire output.
 			const flags = yield* Flags;
@@ -69,6 +76,7 @@ export const commentSource = Fate.source(
 			return yield* pano.getCommentsByIds(ids, {
 				viewerId: sandboxViewer.viewerId,
 				sandboxViewer,
+				mutedIds,
 				parallelStamps,
 			});
 		},

--- a/apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts
@@ -191,3 +191,29 @@ describe("Sozluk.listDefinitionsKeyset — cursor-miss → empty page, NO furthe
 		}).pipe(Effect.provide(sozlukLayer(access)));
 	});
 });
+
+// Mute read-mask (#3113): the muted-author SQL arm is `and()`ed into the definition
+// fetch, so a muted member's definitions are absent from the muter's definition reads.
+// Rendered over the same `.toSQL()` seam — present-with-mute emits `author_id not in
+// (…)`, absent/off emits nothing (byte-for-byte today's definition read).
+describe("Sozluk.listDefinitionsKeyset — mute read-mask (author_id NOT IN …)", () => {
+	it.effect("masks a muted author when `mutedIds` is non-empty", () => {
+		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);
+		return Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			yield* sozluk.listDefinitionsKeyset("a-term", {first: 10, mutedIds: new Set(["u-muted"])});
+			const {sql, params} = fetchQuery(queries);
+			assert.match(sql, /"definition_record"\."author_id" not in \(\?\)/, "muted author excluded");
+			assert.include(params, "u-muted");
+		}).pipe(Effect.provide(sozlukLayer(access)));
+	});
+
+	it.effect("is unchanged with no `mutedIds` (no NOT IN clause)", () => {
+		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);
+		return Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			yield* sozluk.listDefinitionsKeyset("a-term", {first: 10});
+			assert.notMatch(fetchQuery(queries).sql, /not in/, "no mask ⇒ today's definition read");
+		}).pipe(Effect.provide(sozlukLayer(access)));
+	});
+});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -30,6 +30,7 @@ import {
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
+import {mutedAuthorsWhere} from "../mute/read-mask.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Reaction} from "../reaction/Reaction.ts";
 import type {ReportId} from "../report/ids.ts";
@@ -348,6 +349,8 @@ export class Sozluk extends Context.Service<
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				/** Mute read-mask (#3113): muted authors' definitions hidden from the muter. */
+				mutedIds?: ReadonlySet<string> | undefined;
 				/**
 				 * Route the page's independent stamps (viewer scalars + reaction aggregate +
 				 * author identity) through the concurrent {@link parallelStampWave} instead of
@@ -370,6 +373,8 @@ export class Sozluk extends Context.Service<
 			opts?: {
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				/** Mute read-mask (#3113): muted authors' definitions dropped from the batch. */
+				mutedIds?: ReadonlySet<string> | undefined;
 				/** See {@link listDefinitionsKeyset}'s `parallelStamps` (#2709). */
 				parallelStamps?: boolean | undefined;
 			},
@@ -767,6 +772,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				mutedIds?: ReadonlySet<string> | undefined;
 				parallelStamps?: boolean | undefined;
 			} = {},
 		) {
@@ -785,6 +791,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					},
 					viewer,
 				),
+				// Mute read-mask (#3113): hide muted authors' definitions from the muter.
+				mutedAuthorsWhere(schema.definitionRecord.authorId, opts.mutedIds),
 			);
 			const totalCount = yield* run((db) =>
 				db
@@ -856,6 +864,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			opts: {
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
+				mutedIds?: ReadonlySet<string> | undefined;
 				parallelStamps?: boolean | undefined;
 			} = {},
 		) {
@@ -877,6 +886,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 								},
 								viewer,
 							),
+							// Mute read-mask (#3113): drop muted authors' definitions from the batch.
+							mutedAuthorsWhere(schema.definitionRecord.authorId, opts.mutedIds),
 						),
 					),
 			);

--- a/apps/web/worker/features/sozluk/queries.ts
+++ b/apps/web/worker/features/sozluk/queries.ts
@@ -16,6 +16,7 @@ import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
+import {currentMutedIds} from "../mute/read-mask.ts";
 import {Sozluk} from "./Sozluk.ts";
 import {toDefinition, toTermFromPage} from "./shapers.ts";
 import type {Definition} from "./views.ts";
@@ -57,10 +58,14 @@ export const queries = {
 			const parallelStamps = yield* flags
 				.getBoolean(PHOENIX_SOZLUK_STAMP_WAVE, false)
 				.pipe(provideRequestFlags);
+			// Mute read-mask (#3113): hide muted authors' definitions from the muter
+			// (default-off `member-mute` ⇒ empty set ⇒ today's definition reads unchanged).
+			const mutedIds = yield* currentMutedIds;
 			const connection = yield* sozluk.listDefinitionsKeyset(args.slug, {
 				...keysetInput(args.definitions, DEFINITIONS_PAGE_SIZE),
 				viewerId,
 				sandboxViewer,
+				mutedIds,
 				parallelStamps,
 			});
 			const definitions = toConnection<(typeof connection.rows)[number], Definition>(

--- a/apps/web/worker/features/sozluk/sources.ts
+++ b/apps/web/worker/features/sozluk/sources.ts
@@ -10,6 +10,7 @@ import {PHOENIX_SOZLUK_STAMP_WAVE} from "../../../src/flags/keys.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
+import {currentMutedIds} from "../mute/read-mask.ts";
 import {Sozluk} from "./Sozluk.ts";
 import {DefinitionView, TermView} from "./views.ts";
 
@@ -20,6 +21,7 @@ export const definitionSource = Fate.source(
 		byIds: function* (ids) {
 			const sozluk = yield* Sozluk;
 			const sandboxViewer = yield* currentSandboxViewer;
+			const mutedIds = yield* currentMutedIds;
 			// The read-path collapse is contained behind its default-off flag (#2709): off ⇒
 			// the stamps run serially (today), on ⇒ one concurrent wave. Same wire output.
 			const flags = yield* Flags;
@@ -29,6 +31,7 @@ export const definitionSource = Fate.source(
 			return yield* sozluk.getDefinitionsByIds(ids, {
 				viewerId: sandboxViewer.viewerId,
 				sandboxViewer,
+				mutedIds,
 				parallelStamps,
 			});
 		},


### PR DESCRIPTION
## What

Apply the muted-id set at the read stamps so a muted member's content disappears from the muter's reads across every content surface (the "actually stop seeing them" value, #3113). Modeled on the çaylak-sandbox viewer-scoped read filter (`sandboxVisibleWhere`, #1205).

- **New `apps/web/worker/features/mute/read-mask.ts`:**
  - `mutedAuthorsWhere(authorId, mutedIds)` — the `author_id NOT IN (…)` SQL arm the connection/by-id reads `and()` beside their existing sandbox + removal guards. Empty/absent set ⇒ `undefined` ⇒ no clause.
  - `isMutedAuthor` — the in-memory dual for the single-row `getPost`.
  - `currentMutedIds` — the resolver-level, viewer-scoped read of `Mute.readMutedIds(viewerId)`, gated behind the default-off `member-mute` flag (ADR 0083): off ⇒ empty set ⇒ no mask.
- **Pano** (`getPost` / `listPostsConnection` / `getPostsByIds` / `listCommentsKeyset` / `getCommentsByIds`) and **Sözlük** (`listDefinitionsKeyset` / `getDefinitionsByIds`) gained the mask, wired through the pano/sözlük resolvers + sources + feed list.

## Decisions

- **Mask-vs-collapse: fully hidden**, matching the sandbox filter's hide (the issue's stated default).
- **Read-side only** — no `Fate.mutation` touched, so no fate-live fanout classification is involved (the mute write mutations from #3112 are already classified `fanned: false`).
- Out of scope (per the issue): notification suppression (decision child) and the manage-mutes list (sibling).

## Acceptance criteria

- [x] A muted member's posts + comments are absent from the muter's pano feed and threads when the flag is on.
- [x] A muted member's sözlük definitions are masked from the muter's definition reads when the flag is on.
- [x] Flag off ⇒ reads byte-for-byte unchanged (the mask contributes no clause).
- [x] Viewer-scoped: a muted member's content is unaffected for every other viewer (`currentMutedIds` reads the current viewer's own set).
- [x] Unit tests cover the masked reads on each surface (present-without-mute / absent-with-mute / flag-off-unchanged): `mute/read-mask.unit.test.ts` (primitive + flag gate + viewer scope), plus SQL-render assertions on the pano feed + thread (`Pano.connection.unit.test.ts`) and sözlük definitions (`Sozluk.connection.unit.test.ts`).

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm --filter @kampus/web test:unit worker/features/pano worker/features/sozluk worker/features/mute` — 285 passed

Fixes #3113

🤖 Generated with [Claude Code](https://claude.com/claude-code)