### PR TITLE
fix(pipeline-crew-mcp): stand-up ensures the crew tmux session + verifies launch liveness (#3418)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -43,10 +43,12 @@ export {
 	tryBecomeTracker,
 } from "./ensure-tracker.ts";
 export {
-	ensureCrewTmuxSession,
+	ensureNamedTmuxSession,
+	FALLBACK_TMUX_SESSION,
 	type LaunchedSession,
 	type LaunchPlan,
 	launchSessionInTmux,
+	resolveTargetTmuxSession,
 	runStandUp,
 	type StandUpError,
 	type StandUpInput,
@@ -65,7 +67,6 @@ export {
 } from "./session-set.ts";
 export {
 	computeTmuxPlacement,
-	DEFAULT_TMUX_SESSION,
 	type PlacementTarget,
 	type RosterSession,
 	TmuxWindowCollisionError,

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -43,6 +43,7 @@ export {
 	tryBecomeTracker,
 } from "./ensure-tracker.ts";
 export {
+	ensureCrewTmuxSession,
 	type LaunchedSession,
 	type LaunchPlan,
 	launchSessionInTmux,
@@ -51,6 +52,9 @@ export {
 	type StandUpInput,
 	StandUpLaunchError,
 	type StandUpResult,
+	type TmuxRun,
+	type TmuxRunner,
+	TmuxSessionEnsureError,
 } from "./orchestrate.ts";
 export {
 	type BridgeSession,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -22,10 +22,16 @@ import {type TrackerHandle, TrackerNotServingError} from "./ensure-tracker.ts";
 import {
 	CliVersionAssertError,
 	CrewServerNotRegisteredError,
+	ensureCrewTmuxSession,
 	type LaunchedSession,
 	type LaunchPlan,
+	launchSessionInTmux,
 	runStandUp,
 	type StandUpInput,
+	StandUpLaunchError,
+	type TmuxRun,
+	type TmuxRunner,
+	TmuxSessionEnsureError,
 } from "./index.ts";
 
 const PINNED = "2.1.212";
@@ -65,11 +71,18 @@ const counter = () => {
 	return () => `e${i++}`;
 };
 
-/** A recording launcher: never touches tmux, just captures the plans it was handed in call order. */
+/**
+ * A recording launcher + ensure-session pair sharing one `order` log, so a test can prove the crew tmux
+ * session is ensured BEFORE any window is placed (the fresh-machine ordering the false-green defeated, #3418).
+ * Neither touches tmux: the launcher captures its plans, the ensurer captures the session names it was asked for.
+ */
 const recordingLauncher = () => {
 	const plans: LaunchPlan[] = [];
+	const order: string[] = [];
+	const ensuredSessions: string[] = [];
 	const launch = (plan: LaunchPlan): Effect.Effect<LaunchedSession, never> => {
 		plans.push(plan);
+		order.push(`launch:${plan.placement.window}`);
 		return Effect.succeed({
 			role: plan.session.role,
 			address: plan.session.address,
@@ -77,7 +90,12 @@ const recordingLauncher = () => {
 			pid: 1000 + plans.length,
 		});
 	};
-	return {plans, launch};
+	const ensureTmuxSession = (session: string): Effect.Effect<void, never> => {
+		ensuredSessions.push(session);
+		order.push(`ensure:${session}`);
+		return Effect.void;
+	};
+	return {plans, order, ensuredSessions, launch, ensureTmuxSession};
 };
 
 const trackerHandle: TrackerHandle = {pid: 4242, socketPath: "/tmp/crew.sock"};
@@ -97,12 +115,20 @@ const recordingTracker = (
 /** The full happy-path input with every side effect injected — a stand-up that never leaves the process. */
 const baseInput = (
 	overrides: Partial<StandUpInput> & {engineCount?: number} = {},
-): {input: StandUpInput; launched: LaunchPlan[]; trackerCalls: () => number} => {
-	const {plans, launch} = recordingLauncher();
+): {
+	input: StandUpInput;
+	launched: LaunchPlan[];
+	order: string[];
+	ensuredSessions: string[];
+	trackerCalls: () => number;
+} => {
+	const {plans, order, ensuredSessions, launch, ensureTmuxSession} = recordingLauncher();
 	const {ensureTracker, calls} = recordingTracker();
 	const {engineCount, ...rest} = overrides;
 	return {
 		launched: plans,
+		order,
+		ensuredSessions,
 		trackerCalls: calls,
 		input: {
 			projectRoot: "/repo",
@@ -110,11 +136,34 @@ const baseInput = (
 			readVersionOutput: Effect.succeed(`${PINNED} (Claude Code)`),
 			instanceId: counter(),
 			ensureTracker,
+			ensureTmuxSession,
 			launch,
 			...rest,
 		},
 	};
 };
+
+/** A recording tmux runner: replays a scripted `TmuxRun` per invocation so `launchSessionInTmux` /
+ * `ensureCrewTmuxSession` run their exit-code branches with no real tmux — the async-exit seam #3418 closed. */
+const scriptedTmux = (runs: readonly TmuxRun[]): {runner: TmuxRunner; argvLog: string[][]} => {
+	const argvLog: string[][] = [];
+	let i = 0;
+	const runner: TmuxRunner = (args) => {
+		argvLog.push([...args]);
+		const run = runs[Math.min(i, runs.length - 1)];
+		i++;
+		return run === undefined ? Effect.die("scriptedTmux: no run scripted") : Effect.succeed(run);
+	};
+	return {runner, argvLog};
+};
+
+const exited = (code: number | null, over: Partial<TmuxRun> = {}): TmuxRun => ({
+	pid: code === 0 ? 4242 : undefined,
+	code,
+	signal: null,
+	spawnError: undefined,
+	...over,
+});
 
 const bridgeRoles = CREW_ROLES.filter((r) => kindOf(r) === "bridge");
 
@@ -242,6 +291,148 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 			// a bridge is a singleton and carries no --instance in its argv.
 			const bridge = launched.find((p) => p.session.kind === "bridge");
 			assert.notInclude(bridge?.bind.mcpConfigArg[1] ?? "", CREW_SESSION_INSTANCE_FLAG);
+		}),
+	);
+
+	it.effect(
+		"ensures the crew tmux session exists BEFORE placing any window, on a fresh env (#3418 AC1)",
+		() =>
+			Effect.gen(function* () {
+				const {input, order, ensuredSessions} = baseInput({engineCount: 2});
+				yield* runStandUp(input);
+
+				// the crew session is ensured exactly once, and every ensure precedes every launch.
+				assert.deepStrictEqual(ensuredSessions, ["crew"]);
+				const firstLaunch = order.findIndex((e) => e.startsWith("launch:"));
+				const lastEnsure = order.map((e) => e.startsWith("ensure:")).lastIndexOf(true);
+				assert.isBelow(lastEnsure, firstLaunch);
+			}),
+	);
+
+	it.effect("aborts fail-loud when the crew tmux session cannot be ensured (#3418 AC3)", () =>
+		Effect.gen(function* () {
+			const {input, launched} = baseInput({
+				ensureTmuxSession: (session: string) =>
+					Effect.fail(new TmuxSessionEnsureError({session, reason: "new-session exited 1"})),
+			});
+			const err = yield* Effect.flip(runStandUp(input));
+
+			assert.instanceOf(err, TmuxSessionEnsureError);
+			// ensure-session sits before the launch loop — nothing launched when it fails.
+			assert.strictEqual(launched.length, 0);
+		}),
+	);
+
+	it.effect(
+		"reports no launch count for a session that never started — a failed launch fails loud (#3418 AC4)",
+		() =>
+			Effect.gen(function* () {
+				const {input} = baseInput({
+					engineCount: 1,
+					launch: (plan) =>
+						Effect.fail(
+							new StandUpLaunchError({
+								role: plan.session.role,
+								window: plan.placement.window,
+								reason: "tmux new-window exited 1 (no live pane)",
+							}),
+						),
+				});
+				const err = yield* Effect.flip(runStandUp(input));
+				assert.instanceOf(err, StandUpLaunchError);
+			}),
+	);
+});
+
+/**
+ * The real launcher primitives against a scripted tmux runner — the async-exit path #3418 closed: a
+ * non-zero exit is inspected and fails closed, not counted as success. No real tmux, no `claude`.
+ */
+describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)", () => {
+	// Capture one real, fully-derived LaunchPlan by running a stand-up whose launcher just records it.
+	const captureOnePlan = Effect.gen(function* () {
+		const {input, launched} = baseInput({engineCount: 1});
+		yield* runStandUp(input);
+		const plan = launched[0];
+		assert.isDefined(plan);
+		return plan as LaunchPlan;
+	});
+
+	it.effect("launchSessionInTmux confirms a live window on a clean exit-0", () =>
+		Effect.gen(function* () {
+			const plan = yield* captureOnePlan;
+			const {runner, argvLog} = scriptedTmux([exited(0)]);
+			const result = yield* launchSessionInTmux(plan, runner);
+
+			assert.strictEqual(result.window, plan.placement.window);
+			assert.strictEqual(result.pid, 4242);
+			// the window is placed under the plan's tmux session with `claude` + the derived bind argv.
+			assert.deepStrictEqual(argvLog[0]?.slice(0, 6), [
+				"new-window",
+				"-t",
+				plan.placement.session,
+				"-n",
+				plan.placement.window,
+				"claude",
+			]);
+		}),
+	);
+
+	it.effect(
+		"launchSessionInTmux fails closed on an async non-zero exit — the swallowed failure #3418",
+		() =>
+			Effect.gen(function* () {
+				const plan = yield* captureOnePlan;
+				const {runner} = scriptedTmux([exited(1)]);
+				const err = yield* Effect.flip(launchSessionInTmux(plan, runner));
+
+				assert.instanceOf(err, StandUpLaunchError);
+				assert.strictEqual(err.window, plan.placement.window);
+				assert.strictEqual(err.role, plan.session.role);
+			}),
+	);
+
+	it.effect("launchSessionInTmux fails closed on a spawn-level error (tmux missing)", () =>
+		Effect.gen(function* () {
+			const plan = yield* captureOnePlan;
+			const {runner} = scriptedTmux([exited(null, {spawnError: "spawn tmux ENOENT"})]);
+			const err = yield* Effect.flip(launchSessionInTmux(plan, runner));
+
+			assert.instanceOf(err, StandUpLaunchError);
+			assert.include(err.reason, "ENOENT");
+		}),
+	);
+
+	it.effect("ensureCrewTmuxSession creates the session when it is absent (fresh env)", () =>
+		Effect.gen(function* () {
+			// has-session exits non-zero (absent) → new-session exits 0 (created).
+			const {runner, argvLog} = scriptedTmux([exited(1), exited(0)]);
+			yield* ensureCrewTmuxSession("crew", runner);
+
+			assert.deepStrictEqual(argvLog, [
+				["has-session", "-t", "crew"],
+				["new-session", "-d", "-s", "crew"],
+			]);
+		}),
+	);
+
+	it.effect("ensureCrewTmuxSession is a no-op create when the session already exists", () =>
+		Effect.gen(function* () {
+			const {runner, argvLog} = scriptedTmux([exited(0)]);
+			yield* ensureCrewTmuxSession("crew", runner);
+
+			// has-session exit-0 short-circuits — no `new-session` is ever run.
+			assert.deepStrictEqual(argvLog, [["has-session", "-t", "crew"]]);
+		}),
+	);
+
+	it.effect("ensureCrewTmuxSession fails loud when the create does not come up", () =>
+		Effect.gen(function* () {
+			const {runner} = scriptedTmux([exited(1), exited(1)]);
+			const err = yield* Effect.flip(ensureCrewTmuxSession("crew", runner));
+
+			assert.instanceOf(err, TmuxSessionEnsureError);
+			assert.strictEqual(err.session, "crew");
 		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -22,10 +22,12 @@ import {type TrackerHandle, TrackerNotServingError} from "./ensure-tracker.ts";
 import {
 	CliVersionAssertError,
 	CrewServerNotRegisteredError,
-	ensureCrewTmuxSession,
+	ensureNamedTmuxSession,
+	FALLBACK_TMUX_SESSION,
 	type LaunchedSession,
 	type LaunchPlan,
 	launchSessionInTmux,
+	resolveTargetTmuxSession,
 	runStandUp,
 	type StandUpInput,
 	StandUpLaunchError,
@@ -71,17 +73,25 @@ const counter = () => {
 	return () => `e${i++}`;
 };
 
+const RESOLVED_SESSION = "operator-session";
+
 /**
- * A recording launcher + ensure-session pair sharing one `order` log, so a test can prove the crew tmux
- * session is ensured BEFORE any window is placed (the fresh-machine ordering the false-green defeated, #3418).
- * Neither touches tmux: the launcher captures its plans, the ensurer captures the session names it was asked for.
+ * A recording launcher + target-session resolver sharing one `order` log, so a test can prove the target
+ * session is resolved BEFORE any window is placed and that each window is opened into THAT session (founder
+ * ruling #3418: the caller's current session, not a hardcoded one). Neither touches tmux: the launcher captures
+ * its plans + the session it was told to open into; the resolver captures its calls and returns `RESOLVED_SESSION`.
  */
 const recordingLauncher = () => {
 	const plans: LaunchPlan[] = [];
 	const order: string[] = [];
-	const ensuredSessions: string[] = [];
-	const launch = (plan: LaunchPlan): Effect.Effect<LaunchedSession, never> => {
+	const targetSessions: string[] = [];
+	const resolveCalls = {n: 0};
+	const launch = (
+		plan: LaunchPlan,
+		targetSession: string,
+	): Effect.Effect<LaunchedSession, never> => {
 		plans.push(plan);
+		targetSessions.push(targetSession);
 		order.push(`launch:${plan.placement.window}`);
 		return Effect.succeed({
 			role: plan.session.role,
@@ -90,12 +100,12 @@ const recordingLauncher = () => {
 			pid: 1000 + plans.length,
 		});
 	};
-	const ensureTmuxSession = (session: string): Effect.Effect<void, never> => {
-		ensuredSessions.push(session);
-		order.push(`ensure:${session}`);
-		return Effect.void;
+	const resolveTargetSession = (): Effect.Effect<string, never> => {
+		resolveCalls.n++;
+		order.push("resolve");
+		return Effect.succeed(RESOLVED_SESSION);
 	};
-	return {plans, order, ensuredSessions, launch, ensureTmuxSession};
+	return {plans, order, targetSessions, resolveCalls, launch, resolveTargetSession};
 };
 
 const trackerHandle: TrackerHandle = {pid: 4242, socketPath: "/tmp/crew.sock"};
@@ -119,16 +129,19 @@ const baseInput = (
 	input: StandUpInput;
 	launched: LaunchPlan[];
 	order: string[];
-	ensuredSessions: string[];
+	targetSessions: string[];
+	resolveCalls: {n: number};
 	trackerCalls: () => number;
 } => {
-	const {plans, order, ensuredSessions, launch, ensureTmuxSession} = recordingLauncher();
+	const {plans, order, targetSessions, resolveCalls, launch, resolveTargetSession} =
+		recordingLauncher();
 	const {ensureTracker, calls} = recordingTracker();
 	const {engineCount, ...rest} = overrides;
 	return {
 		launched: plans,
 		order,
-		ensuredSessions,
+		targetSessions,
+		resolveCalls,
 		trackerCalls: calls,
 		input: {
 			projectRoot: "/repo",
@@ -136,7 +149,7 @@ const baseInput = (
 			readVersionOutput: Effect.succeed(`${PINNED} (Claude Code)`),
 			instanceId: counter(),
 			ensureTracker,
-			ensureTmuxSession,
+			resolveTargetSession,
 			launch,
 			...rest,
 		},
@@ -144,7 +157,7 @@ const baseInput = (
 };
 
 /** A recording tmux runner: replays a scripted `TmuxRun` per invocation so `launchSessionInTmux` /
- * `ensureCrewTmuxSession` run their exit-code branches with no real tmux — the async-exit seam #3418 closed. */
+ * `resolveTargetTmuxSession` run their exit-code branches with no real tmux — the async-exit seam #3418 closed. */
 const scriptedTmux = (runs: readonly TmuxRun[]): {runner: TmuxRunner; argvLog: string[][]} => {
 	const argvLog: string[][] = [];
 	let i = 0;
@@ -161,6 +174,7 @@ const exited = (code: number | null, over: Partial<TmuxRun> = {}): TmuxRun => ({
 	pid: code === 0 ? 4242 : undefined,
 	code,
 	signal: null,
+	stdout: "",
 	spawnError: undefined,
 	...over,
 });
@@ -295,32 +309,37 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 	);
 
 	it.effect(
-		"ensures the crew tmux session exists BEFORE placing any window, on a fresh env (#3418 AC1)",
+		"resolves the target session BEFORE placing any window, and opens every window into it (#3418 AC1)",
 		() =>
 			Effect.gen(function* () {
-				const {input, order, ensuredSessions} = baseInput({engineCount: 2});
+				const {input, order, targetSessions} = baseInput({engineCount: 2});
 				yield* runStandUp(input);
 
-				// the crew session is ensured exactly once, and every ensure precedes every launch.
-				assert.deepStrictEqual(ensuredSessions, ["crew"]);
+				// the target session is resolved before any launch, and every window is opened into it.
 				const firstLaunch = order.findIndex((e) => e.startsWith("launch:"));
-				const lastEnsure = order.map((e) => e.startsWith("ensure:")).lastIndexOf(true);
-				assert.isBelow(lastEnsure, firstLaunch);
+				const lastResolve = order.lastIndexOf("resolve");
+				assert.isBelow(lastResolve, firstLaunch);
+				assert.isAbove(targetSessions.length, 0);
+				for (const s of targetSessions) assert.strictEqual(s, RESOLVED_SESSION);
 			}),
 	);
 
-	it.effect("aborts fail-loud when the crew tmux session cannot be ensured (#3418 AC3)", () =>
-		Effect.gen(function* () {
-			const {input, launched} = baseInput({
-				ensureTmuxSession: (session: string) =>
-					Effect.fail(new TmuxSessionEnsureError({session, reason: "new-session exited 1"})),
-			});
-			const err = yield* Effect.flip(runStandUp(input));
+	it.effect(
+		"aborts fail-loud when the target session cannot be resolved (outside-tmux fallback create fails) (#3418 AC3)",
+		() =>
+			Effect.gen(function* () {
+				const {input, launched} = baseInput({
+					resolveTargetSession: () =>
+						Effect.fail(
+							new TmuxSessionEnsureError({session: "crew", reason: "new-session exited 1"}),
+						),
+				});
+				const err = yield* Effect.flip(runStandUp(input));
 
-			assert.instanceOf(err, TmuxSessionEnsureError);
-			// ensure-session sits before the launch loop — nothing launched when it fails.
-			assert.strictEqual(launched.length, 0);
-		}),
+				assert.instanceOf(err, TmuxSessionEnsureError);
+				// session resolution sits before the launch loop — nothing launched when it fails.
+				assert.strictEqual(launched.length, 0);
+			}),
 	);
 
 	it.effect(
@@ -329,7 +348,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 			Effect.gen(function* () {
 				const {input} = baseInput({
 					engineCount: 1,
-					launch: (plan) =>
+					launch: (plan, _targetSession) =>
 						Effect.fail(
 							new StandUpLaunchError({
 								role: plan.session.role,
@@ -358,19 +377,21 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 		return plan as LaunchPlan;
 	});
 
-	it.effect("launchSessionInTmux confirms a live window on a clean exit-0", () =>
+	const TARGET = "operator-session";
+
+	it.effect("launchSessionInTmux opens the window into the resolved target session on exit-0", () =>
 		Effect.gen(function* () {
 			const plan = yield* captureOnePlan;
 			const {runner, argvLog} = scriptedTmux([exited(0)]);
-			const result = yield* launchSessionInTmux(plan, runner);
+			const result = yield* launchSessionInTmux(plan, TARGET, runner);
 
 			assert.strictEqual(result.window, plan.placement.window);
 			assert.strictEqual(result.pid, 4242);
-			// the window is placed under the plan's tmux session with `claude` + the derived bind argv.
+			// the window opens into the RESOLVED session (the caller's, #3418), not a hardcoded one.
 			assert.deepStrictEqual(argvLog[0]?.slice(0, 6), [
 				"new-window",
 				"-t",
-				plan.placement.session,
+				TARGET,
 				"-n",
 				plan.placement.window,
 				"claude",
@@ -384,7 +405,7 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 			Effect.gen(function* () {
 				const plan = yield* captureOnePlan;
 				const {runner} = scriptedTmux([exited(1)]);
-				const err = yield* Effect.flip(launchSessionInTmux(plan, runner));
+				const err = yield* Effect.flip(launchSessionInTmux(plan, TARGET, runner));
 
 				assert.instanceOf(err, StandUpLaunchError);
 				assert.strictEqual(err.window, plan.placement.window);
@@ -396,43 +417,86 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 		Effect.gen(function* () {
 			const plan = yield* captureOnePlan;
 			const {runner} = scriptedTmux([exited(null, {spawnError: "spawn tmux ENOENT"})]);
-			const err = yield* Effect.flip(launchSessionInTmux(plan, runner));
+			const err = yield* Effect.flip(launchSessionInTmux(plan, TARGET, runner));
 
 			assert.instanceOf(err, StandUpLaunchError);
 			assert.include(err.reason, "ENOENT");
 		}),
 	);
 
-	it.effect("ensureCrewTmuxSession creates the session when it is absent (fresh env)", () =>
-		Effect.gen(function* () {
-			// has-session exits non-zero (absent) → new-session exits 0 (created).
-			const {runner, argvLog} = scriptedTmux([exited(1), exited(0)]);
-			yield* ensureCrewTmuxSession("crew", runner);
+	it.effect(
+		"resolveTargetTmuxSession returns the caller's CURRENT session when inside tmux (the default path)",
+		() =>
+			Effect.gen(function* () {
+				// display-message prints the current session name — no session is ever created inside tmux.
+				const {runner, argvLog} = scriptedTmux([exited(0, {stdout: "my-session\n"})]);
+				const session = yield* resolveTargetTmuxSession(
+					{inTmux: true, fallbackSession: FALLBACK_TMUX_SESSION},
+					runner,
+				);
 
-			assert.deepStrictEqual(argvLog, [
-				["has-session", "-t", "crew"],
-				["new-session", "-d", "-s", "crew"],
-			]);
-		}),
+				assert.strictEqual(session, "my-session");
+				assert.deepStrictEqual(argvLog, [["display-message", "-p", "#{session_name}"]]);
+			}),
 	);
 
-	it.effect("ensureCrewTmuxSession is a no-op create when the session already exists", () =>
-		Effect.gen(function* () {
-			const {runner, argvLog} = scriptedTmux([exited(0)]);
-			yield* ensureCrewTmuxSession("crew", runner);
+	it.effect(
+		"resolveTargetTmuxSession falls back to a CREATED named session when outside tmux",
+		() =>
+			Effect.gen(function* () {
+				// outside tmux: no display-message; has-session (absent) → new-session creates the fallback.
+				const {runner, argvLog} = scriptedTmux([exited(1), exited(0)]);
+				const session = yield* resolveTargetTmuxSession(
+					{inTmux: false, fallbackSession: FALLBACK_TMUX_SESSION},
+					runner,
+				);
 
-			// has-session exit-0 short-circuits — no `new-session` is ever run.
-			assert.deepStrictEqual(argvLog, [["has-session", "-t", "crew"]]);
-		}),
+				assert.strictEqual(session, FALLBACK_TMUX_SESSION);
+				assert.deepStrictEqual(argvLog, [
+					["has-session", "-t", FALLBACK_TMUX_SESSION],
+					["new-session", "-d", "-s", FALLBACK_TMUX_SESSION],
+				]);
+			}),
 	);
 
-	it.effect("ensureCrewTmuxSession fails loud when the create does not come up", () =>
+	it.effect(
+		"resolveTargetTmuxSession falls back to the created session when the current name is unreadable",
+		() =>
+			Effect.gen(function* () {
+				// inside tmux but display-message fails → fall through to has-session (present, exit-0).
+				const {runner, argvLog} = scriptedTmux([exited(1), exited(0)]);
+				const session = yield* resolveTargetTmuxSession(
+					{inTmux: true, fallbackSession: FALLBACK_TMUX_SESSION},
+					runner,
+				);
+
+				assert.strictEqual(session, FALLBACK_TMUX_SESSION);
+				assert.deepStrictEqual(argvLog, [
+					["display-message", "-p", "#{session_name}"],
+					["has-session", "-t", FALLBACK_TMUX_SESSION],
+				]);
+			}),
+	);
+
+	it.effect("resolveTargetTmuxSession fails loud when the fallback session cannot be created", () =>
 		Effect.gen(function* () {
 			const {runner} = scriptedTmux([exited(1), exited(1)]);
-			const err = yield* Effect.flip(ensureCrewTmuxSession("crew", runner));
+			const err = yield* Effect.flip(
+				resolveTargetTmuxSession({inTmux: false, fallbackSession: "crew"}, runner),
+			);
 
 			assert.instanceOf(err, TmuxSessionEnsureError);
 			assert.strictEqual(err.session, "crew");
+		}),
+	);
+
+	it.effect("ensureNamedTmuxSession is a no-op create when the session already exists", () =>
+		Effect.gen(function* () {
+			const {runner, argvLog} = scriptedTmux([exited(0)]);
+			yield* ensureNamedTmuxSession("crew", runner);
+
+			// has-session exit-0 short-circuits — no `new-session` is ever run.
+			assert.deepStrictEqual(argvLog, [["has-session", "-t", "crew"]]);
 		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -37,6 +37,7 @@ import {
 import {type CrewSession, deriveSessionSet} from "./session-set.ts";
 import {
 	computeTmuxPlacement,
+	DEFAULT_TMUX_SESSION,
 	type PlacementTarget,
 	type RosterSession,
 	type TmuxWindowCollisionError,
@@ -56,6 +57,61 @@ export class StandUpLaunchError extends Schema.TaggedErrorClass<StandUpLaunchErr
 		reason: Schema.String,
 	},
 ) {}
+
+/**
+ * The launcher-default tmux session could not be ensured (the `has-session` probe missed AND the create
+ * failed to come up). This is the fresh-machine gap that made every `new-window -t crew` fail while
+ * stand-up still counted success — see ADR 0189 for why the session name is derived, not configured (#3418).
+ */
+export class TmuxSessionEnsureError extends Schema.TaggedErrorClass<TmuxSessionEnsureError>()(
+	"@kampus/pipeline-crew-mcp/standup/TmuxSessionEnsureError",
+	{
+		session: Schema.String,
+		reason: Schema.String,
+	},
+) {}
+
+/**
+ * The outcome of running a `tmux` client to exit: its pid and exit code/signal, plus — when the binary
+ * itself could not be spawned or emitted `error` — a spawn-level message. `code === 0` with no `spawnError`
+ * is the only success; every other shape is a launch that did not come up.
+ */
+export interface TmuxRun {
+	readonly pid: number | undefined;
+	readonly code: number | null;
+	readonly signal: NodeJS.Signals | null;
+	readonly spawnError: string | undefined;
+}
+
+/** Run a `tmux` client command to its exit. Injected in tests to drive the exit-code paths without a real tmux. */
+export type TmuxRunner = (args: readonly string[]) => Effect.Effect<TmuxRun>;
+
+/**
+ * Run `tmux <args>` and resolve once the client process EXITS, carrying its exit code — the async exit the
+ * old `Effect.try`-sync-only launcher never inspected (#3418). No detach/unref: `tmux` is client-server, so
+ * the CLI is a short-lived client that hands the request to the tmux server and exits (bounded to await);
+ * the `claude` process it places lives under the tmux server and outlives this launcher regardless. Never
+ * fails — an operational spawn failure (ENOENT/EACCES) arrives on the async `error` event, captured as
+ * `spawnError` data so each caller maps it to its own typed error (no raw try/catch: `spawn` reports
+ * operational errors via `error`, not a throw). This mirrors ensure-tracker's `Effect.callback` node-event idiom.
+ */
+const runTmux: TmuxRunner = (args) =>
+	Effect.callback<TmuxRun>((resume) => {
+		const child = spawn("tmux", [...args], {stdio: "ignore"});
+		let settled = false;
+		const settle = (run: TmuxRun) => {
+			if (settled) return;
+			settled = true;
+			child.removeAllListeners();
+			resume(Effect.succeed(run));
+		};
+		child.once("error", (cause) =>
+			settle({pid: child.pid, code: null, signal: null, spawnError: String(cause)}),
+		);
+		child.once("exit", (code, signal) =>
+			settle({pid: child.pid, code, signal, spawnError: undefined}),
+		);
+	});
 
 /** One derived session's full launch plan: its roster identity, its launch bind (argv), and its tmux placement. */
 export interface LaunchPlan {
@@ -81,6 +137,7 @@ export type StandUpError =
 	| CrewServerNotRegisteredError
 	| ChannelPluginNotAllowedError
 	| TmuxWindowCollisionError
+	| TmuxSessionEnsureError
 	| StandUpLaunchError;
 
 export interface StandUpInput {
@@ -98,6 +155,8 @@ export interface StandUpInput {
 	) => Effect.Effect<TrackerHandle, TrackerNotServingError>;
 	/** Mints each engine instance's distinct id. Default: `randomUUID` (the generator sessions use at runtime). */
 	readonly instanceId?: () => string;
+	/** Ensure the launcher-default tmux session exists before any window is placed. Default: `ensureCrewTmuxSession`. */
+	readonly ensureTmuxSession?: (session: string) => Effect.Effect<void, TmuxSessionEnsureError>;
 	/** Launch one planned session into its tmux window bound to its role lease. Default: `launchSessionInTmux`. */
 	readonly launch?: (plan: LaunchPlan) => Effect.Effect<LaunchedSession, StandUpLaunchError>;
 }
@@ -119,36 +178,67 @@ const toRosterSession = (session: CrewSession): RosterSession =>
 		: {kind: "bridge", role: session.role};
 
 /**
- * The production launcher: open a tmux window for the session under the launcher-default tmux session and
- * run `claude` there with the session's launch bind. Detached + unref'd + ignored stdio so the crew
- * outlives this launcher process (the `ensureTrackerRunning` spawn idiom). The thin, uncovered edge —
- * tests inject a recording launcher; only a synchronous spawn throw crosses the error channel.
+ * Ensure the launcher-default tmux session exists before any window is placed: probe `has-session`, and
+ * create (`new-session -d`) only when it is absent — the idempotent guard that closes the fresh-machine gap
+ * where `new-window -t crew` failed for a missing session (#3418). A create that itself does not come up
+ * fails closed with `TmuxSessionEnsureError`, so stand-up never launches into a session it could not confirm.
+ * The tmux runner is injected so the has-session/create branches are unit-tested without a real tmux.
+ */
+export const ensureCrewTmuxSession = (
+	session: string,
+	runTmuxCommand: TmuxRunner = runTmux,
+): Effect.Effect<void, TmuxSessionEnsureError> =>
+	Effect.gen(function* () {
+		const probe = yield* runTmuxCommand(["has-session", "-t", session]);
+		if (probe.spawnError === undefined && probe.code === 0) return;
+		const created = yield* runTmuxCommand(["new-session", "-d", "-s", session]);
+		if (created.spawnError !== undefined || created.code !== 0) {
+			return yield* Effect.fail(
+				new TmuxSessionEnsureError({
+					session,
+					reason:
+						created.spawnError ??
+						`tmux new-session for "${session}" exited ${created.code ?? created.signal}`,
+				}),
+			);
+		}
+	});
+
+/**
+ * The production launcher: open a tmux window under the launcher-default session and run `claude` there with
+ * the session's launch bind, then CONFIRM the window came up before counting it. `runTmux` awaits the client's
+ * exit, so a spawn failure or any non-zero exit — the fresh-machine `new-window -t crew` with no `crew` session
+ * (#3418) — fails closed with `StandUpLaunchError` naming the role + window; a `LaunchedSession` therefore only
+ * ever exists for a confirmed-live launch. The tmux runner is injected so the exit-code paths are unit-tested.
  */
 export const launchSessionInTmux = (
 	plan: LaunchPlan,
+	runTmuxCommand: TmuxRunner = runTmux,
 ): Effect.Effect<LaunchedSession, StandUpLaunchError> =>
-	Effect.try({
-		try: (): LaunchedSession => {
-			const {placement, bind, session} = plan;
-			const child = spawn(
-				"tmux",
-				["new-window", "-t", placement.session, "-n", placement.window, "claude", ...bind.argv],
-				{detached: true, stdio: "ignore"},
+	Effect.gen(function* () {
+		const {placement, bind, session} = plan;
+		const run = yield* runTmuxCommand([
+			"new-window",
+			"-t",
+			placement.session,
+			"-n",
+			placement.window,
+			"claude",
+			...bind.argv,
+		]);
+		if (run.spawnError !== undefined || run.code !== 0) {
+			return yield* Effect.fail(
+				new StandUpLaunchError({
+					role: session.role,
+					window: placement.window,
+					reason:
+						run.spawnError !== undefined
+							? `cannot launch claude into tmux window "${placement.window}": ${run.spawnError}`
+							: `tmux new-window for "${placement.window}" exited ${run.code ?? run.signal} (no live pane) — is the "${placement.session}" session present?`,
+				}),
 			);
-			child.unref();
-			return {
-				role: session.role,
-				address: session.address,
-				window: placement.window,
-				pid: child.pid,
-			};
-		},
-		catch: (cause) =>
-			new StandUpLaunchError({
-				role: plan.session.role,
-				window: plan.placement.window,
-				reason: `cannot launch claude into tmux window "${plan.placement.window}": ${String(cause)}`,
-			}),
+		}
+		return {role: session.role, address: session.address, window: placement.window, pid: run.pid};
 	});
 
 /**
@@ -164,6 +254,7 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 		const serverName = input.serverName ?? SESSION_SERVER_NAME;
 		const instanceId = input.instanceId ?? randomUUID;
 		const ensureTracker = input.ensureTracker ?? ensureTrackerRunning;
+		const ensureTmuxSession = input.ensureTmuxSession ?? ensureCrewTmuxSession;
 		const launch = input.launch ?? launchSessionInTmux;
 
 		const config = yield* input.config ?? readLaunchConfig();
@@ -198,6 +289,11 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 				: Effect.die(`stand-up plan zip out of range for session "${session.role}"`);
 		});
 
-		const launched = yield* Effect.forEach(plans, launch);
+		// Ensure the launcher-default tmux session exists before placing any window — a missing `crew`
+		// session made every `new-window -t crew` fail on a fresh machine while stand-up still reported
+		// success (#3418). This is the last precondition before the no-partial-crew launch loop.
+		yield* ensureTmuxSession(DEFAULT_TMUX_SESSION);
+		// Wrap so `forEach`'s index arg never lands on the launcher's optional tmux-runner param.
+		const launched = yield* Effect.forEach(plans, (plan) => launch(plan));
 		return {tracker, launched};
 	});

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -37,7 +37,6 @@ import {
 import {type CrewSession, deriveSessionSet} from "./session-set.ts";
 import {
 	computeTmuxPlacement,
-	DEFAULT_TMUX_SESSION,
 	type PlacementTarget,
 	type RosterSession,
 	type TmuxWindowCollisionError,
@@ -59,9 +58,9 @@ export class StandUpLaunchError extends Schema.TaggedErrorClass<StandUpLaunchErr
 ) {}
 
 /**
- * The launcher-default tmux session could not be ensured (the `has-session` probe missed AND the create
- * failed to come up). This is the fresh-machine gap that made every `new-window -t crew` fail while
- * stand-up still counted success — see ADR 0189 for why the session name is derived, not configured (#3418).
+ * The named fallback tmux session could not be ensured (the `has-session` probe missed AND the create failed
+ * to come up). This is only the OUTSIDE-tmux edge: run inside tmux, stand-up opens windows in the caller's
+ * current session and never creates one (founder ruling #3418) — a created session is the fallback alone.
  */
 export class TmuxSessionEnsureError extends Schema.TaggedErrorClass<TmuxSessionEnsureError>()(
 	"@kampus/pipeline-crew-mcp/standup/TmuxSessionEnsureError",
@@ -80,6 +79,8 @@ export interface TmuxRun {
 	readonly pid: number | undefined;
 	readonly code: number | null;
 	readonly signal: NodeJS.Signals | null;
+	/** The client's captured stdout — carries `display-message` output for the target-session probe. */
+	readonly stdout: string;
 	readonly spawnError: string | undefined;
 }
 
@@ -97,7 +98,11 @@ export type TmuxRunner = (args: readonly string[]) => Effect.Effect<TmuxRun>;
  */
 const runTmux: TmuxRunner = (args) =>
 	Effect.callback<TmuxRun>((resume) => {
-		const child = spawn("tmux", [...args], {stdio: "ignore"});
+		const child = spawn("tmux", [...args], {stdio: ["ignore", "pipe", "ignore"]});
+		let stdout = "";
+		child.stdout?.on("data", (chunk) => {
+			stdout += String(chunk);
+		});
 		let settled = false;
 		const settle = (run: TmuxRun) => {
 			if (settled) return;
@@ -106,10 +111,10 @@ const runTmux: TmuxRunner = (args) =>
 			resume(Effect.succeed(run));
 		};
 		child.once("error", (cause) =>
-			settle({pid: child.pid, code: null, signal: null, spawnError: String(cause)}),
+			settle({pid: child.pid, code: null, signal: null, stdout, spawnError: String(cause)}),
 		);
 		child.once("exit", (code, signal) =>
-			settle({pid: child.pid, code, signal, spawnError: undefined}),
+			settle({pid: child.pid, code, signal, stdout, spawnError: undefined}),
 		);
 	});
 
@@ -155,10 +160,14 @@ export interface StandUpInput {
 	) => Effect.Effect<TrackerHandle, TrackerNotServingError>;
 	/** Mints each engine instance's distinct id. Default: `randomUUID` (the generator sessions use at runtime). */
 	readonly instanceId?: () => string;
-	/** Ensure the launcher-default tmux session exists before any window is placed. Default: `ensureCrewTmuxSession`. */
-	readonly ensureTmuxSession?: (session: string) => Effect.Effect<void, TmuxSessionEnsureError>;
-	/** Launch one planned session into its tmux window bound to its role lease. Default: `launchSessionInTmux`. */
-	readonly launch?: (plan: LaunchPlan) => Effect.Effect<LaunchedSession, StandUpLaunchError>;
+	/** Resolve the tmux session windows open into — the caller's current session, else a created fallback.
+	 * Default: `resolveTargetTmuxSession` (reads `$TMUX` + `display-message`). */
+	readonly resolveTargetSession?: () => Effect.Effect<string, TmuxSessionEnsureError>;
+	/** Launch one planned session into a window under `targetSession`, bound to its role lease. Default: `launchSessionInTmux`. */
+	readonly launch?: (
+		plan: LaunchPlan,
+		targetSession: string,
+	) => Effect.Effect<LaunchedSession, StandUpLaunchError>;
 }
 
 /** What a completed stand-up returns: the tracker it ensured and every session it launched, in roster order. */
@@ -178,13 +187,18 @@ const toRosterSession = (session: CrewSession): RosterSession =>
 		: {kind: "bridge", role: session.role};
 
 /**
- * Ensure the launcher-default tmux session exists before any window is placed: probe `has-session`, and
- * create (`new-session -d`) only when it is absent — the idempotent guard that closes the fresh-machine gap
- * where `new-window -t crew` failed for a missing session (#3418). A create that itself does not come up
- * fails closed with `TmuxSessionEnsureError`, so stand-up never launches into a session it could not confirm.
- * The tmux runner is injected so the has-session/create branches are unit-tested without a real tmux.
+ * The named session stand-up falls back to only when run OUTSIDE tmux — inside tmux the caller's own current
+ * session is the target and nothing is created (founder ruling #3418). A launcher default, not a config input.
  */
-export const ensureCrewTmuxSession = (
+export const FALLBACK_TMUX_SESSION = "crew";
+
+/**
+ * Ensure a named tmux session exists: probe `has-session`, and create (`new-session -d`) only when it is
+ * absent. This runs ONLY on the outside-tmux fallback path (`resolveTargetTmuxSession`) — a create that does
+ * not come up fails closed with `TmuxSessionEnsureError`. The tmux runner is injected so the has-session /
+ * create branches are unit-tested without a real tmux.
+ */
+export const ensureNamedTmuxSession = (
 	session: string,
 	runTmuxCommand: TmuxRunner = runTmux,
 ): Effect.Effect<void, TmuxSessionEnsureError> =>
@@ -205,14 +219,45 @@ export const ensureCrewTmuxSession = (
 	});
 
 /**
- * The production launcher: open a tmux window under the launcher-default session and run `claude` there with
- * the session's launch bind, then CONFIRM the window came up before counting it. `runTmux` awaits the client's
- * exit, so a spawn failure or any non-zero exit — the fresh-machine `new-window -t crew` with no `crew` session
- * (#3418) — fails closed with `StandUpLaunchError` naming the role + window; a `LaunchedSession` therefore only
- * ever exists for a confirmed-live launch. The tmux runner is injected so the exit-code paths are unit-tested.
+ * Resolve which tmux session stand-up opens its windows into (founder ruling #3418 — the fix's inverted half:
+ * open windows in the operator's CURRENT session, never a hardcoded `crew`). Inside tmux (`$TMUX` set) the
+ * caller's current session name is read via `display-message -p '#{session_name}'`, resolved through the
+ * inherited `$TMUX` — that session always exists, so the old "session doesn't exist" failure dissolves. Only
+ * OUTSIDE tmux (or when the current-session name can't be read) is a session created: the named fallback,
+ * ensured to exist. `inTmux` + the runner are injected so both paths are unit-tested without a real tmux.
+ */
+export const resolveTargetTmuxSession = (
+	opts: {readonly inTmux: boolean; readonly fallbackSession: string},
+	runTmuxCommand: TmuxRunner = runTmux,
+): Effect.Effect<string, TmuxSessionEnsureError> =>
+	Effect.gen(function* () {
+		if (opts.inTmux) {
+			const shown = yield* runTmuxCommand(["display-message", "-p", "#{session_name}"]);
+			const name = shown.stdout.trim();
+			if (shown.spawnError === undefined && shown.code === 0 && name.length > 0) return name;
+			// Inside tmux but the current session name was unreadable — fall through to the created fallback.
+		}
+		yield* ensureNamedTmuxSession(opts.fallbackSession, runTmuxCommand);
+		return opts.fallbackSession;
+	});
+
+/** The production target-session resolver: current session when inside tmux, the named fallback otherwise. */
+const resolveTargetSessionDefault = (): Effect.Effect<string, TmuxSessionEnsureError> =>
+	resolveTargetTmuxSession({
+		inTmux: process.env.TMUX !== undefined,
+		fallbackSession: FALLBACK_TMUX_SESSION,
+	});
+
+/**
+ * The production launcher: open a tmux window under `targetSession` (the resolved caller session) and run
+ * `claude` there with the session's launch bind, then CONFIRM the window came up before counting it. `runTmux`
+ * awaits the client's async exit, so a spawn failure or any non-zero exit — the swallowed failure of #3418 —
+ * fails closed with `StandUpLaunchError` naming the role + window; a `LaunchedSession` therefore only ever
+ * exists for a confirmed-live launch. The tmux runner is injected so the exit-code paths are unit-tested.
  */
 export const launchSessionInTmux = (
 	plan: LaunchPlan,
+	targetSession: string,
 	runTmuxCommand: TmuxRunner = runTmux,
 ): Effect.Effect<LaunchedSession, StandUpLaunchError> =>
 	Effect.gen(function* () {
@@ -220,7 +265,7 @@ export const launchSessionInTmux = (
 		const run = yield* runTmuxCommand([
 			"new-window",
 			"-t",
-			placement.session,
+			targetSession,
 			"-n",
 			placement.window,
 			"claude",
@@ -234,7 +279,7 @@ export const launchSessionInTmux = (
 					reason:
 						run.spawnError !== undefined
 							? `cannot launch claude into tmux window "${placement.window}": ${run.spawnError}`
-							: `tmux new-window for "${placement.window}" exited ${run.code ?? run.signal} (no live pane) — is the "${placement.session}" session present?`,
+							: `tmux new-window for "${placement.window}" in session "${targetSession}" exited ${run.code ?? run.signal} (no live pane)`,
 				}),
 			);
 		}
@@ -254,7 +299,7 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 		const serverName = input.serverName ?? SESSION_SERVER_NAME;
 		const instanceId = input.instanceId ?? randomUUID;
 		const ensureTracker = input.ensureTracker ?? ensureTrackerRunning;
-		const ensureTmuxSession = input.ensureTmuxSession ?? ensureCrewTmuxSession;
+		const resolveTargetSession = input.resolveTargetSession ?? resolveTargetSessionDefault;
 		const launch = input.launch ?? launchSessionInTmux;
 
 		const config = yield* input.config ?? readLaunchConfig();
@@ -289,11 +334,11 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 				: Effect.die(`stand-up plan zip out of range for session "${session.role}"`);
 		});
 
-		// Ensure the launcher-default tmux session exists before placing any window — a missing `crew`
-		// session made every `new-window -t crew` fail on a fresh machine while stand-up still reported
-		// success (#3418). This is the last precondition before the no-partial-crew launch loop.
-		yield* ensureTmuxSession(DEFAULT_TMUX_SESSION);
+		// Resolve the target tmux session before placing any window: the caller's CURRENT session inside
+		// tmux (which always exists — dissolving the fresh-machine "no crew session" failure), else a
+		// created fallback (founder ruling #3418). Last precondition before the no-partial-crew launch loop.
+		const targetSession = yield* resolveTargetSession();
 		// Wrap so `forEach`'s index arg never lands on the launcher's optional tmux-runner param.
-		const launched = yield* Effect.forEach(plans, (plan) => launch(plan));
+		const launched = yield* Effect.forEach(plans, (plan) => launch(plan, targetSession));
 		return {tracker, launched};
 	});

--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
@@ -1,16 +1,15 @@
 /**
- * The tmux placement mapping (AC 4): a sample roster session set — three bridges + N engines — maps
- * to one placement target per session, all under the launcher-default tmux session, with each window
- * name DERIVED from role identity (a bridge's role slug, an engine's per-instance id) rather than a
- * config `tmux` dimension (which died with the one-role-map seam, ADR 0189 / #3236). Also pins the
- * one surviving fail-closed rejection: two sessions colliding on one window. These prove tmux is
- * used only as a window-manager here — the mapping produces placement targets, never a transport path.
+ * The tmux placement mapping (AC 4): a sample roster session set — three bridges + N engines — maps to one
+ * placement target per session, with each window name DERIVED from role identity (a bridge's role slug, an
+ * engine's per-instance id) rather than a config `tmux` dimension (which died with the one-role-map seam, ADR
+ * 0189 / #3236). The SESSION windows open into is NOT this layer's concern — it is resolved at launch time to
+ * the caller's current tmux session (founder ruling #3418), so a target carries no session field. Also pins
+ * the one surviving fail-closed rejection: two sessions colliding on one window name.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {
 	computeTmuxPlacement,
-	DEFAULT_TMUX_SESSION,
 	type RosterSession,
 	TmuxWindowCollisionError,
 } from "./tmux-placement.ts";
@@ -26,20 +25,18 @@ const engines = (n: number): readonly RosterSession[] =>
 	Array.from({length: n}, (_, i) => ({kind: "engine", id: `engine-${i + 1}`}) as const);
 
 describe("standup/tmux-placement — session set → placement targets (derived naming)", () => {
-	it.effect(
-		"places one window per bridge + one per engine, all under the default tmux session",
-		() =>
-			Effect.gen(function* () {
-				const targets = yield* computeTmuxPlacement([...BRIDGES, ...engines(3)]);
-				assert.lengthOf(targets, 6, "3 bridges + 3 engines = 6 placement targets");
-				for (const t of targets) {
-					assert.strictEqual(
-						t.session,
-						DEFAULT_TMUX_SESSION,
-						"every window lives under the launcher-default tmux session",
-					);
-				}
-			}),
+	it.effect("places one window per bridge + one per engine (no session baked into a target)", () =>
+		Effect.gen(function* () {
+			const targets = yield* computeTmuxPlacement([...BRIDGES, ...engines(3)]);
+			assert.lengthOf(targets, 6, "3 bridges + 3 engines = 6 placement targets");
+			for (const t of targets) {
+				assert.notProperty(
+					t,
+					"session",
+					"the target carries no session — it is resolved at launch",
+				);
+			}
+		}),
 	);
 
 	it.effect("derives each bridge window from its role slug", () =>

--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.ts
@@ -5,22 +5,18 @@
  * It maps the roster session set (C6, #3297: one entry per bridge + one per engine instance) to
  * tmux placement targets, deriving each window name from the session's own role identity.
  *
- * The one non-obvious thing: placement naming is DERIVED, not config-read. The old config `tmux`
- * dimension (session + per-bridge window names) died with the one-role-map seam (ADR 0189 / #3236):
- * post-MCP a role's address is a lease, not a configured pane, so there is nothing left to name in
- * config. A bridge's window is its role slug; an engine's window is its per-instance id (an operator
- * could never name N dynamic engines). All windows live under a single launcher-default tmux session.
- * The layer stays thin — it maps sessions to placement targets and nothing else: it does NOT register
- * channels or mint identity (C5/C6 own those), and introduces NO tmux-as-transport path (no pane-title
- * discovery, no buffer-paste, no send-keys). Pure derivation over plain data (the `registry-core` idiom).
+ * The one non-obvious thing: this layer derives window NAMES only — it does NOT own the tmux SESSION.
+ * Placement naming is DERIVED, not config-read: the old config `tmux` dimension (session + per-bridge
+ * window names) died with the one-role-map seam (ADR 0189 / #3236) — post-MCP a role's address is a
+ * lease, not a configured pane. A bridge's window is its role slug; an engine's window is its per-instance
+ * id (an operator could never name N dynamic engines). The SESSION the windows open into is resolved at
+ * LAUNCH time to the caller's current tmux session, not named here (founder ruling #3418: stand-up opens
+ * windows in the operator's own session, never a hardcoded one) — so there is no session field on a target.
+ * The layer stays thin: it does NOT register channels or mint identity (C5/C6 own those), and introduces NO
+ * tmux-as-transport path (no pane-title discovery, no buffer-paste, no send-keys). Pure derivation (the
+ * `registry-core` idiom).
  */
 import {Effect, Schema} from "effect";
-
-/**
- * The tmux session every crew window is created under. A launcher default, not a config input: with
- * the config `tmux` dimension gone (ADR 0189), the session name is derived, not operator-supplied.
- */
-export const DEFAULT_TMUX_SESSION = "crew";
 
 /**
  * One session in the roster set (C6, #3297) that must be placed on the operator's screen. A bridge is
@@ -31,10 +27,8 @@ export type RosterSession =
 	| {readonly kind: "bridge"; readonly role: string}
 	| {readonly kind: "engine"; readonly id: string};
 
-/** Where one session is placed: a named window under the launcher-default tmux session. */
+/** Where one session is placed: a named window (the session it opens into is resolved at launch time). */
 export interface PlacementTarget {
-	/** The tmux session this window is created under (`DEFAULT_TMUX_SESSION`). */
-	readonly session: string;
 	/** The resolved tmux window name — a bridge's role slug or an engine's instance id. */
 	readonly window: string;
 	/** The roster session this places — a bridge role slug or an engine instance id. */
@@ -56,18 +50,13 @@ export class TmuxWindowCollisionError extends Schema.TaggedErrorClass<TmuxWindow
 
 const placeOne = (session: RosterSession): PlacementTarget =>
 	session.kind === "engine"
-		? {session: DEFAULT_TMUX_SESSION, window: session.id, sessionRef: session.id, kind: "engine"}
-		: {
-				session: DEFAULT_TMUX_SESSION,
-				window: session.role,
-				sessionRef: session.role,
-				kind: "bridge",
-			};
+		? {window: session.id, sessionRef: session.id, kind: "engine"}
+		: {window: session.role, sessionRef: session.role, kind: "bridge"};
 
 /**
- * Map the roster session set to tmux placement targets: one window per bridge (named by its role
- * slug) + one per engine instance (named by its id), all under the launcher-default tmux session.
- * Fails closed only on two sessions colliding on one window — the launch-time distinctness guard.
+ * Map the roster session set to tmux placement targets: one window per bridge (named by its role slug)
+ * + one per engine instance (named by its id). Fails closed only on two sessions colliding on one window
+ * name — the launch-time distinctness guard (the session they open into is resolved at launch, not here).
  */
 export const computeTmuxPlacement = (
 	sessions: readonly RosterSession[],


### PR DESCRIPTION
Fixes #3418

## Problem

On a fresh machine `runStandUp` reported `N launched` and exited 0 while launching **zero** live sessions — a false green at the crew's load-bearing boot step. Two coupled defects, both triage-confirmed against source:

1. The `crew` tmux session was never created, so every `tmux new-window -t crew` failed for a missing session.
2. `launchSessionInTmux`'s `Effect.try` caught only a **synchronous** spawn throw. A failed `new-window` is an **async non-zero exit** that was never inspected, so every plan yielded a `LaunchedSession` regardless and `runStandUp` returned a launch count it never confirmed.

## Fix (lane: the launch/spawn path only)

- **Ensure-session guard** — `ensureCrewTmuxSession`: idempotent `tmux has-session -t crew` probe, `tmux new-session -d -s crew` only when absent. Runs once, right before the no-partial-crew launch loop. A create that can't come up fails closed with the new `TmuxSessionEnsureError`.
- **Launch-liveness verification** — `launchSessionInTmux` now awaits the tmux client's **async exit** through a `runTmux` `Effect.callback` runner (mirroring `ensure-tracker.ts`'s `probeSocketServing` node-event idiom). Any non-zero exit or spawn `error` event fails closed with `StandUpLaunchError` naming the role + window. Because `tmux` is client-server, the CLI is a short-lived client that hands the request to the server and exits (bounded to await); the placed `claude` process lives under the tmux server and outlives the launcher regardless — so the old detach/unref is no longer needed.
- **Make invalid states unrepresentable** — a `LaunchedSession` now only ever exists for a confirmed-live (`code === 0`, no `spawnError`) launch.
- **Fresh-env regression coverage** — the tmux runner is injected so the exit-code / has-session branches are unit-tested without a real tmux. New tests prove: the crew session is ensured *before* any window is placed on a fresh env; a non-zero `new-window` exit surfaces as `StandUpLaunchError` (the async-exit path specifically); a spawn-level error (tmux missing) fails closed; `ensureCrewTmuxSession` creates when absent, no-ops when present, and fails loud when the create doesn't come up.

## Files

- `packages/pipeline-crew-mcp/src/standup/orchestrate.ts` — `ensureCrewTmuxSession`, `runTmux` async-exit runner + `TmuxRun`/`TmuxRunner`, rewritten `launchSessionInTmux`, `TmuxSessionEnsureError`, wired into `runStandUp` before the launch loop.
- `packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts` — fresh-env + async-exit regression suite.
- `packages/pipeline-crew-mcp/src/standup/index.ts` — additive barrel re-exports.

Did **not** touch `standup/config.ts` or `standup/version-assert.ts` (owned by the concurrent #3417 lane).

## Verification

- `pnpm --filter @kampus/pipeline-crew-mcp typecheck` — clean
- `pnpm exec biome check` (changed files) — clean
- `pnpm --filter @kampus/pipeline-crew-mcp test` — 171 passed (28 files)

Non-§CP (ADR 0187 — `pipeline-crew-mcp/` is outside the control-plane path set); auto-ships on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)