### PR TITLE
refactor(pipeline-crew-mcp): drop dead protocol kinds EpicHandoff + AckInbox (#3302)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/catalog.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/catalog.test.ts
@@ -17,13 +17,12 @@ describe("crew/catalog — roles mapped to seams over protocol/", () => {
 		assert.strictEqual(crewCatalog.size, CREW_ROLES.length);
 	});
 
-	it("names the six required crew seams over the protocol kinds", () => {
-		// claim/collision-check, role-uniqueness lease, epic handoff, drain tally, intake ping,
+	it("names the required crew seams over the protocol kinds", () => {
+		// claim/collision-check, role-uniqueness lease, drain tally, intake ping,
 		// role discovery/presence (announce + lookup) — the seams the ticket enumerates.
 		for (const seam of [
 			"claimCollisionCheck",
 			"roleUniquenessLease",
-			"epicHandoff",
 			"drainTally",
 			"intakePing",
 			"announcePresence",
@@ -40,11 +39,9 @@ describe("crew/catalog — roles mapped to seams over protocol/", () => {
 
 	it("exposes the crew catalog group as the full protocol catalog", () => {
 		assert.deepStrictEqual([...CrewCatalogGroup.requests.keys()].sort(), [
-			"AckInbox",
 			"AnnouncePresence",
 			"Claim",
 			"DrainProgress",
-			"EpicHandoff",
 			"Heartbeat",
 			"IntakePing",
 			"LookupRole",

--- a/packages/pipeline-crew-mcp/src/crew/catalog.ts
+++ b/packages/pipeline-crew-mcp/src/crew/catalog.ts
@@ -10,12 +10,10 @@
  * and the catalog follows, no per-role special-casing to update.
  */
 import {
-	AckInbox,
 	AnnouncePresence,
 	Claim,
 	CrewProtocol,
 	DrainProgress,
-	EpicHandoff,
 	Heartbeat,
 	IntakePing,
 	LookupRole,
@@ -32,13 +30,11 @@ export const CrewSeams = {
 	claimCollisionCheck: Claim,
 	roleUniquenessLease: Claim,
 	releaseClaim: Release,
-	epicHandoff: EpicHandoff,
 	drainTally: DrainProgress,
 	intakePing: IntakePing,
 	announcePresence: AnnouncePresence,
 	lookupRole: LookupRole,
 	heartbeat: Heartbeat,
-	inboxAck: AckInbox,
 } as const;
 
 export type CrewSeamName = keyof typeof CrewSeams;

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -10,12 +10,12 @@
  */
 import {Context, Effect, Schema} from "effect";
 import {Tool, Toolkit} from "effect/unstable/ai";
-import {type InboxAck, PeerUnreachableError} from "../peer/index.ts";
-import {crewMessageKinds, Messages, payloadSchemaForKind} from "../protocol/index.ts";
+import {InboxAck, PeerUnreachableError} from "../peer/index.ts";
+import {crewMessageKinds, payloadSchemaForKind} from "../protocol/index.ts";
 
 /**
  * A message rejected at the wire because its shape doesn't match the catalog: an unknown
- * `kind` (not one of the 7 catalog kinds) or a `body` that fails that kind's payload schema.
+ * `kind` (not one of the 6 catalog kinds) or a `body` that fails that kind's payload schema.
  * The gate that makes the typed catalog an invariant, not advice (#3229) — the sender gets
  * this typed reject instead of a delivered-to-inbox ack, so a wrong shape never reaches a peer.
  */
@@ -79,7 +79,7 @@ export const SendChannelMessage = Tool.make("channel_send", {
 		kind: Schema.NonEmptyString,
 		body: Schema.Unknown,
 	}),
-	success: Messages.InboxAck,
+	success: InboxAck,
 	failure: Schema.Union([PeerUnreachableError, InvalidMessageError]),
 });
 

--- a/packages/pipeline-crew-mcp/src/peer/inbox.test.ts
+++ b/packages/pipeline-crew-mcp/src/peer/inbox.test.ts
@@ -1,5 +1,5 @@
 /**
- * Inbox-ack semantics (AC 2): a `Deliver` to a peer's inbox returns a `Messages.InboxAck`
+ * Inbox-ack semantics (AC 2): a `Deliver` to a peer's inbox returns an `InboxAck`
  * whose meaning is delivered-to-inbox — it echoes the sender's `messageId` and is stamped
  * `by` the receiving peer. Driven over the in-memory no-serialization RPC transport
  * (`RpcTest`), so the assertion is on the real client/server delivery path, not a stub.

--- a/packages/pipeline-crew-mcp/src/peer/inbox.ts
+++ b/packages/pipeline-crew-mcp/src/peer/inbox.ts
@@ -3,10 +3,11 @@
  * `RpcGroup` an `RpcServer` serves) plus the `Inbox` service that records deliveries and
  * returns an inbox-ack. Generic (crew-agnostic); see the boundary note in `../index.ts`.
  *
- * The one non-obvious thing: a successful `Deliver` reply is a `Messages.InboxAck`, and
- * that ack means exactly delivered-to-peer-inbox — the reception guarantee capture-pane
- * verification used to fake (locked in #3035), never seen-by-model. The envelope reuses
- * the `protocol/` message schemas; peer/ redefines no message type.
+ * The one non-obvious thing: a successful `Deliver` reply is an `InboxAck`, and that ack
+ * means exactly delivered-to-peer-inbox — the reception guarantee capture-pane verification
+ * used to fake (locked in #3035), never seen-by-model. `InboxAck` is the peer data plane's
+ * own ack (the crew message catalog carries no ack kind — nothing sends one, #3302); it and
+ * the envelope are built from the `protocol/` field primitives (`MessageId`/`PeerId`/…).
  */
 import {Context, Effect, Layer, Ref, Schema} from "effect";
 import {Rpc, RpcGroup} from "effect/unstable/rpc";
@@ -29,12 +30,23 @@ export const InboxEnvelope = Schema.Struct({
 	at: Messages.Timestamp,
 });
 export type InboxEnvelope = typeof InboxEnvelope.Type;
-export type InboxAck = typeof Messages.InboxAck.Type;
+
+/**
+ * The delivered-to-inbox ack: the receiving peer (`by`) echoes the delivery's `messageId` so
+ * the sender can correlate the ack to its send. This is the peer data plane's own reply shape,
+ * not a crew message catalog kind — the catalog has no ack kind because nothing sends one (#3302).
+ */
+export const InboxAck = Schema.Struct({
+	messageId: Messages.MessageId,
+	by: Messages.PeerId,
+	at: Messages.Timestamp,
+});
+export type InboxAck = typeof InboxAck.Type;
 
 /** Deliver one message to this peer's inbox; the reply is the delivered-to-inbox ack. */
 export const Deliver = Rpc.make("Deliver", {
 	payload: InboxEnvelope,
-	success: Messages.InboxAck,
+	success: InboxAck,
 });
 
 /** The peer inbox contract — the one `RpcGroup` an inbox `RpcServer` serves and a dialer speaks. */

--- a/packages/pipeline-crew-mcp/src/peer/index.ts
+++ b/packages/pipeline-crew-mcp/src/peer/index.ts
@@ -14,7 +14,7 @@ export {PeerUnreachableError} from "./errors.ts";
 export {
 	Deliver,
 	Inbox,
-	type InboxAck,
+	InboxAck,
 	InboxEnvelope,
 	inboxHandlers,
 	PeerAddress,

--- a/packages/pipeline-crew-mcp/src/protocol/group.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.test.ts
@@ -1,5 +1,5 @@
 /**
- * The catalog-shape guarantees: the `RpcGroup` covers all 7 kinds (acceptance criterion
+ * The catalog-shape guarantees: the `RpcGroup` covers all 6 kinds (acceptance criterion
  * 1), the claim/collision-check kind is a request-response RPC with a typed reply rather
  * than fire-and-forget (criterion 4), and the whole `protocol/` module imports nothing
  * from `crew/` — the generic boundary holds (criterion 3).
@@ -20,13 +20,11 @@ import {
 import * as Messages from "./schema.ts";
 
 describe("protocol/group catalog", () => {
-	it("covers all 8 message kinds (9 rpcs — presence is announce + lookup, claim is claim + release)", () => {
+	it("covers all 6 message kinds (7 rpcs — presence is announce + lookup, claim is claim + release)", () => {
 		assert.deepStrictEqual([...CrewProtocol.requests.keys()].sort(), [
-			"AckInbox",
 			"AnnouncePresence",
 			"Claim",
 			"DrainProgress",
-			"EpicHandoff",
 			"Heartbeat",
 			"IntakePing",
 			"LookupRole",

--- a/packages/pipeline-crew-mcp/src/protocol/group.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/group.ts
@@ -1,5 +1,5 @@
 /**
- * protocol/group — the 8 crew message kinds as one Effect `RpcGroup`.
+ * protocol/group — the 6 crew message kinds as one Effect `RpcGroup`.
  *
  * Generic (crew-agnostic); see the boundary note in `../index.ts`. Each kind is an
  * `Rpc` carrying a Schema payload from `./schema.ts`. Kinds that expect an answer
@@ -24,53 +24,41 @@ export const Release = Rpc.make("Release", {
 	payload: Messages.ReleaseClaim,
 });
 
-/** Kind 2 — planned-epic handoff (EM → builder). */
-export const EpicHandoff = Rpc.make("EpicHandoff", {
-	payload: Messages.EpicHandoffNotice,
-});
-
-/** Kind 3 — drain-progress tally. */
+/** Kind 2 — drain-progress tally. */
 export const DrainProgress = Rpc.make("DrainProgress", {
 	payload: Messages.DrainProgressTally,
 });
 
-/** Kind 4 — intake ping. */
+/** Kind 3 — intake ping. */
 export const IntakePing = Rpc.make("IntakePing", {
 	payload: Messages.IntakePing,
 });
 
-/** Kind 5a — role discovery/presence: announce (fire-and-forget). */
+/** Kind 4a — role discovery/presence: announce (fire-and-forget). */
 export const AnnouncePresence = Rpc.make("AnnouncePresence", {
 	payload: Messages.PresenceAnnouncement,
 });
 
-/** Kind 5b — role discovery/presence: lookup, awaiting a typed `RoleLookupResult`. */
+/** Kind 4b — role discovery/presence: lookup, awaiting a typed `RoleLookupResult`. */
 export const LookupRole = Rpc.make("LookupRole", {
 	payload: Messages.RoleLookupQuery,
 	success: Messages.RoleLookupResult,
 });
 
-/** Kind 6 — heartbeat (presence TTL keepalive). */
+/** Kind 5 — heartbeat (presence TTL keepalive). */
 export const Heartbeat = Rpc.make("Heartbeat", {
 	payload: Messages.Heartbeat,
 });
 
-/** Kind 7 — inbox ack (delivery acknowledgement). */
-export const AckInbox = Rpc.make("AckInbox", {
-	payload: Messages.InboxAck,
-});
-
-/** The full crew message catalog — one transport-agnostic `RpcGroup` over all 8 kinds. */
+/** The full crew message catalog — one transport-agnostic `RpcGroup` over all 6 kinds. */
 export const CrewProtocol = RpcGroup.make(
 	Claim,
 	Release,
-	EpicHandoff,
 	DrainProgress,
 	IntakePing,
 	AnnouncePresence,
 	LookupRole,
 	Heartbeat,
-	AckInbox,
 );
 
 /** The catalog's wire `kind` names — the `_tag` of every rpc, the set a `channel_send` may name. */
@@ -79,7 +67,7 @@ export const crewMessageKinds: ReadonlyArray<string> = [...CrewProtocol.requests
 /**
  * Resolve a wire `kind` name to the Schema payload the catalog types it as — the seam that lets
  * a boundary decode a message's `body` against its kind instead of trusting `Schema.Unknown`,
- * so the 7-kind catalog is enforced at the wire rather than advisory (#3229). Derived straight
+ * so the 6-kind catalog is enforced at the wire rather than advisory (#3229). Derived straight
  * from `CrewProtocol.requests` so it can never drift from the catalog above — the catalog *is*
  * the map. A kind outside the catalog resolves to `undefined`; the caller rejects it.
  *

--- a/packages/pipeline-crew-mcp/src/protocol/index.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/index.ts
@@ -1,17 +1,15 @@
 /**
- * protocol/ — the typed message catalog: the crew's 7 message kinds as an Effect
+ * protocol/ — the typed message catalog: the crew's 6 message kinds as an Effect
  * `RpcGroup` with `effect/Schema` payloads, transport-agnostic. Generic (crew-agnostic);
  * see the boundary note in `../index.ts`. This module defines the wire contract that
  * tracker, peer, and edge all code against.
  */
 export {
-	AckInbox,
 	AnnouncePresence,
 	Claim,
 	CrewProtocol,
 	crewMessageKinds,
 	DrainProgress,
-	EpicHandoff,
 	Heartbeat,
 	IntakePing,
 	LookupRole,

--- a/packages/pipeline-crew-mcp/src/protocol/schema.test.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.test.ts
@@ -39,25 +39,7 @@ describe("protocol/schema round-trips", () => {
 		});
 	});
 
-	it("kind 2 — planned-epic handoff (with and without the optional summary)", () => {
-		roundTrips(Messages.EpicHandoffNotice, {
-			epic: "epic:3045",
-			child: "issue:3054",
-			from: "em",
-			to: "builder",
-			summary: "protocol/ is the foundation edge codes against",
-			at: "2026-07-16T10:01:00Z",
-		});
-		roundTrips(Messages.EpicHandoffNotice, {
-			epic: "epic:3045",
-			child: "issue:3054",
-			from: "em",
-			to: "builder",
-			at: "2026-07-16T10:01:00Z",
-		});
-	});
-
-	it("kind 3 — drain-progress tally", () => {
+	it("kind 2 — drain-progress tally", () => {
 		roundTrips(Messages.DrainProgressTally, {
 			scope: "milestone:crew-mcp",
 			completed: 3,
@@ -68,7 +50,7 @@ describe("protocol/schema round-trips", () => {
 		});
 	});
 
-	it("kind 4 — intake ping (with and without the optional note)", () => {
+	it("kind 3 — intake ping (with and without the optional note)", () => {
 		roundTrips(Messages.IntakePing, {
 			issue: "issue:3100",
 			from: "triage",
@@ -82,7 +64,7 @@ describe("protocol/schema round-trips", () => {
 		});
 	});
 
-	it("kind 5 — presence announce + role lookup query/result", () => {
+	it("kind 4 — presence announce + role lookup query/result", () => {
 		roundTrips(Messages.PresenceAnnouncement, {
 			peer: "peer-a",
 			role: "builder",
@@ -99,19 +81,11 @@ describe("protocol/schema round-trips", () => {
 		roundTrips(Messages.RoleLookupResult, {role: "builder", peers: []});
 	});
 
-	it("kind 6 — heartbeat", () => {
+	it("kind 5 — heartbeat", () => {
 		roundTrips(Messages.Heartbeat, {
 			peer: "peer-a",
 			ttlSeconds: 30,
 			at: "2026-07-16T10:05:00Z",
-		});
-	});
-
-	it("kind 7 — inbox ack", () => {
-		roundTrips(Messages.InboxAck, {
-			messageId: "msg-1",
-			by: "peer-b",
-			at: "2026-07-16T10:06:00Z",
 		});
 	});
 });

--- a/packages/pipeline-crew-mcp/src/protocol/schema.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.ts
@@ -51,18 +51,7 @@ export const ReleaseClaim = Schema.Struct({
 	at: Timestamp,
 });
 
-// Kind 2 — planned-epic handoff (EM → builder).
-
-export const EpicHandoffNotice = Schema.Struct({
-	epic: Schema.NonEmptyString,
-	child: Schema.NonEmptyString,
-	from: RoleId,
-	to: RoleId,
-	summary: Schema.optionalKey(Schema.String),
-	at: Timestamp,
-});
-
-// Kind 3 — drain-progress tally.
+// Kind 2 — drain-progress tally.
 
 export const DrainProgressTally = Schema.Struct({
 	scope: Schema.NonEmptyString,
@@ -73,7 +62,7 @@ export const DrainProgressTally = Schema.Struct({
 	at: Timestamp,
 });
 
-// Kind 4 — intake ping.
+// Kind 3 — intake ping.
 
 export const IntakePing = Schema.Struct({
 	issue: Schema.NonEmptyString,
@@ -82,7 +71,7 @@ export const IntakePing = Schema.Struct({
 	at: Timestamp,
 });
 
-// Kind 5 — role discovery / presence (announce + lookup).
+// Kind 4 — role discovery / presence (announce + lookup).
 
 /** One presence record: a peer, the role it serves, and when it was last seen. */
 export const PresenceEntry = Schema.Struct({
@@ -109,18 +98,10 @@ export const RoleLookupResult = Schema.Struct({
 	peers: Schema.Array(PresenceEntry),
 });
 
-// Kind 6 — heartbeat (presence TTL keepalive).
+// Kind 5 — heartbeat (presence TTL keepalive).
 
 export const Heartbeat = Schema.Struct({
 	peer: PeerId,
 	ttlSeconds: Schema.Int,
-	at: Timestamp,
-});
-
-// Kind 7 — inbox ack (delivery acknowledgement).
-
-export const InboxAck = Schema.Struct({
-	messageId: MessageId,
-	by: PeerId,
 	at: Timestamp,
 });


### PR DESCRIPTION
Fixes #3302 · child of roster-law epic #3234.

## What
The tmux relay is retired (#3188) and the crew roster is kind-typed, leaving two protocol kinds with no sender. This removes both across the substrate:

- **`EpicHandoff`** (was kind 2) — the dead hub-and-spoke edge to a pull-only engine; nothing sends *to* an engine and the board already carries the handoff via `status:triaged`.
- **`AckInbox`** (was kind 7) — vestigial: no sender, no handler. The real ack is `PeerInbox.Deliver`'s success value.

## Changes
- `protocol/schema.ts` — removed `EpicHandoffNotice` and `InboxAck`; renumbered the remaining kind labels (Claim, Release, DrainProgress, IntakePing, presence, Heartbeat).
- `protocol/group.ts` — removed the `EpicHandoff` + `AckInbox` `Rpc.make` defs and their membership in the `CrewProtocol` `RpcGroup`; the group now composes 6 kinds / 7 rpcs.
- `protocol/index.ts` — dropped the two re-exports.
- `crew/catalog.ts` — dropped the `epicHandoff` / `inboxAck` seams from `CrewSeams`/`ALL_SEAMS`; the catalog still maps cleanly over `CREW_ROLES` and `seamsFor` stays total.
- `peer/inbox.ts` — the delivery-ack schema (formerly `Messages.InboxAck`) moves here as the peer data plane's own `InboxAck`, since that Deliver-reply is the only real ack. `peer/index.ts` re-exports it as a value; `edge/send-tool.ts` now references the peer schema.
- Tests updated to match (`protocol/schema.test.ts`, `protocol/group.test.ts`, `crew/catalog.test.ts`).

## Out of scope
The `crew/catalog.ts` membership → sparse directed-edge (`{from, to, kind}`) re-model (epic brief bullet 6) is a separate, larger substrate change — not folded in here.

## Verification
- `pnpm typecheck` — clean
- `pnpm test` — 23 files, 117 tests pass
- biome check — clean

## Collision-cluster note
Per the parallel #3300 (tracker files) lane boundary, this PR touches **no** `tracker/*` file. Two stale references to the removed kinds remain there — a docblock in `tracker/group.ts` and a relay-kind string list in `tracker/server.test.ts` — both harmless to typecheck/tests (string literals / comments). They fall under the #3300 tracker lane; flagging for routing rather than clobbering the sibling lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)