### PR TITLE
feat(atolye): fold the composer in as the first feature-level exhibit (#3095)

### DIFF
--- a/apps/web/src/lab/atolye/exhibits/Composer.exhibit.css
+++ b/apps/web/src/lab/atolye/exhibits/Composer.exhibit.css
@@ -1,0 +1,115 @@
+/* The composer exhibit's live demo. Role tokens only (ADR 0162): sizes from the type ramp,
+   spacing/radius/color from role tokens — no raw hex, no raw px. The rich element-level prose
+   treatment for the seeded sample is a compact subset; the full playground is /lab/composer. */
+
+.kp-atolye-composer {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+	width: 100%;
+}
+
+.kp-atolye-composer__surface {
+	font: var(--t-body);
+	color: var(--text-primary);
+	background: var(--surface-raised);
+	border: 1px solid var(--border);
+	border-radius: var(--r-lg);
+	padding: var(--s-3);
+}
+
+/* The ProseMirror editable drops its own default outline; the shared focus layer in
+   global.css (#2169) is the single source of the ring on focus. */
+.kp-atolye-composer__surface .tiptap {
+	outline: none;
+	min-height: calc(var(--s-8) * 2);
+}
+
+.kp-atolye-composer__surface .tiptap > :first-child {
+	margin-top: 0;
+}
+
+.kp-atolye-composer__surface .tiptap > :last-child {
+	margin-bottom: 0;
+}
+
+.kp-atolye-composer__surface .tiptap h2 {
+	font: var(--t-h-feed);
+	font-weight: 700;
+	color: var(--text-primary);
+	margin: var(--s-3) 0 var(--s-2);
+}
+
+.kp-atolye-composer__surface .tiptap p {
+	margin: var(--s-2) 0;
+}
+
+.kp-atolye-composer__surface .tiptap strong {
+	font-weight: 700;
+	color: var(--text-primary);
+}
+
+.kp-atolye-composer__surface .tiptap em {
+	font-style: italic;
+}
+
+.kp-atolye-composer__surface .tiptap code {
+	font: var(--t-mono);
+	background: var(--surface-sunken);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	padding: 0 var(--s-1);
+}
+
+.kp-atolye-composer__surface .tiptap ul {
+	list-style: disc;
+	margin: var(--s-2) 0;
+	padding-left: var(--s-5);
+}
+
+.kp-atolye-composer__surface .tiptap li {
+	margin: var(--s-1) 0;
+}
+
+.kp-atolye-composer__surface .tiptap blockquote {
+	margin: var(--s-3) 0;
+	padding: var(--s-1) 0 var(--s-1) var(--s-3);
+	border-left: 2px solid var(--border-strong);
+	color: var(--text-secondary);
+}
+
+.kp-atolye-composer__roundtrip {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-atolye-composer__roundtrip-label {
+	font: var(--t-meta);
+	font-weight: 700;
+	color: var(--text-secondary);
+}
+
+.kp-atolye-composer__out {
+	font: var(--t-mono);
+	color: var(--text-primary);
+	background: var(--surface-sunken);
+	border-radius: var(--r-lg);
+	padding: var(--s-2);
+	margin: 0;
+	white-space: pre-wrap;
+	word-break: break-word;
+	overflow-x: auto;
+}
+
+.kp-atolye-composer__note {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	margin: 0;
+}
+
+.kp-atolye-composer__link {
+	color: var(--link);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}

--- a/apps/web/src/lab/atolye/exhibits/Composer.exhibit.live.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Composer.exhibit.live.tsx
@@ -1,0 +1,78 @@
+/**
+ * The composer exhibit's live demo — the tiptap-import boundary. `Composer.exhibit.tsx`
+ * `React.lazy`-loads this module, so `@kampus/composer` (tiptap/ProseMirror) stays out of
+ * the atölye registry/index chunk and only loads when the exhibit actually renders — the
+ * same performance-pillar split the composer routes make (#2523).
+ */
+
+import {Composer, ReadOnlyComposer, useComposerEditor} from "@kampus/composer";
+import {useState} from "react";
+import {Link} from "react-router";
+
+// A compact sample exercising headings, inline marks, a list, and a blockquote — enough to
+// prove the editor is a real rich surface. The exhaustive round-trip fixture lives at the
+// canonical `/lab/composer` playground (linked below), which this exhibit does not touch.
+const SAMPLE_MARKDOWN = [
+	"## Merhaba, atölye",
+	"",
+	"Bu **canlı** editör, *paylaşılan* `@kampus/composer` tabanının üstünde çalışır.",
+	"",
+	"- markdown ↔ tiptap gidiş-dönüşü",
+	"- salt-okunur ile düzenlenebilir tek render yolu",
+	"",
+	"> Yazan ile okuyan aynı yoldan geçer.",
+].join("\n");
+
+/**
+ * Editable ⇄ read-only share ONE render path (editor≈reader parity, #2581). The parent
+ * remounts this on the knob flip (via `key`), so `editable` is fixed per mount and the
+ * read-only branch renders through `ReadOnlyComposer` — the same baseKit path, editing off.
+ */
+export function ComposerExhibitLive({readOnly = false}: {readOnly?: boolean}) {
+	if (readOnly) {
+		return (
+			<div className="kp-atolye-composer">
+				<ReadOnlyComposer
+					content={SAMPLE_MARKDOWN}
+					className="kp-atolye-composer__surface kp-prose"
+				/>
+				<PlaygroundNote />
+			</div>
+		);
+	}
+	return <EditableComposer />;
+}
+
+function EditableComposer() {
+	// Bumped on every transaction so the round-trip readout re-derives `getMarkdown()` live —
+	// the visible proof that the editor's structural state round-trips back to markdown.
+	const [rev, setRev] = useState(0);
+	const composer = useComposerEditor({
+		content: SAMPLE_MARKDOWN,
+		onUpdate: () => setRev((n) => n + 1),
+	});
+	void rev;
+	const markdown = composer ? composer.getMarkdown() : "";
+	return (
+		<div className="kp-atolye-composer">
+			<Composer composer={composer} className="kp-atolye-composer__surface kp-prose" />
+			<div className="kp-atolye-composer__roundtrip">
+				<span className="kp-atolye-composer__roundtrip-label">getMarkdown()</span>
+				<pre className="kp-atolye-composer__out">{markdown}</pre>
+			</div>
+			<PlaygroundNote />
+		</div>
+	);
+}
+
+function PlaygroundNote() {
+	return (
+		<p className="kp-atolye-composer__note">
+			Tam markdown gidiş-dönüş oyun alanı için{" "}
+			<Link to="/lab/composer" className="kp-atolye-composer__link">
+				/lab/composer
+			</Link>
+			.
+		</p>
+	);
+}

--- a/apps/web/src/lab/atolye/exhibits/Composer.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Composer.exhibit.tsx
@@ -1,0 +1,40 @@
+/**
+ * The composer exhibit — atölye's first FEATURE-level exhibit (beyond the UI primitives):
+ * the shared `@kampus/composer` editor folded in as a live, knob-driven piece (#3095).
+ *
+ * This module is deliberately tiptap-free: the heavy demo is `React.lazy`-loaded from
+ * `Composer.exhibit.live` so the atölye registry/index chunk never pays for ProseMirror
+ * (the #2523 performance-pillar split). The standalone `/lab/composer` route stays the
+ * canonical full round-trip playground (documented NOT-throwaway); this exhibit shows a
+ * focused live demo and links out to it — it does not embed or regress that proof.
+ */
+
+import type * as React from "react";
+import {lazy, Suspense} from "react";
+import {defineExhibit} from "../exhibit";
+import "./Composer.exhibit.css";
+
+const ComposerExhibitLive = lazy(() =>
+	import("./Composer.exhibit.live").then((m) => ({default: m.ComposerExhibitLive})),
+);
+
+// Remount on the readOnly flip so `editable` is fixed per mount — the editor≈reader parity
+// path (#2581) branches at mount, not reactively; the `key` makes the knob toggle a remount.
+function ComposerExhibitDemo({readOnly}: {readOnly?: boolean}) {
+	return (
+		<Suspense fallback={<p className="kp-atolye-composer__note">yükleniyor…</p>}>
+			<ComposerExhibitLive key={readOnly ? "ro" : "rw"} readOnly={readOnly ?? false} />
+		</Suspense>
+	);
+}
+
+export const composerExhibit = defineExhibit<React.ComponentProps<typeof ComposerExhibitDemo>>({
+	id: "composer",
+	title: "Composer",
+	summary:
+		"Paylaşılan @kampus/composer editörü — markdown gidiş-dönüşü ve salt-okunur/düzenlenebilir tek render yolu.",
+	component: ComposerExhibitDemo,
+	knobs: {
+		readOnly: {kind: "boolean", label: "Salt-okunur", default: false},
+	},
+});

--- a/apps/web/src/lab/atolye/registry.test.ts
+++ b/apps/web/src/lab/atolye/registry.test.ts
@@ -26,6 +26,17 @@ describe("exhibit registry — headless enumeration", () => {
 		expect(new Set(ids).size).toBe(ids.length);
 	});
 
+	// The composer (#3095) is atölye's first feature-level exhibit — folded in ahead of the UI
+	// primitives it composes, so it leads the curated order the index route lists by.
+	it("leads the catalog with the composer feature exhibit", () => {
+		const exhibits = listExhibits();
+		expect(exhibits[0]?.id).toBe("composer");
+		const composer = getExhibit("composer");
+		expect(composer?.title).toBe("Composer");
+		expect(composer?.component).toBeTruthy();
+		expect(Object.keys(composer?.knobs ?? {})).toContain("readOnly");
+	});
+
 	// The catalog (#3094) covers every UI primitive under components/ui/. This pins the
 	// contract so a newly-added primitive without an exhibit surfaces as a red test.
 	it("catalogs an exhibit for every UI primitive", () => {

--- a/apps/web/src/lab/atolye/registry.ts
+++ b/apps/web/src/lab/atolye/registry.ts
@@ -10,6 +10,7 @@ import {avatarExhibit} from "./exhibits/Avatar.exhibit";
 import {buttonExhibit} from "./exhibits/Button.exhibit";
 import {cardExhibit} from "./exhibits/Card.exhibit";
 import {collapsibleExhibit} from "./exhibits/Collapsible.exhibit";
+import {composerExhibit} from "./exhibits/Composer.exhibit";
 import {copyLinkButtonExhibit} from "./exhibits/CopyLinkButton.exhibit";
 import {countToggleExhibit} from "./exhibits/CountToggle.exhibit";
 import {dialogExhibit} from "./exhibits/Dialog.exhibit";
@@ -28,6 +29,9 @@ import {toggleGroupExhibit} from "./exhibits/ToggleGroup.exhibit";
 import {tooltipExhibit} from "./exhibits/Tooltip.exhibit";
 
 const exhibits: readonly AnyExhibit[] = [
+	// The composer leads the catalog — atölye's first feature-level exhibit (#3095), ahead of
+	// the UI primitives it is built from.
+	composerExhibit,
 	buttonExhibit,
 	avatarExhibit,
 	cardExhibit,


### PR DESCRIPTION
Fixes #3095

## What

Folds `@kampus/composer` into atölye as its **first feature-level exhibit** — ahead of the UI primitives it composes. One colocated `*.exhibit.tsx` module plus one registry line, per the harness contract (`.patterns/atolye-exhibit-harness.md`).

- **`exhibits/Composer.exhibit.tsx`** — the exhibit definition + a lightweight, tiptap-free Suspense wrapper. Title `Composer` (brand/package noun, matching the `/lab/composer` masthead), Turkish summary. One `readOnly` boolean knob.
- **`exhibits/Composer.exhibit.live.tsx`** — the heavy live demo (`React.lazy`-loaded): a live editor seeded with a compact markdown sample, a `getMarkdown()` round-trip readout, and the `readOnly` branch rendering through `ReadOnlyComposer` (the editor≈reader single-render-path parity, #2581).
- **`exhibits/Composer.exhibit.css`** — scoped, role-token-only styles (ADR 0162).
- **`registry.ts`** — one line; `composerExhibit` leads the curated array so it appears first in the `/lab/atolye` index.
- **`registry.test.ts`** — asserts the composer leads the catalog and carries its knob.

## Standalone `/lab/composer` — KEPT (decision, per AC)

The standalone `/lab/composer` route is **kept as the canonical full round-trip playground** — it is documented NOT-throwaway (its docblock: "kept + canonical … NOT throwaway"). This exhibit shows a focused live demo and **links out** to `/lab/composer`; it neither embeds nor modifies that page, so the `@kampus/composer` markdown round-trip proof is unregressed.

## Performance-pillar note

The tiptap/ProseMirror payload is `React.lazy`-split into `Composer.exhibit.live`, so the atölye registry/index chunk stays tiptap-free — the same split the composer routes make (#2523). The `/lab/atolye` index route does not pull the editor.

## Acceptance criteria

- [x] A composer exhibit is registered and appears in the `/lab/atolye` index + detail route (registry-driven index; detail route is #3093, not yet merged — the exhibit is fully registered/resolvable).
- [x] The composer's markdown round-trip demonstration still works (no regression to the `@kampus/composer` proof) — `/lab/composer` untouched.
- [x] The relationship to the standalone `/lab/composer` route is resolved (kept) and stated above.
- [x] No external storybook dep.

## Testing

- `pnpm typecheck` (includes the web build — the lazy chunk resolves) ✓
- `pnpm lint` (biome) — clean on changed files ✓
- atölye unit + client tests (`registry.test.ts`, `AtolyeIndexPage.test.tsx`, `knob.test.ts`) ✓

Public `/lab` surface — containment-exempt; touches `apps/web/src/` → review-design gate applies (role tokens, base-ui, four-pillars, Turkish copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)