### PR TITLE
feat(pipeline-crew-mcp): roster-driven session set — bridge×1 / engine×N (#3297)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/session-set.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/session-set.test.ts
@@ -1,0 +1,98 @@
+/**
+ * standup/session-set — the roster-driven session set (AC 1–4, ADR 0189). These tests pin the
+ * derivation against the confirmed roster (three bridges + the engine pool) and a sample engine
+ * count: bridge cardinality 1, engine cardinality N, distinct per-instance engine identities, and
+ * that the set is derived from the kind-typed roster contract rather than a re-declared role list.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Schema} from "effect";
+import {CREW_ROLES, kindOf} from "../crew/index.ts";
+import {EngineCount} from "./config.ts";
+import {type CrewSession, deriveSessionSet} from "./session-set.ts";
+
+// N as the real branded EngineCount (≥1) the launcher hands the derivation, not a bare cast.
+const n = (count: number): EngineCount => Schema.decodeUnknownSync(EngineCount)(count);
+
+// A deterministic instance-id generator so the derived engine addresses are pinnable: e0, e1, ….
+const counter = () => {
+	let i = 0;
+	return () => `e${i++}`;
+};
+
+const bridges = (set: readonly CrewSession[]) => set.filter((s) => s.kind === "bridge");
+const engines = (set: readonly CrewSession[]) => set.filter((s) => s.kind === "engine");
+
+describe("standup/session-set — roster-driven session set (ADR 0189)", () => {
+	it("stands up exactly one instance per bridge kind and N of the engine kind (AC1)", () => {
+		const N = 3;
+		const set = deriveSessionSet({engineCount: n(N), instanceId: counter()});
+
+		const bridgeRoles = CREW_ROLES.filter((r) => kindOf(r) === "bridge");
+		const engineRoles = CREW_ROLES.filter((r) => kindOf(r) === "engine");
+
+		// one session per bridge kind — the exact confirmed bridges, each cardinality 1.
+		assert.deepStrictEqual(
+			bridges(set)
+				.map((s) => s.role)
+				.sort(),
+			[...bridgeRoles].sort(),
+		);
+		// N engine sessions total, all for the (single) engine role.
+		assert.strictEqual(engines(set).length, N * engineRoles.length);
+		for (const role of engineRoles) {
+			assert.strictEqual(engines(set).filter((s) => s.role === role).length, N);
+		}
+		assert.strictEqual(set.length, bridgeRoles.length + N * engineRoles.length);
+	});
+
+	it("addresses each bridge as its singleton lease key inbox://<role> — no instance (AC3)", () => {
+		const set = deriveSessionSet({engineCount: n(2), instanceId: counter()});
+		for (const bridge of bridges(set)) {
+			assert.strictEqual(bridge.address, `inbox://${bridge.role}`);
+			// A bridge carries no per-instance identity — the discriminated union makes it unrepresentable.
+			assert.isFalse("instance" in bridge);
+		}
+	});
+
+	it("gives each engine instance a distinct per-instance identity + address — no collisions (AC2)", () => {
+		const N = 4;
+		const set = deriveSessionSet({engineCount: n(N), instanceId: counter()});
+		const eng = engines(set);
+
+		const instances = eng.map((s) => s.instance);
+		const addresses = eng.map((s) => s.address);
+		// distinct identities and distinct addresses — no two engine inboxes collide.
+		assert.strictEqual(new Set(instances).size, eng.length);
+		assert.strictEqual(new Set(addresses).size, eng.length);
+		// the address bakes the role + the per-instance discriminator (inboxAddressFor's engine form).
+		for (const s of eng) {
+			assert.strictEqual(s.address, `inbox://${s.role}/${s.instance}`);
+		}
+	});
+
+	it("derives from the kind-typed roster, not a re-declared list — every role is present (AC3)", () => {
+		const set = deriveSessionSet({engineCount: n(1), instanceId: counter()});
+		// every roster role appears at least once, kinded exactly as the roster says.
+		for (const role of CREW_ROLES) {
+			const forRole = set.filter((s) => s.role === role);
+			assert.isTrue(forRole.length >= 1, `role ${role} missing from the session set`);
+			for (const s of forRole) {
+				assert.strictEqual(s.kind, kindOf(role));
+			}
+		}
+		// no session names a role outside the roster.
+		for (const s of set) {
+			assert.isTrue(new Set<string>(CREW_ROLES).has(s.role));
+		}
+	});
+
+	it("scales the engine pool with the config engine count, bridges fixed at 1 (AC1,AC4)", () => {
+		const bridgeCount = CREW_ROLES.filter((r) => kindOf(r) === "bridge").length;
+		for (const N of [1, 2, 5, 10]) {
+			const set = deriveSessionSet({engineCount: n(N), instanceId: counter()});
+			assert.strictEqual(bridges(set).length, bridgeCount);
+			assert.strictEqual(engines(set).length, N);
+			assert.strictEqual(new Set(engines(set).map((s) => s.address)).size, N);
+		}
+	});
+});

--- a/packages/pipeline-crew-mcp/src/standup/session-set.ts
+++ b/packages/pipeline-crew-mcp/src/standup/session-set.ts
@@ -1,0 +1,73 @@
+/**
+ * standup/session-set — derive WHICH sessions the launcher stands up, straight from the kind-typed
+ * roster + its per-kind cardinality contract (ADR 0189): one instance per bridge kind, N instances
+ * of the engine kind (N from the config engine-count dimension). Pure over the roster contract — no
+ * process spawn, no argv (the bind constructor #3296 turns each `{role, address}` into argv, the
+ * orchestration child spawns them).
+ *
+ * The set is derived by iterating the roster (`CREW_ROLES` + `kindOf`), never a re-declared role
+ * list, so a roster change flows through here with no edit. Each session carries the `address`
+ * `inboxAddressFor` mints — which IS its role-lease key: a bridge's singleton `inbox://<role>` (its
+ * cardinality-1 lease keeps discover→dial deterministic), an engine's per-instance
+ * `inbox://<role>/<instance>` (N distinct leases + N collision-free inbox sockets). Bridge sessions
+ * carry no instance because a bridge-with-an-instance is meaningless — the discriminated union makes
+ * that state unrepresentable, mirroring `inboxAddressFor`'s own kind branch.
+ */
+import {CREW_ROLES, type CrewRole, inboxAddressFor, kindOf} from "../crew/index.ts";
+import type {EngineCount} from "./config.ts";
+
+/**
+ * A launcher session bound to its role lease. `kind` discriminates the union: a bridge is the
+ * cardinality-1 singleton (no per-instance identity), an engine carries a distinct `instance` so N
+ * of them coexist. `address` is `inboxAddressFor(role, …)` — the dialable inbox AND the lease key
+ * the session comes up holding.
+ */
+export interface BridgeSession {
+	readonly kind: "bridge";
+	readonly role: CrewRole;
+	readonly address: string;
+}
+
+export interface EngineSession {
+	readonly kind: "engine";
+	readonly role: CrewRole;
+	/** The distinct per-instance discriminator baked into `address` — no two engine inboxes collide. */
+	readonly instance: string;
+	readonly address: string;
+}
+
+export type CrewSession = BridgeSession | EngineSession;
+
+export interface SessionSetInput {
+	/** N — how many engine sessions to start, the validated (≥1) `EngineCount` from `LaunchConfig`. */
+	readonly engineCount: EngineCount;
+	/**
+	 * Mints a distinct per-instance id per engine session — injected so the derivation is pure and
+	 * testable; production passes `randomUUID` (the same generator `crewSessionLayer` threads through
+	 * `inboxAddressFor`). Called exactly once per engine instance, never for a bridge.
+	 */
+	readonly instanceId: () => string;
+}
+
+/**
+ * Derive the stand-up's session set from the roster-law contract: exactly one bridge session per
+ * bridge role and `engineCount` sessions per engine role, each engine instance addressed distinctly.
+ * Total by construction — every roster role is kinded, so no role is dropped or double-counted.
+ */
+export const deriveSessionSet = (input: SessionSetInput): readonly CrewSession[] => {
+	const {engineCount, instanceId} = input;
+	const sessions: CrewSession[] = [];
+	for (const role of CREW_ROLES) {
+		if (kindOf(role) === "engine") {
+			for (let i = 0; i < engineCount; i++) {
+				const instance = instanceId();
+				sessions.push({kind: "engine", role, instance, address: inboxAddressFor(role, instance)});
+			}
+		} else {
+			// A bridge is cardinality 1; `inboxAddressFor` ignores the instance for a bridge kind and
+			// returns the singleton `inbox://<role>`, so no id is minted for it.
+			sessions.push({kind: "bridge", role, address: inboxAddressFor(role, "")});
+		}
+	}
+	return sessions;
+};


### PR DESCRIPTION
## What

Adds `packages/pipeline-crew-mcp/src/standup/session-set.ts` (+ its test): the stand-up launcher's **roster-driven session set** — derives exactly which sessions to stand up from the kind-typed roster + per-kind cardinality contract (ADR 0189).

- **bridge×1 / engine×N.** One session per bridge kind, `engineCount` sessions per engine kind — `N` read from the config engine-count dimension (`EngineCount`, validated ≥1 by the config schema).
- **Distinct per-instance engine identity.** Each engine instance mints a distinct id (injected generator, `randomUUID` in production) threaded through the roster-law `inboxAddressFor(role, instance)` (#3301) — reused, not reinvented — so N engine inboxes never collide (`inbox://<role>/<instance>`). A bridge keeps its singleton `inbox://<role>`.
- **Role-lease binding.** Each session carries its `address`, which IS the lease key it comes up holding — a bridge's singleton lease key, an engine's per-instance one.
- **Derived from the roster contract, not a re-declared list.** Pure iteration over `CREW_ROLES` + `kindOf`; a roster change flows through with no edit here.
- **Invalid states unrepresentable.** A discriminated union on `kind` means a bridge-with-an-instance doesn't typecheck.

## Acceptance criteria

- [x] Session set = one instance per bridge kind + N engine instances (N from config).
- [x] Each engine instance carries a distinct per-instance identity/address (no inbox collision).
- [x] Each session bound to its role-lease key; set derived from the kind-typed roster contract.
- [x] Derivation unit-tested against the confirmed roster + a sample engine count.

## Scope / lane discipline

Adds only `standup/session-set.ts` + `standup/session-set.test.ts`. Reads (does not edit) `standup/config.ts` and the roster-law modules under `crew/`. Does not create `standup/index.ts` (reserved for #3299). Out of scope: the `--mcp-config`/channel argv (bind #3296) and process spawn / tmux placement.

## Verification

`pnpm typecheck` clean; `pnpm lint` (biome) clean; full crew-mcp vitest suite green (143 tests, incl. 5 new).

NON-§CP: pipeline-crew launcher tooling — per ADR 0187 the crew-mcp package is non-§CP; no kamp.us user surface.

Fixes #3297

🤖 Generated with [Claude Code](https://claude.com/claude-code)