### PR TITLE
feat(pipeline-crew-mcp): kind-typed roster seam in crew/roles.ts (bridge/engine)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -22,7 +22,18 @@ export {
 	makeCrewChannel,
 } from "./channel-server.ts";
 export {RoleUniquenessError} from "./errors.ts";
-export {CREW_ROLES, CrewRole, isCrewRole} from "./roles.ts";
+export {
+	type CardinalityOf,
+	CREW_ROLES,
+	CREW_ROSTER,
+	CrewRole,
+	type CrewRoleCardinality,
+	type CrewRoleKind,
+	cardinalityOf,
+	cardinalityOfKind,
+	isCrewRole,
+	kindOf,
+} from "./roles.ts";
 export {
 	type CrewSessionConfig,
 	channelSendFromPeer,

--- a/packages/pipeline-crew-mcp/src/crew/roles.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/roles.test.ts
@@ -1,22 +1,41 @@
 /**
- * The Role enum (AC 1): the five standing crew roles, the canonical agent-type slugs, and
- * that the enum decode-checks a role (accepts a member, rejects a non-role). The roster is a
- * single seam — this test pins the confirmed set so a stale/short list can't slip through.
+ * crew/roles — the kind-typed roster seam (ADR 0189): the roster is three bridges + the engine
+ * pool, cardinality falls out of the KIND, and a role still decode-checks at the wire boundary.
+ * These tests pin the confirmed roster + the kind/cardinality derivation so a stale roster or a
+ * mis-kinded role can't slip through.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Schema} from "effect";
-import {CREW_ROLES, CrewRole, isCrewRole} from "./roles.ts";
+import {
+	CREW_ROLES,
+	CREW_ROSTER,
+	CrewRole,
+	cardinalityOf,
+	cardinalityOfKind,
+	isCrewRole,
+	kindOf,
+} from "./roles.ts";
 
-describe("crew/roles — the five standing roles", () => {
-	it("is exactly the confirmed five-role roster", () => {
-		assert.deepStrictEqual(
-			[...CREW_ROLES],
-			["ea-chief-of-staff", "engineering-manager", "triage-guy", "junior-engineer", "cartographer"],
-		);
+describe("crew/roles — the kind-typed roster (ADR 0189)", () => {
+	it("is exactly the confirmed roster: three bridges + the engine", () => {
+		assert.deepStrictEqual(CREW_ROSTER, {
+			"chief-of-staff": "bridge",
+			cartographer: "bridge",
+			"intake-desk": "bridge",
+			"engineering-manager": "engine",
+		});
 	});
 
-	it("has five distinct roles (no duplicate slug)", () => {
-		assert.strictEqual(new Set(CREW_ROLES).size, 5);
+	it("dropped junior-engineer and the old ea-chief-of-staff / triage-guy slugs", () => {
+		const slugs = new Set<string>(CREW_ROLES);
+		assert.isFalse(slugs.has("junior-engineer"));
+		assert.isFalse(slugs.has("ea-chief-of-staff"));
+		assert.isFalse(slugs.has("triage-guy"));
+		assert.strictEqual(slugs.size, 4);
+	});
+
+	it("CREW_ROLES enumerates exactly the roster keys", () => {
+		assert.deepStrictEqual(new Set(CREW_ROLES), new Set(Object.keys(CREW_ROSTER)));
 	});
 
 	it("decodes a member and rejects a non-role", () => {
@@ -24,7 +43,35 @@ describe("crew/roles — the five standing roles", () => {
 			assert.strictEqual(Schema.decodeUnknownSync(CrewRole)(role), role);
 			assert.isTrue(isCrewRole(role));
 		}
+		assert.isFalse(isCrewRole("junior-engineer"));
+		assert.isFalse(isCrewRole("triage-guy"));
 		assert.isFalse(isCrewRole("reviewer"));
-		assert.isFalse(isCrewRole("builder"));
+	});
+
+	it("kindOf is total and kinds every role bridge/engine per the roster", () => {
+		for (const role of CREW_ROLES) {
+			assert.strictEqual(kindOf(role), CREW_ROSTER[role]);
+		}
+		assert.strictEqual(kindOf("chief-of-staff"), "bridge");
+		assert.strictEqual(kindOf("cartographer"), "bridge");
+		assert.strictEqual(kindOf("intake-desk"), "bridge");
+		assert.strictEqual(kindOf("engineering-manager"), "engine");
+	});
+
+	it("derives cardinality from the kind: bridge → 1, engine → N", () => {
+		assert.strictEqual(cardinalityOfKind("bridge"), 1);
+		assert.strictEqual(cardinalityOfKind("engine"), "N");
+		assert.strictEqual(cardinalityOf("chief-of-staff"), 1);
+		assert.strictEqual(cardinalityOf("engineering-manager"), "N");
+		for (const role of CREW_ROLES) {
+			assert.strictEqual(cardinalityOf(role), kindOf(role) === "bridge" ? 1 : "N");
+		}
+	});
+
+	it("a bridge cardinality is the literal 1 at the type level (2 is unrepresentable)", () => {
+		// The compile-time face of the invariant: cardinalityOfKind("bridge") is typed exactly `1`,
+		// so a bridge-with-cardinality-2 does not typecheck. This `satisfies 1` is the assertion.
+		const bridgeCardinality = cardinalityOfKind("bridge") satisfies 1;
+		assert.strictEqual(bridgeCardinality, 1);
 	});
 });

--- a/packages/pipeline-crew-mcp/src/crew/roles.ts
+++ b/packages/pipeline-crew-mcp/src/crew/roles.ts
@@ -1,30 +1,72 @@
 /**
- * crew/roles — the crew's flat-topology Role enum: the ONE place the concrete role roster
- * is named, so the catalog, the wiring, and the tests reference `CrewRole` / `CREW_ROLES`
- * and never a role string literal. The roster below is the single swap-in seam — nothing
- * else in `crew/` hardcodes a role, so the set can change without reworking anything.
+ * crew/roles — the kind-typed roster seam: the ONE place the concrete roster is named, as a
+ * role → kind map. Everything else in `crew/` (catalog, wiring, tests) references `CrewRole`
+ * / `CREW_ROLES` / `kindOf` and never a role string literal, so the roster changes here alone.
  *
- * The roster is a founder ruling (five standing roles, not four); the slugs are the repo's
- * canonical agent-type identifiers, so a crew role maps 1:1 to the agent-type that fills it.
+ * The roster is a TYPE, not a slug list: cardinality falls out of the KIND (bridge → 1, engine
+ * → N), so a bridge-with-cardinality-2 is unrepresentable. See ADR 0189.
  */
 import {Schema} from "effect";
 
 /**
- * The five standing crew roles, canonical agent-type slugs. Flat topology: every role is a
- * symmetric peer on the substrate — any role may claim, hand off, tally, ping, and discover
- * any other. This tuple is the roster seam; see the module note.
+ * A role's KIND governs its cardinality. A bridge owns a unique factory↔outside seam, so it is
+ * singleton; an engine owns no seam and is fungible throughput, so it scales by count. See ADR 0189.
+ */
+export type CrewRoleKind = "bridge" | "engine";
+
+/**
+ * The standing roster's slugs — the enumeration surface every caller that iterates the roster
+ * consumes (the total catalog, the `--role` flag choices, the wire schema). A definite tuple so
+ * `Schema.Literals` / `Flag.choice` infer the precise `CrewRole` union and index access stays
+ * total; `CREW_ROSTER` below kinds each of these entries.
  */
 export const CREW_ROLES = [
-	"ea-chief-of-staff",
-	"engineering-manager",
-	"triage-guy",
-	"junior-engineer",
+	"chief-of-staff",
 	"cartographer",
+	"intake-desk",
+	"engineering-manager",
 ] as const;
 
 /** The Role enum as an `effect/Schema` literal union — decode-checks a role at the wire boundary. */
 export const CrewRole = Schema.Literals(CREW_ROLES);
-export type CrewRole = typeof CrewRole.Type;
+export type CrewRole = (typeof CREW_ROLES)[number];
 
 /** A total refinement: is `value` one of the standing crew roles? */
 export const isCrewRole = Schema.is(CrewRole);
+
+/**
+ * The kind-typed roster: three bridges + the engine pool — the single source of a role's KIND,
+ * from which every kind/cardinality helper derives. `satisfies Record<CrewRole, CrewRoleKind>`
+ * makes it TOTAL over the roster: add a role to `CREW_ROLES` without kinding it here and this
+ * stops compiling. See ADR 0189.
+ */
+export const CREW_ROSTER = {
+	"chief-of-staff": "bridge",
+	cartographer: "bridge",
+	"intake-desk": "bridge",
+	"engineering-manager": "engine",
+} as const satisfies Record<CrewRole, CrewRoleKind>;
+
+/** Total: the kind of any crew role, read straight off the roster map. */
+export const kindOf = (role: CrewRole): CrewRoleKind => CREW_ROSTER[role];
+
+/**
+ * Cardinality is a FUNCTION of kind, never a free field — a bridge is exactly one (nobody else
+ * owns its seam), an engine is an unbounded pool (`"N"`). Because the only way to name a
+ * cardinality is through the kind, a bridge with cardinality 2 does not typecheck. See ADR 0189.
+ */
+export type CardinalityOf<K extends CrewRoleKind> = K extends "bridge" ? 1 : "N";
+export type CrewRoleCardinality = CardinalityOf<CrewRoleKind>;
+
+const KIND_CARDINALITY = {
+	bridge: 1,
+	engine: "N",
+} as const satisfies {readonly [K in CrewRoleKind]: CardinalityOf<K>};
+
+/** The cardinality a given kind admits: `bridge` → `1`, `engine` → `"N"` (unbounded pool). */
+export const cardinalityOfKind = <K extends CrewRoleKind>(kind: K): CardinalityOf<K> =>
+	KIND_CARDINALITY[kind] as CardinalityOf<K>;
+
+/** The cardinality a given role admits, derived through its kind. */
+export const cardinalityOf = (role: CrewRole): CrewRoleCardinality =>
+	KIND_CARDINALITY[kindOf(role)];

--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -8,7 +8,7 @@
  * the exact `ChannelSend` the `channel_send` MCP tool routes through:
  *   - an intake ping sent through `channelSendFromPeer`'s `ChannelSend` reaches the receiver's
  *     channel edge (its recorded `ChannelSink` wake) and returns its delivered-to-inbox ack,
- *   - `inboxAddressFor` addresses all five standing roles distinctly (no role orphaned — the
+ *   - `inboxAddressFor` addresses every standing role distinctly (no role orphaned — the
  *     cartographer included).
  */
 import {assert, describe, it} from "@effect/vitest";
@@ -130,11 +130,19 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 	);
 });
 
-describe("crew/session — the five-role roster is intact (no role orphaned)", () => {
-	it("inboxAddressFor addresses all five standing roles distinctly", () => {
+describe("crew/session — the roster is intact (no role orphaned)", () => {
+	it("inboxAddressFor addresses every standing role distinctly", () => {
 		const addresses = CREW_ROLES.map(inboxAddressFor);
-		assert.lengthOf(addresses, 5, "the roster is exactly five roles (the cartographer included)");
-		assert.strictEqual(new Set(addresses).size, 5, "every role maps to a distinct inbox address");
+		assert.lengthOf(
+			addresses,
+			CREW_ROLES.length,
+			"every standing role gets an inbox address (the cartographer included)",
+		);
+		assert.strictEqual(
+			new Set(addresses).size,
+			CREW_ROLES.length,
+			"every role maps to a distinct inbox address",
+		);
 		assert.include(addresses, "inbox://cartographer", "the cartographer must have an address");
 	});
 });

--- a/packages/pipeline-crew-mcp/src/index.ts
+++ b/packages/pipeline-crew-mcp/src/index.ts
@@ -5,9 +5,9 @@
  * `Crew.crewSessionLayer` stand up one live session's stdio `McpServer` + `ChannelSend`-from-peer,
  * so every inter-session seam (claim/collision-check, planned-epic handoff, drain tally, intake
  * pings, role discovery/presence, the role-uniqueness lease) runs over the channels protocol
- * instead of the retired tmux relay convention. `Crew.CREW_ROLES` is the single five-role roster
- * every binding consumes — never a re-declared or short list (a four-role list orphans the
- * cartographer, the failure this cutover exists to prevent).
+ * instead of the retired tmux relay convention. `Crew.CREW_ROSTER` is the single kind-typed roster
+ * (three bridges + the engine pool; ADR 0189) every binding consumes via `Crew.CREW_ROLES` /
+ * `Crew.kindOf` — never a re-declared or short list.
  *
  * The one structural invariant the module boundary holds: the generic core is crew-agnostic.
  * `Protocol`, `Tracker`, `Peer`, and `Edge` are the reusable channels substrate and MUST NOT


### PR DESCRIPTION
Fixes #3291 — first child of epic #3234 (roster law in pipeline-crew-mcp), implementing ADR 0189 (crew-roster-law: bridges vs engines, cardinality-from-kind).

## What changed
Makes `packages/pipeline-crew-mcp/src/crew/roles.ts` the kind-typed roster seam — the single swap-in point the epic names.

- **Role → kind roster (`CREW_ROSTER`).** `chief-of-staff` / `cartographer` / `intake-desk` = `bridge`; `engineering-manager` = `engine`. Renames `ea-chief-of-staff` → `chief-of-staff` and `triage-guy` → `intake-desk`; **drops `junior-engineer`** (its only inbound edge was the dead `EpicHandoff` hub-and-spoke — the engine pool is pull-only, per ADR 0189).
- **Kind is first-class.** `CrewRoleKind` (`"bridge" | "engine"`), a total `kindOf(role)`, and cardinality **derived from the kind** (`bridge` → `1`, `engine` → `"N"`) via `CardinalityOf<K>` + `cardinalityOfKind` / `cardinalityOf`. Cardinality is never a free field — a bridge-with-cardinality-2 does not typecheck (make-invalid-states-unrepresentable, ADR 0189).
- **Wire boundary preserved.** `CrewRole` stays a `Schema.Literals` union + `isCrewRole` refinement, so a role still decode-checks at the wire. `CREW_ROLES` stays a definite `as const` tuple (the enumeration surface consumers iterate); `CREW_ROSTER satisfies Record<CrewRole, CrewRoleKind>` makes the kind map total over the roster.
- **Exports.** `crew/index.ts` + the package root `index.ts` export the new seam symbols (`CREW_ROSTER`, `CrewRoleKind`, `kindOf`, `cardinalityOf`, …) for Children B (tracker enforcement) and C (per-instance addressing) to swap against.

## Tests
- `crew/roles.test.ts` rewritten: the confirmed roster, the dropped slugs, `kindOf` totality, the bridge→1 / engine→N cardinality derivation, and a type-level `satisfies 1` pinning the bridge-singleton invariant.
- `crew/session.test.ts`'s roster-count guard (which pinned the now-superseded five-role count) is made count-agnostic (`CREW_ROLES.length`) — the only out-of-lane test that asserted the old cardinality; production `session.ts` is untouched.

## Verification
- `pnpm --filter @kampus/pipeline-crew-mcp typecheck` — clean
- `pnpm --filter @kampus/pipeline-crew-mcp test` — 78 passed (20 files)
- `biome check` — clean on all changed files

Effect idioms grounded in effect-smol: `Schema.Literals<ReadonlyArray<CrewRole>>` infers `Type = CrewRole`, and `Flag.choice` infers `Flag<CrewRole>`, so the out-of-lane consumers (`bin.ts`, `catalog.ts`) keep their precise typing.

Out of scope (later children): the tracker/registry enforcement of the kind cardinality (Child B) and per-instance addressing (Child C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)