### PR TITLE
fix(security): clear 4 HIGH CodeQL alerts — ReDoS regexes + insecure e2e randomness (#3341)

### DIFF
--- a/apps/web/tests/e2e/_helpers/auth.ts
+++ b/apps/web/tests/e2e/_helpers/auth.ts
@@ -1,3 +1,4 @@
+import {randomUUID} from "node:crypto";
 import {expect, type Page} from "@playwright/test";
 
 export interface Credentials {
@@ -18,7 +19,9 @@ export interface Credentials {
  * unique-email constraint when re-run.
  */
 function freshCredentials(opts?: Partial<Credentials>): Credentials {
-	const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	// crypto.randomUUID over Math.random: js/insecure-randomness (#3341) — the suffix
+	// ids a credential fixture, a context where CodeQL expects a cryptographic source.
+	const suffix = `${Date.now()}-${randomUUID().slice(0, 8)}`;
 	return {
 		email: opts?.email ?? `e2e-${suffix}@kamp.us`,
 		password: opts?.password ?? "hunter222!",
@@ -112,7 +115,7 @@ export async function completeBootstrap(page: Page): Promise<void> {
 	const handle =
 		prefilled && prefilled.length >= 3
 			? prefilled
-			: `e2e${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+			: `e2e${Date.now().toString(36)}${randomUUID().slice(0, 4)}`;
 	await input.fill(handle);
 
 	// Select by the stable submit class, NOT the label: the label now varies

--- a/packages/flake-rate/src/inventory.ts
+++ b/packages/flake-rate/src/inventory.ts
@@ -13,14 +13,27 @@
  * mirroring `@kampus/epic-ledger`'s `markdown.ts`.
  */
 
-/** A `### ...` (level-3) heading line; captures the heading text (group 1). */
-const ENTRY_HEADING = /^###\s+(.+?)\s*$/;
+/**
+ * A `### ...` (level-3) heading line; captures the heading text (group 1),
+ * trailing whitespace included — the parser trims the capture in code. The
+ * capture is anchored to a non-whitespace start (`\S.*`) so no two quantified
+ * runs share the whitespace class: this is the linear, non-backtracking form of
+ * the old lazy `(.+?)\s*$`, which CodeQL flagged js/polynomial-redos (#3341).
+ */
+const ENTRY_HEADING = /^###\s+(\S.*)$/;
 
 /** Any deeper section heading; ends the current entry's field scan. */
 const SECTION_BREAK = /^#{1,3}\s+\S/;
 
-/** A `**Status:** \`fixed\`` field, tolerant of casing and surrounding markup. */
-const FIXED_STATUS = /\*\*\s*status\s*:?\s*\*\*\s*:?\s*`?\s*fixed`?/i;
+/**
+ * A `**Status:** \`fixed\`` field, tolerant of casing and surrounding markup.
+ * Each optional colon/backtick is folded into the whitespace run that follows it
+ * (`\s*(?::\s*)?`, `\s*(?::\s*)?(?:`\s*)?`) so no two `\s*` runs are adjacent
+ * across an optional single char — the language is identical to the old
+ * `\s*:?\s*` / `\s*:?\s*`?\s*` form but non-backtracking, clearing the
+ * js/polynomial-redos alerts CodeQL raised at both call sites (#3341).
+ */
+const FIXED_STATUS = /\*\*\s*status\s*(?::\s*)?\*\*\s*(?::\s*)?(?:`\s*)?fixed`?/i;
 
 /** A `PR #NNN` (or `PR [#NNN](...)`) reference; captures the number (group 1). */
 const PR_REF = /\bPR\s*\[?#(\d+)/i;
@@ -58,7 +71,7 @@ export const parseFixedEntries = (markdown: string): ReadonlyArray<FixedEntry> =
 		const head = ENTRY_HEADING.exec(line);
 		if (head?.[1] !== undefined) {
 			flush();
-			heading = head[1];
+			heading = head[1].trimEnd();
 			continue;
 		}
 		if (heading !== undefined && SECTION_BREAK.test(line)) {

--- a/packages/flake-rate/src/inventory.unit.test.ts
+++ b/packages/flake-rate/src/inventory.unit.test.ts
@@ -55,4 +55,36 @@ describe("parseFixedEntries", () => {
 `;
 		assert.strictEqual(parseFixedEntries(md).length, 0);
 	});
+
+	// Behavior-preservation lock for the linear-time regex rewrite (#3341): the
+	// hardened ENTRY_HEADING / FIXED_STATUS must accept and reject EXACTLY the same
+	// inputs as the old backtracking forms. These pin the tolerant-matching contract
+	// the docblocks promise (heading trailing-whitespace trim, casing/colon/backtick
+	// slack in the Status field) so a future regex edit can't silently regress it.
+	it("trims trailing whitespace off the heading (ENTRY_HEADING linear form)", () => {
+		const md = `###   spaced heading with trailing ws   \t
+
+- **Status:** \`fixed\` → fixed in PR [#900](x).
+`;
+		const entries = parseFixedEntries(md);
+		assert.strictEqual(entries.length, 1);
+		assert.strictEqual(entries[0]?.heading, "spaced heading with trailing ws");
+		assert.strictEqual(entries[0]?.fixPr, 900);
+	});
+
+	it("matches the Status field across casing, colon and backtick slack (FIXED_STATUS linear form)", () => {
+		const md = `### no backtick, extra spaces
+- **Status** :  fixed  — fixed in PR #101.
+
+### uppercase and colon inside markup
+- **STATUS:**: \`fixed\` fixed in PR #102.
+
+### backtick, no colon
+- **Status** \`fixed\` PR #103.
+`;
+		const byHeading = new Map(parseFixedEntries(md).map((e) => [e.heading, e.fixPr]));
+		assert.strictEqual(byHeading.get("no backtick, extra spaces"), 101);
+		assert.strictEqual(byHeading.get("uppercase and colon inside markup"), 102);
+		assert.strictEqual(byHeading.get("backtick, no colon"), 103);
+	});
 });


### PR DESCRIPTION
## What

Remediate the **4 open HIGH-severity CodeQL alerts** that reached `main` on 2026-07-03 and sat untracked. Scoped to exactly the three code surfaces in the issue — no CodeQL gate config, no workflow permissions (those are #3331 / #3332).

## Changes

### `packages/flake-rate/src/inventory.ts` — 3× `js/polynomial-redos` (#17, #18, #19)
Both module-level regexes rewritten to linear, non-backtracking forms whose **accepted language is identical** to the old backtracking ones:

- **`ENTRY_HEADING`** (#18): lazy `^###\s+(.+?)\s*$` → anchored `^###\s+(\S.*)$` + a `trimEnd()` on the capture in code. Anchoring the capture to a non-whitespace start removes the two-quantifier whitespace ambiguity.
- **`FIXED_STATUS`** (#17, #19 — same regex, two call sites): each optional colon/backtick is folded into the whitespace run that follows it — `\s*:?\s*` → `\s*(?::\s*)?`, `\s*:?\s*` + backtick + `?\s*` → `\s*(?::\s*)?(?:` + backtick + `\s*)?` — so no two `\s*` runs are adjacent across an optional single char. Same language, no backtracking ambiguity.

**Behavior-preserving:** the existing `parseFixedEntries` fixtures stay green, and two added unit tests lock the heading trailing-whitespace trim and the Status-field casing/colon/backtick tolerance the regexes promise, so a future edit can't silently regress the parse.

### `apps/web/tests/e2e/_helpers/auth.ts` — `js/insecure-randomness` (#20)
Both `Math.random().toString(36)` credential-fixture id generators (`freshCredentials` suffix + `completeBootstrap` handle fallback) switched to `crypto.randomUUID()` from `node:crypto`, a cryptographic source. Test-only path — generates unique e2e credential fixtures, not a production auth secret.

## Verification
- `pnpm --filter @kampus/flake-rate typecheck` — clean
- `pnpm vitest run src/inventory.unit.test.ts` — 6 passed (4 existing + 2 new)
- `pnpm --filter @kampus/web typecheck` — clean
- `pnpm lint` — clean
- CI CodeQL re-scan will close #17/#18/#19/#20 (all fixed in-code; no dismissal needed).

Non-§CP (neither surface is a control-plane path) → auto-ships on green.

Fixes #3341

🤖 Generated with [Claude Code](https://claude.com/claude-code)