### PR TITLE
feat(pipeline-crew): per-session bind constructor — inline --mcp-config + channel flag (#3296)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The per-session bind constructor (AC 1–4): for a role + project root it emits the launch
+ * fragment each crew session comes up with — the per-invocation `--mcp-config` inline JSON baking
+ * `pipeline-crew-mcp session --role <role> --project-root <root>`, plus the channel-registration
+ * flag naming that same server. The tests pin the EXACT argv/JSON for a sample role in both channel
+ * modes (allowlist → `--channels`, development → `--dangerously-load-development-channels`), and the
+ * two fail-closed rejections: a crew server absent from the flag (defined-but-inert), and an
+ * allowlist-mode plugin channel whose plugin the config's `allowedChannelPlugins` doesn't list.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	ALLOWLIST_CHANNEL_FLAG,
+	buildSessionBind,
+	ChannelPluginNotAllowedError,
+	CREW_SESSION_COMMAND,
+	CrewServerNotRegisteredError,
+	DEV_CHANNEL_FLAG,
+	MCP_CONFIG_FLAG,
+	PIPELINE_CREW_MCP_BIN,
+} from "./bind.ts";
+import type {ChannelConfig} from "./config.ts";
+
+const ROLE = "engineering-manager";
+const PROJECT_ROOT = "/work/phoenix";
+const SERVER_NAME = "pipeline-crew";
+
+// The exact inline JSON the --mcp-config value must carry: one server, keyed by the session's own
+// channel-server name, whose command bakes the per-invocation `session --role --project-root`.
+const EXPECTED_MCP_JSON = JSON.stringify({
+	mcpServers: {
+		[SERVER_NAME]: {
+			command: PIPELINE_CREW_MCP_BIN,
+			args: ["session", "--role", ROLE, "--project-root", PROJECT_ROOT],
+		},
+	},
+});
+
+describe("standup/bind — per-session bind constructor", () => {
+	it.effect(
+		"allowlist mode: --mcp-config inline JSON + --channels naming the crew server (AC 1,2,3)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "allowlist",
+					servers: ["server:pipeline-crew", "plugin:kampus:sozluk"],
+					allowedChannelPlugins: ["kampus"],
+				};
+				const bind = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+
+				// AC1: the --mcp-config value is the exact inline JSON baking the session command.
+				assert.deepStrictEqual(bind.mcpConfigArg, [MCP_CONFIG_FLAG, EXPECTED_MCP_JSON]);
+				assert.strictEqual(CREW_SESSION_COMMAND, "session");
+
+				// AC3: allowlist mode selects --channels over the config's server refs (grammar preserved).
+				assert.deepStrictEqual(bind.channelArg, [
+					ALLOWLIST_CHANNEL_FLAG,
+					"server:pipeline-crew",
+					"plugin:kampus:sozluk",
+				]);
+
+				// AC2: the full argv carries BOTH — the crew server is named in the flag, never .mcp.json alone.
+				assert.deepStrictEqual(bind.argv, [
+					MCP_CONFIG_FLAG,
+					EXPECTED_MCP_JSON,
+					ALLOWLIST_CHANNEL_FLAG,
+					"server:pipeline-crew",
+					"plugin:kampus:sozluk",
+				]);
+			}),
+	);
+
+	it.effect(
+		"development mode: --dangerously-load-development-channels, allowlist gate skipped (AC 3)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					// A plugin channel whose plugin is NOT in allowedChannelPlugins — accepted in dev mode,
+					// which is exactly the dev flag's purpose (load channels not on the approved allowlist).
+					servers: ["server:pipeline-crew", "plugin:localdev:scratch"],
+					allowedChannelPlugins: [],
+				};
+				const bind = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+
+				assert.deepStrictEqual(bind.mcpConfigArg, [MCP_CONFIG_FLAG, EXPECTED_MCP_JSON]);
+				assert.deepStrictEqual(bind.channelArg, [
+					DEV_CHANNEL_FLAG,
+					"server:pipeline-crew",
+					"plugin:localdev:scratch",
+				]);
+				assert.deepStrictEqual(bind.argv, [MCP_CONFIG_FLAG, EXPECTED_MCP_JSON, ...bind.channelArg]);
+			}),
+	);
+
+	it.effect(
+		"fails closed when the crew server is absent from the channel flag (defined-but-inert)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "allowlist",
+					servers: ["server:some-other"],
+					allowedChannelPlugins: [],
+				};
+				const error = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				}).pipe(Effect.flip);
+
+				assert.instanceOf(error, CrewServerNotRegisteredError);
+				assert.strictEqual(error.serverName, SERVER_NAME);
+				assert.deepStrictEqual([...error.servers], ["server:some-other"]);
+			}),
+	);
+
+	it.effect("allowlist mode fails closed on a plugin channel whose plugin is not allowlisted", () =>
+		Effect.gen(function* () {
+			const channels: ChannelConfig = {
+				mode: "allowlist",
+				servers: ["server:pipeline-crew", "plugin:untrusted:evil"],
+				allowedChannelPlugins: ["kampus"],
+			};
+			const error = yield* buildSessionBind({
+				role: ROLE,
+				projectRoot: PROJECT_ROOT,
+				serverName: SERVER_NAME,
+				channels,
+			}).pipe(Effect.flip);
+
+			assert.instanceOf(error, ChannelPluginNotAllowedError);
+			assert.strictEqual(error.plugin, "untrusted");
+			assert.strictEqual(error.ref, "plugin:untrusted:evil");
+			assert.deepStrictEqual([...error.allowedChannelPlugins], ["kampus"]);
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -1,0 +1,153 @@
+/**
+ * standup/bind — the per-session bind constructor: the launch-time, launcher-owned binding each
+ * crew session (epic #3237) comes up with. For a role + project root it derives the launch argv
+ * fragment for ONE session — no process spawn here (the orchestration child #3299 spawns), pure
+ * argv/JSON derivation over the already-resolved `LaunchConfig` channels dimension (#3293).
+ *
+ * It produces two coupled outputs the launcher inlines per invocation:
+ *   1. `--mcp-config <json>` — the session's own channel MCP server as INLINE JSON baking
+ *      `pipeline-crew-mcp session --role <role> --project-root <root>`. It must be per-invocation
+ *      inline (not a static shared `.mcp.json`) because `--role`/`--project-root` vary across the
+ *      concurrent sessions a stand-up launches at once.
+ *   2. the channel-registration flag NAMING that same server — `--channels <refs>` for the
+ *      allowlist mode, `--dangerously-load-development-channels <refs>` for dev. A server present
+ *      in `.mcp.json`/`--mcp-config` alone is INERT: the Claude Code CLI only activates a channel
+ *      once its server is also named in this flag (verified against the 2.1.212 bundle:
+ *      `--channels <servers...>`, `--dangerously-load-development-channels <servers...>`,
+ *      `--mcp-config <configs...>` load-from-JSON-string, and the `allowedChannelPlugins` gate).
+ *
+ * The one non-obvious thing: this FAILS CLOSED, like the config reader it consumes. A crew server
+ * defined in `--mcp-config` but absent from the channel flag would come up inert (a silent
+ * half-launch), and an allowlist-mode `plugin:` channel whose plugin the operator never allowlisted
+ * is exactly what the CLI rejects — both are a launch to refuse with a named error, never paper over.
+ */
+import {Effect, Schema} from "effect";
+import type {ChannelConfig} from "./config.ts";
+
+/** The bin the session's channel MCP server runs (the package `bin`; AC1 bakes this verbatim). */
+export const PIPELINE_CREW_MCP_BIN = "pipeline-crew-mcp";
+/** The subcommand that runs one live crew session (`bin.ts`). */
+export const CREW_SESSION_COMMAND = "session";
+export const MCP_CONFIG_FLAG = "--mcp-config";
+/** Allowlist mode: only servers named here load, gated by `allowedChannelPlugins` for plugin refs. */
+export const ALLOWLIST_CHANNEL_FLAG = "--channels";
+/** Dev mode: load channel servers not on the approved allowlist — local development only. */
+export const DEV_CHANNEL_FLAG = "--dangerously-load-development-channels";
+
+/** The `server:<name>` channel ref that names the crew session server registered under `serverName`. */
+const crewServerRef = (serverName: string): string => `server:${serverName}`;
+
+/** The inline `--mcp-config` JSON: one server keyed by `serverName`, baking the per-invocation session command. */
+const sessionMcpConfigJson = (role: string, projectRoot: string, serverName: string): string =>
+	JSON.stringify({
+		mcpServers: {
+			[serverName]: {
+				command: PIPELINE_CREW_MCP_BIN,
+				args: [CREW_SESSION_COMMAND, "--role", role, "--project-root", projectRoot],
+			},
+		},
+	});
+
+/** What one crew session binds at launch: the role, its root, and the derived launch argv fragment. */
+export interface SessionBind {
+	readonly role: string;
+	readonly projectRoot: string;
+	/** `["--mcp-config", "<inline JSON>"]`. */
+	readonly mcpConfigArg: readonly [flag: string, json: string];
+	/** The channel-registration flag + its server refs, e.g. `["--channels", "server:pipeline-crew", …]`. */
+	readonly channelArg: readonly string[];
+	/** The complete fragment `[...mcpConfigArg, ...channelArg]` the launcher inlines for this session. */
+	readonly argv: readonly string[];
+}
+
+export interface SessionBindInput {
+	readonly role: string;
+	readonly projectRoot: string;
+	/**
+	 * The channel-ref name this session's own crew MCP server registers under (the `--mcp-config`
+	 * map key). It MUST appear as `server:<serverName>` in `channels.servers`, else the server is
+	 * defined-but-inert — the fail-closed `CrewServerNotRegisteredError` below.
+	 */
+	readonly serverName: string;
+	/** The resolved channels dimension of the crew `LaunchConfig` (#3293), consumed read-only. */
+	readonly channels: ChannelConfig;
+}
+
+/**
+ * The crew session's own server is defined in `--mcp-config` but not named in the channel flag, so
+ * it would come up INERT (`.mcp.json` alone is insufficient). Refuse the launch (AC2).
+ */
+export class CrewServerNotRegisteredError extends Schema.TaggedErrorClass<CrewServerNotRegisteredError>()(
+	"@kampus/pipeline-crew-mcp/standup/CrewServerNotRegisteredError",
+	{
+		serverName: Schema.String,
+		servers: Schema.Array(Schema.String),
+	},
+) {}
+
+/**
+ * An allowlist-mode `plugin:<plugin>:<server>` channel names a plugin the config's
+ * `allowedChannelPlugins` doesn't list — the exact rejection the CLI raises ("not on the approved
+ * channels allowlist"). Dev mode is the sanctioned escape hatch, so this fires only under `--channels`.
+ */
+export class ChannelPluginNotAllowedError extends Schema.TaggedErrorClass<ChannelPluginNotAllowedError>()(
+	"@kampus/pipeline-crew-mcp/standup/ChannelPluginNotAllowedError",
+	{
+		plugin: Schema.String,
+		ref: Schema.String,
+		allowedChannelPlugins: Schema.Array(Schema.String),
+	},
+) {}
+
+/** The plugin segment of a `plugin:<plugin>:<server>` ref (grammar-guaranteed present by `ChannelServerRef`). */
+const pluginOf = (ref: string): string | undefined =>
+	ref.startsWith("plugin:") ? ref.split(":")[1] : undefined;
+
+/**
+ * Build one crew session's launch bind: the inline `--mcp-config` server + the channel-registration
+ * flag naming that same server. Fails closed if the crew server would be inert (unnamed in the flag),
+ * or — under `--channels` only — if a plugin channel names a plugin outside `allowedChannelPlugins`.
+ */
+export const buildSessionBind = (
+	input: SessionBindInput,
+): Effect.Effect<SessionBind, CrewServerNotRegisteredError | ChannelPluginNotAllowedError> =>
+	Effect.gen(function* () {
+		const {role, projectRoot, serverName, channels} = input;
+		const servers = channels.servers;
+
+		if (!servers.includes(crewServerRef(serverName))) {
+			return yield* Effect.fail(new CrewServerNotRegisteredError({serverName, servers}));
+		}
+
+		// The allowlist gate applies to `--channels` only: dev mode's whole purpose is loading
+		// channels NOT on the approved allowlist, so it deliberately skips the plugin check.
+		if (channels.mode === "allowlist") {
+			for (const ref of servers) {
+				const plugin = pluginOf(ref);
+				if (plugin !== undefined && !channels.allowedChannelPlugins.includes(plugin)) {
+					return yield* Effect.fail(
+						new ChannelPluginNotAllowedError({
+							plugin,
+							ref,
+							allowedChannelPlugins: channels.allowedChannelPlugins,
+						}),
+					);
+				}
+			}
+		}
+
+		const channelFlag = channels.mode === "development" ? DEV_CHANNEL_FLAG : ALLOWLIST_CHANNEL_FLAG;
+		const mcpConfigArg: readonly [string, string] = [
+			MCP_CONFIG_FLAG,
+			sessionMcpConfigJson(role, projectRoot, serverName),
+		];
+		const channelArg: readonly string[] = [channelFlag, ...servers];
+
+		return {
+			role,
+			projectRoot,
+			mcpConfigArg,
+			channelArg,
+			argv: [...mcpConfigArg, ...channelArg],
+		};
+	});


### PR DESCRIPTION
The per-session bind constructor each crew session (epic #3237) comes up with. For a role + project root, `buildSessionBind` derives one session's launch argv fragment — pure argv/JSON derivation over the resolved `LaunchConfig` channels dimension (#3293), no process spawn (the orchestration child #3299 spawns).

**What it produces**
- `--mcp-config` as **inline JSON** baking `pipeline-crew-mcp session --role <role> --project-root <root>`. Per-invocation inline (not a static shared `.mcp.json`) because `--role`/`--project-root` vary across the concurrent sessions a stand-up launches.
- The channel-registration flag **naming that same server** — `--channels <refs>` for allowlist mode, `--dangerously-load-development-channels <refs>` for dev. A server in `--mcp-config` alone is inert; the CLI only activates a channel once its server is also named in the flag.

**Fails closed** (like the config reader it consumes): a crew server absent from the flag (defined-but-inert) → `CrewServerNotRegisteredError`; an allowlist-mode `plugin:` channel whose plugin is outside `allowedChannelPlugins` → `ChannelPluginNotAllowedError`. Dev mode is the sanctioned escape hatch, so the plugin gate fires only under `--channels`.

CLI semantics (`--channels <servers...>`, `--dangerously-load-development-channels <servers...>`, `--mcp-config <configs...>` load-from-JSON-string, the `allowedChannelPlugins` gate) verified against the installed 2.1.212 Claude Code bundle.

Scope: one new file + its test under `packages/pipeline-crew-mcp/src/standup/`; consumes `config.ts` read-only. No barrel/config/roster/tmux/tracker/protocol/crew edits.

Acceptance criteria — all met:
- mcp-config inline JSON bakes the session command (AC1)
- argv also carries the channel flag naming that server (AC2)
- allowlist → `--channels` server:/plugin: grammar; development → `--dangerously-load-development-channels` (AC3)
- both branches unit-tested against exact argv/JSON, plus the two fail-closed rejections (AC4)

Fixes #3296