### PR TITLE
fix(crew-mcp): validate channel_send against the kind's schema at the wire

### DIFF
--- a/packages/pipeline-crew-mcp/src/edge/index.ts
+++ b/packages/pipeline-crew-mcp/src/edge/index.ts
@@ -17,5 +17,11 @@ export {
 	type ChannelNotificationPayload,
 	channelExperimentalCapability,
 } from "./mcp-channel.ts";
-export {ChannelSend, ChannelToolkit, channelToolHandlers, SendChannelMessage} from "./send-tool.ts";
+export {
+	ChannelSend,
+	ChannelToolkit,
+	channelToolHandlers,
+	InvalidMessageError,
+	SendChannelMessage,
+} from "./send-tool.ts";
 export {channelServerLayer} from "./server.ts";

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
@@ -91,12 +91,16 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 		}),
 	);
 
-	it.effect("channel_send routes to the live peer and returns its delivered-to-inbox ack", () =>
+	it.effect("channel_send routes a valid message to the live peer and returns its inbox ack", () =>
 		Effect.gen(function* () {
 			const {client} = yield* makeInitializedClient;
 			const result = yield* client["tools/call"]({
 				name: "channel_send",
-				arguments: {targetRole: "reviewer", kind: "IntakePing", body: {issue: "3057"}},
+				arguments: {
+					targetRole: "reviewer",
+					kind: "IntakePing",
+					body: {issue: "3057", from: "intake", at: "2026-07-16T10:00:00Z"},
+				},
 			});
 			assert.isFalse(result.isError);
 			const ack = result.structuredContent as {by?: string; messageId?: string};
@@ -110,7 +114,37 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 			const {client} = yield* makeInitializedClient;
 			const result = yield* client["tools/call"]({
 				name: "channel_send",
-				arguments: {targetRole: "ghost", kind: "IntakePing", body: {}},
+				arguments: {
+					targetRole: "ghost",
+					kind: "IntakePing",
+					body: {issue: "3057", from: "intake", at: "2026-07-16T10:00:00Z"},
+				},
+			});
+			assert.isTrue(result.isError);
+		}),
+	);
+
+	// The shape gate (#3229): an unknown kind or a body that fails its kind's schema is rejected
+	// BEFORE any dial, so the sender never gets a delivered-to-inbox ack for a malformed message.
+	it.effect("channel_send rejects an unknown kind before reaching a peer", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				// a typo'd kind (`IntakePng`) that the catalog does not carry
+				arguments: {targetRole: "reviewer", kind: "IntakePng", body: {issue: "3057"}},
+			});
+			assert.isTrue(result.isError);
+		}),
+	);
+
+	it.effect("channel_send rejects a body that fails its kind's schema before reaching a peer", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				// a known kind, but the body is missing IntakePing's required `from`/`at`
+				arguments: {targetRole: "reviewer", kind: "IntakePing", body: {issue: "3057"}},
 			});
 			assert.isTrue(result.isError);
 		}),

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -11,7 +11,21 @@
 import {Context, Effect, Schema} from "effect";
 import {Tool, Toolkit} from "effect/unstable/ai";
 import {type InboxAck, PeerUnreachableError} from "../peer/index.ts";
-import {Messages} from "../protocol/index.ts";
+import {crewMessageKinds, Messages, payloadSchemaForKind} from "../protocol/index.ts";
+
+/**
+ * A message rejected at the wire because its shape doesn't match the catalog: an unknown
+ * `kind` (not one of the 7 catalog kinds) or a `body` that fails that kind's payload schema.
+ * The gate that makes the typed catalog an invariant, not advice (#3229) — the sender gets
+ * this typed reject instead of a delivered-to-inbox ack, so a wrong shape never reaches a peer.
+ */
+export class InvalidMessageError extends Schema.TaggedErrorClass<InvalidMessageError>()(
+	"@kampus/pipeline-crew-mcp/InvalidMessageError",
+	{
+		kind: Schema.String,
+		reason: Schema.String,
+	},
+) {}
 
 /** The outbound send capability: dial the live peer serving `targetRole` and deliver `kind`/`body`. */
 export class ChannelSend extends Context.Service<
@@ -25,6 +39,37 @@ export class ChannelSend extends Context.Service<
 	}
 >()("@kampus/pipeline-crew-mcp/edge/ChannelSend") {}
 
+/**
+ * Decode `body` against the catalog schema for `kind` before anything is dialed. An unknown
+ * kind or a body that fails its kind's schema short-circuits with an `InvalidMessageError`, so
+ * the send never reaches `ChannelSend.send` and the sender never sees a delivered-to-inbox ack
+ * for a malformed message (#3229). A valid body passes through unchanged.
+ */
+const validateOutbound = (
+	kind: string,
+	body: unknown,
+): Effect.Effect<void, InvalidMessageError> => {
+	const schema = payloadSchemaForKind(kind);
+	if (schema === undefined) {
+		return Effect.fail(
+			new InvalidMessageError({
+				kind,
+				reason: `unknown kind — not one of the catalog kinds: ${crewMessageKinds.join(", ")}`,
+			}),
+		);
+	}
+	return Schema.decodeUnknownEffect(schema)(body).pipe(
+		Effect.asVoid,
+		Effect.mapError(
+			(error) =>
+				new InvalidMessageError({
+					kind,
+					reason: `body does not match the "${kind}" schema: ${error}`,
+				}),
+		),
+	);
+};
+
 /** The one send tool: `{targetRole, kind, body}` in, the delivered-to-inbox ack out. */
 export const SendChannelMessage = Tool.make("channel_send", {
 	description:
@@ -35,17 +80,18 @@ export const SendChannelMessage = Tool.make("channel_send", {
 		body: Schema.Unknown,
 	}),
 	success: Messages.InboxAck,
-	failure: PeerUnreachableError,
+	failure: Schema.Union([PeerUnreachableError, InvalidMessageError]),
 });
 
 export const ChannelToolkit = Toolkit.make(SendChannelMessage);
 
-/** The toolkit handler, routing each call through the `ChannelSend` port. */
+/** The toolkit handler: validate the message shape, then route the send through the `ChannelSend` port. */
 export const channelToolHandlers = ChannelToolkit.toLayer(
 	Effect.gen(function* () {
 		const sender = yield* ChannelSend;
 		return {
-			channel_send: ({body, kind, targetRole}) => sender.send(targetRole, kind, body),
+			channel_send: ({body, kind, targetRole}) =>
+				validateOutbound(kind, body).pipe(Effect.andThen(sender.send(targetRole, kind, body))),
 		};
 	}),
 );

--- a/packages/pipeline-crew-mcp/src/protocol/group.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.test.ts
@@ -9,7 +9,14 @@ import {fileURLToPath} from "node:url";
 import {assert, describe, it} from "@effect/vitest";
 import {Schema} from "effect";
 import {Rpc} from "effect/unstable/rpc";
-import {AnnouncePresence, Claim, CrewProtocol} from "./group.ts";
+import {
+	AnnouncePresence,
+	Claim,
+	CrewProtocol,
+	crewMessageKinds,
+	payloadSchemaForKind,
+} from "./group.ts";
+import * as Messages from "./schema.ts";
 
 describe("protocol/group catalog", () => {
 	it("covers all 7 message kinds (8 rpcs — presence is announce + lookup)", () => {
@@ -46,6 +53,25 @@ describe("protocol/group catalog", () => {
 
 	it("a fire-and-forget kind carries no reply (success is Void)", () => {
 		assert.strictEqual(AnnouncePresence.successSchema, Schema.Void);
+	});
+
+	it("payloadSchemaForKind resolves a catalog kind to its payload schema (#3229)", () => {
+		// the resolver is derived from the catalog, so every kind resolves and a valid payload decodes
+		assert.strictEqual(payloadSchemaForKind("IntakePing"), Messages.IntakePing);
+		const ping = {issue: "3057", from: "intake", at: "2026-07-16T10:00:00Z"};
+		assert.deepStrictEqual(
+			Schema.decodeUnknownSync(payloadSchemaForKind("IntakePing")!)(ping),
+			ping,
+		);
+	});
+
+	it("payloadSchemaForKind returns undefined for a kind outside the catalog (#3229)", () => {
+		assert.strictEqual(payloadSchemaForKind("IntakePng"), undefined);
+		assert.strictEqual(payloadSchemaForKind(""), undefined);
+	});
+
+	it("crewMessageKinds is exactly the catalog's kind names", () => {
+		assert.deepStrictEqual([...crewMessageKinds].sort(), [...CrewProtocol.requests.keys()].sort());
 	});
 
 	it("no protocol source file imports from crew/ (the generic boundary holds)", () => {

--- a/packages/pipeline-crew-mcp/src/protocol/group.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.ts
@@ -8,6 +8,7 @@
  * `Schema.Void`. That success/void split is exactly what distinguishes a
  * request-response kind from a fire-and-forget one on the wire.
  */
+import type {Schema} from "effect";
 import {Rpc, RpcGroup} from "effect/unstable/rpc";
 import * as Messages from "./schema.ts";
 
@@ -64,3 +65,21 @@ export const CrewProtocol = RpcGroup.make(
 	Heartbeat,
 	AckInbox,
 );
+
+/** The catalog's wire `kind` names — the `_tag` of every rpc, the set a `channel_send` may name. */
+export const crewMessageKinds: ReadonlyArray<string> = [...CrewProtocol.requests.keys()];
+
+/**
+ * Resolve a wire `kind` name to the Schema payload the catalog types it as — the seam that lets
+ * a boundary decode a message's `body` against its kind instead of trusting `Schema.Unknown`,
+ * so the 7-kind catalog is enforced at the wire rather than advisory (#3229). Derived straight
+ * from `CrewProtocol.requests` so it can never drift from the catalog above — the catalog *is*
+ * the map. A kind outside the catalog resolves to `undefined`; the caller rejects it.
+ *
+ * The return is a plain-decoding `Schema.Codec` (no decoding services): `Rpc.payloadSchema`
+ * erases to `Schema.Top` (services `unknown`), but every catalog payload is a plain `Struct`
+ * with no service dependency, so the narrower type is the true one — and it lets a caller
+ * `decodeUnknownEffect` the resolved schema with a `never` requirement channel.
+ */
+export const payloadSchemaForKind = (kind: string): Schema.Codec<unknown> | undefined =>
+	CrewProtocol.requests.get(kind)?.payloadSchema as Schema.Codec<unknown> | undefined;

--- a/packages/pipeline-crew-mcp/src/protocol/index.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/index.ts
@@ -9,10 +9,12 @@ export {
 	AnnouncePresence,
 	Claim,
 	CrewProtocol,
+	crewMessageKinds,
 	DrainProgress,
 	EpicHandoff,
 	Heartbeat,
 	IntakePing,
 	LookupRole,
+	payloadSchemaForKind,
 } from "./group.ts";
 export * as Messages from "./schema.ts";


### PR DESCRIPTION
`channel_send` accepted `kind: NonEmptyString, body: Unknown` and delivered/acked any shape unchecked — the typed 7-kind `protocol/` catalog was advisory at the wire. A typo'd kind (`IntakePng`) or a malformed body reached the peer and was acked identically to a valid message, so the sender always saw success.

## What changed
- **`protocol/group.ts`** — add `payloadSchemaForKind(kind)`, a kind-name→payload-schema resolver **derived straight from `CrewProtocol.requests`** so it can never drift from the catalog (the catalog *is* the map), plus `crewMessageKinds` (the wire kind names). An unknown kind resolves to `undefined`.
- **`edge/send-tool.ts`** — decode `body` against the resolved kind schema at the **send boundary, before any dial**. An unknown kind or a body that fails its kind's schema short-circuits with a new typed `InvalidMessageError`; the widened tool `failure` is `Union([PeerUnreachableError, InvalidMessageError])`. The sender gets a typed reject — never a delivered-to-inbox ack for an invalid message. A valid `{kind, body}` delivers unchanged.
- **`protocol/index.ts` / `edge/index.ts`** — export the resolver and the error.

## Tests
- `edge/send-tool.test.ts` — reject an unknown kind and a malformed body (both error results, never reach the peer); the valid-path and offline-path tests now send fully-valid `IntakePing` bodies.
- `protocol/group.test.ts` — the resolver resolves a catalog kind to its payload schema, returns `undefined` off-catalog, and `crewMessageKinds` matches the catalog.

Full package suite (69 tests) green; `pnpm typecheck` + `pnpm lint:worktree` clean.

## Scope
Validates message **shape**, not **authorization**. The per-edge directed-authority model (`crew/catalog.ts`) is explicitly out of scope here — tracked with #3210 / #3228. This PR does not touch `crew/`.

Fixes #3229