### PR TITLE
roadmap: record Deterministic Crew Mechanics campaign (active)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,6 +35,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 |----------|-----------|-------|
 | Mentor Audit | #27 | active |
 | Crew-MCP Finish — replace the tmux relay with crew-mcp | #28 | active |
+| Deterministic Crew Mechanics | #29 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Records the `deterministic-crew-mechanics` audit wave (map #3247) as a bounded campaign — milestone #29 grouping epics #3258 + #3259, p2 hardening-tier, sequenced behind crew-mcp-finish #28, platform-lane drained. Founder-approval trace verified (verify-trace PASS).

Appends a single row to `ROADMAP.md`'s `## Campaigns` table (the pinned 3-column parsed contract), matching the existing row format:

```
| Deterministic Crew Mechanics | #29 | active |
```

References: map #3247 and milestone #29. The row records the *active* campaign only — it deliberately carries no `Fixes #`/`Closes #` line, because this campaign uses map #3247 as its done-anchor and must NOT close it at campaign-start.

Non-§CP (ROADMAP.md only) → flows through the normal review-doc lane.

**Coexistence with #3244:** the open PR #3244 also appends a Campaigns row (crew-mcp-finish, #28) to this same table. The two may trivially conflict on the shared insertion point — whichever merges second rebases. `roadmap-guard` stays green on each individually once both land: each row claims its own open milestone (#28 for #3244, #29 for this one).
