### PR TITLE
chore(lint): enable biome noTsIgnore at warn (forward-guard)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -74,7 +74,13 @@
 				"noNonNullAssertion": "warn"
 			},
 			"suspicious": {
-				"noExplicitAny": "off"
+				"noExplicitAny": "off",
+				// `warn`, not `error`: a blanket `@ts-ignore` silently discards a
+				// type error with no self-invalidation, so flag every one — but as a
+				// nudge (the error-level flip is a separate capstone). Forward-guard:
+				// 0 sites today; the safe-fix rewrites `@ts-ignore` → the
+				// self-invalidating `@ts-expect-error`.
+				"noTsIgnore": "warn"
 			}
 		}
 	},


### PR DESCRIPTION
Enable biome's built-in `noTsIgnore` rule at `warn` in `biome.jsonc`, closing the currently-unguarded blanket-`@ts-ignore` hole.

## What
One-line rule enablement in the linter `suspicious` block (matching the existing rules-block idiom). No GritQL plugin / custom `.grit` rule — GritQL matches AST nodes, and TS directive comments are lexer trivia that can't compile as a matcher (verified; see issue).

## Why forward-guard
There are **0** `@ts-ignore` directives in the repo today (verified at `origin/main`), so this is a pure forward-guard: `pnpm lint` stays green and any *future* `@ts-ignore` is flagged. The safe-fix rewrites `@ts-ignore` → the self-invalidating `@ts-expect-error` biome recommends.

## Acceptance criteria
- [x] `@ts-ignore` flagged at `warn` via biome's built-in `noTsIgnore` in `biome.jsonc`; no GritQL/custom rule added. (Probed: a `@ts-ignore` fixture reports `lint/suspicious/noTsIgnore` at warn.)
- [x] `pnpm lint` passes — 0 current sites, no remediation needed.

Fixes #3194