### PR TITLE
feat(atolye): exhibit per UI primitive — fill the catalog (#3094)

### DIFF
--- a/apps/web/src/lab/atolye/AtolyeIndexPage.test.tsx
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.test.tsx
@@ -26,9 +26,12 @@ describe("AtolyeIndexPage — /lab/atolye index (#3092)", () => {
 
 	it("links each exhibit to its ASCII /lab/atolye/:exhibit detail path", () => {
 		renderPage();
+		// Resolve each row by its unique detail href, not by a title regex: a link's
+		// accessible name is title+summary, so real Turkish titles that share a word
+		// (`Düğme` inside `Bildir Düğmesi`) would multi-match a name regex.
+		const hrefs = screen.getAllByRole("link").map((l) => l.getAttribute("href"));
 		for (const exhibit of listExhibits()) {
-			const link = screen.getByRole("link", {name: new RegExp(exhibit.title)});
-			expect(link.getAttribute("href")).toBe(`/lab/atolye/${exhibit.id}`);
+			expect(hrefs).toContain(`/lab/atolye/${exhibit.id}`);
 		}
 	});
 });

--- a/apps/web/src/lab/atolye/exhibits/Avatar.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Avatar.exhibit.tsx
@@ -1,0 +1,25 @@
+import type * as React from "react";
+import {Avatar} from "../../../components/ui/Avatar";
+import {defineExhibit} from "../exhibit";
+
+export const avatarExhibit = defineExhibit<React.ComponentProps<typeof Avatar>>({
+	id: "avatar",
+	title: "Avatar",
+	summary: "Kullanıcı avatarı — görsel yoksa ada göre baş harflere düşer, dört boyutta.",
+	component: Avatar,
+	knobs: {
+		name: {kind: "string", label: "Ad", default: "Ada Lovelace"},
+		src: {kind: "string", label: "Görsel URL", default: "", placeholder: "boşsa baş harfler"},
+		size: {
+			kind: "enum",
+			label: "Boyut",
+			default: "md",
+			options: [
+				{value: "sm", label: "Küçük"},
+				{value: "md", label: "Orta"},
+				{value: "lg", label: "Büyük"},
+				{value: "xl", label: "Çok büyük"},
+			],
+		},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/Card.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Card.exhibit.tsx
@@ -1,0 +1,58 @@
+import type * as React from "react";
+import {Card} from "../../../components/ui/Card";
+import {defineExhibit} from "../exhibit";
+
+export const cardExhibit = defineExhibit<React.ComponentProps<typeof Card>>({
+	id: "card",
+	title: "Kart",
+	summary: "Sınırlı, hafif yükseltilmiş yüzey — ton, yükseklik, köşe ve dolgu token'larıyla.",
+	component: Card,
+	knobs: {
+		tone: {
+			kind: "enum",
+			label: "Ton",
+			default: "default",
+			options: [
+				{value: "default", label: "Varsayılan"},
+				{value: "raised", label: "Yükseltilmiş"},
+				{value: "sunken", label: "Çökük"},
+			],
+		},
+		elevation: {
+			kind: "enum",
+			label: "Yükseklik",
+			default: "raised",
+			options: [
+				{value: "flat", label: "Düz"},
+				{value: "raised", label: "Yükseltilmiş"},
+				{value: "dropdown", label: "Açılır"},
+				{value: "overlay", label: "Katman"},
+			],
+		},
+		radius: {
+			kind: "enum",
+			label: "Köşe",
+			default: "md",
+			options: [
+				{value: "none", label: "Yok"},
+				{value: "sm", label: "Küçük"},
+				{value: "md", label: "Orta"},
+				{value: "lg", label: "Büyük"},
+			],
+		},
+		padding: {
+			kind: "enum",
+			label: "Dolgu",
+			default: "md",
+			options: [
+				{value: "none", label: "Yok"},
+				{value: "sm", label: "Küçük"},
+				{value: "md", label: "Orta"},
+				{value: "lg", label: "Büyük"},
+			],
+		},
+		border: {kind: "boolean", label: "Kenarlık", default: true},
+		interactive: {kind: "boolean", label: "Tıklanabilir", default: false},
+	},
+	fixedProps: {children: "Kartın içeriği burada yer alır."},
+});

--- a/apps/web/src/lab/atolye/exhibits/Collapsible.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Collapsible.exhibit.tsx
@@ -1,0 +1,27 @@
+import type * as React from "react";
+import {Collapsible} from "../../../components/ui/Collapsible";
+import {defineExhibit} from "../exhibit";
+
+function CollapsibleDemo({defaultOpen}: {defaultOpen?: boolean}) {
+	return (
+		<Collapsible.Root defaultOpen={defaultOpen}>
+			<div style={{display: "flex", alignItems: "center", gap: "var(--s-2)"}}>
+				<Collapsible.Trigger open={defaultOpen} />
+				<span>Ayrıntılar</span>
+			</div>
+			<Collapsible.Panel>
+				<p style={{margin: "var(--s-2) 0 0"}}>Katlanabilir içerik burada görünür.</p>
+			</Collapsible.Panel>
+		</Collapsible.Root>
+	);
+}
+
+export const collapsibleExhibit = defineExhibit<React.ComponentProps<typeof CollapsibleDemo>>({
+	id: "collapsible",
+	title: "Katlanır",
+	summary: "Bir tetikleyiciyle açılıp kapanan içerik paneli — base-ui Collapsible üstünde.",
+	component: CollapsibleDemo,
+	knobs: {
+		defaultOpen: {kind: "boolean", label: "Açık başlat", default: true},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/CopyLinkButton.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/CopyLinkButton.exhibit.tsx
@@ -1,0 +1,14 @@
+import type * as React from "react";
+import {CopyLinkButton} from "../../../components/ui/CopyLinkButton";
+import {defineExhibit} from "../exhibit";
+
+export const copyLinkButtonExhibit = defineExhibit<React.ComponentProps<typeof CopyLinkButton>>({
+	id: "copy-link-button",
+	title: "Bağlantı Kopyala",
+	summary: "Öğenin bağlantısını panoya kopyalar; tıklayınca yerinde geri bildirim verir.",
+	component: CopyLinkButton,
+	knobs: {
+		path: {kind: "string", label: "Yol", default: "/pano/ornek"},
+		label: {kind: "string", label: "Etiket", default: "paylaş"},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/CountToggle.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/CountToggle.exhibit.tsx
@@ -1,0 +1,17 @@
+import type * as React from "react";
+import {CountToggle} from "../../../components/ui/CountToggle";
+import {defineExhibit} from "../exhibit";
+
+export const countToggleExhibit = defineExhibit<React.ComponentProps<typeof CountToggle>>({
+	id: "count-toggle",
+	title: "Sayaç Düğmesi",
+	summary: "Basılı durumu aria-pressed ve aksan tintiyle taşıyan, sayı rozetli tepki hapı.",
+	component: CountToggle,
+	knobs: {
+		pressed: {kind: "boolean", label: "Basılı", default: false},
+		count: {kind: "number", label: "Sayı", default: 12, min: 0, step: 1},
+		showZero: {kind: "boolean", label: "Sıfırı göster", default: false},
+		disabled: {kind: "boolean", label: "Devre dışı", default: false},
+	},
+	fixedProps: {icon: "♥", children: "beğen", "aria-label": "beğen"},
+});

--- a/apps/web/src/lab/atolye/exhibits/Dialog.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Dialog.exhibit.tsx
@@ -1,0 +1,37 @@
+import type * as React from "react";
+import {Button} from "../../../components/ui/Button";
+import {Dialog} from "../../../components/ui/Dialog";
+import {defineExhibit} from "../exhibit";
+
+function DialogDemo({showClose, defaultOpen}: {showClose?: boolean; defaultOpen?: boolean}) {
+	return (
+		<Dialog.Root defaultOpen={defaultOpen}>
+			<Dialog.Trigger render={<Button variant="secondary">İletişim kutusunu aç</Button>} />
+			<Dialog.Popup>
+				<Dialog.Head
+					title="Başlık"
+					description="Kutunun kısa açıklama metni."
+					showClose={showClose}
+				/>
+				<Dialog.Body>
+					<p style={{margin: 0}}>Gövde içeriği burada yer alır.</p>
+				</Dialog.Body>
+				<Dialog.Foot>
+					<Dialog.Close render={<Button variant="tertiary">Vazgeç</Button>} />
+					<Dialog.Close render={<Button variant="primary">Onayla</Button>} />
+				</Dialog.Foot>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}
+
+export const dialogExhibit = defineExhibit<React.ComponentProps<typeof DialogDemo>>({
+	id: "dialog",
+	title: "İletişim Kutusu",
+	summary: "Başlık, gövde ve eylemleriyle modal iletişim kutusu — base-ui Dialog üstünde.",
+	component: DialogDemo,
+	knobs: {
+		defaultOpen: {kind: "boolean", label: "Açık başlat", default: false},
+		showClose: {kind: "boolean", label: "Kapat düğmesi", default: true},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/DraftRestoreBanner.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/DraftRestoreBanner.exhibit.tsx
@@ -1,0 +1,16 @@
+import type * as React from "react";
+import {DraftRestoreBanner} from "../../../components/ui/DraftRestoreBanner";
+import {defineExhibit} from "../exhibit";
+
+// `onRestore`/`onDismiss` are callbacks (non-knobbable) — pinned to no-ops so the
+// banner's two-button landmark can be rendered on its own.
+export const draftRestoreBannerExhibit = defineExhibit<
+	React.ComponentProps<typeof DraftRestoreBanner>
+>({
+	id: "draft-restore-banner",
+	title: "Taslak Geri Yükleme",
+	summary: "Auth turundan sonra kurtulan taslağı sunar; sessizce geri enjekte etmez.",
+	component: DraftRestoreBanner,
+	knobs: {},
+	fixedProps: {onRestore: () => {}, onDismiss: () => {}},
+});

--- a/apps/web/src/lab/atolye/exhibits/EditedIndicator.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/EditedIndicator.exhibit.tsx
@@ -1,0 +1,17 @@
+import type * as React from "react";
+import {EditedIndicator} from "../../../components/ui/EditedIndicator";
+import {defineExhibit} from "../exhibit";
+
+// `createdAt` is pinned; `updatedAt` is the knob. When the two land within the
+// 60s edit grace window the indicator renders nothing — the boundary is felt by
+// editing the timestamp.
+export const editedIndicatorExhibit = defineExhibit<React.ComponentProps<typeof EditedIndicator>>({
+	id: "edited-indicator",
+	title: "Düzenlendi İşareti",
+	summary: "Bir içerik düzenlendiğinde beliren, tarihini ipucu olarak taşıyan sessiz işaret.",
+	component: EditedIndicator,
+	knobs: {
+		updatedAt: {kind: "string", label: "Güncellenme", default: "2026-01-02T12:00:00Z"},
+	},
+	fixedProps: {createdAt: "2026-01-01T09:00:00Z"},
+});

--- a/apps/web/src/lab/atolye/exhibits/EmptyState.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/EmptyState.exhibit.tsx
@@ -1,0 +1,24 @@
+import type * as React from "react";
+import {Button} from "../../../components/ui/Button";
+import {EmptyState} from "../../../components/ui/EmptyState";
+import {defineExhibit} from "../exhibit";
+
+// Every slot is a ReactNode, so none is knobbable — the prop space is exercised
+// through `fixedProps` (icon + title + description + action), not on-screen knobs.
+export const emptyStateExhibit = defineExhibit<React.ComponentProps<typeof EmptyState>>({
+	id: "empty-state",
+	title: "Boş Durum",
+	summary: "Seyrek bir alanın boşluk yerine gösterdiği ortalanmış blok — ikon, başlık, eylem.",
+	component: EmptyState,
+	knobs: {},
+	fixedProps: {
+		icon: "🗒️",
+		title: "Henüz gönderi yok",
+		description: "İlk gönderiyi paylaşan sen ol.",
+		action: (
+			<Button variant="primary" size="sm">
+				Gönderi oluştur
+			</Button>
+		),
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/Form.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Form.exhibit.tsx
@@ -1,0 +1,29 @@
+import type * as React from "react";
+import {Field, Form, Hint, Input, Label, Textarea} from "../../../components/ui/Form";
+import {defineExhibit} from "../exhibit";
+
+function FormDemo({mono}: {mono?: boolean}) {
+	return (
+		<Form style={{maxWidth: "22rem"}}>
+			<Field name="baslik">
+				<Label>Başlık</Label>
+				<Input placeholder="Bir başlık girin" />
+				<Hint>Listelerde görünen ad.</Hint>
+			</Field>
+			<Field name="icerik">
+				<Label>İçerik</Label>
+				<Textarea rows={4} mono={mono} placeholder="Metni buraya yazın…" />
+			</Field>
+		</Form>
+	);
+}
+
+export const formExhibit = defineExhibit<React.ComponentProps<typeof FormDemo>>({
+	id: "form",
+	title: "Form",
+	summary: "Etiket, ipucu ve hata slotlu alanlar — base-ui Field/Input/Textarea üstünde.",
+	component: FormDemo,
+	knobs: {
+		mono: {kind: "boolean", label: "Tek aralıklı alan", default: false},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/Menu.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Menu.exhibit.tsx
@@ -1,0 +1,57 @@
+import type * as React from "react";
+import {Button} from "../../../components/ui/Button";
+import {Menu} from "../../../components/ui/Menu";
+import {defineExhibit} from "../exhibit";
+
+function MenuDemo({
+	side,
+	align,
+	defaultOpen,
+}: {
+	side?: "top" | "right" | "bottom" | "left";
+	align?: "start" | "center" | "end";
+	defaultOpen?: boolean;
+}) {
+	return (
+		<Menu.Root defaultOpen={defaultOpen}>
+			<Menu.Trigger render={<Button variant="secondary">Menü</Button>} />
+			<Menu.Popup side={side} align={align}>
+				<Menu.Item>Profil</Menu.Item>
+				<Menu.Item shortcut="⌘K">Ara</Menu.Item>
+				<Menu.Separator />
+				<Menu.Item danger>Sil</Menu.Item>
+			</Menu.Popup>
+		</Menu.Root>
+	);
+}
+
+export const menuExhibit = defineExhibit<React.ComponentProps<typeof MenuDemo>>({
+	id: "menu",
+	title: "Menü",
+	summary: "Kısayol, ayraç ve tehlike öğesiyle açılır menü — base-ui Menu üstünde.",
+	component: MenuDemo,
+	knobs: {
+		side: {
+			kind: "enum",
+			label: "Yön",
+			default: "bottom",
+			options: [
+				{value: "top", label: "Üst"},
+				{value: "right", label: "Sağ"},
+				{value: "bottom", label: "Alt"},
+				{value: "left", label: "Sol"},
+			],
+		},
+		align: {
+			kind: "enum",
+			label: "Hizalama",
+			default: "start",
+			options: [
+				{value: "start", label: "Başa"},
+				{value: "center", label: "Ortaya"},
+				{value: "end", label: "Sona"},
+			],
+		},
+		defaultOpen: {kind: "boolean", label: "Açık başlat", default: false},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/MetaRow.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/MetaRow.exhibit.tsx
@@ -1,0 +1,25 @@
+import {MetaRow} from "../../../components/ui/MetaRow";
+import {defineExhibit} from "../exhibit";
+
+// A composed row (author · time · count) so the shared child treatment and the
+// `MetaRow.Dot` separator are shown together; MetaRow's own props are all layout
+// (`as`) or ReactNode children, so there are no knobs — the row is fixed content.
+function MetaRowDemo() {
+	return (
+		<MetaRow>
+			<span className="author">ada</span>
+			<MetaRow.Dot />
+			<span>2 saat önce</span>
+			<MetaRow.Dot />
+			<span>4 yorum</span>
+		</MetaRow>
+	);
+}
+
+export const metaRowExhibit = defineExhibit<Record<string, never>>({
+	id: "meta-row",
+	title: "Üstveri Satırı",
+	summary: "Yazar · zaman · sayı gibi soluk üstverinin nokta ayraçlı ortak satırı.",
+	component: MetaRowDemo,
+	knobs: {},
+});

--- a/apps/web/src/lab/atolye/exhibits/ReportButton.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/ReportButton.exhibit.tsx
@@ -1,0 +1,14 @@
+import type * as React from "react";
+import {ReportButton} from "../../../components/ui/ReportButton";
+import {defineExhibit} from "../exhibit";
+
+// `onReport` is a callback (non-knobbable) — pinned to a stub that resolves
+// `reported`, so the button's in-flight lock and confirmation feedback can be felt.
+export const reportButtonExhibit = defineExhibit<React.ComponentProps<typeof ReportButton>>({
+	id: "report-button",
+	title: "Bildir Düğmesi",
+	summary: "Bir öğeyi bildirir; tıklayınca kilitlenip “bildirildi” geri bildirimine geçer.",
+	component: ReportButton,
+	knobs: {},
+	fixedProps: {onReport: async () => "reported" as const},
+});

--- a/apps/web/src/lab/atolye/exhibits/ReviewBadge.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/ReviewBadge.exhibit.tsx
@@ -1,0 +1,12 @@
+import type * as React from "react";
+import {ReviewBadge} from "../../../components/ui/ReviewBadge";
+import {defineExhibit} from "../exhibit";
+
+// Propsuz bir rozet — durumu rengiyle değil, kelimesiyle taşır; knob yok.
+export const reviewBadgeExhibit = defineExhibit<React.ComponentProps<typeof ReviewBadge>>({
+	id: "review-badge",
+	title: "İnceleme Rozeti",
+	summary: "Bir çaylağın kendi kum havuzundaki içeriğinde gördüğü “incelemede” rozeti.",
+	component: ReviewBadge,
+	knobs: {},
+});

--- a/apps/web/src/lab/atolye/exhibits/Switch.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Switch.exhibit.tsx
@@ -1,0 +1,15 @@
+import type * as React from "react";
+import {Switch} from "../../../components/ui/Switch";
+import {defineExhibit} from "../exhibit";
+
+export const switchExhibit = defineExhibit<React.ComponentProps<typeof Switch>>({
+	id: "switch",
+	title: "Anahtar",
+	summary: "İki durumlu aç/kapa anahtarı — base-ui Switch üstünde, rol token'larıyla.",
+	component: Switch,
+	knobs: {
+		defaultChecked: {kind: "boolean", label: "Açık", default: true},
+		disabled: {kind: "boolean", label: "Devre dışı", default: false},
+	},
+	fixedProps: {"aria-label": "Bildirimler"},
+});

--- a/apps/web/src/lab/atolye/exhibits/Tabs.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Tabs.exhibit.tsx
@@ -1,0 +1,42 @@
+import type * as React from "react";
+import {Tabs} from "../../../components/ui/Tabs";
+import {defineExhibit} from "../exhibit";
+
+function TabsDemo({variant}: {variant?: "underline" | "pill"}) {
+	return (
+		<Tabs.Root variant={variant} defaultValue="genel">
+			<Tabs.List>
+				<Tabs.Tab value="genel">Genel</Tabs.Tab>
+				<Tabs.Tab value="ayarlar">Ayarlar</Tabs.Tab>
+				<Tabs.Tab value="gelismis">Gelişmiş</Tabs.Tab>
+			</Tabs.List>
+			<Tabs.Panel value="genel" style={{paddingTop: "var(--s-3)"}}>
+				Genel içerik.
+			</Tabs.Panel>
+			<Tabs.Panel value="ayarlar" style={{paddingTop: "var(--s-3)"}}>
+				Ayarlar içeriği.
+			</Tabs.Panel>
+			<Tabs.Panel value="gelismis" style={{paddingTop: "var(--s-3)"}}>
+				Gelişmiş içerik.
+			</Tabs.Panel>
+		</Tabs.Root>
+	);
+}
+
+export const tabsExhibit = defineExhibit<React.ComponentProps<typeof TabsDemo>>({
+	id: "tabs",
+	title: "Sekmeler",
+	summary: "Altı çizili veya hap görünümlü sekme grubu — base-ui Tabs üstünde.",
+	component: TabsDemo,
+	knobs: {
+		variant: {
+			kind: "enum",
+			label: "Görünüm",
+			default: "underline",
+			options: [
+				{value: "underline", label: "Altı çizili"},
+				{value: "pill", label: "Hap"},
+			],
+		},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/Toast.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Toast.exhibit.tsx
@@ -1,0 +1,36 @@
+import type * as React from "react";
+import {Button} from "../../../components/ui/Button";
+import {ToastProvider, useToast} from "../../../components/ui/Toast";
+import {defineExhibit} from "../exhibit";
+
+function ToastTrigger({durationMs}: {durationMs: number}) {
+	const {show} = useToast();
+	return (
+		<Button
+			variant="secondary"
+			onClick={() => show({message: "Değişiklikler kaydedildi.", durationMs})}
+		>
+			Bildirim göster
+		</Button>
+	);
+}
+
+// The toast is imperative (a `useToast().show` call), so the exhibit wraps a
+// trigger in its own `ToastProvider`; `durationMs=0` keeps the toast until dismissed.
+function ToastDemo({durationMs}: {durationMs?: number}) {
+	return (
+		<ToastProvider>
+			<ToastTrigger durationMs={durationMs ?? 4000} />
+		</ToastProvider>
+	);
+}
+
+export const toastExhibit = defineExhibit<React.ComponentProps<typeof ToastDemo>>({
+	id: "toast",
+	title: "Bildirim",
+	summary: "Ekranın kenarında beliren, kendiliğinden kapanan geçici bildirim şeridi.",
+	component: ToastDemo,
+	knobs: {
+		durationMs: {kind: "number", label: "Süre (ms, 0=kalıcı)", default: 4000, min: 0, step: 500},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/ToggleGroup.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/ToggleGroup.exhibit.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import {ToggleGroup} from "../../../components/ui/ToggleGroup";
+import {defineExhibit} from "../exhibit";
+
+function ToggleGroupDemo({variant}: {variant?: "pill" | "segmented" | "square" | "swatch"}) {
+	const [value, setValue] = React.useState<string[]>(["orta"]);
+	return (
+		<ToggleGroup.Root variant={variant} value={value} onValueChange={setValue}>
+			<ToggleGroup.Item value="sol">Sol</ToggleGroup.Item>
+			<ToggleGroup.Item value="orta">Orta</ToggleGroup.Item>
+			<ToggleGroup.Item value="sag">Sağ</ToggleGroup.Item>
+		</ToggleGroup.Root>
+	);
+}
+
+export const toggleGroupExhibit = defineExhibit<React.ComponentProps<typeof ToggleGroupDemo>>({
+	id: "toggle-group",
+	title: "Değiştirici Grubu",
+	summary: "Tek seçimli segment/hap/kare varyantlarıyla değiştirici grubu — base-ui üstünde.",
+	component: ToggleGroupDemo,
+	knobs: {
+		variant: {
+			kind: "enum",
+			label: "Görünüm",
+			default: "segmented",
+			options: [
+				{value: "pill", label: "Hap"},
+				{value: "segmented", label: "Segment"},
+				{value: "square", label: "Kare"},
+				{value: "swatch", label: "Renk"},
+			],
+		},
+	},
+});

--- a/apps/web/src/lab/atolye/exhibits/Tooltip.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Tooltip.exhibit.tsx
@@ -1,0 +1,25 @@
+import type * as React from "react";
+import {Tooltip} from "../../../components/ui/Tooltip";
+import {defineExhibit} from "../exhibit";
+
+export const tooltipExhibit = defineExhibit<React.ComponentProps<typeof Tooltip>>({
+	id: "tooltip",
+	title: "İpucu",
+	summary: "Bir tetikleyicinin üstüne konumlanan kısa açıklama balonu — dört yönde.",
+	component: Tooltip,
+	knobs: {
+		side: {
+			kind: "enum",
+			label: "Yön",
+			default: "top",
+			options: [
+				{value: "top", label: "Üst"},
+				{value: "right", label: "Sağ"},
+				{value: "bottom", label: "Alt"},
+				{value: "left", label: "Sol"},
+			],
+		},
+		defaultOpen: {kind: "boolean", label: "Açık başlat", default: true},
+	},
+	fixedProps: {content: "Kısa bir ipucu metni.", children: "üzerine gel"},
+});

--- a/apps/web/src/lab/atolye/registry.test.ts
+++ b/apps/web/src/lab/atolye/registry.test.ts
@@ -25,4 +25,35 @@ describe("exhibit registry — headless enumeration", () => {
 		const ids = listExhibits().map((e) => e.id);
 		expect(new Set(ids).size).toBe(ids.length);
 	});
+
+	// The catalog (#3094) covers every UI primitive under components/ui/. This pins the
+	// contract so a newly-added primitive without an exhibit surfaces as a red test.
+	it("catalogs an exhibit for every UI primitive", () => {
+		const ids = new Set(listExhibits().map((e) => e.id));
+		const expected = [
+			"avatar",
+			"button",
+			"card",
+			"collapsible",
+			"copy-link-button",
+			"count-toggle",
+			"dialog",
+			"draft-restore-banner",
+			"edited-indicator",
+			"empty-state",
+			"form",
+			"menu",
+			"meta-row",
+			"report-button",
+			"review-badge",
+			"switch",
+			"tabs",
+			"toast",
+			"toggle-group",
+			"tooltip",
+		];
+		for (const id of expected) {
+			expect(ids).toContain(id);
+		}
+	});
 });

--- a/apps/web/src/lab/atolye/registry.ts
+++ b/apps/web/src/lab/atolye/registry.ts
@@ -6,9 +6,49 @@
  */
 
 import type {AnyExhibit} from "./exhibit";
+import {avatarExhibit} from "./exhibits/Avatar.exhibit";
 import {buttonExhibit} from "./exhibits/Button.exhibit";
+import {cardExhibit} from "./exhibits/Card.exhibit";
+import {collapsibleExhibit} from "./exhibits/Collapsible.exhibit";
+import {copyLinkButtonExhibit} from "./exhibits/CopyLinkButton.exhibit";
+import {countToggleExhibit} from "./exhibits/CountToggle.exhibit";
+import {dialogExhibit} from "./exhibits/Dialog.exhibit";
+import {draftRestoreBannerExhibit} from "./exhibits/DraftRestoreBanner.exhibit";
+import {editedIndicatorExhibit} from "./exhibits/EditedIndicator.exhibit";
+import {emptyStateExhibit} from "./exhibits/EmptyState.exhibit";
+import {formExhibit} from "./exhibits/Form.exhibit";
+import {menuExhibit} from "./exhibits/Menu.exhibit";
+import {metaRowExhibit} from "./exhibits/MetaRow.exhibit";
+import {reportButtonExhibit} from "./exhibits/ReportButton.exhibit";
+import {reviewBadgeExhibit} from "./exhibits/ReviewBadge.exhibit";
+import {switchExhibit} from "./exhibits/Switch.exhibit";
+import {tabsExhibit} from "./exhibits/Tabs.exhibit";
+import {toastExhibit} from "./exhibits/Toast.exhibit";
+import {toggleGroupExhibit} from "./exhibits/ToggleGroup.exhibit";
+import {tooltipExhibit} from "./exhibits/Tooltip.exhibit";
 
-const exhibits: readonly AnyExhibit[] = [buttonExhibit];
+const exhibits: readonly AnyExhibit[] = [
+	buttonExhibit,
+	avatarExhibit,
+	cardExhibit,
+	collapsibleExhibit,
+	copyLinkButtonExhibit,
+	countToggleExhibit,
+	dialogExhibit,
+	draftRestoreBannerExhibit,
+	editedIndicatorExhibit,
+	emptyStateExhibit,
+	formExhibit,
+	menuExhibit,
+	metaRowExhibit,
+	reportButtonExhibit,
+	reviewBadgeExhibit,
+	switchExhibit,
+	tabsExhibit,
+	toastExhibit,
+	toggleGroupExhibit,
+	tooltipExhibit,
+];
 
 /** Every registered exhibit, in curated order — headless, renders nothing. */
 export function listExhibits(): readonly AnyExhibit[] {


### PR DESCRIPTION
## What

Fills the atölye **exhibit catalog** (epic #2473, C4): one `defineExhibit` module for each remaining UI primitive under `apps/web/src/components/ui/`, extending the C1 `Button` exemplar and `.patterns/atolye-exhibit-harness.md`. 19 new exhibits, each appended as one line to the headless `registry.ts` (Button already ships from C1).

Covered: Avatar, Card, Collapsible, CopyLinkButton, CountToggle, Dialog, DraftRestoreBanner, EditedIndicator, EmptyState, Form, Menu, MetaRow, ReportButton, ReviewBadge, Switch, Tabs, Toast, ToggleGroup, Tooltip.

## How

- Each exhibit exposes **enum** knobs for literal-union props, **boolean** knobs for flags, and **number** knobs where meaningful; `ReactNode` / callback props (which the knob type layer maps to `never`) are pinned via `fixedProps`.
- **Compound** primitives (Dialog, Menu, Tabs, ToggleGroup, Collapsible, Form, Toast) get a small in-file demo wrapper so their composition is knobbable through a single `defineExhibit<React.ComponentProps<typeof Demo>>`.
- Renders ADR-0162 role-token / four-pillar-compliant usage (the real primitives already comply); no new design primitive introduced.
- ASCII kebab `id`s (URL segment), Turkish display `title`/`summary`. No route edits — the registry is the seam (index #3092 + detail #3093 already on main).
- Added a registry coverage test asserting an exhibit exists for every primitive.
- Fixed a latent brittleness in the #3092 index deep-link test: it resolved rows by a title **regex**, which multi-matches real Turkish titles sharing a word (`Düğme` inside `Bildir Düğmesi`). Now resolves each row by its unique detail `href` — more precise, and matches the test's stated intent.

## Acceptance
- [x] Every primitive in `components/ui/` has a registered exhibit (~20 incl. Button).
- [x] Each exposes knobs across its knobbable prop space + renders role-token-compliant usage.
- [x] Each appears in the `/lab/atölye` index and is reachable at its detail route with no route edit.
- [x] No external storybook dep; base-ui + role tokens only.

## Verification
`pnpm -C apps/web typecheck` · `pnpm lint` · `pnpm -C apps/web test:client -- src/lab/atolye` (259 passed) all green.

Containment-exempt (public `/lab` dev/design tooling; no product-behavior change). Non-§CP.

Fixes #3094

🤖 Generated with [Claude Code](https://claude.com/claude-code)