### PR TITLE
feat(pipeline-crew-mcp): crew Claim lifecycle — keyspace split + presence-derived liveness + Release (#3281)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/catalog.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/catalog.test.ts
@@ -48,6 +48,7 @@ describe("crew/catalog — roles mapped to seams over protocol/", () => {
 			"Heartbeat",
 			"IntakePing",
 			"LookupRole",
+			"Release",
 		]);
 	});
 });

--- a/packages/pipeline-crew-mcp/src/crew/catalog.ts
+++ b/packages/pipeline-crew-mcp/src/crew/catalog.ts
@@ -19,16 +19,19 @@ import {
 	Heartbeat,
 	IntakePing,
 	LookupRole,
+	Release,
 } from "../protocol/index.ts";
 import {CREW_ROLES, type CrewRole} from "./roles.ts";
 
 /**
  * The named crew seams, each mapped to the protocol `Rpc` it rides. `claimCollisionCheck`
- * and `roleUniquenessLease` deliberately share `Claim` — same wire kind, two crew meanings.
+ * and `roleUniquenessLease` deliberately share `Claim` — same wire kind, two crew meanings;
+ * `releaseClaim` is the resource claim's free counterpart (ADR 0191 facet 3).
  */
 export const CrewSeams = {
 	claimCollisionCheck: Claim,
 	roleUniquenessLease: Claim,
+	releaseClaim: Release,
 	epicHandoff: EpicHandoff,
 	drainTally: DrainProgress,
 	intakePing: IntakePing,

--- a/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
@@ -10,9 +10,16 @@ import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {assert, describe, it} from "@effect/vitest";
 import {Cause, Context, Effect, Layer, Option} from "effect";
+import {RpcTest} from "effect/unstable/rpc";
 import {SocketServerError, SocketServerOpenError} from "effect/unstable/socket/SocketServer";
+import {TrackerRegistry} from "../tracker/group.ts";
+import {TrackerHandlers} from "../tracker/handlers.ts";
 import {isTrackerAddressInUse} from "../tracker/index.ts";
+import {RegistryLive} from "../tracker/registry.ts";
 import {CrewTracker, crewTrackerHostOrDialLayer} from "./tracker.ts";
+
+const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+const nowIso = () => new Date().toISOString();
 
 const errWithCode = (code: string): Error => Object.assign(new Error(code), {code});
 
@@ -51,6 +58,63 @@ describe("crew/tracker — first-peer-spawn: two sessions on one project root, o
 			const found = yield* tracker.lookup("reviewer");
 			assert.isTrue(Option.isSome(found), "a session with no peer still has a working tracker");
 		}).pipe(Effect.scoped),
+	);
+});
+
+describe("crew/tracker — acquireClaim + release (the claim lifecycle client, ADR 0191 facet 3)", () => {
+	it.effect("acquireClaim frees the claim on scope close so another peer can then claim it", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const ctx = yield* Layer.build(CrewTracker.fromClient(client));
+			const tracker = Context.get(ctx, CrewTracker);
+			// both holders need live presence for their claims to be live (presence-derived liveness)
+			yield* client.AnnouncePresence({peer: "inbox://a", role: "builder", at: nowIso()});
+			yield* client.AnnouncePresence({peer: "inbox://b", role: "reviewer", at: nowIso()});
+
+			// hold the claim for an inner scope; while held, a foreign claim collides
+			yield* Effect.scoped(
+				Effect.gen(function* () {
+					const reply = yield* tracker.acquireClaim({
+						resource: "issue-1",
+						claimant: "inbox://a",
+						role: "builder",
+					});
+					assert.isTrue(reply.granted);
+					const collided = yield* tracker.claim({
+						resource: "issue-1",
+						claimant: "inbox://b",
+						role: "reviewer",
+					});
+					assert.isTrue(collided.collision, "the claim is held while its scope is open");
+				}),
+			);
+
+			// scope closed ⇒ acquireClaim's Release fired ⇒ the resource is free again
+			const afterRelease = yield* tracker.claim({
+				resource: "issue-1",
+				claimant: "inbox://b",
+				role: "reviewer",
+			});
+			assert.isTrue(afterRelease.granted, "the claim was released on scope close");
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect("release frees a claim explicitly (the lane-finish fast path)", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const ctx = yield* Layer.build(CrewTracker.fromClient(client));
+			const tracker = Context.get(ctx, CrewTracker);
+			yield* client.AnnouncePresence({peer: "inbox://a", role: "builder", at: nowIso()});
+			yield* client.AnnouncePresence({peer: "inbox://b", role: "reviewer", at: nowIso()});
+			yield* tracker.claim({resource: "issue-1", claimant: "inbox://a", role: "builder"});
+			yield* tracker.release({resource: "issue-1", claimant: "inbox://a"});
+			const reclaim = yield* tracker.claim({
+				resource: "issue-1",
+				claimant: "inbox://b",
+				role: "reviewer",
+			});
+			assert.isTrue(reclaim.granted, "the explicitly-released resource is free");
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
 	);
 });
 

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -22,19 +22,21 @@ import {isTrackerAddressInUse, TrackerRegistry, trackerServerLayer} from "../tra
 /** The typed answer to a claim/collision-check — re-exported so consumers name one type. */
 export type ClaimReply = typeof Schema.ClaimReply.Type;
 type ClaimRequest = typeof Schema.ClaimRequest.Type;
+type ReleaseClaim = typeof Schema.ReleaseClaim.Type;
 type PresenceAnnouncement = typeof Schema.PresenceAnnouncement.Type;
 type RoleLookupQuery = typeof Schema.RoleLookupQuery.Type;
 type RoleLookupResult = typeof Schema.RoleLookupResult.Type;
 type HeartbeatMessage = typeof Schema.Heartbeat.Type;
 
 /**
- * The structural shape of the registry client the crew depends on — the four registry
+ * The structural shape of the registry client the crew depends on — the five registry
  * kinds it drives. Any `RpcClient(TrackerRegistry)` satisfies it (the real socket client,
  * or an in-memory `RpcTest` client in tests); the error channel is `unknown` because it is
  * `orDie`'d at the seam.
  */
 export interface TrackerRegistryClient {
 	readonly Claim: (payload: ClaimRequest) => Effect.Effect<ClaimReply, unknown>;
+	readonly Release: (payload: ReleaseClaim) => Effect.Effect<void, unknown>;
 	readonly AnnouncePresence: (payload: PresenceAnnouncement) => Effect.Effect<void, unknown>;
 	readonly LookupRole: (payload: RoleLookupQuery) => Effect.Effect<RoleLookupResult, unknown>;
 	readonly Heartbeat: (payload: HeartbeatMessage) => Effect.Effect<void, unknown>;
@@ -51,6 +53,22 @@ export class CrewTracker extends Context.Service<
 			readonly claimant: string;
 			readonly role: string;
 		}) => Effect.Effect<ClaimReply>;
+		/**
+		 * Claim `resource` for the enclosing scope: acquire on entry, and on scope close free the
+		 * claim via `Release` iff it was granted — the lane-finish fast path (ADR 0191 facet 3). The
+		 * reply's granted/collision is a VALUE, so a collision holds the scope open with nothing to
+		 * free (release is holder-guarded + idempotent, so freeing a lost claim is a safe no-op).
+		 */
+		readonly acquireClaim: (input: {
+			readonly resource: string;
+			readonly claimant: string;
+			readonly role: string;
+		}) => Effect.Effect<ClaimReply, never, Scope.Scope>;
+		/** Free a resource claim this session holds — the explicit lane-finish release (ADR 0191 facet 3). */
+		readonly release: (input: {
+			readonly resource: string;
+			readonly claimant: string;
+		}) => Effect.Effect<void>;
 		/** Soft presence announce, held for the enclosing scope (connection-is-lease). */
 		readonly announce: (presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>;
 		/**
@@ -71,6 +89,18 @@ export class CrewTracker extends Context.Service<
 		Layer.succeed(CrewTracker, {
 			claim: ({resource, claimant, role}) =>
 				client.Claim({resource, claimant, role, at: now()}).pipe(Effect.orDie),
+			acquireClaim: ({resource, claimant, role}) =>
+				Effect.acquireRelease(
+					client.Claim({resource, claimant, role, at: now()}).pipe(Effect.orDie),
+					// Free on scope close, but only a claim we actually won — release is holder-guarded, so
+					// releasing a collided (un-held) claim would no-op anyway; gating on `granted` keeps intent clear.
+					(reply) =>
+						reply.granted
+							? client.Release({resource, claimant, at: now()}).pipe(Effect.orDie)
+							: Effect.void,
+				),
+			release: ({resource, claimant}) =>
+				client.Release({resource, claimant, at: now()}).pipe(Effect.orDie),
 			announce: (presence) =>
 				Effect.acquireRelease(
 					// peer-id ≡ inbox-address: announce the dialable address so a lookup can dial it back.

--- a/packages/pipeline-crew-mcp/src/protocol/group.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.test.ts
@@ -15,11 +15,12 @@ import {
 	CrewProtocol,
 	crewMessageKinds,
 	payloadSchemaForKind,
+	Release,
 } from "./group.ts";
 import * as Messages from "./schema.ts";
 
 describe("protocol/group catalog", () => {
-	it("covers all 7 message kinds (8 rpcs — presence is announce + lookup)", () => {
+	it("covers all 8 message kinds (9 rpcs — presence is announce + lookup, claim is claim + release)", () => {
 		assert.deepStrictEqual([...CrewProtocol.requests.keys()].sort(), [
 			"AckInbox",
 			"AnnouncePresence",
@@ -29,6 +30,7 @@ describe("protocol/group catalog", () => {
 			"Heartbeat",
 			"IntakePing",
 			"LookupRole",
+			"Release",
 		]);
 	});
 
@@ -53,6 +55,10 @@ describe("protocol/group catalog", () => {
 
 	it("a fire-and-forget kind carries no reply (success is Void)", () => {
 		assert.strictEqual(AnnouncePresence.successSchema, Schema.Void);
+	});
+
+	it("Release is fire-and-forget: no reply schema, so releasing is idempotent (ADR 0191)", () => {
+		assert.strictEqual(Release.successSchema, Schema.Void);
 	});
 
 	it("payloadSchemaForKind resolves a catalog kind to its payload schema (#3229)", () => {

--- a/packages/pipeline-crew-mcp/src/protocol/group.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.ts
@@ -1,12 +1,13 @@
 /**
- * protocol/group — the 7 crew message kinds as one Effect `RpcGroup`.
+ * protocol/group — the 8 crew message kinds as one Effect `RpcGroup`.
  *
  * Generic (crew-agnostic); see the boundary note in `../index.ts`. Each kind is an
  * `Rpc` carrying a Schema payload from `./schema.ts`. Kinds that expect an answer
  * (claim/collision-check, role lookup) set a `success` schema — a typed reply the
  * caller awaits; the fire-and-forget kinds leave `success` unset, so it defaults to
- * `Schema.Void`. That success/void split is exactly what distinguishes a
- * request-response kind from a fire-and-forget one on the wire.
+ * `Schema.Void` (effect-smol `Rpc.ts` — `const successSchema = options?.success ?? Schema.Void`).
+ * That success/void split is exactly what distinguishes a request-response kind from a
+ * fire-and-forget one on the wire.
  */
 import type {Schema} from "effect";
 import {Rpc, RpcGroup} from "effect/unstable/rpc";
@@ -16,6 +17,11 @@ import * as Messages from "./schema.ts";
 export const Claim = Rpc.make("Claim", {
 	payload: Messages.ClaimRequest,
 	success: Messages.ClaimReply,
+});
+
+/** Kind 1b — release a held resource claim (fire-and-forget; the claim lifecycle's free, ADR 0191). */
+export const Release = Rpc.make("Release", {
+	payload: Messages.ReleaseClaim,
 });
 
 /** Kind 2 — planned-epic handoff (EM → builder). */
@@ -54,9 +60,10 @@ export const AckInbox = Rpc.make("AckInbox", {
 	payload: Messages.InboxAck,
 });
 
-/** The full crew message catalog — one transport-agnostic `RpcGroup` over all 7 kinds. */
+/** The full crew message catalog — one transport-agnostic `RpcGroup` over all 8 kinds. */
 export const CrewProtocol = RpcGroup.make(
 	Claim,
+	Release,
 	EpicHandoff,
 	DrainProgress,
 	IntakePing,

--- a/packages/pipeline-crew-mcp/src/protocol/index.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/index.ts
@@ -16,5 +16,6 @@ export {
 	IntakePing,
 	LookupRole,
 	payloadSchemaForKind,
+	Release,
 } from "./group.ts";
 export * as Messages from "./schema.ts";

--- a/packages/pipeline-crew-mcp/src/protocol/schema.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.test.ts
@@ -31,6 +31,14 @@ describe("protocol/schema round-trips", () => {
 		});
 	});
 
+	it("kind 1b — release claim (fire-and-forget, no reply)", () => {
+		roundTrips(Messages.ReleaseClaim, {
+			resource: "issue:3054",
+			claimant: "peer-a",
+			at: "2026-07-16T10:05:00Z",
+		});
+	});
+
 	it("kind 2 — planned-epic handoff (with and without the optional summary)", () => {
 		roundTrips(Messages.EpicHandoffNotice, {
 			epic: "epic:3045",

--- a/packages/pipeline-crew-mcp/src/protocol/schema.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.ts
@@ -40,6 +40,17 @@ export const ClaimReply = Schema.Struct({
 	since: Timestamp,
 });
 
+/**
+ * A holder freeing its own resource claim (fire-and-forget). The `claimant` must be the claim's
+ * holder — the tracker frees only a claim the caller holds, so steal-release is unrepresentable
+ * (ADR 0191 facet 3). No reply: releasing is idempotent.
+ */
+export const ReleaseClaim = Schema.Struct({
+	resource: Schema.NonEmptyString,
+	claimant: PeerId,
+	at: Timestamp,
+});
+
 // Kind 2 — planned-epic handoff (EM → builder).
 
 export const EpicHandoffNotice = Schema.Struct({

--- a/packages/pipeline-crew-mcp/src/tracker/group.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/group.ts
@@ -2,16 +2,22 @@
  * tracker/group — the registry `RpcGroup` the tracker actually serves: a control-plane-only
  * SUBSET of the crew protocol (`../protocol/`).
  *
- * The tracker serves exactly the four registry kinds — `Claim` (the request/reply lease
- * acquire), `AnnouncePresence` (soft presence), `LookupRole` (discovery), `Heartbeat` (TTL
- * keepalive). It deliberately does NOT serve the four message-relay kinds (`EpicHandoff`,
- * `DrainProgress`, `IntakePing`, `AckInbox`): those payloads travel peer-to-peer on the data
- * plane, never through the registry. This exclusion IS the "no message-relay path" invariant —
- * the tracker cannot relay a message it has no handler for. It reuses the protocol's Rpc
- * definitions verbatim; it never redefines a message type.
+ * The tracker serves exactly the five registry kinds — `Claim` (the request/reply resource
+ * claim), `Release` (freeing a resource claim), `AnnouncePresence` (soft presence), `LookupRole`
+ * (discovery), `Heartbeat` (TTL keepalive). It deliberately does NOT serve the four message-relay
+ * kinds (`EpicHandoff`, `DrainProgress`, `IntakePing`, `AckInbox`): those payloads travel
+ * peer-to-peer on the data plane, never through the registry. This exclusion IS the "no
+ * message-relay path" invariant — the tracker cannot relay a message it has no handler for. It
+ * reuses the protocol's Rpc definitions verbatim; it never redefines a message type.
  */
 import {RpcGroup} from "effect/unstable/rpc";
-import {AnnouncePresence, Claim, Heartbeat, LookupRole} from "../protocol/index.ts";
+import {AnnouncePresence, Claim, Heartbeat, LookupRole, Release} from "../protocol/index.ts";
 
-/** The control-plane registry surface — presence + role leases only, no relay kinds. */
-export const TrackerRegistry = RpcGroup.make(Claim, AnnouncePresence, LookupRole, Heartbeat);
+/** The control-plane registry surface — presence + role leases + resource claims, no relay kinds. */
+export const TrackerRegistry = RpcGroup.make(
+	Claim,
+	Release,
+	AnnouncePresence,
+	LookupRole,
+	Heartbeat,
+);

--- a/packages/pipeline-crew-mcp/src/tracker/handlers.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/handlers.ts
@@ -1,7 +1,9 @@
 /**
  * tracker/handlers — the `TrackerRegistry` handlers, mapping each registry Rpc onto the
- * `Registry` service. The lease name (the registry key) is the role string: `AnnouncePresence`
- * and `LookupRole` key on `role`, `Claim` keys on `resource` (the named lease it acquires).
+ * `Registry` service across the two keyspaces (ADR 0191). `AnnouncePresence` / `LookupRole` /
+ * `Heartbeat` operate on the role/presence keyspace (keyed by `role`); `Claim` / `Release`
+ * operate on the resource-claim keyspace (keyed by `resource`). `ClaimRequest`'s `role` field is
+ * consumed here as the claim's `claimantRole`.
  *
  * `lastSeen`/`since`/`at` cross the wire as ISO-8601 strings (the protocol `Timestamp`), but the
  * registry reasons in epoch millis against its own clock — the conversion happens here at the
@@ -21,20 +23,22 @@ export const TrackerHandlers = TrackerRegistry.toLayer(
 		return {
 			Claim: (payload) =>
 				registry
-					.acquire({
-						role: payload.resource,
-						peer: payload.claimant,
-						ttlSeconds: DEFAULT_TTL_SECONDS,
+					.claim({
+						resource: payload.resource,
+						claimant: payload.claimant,
+						claimantRole: payload.role,
 					})
 					.pipe(
 						Effect.map((outcome) => ({
 							resource: payload.resource,
 							granted: outcome._tag === "Granted",
 							collision: outcome._tag === "Collision",
-							owner: outcome.owner,
+							owner: outcome.holder,
 							since: iso(outcome.sinceMillis),
 						})),
 					),
+			Release: (payload) =>
+				registry.releaseClaim({resource: payload.resource, claimant: payload.claimant}),
 			AnnouncePresence: (payload) =>
 				registry.announce({
 					role: payload.role,

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
@@ -1,13 +1,22 @@
 /**
  * The soft-state registry semantics, tested in isolation from any transport: announce/lookup
  * round-trip, heartbeat-driven TTL aging, connection-is-lease role uniqueness + release, and the
- * explicit not-present result. These are the four acceptance criteria at the domain level.
+ * explicit not-present result — plus the resource-claim lifecycle (ADR 0191): keyspace separation,
+ * presence-derived claim liveness, steal-release protection, and presence-only heartbeat refresh.
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as Core from "./registry-core.ts";
 
 const T0 = 1_000_000; // an arbitrary epoch-millis baseline
 const secs = (n: number) => n * 1000;
+
+/** Give `peer` a live presence lease for `role` as of `at` — the claim-liveness clock. */
+const withPresence = (
+	state: Core.RegistryState,
+	peer: string,
+	role: string,
+	at: number,
+): Core.RegistryState => Core.acquire(state, {role, peer, ttlSeconds: 30, nowMillis: at}).state;
 
 describe("registry-core — announce / lookup", () => {
 	it("announce then lookup round-trips the peer for its role", () => {
@@ -123,5 +132,180 @@ describe("registry-core — connection-is-lease role uniqueness", () => {
 			nowMillis: T0 + secs(5),
 		});
 		assert.deepStrictEqual(outcome, {_tag: "Granted", owner: "peer-a", sinceMillis: T0});
+	});
+});
+
+describe("registry-core — keyspace separation (ADR 0191 facet 1)", () => {
+	it("a claim on a resource never surfaces as a role presence — the keyspaces are disjoint", () => {
+		let state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		// claim resource "3210" whose id COLLIDES with what could be a role string
+		state = Core.claimResource(state, {
+			resource: "3210",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		}).state;
+		// a role lookup of the same string reads the presence keyspace only ⇒ never the claim holder
+		assert.deepStrictEqual(Core.lookup(state, "3210", T0), []);
+		// while the claim keyspace does hold it
+		assert.strictEqual(Core.claimHolder(state, "3210", T0), "peer-a");
+	});
+
+	it("a granted claim records the claimant's role without a schema change", () => {
+		const {state} = Core.claimResource(withPresence(Core.empty(), "peer-a", "builder", T0), {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		});
+		assert.strictEqual(state.claims.get("issue-1")?.claimantRole, "builder");
+	});
+});
+
+describe("registry-core — presence-derived claim liveness (ADR 0191 facet 2)", () => {
+	it("a claim is live exactly while its holder's presence is live", () => {
+		let state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		state = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		}).state;
+		assert.strictEqual(
+			Core.claimHolder(state, "issue-1", T0 + secs(29)),
+			"peer-a",
+			"live before TTL",
+		);
+		assert.isUndefined(
+			Core.claimHolder(state, "issue-1", T0 + secs(31)),
+			"stale once the holder's presence ages out — no independent claim timer",
+		);
+	});
+
+	it("a second claim collides while the holder is present, and is granted once it ages out", () => {
+		let state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		state = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		}).state;
+		const collided = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-b",
+			claimantRole: "reviewer",
+			nowMillis: T0 + secs(1),
+		});
+		assert.deepStrictEqual(collided.outcome, {
+			_tag: "Collision",
+			holder: "peer-a",
+			sinceMillis: T0,
+		});
+		// once peer-a's presence has aged out, its claim is stale and the resource is free again
+		const granted = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-b",
+			claimantRole: "reviewer",
+			nowMillis: T0 + secs(31),
+		});
+		assert.strictEqual(granted.outcome._tag, "Granted");
+	});
+
+	it("a re-claim by the same holder keeps its original `since`", () => {
+		let state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		state = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		}).state;
+		const {outcome} = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0 + secs(5),
+		});
+		assert.deepStrictEqual(outcome, {_tag: "Granted", holder: "peer-a", sinceMillis: T0});
+	});
+});
+
+describe("registry-core — Release + reaping (ADR 0191 facets 2 + 3)", () => {
+	it("releaseClaim frees only the caller's own claim — steal-release is a no-op", () => {
+		let state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		state = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		}).state;
+		const foreign = Core.releaseClaim(state, {resource: "issue-1", claimant: "peer-b"});
+		assert.strictEqual(
+			Core.claimHolder(foreign, "issue-1", T0),
+			"peer-a",
+			"a non-holder cannot free it",
+		);
+		const freed = Core.releaseClaim(state, {resource: "issue-1", claimant: "peer-a"});
+		assert.isUndefined(Core.claimHolder(freed, "issue-1", T0), "the holder frees its own claim");
+	});
+
+	it("releasing a claim that does not exist is an idempotent no-op", () => {
+		const state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		const after = Core.releaseClaim(state, {resource: "never-claimed", claimant: "peer-a"});
+		assert.strictEqual(after, state);
+	});
+
+	it("release(peer) reaps every claim the peer held — its presence is gone with the connection", () => {
+		let state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		state = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		}).state;
+		const closed = Core.release(state, "peer-a");
+		assert.strictEqual(
+			closed.claims.size,
+			0,
+			"the closed peer's claims are reaped with its presence",
+		);
+		assert.strictEqual(closed.leases.size, 0);
+	});
+
+	it("prune reaps a claim whose holder has no live presence, and keeps a live one", () => {
+		let state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		state = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		}).state;
+		assert.strictEqual(
+			Core.prune(state, T0 + secs(10)).claims.size,
+			1,
+			"kept while the holder is present",
+		);
+		assert.strictEqual(
+			Core.prune(state, T0 + secs(31)).claims.size,
+			0,
+			"reaped once the holder ages out",
+		);
+	});
+});
+
+describe("registry-core — heartbeat refreshes presence only (ADR 0191 facet 4)", () => {
+	it("a heartbeat carries the claim's liveness transitively via presence, never touching the claim record", () => {
+		let state = withPresence(Core.empty(), "peer-a", "builder", T0);
+		state = Core.claimResource(state, {
+			resource: "issue-1",
+			holder: "peer-a",
+			claimantRole: "builder",
+			nowMillis: T0,
+		}).state;
+		// beat at T0+20 refreshes the PRESENCE lease; the claim has no timer of its own to bump
+		const beat = Core.heartbeat(state, {peer: "peer-a", ttlSeconds: 30, nowMillis: T0 + secs(20)});
+		// without the heartbeat, presence (and thus the claim) would be stale at T0+40; the beat carries it
+		assert.strictEqual(Core.claimHolder(beat, "issue-1", T0 + secs(40)), "peer-a");
+		// the claim record itself is untouched — the heartbeat iterated the presence keyspace only
+		assert.strictEqual(beat.claims.get("issue-1")?.claimedAtMillis, T0);
 	});
 });

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.ts
@@ -2,18 +2,27 @@
  * tracker/registry-core — the soft-state presence registry as a pure data structure.
  *
  * No Effect, no IO: state transitions only, so the announce / lookup / heartbeat-TTL /
- * role-lease semantics are unit-testable in isolation from the socket transport. The
- * service (`./registry.ts`) holds one of these in a `Ref` and supplies the clock.
+ * role-lease and resource-claim semantics are unit-testable in isolation from the socket
+ * transport. The service (`./registry.ts`) holds one of these in a `Ref` and supplies the clock.
  *
- * The two non-obvious model choices:
- *   - A role maps to at MOST ONE live lease (`RegistryState` is keyed by role) — that is
- *     how "named leases for role uniqueness" is made unrepresentable-otherwise rather than
- *     checked after the fact: you cannot store two live holders of one role.
- *   - "Connection-is-lease" is modelled by the peer id being the connection identity, and
- *     liveness being measured against the tracker's own clock (never the client-supplied
- *     `at`): a peer that stops heart-beating ages past its TTL and its lease frees, and an
- *     explicit `release` (a graceful connection close) frees it immediately. A client can't
- *     extend its own liveness by lying about `at`.
+ * Two keyspaces that never share a map (ADR 0191): role/presence leases keyed by `role`, and
+ * resource claims keyed by `resource`. A role lease and an issue claim are different lifecycles —
+ * keeping them in distinct typed maps makes "a `lookup` returns a claim holder" unrepresentable
+ * rather than checked after the fact.
+ *
+ * The three non-obvious model choices:
+ *   - A role maps to at MOST ONE live lease (`leases` is keyed by role) — that is how "named
+ *     leases for role uniqueness" is made unrepresentable-otherwise rather than checked after the
+ *     fact: you cannot store two live holders of one role.
+ *   - "Connection-is-lease" is modelled by the peer id being the connection identity, and liveness
+ *     being measured against the tracker's own clock (never the client-supplied `at`): a peer that
+ *     stops heart-beating ages past its TTL and its lease frees, and an explicit `release` (a
+ *     graceful connection close) frees it immediately. A client can't extend its own liveness by
+ *     lying about `at`.
+ *   - A resource claim carries NO independent TTL — it is live exactly as long as its holder's
+ *     presence is live (ADR 0191 facet 2). One liveness clock (presence); claims ride it. So a
+ *     `heartbeat` refreshes leases only and never touches claims (facet 4 falls out by construction);
+ *     a claim frees on explicit `releaseClaim` or is reaped once its holder has no live presence.
  */
 
 /** The default presence TTL applied on acquire, until the first `heartbeat` sets a real one. */
@@ -28,8 +37,24 @@ export interface Lease {
 	readonly lastSeenMillis: number;
 }
 
-/** The whole registry: one live lease per role (role uniqueness is structural). */
-export type RegistryState = ReadonlyMap<string, Lease>;
+/**
+ * One resource claim: a deconfliction hold on a resource (an issue id) by a peer. Distinct from
+ * `Lease` — a claim has no TTL of its own; its liveness derives from `holder`'s presence lease
+ * (ADR 0191 facet 2). `claimantRole` records which role holds the claim so tooling can read it
+ * without a schema change (`ClaimRequest`'s existing `role` field feeds it).
+ */
+export interface Claim {
+	readonly resource: string;
+	readonly holder: string;
+	readonly claimantRole: string;
+	readonly claimedAtMillis: number;
+}
+
+/** The whole registry: role/presence leases and resource claims in two separate keyspaces. */
+export interface RegistryState {
+	readonly leases: ReadonlyMap<string, Lease>;
+	readonly claims: ReadonlyMap<string, Claim>;
+}
 
 /** A present peer for a role, as the pure core reports it (millis; the handler formats the ISO). */
 export interface PresenceRecord {
@@ -46,11 +71,31 @@ export type AcquireOutcome =
 	| {readonly _tag: "Granted"; readonly owner: string; readonly sinceMillis: number}
 	| {readonly _tag: "Collision"; readonly owner: string; readonly sinceMillis: number};
 
-/** A fresh, empty registry. */
-export const empty = (): RegistryState => new Map();
+/**
+ * The result of a resource claim: `Granted` when the caller now holds the resource, `Collision`
+ * when a different peer with live presence already holds it (the claim is NOT stolen).
+ */
+export type ClaimOutcome =
+	| {readonly _tag: "Granted"; readonly holder: string; readonly sinceMillis: number}
+	| {readonly _tag: "Collision"; readonly holder: string; readonly sinceMillis: number};
+
+/** A fresh, empty registry — both keyspaces empty. */
+export const empty = (): RegistryState => ({leases: new Map(), claims: new Map()});
 
 const isLive = (lease: Lease, nowMillis: number): boolean =>
 	nowMillis <= lease.lastSeenMillis + lease.ttlSeconds * 1000;
+
+/** True iff `holder` holds any live presence lease — the claim-liveness clock (ADR 0191 facet 2). */
+const holderHasLivePresence = (
+	leases: ReadonlyMap<string, Lease>,
+	holder: string,
+	nowMillis: number,
+): boolean => {
+	for (const lease of leases.values()) {
+		if (lease.peer === holder && isLive(lease, nowMillis)) return true;
+	}
+	return false;
+};
 
 /**
  * Acquire the lease for `role` on behalf of `peer`. Granted when the role is free, held by an
@@ -67,7 +112,7 @@ export const acquire = (
 	},
 ): {readonly state: RegistryState; readonly outcome: AcquireOutcome} => {
 	const {role, peer, ttlSeconds, nowMillis} = input;
-	const existing = state.get(role);
+	const existing = state.leases.get(role);
 	if (existing && existing.peer !== peer && isLive(existing, nowMillis)) {
 		return {
 			state,
@@ -76,54 +121,148 @@ export const acquire = (
 	}
 	const leasedAtMillis = existing && existing.peer === peer ? existing.leasedAtMillis : nowMillis;
 	const lease: Lease = {role, peer, ttlSeconds, leasedAtMillis, lastSeenMillis: nowMillis};
-	const next = new Map(state);
-	next.set(role, lease);
-	return {state: next, outcome: {_tag: "Granted", owner: peer, sinceMillis: leasedAtMillis}};
+	const leases = new Map(state.leases);
+	leases.set(role, lease);
+	return {
+		state: {...state, leases},
+		outcome: {_tag: "Granted", owner: peer, sinceMillis: leasedAtMillis},
+	};
 };
 
-/** Refresh every lease held by `peer`: bump `lastSeen` to now and adopt the heartbeat's TTL. */
+/**
+ * Claim `resource` on behalf of `holder`. Granted when the resource is free, held by a holder
+ * whose presence has aged out (stale claim, reaped as free), or already held by `holder` itself
+ * (re-claim refreshes without moving `since`); a Collision — leaving state untouched — when a
+ * *different* holder with live presence holds it. Claim liveness derives from presence, so a
+ * claim whose holder is no longer present is treated as free here (ADR 0191 facet 2).
+ */
+export const claimResource = (
+	state: RegistryState,
+	input: {
+		readonly resource: string;
+		readonly holder: string;
+		readonly claimantRole: string;
+		readonly nowMillis: number;
+	},
+): {readonly state: RegistryState; readonly outcome: ClaimOutcome} => {
+	const {resource, holder, claimantRole, nowMillis} = input;
+	const existing = state.claims.get(resource);
+	if (
+		existing &&
+		existing.holder !== holder &&
+		holderHasLivePresence(state.leases, existing.holder, nowMillis)
+	) {
+		return {
+			state,
+			outcome: {_tag: "Collision", holder: existing.holder, sinceMillis: existing.claimedAtMillis},
+		};
+	}
+	const claimedAtMillis =
+		existing && existing.holder === holder ? existing.claimedAtMillis : nowMillis;
+	const claim: Claim = {resource, holder, claimantRole, claimedAtMillis};
+	const claims = new Map(state.claims);
+	claims.set(resource, claim);
+	return {
+		state: {...state, claims},
+		outcome: {_tag: "Granted", holder, sinceMillis: claimedAtMillis},
+	};
+};
+
+/**
+ * Free the claim on `resource` — but ONLY if `claimant` is its holder. A peer cannot release a
+ * claim it does not hold (steal-release is unrepresentable, ADR 0191 facet 3); releasing a claim
+ * you do not hold or one that does not exist is an idempotent no-op.
+ */
+export const releaseClaim = (
+	state: RegistryState,
+	input: {readonly resource: string; readonly claimant: string},
+): RegistryState => {
+	const existing = state.claims.get(input.resource);
+	if (!existing || existing.holder !== input.claimant) return state;
+	const claims = new Map(state.claims);
+	claims.delete(input.resource);
+	return {...state, claims};
+};
+
+/**
+ * The live holder of `resource`, or `undefined` when the resource is unclaimed or its holder's
+ * presence has aged out (a stale claim reads as free). The read-side companion to `claimResource`.
+ */
+export const claimHolder = (
+	state: RegistryState,
+	resource: string,
+	nowMillis: number,
+): string | undefined => {
+	const claim = state.claims.get(resource);
+	if (!claim || !holderHasLivePresence(state.leases, claim.holder, nowMillis)) return undefined;
+	return claim.holder;
+};
+
+/**
+ * Refresh every role lease held by `peer`: bump `lastSeen` to now and adopt the heartbeat's TTL.
+ * Resource claims are never touched — they have no TTL to bump, and their liveness rides presence
+ * (ADR 0191 facet 4). Because the keyspaces are split, this loop over `leases` is presence-only
+ * by construction.
+ */
 export const heartbeat = (
 	state: RegistryState,
 	input: {readonly peer: string; readonly ttlSeconds: number; readonly nowMillis: number},
 ): RegistryState => {
 	const {peer, ttlSeconds, nowMillis} = input;
-	const next = new Map(state);
-	for (const [role, lease] of state) {
+	const leases = new Map(state.leases);
+	for (const [role, lease] of state.leases) {
 		if (lease.peer === peer) {
-			next.set(role, {...lease, ttlSeconds, lastSeenMillis: nowMillis});
+			leases.set(role, {...lease, ttlSeconds, lastSeenMillis: nowMillis});
 		}
 	}
-	return next;
+	return {...state, leases};
 };
 
 /**
  * The present holders of `role` — the single live lease, or `[]` when the role is absent or its
  * holder has aged out. An empty array is the explicit not-present result (never a silent drop).
+ * Reads the presence keyspace only, so it can never surface a resource-claim holder (ADR 0191).
  */
 export const lookup = (
 	state: RegistryState,
 	role: string,
 	nowMillis: number,
 ): ReadonlyArray<PresenceRecord> => {
-	const lease = state.get(role);
+	const lease = state.leases.get(role);
 	if (!lease || !isLive(lease, nowMillis)) return [];
 	return [{peer: lease.peer, role: lease.role, lastSeenMillis: lease.lastSeenMillis}];
 };
 
-/** Free every lease held by `peer` — a graceful connection close (connection-is-lease). */
+/**
+ * Free every lease held by `peer` and reap every claim it holds — a graceful connection close
+ * (connection-is-lease). The peer's presence is gone, so under presence-derived liveness its
+ * claims are stale and dropped with it (ADR 0191 facet 2).
+ */
 export const release = (state: RegistryState, peer: string): RegistryState => {
-	const next = new Map(state);
-	for (const [role, lease] of state) {
-		if (lease.peer === peer) next.delete(role);
+	const leases = new Map(state.leases);
+	for (const [role, lease] of state.leases) {
+		if (lease.peer === peer) leases.delete(role);
 	}
-	return next;
+	const claims = new Map(state.claims);
+	for (const [resource, claim] of state.claims) {
+		if (claim.holder === peer) claims.delete(resource);
+	}
+	return {leases, claims};
 };
 
-/** Housekeeping: drop every lease that has aged past its TTL as of `nowMillis`. */
+/**
+ * Housekeeping: drop every lease aged past its TTL, then reap every claim whose holder no longer
+ * has a live presence lease (ADR 0191 facet 2 — a claim never outlives its holder's presence).
+ * Leases are pruned first so a claim is reaped against the freshly-pruned presence keyspace.
+ */
 export const prune = (state: RegistryState, nowMillis: number): RegistryState => {
-	const next = new Map(state);
-	for (const [role, lease] of state) {
-		if (!isLive(lease, nowMillis)) next.delete(role);
+	const leases = new Map(state.leases);
+	for (const [role, lease] of state.leases) {
+		if (!isLive(lease, nowMillis)) leases.delete(role);
 	}
-	return next;
+	const claims = new Map(state.claims);
+	for (const [resource, claim] of state.claims) {
+		if (!holderHasLivePresence(leases, claim.holder, nowMillis)) claims.delete(resource);
+	}
+	return {leases, claims};
 };

--- a/packages/pipeline-crew-mcp/src/tracker/registry.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry.test.ts
@@ -36,11 +36,13 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 		}).pipe(Effect.scoped, Effect.provide(handlers)),
 	);
 
-	it.effect("Claim grants a free role lease and collides on a second live acquire", () =>
+	it.effect("Claim grants a free resource and collides on a second acquire (holder present)", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			// The incumbent's claim is live only while its presence is — announce it first (ADR 0191).
+			yield* client.AnnouncePresence({peer: "peer-a", role: "builder", at});
 			const first = yield* client.Claim({
-				resource: "builder",
+				resource: "issue-3054",
 				claimant: "peer-a",
 				role: "builder",
 				at,
@@ -50,14 +52,50 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 			assert.strictEqual(first.owner, "peer-a");
 
 			const second = yield* client.Claim({
-				resource: "builder",
+				resource: "issue-3054",
 				claimant: "peer-b",
 				role: "builder",
 				at,
 			});
 			assert.isFalse(second.granted);
 			assert.isTrue(second.collision);
-			assert.strictEqual(second.owner, "peer-a", "the incumbent keeps the lease");
+			assert.strictEqual(second.owner, "peer-a", "the incumbent keeps the claim");
+		}).pipe(Effect.scoped, Effect.provide(handlers)),
+	);
+
+	it.effect("Release frees a held claim so another peer can then claim the resource", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			yield* client.AnnouncePresence({peer: "peer-a", role: "builder", at});
+			yield* client.AnnouncePresence({peer: "peer-b", role: "reviewer", at});
+			yield* client.Claim({resource: "issue-3054", claimant: "peer-a", role: "builder", at});
+			yield* client.Release({resource: "issue-3054", claimant: "peer-a", at});
+			const reclaim = yield* client.Claim({
+				resource: "issue-3054",
+				claimant: "peer-b",
+				role: "reviewer",
+				at,
+			});
+			assert.isTrue(reclaim.granted, "the released resource is free for a new claimant");
+			assert.strictEqual(reclaim.owner, "peer-b");
+		}).pipe(Effect.scoped, Effect.provide(handlers)),
+	);
+
+	it.effect("Release by a non-holder is a no-op — a peer cannot steal-release (ADR 0191)", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			yield* client.AnnouncePresence({peer: "peer-a", role: "builder", at});
+			yield* client.Claim({resource: "issue-3054", claimant: "peer-a", role: "builder", at});
+			// peer-b does not hold the claim: its release must not free peer-a's hold.
+			yield* client.Release({resource: "issue-3054", claimant: "peer-b", at});
+			const stillHeld = yield* client.Claim({
+				resource: "issue-3054",
+				claimant: "peer-c",
+				role: "builder",
+				at,
+			});
+			assert.isTrue(stillHeld.collision, "peer-a still holds it — the foreign release was ignored");
+			assert.strictEqual(stillHeld.owner, "peer-a");
 		}).pipe(Effect.scoped, Effect.provide(handlers)),
 	);
 

--- a/packages/pipeline-crew-mcp/src/tracker/registry.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry.ts
@@ -17,6 +17,12 @@ export interface AnnounceInput {
 	readonly ttlSeconds: number;
 }
 
+export interface ClaimInput {
+	readonly resource: string;
+	readonly claimant: string;
+	readonly claimantRole: string;
+}
+
 export class Registry extends Context.Service<
 	Registry,
 	{
@@ -24,14 +30,21 @@ export class Registry extends Context.Service<
 		readonly acquire: (input: AnnounceInput) => Effect.Effect<Core.AcquireOutcome>;
 		/** Soft presence announce — acquire and discard the outcome (the fire-and-forget wire kind). */
 		readonly announce: (input: AnnounceInput) => Effect.Effect<void>;
-		/** Refresh the TTL window for every lease `peer` holds. */
+		/** Claim `resource` for `claimant`, returning granted or a collision with a live-presence holder. */
+		readonly claim: (input: ClaimInput) => Effect.Effect<Core.ClaimOutcome>;
+		/** Free `resource`'s claim iff `claimant` holds it — steal-release is a no-op (ADR 0191 facet 3). */
+		readonly releaseClaim: (input: {
+			readonly resource: string;
+			readonly claimant: string;
+		}) => Effect.Effect<void>;
+		/** Refresh the TTL window for every role lease `peer` holds (never a claim — ADR 0191 facet 4). */
 		readonly heartbeat: (input: {
 			readonly peer: string;
 			readonly ttlSeconds: number;
 		}) => Effect.Effect<void>;
 		/** The present holders of `role` (empty ⇒ absent/expired — the explicit not-present result). */
 		readonly lookup: (role: string) => Effect.Effect<ReadonlyArray<Core.PresenceRecord>>;
-		/** Free every lease `peer` holds — a connection close (connection-is-lease). */
+		/** Free every lease `peer` holds and reap its claims — a connection close (connection-is-lease). */
 		readonly release: (peer: string) => Effect.Effect<void>;
 	}
 >()("@kampus/pipeline-crew-mcp/tracker/Registry") {}
@@ -47,9 +60,24 @@ export const RegistryLive: Layer.Layer<Registry> = Layer.effect(Registry)(
 					return [outcome, next];
 				});
 			});
+		const claim = (input: ClaimInput) =>
+			Effect.gen(function* () {
+				const nowMillis = yield* Clock.currentTimeMillis;
+				return yield* Ref.modify(ref, (state) => {
+					const {state: next, outcome} = Core.claimResource(state, {
+						resource: input.resource,
+						holder: input.claimant,
+						claimantRole: input.claimantRole,
+						nowMillis,
+					});
+					return [outcome, next];
+				});
+			});
 		return {
 			acquire,
 			announce: (input) => Effect.asVoid(acquire(input)),
+			claim,
+			releaseClaim: (input) => Ref.update(ref, (state) => Core.releaseClaim(state, input)),
 			heartbeat: (input) =>
 				Clock.currentTimeMillis.pipe(
 					Effect.flatMap((nowMillis) =>

--- a/packages/pipeline-crew-mcp/src/tracker/server.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.test.ts
@@ -24,12 +24,13 @@ describe("tracker socket path — per-project derivation", () => {
 });
 
 describe("tracker served surface — control-plane only", () => {
-	it("serves exactly the four registry kinds and no message-relay kind", () => {
+	it("serves exactly the five registry kinds and no message-relay kind", () => {
 		assert.deepStrictEqual([...TrackerRegistry.requests.keys()].sort(), [
 			"AnnouncePresence",
 			"Claim",
 			"Heartbeat",
 			"LookupRole",
+			"Release",
 		]);
 		for (const relay of ["AckInbox", "DrainProgress", "EpicHandoff", "IntakePing"]) {
 			assert.isFalse(


### PR DESCRIPTION
Implements **ADR 0191** (crew-mcp Claim lifecycle) as the single bounded PR it mandates, against `packages/pipeline-crew-mcp/`. All four interlocking facets:

**Facet 1 — keyspace split.** `RegistryState` splits into two typed maps that never share a namespace: role/presence leases keyed by `role` (existing `Lease`), and resource claims keyed by `resource` holding a distinct `Claim` record `{resource, holder, claimantRole, claimedAtMillis}` (not the presence `Lease`). `lookup` reads the presence keyspace only, so "a `LookupRole` returns a claim holder" is now unrepresentable. `ClaimRequest`'s existing `role` field is consumed as `claimantRole` (no wire change).

**Facet 2 — presence-derived claim liveness.** A claim carries no independent TTL; it is live exactly while its holder's presence lease is live. Freed by explicit `Release`, or reaped when the holder's presence ages out (treated as free on the next `claimResource`, dropped by `prune`, and reaped by `release(peer)` on connection close). `DEFAULT_TTL_SECONDS` now governs presence only.

**Facet 3 — the `Release` wire kind.** New fire-and-forget `Release` Rpc carrying `ReleaseClaim {resource, claimant, at}` — no `success` schema, so the reply defaults to `Schema.Void` (effect-smol `Rpc.ts`: `const successSchema = options?.success ?? Schema.Void`). Added to `protocol/schema.ts` + `protocol/group.ts` + the `TrackerRegistry` subset. The handler maps to `registry.releaseClaim` which frees the named claim **only if `claim.holder === claimant`** (steal-release unrepresentable). Client side: `CrewTracker.release` + a scoped `acquireClaim` that frees its claim on scope close via `Effect.acquireRelease`.

**Facet 4 (tracker-side) — heartbeat refreshes role/presence leases only.** Falls out of facet 1 by construction: once the keyspaces split, `heartbeat()`'s "refresh every lease this peer holds" loop iterates the presence keyspace only. No claim-refresh behavior — correct-by-construction. (#3218's presence-only sender is honored by the tracker now.)

## Notes
- `Claim`/`ClaimReply` unchanged on the wire. `channel-server.ts` role-uniqueness continues to work: a session announces presence right after claiming its role, so a second session's claim collides against the live-presence incumbent.
- Non-§CP (ADR 0187 — `packages/pipeline-crew-mcp/` is outside the control plane, no `CONTROL_PLANE_RE` match); auto-ships on review-code PASS + green.
- `pnpm typecheck` clean, `pnpm lint:worktree` clean, 93 package tests pass (added claim-lifecycle coverage at the core, registry, protocol, and crew-tracker tiers).

Interlocks with #3218 (presence keepalive sender, already merged) and #3229 (channel_send shape-validation, separate) per ADR 0191 §Scope — no follow-up impl issues spawned.

Fixes #3281