### PR TITLE
feat(pipeline-crew): launch-dimension config schema + typed reader (#3293)

### DIFF
--- a/claude-plugins/pipeline-crew/PERSONALIZATION.md
+++ b/claude-plugins/pipeline-crew/PERSONALIZATION.md
@@ -66,9 +66,24 @@ reference these keys, never a literal.
 | tmux / session naming | `tmux.session`, `tmux.windows.ea`, `tmux.windows.engineeringManager`, `tmux.windows.triage` | The tmux session name and the three per-role window/pane names the stand-up brings up and the roles address each other by. | `<tmux-session-name>`, `<ea-window-name>`, `<em-window-name>`, `<triage-window-name>` |
 | Model-tier preferences | `modelTiers.ea`, `modelTiers.engineeringManager`, `modelTiers.triage` | The model tier each role runs on — the planning-tier intake session vs the execution/build-tier conductor (so a role never silently downgrades a spawned subagent). | `<ea-model-tier>`, `<em-model-tier>`, `<triage-model-tier>` |
 | WIP caps | `wipCaps.productLanes`, `wipCaps.platformLanes` | The engineering-manager's bounded concurrent-lane count per class — how many product vs platform/pipeline coders it drives at once before queueing the rest. | `<wip-cap-product-lanes>`, `<wip-cap-platform-lanes>` |
+| Pinned CLI version | `cliVersion` | The Claude Code CLI version the stand-up launcher asserts before it starts any session — a hard gate so the crew never launches on a drifted CLI (`major.minor.patch`, optional `-suffix`). | `<pinned-claude-code-cli-version>` |
+| Engine count | `engineCount` | How many engine (build) sessions the stand-up starts — a positive integer. | `<engine-count>` |
+| Channel registration | `channels.mode`, `channels.servers`, `channels.allowedChannelPlugins` | How each launched session registers its channel MCP servers: `mode` is `allowlist` (`--channels <refs>`) or `development` (`--dangerously-load-development-channels`, local only); `servers` are the refs each session registers (grammar `server:<name>` / `plugin:<plugin>:<server>`); `allowedChannelPlugins` is the plugin allowlist the `allowlist` mode enforces. | `<channel-mode: allowlist \| development>`, `<channel-server-ref>`, `<allowed-channel-plugin>` |
 
 Adding a new operator-specific dimension is **one row here + one key in the template + one
 reference in the def that needs it** — never a new literal buried in a def.
+
+### The launch dimensions have a typed reader (fail-closed)
+
+The last three rows are **launch dimensions** — inputs the stand-up launcher reads, not
+prose an agent def binds. They resolve through the **same** order as every other seam key
+(`$CREW_CONFIG` → `.claude/crew.config.jsonc`) but are consumed by a typed reader,
+[`packages/pipeline-crew-mcp/src/standup/config.ts`](../../packages/pipeline-crew-mcp/src/standup/config.ts),
+which validates them and **fails closed** — a missing or malformed dimension (a non-version
+CLI pin, an unknown channel mode, a channel ref off-grammar, a non-positive engine count)
+stops the launch with an error naming that dimension, never a silent default. The launcher
+children (version-assert, bind-builder, roster, orchestration) consume the reader's typed
+result; they never re-parse the config.
 
 ## Stand-up
 

--- a/claude-plugins/pipeline-crew/crew.config.template.jsonc
+++ b/claude-plugins/pipeline-crew/crew.config.template.jsonc
@@ -49,5 +49,27 @@
 	"wipCaps": {
 		"productLanes": "<wip-cap-product-lanes>",
 		"platformLanes": "<wip-cap-platform-lanes>"
+	},
+
+	// The pinned Claude Code CLI version the stand-up launcher asserts before it starts
+	// any session — a hard gate so the crew never launches on a drifted CLI. Fill with the
+	// exact `major.minor.patch` (optionally `-suffix`) your `claude --version` reports.
+	"cliVersion": "<pinned-claude-code-cli-version>",
+
+	// How many engine (build) sessions the stand-up starts (a positive integer).
+	"engineCount": "<engine-count>",
+
+	// Channel MCP registration for every launched session.
+	"channels": {
+		// "allowlist" → sessions launch with `--channels <refs>` (only the listed servers load);
+		// "development" → `--dangerously-load-development-channels` (loads every dev channel; local only).
+		"mode": "<channel-mode: allowlist | development>",
+		// The channel servers each session registers, by ref. Grammar per ref:
+		//   "server:<name>"            — a top-level channel MCP server
+		//   "plugin:<plugin>:<server>" — a server contributed by a plugin
+		"servers": ["<channel-server-ref>"],
+		// Plugins whose channel servers are allowed to load — the allowlist the "allowlist"
+		// mode enforces; each name matches a "plugin:<plugin>:..." ref used in `servers`.
+		"allowedChannelPlugins": ["<allowed-channel-plugin>"]
 	}
 }

--- a/packages/pipeline-crew-mcp/src/standup/config.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.test.ts
@@ -1,0 +1,179 @@
+/**
+ * standup/config — the launch-dimension reader (issue #3293). Covers path resolution, the
+ * JSONC strip (comments + trailing commas, string-literal aware), the happy decode against a
+ * FULL crew config (excess seam keys ignored), and — the load-bearing part — fail-closed
+ * decoding: each required launch dimension absent or malformed yields a `LaunchConfigError`
+ * whose reason names that dimension.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	DEFAULT_CONFIG_PATH,
+	decodeLaunchConfig,
+	LaunchConfigError,
+	parseJsonc,
+	resolveConfigPath,
+	stripJsonc,
+} from "./config.ts";
+
+/** A minimal-but-valid launch dimension set, embedded in a fuller crew config below. */
+const validLaunch = {
+	cliVersion: "2.1.207",
+	engineCount: 2,
+	channels: {
+		mode: "allowlist",
+		servers: ["server:crew-channels", "plugin:pipeline-crew:crew-channels"],
+		allowedChannelPlugins: ["pipeline-crew"],
+	},
+};
+
+/** The launch dimensions never arrive alone — they sit inside the full personalization config. */
+const fullCrewConfig = {
+	operator: {name: "op", handle: "op"},
+	tmux: {session: "s", windows: {ea: "ea", engineeringManager: "em", triage: "t"}},
+	...validLaunch,
+};
+
+const decodeErr = (input: unknown) =>
+	Effect.flip(decodeLaunchConfig(input, "/tmp/crew.config.jsonc"));
+
+describe("standup/config — resolveConfigPath", () => {
+	it("prefers $CREW_CONFIG when set and non-blank", () => {
+		assert.strictEqual(resolveConfigPath({CREW_CONFIG: "/opt/crew.jsonc"}), "/opt/crew.jsonc");
+	});
+	it("falls back to the default when $CREW_CONFIG is unset or blank", () => {
+		assert.strictEqual(resolveConfigPath({}), DEFAULT_CONFIG_PATH);
+		assert.strictEqual(resolveConfigPath({CREW_CONFIG: "   "}), DEFAULT_CONFIG_PATH);
+	});
+});
+
+describe("standup/config — stripJsonc / parseJsonc", () => {
+	it("strips line + block comments and trailing commas", () => {
+		const jsonc = `{
+			// line comment
+			"a": 1, /* block */
+			"b": [2, 3,],
+		}`;
+		assert.deepStrictEqual(parseJsonc(jsonc), {a: 1, b: [2, 3]});
+	});
+	it("preserves comment-like and comma sequences inside string values", () => {
+		const jsonc = `{"url": "http://x.y//z", "note": "a, b, c"}`;
+		assert.deepStrictEqual(parseJsonc(jsonc), {url: "http://x.y//z", note: "a, b, c"});
+	});
+	it("does not end a string early on an escaped quote", () => {
+		assert.deepStrictEqual(
+			stripJsonc(`{"q": "he said \\"hi\\" // ok"}`),
+			`{"q": "he said \\"hi\\" // ok"}`,
+		);
+	});
+});
+
+describe("standup/config — decodeLaunchConfig (happy path)", () => {
+	it.effect("extracts the launch dimensions from a full crew config, ignoring excess keys", () =>
+		Effect.gen(function* () {
+			const cfg = yield* decodeLaunchConfig(fullCrewConfig, DEFAULT_CONFIG_PATH);
+			assert.strictEqual(cfg.cliVersion, "2.1.207");
+			assert.strictEqual(cfg.engineCount, 2);
+			assert.strictEqual(cfg.channels.mode, "allowlist");
+			assert.deepStrictEqual(
+				[...cfg.channels.servers],
+				["server:crew-channels", "plugin:pipeline-crew:crew-channels"],
+			);
+			assert.deepStrictEqual([...cfg.channels.allowedChannelPlugins], ["pipeline-crew"]);
+		}),
+	);
+	it.effect("accepts the development channel mode", () =>
+		Effect.gen(function* () {
+			const cfg = yield* decodeLaunchConfig(
+				{...validLaunch, channels: {...validLaunch.channels, mode: "development"}},
+				DEFAULT_CONFIG_PATH,
+			);
+			assert.strictEqual(cfg.channels.mode, "development");
+		}),
+	);
+});
+
+describe("standup/config — fails closed naming the offending dimension", () => {
+	const without = (key: keyof typeof validLaunch) => {
+		const {[key]: _omit, ...rest} = validLaunch;
+		return rest;
+	};
+
+	it.effect("cliVersion missing", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr(without("cliVersion"));
+			assert.instanceOf(err, LaunchConfigError);
+			assert.include(err.reason, "cliVersion");
+			assert.strictEqual(err.configPath, "/tmp/crew.config.jsonc");
+		}),
+	);
+	it.effect("cliVersion malformed (not a version)", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({...validLaunch, cliVersion: "latest"});
+			assert.include(err.reason, "cliVersion");
+		}),
+	);
+	it.effect("engineCount missing", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr(without("engineCount"));
+			assert.include(err.reason, "engineCount");
+		}),
+	);
+	it.effect("engineCount below one", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({...validLaunch, engineCount: 0});
+			assert.include(err.reason, "engineCount");
+		}),
+	);
+	it.effect("engineCount non-integer", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({...validLaunch, engineCount: 2.5});
+			assert.include(err.reason, "engineCount");
+		}),
+	);
+	it.effect("channels missing", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr(without("channels"));
+			assert.include(err.reason, "channels");
+		}),
+	);
+	it.effect("channels.mode invalid", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				channels: {...validLaunch.channels, mode: "yolo"},
+			});
+			assert.include(err.reason, "mode");
+		}),
+	);
+	it.effect("channels.servers empty", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				channels: {...validLaunch.channels, servers: []},
+			});
+			assert.include(err.reason, "servers");
+		}),
+	);
+	it.effect("channels.servers holds a malformed ref", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				channels: {...validLaunch.channels, servers: ["not-a-valid-ref"]},
+			});
+			assert.include(err.reason, "servers");
+		}),
+	);
+	it.effect("channels.allowedChannelPlugins missing", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				channels: {
+					mode: validLaunch.channels.mode,
+					servers: validLaunch.channels.servers,
+				},
+			});
+			assert.include(err.reason, "allowedChannelPlugins");
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/standup/config.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.ts
@@ -1,0 +1,203 @@
+/**
+ * standup/config — the launch-dimension schema + typed reader for the stand-up launcher.
+ *
+ * The distributable pipeline-crew plugin ships ZERO operator data (the personalization
+ * seam, claude-plugins/pipeline-crew/PERSONALIZATION.md), so every launch input the
+ * stand-up reads — the pinned CLI version, the channel registration mode + server refs,
+ * the engine count — enters through the operator-owned crew config. This module is the
+ * decode boundary that turns that untrusted JSONC into the typed `LaunchConfig` the
+ * version-assert, bind-builder, roster, and orchestration children consume; consuming the
+ * values is out of scope here (issue #3293, decision on #3292).
+ *
+ * The one non-obvious thing: the reader FAILS CLOSED. A missing or malformed launch
+ * dimension is a `LaunchConfigError` naming the offending dimension, never a silent default
+ * — a drifted CLI pin or an unlisted channel server is a launch to refuse, not paper over.
+ * Excess keys (operator, tmux, modelTiers, …) are ignored: this schema extracts only the
+ * launch dimensions from the full crew config, so it composes with the rest of the seam.
+ */
+import {readFileSync} from "node:fs";
+import {Effect, Schema} from "effect";
+
+/**
+ * A channel-server ref, in the launcher's registration grammar:
+ *   - `server:<name>`            — a top-level channel MCP server
+ *   - `plugin:<plugin>:<server>` — a server contributed by a plugin
+ * The two forms are exactly what the bind-builder (#3296) turns into `--channels` args.
+ */
+export const CHANNEL_SERVER_REF_RE = /^(?:server:[^:\s]+|plugin:[^:\s]+:[^:\s]+)$/;
+
+export const ChannelServerRef = Schema.String.check(
+	Schema.isPattern(CHANNEL_SERVER_REF_RE, {
+		title: "ChannelServerRef",
+		description: 'a channel-server ref: "server:<name>" or "plugin:<plugin>:<server>"',
+	}),
+);
+export type ChannelServerRef = typeof ChannelServerRef.Type;
+
+/**
+ * The pinned Claude Code CLI version the stand-up asserts before launching any session
+ * (#3295 consumes it). A `major.minor.patch` core with an optional pre-release suffix — the
+ * shape `claude --version` reports — so a non-version placeholder or a partial pin is rejected.
+ */
+export const CLI_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/;
+
+export const CliVersion = Schema.String.check(
+	Schema.isPattern(CLI_VERSION_RE, {
+		title: "CliVersion",
+		description: "a pinned Claude Code CLI version, e.g. 2.1.207",
+	}),
+);
+export type CliVersion = typeof CliVersion.Type;
+
+/**
+ * How each launched session registers its channel MCP servers:
+ *   - `allowlist`   → `--channels <refs>` (only the listed servers load)
+ *   - `development` → `--dangerously-load-development-channels` (every dev channel; local only)
+ */
+export const ChannelMode = Schema.Literals(["allowlist", "development"]);
+export type ChannelMode = typeof ChannelMode.Type;
+
+/** How many engine (build) sessions the stand-up starts — at least one. */
+export const EngineCount = Schema.Int.check(
+	Schema.isGreaterThanOrEqualTo(1, {
+		title: "EngineCount",
+		description: "the number of engine sessions to start (>= 1)",
+	}),
+);
+export type EngineCount = typeof EngineCount.Type;
+
+/** The channel-registration dimension: the mode, the servers each session registers, and the plugin allowlist. */
+export const ChannelConfig = Schema.Struct({
+	mode: ChannelMode,
+	servers: Schema.NonEmptyArray(ChannelServerRef),
+	allowedChannelPlugins: Schema.Array(Schema.NonEmptyString),
+});
+export type ChannelConfig = typeof ChannelConfig.Type;
+
+/** The launch dimensions the stand-up reads — the clean type every launcher child imports. */
+export const LaunchConfig = Schema.Struct({
+	cliVersion: CliVersion,
+	engineCount: EngineCount,
+	channels: ChannelConfig,
+});
+export type LaunchConfig = typeof LaunchConfig.Type;
+
+/** A crew config that could not be resolved, read, parsed, or validated — carries the offending dimension. */
+export class LaunchConfigError extends Schema.TaggedErrorClass<LaunchConfigError>()(
+	"@kampus/pipeline-crew-mcp/standup/LaunchConfigError",
+	{
+		configPath: Schema.String,
+		reason: Schema.String,
+	},
+) {}
+
+/** The default operator-owned config path when `$CREW_CONFIG` is unset (ADR 0062 / PERSONALIZATION.md). */
+export const DEFAULT_CONFIG_PATH = ".claude/crew.config.jsonc";
+
+/** Resolve the config path: `$CREW_CONFIG` if set and non-blank, else `.claude/crew.config.jsonc`. */
+export const resolveConfigPath = (
+	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
+): string => {
+	const override = env.CREW_CONFIG?.trim();
+	return override && override.length > 0 ? override : DEFAULT_CONFIG_PATH;
+};
+
+/**
+ * Strip JSONC to strict JSON: line/block comments and trailing commas. String-literal aware,
+ * so a `//`, `/*`, or comma inside a string value is preserved — the template is `.jsonc`, so
+ * the reader must handle the comments the operator keeps, not choke on them.
+ */
+export const stripJsonc = (text: string): string => {
+	let out = "";
+	let inString = false;
+	let inLineComment = false;
+	let inBlockComment = false;
+	for (let i = 0; i < text.length; i++) {
+		const ch = text[i];
+		const next = text[i + 1];
+		if (inLineComment) {
+			if (ch === "\n") {
+				inLineComment = false;
+				out += ch;
+			}
+			continue;
+		}
+		if (inBlockComment) {
+			if (ch === "*" && next === "/") {
+				inBlockComment = false;
+				i++;
+			}
+			continue;
+		}
+		if (inString) {
+			out += ch;
+			if (ch === "\\") {
+				// Copy the escaped char verbatim so an escaped quote can't end the string early.
+				out += next ?? "";
+				i++;
+			} else if (ch === '"') {
+				inString = false;
+			}
+			continue;
+		}
+		if (ch === '"') {
+			inString = true;
+			out += ch;
+			continue;
+		}
+		if (ch === "/" && next === "/") {
+			inLineComment = true;
+			i++;
+			continue;
+		}
+		if (ch === "/" && next === "*") {
+			inBlockComment = true;
+			i++;
+			continue;
+		}
+		out += ch;
+	}
+	// Drop trailing commas (`,]` / `,}`), now that string bodies are safely behind us.
+	return out.replace(/,(\s*[}\]])/g, "$1");
+};
+
+/** Parse operator JSONC into an untyped value; throws on malformed JSON (the reader maps it to a typed error). */
+export const parseJsonc = (text: string): unknown => JSON.parse(stripJsonc(text));
+
+/**
+ * Decode an already-parsed value into `LaunchConfig`, failing closed with a `LaunchConfigError`
+ * whose `reason` names the offending dimension (the schema issue tree carries the field path).
+ */
+export const decodeLaunchConfig = (
+	input: unknown,
+	configPath: string,
+): Effect.Effect<LaunchConfig, LaunchConfigError> =>
+	Schema.decodeUnknownEffect(LaunchConfig)(input).pipe(
+		Effect.mapError((error) => new LaunchConfigError({configPath, reason: error.message})),
+	);
+
+/**
+ * Resolve → read → parse → decode the crew config's launch dimensions. Every failure along the
+ * way (path unreadable, JSONC malformed, a dimension missing/invalid) collapses to a single
+ * `LaunchConfigError` carrying the resolved path and the reason — never a partial or a default.
+ */
+export const readLaunchConfig = (
+	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
+): Effect.Effect<LaunchConfig, LaunchConfigError> =>
+	Effect.gen(function* () {
+		const configPath = resolveConfigPath(env);
+		const text = yield* Effect.try({
+			try: () => readFileSync(configPath, "utf8"),
+			catch: (cause) =>
+				new LaunchConfigError({
+					configPath,
+					reason: `cannot read crew config (run pipeline-crew stand-up first): ${String(cause)}`,
+				}),
+		});
+		const parsed = yield* Effect.try({
+			try: () => parseJsonc(text),
+			catch: (cause) =>
+				new LaunchConfigError({configPath, reason: `invalid JSONC: ${String(cause)}`}),
+		});
+		return yield* decodeLaunchConfig(parsed, configPath);
+	});


### PR DESCRIPTION
## What

Adds the stand-up launcher's **launch dimensions** to the pipeline-crew personalization seam and a typed, fail-closed reader for them. Schema + reader only — consuming the values is later children (version-assert #3295, bind-builder #3296, roster #3297, orchestration #3299).

Fixes #3293.

## Changes

- **`packages/pipeline-crew-mcp/src/standup/config.ts`** — the `LaunchConfig` schema (Effect Schema) covering:
  - `cliVersion` — pinned Claude Code CLI version (`major.minor.patch[-suffix]`).
  - `engineCount` — number of engine sessions (integer ≥ 1).
  - `channels` — `mode` (`allowlist` | `development`), `servers` (non-empty; grammar `server:<name>` / `plugin:<plugin>:<server>`), and `allowedChannelPlugins`.

  The reader resolves the config via `$CREW_CONFIG` → `.claude/crew.config.jsonc` (ADR 0062 order), strips JSONC (comment/trailing-comma, string-literal aware), and decodes — **failing closed** with a `LaunchConfigError` naming the specific missing/invalid dimension. Excess seam keys (operator, tmux, …) are ignored, so it extracts the launch dimensions from the full crew config.
- **`crew.config.template.jsonc`** — placeholder-only entries for the new dimensions (zero operator data).
- **`PERSONALIZATION.md`** — documents each launch dimension + its resolution, and points at the typed reader.

## Acceptance criteria

- [x] Template gains placeholders for pinned CLI version, channel mode + server refs, `allowedChannelPlugins`, and engine count (placeholders only).
- [x] `PERSONALIZATION.md` documents each new launch dimension and its resolution.
- [x] Typed reader resolves via `$CREW_CONFIG` → `.claude/crew.config.jsonc` and returns the parsed launch dimensions.
- [x] Reader fails closed with a clear error naming the specific missing/invalid dimension — unit-tested for each required dimension absent/malformed (`config.test.ts`, 17 tests).

## Verification

- `pnpm vitest run src/standup/config.test.ts` → 17 passed
- `pnpm typecheck` → clean
- `pnpm biome check` → clean

## Notes for siblings (lane discipline)

- No `standup/index.ts` barrel created — reserved for the orchestrator (#3299). The config type is exported from `config.ts` for #3295/#3296 to import.
- Touched only `standup/config.ts` (+ test) and the two plugin config files; no registry-core / crew / protocol edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)