### PR TITLE
feat(pipeline): classify lint/GritQL governance config as §CP (ADR 0193)

### DIFF
--- a/.decisions/0193-lint-governance-config-is-control-plane.md
+++ b/.decisions/0193-lint-governance-config-is-control-plane.md
@@ -1,0 +1,74 @@
+---
+id: 0193
+title: lint/GritQL governance config (biome.jsonc + biome-plugins/) is §CP — an ungated path to weaken a lint rule is a guard-relaxing vector
+status: accepted
+date: 2026-07-16
+tags: [pipeline, control-plane, ship-it, lint, gritql, classifier]
+---
+
+# 0193 — lint/GritQL governance config is control-plane
+
+## Context
+
+The control-plane boundary (ADR [0053](0053-control-plane-boundary.md), enforced at GitHub
+per ADR [0071](0071-enforce-control-plane-at-github.md)) marks the surfaces where an
+autonomous green-then-ship merge could compromise the pipeline's own guards, so those PRs
+bank for a human control-plane (§CP) merge instead of auto-shipping. The concrete boundary
+is the single-source path regex in
+[`packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts`](../packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts),
+its byte-synced `CONTROL_PLANE_RE=` copy in `gh-issue-intake-formats.md`,
+`.github/CODEOWNERS`, and the classifier tests.
+
+The repo enforces code invariants through two lint surfaces: `biome.jsonc` (the biome
+config — which rules run, at what severity) and `biome-plugins/*.grit` (the GritQL plugin
+rules — e.g. `no-raw-try-catch`, `no-type-assertions`, `no-data-taggederror`). These are
+**guards**: they mechanically block classes of unsafe code. Until now those two paths were
+outside §CP, so a PR that **weakened** one — disabling a security lint, downgrading a rule
+to a warning, deleting or neutering a GritQL rule — could auto-ship on green without any
+human control-plane sign-off. That is an ungated path to relax a guard.
+
+ADR [0187](0187-crew-mcp-is-not-control-plane.md) fixed the §CP discriminator as an
+**enforcement-surface test**: a path is §CP if merging it unreviewed could weaken the
+pipeline's enforcement of its own rules — not because it is merely pipeline-adjacent. The
+lint/GritQL governance config passes that test directly: the lint rules *are* enforcement,
+and an unreviewed edit that loosens them weakens a gate. This is the sibling scope decision
+to 0187 — same principle, opposite direction (0187 narrowed the boundary by one over-broad
+clause; this widens it by one genuine enforcement surface).
+
+The founder ruled directly this session (2026-07-16, ruling B): the lint/GritQL governance
+config must be §CP, because an ungated path to weaken a lint rule is a guard-relaxing
+vector, exactly what the control plane exists to gate. This is a conversation-authored ADR
+(ADR [0075](0075-issueless-doc-pr-merge-seam.md)): it is the durable corroboration of that
+ruling, not a report→triage item. Ruling-driven, so there is no `Fixes #N` tracking issue.
+
+## Decision
+
+`biome.jsonc` (the repo-root file) and `biome-plugins/` (the GritQL plugin dir, all
+`*.grit`) are **§CP**. Both §CP mechanisms now cover them:
+
+- **The `CONTROL_PLANE_RE` classifier** (ship-it's soft gate) gains two anchored branches:
+  `^biome\.jsonc$` (the exact root file, end-anchored so a look-alike suffix like
+  `biome.jsonc.bak` stays out) and `^biome-plugins/` (the dir prefix, covering every
+  `*.grit` rule at any depth). Synced across the single-source const, the byte-equal
+  formats-doc copy, and the classifier tests.
+- **`.github/CODEOWNERS`** (the GitHub-enforced teeth) gains `/biome.jsonc` and
+  `/biome-plugins/`, both routed to `@kamp-us/control-plane`, so
+  `require_code_owner_review` hard-blocks a biome-governance edit at merge time without
+  control-plane approval. The classifier is ship-it's soft gate; CODEOWNERS is the
+  merge-time teeth — a biome-governance PR needs both to pass.
+
+## Consequences
+
+- A PR touching `biome.jsonc` or any `biome-plugins/*.grit` rule no longer auto-ships on
+  green; it banks at the §CP human-merge approver, where a second human confirms the change
+  does not silently relax a guard.
+- The §CP↔CODEOWNERS drift gate (`codeowners-cp`) and `validate-gate-path-drift.sh` both
+  keep the two new branches in lockstep with their CODEOWNERS rows; the classifier unit
+  tests assert `biome.jsonc` → §CP, `biome-plugins/*.grit` → §CP, and a negative
+  (`turbo.json` / `pnpm-workspace.yaml` / `biome.jsonc.bak` stay non-§CP).
+- This narrows nothing elsewhere — every prior §CP clause is unchanged; the boundary widens
+  by exactly the biome-governance surface. Future authors extending §CP apply ADR 0187's
+  enforcement-surface test: a path is §CP when an unreviewed merge of it could weaken a gate.
+- Note: routing (which reviewer gate verifies) is a separate axis — `class-probe` already
+  classifies these paths as `has-code` (review-code-routed). This ADR governs *who merges*
+  (§CP human-merge), not *which gate verifies*.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,3 +42,8 @@
 # stays standalone (ADR 0092) and keeps its own owner line.
 /packages/ci-required/          @kamp-us/control-plane
 /packages/pipeline-cli/         @kamp-us/control-plane
+# Control-plane: lint/GritQL governance config — the biome config + GritQL plugin rules. An
+# ungated path to weaken a lint rule (disable a security lint, downgrade a GritQL guard) is a
+# guard-relaxing vector. The §CP `biome\.jsonc$` + `biome-plugins/` branches (ADR 0193).
+/biome.jsonc                    @kamp-us/control-plane
+/biome-plugins/                 @kamp-us/control-plane

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1414,7 +1414,10 @@ since a gate/merge agent's own instructions are a self-weakening surface; the **
 `.sh` guards** under `skills/` and the **`release`/`review-trivial` skill dirs** added by ADR
 [0174](https://github.com/kamp-us/phoenix/blob/main/.decisions/0174-bare-sh-guards-control-plane-gate.md)
 (#2576/#2679), since a guard script and a SHA-bound-verdict gate are self-weakening surfaces that
-were escaping the boundary). Everything else — `apps/**`,
+were escaping the boundary; the **lint/GritQL governance config** — `biome.jsonc` and
+`biome-plugins/**` — added by ADR
+[0193](https://github.com/kamp-us/phoenix/blob/main/.decisions/0193-lint-governance-config-is-control-plane.md),
+since an ungated path to weaken a lint rule is a guard-relaxing vector). Everything else — `apps/**`,
 **non**-guard `packages/**`, `.decisions/**` (**except a guard-touching ADR** — see the content
 clause below), `.patterns/**`, every prose doc `*.md` (the
 §DOC class), and every **non**-gate-critical `skills/**` — is **non-blocking** and
@@ -1444,7 +1447,7 @@ against MAIN's boundary, not its own edit) and must not move to an in-tree impor
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — kept byte-in-sync with the pipeline-cli const (issue #2761); the live gates
 # re-resolve THIS line from origin/main (#981), so it stays here as the one un-importable copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\.jsonc$|^biome-plugins/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -43,6 +43,8 @@ describe("splitTopLevelBranches", () => {
 			"claude-plugins/kampus-pipeline/hooks(/|\\.json$)",
 			"packages/ci-required/",
 			"packages/pipeline-cli/",
+			"biome\\.jsonc$",
+			"biome-plugins/",
 		]);
 	});
 });
@@ -107,10 +109,15 @@ describe("expandBranch", () => {
 			{path: "packages/pipeline-cli/", kind: "dir"},
 		]);
 	});
+
+	it("expands the biome-governance branches: an exact file + a dir prefix (ADR 0193)", () => {
+		expect(expandBranch("biome\\.jsonc$")).toEqual([{path: "biome.jsonc", kind: "file"}]);
+		expect(expandBranch("biome-plugins/")).toEqual([{path: "biome-plugins/", kind: "dir"}]);
+	});
 });
 
 describe("cpPaths over the live regex", () => {
-	it("resolves the full §CP path set (20 paths: dirs, the two exact files, + the **/*.sh glob)", () => {
+	it("resolves the full §CP path set (dirs, the exact files, the **/*.sh glob, + the biome-governance surfaces)", () => {
 		expect(cpPaths(LIVE_RE).map((p) => p.path)).toEqual([
 			".claude/",
 			".github/",
@@ -132,6 +139,8 @@ describe("cpPaths over the live regex", () => {
 			"claude-plugins/kampus-pipeline/hooks.json",
 			"packages/ci-required/",
 			"packages/pipeline-cli/",
+			"biome.jsonc",
+			"biome-plugins/",
 		]);
 	});
 
@@ -217,6 +226,8 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/hooks.json @usirin",
 			"/packages/ci-required/ @usirin",
 			"/packages/pipeline-cli/ @usirin",
+			"/biome.jsonc @usirin",
+			"/biome-plugins/ @usirin",
 		].join("\n");
 		expect(findUncovered(paths, parseCodeownersPatterns(codeowners))).toEqual([]);
 	});
@@ -241,6 +252,8 @@ describe("findUncovered — the drift check", () => {
 			"/claude-plugins/kampus-pipeline/agents/ @usirin",
 			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
 			"/packages/ci-required/ @usirin",
+			"/biome.jsonc @usirin",
+			"/biome-plugins/ @usirin",
 		].join("\n");
 		const uncovered = findUncovered(paths, parseCodeownersPatterns(stale)).map((p) => p.path);
 		expect(uncovered).toEqual([

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -31,6 +31,8 @@ const FULL_CODEOWNERS = [
 	"/claude-plugins/kampus-pipeline/hooks.json @usirin",
 	"/packages/ci-required/ @usirin",
 	"/packages/pipeline-cli/ @usirin",
+	"/biome.jsonc @usirin",
+	"/biome-plugins/ @usirin",
 ].join("\n");
 
 /** A throwaway repo carrying just the two source files the gate reads. */

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-paths.unit.test.ts
@@ -31,6 +31,14 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/report/lib/helper.sh")).toBe(true);
 	});
 
+	it("classifies the lint/GritQL governance config as control-plane (ADR 0193)", () => {
+		// An ungated path to weaken a lint rule is a guard-relaxing vector — same class as ADR 0187's
+		// enforcement-surface test. The root biome config and every GritQL plugin rule are §CP.
+		expect(isControlPlane("biome.jsonc")).toBe(true);
+		expect(isControlPlane("biome-plugins/no-raw-try-catch.grit")).toBe(true);
+		expect(isControlPlane("biome-plugins/no-type-assertions.grit")).toBe(true);
+	});
+
 	it("does NOT classify the four deliberately-OUT skill dirs (operational, not gate-critical)", () => {
 		for (const skill of ["heal-ci", "what-shipped", "doctor", "wayfinder"]) {
 			expect(isControlPlane(`claude-plugins/kampus-pipeline/skills/${skill}/SKILL.md`)).toBe(false);
@@ -52,6 +60,11 @@ describe("CONTROL_PLANE_RE classifies the ADR-0174 boundary broadenings (#2761)"
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/doctor/notes.txt")).toBe(false);
 		// a `.sh`-suffixed name that is NOT a `.sh` file (no such extension boundary) also stays out
 		expect(isControlPlane("claude-plugins/kampus-pipeline/skills/doctor/doctor.shell")).toBe(false);
+		// biome-governance §CP (ADR 0193) is tightly anchored: some OTHER root config/file stays
+		// non-§CP (a NEGATIVE), and `biome\.jsonc$` end-anchors so a look-alike suffix is not §CP.
+		expect(isControlPlane("turbo.json")).toBe(false);
+		expect(isControlPlane("pnpm-workspace.yaml")).toBe(false);
+		expect(isControlPlane("biome.jsonc.bak")).toBe(false);
 	});
 
 	it("still classifies every PRE-EXISTING §CP path (no branch dropped)", () => {

--- a/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
+++ b/packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts
@@ -26,6 +26,12 @@
  * sign-off. Anchoring to one depth was an accident, not a "subdir helpers are safe"
  * carve-out — a skill's shell helper is control-plane wherever it sits.
  *
+ * The biome-governance clauses (`^biome\.jsonc$`, `^biome-plugins/`) are §CP because
+ * lint/GritQL governance config is a guard-relaxing vector: an ungated path to weaken a
+ * lint rule (disable a security lint, downgrade a GritQL guard) could pass the enforcement
+ * test of ADR 0187 — merging it unreviewed CAN weaken a gate. Same class of decision as
+ * ADR 0187's enforcement-surface test; recorded in ADR 0193.
+ *
  * Anti-self-authorization is preserved (#981): the live merge-deciding gates still
  * re-resolve the boundary from the formats doc on `origin/main` at run time, so a
  * boundary-editing PR is classified against MAIN's boundary, not its own edit. This
@@ -33,4 +39,4 @@
  * runtime resolution off the origin/main read.
  */
 export const CONTROL_PLANE_RE =
-	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-design|review-plan|triage|write-code|plan-epic|release|review-trivial)/|^claude-plugins/kampus-pipeline/skills/([^/]+/)*[^/]+\\.sh$|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/|^biome\\.jsonc$|^biome-plugins/";


### PR DESCRIPTION
## What & why

Founder ruling B (2026-07-16): the lint/GritQL **governance config** — the repo-root `biome.jsonc` and `biome-plugins/*.grit` — is classified **§CP (control-plane)**. An ungated path to *weaken* a lint rule (disable a security lint, downgrade a GritQL guard) is a guard-relaxing vector — exactly what the control plane exists to gate. Same class of decision as ADR 0187, and it passes 0187's enforcement-surface test: an unreviewed merge of these paths *can* weaken a gate.

No `Fixes #N` — this is founder-ruling/conversation-driven, not issue-tracked. There is no tracking issue.

## ⚠️ This PR is itself §CP

It edits the classifier single source (`packages/pipeline-cli/src/tools/control-plane-paths/control-plane-re.ts`, which matches `CONTROL_PLANE_RE`) plus `.github/CODEOWNERS`. Do **not** enqueue/merge on green — bank at the §CP human approver (cansirin + notusirin). Author ≠ approver, hard invariant.

## Changes (one coherent PR)

1. **Classifier (ship-it soft gate).** Added two anchored branches to `CONTROL_PLANE_RE` (the single source): `^biome\.jsonc$` (end-anchored exact root file) and `^biome-plugins/` (dir prefix, all `*.grit` at any depth). Synced byte-equal into the only un-importable copy — the `CONTROL_PLANE_RE=` line in `gh-issue-intake-formats.md` (the origin/main-read copy, #981) — plus the prose surface enumeration. `codeowners-cp` + `validate-gate-path-drift.sh` verified: the const, the formats line, and CODEOWNERS agree.
2. **Tests.** `control-plane-paths.unit.test.ts`: `biome.jsonc` → §CP, `biome-plugins/no-raw-try-catch.grit` → §CP, and negatives (`turbo.json` / `pnpm-workspace.yaml` / `biome.jsonc.bak` stay non-§CP). Kept the `codeowners-cp` / `gate` drift fixtures in lockstep (split-branch, cpPaths set, findUncovered both-cases).
3. **CODEOWNERS (merge-time teeth).** `/biome.jsonc` and `/biome-plugins/` → `@kamp-us/control-plane`, matching the existing §CP row pattern, so `require_code_owner_review` hard-blocks a biome-governance edit without control-plane approval.
4. **ADR 0193** (`.decisions/0193-lint-governance-config-is-control-plane.md`, status: accepted) recording the decision, citing ADR 0187 as the sibling scope decision and noting both §CP mechanisms (classifier + CODEOWNERS teeth) now cover the surface.

## Verification

- `pipeline-cli control-plane-paths` prints the two new branches.
- Full pipeline-cli test suite: **1344 passed (97 files)**, including the new §CP classifier cases.
- `pnpm typecheck` clean, `pnpm lint` clean, all pre-commit guards (biome / leak-guard / primary-index) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Fixes #3343 (tracking issue for the §CP-scope ruling recorded in ADR 0193).