### PR TITLE
chore(lint): enable biome noNonNullAssertion at warn for non-test code

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -64,6 +64,14 @@
 				"noUnusedImports": "error",
 				"noUnusedVariables": "error"
 			},
+			"style": {
+				// `warn`, not `error`: a non-null assertion (`x!`) discards the
+				// compiler's null-safety proof, so surface every one — but as a
+				// nudge, not a hard gate (the error-level flip is a separate
+				// capstone). The test carve-out below stays `off` on purpose:
+				// idiomatic `!` in fixtures/mocks (PR #9) is not worth the noise.
+				"noNonNullAssertion": "warn"
+			},
 			"suspicious": {
 				"noExplicitAny": "off"
 			}


### PR DESCRIPTION
Fixes #3195

## What
Make Biome's built-in `noNonNullAssertion` an **explicit** `warn` at the top-level `linter.rules.style` in `biome.jsonc`, so every non-null assertion (`x!`) in non-test code surfaces as a nudge. The test-file `overrides` carve-out stays `off`.

## AC1 — Why it was `"off"` first (investigated + recorded)
`noNonNullAssertion` only ever appeared in the **test-file `overrides` block** as `"off"`, introduced by commit `5e26718a` — "formatting: biome across repo, fix all lint errors, enforce in CI (#9)". That commit's own message states the reason verbatim:

> - biome.jsonc: disable noNonNullAssertion for test files (idiomatic `!`)

So the disable was **never a repo-wide suppression** — it was a narrow, deliberate carve-out for test files, where `x!` on fixtures/mocks is idiomatic and not worth the noise. It was scoped to `**/tests/**`, `**/*.test.ts(x)`, `**/*.spec.ts` only. There was no history of the rule being disabled for non-test code.

Key grounding (verified empirically against the pinned Biome `2.4.15`, not intuition): for **non-test** code the rule was **already active at `warn`** via `recommended: true` — a temp non-test `x!` emits `lint/style/noNonNullAssertion` "Found 1 warning" under the pre-change config. So "off" was only ever the test override; non-test code already warned by the recommended default.

## AC2 — Set to `warn` for non-test code + test carve-out decision (documented)
Added an explicit `style.noNonNullAssertion: "warn"` to the base `linter.rules`. This is a **no-op in current severity** (recommended already warns) but makes the policy **explicit and version-stable** — it survives any future Biome de-recommending of the rule and reads as intentional governance rather than an implicit default.

**Test carve-out decision: the test override STAYS `off`** (does not also flip). Rationale: idiomatic `!` in fixtures/mocks was the original #9 reason and still holds; this child is the low-cost warn freebie, and adding test-file noise here buys nothing. (The error-level flip is out of scope — a separate capstone child.)

## AC3 — `pnpm lint` passes; remediation
- Full-repo `biome check .` finds **zero** non-null assertions in non-test source — there is nothing to remediate (the freebie). No `x!`→guard rewrites, no per-line justifications, no blanket suppressions.
- Grounded that `warn` does not fail CI: `biome lint` on a warning-only file exits **0** (only `--error-on-warnings`, which CI does not pass, would flip that). So warnings surface without breaking the gate.
- `pnpm lint` (worktree mode) and `pnpm typecheck` both green locally.

## Scope / collision guard
Only `biome.jsonc` (repo root) changed. Nothing lands under `packages/pipeline-cli/**` or `packages/pipeline-crew-mcp/**`. Out of scope: the error-flip capstone.

TDD: no (lint-config flip; the acceptance test is `pnpm lint` passing).