### PR TITLE
feat(pipeline-crew-mcp): per-instance engine addressing + array-returning role discovery (#3301)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
@@ -10,7 +10,7 @@
  *     (cardinality 1), a second live session for an ENGINE role is admitted (cardinality N).
  */
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Option, Ref} from "effect";
+import {Effect, Layer, Ref} from "effect";
 import {RpcTest} from "effect/unstable/rpc";
 import {ChannelSink, channelInboxLayer} from "../edge/index.ts";
 import {
@@ -24,7 +24,7 @@ import {
 import {TrackerRegistry} from "../tracker/group.ts";
 import {TrackerHandlers} from "../tracker/handlers.ts";
 import {RegistryLive} from "../tracker/registry.ts";
-import {makeCrewChannel} from "./channel-server.ts";
+import {inboxSocketPathFor, makeCrewChannel} from "./channel-server.ts";
 import {RoleUniquenessError} from "./errors.ts";
 import {CREW_ROLES, kindOf} from "./roles.ts";
 import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
@@ -68,13 +68,13 @@ describe("crew/channel-server — announce, discover, claim/collision-check (AC 
 				Effect.provide(channelLayers(tracker, "inbox://b", alwaysUnreachable)),
 			);
 
-			// discover each other across the flat topology
+			// discover each other across the flat topology (each a singleton set here)
 			const aFindsB = yield* a.discover(roleB);
 			const bFindsA = yield* b.discover(roleA);
-			assert.isTrue(Option.isSome(aFindsB));
-			assert.strictEqual(Option.getOrThrow(aFindsB).address, "inbox://b");
-			assert.isTrue(Option.isSome(bFindsA));
-			assert.strictEqual(Option.getOrThrow(bFindsA).address, "inbox://a");
+			assert.lengthOf(aFindsB, 1);
+			assert.strictEqual(aFindsB[0]?.address, "inbox://b");
+			assert.lengthOf(bFindsA, 1);
+			assert.strictEqual(bFindsA[0]?.address, "inbox://a");
 
 			// a synchronous claim/collision-check with a typed reply: A grants, B collides
 			const granted = yield* a.claim("issue-3059");
@@ -233,6 +233,105 @@ describe("crew/channel-server — per-kind cardinality lease (AC 3)", () => {
 				const result = yield* client.LookupRole({role});
 				assert.lengthOf(result.peers, 1, `${role} should be present`);
 			}
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+});
+
+describe("crew/channel-server — engine pool discovery + per-instance dial (AC 2)", () => {
+	it.effect("discover returns every live engine instance, each at a distinct inbox socket", () =>
+		Effect.gen(function* () {
+			const engineRole = ENGINE_ROLES[0];
+			const senderRole = BRIDGE_ROLES[0];
+			assert(engineRole !== undefined, "the roster must carry an engine role");
+			assert(senderRole !== undefined, "the roster must carry a bridge role");
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const tracker = CrewTracker.fromClient(client);
+
+			// two engine instances of one role, distinct per-instance addresses, both live
+			const addr1 = `inbox://${engineRole}/1`;
+			const addr2 = `inbox://${engineRole}/2`;
+			const at = new Date().toISOString();
+			yield* client.AnnouncePresence({peer: addr1, role: engineRole, at});
+			yield* client.AnnouncePresence({peer: addr2, role: engineRole, at});
+
+			// a sender channel discovers the WHOLE pool, not a single collapsed holder
+			const senderAddr = `inbox://${senderRole}`;
+			const sender = yield* makeCrewChannel({role: senderRole, address: senderAddr}).pipe(
+				Effect.provide(channelLayers(tracker, senderAddr, alwaysUnreachable)),
+			);
+			const pool = yield* sender.discover(engineRole);
+			assert.lengthOf(pool, 2, "both engine instances are discoverable (no peers[0] collapse)");
+			assert.deepStrictEqual([...pool.map((p) => p.address)].sort(), [addr1, addr2].sort());
+			// two instances resolve to two DISTINCT inbox sockets — per-instance addressing, no collision
+			assert.notStrictEqual(inboxSocketPathFor(addr1), inboxSocketPathFor(addr2));
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect("a sender dials ONE chosen engine instance — delivery reaches only that instance", () =>
+		Effect.gen(function* () {
+			const engineRole = ENGINE_ROLES[0];
+			const senderRole = BRIDGE_ROLES[0];
+			assert(engineRole !== undefined, "the roster must carry an engine role");
+			assert(senderRole !== undefined, "the roster must carry a bridge role");
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const tracker = CrewTracker.fromClient(client);
+			const addr1 = `inbox://${engineRole}/1`;
+			const addr2 = `inbox://${engineRole}/2`;
+
+			// each engine instance has its own recording channel edge, reachable by its address
+			const recordingInbox = (address: string) =>
+				Effect.gen(function* () {
+					const wakes = yield* Ref.make<ReadonlyArray<unknown>>([]);
+					const sink = Layer.succeed(ChannelSink, {
+						wake: (payload) => Ref.update(wakes, (xs) => [...xs, payload]),
+					});
+					const inbox = yield* RpcTest.makeClient(PeerInbox).pipe(
+						Effect.provide(
+							Layer.provideMerge(
+								inboxHandlers,
+								channelInboxLayer(address).pipe(Layer.provide(sink)),
+							),
+						),
+					);
+					return {wakes, inbox};
+				});
+			const one = yield* recordingInbox(addr1);
+			const two = yield* recordingInbox(addr2);
+			const connect: Connect = (address) =>
+				address === addr1
+					? Effect.succeed(one.inbox)
+					: address === addr2
+						? Effect.succeed(two.inbox)
+						: Effect.fail(new PeerUnreachableError({target: address, reason: "no route"}));
+
+			const at = new Date().toISOString();
+			yield* client.AnnouncePresence({peer: addr1, role: engineRole, at});
+			yield* client.AnnouncePresence({peer: addr2, role: engineRole, at});
+
+			// discover the pool, pick instance #2 specifically, and dial IT by address via the Dialer
+			const senderAddr = `inbox://${senderRole}`;
+			const ack = yield* Effect.gen(function* () {
+				const dialer = yield* Dialer;
+				const sender = yield* makeCrewChannel({role: senderRole, address: senderAddr});
+				const pool = yield* sender.discover(engineRole);
+				const chosen = pool.find((p) => p.address === addr2);
+				assert(chosen !== undefined, "instance #2 is in the discovered pool");
+				return yield* dialer.send(chosen.address, {
+					messageId: "m-1",
+					from: senderAddr,
+					kind: "IntakePing",
+					body: {issue: "x"},
+					at: new Date().toISOString(),
+				});
+			}).pipe(Effect.provide(channelLayers(tracker, senderAddr, Dialer.layerFromConnect(connect))));
+
+			assert.strictEqual(ack.by, addr2, "the ack came from instance #2's inbox");
+			assert.lengthOf(yield* Ref.get(two.wakes), 1, "instance #2 received the delivery");
+			assert.lengthOf(
+				yield* Ref.get(one.wakes),
+				0,
+				"instance #1 did NOT — the dial was per-instance",
+			);
 		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.ts
@@ -19,7 +19,7 @@
  */
 import {createHash} from "node:crypto";
 import {NodeSocket, NodeSocketServer} from "@effect/platform-node";
-import {Effect, Layer, type Option} from "effect";
+import {Effect, Layer} from "effect";
 import {RpcClient, RpcSerialization, RpcServer} from "effect/unstable/rpc";
 import {type ChannelSink, channelInboxLayer} from "../edge/index.ts";
 import {
@@ -64,8 +64,12 @@ export interface CrewChannel {
 	readonly address: string;
 	/** The composed peer: its inbox (`received`) + its direct peer-to-peer `send`. */
 	readonly peer: Peer;
-	/** Role discovery: the live holder of `role` across the flat topology, or `None`. */
-	readonly discover: (role: CrewRole) => Effect.Effect<Option.Option<RolePresence>>;
+	/**
+	 * Role discovery: the live holders of `role` across the flat topology (`[]` ⇒ none). A bridge
+	 * resolves to its single holder; an engine to its whole live pool, so a caller can address one
+	 * chosen instance (dial its `address`) or fan across the set.
+	 */
+	readonly discover: (role: CrewRole) => Effect.Effect<ReadonlyArray<RolePresence>>;
 	/** A claim/collision-check on a resource (e.g. an issue) — the typed granted/collision reply. */
 	readonly claim: (resource: string) => Effect.Effect<ClaimReply>;
 }

--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -27,7 +27,7 @@ import {
 import {TrackerRegistry} from "../tracker/group.ts";
 import {TrackerHandlers} from "../tracker/handlers.ts";
 import {RegistryLive} from "../tracker/registry.ts";
-import {CREW_ROLES} from "./roles.ts";
+import {CREW_ROLES, kindOf} from "./roles.ts";
 import {channelSendFromPeer, inboxAddressFor} from "./session.ts";
 import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
 
@@ -53,7 +53,8 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
 			const tracker = CrewTracker.fromClient(client);
 			const [senderRole, receiverRole] = [CREW_ROLES[0], CREW_ROLES[1]];
-			const receiverAddress = inboxAddressFor(receiverRole);
+			const senderAddress = inboxAddressFor(senderRole, "sender");
+			const receiverAddress = inboxAddressFor(receiverRole, "receiver");
 
 			// The receiver's channel edge: a channel-bridging inbox recording each wake, reachable as
 			// an in-memory PeerInbox client. This is what a live receiver's inbox socket server hosts.
@@ -87,10 +88,8 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 				return yield* sender.send(receiverRole, "IntakePing", {issue: "3062", from: senderRole});
 			}).pipe(
 				Effect.provide(
-					channelSendFromPeer(senderRole).pipe(
-						Layer.provide(
-							substrate(tracker, inboxAddressFor(senderRole), Dialer.layerFromConnect(connect)),
-						),
+					channelSendFromPeer(senderRole, senderAddress).pipe(
+						Layer.provide(substrate(tracker, senderAddress, Dialer.layerFromConnect(connect))),
 					),
 				),
 			);
@@ -100,7 +99,7 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 			const recorded = yield* Ref.get(wakes);
 			assert.lengthOf(recorded, 1);
 			assert.match(recorded[0]?.message ?? "", /IntakePing/, "the seam rode a channel wake");
-			assert.strictEqual(recorded[0]?._meta?.from, inboxAddressFor(senderRole));
+			assert.strictEqual(recorded[0]?._meta?.from, senderAddress);
 		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
 	);
 
@@ -109,6 +108,7 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 			const client = yield* RpcTest.makeClient(TrackerRegistry);
 			const tracker = CrewTracker.fromClient(client);
 			const [senderRole, offlineRole] = [CREW_ROLES[0], CREW_ROLES[2]];
+			const senderAddress = inboxAddressFor(senderRole, "sender");
 			const alwaysUnreachable = Dialer.layerFromConnect((address) =>
 				Effect.fail(new PeerUnreachableError({target: address, reason: "no route"})),
 			);
@@ -118,8 +118,8 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 				return yield* sender.send(offlineRole, "IntakePing", {});
 			}).pipe(
 				Effect.provide(
-					channelSendFromPeer(senderRole).pipe(
-						Layer.provide(substrate(tracker, inboxAddressFor(senderRole), alwaysUnreachable)),
+					channelSendFromPeer(senderRole, senderAddress).pipe(
+						Layer.provide(substrate(tracker, senderAddress, alwaysUnreachable)),
 					),
 				),
 				Effect.flip,
@@ -132,7 +132,7 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 
 describe("crew/session — the roster is intact (no role orphaned)", () => {
 	it("inboxAddressFor addresses every standing role distinctly", () => {
-		const addresses = CREW_ROLES.map(inboxAddressFor);
+		const addresses = CREW_ROLES.map((role) => inboxAddressFor(role, "i"));
 		assert.lengthOf(
 			addresses,
 			CREW_ROLES.length,
@@ -144,5 +144,28 @@ describe("crew/session — the roster is intact (no role orphaned)", () => {
 			"every role maps to a distinct inbox address",
 		);
 		assert.include(addresses, "inbox://cartographer", "the cartographer must have an address");
+	});
+});
+
+describe("crew/session — per-instance engine addressing (AC 1)", () => {
+	const engineRole = CREW_ROLES.find((role) => kindOf(role) === "engine");
+	const bridgeRole = CREW_ROLES.find((role) => kindOf(role) === "bridge");
+
+	it("a bridge keeps the deterministic singleton address, ignoring the instance", () => {
+		assert(bridgeRole !== undefined, "the roster must carry a bridge role");
+		assert.strictEqual(inboxAddressFor(bridgeRole, "one"), `inbox://${bridgeRole}`);
+		assert.strictEqual(
+			inboxAddressFor(bridgeRole, "one"),
+			inboxAddressFor(bridgeRole, "two"),
+			"a bridge's cardinality-1 lease keeps discover→dial deterministic — no instance in the address",
+		);
+	});
+
+	it("an engine folds the instance in — two instances resolve to two distinct addresses", () => {
+		assert(engineRole !== undefined, "the roster must carry an engine role");
+		const one = inboxAddressFor(engineRole, "one");
+		const two = inboxAddressFor(engineRole, "two");
+		assert.strictEqual(one, `inbox://${engineRole}/one`);
+		assert.notStrictEqual(one, two, "N engine instances never collapse onto a single address");
 	});
 });

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -16,10 +16,12 @@
  * the toolkit registers on, and the sink wakes through, the exact transport serving stdio — the
  * same memoization the edge server (#3162) relies on when it provides `layerStdio` to the toolkit.
  *
- * The role-uniqueness lease + presence announce ride the peer's scope (`makeCrewChannel`): a
- * second live session for a held role fails the build with `RoleUniquenessError`, and presence
- * frees on teardown (connection-is-lease, #3035). The address is keyed on the role because the
- * lease guarantees one live session per role, so discovery→dial is deterministic.
+ * The per-kind cardinality lease + presence announce ride the peer's scope (`makeCrewChannel`): a
+ * second live session for a held BRIDGE role fails the build with `RoleUniquenessError`, an ENGINE
+ * role admits N instances, and presence frees on teardown (connection-is-lease, #3035). A bridge's
+ * address is its role (`inbox://<role>`) — its singleton lease keeps discover→dial deterministic;
+ * an engine's is per-instance (`inbox://<role>/<instance>`) so its pool never collapses. See
+ * `inboxAddressFor` (ADR 0189).
  *
  * The binding is transport-injected: `channelSendFromPeer` takes the peer substrate as a
  * requirement (production supplies `peerSocketSubstrate` over unix sockets), so `session.test.ts`
@@ -27,6 +29,7 @@
  * in-memory `Connect`) — the same transport-free idiom `channel-server.test.ts` uses. The one seam
  * not exercised without a live MCP client is the stdio `McpServer` wake itself.
  */
+import {randomUUID} from "node:crypto";
 import {NodeStdio} from "@effect/platform-node";
 import {Effect, Layer} from "effect";
 import {McpServer} from "effect/unstable/ai";
@@ -48,7 +51,7 @@ import {
 } from "./channel-server.ts";
 import type {RoleUniquenessError} from "./errors.ts";
 import {crewHeartbeatLayer} from "./heartbeat.ts";
-import type {CrewRole} from "./roles.ts";
+import {type CrewRole, kindOf} from "./roles.ts";
 import {type CrewTracker, crewTrackerHostOrDialLayer, peerTrackerLayer} from "./tracker.ts";
 
 /** The MCP server identity a crew session advertises over stdio when none is configured. */
@@ -65,15 +68,20 @@ export interface CrewSessionConfig {
 }
 
 /**
- * This session's dialable inbox address. The crew binds peer-id ≡ inbox-address, and the
- * role-uniqueness lease guarantees one live session per role, so keying the address on the role
- * makes discovery→dial deterministic: any peer that discovers `role` dials this exact address
- * (`inboxSocketPathFor` maps it to the unix socket the inbound server binds).
+ * This session's dialable inbox address, keyed by the role's KIND (ADR 0189). A BRIDGE keeps the
+ * deterministic singleton `inbox://<role>`: its cardinality-1 lease guarantees one live session, so
+ * discover→dial stays deterministic without an instance. An ENGINE carries a per-instance
+ * discriminator `inbox://<role>/<instance>`, so N engine sessions hold N distinct presence leases
+ * (keyed by peer in the registry) and resolve to N distinct inbox sockets — never overwriting each
+ * other. `inboxSocketPathFor` hashes the whole address, so two engine instances get collision-free
+ * sockets. The `instance` is a per-session id, generated once in `crewSessionLayer`.
  */
-export const inboxAddressFor = (role: CrewRole): string => `inbox://${role}`;
+export const inboxAddressFor = (role: CrewRole, instance: string): string =>
+	kindOf(role) === "engine" ? `inbox://${role}/${instance}` : `inbox://${role}`;
 
 /** The unix socket this session's peer inbox is served on — the address resolved to a socket path. */
-export const inboxSocketFor = (role: CrewRole): string => inboxSocketPathFor(inboxAddressFor(role));
+export const inboxSocketFor = (role: CrewRole, instance: string): string =>
+	inboxSocketPathFor(inboxAddressFor(role, instance));
 
 /**
  * The peer substrate over real unix sockets: the first-peer-spawn `CrewTracker` (host the tracker
@@ -88,11 +96,12 @@ export const inboxSocketFor = (role: CrewRole): string => inboxSocketPathFor(inb
  */
 export const peerSocketSubstrate = (
 	config: CrewSessionConfig,
+	address: string,
 ): Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown> => {
 	const crewTracker = crewTrackerHostOrDialLayer(socketPathFor(config.projectRoot));
 	return Layer.mergeAll(
 		peerTrackerLayer.pipe(Layer.provideMerge(crewTracker)),
-		Inbox.layer(inboxAddressFor(config.role)),
+		Inbox.layer(address),
 		crewSocketDialerLayer,
 	);
 };
@@ -108,11 +117,12 @@ export const peerSocketSubstrate = (
  */
 export const channelSendFromPeer = (
 	role: CrewRole,
+	address: string,
 ): Layer.Layer<ChannelSend, RoleUniquenessError, CrewTracker | Tracker | Inbox | Dialer> =>
 	Layer.effect(
 		ChannelSend,
 		Effect.gen(function* () {
-			const channel = yield* makeCrewChannel({role, address: inboxAddressFor(role)});
+			const channel = yield* makeCrewChannel({role, address});
 			return {send: channel.peer.send};
 		}),
 	);
@@ -123,7 +133,10 @@ export const channelSendFromPeer = (
  * inbound socket server's `ChannelSink` wakes through it — memoized to a single running transport.
  */
 export const crewSessionLayer = (config: CrewSessionConfig) => {
-	const address = inboxAddressFor(config.role);
+	// One per-session instance id, generated once here and threaded to every address derivation, so
+	// an engine session's inbox/announce/heartbeat all agree on the same per-instance address (a
+	// bridge ignores it and keeps its singleton address). See `inboxAddressFor`.
+	const address = inboxAddressFor(config.role, randomUUID());
 	// The one running stdio McpServer + its channel capability; shared across both channel edges.
 	const server = McpServer.layerStdio({
 		name: config.name ?? SESSION_SERVER_NAME,
@@ -133,12 +146,12 @@ export const crewSessionLayer = (config: CrewSessionConfig) => {
 
 	// The peer substrate, built once and SHARED (by memoization) between the outbound binding and the
 	// heartbeat loop, so both drive the one hosted tracker / registry this session announces on.
-	const substrate = peerSocketSubstrate(config);
+	const substrate = peerSocketSubstrate(config, address);
 
 	// outbound: the channel_send toolkit, its ChannelSend bound to this session's peer.
 	const outbound = McpServer.toolkit(ChannelToolkit).pipe(
 		Layer.provide(channelToolHandlers),
-		Layer.provide(channelSendFromPeer(config.role).pipe(Layer.provide(substrate))),
+		Layer.provide(channelSendFromPeer(config.role, address).pipe(Layer.provide(substrate))),
 		Layer.provide(server),
 	);
 

--- a/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
@@ -9,7 +9,7 @@ import {randomUUID} from "node:crypto";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {assert, describe, it} from "@effect/vitest";
-import {Cause, Context, Effect, Layer, Option} from "effect";
+import {Cause, Context, Effect, Layer} from "effect";
 import {RpcTest} from "effect/unstable/rpc";
 import {SocketServerError, SocketServerOpenError} from "effect/unstable/socket/SocketServer";
 import {TrackerRegistry} from "../tracker/group.ts";
@@ -40,8 +40,8 @@ describe("crew/tracker — first-peer-spawn: two sessions on one project root, o
 				address: "inbox://builder",
 			});
 			const found = yield* trackerB.lookup("builder");
-			assert.isTrue(Option.isSome(found), "the dialing session sees the host's registry state");
-			if (Option.isSome(found)) assert.strictEqual(found.value.address, "inbox://builder");
+			assert.lengthOf(found, 1, "the dialing session sees the host's registry state");
+			assert.strictEqual(found[0]?.address, "inbox://builder");
 		}).pipe(Effect.scoped),
 	);
 
@@ -56,7 +56,7 @@ describe("crew/tracker — first-peer-spawn: two sessions on one project root, o
 				address: "inbox://reviewer",
 			});
 			const found = yield* tracker.lookup("reviewer");
-			assert.isTrue(Option.isSome(found), "a session with no peer still has a working tracker");
+			assert.lengthOf(found, 1, "a session with no peer still has a working tracker");
 		}).pipe(Effect.scoped),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -13,7 +13,7 @@
  *     that address back out (matching the `inbox://…` convention the tracker socket test uses).
  */
 import {NodeSocket} from "@effect/platform-node";
-import {Context, Effect, Layer, Option, type Scope} from "effect";
+import {Array as Arr, Context, Effect, Layer, type Scope} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
 import {type RolePresence, Tracker} from "../peer/index.ts";
 import type * as Schema from "../protocol/schema.ts";
@@ -80,8 +80,12 @@ export class CrewTracker extends Context.Service<
 			readonly peer: string;
 			readonly ttlSeconds: number;
 		}) => Effect.Effect<void>;
-		/** The live holder of `role`, or `None` when absent/expired — the explicit not-present result. */
-		readonly lookup: (role: string) => Effect.Effect<Option.Option<RolePresence>>;
+		/**
+		 * The live holders of `role` — every present instance (`[]` ⇒ absent/expired). A bridge
+		 * resolves to its single holder; an engine to its whole live pool, so a sender can address one
+		 * chosen instance or fan across all of them (the wire's `RoleLookupResult.peers` is an array).
+		 */
+		readonly lookup: (role: string) => Effect.Effect<ReadonlyArray<RolePresence>>;
 	}
 >()("@kampus/pipeline-crew-mcp/crew/CrewTracker") {
 	/** Build the service from a live registry client (real socket or in-memory `RpcTest`). */
@@ -115,25 +119,34 @@ export class CrewTracker extends Context.Service<
 				),
 			heartbeat: ({peer, ttlSeconds}) =>
 				client.Heartbeat({peer, ttlSeconds, at: now()}).pipe(Effect.orDie),
+			// peer-id ≡ inbox-address: each present peer IS its own dialable address, so a lookup
+			// recovers the full live set of addresses (one per bridge, N across an engine pool).
 			lookup: (role) =>
 				client.LookupRole({role}).pipe(
 					Effect.orDie,
-					Effect.map((result) => {
-						const first = result.peers[0];
-						return first
-							? Option.some<RolePresence>({role: first.role, peer: first.peer, address: first.peer})
-							: Option.none<RolePresence>();
-					}),
+					Effect.map((result) =>
+						result.peers.map(
+							(entry): RolePresence => ({role: entry.role, peer: entry.peer, address: entry.peer}),
+						),
+					),
 				),
 		});
 }
 
-/** The generic `peer/Tracker` port, derived from `CrewTracker` — what `Peer.make` consumes. */
+/**
+ * The generic `peer/Tracker` port, derived from `CrewTracker` — what `Peer.make` consumes. The
+ * peer port resolves ONE live holder to dial (`peer.send` addresses a role, not an instance), so
+ * it takes the head of `CrewTracker`'s live set: a bridge's single holder, or any one instance of
+ * an engine pool. Fanning across the pool is the crew-facing `discover`'s job, not this port's.
+ */
 export const peerTrackerLayer: Layer.Layer<Tracker, never, CrewTracker> = Layer.effect(
 	Tracker,
 	Effect.gen(function* () {
 		const tracker = yield* CrewTracker;
-		return {announce: tracker.announce, lookup: tracker.lookup};
+		return {
+			announce: tracker.announce,
+			lookup: (role) => tracker.lookup(role).pipe(Effect.map(Arr.head)),
+		};
 	}),
 );
 

--- a/packages/pipeline-crew-mcp/src/tracker/group.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/group.ts
@@ -4,11 +4,11 @@
  *
  * The tracker serves exactly the five registry kinds — `Claim` (the request/reply resource
  * claim), `Release` (freeing a resource claim), `AnnouncePresence` (soft presence), `LookupRole`
- * (discovery), `Heartbeat` (TTL keepalive). It deliberately does NOT serve the four message-relay
- * kinds (`EpicHandoff`, `DrainProgress`, `IntakePing`, `AckInbox`): those payloads travel
- * peer-to-peer on the data plane, never through the registry. This exclusion IS the "no
- * message-relay path" invariant — the tracker cannot relay a message it has no handler for. It
- * reuses the protocol's Rpc definitions verbatim; it never redefines a message type.
+ * (discovery), `Heartbeat` (TTL keepalive). It deliberately does NOT serve the message-relay
+ * kinds (`DrainProgress`, `IntakePing`): those payloads travel peer-to-peer on the data plane,
+ * never through the registry. This exclusion IS the "no message-relay path" invariant — the
+ * tracker cannot relay a message it has no handler for. It reuses the protocol's Rpc definitions
+ * verbatim; it never redefines a message type.
  */
 import {RpcGroup} from "effect/unstable/rpc";
 import {AnnouncePresence, Claim, Heartbeat, LookupRole, Release} from "../protocol/index.ts";

--- a/packages/pipeline-crew-mcp/src/tracker/handlers.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/handlers.ts
@@ -1,9 +1,9 @@
 /**
  * tracker/handlers — the `TrackerRegistry` handlers, mapping each registry Rpc onto the
  * `Registry` service across the two keyspaces (ADR 0191). `AnnouncePresence` / `LookupRole` /
- * `Heartbeat` operate on the role/presence keyspace (keyed by `role`); `Claim` / `Release`
- * operate on the resource-claim keyspace (keyed by `resource`). `ClaimRequest`'s `role` field is
- * consumed here as the claim's `claimantRole`.
+ * `Heartbeat` operate on the presence keyspace (keyed by `peer`, so a role's engine pool
+ * coexists); `Claim` / `Release` operate on the resource-claim keyspace (keyed by `resource`).
+ * `ClaimRequest`'s `role` field is consumed here as the claim's `claimantRole`.
  *
  * `lastSeen`/`since`/`at` cross the wire as ISO-8601 strings (the protocol `Timestamp`), but the
  * registry reasons in epoch millis against its own clock — the conversion happens here at the

--- a/packages/pipeline-crew-mcp/src/tracker/index.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/index.ts
@@ -8,7 +8,6 @@ export {TrackerRegistry} from "./group.ts";
 export {TrackerHandlers} from "./handlers.ts";
 export {type AnnounceInput, Registry, RegistryLive} from "./registry.ts";
 export {
-	type AcquireOutcome,
 	DEFAULT_TTL_SECONDS,
 	type Lease,
 	type PresenceRecord,

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
@@ -1,8 +1,9 @@
 /**
  * The soft-state registry semantics, tested in isolation from any transport: announce/lookup
- * round-trip, heartbeat-driven TTL aging, connection-is-lease role uniqueness + release, and the
- * explicit not-present result — plus the resource-claim lifecycle (ADR 0191): keyspace separation,
- * presence-derived claim liveness, steal-release protection, and presence-only heartbeat refresh.
+ * round-trip, heartbeat-driven TTL aging, per-peer presence multiplicity (an engine pool) + release,
+ * and the explicit not-present result — plus the resource-claim lifecycle (ADR 0191): keyspace
+ * separation, presence-derived claim liveness, steal-release protection, and presence-only heartbeat
+ * refresh.
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as Core from "./registry-core.ts";
@@ -16,11 +17,11 @@ const withPresence = (
 	peer: string,
 	role: string,
 	at: number,
-): Core.RegistryState => Core.acquire(state, {role, peer, ttlSeconds: 30, nowMillis: at}).state;
+): Core.RegistryState => Core.announce(state, {role, peer, ttlSeconds: 30, nowMillis: at});
 
 describe("registry-core — announce / lookup", () => {
 	it("announce then lookup round-trips the peer for its role", () => {
-		const {state} = Core.acquire(Core.empty(), {
+		const state = Core.announce(Core.empty(), {
 			role: "builder",
 			peer: "peer-a",
 			ttlSeconds: 30,
@@ -37,7 +38,7 @@ describe("registry-core — announce / lookup", () => {
 
 describe("registry-core — heartbeat TTL aging", () => {
 	it("a peer that stops heart-beating ages out of lookups past its TTL", () => {
-		const {state} = Core.acquire(Core.empty(), {
+		const state = Core.announce(Core.empty(), {
 			role: "builder",
 			peer: "peer-a",
 			ttlSeconds: 30,
@@ -48,13 +49,13 @@ describe("registry-core — heartbeat TTL aging", () => {
 	});
 
 	it("a heartbeat refreshes the window, keeping the peer discoverable", () => {
-		const acquired = Core.acquire(Core.empty(), {
+		const announced = Core.announce(Core.empty(), {
 			role: "builder",
 			peer: "peer-a",
 			ttlSeconds: 30,
 			nowMillis: T0,
-		}).state;
-		const beat = Core.heartbeat(acquired, {
+		});
+		const beat = Core.heartbeat(announced, {
 			peer: "peer-a",
 			ttlSeconds: 30,
 			nowMillis: T0 + secs(20),
@@ -64,74 +65,71 @@ describe("registry-core — heartbeat TTL aging", () => {
 	});
 });
 
-describe("registry-core — connection-is-lease role uniqueness", () => {
-	it("a second live acquire of a held role collides and does not steal the lease", () => {
-		const held = Core.acquire(Core.empty(), {
-			role: "builder",
-			peer: "peer-a",
+describe("registry-core — per-peer presence multiplicity (an engine pool)", () => {
+	it("two peers on one role both stay present — a lookup returns the whole live set", () => {
+		let state = Core.announce(Core.empty(), {
+			role: "em",
+			peer: "em-a",
 			ttlSeconds: 30,
 			nowMillis: T0,
-		}).state;
-		const {state, outcome} = Core.acquire(held, {
-			role: "builder",
-			peer: "peer-b",
-			ttlSeconds: 30,
-			nowMillis: T0 + secs(1),
 		});
-		assert.deepStrictEqual(outcome, {_tag: "Collision", owner: "peer-a", sinceMillis: T0});
-		assert.deepStrictEqual(Core.lookup(state, "builder", T0 + secs(1)), [
-			{peer: "peer-a", role: "builder", lastSeenMillis: T0},
-		]);
+		state = Core.announce(state, {role: "em", peer: "em-b", ttlSeconds: 30, nowMillis: T0});
+		const found = Core.lookup(state, "em", T0);
+		assert.lengthOf(found, 2, "the second announce does NOT overwrite the first (keyed by peer)");
+		assert.deepStrictEqual(
+			found.map((r) => r.peer).sort(),
+			["em-a", "em-b"],
+			"both engine instances are discoverable",
+		);
 	});
 
-	it("releasing the connection frees the lease for another peer", () => {
-		const held = Core.acquire(Core.empty(), {
-			role: "builder",
-			peer: "peer-a",
+	it("a re-announce by the same peer refreshes its lease in place (no duplicate)", () => {
+		let state = Core.announce(Core.empty(), {
+			role: "em",
+			peer: "em-a",
 			ttlSeconds: 30,
 			nowMillis: T0,
-		}).state;
-		const freed = Core.release(held, "peer-a");
-		assert.deepStrictEqual(Core.lookup(freed, "builder", T0), []);
-		const {outcome} = Core.acquire(freed, {
-			role: "builder",
-			peer: "peer-b",
-			ttlSeconds: 30,
-			nowMillis: T0 + secs(1),
 		});
-		assert.deepStrictEqual(outcome, {_tag: "Granted", owner: "peer-b", sinceMillis: T0 + secs(1)});
-	});
-
-	it("an expired holder frees the lease — a later acquire is granted, not a collision", () => {
-		const held = Core.acquire(Core.empty(), {
-			role: "builder",
-			peer: "peer-a",
-			ttlSeconds: 30,
-			nowMillis: T0,
-		}).state;
-		const {outcome} = Core.acquire(held, {
-			role: "builder",
-			peer: "peer-b",
-			ttlSeconds: 30,
-			nowMillis: T0 + secs(31),
-		});
-		assert.strictEqual(outcome._tag, "Granted");
-	});
-
-	it("a re-acquire by the same peer keeps its original `since`", () => {
-		const held = Core.acquire(Core.empty(), {
-			role: "builder",
-			peer: "peer-a",
-			ttlSeconds: 30,
-			nowMillis: T0,
-		}).state;
-		const {outcome} = Core.acquire(held, {
-			role: "builder",
-			peer: "peer-a",
+		state = Core.announce(state, {
+			role: "em",
+			peer: "em-a",
 			ttlSeconds: 30,
 			nowMillis: T0 + secs(5),
 		});
-		assert.deepStrictEqual(outcome, {_tag: "Granted", owner: "peer-a", sinceMillis: T0});
+		const found = Core.lookup(state, "em", T0 + secs(5));
+		assert.deepStrictEqual(found, [{peer: "em-a", role: "em", lastSeenMillis: T0 + secs(5)}]);
+	});
+
+	it("releasing one peer leaves the rest of the pool present (its lease frees alone)", () => {
+		let state = Core.announce(Core.empty(), {
+			role: "em",
+			peer: "em-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		});
+		state = Core.announce(state, {role: "em", peer: "em-b", ttlSeconds: 30, nowMillis: T0});
+		const freed = Core.release(state, "em-a");
+		assert.deepStrictEqual(Core.lookup(freed, "em", T0), [
+			{peer: "em-b", role: "em", lastSeenMillis: T0},
+		]);
+	});
+
+	it("one peer aging out does not evict a live sibling on the same role", () => {
+		let state = Core.announce(Core.empty(), {
+			role: "em",
+			peer: "em-a",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		});
+		// em-b beats later, so it outlives em-a's window
+		state = Core.announce(state, {
+			role: "em",
+			peer: "em-b",
+			ttlSeconds: 30,
+			nowMillis: T0 + secs(20),
+		});
+		const found = Core.lookup(state, "em", T0 + secs(40));
+		assert.deepStrictEqual(found, [{peer: "em-b", role: "em", lastSeenMillis: T0 + secs(20)}]);
 	});
 });
 

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.ts
@@ -2,18 +2,20 @@
  * tracker/registry-core — the soft-state presence registry as a pure data structure.
  *
  * No Effect, no IO: state transitions only, so the announce / lookup / heartbeat-TTL /
- * role-lease and resource-claim semantics are unit-testable in isolation from the socket
+ * presence and resource-claim semantics are unit-testable in isolation from the socket
  * transport. The service (`./registry.ts`) holds one of these in a `Ref` and supplies the clock.
  *
- * Two keyspaces that never share a map (ADR 0191): role/presence leases keyed by `role`, and
- * resource claims keyed by `resource`. A role lease and an issue claim are different lifecycles —
- * keeping them in distinct typed maps makes "a `lookup` returns a claim holder" unrepresentable
- * rather than checked after the fact.
+ * Two keyspaces that never share a map (ADR 0191): presence leases keyed by `peer`, and
+ * resource claims keyed by `resource`. A presence lease and an issue claim are different
+ * lifecycles — keeping them in distinct typed maps makes "a `lookup` returns a claim holder"
+ * unrepresentable rather than checked after the fact.
  *
  * The three non-obvious model choices:
- *   - A role maps to at MOST ONE live lease (`leases` is keyed by role) — that is how "named
- *     leases for role uniqueness" is made unrepresentable-otherwise rather than checked after the
- *     fact: you cannot store two live holders of one role.
+ *   - Presence is keyed by `peer` (the connection identity), NOT by role — so N distinct peers
+ *     serving one role coexist as N distinct leases (a role's engine pool), and `lookup(role)`
+ *     returns the whole live set. Role uniqueness is NOT a presence concern: a bridge's
+ *     singleton-ness is enforced upstream by the crew per-kind cardinality claim, never here
+ *     (ADR 0189) — so the presence registry stays role-agnostic and never collapses a pool.
  *   - "Connection-is-lease" is modelled by the peer id being the connection identity, and liveness
  *     being measured against the tracker's own clock (never the client-supplied `at`): a peer that
  *     stops heart-beating ages past its TTL and its lease frees, and an explicit `release` (a
@@ -25,15 +27,14 @@
  *     a claim frees on explicit `releaseClaim` or is reaped once its holder has no live presence.
  */
 
-/** The default presence TTL applied on acquire, until the first `heartbeat` sets a real one. */
+/** The default presence TTL applied on announce, until the first `heartbeat` sets a real one. */
 export const DEFAULT_TTL_SECONDS = 30;
 
-/** One role lease: who holds the role, when they took it, and their soft-state liveness window. */
+/** One presence lease: a peer, the role it serves, and its soft-state liveness window. */
 export interface Lease {
 	readonly role: string;
 	readonly peer: string;
 	readonly ttlSeconds: number;
-	readonly leasedAtMillis: number;
 	readonly lastSeenMillis: number;
 }
 
@@ -50,7 +51,7 @@ export interface Claim {
 	readonly claimedAtMillis: number;
 }
 
-/** The whole registry: role/presence leases and resource claims in two separate keyspaces. */
+/** The whole registry: presence leases (keyed by peer) and resource claims (keyed by resource). */
 export interface RegistryState {
 	readonly leases: ReadonlyMap<string, Lease>;
 	readonly claims: ReadonlyMap<string, Claim>;
@@ -62,14 +63,6 @@ export interface PresenceRecord {
 	readonly role: string;
 	readonly lastSeenMillis: number;
 }
-
-/**
- * The result of an acquire: `Granted` when the caller now holds the role, `Collision` when a
- * different live peer already holds it (the lease is NOT stolen — the incumbent keeps it).
- */
-export type AcquireOutcome =
-	| {readonly _tag: "Granted"; readonly owner: string; readonly sinceMillis: number}
-	| {readonly _tag: "Collision"; readonly owner: string; readonly sinceMillis: number};
 
 /**
  * The result of a resource claim: `Granted` when the caller now holds the resource, `Collision`
@@ -85,24 +78,23 @@ export const empty = (): RegistryState => ({leases: new Map(), claims: new Map()
 const isLive = (lease: Lease, nowMillis: number): boolean =>
 	nowMillis <= lease.lastSeenMillis + lease.ttlSeconds * 1000;
 
-/** True iff `holder` holds any live presence lease — the claim-liveness clock (ADR 0191 facet 2). */
+/** True iff `holder` holds a live presence lease — the claim-liveness clock (ADR 0191 facet 2). */
 const holderHasLivePresence = (
 	leases: ReadonlyMap<string, Lease>,
 	holder: string,
 	nowMillis: number,
 ): boolean => {
-	for (const lease of leases.values()) {
-		if (lease.peer === holder && isLive(lease, nowMillis)) return true;
-	}
-	return false;
+	const lease = leases.get(holder);
+	return lease !== undefined && isLive(lease, nowMillis);
 };
 
 /**
- * Acquire the lease for `role` on behalf of `peer`. Granted when the role is free, held by an
- * expired peer, or already held by `peer` itself (re-announce refreshes without moving `since`);
- * a Collision — leaving state untouched — when a *different* live peer holds it.
+ * Register `peer`'s presence for `role`: upsert its lease, bumping `lastSeen` to now. Keyed by
+ * `peer`, so a re-announce refreshes the same lease and two distinct peers on one role coexist —
+ * presence never rejects (role uniqueness is the crew cardinality claim's job, ADR 0189), it only
+ * records who is live where.
  */
-export const acquire = (
+export const announce = (
 	state: RegistryState,
 	input: {
 		readonly role: string;
@@ -110,23 +102,12 @@ export const acquire = (
 		readonly ttlSeconds: number;
 		readonly nowMillis: number;
 	},
-): {readonly state: RegistryState; readonly outcome: AcquireOutcome} => {
+): RegistryState => {
 	const {role, peer, ttlSeconds, nowMillis} = input;
-	const existing = state.leases.get(role);
-	if (existing && existing.peer !== peer && isLive(existing, nowMillis)) {
-		return {
-			state,
-			outcome: {_tag: "Collision", owner: existing.peer, sinceMillis: existing.leasedAtMillis},
-		};
-	}
-	const leasedAtMillis = existing && existing.peer === peer ? existing.leasedAtMillis : nowMillis;
-	const lease: Lease = {role, peer, ttlSeconds, leasedAtMillis, lastSeenMillis: nowMillis};
+	const lease: Lease = {role, peer, ttlSeconds, lastSeenMillis: nowMillis};
 	const leases = new Map(state.leases);
-	leases.set(role, lease);
-	return {
-		state: {...state, leases},
-		outcome: {_tag: "Granted", owner: peer, sinceMillis: leasedAtMillis},
-	};
+	leases.set(peer, lease);
+	return {...state, leases};
 };
 
 /**
@@ -199,50 +180,51 @@ export const claimHolder = (
 };
 
 /**
- * Refresh every role lease held by `peer`: bump `lastSeen` to now and adopt the heartbeat's TTL.
- * Resource claims are never touched — they have no TTL to bump, and their liveness rides presence
- * (ADR 0191 facet 4). Because the keyspaces are split, this loop over `leases` is presence-only
- * by construction.
+ * Refresh `peer`'s presence lease: bump `lastSeen` to now and adopt the heartbeat's TTL. Resource
+ * claims are never touched — they have no TTL to bump, and their liveness rides presence (ADR 0191
+ * facet 4). A beat for a peer with no lease is a no-op (nothing to refresh).
  */
 export const heartbeat = (
 	state: RegistryState,
 	input: {readonly peer: string; readonly ttlSeconds: number; readonly nowMillis: number},
 ): RegistryState => {
 	const {peer, ttlSeconds, nowMillis} = input;
+	const lease = state.leases.get(peer);
+	if (!lease) return state;
 	const leases = new Map(state.leases);
-	for (const [role, lease] of state.leases) {
-		if (lease.peer === peer) {
-			leases.set(role, {...lease, ttlSeconds, lastSeenMillis: nowMillis});
-		}
-	}
+	leases.set(peer, {...lease, ttlSeconds, lastSeenMillis: nowMillis});
 	return {...state, leases};
 };
 
 /**
- * The present holders of `role` — the single live lease, or `[]` when the role is absent or its
- * holder has aged out. An empty array is the explicit not-present result (never a silent drop).
- * Reads the presence keyspace only, so it can never surface a resource-claim holder (ADR 0191).
+ * The present holders of `role` — every live lease whose peer serves `role`, or `[]` when none is
+ * present. For a bridge the crew cardinality claim guarantees at most one live session, so the set
+ * has one entry; for an engine the set carries every live instance in the pool (ADR 0189). An empty
+ * array is the explicit not-present result (never a silent drop). Reads the presence keyspace only,
+ * so it can never surface a resource-claim holder (ADR 0191).
  */
 export const lookup = (
 	state: RegistryState,
 	role: string,
 	nowMillis: number,
 ): ReadonlyArray<PresenceRecord> => {
-	const lease = state.leases.get(role);
-	if (!lease || !isLive(lease, nowMillis)) return [];
-	return [{peer: lease.peer, role: lease.role, lastSeenMillis: lease.lastSeenMillis}];
+	const present: Array<PresenceRecord> = [];
+	for (const lease of state.leases.values()) {
+		if (lease.role === role && isLive(lease, nowMillis)) {
+			present.push({peer: lease.peer, role: lease.role, lastSeenMillis: lease.lastSeenMillis});
+		}
+	}
+	return present;
 };
 
 /**
- * Free every lease held by `peer` and reap every claim it holds — a graceful connection close
+ * Free `peer`'s presence lease and reap every claim it holds — a graceful connection close
  * (connection-is-lease). The peer's presence is gone, so under presence-derived liveness its
  * claims are stale and dropped with it (ADR 0191 facet 2).
  */
 export const release = (state: RegistryState, peer: string): RegistryState => {
 	const leases = new Map(state.leases);
-	for (const [role, lease] of state.leases) {
-		if (lease.peer === peer) leases.delete(role);
-	}
+	leases.delete(peer);
 	const claims = new Map(state.claims);
 	for (const [resource, claim] of state.claims) {
 		if (claim.holder === peer) claims.delete(resource);
@@ -257,8 +239,8 @@ export const release = (state: RegistryState, peer: string): RegistryState => {
  */
 export const prune = (state: RegistryState, nowMillis: number): RegistryState => {
 	const leases = new Map(state.leases);
-	for (const [role, lease] of state.leases) {
-		if (!isLive(lease, nowMillis)) leases.delete(role);
+	for (const [peer, lease] of state.leases) {
+		if (!isLive(lease, nowMillis)) leases.delete(peer);
 	}
 	const claims = new Map(state.claims);
 	for (const [resource, claim] of state.claims) {

--- a/packages/pipeline-crew-mcp/src/tracker/registry.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry.test.ts
@@ -36,6 +36,21 @@ describe("tracker registry — wire round-trips (RpcTest in-memory)", () => {
 		}).pipe(Effect.scoped, Effect.provide(handlers)),
 	);
 
+	it.effect("two peers announcing one role both surface — the engine pool is not collapsed", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			// two engine instances of the same role, distinct per-instance inbox addresses
+			yield* client.AnnouncePresence({peer: "inbox://em/one", role: "em", at});
+			yield* client.AnnouncePresence({peer: "inbox://em/two", role: "em", at});
+			const result = yield* client.LookupRole({role: "em"});
+			assert.lengthOf(result.peers, 2, "the second announce did not overwrite the first");
+			assert.deepStrictEqual(result.peers.map((p) => p.peer).sort(), [
+				"inbox://em/one",
+				"inbox://em/two",
+			]);
+		}).pipe(Effect.scoped, Effect.provide(handlers)),
+	);
+
 	it.effect("Claim grants a free resource and collides on a second acquire (holder present)", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);

--- a/packages/pipeline-crew-mcp/src/tracker/registry.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry.ts
@@ -26,9 +26,7 @@ export interface ClaimInput {
 export class Registry extends Context.Service<
 	Registry,
 	{
-		/** Acquire `role` for `peer`, returning whether it was granted or collided with a live holder. */
-		readonly acquire: (input: AnnounceInput) => Effect.Effect<Core.AcquireOutcome>;
-		/** Soft presence announce — acquire and discard the outcome (the fire-and-forget wire kind). */
+		/** Register `peer`'s presence for `role` — keyed by peer, so a role's engine pool coexists. */
 		readonly announce: (input: AnnounceInput) => Effect.Effect<void>;
 		/** Claim `resource` for `claimant`, returning granted or a collision with a live-presence holder. */
 		readonly claim: (input: ClaimInput) => Effect.Effect<Core.ClaimOutcome>;
@@ -52,14 +50,6 @@ export class Registry extends Context.Service<
 export const RegistryLive: Layer.Layer<Registry> = Layer.effect(Registry)(
 	Effect.gen(function* () {
 		const ref = yield* Ref.make(Core.empty());
-		const acquire = (input: AnnounceInput) =>
-			Effect.gen(function* () {
-				const nowMillis = yield* Clock.currentTimeMillis;
-				return yield* Ref.modify(ref, (state) => {
-					const {state: next, outcome} = Core.acquire(state, {...input, nowMillis});
-					return [outcome, next];
-				});
-			});
 		const claim = (input: ClaimInput) =>
 			Effect.gen(function* () {
 				const nowMillis = yield* Clock.currentTimeMillis;
@@ -74,8 +64,12 @@ export const RegistryLive: Layer.Layer<Registry> = Layer.effect(Registry)(
 				});
 			});
 		return {
-			acquire,
-			announce: (input) => Effect.asVoid(acquire(input)),
+			announce: (input) =>
+				Clock.currentTimeMillis.pipe(
+					Effect.flatMap((nowMillis) =>
+						Ref.update(ref, (state) => Core.announce(state, {...input, nowMillis})),
+					),
+				),
 			claim,
 			releaseClaim: (input) => Ref.update(ref, (state) => Core.releaseClaim(state, input)),
 			heartbeat: (input) =>

--- a/packages/pipeline-crew-mcp/src/tracker/server.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.test.ts
@@ -32,7 +32,7 @@ describe("tracker served surface — control-plane only", () => {
 			"LookupRole",
 			"Release",
 		]);
-		for (const relay of ["AckInbox", "DrainProgress", "EpicHandoff", "IntakePing"]) {
+		for (const relay of ["DrainProgress", "IntakePing"]) {
 			assert.isFalse(
 				TrackerRegistry.requests.has(relay),
 				`tracker must not serve relay kind ${relay}`,


### PR DESCRIPTION
Fixes #3301 — the last child of roster-law epic #3234.

Resolves the presence deferral #3300 left behind. The presence `leases` map in `tracker/registry-core.ts` was keyed by **role**, so a second engine instance's `AnnouncePresence` silently overwrote the first and `lookup(role)` surfaced only one holder.

## What changed

**1. Per-instance presence (registry, `tracker/`)**
- Presence leases now key by **peer** (the connection identity), not role — so N engine instances coexist as N distinct leases and `lookup(role)` returns the whole live set. Role uniqueness is not a presence concern: a bridge's singleton-ness is enforced upstream by the per-kind cardinality claim (#3300, ADR 0189), so the registry stays role-agnostic and never collapses a pool. `heartbeat`/`release` become O(1) by peer key; `holderHasLivePresence` is a direct lookup.
- The now-dead presence-collision (`AcquireOutcome` + the `acquire`-returning-outcome service method) is removed — a presence collision is no longer representable.

**2. Per-instance engine addressing (`crew/session.ts`)**
- `inboxAddressFor(role, instance)`: an **engine** carries `inbox://<role>/<instance>`, a **bridge** keeps the deterministic singleton `inbox://<role>`. Two engine instances resolve to two collision-free inbox sockets (`inboxSocketPathFor` hashes the whole address). The instance id is generated once per session in `crewSessionLayer` and threaded to the inbox/announce/heartbeat so they all agree.

**3. Array-returning discovery (`crew/tracker.ts`, `crew/channel-server.ts`)**
- `CrewTracker.lookup` / `CrewChannel.discover` return the live **set** (`ReadonlyArray<RolePresence>`) — a bridge to its single holder, an engine to its whole pool — instead of collapsing `peers[0]`. The generic `peer/Tracker` port (which `peer.send` uses to dial one holder) takes the head via `Array.head` (effect-smol `Array.ts`), keeping `peer.send` unchanged.

**Fold-in** (epic AC "no test references the removed kinds", #3302 cleanup in the `tracker/` lane): dropped the removed `EpicHandoff`/`AckInbox` from `tracker/group.ts`'s docblock and `tracker/server.test.ts`'s relay-kind list.

## Out of scope
No change to the peer inbox socket protocol or `PeerInbox.Deliver` (addressing + discovery only).

## Acceptance criteria
- [x] Engine address carries a per-instance discriminator; two engine instances → two distinct inbox sockets; a bridge keeps `inbox://<role>`.
- [x] Engine role discovery returns all live instances (not a collapsed `peers[0]`); a sender can dial one specific engine instance.
- [x] Bridge role discovery still resolves its single live holder deterministically.
- [x] No change to the peer inbox socket protocol / `PeerInbox.Deliver`; tests cover multi-engine discovery + per-instance dial and single-bridge discovery; package typecheck + suite pass (138 tests).

Effect `Option`/array idioms grounded in effect-smol `LLMS.md` / `Array.ts` (`Array.head`).