### PR TITLE
feat(bildirim): suppress notifications from a muted member (#3238)

### DIFF
--- a/apps/web/worker/features/bildirim/conversation-emitters.ts
+++ b/apps/web/worker/features/bildirim/conversation-emitters.ts
@@ -27,6 +27,7 @@
 import {Effect} from "effect";
 import {bildirimOn} from "./gate.ts";
 import type {NotificationKind} from "./kind.ts";
+import {bildirimMutedBy} from "./mute-suppression.ts";
 import {Notification} from "./Notification.ts";
 
 export const REPLY_KIND: NotificationKind = "reply";
@@ -71,6 +72,8 @@ export const notifyCommentReply = (input: {
 		if (!(yield* bildirimOn)) return;
 		const bildirim = yield* Notification;
 		for (const recipientId of recipients) {
+			// Per-recipient: each recipient is a distinct muter with their own muted set.
+			if (yield* bildirimMutedBy(recipientId, input.actorId)) continue;
 			yield* bildirim.record({
 				recipientId,
 				kind: REPLY_KIND,

--- a/apps/web/worker/features/bildirim/conversation-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/conversation-emitters.unit.test.ts
@@ -14,6 +14,7 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {Flags} from "../flagship/Flags.ts";
+import {Mute} from "../mute/Mute.ts";
 import {notifyCommentReply, REPLY_KIND, replyRecipients} from "./conversation-emitters.ts";
 import {makeNotificationStub} from "./Notification.testing.ts";
 import type {NotificationRecordInput} from "./Notification.ts";
@@ -50,6 +51,16 @@ const noopLivePublisher = Layer.succeed(LivePublisher)({
 	},
 } as typeof LivePublisher.Service);
 
+// A `Mute` returning no mutes: the emitter now consults `bildirimMutedBy` per recipient,
+// which reads `readMutedIds` — an empty set means no member is muted, so these cases
+// exercise the unchanged (deliver) path. Muted-suppression itself is covered in
+// mute-suppression.unit.test.ts.
+const noMutes = Layer.succeed(Mute, {
+	set: () => Effect.die("Mute.set not exercised"),
+	listMine: () => Effect.die("Mute.listMine not exercised"),
+	readMutedIds: () => Effect.succeed(new Set<string>()),
+});
+
 const requestContext = (on: boolean) =>
 	Layer.mergeAll(
 		flagsStub(on),
@@ -57,6 +68,7 @@ const requestContext = (on: boolean) =>
 		Layer.succeed(RuntimeContext, runtimeContextStub),
 		noRequestFlagOverrides,
 		noopLivePublisher,
+		noMutes,
 	);
 
 const recordingStub = (calls: NotificationRecordInput[]) =>

--- a/apps/web/worker/features/bildirim/mute-suppression.ts
+++ b/apps/web/worker/features/bildirim/mute-suppression.ts
@@ -1,0 +1,50 @@
+/**
+ * Bildirim mute-suppression (#3238) — the notification analogue of the content
+ * read-mask (`../mute/read-mask.ts`). ADR 0188 ruled v1 mute (sustur) suppresses the
+ * bildirim a muted member's interactions would raise to the muter, not merely a
+ * content read-mask; this is the seam the interaction emitters consult before they
+ * record.
+ *
+ * Generation-time, not read-time: the anti-hype vote aggregate stores `actorId: null`
+ * (see `vote-emitters.ts` / `rite-emitters.ts`), so the interacting member's identity
+ * survives ONLY at emit time — a read-time filter on `notification.actor_id` could
+ * never suppress an aggregated vote. The seam is therefore a per-emit predicate keyed
+ * on (recipient = the muter, actor = the interacting member): suppress iff the
+ * recipient has muted the actor.
+ */
+import type {CurrentUser} from "@kampus/fate-effect";
+import type {RuntimeContext} from "alchemy";
+import {Effect} from "effect";
+import {MEMBER_MUTE} from "../../../src/flags/keys.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags, type RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import {Mute} from "../mute/Mute.ts";
+
+/**
+ * True iff a bildirim to `recipientId` about `actorId`'s interaction must be
+ * suppressed — the recipient (muter) has muted the actor. A null/absent actor is a
+ * system moment with no interacting member (a `terfi`/`caylak-pending` emit), so
+ * nothing to suppress, resolved before any flag or DB read. Gated behind the
+ * default-off `member-mute` flag the read-mask also uses (safe default `false`: an
+ * unflipped default or a Flagship outage both read off) ⇒ `false` ⇒ unchanged
+ * delivery. Viewer-scoped through `Mute.readMutedIds(recipientId)` — the muter IS the
+ * recipient — the same set the content read-mask reads from, no divergent muted-id
+ * source.
+ */
+export const bildirimMutedBy = (
+	recipientId: string,
+	actorId: string | null | undefined,
+): Effect.Effect<
+	boolean,
+	never,
+	Flags | RuntimeContext | RequestFlagOverrides | CurrentUser | Mute
+> =>
+	Effect.gen(function* () {
+		if (!actorId) return false;
+		const flags = yield* Flags;
+		const on = yield* flags.getBoolean(MEMBER_MUTE, false).pipe(provideRequestFlags);
+		if (!on) return false;
+		const mute = yield* Mute;
+		const muted = yield* mute.readMutedIds(recipientId);
+		return muted.has(actorId);
+	});

--- a/apps/web/worker/features/bildirim/mute-suppression.unit.test.ts
+++ b/apps/web/worker/features/bildirim/mute-suppression.unit.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Bildirim mute-suppression seam (#3238, ADR 0188) — the decisions that are
+ * wrong-or-right with no database (ADR 0082 T1/T2): the flag gate (default-off ⇒ no
+ * suppression), the null-actor short-circuit (a system moment suppresses nobody), and
+ * the viewer-scoped membership test (`recipient` = the muter, suppress iff the
+ * recipient muted the actor). Row-level EXCLUSION against real D1 (a muted member's
+ * interaction actually raising no bildirim end-to-end) is the integration tier's job,
+ * like the content read-mask.
+ *
+ * The `Mute` stub either returns a fixed set or DIES on contact, so a path that must
+ * short-circuit before the read (null actor / flag off) proves it never reaches `Mute`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {Flags} from "../flagship/Flags.ts";
+import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import {Mute} from "../mute/Mute.ts";
+import {bildirimMutedBy} from "./mute-suppression.ts";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "bildirim-mute-suppression-test",
+	id: "bildirim-mute-suppression-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(on),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service);
+
+// A `Mute` whose `readMutedIds` returns a fixed set — or dies on contact, proving a
+// path that must short-circuit before the read (null actor / flag off) never reaches it.
+const muteStub = (
+	readMutedIds?: (viewerId: string | null | undefined) => Effect.Effect<Set<string>>,
+) =>
+	Layer.succeed(Mute, {
+		set: () => Effect.die("Mute.set not exercised"),
+		listMine: () => Effect.die("Mute.listMine not exercised"),
+		readMutedIds:
+			readMutedIds ??
+			(() => Effect.die("Mute.readMutedIds reached on a path that must short-circuit")),
+	});
+
+const resolve = (opts: {
+	on: boolean;
+	recipientId: string;
+	actorId: string | null | undefined;
+	mute: ReturnType<typeof muteStub>;
+}) =>
+	bildirimMutedBy(opts.recipientId, opts.actorId).pipe(
+		// The recipient IS the muter, passed explicitly — `CurrentUser` here is only what
+		// `provideRequestFlags` reads to build the flag context, never the muted-id scope.
+		Effect.provideService(CurrentUser, {user: {id: opts.recipientId} as never}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+		Effect.provideService(RequestFlagOverrides, {cookieHeader: null, overridesAllowed: false}),
+		Effect.provide(Layer.mergeAll(flagsStub(opts.on), opts.mute)),
+	);
+
+describe("bildirimMutedBy — flag-gated, viewer-scoped suppression", () => {
+	it.effect("a null actor is a system moment ⇒ not suppressed, Mute never read", () =>
+		Effect.gen(function* () {
+			const suppressed = yield* resolve({
+				on: true,
+				recipientId: "u-muter",
+				actorId: null,
+				mute: muteStub(),
+			});
+			assert.isFalse(suppressed);
+		}),
+	);
+
+	it.effect("flag OFF ⇒ never suppressed, and Mute is never read (byte-for-byte today)", () =>
+		Effect.gen(function* () {
+			const suppressed = yield* resolve({
+				on: false,
+				recipientId: "u-muter",
+				actorId: "u-actor",
+				mute: muteStub(),
+			});
+			assert.isFalse(suppressed);
+		}),
+	);
+
+	it.effect("flag ON + the actor is NOT muted ⇒ delivered (not suppressed)", () =>
+		Effect.gen(function* () {
+			const suppressed = yield* resolve({
+				on: true,
+				recipientId: "u-muter",
+				actorId: "u-actor",
+				mute: muteStub(() => Effect.succeed(new Set(["u-someone-else"]))),
+			});
+			assert.isFalse(suppressed);
+		}),
+	);
+
+	it.effect("flag ON + the recipient muted the actor ⇒ suppressed (viewer-scoped)", () =>
+		Effect.gen(function* () {
+			const suppressed = yield* resolve({
+				on: true,
+				recipientId: "u-muter",
+				actorId: "u-actor",
+				mute: muteStub((viewerId) => {
+					assert.strictEqual(
+						viewerId,
+						"u-muter",
+						"reads the RECIPIENT's mutes (the muter), never the actor's",
+					);
+					return Effect.succeed(new Set(["u-actor"]));
+				}),
+			});
+			assert.isTrue(suppressed);
+		}),
+	);
+});

--- a/apps/web/worker/features/bildirim/rite-emitters.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.ts
@@ -27,6 +27,7 @@ import {Effect} from "effect";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {bildirimOn} from "./gate.ts";
 import type {NotificationKind} from "./kind.ts";
+import {bildirimMutedBy} from "./mute-suppression.ts";
 import {Notification} from "./Notification.ts";
 
 export const DIVAN_VOTE_KIND: NotificationKind = "divan-vote";
@@ -52,6 +53,9 @@ export const notifyDivanVote = (input: {
 		const recipientId = riteRecipient(input.authorId, input.actorId);
 		if (recipientId === null) return;
 		if (!(yield* bildirimOn)) return;
+		// The aggregate stores `actorId: null`, so the muted check keys on the real
+		// interacting divan voter (`actorId`), the identity that survives only here.
+		if (yield* bildirimMutedBy(recipientId, input.actorId)) return;
 		const bildirim = yield* Notification;
 		yield* bildirim.recordAggregate({
 			recipientId,
@@ -68,6 +72,7 @@ export const notifyKefil = (input: {candidateId: string; voucherId: string}) =>
 		const recipientId = riteRecipient(input.candidateId, input.voucherId);
 		if (recipientId === null) return;
 		if (!(yield* bildirimOn)) return;
+		if (yield* bildirimMutedBy(recipientId, input.voucherId)) return;
 		const bildirim = yield* Notification;
 		yield* bildirim.record({
 			recipientId,

--- a/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
@@ -13,6 +13,7 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {Flags} from "../flagship/Flags.ts";
+import {Mute} from "../mute/Mute.ts";
 import {makeNotificationStub} from "./Notification.testing.ts";
 import type {NotificationAggregateInput, NotificationRecordInput} from "./Notification.ts";
 import {
@@ -58,6 +59,15 @@ const noopLivePublisher = Layer.succeed(LivePublisher)({
 	},
 } as typeof LivePublisher.Service);
 
+// A `Mute` returning no mutes: the divan-vote/kefil emitters now consult `bildirimMutedBy`,
+// which reads `readMutedIds` — an empty set means no member is muted, so these cases exercise
+// the unchanged (deliver) path. Muted-suppression itself is covered in mute-suppression.unit.test.ts.
+const noMutes = Layer.succeed(Mute, {
+	set: () => Effect.die("Mute.set not exercised"),
+	listMine: () => Effect.die("Mute.listMine not exercised"),
+	readMutedIds: () => Effect.succeed(new Set<string>()),
+});
+
 const requestContext = (on: boolean) =>
 	Layer.mergeAll(
 		flagsStub(on),
@@ -65,6 +75,7 @@ const requestContext = (on: boolean) =>
 		Layer.succeed(RuntimeContext, runtimeContextStub),
 		noRequestFlagOverrides,
 		noopLivePublisher,
+		noMutes,
 	);
 
 describe("riteRecipient — self-suppression, pure", () => {

--- a/apps/web/worker/features/bildirim/vote-emitters.ts
+++ b/apps/web/worker/features/bildirim/vote-emitters.ts
@@ -28,6 +28,7 @@ import {Effect} from "effect";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {bildirimOn} from "./gate.ts";
 import type {NotificationKind} from "./kind.ts";
+import {bildirimMutedBy} from "./mute-suppression.ts";
 import {Notification} from "./Notification.ts";
 
 export const VOTE_KIND: NotificationKind = "vote";
@@ -55,6 +56,9 @@ export const notifyContentVote = (input: {
 		const recipientId = voteRecipient(input.authorId, input.voterId);
 		if (recipientId === null) return;
 		if (!(yield* bildirimOn)) return;
+		// The aggregate stores `actorId: null`, so the muted-voter check keys on the
+		// real interacting member (`voterId`), the identity that survives only here.
+		if (yield* bildirimMutedBy(recipientId, input.voterId)) return;
 		const bildirim = yield* Notification;
 		yield* bildirim.recordAggregate({
 			recipientId,

--- a/apps/web/worker/features/bildirim/vote-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/vote-emitters.unit.test.ts
@@ -14,6 +14,7 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {Flags} from "../flagship/Flags.ts";
+import {Mute} from "../mute/Mute.ts";
 import {makeNotificationStub} from "./Notification.testing.ts";
 import type {NotificationAggregateInput} from "./Notification.ts";
 import {notifyContentVote, VOTE_KIND, voteRecipient} from "./vote-emitters.ts";
@@ -51,6 +52,15 @@ const noopLivePublisher = Layer.succeed(LivePublisher)({
 	},
 } as typeof LivePublisher.Service);
 
+// A `Mute` returning no mutes: the emitters now consult `bildirimMutedBy`, which reads
+// `readMutedIds` — an empty set means no member is muted, so these cases exercise the
+// unchanged (deliver) path. Muted-suppression itself is covered in mute-suppression.unit.test.ts.
+const noMutes = Layer.succeed(Mute, {
+	set: () => Effect.die("Mute.set not exercised"),
+	listMine: () => Effect.die("Mute.listMine not exercised"),
+	readMutedIds: () => Effect.succeed(new Set<string>()),
+});
+
 const requestContext = (on: boolean) =>
 	Layer.mergeAll(
 		flagsStub(on),
@@ -58,6 +68,7 @@ const requestContext = (on: boolean) =>
 		Layer.succeed(RuntimeContext, runtimeContextStub),
 		noRequestFlagOverrides,
 		noopLivePublisher,
+		noMutes,
 	);
 
 describe("voteRecipient — self-suppression, pure", () => {

--- a/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
+++ b/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
@@ -33,6 +33,7 @@ import {Kunye} from "../kunye/Kunye.ts";
 import type {Tier} from "../kunye/standing.ts";
 import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
 import type {VouchLedger} from "../kunye/VouchLedger.ts";
+import {Mute} from "../mute/Mute.ts";
 import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
 import type {Pasaport} from "../pasaport/Pasaport.ts";
 import {noopLive} from "../pasaport/promote-live.testing.ts";
@@ -160,8 +161,17 @@ const voteFailOnContact: Layer.Layer<Vote> = Layer.succeed(Vote, {
 // landed flip — so `LivePublisher` is a static requirement of every case (even a
 // denial). `noopLive` satisfies it universally; the case that actually promotes
 // asserts on nothing published, and the tandem-promote case builds its own record.
+// The divan-vote emit now consults `bildirimMutedBy` (#3238), which reads `Mute` — an
+// empty-set stub means no member is muted, so these cases exercise the deliver path
+// unchanged. Muted-suppression is covered in bildirim/mute-suppression.unit.test.ts.
+const noMutes = Layer.succeed(Mute, {
+	set: () => Effect.die("Mute.set not exercised"),
+	listMine: () => Effect.die("Mute.listMine not exercised"),
+	readMutedIds: () => Effect.succeed(new Set<string>()),
+});
+
 const requestContext = (actor: Actor, on: boolean) =>
-	Layer.mergeAll(flagsStub(on), noopLive).pipe(
+	Layer.mergeAll(flagsStub(on), noopLive, noMutes).pipe(
 		Layer.provideMerge(Layer.succeed(CurrentUser, {user: {id: actorId(actor)} as never})),
 		Layer.provideMerge(Layer.succeed(CurrentActor, {actor})),
 		Layer.provideMerge(Layer.succeed(RuntimeContext, runtimeContextStub)),

--- a/apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts
+++ b/apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts
@@ -25,6 +25,7 @@ import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import type {PublishMessage} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
+import {Mute} from "../mute/Mute.ts";
 import {mutations} from "./mutations.ts";
 import {Pano, type PostSummaryRow, type VoteOnPostResult} from "./Pano.ts";
 
@@ -132,6 +133,14 @@ const notificationStub = makeNotificationStub({
 	recordAggregate: () => Effect.succeed({aggregated: false}),
 });
 
+// The vote emit now consults `bildirimMutedBy` (#3238), which reads `Mute` — an
+// empty-set stub means no member is muted, so the deliver path is unchanged.
+const noMutes = Layer.succeed(Mute, {
+	set: () => Effect.die("Mute.set not exercised"),
+	listMine: () => Effect.die("Mute.listMine not exercised"),
+	readMutedIds: () => Effect.succeed(new Set<string>()),
+});
+
 const drive = (
 	op: (typeof mutations)["post.vote" | "post.retractVote"],
 	pano: Layer.Layer<Pano>,
@@ -141,7 +150,7 @@ const drive = (
 		input: {id: "post_1"},
 		select: ["id", "isSaved", "authorUsername", "authorDisplayName", "myVote", "score"],
 	}).pipe(
-		Effect.provide(Layer.mergeAll(pano, recordingLive(frames), flagsOn, notificationStub)),
+		Effect.provide(Layer.mergeAll(pano, recordingLive(frames), flagsOn, notificationStub, noMutes)),
 		Effect.provideService(CurrentUser, {user: VOTER}),
 		Effect.provideService(RuntimeContext, runtimeContextStub),
 	);

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -31,6 +31,7 @@ import {Flags} from "../flagship/Flags.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import type {Tier} from "../kunye/standing.ts";
 import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
+import {Mute} from "../mute/Mute.ts";
 import {mutations} from "./mutations.ts";
 import {makePasaportStub} from "./Pasaport.testing.ts";
 import {noopLive, relationStoreNoModerators} from "./promote-live.testing.ts";
@@ -95,8 +96,16 @@ const kunyeOf = (
 // promote path, so `LivePublisher` is a static requirement of EVERY case (even a
 // denial that never runs the flip). `noopLive` satisfies it universally here; the
 // vouch/withdraw cases (no `RelationStore` of their own) add `relationStoreNone`.
+// The kefil (vouch) emit now consults `bildirimMutedBy` (#3238), which reads `Mute` —
+// an empty-set stub means no member is muted, so the deliver path is unchanged.
+const noMutes = Layer.succeed(Mute, {
+	set: () => Effect.die("Mute.set not exercised"),
+	listMine: () => Effect.die("Mute.listMine not exercised"),
+	readMutedIds: () => Effect.succeed(new Set<string>()),
+});
+
 const requestContext = (actor: Actor, on: boolean) =>
-	Layer.mergeAll(flagsStub(on), noopLive).pipe(
+	Layer.mergeAll(flagsStub(on), noopLive, noMutes).pipe(
 		Layer.provideMerge(Layer.succeed(CurrentUser, {user: undefined})),
 		Layer.provideMerge(Layer.succeed(CurrentActor, {actor})),
 		Layer.provideMerge(Layer.succeed(RuntimeContext, runtimeContextStub)),


### PR DESCRIPTION
Fixes #3238

## What

ADR 0188 ruled v1 mute (sustur) suppresses the bildirim a muted member's interactions would raise to the muter — not merely a content read-mask. This adds the notification-path suppression the decision explicitly authorized as follow-up.

## How

- New seam `bildirimMutedBy` in `apps/web/worker/features/bildirim/mute-suppression.ts` — the notification analogue of the content read-mask (`features/mute/read-mask.ts`). Given `(recipient = the muter, actor = the interacting member)` it resolves the viewer-scoped `Mute.readMutedIds` set (no divergent muted-id source) and returns whether to suppress, gated behind the default-off `member-mute` flag.
- **Generation-time, not read-time.** The anti-hype vote aggregate stores `actorId: null`, so the interacting member's identity survives only at emit time — a read-time filter on `notification.actor_id` could never suppress an aggregated vote. So the interaction emitters consult the seam before recording: `vote` (`vote-emitters.ts`), `reply` (`conversation-emitters.ts`, per-recipient), and `divan-vote` + `kefil` (`rite-emitters.ts`).
- **Flag-off is byte-for-byte today.** With `member-mute` off (default) the seam short-circuits to `false` before any DB read.

## Scope boundary

- The moderator-queue operational pages (`report-filed` / `caylak-pending`) and system events (`terfi`) are left unchanged. Those are role-scoped operational/system notifications, not "an interaction raised to the muter"; suppressing a moderation signal on a personal mute is a separate decision ADR 0188 does not make (and would create a moderation-integrity gap). `caylak-pending`/`terfi` carry `actorId: null` anyway.
- Block (engelle) remains out of v1 per ADR 0188.

## Tests

- New `bildirim/mute-suppression.unit.test.ts` covers the seam: null-actor → not suppressed (Mute never read), flag-off → not suppressed (Mute never read), non-muted actor → delivered, recipient-muted-actor → suppressed (asserting the read is viewer-scoped to the recipient).
- Existing emitter + mutation tests (vote / reply / divan-vote / kefil callers) updated to provide a no-mutes `Mute` stub, keeping their deliver-path assertions.
- `pnpm typecheck`, `pnpm lint`, and the full `unit` project (2366 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)