### PR TITLE
fix(lefthook): docs-only fast-path for the pre-push typecheck leg (#3130)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -148,13 +148,29 @@ pre-push:
   parallel: false
   commands:
     typecheck:
-      # tsgo across the workspace (the same `pnpm typecheck` CI runs) — fast enough to run
-      # whole-repo per push; a type error fails closed and blocks the push.
+      # tsgo across the workspace (the same `pnpm typecheck` CI runs); a type error fails
+      # closed and blocks the push. Docs-only fast-path (#3130): a push whose diff vs
+      # origin/main touches ONLY non-code paths (markdown/docs) has nothing tsgo checks, so
+      # it skips the whole-repo run — mirroring the change-scoping the sibling `unit-changed`
+      # leg gets from `--changed origin/main`. Fail-SAFE: any changed path not recognized as
+      # docs — or a diff that can't be computed (origin/main unfetched) — runs the full
+      # typecheck, so a code change is NEVER skipped. Toolchain-absence still fails open.
       run: |
         command -v pnpm >/dev/null 2>&1 || {
           echo "typecheck: no pnpm on PATH (stripped-PATH/lean worktree); skipping local pre-push typecheck — CI is the authority" >&2
           exit 0
         }
+        CHANGED=$(git diff --name-only origin/main...HEAD 2>/dev/null) || CHANGED=""
+        # NON-DOC = changed paths that are NOT markdown/docs. Empty NON-DOC (with a non-empty
+        # diff) ⇒ docs-only ⇒ skip. Tested via empty-output, not `grep -qv`: the `-q`+`-v`
+        # combo misbehaves under some grep variants (ugrep returns non-zero even with
+        # non-matching lines), which the empty-output form sidesteps portably.
+        NONDOC=""
+        [ -n "$CHANGED" ] && NONDOC=$(printf '%s\n' "$CHANGED" | grep -vE '\.(md|mdx|txt)$')
+        if [ -n "$CHANGED" ] && [ -z "$NONDOC" ]; then
+          echo "typecheck: docs-only push (every path changed vs origin/main is markdown/docs); skipping whole-repo typecheck — CI is the authority" >&2
+          exit 0
+        fi
         pnpm typecheck
     unit-changed:
       # `vitest run --changed origin/main` (unit project) — only the suites related to files


### PR DESCRIPTION
## What

Give the pre-push `typecheck` leg in `lefthook.yml` a docs-only fast-path, mirroring the change-scoping the sibling `unit-changed` leg already gets from `--changed origin/main`.

Before: the `typecheck` leg ran whole-repo `pnpm typecheck` (tsgo) unconditionally, so a docs-only push (e.g. a `.decisions/*.md` ADR) paid the full ~91s type tax for zero type-relevant change — pure friction, and it fed the wall the environment then SIGTERMs (the env kill itself is tracked separately in #3137).

After: when the diff vs `origin/main` (`git diff --name-only origin/main...HEAD`) touches **only** markdown/docs paths, the leg fast-paths to a clean exit 0. Any code change still runs the full typecheck and still fails closed on a type error.

## How it satisfies the acceptance criteria

- Docs-only push (all paths `.md`/`.mdx`/`.txt`) → skip the whole-repo typecheck (exit 0).
- Any code path changed → `pnpm typecheck` runs and fails closed on a type error (no regression).
- Uses the same "changed vs `origin/main`" signal the sibling `unit-changed` leg uses, so the two legs scope consistently.
- The existing fail-open-on-absent-toolchain guard (no pnpm on PATH → skip, CI is authority) is preserved unchanged; the scoping is additive.

## Notes

- **Fail-SAFE**: a changed path not recognized as docs — or a diff that can't be computed (`origin/main` unfetched → empty `CHANGED`) — runs the full typecheck, so a code change is never skipped.
- The docs-only test uses an empty-output form, **not** `grep -qv`: the `-q`+`-v` combo misbehaves under some grep variants (ugrep returns non-zero even when non-matching lines exist), which the empty-output form sidesteps portably across dash/GNU/BSD/ugrep.
- Scope: only `lefthook.yml` (the single tracked source of truth; the generated git-hooks wrapper is untracked/derived).

Fixes #3130