### PR TITLE
feat(pipeline-crew-mcp): make the stand-up cliVersion pin optional (#3417)

### DIFF
--- a/claude-plugins/pipeline-crew/PERSONALIZATION.md
+++ b/claude-plugins/pipeline-crew/PERSONALIZATION.md
@@ -70,7 +70,7 @@ reference these keys, never a literal.
 | — engine count | `roles.engineering-manager.count` | How many `engineering-manager` engines the stand-up boots — the engine is kind `engine` (cardinality N); a positive integer. Bridges omit `count` (they are cardinality 1). | `<engine-count>` |
 | — engine WIP cap | `roles.engineering-manager.wipCap.{productLanes, platformLanes}` | A conductor engine's bounded concurrent-lane count, lane-partitioned — how many product vs platform/pipeline coders one engine drives at once before queueing the rest. The overall cap is the split's sum; the borrow/rebalance behavior is doctrine shipped in the engineering-manager def (the seam carries only the per-install values). | `<wip-cap-product-lanes>`, `<wip-cap-platform-lanes>` |
 | Notification — per recipient | `notification.operator.{command, handle}`, `notification.controlPlaneApprover.{command, handle}` | Per-recipient human notification. The plugin ships **who** gets pinged and **when**; the config supplies **how** — an operator-supplied transport `command` the chief-of-staff invokes, targeting `handle`. The plugin knows nothing of the channel (iMessage/Slack/Discord), so a Discord-bot future is a config swap, not a code change. Any local script path lives only in the operator's config, never in the repo. | `<operator-notification-command>`, `<operator-notification-handle>`, `<control-plane-approver-notification-command>`, `<control-plane-approver-notification-handle>` |
-| Pinned CLI version | `cliVersion` | The Claude Code CLI version the stand-up launcher asserts before it starts any session — a hard gate so the crew never launches on a drifted CLI (`major.minor.patch`, optional `-suffix`). | `<pinned-claude-code-cli-version>` |
+| Pinned CLI version | `cliVersion` | **Optional** (issue #3417). OMIT ⇒ the launcher accepts whatever `claude --version` reports (an "unpinned" launch — so the boot no longer fail-closes on every frequent Claude Code auto-update). Set it ONLY to deliberately lock a version: a present pin (`major.minor.patch`, optional `-suffix`) is a hard exact-match gate asserted before any session starts, so a drifted CLI refuses to launch. | omit, or `<pinned-claude-code-cli-version>` |
 | Channel registration | `channels.mode`, `channels.servers`, `channels.allowedChannelPlugins` | How each launched session registers its channel MCP servers: `mode` is `allowlist` (`--channels <refs>`) or `development` (`--dangerously-load-development-channels`, local only); `servers` are the refs each session registers (grammar `server:<name>` / `plugin:<name>@<marketplace>`); `allowedChannelPlugins` is the plugin allowlist the `allowlist` mode enforces. | `<channel-mode: allowlist \| development>`, `<channel-server-ref>`, `<allowed-channel-plugin>` |
 
 Adding a new operator-specific dimension is **one row here + one key in the template + one
@@ -85,9 +85,11 @@ stand-up launcher reads, not prose an agent def binds. They resolve through the 
 order as every other seam key (`$CREW_CONFIG` → `.claude/crew.config.jsonc`) but are
 consumed by a typed reader,
 [`packages/pipeline-crew-mcp/src/standup/config.ts`](../../packages/pipeline-crew-mcp/src/standup/config.ts),
-which validates them and **fails closed** — a missing or malformed dimension (a non-version
-CLI pin, an unknown channel mode, a channel ref off-grammar, a non-positive engine count)
-stops the launch with an error naming that dimension, never a silent default. The launcher
+which validates them and **fails closed** — a missing or malformed dimension (an unknown
+channel mode, a channel ref off-grammar, a non-positive engine count, or a present-but-non-version
+CLI pin) stops the launch with an error naming that dimension, never a silent default. The lone
+exception is `cliVersion`, which is optional (issue #3417): an OMITTED pin decodes cleanly to an
+unpinned launch — only a present pin is validated and asserted. The launcher
 children (version-assert, bind-builder, roster, orchestration) consume the reader's typed
 result; they never re-parse the config. Because the template leads the launcher in this
 crew-architecture wave (wayfinder:map #3207), reconciling the typed reader to consume the

--- a/claude-plugins/pipeline-crew/crew.config.template.jsonc
+++ b/claude-plugins/pipeline-crew/crew.config.template.jsonc
@@ -68,8 +68,10 @@
 		}
 	},
 
-	// The pinned Claude Code CLI version the stand-up launcher asserts before it starts any
-	// session — a hard gate so the crew never launches on a drifted CLI. Fill with the exact
+	// OPTIONAL (issue #3417). Omit this key to accept whatever `claude --version` reports (an
+	// "unpinned" launch — the boot no longer fail-closes on every frequent Claude Code
+	// auto-update). Set it ONLY to deliberately lock a version: a present pin is a hard
+	// exact-match gate asserted before any session starts. Fill with the exact
 	// `major.minor.patch` (optionally `-suffix`) your `claude --version` reports.
 	"cliVersion": "<pinned-claude-code-cli-version>",
 

--- a/packages/pipeline-crew-mcp/src/standup/config.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.test.ts
@@ -109,6 +109,19 @@ describe("standup/config — decodeLaunchConfig (happy path, one-role-map shape)
 				assert.deepStrictEqual([...cfg.channels.allowedChannelPlugins], ["pipeline-crew"]);
 			}),
 	);
+	it.effect("an omitted cliVersion decodes cleanly to an unpinned launch (issue #3417)", () =>
+		Effect.gen(function* () {
+			// The pin is optional: absent ⇒ NOT a LaunchConfigError, and the field is simply not
+			// present on the decoded config (the "unpinned" launch — a clean absence, not a sentinel).
+			const {cliVersion: _omit, ...unpinned} = validLaunch;
+			const cfg = yield* decodeLaunchConfig(unpinned, DEFAULT_CONFIG_PATH);
+			assert.strictEqual(cfg.cliVersion, undefined);
+			assert.isFalse(Object.hasOwn(cfg, "cliVersion"));
+			// the rest of the launch dimensions still decode as usual
+			assert.strictEqual(cfg.engineCount, 2);
+			assert.strictEqual(cfg.channels.mode, "allowlist");
+		}),
+	);
 	it.effect("accepts the development channel mode carrying a top-level server: ref", () =>
 		Effect.gen(function* () {
 			// A `server:` ref rides --dangerously-load-development-channels, so it is
@@ -237,18 +250,19 @@ describe("standup/config — engine count reads off roles['engineering-manager']
 });
 
 describe("standup/config — fails closed naming the offending dimension", () => {
-	it.effect("cliVersion missing", () =>
+	// NB: an ABSENT cliVersion is NOT a failure — it decodes to the unpinned launch (issue #3417),
+	// covered in the happy-path describe above. Only a PRESENT-but-malformed pin fails closed here.
+	it.effect("cliVersion malformed (present but not a version) still fails closed", () =>
 		Effect.gen(function* () {
-			const {cliVersion: _omit, ...rest} = validLaunch;
-			const err = yield* decodeErr(rest);
+			const err = yield* decodeErr({...validLaunch, cliVersion: "latest"});
 			assert.instanceOf(err, LaunchConfigError);
 			assert.include(err.reason, "cliVersion");
 			assert.strictEqual(err.configPath, "/tmp/crew.config.jsonc");
 		}),
 	);
-	it.effect("cliVersion malformed (not a version)", () =>
+	it.effect("cliVersion present but null still fails closed", () =>
 		Effect.gen(function* () {
-			const err = yield* decodeErr({...validLaunch, cliVersion: "latest"});
+			const err = yield* decodeErr({...validLaunch, cliVersion: null});
 			assert.include(err.reason, "cliVersion");
 		}),
 	);

--- a/packages/pipeline-crew-mcp/src/standup/config.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.ts
@@ -11,7 +11,11 @@
  *
  * The one non-obvious thing: the reader FAILS CLOSED. A missing or malformed launch
  * dimension is a `LaunchConfigError` naming the offending dimension, never a silent default
- * — a drifted CLI pin or an unlisted channel server is a launch to refuse, not paper over.
+ * — an unlisted channel server or a bad engine count is a launch to refuse, not paper over.
+ * The lone exception is `cliVersion`: it is OPTIONAL (issue #3417) — an omitted pin decodes
+ * to an "unpinned" launch (the key is simply absent), so the crew boot stops fail-closing on
+ * every frequent Claude Code auto-update; pin ONLY to deliberately lock a version. A pin that
+ * IS present must still be a valid `CLI_VERSION_RE` version — a malformed present pin fails closed.
  * `LaunchConfig` extracts only the launch dimensions from the one-role-map seam shape (ADR 0189):
  * the engine count is folded into `roles["engineering-manager"].count`, and excess seam keys
  * (operator/notification/tier/wipCap/…) are ignored. There is no config-read tmux dimension —
@@ -54,6 +58,8 @@ const isServerRef = (ref: string): boolean => ref.startsWith("server:");
  * The pinned Claude Code CLI version the stand-up asserts before launching any session
  * (#3295 consumes it). A `major.minor.patch` core with an optional pre-release suffix — the
  * shape `claude --version` reports — so a non-version placeholder or a partial pin is rejected.
+ * The pin itself is optional (issue #3417 — see `LaunchConfig.cliVersion`); this regex constrains
+ * a pin only when one is PRESENT — an omitted pin never reaches it.
  */
 export const CLI_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/;
 
@@ -112,9 +118,16 @@ export const ChannelConfig = Schema.Struct({
 );
 export type ChannelConfig = typeof ChannelConfig.Type;
 
-/** The launch dimensions the stand-up reads — the clean type every launcher child imports. */
+/**
+ * The launch dimensions the stand-up reads — the clean type every launcher child imports.
+ *
+ * `cliVersion` is an EXACT-optional key (`Schema.optionalKey`, issue #3417): absent ⇒ the field
+ * is simply not present (`cliVersion?: CliVersion`), which IS the "unpinned" launch — a clean
+ * representable variant, not a sentinel. `optionalKey` (not `optional`) so the only two states are
+ * "absent = unpinned" and "present = a valid pin"; there is no third `undefined`-but-present state.
+ */
 export const LaunchConfig = Schema.Struct({
-	cliVersion: CliVersion,
+	cliVersion: Schema.optionalKey(CliVersion),
 	engineCount: EngineCount,
 	channels: ChannelConfig,
 });
@@ -126,9 +139,10 @@ export type LaunchConfig = typeof LaunchConfig.Type;
  * `roles["engineering-manager"].count`. The rest of each role entry (`tier`, `wipCap`) and the
  * whole bridge entries are def-spawn / prose bindings, not launch inputs, so they decode as ignored
  * excess keys — only `engineering-manager.count` is a required launch dimension here, fail-closed.
+ * `cliVersion` mirrors `LaunchConfig`'s exact-optional shape (issue #3417): omit ⇒ unpinned.
  */
 const RawLaunchConfig = Schema.Struct({
-	cliVersion: CliVersion,
+	cliVersion: Schema.optionalKey(CliVersion),
 	roles: Schema.Struct({
 		"engineering-manager": Schema.Struct({count: EngineCount}),
 	}),
@@ -222,7 +236,9 @@ export const parseJsonc = (text: string): unknown => JSON.parse(stripJsonc(text)
  * whose `reason` names the offending dimension (the schema issue tree carries the field path).
  * The engine count is folded out of the role map — `roles["engineering-manager"].count` (ADR 0189)
  * — into the flat `engineCount` every launcher child consumes, so `LaunchConfig`'s shape is stable
- * across the seam move; a missing/blank/non-positive count fails closed naming that path.
+ * across the seam move; a missing/blank/non-positive count fails closed naming that path. An
+ * omitted `cliVersion` stays omitted through the fold (exact-optional, issue #3417) — the
+ * "unpinned" launch — so the key is spread only when the operator supplied a pin.
  */
 export const decodeLaunchConfig = (
 	input: unknown,
@@ -231,7 +247,7 @@ export const decodeLaunchConfig = (
 	Schema.decodeUnknownEffect(RawLaunchConfig)(input).pipe(
 		Effect.map(
 			(raw): LaunchConfig => ({
-				cliVersion: raw.cliVersion,
+				...(raw.cliVersion !== undefined ? {cliVersion: raw.cliVersion} : {}),
 				engineCount: raw.roles["engineering-manager"].count,
 				channels: raw.channels,
 			}),

--- a/packages/pipeline-crew-mcp/src/standup/version-assert.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/version-assert.test.ts
@@ -1,8 +1,9 @@
 /**
  * standup/version-assert — the pre-launch pinned-CLI-version assert (issue #3295). Covers the
- * three decisions the assert makes with the launch side stubbed via an injected version reader:
- * installed == pinned proceeds silently, installed != pinned aborts naming both versions, and an
- * unreadable/unparseable installed version aborts. Also covers the pure `parseCliVersion` extractor.
+ * decisions the assert makes with the launch side stubbed via an injected version reader: an
+ * absent pin skips the assert unread (the unpinned launch, issue #3417), installed == pinned
+ * proceeds silently, installed != pinned aborts naming both versions, and an unreadable/unparseable
+ * installed version aborts. Also covers the pure `parseCliVersion` extractor.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -25,6 +26,17 @@ describe("standup/version-assert — parseCliVersion", () => {
 });
 
 describe("standup/version-assert — assertPinnedCliVersion", () => {
+	it.effect(
+		"proceeds without reading the installed version when the pin is absent (unpinned)",
+		() =>
+			Effect.gen(function* () {
+				// The unpinned launch (issue #3417): with no pin the assert is skipped entirely and the
+				// installed version is accepted UNREAD — a reader that would fail proves it is never run.
+				const readerNeverRuns = Effect.fail("reader must not be invoked when unpinned");
+				yield* assertPinnedCliVersion({}, readerNeverRuns);
+			}),
+	);
+
 	it.effect("proceeds silently when installed == pinned", () =>
 		Effect.gen(function* () {
 			// A void success is the whole contract of a match — no error, nothing to assert on but the exit.

--- a/packages/pipeline-crew-mcp/src/standup/version-assert.ts
+++ b/packages/pipeline-crew-mcp/src/standup/version-assert.ts
@@ -3,13 +3,15 @@
  * (issue #3295). At stand-up it reads the installed Claude Code CLI version and compares it to the
  * pinned `cliVersion` the operator config carries (#3293's `LaunchConfig`, consumed read-only).
  *
- * The one non-obvious thing: it FAILS FAST, before any tracker or session launch. Channels are a
- * research preview whose behavior varies across CLI versions, so a drift between the installed CLI
- * and the pin is a stand-up to refuse, not paper over — a mismatch (or an unreadable installed
- * version) aborts with a `CliVersionAssertError` naming both versions, and a match proceeds
- * silently. The reader of the installed version is INJECTED so the launcher (#3299) wires the real
- * `claude --version` while tests stub it; running the subprocess synchronously in an `Effect.try`
- * mirrors config.ts's `readFileSync` idiom (no new dependency for a one-shot pre-launch read).
+ * The one non-obvious thing: when a pin IS present it FAILS FAST, before any tracker or session
+ * launch. Channels are a research preview whose behavior varies across CLI versions, so a drift
+ * between the installed CLI and the pin is a stand-up to refuse, not paper over — a mismatch (or an
+ * unreadable installed version) aborts with a `CliVersionAssertError` naming both versions, and a
+ * match proceeds silently. The pin is OPTIONAL (issue #3417): when it is ABSENT the assert is
+ * SKIPPED entirely — the installed version is accepted unread — so the crew boot stops fail-closing
+ * on every frequent Claude Code auto-update. The reader of the installed version is INJECTED so the
+ * launcher (#3299) wires the real `claude --version` while tests stub it; running the subprocess
+ * synchronously in an `Effect.try` mirrors config.ts's `readFileSync` idiom (no new dependency).
  */
 import {execFileSync} from "node:child_process";
 import {Effect, Schema} from "effect";
@@ -57,6 +59,10 @@ export const readInstalledCliVersionOutput: Effect.Effect<string, string> = Effe
  * launch. Reads the installed version via the injected reader (default: the real `claude --version`),
  * and yields `CliVersionAssertError` on an unreadable version, an unparseable version, or a mismatch;
  * a match returns void so the caller proceeds silently.
+ *
+ * The pin is optional (issue #3417): an ABSENT `cliVersion` is the "unpinned" launch — the assert is
+ * skipped and the installed version accepted unread (no subprocess call), so a frequent CLI
+ * auto-update never fail-closes the boot. Only a PRESENT pin runs the read/parse/exact-match below.
  */
 export const assertPinnedCliVersion = (
 	config: Pick<LaunchConfig, "cliVersion">,
@@ -64,6 +70,7 @@ export const assertPinnedCliVersion = (
 ): Effect.Effect<void, CliVersionAssertError> =>
 	Effect.gen(function* () {
 		const pinned = config.cliVersion;
+		if (pinned === undefined) return;
 		const raw = yield* readVersionOutput.pipe(
 			Effect.mapError(
 				(cause) =>


### PR DESCRIPTION
## What

Makes the stand-up launcher's `cliVersion` pin **optional** so the crew boot stops fail-closing on every frequent Claude Code auto-update. Per the founder ruling on #3417: omit ⇒ accept whatever `claude --version` reports (an "unpinned" launch); pin only to deliberately lock a version, in which case the exact-match fail-fast behavior is unchanged. (The `>= X` min-version range runner-up shape was explicitly not built.)

## How the optional/unpinned state is modeled

`LaunchConfig.cliVersion` (and `RawLaunchConfig.cliVersion`) become `Schema.optionalKey(CliVersion)` — the effect-smol **exact-optional key** idiom (`Schema.ts`, `optionalKey`: "creates exact optional properties (not `| undefined`) that can be completely omitted"). Chosen over `Schema.optional` (= `optionalKey(UndefinedOr(S))`) deliberately: the only two states are **absent = unpinned** and **present = a valid pin** — there is no third present-but-`undefined` state, so the "unpinned" launch is a clean representable variant (the key is simply absent), not a sentinel. Invalid states stay unrepresentable, and a present-but-malformed pin still fails closed against `CLI_VERSION_RE`.

## Acceptance criteria

- [x] **AC1** — `LaunchConfig.cliVersion` in `config.ts` is optional/omittable: an absent pin decodes cleanly (not a `LaunchConfigError`) to an unpinned config; a present-but-malformed pin still fails closed.
- [x] **AC2** — `assertPinnedCliVersion` in `version-assert.ts` skips the assert and proceeds (accepts installed, unread — no subprocess call) when the pin is absent; a present pin keeps the exact-match `installed !== pinned` fail-fast and the unreadable/unparseable-installed abort unchanged.
- [x] **AC3** — the PERSONALIZATION.md "Pinned CLI version" row (and the `crew.config.template.jsonc` comment + the fail-closed prose) document the pin as optional (omit ⇒ accept installed; pin only to lock).
- [x] **AC4** — config + version-assert tests updated; added the unpinned path (absent pin decodes clean + assert proceeds unread), kept present-malformed/null fail-closed cases.

## Verification

- `pnpm --filter @kampus/pipeline-crew-mcp typecheck` — clean
- `biome check` on the four touched src files — clean
- `pnpm --filter @kampus/pipeline-crew-mcp vitest run` — 164 passed (28 files)

Fixes #3417

🤖 Generated with [Claude Code](https://claude.com/claude-code)