### PR TITLE
chore(pipeline-crew): sync channel-ref grammar in crew.config.template.jsonc

### DIFF
--- a/claude-plugins/pipeline-crew/crew.config.template.jsonc
+++ b/claude-plugins/pipeline-crew/crew.config.template.jsonc
@@ -65,11 +65,11 @@
 		// "development" → `--dangerously-load-development-channels` (loads every dev channel; local only).
 		"mode": "<channel-mode: allowlist | development>",
 		// The channel servers each session registers, by ref. Grammar per ref:
-		//   "server:<name>"            — a top-level channel MCP server
-		//   "plugin:<plugin>:<server>" — a server contributed by a plugin
+		//   "server:<name>"              — a top-level channel MCP server
+		//   "plugin:<name>@<marketplace>" — a channel server contributed by a plugin
 		"servers": ["<channel-server-ref>"],
 		// Plugins whose channel servers are allowed to load — the allowlist the "allowlist"
-		// mode enforces; each name matches a "plugin:<plugin>:..." ref used in `servers`.
+		// mode enforces; each name matches the plugin `<name>` in a "plugin:<name>@<marketplace>" ref used in `servers`.
 		"allowedChannelPlugins": ["<allowed-channel-plugin>"]
 	}
 }


### PR DESCRIPTION
## What

Sync the stale channel-ref grammar in `claude-plugins/pipeline-crew/crew.config.template.jsonc`'s `channels`-block comments (lines ~67–72) to the corrected `plugin:<name>@<marketplace>` form.

- L69: `plugin:<plugin>:<server>` → `plugin:<name>@<marketplace>`
- L72: the `allowedChannelPlugins` note's `"plugin:<plugin>:..."` → `"plugin:<name>@<marketplace>"`

## Why

The corrected grammar was established by #3328 and is enforced by `packages/pipeline-crew-mcp/src/standup/config.ts`'s `CHANNEL_SERVER_REF_RE` (`/^(?:server:[^:\\s]+|plugin:[^@\\s]+@[^@\\s]+)$/`) against the Claude Code 2.1.212 bundle. The #3338/#3342 grammar sweeps synced `PERSONALIZATION.md` and the epic body but missed this template — an operator filling the template to its own stale comment would hit a validation failure at stand-up.

## Scope

Comment-only. No config-key, schema, or code change; topology/role-map keys (lines ~33–44) are untouched (that restructure is #3236's). NON-§CP path — auto-ships on green.

Fixes #3358