### PR TITLE
feat(pipeline-crew): tmux window-manager placement for the stand-up launcher (#3298)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The tmux placement mapping (AC 4): a sample roster session set — three bridges + N engines —
+ * maps to one placement target per session, all under the operator-configured tmux session, with
+ * bridge windows resolved from the operator config's tmux naming and engine windows from each
+ * engine's per-instance id. Also pins the two fail-closed rejections: a bridge whose window key
+ * the operator config omits, and two sessions colliding on one window. These prove tmux is used
+ * only as a window-manager here — the mapping produces placement targets, never a transport path.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	computeTmuxPlacement,
+	type RosterSession,
+	type TmuxNaming,
+	TmuxWindowCollisionError,
+	TmuxWindowUnnamedError,
+} from "./tmux-placement.ts";
+
+// Operator-configured tmux naming — the shape #3293's reader resolves from the config `tmux`
+// dimension. Placeholder values stand in for operator data; the layer never hardcodes them.
+const NAMING: TmuxNaming = {
+	session: "crew",
+	windows: {
+		ea: "chief-of-staff",
+		engineeringManager: "em",
+		triage: "intake-desk",
+	},
+};
+
+// A sample roster: the three bridges + an engine count of N (here N = 3, each engine already
+// carrying its per-instance identity from #3297).
+const BRIDGES: readonly RosterSession[] = [
+	{kind: "bridge", role: "ea-chief-of-staff", windowKey: "ea"},
+	{kind: "bridge", role: "engineering-manager", windowKey: "engineeringManager"},
+	{kind: "bridge", role: "triage-guy", windowKey: "triage"},
+];
+const engines = (n: number): readonly RosterSession[] =>
+	Array.from({length: n}, (_, i) => ({kind: "engine", id: `engine-${i + 1}`}) as const);
+
+describe("standup/tmux-placement — session set → placement targets", () => {
+	it.effect("places one window per bridge + one per engine, all under the tmux session", () =>
+		Effect.gen(function* () {
+			const targets = yield* computeTmuxPlacement(NAMING, [...BRIDGES, ...engines(3)]);
+			assert.lengthOf(targets, 6, "3 bridges + 3 engines = 6 placement targets");
+			for (const t of targets) {
+				assert.strictEqual(
+					t.session,
+					"crew",
+					"every window lives under the configured tmux session",
+				);
+			}
+		}),
+	);
+
+	it.effect("resolves each bridge window from the operator config's tmux naming", () =>
+		Effect.gen(function* () {
+			const targets = yield* computeTmuxPlacement(NAMING, BRIDGES);
+			assert.deepStrictEqual(
+				targets.map((t) => ({window: t.window, sessionRef: t.sessionRef, kind: t.kind})),
+				[
+					{window: "chief-of-staff", sessionRef: "ea-chief-of-staff", kind: "bridge"},
+					{window: "em", sessionRef: "engineering-manager", kind: "bridge"},
+					{window: "intake-desk", sessionRef: "triage-guy", kind: "bridge"},
+				],
+			);
+		}),
+	);
+
+	it.effect("names each engine window from its per-instance id (distinct across the count)", () =>
+		Effect.gen(function* () {
+			const targets = yield* computeTmuxPlacement(NAMING, engines(4));
+			assert.deepStrictEqual(
+				targets.map((t) => ({window: t.window, sessionRef: t.sessionRef, kind: t.kind})),
+				[
+					{window: "engine-1", sessionRef: "engine-1", kind: "engine"},
+					{window: "engine-2", sessionRef: "engine-2", kind: "engine"},
+					{window: "engine-3", sessionRef: "engine-3", kind: "engine"},
+					{window: "engine-4", sessionRef: "engine-4", kind: "engine"},
+				],
+			);
+			assert.strictEqual(
+				new Set(targets.map((t) => t.window)).size,
+				4,
+				"engine windows are distinct",
+			);
+		}),
+	);
+
+	it.effect("fails closed when a bridge names a window key the operator config omits", () =>
+		Effect.gen(function* () {
+			const failure = yield* computeTmuxPlacement(NAMING, [
+				{kind: "bridge", role: "cartographer", windowKey: "cartographer"},
+			]).pipe(Effect.flip);
+			assert.instanceOf(failure, TmuxWindowUnnamedError);
+			assert.strictEqual(failure.windowKey, "cartographer");
+			assert.strictEqual(failure.role, "cartographer");
+		}),
+	);
+
+	it.effect("fails closed when two sessions collide on one window", () =>
+		Effect.gen(function* () {
+			const failure = yield* computeTmuxPlacement(NAMING, [
+				{kind: "bridge", role: "ea-chief-of-staff", windowKey: "ea"},
+				// an engine whose id equals the already-placed bridge window name
+				{kind: "engine", id: "chief-of-staff"},
+			]).pipe(Effect.flip);
+			assert.instanceOf(failure, TmuxWindowCollisionError);
+			assert.strictEqual(failure.window, "chief-of-staff");
+			assert.deepStrictEqual([...failure.sessionRefs], ["ea-chief-of-staff", "chief-of-staff"]);
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.ts
@@ -1,0 +1,126 @@
+/**
+ * standup/tmux-placement — tmux in its SURVIVING role: window-manager, not transport. The
+ * stand-up launcher (epic #3237) coordinates the crew over the channels substrate now, but
+ * something must still put each launched session on the operator's screen — that is this layer.
+ * It maps the roster session set (C6, #3297: one entry per bridge + one per engine instance) to
+ * tmux placement targets under the operator-configured tmux session, resolving each window name
+ * from the operator's tmux naming.
+ *
+ * The layer is deliberately thin: it maps sessions to placement targets and nothing else. It does
+ * NOT register channels or mint identity (C5/C6 own those), it does NOT read the config file (the
+ * `tmux` dimension reader/validator is #3293; here we consume the already-resolved `TmuxNaming`),
+ * and it introduces NO tmux-as-transport path — no pane-title discovery, no buffer-paste, no
+ * send-keys. Pure derivation over plain data (the `registry-core` idiom); the launcher (#3299)
+ * issues the actual window/pane creation from the targets this returns.
+ */
+import {Effect, Schema} from "effect";
+
+/**
+ * The operator-configured tmux naming this layer consumes — the `tmux` dimension of the crew
+ * config personalization seam (ADR 0062: operator data lives in the operator's config, never the
+ * distributable plugin). Loaded and validated by #3293's reader; here we take the resolved shape.
+ */
+export interface TmuxNaming {
+	/** The tmux session every crew window is created under — operator-configured, never hardcoded. */
+	readonly session: string;
+	/** Operator-configured window names, keyed by a bridge's window key. */
+	readonly windows: Readonly<Record<string, string>>;
+}
+
+/**
+ * One session in the roster set (C6, #3297) that must be placed on the operator's screen. A bridge
+ * is a singleton role window whose name the operator configures; an engine is one of N instances
+ * whose per-instance identity (#3297 generates it) already names its window — the operator cannot
+ * name N dynamic engines, so the generated id is the (non-operator, non-hardcoded) window name.
+ */
+export type RosterSession =
+	| {readonly kind: "bridge"; readonly role: string; readonly windowKey: string}
+	| {readonly kind: "engine"; readonly id: string};
+
+/** Where one session is placed: a named window under the operator-configured tmux session. */
+export interface PlacementTarget {
+	/** The tmux session this window is created under (from `TmuxNaming.session`). */
+	readonly session: string;
+	/** The resolved tmux window name. */
+	readonly window: string;
+	/** The roster session this places — a bridge role slug or an engine instance id. */
+	readonly sessionRef: string;
+	readonly kind: "bridge" | "engine";
+}
+
+/**
+ * A bridge names a window key the operator's tmux config does not define — fail loud rather than
+ * invent a name, because the window name MUST come from operator config (no hardcoded operator
+ * data). A REJECTION, not a value (the `crew/errors` idiom).
+ */
+export class TmuxWindowUnnamedError extends Schema.TaggedErrorClass<TmuxWindowUnnamedError>()(
+	"@kampus/pipeline-crew-mcp/standup/TmuxWindowUnnamedError",
+	{
+		role: Schema.String,
+		windowKey: Schema.String,
+	},
+) {}
+
+/**
+ * Two sessions resolved to the same window under the tmux session — a placement that would stack
+ * them invisibly on one window. The distinctness invariant is enforced here at its result site.
+ */
+export class TmuxWindowCollisionError extends Schema.TaggedErrorClass<TmuxWindowCollisionError>()(
+	"@kampus/pipeline-crew-mcp/standup/TmuxWindowCollisionError",
+	{
+		window: Schema.String,
+		sessionRefs: Schema.Array(Schema.String),
+	},
+) {}
+
+const placeOne = (
+	naming: TmuxNaming,
+	session: RosterSession,
+): Effect.Effect<PlacementTarget, TmuxWindowUnnamedError> => {
+	if (session.kind === "engine") {
+		return Effect.succeed({
+			session: naming.session,
+			window: session.id,
+			sessionRef: session.id,
+			kind: "engine",
+		});
+	}
+	const window = naming.windows[session.windowKey];
+	if (window === undefined) {
+		return Effect.fail(
+			new TmuxWindowUnnamedError({role: session.role, windowKey: session.windowKey}),
+		);
+	}
+	return Effect.succeed({
+		session: naming.session,
+		window,
+		sessionRef: session.role,
+		kind: "bridge",
+	});
+};
+
+/**
+ * Map the roster session set to tmux placement targets: one window per bridge + one per engine
+ * instance, all under the operator-configured tmux session. Fails closed on a bridge whose window
+ * key the operator config omits, or on two sessions colliding on one window.
+ */
+export const computeTmuxPlacement = (
+	naming: TmuxNaming,
+	sessions: readonly RosterSession[],
+): Effect.Effect<readonly PlacementTarget[], TmuxWindowUnnamedError | TmuxWindowCollisionError> =>
+	Effect.forEach(sessions, (session) => placeOne(naming, session)).pipe(
+		Effect.flatMap((targets) => {
+			const byWindow = new Map<string, string[]>();
+			for (const t of targets) {
+				const refs = byWindow.get(t.window) ?? [];
+				refs.push(t.sessionRef);
+				byWindow.set(t.window, refs);
+			}
+			for (const [window, sessionRefs] of byWindow) {
+				if (sessionRefs.length > 1) {
+					return Effect.fail(new TmuxWindowCollisionError({window, sessionRefs}));
+				}
+			}
+			return Effect.succeed(targets);
+		}),
+	);


### PR DESCRIPTION
Maps the roster session set (C6) to tmux placement targets for the stand-up launcher (epic #3237). tmux in its surviving role — **window-manager, not transport**: the crew coordinates over the channels substrate now, but something must still put each launched session on the operator's screen, and that is this layer.

`computeTmuxPlacement(naming, sessions)` produces one placement target per session — one window per bridge + one per engine instance — all under the operator-configured tmux session:

- **Bridge windows** resolve from the operator config's `tmux` naming (`TmuxNaming.windows`), keyed by the bridge's window key. No hardcoded operator data.
- **Engine windows** take each engine's per-instance id (#3297 generates it) — the operator cannot name N dynamic engines, so the generated id is the (non-operator, non-hardcoded) window name.
- **Fails closed** on a bridge whose window key the operator config omits (`TmuxWindowUnnamedError`) and on two sessions colliding on one window (`TmuxWindowCollisionError`).

Thin by design: it maps sessions to placement targets and nothing else — no channel registration or identity (C5/C6 own those), no config-file read (the `tmux` dimension reader is #3293; this consumes the resolved shape), and **no tmux-as-transport path** — no pane-title discovery, buffer-paste, or send-keys. Pure derivation over plain data (the `registry-core` idiom); the launcher (#3299) issues the actual window/pane creation from these targets.

Acceptance criteria:
- [x] Each roster session gets a tmux window under the operator-configured tmux session, one per bridge + one per engine instance.
- [x] Placement uses the operator config's tmux naming (no hardcoded operator data).
- [x] tmux used only as a window-manager — no pane-title/buffer-paste/send-keys transport path.
- [x] The session-set → placement-target mapping is unit-tested for a sample roster + engine count.

Scope: this is the placement-mapping slice only (#3298 in the epic task-split); the one-command orchestration that composes it is #3299.

Fixes #3298