### PR TITLE
docs(pipeline-crew): drop bare repo-local `epic #2342` provenance cite

### DIFF
--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -143,7 +143,7 @@ kampus-pipeline carries a **control-plane (§CP)** boundary: PRs that touch the 
 plane bank for a human merge behind a hard GitHub gate (ADR
 [0135](../../.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)).
 **pipeline-crew's `agents/` is deliberately *not* part of that boundary** — the crew is an
-optional layer whose PRs **auto-ship on green** by design (epic #2342's resolved questions),
+optional layer whose PRs **auto-ship on green** by design (a founder ruling in the crew's resolved design questions),
 with no extension of the §CP path set to this directory. Edits to the crew defs here merge
 automatically once their review gate passes; PRs that touch kampus-pipeline's own §CP surfaces
 still bank for a human merge.


### PR DESCRIPTION
Fixes #3365

## What

`claude-plugins/pipeline-crew/README.md` cited a bare repo-local `epic #2342` as design provenance for the crew's auto-ship-on-green / outside-§CP boundary. A raw issue number dead-ends for a second operator or an external consumer of the portable plugin — there is no link or `.decisions/` pointer behind it, so it is unresolvable outside this repo's issue tracker, against the plugin's "opinionated, portable, no repo-local numbers" doctrine.

## Change

Single prose edit at `claude-plugins/pipeline-crew/README.md` (the one remaining `epic #2342` cite): drop the bare number, keep the generalized rationale inline (option (b) from the AC / triage steer):

> `(epic #2342's resolved questions)` → `(a founder ruling in the crew's resolved design questions)`

Checked both ADRs that reference #2342 (`.decisions/0171`, `.decisions/0192`) — neither records the founder ruling *itself* (crew is optional / auto-ships), so there is no resolvable ADR to link to; option (b) applies. Swept the whole README for any other bare repo-local `#NNNN` provenance cite of the same class — the remaining `#`/number references are resolvable ADR links or a code-block comment, not bare issue-number provenance.

## Acceptance criteria

- [x] Neither `epic #2342` cite leaves a bare, unresolvable repo-local issue number (only one remained in the current README).
- [x] Resolved via option (b) — bare number dropped, generalized rationale kept inline.
- [x] No new bare repo-local issue/PR number introduced.

Docs-hygiene only, no behavior change (`type:chore`). Non-§CP (`pipeline-crew/` is outside `CONTROL_PLANE_RE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)