### PR TITLE
fix(pipeline-crew-mcp): reclaim a crashed tracker host's stale socket at bind time

### DIFF
--- a/packages/pipeline-crew-mcp/src/tracker/server.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.test.ts
@@ -1,17 +1,20 @@
 /**
  * The socket transport: the per-project socket path derivation, the control-plane-only served
- * surface (no relay kinds), and a real unix-socket announce→lookup round-trip proving the tracker
- * runs as an `RpcServer` over `layerProtocolSocketServer`.
+ * surface (no relay kinds), a real unix-socket announce→lookup round-trip proving the tracker runs
+ * as an `RpcServer` over `layerProtocolSocketServer`, and the stale-socket crash-recovery contract
+ * (#3280 — reclaim a crashed host's orphaned socket, never reclaim a live one).
  */
+import {spawn} from "node:child_process";
 import {randomUUID} from "node:crypto";
+import {existsSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {NodeSocket} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer} from "effect";
+import {Effect, Exit, Layer} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
 import {TrackerRegistry} from "./group.ts";
-import {socketPathFor, trackerServerLayer} from "./server.ts";
+import {isTrackerAddressInUse, socketPathFor, trackerServerLayer} from "./server.ts";
 
 describe("tracker socket path — per-project derivation", () => {
 	it("is deterministic and normalizes the root", () => {
@@ -41,12 +44,14 @@ describe("tracker served surface — control-plane only", () => {
 	});
 });
 
+const socketClientLayer = (socketPath: string) =>
+	RpcClient.layerProtocolSocket().pipe(
+		Layer.provide([NodeSocket.layerNet({path: socketPath}), RpcSerialization.layerNdjson]),
+	);
+
 describe("tracker over a unix socket — RpcServer round-trip", () => {
 	it.effect("announce then lookup round-trips over layerProtocolSocketServer", () => {
 		const socketPath = join(tmpdir(), `crew-test-${randomUUID().slice(0, 8)}.sock`);
-		const clientLayer = RpcClient.layerProtocolSocket().pipe(
-			Layer.provide([NodeSocket.layerNet({path: socketPath}), RpcSerialization.layerNdjson]),
-		);
 		return Effect.gen(function* () {
 			const client = yield* RpcClient.make(TrackerRegistry);
 			yield* client.AnnouncePresence({
@@ -59,8 +64,93 @@ describe("tracker over a unix socket — RpcServer round-trip", () => {
 			assert.lengthOf(result.peers, 1);
 			assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
 		}).pipe(
-			Effect.provide(Layer.mergeAll(clientLayer, trackerServerLayer(socketPath))),
+			Effect.provide(Layer.mergeAll(socketClientLayer(socketPath), trackerServerLayer(socketPath))),
 			Effect.scoped,
 		);
 	});
+});
+
+/**
+ * Faithfully reproduce a crashed tracker host: a child binds `socketPath`, then `SIGKILL` leaves the
+ * `.sock` file on disk with no listener. node unlinks the socket file only on a CLEAN `server.close()`,
+ * so an ungraceful exit is what strands it — exactly the crash path this hardens. The stranded file
+ * then refuses a connect with `ECONNREFUSED`, the stale signal `reclaimStaleSocket` keys on (#3280).
+ */
+const leaveStaleSocket = (socketPath: string): Effect.Effect<void> =>
+	Effect.callback<void>((resume) => {
+		const source = `const net=require("node:net");const s=net.createServer();s.listen(${JSON.stringify(
+			socketPath,
+		)},()=>process.stdout.write("L"));setInterval(()=>{},1000);`;
+		const child = spawn(process.execPath, ["-e", source]);
+		child.stdout.on("data", (chunk) => {
+			if (String(chunk).includes("L")) {
+				child.once("exit", () => resume(Effect.void));
+				child.kill("SIGKILL");
+			}
+		});
+	});
+
+describe("tracker stale-socket crash recovery (#3280)", () => {
+	// `it.live`: spawns a real child + SIGKILLs it, so it needs real time, not the frozen TestClock.
+	it.live(
+		"reclaims a crashed host's stale socket and re-hosts the tracker",
+		() => {
+			const socketPath = join(tmpdir(), `crew-stale-${randomUUID().slice(0, 8)}.sock`);
+			return Effect.gen(function* () {
+				// Strand the stale socket BEFORE the tracker layer is built — the layer runs reclaim at
+				// build time, so building it must observe the crashed host's orphaned file, not a clean path.
+				yield* leaveStaleSocket(socketPath);
+				assert.isTrue(
+					existsSync(socketPath),
+					"expected a stale socket file after the simulated crash",
+				);
+				// Build the server FIRST so it reclaims the stale file and is listening, THEN dial a client
+				// (the production sequencing: `crewTrackerHostOrDialLayer` provides the client onto the
+				// hosted server). A successful round-trip proves the reclaim re-hosted the tracker.
+				yield* Layer.build(trackerServerLayer(socketPath));
+				const result = yield* Effect.gen(function* () {
+					const client = yield* RpcClient.make(TrackerRegistry);
+					yield* client.AnnouncePresence({
+						peer: "inbox://peer-a",
+						role: "builder",
+						at: "2026-07-16T10:00:00Z",
+					});
+					return yield* client.LookupRole({role: "builder"});
+				}).pipe(Effect.provide(socketClientLayer(socketPath)));
+				assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
+			}).pipe(Effect.scoped);
+		},
+		20_000,
+	); // a real node child spawn + SIGKILL + rebind (node + TS + Effect startup)
+
+	it.effect(
+		"leaves a LIVE socket intact — a second bind still gets EADDRINUSE (dial, not reclaim)",
+		() => {
+			const socketPath = join(tmpdir(), `crew-live-${randomUUID().slice(0, 8)}.sock`);
+			return Effect.gen(function* () {
+				// host A is live for the scope; reclaim must NOT unlink it out from under the running host.
+				yield* Layer.build(trackerServerLayer(socketPath));
+				const exit = yield* Effect.exit(Layer.build(trackerServerLayer(socketPath)));
+				assert.isTrue(
+					Exit.isFailure(exit),
+					"a second bind on a LIVE socket must fail, not reclaim",
+				);
+				if (Exit.isFailure(exit)) {
+					assert.isTrue(
+						isTrackerAddressInUse(exit.cause),
+						"the live socket must surface EADDRINUSE (the dial signal), proving it was not reclaimed",
+					);
+				}
+				// host A keeps serving after the refused second bind — the graceful happy path is unchanged.
+				const client = yield* RpcClient.make(TrackerRegistry);
+				yield* client.AnnouncePresence({
+					peer: "inbox://peer-a",
+					role: "builder",
+					at: "2026-07-16T10:00:00Z",
+				});
+				const result = yield* client.LookupRole({role: "builder"});
+				assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
+			}).pipe(Effect.provide(socketClientLayer(socketPath)), Effect.scoped);
+		},
+	);
 });

--- a/packages/pipeline-crew-mcp/src/tracker/server.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.ts
@@ -1,7 +1,7 @@
 /**
- * tracker/server — the standing registry `RpcServer` over a per-project unix socket: the raw
- * `trackerServerLayer` bind, the standalone `launchTracker` entry, and the `EADDRINUSE` detector
- * (`isTrackerAddressInUse`) the first-peer-spawn dial fallback keys on.
+ * tracker/server — the standing registry `RpcServer` over a per-project unix socket: the
+ * `trackerServerLayer` bind (with stale-socket reclamation), the standalone `launchTracker` entry,
+ * and the `EADDRINUSE` detector (`isTrackerAddressInUse`) the first-peer-spawn dial fallback keys on.
  *
  * The socket path is derived deterministically from the project root (`socketPathFor`), so every
  * peer of one project rendezvous on the same socket while different projects stay isolated — the
@@ -12,14 +12,24 @@
  * `../crew/tracker.ts` (`crewTrackerHostOrDialLayer`), because it needs both halves; this module
  * owns only the server half plus the bind-error primitive that path branches on.
  *
+ * Crash recovery lives here too (#3280): a unix socket *file* survives an ungraceful host exit —
+ * crash / SIGKILL runs no scope teardown, and node only unlinks the file on a CLEAN `server.close()`,
+ * so the file is left orphaned. That stale file would poison the next spawn — its bind still fails
+ * `EADDRINUSE`, so the caller dials, but the dial hits `ECONNREFUSED` (nothing listening) and the
+ * whole project wedges until someone `rm`s the file. `trackerServerLayer` therefore reclaims a
+ * *stale* socket at bind time (`reclaimStaleSocket`); the liveness probe is what keeps that reclaim
+ * from racing a genuinely-live host offline — it unlinks ONLY on a proven-refused connect.
+ *
  * The served surface is `TrackerRegistry` — registry kinds only (see `./group.ts`); the tracker
  * has no handler for any message-relay kind, so it structurally cannot relay a message.
  */
 import {createHash} from "node:crypto";
+import {unlink} from "node:fs";
+import {connect} from "node:net";
 import {tmpdir} from "node:os";
 import {join, resolve} from "node:path";
 import {NodeSocketServer} from "@effect/platform-node";
-import {Cause, type Effect, Layer, Option} from "effect";
+import {Cause, Effect, Layer, Option} from "effect";
 import {RpcSerialization, RpcServer} from "effect/unstable/rpc";
 import {SocketServerError} from "effect/unstable/socket/SocketServer";
 import {TrackerRegistry} from "./group.ts";
@@ -39,12 +49,61 @@ export const socketPathFor = (projectRoot: string): string => {
 };
 
 /**
+ * Reclaim a *stale* unix socket at `socketPath` before a bind: unlink the file iff a connect to it
+ * is definitively refused (`ECONNREFUSED` — the file exists but no host listens, the crash-path
+ * signature grounded in node's `net` semantics, see `probeStaleSocket`). Any other outcome leaves
+ * the file untouched: a live host (connect succeeds) is dialed by the caller, not reclaimed out from
+ * under it (#3280 AC — never an unconditional unlink); an absent file (`ENOENT`) is the normal
+ * first-spawn and needs no reclaim; an ambiguous error is left for the real bind to surface. The
+ * unlink is best-effort — if a concurrent peer reclaimed+rebound in the probe→unlink window, our
+ * bind then loses the race with `EADDRINUSE` and the caller dials, the same convergence as a live host.
+ */
+const reclaimStaleSocket = (socketPath: string): Effect.Effect<void> =>
+	probeStaleSocket(socketPath).pipe(
+		Effect.flatMap((isStale) =>
+			isStale
+				? Effect.callback<void>((resume) => {
+						unlink(socketPath, () => resume(Effect.void));
+					})
+				: Effect.void,
+		),
+	);
+
+/**
+ * Probe whether `socketPath` is a *stale* socket — a file present on disk with nothing listening.
+ * Grounded in node `net` connect semantics (verified against the real platform, #3280): a live
+ * listener answers with `"connect"`; a crashed host's orphaned socket file refuses with
+ * `ECONNREFUSED`; an absent path errors `ENOENT`. Stale is EXACTLY `ECONNREFUSED` — every other
+ * outcome (connected, `ENOENT`, or any other error such as a non-socket file's `ENOTSOCK`) is
+ * reported not-stale, so the caller never unlinks a live or ambiguous socket.
+ */
+const probeStaleSocket = (socketPath: string): Effect.Effect<boolean> =>
+	Effect.callback<boolean>((resume) => {
+		const sock = connect(socketPath);
+		const settle = (isStale: boolean) => {
+			sock.removeAllListeners();
+			sock.destroy();
+			resume(Effect.succeed(isStale));
+		};
+		sock.once("connect", () => settle(false));
+		sock.once("error", (error) => settle((error as NodeJS.ErrnoException).code === "ECONNREFUSED"));
+	});
+
+/**
  * The composed tracker server layer: the registry `RpcServer` (its handlers over `RegistryLive`)
  * bound to a unix `SocketServer` at `socketPath`, NDJSON-framed. Building the layer starts the
  * server listening on a scoped fiber; closing the scope stops it. Its error channel carries the
  * `SocketServerError` a failed bind (e.g. `EADDRINUSE`) raises.
+ *
+ * `reclaimStaleSocket` runs first (sequenced by `Layer.unwrap`) so a crashed host's orphaned socket
+ * is cleared before the bind — the crash-recovery contract in the module docblock (#3280). A live
+ * host's socket is left intact, so a genuine second peer still hits `EADDRINUSE` and dials it.
  */
 export const trackerServerLayer = (socketPath: string) =>
+	Layer.unwrap(reclaimStaleSocket(socketPath).pipe(Effect.as(boundTrackerServerLayer(socketPath))));
+
+/** The raw bind, no reclamation — `trackerServerLayer` runs `reclaimStaleSocket` ahead of this. */
+const boundTrackerServerLayer = (socketPath: string) =>
 	RpcServer.layer(TrackerRegistry).pipe(
 		Layer.provide(TrackerHandlers.pipe(Layer.provide(RegistryLive))),
 		Layer.provide(


### PR DESCRIPTION
Fixes #3280

## Problem

An ungraceful tracker-host exit (crash / `SIGKILL`) runs no scope teardown, and node only unlinks a unix socket file on a clean `server.close()` — so the per-project `.sock` file is left orphaned on disk. That stale file poisoned the next first-peer spawn: the bind still failed `EADDRINUSE` (the file exists), so the caller took the **dial** branch, but the dial hit `ECONNREFUSED` (nothing listening) and the whole project's crew stayed wedged until someone `rm`'d the file by hand.

## Fix (tracker-side only)

`trackerServerLayer` now reclaims a **stale** socket before it binds (`reclaimStaleSocket`, sequenced ahead of the bind via `Layer.unwrap`):

- It probes the socket with a short connect and **unlinks it only on a definitively refused connect** (`ECONNREFUSED` — the file-present-no-listener signature).
- Every other outcome leaves the file untouched: a **live** host (connect succeeds) is dialed as a client, never reclaimed out from under the running host; an **absent** path (`ENOENT`) is the normal first spawn; any **ambiguous** error (e.g. a plain file's `ENOTSOCK`) is left for the real bind to surface.
- This is **never an unconditional unlink**, so it cannot race a genuinely-live host offline (the load-bearing guard from the issue).

The change lands on `trackerServerLayer`, so both `crewTrackerHostOrDialLayer` (first-peer-spawn) and `ensureTrackerRunning` inherit the recovery — no edits to `crew/` or `standup/`.

## Grounding

- `net` connect/bind semantics verified against the real platform: a SIGKILL'd host's orphaned socket refuses a connect with `ECONNREFUSED`; an absent path errors `ENOENT`; a plain (non-socket) file errors `ENOTSOCK`.
- The `SocketServer` bind path grounded in `@effect/platform-node-shared`'s `NodeSocketServer` (`Net.createServer` + `server.listen`, `EADDRINUSE` surfaced as `SocketServerError { reason: SocketServerOpenError }`).

## Tests

- **Reclaim + re-host:** a stale socket is simulated faithfully by SIGKILL'ing a child that bound the socket (leaving the file with no listener), then asserting the next bind reclaims and re-hosts the tracker (a real announce→lookup round-trip proves it).
- **Live socket left intact:** a live host is stood up, and a second bind is asserted to still fail with `EADDRINUSE` (the dial signal), with the live host continuing to serve — proving reclaim only touches a genuinely stale socket.

Scope: `packages/pipeline-crew-mcp/src/tracker/server.ts` + `server.test.ts`. Non-§CP (ADR 0187) → auto-ships on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)