### PR TITLE
feat(pipeline-crew-mcp): per-kind cardinality lease — bridge rejects a 2nd holder, engine admits N

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
@@ -6,8 +6,8 @@
  *   - AC 2: two roles stand up (tracker + peer + edge composed), announce, discover each other,
  *     and exchange a claim/collision-check with a typed reply; a peer-to-peer intake ping wakes
  *     the receiver's edge channel sink and returns its inbox-ack (peer + edge in the loop).
- *   - AC 3: the role-uniqueness lease rejects a second live session for a held role, across all
- *     five standing roles.
+ *   - AC 3: the per-kind cardinality lease — a second live session for a BRIDGE role is rejected
+ *     (cardinality 1), a second live session for an ENGINE role is admitted (cardinality N).
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer, Option, Ref} from "effect";
@@ -26,8 +26,11 @@ import {TrackerHandlers} from "../tracker/handlers.ts";
 import {RegistryLive} from "../tracker/registry.ts";
 import {makeCrewChannel} from "./channel-server.ts";
 import {RoleUniquenessError} from "./errors.ts";
-import {CREW_ROLES} from "./roles.ts";
+import {CREW_ROLES, kindOf} from "./roles.ts";
 import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
+
+const BRIDGE_ROLES = CREW_ROLES.filter((role) => kindOf(role) === "bridge");
+const ENGINE_ROLES = CREW_ROLES.filter((role) => kindOf(role) === "engine");
 
 const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
 
@@ -130,20 +133,21 @@ describe("crew/channel-server — announce, discover, claim/collision-check (AC 
 	);
 });
 
-describe("crew/channel-server — role-uniqueness lease (AC 3)", () => {
-	it.effect("a second live session for a held role is rejected, across all five roles", () =>
+describe("crew/channel-server — per-kind cardinality lease (AC 3)", () => {
+	it.effect("a second live session for a BRIDGE role is rejected (cardinality 1)", () =>
 		Effect.gen(function* () {
-			for (const role of CREW_ROLES) {
+			assert.isAbove(BRIDGE_ROLES.length, 0, "the roster must carry at least one bridge role");
+			for (const role of BRIDGE_ROLES) {
 				const client = yield* RpcTest.makeClient(TrackerRegistry);
 				const tracker = CrewTracker.fromClient(client);
 
-				// first session for the role acquires the lease
+				// first session for the bridge role acquires the singleton lease
 				const first = yield* makeCrewChannel({role, address: `inbox://${role}-1`}).pipe(
 					Effect.provide(channelLayers(tracker, `inbox://${role}-1`, alwaysUnreachable)),
 				);
 				assert.strictEqual(first.role, role);
 
-				// a second session (a DIFFERENT peer) for the same held role is rejected, not shared
+				// a second session (a DIFFERENT peer) for the same held bridge role is rejected, not shared
 				const rejection = yield* makeCrewChannel({role, address: `inbox://${role}-2`}).pipe(
 					Effect.provide(channelLayers(tracker, `inbox://${role}-2`, alwaysUnreachable)),
 					Effect.flip,
@@ -155,23 +159,80 @@ describe("crew/channel-server — role-uniqueness lease (AC 3)", () => {
 		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
 	);
 
-	it.effect(
-		"all five distinct roles hold their leases simultaneously (uniqueness is per role)",
-		() =>
-			Effect.gen(function* () {
+	it.effect("a second live session for an ENGINE role boots cleanly (cardinality N)", () =>
+		Effect.gen(function* () {
+			assert.isAbove(ENGINE_ROLES.length, 0, "the roster must carry at least one engine role");
+			for (const role of ENGINE_ROLES) {
 				const client = yield* RpcTest.makeClient(TrackerRegistry);
 				const tracker = CrewTracker.fromClient(client);
-				for (const role of CREW_ROLES) {
-					const channel = yield* makeCrewChannel({role, address: `inbox://${role}`}).pipe(
-						Effect.provide(channelLayers(tracker, `inbox://${role}`, alwaysUnreachable)),
-					);
-					assert.strictEqual(channel.role, role);
-				}
-				// every role is independently discoverable — five distinct leases coexist
-				for (const role of CREW_ROLES) {
-					const result = yield* client.LookupRole({role});
-					assert.lengthOf(result.peers, 1, `${role} should be present`);
-				}
+
+				// two DIFFERENT-peer sessions for the same engine role both stand up — the per-instance
+				// lease key never collapses onto the single-role key, so neither rejects the other
+				const first = yield* makeCrewChannel({role, address: `inbox://${role}-1`}).pipe(
+					Effect.provide(channelLayers(tracker, `inbox://${role}-1`, alwaysUnreachable)),
+				);
+				const second = yield* makeCrewChannel({role, address: `inbox://${role}-2`}).pipe(
+					Effect.provide(channelLayers(tracker, `inbox://${role}-2`, alwaysUnreachable)),
+				);
+				assert.strictEqual(first.role, role);
+				assert.strictEqual(second.role, role);
+				assert.notStrictEqual(first.address, second.address, "two distinct engine instances");
+
+				// both hold a live per-instance lease: a fresh third instance still boots (N unbounded)
+				const third = yield* makeCrewChannel({role, address: `inbox://${role}-3`}).pipe(
+					Effect.provide(channelLayers(tracker, `inbox://${role}-3`, alwaysUnreachable)),
+				);
+				assert.strictEqual(third.role, role);
+			}
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect(
+		"connection-is-lease per kind: a freed bridge lease lets a replacement bridge boot",
+		() =>
+			Effect.gen(function* () {
+				const role = BRIDGE_ROLES[0];
+				assert(role !== undefined, "the roster must carry a bridge role");
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				const tracker = CrewTracker.fromClient(client);
+
+				// a bridge boots, holding the singleton lease on the bare role key
+				const incumbent = yield* makeCrewChannel({role, address: `inbox://${role}-a`}).pipe(
+					Effect.provide(channelLayers(tracker, `inbox://${role}-a`, alwaysUnreachable)),
+				);
+				assert.strictEqual(incumbent.role, role);
+
+				// the connection closes → its lease frees (the singleton key is released); a second
+				// bridge before the release would collide, but a release makes the key acquirable again
+				yield* client.Release({
+					resource: role,
+					claimant: `inbox://${role}-a`,
+					at: new Date().toISOString(),
+				});
+
+				// a replacement bridge (a fresh peer) boots cleanly onto the freed singleton lease
+				const replacement = yield* makeCrewChannel({role, address: `inbox://${role}-b`}).pipe(
+					Effect.provide(channelLayers(tracker, `inbox://${role}-b`, alwaysUnreachable)),
+				);
+				assert.strictEqual(replacement.role, role);
 			}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect("all distinct roles hold their leases simultaneously (uniqueness is per role)", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const tracker = CrewTracker.fromClient(client);
+			for (const role of CREW_ROLES) {
+				const channel = yield* makeCrewChannel({role, address: `inbox://${role}`}).pipe(
+					Effect.provide(channelLayers(tracker, `inbox://${role}`, alwaysUnreachable)),
+				);
+				assert.strictEqual(channel.role, role);
+			}
+			// every role is independently discoverable — five distinct leases coexist
+			for (const role of CREW_ROLES) {
+				const result = yield* client.LookupRole({role});
+				assert.lengthOf(result.peers, 1, `${role} should be present`);
+			}
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.ts
@@ -8,8 +8,10 @@
  * (`CrewTracker`, the peer `Inbox`/`Dialer`/`Tracker` ports) in context, so the tests drive it
  * fully in-memory (`RpcTest` client + an in-memory connect) while production supplies the socket
  * bindings below. The one crew-specific rule the wiring enforces that the generic peer does not:
- * the role-uniqueness lease — a session claims its ROLE up front, and a second live session for a
- * held role is rejected (`RoleUniquenessError`), never allowed to co-occupy it.
+ * the per-kind cardinality lease — a session claims its role slot up front, and a second live
+ * session is rejected (`RoleUniquenessError`) or admitted depending on the role's KIND. This is
+ * the ONE place cardinality is enforced, off `kindOf` (ADR 0189); the generic tracker/protocol
+ * stay role-agnostic (`RoleId` opaque), fed only the derived string lease key.
  *
  * The runnable stdio entry (the edge MCP server + `ChannelSink.layerFromMcpServer` + the send
  * tool's `ChannelSend` bound to this session's peer) is assembled by the bin/cutover (#3062,
@@ -30,8 +32,26 @@ import {
 	type RolePresence,
 } from "../peer/index.ts";
 import {RoleUniquenessError} from "./errors.ts";
-import type {CrewRole} from "./roles.ts";
+import {type CrewRole, kindOf} from "./roles.ts";
 import {type ClaimReply, CrewTracker} from "./tracker.ts";
+
+/**
+ * The cardinality lease key for a role, derived from its KIND — the ONE expression of per-kind
+ * cardinality (ADR 0189). A `bridge` (cardinality 1) leases the bare role, so a second bridge
+ * necessarily targets the SAME key and collides; an `engine` (cardinality N) leases a per-instance
+ * key (role + its inbox address), so N engine instances target DISTINCT keys and never collide.
+ * Cardinality thus falls entirely out of the key — the claim/collision path is identical for both
+ * kinds — which is what makes a bridge-with-two-holders structurally unrepresentable rather than
+ * runtime-checked. The exhaustive switch means a new `CrewRoleKind` fails to compile until kinded.
+ */
+const cardinalityLeaseKey = (role: CrewRole, address: string): string => {
+	switch (kindOf(role)) {
+		case "bridge":
+			return role;
+		case "engine":
+			return `${role}#${address}`;
+	}
+};
 
 export interface CrewChannelConfig {
 	readonly role: CrewRole;
@@ -51,21 +71,21 @@ export interface CrewChannel {
 }
 
 /**
- * Stand up a crew channel for one role: acquire the role-uniqueness lease, then compose the
- * peer (which announces its presence for the connection lifetime). Requires the substrate
- * seams — `CrewTracker`, the peer `Tracker`/`Inbox`/`Dialer` ports — in context.
+ * Stand up a crew channel for one role: acquire its per-kind cardinality lease, then compose the
+ * peer (which announces its presence for the connection lifetime). Requires the substrate seams —
+ * `CrewTracker`, the peer `Tracker`/`Inbox`/`Dialer` ports — in context.
  *
- * The role-uniqueness lease is the one crew-specific rule the generic peer does not enforce:
- * a session claims its ROLE and is REJECTED (not co-occupied) when a different live session
- * already holds it. A resource collision is a value; a role collision is a rejection — that
- * asymmetry is the whole point of the lease (see `./errors.ts`).
+ * The lease is keyed by `cardinalityLeaseKey` (see above): a bridge collides on its shared role
+ * key (a second live holder is REJECTED with `RoleUniquenessError`), an engine gets a per-instance
+ * key (a second holder is admitted). A resource collision is a value; a bridge role collision is a
+ * rejection — that asymmetry is the whole point of the lease (see `./errors.ts`).
  */
 export const makeCrewChannel = Effect.fn("crew.makeCrewChannel")(function* (
 	config: CrewChannelConfig,
 ) {
 	const tracker = yield* CrewTracker;
 	const lease = yield* tracker.claim({
-		resource: config.role,
+		resource: cardinalityLeaseKey(config.role, config.address),
 		claimant: config.address,
 		role: config.role,
 	});


### PR DESCRIPTION
Fixes #3300 (roster-law epic #3234).

## What changed
Drives the crew role-uniqueness lease off the role's **kind** (`kindOf`, ADR 0189) instead of a flat per-role singleton:

- **bridge** (cardinality 1) leases the **bare role key** — a second live bridge session targets the same key, collides, and is rejected with `RoleUniquenessError` at boot.
- **engine** (cardinality N) leases a **per-instance key** (`role#address`) — N engine instances target distinct keys and never collide, so a second `engineering-manager` boots cleanly.

Cardinality falls entirely out of the lease **key** — the claim/collision path in `makeCrewChannel` is identical for both kinds. A `bridge`-with-two-holders is thus structurally unrepresentable rather than runtime-checked late. The lease-key derivation is an exhaustive `switch` on `kindOf`, so a new `CrewRoleKind` fails to compile until it's kinded.

## Scope / boundary (AC 3)
Enforcement stays in the **crew composition layer** (`crew/channel-server.ts`). The generic `tracker/registry-core.ts` and `protocol/*` remain role-agnostic (`RoleId` opaque) — they receive only the derived string lease key; the crew roster is never imported into them. No `protocol/*` or `crew/catalog.ts` file is touched (owned by the parallel #3302 lane).

## Acceptance criteria
- [x] A second live **bridge** session is rejected with `RoleUniquenessError` (cardinality 1).
- [x] A second live **engine** session boots cleanly, both hold a live per-instance lease (cardinality N), no collision.
- [x] `tracker/registry-core.ts` + `protocol/` stay role-agnostic; the per-kind decision reads `kindOf` from the roster seam.
- [x] Connection-is-lease per kind: a freed bridge lease lets a replacement bridge boot. Tests cover second-bridge-rejected and second-engine-admitted.

## Verification
- `pnpm --filter @kampus/pipeline-crew-mcp typecheck` — clean
- `pnpm biome check` on the two changed files — clean
- Package suite: 23 files / 121 tests pass (channel-server AC-3 grew 4 → 6 cases)

## Files
- `packages/pipeline-crew-mcp/src/crew/channel-server.ts`
- `packages/pipeline-crew-mcp/src/crew/channel-server.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)