### PR TITLE
feat(pipeline-crew): launcher ensure-tracker-running step (#3294)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The ensure-tracker-running step's two behaviors, both asserted against the actual socket-bind
+ * outcome: `tryBecomeTracker` classifies start-if-absent vs reuse-if-present in-process, and
+ * `ensureTrackerRunning` spawns the standing tracker as a detached process that serves the socket and
+ * survives a second stand-up (which reuses it via EADDRINUSE rather than double-binding).
+ */
+import {randomUUID} from "node:crypto";
+import {mkdtempSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeSocket} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
+import {socketPathFor, TrackerRegistry, trackerServerLayer} from "../tracker/index.ts";
+import {ensureTrackerRunning, tryBecomeTracker} from "./ensure-tracker.ts";
+
+const freshSocketPath = () => join(tmpdir(), `ensure-tracker-${randomUUID().slice(0, 8)}.sock`);
+
+const clientLayer = (socketPath: string) =>
+	RpcClient.layerProtocolSocket().pipe(
+		Layer.provide([NodeSocket.layerNet({path: socketPath}), RpcSerialization.layerNdjson]),
+	);
+
+// Reap the detached standing tracker so the suite leaves nothing running; a `kill` on an
+// already-exited child (the reuse child exits on EADDRINUSE) throws ESRCH, which we ignore.
+const reap = (pid: number | undefined) =>
+	pid === undefined ? Effect.void : Effect.try(() => process.kill(pid)).pipe(Effect.ignore);
+
+describe("tryBecomeTracker — the bind-outcome core", () => {
+	it.effect("start-if-absent: an unbound socket is won ('started') and served afterward", () => {
+		const socketPath = freshSocketPath();
+		return Effect.gen(function* () {
+			const outcome = yield* tryBecomeTracker(socketPath);
+			assert.strictEqual(outcome, "started");
+			// served afterward: a client round-trips through the just-started tracker.
+			const client = yield* RpcClient.make(TrackerRegistry);
+			yield* client.AnnouncePresence({
+				peer: "inbox://peer-a",
+				role: "builder",
+				at: "2026-07-16T10:00:00Z",
+			});
+			const result = yield* client.LookupRole({role: "builder"});
+			assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
+		}).pipe(Effect.provide(clientLayer(socketPath)), Effect.scoped);
+	});
+
+	it.effect(
+		"reuse-if-present: a second bind on a served socket reuses it ('already-serving')",
+		() => {
+			const socketPath = freshSocketPath();
+			return Effect.gen(function* () {
+				// A tracker is already serving this socket (built into the scope).
+				yield* Layer.build(trackerServerLayer(socketPath));
+				// The second attempt must not crash or double-bind — it reads the EADDRINUSE reuse signal.
+				const outcome = yield* tryBecomeTracker(socketPath);
+				assert.strictEqual(outcome, "already-serving");
+			}).pipe(Effect.scoped);
+		},
+	);
+});
+
+describe("ensureTrackerRunning — the detached standing process", () => {
+	// `it.live`, not `it.effect`: this spawns a real detached node process and polls the socket with
+	// real-time `Effect.sleep` — the default TestClock would freeze that poll (sleep never elapses).
+	it.live(
+		"starts a detached tracker that serves the socket and reuses it on a second stand-up",
+		() => {
+			const projectDir = mkdtempSync(join(tmpdir(), "ensure-tracker-proj-"));
+			const socketPath = socketPathFor(projectDir);
+			return Effect.gen(function* () {
+				// First stand-up: no tracker running -> a detached child is spawned and serves the socket.
+				const started = yield* ensureTrackerRunning(projectDir);
+				assert.strictEqual(started.socketPath, socketPath);
+				assert.isNumber(started.pid);
+
+				// A client round-trip proves the detached child is actually serving.
+				yield* Effect.gen(function* () {
+					const client = yield* RpcClient.make(TrackerRegistry);
+					yield* client.AnnouncePresence({
+						peer: "inbox://peer-a",
+						role: "builder",
+						at: "2026-07-16T10:00:00Z",
+					});
+					const result = yield* client.LookupRole({role: "builder"});
+					assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
+				}).pipe(Effect.provide(clientLayer(socketPath)), Effect.scoped);
+
+				// Second stand-up: the tracker already serves -> reuse (no crash, no double-bind).
+				const reused = yield* ensureTrackerRunning(projectDir);
+				assert.strictEqual(reused.socketPath, socketPath);
+
+				// The standing tracker is a detached child that outlives this test process; reap both.
+				yield* reap(started.pid);
+				yield* reap(reused.pid);
+			}).pipe(
+				Effect.ensuring(Effect.sync(() => rmSync(projectDir, {recursive: true, force: true}))),
+			);
+		},
+		30_000,
+	); // two real detached node child spawns (each ~1-3s of node + TS + Effect startup)
+});

--- a/packages/pipeline-crew-mcp/src/standup/ensure-tracker.ts
+++ b/packages/pipeline-crew-mcp/src/standup/ensure-tracker.ts
@@ -1,0 +1,139 @@
+/**
+ * standup/ensure-tracker — the launcher's ensure-tracker-running step: guarantee the per-project
+ * tracker is up as a standing process before any crew session is stood up.
+ *
+ * The one non-obvious thing is first-peer-spawn (see `../tracker/server.ts`): a successful bind on
+ * the per-project socket means WE started the tracker; an `EADDRINUSE` means one is already serving
+ * this project and we reuse it. `tryBecomeTracker` classifies that bind outcome (the unit-tested
+ * core); `ensureTrackerRunning` detaches the tracker into its own OS process so it outlives the
+ * launcher and every session the launcher spawns — the open-peer-surface reason a non-Claude peer
+ * can announce when no crew session is up. This module wraps `../tracker/`'s primitives read-only;
+ * it never edits the registry/protocol.
+ */
+import {spawn} from "node:child_process";
+import {connect} from "node:net";
+import {fileURLToPath} from "node:url";
+import {NodeRuntime} from "@effect/platform-node";
+import {Effect, Layer, type Scope} from "effect";
+import * as Schema from "effect/Schema";
+import type {SocketServerError} from "effect/unstable/socket/SocketServer";
+import {socketPathFor, trackerServerLayer} from "../tracker/index.ts";
+
+/** Which side of the first-peer-spawn race a stand-up landed on. */
+export type TrackerBindOutcome = "started" | "already-serving";
+
+/** The launcher couldn't confirm the per-project socket was serving within the wait budget. */
+export class TrackerNotServingError extends Schema.TaggedErrorClass<TrackerNotServingError>()(
+	"@kampus/pipeline-crew-mcp/standup/TrackerNotServingError",
+	{socketPath: Schema.String},
+) {}
+
+/** A detached standing tracker: the child's pid and the socket every peer of the project dials. */
+export interface TrackerHandle {
+	readonly pid: number | undefined;
+	readonly socketPath: string;
+}
+
+/** EADDRINUSE is the first-peer-spawn signal that a tracker already serves this socket. */
+const isAddressInUse = (error: SocketServerError): boolean => {
+	const cause = error.reason.cause;
+	return (
+		typeof cause === "object" &&
+		cause !== null &&
+		"code" in cause &&
+		(cause as {readonly code?: unknown}).code === "EADDRINUSE"
+	);
+};
+
+/**
+ * Attempt to become the tracker on `socketPath` within the ambient scope: a won bind is `"started"`
+ * and the server is live for the scope's lifetime; an `EADDRINUSE` is `"already-serving"` (reuse, no
+ * double-bind). Any other bind failure crosses the error channel. This is the bind-outcome core the
+ * standing-process wrapper and the tests both drive.
+ */
+export const tryBecomeTracker = (
+	socketPath: string,
+): Effect.Effect<TrackerBindOutcome, SocketServerError, Scope.Scope> =>
+	Layer.build(trackerServerLayer(socketPath)).pipe(
+		Effect.map((): TrackerBindOutcome => "started"),
+		Effect.catchTag("SocketServerError", (error) =>
+			isAddressInUse(error)
+				? Effect.succeed<TrackerBindOutcome>("already-serving")
+				: Effect.fail(error),
+		),
+	);
+
+/**
+ * The standing-tracker entry the detached child runs: win the bind and block so the server stays up
+ * (`Effect.never` holds the scope open), or return promptly when a tracker already serves. This is
+ * the reuse-tolerant sibling of `../tracker/server.ts`'s raw `launchTracker` — it exits cleanly on
+ * `EADDRINUSE` instead of surfacing it as a failure.
+ */
+export const runStandingTracker = (
+	projectRoot: string,
+): Effect.Effect<TrackerBindOutcome, SocketServerError> =>
+	Effect.scoped(
+		tryBecomeTracker(socketPathFor(projectRoot)).pipe(
+			Effect.tap((outcome) => (outcome === "started" ? Effect.never : Effect.void)),
+		),
+	);
+
+/** Non-destructively probe whether something is serving `socketPath` (a client connect, then hang up). */
+const probeSocketServing = (socketPath: string): Effect.Effect<boolean> =>
+	Effect.callback<boolean>((resume) => {
+		const sock = connect(socketPath);
+		const settle = (serving: boolean) => {
+			sock.removeAllListeners();
+			sock.destroy();
+			resume(Effect.succeed(serving));
+		};
+		sock.once("connect", () => settle(true));
+		sock.once("error", () => settle(false));
+	});
+
+/** Poll until the socket is serving, or fail once the attempt budget is spent (~5s at 100ms spacing). */
+const awaitSocketServing = (
+	socketPath: string,
+	attemptsLeft: number,
+): Effect.Effect<void, TrackerNotServingError> =>
+	probeSocketServing(socketPath).pipe(
+		Effect.flatMap((serving) =>
+			serving
+				? Effect.void
+				: attemptsLeft <= 0
+					? Effect.fail(new TrackerNotServingError({socketPath}))
+					: Effect.sleep("100 millis").pipe(
+							Effect.andThen(awaitSocketServing(socketPath, attemptsLeft - 1)),
+						),
+		),
+	);
+
+/** Absolute path to this module — the entry the detached standing-tracker child re-enters at. */
+const SELF_PATH = fileURLToPath(import.meta.url);
+
+/**
+ * Ensure a standing tracker for `projectRoot` before stand-up. Spawns the standing tracker as a
+ * detached child (`detached` + `unref` + ignored stdio) so it outlives this launcher process and
+ * every session it spawns, then waits until the per-project socket is confirmed serving — whether by
+ * the child we just spawned (start-if-absent) or one that was already up (reuse-if-present, the child
+ * exits on `EADDRINUSE`). Returns the child pid and the socket path peers dial.
+ */
+export const ensureTrackerRunning = (
+	projectRoot: string,
+): Effect.Effect<TrackerHandle, TrackerNotServingError> =>
+	Effect.gen(function* () {
+		const socketPath = socketPathFor(projectRoot);
+		const child = spawn(process.execPath, [SELF_PATH, projectRoot], {
+			detached: true,
+			stdio: "ignore",
+		});
+		child.unref();
+		yield* awaitSocketServing(socketPath, 50);
+		return {pid: child.pid, socketPath};
+	});
+
+// Detached-child entry: when this module is the process entrypoint, run the standing tracker for the
+// project root passed as argv[2]. `ensureTrackerRunning` re-enters here in the spawned child.
+if (import.meta.main) {
+	NodeRuntime.runMain(runStandingTracker(process.argv[2] ?? process.cwd()));
+}


### PR DESCRIPTION
Fixes #3294

Child of epic #3237 (stand-up launcher). Per the #3292 decision (Option B), launcher mechanics live under `packages/pipeline-crew-mcp/src/standup/`. This is the **ensure-tracker-running** step: before any session is stood up, guarantee the per-project tracker is up as a standing process that outlives the launcher and every session it spawns.

## What landed

New file `packages/pipeline-crew-mcp/src/standup/ensure-tracker.ts` (+ test), read-only over `../tracker/`'s primitives (`socketPathFor` / `trackerServerLayer`, EADDRINUSE via `SocketServerError`) that #3219 shipped — no edit to the registry/protocol.

- **`tryBecomeTracker(socketPath)`** — the unit-tested bind-outcome core. A won bind on the per-project socket is `"started"` (server live for the scope); an `EADDRINUSE` is `"already-serving"` (reuse, no double-bind), honoring the first-peer-spawn convention.
- **`runStandingTracker(projectRoot)`** — the reuse-tolerant standing form the detached child runs: win the bind and block (`Effect.never`), or exit cleanly on reuse (vs raw `launchTracker`, which surfaces EADDRINUSE as a failure).
- **`ensureTrackerRunning(projectRoot)`** — the launcher step: spawns the standing tracker as a **detached** OS process (`detached` + `unref` + ignored stdio) so it survives the launcher, then waits until the per-project socket is confirmed serving.

## Acceptance criteria

- [x] Standing up with no tracker running starts one; the per-project socket (`socketPathFor`) is served afterward.
- [x] Standing up when a tracker already serves reuses it (no crash, no double-bind) via the `EADDRINUSE` signal.
- [x] The tracker runs as a standing process that outlives the launcher and every session it spawns (detached child).
- [x] Behavior (start-if-absent / reuse-if-present) is unit-tested against the socket-bind outcome.

## Notes

- The integration test uses `@effect/vitest`'s `it.live` (not `it.effect`): it spawns a real detached node process and polls the socket with real-time `Effect.sleep`, which the default TestClock would freeze.
- `TrackerNotServingError` is a `Schema.TaggedErrorClass` with no `FateWireCode` (launcher tooling, never reaches the fate wire), per `.patterns/effect-errors.md`.

Package suite green (80 tests), typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)