### PR TITLE
fix(pipeline-crew): channel-ref grammar matches Claude Code 2.1.212 (#3328)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/config.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.test.ts
@@ -16,13 +16,18 @@ import {
 	stripJsonc,
 } from "./config.ts";
 
-/** A minimal-but-valid launch dimension set, embedded in a fuller crew config below. */
+/**
+ * A minimal-but-valid launch dimension set, embedded in a fuller crew config below. The
+ * allowlist-mode channels carry only `plugin:<name>@<marketplace>` refs — the exact grammar
+ * Claude Code 2.1.212's `--channels` allowlist accepts (a bare `server:` ref can't ride
+ * `--channels`; #3328).
+ */
 const validLaunch = {
 	cliVersion: "2.1.207",
 	engineCount: 2,
 	channels: {
 		mode: "allowlist",
-		servers: ["server:crew-channels", "plugin:pipeline-crew:crew-channels"],
+		servers: ["plugin:crew-channels@pipeline-crew"],
 		allowedChannelPlugins: ["pipeline-crew"],
 	},
 };
@@ -75,20 +80,85 @@ describe("standup/config — decodeLaunchConfig (happy path)", () => {
 			assert.strictEqual(cfg.cliVersion, "2.1.207");
 			assert.strictEqual(cfg.engineCount, 2);
 			assert.strictEqual(cfg.channels.mode, "allowlist");
-			assert.deepStrictEqual(
-				[...cfg.channels.servers],
-				["server:crew-channels", "plugin:pipeline-crew:crew-channels"],
-			);
+			assert.deepStrictEqual([...cfg.channels.servers], ["plugin:crew-channels@pipeline-crew"]);
 			assert.deepStrictEqual([...cfg.channels.allowedChannelPlugins], ["pipeline-crew"]);
 		}),
 	);
-	it.effect("accepts the development channel mode", () =>
+	it.effect("accepts the development channel mode carrying a top-level server: ref", () =>
 		Effect.gen(function* () {
+			// A `server:` ref rides --dangerously-load-development-channels, so it is
+			// representable only under development mode — not allowlist (#3328).
 			const cfg = yield* decodeLaunchConfig(
-				{...validLaunch, channels: {...validLaunch.channels, mode: "development"}},
+				{
+					...validLaunch,
+					channels: {
+						...validLaunch.channels,
+						mode: "development",
+						servers: ["server:pipeline-crew"],
+					},
+				},
 				DEFAULT_CONFIG_PATH,
 			);
 			assert.strictEqual(cfg.channels.mode, "development");
+			assert.deepStrictEqual([...cfg.channels.servers], ["server:pipeline-crew"]);
+		}),
+	);
+});
+
+describe("standup/config — channel-ref grammar matches Claude Code 2.1.212", () => {
+	// The 2.1.212 bundle's --channels tag loop parses a plugin entry as
+	// plugin:<name>@<marketplace> (split on @, both parts non-empty); the old
+	// plugin:<plugin>:<server> shape (#3293) has no @ and is rejected (#3328).
+	it.effect("accepts a plugin:<name>@<marketplace> ref under allowlist", () =>
+		Effect.gen(function* () {
+			const cfg = yield* decodeLaunchConfig(
+				{...validLaunch, channels: {...validLaunch.channels, servers: ["plugin:sozluk@kampus"]}},
+				DEFAULT_CONFIG_PATH,
+			);
+			assert.deepStrictEqual([...cfg.channels.servers], ["plugin:sozluk@kampus"]);
+		}),
+	);
+	it.effect("rejects the old plugin:<plugin>:<server> shape", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				channels: {...validLaunch.channels, servers: ["plugin:kampus:sozluk"]},
+			});
+			assert.include(err.reason, "servers");
+		}),
+	);
+	it.effect("rejects a plugin ref with an empty name or marketplace", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				channels: {...validLaunch.channels, servers: ["plugin:@kampus"]},
+			});
+			assert.include(err.reason, "servers");
+		}),
+	);
+});
+
+describe("standup/config — server: ref reconciles with mode", () => {
+	it.effect("rejects a bare server: ref under allowlist mode (runtime skips it)", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				channels: {...validLaunch.channels, mode: "allowlist", servers: ["server:pipeline-crew"]},
+			});
+			assert.include(err.reason, "servers");
+		}),
+	);
+	it.effect("rejects a server: ref mixed among plugin refs under allowlist mode", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				channels: {
+					...validLaunch.channels,
+					mode: "allowlist",
+					servers: ["plugin:crew-channels@pipeline-crew", "server:pipeline-crew"],
+				},
+			});
+			assert.include(err.reason, "servers");
 		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/standup/config.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.ts
@@ -19,20 +19,34 @@ import {readFileSync} from "node:fs";
 import {Effect, Schema} from "effect";
 
 /**
- * A channel-server ref, in the launcher's registration grammar:
- *   - `server:<name>`            — a top-level channel MCP server
- *   - `plugin:<plugin>:<server>` — a server contributed by a plugin
- * The two forms are exactly what the bind-builder (#3296) turns into `--channels` args.
+ * A channel-server ref, in the exact registration grammar Claude Code 2.1.212 accepts —
+ * grounded against the installed bundle's channel-tag parser, NOT intuited (CLAUDE.md's
+ * "ground falsifiable runtime claims in source"; VERSION 2.1.212, GIT_SHA 8b2783a):
+ *   - `server:<name>`             — a top-level channel MCP server
+ *   - `plugin:<name>@<marketplace>` — a plugin-provided channel (allowlist enforced)
+ *
+ * The bundle's `--channels` tag loop parses a `plugin:` entry by splitting on `@`
+ * (`let xl=mu.indexOf("@"); if(xl<=0||xl===mu.length-1) reject; else {name:mu.slice(0,xl),
+ * marketplace:mu.slice(xl+1)}`) and its marketplace parser requires exactly two non-empty
+ * parts (`split("@"); if(t.length!==2||!t[0]||!t[1]) return null`). So the OLD
+ * `plugin:<plugin>:<server>` shape (#3293) — no `@` — is rejected by the real runtime; the
+ * channel grammar is unambiguously `<name>@<marketplace>`. (The bundle's distinct
+ * split-on-`:` `plugin:<plugin>:<server>` parser is MCP-server identity within a plugin — a
+ * different surface from this `--channels` allowlist grammar.) See #3328.
  */
-export const CHANNEL_SERVER_REF_RE = /^(?:server:[^:\s]+|plugin:[^:\s]+:[^:\s]+)$/;
+export const CHANNEL_PLUGIN_REF_RE = /^plugin:[^@\s]+@[^@\s]+$/;
+export const CHANNEL_SERVER_REF_RE = /^(?:server:[^:\s]+|plugin:[^@\s]+@[^@\s]+)$/;
 
 export const ChannelServerRef = Schema.String.check(
 	Schema.isPattern(CHANNEL_SERVER_REF_RE, {
 		title: "ChannelServerRef",
-		description: 'a channel-server ref: "server:<name>" or "plugin:<plugin>:<server>"',
+		description: 'a channel-server ref: "server:<name>" or "plugin:<name>@<marketplace>"',
 	}),
 );
 export type ChannelServerRef = typeof ChannelServerRef.Type;
+
+/** Whether a validated channel-server ref is a top-level `server:` ref (vs a `plugin:` ref). */
+const isServerRef = (ref: string): boolean => ref.startsWith("server:");
 
 /**
  * The pinned Claude Code CLI version the stand-up asserts before launching any session
@@ -66,12 +80,34 @@ export const EngineCount = Schema.Int.check(
 );
 export type EngineCount = typeof EngineCount.Type;
 
-/** The channel-registration dimension: the mode, the servers each session registers, and the plugin allowlist. */
+/**
+ * The channel-registration dimension: the mode, the servers each session registers, and the
+ * plugin allowlist.
+ *
+ * The cross-field check makes the runtime-invalid combination unrepresentable at decode: a
+ * top-level `server:` ref only registers via `--dangerously-load-development-channels` (which
+ * alone sets the bundle's `dev` flag). 2.1.212's runtime validator SKIPS a non-dev `server:`
+ * channel under `--channels` (`else if(!o.dev) return {action:"skip", ... "server <X> is not on
+ * the approved channels allowlist (use --dangerously-load-development-channels for local dev)"}`,
+ * VERSION 2.1.212, GIT_SHA 8b2783a). So an `allowlist` config carrying a `server:` ref would
+ * name a channel the runtime silently drops — fail closed here instead (#3328).
+ */
 export const ChannelConfig = Schema.Struct({
 	mode: ChannelMode,
 	servers: Schema.NonEmptyArray(ChannelServerRef),
 	allowedChannelPlugins: Schema.Array(Schema.NonEmptyString),
-});
+}).check(
+	Schema.makeFilter((cfg) => {
+		if (cfg.mode !== "allowlist") return undefined;
+		const bare = cfg.servers.filter(isServerRef);
+		return bare.length === 0
+			? undefined
+			: {
+					path: ["servers"],
+					issue: `allowlist mode registers channels via --channels, which loads only plugin:<name>@<marketplace> refs; a top-level server: ref (${bare.join(", ")}) registers only in development mode (--dangerously-load-development-channels)`,
+				};
+	}),
+);
 export type ChannelConfig = typeof ChannelConfig.Type;
 
 /** The launch dimensions the stand-up reads — the clean type every launcher child imports. */


### PR DESCRIPTION
Fixes #3328.

The stand-up launcher's channel-ref schema in `packages/pipeline-crew-mcp/src/standup/config.ts` (from #3293) validated a grammar the pinned runtime — **Claude Code 2.1.212** — rejects, so #3296's bind-builder would faithfully construct an invalid `--channels` invocation and #3299's spawn would be refused at channel-registration time. Both corrections are **grounded against the installed 2.1.212 bundle** (VERSION `2.1.212`, GIT_SHA `8b2783a`), per CLAUDE.md's "ground falsifiable runtime claims in source".

## What changed

**1. Plugin-ref grammar `plugin:<name>@<marketplace>` (was `plugin:<plugin>:<server>`).**
- `CHANNEL_SERVER_REF_RE` now accepts `plugin:[^@\s]+@[^@\s]+` (name and marketplace both non-empty) and rejects the old colon-triple shape.
- Bundle grounding — the `--channels` tag loop parses a `plugin:` entry by splitting on `@`:
  `let xl=mu.indexOf("@"); if(xl<=0||xl===mu.length-1) reject; else {name:mu.slice(0,xl),marketplace:mu.slice(xl+1)}`
  and the marketplace parser requires exactly two non-empty parts:
  `split("@"); if(t.length!==2||!t[0]||!t[1]) return null; return{name:t[0],marketplace:t[1]}`.
  Help text: `plugin:<name>@<marketplace>  — plugin-provided channel (allowlist enforced)`.
  So `plugin:kampus:sozluk` (no `@`) is routed to the reject bucket. (The bundle's distinct split-on-`:` `plugin:<plugin>:<server>` parser is MCP-server identity *within* a plugin — a different surface from the `--channels` allowlist grammar.)

**2. A bare `server:` ref can't ride allowlist mode — made unrepresentable at decode.**
- `ChannelConfig` gains a cross-field `Schema.makeFilter` check: when `mode === "allowlist"`, any `server:` ref fails closed with a `LaunchConfigError` naming `servers`.
- Bundle grounding — the runtime validator skips a non-dev `server:` channel under `--channels`:
  `else if(!o.dev) return {action:"skip", kind:"allowlist", reason:` + "`server ${o.name} is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)`" + `}`.
  `o.dev` is set true only for channels loaded via `--dangerously-load-development-channels`. So a top-level `server:` channel registers only in **development** mode; under **allowlist** (`--channels`) only `plugin:...@...` channels register.

## Tests

`packages/pipeline-crew-mcp/src/standup/config.test.ts`:
- a valid `plugin:<name>@<marketplace>` ref decodes clean under allowlist;
- the old `plugin:<plugin>:<server>` shape and an empty-name/marketplace plugin ref fail closed;
- a `server:` ref decodes clean under **development** mode;
- a bare `server:` ref (alone, and mixed among plugin refs) fails closed under **allowlist** mode.

`pnpm typecheck`, `pnpm lint:worktree`, and the package test suite (`@kampus/pipeline-crew-mcp`, 138 tests) all green.

## Scope / sequencing

- Touches only `packages/pipeline-crew-mcp/src/standup/config.ts` + its test — **NON-§CP** (confirmed against `CONTROL_PLANE_RE`: under `packages/`, only `packages/ci-required/` and `packages/pipeline-cli/` are control-plane; `packages/pipeline-crew-mcp/` matches neither), so it auto-ships on `review-code` PASS.
- `bind.ts` (#3296) is pure argv off this schema, so the schema fix is sufficient; no ripple needed.
- Unblocks #3299 (the orchestrator wires the spawn off these refs), which was held until #3328 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)