### PR TITLE
test(atolye): smoke journey e2e over the public /lab/atolye harness (#3096)

### DIFF
--- a/apps/web/tests/e2e/30-lab-atolye-smoke.spec.ts
+++ b/apps/web/tests/e2e/30-lab-atolye-smoke.spec.ts
@@ -1,0 +1,79 @@
+import {expect, type Page, test} from "@playwright/test";
+import {isCloudflarePlaceholder404} from "../integration/_edge-ready";
+
+/**
+ * atölye smoke journey (#3096, capstone of epic #2473) — the reachability guarantee for the
+ * public `/lab/atolye` harness. One representative journey: load the registry-driven index, open a
+ * known exhibit's detail route, twiddle a knob, and confirm the render updates AND the knob state
+ * round-trips through the URL (#3093). atölye ships as a plain public route (not behind a Flagship
+ * flag), so ADR-0173 flag-keyed reachability doesn't apply — this e2e is the `/lab`-convention
+ * equivalent, keeping the harness reachable and unbroken as exhibits evolve.
+ *
+ * Route/slug are ASCII English (`/lab/atolye`) per the routes-are-English convention + founder
+ * ruling; the visible brand copy is Turkish (`atölye`, exhibit titles like `Düğme`).
+ *
+ * The Button exhibit (`button`) is the fixed anchor: it's the harness's worked exemplar, first in
+ * the registry, with a `variant` enum knob whose value paints `kp-btn--<variant>` on the rendered
+ * button — a directly observable render change and a serializable URL param in one.
+ */
+
+// Public route served by the SPA fallback: a fresh Playwright context's first paint can hit a cold
+// Cloudflare edge PoP the preview-ready warm gate never touched, which serves the typed
+// placeholder-404 (ADR 0127). Poll THROUGH that bounded window; a structured worker 404 or any
+// other response returns at once for the caller's assertion to judge — same shape as 00-smoke.
+const SPA_READY_DEADLINE_MS = 30_000;
+const SPA_READY_POLL_MS = 1_500;
+
+async function gotoSpaReady(page: Page, route: string): Promise<void> {
+	const deadline = Date.now() + SPA_READY_DEADLINE_MS;
+	while (Date.now() < deadline) {
+		const res = await page.goto(route);
+		if (!res || res.status() !== 404) return;
+		if (!isCloudflarePlaceholder404(res.status(), await res.text())) return;
+		await page.waitForTimeout(SPA_READY_POLL_MS);
+	}
+}
+
+test("atölye smoke journey: index lists exhibits → open exhibit → change knob updates render", async ({
+	page,
+}) => {
+	test.setTimeout(SPA_READY_DEADLINE_MS + 15_000);
+
+	// 1. The index renders and lists exhibits — registry-driven, not a hardcoded route menu.
+	await gotoSpaReady(page, "/lab/atolye");
+	await expect(page.getByTestId("lab-atolye-index")).toBeVisible();
+	const cards = page.locator(".kp-atolye__item");
+	expect(await cards.count()).toBeGreaterThan(1);
+	const buttonCard = page.locator('a[href="/lab/atolye/button"]');
+	await expect(buttonCard).toBeVisible();
+
+	// 2. Opening an exhibit deep-links to its detail route and mounts the ExhibitStage.
+	await buttonCard.click();
+	await expect(page).toHaveURL(/\/lab\/atolye\/button$/);
+	await expect(page.getByTestId("lab-atolye-detail")).toBeVisible();
+	const stagedButton = page.locator('[data-testid="exhibit-stage"] .kp-btn');
+	await expect(stagedButton).toBeVisible();
+	// Default variant knob → primary.
+	await expect(stagedButton).toHaveClass(/kp-btn--primary/);
+
+	// 3. Changing the `variant` enum knob re-renders the component AND reflects into the URL.
+	await page.locator('[data-knob="variant"]').getByRole("button", {name: "İkincil"}).click();
+	await expect(stagedButton).toHaveClass(/kp-btn--secondary/);
+	await expect(page).toHaveURL(/[?&]variant=secondary(&|$)/);
+});
+
+test("atölye knob state round-trips through the URL (deep-link ↔ live twiddle)", async ({page}) => {
+	test.setTimeout(SPA_READY_DEADLINE_MS + 15_000);
+
+	// URL → state: landing a knob param restores that exhibit state (a shareable deep-link).
+	await gotoSpaReady(page, "/lab/atolye/button?variant=danger");
+	const stagedButton = page.locator('[data-testid="exhibit-stage"] .kp-btn');
+	await expect(stagedButton).toBeVisible();
+	await expect(stagedButton).toHaveClass(/kp-btn--danger/);
+
+	// state → URL: toggling back to the schema default drops the param (a pristine exhibit's URL is
+	// param-free), closing the round-trip in both directions.
+	await page.locator('[data-knob="variant"]').getByRole("button", {name: "Birincil"}).click();
+	await expect(stagedButton).toHaveClass(/kp-btn--primary/);
+	await expect(page).not.toHaveURL(/[?&]variant=/);
+});


### PR DESCRIPTION
Closes the ATÖLYE epic (#2473) capstone: a Playwright smoke journey that keeps the public `/lab/atolye` harness reachable and unbroken as exhibits evolve.

## What
`apps/web/tests/e2e/30-lab-atolye-smoke.spec.ts` — one representative journey plus a URL round-trip:
- **index → registry-driven list:** loads `/lab/atolye`, asserts the index renders and lists more than one exhibit (driven by the headless registry, not a hardcoded menu), including the `button` exhibit card.
- **open exhibit → ExhibitStage:** clicks through to `/lab/atolye/button`, asserts the detail route mounts the `ExhibitStage` and renders the `Düğme` button.
- **change knob → render updates + URL reflects:** flips the `variant` enum knob to secondary, asserts the staged button repaints `kp-btn--secondary` and the URL gains `?variant=secondary`.
- **knob-state deep-link round-trips:** lands `?variant=danger` (URL → state), then toggles back to the schema default and asserts the param drops (state → URL) — both directions of the #3093 contract.

## Notes
- Route slug is ASCII `/lab/atolye` (founder ruling); brand copy stays Turkish (`atölye`, `Düğme`).
- Follows the existing numbered-spec + `gotoSpaReady` cold-PoP conventions (mirrors `00-smoke`); lands in the no-auth `flows` project (public route, no session). No external storybook dep.
- atölye ships as a plain public `/lab` route (not a Flagship flag), so ADR-0173 flag-keyed reachability doesn't apply — this e2e is the `/lab`-convention reachability equivalent.
- Verified green locally against a dev server (2/2 passing).
- e2e runs in the merge group under the active #3016 preview-deploy flake ('preview never served worker API within 10min') — that is infra, not a defect in this spec.

Fixes #3096