### PR TITLE
fix(pipeline-crew-mcp): resolvable node+bin.ts in --mcp-config + resolvability guard (#3425)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -7,18 +7,20 @@
  * two fail-closed rejections: a crew server absent from the flag (defined-but-inert), and an
  * allowlist-mode plugin channel whose plugin the config's `allowedChannelPlugins` doesn't list.
  */
+import {existsSync} from "node:fs";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {
 	ALLOWLIST_CHANNEL_FLAG,
 	buildSessionBind,
 	ChannelPluginNotAllowedError,
+	CREW_SESSION_BIN_PATH,
 	CREW_SESSION_COMMAND,
 	CREW_SESSION_INSTANCE_FLAG,
 	CrewServerNotRegisteredError,
+	CrewSessionBinUnresolvableError,
 	DEV_CHANNEL_FLAG,
 	MCP_CONFIG_FLAG,
-	PIPELINE_CREW_MCP_BIN,
 } from "./bind.ts";
 import type {ChannelConfig} from "./config.ts";
 
@@ -27,12 +29,13 @@ const PROJECT_ROOT = "/work/phoenix";
 const SERVER_NAME = "pipeline-crew";
 
 // The exact inline JSON the --mcp-config value must carry: one server, keyed by the session's own
-// channel-server name, whose command bakes the per-invocation `session --role --project-root`.
+// channel-server name, whose command is the launcher's own node (`process.execPath`) running the
+// ABSOLUTE bin.ts path — a resolvable invocation, never the bare unlinked package bin name (#3425).
 const EXPECTED_MCP_JSON = JSON.stringify({
 	mcpServers: {
 		[SERVER_NAME]: {
-			command: PIPELINE_CREW_MCP_BIN,
-			args: ["session", "--role", ROLE, "--project-root", PROJECT_ROOT],
+			command: process.execPath,
+			args: [CREW_SESSION_BIN_PATH, "session", "--role", ROLE, "--project-root", PROJECT_ROOT],
 		},
 	},
 });
@@ -148,8 +151,9 @@ describe("standup/bind — per-session bind constructor", () => {
 				const expected = JSON.stringify({
 					mcpServers: {
 						[SERVER_NAME]: {
-							command: PIPELINE_CREW_MCP_BIN,
+							command: process.execPath,
 							args: [
+								CREW_SESSION_BIN_PATH,
 								CREW_SESSION_COMMAND,
 								"--role",
 								ROLE,
@@ -181,6 +185,57 @@ describe("standup/bind — per-session bind constructor", () => {
 					channels,
 				});
 				assert.notInclude(bind.mcpConfigArg[1], CREW_SESSION_INSTANCE_FLAG);
+			}),
+	);
+
+	it.effect(
+		"the bound server command is a RESOLVABLE invocation: node + an existing absolute bin.ts (#3425)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const bind = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+
+				const server = JSON.parse(bind.mcpConfigArg[1]).mcpServers[SERVER_NAME];
+				// Not the old bare, unlinked package bin name — an absolute node + an absolute bin path.
+				assert.strictEqual(server.command, process.execPath);
+				assert.notStrictEqual(server.command, "pipeline-crew-mcp");
+				assert.strictEqual(server.args[0], CREW_SESSION_BIN_PATH);
+				assert.isTrue(CREW_SESSION_BIN_PATH.startsWith("/"), "bin path must be absolute");
+				assert.match(CREW_SESSION_BIN_PATH, /bin\.ts$/);
+				// The resolvable invocation actually resolves: the baked bin.ts exists on disk.
+				assert.isTrue(existsSync(CREW_SESSION_BIN_PATH), "baked bin.ts must resolve on disk");
+			}),
+	);
+
+	it.effect(
+		"fails closed when the crew server bin.ts does not resolve on disk (the missing sibling guard, #3425)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const error = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+					// The injected resolvability probe reports the bin absent — the launch must refuse.
+					binExists: () => false,
+				}).pipe(Effect.flip);
+
+				assert.instanceOf(error, CrewSessionBinUnresolvableError);
+				assert.strictEqual(error.binPath, CREW_SESSION_BIN_PATH);
 			}),
 	);
 

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -6,9 +6,13 @@
  *
  * It produces two coupled outputs the launcher inlines per invocation:
  *   1. `--mcp-config <json>` — the session's own channel MCP server as INLINE JSON baking
- *      `pipeline-crew-mcp session --role <role> --project-root <root>`. It must be per-invocation
+ *      `<node> <abs bin.ts> session --role <role> --project-root <root>`. It must be per-invocation
  *      inline (not a static shared `.mcp.json`) because `--role`/`--project-root` vary across the
- *      concurrent sessions a stand-up launches at once.
+ *      concurrent sessions a stand-up launches at once. The command is the launcher's own node
+ *      (`process.execPath`) + the ABSOLUTE `bin.ts` path — a bare, unlinked package bin name never
+ *      resolves on the launched session's PATH, so it would come up silently inert (#3425); this
+ *      mirrors ensure-tracker.ts's detached-child spawn (`process.execPath` + a `fileURLToPath`
+ *      module path), the package's canonical bin.ts runner.
  *   2. the channel-registration flag NAMING that same server — `--channels <refs>` for the
  *      allowlist mode, `--dangerously-load-development-channels <refs>` for dev. A server present
  *      in `.mcp.json`/`--mcp-config` alone is INERT: the Claude Code CLI only activates a channel
@@ -16,16 +20,25 @@
  *      `--channels <servers...>`, `--dangerously-load-development-channels <servers...>`,
  *      `--mcp-config <configs...>` load-from-JSON-string, and the `allowedChannelPlugins` gate).
  *
- * The one non-obvious thing: this FAILS CLOSED, like the config reader it consumes. A crew server
- * defined in `--mcp-config` but absent from the channel flag would come up inert (a silent
- * half-launch), and an allowlist-mode `plugin:` channel whose plugin the operator never allowlisted
- * is exactly what the CLI rejects — both are a launch to refuse with a named error, never paper over.
+ * The one non-obvious thing: this FAILS CLOSED, like the config reader it consumes. Three ways a
+ * bind would come up inert are each a launch to refuse with a named error, never paper over: the
+ * crew server's `bin.ts` not resolving on disk (`CrewSessionBinUnresolvableError`, #3425), the crew
+ * server defined in `--mcp-config` but absent from the channel flag (`CrewServerNotRegisteredError`),
+ * and an allowlist-mode `plugin:` channel whose plugin the operator never allowlisted
+ * (`ChannelPluginNotAllowedError`, the exact rejection the CLI raises).
  */
+import {existsSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 import {Effect, Schema} from "effect";
 import type {ChannelConfig} from "./config.ts";
 
-/** The bin the session's channel MCP server runs (the package `bin`; AC1 bakes this verbatim). */
-export const PIPELINE_CREW_MCP_BIN = "pipeline-crew-mcp";
+/**
+ * The absolute path to this package's `bin.ts` entry, resolved from THIS module's own location so it
+ * is correct wherever the package is installed (a distributable plugin), never a machine-hardcoded
+ * path. The launched crew MCP server runs `<node> <this> session …`; a bare unlinked bin name would
+ * not resolve on the launched session's PATH (#3425). Same idiom as ensure-tracker.ts's `SELF_PATH`.
+ */
+export const CREW_SESSION_BIN_PATH = fileURLToPath(new URL("../bin.ts", import.meta.url));
 /** The subcommand that runs one live crew session (`bin.ts`). */
 export const CREW_SESSION_COMMAND = "session";
 /**
@@ -58,8 +71,9 @@ const sessionMcpConfigJson = (
 	JSON.stringify({
 		mcpServers: {
 			[serverName]: {
-				command: PIPELINE_CREW_MCP_BIN,
+				command: process.execPath,
 				args: [
+					CREW_SESSION_BIN_PATH,
 					CREW_SESSION_COMMAND,
 					"--role",
 					role,
@@ -100,7 +114,26 @@ export interface SessionBindInput {
 	readonly instance?: string | undefined;
 	/** The resolved channels dimension of the crew `LaunchConfig` (#3293), consumed read-only. */
 	readonly channels: ChannelConfig;
+	/**
+	 * Whether the crew server's `bin.ts` resolves on disk — injected so the fail-closed
+	 * resolvability guard is unit-testable without moving the real file. Default: the real
+	 * `existsSync`, checked against `CREW_SESSION_BIN_PATH` (#3425).
+	 */
+	readonly binExists?: (binPath: string) => boolean;
 }
+
+/**
+ * The crew session's own MCP server names a `bin.ts` that does not resolve on disk, so `<node>
+ * <bin.ts>` would fail to spawn and the channel would come up silently inert — the missing sibling
+ * to `CrewServerNotRegisteredError` that let #3425 be SILENT (registration was guarded, resolvability
+ * was not). Refuse the launch: a bound bind now implies the bin actually resolves.
+ */
+export class CrewSessionBinUnresolvableError extends Schema.TaggedErrorClass<CrewSessionBinUnresolvableError>()(
+	"@kampus/pipeline-crew-mcp/standup/CrewSessionBinUnresolvableError",
+	{
+		binPath: Schema.String,
+	},
+) {}
 
 /**
  * The crew session's own server is defined in `--mcp-config` but not named in the channel flag, so
@@ -139,10 +172,22 @@ const pluginOf = (ref: string): string | undefined =>
  */
 export const buildSessionBind = (
 	input: SessionBindInput,
-): Effect.Effect<SessionBind, CrewServerNotRegisteredError | ChannelPluginNotAllowedError> =>
+): Effect.Effect<
+	SessionBind,
+	CrewSessionBinUnresolvableError | CrewServerNotRegisteredError | ChannelPluginNotAllowedError
+> =>
 	Effect.gen(function* () {
 		const {role, projectRoot, serverName, instance, channels} = input;
+		const binExists = input.binExists ?? existsSync;
 		const servers = channels.servers;
+
+		// Resolvability before anything else: the bin the `--mcp-config` command runs must exist on
+		// disk, else the launched `<node> <bin.ts>` fails to spawn and the channel is inert (#3425).
+		if (!binExists(CREW_SESSION_BIN_PATH)) {
+			return yield* Effect.fail(
+				new CrewSessionBinUnresolvableError({binPath: CREW_SESSION_BIN_PATH}),
+			);
+		}
 
 		if (!servers.includes(crewServerRef(serverName))) {
 			return yield* Effect.fail(new CrewServerNotRegisteredError({serverName, servers}));

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -8,11 +8,12 @@ export {
 	ALLOWLIST_CHANNEL_FLAG,
 	buildSessionBind,
 	ChannelPluginNotAllowedError,
+	CREW_SESSION_BIN_PATH,
 	CREW_SESSION_COMMAND,
 	CrewServerNotRegisteredError,
+	CrewSessionBinUnresolvableError,
 	DEV_CHANNEL_FLAG,
 	MCP_CONFIG_FLAG,
-	PIPELINE_CREW_MCP_BIN,
 	type SessionBind,
 	type SessionBindInput,
 } from "./bind.ts";

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -26,6 +26,7 @@ import {
 	buildSessionBind,
 	type ChannelPluginNotAllowedError,
 	type CrewServerNotRegisteredError,
+	type CrewSessionBinUnresolvableError,
 	type SessionBind,
 } from "./bind.ts";
 import {type LaunchConfig, type LaunchConfigError, readLaunchConfig} from "./config.ts";
@@ -139,6 +140,7 @@ export type StandUpError =
 	| LaunchConfigError
 	| CliVersionAssertError
 	| TrackerNotServingError
+	| CrewSessionBinUnresolvableError
 	| CrewServerNotRegisteredError
 	| ChannelPluginNotAllowedError
 	| TmuxWindowCollisionError


### PR DESCRIPTION
Fixes #3425

## Problem

The stand-up baked the bare, unlinked package bin name `pipeline-crew-mcp` verbatim as the inline `--mcp-config` server `command`. `@kampus/pipeline-crew-mcp` is `private: true` with **zero workspace dependents**, so pnpm links `node_modules/.bin/pipeline-crew-mcp` nowhere — the bare name never resolves on the launched claude session's PATH, the crew MCP server never starts, and the channel comes up **silently inert** (the deepest boot-cluster blocker of milestone #28, and why the successor crew fell back to tmux).

The module claimed to fail closed against a "silent half-launch" but guarded **only the registration case** (`CrewServerNotRegisteredError`), never bin **resolvability** — that missing sibling guard is why the failure was silent.

## Fix (two parts)

**1. A resolvable invocation.** `sessionMcpConfigJson` now emits:
- `command: process.execPath` — the launcher's own node (an absolute path, guaranteed present + TS-capable at the volta-pinned node 26.2.0), never a bare name.
- `args: [CREW_SESSION_BIN_PATH, "session", …]` where `CREW_SESSION_BIN_PATH = fileURLToPath(new URL("../bin.ts", import.meta.url))` — the absolute `bin.ts` path resolved from **this module's own location**, so it is correct wherever the package is installed (a distributable plugin) and is **never a machine-hardcoded path** committed to source (it is computed dynamically at launch).

Grounded in the package's own canonical bin runner: `standup/ensure-tracker.ts` already spawns this package's entry as `spawn(process.execPath, [SELF_PATH, …])` with `SELF_PATH = fileURLToPath(import.meta.url)`. This change mirrors that exact idiom for the inline `--mcp-config` command. (It also matches `package.json`'s `"cli": "node src/bin.ts"` — node runs `bin.ts` directly under unflagged TS type-stripping.)

**2. The missing fail-closed guard.** New `CrewSessionBinUnresolvableError` (sibling to `CrewServerNotRegisteredError`). `buildSessionBind` now checks the bin resolves on disk **before** the registration/allowlist checks and fails closed if not — so a *bound* bind now implies the bin actually resolves (invalid state made unrepresentable). The existence probe is injectable (`binExists`, default `existsSync`) so the guard is unit-testable without moving the real file.

## Tests

Added to `bind.test.ts`:
- **the bound server command is a resolvable invocation** — asserts `command === process.execPath` (not `"pipeline-crew-mcp"`), `args[0]` is the absolute `bin.ts` path, and that path actually `existsSync` on disk.
- **the resolvability guard fails closed** — injecting `binExists: () => false` yields `CrewSessionBinUnresolvableError` carrying the bin path.

Existing argv/JSON assertions updated to the new node+bin.ts command shape.

## Scope

Localized to `standup/bind.ts` (+ its tests) and the necessary error-union propagation:
- `standup/index.ts` barrel: drop the removed `PIPELINE_CREW_MCP_BIN`, export `CREW_SESSION_BIN_PATH` + `CrewSessionBinUnresolvableError`.
- `standup/orchestrate.ts`: one import + one `StandUpError` union member for the new error (no logic rewrite — the tiled-panes / tmux region is untouched for the sibling #3424 lane). The `--model` argv area (sibling #3423) does not exist yet and is untouched.

Verified locally: `pnpm typecheck` clean, `pnpm --filter @kampus/pipeline-crew-mcp test` 177/177 pass, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)