### PR TITLE
fix(pipeline-crew-mcp): wire the tracker launch — first-peer-spawn hosts the socket (#3219)

### DIFF
--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -4,12 +4,18 @@
  *
  *   node src/bin.ts                                  # the root command (no seam wired)
  *   node src/bin.ts session --role <role>            # run one live crew session (stdio MCP)
+ *   node src/bin.ts tracker                           # run a standalone per-project tracker
  *
  * The `session` subcommand is the runnable stdio MCP entry (#3062): it stands up one live crew
  * session's `McpServer` over stdio + its channel peer, so the crew's inter-session seams run over
  * the channels protocol. `--role` is one of the five standing `CREW_ROLES` (the roster is the
  * single source — the flag chooses from it, never a re-declared list); the session joins the
- * per-project tracker at `--project-root` (default: cwd). It runs until interrupted.
+ * per-project tracker at `--project-root` (default: cwd), first-peer-spawn hosting it if no peer
+ * has yet. It runs until interrupted.
+ *
+ * The `tracker` subcommand stands a project's tracker up on its own (`launchTracker`), decoupled
+ * from any role session — the explicit way to pre-warm or keep a registry alive across session
+ * restarts. It is idempotent: if a tracker already serves the project it reports so and exits 0.
  *
  * NB: an MCP stdio server owns stdout for JSON-RPC, so the one startup line goes to STDERR — a
  * log on stdout would corrupt the protocol stream.
@@ -18,10 +24,11 @@
  * for the typed command, the Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Effect} from "effect";
+import {Cause, Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 
 import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
+import {isTrackerAddressInUse, launchTracker} from "./tracker/index.ts";
 import {VERSION} from "./version.ts";
 
 const roleFlag = Flag.choice("role", CREW_ROLES).pipe(
@@ -51,6 +58,27 @@ const session = Command.make(
 	}),
 ).pipe(Command.withDescription("Run one live crew session: stdio MCP server + channel peer"));
 
+const tracker = Command.make(
+	"tracker",
+	{projectRoot: projectRootFlag},
+	Effect.fn(function* ({projectRoot}) {
+		yield* Console.error(
+			`pipeline-crew-mcp ${VERSION} — standalone tracker for project ${projectRoot}`,
+		);
+		return yield* launchTracker(projectRoot).pipe(
+			Effect.catchCause((cause) =>
+				isTrackerAddressInUse(cause)
+					? Console.error(`a tracker already serves project ${projectRoot} — nothing to do`)
+					: Console.error(`tracker failed to start: ${String(Cause.squash(cause))}`).pipe(
+							Effect.andThen(Effect.sync(() => process.exit(1))),
+						),
+			),
+		);
+	}),
+).pipe(
+	Command.withDescription("Run a standalone per-project tracker (the registry socket server)"),
+);
+
 const cli = Command.make(
 	"pipeline-crew-mcp",
 	{},
@@ -61,7 +89,7 @@ const cli = Command.make(
 	}),
 ).pipe(
 	Command.withDescription("The crew's channels-backed messaging substrate (epic #3045)"),
-	Command.withSubcommands([session]),
+	Command.withSubcommands([session, tracker]),
 );
 
 cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -35,6 +35,7 @@ export {
 export {
 	type ClaimReply,
 	CrewTracker,
+	crewTrackerHostOrDialLayer,
 	crewTrackerSocketLayer,
 	peerTrackerLayer,
 	type TrackerRegistryClient,

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -48,7 +48,7 @@ import {
 } from "./channel-server.ts";
 import type {RoleUniquenessError} from "./errors.ts";
 import type {CrewRole} from "./roles.ts";
-import {type CrewTracker, crewTrackerSocketLayer, peerTrackerLayer} from "./tracker.ts";
+import {type CrewTracker, crewTrackerHostOrDialLayer, peerTrackerLayer} from "./tracker.ts";
 
 /** The MCP server identity a crew session advertises over stdio when none is configured. */
 export const SESSION_SERVER_NAME = "@kampus/pipeline-crew-mcp" as const;
@@ -75,15 +75,20 @@ export const inboxAddressFor = (role: CrewRole): string => `inbox://${role}`;
 export const inboxSocketFor = (role: CrewRole): string => inboxSocketPathFor(inboxAddressFor(role));
 
 /**
- * The peer substrate over real unix sockets: the socket `CrewTracker`, the peer `Tracker` port
+ * The peer substrate over real unix sockets: the first-peer-spawn `CrewTracker` (host the tracker
+ * if the project socket is free, else dial the peer already hosting it), the peer `Tracker` port
  * derived from it (one shared tracker client), this peer's local inbox log, and the socket dialer.
  * The production substrate `channelSendFromPeer` runs on; the tests inject an in-memory one
  * (an `RpcTest` `CrewTracker` + an in-memory `Dialer`) to drive the same binding transport-free.
+ *
+ * Hosting the tracker here (`crewTrackerHostOrDialLayer`) is what makes a session self-sufficient:
+ * the first session for a project stands the tracker up, later sessions dial it, so a crew no longer
+ * fails at startup on an unserved socket.
  */
 export const peerSocketSubstrate = (
 	config: CrewSessionConfig,
 ): Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown> => {
-	const crewTracker = crewTrackerSocketLayer(socketPathFor(config.projectRoot));
+	const crewTracker = crewTrackerHostOrDialLayer(socketPathFor(config.projectRoot));
 	return Layer.mergeAll(
 		peerTrackerLayer.pipe(Layer.provideMerge(crewTracker)),
 		Inbox.layer(inboxAddressFor(config.role)),

--- a/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
@@ -1,0 +1,75 @@
+/**
+ * crew/tracker — the first-peer-spawn host-or-dial binding: one project socket, one live tracker.
+ *
+ * The socket cases need a REAL unix socket — a bind a second peer's bind can race — so they drive
+ * `crewTrackerHostOrDialLayer` end to end rather than an in-memory `RpcTest` client. The bind-race
+ * detector (`isTrackerAddressInUse`) is a pure unit check.
+ */
+import {randomUUID} from "node:crypto";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Context, Effect, Layer, Option} from "effect";
+import {SocketServerError, SocketServerOpenError} from "effect/unstable/socket/SocketServer";
+import {isTrackerAddressInUse} from "../tracker/index.ts";
+import {CrewTracker, crewTrackerHostOrDialLayer} from "./tracker.ts";
+
+const errWithCode = (code: string): Error => Object.assign(new Error(code), {code});
+
+describe("crew/tracker — first-peer-spawn: two sessions on one project root, one live tracker", () => {
+	it.effect("the second layer binds→EADDRINUSE→dials the first's tracker (shared registry)", () =>
+		Effect.gen(function* () {
+			const socketPath = join(tmpdir(), `crew-hostdial-${randomUUID().slice(0, 8)}.sock`);
+			// Two concurrent sessions on ONE socket: the first hosts, the second must dial the host —
+			// exactly one server binds. If two bound, they'd be two registries and the cross-lookup fails.
+			const ctxA = yield* Layer.build(crewTrackerHostOrDialLayer(socketPath));
+			const ctxB = yield* Layer.build(crewTrackerHostOrDialLayer(socketPath));
+			const trackerA = Context.get(ctxA, CrewTracker);
+			const trackerB = Context.get(ctxB, CrewTracker);
+			// A announces; B looks it up and finds it ⇒ both speak to the SAME registry ⇒ one tracker.
+			yield* trackerA.announce({
+				role: "builder",
+				peer: "inbox://builder",
+				address: "inbox://builder",
+			});
+			const found = yield* trackerB.lookup("builder");
+			assert.isTrue(Option.isSome(found), "the dialing session sees the host's registry state");
+			if (Option.isSome(found)) assert.strictEqual(found.value.address, "inbox://builder");
+		}).pipe(Effect.scoped),
+	);
+
+	it.effect("a lone session hosts its own tracker (announce→lookup round-trips on one layer)", () =>
+		Effect.gen(function* () {
+			const socketPath = join(tmpdir(), `crew-solo-${randomUUID().slice(0, 8)}.sock`);
+			const ctx = yield* Layer.build(crewTrackerHostOrDialLayer(socketPath));
+			const tracker = Context.get(ctx, CrewTracker);
+			yield* tracker.announce({
+				role: "reviewer",
+				peer: "inbox://reviewer",
+				address: "inbox://reviewer",
+			});
+			const found = yield* tracker.lookup("reviewer");
+			assert.isTrue(Option.isSome(found), "a session with no peer still has a working tracker");
+		}).pipe(Effect.scoped),
+	);
+});
+
+describe("crew/tracker — isTrackerAddressInUse (the bind-race detector the dial fallback keys on)", () => {
+	it("is true for a SocketServerError whose open cause is EADDRINUSE", () => {
+		const error = new SocketServerError({
+			reason: new SocketServerOpenError({cause: errWithCode("EADDRINUSE")}),
+		});
+		assert.isTrue(isTrackerAddressInUse(Cause.fail(error)));
+	});
+
+	it("is false for a non-EADDRINUSE bind failure (it must propagate, never be dialed over)", () => {
+		const error = new SocketServerError({
+			reason: new SocketServerOpenError({cause: errWithCode("EACCES")}),
+		});
+		assert.isFalse(isTrackerAddressInUse(Cause.fail(error)));
+	});
+
+	it("is false for an unrelated failure", () => {
+		assert.isFalse(isTrackerAddressInUse(Cause.fail(new Error("not a bind error"))));
+	});
+});

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -17,7 +17,7 @@ import {Context, Effect, Layer, Option, type Scope} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
 import {type RolePresence, Tracker} from "../peer/index.ts";
 import type * as Schema from "../protocol/schema.ts";
-import {TrackerRegistry} from "../tracker/index.ts";
+import {isTrackerAddressInUse, TrackerRegistry, trackerServerLayer} from "../tracker/index.ts";
 
 /** The typed answer to a claim/collision-check — re-exported so consumers name one type. */
 export type ClaimReply = typeof Schema.ClaimReply.Type;
@@ -106,4 +106,25 @@ const trackerClientSocketProtocol = (socketPath: string) =>
 export const crewTrackerSocketLayer = (socketPath: string) =>
 	Layer.unwrap(RpcClient.make(TrackerRegistry).pipe(Effect.map(CrewTracker.fromClient))).pipe(
 		Layer.provide(trackerClientSocketProtocol(socketPath)),
+	);
+
+/**
+ * The first-peer-spawn `CrewTracker` binding a runnable session uses: host the tracker for this
+ * project if the socket is free, otherwise dial the peer that already hosts it. The first bind wins
+ * the socket; a racing peer's bind raises `EADDRINUSE`, caught here so it dials the existing tracker
+ * instead of crashing — the exact story `../tracker/server.ts` documents, now wired. Two concurrent
+ * sessions on one project root thus resolve to exactly one live tracker.
+ *
+ * `Layer.provide` sequences the bind before the dial (the server layer is built first, so the socket
+ * is listening before the client connects) and keeps the hosted server scoped for the session's
+ * lifetime. A non-`EADDRINUSE` bind failure is re-raised, never dialed over.
+ */
+export const crewTrackerHostOrDialLayer = (socketPath: string): Layer.Layer<CrewTracker, unknown> =>
+	crewTrackerSocketLayer(socketPath).pipe(
+		Layer.provide(trackerServerLayer(socketPath)),
+		Layer.catchCause((cause) =>
+			isTrackerAddressInUse(cause)
+				? crewTrackerSocketLayer(socketPath)
+				: Layer.effect(CrewTracker, Effect.failCause(cause)),
+		),
 	);

--- a/packages/pipeline-crew-mcp/src/tracker/index.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/index.ts
@@ -14,4 +14,9 @@ export {
 	type PresenceRecord,
 	type RegistryState,
 } from "./registry-core.ts";
-export {launchTracker, socketPathFor, trackerServerLayer} from "./server.ts";
+export {
+	isTrackerAddressInUse,
+	launchTracker,
+	socketPathFor,
+	trackerServerLayer,
+} from "./server.ts";

--- a/packages/pipeline-crew-mcp/src/tracker/server.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.ts
@@ -1,12 +1,16 @@
 /**
- * tracker/server — the standing registry `RpcServer` over a per-project unix socket, and the
- * first-peer-spawn launch entry.
+ * tracker/server — the standing registry `RpcServer` over a per-project unix socket: the raw
+ * `trackerServerLayer` bind, the standalone `launchTracker` entry, and the `EADDRINUSE` detector
+ * (`isTrackerAddressInUse`) the first-peer-spawn dial fallback keys on.
  *
  * The socket path is derived deterministically from the project root (`socketPathFor`), so every
  * peer of one project rendezvous on the same socket while different projects stay isolated — the
  * "per-project socket". The tracker is brought up by whichever peer needs it first (first-peer-
  * spawn): the first bind wins the socket; a later peer's bind gets `EADDRINUSE`, the signal that a
- * tracker is already serving this project, and it connects as a client instead.
+ * tracker is already serving this project, and it connects as a client instead. That host-or-dial
+ * wiring — which combines this server layer with the crew's registry client — lives in
+ * `../crew/tracker.ts` (`crewTrackerHostOrDialLayer`), because it needs both halves; this module
+ * owns only the server half plus the bind-error primitive that path branches on.
  *
  * The served surface is `TrackerRegistry` — registry kinds only (see `./group.ts`); the tracker
  * has no handler for any message-relay kind, so it structurally cannot relay a message.
@@ -15,8 +19,9 @@ import {createHash} from "node:crypto";
 import {tmpdir} from "node:os";
 import {join, resolve} from "node:path";
 import {NodeSocketServer} from "@effect/platform-node";
-import {type Effect, Layer} from "effect";
+import {Cause, type Effect, Layer, Option} from "effect";
 import {RpcSerialization, RpcServer} from "effect/unstable/rpc";
+import {SocketServerError} from "effect/unstable/socket/SocketServer";
 import {TrackerRegistry} from "./group.ts";
 import {TrackerHandlers} from "./handlers.ts";
 import {RegistryLive} from "./registry.ts";
@@ -50,9 +55,32 @@ export const trackerServerLayer = (socketPath: string) =>
 	);
 
 /**
- * First-peer-spawn entry: launch the tracker for `projectRoot` and keep it running until
- * interrupted (`Layer.launch` builds the server layer and blocks, closing it on teardown). A
- * `SocketServerError` from an already-bound socket means a tracker is already up for this project.
+ * Standalone tracker entry: launch a dedicated tracker for `projectRoot` and keep it running until
+ * interrupted (`Layer.launch` builds the server layer and blocks, closing it on teardown). Drives
+ * the bin's `tracker` subcommand — the explicit way to stand a project's tracker up decoupled from
+ * any role session. It fails fast with a `SocketServerError` when the socket is already bound
+ * (`isTrackerAddressInUse`), the signal that a tracker is already up for this project; the caller
+ * decides whether that is a clean no-op (the subcommand treats it as "already serving").
+ *
+ * A live crew session does NOT use this blocking entry — it hosts the tracker as a scoped layer via
+ * `crewTrackerHostOrDialLayer` (first-peer-spawn), so the server runs alongside the session rather
+ * than blocking it.
  */
 export const launchTracker = (projectRoot: string): Effect.Effect<never, unknown> =>
 	Layer.launch(trackerServerLayer(socketPathFor(projectRoot)));
+
+/**
+ * Is this cause a tracker-socket bind that lost the race — an `EADDRINUSE` raised while opening the
+ * server? The first-peer-spawn signal that a tracker is already serving the socket, so the caller
+ * should dial the existing one instead of failing. Narrow on purpose: a non-`EADDRINUSE` bind
+ * failure (bad permissions, a missing runtime dir) is a real error that must propagate, never be
+ * silently swallowed into a dial that would only fail more opaquely.
+ */
+export const isTrackerAddressInUse = (cause: Cause.Cause<unknown>): boolean =>
+	Option.match(Cause.findErrorOption(cause), {
+		onNone: () => false,
+		onSome: (error) =>
+			error instanceof SocketServerError &&
+			error.reason._tag === "SocketServerOpenError" &&
+			(error.reason.cause as NodeJS.ErrnoException | undefined)?.code === "EADDRINUSE",
+	});


### PR DESCRIPTION
Fixes #3219

## Problem

The shipped `session` subcommand dialed a per-project tracker socket that **nothing bound**, so every crew session failed at startup on an unserved socket. `launchTracker` existed but was referenced from nowhere, and `tracker/server.ts`'s docblock described a first-peer-spawn / `EADDRINUSE` launch story that was **described, not wired**.

## Change

The first-peer-spawn story, now wired — plus a real call site for `launchTracker`:

- **`crew/tracker.ts` — `crewTrackerHostOrDialLayer(socketPath)`**: the session binding. Bind the tracker server for the project (host); on `EADDRINUSE` (a peer already hosts it) catch and dial the existing tracker. `Layer.provide` sequences bind-before-dial (the server layer builds first, so the socket is listening before the client connects) and keeps the hosted server scoped for the session's lifetime. A **non-`EADDRINUSE`** bind failure re-raises — never silently dialed over.
- **`crew/session.ts`**: `peerSocketSubstrate` now uses the host-or-dial binding, so running the `session` subcommand brings up a working tracker — the first session hosts, later sessions dial.
- **`tracker/server.ts` — `isTrackerAddressInUse`**: the narrow `EADDRINUSE` detector the dial fallback keys on (a `SocketServerError` whose open cause is `EADDRINUSE`). Docblock reconciled: the host-or-dial wiring lives in `crew/tracker.ts`; this module owns the server half + the bind-error primitive.
- **`bin.ts`**: a standalone `tracker` subcommand runs `launchTracker` (its real call site) — the explicit way to stand a project tracker up decoupled from a session. Idempotent: an already-serving socket reports so and exits 0.

## Acceptance criteria

- [x] Running the shipped bin brings up a working tracker for a project root — a session no longer fails at startup on an unserved socket (`session` first-peer-spawn hosts; `tracker` subcommand stands one up standalone).
- [x] Launch wired the way `tracker/server.ts` documents (first-peer-spawn: bind wins, a racing peer catches `EADDRINUSE` and dials) — and the docblock reconciled to point at where the host-or-dial wiring lives.
- [x] `launchTracker` has a real call site (the `tracker` subcommand) — no longer dead-except-for-re-export.
- [x] Two concurrent sessions for one project root resolve to **exactly one live tracker** (the second binds→`EADDRINUSE`→dials) — proven by `crew/tracker.test.ts` (announce on the host's layer is visible via the dialer's layer ⇒ one shared registry).

## Verification

- `pnpm typecheck` clean; `pnpm test` — 69 passed (5 new in `crew/tracker.test.ts`: two real-unix-socket first-peer-spawn cases + three `isTrackerAddressInUse` unit cases).
- Smoke: `node src/bin.ts tracker` binds; a second invocation on the same project root prints `already serves … — nothing to do` and exits 0.

## Notes

- **NON-§CP** by path, but `packages/pipeline-crew-mcp/` merges via the control-plane PR path (a merge-time property, per the issue's triage notes).
- Stayed within the tracker-launch write-surface (`bin.ts`, `crew/tracker.ts`, `crew/session.ts`, `tracker/server.ts` + their index re-exports); did **not** touch `protocol/schema.ts`, `edge/send-tool.ts`, or `peer/inbox.ts` (sibling lane #3229). Left `crew/session.ts` + `crew/tracker.ts` clean for the downstream heartbeat sender (#3218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)