### PR TITLE
fix(pipeline-crew-mcp): reconcile the stand-up config reader to the one-role-map seam (#3382)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/config.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.test.ts
@@ -1,16 +1,17 @@
 /**
- * standup/config — the launch-dimension reader (issue #3293). Covers path resolution, the
- * JSONC strip (comments + trailing commas, string-literal aware), the happy decode against a
- * FULL crew config (excess seam keys ignored), and — the load-bearing part — fail-closed
- * decoding: each required launch dimension absent or malformed yields a `LaunchConfigError`
- * whose reason names that dimension.
+ * standup/config — the launch-dimension reader (issue #3293), reconciled to the one-role-map seam
+ * shape (ADR 0189 / #3236). Covers path resolution, the JSONC strip (comments + trailing commas,
+ * string-literal aware), the happy decode against a FULL one-role-map crew config (excess seam keys
+ * — bridge role entries, per-role tier/wipCap, operator/notification, and no tmux key — ignored),
+ * and — the load-bearing part — fail-closed decoding: each required launch dimension absent or
+ * malformed yields a `LaunchConfigError` whose reason names that dimension. The engine count now
+ * lives at `roles["engineering-manager"].count`, so its fail-closed cases exercise that path.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {
 	DEFAULT_CONFIG_PATH,
 	decodeLaunchConfig,
-	decodeTmuxNaming,
 	LaunchConfigError,
 	parseJsonc,
 	resolveConfigPath,
@@ -18,14 +19,16 @@ import {
 } from "./config.ts";
 
 /**
- * A minimal-but-valid launch dimension set, embedded in a fuller crew config below. The
- * allowlist-mode channels carry only `plugin:<name>@<marketplace>` refs — the exact grammar
- * Claude Code 2.1.212's `--channels` allowlist accepts (a bare `server:` ref can't ride
- * `--channels`; #3328).
+ * A minimal-but-valid launch dimension set in the one-role-map shape: the engine count folds into
+ * `roles["engineering-manager"].count`. The allowlist-mode channels carry only
+ * `plugin:<name>@<marketplace>` refs — the exact grammar Claude Code 2.1.212's `--channels`
+ * allowlist accepts (a bare `server:` ref can't ride `--channels`; #3328).
  */
 const validLaunch = {
 	cliVersion: "2.1.207",
-	engineCount: 2,
+	roles: {
+		"engineering-manager": {count: 2},
+	},
 	channels: {
 		mode: "allowlist",
 		servers: ["plugin:crew-channels@pipeline-crew"],
@@ -33,15 +36,33 @@ const validLaunch = {
 	},
 };
 
-/** The launch dimensions never arrive alone — they sit inside the full personalization config. */
+/**
+ * The launch dimensions never arrive alone — they sit inside the full one-role-map personalization
+ * config (ADR 0189): every bridge role entry, each role's `tier`/`wipCap`, the operator +
+ * notification + controlPlaneApprover blocks, and — post-#3236 — NO tmux key. All of it is excess
+ * to the launch reader, which extracts only cliVersion + the engine count + channels.
+ */
 const fullCrewConfig = {
 	operator: {name: "op", handle: "op"},
-	tmux: {session: "s", windows: {ea: "ea", engineeringManager: "em", triage: "t"}},
+	controlPlaneApprover: {name: "cp", login: "cp"},
+	notification: {operator: {command: "notify", handle: "op"}},
 	...validLaunch,
+	roles: {
+		"chief-of-staff": {tier: "opus"},
+		cartographer: {tier: "fable"},
+		"intake-desk": {tier: "fable"},
+		"engineering-manager": {tier: "opus", count: 2, wipCap: {productLanes: 1, platformLanes: 1}},
+	},
 };
 
 const decodeErr = (input: unknown) =>
 	Effect.flip(decodeLaunchConfig(input, "/tmp/crew.config.jsonc"));
+
+/** A `validLaunch` variant carrying an arbitrary `roles["engineering-manager"].count` value. */
+const withCount = (count: unknown) => ({
+	...validLaunch,
+	roles: {"engineering-manager": {count}},
+});
 
 describe("standup/config — resolveConfigPath", () => {
 	it("prefers $CREW_CONFIG when set and non-blank", () => {
@@ -74,16 +95,19 @@ describe("standup/config — stripJsonc / parseJsonc", () => {
 	});
 });
 
-describe("standup/config — decodeLaunchConfig (happy path)", () => {
-	it.effect("extracts the launch dimensions from a full crew config, ignoring excess keys", () =>
-		Effect.gen(function* () {
-			const cfg = yield* decodeLaunchConfig(fullCrewConfig, DEFAULT_CONFIG_PATH);
-			assert.strictEqual(cfg.cliVersion, "2.1.207");
-			assert.strictEqual(cfg.engineCount, 2);
-			assert.strictEqual(cfg.channels.mode, "allowlist");
-			assert.deepStrictEqual([...cfg.channels.servers], ["plugin:crew-channels@pipeline-crew"]);
-			assert.deepStrictEqual([...cfg.channels.allowedChannelPlugins], ["pipeline-crew"]);
-		}),
+describe("standup/config — decodeLaunchConfig (happy path, one-role-map shape)", () => {
+	it.effect(
+		"extracts the launch dimensions from a full tmux-free one-role-map config, ignoring excess keys",
+		() =>
+			Effect.gen(function* () {
+				const cfg = yield* decodeLaunchConfig(fullCrewConfig, DEFAULT_CONFIG_PATH);
+				assert.strictEqual(cfg.cliVersion, "2.1.207");
+				// engine count read off roles["engineering-manager"].count, not a top-level field.
+				assert.strictEqual(cfg.engineCount, 2);
+				assert.strictEqual(cfg.channels.mode, "allowlist");
+				assert.deepStrictEqual([...cfg.channels.servers], ["plugin:crew-channels@pipeline-crew"]);
+				assert.deepStrictEqual([...cfg.channels.allowedChannelPlugins], ["pipeline-crew"]);
+			}),
 	);
 	it.effect("accepts the development channel mode carrying a top-level server: ref", () =>
 		Effect.gen(function* () {
@@ -164,59 +188,59 @@ describe("standup/config — server: ref reconciles with mode", () => {
 	);
 });
 
-describe("standup/config — decodeTmuxNaming (tmux placement dimension, seam 1 #3354)", () => {
-	const decodeTmuxErr = (input: unknown) =>
-		Effect.flip(decodeTmuxNaming(input, "/tmp/crew.config.jsonc"));
-
-	it.effect(
-		"extracts session + window naming from the tmux dimension of the full crew config",
-		() =>
-			Effect.gen(function* () {
-				const naming = yield* decodeTmuxNaming(fullCrewConfig, DEFAULT_CONFIG_PATH);
-				assert.strictEqual(naming.session, "s");
-				assert.deepStrictEqual(
-					{...naming.windows},
-					{ea: "ea", engineeringManager: "em", triage: "t"},
-				);
-			}),
-	);
-	it.effect("fails closed naming tmux when the dimension is absent", () =>
+describe("standup/config — engine count reads off roles['engineering-manager'].count, fail-closed", () => {
+	it.effect("the roles map absent → fails closed naming roles", () =>
 		Effect.gen(function* () {
-			const err = yield* decodeTmuxErr(validLaunch);
+			const {roles: _omit, ...noRoles} = validLaunch;
+			const err = yield* decodeErr(noRoles);
 			assert.instanceOf(err, LaunchConfigError);
-			assert.include(err.reason, "tmux");
+			assert.include(err.reason, "roles");
 			assert.strictEqual(err.configPath, "/tmp/crew.config.jsonc");
 		}),
 	);
-	it.effect("fails closed on a missing session name", () =>
+	it.effect("the engineering-manager role entry absent → fails closed naming it", () =>
 		Effect.gen(function* () {
-			const err = yield* decodeTmuxErr({tmux: {windows: {ea: "ea"}}});
-			assert.include(err.reason, "session");
+			const err = yield* decodeErr({...validLaunch, roles: {}});
+			assert.include(err.reason, "engineering-manager");
 		}),
 	);
-	it.effect("fails closed on a blank session name", () =>
+	it.effect("count missing → fails closed naming count", () =>
 		Effect.gen(function* () {
-			const err = yield* decodeTmuxErr({tmux: {session: "", windows: {ea: "ea"}}});
-			assert.include(err.reason, "session");
+			const err = yield* decodeErr({...validLaunch, roles: {"engineering-manager": {}}});
+			assert.include(err.reason, "count");
 		}),
 	);
-	it.effect("fails closed on a blank window name", () =>
+	it.effect("count blank/non-numeric → fails closed naming count", () =>
 		Effect.gen(function* () {
-			const err = yield* decodeTmuxErr({tmux: {session: "crew", windows: {ea: ""}}});
-			assert.include(err.reason, "windows");
+			const err = yield* decodeErr(withCount(""));
+			assert.include(err.reason, "count");
+		}),
+	);
+	it.effect("count zero → fails closed naming count", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr(withCount(0));
+			assert.include(err.reason, "count");
+		}),
+	);
+	it.effect("count negative → fails closed naming count", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr(withCount(-1));
+			assert.include(err.reason, "count");
+		}),
+	);
+	it.effect("count non-integer → fails closed naming count", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr(withCount(2.5));
+			assert.include(err.reason, "count");
 		}),
 	);
 });
 
 describe("standup/config — fails closed naming the offending dimension", () => {
-	const without = (key: keyof typeof validLaunch) => {
-		const {[key]: _omit, ...rest} = validLaunch;
-		return rest;
-	};
-
 	it.effect("cliVersion missing", () =>
 		Effect.gen(function* () {
-			const err = yield* decodeErr(without("cliVersion"));
+			const {cliVersion: _omit, ...rest} = validLaunch;
+			const err = yield* decodeErr(rest);
 			assert.instanceOf(err, LaunchConfigError);
 			assert.include(err.reason, "cliVersion");
 			assert.strictEqual(err.configPath, "/tmp/crew.config.jsonc");
@@ -228,27 +252,10 @@ describe("standup/config — fails closed naming the offending dimension", () =>
 			assert.include(err.reason, "cliVersion");
 		}),
 	);
-	it.effect("engineCount missing", () =>
-		Effect.gen(function* () {
-			const err = yield* decodeErr(without("engineCount"));
-			assert.include(err.reason, "engineCount");
-		}),
-	);
-	it.effect("engineCount below one", () =>
-		Effect.gen(function* () {
-			const err = yield* decodeErr({...validLaunch, engineCount: 0});
-			assert.include(err.reason, "engineCount");
-		}),
-	);
-	it.effect("engineCount non-integer", () =>
-		Effect.gen(function* () {
-			const err = yield* decodeErr({...validLaunch, engineCount: 2.5});
-			assert.include(err.reason, "engineCount");
-		}),
-	);
 	it.effect("channels missing", () =>
 		Effect.gen(function* () {
-			const err = yield* decodeErr(without("channels"));
+			const {channels: _omit, ...rest} = validLaunch;
+			const err = yield* decodeErr(rest);
 			assert.include(err.reason, "channels");
 		}),
 	);

--- a/packages/pipeline-crew-mcp/src/standup/config.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.ts
@@ -12,13 +12,13 @@
  * The one non-obvious thing: the reader FAILS CLOSED. A missing or malformed launch
  * dimension is a `LaunchConfigError` naming the offending dimension, never a silent default
  * — a drifted CLI pin or an unlisted channel server is a launch to refuse, not paper over.
- * `LaunchConfig` extracts only the launch dimensions (excess keys operator/modelTiers/… are
- * ignored); the tmux *placement* dimension has its own sibling reader `readTmuxNaming` (#3354),
- * fail-closed the same way, so tmux naming enters from the operator config rather than injected.
+ * `LaunchConfig` extracts only the launch dimensions from the one-role-map seam shape (ADR 0189):
+ * the engine count is folded into `roles["engineering-manager"].count`, and excess seam keys
+ * (operator/notification/tier/wipCap/…) are ignored. There is no config-read tmux dimension —
+ * tmux window placement now derives from role identity at launch (tmux-placement.ts), not config.
  */
 import {readFileSync} from "node:fs";
 import {Effect, Schema} from "effect";
-import type {TmuxNaming} from "./tmux-placement.ts";
 
 /**
  * A channel-server ref, in the exact registration grammar Claude Code 2.1.212 accepts —
@@ -121,20 +121,19 @@ export const LaunchConfig = Schema.Struct({
 export type LaunchConfig = typeof LaunchConfig.Type;
 
 /**
- * The tmux placement dimension of the crew config: the tmux session every crew window is created
- * under + the per-bridge window names, keyed by window key. It decodes to `tmux-placement.ts`'s
- * `TmuxNaming` (the placement layer consumes the resolved shape) — this is the reader #3298's
- * placement doc already anticipated ("#3293's reader resolves from the config `tmux` dimension")
- * but no child built, so `runStandUp` had to inject it in code (#3354, seam 1). Names are
- * `NonEmptyString`: an empty tmux session / window name is a launch to refuse, not paper over.
+ * The one-role-map seam shape on disk (ADR 0189): a `roles` map keyed by the crew role slugs, from
+ * which the launch reader takes exactly ONE value — the engine pool size at
+ * `roles["engineering-manager"].count`. The rest of each role entry (`tier`, `wipCap`) and the
+ * whole bridge entries are def-spawn / prose bindings, not launch inputs, so they decode as ignored
+ * excess keys — only `engineering-manager.count` is a required launch dimension here, fail-closed.
  */
-export const TmuxConfig = Schema.Struct({
-	session: Schema.NonEmptyString,
-	windows: Schema.Record(Schema.String, Schema.NonEmptyString),
+const RawLaunchConfig = Schema.Struct({
+	cliVersion: CliVersion,
+	roles: Schema.Struct({
+		"engineering-manager": Schema.Struct({count: EngineCount}),
+	}),
+	channels: ChannelConfig,
 });
-
-/** The crew config carries the tmux placement dimension under its `tmux` key — read only that key. */
-const CrewConfigTmux = Schema.Struct({tmux: TmuxConfig});
 
 /** A crew config that could not be resolved, read, parsed, or validated — carries the offending dimension. */
 export class LaunchConfigError extends Schema.TaggedErrorClass<LaunchConfigError>()(
@@ -221,26 +220,22 @@ export const parseJsonc = (text: string): unknown => JSON.parse(stripJsonc(text)
 /**
  * Decode an already-parsed value into `LaunchConfig`, failing closed with a `LaunchConfigError`
  * whose `reason` names the offending dimension (the schema issue tree carries the field path).
+ * The engine count is folded out of the role map — `roles["engineering-manager"].count` (ADR 0189)
+ * — into the flat `engineCount` every launcher child consumes, so `LaunchConfig`'s shape is stable
+ * across the seam move; a missing/blank/non-positive count fails closed naming that path.
  */
 export const decodeLaunchConfig = (
 	input: unknown,
 	configPath: string,
 ): Effect.Effect<LaunchConfig, LaunchConfigError> =>
-	Schema.decodeUnknownEffect(LaunchConfig)(input).pipe(
-		Effect.mapError((error) => new LaunchConfigError({configPath, reason: error.message})),
-	);
-
-/**
- * Decode an already-parsed value's `tmux` dimension into `TmuxNaming`, failing closed with a
- * `LaunchConfigError` whose `reason` names the offending field — the same fail-closed shape as
- * `decodeLaunchConfig`, so a missing/blank tmux session or window is a launch to refuse (#3354).
- */
-export const decodeTmuxNaming = (
-	input: unknown,
-	configPath: string,
-): Effect.Effect<TmuxNaming, LaunchConfigError> =>
-	Schema.decodeUnknownEffect(CrewConfigTmux)(input).pipe(
-		Effect.map((cfg) => cfg.tmux),
+	Schema.decodeUnknownEffect(RawLaunchConfig)(input).pipe(
+		Effect.map(
+			(raw): LaunchConfig => ({
+				cliVersion: raw.cliVersion,
+				engineCount: raw.roles["engineering-manager"].count,
+				channels: raw.channels,
+			}),
+		),
 		Effect.mapError((error) => new LaunchConfigError({configPath, reason: error.message})),
 	);
 
@@ -280,16 +275,4 @@ export const readLaunchConfig = (
 ): Effect.Effect<LaunchConfig, LaunchConfigError> =>
 	readParsedConfig(env).pipe(
 		Effect.flatMap(({parsed, configPath}) => decodeLaunchConfig(parsed, configPath)),
-	);
-
-/**
- * Resolve → read → parse → decode the crew config's tmux placement dimension. Same collapse-to-one
- * `LaunchConfigError` contract as `readLaunchConfig`, so `runStandUp` reads tmux naming from the
- * operator config (fail-closed) instead of taking it injected in code (#3354, seam 1).
- */
-export const readTmuxNaming = (
-	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
-): Effect.Effect<TmuxNaming, LaunchConfigError> =>
-	readParsedConfig(env).pipe(
-		Effect.flatMap(({parsed, configPath}) => decodeTmuxNaming(parsed, configPath)),
 	);

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -61,11 +61,10 @@ export {
 } from "./session-set.ts";
 export {
 	computeTmuxPlacement,
+	DEFAULT_TMUX_SESSION,
 	type PlacementTarget,
 	type RosterSession,
-	type TmuxNaming,
 	TmuxWindowCollisionError,
-	TmuxWindowUnnamedError,
 } from "./tmux-placement.ts";
 export {
 	assertPinnedCliVersion,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -1,16 +1,23 @@
 /**
- * standup/orchestrate — the one stand-up command (issue #3299). These tests pin the two properties
- * the composition owns: the MANDATED ORDER (version assert → ensure tracker → derive roster → per-
- * session bind + tmux placement → launch) and FAIL-LOUD WITH NO PARTIAL CREW (every precondition
- * failure aborts, naming its cause, with zero sessions launched). Every side-effecting step is
- * injected — a version reader, a recording tracker, a recording launcher — so the whole boot runs in
- * a unit test with no real subprocess, tmux, or `claude`.
+ * standup/orchestrate — the one stand-up command (issue #3299), booting against the post-#3236
+ * one-role-map config (ADR 0189): the engine count folds into `roles["engineering-manager"].count`
+ * and there is NO config tmux dimension — window placement derives from role identity at launch.
+ * These tests pin the two properties the composition owns: the MANDATED ORDER (version assert →
+ * ensure tracker → derive roster → per-session bind + tmux placement → launch) and FAIL-LOUD WITH NO
+ * PARTIAL CREW (every precondition failure aborts, naming its cause, with zero sessions launched).
+ * Every side-effecting step is injected — a version reader, a recording tracker, a recording launcher
+ * — so the whole boot runs in a unit test with no real subprocess, tmux, or `claude`.
  */
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Schema} from "effect";
+import {Effect} from "effect";
 import {CREW_ROLES, kindOf} from "../crew/index.ts";
 import {CREW_SESSION_INSTANCE_FLAG} from "./bind.ts";
-import {LaunchConfig, LaunchConfigError} from "./config.ts";
+import {
+	DEFAULT_CONFIG_PATH,
+	decodeLaunchConfig,
+	type LaunchConfig,
+	LaunchConfigError,
+} from "./config.ts";
 import {type TrackerHandle, TrackerNotServingError} from "./ensure-tracker.ts";
 import {
 	CliVersionAssertError,
@@ -19,29 +26,38 @@ import {
 	type LaunchPlan,
 	runStandUp,
 	type StandUpInput,
-	TmuxWindowUnnamedError,
 } from "./index.ts";
 
 const PINNED = "2.1.212";
 const SERVER = "@kampus/pipeline-crew-mcp";
 
-/** A dev-mode config carrying the crew's own `server:` ref — the shape bind + config both accept. */
-const configAt = (cliVersion: string, engineCount: number): LaunchConfig =>
-	Schema.decodeUnknownSync(LaunchConfig)({
-		cliVersion,
-		engineCount,
-		channels: {mode: "development", servers: [`server:${SERVER}`], allowedChannelPlugins: []},
-	});
-
-/** Operator tmux naming: a window per bridge role, keyed by the role slug (engines self-name by id). */
-const tmuxNaming = {
-	session: "crew",
-	windows: {
-		"chief-of-staff": "cos",
-		cartographer: "carto",
-		"intake-desk": "intake",
+/**
+ * A post-#3236 one-role-map crew config (raw, on-disk shape): the engine count lives at
+ * `roles["engineering-manager"].count`; bridge entries + per-role tier/wipCap are excess seam keys;
+ * there is NO tmux key. Decoded through `decodeLaunchConfig` so the boot exercises the real
+ * new-template decode end to end (the dogfood: stand up from a config regenerated from the template).
+ */
+const rawConfigAt = (cliVersion: string, engineCount: number): unknown => ({
+	cliVersion,
+	roles: {
+		"chief-of-staff": {tier: "opus"},
+		cartographer: {tier: "fable"},
+		"intake-desk": {tier: "fable"},
+		"engineering-manager": {
+			tier: "opus",
+			count: engineCount,
+			wipCap: {productLanes: 1, platformLanes: 1},
+		},
 	},
-};
+	// dev mode carries the crew's own `server:` ref — the shape bind + config both accept.
+	channels: {mode: "development", servers: [`server:${SERVER}`], allowedChannelPlugins: []},
+});
+
+const configAt = (
+	cliVersion: string,
+	engineCount: number,
+): Effect.Effect<LaunchConfig, LaunchConfigError> =>
+	decodeLaunchConfig(rawConfigAt(cliVersion, engineCount), DEFAULT_CONFIG_PATH);
 
 /** A deterministic engine instance-id generator so the derived set + windows are pinnable. */
 const counter = () => {
@@ -90,8 +106,7 @@ const baseInput = (
 		trackerCalls: calls,
 		input: {
 			projectRoot: "/repo",
-			tmuxConfig: Effect.succeed(tmuxNaming),
-			config: Effect.succeed(configAt(PINNED, engineCount ?? 2)),
+			config: configAt(PINNED, engineCount ?? 2),
 			readVersionOutput: Effect.succeed(`${PINNED} (Claude Code)`),
 			instanceId: counter(),
 			ensureTracker,
@@ -127,9 +142,9 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 					assert.strictEqual(p.bind.role, p.session.role);
 					assert.match(p.session.address, /^inbox:\/\//);
 				}
-				// bridges placed on their operator-named windows, engines on their generated instance ids.
+				// bridges placed on windows derived from their role slug, engines on their generated ids.
 				const cos = launchedBridges.find((p) => p.session.role === "chief-of-staff");
-				assert.strictEqual(cos?.placement.window, "cos");
+				assert.strictEqual(cos?.placement.window, "chief-of-staff");
 				assert.deepStrictEqual(launchedEngines.map((p) => p.placement.window).sort(), [
 					"e0",
 					"e1",
@@ -197,21 +212,6 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 		}),
 	);
 
-	it.effect("aborts when a bridge names no operator tmux window — no partial crew (AC3)", () =>
-		Effect.gen(function* () {
-			const {input, launched} = baseInput({
-				// cartographer/intake-desk unnamed
-				tmuxConfig: Effect.succeed({session: "crew", windows: {"chief-of-staff": "cos"}}),
-			});
-			const err = yield* Effect.flip(runStandUp(input));
-
-			assert.instanceOf(err, TmuxWindowUnnamedError);
-			// placement is resolved for the WHOLE set before the first launch — a single unnamed window
-			// aborts stand-up with zero sessions up (the no-partial-crew line).
-			assert.strictEqual(launched.length, 0);
-		}),
-	);
-
 	it.effect(
 		"aborts when the crew server would be inert (unregistered channel), before any launch (AC3)",
 		() =>
@@ -220,24 +220,6 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 				const err = yield* Effect.flip(runStandUp(input));
 
 				assert.instanceOf(err, CrewServerNotRegisteredError);
-				assert.strictEqual(launched.length, 0);
-			}),
-	);
-
-	it.effect(
-		"reads tmux naming from config: a malformed tmux dimension aborts before launch (seam 1)",
-		() =>
-			Effect.gen(function* () {
-				const {input, launched, trackerCalls} = baseInput({
-					tmuxConfig: Effect.fail(
-						new LaunchConfigError({configPath: ".claude/crew.config.jsonc", reason: "tmux"}),
-					),
-				});
-				const err = yield* Effect.flip(runStandUp(input));
-
-				assert.instanceOf(err, LaunchConfigError);
-				// tmux is read alongside the launch config, before the tracker or any launch.
-				assert.strictEqual(trackerCalls(), 0);
 				assert.strictEqual(launched.length, 0);
 			}),
 	);

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -10,7 +10,7 @@
  * roster session set → build EVERY per-session bind + compute ALL tmux placements → launch. Every
  * bind and every placement is resolved (and validated) BEFORE the first session launches, so any
  * precondition failure — a drifted CLI pin, a missing config dimension, an inert channel, a colliding
- * or unnamed tmux window — aborts with a named error while zero sessions are up, never a half-launched
+ * tmux window — aborts with a named error while zero sessions are up, never a half-launched
  * crew. No session is hand-launched: the launch of each `claude` session, bound to its role lease, is
  * the injected `launch` step the orchestration drives for the whole derived set.
  *
@@ -28,12 +28,7 @@ import {
 	type CrewServerNotRegisteredError,
 	type SessionBind,
 } from "./bind.ts";
-import {
-	type LaunchConfig,
-	type LaunchConfigError,
-	readLaunchConfig,
-	readTmuxNaming,
-} from "./config.ts";
+import {type LaunchConfig, type LaunchConfigError, readLaunchConfig} from "./config.ts";
 import {
 	ensureTrackerRunning,
 	type TrackerHandle,
@@ -44,9 +39,7 @@ import {
 	computeTmuxPlacement,
 	type PlacementTarget,
 	type RosterSession,
-	type TmuxNaming,
 	type TmuxWindowCollisionError,
-	type TmuxWindowUnnamedError,
 } from "./tmux-placement.ts";
 import {
 	assertPinnedCliVersion,
@@ -87,19 +80,12 @@ export type StandUpError =
 	| TrackerNotServingError
 	| CrewServerNotRegisteredError
 	| ChannelPluginNotAllowedError
-	| TmuxWindowUnnamedError
 	| TmuxWindowCollisionError
 	| StandUpLaunchError;
 
 export interface StandUpInput {
 	/** The project root the tracker + every session join (the per-project socket key). */
 	readonly projectRoot: string;
-	/**
-	 * The operator-configured tmux naming (session + per-bridge window names). Read from the crew
-	 * config's tmux dimension by default (`readTmuxNaming`, #3354 seam 1) rather than injected in
-	 * code; injectable here so the composition stays unit-testable without a config file on disk.
-	 */
-	readonly tmuxConfig?: Effect.Effect<TmuxNaming, LaunchConfigError>;
 	/** The channel-ref name each session's own crew MCP server registers under. Default: `SESSION_SERVER_NAME`. */
 	readonly serverName?: string;
 	/** The launch dimensions to stand up under. Default: read the operator crew config (`readLaunchConfig`). */
@@ -123,17 +109,17 @@ export interface StandUpResult {
 }
 
 /**
- * Project a derived `CrewSession` onto the `RosterSession` tmux-placement consumes: a bridge's window
- * key is its role slug (the operator's `windows` map is keyed by role), an engine's window is its
- * generated per-instance id (an operator cannot name N dynamic engines).
+ * Project a derived `CrewSession` onto the `RosterSession` tmux-placement consumes: a bridge places
+ * on a window named by its role slug, an engine on its generated per-instance id (an operator cannot
+ * name N dynamic engines). Both window names derive from identity — there is no config tmux dimension.
  */
 const toRosterSession = (session: CrewSession): RosterSession =>
 	session.kind === "engine"
 		? {kind: "engine", id: session.instance}
-		: {kind: "bridge", role: session.role, windowKey: session.role};
+		: {kind: "bridge", role: session.role};
 
 /**
- * The production launcher: open a tmux window for the session under the operator's tmux session and
+ * The production launcher: open a tmux window for the session under the launcher-default tmux session and
  * run `claude` there with the session's launch bind. Detached + unref'd + ignored stdio so the crew
  * outlives this launcher process (the `ensureTrackerRunning` spawn idiom). The thin, uncovered edge —
  * tests inject a recording launcher; only a synchronous spawn throw crosses the error channel.
@@ -181,9 +167,6 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 		const launch = input.launch ?? launchSessionInTmux;
 
 		const config = yield* input.config ?? readLaunchConfig();
-		// Read the tmux placement dimension from the operator config too (#3354 seam 1) — a malformed
-		// tmux dimension is a config-time abort, before the tracker or any session launches.
-		const tmuxNaming = yield* input.tmuxConfig ?? readTmuxNaming();
 		// Fail fast on a version drift before starting the tracker or any session — channels vary
 		// across CLI versions, so a mismatch is a stand-up to refuse (version-assert.ts / #3295).
 		yield* assertPinnedCliVersion(config, input.readVersionOutput ?? readInstalledCliVersionOutput);
@@ -192,7 +175,7 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 		const sessions = deriveSessionSet({engineCount: config.engineCount, instanceId});
 
 		// Resolve EVERY bind + placement before launching anything — this is the no-partial-crew line:
-		// an inert channel, an unnamed or colliding window fails here, while zero sessions are up.
+		// an inert channel or a colliding window fails here, while zero sessions are up.
 		const binds = yield* Effect.forEach(sessions, (session) =>
 			buildSessionBind({
 				role: session.role,
@@ -204,7 +187,7 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 				channels: config.channels,
 			}),
 		);
-		const placements = yield* computeTmuxPlacement(tmuxNaming, sessions.map(toRosterSession));
+		const placements = yield* computeTmuxPlacement(sessions.map(toRosterSession));
 		// `binds` and `placements` are each derived from `sessions` in order, so the index is always
 		// populated; the die guard is the unreachable branch that satisfies noUncheckedIndexedAccess.
 		const plans = yield* Effect.forEach(sessions, (session, i) => {

--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
@@ -1,67 +1,56 @@
 /**
- * The tmux placement mapping (AC 4): a sample roster session set — three bridges + N engines —
- * maps to one placement target per session, all under the operator-configured tmux session, with
- * bridge windows resolved from the operator config's tmux naming and engine windows from each
- * engine's per-instance id. Also pins the two fail-closed rejections: a bridge whose window key
- * the operator config omits, and two sessions colliding on one window. These prove tmux is used
- * only as a window-manager here — the mapping produces placement targets, never a transport path.
+ * The tmux placement mapping (AC 4): a sample roster session set — three bridges + N engines — maps
+ * to one placement target per session, all under the launcher-default tmux session, with each window
+ * name DERIVED from role identity (a bridge's role slug, an engine's per-instance id) rather than a
+ * config `tmux` dimension (which died with the one-role-map seam, ADR 0189 / #3236). Also pins the
+ * one surviving fail-closed rejection: two sessions colliding on one window. These prove tmux is
+ * used only as a window-manager here — the mapping produces placement targets, never a transport path.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {decodeTmuxNaming} from "./config.ts";
 import {
 	computeTmuxPlacement,
+	DEFAULT_TMUX_SESSION,
 	type RosterSession,
-	type TmuxNaming,
 	TmuxWindowCollisionError,
-	TmuxWindowUnnamedError,
 } from "./tmux-placement.ts";
 
-// Operator-configured tmux naming — the shape #3293's reader resolves from the config `tmux`
-// dimension. Placeholder values stand in for operator data; the layer never hardcodes them.
-const NAMING: TmuxNaming = {
-	session: "crew",
-	windows: {
-		ea: "chief-of-staff",
-		engineeringManager: "em",
-		triage: "intake-desk",
-	},
-};
-
 // A sample roster: the three bridges + an engine count of N (here N = 3, each engine already
-// carrying its per-instance identity from #3297).
+// carrying its per-instance identity from #3297). Bridges name their window by role slug.
 const BRIDGES: readonly RosterSession[] = [
-	{kind: "bridge", role: "ea-chief-of-staff", windowKey: "ea"},
-	{kind: "bridge", role: "engineering-manager", windowKey: "engineeringManager"},
-	{kind: "bridge", role: "triage-guy", windowKey: "triage"},
+	{kind: "bridge", role: "chief-of-staff"},
+	{kind: "bridge", role: "cartographer"},
+	{kind: "bridge", role: "intake-desk"},
 ];
 const engines = (n: number): readonly RosterSession[] =>
 	Array.from({length: n}, (_, i) => ({kind: "engine", id: `engine-${i + 1}`}) as const);
 
-describe("standup/tmux-placement — session set → placement targets", () => {
-	it.effect("places one window per bridge + one per engine, all under the tmux session", () =>
-		Effect.gen(function* () {
-			const targets = yield* computeTmuxPlacement(NAMING, [...BRIDGES, ...engines(3)]);
-			assert.lengthOf(targets, 6, "3 bridges + 3 engines = 6 placement targets");
-			for (const t of targets) {
-				assert.strictEqual(
-					t.session,
-					"crew",
-					"every window lives under the configured tmux session",
-				);
-			}
-		}),
+describe("standup/tmux-placement — session set → placement targets (derived naming)", () => {
+	it.effect(
+		"places one window per bridge + one per engine, all under the default tmux session",
+		() =>
+			Effect.gen(function* () {
+				const targets = yield* computeTmuxPlacement([...BRIDGES, ...engines(3)]);
+				assert.lengthOf(targets, 6, "3 bridges + 3 engines = 6 placement targets");
+				for (const t of targets) {
+					assert.strictEqual(
+						t.session,
+						DEFAULT_TMUX_SESSION,
+						"every window lives under the launcher-default tmux session",
+					);
+				}
+			}),
 	);
 
-	it.effect("resolves each bridge window from the operator config's tmux naming", () =>
+	it.effect("derives each bridge window from its role slug", () =>
 		Effect.gen(function* () {
-			const targets = yield* computeTmuxPlacement(NAMING, BRIDGES);
+			const targets = yield* computeTmuxPlacement(BRIDGES);
 			assert.deepStrictEqual(
 				targets.map((t) => ({window: t.window, sessionRef: t.sessionRef, kind: t.kind})),
 				[
-					{window: "chief-of-staff", sessionRef: "ea-chief-of-staff", kind: "bridge"},
-					{window: "em", sessionRef: "engineering-manager", kind: "bridge"},
-					{window: "intake-desk", sessionRef: "triage-guy", kind: "bridge"},
+					{window: "chief-of-staff", sessionRef: "chief-of-staff", kind: "bridge"},
+					{window: "cartographer", sessionRef: "cartographer", kind: "bridge"},
+					{window: "intake-desk", sessionRef: "intake-desk", kind: "bridge"},
 				],
 			);
 		}),
@@ -69,7 +58,7 @@ describe("standup/tmux-placement — session set → placement targets", () => {
 
 	it.effect("names each engine window from its per-instance id (distinct across the count)", () =>
 		Effect.gen(function* () {
-			const targets = yield* computeTmuxPlacement(NAMING, engines(4));
+			const targets = yield* computeTmuxPlacement(engines(4));
 			assert.deepStrictEqual(
 				targets.map((t) => ({window: t.window, sessionRef: t.sessionRef, kind: t.kind})),
 				[
@@ -87,49 +76,16 @@ describe("standup/tmux-placement — session set → placement targets", () => {
 		}),
 	);
 
-	it.effect("fails closed when a bridge names a window key the operator config omits", () =>
-		Effect.gen(function* () {
-			const failure = yield* computeTmuxPlacement(NAMING, [
-				{kind: "bridge", role: "cartographer", windowKey: "cartographer"},
-			]).pipe(Effect.flip);
-			assert.instanceOf(failure, TmuxWindowUnnamedError);
-			assert.strictEqual(failure.windowKey, "cartographer");
-			assert.strictEqual(failure.role, "cartographer");
-		}),
-	);
-
 	it.effect("fails closed when two sessions collide on one window", () =>
 		Effect.gen(function* () {
-			const failure = yield* computeTmuxPlacement(NAMING, [
-				{kind: "bridge", role: "ea-chief-of-staff", windowKey: "ea"},
+			const failure = yield* computeTmuxPlacement([
+				{kind: "bridge", role: "chief-of-staff"},
 				// an engine whose id equals the already-placed bridge window name
 				{kind: "engine", id: "chief-of-staff"},
 			]).pipe(Effect.flip);
 			assert.instanceOf(failure, TmuxWindowCollisionError);
 			assert.strictEqual(failure.window, "chief-of-staff");
-			assert.deepStrictEqual([...failure.sessionRefs], ["ea-chief-of-staff", "chief-of-staff"]);
-		}),
-	);
-
-	// Seam 1 (#3354): the config tmux-dimension reader's output feeds this placement layer directly —
-	// the naming that was injected in code now comes from the operator config, end to end.
-	it.effect("places sessions from a config-decoded TmuxNaming (reader → placement)", () =>
-		Effect.gen(function* () {
-			const naming = yield* decodeTmuxNaming(
-				{tmux: {session: "crew", windows: {ea: "chief-of-staff"}}},
-				"/tmp/crew.config.jsonc",
-			);
-			const targets = yield* computeTmuxPlacement(naming, [
-				{kind: "bridge", role: "ea-chief-of-staff", windowKey: "ea"},
-				{kind: "engine", id: "engine-1"},
-			]);
-			assert.deepStrictEqual(
-				targets.map((t) => ({session: t.session, window: t.window})),
-				[
-					{session: "crew", window: "chief-of-staff"},
-					{session: "crew", window: "engine-1"},
-				],
-			);
+			assert.deepStrictEqual([...failure.sessionRefs], ["chief-of-staff", "chief-of-staff"]);
 		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.ts
@@ -3,63 +3,44 @@
  * stand-up launcher (epic #3237) coordinates the crew over the channels substrate now, but
  * something must still put each launched session on the operator's screen — that is this layer.
  * It maps the roster session set (C6, #3297: one entry per bridge + one per engine instance) to
- * tmux placement targets under the operator-configured tmux session, resolving each window name
- * from the operator's tmux naming.
+ * tmux placement targets, deriving each window name from the session's own role identity.
  *
- * The layer is deliberately thin: it maps sessions to placement targets and nothing else. It does
- * NOT register channels or mint identity (C5/C6 own those), it does NOT read the config file (the
- * `tmux` dimension reader/validator is #3293; here we consume the already-resolved `TmuxNaming`),
- * and it introduces NO tmux-as-transport path — no pane-title discovery, no buffer-paste, no
- * send-keys. Pure derivation over plain data (the `registry-core` idiom); the launcher (#3299)
- * issues the actual window/pane creation from the targets this returns.
+ * The one non-obvious thing: placement naming is DERIVED, not config-read. The old config `tmux`
+ * dimension (session + per-bridge window names) died with the one-role-map seam (ADR 0189 / #3236):
+ * post-MCP a role's address is a lease, not a configured pane, so there is nothing left to name in
+ * config. A bridge's window is its role slug; an engine's window is its per-instance id (an operator
+ * could never name N dynamic engines). All windows live under a single launcher-default tmux session.
+ * The layer stays thin — it maps sessions to placement targets and nothing else: it does NOT register
+ * channels or mint identity (C5/C6 own those), and introduces NO tmux-as-transport path (no pane-title
+ * discovery, no buffer-paste, no send-keys). Pure derivation over plain data (the `registry-core` idiom).
  */
 import {Effect, Schema} from "effect";
 
 /**
- * The operator-configured tmux naming this layer consumes — the `tmux` dimension of the crew
- * config personalization seam (ADR 0062: operator data lives in the operator's config, never the
- * distributable plugin). Loaded and validated by #3293's reader; here we take the resolved shape.
+ * The tmux session every crew window is created under. A launcher default, not a config input: with
+ * the config `tmux` dimension gone (ADR 0189), the session name is derived, not operator-supplied.
  */
-export interface TmuxNaming {
-	/** The tmux session every crew window is created under — operator-configured, never hardcoded. */
-	readonly session: string;
-	/** Operator-configured window names, keyed by a bridge's window key. */
-	readonly windows: Readonly<Record<string, string>>;
-}
+export const DEFAULT_TMUX_SESSION = "crew";
 
 /**
- * One session in the roster set (C6, #3297) that must be placed on the operator's screen. A bridge
- * is a singleton role window whose name the operator configures; an engine is one of N instances
- * whose per-instance identity (#3297 generates it) already names its window — the operator cannot
- * name N dynamic engines, so the generated id is the (non-operator, non-hardcoded) window name.
+ * One session in the roster set (C6, #3297) that must be placed on the operator's screen. A bridge is
+ * a singleton role window named by its role slug; an engine is one of N instances whose per-instance
+ * identity (#3297 generates it) names its window — both derived from identity, never config.
  */
 export type RosterSession =
-	| {readonly kind: "bridge"; readonly role: string; readonly windowKey: string}
+	| {readonly kind: "bridge"; readonly role: string}
 	| {readonly kind: "engine"; readonly id: string};
 
-/** Where one session is placed: a named window under the operator-configured tmux session. */
+/** Where one session is placed: a named window under the launcher-default tmux session. */
 export interface PlacementTarget {
-	/** The tmux session this window is created under (from `TmuxNaming.session`). */
+	/** The tmux session this window is created under (`DEFAULT_TMUX_SESSION`). */
 	readonly session: string;
-	/** The resolved tmux window name. */
+	/** The resolved tmux window name — a bridge's role slug or an engine's instance id. */
 	readonly window: string;
 	/** The roster session this places — a bridge role slug or an engine instance id. */
 	readonly sessionRef: string;
 	readonly kind: "bridge" | "engine";
 }
-
-/**
- * A bridge names a window key the operator's tmux config does not define — fail loud rather than
- * invent a name, because the window name MUST come from operator config (no hardcoded operator
- * data). A REJECTION, not a value (the `crew/errors` idiom).
- */
-export class TmuxWindowUnnamedError extends Schema.TaggedErrorClass<TmuxWindowUnnamedError>()(
-	"@kampus/pipeline-crew-mcp/standup/TmuxWindowUnnamedError",
-	{
-		role: Schema.String,
-		windowKey: Schema.String,
-	},
-) {}
 
 /**
  * Two sessions resolved to the same window under the tmux session — a placement that would stack
@@ -73,42 +54,25 @@ export class TmuxWindowCollisionError extends Schema.TaggedErrorClass<TmuxWindow
 	},
 ) {}
 
-const placeOne = (
-	naming: TmuxNaming,
-	session: RosterSession,
-): Effect.Effect<PlacementTarget, TmuxWindowUnnamedError> => {
-	if (session.kind === "engine") {
-		return Effect.succeed({
-			session: naming.session,
-			window: session.id,
-			sessionRef: session.id,
-			kind: "engine",
-		});
-	}
-	const window = naming.windows[session.windowKey];
-	if (window === undefined) {
-		return Effect.fail(
-			new TmuxWindowUnnamedError({role: session.role, windowKey: session.windowKey}),
-		);
-	}
-	return Effect.succeed({
-		session: naming.session,
-		window,
-		sessionRef: session.role,
-		kind: "bridge",
-	});
-};
+const placeOne = (session: RosterSession): PlacementTarget =>
+	session.kind === "engine"
+		? {session: DEFAULT_TMUX_SESSION, window: session.id, sessionRef: session.id, kind: "engine"}
+		: {
+				session: DEFAULT_TMUX_SESSION,
+				window: session.role,
+				sessionRef: session.role,
+				kind: "bridge",
+			};
 
 /**
- * Map the roster session set to tmux placement targets: one window per bridge + one per engine
- * instance, all under the operator-configured tmux session. Fails closed on a bridge whose window
- * key the operator config omits, or on two sessions colliding on one window.
+ * Map the roster session set to tmux placement targets: one window per bridge (named by its role
+ * slug) + one per engine instance (named by its id), all under the launcher-default tmux session.
+ * Fails closed only on two sessions colliding on one window — the launch-time distinctness guard.
  */
 export const computeTmuxPlacement = (
-	naming: TmuxNaming,
 	sessions: readonly RosterSession[],
-): Effect.Effect<readonly PlacementTarget[], TmuxWindowUnnamedError | TmuxWindowCollisionError> =>
-	Effect.forEach(sessions, (session) => placeOne(naming, session)).pipe(
+): Effect.Effect<readonly PlacementTarget[], TmuxWindowCollisionError> =>
+	Effect.sync(() => sessions.map(placeOne)).pipe(
 		Effect.flatMap((targets) => {
 			const byWindow = new Map<string, string[]>();
 			for (const t of targets) {


### PR DESCRIPTION
Reconciles the pipeline-crew stand-up launcher's typed config reader to the one-role-map seam shape that #3381 (ADR 0189/0192) introduced. Until this lands, `pipeline-crew-mcp stand-up` fail-closes against any config regenerated from the new template — the DOGFOOD acceptance proof (booting the crew from the new #3236 config) is blocked.

Two landed reader dimensions were desynced from the template; this reconciles both, scoped strictly to `packages/pipeline-crew-mcp/src/standup/**` (+ tests).

## engineCount → `roles["engineering-manager"].count`
The top-level `engineCount` decode is dropped. `decodeLaunchConfig` now decodes the one-role-map shape and folds the engine count out of `roles["engineering-manager"].count`; `LaunchConfig` still exposes a flat `engineCount`, so `deriveSessionSet({engineCount})` is untouched. `tier`/`wipCap` and the bridge role entries decode as ignored excess keys (as do `operator`/`notification`/`controlPlaneApprover`). A missing/blank/zero/negative/non-integer count fails closed with a `LaunchConfigError` naming the offending path.

## tmux CONFIG dimension removed; tmux PLACEMENT feature kept (derived)
Grounded in #3213/#3236 (the tmux config dimension dies — later, ADR-blessed, shipped) and #3237/#3298/ADR 0192 (the placement feature survives — something must still put each session on the operator's screen):

- Removed: `TmuxConfig`, `CrewConfigTmux`, `decodeTmuxNaming`, `readTmuxNaming`, and the whole config `tmux` read; plus the `TmuxNaming` shape and `TmuxWindowUnnamedError` path (a bridge can no longer be "unnamed" — its window is its slug).
- Kept: `computeTmuxPlacement` + the collision check, and `launchSessionInTmux`. Placement naming now DERIVES from role identity — bridge window = role slug, engine window = per-instance id — all under a launcher-default tmux session (`"crew"`, `DEFAULT_TMUX_SESSION`), no config input. `TmuxWindowCollisionError` stays as the launch-time distinctness guard.

`runStandUp` no longer reads a config tmux dimension (`tmuxConfig` input dropped).

## Tests
- `config.test.ts`: engine count decoded off `roles["engineering-manager"].count`; a tmux-free one-role-map config accepted with excess seam keys ignored; missing roles / missing engineering-manager entry / missing/blank/0/negative/non-integer count each fail closed naming the offending dimension.
- `tmux-placement.test.ts`: derived placement (bridge window = slug, engine window = instance id, all under the default session); two-same-window still raises `TmuxWindowCollisionError`.
- `orchestrate.test.ts`: `runStandUp` boots against a post-#3236 one-role-map config (no `tmux` key), decoded through `decodeLaunchConfig` end to end → one placed window per bridge + N per engine (the dogfood acceptance proof).

`pnpm typecheck` + the full `pipeline-crew-mcp` suite (162 tests) green locally; biome clean.

## Notes
- NON-§CP (`packages/pipeline-crew-mcp/` is outside `CONTROL_PLANE_RE`, ADR 0187) — normal auto-merge.
- Depends on #3381 (the template rewrite) merging first; do not ship ahead of it.

Fixes #3382

🤖 Generated with [Claude Code](https://claude.com/claude-code)