### PR TITLE
chore(biome): flip the 4 Effect-v4 GritQL rules warn→error — standing gate goes live (#2753)

### DIFF
--- a/biome-plugins/no-context-tag.grit
+++ b/biome-plugins/no-context-tag.grit
@@ -23,21 +23,21 @@ or {
 		register_diagnostic(
 			span = $ref,
 			message = "`Context.Tag(...)` is the Effect-v3 service form and is banned — phoenix is on Effect v4 (.patterns/effect-context-service.md; #2736). Fix: define the service as `class S extends Context.Service<S, Shape>()('id') {}` — copy `packages/fate-effect/src/CurrentUser.ts` (or `apps/web/worker/db/Drizzle.ts`). Exception: // biome-ignore lint/plugin: <reason>.",
-			severity = "warn"
+			severity = "error"
 		)
 	},
 	`Context.GenericTag` as $ref where {
 		register_diagnostic(
 			span = $ref,
 			message = "`Context.GenericTag(...)` is the Effect-v3 service form and is banned — phoenix is on Effect v4 (.patterns/effect-context-service.md; #2736). Fix: define the service as `class S extends Context.Service<S, Shape>()('id') {}` — copy `packages/fate-effect/src/CurrentUser.ts` (or `apps/web/worker/db/Drizzle.ts`). Exception: // biome-ignore lint/plugin: <reason>.",
-			severity = "warn"
+			severity = "error"
 		)
 	},
 	`Effect.Service` as $ref where {
 		register_diagnostic(
 			span = $ref,
 			message = "`Effect.Service(...)` is not used in phoenix — v4 uses `Context.Service` only (.patterns/effect-context-service.md; #2736). Fix: define the service as `class S extends Context.Service<S, Shape>()('id') {}` — copy `packages/fate-effect/src/CurrentUser.ts` (or `apps/web/worker/db/Drizzle.ts`). Exception: // biome-ignore lint/plugin: <reason>.",
-			severity = "warn"
+			severity = "error"
 		)
 	}
 }

--- a/biome-plugins/no-data-taggederror.grit
+++ b/biome-plugins/no-data-taggederror.grit
@@ -19,6 +19,6 @@ language js;
 	register_diagnostic(
 		span = $ref,
 		message = "`class ... extends Data.TaggedError` is banned — errors must be `Schema.TaggedErrorClass` so the `FateWireCode` annotation can ride the AST (.patterns/effect-errors.md; #2736). Fix: `class MyError extends Schema.TaggedErrorClass<MyError>()('feature/MyError', { ...fields }, { [FateWireCode]: 'CODE' }) {}` — copy `packages/fate-effect/src/CurrentUser.ts` (or `packages/pipeline-cli/src/tools/epic-ledger/github.ts` for a CLI-only error). Exception: // biome-ignore lint/plugin: <reason>.",
-		severity = "warn"
+		severity = "error"
 	)
 }

--- a/biome-plugins/no-effect-promise.grit
+++ b/biome-plugins/no-effect-promise.grit
@@ -23,7 +23,7 @@ or {
 		register_diagnostic(
 			span = $arg,
 			message = "`Effect.promise(...)` is banned — a rejection becomes an uncatchable defect with an empty error channel (.patterns/index.md; #2736). Fix: use object-notation `Effect.tryPromise({ try, catch: (cause) => new SomeError({ cause }) })` with a `Schema.TaggedErrorClass`, or lift the pure core to an `Effect.fn` returning a typed `Effect` — copy `packages/pipeline-cli/src/tools/epic-ledger/github.ts` (or `packages/fate-effect`). Exception: // biome-ignore lint/plugin: <reason>.",
-			severity = "warn"
+			severity = "error"
 		)
 	},
 	`Effect.tryPromise($arg)` where {
@@ -31,7 +31,7 @@ or {
 		register_diagnostic(
 			span = $arg,
 			message = "Single-arg `Effect.tryPromise(() => ...)` is banned — with no `catch` a rejection becomes an uncatchable defect with an empty error channel (.patterns/index.md; #2736). Fix: use object-notation `Effect.tryPromise({ try, catch: (cause) => new SomeError({ cause }) })` with a `Schema.TaggedErrorClass` — copy `packages/pipeline-cli/src/tools/epic-ledger/github.ts` (or `packages/fate-effect`). Exception: // biome-ignore lint/plugin: <reason>.",
-			severity = "warn"
+			severity = "error"
 		)
 	}
 }

--- a/biome-plugins/no-raw-try-catch.grit
+++ b/biome-plugins/no-raw-try-catch.grit
@@ -31,6 +31,6 @@ JsTryStatement() as $try where {
 	register_diagnostic(
 		span = $try,
 		message = "Raw `try/catch` is banned in an effect-importing file — real Effect code models failure in the `E` channel, not a native throw (#2736). Fix: use `Effect.try({ try, catch })` (sync) or `Effect.tryPromise({ try, catch })` (async), mapping the cause into a `Schema.TaggedErrorClass` — copy `packages/pipeline-cli/src/tools/epic-ledger/github.ts` (or `packages/fate-effect`). Exception (e.g. a pre-runtime bootstrap guard): // biome-ignore lint/plugin: <reason>.",
-		severity = "warn"
+		severity = "error"
 	)
 }


### PR DESCRIPTION
## What

Phase-3 capstone of the Effect-v4 GritQL lint epic: flip the **four Effect-v4 idiom plugins** from `warn` to **`error`** severity, so CI's `pnpm lint` now hard-fails on a newly-introduced violation. The standing gate goes live.

Severity is registered inside each `.grit` plugin's `register_diagnostic(...)` block (biome.jsonc only lists the plugin paths). The four rules flipped (all tagged `#2736`):

| plugin | idiom banned |
|---|---|
| `biome-plugins/no-context-tag.grit` | `Context.Tag` / `Context.GenericTag` / `Effect.Service` → `Context.Service` (3 diagnostics) |
| `biome-plugins/no-data-taggederror.grit` | `class … extends Data.TaggedError` → `Schema.TaggedErrorClass` |
| `biome-plugins/no-effect-promise.grit` | `Effect.promise(…)` / single-arg `Effect.tryPromise(…)` → object-notation (2 diagnostics) |
| `biome-plugins/no-raw-try-catch.grit` | raw `try/catch` in an effect-importing file → `Effect.try` / `Effect.tryPromise` |

7 severity strings flipped, no other change. `no-numeric-duration.grit` (`#3196`, a separate rule) and the non-`#2736` plugins (`no-type-assertions`, `no-node-sqlite-test-backing`) are untouched.

## Verification — zero violations before the flip (no baseline / grandfathering)

The flip must land green, so before changing severity I ran the **whole-repo** biome check on a fresh `origin/main` worktree:

- **Full-repo scan** across all 1712 biome-handled tracked files (root + `apps/web` + `packages/**` + `infra/**`), passing files explicitly because the config's own `!**/.claude/worktrees` exclusion zeroes a bare `biome check .` from inside a worktree. Result: **0 violations of any of the 4 rules**; the only diagnostics repo-wide were 5 pre-existing unrelated warnings (`noDescendingSpecificity`, `useOptionalChain` ×3, `noTemplateCurlyInString`).
- **Plugin-active probe:** ran biome against a scratch file with a known violation of each of the 4 idioms — all four plugin diagnostics fired, confirming the GritQL plugins actually load (a "0 violations" that isn't a silent skip).
- **Post-flip re-scan:** same 1712-file scan with the rules now at `error` → exit 0, 0 errors (the 5 pre-existing warnings unchanged). Green.

`pnpm typecheck` passes (33/33).

## Control plane

`biome.jsonc` / `biome-plugins/*.grit` do not match `CONTROL_PLANE_RE`, so per the issue this child auto-ships once the gate passes.

Closes the biome lane (its last predecessor #3194 / PR #3408 already merged).

Fixes #2753