### PR TITLE
refactor(depo): Effect-v4 idiom remediation for infra/depo/worker (#3189)

### DIFF
--- a/infra/depo/worker/domain.ts
+++ b/infra/depo/worker/domain.ts
@@ -11,7 +11,7 @@
  * the *decision* the orchestrator needs — the content address a body maps to.
  */
 import * as Effect from "effect/Effect";
-import {PayloadTooLarge, UnsupportedMediaType} from "./errors.ts";
+import {DigestFailed, PayloadTooLarge, UnsupportedMediaType} from "./errors.ts";
 
 /**
  * The content-type allowlist and its extension. depo holds exactly PNG / JPEG /
@@ -59,7 +59,13 @@ export const withinSizeCap = (size: number): Effect.Effect<number, PayloadTooLar
 
 /** Lowercase hex of a SHA-256 digest — the content-address stem. */
 export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string> =>
-	Effect.promise(() => crypto.subtle.digest("SHA-256", bytes)).pipe(
+	Effect.tryPromise({
+		try: () => crypto.subtle.digest("SHA-256", bytes),
+		catch: (cause) => new DigestFailed({cause}),
+	}).pipe(
+		// The digest is a guaranteed-success content-address computation; a rejection is
+		// a genuine defect, not a domain failure — keep the `E` channel `never`.
+		Effect.orDie,
 		Effect.map((buf) =>
 			Array.from(new Uint8Array(buf))
 				.map((b) => b.toString(16).padStart(2, "0"))

--- a/infra/depo/worker/errors.ts
+++ b/infra/depo/worker/errors.ts
@@ -1,44 +1,59 @@
 /**
  * The doorman's tagged errors — one file for the whole write path (the
- * `.patterns/effect-errors.md` one-`errors.ts`-per-surface rule). Each is a plain
- * `Data.TaggedError`: the doorman is a standalone infra worker with no fate wire
- * codec in scope, so these carry no `FateWireCode` annotation — they map to HTTP
- * status in one place (`worker/index.ts`), not to a wire code.
+ * `.patterns/effect-errors.md` one-`errors.ts`-per-surface rule). Each is a
+ * `Schema.TaggedErrorClass` (the phoenix error idiom the `no-data-taggederror`
+ * rule enforces): the doorman is a standalone infra worker with no fate wire codec
+ * in scope, so these carry no `FateWireCode` annotation — they map to HTTP status
+ * in one place (`worker/index.ts`), not to a wire code.
  *
  * The split mirrors the pattern's domain/infra divide: `Unauthorized`,
- * `UnsupportedMediaType`, `PayloadTooLarge`, and `ContentAddressMismatch` are
+ * `UnsupportedMediaType`, `PayloadTooLarge`, and `ContentAddressConflict` are
  * domain refusals (the caller did something the doorman must reject → 4xx);
- * `StorageError` is infra (an R2 op failed below the domain → 500).
+ * `StorageError`, `DigestFailed`, and `RequestBodyUnreadable` are infra (something
+ * failed below the domain → a 500 or an `orDie`'d defect).
  */
-import * as Data from "effect/Data";
+import * as Schema from "effect/Schema";
 
 /** No/invalid pasaport `apiKey` → 401. Stores nothing. */
-export class Unauthorized extends Data.TaggedError("depo/Unauthorized")<{
-	readonly reason: string;
-}> {}
+export class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()("depo/Unauthorized", {
+	reason: Schema.String,
+}) {}
 
 /** Content-type outside the PNG/JPEG/WebP allowlist → 415. */
-export class UnsupportedMediaType extends Data.TaggedError("depo/UnsupportedMediaType")<{
-	readonly contentType: string;
-}> {}
+export class UnsupportedMediaType extends Schema.TaggedErrorClass<UnsupportedMediaType>()(
+	"depo/UnsupportedMediaType",
+	{contentType: Schema.String},
+) {}
 
 /** Body over the size cap → 413. */
-export class PayloadTooLarge extends Data.TaggedError("depo/PayloadTooLarge")<{
-	readonly size: number;
-	readonly cap: number;
-}> {}
+export class PayloadTooLarge extends Schema.TaggedErrorClass<PayloadTooLarge>()(
+	"depo/PayloadTooLarge",
+	{size: Schema.Number, cap: Schema.Number},
+) {}
 
 /**
  * A second PUT to an existing content-address key whose stored bytes differ from
  * the presented bytes → 409. Write-once immutability: a key never changes content.
  * (A byte-identical re-PUT is NOT this error — it is a benign idempotent success.)
  */
-export class ContentAddressConflict extends Data.TaggedError("depo/ContentAddressConflict")<{
-	readonly key: string;
-}> {}
+export class ContentAddressConflict extends Schema.TaggedErrorClass<ContentAddressConflict>()(
+	"depo/ContentAddressConflict",
+	{key: Schema.String},
+) {}
 
 /** An R2 head/put failed below the domain → 500. Never leaks detail to the caller. */
-export class StorageError extends Data.TaggedError("depo/StorageError")<{
-	readonly op: "head" | "put";
-	readonly cause: unknown;
-}> {}
+export class StorageError extends Schema.TaggedErrorClass<StorageError>()("depo/StorageError", {
+	op: Schema.Literals(["head", "put"]),
+	cause: Schema.Defect(),
+}) {}
+
+/** `crypto.subtle.digest` rejected while content-addressing — an `orDie`'d defect. */
+export class DigestFailed extends Schema.TaggedErrorClass<DigestFailed>()("depo/DigestFailed", {
+	cause: Schema.Defect(),
+}) {}
+
+/** Reading the request body rejected — an `orDie`'d defect. */
+export class RequestBodyUnreadable extends Schema.TaggedErrorClass<RequestBodyUnreadable>()(
+	"depo/RequestBodyUnreadable",
+	{cause: Schema.Defect()},
+) {}

--- a/infra/depo/worker/index.ts
+++ b/infra/depo/worker/index.ts
@@ -19,7 +19,12 @@ import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import {type PayloadTooLarge, StorageError, type UnsupportedMediaType} from "./errors.ts";
+import {
+	type PayloadTooLarge,
+	RequestBodyUnreadable,
+	StorageError,
+	type UnsupportedMediaType,
+} from "./errors.ts";
 import {DepoBucket, PasaportDb} from "./resources.ts";
 import {Storage} from "./storage.ts";
 import {upload} from "./upload.ts";
@@ -114,7 +119,14 @@ export default Doorman.make(
 			"/",
 			Effect.gen(function* () {
 				const raw = yield* Cloudflare.Request;
-				const body = new Uint8Array(yield* Effect.promise(() => raw.arrayBuffer()));
+				// Reading the body is guaranteed-success here; a rejection is a defect, not a
+				// domain failure — `orDie` keeps the route's `E` channel to its typed refusals.
+				const body = new Uint8Array(
+					yield* Effect.tryPromise({
+						try: () => raw.arrayBuffer(),
+						catch: (cause) => new RequestBodyUnreadable({cause}),
+					}).pipe(Effect.orDie),
+				);
 				return yield* upload({
 					apiKey: apiKeyOf(raw.headers),
 					contentType: raw.headers.get("content-type"),


### PR DESCRIPTION
Fixes #3189

## What

Effect-v4 idiom remediation for the `infra/depo/worker/**` surface — the non-§CP slice of the coverage/regression gap split from #3184. Greens the surface so the capstone #2753 can flip the four GritQL rules `warn→error` at a zero baseline.

## Changes

- **`no-data-taggederror`** — `infra/depo/worker/errors.ts`: the five doorman tagged errors move from `Data.TaggedError(...)` to `Schema.TaggedErrorClass<T>()(...)` (the phoenix error idiom; `.patterns/effect-errors.md`). Tag strings, fields, and construction sites are unchanged; these are infra-worker errors with no fate wire codec in scope, so they carry no `FateWireCode` annotation (as before).
- **`no-effect-promise`** — `infra/depo/worker/domain.ts` (`sha256Hex`) and `infra/depo/worker/index.ts` (request-body read): both `Effect.promise(...)` calls become object-notation `Effect.tryPromise({try, catch})` piped to `Effect.orDie`.

## No behavior change

Both promises are guaranteed-success. `Effect.promise` maps a rejection to a **defect**; `tryPromise({try, catch}).pipe(Effect.orDie)` maps a rejection to the tagged `catch` value and then `orDie` collapses it back to a **defect** — identical runtime behavior, and the `E` channel stays `never` so no signature ripples into `upload.ts` or `toResponse`. The two added errors (`DigestFailed`, `RequestBodyUnreadable`) only name the `orDie`'d cause and never surface. Idiom grounded in effect-smol `Effect.ts` (`promise`/`tryPromise` docs) and the in-repo `tryPromise({...}).pipe(Effect.orDie)` precedent (`apps/web/worker/index.ts`).

## Verification

- `pnpm biome check infra/depo` — 0 in-scope `no-data-taggederror` / `no-effect-promise` violations.
- `tsgo` typecheck clean.
- 17 depo unit tests pass.

Scoped to exactly this issue — no `packages/pipeline-cli` (§CP sibling #3184) and no `apps/web/tests/integration` (#3182) touched.