### PR TITLE
roadmap: Atölye arc → done (#26 fully shipped)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Direction flows top-down: **vision → arcs → milestones → epics → feature
 | Four Pillars | #17 | active |
 | Geçit | #24 | queued |
 | Mecmua v2 | #25 | queued |
-| Atölye | #26 | queued |
+| Atölye | #26 | done |
 
 **Four Pillars** — *active.* Frontend polish and the encoded design system: the four pillars — Performance, Cohesiveness, Usability, Accessibility — made real and enforced (ADR 0162, the design-system manifest). The surface of kamp.us becomes excellent and self-consistent. The nav-IA discipline is mid-flight here.
 


### PR DESCRIPTION
## What

Flip the **Atölye** arc's `## Arcs` row from `queued` → `done`.

```diff
-| Atölye | #26 | queued |
+| Atölye | #26 | done |
```

Milestone **#26 is closed** — 0 open / 15 closed. The museum-of-craft build (#2473), exhibit catalog, profile-canvas, and free-paint all shipped. The `## Arcs` table still listed Atölye as `queued`; this reconciles that stale row. Every other arc row is left exactly as-is.

## Guard

`roadmap-guard check` passes green (I1–I5):
- **I2** (exactly one active arc): Four Pillars #17 stays the only `active` — untouched.
- **I5** (active↔done symmetry): a `done` row's milestone must be CLOSED — #26 is already closed, so `| Atölye | #26 | done |` satisfies I5.

## Coexistence

No other open PR touches `ROADMAP.md`, so no textual conflict. The active Campaigns rows live in a separate `## Campaigns` section regardless.

## Provenance

Founder-approved (umut, via EA), conversation-authored ROADMAP edit — ADR 0075 idiom. NON-§CP (ROADMAP.md only) → review-doc lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
