### PR TITLE
feat(pipeline-crew-mcp): heartbeat sender keeps a live session's presence lease alive

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/heartbeat.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/heartbeat.test.ts
@@ -1,0 +1,79 @@
+/**
+ * crew/heartbeat — the presence keepalive keeps a live session's lease from aging out (#3218).
+ *
+ * Two properties: the interval-vs-TTL relationship (a pure constant check — the load-bearing
+ * invariant that a beat lands before the lease ages), and the behavioral proof over a `TestClock`
+ * that a session live past `DEFAULT_TTL_SECONDS` stays present WITH the loop and ages out WITHOUT
+ * it — driven fully in-memory against the real `TrackerRegistry` (an `RpcTest` client + the
+ * registry handlers), the same transport-free idiom `session.test.ts` uses.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Duration, Effect, Layer} from "effect";
+import {TestClock} from "effect/testing";
+import {RpcTest} from "effect/unstable/rpc";
+import {TrackerRegistry} from "../tracker/group.ts";
+import {TrackerHandlers} from "../tracker/handlers.ts";
+import {DEFAULT_TTL_SECONDS} from "../tracker/index.ts";
+import {RegistryLive} from "../tracker/registry.ts";
+import {
+	crewHeartbeatLayer,
+	HEARTBEAT_INTERVAL_SECONDS,
+	HEARTBEAT_TTL_SECONDS,
+} from "./heartbeat.ts";
+import {CrewTracker} from "./tracker.ts";
+
+const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+
+const role = "builder";
+const peer = "inbox://builder";
+// Well past the TTL: the loop must refresh the lease across multiple windows to keep it live.
+const pastTtl = Duration.seconds(HEARTBEAT_TTL_SECONDS * 3);
+
+describe("crew/heartbeat — the send interval stays safely under the TTL", () => {
+	it("beats more than once per TTL window, with headroom for a dropped beat", () => {
+		assert.isBelow(
+			HEARTBEAT_INTERVAL_SECONDS,
+			HEARTBEAT_TTL_SECONDS,
+			"the send interval must be under the TTL or the lease ages out between beats",
+		);
+		assert.isAtMost(
+			HEARTBEAT_INTERVAL_SECONDS * 2,
+			HEARTBEAT_TTL_SECONDS,
+			"two intervals must fit in the TTL so a single missed beat is survivable",
+		);
+		assert.strictEqual(
+			HEARTBEAT_TTL_SECONDS,
+			DEFAULT_TTL_SECONDS,
+			"a beat requests the tracker's default TTL, so it renews the full lease window",
+		);
+	});
+});
+
+describe("crew/heartbeat — a live session outlives the TTL with the loop, ages out without it", () => {
+	it.effect("with the heartbeat loop, presence survives past DEFAULT_TTL_SECONDS", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			yield* client.AnnouncePresence({peer, role, at: new Date().toISOString()});
+			// Fork the keepalive loop into this scope; it refreshes the lease every interval.
+			yield* Layer.build(
+				crewHeartbeatLayer(peer).pipe(Layer.provide(CrewTracker.fromClient(client))),
+			);
+			yield* TestClock.adjust(pastTtl);
+			const present = yield* client.LookupRole({role});
+			assert.lengthOf(present.peers, 1, "the lease is still live — the heartbeat refreshed it");
+			assert.strictEqual(present.peers[0]?.peer, peer);
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect(
+		"without the loop, the same presence ages out past DEFAULT_TTL_SECONDS (the #3218 bug)",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				yield* client.AnnouncePresence({peer, role, at: new Date().toISOString()});
+				yield* TestClock.adjust(pastTtl);
+				const present = yield* client.LookupRole({role});
+				assert.lengthOf(present.peers, 0, "with no keepalive the one-shot announce ages out");
+			}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/crew/heartbeat.ts
+++ b/packages/pipeline-crew-mcp/src/crew/heartbeat.ts
@@ -1,0 +1,45 @@
+/**
+ * crew/heartbeat — the presence keepalive sender: a background fiber that re-sends `Heartbeat`
+ * on an interval safely under `DEFAULT_TTL_SECONDS`, so a live session's presence + role lease
+ * never ages out. Without it the substrate only functions for the first ~30s window (#3218).
+ *
+ * Presence-only by construction: each tick sends exactly one `Heartbeat {peer, ttlSeconds}` and
+ * nothing else — it never refreshes or iterates a resource claim. A finished claim is freed by
+ * `Release`; a crashed holder's claims are reaped when its presence ages out. Keeping the sender
+ * presence-only is what stops a live session's beats from holding a stale claim alive (#3228).
+ * The tracker-side keyspace split that makes the registry's own refresh presence-only is #3281,
+ * layered on after this.
+ */
+import {Duration, Effect, Layer, Schedule} from "effect";
+import {DEFAULT_TTL_SECONDS} from "../tracker/index.ts";
+import {CrewTracker} from "./tracker.ts";
+
+/** The TTL window each heartbeat requests — the tracker's default, so a beat renews the full lease. */
+export const HEARTBEAT_TTL_SECONDS = DEFAULT_TTL_SECONDS;
+
+/**
+ * The send interval, a third of the TTL: a live session refreshes ~3× per window, so even a dropped
+ * beat still lands the next refresh under the TTL before the lease ages out. The interval-under-TTL
+ * relationship is the load-bearing invariant (`heartbeat.test.ts`).
+ */
+export const HEARTBEAT_INTERVAL_SECONDS = DEFAULT_TTL_SECONDS / 3;
+
+const heartbeatInterval = Duration.seconds(HEARTBEAT_INTERVAL_SECONDS);
+
+/**
+ * The keepalive loop as a background-task layer (the `Layer.effectDiscard` + `forkScoped` idiom):
+ * on build it forks a scoped fiber that sends a `Heartbeat` for `peer` immediately and then every
+ * `HEARTBEAT_INTERVAL_SECONDS`, refreshing this session's presence + role lease. The fiber is
+ * interrupted when the session scope closes, leaving the lease to TTL-age. Share this layer's
+ * `CrewTracker` with the rest of the session (by memoization) so the beats reach the same registry
+ * the presence was announced on.
+ */
+export const crewHeartbeatLayer = (peer: string): Layer.Layer<never, never, CrewTracker> =>
+	Layer.effectDiscard(
+		Effect.gen(function* () {
+			const tracker = yield* CrewTracker;
+			yield* tracker
+				.heartbeat({peer, ttlSeconds: HEARTBEAT_TTL_SECONDS})
+				.pipe(Effect.repeat(Schedule.spaced(heartbeatInterval)), Effect.forkScoped);
+		}),
+	);

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -47,6 +47,7 @@ import {
 	makeCrewChannel,
 } from "./channel-server.ts";
 import type {RoleUniquenessError} from "./errors.ts";
+import {crewHeartbeatLayer} from "./heartbeat.ts";
 import type {CrewRole} from "./roles.ts";
 import {type CrewTracker, crewTrackerHostOrDialLayer, peerTrackerLayer} from "./tracker.ts";
 
@@ -130,14 +131,20 @@ export const crewSessionLayer = (config: CrewSessionConfig) => {
 		experimental: channelExperimentalCapability,
 	}).pipe(Layer.provide(NodeStdio.layer));
 
+	// The peer substrate, built once and SHARED (by memoization) between the outbound binding and the
+	// heartbeat loop, so both drive the one hosted tracker / registry this session announces on.
+	const substrate = peerSocketSubstrate(config);
+
 	// outbound: the channel_send toolkit, its ChannelSend bound to this session's peer.
 	const outbound = McpServer.toolkit(ChannelToolkit).pipe(
 		Layer.provide(channelToolHandlers),
-		Layer.provide(
-			channelSendFromPeer(config.role).pipe(Layer.provide(peerSocketSubstrate(config))),
-		),
+		Layer.provide(channelSendFromPeer(config.role).pipe(Layer.provide(substrate))),
 		Layer.provide(server),
 	);
+
+	// keepalive: refresh this session's presence + role lease under the TTL so it never ages out while
+	// the session is live (#3218). Shares `substrate`, so the beats reach the registry announced on.
+	const heartbeat = crewHeartbeatLayer(address).pipe(Layer.provide(substrate));
 
 	// inbound: the peer-inbox socket server, its deliveries waking THIS running server.
 	const inbound = inboxServerSocketLayer(address).pipe(
@@ -145,7 +152,7 @@ export const crewSessionLayer = (config: CrewSessionConfig) => {
 		Layer.provide(server),
 	);
 
-	return Layer.mergeAll(outbound, inbound);
+	return Layer.mergeAll(outbound, heartbeat, inbound);
 };
 
 /**

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -25,9 +25,10 @@ type ClaimRequest = typeof Schema.ClaimRequest.Type;
 type PresenceAnnouncement = typeof Schema.PresenceAnnouncement.Type;
 type RoleLookupQuery = typeof Schema.RoleLookupQuery.Type;
 type RoleLookupResult = typeof Schema.RoleLookupResult.Type;
+type HeartbeatMessage = typeof Schema.Heartbeat.Type;
 
 /**
- * The structural shape of the registry client the crew depends on — the three registry
+ * The structural shape of the registry client the crew depends on — the four registry
  * kinds it drives. Any `RpcClient(TrackerRegistry)` satisfies it (the real socket client,
  * or an in-memory `RpcTest` client in tests); the error channel is `unknown` because it is
  * `orDie`'d at the seam.
@@ -36,6 +37,7 @@ export interface TrackerRegistryClient {
 	readonly Claim: (payload: ClaimRequest) => Effect.Effect<ClaimReply, unknown>;
 	readonly AnnouncePresence: (payload: PresenceAnnouncement) => Effect.Effect<void, unknown>;
 	readonly LookupRole: (payload: RoleLookupQuery) => Effect.Effect<RoleLookupResult, unknown>;
+	readonly Heartbeat: (payload: HeartbeatMessage) => Effect.Effect<void, unknown>;
 }
 
 const now = (): string => new Date().toISOString();
@@ -51,6 +53,15 @@ export class CrewTracker extends Context.Service<
 		}) => Effect.Effect<ClaimReply>;
 		/** Soft presence announce, held for the enclosing scope (connection-is-lease). */
 		readonly announce: (presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>;
+		/**
+		 * Refresh this session's presence + role lease before it ages out. Presence-only: the sender
+		 * sends one `Heartbeat {peer, ttlSeconds}` and never touches a resource claim (#3228). Driven
+		 * on an interval under the TTL by `crew/heartbeat.ts`.
+		 */
+		readonly heartbeat: (input: {
+			readonly peer: string;
+			readonly ttlSeconds: number;
+		}) => Effect.Effect<void>;
 		/** The live holder of `role`, or `None` when absent/expired — the explicit not-present result. */
 		readonly lookup: (role: string) => Effect.Effect<Option.Option<RolePresence>>;
 	}
@@ -66,10 +77,14 @@ export class CrewTracker extends Context.Service<
 					client
 						.AnnouncePresence({peer: presence.address, role: presence.role, at: now()})
 						.pipe(Effect.orDie),
-					// The release rides the socket lifecycle (a dropped connection ages/frees the lease);
-					// there is no wire release kind, so scope close is a no-op on the client side.
+					// No wire release kind exists, so scope close is a client-side no-op. A live session
+					// keeps its lease via the heartbeat loop (crew/heartbeat.ts) refreshing it under
+					// DEFAULT_TTL_SECONDS; a dropped session's lease frees by TTL-aging once the beats
+					// stop — the tracker has no disconnect hook.
 					() => Effect.void,
 				),
+			heartbeat: ({peer, ttlSeconds}) =>
+				client.Heartbeat({peer, ttlSeconds, at: now()}).pipe(Effect.orDie),
 			lookup: (role) =>
 				client.LookupRole({role}).pipe(
 					Effect.orDie,


### PR DESCRIPTION
`packages/pipeline-crew-mcp` defined a `Heartbeat` message and the tracker served it, but nothing on the session side ever sent one — so a session's presence + role lease aged out ~30s after startup (`DEFAULT_TTL_SECONDS`), after which every `channel_send` failed `PeerUnreachableError` and the role became reclaimable by a duplicate. The substrate only worked inside a single ~30s window.

This wires the **sender** (only):

- **`crew/tracker.ts`** — a presence-only `heartbeat` method on `CrewTracker` (+ `Heartbeat` on the `TrackerRegistryClient` interface) that sends `Heartbeat {peer, ttlSeconds}`. Each beat sends one presence keepalive and never touches a resource claim (#3228).
- **`crew/heartbeat.ts`** (new) — a background-task layer (`Layer.effectDiscard` + `forkScoped`, the effect-smol idiom) that forks a scoped fiber sending a beat immediately and then every `HEARTBEAT_INTERVAL_SECONDS` (a third of the TTL, headroom for a dropped beat), refreshing the session's presence + role lease and interrupting on scope close.
- **`crew/session.ts`** — merges the loop into `crewSessionLayer`, sharing the peer substrate (one `CrewTracker` / registry) by memoization so the beats reach the tracker the presence was announced on.
- **`crew/tracker.ts`** — reconciles the `announce` finalizer docblock (AC3): the release is a client-side no-op because there is no wire release kind; a live session keeps its lease via the heartbeat loop, a dropped one frees by TTL-aging — the tracker has no disconnect hook.

**Scope guard:** presence-only by construction — this adds no claim-refresh behavior. The tracker-side keyspace split that makes the registry's own refresh presence-only is #3281, layered on after this merges.

**Tests** (`crew/heartbeat.test.ts`): the interval-vs-TTL invariant (AC4), plus a `TestClock` proof that a session live past `DEFAULT_TTL_SECONDS` stays present WITH the loop and ages out WITHOUT it (AC1/AC2).

Acceptance criteria:
- [x] Periodic heartbeat loop re-sends `Heartbeat` at an interval safely under `DEFAULT_TTL_SECONDS`.
- [x] A session live longer than `DEFAULT_TTL_SECONDS` still resolves (lease non-expired; role non-claimable), proven over `TestClock`.
- [x] The `announce` finalizer docblock reconciled — states TTL-aging + heartbeat-refresh as the real mechanism.
- [x] Interval-vs-TTL relationship covered by a unit test.

Fixes #3218