### PR TITLE
feat(pipeline-crew): pre-launch pinned-CLI-version assert (#3295)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/version-assert.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/version-assert.test.ts
@@ -1,0 +1,72 @@
+/**
+ * standup/version-assert — the pre-launch pinned-CLI-version assert (issue #3295). Covers the
+ * three decisions the assert makes with the launch side stubbed via an injected version reader:
+ * installed == pinned proceeds silently, installed != pinned aborts naming both versions, and an
+ * unreadable/unparseable installed version aborts. Also covers the pure `parseCliVersion` extractor.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {assertPinnedCliVersion, CliVersionAssertError, parseCliVersion} from "./version-assert.ts";
+
+/** The whole assert consumes is the pinned version; a `Pick<LaunchConfig, "cliVersion">` is enough. */
+const pinnedAt = (cliVersion: string) => ({cliVersion});
+
+describe("standup/version-assert — parseCliVersion", () => {
+	it("extracts the version token from real `claude --version` output", () => {
+		assert.strictEqual(parseCliVersion("2.1.207 (Claude Code)\n"), "2.1.207");
+	});
+	it("extracts a pre-release version", () => {
+		assert.strictEqual(parseCliVersion("2.1.207-beta.3 (Claude Code)"), "2.1.207-beta.3");
+	});
+	it("returns null when no version token is present", () => {
+		assert.strictEqual(parseCliVersion("command not found"), null);
+		assert.strictEqual(parseCliVersion(""), null);
+	});
+});
+
+describe("standup/version-assert — assertPinnedCliVersion", () => {
+	it.effect("proceeds silently when installed == pinned", () =>
+		Effect.gen(function* () {
+			// A void success is the whole contract of a match — no error, nothing to assert on but the exit.
+			yield* assertPinnedCliVersion(pinnedAt("2.1.207"), Effect.succeed("2.1.207 (Claude Code)"));
+		}),
+	);
+
+	it.effect("aborts naming BOTH versions when installed != pinned", () =>
+		Effect.gen(function* () {
+			const err = yield* Effect.flip(
+				assertPinnedCliVersion(pinnedAt("2.1.207"), Effect.succeed("2.1.300 (Claude Code)")),
+			);
+			assert.instanceOf(err, CliVersionAssertError);
+			assert.strictEqual(err.installed, "2.1.300");
+			assert.strictEqual(err.pinned, "2.1.207");
+			// the error must name both versions so the operator can see the drift at a glance
+			assert.include(err.reason, "2.1.300");
+			assert.include(err.reason, "2.1.207");
+		}),
+	);
+
+	it.effect("aborts when the installed version cannot be read (launch side unreadable)", () =>
+		Effect.gen(function* () {
+			// a stubbed reader whose error channel is a plain string models the launch-side subprocess failing
+			const err = yield* Effect.flip(
+				assertPinnedCliVersion(pinnedAt("2.1.207"), Effect.fail("spawn claude ENOENT")),
+			);
+			assert.instanceOf(err, CliVersionAssertError);
+			assert.strictEqual(err.installed, null);
+			assert.strictEqual(err.pinned, "2.1.207");
+			assert.include(err.reason, "ENOENT");
+		}),
+	);
+
+	it.effect("aborts when the installed version output has no parseable version", () =>
+		Effect.gen(function* () {
+			const err = yield* Effect.flip(
+				assertPinnedCliVersion(pinnedAt("2.1.207"), Effect.succeed("not a version at all")),
+			);
+			assert.instanceOf(err, CliVersionAssertError);
+			assert.strictEqual(err.installed, null);
+			assert.include(err.reason, "not a version at all");
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/standup/version-assert.ts
+++ b/packages/pipeline-crew-mcp/src/standup/version-assert.ts
@@ -1,0 +1,92 @@
+/**
+ * standup/version-assert — the pre-launch pinned-CLI-version assert for the stand-up launcher
+ * (issue #3295). At stand-up it reads the installed Claude Code CLI version and compares it to the
+ * pinned `cliVersion` the operator config carries (#3293's `LaunchConfig`, consumed read-only).
+ *
+ * The one non-obvious thing: it FAILS FAST, before any tracker or session launch. Channels are a
+ * research preview whose behavior varies across CLI versions, so a drift between the installed CLI
+ * and the pin is a stand-up to refuse, not paper over — a mismatch (or an unreadable installed
+ * version) aborts with a `CliVersionAssertError` naming both versions, and a match proceeds
+ * silently. The reader of the installed version is INJECTED so the launcher (#3299) wires the real
+ * `claude --version` while tests stub it; running the subprocess synchronously in an `Effect.try`
+ * mirrors config.ts's `readFileSync` idiom (no new dependency for a one-shot pre-launch read).
+ */
+import {execFileSync} from "node:child_process";
+import {Effect, Schema} from "effect";
+import {CLI_VERSION_RE, type LaunchConfig} from "./config.ts";
+
+/**
+ * A version drift caught before launch: the installed CLI version does not match the pinned one, or
+ * the installed version could not be read/parsed. `installed` is null when unreadable/unparseable;
+ * `reason` names both versions (a fail-fast, loud, operator-facing message).
+ */
+export class CliVersionAssertError extends Schema.TaggedErrorClass<CliVersionAssertError>()(
+	"@kampus/pipeline-crew-mcp/standup/CliVersionAssertError",
+	{
+		pinned: Schema.String,
+		installed: Schema.NullOr(Schema.String),
+		reason: Schema.String,
+	},
+) {}
+
+/** Match the `major.minor.patch[-prerelease]` core anywhere in the output — the unanchored twin of config's anchored `CLI_VERSION_RE`. */
+const VERSION_TOKEN_RE = /\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?/;
+
+/**
+ * Extract the pinned-shape version token from `claude --version` output (e.g. "2.1.207 (Claude
+ * Code)" → "2.1.207"), or null when none is present. The extracted token is re-validated against
+ * config's `CLI_VERSION_RE` so parse accepts exactly what the pin accepts.
+ */
+export const parseCliVersion = (raw: string): string | null => {
+	const token = raw.match(VERSION_TOKEN_RE)?.[0];
+	return token !== undefined && CLI_VERSION_RE.test(token) ? token : null;
+};
+
+/**
+ * The production installed-version reader: run `claude --version` and return its stdout. This is the
+ * launch-side effect the assert injects by default and that tests replace with a stub — a failure
+ * (binary absent, non-zero exit) surfaces as the thrown cause, which the assert maps to an error.
+ */
+export const readInstalledCliVersionOutput: Effect.Effect<string, string> = Effect.try({
+	try: () => execFileSync("claude", ["--version"], {encoding: "utf8"}),
+	catch: (cause) => String(cause),
+});
+
+/**
+ * Assert the installed CLI version matches the config's pinned `cliVersion`, failing fast before any
+ * launch. Reads the installed version via the injected reader (default: the real `claude --version`),
+ * and yields `CliVersionAssertError` on an unreadable version, an unparseable version, or a mismatch;
+ * a match returns void so the caller proceeds silently.
+ */
+export const assertPinnedCliVersion = (
+	config: Pick<LaunchConfig, "cliVersion">,
+	readVersionOutput: Effect.Effect<string, unknown> = readInstalledCliVersionOutput,
+): Effect.Effect<void, CliVersionAssertError> =>
+	Effect.gen(function* () {
+		const pinned = config.cliVersion;
+		const raw = yield* readVersionOutput.pipe(
+			Effect.mapError(
+				(cause) =>
+					new CliVersionAssertError({
+						pinned,
+						installed: null,
+						reason: `cannot read the installed Claude Code CLI version (is \`claude\` on PATH?): ${String(cause)}`,
+					}),
+			),
+		);
+		const installed = parseCliVersion(raw);
+		if (installed === null) {
+			return yield* new CliVersionAssertError({
+				pinned,
+				installed: null,
+				reason: `could not parse an installed Claude Code CLI version from \`claude --version\` output: ${JSON.stringify(raw)}`,
+			});
+		}
+		if (installed !== pinned) {
+			return yield* new CliVersionAssertError({
+				pinned,
+				installed,
+				reason: `installed Claude Code CLI ${installed} != pinned ${pinned} — channels are a research preview whose behavior varies across versions; align the installed CLI or the pinned version before stand-up`,
+			});
+		}
+	});


### PR DESCRIPTION
Add `standup/version-assert` — the stand-up launcher's pinned-CLI-version assertion (child of stand-up launcher epic #3237).

## What
At stand-up, read the installed Claude Code CLI version and compare it to the pinned `cliVersion` from the operator config (#3293's `LaunchConfig`, consumed **read-only**). Channels are a research preview whose behavior varies across versions, so a drift must fail fast — loud, named, **before any tracker or session launch**.

- `assertPinnedCliVersion(config, readVersionOutput?)` — reads the installed version via an **injected** reader (default: the real `claude --version`), then decides:
  - installed **==** pinned → proceeds silently (void)
  - installed **!=** pinned → aborts with `CliVersionAssertError` naming **both** versions
  - installed **unreadable / unparseable** → aborts with `CliVersionAssertError`
- `CliVersionAssertError` — a `Schema.TaggedErrorClass` carrying `pinned`, `installed` (null when unknown), and a `reason`.
- `parseCliVersion(raw)` — pure extraction of the version token from `claude --version` output, re-validated against config's `CLI_VERSION_RE`.

The reader is injected so the launcher (#3299) wires the real subprocess while the unit tests stub the launch side; running `claude --version` synchronously in an `Effect.try` mirrors config.ts's `readFileSync` idiom (no new dependency).

## Scope
One new file + its test under `packages/pipeline-crew-mcp/src/standup/`; `config.ts` consumed read-only. Choosing/storing the pin is the config child's job (#3293), not this one.

## Acceptance criteria
- [x] Launcher reads installed CLI version + pinned version from config and compares at stand-up.
- [x] A mismatch aborts with a clear error naming both installed and pinned, before any launch.
- [x] A match proceeds silently.
- [x] The match/mismatch/unreadable decision is unit-tested with the launch side stubbed.

## Verification
- `pnpm --filter @kampus/pipeline-crew-mcp test` — 7 passing
- `pnpm typecheck` (full workspace) — green
- `pnpm lint:worktree` — clean

Fixes #3295