### PR TITLE
fix(integration): harden the shared deploy/readiness gate against merge_group batch flakes (#3409)

### DIFF
--- a/apps/web/tests/integration/_deploy-transient.ts
+++ b/apps/web/tests/integration/_deploy-transient.ts
@@ -48,15 +48,21 @@ const DEPLOY_TRANSIENT_TAGS = new Set([
 // This precise substring is the version-propagation race alone.
 const NO_VERSIONS_MESSAGE = "no versions";
 
-// The preview-deploy secret probe's eventually-consistent signature: the `AuthError` _tag with a
-// "Edge-preview secret read failed: Secret probe returned <code>" message (a non-2xx probe result,
-// e.g. `400: <!DOCTYPE html>` or a 5xx). ADR 0061 already documents this verbatim string as a
-// Cloudflare preview-deploy infra flake unrelated to a PR that adds no worker/deploy code; it fired
-// in merge-group CI and ejected an approved PR from the queue (#2156, #2148). Matched on the MESSAGE
-// substring, NOT the bare `AuthError` _tag: a blanket AuthError retry would mask a genuine auth
-// failure (bad/expired token, wrong account), which must still fail fast — only the secret-probe
-// propagation race rides the bounded backoff.
-const SECRET_PROBE_MESSAGE = "Secret probe returned";
+// The preview-deploy edge-session's eventually-consistent signature: the `AuthError` _tag whose
+// message carries the "Edge-preview secret read failed:" prefix. That prefix is the single wrapper
+// alchemy stamps on EVERY `EdgeSessionError` at `Cloudflare/StateStore/State.ts`'s
+// `catchTag("EdgeSessionError")` (grounded: alchemy@2.0.0-beta.59 `State.ts:597`), so it fronts BOTH
+// preview-deploy infra transients we've observed eject an innocent merge_group PR:
+//   - "…: Secret probe returned <code>" — a non-2xx secret probe (`State.ts:792`; 400-HTML / 5xx).
+//     ADR 0061 documents this verbatim as the flake that ejected approved PR #2148 (#2156).
+//   - "…: Failed to create edge preview session" — the edge-session bootstrap itself failing under
+//     the shared account's cross-PR load (`EdgeSession.ts:155`; observed on merge_group run
+//     29560455218, #3409). The prior match pinned only the probe wording, so this sibling escaped
+//     unretried and hard-failed the batch.
+// Matched on the wrapper PREFIX, NOT the bare `AuthError` _tag: a genuine auth failure (bad/expired
+// token, wrong account) is a DIFFERENT AuthError without this prefix and must still fail fast — the
+// bounded `deployTransientRetry` cap also fails fast on a persistent edge-session error.
+const EDGE_PREVIEW_MESSAGE = "Edge-preview secret read failed";
 
 export const isTransientDeployError = (error: unknown): boolean => {
 	if (typeof error !== "object" || error === null || !("_tag" in error)) return false;
@@ -65,6 +71,6 @@ export const isTransientDeployError = (error: unknown): boolean => {
 	if (tag === "NotFound" && typeof message === "string" && message.includes(NO_VERSIONS_MESSAGE))
 		return true;
 	return (
-		tag === "AuthError" && typeof message === "string" && message.includes(SECRET_PROBE_MESSAGE)
+		tag === "AuthError" && typeof message === "string" && message.includes(EDGE_PREVIEW_MESSAGE)
 	);
 };

--- a/apps/web/tests/integration/_deploy-transient.unit.test.ts
+++ b/apps/web/tests/integration/_deploy-transient.unit.test.ts
@@ -41,25 +41,31 @@ describe("isTransientDeployError", () => {
 		).toBe(true);
 	});
 
-	// #2156: the preview-deploy secret-probe AuthError (a non-2xx probe result) — the merge-group
-	// flake that ejected approved PR #2148. Matched on the message, not the bare `AuthError` _tag,
-	// so a genuine auth failure (below) still fails fast.
+	// The preview-deploy edge-session AuthError — every `EdgeSessionError` alchemy wraps carries the
+	// "Edge-preview secret read failed:" prefix (`State.ts:597`), so the match is the prefix, not one
+	// wording. Both observed merge_group-ejecting variants ride out: the #2156 secret-probe result
+	// (ejected approved PR #2148) and the #3409 session-bootstrap failure (run 29560455218). Matched
+	// on the prefix, not the bare `AuthError` _tag, so a genuine auth failure (below) still fails fast.
 	it.each([
 		[
 			"a 400-HTML probe result",
 			"Edge-preview secret read failed: Secret probe returned 400: <!DOCTYPE html>",
 		],
 		["a 502 probe result", "Edge-preview secret read failed: Secret probe returned 502"],
-	])("retries the transient preview-deploy secret-probe AuthError (%s)", (_label, message) => {
+		[
+			"a failed edge-session bootstrap (#3409)",
+			"Edge-preview secret read failed: Failed to create edge preview session",
+		],
+	])("retries the transient preview-deploy edge-session AuthError (%s)", (_label, message) => {
 		expect(isTransientDeployError({_tag: "AuthError", message})).toBe(true);
 	});
 
 	it.each([
 		["a bare NotFound (a genuinely missing resource)", {_tag: "NotFound", message: "gone"}],
-		// A real auth failure carries `AuthError` WITHOUT the secret-probe message — it must fail
-		// fast, never be swallowed by the #2156 secret-probe retry.
+		// A real auth failure carries `AuthError` WITHOUT the edge-preview wrapper prefix — it must
+		// fail fast, never be swallowed by the edge-session retry.
 		[
-			"a genuine auth failure (AuthError without the secret-probe message)",
+			"a genuine auth failure (AuthError without the edge-preview prefix)",
 			{_tag: "AuthError", message: "invalid API token"},
 		],
 		["an auth failure", {_tag: "Unauthorized", message: "bad token"}],

--- a/apps/web/tests/integration/_edge-ready.ts
+++ b/apps/web/tests/integration/_edge-ready.ts
@@ -73,7 +73,7 @@ export const EDGE_READY_POLL_MS = 1_500;
 // and `@vitest/runner@4.1.5` `beforeAll(fn, timeout = config.hookTimeout)`. `integrationStack` threads
 // `{timeout: HOOK_TIMEOUT_MS}` to UNDO that dependency-default override — restoring the already-declared
 // ceiling, NOT raising a working one.
-export const HOOK_TIMEOUT_MS = 180_000;
+export const HOOK_TIMEOUT_MS = 300_000;
 
 // The DEPLOY-time worker-health readiness budget for the SHARED-stage (`_global-setup`) path —
 // UNCHANGED (no shared-path regression). The shared stage deploys once per run (low concurrency), is
@@ -83,11 +83,19 @@ export const DEPLOY_HEALTH_DEADLINE_MS = 120_000;
 
 // The per-file readiness budget for the hook-bound `integrationStack` deploy `beforeAll` (#3146).
 // Sized STRICTLY BELOW `HOOK_TIMEOUT_MS` with headroom for the deploy-before (~40-60s under
-// concurrent-stage batch load) + the trailing non-fatal warms, so the poll GRACEFULLY bounded-returns
-// a typed `WorkerNotReadyError` diagnostic WELL before the vitest hook fires — a deterministic, named
-// failure instead of the opaque "Hook timed out" guillotine that evicted clean product PRs from the
-// merge queue: deploy(≤60) + readiness(100) = 160 < 180, so the typed throw wins the race every time.
-export const PER_FILE_HEALTH_DEADLINE_MS = 100_000;
+// concurrent-stage batch load, more with the widened `deployTransientRetry`) + the trailing non-fatal
+// warms, so the poll GRACEFULLY bounded-returns a typed `WorkerNotReadyError`/re-thrown
+// `CloudflarePlaceholder404Error` diagnostic WELL before the vitest hook fires — a deterministic,
+// named failure instead of the opaque "Hook timed out" guillotine that evicted clean product PRs from
+// the merge queue: deploy(≤90) + readiness(180) = 270 < 300, so the typed throw wins the race.
+//
+// Raised 100s→180s for #3409: under merge_group BATCH load (~24 fresh `*.workers.dev` hostnames
+// propagating across the CF edge at once), `/api/health` edge propagation exceeded the prior 100s
+// budget, so `awaitEdgeReady` re-threw the edge-not-propagated `CloudflarePlaceholder404Error` and the
+// documented transient hard-failed the beforeAll instead of riding out as a WAIT — ejecting an
+// innocent co-batched PR (run 29561658100, fts-backfill). 180s gives the propagation transient enough
+// headroom while staying bounded: a worker that genuinely never serves still fails after the budget.
+export const PER_FILE_HEALTH_DEADLINE_MS = 180_000;
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -326,10 +326,21 @@ export const warmFateRead = (url: string): Effect.Effect<void, never, never> =>
  * are convergent: re-running `deploy(Stack, {stage})` reconciles the SAME stage's state
  * (idempotent), so the retry resolves the lag without standing up a duplicate stage or
  * compounding the #1020/#690 teardown leak. Bounded — a persistent error still fails fast.
+ *
+ * The schedule is a delay-capped exponential over up to 10 retries: `exponential("1 second")`
+ * ramps 1→2→4→8s, `either(spaced("10 seconds"))` caps each subsequent wait at 10s, and
+ * `both(recurs(10))` bounds the total (~1+2+4+8+10·6 ≈ 75s worst case). The wider budget is
+ * for the merge_group BATCH: ~24 stages deploy against the one shared account at once, and the
+ * CF control-plane `TooManyRequests` (429) storm that produces outlasted the prior 5-retry cap,
+ * ejecting an innocent co-batched PR (#3409, run 29560455218). Still bounded — a persistent
+ * transient exhausts the 10 retries and fails fast, and a non-transient error never retries.
  */
 export const deployTransientRetry = Effect.retry({
 	while: isTransientDeployError,
-	schedule: Schedule.exponential("1 second").pipe(Schedule.both(Schedule.recurs(5))),
+	schedule: Schedule.exponential("1 second").pipe(
+		Schedule.either(Schedule.spaced("10 seconds")),
+		Schedule.both(Schedule.recurs(10)),
+	),
 });
 
 /**


### PR DESCRIPTION
Fixes #3409

## The bug

The `merge_group` batch runs the real-CF integration suite whenever **any** co-batched PR is worker-relevant (the `packages/worker-relevance` OR across the batch). So an **environmental** flake in that suite ejects an innocent, worker-irrelevant co-batched PR (#3381 ejected 3× with a green head). A mixed batch legitimately *must* run integration, so the only fix that saves the innocent PR is to **stop the flake from reding the batch** — harden the shared deploy/readiness mechanism, per the triage-endorsed direction.

Grounded against the two failing `merge_group` runs the issue cites, two distinct classes each **hard-failed** the batch where the documented transient should have ridden out as a bounded wait:

## Class A — edge propagation (run 29561658100, `fts-backfill`)

`beforeAll` died with `CloudflarePlaceholder404Error: … /api/health (edge not propagated)`. The per-file `awaitWorkerReady` gate exhausted its **100s** `PER_FILE_HEALTH_DEADLINE_MS` still seeing the CF edge placeholder — under ~24 fresh `*.workers.dev` hostnames propagating across the edge at once (batch load), 100s wasn't enough, so `awaitEdgeReady` re-threw the transient instead of waiting it out.

**Fix:** raise `PER_FILE_HEALTH_DEADLINE_MS` 100s→180s and `HOOK_TIMEOUT_MS` 180s→300s (`_edge-ready.ts`), preserving the #3146 sub-ceiling invariant (`deploy + readiness < hook ceiling`, now 90+180 = 270 < 300) so the typed diagnostic still beats the vitest hook guillotine. Bounded: a worker that genuinely never serves still fails after the (larger) budget.

## Class B — deploy control-plane (run 29560455218, 6 shared-stage files)

Two deploy-time transients that `deployTransientRetry` didn't ride out:
- A `TooManyRequests` (429) storm from ~24 stages hitting the one shared CF account **outlasted the 5-retry cap**.
- `AuthError: Edge-preview secret read failed: Failed to create edge preview session` — the edge-session bootstrap flake — **wasn't classified transient at all**: `isTransientDeployError` matched only the sibling `"Secret probe returned"` wording, not this variant.

**Fix:**
- Widen `deployTransientRetry` to a **delay-capped exponential over 10 retries** (`exponential(1s)` capped at 10s via `either(spaced(10s))`, bounded by `both(recurs(10))` — ~75s worst case) in `_integration.ts`, so a longer 429 storm rides out. Still bounded: a persistent transient exhausts the cap and fails fast.
- Match the edge-preview `AuthError` on its **wrapper prefix** `"Edge-preview secret read failed"` in `_deploy-transient.ts` — the single prefix alchemy stamps on *every* `EdgeSessionError` at `Cloudflare/StateStore/State.ts:597` (grounded: alchemy@2.0.0-beta.59), so it fronts **both** the probe (`State.ts:792`) and the session-bootstrap (`EdgeSession.ts:155`) variants. A genuine auth failure (bad token) lacks the prefix and still fails fast — pinned in the unit test.

## Why it's bounded (won't mask a real failure)

Every change only widens the **wait/retry budget** for a signal that is already **typed/classified** as the documented edge/deploy transient — a real worker 404 (structured JSON), a genuine auth failure, or a persistent unhealthy worker all still surface (immediately, or after the bounded timeout). No suite is disabled; the batch's worker-relevant coverage is fully preserved.

## §CP

Non-§CP: all four files are under `apps/web/tests/integration/**` (no `.github/workflows/**` edit), so this is a normal auto-mergeable PR.

## Tests

- `_deploy-transient.unit.test.ts` extended: covers the new session-bootstrap variant + keeps the genuine-auth-failure fail-fast case. 17/17 pass.
- `pnpm --filter @kampus/web typecheck` clean (verifies the capped-`Schedule` composition), `biome check` clean.
- The integration tier itself needs real CF creds — it runs on this PR head in CI (the diff is worker-relevant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)