### PR TITLE
roadmap: record Crew-MCP Finish campaign (active)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Campaign | Milestone | State |
 |----------|-----------|-------|
 | Mentor Audit | #27 | active |
+| Crew-MCP Finish — run the crew off tmux | #28 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Campaign | Milestone | State |
 |----------|-----------|-------|
 | Mentor Audit | #27 | active |
-| Crew-MCP Finish — run the crew off tmux | #28 | active |
+| Crew-MCP Finish — replace the tmux relay with crew-mcp | #28 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Records the crew-mcp-finish audit wave (label `crew-mcp-finish`) as a bounded, milestone-backed campaign on ROADMAP.md.

Appends one row to the `## Campaigns` table:

`| Crew-MCP Finish — replace the tmux relay with crew-mcp | #28 | active |`

- **Milestone #28**, pinned by number (satisfies roadmap-guard's "no unclaimed open milestone" + row→milestone-by-number binding).
- **State `active`** — the campaign opens draining concurrently with the active product arc, through the platform lane (ADR 0072/0078).
- **p1**, wave issues re-priced so they drain concurrent with the active arc.
- **Platform-lane drained**, founder-approval trace verified (PASS via `pipeline-cli campaign verify-trace`).

This is Step 4 of the campaign ritual — the gate, milestone provisioning, and p1 re-price are already done; this PR is the ROADMAP.md record only.

Context (not closed by this PR — the campaign has no single tracking issue): the graduated map #3207 and the 9-issue `crew-mcp-finish` wave.

roadmap-guard is green by construction (`roadmap-guard check`: in sync, 2 campaign rows validated).