### PR TITLE
fix(pipeline-crew-mcp): apply per-role tier as the launched session's --model (#3423)

### DIFF
--- a/claude-plugins/pipeline-crew/crew.config.template.jsonc
+++ b/claude-plugins/pipeline-crew/crew.config.template.jsonc
@@ -30,8 +30,10 @@
 	// One role map — a roster change is ONE edit here. Keyed off the role KINDs declared in
 	// packages/pipeline-crew-mcp/src/crew/roles.ts (ADR 0189): the three bridges are singleton
 	// (cardinality falls out of the kind — no count), the one engine scales by `count`. Each
-	// entry: `tier` (the model tier the role's session runs on), `count?` (engine pool size,
-	// engine-only), `wipCap?` (a conductor engine's concurrent-lane cap, engine-only).
+	// entry: `tier` (the model tier the role's session boots on — one of "opus" | "sonnet" |
+	// "haiku" | "fable", passed as the launched session's `claude --model <tier>`; omit it to
+	// boot on the CLI default; #3423), `count?` (engine pool size, engine-only), `wipCap?` (a
+	// conductor engine's concurrent-lane cap, engine-only).
 	"roles": {
 		// Bridges — singleton, tier only.
 		"chief-of-staff": { "tier": "<chief-of-staff-model-tier>" },

--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -21,6 +21,7 @@ import {
 	CrewSessionBinUnresolvableError,
 	DEV_CHANNEL_FLAG,
 	MCP_CONFIG_FLAG,
+	MODEL_FLAG,
 } from "./bind.ts";
 import type {ChannelConfig} from "./config.ts";
 
@@ -236,6 +237,73 @@ describe("standup/bind — per-session bind constructor", () => {
 
 				assert.instanceOf(error, CrewSessionBinUnresolvableError);
 				assert.strictEqual(error.binPath, CREW_SESSION_BIN_PATH);
+			}),
+	);
+
+	it.effect("emits --model <tier> at the front of the argv when the role has a tier (#3423)", () =>
+		Effect.gen(function* () {
+			const channels: ChannelConfig = {
+				mode: "development",
+				servers: ["server:pipeline-crew"],
+				allowedChannelPlugins: [],
+			};
+			const bind = yield* buildSessionBind({
+				role: ROLE,
+				projectRoot: PROJECT_ROOT,
+				serverName: SERVER_NAME,
+				tier: "opus",
+				channels,
+			});
+			// The tier boots the session's model — a family tier is a verbatim --model alias (config.ts
+			// Tier, grounded on the 2.1.212 bundle), so tier:opus yields `--model opus`.
+			assert.deepStrictEqual([...bind.modelArg], [MODEL_FLAG, "opus"]);
+			// --model leads the argv; the #3425 mcp-config + channel fragment follows it unchanged.
+			assert.deepStrictEqual(
+				[...bind.argv],
+				[MODEL_FLAG, "opus", ...bind.mcpConfigArg, ...bind.channelArg],
+			);
+		}),
+	);
+
+	it.effect(
+		"cartographer's tier:fable yields --model fable (the planning-tier bridge, #3423)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const bind = yield* buildSessionBind({
+					role: "cartographer",
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					tier: "fable",
+					channels,
+				});
+				assert.deepStrictEqual([...bind.modelArg], [MODEL_FLAG, "fable"]);
+			}),
+	);
+
+	it.effect(
+		"emits NO --model when the role has no tier — preserves the CLI-default boot (#3423)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const bind = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+				assert.deepStrictEqual([...bind.modelArg], []);
+				assert.notInclude(bind.argv, MODEL_FLAG);
+				// argv is exactly the pre-#3423 fragment when no tier is set.
+				assert.deepStrictEqual([...bind.argv], [...bind.mcpConfigArg, ...bind.channelArg]);
 			}),
 	);
 

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -30,7 +30,7 @@
 import {existsSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {Effect, Schema} from "effect";
-import type {ChannelConfig} from "./config.ts";
+import {type ChannelConfig, type Tier, tierModel} from "./config.ts";
 
 /**
  * The absolute path to this package's `bin.ts` entry, resolved from THIS module's own location so it
@@ -48,6 +48,8 @@ export const CREW_SESSION_COMMAND = "session";
  */
 export const CREW_SESSION_INSTANCE_FLAG = "--instance";
 export const MCP_CONFIG_FLAG = "--mcp-config";
+/** Sets the launched session's model to the role's configured tier (#3423); omitted when no tier. */
+export const MODEL_FLAG = "--model";
 /** Allowlist mode: only servers named here load, gated by `allowedChannelPlugins` for plugin refs. */
 export const ALLOWLIST_CHANNEL_FLAG = "--channels";
 /** Dev mode: load channel servers not on the approved allowlist — local development only. */
@@ -93,7 +95,9 @@ export interface SessionBind {
 	readonly mcpConfigArg: readonly [flag: string, json: string];
 	/** The channel-registration flag + its server refs, e.g. `["--channels", "server:pipeline-crew", …]`. */
 	readonly channelArg: readonly string[];
-	/** The complete fragment `[...mcpConfigArg, ...channelArg]` the launcher inlines for this session. */
+	/** `["--model", "<alias>"]` when the role has a configured tier (#3423), else `[]` (CLI default). */
+	readonly modelArg: readonly string[];
+	/** The complete fragment `[...modelArg, ...mcpConfigArg, ...channelArg]` the launcher inlines for this session. */
 	readonly argv: readonly string[];
 }
 
@@ -112,6 +116,12 @@ export interface SessionBindInput {
 	 * re-minting its own runtime instance (#3354, seam 3). A bridge is a singleton and omits it.
 	 */
 	readonly instance?: string | undefined;
+	/**
+	 * The role's configured model tier (#3423) — emitted as `--model <alias>` so the launched session
+	 * boots on that tier's model, not the CLI default. Omitted (undefined) ⇒ no `--model`: a role that
+	 * set no tier keeps today's default-model boot rather than being forced onto a guessed one.
+	 */
+	readonly tier?: Tier | undefined;
 	/** The resolved channels dimension of the crew `LaunchConfig` (#3293), consumed read-only. */
 	readonly channels: ChannelConfig;
 	/**
@@ -177,7 +187,7 @@ export const buildSessionBind = (
 	CrewSessionBinUnresolvableError | CrewServerNotRegisteredError | ChannelPluginNotAllowedError
 > =>
 	Effect.gen(function* () {
-		const {role, projectRoot, serverName, instance, channels} = input;
+		const {role, projectRoot, serverName, instance, tier, channels} = input;
 		const binExists = input.binExists ?? existsSync;
 		const servers = channels.servers;
 
@@ -216,12 +226,16 @@ export const buildSessionBind = (
 			sessionMcpConfigJson(role, projectRoot, serverName, instance),
 		];
 		const channelArg: readonly string[] = [channelFlag, ...servers];
+		// The role's tier boots the session on its `--model` (#3423); a role with no tier emits none,
+		// keeping the CLI-default boot rather than guessing. `tierModel` is total over the `Tier` enum.
+		const modelArg: readonly string[] = tier !== undefined ? [MODEL_FLAG, tierModel(tier)] : [];
 
 		return {
 			role,
 			projectRoot,
 			mcpConfigArg,
 			channelArg,
-			argv: [...mcpConfigArg, ...channelArg],
+			modelArg,
+			argv: [...modelArg, ...mcpConfigArg, ...channelArg],
 		};
 	});

--- a/packages/pipeline-crew-mcp/src/standup/config.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.test.ts
@@ -109,6 +109,29 @@ describe("standup/config — decodeLaunchConfig (happy path, one-role-map shape)
 				assert.deepStrictEqual([...cfg.channels.allowedChannelPlugins], ["pipeline-crew"]);
 			}),
 	);
+	it.effect(
+		"folds each role's tier into roleTiers instead of dropping it as an excess key (#3423)",
+		() =>
+			Effect.gen(function* () {
+				const cfg = yield* decodeLaunchConfig(fullCrewConfig, DEFAULT_CONFIG_PATH);
+				// The founder ruling — "cartographer = fable, the rest is opus" — is now a real launch
+				// dimension: every configured tier is surfaced by role, no longer a silent no-op.
+				assert.deepStrictEqual(cfg.roleTiers, {
+					"chief-of-staff": "opus",
+					cartographer: "fable",
+					"intake-desk": "fable",
+					"engineering-manager": "opus",
+				});
+			}),
+	);
+	it.effect("a role that omits its tier is simply absent from roleTiers (no guessed default)", () =>
+		Effect.gen(function* () {
+			// validLaunch's only role entry (engineering-manager) carries no tier, so roleTiers is empty
+			// — the bind then emits no --model for it, preserving the CLI-default boot.
+			const cfg = yield* decodeLaunchConfig(validLaunch, DEFAULT_CONFIG_PATH);
+			assert.deepStrictEqual(cfg.roleTiers, {});
+		}),
+	);
 	it.effect("an omitted cliVersion decodes cleanly to an unpinned launch (issue #3417)", () =>
 		Effect.gen(function* () {
 			// The pin is optional: absent ⇒ NOT a LaunchConfigError, and the field is simply not
@@ -245,6 +268,33 @@ describe("standup/config — engine count reads off roles['engineering-manager']
 		Effect.gen(function* () {
 			const err = yield* decodeErr(withCount(2.5));
 			assert.include(err.reason, "count");
+		}),
+	);
+});
+
+describe("standup/config — role tier fails closed (#3423)", () => {
+	it.effect(
+		"an unknown tier is a LaunchConfigError naming the tier path, not a silent default",
+		() =>
+			Effect.gen(function* () {
+				const err = yield* decodeErr({
+					...validLaunch,
+					roles: {"engineering-manager": {count: 2, tier: "turbo"}},
+				});
+				assert.instanceOf(err, LaunchConfigError);
+				assert.include(err.reason, "tier");
+			}),
+	);
+	it.effect("a bridge role's unknown tier also fails closed naming tier", () =>
+		Effect.gen(function* () {
+			const err = yield* decodeErr({
+				...validLaunch,
+				roles: {
+					"chief-of-staff": {tier: "gpt"},
+					"engineering-manager": {count: 1},
+				},
+			});
+			assert.include(err.reason, "tier");
 		}),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/standup/config.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.ts
@@ -16,13 +16,15 @@
  * to an "unpinned" launch (the key is simply absent), so the crew boot stops fail-closing on
  * every frequent Claude Code auto-update; pin ONLY to deliberately lock a version. A pin that
  * IS present must still be a valid `CLI_VERSION_RE` version — a malformed present pin fails closed.
- * `LaunchConfig` extracts only the launch dimensions from the one-role-map seam shape (ADR 0189):
- * the engine count is folded into `roles["engineering-manager"].count`, and excess seam keys
- * (operator/notification/tier/wipCap/…) are ignored. There is no config-read tmux dimension —
+ * `LaunchConfig` extracts the launch dimensions from the one-role-map seam shape (ADR 0189): the
+ * engine count is folded into `roles["engineering-manager"].count`, and each role's optional `tier`
+ * — the session model, #3423 — is folded into `roleTiers`. Remaining seam keys
+ * (operator/notification/wipCap/…) are ignored. There is no config-read tmux dimension —
  * tmux window placement now derives from role identity at launch (tmux-placement.ts), not config.
  */
 import {readFileSync} from "node:fs";
 import {Effect, Schema} from "effect";
+import {CREW_ROLES} from "../crew/index.ts";
 
 /**
  * A channel-server ref, in the exact registration grammar Claude Code 2.1.212 accepts —
@@ -89,6 +91,37 @@ export const EngineCount = Schema.Int.check(
 export type EngineCount = typeof EngineCount.Type;
 
 /**
+ * A role's model tier — the operator's per-role cost/capability control (#3423), decoded so the
+ * launcher can boot each session's `claude` on the tier's model (`--model <alias>`), not the CLI
+ * default. The vocabulary is the set of "latest model family" aliases the installed Claude Code
+ * CLI's `--model` flag accepts, grounded against the bundle NOT intuited (CLAUDE.md's "ground
+ * falsifiable runtime claims in source"): the 2.1.212 `--model` help reads *"Provide an alias for
+ * the latest model (e.g. 'fable', 'opus', or 'sonnet') or a model's full name (e.g.
+ * 'claude-fable-5')"*, and its `resolveModelAlias` accepts `fable | haiku | opus | sonnet` (VERSION
+ * 2.1.212, GIT_SHA 8b2783a). The `[1m]` / `opusplan` / `default` alias variants are deliberately
+ * excluded — a crew tier names a model FAMILY, not a context-window or plan-mode combo. A malformed
+ * tier decodes to a `LaunchConfigError` naming the `tier` path (fail-closed, no silent default).
+ */
+export const Tier = Schema.Literals(["opus", "sonnet", "haiku", "fable"]);
+export type Tier = typeof Tier.Type;
+
+/**
+ * tier → the `claude --model` alias the launched session boots on. Each family tier is a verbatim
+ * `--model` alias in the installed bundle (grounded on `Tier` above), so the map is identity today —
+ * but it stays an explicit single-source seam so a future tier whose name diverges from its `--model`
+ * alias is one edit here, never a scatter of string literals across the launcher (#3423).
+ */
+export const TIER_MODEL = {
+	opus: "opus",
+	sonnet: "sonnet",
+	haiku: "haiku",
+	fable: "fable",
+} as const satisfies Record<Tier, string>;
+
+/** The `--model <alias>` a tier boots the session on. Total over `Tier` by `TIER_MODEL`'s satisfies. */
+export const tierModel = (tier: Tier): string => TIER_MODEL[tier];
+
+/**
  * The channel-registration dimension: the mode, the servers each session registers, and the
  * plugin allowlist.
  *
@@ -130,21 +163,34 @@ export const LaunchConfig = Schema.Struct({
 	cliVersion: Schema.optionalKey(CliVersion),
 	engineCount: EngineCount,
 	channels: ChannelConfig,
+	/**
+	 * The per-role model tiers (#3423), folded out of the role map into a flat lookup the bind
+	 * constructor consumes by role. A role that omits `tier` is simply absent here — the launcher then
+	 * emits no `--model` for it, preserving the CLI-default boot rather than guessing a tier.
+	 */
+	roleTiers: Schema.Record(Schema.String, Tier),
 });
 export type LaunchConfig = typeof LaunchConfig.Type;
 
+/** A role entry's optional `tier` — the launch dimension #3423 promotes from ignored excess key. */
+const RoleTierEntry = Schema.Struct({tier: Schema.optionalKey(Tier)});
+
 /**
- * The one-role-map seam shape on disk (ADR 0189): a `roles` map keyed by the crew role slugs, from
- * which the launch reader takes exactly ONE value — the engine pool size at
- * `roles["engineering-manager"].count`. The rest of each role entry (`tier`, `wipCap`) and the
- * whole bridge entries are def-spawn / prose bindings, not launch inputs, so they decode as ignored
- * excess keys — only `engineering-manager.count` is a required launch dimension here, fail-closed.
- * `cliVersion` mirrors `LaunchConfig`'s exact-optional shape (issue #3417): omit ⇒ unpinned.
+ * The one-role-map seam shape on disk (ADR 0189): a `roles` map keyed by the crew role slugs. The
+ * launch reader takes the engine pool size at `roles["engineering-manager"].count` AND — as of
+ * #3423 — each role's optional `tier` (its session's `--model`), no longer an ignored excess key.
+ * The bridge entries are `optionalKey` (a role may omit its tier → no `--model`, the CLI default);
+ * `engineering-manager` is required for its `count`, its `tier` optional. Remaining entry keys
+ * (`wipCap`, the operator/notification blocks) stay ignored excess. `cliVersion` mirrors
+ * `LaunchConfig`'s exact-optional shape (issue #3417): omit ⇒ unpinned.
  */
 const RawLaunchConfig = Schema.Struct({
 	cliVersion: Schema.optionalKey(CliVersion),
 	roles: Schema.Struct({
-		"engineering-manager": Schema.Struct({count: EngineCount}),
+		"chief-of-staff": Schema.optionalKey(RoleTierEntry),
+		cartographer: Schema.optionalKey(RoleTierEntry),
+		"intake-desk": Schema.optionalKey(RoleTierEntry),
+		"engineering-manager": Schema.Struct({count: EngineCount, tier: Schema.optionalKey(Tier)}),
 	}),
 	channels: ChannelConfig,
 });
@@ -245,13 +291,21 @@ export const decodeLaunchConfig = (
 	configPath: string,
 ): Effect.Effect<LaunchConfig, LaunchConfigError> =>
 	Schema.decodeUnknownEffect(RawLaunchConfig)(input).pipe(
-		Effect.map(
-			(raw): LaunchConfig => ({
+		Effect.map((raw): LaunchConfig => {
+			// Fold each role's decoded `tier` into the flat lookup, skipping a role that omitted one so
+			// its absence stays absence — the bind then emits no `--model`, preserving the CLI default.
+			const roleTiers: Record<string, Tier> = {};
+			for (const role of CREW_ROLES) {
+				const tier = raw.roles[role]?.tier;
+				if (tier !== undefined) roleTiers[role] = tier;
+			}
+			return {
 				...(raw.cliVersion !== undefined ? {cliVersion: raw.cliVersion} : {}),
 				engineCount: raw.roles["engineering-manager"].count,
 				channels: raw.channels,
-			}),
-		),
+				roleTiers,
+			};
+		}),
 		Effect.mapError((error) => new LaunchConfigError({configPath, reason: error.message})),
 	);
 

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -308,6 +308,27 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 		}),
 	);
 
+	it.effect("threads each role's config tier into its launch --model (#3423, end to end)", () =>
+		Effect.gen(function* () {
+			// rawConfigAt sets the founder ruling — cartographer=fable, the rest=opus — so the boot
+			// proves each session comes up on its configured tier's model, not the CLI default.
+			const {input, launched} = baseInput({engineCount: 2});
+			yield* runStandUp(input);
+
+			const modelOf = (role: string): readonly string[] | undefined =>
+				launched.find((p) => p.session.role === role)?.bind.modelArg;
+			assert.deepStrictEqual([...(modelOf("chief-of-staff") ?? [])], ["--model", "opus"]);
+			assert.deepStrictEqual([...(modelOf("cartographer") ?? [])], ["--model", "fable"]);
+			assert.deepStrictEqual([...(modelOf("intake-desk") ?? [])], ["--model", "fable"]);
+			// every engine boots on the engineering-manager tier (opus).
+			for (const p of launched.filter((x) => x.session.kind === "engine")) {
+				assert.deepStrictEqual([...p.bind.modelArg], ["--model", "opus"]);
+				// --model leads the argv, ahead of the #3425 mcp-config fragment.
+				assert.strictEqual(p.bind.argv[0], "--model");
+			}
+		}),
+	);
+
 	it.effect(
 		"resolves the target session BEFORE placing any window, and opens every window into it (#3418 AC1)",
 		() =>

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -322,6 +322,9 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 				// Thread the session-set-derived per-instance identity so the launched engine binds it
 				// rather than re-minting its own (#3354 seam 3); a bridge is a singleton and has none.
 				instance: session.kind === "engine" ? session.instance : undefined,
+				// The role's configured model tier → the session's `--model` (#3423); undefined for a
+				// role that set none, so bind emits no `--model` and it boots on the CLI default.
+				tier: config.roleTiers[session.role],
 				channels: config.channels,
 			}),
 		);


### PR DESCRIPTION
Fixes #3423

## Problem

The operator config's per-role `tier` was a **silent no-op**. Two halves both dropped it:

1. `standup/config.ts` — `RawLaunchConfig` decoded only `roles["engineering-manager"].count` / `channels` / optional `cliVersion`; `roles.<role>.tier` was a documented *ignored excess key*.
2. `standup/bind.ts` — `buildSessionBind`'s argv emitted `--mcp-config` + the channel flag (+ `--instance`), **never `--model`**.

Net: every crew session booted the CLI **default** model. The founder's ruling *"cartographer = fable, the rest is opus"* was violated — `chief-of-staff` and the execution EM engines came up on Fable.

## The fix — wire per-role tier → the spawned `claude`'s `--model`, end to end

- **`config.ts`** — promote `roles.<role>.tier` to a real launch dimension, folded into `LaunchConfig.roleTiers`. A `Tier` enum `"opus" | "sonnet" | "haiku" | "fable"`. A role that **omits** tier stays absent (→ no `--model` → CLI default preserved, not a guess). A malformed/unknown tier **fails closed** as a `LaunchConfigError` naming the `tier` path (consistent with the rest of the reader).
- **`bind.ts`** — `buildSessionBind` emits `--model <tier>` at the **front** of the argv when the role has a tier. The #3425 server-command / resolvability-guard region is untouched — this only *adds* to the argv array.
- **`orchestrate.ts`** — thread `config.roleTiers[session.role]` into each `buildSessionBind` call (one localized field; `launchSessionInTmux` untouched for #3424).
- **`crew.config.template.jsonc`** — document the accepted tier vocabulary for operators.

## Tier → `--model` mapping (grounded, not guessed)

Grounded against the **installed Claude Code 2.1.212 bundle** (`~/.local/share/claude/versions/2.1.212`, per CLAUDE.md's "ground falsifiable runtime claims in source"):

- The `--model` flag help: *"Provide an alias for the latest model (e.g. 'fable', 'opus', or 'sonnet') or a model's full name (e.g. 'claude-fable-5')"*.
- Its `resolveModelAlias` accepts `fable | haiku | opus | sonnet` (plus the `[1m]` / `opusplan` / `default` variants, deliberately excluded — a crew tier names a model **family**, not a context-window / plan-mode combo).

So each family tier is a **verbatim** `--model` alias — the map is a clean 1:1 pass-through (`opus`→`opus`, `fable`→`fable`). **No tier lacks a clean `--model` value**, so nothing needed to be surfaced as a founder mapping question.

## Tests (177 pass)

- `config.test.ts` — tiers decode into `roleTiers` (no longer dropped); a role that omits tier is absent; an unknown tier (bridge or engine) fails closed naming `tier`.
- `bind.test.ts` — `tier:opus` → `--model opus` at argv front; `tier:fable` → `--model fable`; no tier → **no** `--model` (argv identical to pre-#3423).
- `orchestrate.test.ts` — end-to-end: each role's config tier reaches its launch `--model` (cartographer=fable, chief-of-staff/intake-desk/engines=opus).

typecheck + biome + `@kampus/pipeline-crew-mcp` tests all green.

**NON-§CP** (`packages/pipeline-crew-mcp/` + `claude-plugins/pipeline-crew/` are outside `CONTROL_PLANE_RE`, ADR 0187) → auto-ships on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)