### PR TITLE
ci(security): least-privilege top-level permissions on 14 workflows (#3332)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Least-privilege baseline: every job gets a read-only token unless it declares its own
+# block. `changes` and `e2e` elevate to `pull-requests: read` at the job level below.
+permissions:
+  contents: read
+
 jobs:
   # Which parts of the tree changed — gates the cost-bearing jobs so a docs- or
   # skills-only PR doesn't pay for checks that cover none of the changed files.

--- a/.github/workflows/codeowners-cp.yml
+++ b/.github/workflows/codeowners-cp.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check §CP paths are all owned in CODEOWNERS

--- a/.github/workflows/decisions-index.yml
+++ b/.github/workflows/decisions-index.yml
@@ -10,6 +10,9 @@ name: decisions-index
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: validate ADR files — no duplicate/mismatched ADR number

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,9 @@ concurrency:
 env:
   STAGE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'prod' }}
 
+permissions:
+  contents: read
+
 jobs:
   # Job-level change-detection gating ONLY the `deploy` job (issue #2366): a
   # docs/canon/pipeline-only PR (`.decisions/`, `.patterns/`, `.glossary/`, `*.md`,

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check docs have no dead internal links

--- a/.github/workflows/fanout-guard.yml
+++ b/.github/workflows/fanout-guard.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check every fanned mutation publishes its /fate/live invalidation

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: scan changed files for leaks

--- a/.github/workflows/migrations-guard.yml
+++ b/.github/workflows/migrations-guard.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check the D1 migrations tree is consistent, ordered, and immutable

--- a/.github/workflows/pointer-guard.yml
+++ b/.github/workflows/pointer-guard.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check CLAUDE.md path pointers resolve

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -39,6 +39,9 @@ concurrency:
 env:
   STAGE: pr-${{ github.event.pull_request.number }}
 
+permissions:
+  contents: read
+
 jobs:
   app-roster:
     name: resolve app roster

--- a/.github/workflows/readme-guard.yml
+++ b/.github/workflows/readme-guard.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check every packages/* member has a README.md

--- a/.github/workflows/run-evidence.yml
+++ b/.github/workflows/run-evidence.yml
@@ -35,6 +35,9 @@ concurrency:
   group: run-evidence-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   produce:
     name: produce run-evidence bundle

--- a/.github/workflows/skill-gh-lint.yml
+++ b/.github/workflows/skill-gh-lint.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: lint skill corpus for GraphQL-path gh calls + invalid YAML frontmatter

--- a/.github/workflows/workflow-contract.yml
+++ b/.github/workflows/workflow-contract.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check every .claude/workflows/*.js conforms to the runtime contract


### PR DESCRIPTION
Fixes #3332

## What & why
The repo `default_workflow_permissions` is `write`, so any `.github/workflows/*.yml` without a top-level `permissions:` block ran its jobs with a **write-scoped `GITHUB_TOKEN`** — a latent least-privilege violation CodeQL flags per-PR (the #3329-class missing-permissions finding).

Per the EM ruling (2026-07-17), this takes **approach (b): per-workflow explicit least-privilege top-level `permissions:` blocks, all in-PR** — the repo-`default_workflow_permissions` flip is off-the-table (repo-admin setting, routed separately). **No repo setting is changed here.**

## What changed
Added a `contents: read` top-level baseline to the **14** workflows that had no top-level block. Each job's real token needs were read per-job (not a blind sweep): all 14 are read-only guards or build/test jobs, except the two preview-comment writers whose existing **job-level** grants are preserved untouched (job-level blocks override the top-level baseline, so no job loses scope):

- **deploy.yml** — `deploy` keeps `contents: read` + `pull-requests: write`; `changes` keeps `pull-requests: read`
- **pr-cleanup.yml** (`pull_request_target`) — `cleanup` keeps `contents: read` + `pull-requests: write`; `app-roster` keeps `contents: read`
- **ci.yml** — `changes`/`e2e` keep their job-level `pull-requests: read`
- **run-evidence.yml** — `produce` keeps its job-level `contents: read`

The other 10 (`decisions-index`, `leak-guard`, `fanout-guard`, `codeowners-cp`, `migrations-guard`, `doc-links`, `pointer-guard`, `workflow-contract`, `readme-guard`, `skill-gh-lint`) are pure checkout+run guards → `contents: read` suffices.

Excluded per the ruling: `commands-guard.yml` (blocked in #3329) and `unresolved-threads-guard.yml` (scoped in #3331/#3348). Scope is limited to `.github/workflows/*.yml` — no `pipeline-cli/**` or `pipeline-crew-mcp/**` touched, no new workflow files.

## Acceptance
- [x] Every targeted workflow now sets a least-privilege top-level `permissions:` block (`grep -L '^permissions:'` → empty)
- [x] The two preview-comment / `pull_request_target` workflows retain their job-level grants (not loosened)
- [x] No job loses scope — job-level blocks override the baseline; write-needing jobs keep exactly their scope
- [x] `actionlint` passes on all 14; no behavior change — the CodeQL missing-`permissions` findings should clear

## §CP
`.github/` is control-plane surface → **banks for @kamp-us/control-plane (cansirin) approval**.