### PR TITLE
feat(pipeline-crew): restructure the personalization seam — one role map, per-recipient notification commands (#3236)

### DIFF
--- a/claude-plugins/pipeline-crew/PERSONALIZATION.md
+++ b/claude-plugins/pipeline-crew/PERSONALIZATION.md
@@ -2,14 +2,17 @@
 
 The **personalization seam** is the single per-install configuration surface through
 which every operator-specific detail enters a crew install. The shipped plugin content
-(the three agent defs, this doc, the config template) carries **zero real operator
+(the four agent defs, this doc, the config template) carries **zero real operator
 data** — only `<placeholders>`. An operator supplies their own people and machine once,
 at stand-up, and the crew addresses *them* instead of the original author.
 
-This doc is the **contract the three crew agent defs write against** (issues #2360 /
-#2354 / #2355): a def never hardcodes an operator name, an approver login, a
-notification handle, a tmux session name, or a model tier — it names the corresponding
-seam key and resolves the value at spawn from the operator's config.
+This doc is the **contract the crew agent defs write against**: a def never hardcodes an
+operator name, an approver login, a notification handle, or a model tier — it names the
+corresponding seam key and resolves the value at spawn from the operator's config. The
+config expresses the **settled crew shape** (the roster law of
+[ADR 0189](../../.decisions/0189-crew-roster-law-bridges-engines.md)): one role map keyed by
+role kind, and per-recipient notification commands. A role's address is a runtime lease it
+acquires from the tracker, so no session-placement keys enter the seam.
 
 ## Why a read-at-runtime config file (grounded in the plugin spec)
 
@@ -61,29 +64,54 @@ reference these keys, never a literal.
 | Dimension | Config key | What it supplies | Placeholder |
 |---|---|---|---|
 | Operator / founder | `operator.name`, `operator.handle` | The human the crew serves and addresses — the founder/operator identity every role reports to. | `<operator-name>`, `<operator-handle>` |
-| Control-plane approver | `controlPlaneApprover.name`, `controlPlaneApprover.login` | Who reviews/approves/merges control-plane (§CP) PRs — the second human the EA banks §CP work for and relays to (ADR [0135](../../.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)). | `<control-plane-approver-name>`, `<control-plane-approver-login>` |
-| Notification channel/handle | `notification.channel`, `notification.handle` | Where the single-owner human-notification protocol delivers pings (the EA-owned channel + the addressee handle). | `<notification-channel>`, `<notification-handle>` |
-| tmux / session naming | `tmux.session`, `tmux.windows.ea`, `tmux.windows.engineeringManager`, `tmux.windows.triage` | The tmux session name and the three per-role window/pane names the stand-up brings up and the roles address each other by. | `<tmux-session-name>`, `<ea-window-name>`, `<em-window-name>`, `<triage-window-name>` |
-| Model-tier preferences | `modelTiers.ea`, `modelTiers.engineeringManager`, `modelTiers.triage` | The model tier each role runs on — the planning-tier intake session vs the execution/build-tier conductor (so a role never silently downgrades a spawned subagent). | `<ea-model-tier>`, `<em-model-tier>`, `<triage-model-tier>` |
-| WIP caps | `wipCaps.productLanes`, `wipCaps.platformLanes` | The engineering-manager's bounded concurrent-lane count per class — how many product vs platform/pipeline coders it drives at once before queueing the rest. | `<wip-cap-product-lanes>`, `<wip-cap-platform-lanes>` |
+| Control-plane approver identity | `controlPlaneApprover.name`, `controlPlaneApprover.login` | Who reviews/approves/merges control-plane (§CP) PRs — the human the engine banks §CP work for on the board (assigning the banked PR to this `login`) and the chief-of-staff carries out to (ADR [0135](../../.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)). This is the *identity*; the *transport* that pings them is the notification row below. | `<control-plane-approver-name>`, `<control-plane-approver-login>` |
+| Role map | `roles.<role>.{tier, count?, wipCap?}` | **One map, keyed by the role KINDs** of [`crew/roles.ts`](../../packages/pipeline-crew-mcp/src/crew/roles.ts) — a roster change is one map edit, not N key-family edits. Each entry carries the role's `tier` (its session's model tier — a role never silently downgrades a spawned subagent); an *engine* also carries `count` (its pool size) and `wipCap` (its concurrent-lane cap). A *bridge* is singleton, so it takes neither — cardinality falls out of the kind (ADR 0189). | see the per-field rows below |
+| — role model tier | `roles.<role>.tier` | The model tier each role's session runs on — the planning-tier bridges (`chief-of-staff`, `cartographer`, `intake-desk`) vs the execution/build-tier engine (`engineering-manager`). | `<chief-of-staff-model-tier>`, `<cartographer-model-tier>`, `<intake-desk-model-tier>`, `<engineering-manager-model-tier>` |
+| — engine count | `roles.engineering-manager.count` | How many `engineering-manager` engines the stand-up boots — the engine is kind `engine` (cardinality N); a positive integer. Bridges omit `count` (they are cardinality 1). | `<engine-count>` |
+| — engine WIP cap | `roles.engineering-manager.wipCap.{productLanes, platformLanes}` | A conductor engine's bounded concurrent-lane count, lane-partitioned — how many product vs platform/pipeline coders one engine drives at once before queueing the rest. The overall cap is the split's sum; the borrow/rebalance behavior is doctrine shipped in the engineering-manager def (the seam carries only the per-install values). | `<wip-cap-product-lanes>`, `<wip-cap-platform-lanes>` |
+| Notification — per recipient | `notification.operator.{command, handle}`, `notification.controlPlaneApprover.{command, handle}` | Per-recipient human notification. The plugin ships **who** gets pinged and **when**; the config supplies **how** — an operator-supplied transport `command` the chief-of-staff invokes, targeting `handle`. The plugin knows nothing of the channel (iMessage/Slack/Discord), so a Discord-bot future is a config swap, not a code change. Any local script path lives only in the operator's config, never in the repo. | `<operator-notification-command>`, `<operator-notification-handle>`, `<control-plane-approver-notification-command>`, `<control-plane-approver-notification-handle>` |
 | Pinned CLI version | `cliVersion` | The Claude Code CLI version the stand-up launcher asserts before it starts any session — a hard gate so the crew never launches on a drifted CLI (`major.minor.patch`, optional `-suffix`). | `<pinned-claude-code-cli-version>` |
-| Engine count | `engineCount` | How many engine (build) sessions the stand-up starts — a positive integer. | `<engine-count>` |
-| Channel registration | `channels.mode`, `channels.servers`, `channels.allowedChannelPlugins` | How each launched session registers its channel MCP servers: `mode` is `allowlist` (`--channels <refs>`) or `development` (`--dangerously-load-development-channels`, local only); `servers` are the refs each session registers (grammar `server:<ref>` / `plugin:<name>@<marketplace>`); `allowedChannelPlugins` is the plugin allowlist the `allowlist` mode enforces. | `<channel-mode: allowlist \| development>`, `<channel-server-ref>`, `<allowed-channel-plugin>` |
+| Channel registration | `channels.mode`, `channels.servers`, `channels.allowedChannelPlugins` | How each launched session registers its channel MCP servers: `mode` is `allowlist` (`--channels <refs>`) or `development` (`--dangerously-load-development-channels`, local only); `servers` are the refs each session registers (grammar `server:<name>` / `plugin:<name>@<marketplace>`); `allowedChannelPlugins` is the plugin allowlist the `allowlist` mode enforces. | `<channel-mode: allowlist \| development>`, `<channel-server-ref>`, `<allowed-channel-plugin>` |
 
 Adding a new operator-specific dimension is **one row here + one key in the template + one
-reference in the def that needs it** — never a new literal buried in a def.
+reference in the def that needs it** — never a new literal buried in a def. Adding a role to
+the crew is **one entry in `roles`** (and one kind in `crew/roles.ts`), never a new key
+family.
 
 ### The launch dimensions have a typed reader (fail-closed)
 
-The last three rows are **launch dimensions** — inputs the stand-up launcher reads, not
-prose an agent def binds. They resolve through the **same** order as every other seam key
-(`$CREW_CONFIG` → `.claude/crew.config.jsonc`) but are consumed by a typed reader,
+The launch dimensions — the engine `count`, `cliVersion`, and `channels` — are inputs the
+stand-up launcher reads, not prose an agent def binds. They resolve through the **same**
+order as every other seam key (`$CREW_CONFIG` → `.claude/crew.config.jsonc`) but are
+consumed by a typed reader,
 [`packages/pipeline-crew-mcp/src/standup/config.ts`](../../packages/pipeline-crew-mcp/src/standup/config.ts),
 which validates them and **fails closed** — a missing or malformed dimension (a non-version
 CLI pin, an unknown channel mode, a channel ref off-grammar, a non-positive engine count)
 stops the launch with an error naming that dimension, never a silent default. The launcher
 children (version-assert, bind-builder, roster, orchestration) consume the reader's typed
-result; they never re-parse the config.
+result; they never re-parse the config. Because the template leads the launcher in this
+crew-architecture wave (wayfinder:map #3207), reconciling the typed reader to consume the
+engine count off `roles.engineering-manager.count` is a launcher follow-up in
+`packages/pipeline-crew-mcp`, outside this seam's plugin surface.
+
+## Tied-off and deferred seam gaps
+
+The wayfinder map (#3207) flagged three seam questions to resolve here rather than drop:
+
+- **Operator gh identity — tied off as a live-resolution contract, not a key.** The
+  intake-desk's triage routing rule keys on the session's **live-authenticated `gh`
+  login** (`gh api user`), resolved fresh per run. That is deliberately *not* a config key:
+  a static copy would drift from the identity the session actually authenticates as. The
+  contract is the seam — a role reads its own live login, never a stored one.
+- **Operator interaction preferences — deferred.** Language constraints, do-and-report
+  posture, and similar interaction preferences have **no def-side consumer today**. Adding
+  an `operator.interaction.*` block (or a free-text operator-briefing overlay) now would
+  ship dead config, violating the seam-only-genuinely-consumed-values rule. Deferred to a
+  future issue that lands the consuming def surface alongside the key.
+- **Repo-specific tool surface — out of scope of this seam.** The target repo's tool
+  surface (a flags CLI, a main-sync tool) is **target-REPO config, not operator config**,
+  and belongs to a separate repo-config seam (the ADR 0062 repo-as-config surface), not
+  `crew.config`. It is intentionally absent here.
 
 ## Stand-up
 
@@ -112,12 +140,10 @@ pipeline-crew-mcp stand-up            # defaults --project-root to the working d
 
 It resolves the config through the **same** `$CREW_CONFIG` → `.claude/crew.config.jsonc`
 order as every seam key, asserts the pinned CLI version, ensures the tracker, derives the
-roster session set, and launches every session bound to its role lease and placed in tmux —
-**fail-loud with no partial crew**: a missing or malformed launch dimension (or `tmux`
-dimension) aborts the launch naming that dimension, before any session starts. The
-launch-dimension reader ([`config.ts`](../../packages/pipeline-crew-mcp/src/standup/config.ts))
-is the fail-closed validator for the `cliVersion` / `engineCount` / `channels` dimensions.
+roster session set (one per bridge + N engines from the `roles` map), and launches every
+session bound to its role lease — **fail-loud with no partial crew**: a missing or malformed
+launch dimension aborts the launch naming that dimension, before any session starts.
 
-The three-session tmux topology the config drives (intake → execution → human) and the
-full stand-up walkthrough are the pipeline-crew **README**'s scope (issue #2356); this doc
-owns the *seam* — the config mechanism and the dimension contract.
+This doc owns the **seam** — the config mechanism and the dimension contract. The full
+stand-up walkthrough and the crew topology (intake → execution → human) are the
+pipeline-crew **README**'s scope.

--- a/claude-plugins/pipeline-crew/commands/stand-up.md
+++ b/claude-plugins/pipeline-crew/commands/stand-up.md
@@ -8,7 +8,7 @@ allowed-tools: ["Bash"]
 
 This is the **one stand-up command**: it boots the entire crew from your filled operator
 config in one shot. It is a thin front for the substrate launcher — the mechanical logic
-(version assert, tracker ensure, roster derivation, per-session bind, tmux placement,
+(version assert, tracker ensure, roster derivation, per-session bind, screen placement,
 launch) lives in the `@kampus/pipeline-crew-mcp` substrate's `stand-up` subcommand
 (ADR 0192), never in this plugin.
 
@@ -37,9 +37,9 @@ pipeline-crew-mcp stand-up $ARGUMENTS
 
 The launcher runs, **in order**: assert the pinned CLI version → ensure the per-project
 tracker is up → derive the roster session set (one per bridge + N engines) → build each
-session's channel bind + tmux placement → launch each `claude` session bound to its role
+session's channel bind + screen placement → launch each `claude` session bound to its role
 lease. It is **fail-loud with no partial crew**: a drifted CLI pin, a missing config
-dimension, an unstartable tracker, an inert channel, or an unnamed/colliding tmux window
+dimension, an unstartable tracker, an inert channel, or a failed screen placement
 aborts **before any session is launched** and names the cause. Nothing is hand-launched.
 
 Report the tracker pid + socket and the launched sessions on success, or the named abort

--- a/claude-plugins/pipeline-crew/crew.config.template.jsonc
+++ b/claude-plugins/pipeline-crew/crew.config.template.jsonc
@@ -12,52 +12,66 @@
 	"operator": {
 		"name": "<operator-name>",
 		"handle": "<operator-handle>"
+		// The operator's gh identity is deliberately NOT a key here — the intake-desk's triage
+		// routing rule keys on the session's live-authenticated `gh` login, resolved fresh per
+		// run, so a static copy would drift from the actual identity. See PERSONALIZATION.md
+		// § "Tied-off and deferred seam gaps".
 	},
 
-	// Who reviews / approves / merges control-plane (§CP) PRs — the human the EA
-	// banks §CP work for and relays to (ADR 0135).
+	// Who reviews / approves / merges control-plane (§CP) PRs — the human the engine banks
+	// §CP work for on the board and the chief-of-staff relays to (ADR 0135). This is the
+	// approver IDENTITY (who to assign the banked PR to); the transport that PINGS them is
+	// notification.controlPlaneApprover below.
 	"controlPlaneApprover": {
 		"name": "<control-plane-approver-name>",
 		"login": "<control-plane-approver-login>"
 	},
 
-	// Where the single-owner human-notification protocol delivers pings.
-	"notification": {
-		"channel": "<notification-channel>",
-		"handle": "<notification-handle>"
-	},
-
-	// tmux session + the three per-role window/pane names the stand-up brings up.
-	"tmux": {
-		"session": "<tmux-session-name>",
-		"windows": {
-			"ea": "<ea-window-name>",
-			"engineeringManager": "<em-window-name>",
-			"triage": "<triage-window-name>"
+	// One role map — a roster change is ONE edit here. Keyed off the role KINDs declared in
+	// packages/pipeline-crew-mcp/src/crew/roles.ts (ADR 0189): the three bridges are singleton
+	// (cardinality falls out of the kind — no count), the one engine scales by `count`. Each
+	// entry: `tier` (the model tier the role's session runs on), `count?` (engine pool size,
+	// engine-only), `wipCap?` (a conductor engine's concurrent-lane cap, engine-only).
+	"roles": {
+		// Bridges — singleton, tier only.
+		"chief-of-staff": { "tier": "<chief-of-staff-model-tier>" },
+		"cartographer": { "tier": "<cartographer-model-tier>" },
+		"intake-desk": { "tier": "<intake-desk-model-tier>" },
+		// Engine — fungible throughput; `count` engines boot, each holds its own `wipCap`.
+		// The overall cap is the lane split's sum and the borrow/rebalance rule is doctrine
+		// shipped in the engineering-manager def — only the per-install lane values seam here.
+		"engineering-manager": {
+			"tier": "<engineering-manager-model-tier>",
+			"count": "<engine-count>",
+			"wipCap": {
+				"productLanes": "<wip-cap-product-lanes>",
+				"platformLanes": "<wip-cap-platform-lanes>"
+			}
 		}
 	},
 
-	// The model tier each role runs on (planning tier vs execution/build tier).
-	"modelTiers": {
-		"ea": "<ea-model-tier>",
-		"engineeringManager": "<em-model-tier>",
-		"triage": "<triage-model-tier>"
+	// Per-recipient human notification. The plugin ships WHO gets pinged and WHEN; the config
+	// supplies HOW — an operator-supplied transport `command` the chief-of-staff invokes. The
+	// plugin knows nothing of the channel (iMessage / Slack / Discord), so a Discord-bot future
+	// is a config swap, not a code change. Any local script path lives ONLY here, never in the
+	// repo. `handle` is the addressee the command targets.
+	"notification": {
+		// The operator — situational-awareness reads, ping-me-when-X-lands.
+		"operator": {
+			"command": "<operator-notification-command>",
+			"handle": "<operator-notification-handle>"
+		},
+		// The §CP approver — the bank-and-carry relay for a §CP PR at its live head (ADR 0135).
+		"controlPlaneApprover": {
+			"command": "<control-plane-approver-notification-command>",
+			"handle": "<control-plane-approver-notification-handle>"
+		}
 	},
 
-	// The engineering-manager's WIP caps — the bounded number of concurrent lanes
-	// it runs at once, partitioned by class (product vs platform/pipeline).
-	"wipCaps": {
-		"productLanes": "<wip-cap-product-lanes>",
-		"platformLanes": "<wip-cap-platform-lanes>"
-	},
-
-	// The pinned Claude Code CLI version the stand-up launcher asserts before it starts
-	// any session — a hard gate so the crew never launches on a drifted CLI. Fill with the
-	// exact `major.minor.patch` (optionally `-suffix`) your `claude --version` reports.
+	// The pinned Claude Code CLI version the stand-up launcher asserts before it starts any
+	// session — a hard gate so the crew never launches on a drifted CLI. Fill with the exact
+	// `major.minor.patch` (optionally `-suffix`) your `claude --version` reports.
 	"cliVersion": "<pinned-claude-code-cli-version>",
-
-	// How many engine (build) sessions the stand-up starts (a positive integer).
-	"engineCount": "<engine-count>",
 
 	// Channel MCP registration for every launched session.
 	"channels": {
@@ -65,11 +79,11 @@
 		// "development" → `--dangerously-load-development-channels` (loads every dev channel; local only).
 		"mode": "<channel-mode: allowlist | development>",
 		// The channel servers each session registers, by ref. Grammar per ref:
-		//   "server:<name>"              — a top-level channel MCP server
-		//   "plugin:<name>@<marketplace>" — a channel server contributed by a plugin
+		//   "server:<name>"                — a top-level channel MCP server (development mode only)
+		//   "plugin:<name>@<marketplace>"  — a server contributed by an installed plugin
 		"servers": ["<channel-server-ref>"],
 		// Plugins whose channel servers are allowed to load — the allowlist the "allowlist"
-		// mode enforces; each name matches the plugin `<name>` in a "plugin:<name>@<marketplace>" ref used in `servers`.
+		// mode enforces; each name matches a "plugin:<name>@<marketplace>" ref used in `servers`.
 		"allowedChannelPlugins": ["<allowed-channel-plugin>"]
 	}
 }


### PR DESCRIPTION
Fixes #3236.

Restructures the pipeline-crew **personalization seam** to express the settled crew shape (roster law, [ADR 0189](https://github.com/kamp-us/phoenix/blob/main/.decisions/0189-crew-roster-law-bridges-engines.md)): one role map, per-recipient notification commands, zero tmux keys. Confined to the plugin's personalization surface — the config template + its doc + the residual-tmux sweep of `commands/stand-up.md`.

## What changed

**`claude-plugins/pipeline-crew/crew.config.template.jsonc`**
- **One role map** `roles.<role>.{tier, count?, wipCap?}`, keyed off the role KINDs of `packages/pipeline-crew-mcp/src/crew/roles.ts` — the three bridges (`chief-of-staff`, `cartographer`, `intake-desk`) are singleton (`tier` only); the one engine (`engineering-manager`) scales by `count` and carries a per-conductor lane-partitioned `wipCap.{productLanes, platformLanes}`. Replaces `modelTiers.{ea,em,triage}` + flat `wipCaps`. The old top-level `engineCount` folds into `roles.engineering-manager.count`.
- **Dropped `tmux.session` / `tmux.windows` entirely** — a role's address is a runtime lease, not a pane.
- **Per-recipient notification** `notification.{operator,controlPlaneApprover}.{command,handle}` — the plugin ships **who + when**; the config supplies **how** (an operator-supplied transport `command`; the plugin knows nothing of iMessage/Slack/Discord, so a Discord-bot future is a config swap). Replaces single-owner `notification.{channel,handle}` and closes the #3214 gap that `controlPlaneApprover` had `{name,login}` but no transport. The `controlPlaneApprover.{name,login}` **identity** block is retained (ADR 0135 banking/relay assigns the banked PR to `login`).

**`claude-plugins/pipeline-crew/PERSONALIZATION.md`** — rewritten for the one-role-map shape, the per-recipient notification-command mechanism, the dimension contract, and stand-up; no tmux vocabulary. Adds a **"Tied-off and deferred seam gaps"** section resolving the three wayfinder-flagged gaps (below).

**`claude-plugins/pipeline-crew/commands/stand-up.md`** — swept residual tmux vocabulary (the "kill all tmux keys plugin-wide" sweep); the launcher's placement step reads as mechanism-agnostic "screen placement."

## Seam gaps (tied off / deferred, not dropped)
- **Operator gh identity** — tied off as a **live-resolution contract**, not a key: the intake-desk's triage routing keys on the session's live-authenticated `gh` login, resolved fresh per run; a static copy would drift.
- **Operator interaction preferences** — **explicitly deferred**: no def-side consumer today, so an `operator.interaction.*` block would ship dead config. Deferred to a future issue that lands the consumer.
- **Repo-specific tool surface** (flags CLI, main-sync) — **out of scope**: target-REPO config, a separate repo-as-config seam (ADR 0062), not `crew.config`.

## Sequencing / follow-up (launcher, out of this seam's scope)
The template **leads the launcher** in this crew-architecture wave (#3207). The typed reader `packages/pipeline-crew-mcp/src/standup/config.ts` still fail-closes on a top-level `engineCount` and a required `tmux` placement dimension — both dropped/moved by this template. Reconciling the reader (read the engine count off `roles.engineering-manager.count`; drop the `tmux` read + `tmux-placement.ts`/`session-set.ts` coupling) is a **substrate follow-up in `packages/pipeline-crew-mcp`**, outside this issue's declared personalization-surface scope. Filed as needs-triage follow-up #3382.

## Verification
- `roles.<role>.{tier, count?, wipCap?}` map present; `modelTiers`, `tmux.*`, flat `wipCaps` gone (grep-clean).
- Notification per-recipient with `command` + `handle`; single-owner `notification.{channel,handle}` gone.
- **Zero real operator data** — placeholders only; leak-guard clean; no `tmux`/`pane` vocabulary anywhere in the plugin (grep-clean).
- Role-map keys are consistent with the kind-typed roster of #3234 (landed on main).
- JSONC parses; biome-formatted.

Class: **NON-§CP** (`claude-plugins/pipeline-crew/`, outside `CONTROL_PLANE_RE`). The `notification.controlPlaneApprover` split is §CP-adjacent (governs how §CP merge work is banked/relayed, ADR 0135) but is not a §CP-path label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)