### PR TITLE
docs(adr): 0194 design-law JSDoc firewall — descriptive inventory vs founder-authored normative law

### DIFF
--- a/.decisions/0194-design-law-jsdoc-firewall.md
+++ b/.decisions/0194-design-law-jsdoc-firewall.md
@@ -1,0 +1,41 @@
+---
+id: 0194
+title: Design-law JSDoc firewall — descriptive component inventory vs. founder-authored normative law, minimal-v1 schema
+status: accepted
+date: 2026-07-17
+tags: [design-system, docs, glossary, agents]
+---
+
+# 0194 — Design-law JSDoc firewall
+
+**What this decides:** Agents may auto-generate the *descriptive* half of the design docs — the component inventory (which primitives exist, their props/slots, and a per-component when-to-use) — but the *normative* half (the four pillars, the prohibitions, and the role-token values in `design-system-manifest.md`) stays founder-authored and is never auto-written; the two are separated by a hard firewall, and the metadata carrying the descriptive half is a deliberately-minimal JSDoc schema that we expect to evolve with real use.
+
+## Context
+
+Design coverage (#3152) needs an extractor/agent that keeps component documentation current without letting an agent quietly rewrite the design *law*. The four-pillars design law ([0162](0162-four-pillars-design-law.md)) is the founder-authored normative manifest that `write-code` reads before generating UI; ADR [0078](0078-product-driven-decisions-by-default.md) fixes that product/design decisions are founder-ratified, not agent-minted. An extractor that regenerates docs sits exactly on that boundary — so the boundary has to be drawn firmly before any annotation (#3153) or rollout (#3154) work begins.
+
+The founder ratified the shape on 2026-07-17 (issue #3152). This ADR records that settled decision. It is not re-deciding anything: the firewall is ratified *firmly* as the durable boundary, while the JSDoc schema is ratified as a good-enough v1 that is **expected to evolve** — not an exhaustive final spec.
+
+## Decision
+
+**1. The descriptive/normative firewall (the durable boundary).**
+
+- **Descriptive** — the extractor/agent MAY generate and update: the *component inventory* — the primitives that exist, their props/slots, and a per-component **when-to-use**.
+- **Normative** — founder-authored, NEVER auto-written: the four pillars, the prohibitions, and the role-token values in `design-system-manifest.md` ([0162](0162-four-pillars-design-law.md)).
+- **The firewall on the edge case (per-component when-to-use).** A component's when-to-use lives *on* the component but is `@agent`-generated and **references** the manifest's law — it never mints new law. It is a descriptive echo that *points at* the normative, not a second copy of it. This is the [0078](0078-product-driven-decisions-by-default.md) guard applied at the doc layer: an agent may describe what exists and cite the law, but only the founder writes the law.
+
+**2. The JSDoc metadata schema + output — a deliberately-minimal v1, expected to evolve.**
+
+- Metadata lives as **JSDoc tags on each primitive**: `@component`, `@slot`, prop docs, and `@agent` directives (the protected, human-seeded steering the extractor must preserve).
+- **Source of truth = JSDoc + code, colocated** in the component file.
+- **Output = one central curated-hybrid INDEX** — inline the when-to-use core, link to source for depth (the effect-smol `LLMS.md` idiom).
+- **Enforcement = a generate command + a fail-closed drift guard** (pre-commit + CI), so a stale or hand-diverged index reddens rather than rots.
+- Keep the tag vocabulary **lean**; iterate as real use surfaces gaps. This v1 is intentionally under-specified — do not treat this section as a frozen final spec.
+
+## Consequences
+
+- The boundary is now explicit and citable: an extractor may regenerate the component inventory freely, but any change to the four pillars / prohibitions / role-token values is a founder edit to `design-system-manifest.md`, out of the agent's reach. A per-component when-to-use that mints new law (rather than referencing it) is a firewall violation.
+- Unblocks #3153 (pilot annotation of the first primitive) → #3154 (rollout). Those build against this schema.
+- The schema is expected to change: as annotation surfaces gaps, the tag vocabulary grows by iteration, not by re-litigating the firewall. The firewall is fixed; the schema is a living v1.
+- A new drift guard (generate + fail-closed check) joins the CI guard family; a component whose index row diverges from its JSDoc reddens the build.
+- Three nouns enter the shared vocabulary (`.glossary/TERMS.md`): `@agent` directive, descriptive component inventory, and descriptive/normative firewall.

--- a/.glossary/TERMS.md
+++ b/.glossary/TERMS.md
@@ -312,6 +312,21 @@ by the campaign-skill epic #2652 (roadmap map #2620, decisions #2641); grounded 
 | founder-approval trace | The **fail-closed approval marker** on a **wave label** that gates **campaign** creation — a campaign is created only with the trace present. **Invoker-agnostic:** a human OR an agent may invoke the campaign skill, but the *trace* (not the invoker's identity) is the gate — the gated-audit-wave play, findings returned to the founder for approval before filing (#2641). | the invoker's identity (the trace is the gate, not who invokes); a default-open path (absent trace ⇒ no campaign — fail-closed); wayfinder's founder-decision-fork (a different human seam) |
 | campaign lifecycle (active/done) | The two **symmetric campaign states** — `active` (draining) and `done` (complete) — carried in the `ROADMAP.md` `## Campaigns` table's State column, with **guard coverage**: the active↔done lifecycle guard (the `roadmap-guard` idiom, #2660) fails closed on an ill-formed transition. | a one-way / write-once status (the two states are symmetric); an unguarded free-text field (the lifecycle guard covers the transition) |
 
+## Design coverage (the descriptive/normative firewall — ADR 0194)
+
+The boundary the design-coverage extractor is built on (ADR [0194](../.decisions/0194-design-law-jsdoc-firewall.md),
+issue #3152): an agent may auto-generate the *descriptive* half of the design docs (the component
+inventory) but never the *normative* half (the founder-authored four pillars / prohibitions /
+role-token values in [`design-system-manifest.md`](../design-system-manifest.md)). Grounded in
+ADR [0078](../.decisions/0078-product-driven-decisions-by-default.md) (design-law is founder-authored)
+and ADR [0162](../.decisions/0162-four-pillars-design-law.md) (the four-pillars design law).
+
+| Term | Definition | Not |
+|---|---|---|
+| descriptive/normative firewall | The **hard boundary** (ADR [0194](../.decisions/0194-design-law-jsdoc-firewall.md)) separating what a design-coverage extractor/agent MAY write from what only the founder writes. **Descriptive** (agent-writable): the component inventory — primitives that exist, their props/slots, and a per-component *when-to-use*. **Normative** (founder-authored, never auto-written): the four pillars, the prohibitions, and the role-token values in `design-system-manifest.md`. The edge case — a per-component when-to-use — is firewalled by living *on* the component but being `@agent`-generated and **referencing** the manifest's law, never minting new law (the ADR [0078](../.decisions/0078-product-driven-decisions-by-default.md) guard at the doc layer). | a license to auto-edit the manifest (the normative half is out of the agent's reach); a soft convention (it is a fail-closed drift-guarded boundary); a per-component *copy* of the law (a when-to-use references the law, it does not restate it) |
+| descriptive component inventory | The **agent-writable half** of the design docs (ADR [0194](../.decisions/0194-design-law-jsdoc-firewall.md)): the catalogue of which primitives exist, their props/slots, and each one's *when-to-use*, extracted from JSDoc-on-code and rendered into one central curated-hybrid **index** (inline the when-to-use core, link to source for depth — the effect-smol `LLMS.md` idiom). Kept fresh by a generate command + fail-closed drift guard (pre-commit + CI). | the **normative** design law (the four pillars / prohibitions / role tokens — founder-authored); a hand-maintained doc (it is generated + drift-guarded); a place new design law may be introduced (it only *describes* + *references* the law) |
+| `@agent` directive | A **human-seeded JSDoc tag** on a component (ADR [0194](../.decisions/0194-design-law-jsdoc-firewall.md)) that steers the extractor — the *protected seed* the generate step must preserve rather than overwrite. Rides alongside the descriptive tags (`@component`, `@slot`, prop docs) that source the component inventory; keeps the tag vocabulary lean, a deliberately-minimal v1 expected to evolve with real use. | a descriptive tag the extractor regenerates (`@component`/`@slot`/prop docs are generated; `@agent` is preserved); design law (a directive steers extraction, it does not mint pillars/prohibitions/role tokens); a frozen final schema (the tag vocabulary iterates as gaps surface) |
+
 ## Apps
 
 | Term | Definition | Not |


### PR DESCRIPTION
Ratifies the founder-approved **descriptive/normative firewall** for design coverage (issue #3152, founder ratification 2026-07-17).

## What this ADR records
- **Firewall (firm, durable boundary):** an extractor/agent MAY generate the *descriptive* component inventory (primitives, props/slots, per-component when-to-use), but the *normative* half — the four pillars, prohibitions, and role-token values in `design-system-manifest.md` — stays founder-authored and is never auto-written. The edge case (per-component when-to-use) is firewalled by living on the component but being `@agent`-generated and *referencing* the manifest's law, never minting new law (the ADR 0078 guard at the doc layer).
- **JSDoc schema (deliberately-minimal v1, expected to evolve):** metadata as JSDoc tags on each primitive (`@component`, `@slot`, prop docs, `@agent` directives); source of truth = JSDoc + code colocated; output = one central curated-hybrid index (the effect-smol `LLMS.md` idiom); enforced by a generate command + fail-closed drift guard (pre-commit + CI). Lean tag vocabulary, iterate on real use.
- Cites ADR 0078 (design-law is founder-authored) + ADR 0162 (four-pillars design law).

## Vocabulary
Blesses three nouns into `.glossary/TERMS.md`: `@agent` directive · descriptive component inventory · descriptive/normative firewall.

## Files
- `.decisions/0194-design-law-jsdoc-firewall.md` (new)
- `.glossary/TERMS.md` (new *Design coverage* section)

On merge → unblocks #3153 (pilot annotation) → #3154 (rollout).

Fixes #3152

🤖 Generated with [Claude Code](https://claude.com/claude-code)