### PR TITLE
docs(glossary): showcase chrome = English, only in-exhibit sample content = Turkish (#3231)

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -363,6 +363,18 @@ though the surface it powers renders Turkish UI copy. Collapsing the two axes ("
 concept shows on a Turkish screen, so its glossary term must be Turkish") is the mistake
 this note exists to stop.
 
+**On a showcase / exhibit surface, the chrome is technical, only the sample content is
+product copy.** Any surface that *demonstrates* components — a design-system storyboard,
+a component gallery, a pattern showcase — layers a component/primitive that renders some
+example content. Split them: the **names** — component names, primitive names, section
+and exhibit labels, and every code identifier or route path around them — are technical,
+so they stay **English**; **only the in-exhibit example/sample content** the component
+renders is user-facing product copy, so **it** is Turkish. Turkish never bleeds up from
+the rendered sample into the technical chrome that frames it: a `Button` exhibit is
+labeled `Button` (English name) showing a `Gönder` sample (Turkish content), never a
+`Düğme` exhibit. This is the general rule for every showcase surface — Turkish-naming the
+components was the atölye-storyboard inversion the founder ruled a standing don't.
+
 The Turkish product/brand nouns this repo uses:
 
 | Noun | What it names |


### PR DESCRIPTION
## What

Sharpens the "Turkish for product/brand, English for technical" convention in `.glossary/LANGUAGE.md` so it states **explicitly** what "technical" already implied but a showcase-builder could mis-read: on any showcase / exhibit surface the component/primitive/section **names** (and the code identifiers and route paths around them) are technical → **English**, and **only the in-exhibit example/sample content** the component renders is product copy → **Turkish**.

Transcribes a fixed founder directive after the atölye design-system storyboard shipped it inverted (Turkish component names); the founder ruled that a standing don't. This is the durable-convention-capture half of `#3230` (whose one-off copy fix lives separately).

## Why

The prior phrasing left "technical" implicitly covering component/primitive names, so a reader could bucket demo copy and component labels together as "product-facing." Naming the split removes the ambiguity at the exact register meant to teach it — worked example: a `Button` exhibit is labeled `Button` (English name) rendering a `Gönder` sample (Turkish content), never a `Düğme` exhibit.

## Scope

- Doc-only, single file: `.glossary/LANGUAGE.md`.
- Phrased as a general rule for **any** showcase/exhibit surface, not scoped to atölye.
- `LANGUAGE.md` stays the single source — deliberately **not** duplicated into `CLAUDE.md` (AC #4).
- No behavior change, no code touched.

Fixes #3231