### PR TITLE
refactor(pipeline-cli): remediate Effect-v4 idiom violations (§CP-adjacent)

### DIFF
--- a/packages/pipeline-cli/src/tools/catalog-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/gate.ts
@@ -14,7 +14,8 @@
  */
 import {existsSync, readdirSync, readFileSync, statSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {
 	type AllowlistEntry,
 	DEFAULT_ALLOWLIST,
@@ -26,13 +27,15 @@ import {
 } from "./catalog-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 /**
  * Expand the declared workspace globs into repo-relative `package.json` paths, plus

--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -74,6 +74,7 @@ const namespacesFlag = Flag.boolean("namespaces").pipe(
 /** Read the changed-file list from `--files-from` or stdin; empty/failed read ⇒ no files. */
 const readFiles = (filesFrom: Option.Option<string>): ReadonlyArray<string> => {
 	let raw: string;
+	// biome-ignore lint/plugin: best-effort read — an empty/failed read is absorbed into no files ([]), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		raw = Option.match(filesFrom, {
 			onSome: (path) => readFileSync(path, "utf8"),
@@ -90,6 +91,7 @@ const readFiles = (filesFrom: Option.Option<string>): ReadonlyArray<string> => {
 
 /** Read local §CLASS text; null (⇒ fail-closed probes) if the file is unreadable. */
 const readFormats = (root: string): string | null => {
+	// biome-ignore lint/plugin: best-effort read — an unreadable file is absorbed into null (⇒ fail-closed probes), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		return readFileSync(join(root, FORMATS_PATH), "utf8");
 	} catch {
@@ -99,6 +101,7 @@ const readFormats = (root: string): string | null => {
 
 /** Read local ship-it/SKILL.md text; null (⇒ fail-closed `UI_RE`) if the file is unreadable. */
 const readShipIt = (root: string): string | null => {
+	// biome-ignore lint/plugin: best-effort read — an unreadable file is absorbed into null (⇒ fail-closed UI_RE), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		return readFileSync(join(root, SHIP_IT_PATH), "utf8");
 	} catch {

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.ts
@@ -17,7 +17,8 @@
  */
 import {existsSync, readFileSync} from "node:fs";
 import {dirname, join, resolve} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
 import {
 	type CpPath,
@@ -34,13 +35,15 @@ export const FORMATS_PATH = "claude-plugins/kampus-pipeline/skills/gh-issue-inta
 export const CODEOWNERS_PATH = ".github/CODEOWNERS";
 
 /** A file/IO failure: the run couldn't read a required source. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the reason is already rendered for stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 const readRepoFile = (root: string, rel: string): Effect.Effect<string, IoError> =>
 	Effect.try({

--- a/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
+++ b/packages/pipeline-cli/src/tools/cp-cardinality/command.ts
@@ -40,6 +40,7 @@ const selfApprovalFlag = Flag.boolean("self-approval-at-head").pipe(
 /** Read the control-plane member logins from stdin; empty/failed read ⇒ N==0 (fail closed). */
 const readMembers = (): ReadonlyArray<string> => {
 	let raw: string;
+	// biome-ignore lint/plugin: best-effort read — an empty/failed stdin is absorbed into [] (⇒ N==0, fail closed), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		raw = readFileSync(0, "utf8");
 	} catch {

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.ts
@@ -160,6 +160,7 @@ export const parseJUnit = (xml: string | null | undefined): TestSummary => {
 	if (text.length === 0) return {...ZERO_TESTS};
 
 	let root: unknown;
+	// biome-ignore lint/plugin: best-effort parse — malformed XML is absorbed into ZERO_TESTS (ADR 0054 §2: a no-JUnit run must not crash), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		root = xmlParser.parse(text);
 	} catch {

--- a/packages/pipeline-cli/src/tools/decisions-index/gate.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/gate.ts
@@ -15,7 +15,8 @@
  */
 import {readdirSync, readFileSync, writeFileSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {
 	type AdrFile,
 	buildCompact,
@@ -28,13 +29,15 @@ const INDEX_FILE = "index.md";
 const ADR_FILE = /^\d+[A-Za-z]*-.+\.md$/;
 
 /** A directory/file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 /** Read every ADR file (NNNN[a]-slug.md) in `dir`, excluding the generated index. */
 export const readAdrFiles = (dir: string): Effect.Effect<ReadonlyArray<AdrFile>, IoError> =>

--- a/packages/pipeline-cli/src/tools/design-token-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/design-token-guard/gate.ts
@@ -17,7 +17,8 @@
  */
 import {readdirSync, readFileSync, writeFileSync} from "node:fs";
 import {join, relative, sep} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {
 	type CssFileFacts,
 	type DesignTokenConfig,
@@ -30,13 +31,15 @@ import {
 } from "./design-token-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 const CSS_ROOT = join("apps", "web", "src");
 const CONFIG_PATH = join("apps", "web", "src", "styles", "design-token-lint.config.json");

--- a/packages/pipeline-cli/src/tools/failure-classifier/command.ts
+++ b/packages/pipeline-cli/src/tools/failure-classifier/command.ts
@@ -44,12 +44,14 @@ const stageFlag = Flag.string("stage").pipe(
  */
 const readStdinSignal = (): CrashSignal => {
 	let raw = "";
+	// biome-ignore lint/plugin: best-effort read — an unreadable stdin is absorbed into an empty signal (the core default-denies), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		raw = readFileSync(0, "utf8");
 	} catch {
 		return {};
 	}
 	if (raw.trim() === "") return {};
+	// biome-ignore lint/plugin: best-effort parse — a non-JSON stdin is absorbed into a reason-only signal, never the E channel; a total helper, not Effect-cosplay.
 	try {
 		const parsed = JSON.parse(raw) as Record<string, unknown>;
 		return {

--- a/packages/pipeline-cli/src/tools/fanout-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/fanout-guard/gate.ts
@@ -15,7 +15,8 @@
  */
 import {existsSync, readdirSync, readFileSync, statSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {
 	type DiscoveredMutation,
 	type FeaturePublishes,
@@ -33,13 +34,15 @@ import {
 } from "./fanout-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 const FEATURES_DIR = join("apps", "web", "worker", "features");
 const MUTATIONS_FILE = "mutations.ts";

--- a/packages/pipeline-cli/src/tools/leak-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.ts
@@ -26,7 +26,8 @@
  */
 import {existsSync, readFileSync} from "node:fs";
 import {dirname, join, resolve} from "node:path";
-import {Console, Data, Effect, Option} from "effect";
+import {Console, Effect, Option} from "effect";
+import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, CREW_DIR, sweepCrew} from "./crew-gate.ts";
@@ -45,7 +46,9 @@ interface FileLeaks {
 }
 
 // Carries a non-zero process exit (the report is already on stderr).
-class LeakFound extends Data.TaggedError("LeakFound")<{readonly count: number}> {}
+class LeakFound extends Schema.TaggedErrorClass<LeakFound>()("LeakFound", {
+	count: Schema.Number,
+}) {}
 
 /** Read a file as UTF-8, or `null` when it is missing/unreadable (skip, never crash). */
 const readFileOrSkip = (file: string): Effect.Effect<string | null> =>

--- a/packages/pipeline-cli/src/tools/leak-guard/crew-gate.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/crew-gate.ts
@@ -12,17 +12,20 @@
  */
 import {readdirSync, readFileSync, statSync} from "node:fs";
 import {join, relative} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {type CrewLeak, findCrewLeaks} from "./crew-leak.ts";
 
 /** A directory/file IO failure: the sweep couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 /** The default crew directory the sweep scopes over, repo-root-relative. */
 export const CREW_DIR = "claude-plugins/pipeline-crew";

--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -49,6 +49,7 @@ interface GitResult {
 }
 
 const runGit = (args: ReadonlyArray<string>): GitResult => {
+	// biome-ignore lint/plugin: best-effort git shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
 	try {
 		const stdout = execFileSync("git", [...args], {encoding: "utf8"});
 		return {ok: true, stdout, stderr: ""};

--- a/packages/pipeline-cli/src/tools/patch-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/patch-guard/gate.ts
@@ -14,7 +14,8 @@
  */
 import {readdirSync, readFileSync, statSync} from "node:fs";
 import {join, relative, sep} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {
 	judge,
 	type PatchedDep,
@@ -25,13 +26,15 @@ import {
 } from "./patch-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 // Dirs never worth walking for test files: dependency trees, VCS, nested agent
 // worktrees/checkouts (present only in a dev tree, never on a fresh CI checkout), and

--- a/packages/pipeline-cli/src/tools/path-filter-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/gate.ts
@@ -12,17 +12,20 @@
  */
 import {readFileSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {CI_E2E_SOURCE, DEPLOY_SOURCE, judge, renderReport} from "./path-filter-guard.ts";
 
 /** A file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 const readWorkflow = (root: string, relPath: string): Effect.Effect<string, IoError> =>
 	Effect.try({

--- a/packages/pipeline-cli/src/tools/pointer-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/gate.ts
@@ -28,17 +28,20 @@
 import {execFileSync} from "node:child_process";
 import {existsSync, readFileSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {findStalePointersIn, renderReport, type StalePointer} from "./pointer-guard.ts";
 
 /** A directory/file/git IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 /**
  * List the repo's git-tracked `CLAUDE.md` files at any depth (NUL-delimited, so
@@ -63,6 +66,7 @@ export const listClaudeMdFiles = (root: string): Effect.Effect<ReadonlyArray<str
  * generated/runtime path (`apps/web/.env`), so it counts as resolved, not as rot.
  */
 const isGitIgnored = (root: string, path: string): boolean => {
+	// biome-ignore lint/plugin: best-effort probe — check-ignore throws on no-match (exit 1) or error (128), both absorbed into false ("not ignored"), never the E channel; a total predicate, not Effect-cosplay.
 	try {
 		execFileSync("git", ["-C", root, "check-ignore", "-q", "--", path], {stdio: "ignore"});
 		return true;

--- a/packages/pipeline-cli/src/tools/primary-index-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/primary-index-guard/command.ts
@@ -31,6 +31,7 @@ import {decidePrimaryIndexCommit, MASS_DELETION_BLOCK_THRESHOLD} from "./primary
 export const REFUSE_EXIT_CODE = 3;
 
 const runGit = (args: ReadonlyArray<string>): {ok: boolean; stdout: string} => {
+	// biome-ignore lint/plugin: best-effort git shell — a non-zero exit is fully absorbed into {ok:false} the caller branches on, never the E channel; a total helper, not Effect-cosplay.
 	try {
 		const stdout = execFileSync("git", [...args], {
 			encoding: "utf8",

--- a/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/reachability-guard/gate.ts
@@ -13,7 +13,8 @@
  */
 import {existsSync, readdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {
 	consumedConstantsIn,
 	type FlagDefinition,
@@ -24,13 +25,15 @@ import {
 } from "./reachability-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 const KEYS_PATH = join("apps", "web", "src", "flags", "keys.ts");
 const SRC_ROOT = join("apps", "web", "src");

--- a/packages/pipeline-cli/src/tools/readme-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/readme-guard/gate.ts
@@ -14,7 +14,8 @@
  */
 import {existsSync, readdirSync, readFileSync, statSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {
 	judge,
 	type PackageDirCandidate,
@@ -23,13 +24,15 @@ import {
 } from "./readme-guard.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 /** The workspace glob that scopes this guard — the convention is about `packages/*` specifically. */
 const PACKAGES_GLOB = "packages/*";

--- a/packages/pipeline-cli/src/tools/ref-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/ref-guard/command.ts
@@ -37,6 +37,7 @@
  */
 import {execFileSync} from "node:child_process";
 import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {Argument, Command} from "effect/unstable/cli";
 import {
 	type CheckoutContext,
@@ -61,13 +62,21 @@ import {
  */
 export const REFUSE_EXIT_CODE = 3;
 
-/** Read the whole hook stdin (may be empty) synchronously. */
+/** A stdin read that rejected — absorbed to "" so the guard evaluates no updates (fail-open). */
+class StdinUnreadable extends Schema.TaggedErrorClass<StdinUnreadable>()("StdinUnreadable", {
+	cause: Schema.Unknown,
+}) {}
+
+/** Read the whole hook stdin (may be empty); an unreadable stdin is absorbed to "". */
 const readStdin = (): Effect.Effect<string> =>
-	Effect.promise(async () => {
-		const chunks: Buffer[] = [];
-		for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
-		return Buffer.concat(chunks).toString("utf8");
-	});
+	Effect.tryPromise({
+		try: async () => {
+			const chunks: Buffer[] = [];
+			for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+			return Buffer.concat(chunks).toString("utf8");
+		},
+		catch: (cause) => new StdinUnreadable({cause}),
+	}).pipe(Effect.orElseSucceed(() => ""));
 
 /**
  * Parse git's `reference-transaction` stdin — one `<old-oid> SP <new-oid> SP <ref-name>`
@@ -88,6 +97,7 @@ const parseUpdates = (stdin: string): ReadonlyArray<RefUpdate> => {
 };
 
 const runGit = (args: ReadonlyArray<string>): {ok: boolean; stdout: string} => {
+	// biome-ignore lint/plugin: best-effort probe — a failed git invocation is fully absorbed into {ok:false} (a fail-safe sentinel the caller reads), never the E channel; lifting to Effect.try to re-collapse to the same sentinel is noise, not the failure-modeling no-raw-try-catch targets.
 	try {
 		const stdout = execFileSync("git", [...args], {
 			encoding: "utf8",
@@ -118,6 +128,7 @@ const resolveOriginMain = (): string | null => {
  * the guarded ref the core refuses when a fast-forward can't be proven).
  */
 const originIsAncestorOf = (newOid: string): boolean => {
+	// biome-ignore lint/plugin: best-effort probe — an indeterminate merge-base (bad OID/git error) is absorbed into false (fail-safe: the core refuses when a fast-forward can't be proven), never the E channel; this is a total predicate, not Effect-cosplay.
 	try {
 		execFileSync("git", ["merge-base", "--is-ancestor", "origin/main", newOid], {
 			stdio: "ignore",

--- a/packages/pipeline-cli/src/tools/resume-policy/command.ts
+++ b/packages/pipeline-cli/src/tools/resume-policy/command.ts
@@ -75,12 +75,14 @@ interface StdinPayload {
  */
 const readStdin = (): StdinPayload => {
 	let raw = "";
+	// biome-ignore lint/plugin: best-effort read — an unreadable stdin is absorbed into empties (the flags fill in, or the core default-denies), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		raw = readFileSync(0, "utf8");
 	} catch {
 		return {signal: {}, ledger: {}};
 	}
 	if (raw.trim() === "") return {signal: {}, ledger: {}};
+	// biome-ignore lint/plugin: best-effort parse — a non-JSON stdin is absorbed into empties (the core default-denies), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		const p = JSON.parse(raw) as Record<string, unknown>;
 		return {

--- a/packages/pipeline-cli/src/tools/roadmap-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/roadmap-guard/gate.ts
@@ -9,20 +9,22 @@
  */
 import {existsSync, readFileSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
-import type * as Schema from "effect/Schema";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {Milestones} from "./github.ts";
 import {judge, parseRoadmap, renderReport} from "./roadmap-guard.ts";
 
 /** Couldn't read `ROADMAP.md` (absent or unreadable). */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 const ROADMAP_FILE = "ROADMAP.md";
 

--- a/packages/pipeline-cli/src/tools/settings-env-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/gate.ts
@@ -12,17 +12,20 @@
  */
 import {readFileSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {type EnvEntry, judge, renderReport} from "./settings-env-guard.ts";
 
 /** A read/parse failure: the guard couldn't scan the settings file — fail-closed (ADR 0092). */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 const SETTINGS_PATH = ".claude/settings.json";
 

--- a/packages/pipeline-cli/src/tools/spawn-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.ts
@@ -143,6 +143,7 @@ const RUNTIME_DEP = "@effect/platform-node";
 
 /** Is `dep` resolvable from here? `false` ⇒ stale `node_modules` (pre-`pnpm install`). */
 const depsInstalled = (dep: string = RUNTIME_DEP): boolean => {
+	// biome-ignore lint/plugin: a pre-runtime dep-resolution probe (the rule's named exception) — an unresolvable dep is absorbed into false (stale node_modules), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		createRequire(import.meta.url).resolve(dep);
 		return true;

--- a/packages/pipeline-cli/src/tools/structured-output-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/structured-output-guard/command.ts
@@ -35,6 +35,7 @@ const EXIT_FAIL = 1;
 const EXIT_RETRY = 2;
 
 const readStdin = (): string => {
+	// biome-ignore lint/plugin: best-effort read — an unreadable stdin is absorbed into "" (no input), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		return readFileSync(0, "utf8");
 	} catch {

--- a/packages/pipeline-cli/src/tools/trivial-diff/command.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/command.ts
@@ -68,6 +68,7 @@ const repoFlag = Flag.string("repo").pipe(
 
 /** Read the diff: from `--diff-file` if given, else stdin (fd 0). Any read failure ⇒ null (fail-closed). */
 const readDiff = (diffFile: Option.Option<string>): string | null => {
+	// biome-ignore lint/plugin: best-effort read — any read failure is absorbed into null (fail-closed: the core then refuses), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		return Option.match(diffFile, {
 			onSome: (path) => readFileSync(path, "utf8"),
@@ -82,6 +83,7 @@ const readDiff = (diffFile: Option.Option<string>): string | null => {
 const resolveRepo = (repo: Option.Option<string>): string | null => {
 	const explicit = Option.getOrUndefined(repo) ?? process.env.CLAUDE_PIPELINE_REPO;
 	if (explicit !== undefined && explicit.trim() !== "") return explicit.trim();
+	// biome-ignore lint/plugin: best-effort probe — a failed gh repo view is absorbed into null (unresolved repo ⇒ fail-closed), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], {
 			encoding: "utf8",
@@ -99,6 +101,7 @@ const resolveRepo = (repo: Option.Option<string>): string | null => {
  */
 const resolveControlPlaneRe = (repo: string | null): string | null => {
 	if (repo === null) return null;
+	// biome-ignore lint/plugin: best-effort probe — any failure (gh missing/unauth, repo unresolved, file absent) is absorbed into null (the core then fails closed), never the E channel; a total helper, not Effect-cosplay.
 	try {
 		const raw = execFileSync(
 			"gh",

--- a/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
@@ -15,17 +15,20 @@
  */
 import {existsSync, readdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";
-import {Console, Data, Effect} from "effect";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import {judge, judgeScript, renderReport, type ScriptVerdict} from "./workflow-contract.ts";
 
 /** A directory/file IO failure: the run couldn't complete. */
-export class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
 
 /** Carries the non-zero gate-fail exit (the report is already on stderr). */
-export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
 
 /** The workflow-script surface this guard owns (ADR 0062 — repo-relative). */
 const WORKFLOWS_DIR = join(".claude", "workflows");

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -28,6 +28,13 @@
  * `bin.ts` #777 stale-tree shim (a dynamic import gated on a dep-resolution probe)
  * is dropped: the `pipeline-cli` bin imports `@effect/platform-node` statically, so
  * by the time a subcommand runs the runtime dep is always resolved.
+ *
+ * The sync git/fs probe helpers below are best-effort by contract: a hook must never
+ * crash on a git/fs hiccup, so every probe degrades to a SAFE fallback (allow / keep /
+ * dirty), absorbing the failure into a returned value rather than the `E` channel. That
+ * is why each carries a per-line `biome-ignore lint/plugin` — lifting them into
+ * `Effect.try` only to re-collapse the error to the same fallback is noise, not the
+ * failure-modeling `no-raw-try-catch` targets (the design-capture/upload.ts precedent).
  */
 import {execFileSync} from "node:child_process";
 import {existsSync, readFileSync, statSync} from "node:fs";
@@ -38,7 +45,8 @@ import {
 	defaultLogPath,
 	renderBashStagingNote,
 } from "@kampus/primary-index-tripwire";
-import {Console, Data, Effect, Option} from "effect";
+import {Console, Effect, Option} from "effect";
+import * as Schema from "effect/Schema";
 import {Command, Flag} from "effect/unstable/cli";
 import {isIsolationExpected, pinBash} from "./bash-pin.ts";
 import {decideCleanTree} from "./clean-tree.ts";
@@ -59,6 +67,7 @@ const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
 // today's allow, never a spurious refusal).
 const onPrimaryCheckout = (cwd: string): boolean => {
 	const base = cwd || process.cwd();
+	// biome-ignore lint/plugin: best-effort probe — an unknowable git dir degrades to false (not primary), never E (see file header).
 	try {
 		const opts = {cwd: base, encoding: "utf8" as const};
 		const gitDir = resolve(
@@ -83,6 +92,7 @@ const onPrimaryCheckout = (cwd: string): boolean => {
  * same out-of-repo log the read-only `primary-index-tripwire record` bin uses (no second surface).
  */
 const recordBashStaging = (command: string, cwd: string): void => {
+	// biome-ignore lint/plugin: best-effort attribution — any recording failure is swallowed so it can never perturb the pin decision, never E (see file header).
 	try {
 		const decision = decideBashStagingAttribution({
 			command,
@@ -103,20 +113,31 @@ const recordBashStaging = (command: string, cwd: string): void => {
 
 // A non-force `git worktree remove` that errors means git judged the tree unsafe to
 // remove — we KEEP it (never escalate to --force). Tagged so the error channel stays typed.
-class RemoveRefused extends Data.TaggedError("RemoveRefused")<{readonly path: string}> {}
+class RemoveRefused extends Schema.TaggedErrorClass<RemoveRefused>()("RemoveRefused", {
+	path: Schema.String,
+}) {}
+
+/** A stdin read that rejected — absorbed to the `{}` envelope so a hook never crashes on it. */
+class StdinUnreadable extends Schema.TaggedErrorClass<StdinUnreadable>()("StdinUnreadable", {
+	cause: Schema.Unknown,
+}) {}
 
 const readStdin = (): Effect.Effect<unknown> =>
-	Effect.promise(async () => {
-		const chunks: Buffer[] = [];
-		for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
-		const raw = Buffer.concat(chunks).toString("utf8").trim();
-		if (raw === "") return {};
-		try {
-			return JSON.parse(raw) as unknown;
-		} catch {
-			return {};
-		}
-	});
+	Effect.tryPromise({
+		try: async () => {
+			const chunks: Buffer[] = [];
+			for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+			const raw = Buffer.concat(chunks).toString("utf8").trim();
+			if (raw === "") return {};
+			// biome-ignore lint/plugin: best-effort parse — a malformed stdin envelope degrades to {} (no fields), never E (see file header).
+			try {
+				return JSON.parse(raw) as unknown;
+			} catch {
+				return {};
+			}
+		},
+		catch: (cause) => new StdinUnreadable({cause}),
+	}).pipe(Effect.orElseSucceed(() => ({})));
 
 const field = (obj: unknown, ...path: string[]): unknown => {
 	let cur: unknown = obj;
@@ -166,6 +187,7 @@ const preFile = Command.make(
 			cwd,
 			candidatePath: candidate,
 			existsInWorktree: (p) => {
+				// biome-ignore lint/plugin: best-effort probe — an unstattable path degrades to false (absent), never E (see file header).
 				try {
 					return existsSync(p);
 				} catch {
@@ -246,6 +268,7 @@ const ownedWorktreeFromPayload = (input: unknown): string => {
 	if (!transcriptPath) return "";
 	const metaPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
 	if (metaPath === transcriptPath || !existsSync(metaPath)) return "";
+	// biome-ignore lint/plugin: best-effort read — an unreadable/malformed sidecar degrades to "" (ownership unprovable ⇒ decideReap KEEPs), never E (see file header).
 	try {
 		return str(field(JSON.parse(readFileSync(metaPath, "utf8")) as unknown, "worktreePath"));
 	} catch {
@@ -255,6 +278,7 @@ const ownedWorktreeFromPayload = (input: unknown): string => {
 
 /** Is the worktree dirty? `git status --porcelain` non-empty ⇒ dirty (also dirty if we can't tell — fail-safe to KEEP). */
 const worktreeIsDirty = (root: string): boolean => {
+	// biome-ignore lint/plugin: best-effort probe — an indeterminate status degrades to dirty (never reap), never E (see file header).
 	try {
 		const out = execFileSync("git", ["-C", root, "status", "--porcelain"], {
 			encoding: "utf8",
@@ -275,6 +299,7 @@ const reap = Command.make(
 			return yield* Console.error("worktree-guard reap: no $WORKTREE_ROOT to reap (skip)");
 		}
 		let dir = true;
+		// biome-ignore lint/plugin: best-effort probe — an unstattable root degrades to not-a-directory (skip), never E (see file header).
 		try {
 			dir = statSync(WORKTREE_ROOT).isDirectory();
 		} catch {
@@ -332,6 +357,7 @@ const pathFlag = Flag.string("path").pipe(
 // Read `git status --porcelain` at a path; null when git cannot run there (not a repo, missing
 // dir) — the null is the fail-closed signal decideCleanTree maps to DIRTY, never a false clean.
 const readPorcelain = (path: string): string | null => {
+	// biome-ignore lint/plugin: best-effort probe — a non-repo/missing dir degrades to null (decideCleanTree maps to DIRTY, fail-closed), never E (see file header).
 	try {
 		return execFileSync("git", ["-C", path, "status", "--porcelain"], {encoding: "utf8"});
 	} catch {

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -46,6 +46,7 @@ interface GitResult {
 }
 
 const runGit = (args: ReadonlyArray<string>): GitResult => {
+	// biome-ignore lint/plugin: best-effort git shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
 	try {
 		const stdout = execFileSync("git", [...args], {encoding: "utf8"});
 		return {ok: true, stdout, stderr: ""};
@@ -108,6 +109,7 @@ const IDLE_THRESHOLD_MS = 30 * 60 * 1000;
 const newestMtimeMs = (paths: ReadonlyArray<string>): number | null => {
 	let newest: number | null = null;
 	for (const p of paths) {
+		// biome-ignore lint/plugin: best-effort probe — an absent/unreadable path is skipped (a wholly unresolvable set falls to the null fail-safe), never the E channel; a total helper, not Effect-cosplay.
 		try {
 			const m = statSync(p).mtimeMs;
 			if (newest === null || m > newest) newest = m;
@@ -138,6 +140,7 @@ const worktreeRecentlyActive = (path: string): boolean => {
 };
 
 const runGh = (args: ReadonlyArray<string>): GitResult => {
+	// biome-ignore lint/plugin: best-effort gh shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
 	try {
 		const stdout = execFileSync("gh", [...args], {encoding: "utf8"});
 		return {ok: true, stdout, stderr: ""};


### PR DESCRIPTION
Closes the §CP-adjacent half of the Effect-v4 coverage gap blocking capstone #2753. The three GritQL rules #2746 declared at `warn` — `no-data-taggederror`, `no-raw-try-catch`, `no-effect-promise` — now report **zero** in `packages/pipeline-cli`, so the last dirty surface is green and #2753 can flip warn→error at a zero baseline.

## What changed (scope: `packages/pipeline-cli/src/tools/**` only)

- **`no-data-taggederror`** — every guard `IoError`/`CheckFailed` across 14 `gate.ts` files, plus the local `RemoveRefused` (worktree-guard) and `LeakFound` (leak-guard), converted `Data.TaggedError` → `Schema.TaggedErrorClass` (the idiom in `.patterns/effect-errors.md`, grounded in `epic-ledger/github.ts`). **Bare `_tag` strings are preserved** so every `Effect.catchTag("CheckFailed"/"LeakFound", …)` and every `instanceof` in the `gate.unit.test.ts` suites stays behavior-identical — no pass/fail-contract change.
- **`no-effect-promise`** — `readStdin` in `ref-guard`/`worktree-guard` converted `Effect.promise(…)` → object-notation `Effect.tryPromise({ try, catch })` with a `Schema.TaggedErrorClass` catch, absorbed via `Effect.orElseSucceed` so the helper stays total (fail-open `""` / `{}` envelope — matching the roadmap-guard/github.ts precedent).
- **`no-raw-try-catch`** — the remaining raw `try/catch` are pure-sync **total** helpers that absorb failure into a fail-safe/fail-closed fallback value (`null` / `[]` / `{ok:false}` / `ZERO_TESTS` / skip), never the `E` channel. The signature is honest and this is *not* the Effect-cosplay the rule targets, so each carries a per-line `// biome-ignore lint/plugin: <reason>` — the sanctioned exception (the `design-capture/upload.ts`, `depo/client.ts` precedent). The shared *why* is stated once in `worktree-guard/command.ts`'s header to avoid a duplicated-docblock wall.

## Verification

- `pnpm --filter @kampus/pipeline-cli typecheck` (tsgo) — clean.
- `pnpm --filter @kampus/pipeline-cli test` — 1342 passed / 97 files, 0 failures.
- `pnpm lint:worktree` — zero plugin diagnostics across all 28 changed files.

## §CP note

`packages/pipeline-cli` matches `CONTROL_PLANE_RE` → this PR routes through the §CP merge lane (control-plane tooling), unlike the sibling `apps/web` slices #3182/#3189.

Fixes #3184