### PR TITLE
fix(pipeline-crew-mcp): stand-up launcher seams 1 + 3 — config tmux reader, bind instance (#3354)

### DIFF
--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -30,19 +30,12 @@
  * Wired per effect-smol's CLI guidance (mirrors `@kampus/pipeline-cli`'s bin): `effect/unstable/cli`
  * for the typed command, the Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
-import {readFileSync} from "node:fs";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Cause, Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 
 import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
-import {
-	LaunchConfigError,
-	parseJsonc,
-	resolveConfigPath,
-	runStandUp,
-	type TmuxNaming,
-} from "./standup/index.ts";
+import {runStandUp} from "./standup/index.ts";
 import {isTrackerAddressInUse, launchTracker} from "./tracker/index.ts";
 import {VERSION} from "./version.ts";
 
@@ -94,49 +87,6 @@ const tracker = Command.make(
 	Command.withDescription("Run a standalone per-project tracker (the registry socket server)"),
 );
 
-/**
- * Read the operator's tmux naming (session + per-window names) from the crew config. The typed,
- * validated tmux-dimension reader is tracked separately (config.ts reads only the launch dimensions
- * today); this thin entrypoint marshal threads the operator's `tmux` block through to the
- * orchestration, which fails loud on any bridge window it cannot name. Resolves the config path by
- * the same `$CREW_CONFIG` → `.claude/crew.config.jsonc` order as the launch-dimension reader.
- */
-const readTmuxNaming = (
-	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
-): Effect.Effect<TmuxNaming, LaunchConfigError> =>
-	Effect.gen(function* () {
-		const configPath = resolveConfigPath(env);
-		const text = yield* Effect.try({
-			try: () => readFileSync(configPath, "utf8"),
-			catch: (cause) =>
-				new LaunchConfigError({
-					configPath,
-					reason: `cannot read crew config (run pipeline-crew stand-up first): ${String(cause)}`,
-				}),
-		});
-		const parsed = yield* Effect.try({
-			try: () => parseJsonc(text),
-			catch: (cause) =>
-				new LaunchConfigError({configPath, reason: `invalid JSONC: ${String(cause)}`}),
-		});
-		const tmux = (
-			parsed as {readonly tmux?: {readonly session?: unknown; readonly windows?: unknown}}
-		).tmux;
-		if (
-			tmux === undefined ||
-			typeof tmux.session !== "string" ||
-			tmux.windows === null ||
-			typeof tmux.windows !== "object"
-		) {
-			return yield* new LaunchConfigError({
-				configPath,
-				reason:
-					"missing or malformed `tmux` dimension — expected { session: string, windows: {...} }",
-			});
-		}
-		return {session: tmux.session, windows: tmux.windows as Readonly<Record<string, string>>};
-	});
-
 const standUp = Command.make(
 	"stand-up",
 	{projectRoot: projectRootFlag},
@@ -144,8 +94,9 @@ const standUp = Command.make(
 		yield* Console.error(
 			`pipeline-crew-mcp ${VERSION} — standing up the crew from the operator config (project ${projectRoot})`,
 		);
-		const tmuxNaming = yield* readTmuxNaming();
-		return yield* runStandUp({projectRoot, tmuxNaming}).pipe(
+		// runStandUp reads every launch dimension — including the tmux placement dimension — from the
+		// operator crew config itself (config.ts's typed reader, #3354 seam 1); nothing to inject here.
+		return yield* runStandUp({projectRoot}).pipe(
 			Effect.flatMap((result) =>
 				Console.error(
 					`crew up: tracker pid ${result.tracker.pid ?? "?"} on ${result.tracker.socketPath}; ${result.launched.length} sessions launched (${result.launched

--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -14,6 +14,7 @@ import {
 	buildSessionBind,
 	ChannelPluginNotAllowedError,
 	CREW_SESSION_COMMAND,
+	CREW_SESSION_INSTANCE_FLAG,
 	CrewServerNotRegisteredError,
 	DEV_CHANNEL_FLAG,
 	MCP_CONFIG_FLAG,
@@ -122,6 +123,64 @@ describe("standup/bind — per-session bind constructor", () => {
 				assert.instanceOf(error, CrewServerNotRegisteredError);
 				assert.strictEqual(error.serverName, SERVER_NAME);
 				assert.deepStrictEqual([...error.servers], ["server:some-other"]);
+			}),
+	);
+
+	it.effect(
+		"bakes the launcher-assigned per-instance identity into the session argv (seam 3, #3354)",
+		() =>
+			Effect.gen(function* () {
+				const INSTANCE = "e-7f3a";
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const bind = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					instance: INSTANCE,
+					channels,
+				});
+
+				// the instance flag + id ride the inline --mcp-config server command, after --project-root.
+				const expected = JSON.stringify({
+					mcpServers: {
+						[SERVER_NAME]: {
+							command: PIPELINE_CREW_MCP_BIN,
+							args: [
+								CREW_SESSION_COMMAND,
+								"--role",
+								ROLE,
+								"--project-root",
+								PROJECT_ROOT,
+								CREW_SESSION_INSTANCE_FLAG,
+								INSTANCE,
+							],
+						},
+					},
+				});
+				assert.deepStrictEqual(bind.mcpConfigArg, [MCP_CONFIG_FLAG, expected]);
+			}),
+	);
+
+	it.effect(
+		"omits the instance flag when no per-instance identity is given (a bridge singleton)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const bind = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+				assert.notInclude(bind.mcpConfigArg[1], CREW_SESSION_INSTANCE_FLAG);
 			}),
 	);
 

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -28,6 +28,12 @@ import type {ChannelConfig} from "./config.ts";
 export const PIPELINE_CREW_MCP_BIN = "pipeline-crew-mcp";
 /** The subcommand that runs one live crew session (`bin.ts`). */
 export const CREW_SESSION_COMMAND = "session";
+/**
+ * Binds the launcher-assigned per-instance identity (#3297) into the session command, so the
+ * launched engine comes up on THAT address instead of `crew/session.ts` re-minting its own runtime
+ * instance — the C5 handoff #3297 left for bind to turn into argv (#3354, seam 3).
+ */
+export const CREW_SESSION_INSTANCE_FLAG = "--instance";
 export const MCP_CONFIG_FLAG = "--mcp-config";
 /** Allowlist mode: only servers named here load, gated by `allowedChannelPlugins` for plugin refs. */
 export const ALLOWLIST_CHANNEL_FLAG = "--channels";
@@ -37,13 +43,30 @@ export const DEV_CHANNEL_FLAG = "--dangerously-load-development-channels";
 /** The `server:<name>` channel ref that names the crew session server registered under `serverName`. */
 const crewServerRef = (serverName: string): string => `server:${serverName}`;
 
-/** The inline `--mcp-config` JSON: one server keyed by `serverName`, baking the per-invocation session command. */
-const sessionMcpConfigJson = (role: string, projectRoot: string, serverName: string): string =>
+/**
+ * The inline `--mcp-config` JSON: one server keyed by `serverName`, baking the per-invocation session
+ * command. When an engine's launcher-assigned `instance` (#3297) is present it is baked as
+ * `--instance <id>` so the launched session binds THAT identity; a bridge (singleton, no instance)
+ * omits the flag.
+ */
+const sessionMcpConfigJson = (
+	role: string,
+	projectRoot: string,
+	serverName: string,
+	instance: string | undefined,
+): string =>
 	JSON.stringify({
 		mcpServers: {
 			[serverName]: {
 				command: PIPELINE_CREW_MCP_BIN,
-				args: [CREW_SESSION_COMMAND, "--role", role, "--project-root", projectRoot],
+				args: [
+					CREW_SESSION_COMMAND,
+					"--role",
+					role,
+					"--project-root",
+					projectRoot,
+					...(instance !== undefined ? [CREW_SESSION_INSTANCE_FLAG, instance] : []),
+				],
 			},
 		},
 	});
@@ -69,6 +92,12 @@ export interface SessionBindInput {
 	 * defined-but-inert — the fail-closed `CrewServerNotRegisteredError` below.
 	 */
 	readonly serverName: string;
+	/**
+	 * The launcher-assigned per-instance identity (#3297) an engine session binds — baked into the
+	 * session argv as `--instance <id>` so the launched engine comes up on that address rather than
+	 * re-minting its own runtime instance (#3354, seam 3). A bridge is a singleton and omits it.
+	 */
+	readonly instance?: string | undefined;
 	/** The resolved channels dimension of the crew `LaunchConfig` (#3293), consumed read-only. */
 	readonly channels: ChannelConfig;
 }
@@ -112,7 +141,7 @@ export const buildSessionBind = (
 	input: SessionBindInput,
 ): Effect.Effect<SessionBind, CrewServerNotRegisteredError | ChannelPluginNotAllowedError> =>
 	Effect.gen(function* () {
-		const {role, projectRoot, serverName, channels} = input;
+		const {role, projectRoot, serverName, instance, channels} = input;
 		const servers = channels.servers;
 
 		if (!servers.includes(crewServerRef(serverName))) {
@@ -139,7 +168,7 @@ export const buildSessionBind = (
 		const channelFlag = channels.mode === "development" ? DEV_CHANNEL_FLAG : ALLOWLIST_CHANNEL_FLAG;
 		const mcpConfigArg: readonly [string, string] = [
 			MCP_CONFIG_FLAG,
-			sessionMcpConfigJson(role, projectRoot, serverName),
+			sessionMcpConfigJson(role, projectRoot, serverName, instance),
 		];
 		const channelArg: readonly string[] = [channelFlag, ...servers];
 

--- a/packages/pipeline-crew-mcp/src/standup/config.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.test.ts
@@ -10,6 +10,7 @@ import {Effect} from "effect";
 import {
 	DEFAULT_CONFIG_PATH,
 	decodeLaunchConfig,
+	decodeTmuxNaming,
 	LaunchConfigError,
 	parseJsonc,
 	resolveConfigPath,
@@ -159,6 +160,50 @@ describe("standup/config — server: ref reconciles with mode", () => {
 				},
 			});
 			assert.include(err.reason, "servers");
+		}),
+	);
+});
+
+describe("standup/config — decodeTmuxNaming (tmux placement dimension, seam 1 #3354)", () => {
+	const decodeTmuxErr = (input: unknown) =>
+		Effect.flip(decodeTmuxNaming(input, "/tmp/crew.config.jsonc"));
+
+	it.effect(
+		"extracts session + window naming from the tmux dimension of the full crew config",
+		() =>
+			Effect.gen(function* () {
+				const naming = yield* decodeTmuxNaming(fullCrewConfig, DEFAULT_CONFIG_PATH);
+				assert.strictEqual(naming.session, "s");
+				assert.deepStrictEqual(
+					{...naming.windows},
+					{ea: "ea", engineeringManager: "em", triage: "t"},
+				);
+			}),
+	);
+	it.effect("fails closed naming tmux when the dimension is absent", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeTmuxErr(validLaunch);
+			assert.instanceOf(err, LaunchConfigError);
+			assert.include(err.reason, "tmux");
+			assert.strictEqual(err.configPath, "/tmp/crew.config.jsonc");
+		}),
+	);
+	it.effect("fails closed on a missing session name", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeTmuxErr({tmux: {windows: {ea: "ea"}}});
+			assert.include(err.reason, "session");
+		}),
+	);
+	it.effect("fails closed on a blank session name", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeTmuxErr({tmux: {session: "", windows: {ea: "ea"}}});
+			assert.include(err.reason, "session");
+		}),
+	);
+	it.effect("fails closed on a blank window name", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeTmuxErr({tmux: {session: "crew", windows: {ea: ""}}});
+			assert.include(err.reason, "windows");
 		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/standup/config.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.ts
@@ -12,11 +12,13 @@
  * The one non-obvious thing: the reader FAILS CLOSED. A missing or malformed launch
  * dimension is a `LaunchConfigError` naming the offending dimension, never a silent default
  * — a drifted CLI pin or an unlisted channel server is a launch to refuse, not paper over.
- * Excess keys (operator, tmux, modelTiers, …) are ignored: this schema extracts only the
- * launch dimensions from the full crew config, so it composes with the rest of the seam.
+ * `LaunchConfig` extracts only the launch dimensions (excess keys operator/modelTiers/… are
+ * ignored); the tmux *placement* dimension has its own sibling reader `readTmuxNaming` (#3354),
+ * fail-closed the same way, so tmux naming enters from the operator config rather than injected.
  */
 import {readFileSync} from "node:fs";
 import {Effect, Schema} from "effect";
+import type {TmuxNaming} from "./tmux-placement.ts";
 
 /**
  * A channel-server ref, in the exact registration grammar Claude Code 2.1.212 accepts —
@@ -118,6 +120,22 @@ export const LaunchConfig = Schema.Struct({
 });
 export type LaunchConfig = typeof LaunchConfig.Type;
 
+/**
+ * The tmux placement dimension of the crew config: the tmux session every crew window is created
+ * under + the per-bridge window names, keyed by window key. It decodes to `tmux-placement.ts`'s
+ * `TmuxNaming` (the placement layer consumes the resolved shape) — this is the reader #3298's
+ * placement doc already anticipated ("#3293's reader resolves from the config `tmux` dimension")
+ * but no child built, so `runStandUp` had to inject it in code (#3354, seam 1). Names are
+ * `NonEmptyString`: an empty tmux session / window name is a launch to refuse, not paper over.
+ */
+export const TmuxConfig = Schema.Struct({
+	session: Schema.NonEmptyString,
+	windows: Schema.Record(Schema.String, Schema.NonEmptyString),
+});
+
+/** The crew config carries the tmux placement dimension under its `tmux` key — read only that key. */
+const CrewConfigTmux = Schema.Struct({tmux: TmuxConfig});
+
 /** A crew config that could not be resolved, read, parsed, or validated — carries the offending dimension. */
 export class LaunchConfigError extends Schema.TaggedErrorClass<LaunchConfigError>()(
 	"@kampus/pipeline-crew-mcp/standup/LaunchConfigError",
@@ -213,13 +231,27 @@ export const decodeLaunchConfig = (
 	);
 
 /**
- * Resolve → read → parse → decode the crew config's launch dimensions. Every failure along the
- * way (path unreadable, JSONC malformed, a dimension missing/invalid) collapses to a single
- * `LaunchConfigError` carrying the resolved path and the reason — never a partial or a default.
+ * Decode an already-parsed value's `tmux` dimension into `TmuxNaming`, failing closed with a
+ * `LaunchConfigError` whose `reason` names the offending field — the same fail-closed shape as
+ * `decodeLaunchConfig`, so a missing/blank tmux session or window is a launch to refuse (#3354).
  */
-export const readLaunchConfig = (
-	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
-): Effect.Effect<LaunchConfig, LaunchConfigError> =>
+export const decodeTmuxNaming = (
+	input: unknown,
+	configPath: string,
+): Effect.Effect<TmuxNaming, LaunchConfigError> =>
+	Schema.decodeUnknownEffect(CrewConfigTmux)(input).pipe(
+		Effect.map((cfg) => cfg.tmux),
+		Effect.mapError((error) => new LaunchConfigError({configPath, reason: error.message})),
+	);
+
+/**
+ * Resolve → read → parse the crew config once, collapsing an unreadable path or malformed JSONC to
+ * a single `LaunchConfigError`. Shared by both dimension readers so the resolve/read/parse contract
+ * lives in one place; each reader decodes its own dimension off the parsed value.
+ */
+const readParsedConfig = (env: {
+	readonly CREW_CONFIG?: string | undefined;
+}): Effect.Effect<{readonly parsed: unknown; readonly configPath: string}, LaunchConfigError> =>
 	Effect.gen(function* () {
 		const configPath = resolveConfigPath(env);
 		const text = yield* Effect.try({
@@ -235,5 +267,29 @@ export const readLaunchConfig = (
 			catch: (cause) =>
 				new LaunchConfigError({configPath, reason: `invalid JSONC: ${String(cause)}`}),
 		});
-		return yield* decodeLaunchConfig(parsed, configPath);
+		return {parsed, configPath};
 	});
+
+/**
+ * Resolve → read → parse → decode the crew config's launch dimensions. Every failure along the
+ * way (path unreadable, JSONC malformed, a dimension missing/invalid) collapses to a single
+ * `LaunchConfigError` carrying the resolved path and the reason — never a partial or a default.
+ */
+export const readLaunchConfig = (
+	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
+): Effect.Effect<LaunchConfig, LaunchConfigError> =>
+	readParsedConfig(env).pipe(
+		Effect.flatMap(({parsed, configPath}) => decodeLaunchConfig(parsed, configPath)),
+	);
+
+/**
+ * Resolve → read → parse → decode the crew config's tmux placement dimension. Same collapse-to-one
+ * `LaunchConfigError` contract as `readLaunchConfig`, so `runStandUp` reads tmux naming from the
+ * operator config (fail-closed) instead of taking it injected in code (#3354, seam 1).
+ */
+export const readTmuxNaming = (
+	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
+): Effect.Effect<TmuxNaming, LaunchConfigError> =>
+	readParsedConfig(env).pipe(
+		Effect.flatMap(({parsed, configPath}) => decodeTmuxNaming(parsed, configPath)),
+	);

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -9,6 +9,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Schema} from "effect";
 import {CREW_ROLES, kindOf} from "../crew/index.ts";
+import {CREW_SESSION_INSTANCE_FLAG} from "./bind.ts";
 import {LaunchConfig, LaunchConfigError} from "./config.ts";
 import {type TrackerHandle, TrackerNotServingError} from "./ensure-tracker.ts";
 import {
@@ -89,7 +90,7 @@ const baseInput = (
 		trackerCalls: calls,
 		input: {
 			projectRoot: "/repo",
-			tmuxNaming,
+			tmuxConfig: Effect.succeed(tmuxNaming),
 			config: Effect.succeed(configAt(PINNED, engineCount ?? 2)),
 			readVersionOutput: Effect.succeed(`${PINNED} (Claude Code)`),
 			instanceId: counter(),
@@ -199,7 +200,8 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 	it.effect("aborts when a bridge names no operator tmux window — no partial crew (AC3)", () =>
 		Effect.gen(function* () {
 			const {input, launched} = baseInput({
-				tmuxNaming: {session: "crew", windows: {"chief-of-staff": "cos"}}, // cartographer/intake-desk unnamed
+				// cartographer/intake-desk unnamed
+				tmuxConfig: Effect.succeed({session: "crew", windows: {"chief-of-staff": "cos"}}),
 			});
 			const err = yield* Effect.flip(runStandUp(input));
 
@@ -220,5 +222,44 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 				assert.instanceOf(err, CrewServerNotRegisteredError);
 				assert.strictEqual(launched.length, 0);
 			}),
+	);
+
+	it.effect(
+		"reads tmux naming from config: a malformed tmux dimension aborts before launch (seam 1)",
+		() =>
+			Effect.gen(function* () {
+				const {input, launched, trackerCalls} = baseInput({
+					tmuxConfig: Effect.fail(
+						new LaunchConfigError({configPath: ".claude/crew.config.jsonc", reason: "tmux"}),
+					),
+				});
+				const err = yield* Effect.flip(runStandUp(input));
+
+				assert.instanceOf(err, LaunchConfigError);
+				// tmux is read alongside the launch config, before the tracker or any launch.
+				assert.strictEqual(trackerCalls(), 0);
+				assert.strictEqual(launched.length, 0);
+			}),
+	);
+
+	it.effect("threads each engine's per-instance identity into its launch argv (seam 3)", () =>
+		Effect.gen(function* () {
+			const {input, launched} = baseInput({engineCount: 3});
+			yield* runStandUp(input);
+
+			const engines = launched.filter((p) => p.session.kind === "engine");
+			assert.strictEqual(engines.length, 3);
+			for (const p of engines) {
+				assert.strictEqual(p.session.kind, "engine");
+				const instance = p.session.kind === "engine" ? p.session.instance : "";
+				// the instance-flag pair rides the inline --mcp-config JSON (mcpConfigArg[1]).
+				const mcpJson = p.bind.mcpConfigArg[1];
+				assert.include(mcpJson, `"${CREW_SESSION_INSTANCE_FLAG}"`);
+				assert.include(mcpJson, `"${instance}"`);
+			}
+			// a bridge is a singleton and carries no --instance in its argv.
+			const bridge = launched.find((p) => p.session.kind === "bridge");
+			assert.notInclude(bridge?.bind.mcpConfigArg[1] ?? "", CREW_SESSION_INSTANCE_FLAG);
+		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -28,7 +28,12 @@ import {
 	type CrewServerNotRegisteredError,
 	type SessionBind,
 } from "./bind.ts";
-import {type LaunchConfig, type LaunchConfigError, readLaunchConfig} from "./config.ts";
+import {
+	type LaunchConfig,
+	type LaunchConfigError,
+	readLaunchConfig,
+	readTmuxNaming,
+} from "./config.ts";
 import {
 	ensureTrackerRunning,
 	type TrackerHandle,
@@ -90,11 +95,11 @@ export interface StandUpInput {
 	/** The project root the tracker + every session join (the per-project socket key). */
 	readonly projectRoot: string;
 	/**
-	 * The operator-configured tmux naming (session + per-bridge window names). It is NOT a launch
-	 * dimension of `LaunchConfig` — config.ts reads only the CLI pin, engine count, and channels — so
-	 * the caller resolves the tmux dimension and threads it here.
+	 * The operator-configured tmux naming (session + per-bridge window names). Read from the crew
+	 * config's tmux dimension by default (`readTmuxNaming`, #3354 seam 1) rather than injected in
+	 * code; injectable here so the composition stays unit-testable without a config file on disk.
 	 */
-	readonly tmuxNaming: TmuxNaming;
+	readonly tmuxConfig?: Effect.Effect<TmuxNaming, LaunchConfigError>;
 	/** The channel-ref name each session's own crew MCP server registers under. Default: `SESSION_SERVER_NAME`. */
 	readonly serverName?: string;
 	/** The launch dimensions to stand up under. Default: read the operator crew config (`readLaunchConfig`). */
@@ -169,13 +174,16 @@ export const launchSessionInTmux = (
  */
 export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, StandUpError> =>
 	Effect.gen(function* () {
-		const {projectRoot, tmuxNaming} = input;
+		const {projectRoot} = input;
 		const serverName = input.serverName ?? SESSION_SERVER_NAME;
 		const instanceId = input.instanceId ?? randomUUID;
 		const ensureTracker = input.ensureTracker ?? ensureTrackerRunning;
 		const launch = input.launch ?? launchSessionInTmux;
 
 		const config = yield* input.config ?? readLaunchConfig();
+		// Read the tmux placement dimension from the operator config too (#3354 seam 1) — a malformed
+		// tmux dimension is a config-time abort, before the tracker or any session launches.
+		const tmuxNaming = yield* input.tmuxConfig ?? readTmuxNaming();
 		// Fail fast on a version drift before starting the tracker or any session — channels vary
 		// across CLI versions, so a mismatch is a stand-up to refuse (version-assert.ts / #3295).
 		yield* assertPinnedCliVersion(config, input.readVersionOutput ?? readInstalledCliVersionOutput);
@@ -186,7 +194,15 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 		// Resolve EVERY bind + placement before launching anything — this is the no-partial-crew line:
 		// an inert channel, an unnamed or colliding window fails here, while zero sessions are up.
 		const binds = yield* Effect.forEach(sessions, (session) =>
-			buildSessionBind({role: session.role, projectRoot, serverName, channels: config.channels}),
+			buildSessionBind({
+				role: session.role,
+				projectRoot,
+				serverName,
+				// Thread the session-set-derived per-instance identity so the launched engine binds it
+				// rather than re-minting its own (#3354 seam 3); a bridge is a singleton and has none.
+				instance: session.kind === "engine" ? session.instance : undefined,
+				channels: config.channels,
+			}),
 		);
 		const placements = yield* computeTmuxPlacement(tmuxNaming, sessions.map(toRosterSession));
 		// `binds` and `placements` are each derived from `sessions` in order, so the index is always

--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
@@ -8,6 +8,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
+import {decodeTmuxNaming} from "./config.ts";
 import {
 	computeTmuxPlacement,
 	type RosterSession,
@@ -107,6 +108,28 @@ describe("standup/tmux-placement — session set → placement targets", () => {
 			assert.instanceOf(failure, TmuxWindowCollisionError);
 			assert.strictEqual(failure.window, "chief-of-staff");
 			assert.deepStrictEqual([...failure.sessionRefs], ["ea-chief-of-staff", "chief-of-staff"]);
+		}),
+	);
+
+	// Seam 1 (#3354): the config tmux-dimension reader's output feeds this placement layer directly —
+	// the naming that was injected in code now comes from the operator config, end to end.
+	it.effect("places sessions from a config-decoded TmuxNaming (reader → placement)", () =>
+		Effect.gen(function* () {
+			const naming = yield* decodeTmuxNaming(
+				{tmux: {session: "crew", windows: {ea: "chief-of-staff"}}},
+				"/tmp/crew.config.jsonc",
+			);
+			const targets = yield* computeTmuxPlacement(naming, [
+				{kind: "bridge", role: "ea-chief-of-staff", windowKey: "ea"},
+				{kind: "engine", id: "engine-1"},
+			]);
+			assert.deepStrictEqual(
+				targets.map((t) => ({session: t.session, window: t.window})),
+				[
+					{session: "crew", window: "chief-of-staff"},
+					{session: "crew", window: "engine-1"},
+				],
+			);
 		}),
 	);
 });


### PR DESCRIPTION
Wires two of the three stand-up launcher integration seams from #3237 that don't
compose end-to-end on `origin/main`. **Seams 1 and 3 land here; seam 2 is a founder
design decision and is intentionally left open** (see below).

Fixes #3354 — does **not** fully close it (seam 2 unresolved), so no `Fixes`.

## Seam 1 — config exposes a typed tmux-placement-dimension reader (AC1) ✅
`config.ts` now decodes the crew config's `tmux` block:
- `TmuxConfig` schema + `decodeTmuxNaming` / `readTmuxNaming`, decoding into
  `tmux-placement.ts`'s `TmuxNaming`, **fail-closed** the same way as the launch-dimension
  reader — a missing/blank tmux session or window name yields a `LaunchConfigError` naming
  the offending field.
- `runStandUp` reads `tmuxNaming` from config by default (`tmuxConfig` injectable for tests)
  instead of taking it injected in code.
- `src/bin.ts`'s hand-rolled tmux reader — whose own docblock deferred to "the typed reader
  tracked separately" — is removed in favor of the config reader (the seam it anticipated).

## Seam 3 — bind threads the #3297-derived per-instance identity into argv (AC3) ✅
`bind.ts` gains `SessionBindInput.instance`, baked as `--instance <id>` into the inline
`--mcp-config` session command, so a launched engine binds the launcher-assigned identity
rather than `crew/session.ts` re-minting its own; a bridge (singleton) omits the flag.
`runStandUp` passes each engine session's `instance` through.

## Seam 2 — allowlist-mode crew-server binding (AC2) ⛔ STOPPED — founder decision
Not done here, and **not a mechanical fix**. bind's inline `--mcp-config` defines the crew
server under the `server:<name>` grammar (a top-level channel MCP server). The 2.1.212
runtime **skips a non-dev `server:` channel under `--channels`** (allowlist), which accepts
only `plugin:<name>@<marketplace>` **marketplace** refs (grounded in `config.ts` /  #3328).
So an inline-defined server is inherently dev-mode-only; making the crew's own server
allowlist-bindable would require **packaging it as a distributable marketplace plugin
channel** (well past a bounded wiring change), or the **decision that allowlist-mode crew
launch is a non-goal** (dev mode only). Both are founder rulings, not the coder's to make —
so this seam is left as the pre-existing `origin/main` contradiction, unrecorded, pending
that decision.

## Tests
- `config.test.ts` — tmux reader happy path + fail-closed (absent `tmux`, blank session,
  blank window).
- `bind.test.ts` — instance baked into argv when present; omitted when absent.
- `tmux-placement.test.ts` — config-decoded `TmuxNaming` feeds `computeTmuxPlacement`.
- `orchestrate.test.ts` — `runStandUp` reads tmux from config (malformed aborts pre-launch);
  each engine's per-instance identity threaded into its launch argv.

`pnpm --filter @kampus/pipeline-crew-mcp typecheck` + `vitest run` (165 tests) + biome all green.

Non-§CP (`packages/pipeline-crew-mcp/**`, `src/bin.ts` — outside `CONTROL_PLANE_RE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)