### PR TITLE
feat(pipeline-cli): fail-closed unresolved-threads-guard for the ADR-0158 merge gate (#3331)

### DIFF
--- a/.github/workflows/unresolved-threads-guard.yml
+++ b/.github/workflows/unresolved-threads-guard.yml
@@ -1,0 +1,75 @@
+name: unresolved-threads-guard
+
+# CI gate for #3331 (ADR 0158 enforcement). ADR 0158 made an unresolved inline review
+# thread — human OR bot (CodeQL/github-advanced-security) — a merge gate: review-code
+# Step 3e surfaces it in the verdict, ship-it Step 3.6 refuses to enqueue on it. But
+# Step 3e was soft reviewer-prose (a review-code PASS could silently omit the accounting),
+# AND §CP PRs bank for a MANUAL merge that never touches ship-it Step 3.6 — so a §CP PR's
+# only line of defense was that soft prose. On PR #3329 a CodeQL finding on
+# `.github/workflows/commands-guard.yml:35` reached a human merger flagged merge-ready with
+# no flag. This job runs `pipeline-cli unresolved-threads-guard check --pr <n>`: it reads the
+# PR's review threads (the ONE sanctioned GraphQL `reviewThreads` read, ADR 0158 — REST has
+# no isResolved) + the latest author-gated review-code verdict, and reds when a live
+# unresolved thread is unaccounted-for in that verdict. Running on every PR, it covers the
+# §CP manual-merge path the ship-it backstop never sees. Fails closed if it can't read the
+# thread state. The scan/decision live once in the tool.
+#
+# NOTE (founder step, mirrors ADR 0158's founder-gated flag): to HARD-block the merge button
+# this context must be added to the `main protection` ruleset's required_status_checks — a
+# ruleset edit, not a workflow change. Until then the red check SURFACES the finding on the
+# PR (the §CP hole this closes); promoting it to required makes the block enforced. The
+# `merge_group` no-op below keeps it safe to promote without wedging the queue (see there).
+on:
+  pull_request:
+  # If this is later promoted to a required check, the merge queue will await it on the
+  # batched `merge_group` ref. There is no PR number on that event, and ADR 0158's
+  # conversation-resolution gate is a PR-ADMISSION condition (evaluated before the queue adds
+  # the PR), not a batch-merge condition — so the guard's real work already happened at PR
+  # time. Report a trivial green on the batch rather than await a PR number that isn't there
+  # (the leak-guard/ci.yml merge_group pattern, ADR 0132), so promotion can't hang the queue.
+  merge_group:
+
+# Least-privilege GITHUB_TOKEN: the job reads the repo + the PR's review threads, comments,
+# and collaborator permissions, and fails via exit code — it posts no check-run/status/PR
+# comment. `pull-requests: read` covers the reviewThreads GraphQL read + the issue comments;
+# `contents: read` covers checkout. Default-deny every other scope (CodeQL least-privilege).
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: check no unaccounted unresolved review thread reaches merge-ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # On the merge queue's batched ref there is no PR to resolve threads for, and the
+      # PR-admission gate already ran at PR time (ADR 0158/0132) — report green so a required
+      # promotion can't wedge the batch. The real check runs on `pull_request` below.
+      - name: Skip on merge_group (gating happened at PR admission)
+        if: github.event_name == 'merge_group'
+        run: |
+          echo "unresolved-threads-guard: merge_group batch — gated at PR admission (ADR 0158/0132), nothing to re-check."
+
+      # Exit 1 when a substantive unresolved inline review thread (human or CodeQL/GHAS bot)
+      # is unaccounted-for in the latest review-code verdict, or when the review-thread state
+      # can't be read (fail-closed). See #3331 / ADR 0158.
+      - name: Check for unaccounted unresolved review threads
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node packages/pipeline-cli/src/bin.ts unresolved-threads-guard check --pr "${{ github.event.pull_request.number }}"

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1181,6 +1181,18 @@ Surfacing the thread here does **not** resolve it or merge past it — the split
 that refuses to enqueue on a substantive unresolved thread; this step makes the same objection
 **visible at review time**, so it never reaches merge unread.
 
+**This step is machine-enforced fail-closed — it is no longer on your memory (#3331).** The
+`unresolved-threads-guard` CI job (`pipeline-cli unresolved-threads-guard check --pr <n>`,
+`.github/workflows/unresolved-threads-guard.yml`) independently reads the same `reviewThreads`
+state and **reds the PR when a live unresolved thread is unaccounted-for in this verdict** — so a
+`review-code: PASS` that silently omits the accounting cannot pass (the #3329 defect it closes), and
+because it runs on **every** PR it also covers the **§CP manual-merge path**, which never touches
+ship-it Step 3.6. To satisfy the guard, an unresolved substantive thread's accounting row **must name
+its exact `path:line` token** (e.g. `.github/workflows/commands-guard.yml:35`) — that token, verbatim,
+is the guard's accounting key. The only other discharge is ADR 0158's nit path: **resolve the thread
+with a written rationale** (which clears `isResolved`), never a silent skip. Do not rely on
+remembering this row — the guard fails closed if you forget it.
+
 ### Step 3f — Session-caching two-axis staleness gate (ADR 0169)
 
 Session freshness is **security-load-bearing** and a session-perf/caching review is a **two-axis

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -208,6 +208,13 @@ don't re-derive it. The has-code/docs-exclusion probes both name `.glossary/**` 
 **code**, never docs (the #663/#919 agreement invariant). If the diff is **glossary-only**, report
 `not a doc PR — route to review-code` (a plain note, **not** a `review-doc:` marker) and stop.
 
+**Unresolved inline review threads are not yours to gate either.** `review-doc` has **no**
+unresolved-thread step (the ADR-0158 read lives only in `review-code` Step 3e and `ship-it`
+Step 3.6). Do not add one and do not treat a `review-doc: PASS` as attesting anything about
+inline threads — that channel is enforced fail-closed by the `unresolved-threads-guard` CI job
+on every PR (`.github/workflows/unresolved-threads-guard.yml`, ADR 0158/#3331), independent of
+which review gate ran.
+
 If the diff is **pure product code** with no doc/knowledge file at all, this is the wrong
 gate — that's `review-code`'s PR. Report `not a doc PR — route to review-code` (a plain note,
 **not** a `review-doc:` marker — there's no doc to verdict) and stop.

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -52,6 +52,7 @@ import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
 import {tokenSpendCommand} from "./tools/token-spend/command.ts";
 import {trivialDiffCommand} from "./tools/trivial-diff/command.ts";
+import {unresolvedThreadsGuardCommand} from "./tools/unresolved-threads-guard/command.ts";
 import {verdictCommand} from "./tools/verdict/command.ts";
 import {wayfinderMapCommand} from "./tools/wayfinder-map/command.ts";
 import {workflowContractCommand} from "./tools/workflow-contract/command.ts";
@@ -138,4 +139,8 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	intakeDedupCommand,
 	redactLeaksCommand,
 	commandsCommand,
+	// The ADR-0158 unresolved-inline-thread merge gate's fail-closed enforcement (#3331):
+	// reds a PR when a substantive unresolved review thread is unaccounted-for in the
+	// review-code verdict, covering the §CP manual-merge path ship-it Step 3.6 never sees.
+	unresolvedThreadsGuardCommand,
 ];

--- a/packages/pipeline-cli/src/tools/unresolved-threads-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/unresolved-threads-guard/command.ts
@@ -1,0 +1,84 @@
+/**
+ * The `unresolved-threads-guard` tool — `pipeline-cli unresolved-threads-guard check --pr N`
+ * (ADR 0158 enforcement, #3331).
+ *
+ * The fail-closed machine gate behind ADR 0158's unresolved-inline-thread merge gate, giving
+ * review-code Step 3e the teeth it lacked (soft reviewer-prose a PASS could omit) AND covering
+ * the §CP manual-merge path, which never touches ship-it Step 3.6. It reds when a live
+ * unresolved inline review thread (human OR github-advanced-security[bot]/CodeQL) is
+ * unaccounted-for in the latest authorized review-code verdict — the scan/IO lives in
+ * `github.ts`, the decision in the pure core (`unresolved-threads-guard.ts`).
+ *
+ *   pipeline-cli unresolved-threads-guard check --pr <n>
+ *
+ * Exit-code contract: 0 = clean (no unaccounted unresolved thread), non-zero = failure — a
+ * gate failure (report on stderr) AND an IO failure that can't determine thread state both
+ * exit non-zero, FAIL-CLOSED: an unreadable review-thread channel reds rather than waves the
+ * PR through (ADR 0092's zero-scope stance at the unreadable-channel seam). `GithubLive` is
+ * baked in with `Command.provide(...)` so the registered command's residual requirement is the
+ * Node platform union (the registry seam, epic #994).
+ */
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {Github, GithubLive} from "./github.ts";
+import {judge} from "./unresolved-threads-guard.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+
+const prFlag = Flag.integer("pr").pipe(
+	Flag.withDescription(
+		"the pull request number to check for unaccounted unresolved review threads",
+	),
+);
+
+/** Print `reason` on stderr and exit non-zero — both a gate fail and an unreadable-channel fail. */
+const failClosed = (reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stderr.write(`${reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{pr: prFlag},
+	Effect.fn(function* ({pr}) {
+		// Any failure to READ the thread state (repo unresolved, gh non-zero, malformed JSON)
+		// fails closed: the guard reds rather than passing a PR whose review-thread channel it
+		// could not read (the ADR 0092 zero-scope stance — an unreadable channel is not a clean one).
+		const result = yield* (yield* Github).gather(pr).pipe(
+			Effect.catchTags({
+				"@kampus/unresolved-threads-guard/RepoResolutionError": (e) => failClosed(e.message),
+				"@kampus/unresolved-threads-guard/GhCommandError": (e) =>
+					failClosed(
+						`unresolved-threads-guard: could not read PR #${pr} review-thread state (gh exit ${e.exitCode}: ${e.stderr.trim() || "no stderr"}) — failing closed`,
+					),
+				"@kampus/unresolved-threads-guard/GhParseError": (e) =>
+					failClosed(
+						`unresolved-threads-guard: could not parse PR #${pr} review-thread state (${e.message}) — failing closed`,
+					),
+				SchemaError: (e) =>
+					failClosed(
+						`unresolved-threads-guard: unexpected review-thread/comment shape for PR #${pr} (${e.message}) — failing closed`,
+					),
+			}),
+		);
+		const verdict = judge(result);
+		if (verdict.pass) {
+			yield* Console.log(verdict.report);
+			return;
+		}
+		return yield* failClosed(verdict.report);
+	}),
+).pipe(
+	Command.withDescription(
+		"Red the PR when a substantive unresolved inline review thread is unaccounted-for in the review-code verdict",
+	),
+);
+
+export const unresolvedThreadsGuardCommand = Command.make("unresolved-threads-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: no unaccounted unresolved inline review thread reaches a merge-ready PR (ADR 0158, #3331)",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/unresolved-threads-guard/github.ts
+++ b/packages/pipeline-cli/src/tools/unresolved-threads-guard/github.ts
@@ -1,0 +1,335 @@
+/**
+ * The GitHub boundary for `unresolved-threads-guard`: the live `Github` capability that
+ * gathers a PR's review threads + its latest authorized review-code verdict body, driving
+ * the IO-free `unresolved-threads-guard.ts` core.
+ *
+ * Same `Context.Service` on `ChildProcessSpawner` shape as the `verdict` service (LLMS.md
+ * §"Writing Effect services" / Context.Service): every infra failure a typed error in the
+ * `E` channel (`GhCommandError` / `GhParseError` / `RepoResolutionError`), untrusted output
+ * Schema-decoded at the boundary.
+ *
+ * REST for everything EXCEPT the one read ADR 0158 sanctions as the single GraphQL exception:
+ * inline-thread RESOLUTION state (`isResolved`) is a GraphQL-only field — the REST
+ * `pulls/{n}/comments` endpoint exposes the comments but has no `isResolved`, so it cannot
+ * tell resolved from unresolved (ADR 0158; verified working on this org, the Projects-classic
+ * breakage is scoped to Projects fields, not `reviewThreads`).
+ *
+ * One verb — `gather(pr)`:
+ *   1. `reviewThreads` (GraphQL, the sanctioned exception) → the PR's threads with resolution state;
+ *   2. the PR's issue comments (REST), author-gated to write+ collaborators (ADR 0055), latest
+ *      `review-code:` marker by (created_at, id) → the verdict body the core checks accounting against.
+ * A forged `review-code: PASS … path:line` marker from a non-collaborator can't spoof accounting:
+ * the author-gate drops it before it can count.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {isReviewCodeVerdict, type ReviewThread} from "./unresolved-threads-guard.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, a GraphQL error, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/unresolved-threads-guard/GhCommandError",
+	{args: Schema.Array(Schema.String), exitCode: Schema.Number, stderr: Schema.String},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/unresolved-threads-guard/GhParseError",
+	{args: Schema.Array(Schema.String), message: Schema.String},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/unresolved-threads-guard/RepoResolutionError",
+	{message: Schema.String},
+) {}
+
+/** The gathered facts the pure core judges: the PR's threads + its latest authorized verdict body. */
+export interface GatherResult {
+	readonly threads: ReadonlyArray<ReviewThread>;
+	readonly verdictBody: string | null;
+}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the
+ * direct-spawn shape `verdict`/`epic-lock` use, so a non-zero exit + stderr lower into a
+ * typed error rather than a throw (LLMS.md §"Working with child processes"). A spawn/IO
+ * `PlatformError` (`gh` not on PATH) folds in as exit `-1`.
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
+ * defaults — with no env and no resolvable current repo it fails `RepoResolutionError`.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/unresolved-threads-guard/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// The ONE GraphQL read the guard makes — ADR 0158's single sanctioned exception (REST has no
+// isResolved). `first:100` matches Step 3e's read; a PR with >100 threads is far outside any
+// real pipeline PR and would surface its first 100.
+const REVIEW_THREADS_QUERY = `
+	query($o:String!,$n:String!,$pr:Int!) {
+		repository(owner:$o, name:$n) {
+			pullRequest(number:$pr) {
+				reviewThreads(first:100) {
+					nodes {
+						isResolved
+						isOutdated
+						path
+						line
+						comments(first:1) { nodes { author { login } body } }
+					}
+				}
+			}
+		}
+	}`;
+
+const reviewThreadsArgs = (owner: string, name: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	"graphql",
+	"-f",
+	`query=${REVIEW_THREADS_QUERY}`,
+	"-F",
+	`o=${owner}`,
+	"-F",
+	`n=${name}`,
+	"-F",
+	`pr=${pr}`,
+];
+
+const listCommentsArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${pr}/comments?per_page=100`,
+];
+
+const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/collaborators/${login}/permission`,
+	"--jq",
+	".permission",
+];
+
+/** The GraphQL `reviewThreads` response shape — only the fields the guard reads. */
+const RawThread = Schema.Struct({
+	isResolved: Schema.Boolean,
+	isOutdated: Schema.Boolean,
+	path: Schema.NullOr(Schema.String),
+	line: Schema.NullOr(Schema.Number),
+	comments: Schema.Struct({
+		nodes: Schema.Array(
+			Schema.Struct({
+				author: Schema.NullOr(Schema.Struct({login: Schema.String})),
+				body: Schema.NullOr(Schema.String),
+			}),
+		),
+	}),
+});
+const ReviewThreadsResponse = Schema.Struct({
+	data: Schema.Struct({
+		repository: Schema.Struct({
+			pullRequest: Schema.Struct({
+				reviewThreads: Schema.Struct({nodes: Schema.Array(RawThread)}),
+			}),
+		}),
+	}),
+});
+const decodeThreads = Schema.decodeUnknownEffect(ReviewThreadsResponse);
+
+/** A raw issue comment as the REST endpoint returns it; only these fields are read. */
+const RawComment = Schema.Struct({
+	id: Schema.Number,
+	created_at: Schema.String,
+	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
+});
+const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+const EXCERPT_LEN = 200;
+
+const toReviewThread = (raw: (typeof RawThread)["Type"]): ReviewThread => {
+	const first = raw.comments.nodes[0];
+	return {
+		isResolved: raw.isResolved,
+		isOutdated: raw.isOutdated,
+		path: raw.path,
+		line: raw.line,
+		author: first?.author?.login ?? null,
+		excerpt: (first?.body ?? "").slice(0, EXCERPT_LEN),
+	};
+};
+
+const readThreads = Effect.fn("Github.readThreads")(function* (repo: string, pr: number) {
+	const [owner, name] = repo.split("/");
+	const args = reviewThreadsArgs(owner ?? "", name ?? "", pr);
+	const decoded = yield* decodeThreads(yield* json(args));
+	return decoded.data.repository.pullRequest.reviewThreads.nodes.map(toReviewThread);
+});
+
+/**
+ * The write+ collaborator subset of `logins` — the ADR 0055 trust root. Each login is probed
+ * with `collaborators/<login>/permission`; a non-`admin|maintain|write` permission, or any
+ * `gh` fault (a non-collaborator commonly 404s), drops the login. A forged review-code marker
+ * from a non-collaborator therefore never counts as accounting.
+ */
+const authorizedAuthors = Effect.fn("Github.authorizedAuthors")(function* (
+	repo: string,
+	logins: ReadonlyArray<string>,
+) {
+	const results = yield* Effect.forEach(
+		logins,
+		(login) =>
+			runGh(permissionArgs(repo, login)).pipe(
+				Effect.map((out) => ({login, permission: out.trim()})),
+				Effect.catchTag("@kampus/unresolved-threads-guard/GhCommandError", () =>
+					Effect.succeed({login, permission: "none"}),
+				),
+			),
+		{concurrency: "unbounded"},
+	);
+	return new Set(
+		results
+			.filter(
+				(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
+			)
+			.map((r) => r.login),
+	);
+});
+
+/**
+ * Resolve the latest AUTHORIZED review-code verdict body on the PR, or null. Filter the PR's
+ * comments to `review-code:` markers, author-gate the distinct authors to write+ collaborators
+ * (ADR 0055), keep only authorized markers, take the newest by (created_at, id) — the same
+ * latest-wins the verdict tool resolves with.
+ */
+const readVerdictBody = Effect.fn("Github.readVerdictBody")(function* (repo: string, pr: number) {
+	const raw = yield* decodeComments(yield* json(listCommentsArgs(repo, pr)));
+	const markers = raw
+		.map((c) => ({
+			id: c.id,
+			createdAt: c.created_at,
+			author: c.user?.login ?? "",
+			body: c.body ?? "",
+		}))
+		.filter((c) => c.author.length > 0 && isReviewCodeVerdict(c.body));
+	if (markers.length === 0) return null;
+	const authors = [...new Set(markers.map((m) => m.author))];
+	const authorized = yield* authorizedAuthors(repo, authors);
+	const trusted = markers.filter((m) => authorized.has(m.author));
+	if (trusted.length === 0) return null;
+	trusted.sort((a, b) =>
+		a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id,
+	);
+	return trusted[trusted.length - 1]?.body ?? null;
+});
+
+const gather = Effect.fn("Github.gather")(function* (repo: string, pr: number) {
+	const [threads, verdictBody] = yield* Effect.all(
+		[readThreads(repo, pr), readVerdictBody(repo, pr)],
+		{concurrency: "unbounded"},
+	);
+	return {threads, verdictBody} satisfies GatherResult;
+});
+
+/**
+ * `Github` — the IO shell over `gh` for the unresolved-threads gate. `gather(pr)` returns the
+ * PR's review threads + its latest authorized review-code verdict body; the command runs the
+ * pure `judge` over the result. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly gather: (
+			pr: number,
+		) => Effect.Effect<
+			GatherResult,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/unresolved-threads-guard/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once and
+ * provided into the method body, so the public method carries `R = never`. Repo resolution
+ * is deferred to first use (`Effect.cached`, ADR 0062 §1): the layer build is side-effect
+ * free, and `RepoResolutionError` lives in the method's `E` channel.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				gather: (pr) => repo.pipe(Effect.flatMap((r) => withSpawner(gather(r, pr)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/unresolved-threads-guard/unresolved-threads-guard.ts
+++ b/packages/pipeline-cli/src/tools/unresolved-threads-guard/unresolved-threads-guard.ts
@@ -1,0 +1,133 @@
+/**
+ * The pure core of `unresolved-threads-guard` — IO-free, total, unit-testable.
+ *
+ * Gives ADR-0158's unresolved-inline-thread merge gate the machine teeth it lacked:
+ * review-code Step 3e ("surface an unresolved thread in the verdict") was soft
+ * reviewer-prose, so a review-code agent could post `PASS … merge-ready` while omitting
+ * the `unresolved-threads` accounting entirely — and for a §CP PR (which banks for manual
+ * merge and never touches ship-it Step 3.6, the terminal enqueue refusal) that soft prose
+ * was the ONLY line of defense. That is exactly what happened on PR #3329: a CodeQL/GHAS
+ * inline finding reached a human merger flagged merge-ready with no flag (#3331).
+ *
+ * The decision this core encodes: an unresolved inline review thread (human OR bot) is
+ * unaccounted-for unless the latest authorized review-code verdict body NAMES its site
+ * token (`path:line`). An unaccounted live thread reds the gate. This is polarity-blind —
+ * a correctly-surfaced substantive thread lands as a `[FAIL] unresolved-threads — path:line`
+ * row (accounted here; the FAIL blocks merge on its own), while a PASS that omits the row
+ * (the #3329 bug) leaves the thread unaccounted → red. It does NOT re-decide ADR 0158's
+ * substantive-vs-nit policy: a genuine nit is discharged the ADR-0158 way — resolve the
+ * thread with a written rationale (isResolved=true removes it from the live set), never a
+ * silent whole-channel skip. See ADR 0158.
+ *
+ * The `review-code:` marker grammar is single-sourced from `verdict-match.ts` (`namespaceRe`),
+ * not re-derived; the IO shell (`github.ts`) resolves the authorized latest verdict body and
+ * the PR's review threads and drives this decision at the boundary.
+ */
+import {namespaceRe} from "../verdict/verdict-match.ts";
+
+/**
+ * One PR review thread as ADR-0158's sanctioned GraphQL `reviewThreads` read surfaces it.
+ * `line`/`path` are null for a pr-level or file-level thread; `author` is the first
+ * comment's login (the bot/human that opened the thread); `excerpt` is a short slice of the
+ * opening comment for the CI report.
+ */
+export interface ReviewThread {
+	readonly isResolved: boolean;
+	readonly isOutdated: boolean;
+	readonly path: string | null;
+	readonly line: number | null;
+	readonly author: string | null;
+	readonly excerpt: string;
+}
+
+/**
+ * The stable site token — both the CI report's identifier and the accounting key the
+ * verdict must name. `path:line` matches Step 3e's documented row format exactly; a
+ * line-less thread degrades to the bare path, and a path-less (pr-level) thread to a fixed
+ * sentinel that a verdict cannot coincidentally satisfy (so it fails closed as unaccounted).
+ */
+export const siteToken = (thread: ReviewThread): string => {
+	if (thread.path === null) return "(pr-level review thread)";
+	return thread.line !== null ? `${thread.path}:${thread.line}` : thread.path;
+};
+
+/**
+ * The live-unresolved set — the EXACT set Step 3e's GraphQL read surfaces: `isResolved`
+ * false. `isOutdated` is captured for the report but does NOT exempt a thread: the
+ * ADR-0158 sanctioned read keys solely on `isResolved`, and an outdated-but-unresolved
+ * thread is still an unaddressed objection until its author resolves it — inventing an
+ * `isOutdated` exemption the sanctioned read doesn't make would be a silent fail-open.
+ */
+export const liveUnresolved = (threads: ReadonlyArray<ReviewThread>): ReadonlyArray<ReviewThread> =>
+	threads.filter((thread) => !thread.isResolved);
+
+/**
+ * Is this thread accounted-for in the latest authorized review-code verdict? True iff the
+ * verdict body names the thread's `siteToken`. A null body (no authorized review-code
+ * verdict yet) accounts for nothing — every live thread is then unaccounted (fail-closed:
+ * a PR is not merge-ready with an unresolved thread and no verdict naming it).
+ */
+export const isAccounted = (thread: ReviewThread, verdictBody: string | null): boolean =>
+	verdictBody === null ? false : verdictBody.includes(siteToken(thread));
+
+/** Is `body` a review-code verdict marker (its first line opens with `review-code:`)? */
+export const isReviewCodeVerdict = (body: string): boolean => namespaceRe("code").test(body);
+
+export interface JudgeInput {
+	readonly threads: ReadonlyArray<ReviewThread>;
+	/** The latest AUTHORIZED (write+ collaborator) review-code verdict body, or null if none. */
+	readonly verdictBody: string | null;
+}
+
+export interface Verdict {
+	readonly pass: boolean;
+	readonly unaccounted: ReadonlyArray<ReviewThread>;
+	readonly report: string;
+}
+
+/**
+ * The gate decision: red when any live-unresolved thread is unaccounted-for in the latest
+ * review-code verdict. Zero threads, or every live thread accounted, passes — zero threads
+ * is a real, common, valid state (nothing to gate), NOT a broken scan, so it is a clean
+ * pass rather than a fail-closed zero-scope red; the fail-closed-on-unreadable case lives in
+ * the IO shell, which reds when it cannot READ the thread state at all (ADR 0092's
+ * zero-scope stance applied at the right seam — an unreadable channel, not an empty one).
+ */
+export const judge = (input: JudgeInput): Verdict => {
+	const live = liveUnresolved(input.threads);
+	const unaccounted = live.filter((thread) => !isAccounted(thread, input.verdictBody));
+	const pass = unaccounted.length === 0;
+	return {pass, unaccounted, report: renderReport(input, live, unaccounted)};
+};
+
+const describeThread = (thread: ReviewThread): string => {
+	const who = thread.author ? `@${thread.author}` : "(unknown author)";
+	const outdated = thread.isOutdated ? " [outdated]" : "";
+	const excerpt = thread.excerpt.trim().replace(/\s+/g, " ");
+	return `${siteToken(thread)} ${who}${outdated}: "${excerpt}"`;
+};
+
+const renderReport = (
+	input: JudgeInput,
+	live: ReadonlyArray<ReviewThread>,
+	unaccounted: ReadonlyArray<ReviewThread>,
+): string => {
+	if (unaccounted.length === 0) {
+		const scanned = input.threads.length;
+		if (scanned === 0) return "unresolved-threads-guard: no review threads on this PR — clean.";
+		return `unresolved-threads-guard: scanned ${scanned} review thread(s), ${live.length} unresolved, all accounted-for in the review-code verdict — clean.`;
+	}
+	const rows = unaccounted.map((thread) => `  - ${describeThread(thread)}`).join("\n");
+	const verdictState =
+		input.verdictBody === null
+			? "there is no authorized review-code verdict naming it yet"
+			: "the latest review-code verdict does not name its path:line";
+	return [
+		`unresolved-threads-guard: ${unaccounted.length} substantive unresolved inline review thread(s) are unaccounted-for — ${verdictState}.`,
+		rows,
+		"",
+		"Per ADR 0158, discharge each by EITHER resolving the thread with a written rationale (a genuine nit),",
+		"OR surfacing it in the review-code verdict as a `[FAIL] unresolved-threads — path:line ...` row (a real",
+		"objection, which routes back to write-code). A review-code PASS cannot silently omit an unresolved thread.",
+	].join("\n");
+};

--- a/packages/pipeline-cli/src/tools/unresolved-threads-guard/unresolved-threads-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/unresolved-threads-guard/unresolved-threads-guard.unit.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Pure-core tests for `unresolved-threads-guard` (ADR 0158 enforcement, #3331). The gate
+ * decision over fixtures — deterministic, no live PR state:
+ *   - the #3329 exemplar reproduction: an unresolved GHAS/CodeQL thread on
+ *     `.github/workflows/commands-guard.yml:35` + a review-code PASS with NO accounting row
+ *     → RED, naming that thread (AC: re-running the check against #3329's state surfaces it);
+ *   - a resolved thread, or zero threads → clean pass;
+ *   - a substantive thread accounted-for by a `[FAIL] unresolved-threads — path:line` row → pass;
+ *   - a human inline thread on the same footing as a bot thread;
+ *   - null verdict (review-code hasn't posted) with a live thread → RED (fail-closed);
+ *   - a nit resolved-with-rationale (isResolved=true) → pass (ADR 0158 discharge path);
+ *   - accounting keys on the exact path:line (a different site's accounting doesn't cover it).
+ * The IO seam (GraphQL threads read + author-gated verdict body) lives in `github.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	isAccounted,
+	isReviewCodeVerdict,
+	judge,
+	liveUnresolved,
+	type ReviewThread,
+	siteToken,
+} from "./unresolved-threads-guard.ts";
+
+const thread = (over: Partial<ReviewThread> = {}): ReviewThread => ({
+	isResolved: false,
+	isOutdated: false,
+	path: "apps/web/worker/features/pano/mutations.ts",
+	line: 18,
+	author: "github-code-quality",
+	excerpt: "Unused import PHOENIX_KARMA_GATES",
+	...over,
+});
+
+// The #3329 exemplar: the CodeQL/GHAS inline finding on the commands-guard workflow.
+const codeqlThread = thread({
+	path: ".github/workflows/commands-guard.yml",
+	line: 35,
+	author: "github-advanced-security",
+	excerpt: "Workflow does not contain permissions",
+});
+
+// A review-code PASS marker with NO unresolved-threads accounting — the #3329 bug shape.
+const passNoAccounting =
+	"review-code: PASS @ 4da28749abc0000000000000000000000000000 — AC met, merge-ready";
+
+describe("siteToken", () => {
+	it("is path:line when both present (Step 3e's documented row format)", () => {
+		expect(siteToken(codeqlThread)).toBe(".github/workflows/commands-guard.yml:35");
+	});
+	it("degrades to the bare path when line is null", () => {
+		expect(siteToken(thread({line: null}))).toBe("apps/web/worker/features/pano/mutations.ts");
+	});
+	it("is a non-satisfiable sentinel for a path-less pr-level thread", () => {
+		expect(siteToken(thread({path: null, line: null}))).toBe("(pr-level review thread)");
+	});
+});
+
+describe("liveUnresolved", () => {
+	it("keeps isResolved=false and drops resolved threads, regardless of isOutdated", () => {
+		const threads = [
+			thread({isResolved: false, isOutdated: false}),
+			thread({isResolved: false, isOutdated: true}),
+			thread({isResolved: true, isOutdated: false}),
+		];
+		expect(liveUnresolved(threads)).toHaveLength(2);
+	});
+});
+
+describe("isAccounted", () => {
+	it("is false against a null verdict body", () => {
+		expect(isAccounted(codeqlThread, null)).toBe(false);
+	});
+	it("is true when the verdict names the exact path:line", () => {
+		const verdict = `review-code: FAIL @ deadbeef\n- [FAIL] unresolved-threads — ${siteToken(codeqlThread)} @github-advanced-security: "no permissions" is substantive (ADR 0158)`;
+		expect(isAccounted(codeqlThread, verdict)).toBe(true);
+	});
+	it("is false when the verdict names a DIFFERENT site (accounting is per-site)", () => {
+		const verdict =
+			"review-code: FAIL @ deadbeef\n- [FAIL] unresolved-threads — apps/web/worker/features/pano/mutations.ts:18 substantive";
+		expect(isAccounted(codeqlThread, verdict)).toBe(false);
+	});
+});
+
+describe("isReviewCodeVerdict", () => {
+	it("matches a review-code marker on line one", () => {
+		expect(isReviewCodeVerdict(passNoAccounting)).toBe(true);
+	});
+	it("does not match a review-doc marker or chatter", () => {
+		expect(isReviewCodeVerdict("review-doc: PASS @ abc123")).toBe(false);
+		expect(isReviewCodeVerdict("just a normal comment")).toBe(false);
+	});
+});
+
+describe("judge", () => {
+	it("REDS the #3329 exemplar: unresolved CodeQL thread + a PASS with no accounting row", () => {
+		const verdict = judge({threads: [codeqlThread], verdictBody: passNoAccounting});
+		expect(verdict.pass).toBe(false);
+		expect(verdict.unaccounted).toHaveLength(1);
+		expect(verdict.report).toContain(".github/workflows/commands-guard.yml:35");
+		expect(verdict.report).toContain("github-advanced-security");
+	});
+
+	it("passes when there are zero review threads (nothing to gate — a valid state)", () => {
+		const verdict = judge({threads: [], verdictBody: passNoAccounting});
+		expect(verdict.pass).toBe(true);
+		expect(verdict.report).toContain("no review threads");
+	});
+
+	it("passes when the only thread is resolved (ADR 0158 nit discharge: resolve-with-rationale)", () => {
+		const verdict = judge({
+			threads: [codeqlThread, thread({isResolved: true})],
+			verdictBody: passNoAccounting,
+		});
+		// codeqlThread is still live+unaccounted here, so this asserts the resolved one is dropped:
+		expect(verdict.unaccounted).toHaveLength(1);
+		expect(verdict.unaccounted[0]?.author).toBe("github-advanced-security");
+	});
+
+	it("passes when EVERY live thread is resolved", () => {
+		const verdict = judge({
+			threads: [thread({isResolved: true}), {...codeqlThread, isResolved: true}],
+			verdictBody: null,
+		});
+		expect(verdict.pass).toBe(true);
+	});
+
+	it("passes when a substantive thread is accounted-for by a FAIL unresolved-threads row", () => {
+		const accounted = `review-code: FAIL @ 4da28749abc — one criterion unmet\n- [FAIL] unresolved-threads — ${siteToken(codeqlThread)} @github-advanced-security: "no permissions" → address on the branch (ADR 0158)`;
+		const verdict = judge({threads: [codeqlThread], verdictBody: accounted});
+		expect(verdict.pass).toBe(true);
+	});
+
+	it("REDS a HUMAN inline thread on the same footing as a bot thread (ADR 0158 human-or-bot)", () => {
+		const human = thread({author: "cansirin", excerpt: "handle the null case here"});
+		const verdict = judge({threads: [human], verdictBody: passNoAccounting});
+		expect(verdict.pass).toBe(false);
+		expect(verdict.report).toContain("@cansirin");
+	});
+
+	it("REDS a live thread when review-code has posted NO verdict yet (fail-closed)", () => {
+		const verdict = judge({threads: [codeqlThread], verdictBody: null});
+		expect(verdict.pass).toBe(false);
+		expect(verdict.report).toContain("no authorized review-code verdict naming it yet");
+	});
+
+	it("REDS a mix: accounts for one thread, reds the other unaccounted one", () => {
+		const other = thread({path: "apps/web/worker/features/sozluk/mutations.ts", line: 42});
+		const partial = `review-code: PASS @ abc\n- [FAIL] unresolved-threads — ${siteToken(codeqlThread)} substantive`;
+		const verdict = judge({threads: [codeqlThread, other], verdictBody: partial});
+		expect(verdict.pass).toBe(false);
+		expect(verdict.unaccounted).toHaveLength(1);
+		expect(verdict.unaccounted[0]?.path).toBe("apps/web/worker/features/sozluk/mutations.ts");
+	});
+});


### PR DESCRIPTION
Fixes #3331

## What & why

ADR [0158](.decisions/0158-unresolved-review-thread-is-a-merge-gate.md) made an unresolved inline review thread (human OR CodeQL/GHAS bot) a merge gate: `review-code` Step 3e surfaces it in the verdict, `ship-it` Step 3.6 refuses to enqueue on it. Two holes let a finding through anyway (grounded on PR #3329):

1. **Step 3e was unenforced reviewer-prose** — a `review-code` agent could post `PASS … merge-ready` while omitting the `unresolved-threads` accounting entirely, and nothing caught the omission (unlike `readme-guard`/`catalog-guard`/`fanout-guard`).
2. **§CP PRs bypass the terminal backstop** — a §CP PR banks for a manual merge and never touches `ship-it` Step 3.6, so for a §CP PR the soft Step 3e was the *only* line of defense. On #3329 a CodeQL finding on `.github/workflows/commands-guard.yml:35` reached a human merger flagged merge-ready with no flag.

This gives the ADR-0158 channel **machine teeth that cover the §CP path** — it hardens ADR 0158's enforcement, it does **not** re-open its policy (no new ADR).

## The fix

- **New guard** `pipeline-cli unresolved-threads-guard check --pr N` (`packages/pipeline-cli/src/tools/unresolved-threads-guard/`): pure unit-tested core + `github.ts` IO shell + thin Effect command, mirroring `readme`/`catalog`/`fanout`/`verdict` and the `effect-process-cli-shell` pattern. It reads the PR's review threads via the **one sanctioned GraphQL `reviewThreads` read** (ADR 0158 — REST exposes no `isResolved`) and the latest **author-gated** (ADR 0055 write+) `review-code` verdict, and **reds when a live unresolved thread is unaccounted-for** by its `path:line` token. Registered in `registry.ts` as its own appended block.
- **CI job** `.github/workflows/unresolved-threads-guard.yml` runs it on **every PR**, so it **covers the §CP manual-merge path** `ship-it` Step 3.6 never sees. Least-privilege token; a `merge_group` no-op keeps it safe to promote to a required check without wedging the queue.
- **Fail-closed / zero-scope** — an *unreadable* thread channel reds (ADR 0092 at the right seam); zero threads is a clean pass (a real, valid state, not a broken scan).
- **Skill prose** — `review-code` Step 3e now points at the enforcing guard and mandates the `path:line` accounting token; `review-doc` notes thread-gating is the CI guard's job (it has no unresolved-thread step).

## Discharge policy (unchanged, ADR 0158)

A genuine nit is **resolved-with-rationale** (clears `isResolved` → drops from the live set); a real objection is a `[FAIL] unresolved-threads — path:line` row that **routes back** to write-code — never a silent whole-channel skip. CodeQL/GHAS threads are on the same footing as human threads.

## Acceptance criteria

- [x] A `review-code` PASS cannot coexist with a substantive unresolved thread unaccounted-for (fail-closed, machine-enforced).
- [x] Enforcement covers the §CP manual-merge path (runs on every PR).
- [x] CodeQL/GHAS inline threads treated as human threads; benign-nit handling follows ADR 0158 default-route-back.
- [x] **Re-running against PR #3329's state** surfaces the `.github/workflows/commands-guard.yml:35` CodeQL thread — covered deterministically by the `unresolved-threads-guard.unit.test.ts` fixture (an unresolved GHAS thread + a PASS verdict with no accounting row → RED naming that thread), since #3329's live thread is now resolved. Live end-to-end run against #3329 executes cleanly (`scanned 1 review thread, 0 unresolved … clean`), proving the GraphQL + REST + author-gate IO path.

## Verification

`pnpm typecheck`, `biome check`, and the full pipeline-cli vitest suite (1359 tests incl. 17 new) all green; `actionlint` clean on the new workflow.

## §CP — reviewed-ready, do not enqueue/merge

This PR edits `review-code`/`review-doc` skills + `pipeline-cli` + `.github/workflows/**` (all match `CONTROL_PLANE_RE`), so it **banks at cansirin for approval** and does **not** auto-merge. Promoting the new check into the `main protection` required-status-checks ruleset is a **founder ruleset step** (mirrors ADR 0158's founder-gated flag) — until then the red check surfaces the finding on the PR; promotion makes it a hard block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)