### PR TITLE
feat(pipeline-crew): fail-open probe discipline — an unrunnable probe is unknown, never down (#3411)

### DIFF
--- a/claude-plugins/pipeline-crew/PROBES.md
+++ b/claude-plugins/pipeline-crew/PROBES.md
@@ -1,0 +1,74 @@
+# Probe discipline — fail-OPEN liveness/health probes
+
+The crew's conducting roles (the **engineering-manager** engine, the **chief-of-staff**
+verifier) routinely probe an external surface for liveness — most often "is the GitHub API
+reachable/healthy right now?" before dispatching a lane, verifying a landing, or reading the
+board. **This doc is the single source for how those probes must behave.** The two conductor
+defs cite it; they never re-derive the rule inline.
+
+A probe that cannot itself execute must resolve to **"unknown", never "down".** That one rule
+is the durable fix; the no-bare-`timeout` convention below is belt-and-suspenders.
+
+## Why this exists — the ~5h false-outage stall (#3411)
+
+A conductor session wrapped its GitHub-API liveness probe in a bare `timeout …`. On the macOS
+shell the crew runs on there is **no `timeout` on PATH** — GNU `timeout` ships as `gtimeout`
+via coreutils, or is absent (`command -v timeout` → not found, `command -v gtimeout` → not
+found). So every probe command exited non-zero because the **wrapper binary was missing**, not
+because the probed API was unhealthy. The conductor mapped that non-zero to "API still down",
+held all agent dispatches, and baked idle for ~5 hours — while the API was fine throughout
+(concurrent `gh` reads kept succeeding; rate limit ~4994). A real transient blip earlier had
+killed the in-flight agents; the missing-binary probe is what turned a momentary blip into a
+5-hour false outage, silent until a human asked why the conductor wasn't working.
+
+That is a **fail-CLOSED probe**: a probe that could not execute resolved to "down" instead of
+"unknown", and a broken liveness probe that concludes "system down" can strand a whole
+conductor lane indefinitely with nothing surfaced upward. It is the same class as the
+harness-worktree stripped-PATH incident (#787–#789): an agent command assuming a binary/PATH
+that isn't there. Grounding it once here keeps a future conductor from re-improvising the trap.
+
+## The rule — three outcomes, and "unknown" never gates
+
+A liveness/health probe resolves to **exactly one of three** outcomes; keep them distinct:
+
+1. **reachable / healthy** — the probe ran and the target answered healthy. Proceed.
+2. **reachable / unhealthy ("down")** — the probe **actually ran** and observed the target
+   failing (a real HTTP error, a timeout the target itself blew, a definitive unhealthy body).
+   This is the **only** outcome that may gate/hold dispatches.
+3. **UNRUNNABLE ("unknown")** — the probe **could not execute**: a missing binary (the `timeout`
+   trap above), a PATH strip, an exec/spawn error, no network stack, a malformed command. This is
+   **not** "down". It carries no information about the target's health.
+
+The load-bearing distinction is between (2) and (3): "the target answered unhealthy" versus "I
+could not ask the target". A non-zero exit alone does **not** distinguish them — the missing-
+binary exit and the target-is-down exit look identical at the shell. So a conductor must not
+collapse "the probe failed" into "the API is down".
+
+**A conductor never takes a destructive or holding action on "unknown".** Never hold dispatches,
+strand a lane, or conclude an outage from an unrunnable probe. On "unknown" the safe default is
+to **proceed as if reachable** (fail-open) and let the *actual* operation surface a real error if
+the target truly is down — the board is the durable truth surface (a climbing needs-triage count,
+an unmoving PR), not a probe's inability to run. Only outcome (2) — a probe that ran and observed
+the target unhealthy — may gate.
+
+## The no-bare-`timeout` convention (belt-and-suspenders)
+
+Don't wrap a probe (or any command) in a binary that may not exist on the shell. Concretely:
+
+- **Never assume `timeout` is on PATH.** It is absent on the crew's macOS shell. A bare
+  `timeout N cmd …` fails on the *missing wrapper*, not on `cmd`, and that failure is exactly
+  the fail-closed trap above.
+- **If you need a bound, use a portable one:** `gtimeout` *only if* `command -v gtimeout`
+  succeeds; else a backgrounded-PID + kill; else no bound at all. The harness Bash tool already
+  enforces its own multi-minute ceiling, so most probes need no explicit timeout wrapper.
+- **A node-based bounded probe** (an `AbortController` + `fetch`, run with `node`) is the
+  portable, dependency-free bound when you genuinely need one — it needs no coreutils binary and
+  distinguishes "could not run" from "ran, target failed" cleanly in its own exit handling. This
+  matches the crew's Node-over-shell-glue convention.
+- **Guard the binary before you lean on it:** `command -v <bin> >/dev/null || { … treat as
+  unknown, do not conclude down … }`. A guard that resolves a missing binary to "unknown" is the
+  code-level shape of the fail-open rule.
+
+Carry both rules together: fail-open semantics neutralize the whole class regardless of which
+binary a future probe reaches for, and the portable-bound convention keeps a probe from tripping
+on the missing binary in the first place.

--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -196,6 +196,7 @@ pipeline-crew/
 │   ├── engineering-manager.md    # execution engine (coder → reviewer → shipper), ×N
 │   └── chief-of-staff.md         # outbound-awareness bridge (live verifier, human comms)
 ├── PERSONALIZATION.md            # the personalization seam — the config contract + dimensions
+├── PROBES.md                     # probe discipline — fail-open liveness/health probes (#3411)
 ├── crew.config.template.jsonc    # placeholder-only per-install config template
 └── README.md                     # this file
 ```
@@ -204,6 +205,8 @@ pipeline-crew/
 
 - [`PERSONALIZATION.md`](PERSONALIZATION.md) — the seam mechanism, the dimension table, and the
   stand-up contract the four defs write against.
+- [`PROBES.md`](PROBES.md) — probe discipline: liveness/health probes fail OPEN (an unrunnable
+  probe is "unknown", never "down") + the no-bare-`timeout` convention. The conductor defs cite it.
 - [`../kampus-pipeline/`](../kampus-pipeline/) — the pipeline this crew conducts (the skills +
   ephemeral agents).
 - [`../../packages/pipeline-crew-mcp/`](../../packages/pipeline-crew-mcp/) — the channel

--- a/claude-plugins/pipeline-crew/agents/chief-of-staff.md
+++ b/claude-plugins/pipeline-crew/agents/chief-of-staff.md
@@ -173,6 +173,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   and stepped over, never retried or escalated.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries, so this is a hard constraint.
+- **Liveness/health probes fail OPEN — an unrunnable probe is "unknown", never "down".** When you
+  ground-truth reachability (is the GitHub API answering before you read the board or verify a
+  landing) a probe that **could not execute** — a missing binary, a PATH strip, an exec error —
+  resolves to **"unknown", never "down"**; an unrunnable probe carries no evidence of an outage, so
+  you never report one from it. Only a probe that **actually ran and observed the target unhealthy**
+  is a real "down". Never wrap a probe in a bare `timeout` (it is absent on the crew's macOS shell —
+  a missing-wrapper exit is indistinguishable from a real outage, the fail-closed trap that stalled a
+  conductor ~5h; #3411, same class as #787–#789); use a portable bound or none. The full three-outcome
+  rule + the portable-bound convention live in [`../PROBES.md`](../PROBES.md).
 - **Every operator/machine reference goes through the seam — never a literal.** No real-person
   name, approver login, notification transport, or model tier appears in your prose or commands as
   a literal; each is a config key bound at spawn.

--- a/claude-plugins/pipeline-crew/agents/engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/engineering-manager.md
@@ -158,6 +158,16 @@ rule exists to catch.
   integration that breaks GraphQL issue/PR queries.
 - **Never spawn `coder` on a non-triaged issue.** You conduct execution over triaged work only;
   untriaged work routes back through the intake seam (the intake-desk), never straight to a coder.
+- **Liveness/health probes fail OPEN — an unrunnable probe is "unknown", never "down".** When you
+  probe an external surface (is the GitHub API reachable before you dispatch a lane, is a stalled
+  lane's target alive) a probe that **could not execute** — a missing binary, a PATH strip, an exec
+  error — resolves to **"unknown", never "down"**; you never hold dispatches or conclude an outage
+  on "unknown". Only a probe that **actually ran and observed the target unhealthy** may gate. Never
+  wrap a probe in a bare `timeout` (it is absent on the crew's macOS shell — a missing-wrapper exit
+  is indistinguishable from a real outage, the exact fail-closed trap that stalled a conductor ~5h;
+  #3411, same class as the #787–#789 stripped-PATH incident); use a portable bound or none. The full
+  three-outcome rule + the portable-bound convention live in [`../PROBES.md`](../PROBES.md) — read it
+  before improvising a probe.
 - **No home / local / absolute / sibling-repo paths in any artifact.** Any comment or note you post
   cites repo-relative paths only — never a home-directory, machine-local absolute, or sibling-clone
   path.


### PR DESCRIPTION
Fixes #3411

## What this introduces

Fail-**OPEN** liveness/health probe semantics + a no-bare-`timeout` convention, codified where the crew conductors read before improvising a probe. This is a `type:feature` deliverable — there was **no committed artifact doing the wrong thing** (the offending probe was runtime-improvised by a conductor session, not built anywhere), so this *introduces* the guard rather than patching a file.

### The three-outcome rule (durable fix)

A liveness/health probe resolves to exactly one of three outcomes:

1. **reachable / healthy** — proceed.
2. **reachable / unhealthy ("down")** — the probe **actually ran** and observed the target failing. The **only** outcome that may gate/hold dispatches.
3. **UNRUNNABLE ("unknown")** — the probe **could not execute** (missing binary, PATH strip, exec error, no network stack). **Not "down"** — carries no evidence about the target.

A conductor **never** takes a destructive/holding action on "unknown"; on "unknown" the safe default is proceed-as-reachable and let the real operation surface a real error. Only outcome (2) gates. This neutralizes the whole class regardless of which binary a future probe reaches for.

### The no-bare-`timeout` convention (belt-and-suspenders)

Crew agents never depend on a bare `timeout` on PATH — it is absent on the crew's macOS shell (GNU `timeout` ships as `gtimeout` or is absent), so a bare `timeout N cmd` fails on the *missing wrapper*, indistinguishable from a real outage. Use a portable bound (`gtimeout` only if present, a backgrounded-PID kill, a node `AbortController` probe) or none.

### Why (grounded)

A conductor wrapped its GitHub-API liveness probe in a bare `timeout`; the missing binary made every probe exit non-zero, the conductor read that as "API down", and held all dispatches for ~5h while the API was fine (concurrent `gh` reads succeeded, rate limit ~4994). Same fail-closed class as the #787–#789 harness-worktree stripped-PATH incident. Both citations are carried in the convention.

## Files touched

- `claude-plugins/pipeline-crew/PROBES.md` (new) — single source: the three-outcome rule + the portable-bound convention + the grounded #3411 / #787–789 citation.
- `claude-plugins/pipeline-crew/agents/engineering-manager.md` — standing-invariant pointer (the engine conducts dispatch; it improvised the failed probe).
- `claude-plugins/pipeline-crew/agents/chief-of-staff.md` — standing-invariant pointer (the verifier ground-truths API reachability).
- `claude-plugins/pipeline-crew/README.md` — Layout + See-also wiring so `PROBES.md` isn't an orphan.

The *why* is stated once in `PROBES.md`; each conductor def carries a self-contained operative invariant + a pointer, not a duplicated rationale.

## Acceptance criteria

- [x] An unrunnable probe resolves to "unknown", never "down"; a conductor never holds dispatches on "unknown".
- [x] Only a probe that actually ran and observed the API unhealthy may gate dispatch.
- [x] Crew agents do not depend on a bare `timeout`; the convention is written where a future crew session reads before improvising.
- [x] The convention cites the failure class (#3411 + #787–#789).

## §CP determination

**NON-§CP — auto-ships.** All four touched paths are under `claude-plugins/pipeline-crew/`, which the live `CONTROL_PLANE_RE` does **not** cover (it matches `claude-plugins/kampus-pipeline/…`, `.claude/`, `.github/`, `packages/pipeline-cli/`, etc.). Verified each path against the regex from `pipeline-cli control-plane-paths`. No `.claude/agents/`, `packages/pipeline-cli/`, or `kampus-pipeline` surface was touched, so this does not bank for @kamp-us/control-plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)