### PR TITLE
test(e2e): sweep Math.random() out of the test tree to clear CodeQL alert #20

### DIFF
--- a/apps/web/tests/e2e/05-pano-vote.spec.ts
+++ b/apps/web/tests/e2e/05-pano-vote.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {completeBootstrap, signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 
 /**
@@ -31,7 +32,7 @@ test.fixme("upvote increments and toggles back (signed in)", async ({page}) => {
 	// Submit a fresh post so we vote on a card nothing else is touching.
 	await page.goto("/pano/yeni");
 	await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({timeout: 10_000});
-	const title = `vote feed target ${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+	const title = `vote feed target ${Date.now().toString(36)}${randomSuffix(4)}`;
 	await page
 		.locator('[data-testid="pano-submit-url"]')
 		.fill(`https://example.com/${Date.now().toString(36)}`);

--- a/apps/web/tests/e2e/09-profile.spec.ts
+++ b/apps/web/tests/e2e/09-profile.spec.ts
@@ -1,5 +1,6 @@
 import {expect, type Page, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Helper: complete the bootstrap form so the signed-in user is past the
@@ -7,7 +8,7 @@ import {signUp} from "./_helpers/auth";
  * blocks the Outlet (T13 behaviour).
  */
 async function bootstrapUsername(page: Page): Promise<void> {
-	const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+	const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 	await page.locator("input#bootstrap-username").fill(handle);
 	await page.getByRole("button", {name: /devam et/i}).click();
 	await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {

--- a/apps/web/tests/e2e/10-username-bootstrap.spec.ts
+++ b/apps/web/tests/e2e/10-username-bootstrap.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Username bootstrap + topbar profile link.
@@ -32,10 +33,10 @@ test.describe("Username bootstrap", () => {
 	test("submitting the bootstrap form sets username + profile reachable via user menu", async ({
 		page,
 	}) => {
-		const localPart = `bs${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `bs${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
 
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		const input = page.locator("input#bootstrap-username");
 		await input.fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
@@ -51,7 +52,7 @@ test.describe("Username bootstrap", () => {
 	});
 
 	test("client-side validation rejects invalid usernames", async ({page}) => {
-		const localPart = `bs${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `bs${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
 		const input = page.locator("input#bootstrap-username");
 		await expect(input).toBeVisible();

--- a/apps/web/tests/e2e/11-sozluk-add-definition.spec.ts
+++ b/apps/web/tests/e2e/11-sozluk-add-definition.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Sözlük addDefinition end-to-end.
@@ -22,9 +23,9 @@ test.describe("Sözlük addDefinition", () => {
 		page,
 	}) => {
 		// Fresh sign-up + bootstrap so the user is fully authenticated.
-		const localPart = `bs${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `bs${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.locator("input#bootstrap-username").fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {
@@ -32,7 +33,7 @@ test.describe("Sözlük addDefinition", () => {
 		});
 
 		// Navigate to a slug that doesn't exist yet.
-		const slug = `e2e-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const slug = `e2e-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.goto(`/sozluk/${slug}`);
 
 		const composerBody = page.locator('[data-testid="sozluk-composer-body"]');
@@ -61,16 +62,16 @@ test.describe("Sözlük addDefinition", () => {
 	test("submit is disabled for empty body and surfaces an error for >10000 chars", async ({
 		page,
 	}) => {
-		const localPart = `bs${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `bs${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.locator("input#bootstrap-username").fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {
 			timeout: 10_000,
 		});
 
-		const slug = `e2e-validate-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const slug = `e2e-validate-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.goto(`/sozluk/${slug}`);
 
 		const composerBody = page.locator('[data-testid="sozluk-composer-body"]');

--- a/apps/web/tests/e2e/12-sozluk-vote.spec.ts
+++ b/apps/web/tests/e2e/12-sozluk-vote.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 
 /**
@@ -35,9 +36,9 @@ test.describe("Sözlük voteDefinition", () => {
 	// Re-enable = revert to plain test(...).
 	test.fixme("vote → unvote → vote round-trip on a fresh definition", async ({page}) => {
 		// Fresh sign-up + bootstrap so the user is fully authenticated.
-		const localPart = `vt${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `vt${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.locator("input#bootstrap-username").fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {
@@ -45,7 +46,7 @@ test.describe("Sözlük voteDefinition", () => {
 		});
 
 		// Navigate to a fresh slug + add a definition.
-		const slug = `vote-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const slug = `vote-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.goto(`/sozluk/${slug}`);
 
 		const composerBody = page.locator('[data-testid="sozluk-composer-body"]');

--- a/apps/web/tests/e2e/13-sozluk-edit-delete.spec.ts
+++ b/apps/web/tests/e2e/13-sozluk-edit-delete.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signOut, signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Sözlük editDefinition / deleteDefinition end-to-end.
@@ -25,7 +26,7 @@ import {signOut, signUp} from "./_helpers/auth";
  */
 test.describe("Sözlük editDefinition / deleteDefinition", () => {
 	test("author can edit and delete their own definition", async ({page}) => {
-		const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `ed${suffix}@kamp.us`});
 		const handle = `u-${suffix}`;
 		await page.locator("input#bootstrap-username").fill(handle);
@@ -97,7 +98,7 @@ test.describe("Sözlük editDefinition / deleteDefinition", () => {
 		page,
 	}) => {
 		// User A signs up, bootstraps, writes a definition.
-		const aSuffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const aSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `aa${aSuffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`a-${aSuffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();
@@ -117,7 +118,7 @@ test.describe("Sözlük editDefinition / deleteDefinition", () => {
 
 		// Sign A out, sign B up.
 		await signOut(page);
-		const bSuffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const bSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `bb${bSuffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`b-${bSuffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();

--- a/apps/web/tests/e2e/14-pano-submit-post.spec.ts
+++ b/apps/web/tests/e2e/14-pano-submit-post.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Pano submitPost end-to-end.
@@ -13,9 +14,9 @@ import {signUp} from "./_helpers/auth";
  */
 test.describe("Pano submitPost", () => {
 	test("submits a link post and lands on /pano/<id>", async ({page}) => {
-		const localPart = `pp${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `pp${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.locator("input#bootstrap-username").fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {
@@ -49,9 +50,9 @@ test.describe("Pano submitPost", () => {
 	test("blocks submit while the title is too short and surfaces validation hint", async ({
 		page,
 	}) => {
-		const localPart = `pp${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `pp${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.locator("input#bootstrap-username").fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {

--- a/apps/web/tests/e2e/15-pano-vote-post.spec.ts
+++ b/apps/web/tests/e2e/15-pano-vote-post.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 
 /**
@@ -30,9 +31,9 @@ test.describe("Pano voteOnPost", () => {
 	// Re-enable = revert to plain test(...).
 	test.fixme("vote → unvote → vote round-trip on a fresh post", async ({page}) => {
 		// Fresh sign-up + bootstrap so the user is fully authenticated.
-		const localPart = `vp${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `vp${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.locator("input#bootstrap-username").fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {

--- a/apps/web/tests/e2e/16-pano-edit-delete-post.spec.ts
+++ b/apps/web/tests/e2e/16-pano-edit-delete-post.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signOut, signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Pano editPost / deletePost end-to-end.
@@ -18,7 +19,7 @@ import {signOut, signUp} from "./_helpers/auth";
  */
 test.describe("Pano editPost / deletePost", () => {
 	test("author can edit and delete their own post", async ({page}) => {
-		const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `ep${suffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`u-${suffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();
@@ -88,7 +89,7 @@ test.describe("Pano editPost / deletePost", () => {
 
 	test("non-author does not see edit/delete buttons on someone else's post", async ({page}) => {
 		// User A signs up, bootstraps, submits a post.
-		const aSuffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const aSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `aa${aSuffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`a-${aSuffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();
@@ -113,7 +114,7 @@ test.describe("Pano editPost / deletePost", () => {
 
 		// Sign A out, sign B up.
 		await signOut(page);
-		const bSuffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const bSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `bb${bSuffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`b-${bSuffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();

--- a/apps/web/tests/e2e/17-pano-add-comment.spec.ts
+++ b/apps/web/tests/e2e/17-pano-add-comment.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Pano addComment end-to-end.
@@ -16,7 +17,7 @@ import {signUp} from "./_helpers/auth";
  */
 test.describe("Pano addComment", () => {
 	test("submits a top-level comment, then a nested reply", async ({page}) => {
-		const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `cm${suffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`u-${suffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();

--- a/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
+++ b/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 
 /**
@@ -34,9 +35,9 @@ test.describe("Pano voteOnComment", () => {
 	// Re-enable = revert to plain test(...).
 	test.fixme("vote → unvote → vote round-trip on a fresh comment", async ({page}) => {
 		// Fresh sign-up + bootstrap.
-		const localPart = `vc${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `vc${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.locator("input#bootstrap-username").fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {

--- a/apps/web/tests/e2e/19-pano-edit-delete-comment.spec.ts
+++ b/apps/web/tests/e2e/19-pano-edit-delete-comment.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signOut, signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Pano editComment / deleteComment end-to-end.
@@ -22,7 +23,7 @@ test.describe("Pano editComment / deleteComment", () => {
 	test("author can edit a comment, delete a parent → [silindi], delete a leaf → removed", async ({
 		page,
 	}) => {
-		const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `cm${suffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`u-${suffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();
@@ -132,7 +133,7 @@ test.describe("Pano editComment / deleteComment", () => {
 
 	test("non-author does not see edit/delete buttons on someone else's comment", async ({page}) => {
 		// User A signs up, posts, adds a comment.
-		const aSuffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const aSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `aa${aSuffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`a-${aSuffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();
@@ -168,7 +169,7 @@ test.describe("Pano editComment / deleteComment", () => {
 
 		// Sign A out, sign B up.
 		await signOut(page);
-		const bSuffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const bSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `bb${bSuffix}@kamp.us`});
 		await page.locator("input#bootstrap-username").fill(`b-${bSuffix}`);
 		await page.getByRole("button", {name: /devam et/i}).click();

--- a/apps/web/tests/e2e/20-profile-page.spec.ts
+++ b/apps/web/tests/e2e/20-profile-page.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Profile page (T14) — `/u/<username>` route + GraphQL `profile(username)`
@@ -16,7 +17,7 @@ import {signUp} from "./_helpers/auth";
  */
 test.describe("Profile page", () => {
 	test("aggregates 1 definition + 1 post + 1 comment on /u/<username>", async ({page}) => {
-		const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `pf${suffix}@kamp.us`});
 		const handle = `u-${suffix}`;
 		await page.locator("input#bootstrap-username").fill(handle);

--- a/apps/web/tests/e2e/21-landing-stats.spec.ts
+++ b/apps/web/tests/e2e/21-landing-stats.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Landing stats — `landingStats` GraphQL query feeding the landing-page
@@ -26,7 +27,7 @@ test.describe("Landing stats", () => {
 	});
 
 	test("submitting a post bumps totalPosts on /", async ({page}) => {
-		const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `ls${suffix}@kamp.us`});
 		const handle = `ls-${suffix}`;
 		await page.locator("input#bootstrap-username").fill(handle);

--- a/apps/web/tests/e2e/22-pano-live.spec.ts
+++ b/apps/web/tests/e2e/22-pano-live.spec.ts
@@ -1,6 +1,7 @@
 import {type BrowserContext, expect, type Page, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
 import {promoteToYazar} from "./_helpers/promote";
+import {randomSuffix} from "./_helpers/rand";
 
 declare global {
 	interface Window {
@@ -36,7 +37,7 @@ declare global {
  * doesn't surface the assigned user id.
  */
 async function signUpAndBootstrap(page: Page): Promise<{email: string}> {
-	const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+	const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 	const email = `live${suffix}@kamp.us`;
 	await signUp(page, {email});
 	await page.locator("input#bootstrap-username").fill(`lv-${suffix}`);
@@ -85,7 +86,7 @@ test.describe("Pano live (two clients)", () => {
 
 			// Client B creates the post all live action targets and stays on its detail view —
 			// its live SSE connection + comments/header subscriptions are the observer.
-			const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`;
+			const stamp = `${Date.now().toString(36)}${randomSuffix(3)}`;
 			const title = `live target ${stamp}`;
 			const postPath = await submitPost(pageB, title);
 			await expect(pageB.locator(".kp-pano-postpage__thread-heading")).toHaveText("0 yorum", {
@@ -147,7 +148,7 @@ test.describe("Pano live (two clients)", () => {
 			await promoteToYazar(emailA);
 			await promoteToYazar(emailB);
 
-			const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`;
+			const stamp = `${Date.now().toString(36)}${randomSuffix(3)}`;
 			const title = `reconnect target ${stamp}`;
 			const postPath = await submitPost(pageB, title);
 
@@ -208,7 +209,7 @@ test.describe("Pano live (two clients)", () => {
 	test("definition add/delete + comment delete update in place without a reload", async ({
 		page,
 	}) => {
-		const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUpAndBootstrap(page);
 
 		// --- definition.add: the new row appears live on the term page. ---
@@ -332,7 +333,7 @@ test.describe("Pano live (two clients)", () => {
 			});
 
 			// Client A submits a brand-new post.
-			const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`;
+			const stamp = `${Date.now().toString(36)}${randomSuffix(3)}`;
 			const title = `feed live ${stamp}`;
 			await submitPost(pageA, title);
 

--- a/apps/web/tests/e2e/23-auth-redirect.spec.ts
+++ b/apps/web/tests/e2e/23-auth-redirect.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * T17 auth-redirect E2E: signed-out vote on a definition routes to
@@ -15,7 +16,7 @@ test.describe("T17 auth-redirect with returnTo", () => {
 		page,
 	}) => {
 		// --- seed: sign up author A, drop a definition, sign out -------------
-		const slug = `t17-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const slug = `t17-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `author-${slug}@kamp.us`});
 		const handleA = `a-${slug}`;
 		await page.locator("input#bootstrap-username").fill(handleA);

--- a/apps/web/tests/e2e/26-pano-draft-save.spec.ts
+++ b/apps/web/tests/e2e/26-pano-draft-save.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * Pano taslak (draft-save) dark-ship invariant — the off-path proven in-browser.
@@ -19,9 +20,9 @@ import {signUp} from "./_helpers/auth";
  */
 test.describe("Pano draft-save (dark-ship, flag default off)", () => {
 	test("the taslak draft button is absent while the flag defaults off", async ({page}) => {
-		const localPart = `pd${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const localPart = `pd${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
-		const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.locator("input#bootstrap-username").fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {

--- a/apps/web/tests/e2e/27-delete-account.spec.ts
+++ b/apps/web/tests/e2e/27-delete-account.spec.ts
@@ -1,10 +1,11 @@
 import {expect, type Page, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 const CONFIRMATION = "hesabımı kalıcı olarak sil";
 
 async function bootstrapUsername(page: Page): Promise<void> {
-	const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+	const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 	await page.locator("input#bootstrap-username").fill(handle);
 	await page.getByRole("button", {name: /devam et/i}).click();
 	await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {

--- a/apps/web/tests/e2e/30-member-mute-journey.spec.ts
+++ b/apps/web/tests/e2e/30-member-mute-journey.spec.ts
@@ -1,5 +1,6 @@
 import {expect, type Page, test} from "@playwright/test";
 import {completeBootstrap, signUp} from "./_helpers/auth";
+import {randomSuffix} from "./_helpers/rand";
 
 /**
  * The reachability journey for the member-mute (sustur) vertical (ADR 0173 §2, epic #2035).
@@ -144,7 +145,7 @@ test.describe("member mute (sustur) @journey:member-mute", () => {
 
 		// A real signed-in session — muting is a signed-in act (CurrentUser is the muter).
 		await signUp(page, {
-			email: `mm${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}@kamp.us`,
+			email: `mm${Date.now().toString(36)}${randomSuffix(4)}@kamp.us`,
 		});
 		await completeBootstrap(page);
 

--- a/apps/web/tests/e2e/_helpers/rand.ts
+++ b/apps/web/tests/e2e/_helpers/rand.ts
@@ -1,20 +1,22 @@
-import {randomBytes} from "node:crypto";
+import {randomInt} from "node:crypto";
 
 const BASE36 = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 /**
- * Cryptographically-secure drop-in for `Math.random().toString(36).slice(2, 2 + len)`:
- * a `len`-char base36 (0-9a-z) suffix, unique per call, sourced from `node:crypto` so a
- * generated e2e identifier can't trip CodeQL's `js/insecure-randomness` where it flows
+ * Cryptographically-secure drop-in for the old `.toString(36).slice(2, 2 + len)` idiom on a
+ * weak RNG: a `len`-char base36 (0-9a-z) suffix, unique per call, sourced from `node:crypto`
+ * so a generated e2e identifier can't trip CodeQL's `js/insecure-randomness` where it flows
  * into the sign-up credential sink in `./auth.ts` (#3361, alert #20). Callers keep their
  * `Date.now()` prefixes for human-readable ordering — the weakness CodeQL flags is the RNG,
  * not the timestamp.
+ *
+ * `randomInt(36)` draws each index uniformly over [0, 36) — no `randomBytes() % 36`, which
+ * would bias residues 0–3 (256 = 7·36 + 4) and trip js/biased-cryptographic-random.
  */
 export function randomSuffix(len = 6): string {
-	const bytes = randomBytes(len);
 	let out = "";
 	for (let i = 0; i < len; i++) {
-		out += BASE36[bytes[i]! % 36];
+		out += BASE36[randomInt(36)];
 	}
 	return out;
 }

--- a/apps/web/tests/e2e/_helpers/rand.ts
+++ b/apps/web/tests/e2e/_helpers/rand.ts
@@ -1,0 +1,20 @@
+import {randomBytes} from "node:crypto";
+
+const BASE36 = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Cryptographically-secure drop-in for `Math.random().toString(36).slice(2, 2 + len)`:
+ * a `len`-char base36 (0-9a-z) suffix, unique per call, sourced from `node:crypto` so a
+ * generated e2e identifier can't trip CodeQL's `js/insecure-randomness` where it flows
+ * into the sign-up credential sink in `./auth.ts` (#3361, alert #20). Callers keep their
+ * `Date.now()` prefixes for human-readable ordering — the weakness CodeQL flags is the RNG,
+ * not the timestamp.
+ */
+export function randomSuffix(len = 6): string {
+	const bytes = randomBytes(len);
+	let out = "";
+	for (let i = 0; i < len; i++) {
+		out += BASE36[bytes[i]! % 36];
+	}
+	return out;
+}

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -34,6 +34,7 @@
  *   - `h.openSse(...)` / `readFrame(...)` — live SSE transport helpers
  */
 
+import {randomBytes} from "node:crypto";
 import {cfApiThrottle} from "./_cf-api-throttle.ts";
 import {cfFetchWithRateLimitRetry} from "./_d1-rest-retry.ts";
 import {
@@ -208,7 +209,7 @@ const liveControlReady = (res: Response): boolean => res.status !== 503;
 // isolated stage + D1, but a `NO_DESTROY` re-run reuses the same stage's D1, so a
 // fresh stamp per process keeps re-run seed identities from colliding with users a
 // prior run left behind.
-const STAMP_SEED = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const STAMP_SEED = `${Date.now()}-${randomBytes(4).toString("hex").slice(0, 6)}`;
 
 // The seed-id counter MUST live at module scope, the SAME scope as STAMP_SEED — NOT inside
 // `harness()`. Every test file builds its own `harness()` (each `const h = sharedStack()`), so a

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -150,8 +150,8 @@ const NO_DESTROY = !!process.env.NO_DESTROY;
 
 // Per-PROCESS token for local default (destroy-on) runs: stable for one vitest
 // process, distinct across concurrent local processes. The stage is destroyed in
-// afterAll, so this name never outlives the run — pid + hrtime base36, not
-// Date.now()/Math.random() (the stage is single-use; this is deterministic-enough, short).
+// afterAll, so this name never outlives the run — pid + hrtime base36, not a
+// wall-clock + RNG stamp (the stage is single-use; this is deterministic-enough, short).
 const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toString(36)}`.replace(
 	/[^a-z0-9]/g,
 	"",

--- a/apps/web/tests/integration/pano-read.test.ts
+++ b/apps/web/tests/integration/pano-read.test.ts
@@ -31,6 +31,7 @@
  * file's (and this test's) rows. The host-scoping IS the namespace: no ordered assertion
  * reads a feed unfiltered by an NS-host.
  */
+import {randomBytes} from "node:crypto";
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
@@ -326,7 +327,7 @@ describe("pano reads — /fate", () => {
 	});
 
 	it("host filter narrows to the requested host", async () => {
-		const tag = `${NS}-${Math.random().toString(36).slice(2, 8)}`;
+		const tag = `${NS}-${randomBytes(4).toString("hex").slice(0, 6)}`;
 		const hostA = `${tag}-a.example.com`;
 		const hostB = `${tag}-b.example.com`;
 


### PR DESCRIPTION
## What

Fixes #3361 — clears the last open HIGH CodeQL alert (`js/insecure-randomness`, alert #20), the sole blocker to arming the "Require code scanning results" branch-protection gate.

## Why the issue's stated fix was wrong (record corrected on the issue)

The issue body's "2-line fix at `auth.ts:21`+`:115`" was **already shipped by #3345** and did **not** clear the alert. Ground-truthed against current `main` (HEAD `12220b76`, re-scanned after #3345 merged): alert #20 is still **open** because it's a **cross-file data flow**, not a local one —

- **Sink:** `apps/web/tests/e2e/_helpers/auth.ts:59` (the credential in `signUp` → `freshCredentials`).
- **Sources:** the ~44 `Math.random().toString(36).slice(...)` sites across the e2e **spec** files that build handles / localParts / slugs and flow into user creation. #3345 fixed only `auth.ts`'s own two calls; the spec-file sources kept the alert live.

## The fix (root cause)

Eliminate **every** `Math.random()` in the test tree so no weak-randomness source can reach the auth sink:

- Add `apps/web/tests/e2e/_helpers/rand.ts` — `randomSuffix(len = 6)` on `node:crypto` `randomBytes`, base36 (0-9a-z) output. Same char class + width as `Math.random().toString(36).slice(2, 2+len)`, unique per call.
- Replace every inline call across the e2e specs (`slice(2, 6)` → `randomSuffix(4)`, `slice(2, 5)` → `randomSuffix(3)`). `Date.now()` prefixes kept (human-readable ordering; the weakness CodeQL flags is the RNG, not the timestamp).
- The two integration-tier sites (`_harness.ts`, `pano-read.test.ts`) swap to `node:crypto` `randomBytes` inline; a stale comment in `_integration.ts` reworded.

## Verification

- `git grep 'Math\.random()' -- apps/web/tests` → **zero** (was 46 real calls across 22 files).
- `pnpm typecheck` (apps/web) passes; `biome check` clean; `randomSuffix` uniqueness + base36 format spot-verified at widths 3/4/6.
- Behavior preserved: each site still emits a unique base36 suffix of the same length, so existing slug/handle formats and assertions hold.

Clears alert #20 on the next CodeQL-on-push run at merge → open HIGH count reaches 0.

## Scope / §CP

Strictly `apps/web/tests/**` (outside `CONTROL_PLANE_RE`) — NON-§CP, auto-ships on green. No app/worker source touched. No ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)