### PR TITLE
feat(anka-ops): votes-vs-reactions — kamp.us's first report-catalog entry (#3135)

### DIFF
--- a/packages/anka-ops/src/report-catalog.ts
+++ b/packages/anka-ops/src/report-catalog.ts
@@ -1,11 +1,12 @@
 /**
  * The product report registry — the single injection point for report *content*, wired into the
- * runtime by `cli.ts`. The anka-ops core ships this EMPTY: it is the mechanism-vs-content boundary
- * (ADR 0153) made concrete — the generic runner in `report.ts` carries no query, and a product adds
- * its definitions here (the first, `votes-vs-reactions`, is a separate child). Until one is wired,
- * `report --name <id>` fails loud listing an empty catalog rather than inventing a built-in report.
+ * runtime by `cli.ts`. It is the mechanism-vs-content boundary (ADR 0153) made concrete: the generic
+ * runner in `report.ts` carries no query, and a product's report definitions land here. Each entry is
+ * authored as its own content module under `reports/`; this file only lists them, so `report --name
+ * <id>` resolves the id against the registered set.
  */
 
 import type {ReportDefinition} from "./report.ts";
+import {votesVsReactions} from "./reports/votes-vs-reactions.ts";
 
-export const REPORT_CATALOG: ReadonlyArray<ReportDefinition> = [];
+export const REPORT_CATALOG: ReadonlyArray<ReportDefinition> = [votesVsReactions];

--- a/packages/anka-ops/src/reports/votes-vs-reactions.ts
+++ b/packages/anka-ops/src/reports/votes-vs-reactions.ts
@@ -1,0 +1,24 @@
+/**
+ * kamp.us's first report-catalog entry (ADR 0153) — product content, not framework mechanism.
+ * It answers ADR 0153's forcing question: are reactions (ungated, karma-free) cannibalising votes
+ * (the karma-bearing ranking signal)? Compared on the `feature` axis — the one exact-under-sampling
+ * dimension (`index1`) — over the `app_events` seam, bucketed per day across a 30-day window. This
+ * only declares the axes; the generic runner (report.ts) renders them sampling-correct (`sumIf` over
+ * `_sample_interval`, never `count()`). It is the canonical query ADR 0153 names verbatim.
+ */
+
+import type {ReportDefinition} from "../report.ts";
+
+export const votesVsReactions: ReportDefinition = {
+	id: "votes-vs-reactions",
+	version: 1,
+	description: "daily vote vs reaction feature-key volume — are reactions cannibalising votes?",
+	query: {
+		measures: [
+			{name: "votes", feature: "vote"},
+			{name: "reactions", feature: "reaction"},
+		],
+		windowDays: 30,
+		groupByDay: true,
+	},
+};

--- a/packages/anka-ops/src/reports/votes-vs-reactions.unit.test.ts
+++ b/packages/anka-ops/src/reports/votes-vs-reactions.unit.test.ts
@@ -1,0 +1,45 @@
+/**
+ * kamp.us's reference report-catalog entry: the `votes-vs-reactions` definition is well-formed
+ * against child C's catalog-entry interface, is registered so `report --name` resolves it, and
+ * renders into the exact sampling-correct AE query ADR 0153 names verbatim (`sumIf` over
+ * `_sample_interval`, never `count()`). Pure — no AE, no keychain.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {knownReportIds, renderReportSql, resolveReport} from "../report.ts";
+import {REPORT_CATALOG} from "../report-catalog.ts";
+import {votesVsReactions} from "./votes-vs-reactions.ts";
+
+describe("votes-vs-reactions definition", () => {
+	it("compares the vote and reaction feature-keys on the index1 axis", () => {
+		assert.strictEqual(votesVsReactions.id, "votes-vs-reactions");
+		assert.deepStrictEqual(
+			votesVsReactions.query.measures.map((measure) => measure.feature),
+			["vote", "reaction"],
+		);
+	});
+
+	it("is registered in the product catalog and resolves by name", () => {
+		assert.include(knownReportIds(REPORT_CATALOG), "votes-vs-reactions");
+		const resolved = Effect.runSync(resolveReport(REPORT_CATALOG, "votes-vs-reactions"));
+		assert.strictEqual(resolved, votesVsReactions);
+	});
+});
+
+describe("votes-vs-reactions AE query shape", () => {
+	const sql = renderReportSql(votesVsReactions.query);
+
+	it("weights each feature-key by _sample_interval, never count() (ADR 0153)", () => {
+		assert.include(sql, "sumIf(_sample_interval, index1 = 'vote') AS votes");
+		assert.include(sql, "sumIf(_sample_interval, index1 = 'reaction') AS reactions");
+		assert.notMatch(sql, /count\s*\(/i);
+	});
+
+	it("reads app_events per day over the 30-day window", () => {
+		assert.include(sql, "FROM app_events");
+		assert.include(sql, "WHERE timestamp > NOW() - INTERVAL '30' DAY");
+		assert.include(sql, "toStartOfDay(timestamp) AS day");
+		assert.include(sql, "GROUP BY day");
+		assert.include(sql, "ORDER BY day");
+	});
+});


### PR DESCRIPTION
Ships `votes-vs-reactions` as kamp.us's first report-catalog entry — the reference report proving the `anka-ops report --name` runner (#3134) end to end.

## What

- New content module `packages/anka-ops/src/reports/votes-vs-reactions.ts` authors the definition against child C's catalog-entry interface (`ReportDefinition`): compares `vote` vs `reaction` feature-key volume over the ADR-0153 `app_events` seam on the `index1` axis, bucketed per day across a 30-day window — ADR 0153's forcing question (are reactions cannibalising votes?).
- `packages/anka-ops/src/report-catalog.ts` registers it in `REPORT_CATALOG` (the injectable catalog `cli.ts` wires via `makeReportCatalog`), so `anka-ops report --name votes-vs-reactions` resolves and runs it.
- The query lives in the product catalog, not the anka-ops core — the mechanism-vs-content seam ADR 0153 locks. The generic runner renders it sampling-correct (`sumIf` over `_sample_interval`, never `count()`); the entry only declares the axes.

## Tests

`packages/anka-ops/src/reports/votes-vs-reactions.unit.test.ts` asserts the definition is well-formed, registers + resolves by name, and renders the canonical ADR-0153 query shape. `pnpm --filter @kampus/anka-ops test` green (41 passed), typecheck + lint clean.

## Acceptance criteria
- [x] A `votes-vs-reactions` report definition exists in the product report catalog, satisfying child C's catalog-entry interface.
- [x] `anka-ops report --name votes-vs-reactions` resolves and runs it, reading the ADR-0153 `app_events` seam sampling-correct.
- [x] The query lives in the product catalog, not the anka-ops core.
- [x] A unit test asserts the definition decodes and produces the expected AE query shape over the fixed positional schema.

Fixes #3135

🤖 Generated with [Claude Code](https://claude.com/claude-code)