### PR TITLE
feat(pipeline-crew): the one stand-up command — compose the launcher pipeline + standup barrel (#3299)

### DIFF
--- a/claude-plugins/pipeline-crew/PERSONALIZATION.md
+++ b/claude-plugins/pipeline-crew/PERSONALIZATION.md
@@ -99,6 +99,25 @@ cp "${CLAUDE_PLUGIN_ROOT}/crew.config.template.jsonc" .claude/crew.config.jsonc
 echo ".claude/crew.config.jsonc" >> .gitignore
 ```
 
+### The one stand-up command
+
+Once the config is filled, boot the whole crew from it in **one command** — `/stand-up`
+(the plugin's thin [`commands/stand-up.md`](commands/stand-up.md)), which invokes the
+`@kampus/pipeline-crew-mcp` substrate's `stand-up` subcommand (ADR
+[0192](../../.decisions/0192-standup-launcher-crew-mcp-subcommand.md)):
+
+```bash
+pipeline-crew-mcp stand-up            # defaults --project-root to the working directory
+```
+
+It resolves the config through the **same** `$CREW_CONFIG` → `.claude/crew.config.jsonc`
+order as every seam key, asserts the pinned CLI version, ensures the tracker, derives the
+roster session set, and launches every session bound to its role lease and placed in tmux —
+**fail-loud with no partial crew**: a missing or malformed launch dimension (or `tmux`
+dimension) aborts the launch naming that dimension, before any session starts. The
+launch-dimension reader ([`config.ts`](../../packages/pipeline-crew-mcp/src/standup/config.ts))
+is the fail-closed validator for the `cliVersion` / `engineCount` / `channels` dimensions.
+
 The three-session tmux topology the config drives (intake → execution → human) and the
 full stand-up walkthrough are the pipeline-crew **README**'s scope (issue #2356); this doc
 owns the *seam* — the config mechanism and the dimension contract.

--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -157,11 +157,47 @@ The model tiers are load-bearing, not cosmetic: because the ephemeral pipeline a
 subagent it spawns. Bring the **engineering-manager** up on the build tier and the intake
 session on the planning tier — the config records which is which so no role guesses.
 
-## Stand up the three tmux sessions
+## Stand up — one command
 
-Once the config is filled, bring up one tmux session with one window per seam and start a
-Claude Code session in each. The window names come from your `tmux.*` config — the fictional
-fill below uses session `crew` with windows `triage`, `em`, `ea`:
+Once the config is filled, boot the **whole crew in one command**:
+
+```
+/stand-up
+```
+
+That runs the plugin's thin [`commands/stand-up.md`](commands/stand-up.md), which invokes the
+`@kampus/pipeline-crew-mcp` substrate's `stand-up` subcommand (the launcher home ratified by
+ADR [0192](../../.decisions/0192-standup-launcher-crew-mcp-subcommand.md) — the plugin carries
+**no launcher logic**, only this thin front). You can also run the substrate directly:
+
+```bash
+pipeline-crew-mcp stand-up            # defaults --project-root to the working directory
+```
+
+The launcher runs, **in order**:
+
+1. **Assert the pinned CLI version** (`cliVersion`) — a hard gate, so the crew never launches
+   on a drifted Claude Code CLI (channels are a research preview whose behavior varies by
+   version).
+2. **Ensure the per-project tracker** is up (start-if-absent / reuse-if-present).
+3. **Derive the roster session set** — one session per bridge role + `engineCount` engine
+   sessions, each addressed to its role-lease inbox.
+4. **Build each session's bind** (its inline channel `--mcp-config` + registration flag) and
+   **compute its tmux placement** (a window under `tmux.session`).
+5. **Launch** each `claude` session, bound to its role lease and placed on your screen.
+
+It is **fail-loud with no partial crew**: every bind and placement is resolved and validated
+*before the first session launches*, so a drifted CLI pin, a missing config dimension, an
+unstartable tracker, an inert channel, or an unnamed/colliding tmux window **aborts before any
+session is launched** and names the cause. Nothing is hand-launched — fix the named precondition
+and re-run. This is the launcher-automated path; the by-hand walkthrough below shows what each
+session is and how to bring the crew up manually.
+
+## Stand up by hand — what each session is
+
+You can also bring the crew up manually. Create one tmux session with one window per seam and
+start a Claude Code session in each. The window names come from your `tmux.*` config — the
+fictional fill below uses session `crew` with windows `triage`, `em`, `ea`:
 
 ```bash
 # Create the session with the intake window, then add the execution + human windows.
@@ -213,15 +249,25 @@ pipeline-crew/
 │   ├── triage-guy.md             # intake seam
 │   ├── engineering-manager.md    # execution seam
 │   └── exec-assistant.md         # human seam (EA / chief-of-staff)
+├── commands/
+│   └── stand-up.md               # the one stand-up command (thin front for the substrate launcher, ADR 0192)
 ├── PERSONALIZATION.md            # the personalization seam — the def contract + dimension table
 ├── crew.config.template.jsonc    # placeholder-only per-install config template
 └── README.md                     # this file
 ```
 
+The launcher's mechanical logic lives in the `@kampus/pipeline-crew-mcp` substrate
+(`packages/pipeline-crew-mcp/src/standup/`), invoked by the thin `commands/stand-up.md` — the
+plugin ships no launcher Node code (ADR 0192).
+
 ## See also
 
 - [`PERSONALIZATION.md`](PERSONALIZATION.md) — the seam mechanism, the canonical dimension
   table, and the stand-up contract the three defs write against.
+- [`commands/stand-up.md`](commands/stand-up.md) — the one stand-up command (the thin front for
+  the substrate launcher).
+- ADR [0192](../../.decisions/0192-standup-launcher-crew-mcp-subcommand.md) — the launcher's home
+  + form (the `pipeline-crew-mcp stand-up` subcommand invoked by one thin plugin command).
 - [`../kampus-pipeline/`](../kampus-pipeline/) — the pipeline this crew conducts (the skills +
   ephemeral agents).
 - ADR [0062](../../.decisions/0062-repo-as-config-plugin.md) — the repo-as-config seam this

--- a/claude-plugins/pipeline-crew/commands/stand-up.md
+++ b/claude-plugins/pipeline-crew/commands/stand-up.md
@@ -1,0 +1,47 @@
+---
+description: Stand the whole pipeline crew up from the operator config — tracker + all bridge sessions + N engine sessions, each launched bound to its role lease, fail-loud with no partial crew.
+argument-hint: "[--project-root <path>]"
+allowed-tools: ["Bash"]
+---
+
+# Stand up the crew
+
+This is the **one stand-up command**: it boots the entire crew from your filled operator
+config in one shot. It is a thin front for the substrate launcher — the mechanical logic
+(version assert, tracker ensure, roster derivation, per-session bind, tmux placement,
+launch) lives in the `@kampus/pipeline-crew-mcp` substrate's `stand-up` subcommand
+(ADR 0192), never in this plugin.
+
+## Preconditions
+
+You must have a **filled** operator config before standing up — the plugin ships only a
+placeholder template. If you have not done this yet, follow the
+[PERSONALIZATION.md](../PERSONALIZATION.md) stand-up steps first:
+
+```bash
+cp "${CLAUDE_PLUGIN_ROOT}/crew.config.template.jsonc" .claude/crew.config.jsonc
+# fill EVERY <placeholder>, then git-ignore your copy
+```
+
+The launcher resolves the config by the same order as every seam key: `$CREW_CONFIG` if
+set, otherwise the working repo's `.claude/crew.config.jsonc`.
+
+## Run it
+
+Invoke the substrate's `stand-up` subcommand (pass through `$ARGUMENTS`, e.g.
+`--project-root <path>`; it defaults to the current working directory):
+
+```bash
+pipeline-crew-mcp stand-up $ARGUMENTS
+```
+
+The launcher runs, **in order**: assert the pinned CLI version → ensure the per-project
+tracker is up → derive the roster session set (one per bridge + N engines) → build each
+session's channel bind + tmux placement → launch each `claude` session bound to its role
+lease. It is **fail-loud with no partial crew**: a drifted CLI pin, a missing config
+dimension, an unstartable tracker, an inert channel, or an unnamed/colliding tmux window
+aborts **before any session is launched** and names the cause. Nothing is hand-launched.
+
+Report the tracker pid + socket and the launched sessions on success, or the named abort
+cause on failure. Do not hand-launch any session to "finish" a partial stand-up — re-run
+this command once the named precondition is fixed.

--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -5,6 +5,7 @@
  *   node src/bin.ts                                  # the root command (no seam wired)
  *   node src/bin.ts session --role <role>            # run one live crew session (stdio MCP)
  *   node src/bin.ts tracker                           # run a standalone per-project tracker
+ *   node src/bin.ts stand-up                          # stand the whole crew up from the operator config
  *
  * The `session` subcommand is the runnable stdio MCP entry (#3062): it stands up one live crew
  * session's `McpServer` over stdio + its channel peer, so the crew's inter-session seams run over
@@ -17,17 +18,31 @@
  * from any role session — the explicit way to pre-warm or keep a registry alive across session
  * restarts. It is idempotent: if a tracker already serves the project it reports so and exits 0.
  *
+ * The `stand-up` subcommand is the one stand-up command (ADR 0192, issue #3299): it reads the
+ * operator crew config and boots the whole crew — tracker + every bridge + N engine sessions — via
+ * the `standup/` orchestration (`runStandUp`), fail-loud with no partial crew. The distributable
+ * plugin's thin `commands/stand-up.md` invokes this subcommand; the launcher logic lives here in the
+ * substrate, never duplicated in the plugin (ADR 0192 decision B).
+ *
  * NB: an MCP stdio server owns stdout for JSON-RPC, so the one startup line goes to STDERR — a
  * log on stdout would corrupt the protocol stream.
  *
  * Wired per effect-smol's CLI guidance (mirrors `@kampus/pipeline-cli`'s bin): `effect/unstable/cli`
  * for the typed command, the Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
+import {readFileSync} from "node:fs";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Cause, Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 
 import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
+import {
+	LaunchConfigError,
+	parseJsonc,
+	resolveConfigPath,
+	runStandUp,
+	type TmuxNaming,
+} from "./standup/index.ts";
 import {isTrackerAddressInUse, launchTracker} from "./tracker/index.ts";
 import {VERSION} from "./version.ts";
 
@@ -79,17 +94,91 @@ const tracker = Command.make(
 	Command.withDescription("Run a standalone per-project tracker (the registry socket server)"),
 );
 
+/**
+ * Read the operator's tmux naming (session + per-window names) from the crew config. The typed,
+ * validated tmux-dimension reader is tracked separately (config.ts reads only the launch dimensions
+ * today); this thin entrypoint marshal threads the operator's `tmux` block through to the
+ * orchestration, which fails loud on any bridge window it cannot name. Resolves the config path by
+ * the same `$CREW_CONFIG` → `.claude/crew.config.jsonc` order as the launch-dimension reader.
+ */
+const readTmuxNaming = (
+	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
+): Effect.Effect<TmuxNaming, LaunchConfigError> =>
+	Effect.gen(function* () {
+		const configPath = resolveConfigPath(env);
+		const text = yield* Effect.try({
+			try: () => readFileSync(configPath, "utf8"),
+			catch: (cause) =>
+				new LaunchConfigError({
+					configPath,
+					reason: `cannot read crew config (run pipeline-crew stand-up first): ${String(cause)}`,
+				}),
+		});
+		const parsed = yield* Effect.try({
+			try: () => parseJsonc(text),
+			catch: (cause) =>
+				new LaunchConfigError({configPath, reason: `invalid JSONC: ${String(cause)}`}),
+		});
+		const tmux = (
+			parsed as {readonly tmux?: {readonly session?: unknown; readonly windows?: unknown}}
+		).tmux;
+		if (
+			tmux === undefined ||
+			typeof tmux.session !== "string" ||
+			tmux.windows === null ||
+			typeof tmux.windows !== "object"
+		) {
+			return yield* new LaunchConfigError({
+				configPath,
+				reason:
+					"missing or malformed `tmux` dimension — expected { session: string, windows: {...} }",
+			});
+		}
+		return {session: tmux.session, windows: tmux.windows as Readonly<Record<string, string>>};
+	});
+
+const standUp = Command.make(
+	"stand-up",
+	{projectRoot: projectRootFlag},
+	Effect.fn(function* ({projectRoot}) {
+		yield* Console.error(
+			`pipeline-crew-mcp ${VERSION} — standing up the crew from the operator config (project ${projectRoot})`,
+		);
+		const tmuxNaming = yield* readTmuxNaming();
+		return yield* runStandUp({projectRoot, tmuxNaming}).pipe(
+			Effect.flatMap((result) =>
+				Console.error(
+					`crew up: tracker pid ${result.tracker.pid ?? "?"} on ${result.tracker.socketPath}; ${result.launched.length} sessions launched (${result.launched
+						.map((s) => `${s.role}→${s.window}`)
+						.join(", ")})`,
+				),
+			),
+			// Fail-loud, no partial crew: a bad config, a version drift, an unstartable tracker, an inert
+			// channel, or an unnamed/colliding window aborts naming its cause — String(error) carries the tag.
+			Effect.catch((error: unknown) =>
+				Console.error(`stand-up aborted (no partial crew): ${String(error)}`).pipe(
+					Effect.andThen(Effect.sync(() => process.exit(1))),
+				),
+			),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Stand the whole crew up from the operator config (tracker + bridges + N engines), fail-loud",
+	),
+);
+
 const cli = Command.make(
 	"pipeline-crew-mcp",
 	{},
 	Effect.fn(function* () {
 		yield* Console.error(
-			`pipeline-crew-mcp ${VERSION} — run \`session --role <role>\` to start a live crew session`,
+			`pipeline-crew-mcp ${VERSION} — run \`stand-up\` to boot the crew, or \`session --role <role>\` for one session`,
 		);
 	}),
 ).pipe(
 	Command.withDescription("The crew's channels-backed messaging substrate (epic #3045)"),
-	Command.withSubcommands([session, tracker]),
+	Command.withSubcommands([session, tracker, standUp]),
 );
 
 cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -1,0 +1,75 @@
+/**
+ * standup/ — the launcher: boot the whole crew from the operator config. This barrel is the module's
+ * one public surface, re-exporting every launcher primitive and the `runStandUp` orchestration that
+ * composes them in order (version-assert → ensure-tracker → roster session-set → per-session bind →
+ * tmux placement → launch), fail-loud with no partial crew (epic #3237, issue #3299).
+ */
+export {
+	ALLOWLIST_CHANNEL_FLAG,
+	buildSessionBind,
+	ChannelPluginNotAllowedError,
+	CREW_SESSION_COMMAND,
+	CrewServerNotRegisteredError,
+	DEV_CHANNEL_FLAG,
+	MCP_CONFIG_FLAG,
+	PIPELINE_CREW_MCP_BIN,
+	type SessionBind,
+	type SessionBindInput,
+} from "./bind.ts";
+export {
+	CHANNEL_PLUGIN_REF_RE,
+	CHANNEL_SERVER_REF_RE,
+	ChannelConfig,
+	ChannelMode,
+	ChannelServerRef,
+	CLI_VERSION_RE,
+	CliVersion,
+	DEFAULT_CONFIG_PATH,
+	decodeLaunchConfig,
+	EngineCount,
+	LaunchConfig,
+	LaunchConfigError,
+	parseJsonc,
+	readLaunchConfig,
+	resolveConfigPath,
+	stripJsonc,
+} from "./config.ts";
+export {
+	ensureTrackerRunning,
+	runStandingTracker,
+	type TrackerBindOutcome,
+	type TrackerHandle,
+	TrackerNotServingError,
+	tryBecomeTracker,
+} from "./ensure-tracker.ts";
+export {
+	type LaunchedSession,
+	type LaunchPlan,
+	launchSessionInTmux,
+	runStandUp,
+	type StandUpError,
+	type StandUpInput,
+	StandUpLaunchError,
+	type StandUpResult,
+} from "./orchestrate.ts";
+export {
+	type BridgeSession,
+	type CrewSession,
+	deriveSessionSet,
+	type EngineSession,
+	type SessionSetInput,
+} from "./session-set.ts";
+export {
+	computeTmuxPlacement,
+	type PlacementTarget,
+	type RosterSession,
+	type TmuxNaming,
+	TmuxWindowCollisionError,
+	TmuxWindowUnnamedError,
+} from "./tmux-placement.ts";
+export {
+	assertPinnedCliVersion,
+	CliVersionAssertError,
+	parseCliVersion,
+	readInstalledCliVersionOutput,
+} from "./version-assert.ts";

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -1,0 +1,224 @@
+/**
+ * standup/orchestrate — the one stand-up command (issue #3299). These tests pin the two properties
+ * the composition owns: the MANDATED ORDER (version assert → ensure tracker → derive roster → per-
+ * session bind + tmux placement → launch) and FAIL-LOUD WITH NO PARTIAL CREW (every precondition
+ * failure aborts, naming its cause, with zero sessions launched). Every side-effecting step is
+ * injected — a version reader, a recording tracker, a recording launcher — so the whole boot runs in
+ * a unit test with no real subprocess, tmux, or `claude`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Schema} from "effect";
+import {CREW_ROLES, kindOf} from "../crew/index.ts";
+import {LaunchConfig, LaunchConfigError} from "./config.ts";
+import {type TrackerHandle, TrackerNotServingError} from "./ensure-tracker.ts";
+import {
+	CliVersionAssertError,
+	CrewServerNotRegisteredError,
+	type LaunchedSession,
+	type LaunchPlan,
+	runStandUp,
+	type StandUpInput,
+	TmuxWindowUnnamedError,
+} from "./index.ts";
+
+const PINNED = "2.1.212";
+const SERVER = "@kampus/pipeline-crew-mcp";
+
+/** A dev-mode config carrying the crew's own `server:` ref — the shape bind + config both accept. */
+const configAt = (cliVersion: string, engineCount: number): LaunchConfig =>
+	Schema.decodeUnknownSync(LaunchConfig)({
+		cliVersion,
+		engineCount,
+		channels: {mode: "development", servers: [`server:${SERVER}`], allowedChannelPlugins: []},
+	});
+
+/** Operator tmux naming: a window per bridge role, keyed by the role slug (engines self-name by id). */
+const tmuxNaming = {
+	session: "crew",
+	windows: {
+		"chief-of-staff": "cos",
+		cartographer: "carto",
+		"intake-desk": "intake",
+	},
+};
+
+/** A deterministic engine instance-id generator so the derived set + windows are pinnable. */
+const counter = () => {
+	let i = 0;
+	return () => `e${i++}`;
+};
+
+/** A recording launcher: never touches tmux, just captures the plans it was handed in call order. */
+const recordingLauncher = () => {
+	const plans: LaunchPlan[] = [];
+	const launch = (plan: LaunchPlan): Effect.Effect<LaunchedSession, never> => {
+		plans.push(plan);
+		return Effect.succeed({
+			role: plan.session.role,
+			address: plan.session.address,
+			window: plan.placement.window,
+			pid: 1000 + plans.length,
+		});
+	};
+	return {plans, launch};
+};
+
+const trackerHandle: TrackerHandle = {pid: 4242, socketPath: "/tmp/crew.sock"};
+
+/** A recording tracker-ensurer: counts calls so "was the tracker reached before the abort?" is checkable. */
+const recordingTracker = (
+	result: Effect.Effect<TrackerHandle, TrackerNotServingError> = Effect.succeed(trackerHandle),
+) => {
+	let calls = 0;
+	const ensureTracker = (_projectRoot: string) => {
+		calls++;
+		return result;
+	};
+	return {ensureTracker, calls: () => calls};
+};
+
+/** The full happy-path input with every side effect injected — a stand-up that never leaves the process. */
+const baseInput = (
+	overrides: Partial<StandUpInput> & {engineCount?: number} = {},
+): {input: StandUpInput; launched: LaunchPlan[]; trackerCalls: () => number} => {
+	const {plans, launch} = recordingLauncher();
+	const {ensureTracker, calls} = recordingTracker();
+	const {engineCount, ...rest} = overrides;
+	return {
+		launched: plans,
+		trackerCalls: calls,
+		input: {
+			projectRoot: "/repo",
+			tmuxNaming,
+			config: Effect.succeed(configAt(PINNED, engineCount ?? 2)),
+			readVersionOutput: Effect.succeed(`${PINNED} (Claude Code)`),
+			instanceId: counter(),
+			ensureTracker,
+			launch,
+			...rest,
+		},
+	};
+};
+
+const bridgeRoles = CREW_ROLES.filter((r) => kindOf(r) === "bridge");
+
+describe("standup/orchestrate — the one stand-up command (issue #3299)", () => {
+	it.effect(
+		"stands up tracker + one window per bridge + N engine sessions, in roster order (AC1,AC2)",
+		() =>
+			Effect.gen(function* () {
+				const N = 3;
+				const {input, launched, trackerCalls} = baseInput({engineCount: N});
+				const result = yield* runStandUp(input);
+
+				assert.strictEqual(trackerCalls(), 1);
+				assert.strictEqual(result.tracker, trackerHandle);
+				// one launch per bridge + N engines, and the result mirrors the launched set.
+				assert.strictEqual(launched.length, bridgeRoles.length + N);
+				assert.strictEqual(result.launched.length, launched.length);
+
+				const launchedBridges = launched.filter((p) => p.session.kind === "bridge");
+				const launchedEngines = launched.filter((p) => p.session.kind === "engine");
+				assert.strictEqual(launchedBridges.length, bridgeRoles.length);
+				assert.strictEqual(launchedEngines.length, N);
+				// each session is launched bound to its role lease (the session-set address) — no hand-launch.
+				for (const p of launched) {
+					assert.strictEqual(p.bind.role, p.session.role);
+					assert.match(p.session.address, /^inbox:\/\//);
+				}
+				// bridges placed on their operator-named windows, engines on their generated instance ids.
+				const cos = launchedBridges.find((p) => p.session.role === "chief-of-staff");
+				assert.strictEqual(cos?.placement.window, "cos");
+				assert.deepStrictEqual(launchedEngines.map((p) => p.placement.window).sort(), [
+					"e0",
+					"e1",
+					"e2",
+				]);
+			}),
+	);
+
+	it.effect("scales the engine pool with the config engine count (AC2)", () =>
+		Effect.gen(function* () {
+			for (const N of [1, 4]) {
+				const {input, launched} = baseInput({engineCount: N, instanceId: counter()});
+				yield* runStandUp(input);
+				assert.strictEqual(launched.filter((p) => p.session.kind === "engine").length, N);
+				assert.strictEqual(
+					launched.filter((p) => p.session.kind === "bridge").length,
+					bridgeRoles.length,
+				);
+			}
+		}),
+	);
+
+	it.effect(
+		"aborts on a CLI version drift BEFORE the tracker or any launch (AC3, fail-loud order)",
+		() =>
+			Effect.gen(function* () {
+				const {input, launched, trackerCalls} = baseInput({
+					readVersionOutput: Effect.succeed("2.1.300 (Claude Code)"),
+				});
+				const err = yield* Effect.flip(runStandUp(input));
+
+				assert.instanceOf(err, CliVersionAssertError);
+				// version assert runs before ensure-tracker: the tracker was never reached, nothing launched.
+				assert.strictEqual(trackerCalls(), 0);
+				assert.strictEqual(launched.length, 0);
+			}),
+	);
+
+	it.effect("aborts on an unreadable operator config before any side effect (AC3)", () =>
+		Effect.gen(function* () {
+			const {input, launched, trackerCalls} = baseInput({
+				config: Effect.fail(
+					new LaunchConfigError({configPath: ".claude/crew.config.jsonc", reason: "missing"}),
+				),
+			});
+			const err = yield* Effect.flip(runStandUp(input));
+
+			assert.instanceOf(err, LaunchConfigError);
+			assert.strictEqual(trackerCalls(), 0);
+			assert.strictEqual(launched.length, 0);
+		}),
+	);
+
+	it.effect("aborts when the tracker cannot be brought up, before any session launches (AC3)", () =>
+		Effect.gen(function* () {
+			const {input, launched} = baseInput({
+				ensureTracker: (_root: string) =>
+					Effect.fail(new TrackerNotServingError({socketPath: "/tmp/crew.sock"})),
+			});
+			const err = yield* Effect.flip(runStandUp(input));
+
+			assert.instanceOf(err, TrackerNotServingError);
+			// derive/bind/placement/launch all sit after ensure-tracker — nothing launched.
+			assert.strictEqual(launched.length, 0);
+		}),
+	);
+
+	it.effect("aborts when a bridge names no operator tmux window — no partial crew (AC3)", () =>
+		Effect.gen(function* () {
+			const {input, launched} = baseInput({
+				tmuxNaming: {session: "crew", windows: {"chief-of-staff": "cos"}}, // cartographer/intake-desk unnamed
+			});
+			const err = yield* Effect.flip(runStandUp(input));
+
+			assert.instanceOf(err, TmuxWindowUnnamedError);
+			// placement is resolved for the WHOLE set before the first launch — a single unnamed window
+			// aborts stand-up with zero sessions up (the no-partial-crew line).
+			assert.strictEqual(launched.length, 0);
+		}),
+	);
+
+	it.effect(
+		"aborts when the crew server would be inert (unregistered channel), before any launch (AC3)",
+		() =>
+			Effect.gen(function* () {
+				const {input, launched} = baseInput({serverName: "not-in-servers"});
+				const err = yield* Effect.flip(runStandUp(input));
+
+				assert.instanceOf(err, CrewServerNotRegisteredError);
+				assert.strictEqual(launched.length, 0);
+			}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -1,0 +1,204 @@
+/**
+ * standup/orchestrate — the one stand-up command: compose every launcher primitive into a single
+ * boot of the whole crew from the operator config (epic #3237, issue #3299). This module owns the
+ * ORDER and the composition only; every step is a merged child it wires read-only, never
+ * reimplements — config (#3293), version-assert (#3295), ensure-tracker (#3294), session-set
+ * (#3297), bind (#3296), tmux-placement (#3298).
+ *
+ * The one non-obvious thing: the orchestration is FAIL-LOUD with NO PARTIAL CREW. The steps run in
+ * the mandated order — read config → assert the pinned CLI version → ensure the tracker → derive the
+ * roster session set → build EVERY per-session bind + compute ALL tmux placements → launch. Every
+ * bind and every placement is resolved (and validated) BEFORE the first session launches, so any
+ * precondition failure — a drifted CLI pin, a missing config dimension, an inert channel, a colliding
+ * or unnamed tmux window — aborts with a named error while zero sessions are up, never a half-launched
+ * crew. No session is hand-launched: the launch of each `claude` session, bound to its role lease, is
+ * the injected `launch` step the orchestration drives for the whole derived set.
+ *
+ * The side-effecting steps are injected (defaulting to production) so the composition is pure over
+ * its inputs and unit-testable end to end — the same injection idiom version-assert (its version
+ * reader) and session-set (its instance-id generator) already use.
+ */
+import {spawn} from "node:child_process";
+import {randomUUID} from "node:crypto";
+import {Effect, Schema} from "effect";
+import {SESSION_SERVER_NAME} from "../crew/index.ts";
+import {
+	buildSessionBind,
+	type ChannelPluginNotAllowedError,
+	type CrewServerNotRegisteredError,
+	type SessionBind,
+} from "./bind.ts";
+import {type LaunchConfig, type LaunchConfigError, readLaunchConfig} from "./config.ts";
+import {
+	ensureTrackerRunning,
+	type TrackerHandle,
+	type TrackerNotServingError,
+} from "./ensure-tracker.ts";
+import {type CrewSession, deriveSessionSet} from "./session-set.ts";
+import {
+	computeTmuxPlacement,
+	type PlacementTarget,
+	type RosterSession,
+	type TmuxNaming,
+	type TmuxWindowCollisionError,
+	type TmuxWindowUnnamedError,
+} from "./tmux-placement.ts";
+import {
+	assertPinnedCliVersion,
+	type CliVersionAssertError,
+	readInstalledCliVersionOutput,
+} from "./version-assert.ts";
+
+/** A `claude` session that could not be launched into its tmux window — carries the window + role it named. */
+export class StandUpLaunchError extends Schema.TaggedErrorClass<StandUpLaunchError>()(
+	"@kampus/pipeline-crew-mcp/standup/StandUpLaunchError",
+	{
+		role: Schema.String,
+		window: Schema.String,
+		reason: Schema.String,
+	},
+) {}
+
+/** One derived session's full launch plan: its roster identity, its launch bind (argv), and its tmux placement. */
+export interface LaunchPlan {
+	readonly session: CrewSession;
+	readonly bind: SessionBind;
+	readonly placement: PlacementTarget;
+}
+
+/** A launched crew session: the role + lease it came up holding, the tmux window it lives in, and its pid. */
+export interface LaunchedSession {
+	readonly role: string;
+	/** The role-lease key inbox address the session-set minted (`inbox://<role>[/<instance>]`). */
+	readonly address: string;
+	readonly window: string;
+	readonly pid: number | undefined;
+}
+
+/** Every way stand-up can abort — the union of every wired child's error plus the launch error. */
+export type StandUpError =
+	| LaunchConfigError
+	| CliVersionAssertError
+	| TrackerNotServingError
+	| CrewServerNotRegisteredError
+	| ChannelPluginNotAllowedError
+	| TmuxWindowUnnamedError
+	| TmuxWindowCollisionError
+	| StandUpLaunchError;
+
+export interface StandUpInput {
+	/** The project root the tracker + every session join (the per-project socket key). */
+	readonly projectRoot: string;
+	/**
+	 * The operator-configured tmux naming (session + per-bridge window names). It is NOT a launch
+	 * dimension of `LaunchConfig` — config.ts reads only the CLI pin, engine count, and channels — so
+	 * the caller resolves the tmux dimension and threads it here.
+	 */
+	readonly tmuxNaming: TmuxNaming;
+	/** The channel-ref name each session's own crew MCP server registers under. Default: `SESSION_SERVER_NAME`. */
+	readonly serverName?: string;
+	/** The launch dimensions to stand up under. Default: read the operator crew config (`readLaunchConfig`). */
+	readonly config?: Effect.Effect<LaunchConfig, LaunchConfigError>;
+	/** The installed-CLI-version reader the pin is asserted against. Default: the real `claude --version`. */
+	readonly readVersionOutput?: Effect.Effect<string, unknown>;
+	/** Start-or-reuse the per-project tracker. Default: `ensureTrackerRunning` (detached standing process). */
+	readonly ensureTracker?: (
+		projectRoot: string,
+	) => Effect.Effect<TrackerHandle, TrackerNotServingError>;
+	/** Mints each engine instance's distinct id. Default: `randomUUID` (the generator sessions use at runtime). */
+	readonly instanceId?: () => string;
+	/** Launch one planned session into its tmux window bound to its role lease. Default: `launchSessionInTmux`. */
+	readonly launch?: (plan: LaunchPlan) => Effect.Effect<LaunchedSession, StandUpLaunchError>;
+}
+
+/** What a completed stand-up returns: the tracker it ensured and every session it launched, in roster order. */
+export interface StandUpResult {
+	readonly tracker: TrackerHandle;
+	readonly launched: readonly LaunchedSession[];
+}
+
+/**
+ * Project a derived `CrewSession` onto the `RosterSession` tmux-placement consumes: a bridge's window
+ * key is its role slug (the operator's `windows` map is keyed by role), an engine's window is its
+ * generated per-instance id (an operator cannot name N dynamic engines).
+ */
+const toRosterSession = (session: CrewSession): RosterSession =>
+	session.kind === "engine"
+		? {kind: "engine", id: session.instance}
+		: {kind: "bridge", role: session.role, windowKey: session.role};
+
+/**
+ * The production launcher: open a tmux window for the session under the operator's tmux session and
+ * run `claude` there with the session's launch bind. Detached + unref'd + ignored stdio so the crew
+ * outlives this launcher process (the `ensureTrackerRunning` spawn idiom). The thin, uncovered edge —
+ * tests inject a recording launcher; only a synchronous spawn throw crosses the error channel.
+ */
+export const launchSessionInTmux = (
+	plan: LaunchPlan,
+): Effect.Effect<LaunchedSession, StandUpLaunchError> =>
+	Effect.try({
+		try: (): LaunchedSession => {
+			const {placement, bind, session} = plan;
+			const child = spawn(
+				"tmux",
+				["new-window", "-t", placement.session, "-n", placement.window, "claude", ...bind.argv],
+				{detached: true, stdio: "ignore"},
+			);
+			child.unref();
+			return {
+				role: session.role,
+				address: session.address,
+				window: placement.window,
+				pid: child.pid,
+			};
+		},
+		catch: (cause) =>
+			new StandUpLaunchError({
+				role: plan.session.role,
+				window: plan.placement.window,
+				reason: `cannot launch claude into tmux window "${plan.placement.window}": ${String(cause)}`,
+			}),
+	});
+
+/**
+ * Stand up the whole crew from the operator config, in the mandated order and fail-loud with no
+ * partial crew (issue #3299): read config → assert the pinned CLI version → ensure the tracker →
+ * derive the roster session set → build every per-session bind + compute all tmux placements →
+ * launch each session bound to its role lease. Every derivation and validation completes before the
+ * first launch, so any precondition failure aborts (naming its cause) with zero sessions up.
+ */
+export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, StandUpError> =>
+	Effect.gen(function* () {
+		const {projectRoot, tmuxNaming} = input;
+		const serverName = input.serverName ?? SESSION_SERVER_NAME;
+		const instanceId = input.instanceId ?? randomUUID;
+		const ensureTracker = input.ensureTracker ?? ensureTrackerRunning;
+		const launch = input.launch ?? launchSessionInTmux;
+
+		const config = yield* input.config ?? readLaunchConfig();
+		// Fail fast on a version drift before starting the tracker or any session — channels vary
+		// across CLI versions, so a mismatch is a stand-up to refuse (version-assert.ts / #3295).
+		yield* assertPinnedCliVersion(config, input.readVersionOutput ?? readInstalledCliVersionOutput);
+		const tracker = yield* ensureTracker(projectRoot);
+
+		const sessions = deriveSessionSet({engineCount: config.engineCount, instanceId});
+
+		// Resolve EVERY bind + placement before launching anything — this is the no-partial-crew line:
+		// an inert channel, an unnamed or colliding window fails here, while zero sessions are up.
+		const binds = yield* Effect.forEach(sessions, (session) =>
+			buildSessionBind({role: session.role, projectRoot, serverName, channels: config.channels}),
+		);
+		const placements = yield* computeTmuxPlacement(tmuxNaming, sessions.map(toRosterSession));
+		// `binds` and `placements` are each derived from `sessions` in order, so the index is always
+		// populated; the die guard is the unreachable branch that satisfies noUncheckedIndexedAccess.
+		const plans = yield* Effect.forEach(sessions, (session, i) => {
+			const bind = binds[i];
+			const placement = placements[i];
+			return bind !== undefined && placement !== undefined
+				? Effect.succeed<LaunchPlan>({session, bind, placement})
+				: Effect.die(`stand-up plan zip out of range for session "${session.role}"`);
+		});
+
+		const launched = yield* Effect.forEach(plans, launch);
+		return {tracker, launched};
+	});


### PR DESCRIPTION
Fixes #3299

## What — all four ACs, in-diff
The one stand-up command that boots the whole crew from the operator config, composing every merged launcher primitive of epic #3237, per the artifact home + form ratified in ADR 0192 (decision B).

**AC1 — one command that stands up the whole crew.** Two coupled artifacts (ADR 0192): the executable `stand-up` subcommand in `pipeline-crew-mcp`'s bin (imports `runStandUp`, resolves the operator config + tmux dimension, boots tracker + all bridges + N engines), invoked by the thin `claude-plugins/pipeline-crew/commands/stand-up.md` — the plugin carries no launcher Node code.

**AC2 — mandated order.** `runStandUp` runs: version assert → ensure tracker → derive roster session set → per-session bind + tmux placement → launch. No session is hand-launched.

**AC3 — fail-loud, no partial crew.** Every bind and placement is resolved + validated *before the first launch*, so a drifted CLI pin, a missing config dimension, an inert channel, or an unnamed/colliding tmux window aborts (naming its cause) with zero sessions up. The bin's `stand-up` catch prints the aborting cause and exits non-zero.

**AC4 — docs for a second operator.** The plugin README gains a "Stand up — one command" section (manual walkthrough kept as the by-hand path); PERSONALIZATION.md gains an additive one-command note. Both reference only the distributable plugin + the `pipeline-crew-mcp` substrate — no operator-local crew def. #3342's corrected `plugin:<name>@<marketplace>` channel-ref grammar left intact.

## Files
- `packages/pipeline-crew-mcp/src/standup/orchestrate.ts` — `runStandUp` + `launchSessionInTmux` + `StandUpLaunchError`
- `packages/pipeline-crew-mcp/src/standup/index.ts` — the module barrel (reserved by this issue)
- `packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts` — order + every precondition abort (7 tests)
- `packages/pipeline-crew-mcp/src/bin.ts` — the `stand-up` subcommand (ADR 0192 home for #3299)
- `claude-plugins/pipeline-crew/commands/stand-up.md` — the thin plugin command
- `claude-plugins/pipeline-crew/README.md`, `PERSONALIZATION.md` — the one-command stand-up docs

## Scope notes (for the reviewer)
- The bin's tmux read is a thin entrypoint marshal pending the **typed tmux-dimension reader** (config.ts reads only cliVersion/engineCount/channels today); config.ts is unchanged. That typed reader + two other cross-module seam gaps (bind server-ref vs allowlist mode; bind per-instance lease not threaded into launch argv) are tracked separately, out of #3299's scope.
- Whole PR is NON-§CP: `packages/pipeline-crew-mcp/**` (ADR 0187) and `claude-plugins/pipeline-crew/**` (epic #2342 ruling) are both outside the §CP boundary. No `claude-plugins/kampus-pipeline/**` touched.

## Verification
- `pnpm typecheck` (crew-mcp) — clean
- `pnpm lint` (worktree, 8 files) — clean
- `pnpm test` (crew-mcp vitest) — 155 passed / 28 files
- `node src/bin.ts --help` lists the `stand-up` subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)