### PR TITLE
chore(lint): enable biome noNonNullAssertion at warn for non-test code (#3195)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -64,6 +64,14 @@
 				"noUnusedImports": "error",
 				"noUnusedVariables": "error"
 			},
+			"style": {
+				// `warn`, not `error`: a non-null assertion (`x!`) discards the
+				// compiler's null-safety proof, so surface every one — but as a
+				// nudge, not a hard gate (the error-level flip is a separate
+				// capstone). The test carve-out below stays `off` on purpose:
+				// idiomatic `!` in fixtures/mocks (PR #9) is not worth the noise.
+				"noNonNullAssertion": "warn"
+			},
 			"suspicious": {
 				"noExplicitAny": "off"
 			}


### PR DESCRIPTION
## What
Enable biome's built-in `noNonNullAssertion` at **`warn`** for non-test code, added explicitly to the top-level `linter.rules.style` block of `biome.jsonc`. The test-file `overrides` carve-out stays `off`.

## Why it was `off` first (investigated before flipping)
`noNonNullAssertion` was never disabled for non-test code — it only ever appeared in the `overrides` **test block** as `"style": { "noNonNullAssertion": "off" }`. Git history pins the origin to PR #9 (`5e26718a`, "formatting: biome across repo, fix all lint errors, enforce in CI"), whose commit message is explicit: *"biome.jsonc: disable noNonNullAssertion for test files (idiomatic `!`)"*. So the disable was a **scoped, deliberate carve-out for test files** — where `!` on fixtures/mocks/DOM handles is idiomatic and a hard rule would be pure churn — not a repo-wide false-positive escape. For non-test code the rule simply sat at biome's recommended default; this PR pins it to an explicit `warn`.

## Test carve-out decision
**Stays `off`.** The PR #9 rationale (idiomatic `!` in fixtures/mocks) still holds, and this child only *warns* rather than hard-gates, so warning on test `!` would add noise with no enforcement payoff. Documented inline in `biome.jsonc` next to the rule.

## Remediation
Ran a full-repo biome scan for `noNonNullAssertion` (grep is unreliable for postfix `!`, so I used a standalone biome config with the same test-override, then sanity-checked it fires on a known `x!` and stays off for test files). Result: **zero** non-null-assertion violations in non-test source — nothing to remediate. This is the freebie. No sites under `packages/pipeline-cli/**` or `packages/pipeline-crew-mcp/**` (none anywhere).

## Scope
Out of scope: the error-level flip (separate capstone child). One file changed: `biome.jsonc`.

## Verification
- `pnpm lint` — clean
- `pnpm typecheck` — passes

Fixes #3195