### PR TITLE
feat(pipeline-crew-mcp): stand up the crew as panes of one tiled window (#3424)

### DIFF
--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -35,7 +35,7 @@ import {Cause, Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 
 import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
-import {runStandUp} from "./standup/index.ts";
+import {CREW_WINDOW, runStandUp} from "./standup/index.ts";
 import {isTrackerAddressInUse, launchTracker} from "./tracker/index.ts";
 import {VERSION} from "./version.ts";
 
@@ -99,13 +99,13 @@ const standUp = Command.make(
 		return yield* runStandUp({projectRoot}).pipe(
 			Effect.flatMap((result) =>
 				Console.error(
-					`crew up: tracker pid ${result.tracker.pid ?? "?"} on ${result.tracker.socketPath}; ${result.launched.length} sessions launched (${result.launched
-						.map((s) => `${s.role}→${s.window}`)
+					`crew up: tracker pid ${result.tracker.pid ?? "?"} on ${result.tracker.socketPath}; ${result.launched.length} panes launched in the ${CREW_WINDOW} window (${result.launched
+						.map((s) => `${s.role}→${s.pane}`)
 						.join(", ")})`,
 				),
 			),
 			// Fail-loud, no partial crew: a bad config, a version drift, an unstartable tracker, an inert
-			// channel, or an unnamed/colliding window aborts naming its cause — String(error) carries the tag.
+			// channel, or a colliding pane label aborts naming its cause — String(error) carries the tag.
 			Effect.catch((error: unknown) =>
 				Console.error(`stand-up aborted (no partial crew): ${String(error)}`).pipe(
 					Effect.andThen(Effect.sync(() => process.exit(1))),

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -44,6 +44,7 @@ export {
 	tryBecomeTracker,
 } from "./ensure-tracker.ts";
 export {
+	CREW_WINDOW,
 	ensureNamedTmuxSession,
 	FALLBACK_TMUX_SESSION,
 	type LaunchedSession,
@@ -70,7 +71,7 @@ export {
 	computeTmuxPlacement,
 	type PlacementTarget,
 	type RosterSession,
-	TmuxWindowCollisionError,
+	TmuxPaneCollisionError,
 } from "./tmux-placement.ts";
 export {
 	assertPinnedCliVersion,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -1,7 +1,7 @@
 /**
  * standup/orchestrate — the one stand-up command (issue #3299), booting against the post-#3236
  * one-role-map config (ADR 0189): the engine count folds into `roles["engineering-manager"].count`
- * and there is NO config tmux dimension — window placement derives from role identity at launch.
+ * and there is NO config tmux dimension — pane placement derives from role identity at launch.
  * These tests pin the two properties the composition owns: the MANDATED ORDER (version assert →
  * ensure tracker → derive roster → per-session bind + tmux placement → launch) and FAIL-LOUD WITH NO
  * PARTIAL CREW (every precondition failure aborts, naming its cause, with zero sessions launched).
@@ -21,6 +21,7 @@ import {
 import {type TrackerHandle, TrackerNotServingError} from "./ensure-tracker.ts";
 import {
 	CliVersionAssertError,
+	CREW_WINDOW,
 	CrewServerNotRegisteredError,
 	ensureNamedTmuxSession,
 	FALLBACK_TMUX_SESSION,
@@ -75,28 +76,38 @@ const counter = () => {
 
 const RESOLVED_SESSION = "operator-session";
 
+/** The window id the recording launcher's first pane "opens" — threaded into every later pane's `intoWindow`. */
+const RECORDED_CREW_WINDOW = "@crew";
+
 /**
  * A recording launcher + target-session resolver sharing one `order` log, so a test can prove the target
- * session is resolved BEFORE any window is placed and that each window is opened into THAT session (founder
- * ruling #3418: the caller's current session, not a hardcoded one). Neither touches tmux: the launcher captures
- * its plans + the session it was told to open into; the resolver captures its calls and returns `RESOLVED_SESSION`.
+ * session is resolved BEFORE any pane is placed and that every pane opens into THAT session (founder ruling
+ * #3418: the caller's current session, not a hardcoded one). It also records each launch's `intoWindow`, so a
+ * test can prove the FIRST session opens the crew window (`intoWindow` undefined) and every later one splits into
+ * the window id the first returned (founder ruling #3424). Neither touches tmux: the launcher captures its plans,
+ * the session it was told to open into, and its `intoWindow`; the resolver captures its calls and returns `RESOLVED_SESSION`.
  */
 const recordingLauncher = () => {
 	const plans: LaunchPlan[] = [];
 	const order: string[] = [];
 	const targetSessions: string[] = [];
+	const intoWindows: (string | undefined)[] = [];
 	const resolveCalls = {n: 0};
 	const launch = (
 		plan: LaunchPlan,
 		targetSession: string,
+		intoWindow: string | undefined,
 	): Effect.Effect<LaunchedSession, never> => {
 		plans.push(plan);
 		targetSessions.push(targetSession);
-		order.push(`launch:${plan.placement.window}`);
+		intoWindows.push(intoWindow);
+		order.push(`launch:${plan.placement.paneLabel}`);
 		return Effect.succeed({
 			role: plan.session.role,
 			address: plan.session.address,
-			window: plan.placement.window,
+			// the first pane opens the crew window and returns its id; every later pane rides the threaded id.
+			window: intoWindow ?? RECORDED_CREW_WINDOW,
+			pane: plan.placement.paneLabel,
 			pid: 1000 + plans.length,
 		});
 	};
@@ -105,7 +116,7 @@ const recordingLauncher = () => {
 		order.push("resolve");
 		return Effect.succeed(RESOLVED_SESSION);
 	};
-	return {plans, order, targetSessions, resolveCalls, launch, resolveTargetSession};
+	return {plans, order, targetSessions, intoWindows, resolveCalls, launch, resolveTargetSession};
 };
 
 const trackerHandle: TrackerHandle = {pid: 4242, socketPath: "/tmp/crew.sock"};
@@ -130,10 +141,11 @@ const baseInput = (
 	launched: LaunchPlan[];
 	order: string[];
 	targetSessions: string[];
+	intoWindows: (string | undefined)[];
 	resolveCalls: {n: number};
 	trackerCalls: () => number;
 } => {
-	const {plans, order, targetSessions, resolveCalls, launch, resolveTargetSession} =
+	const {plans, order, targetSessions, intoWindows, resolveCalls, launch, resolveTargetSession} =
 		recordingLauncher();
 	const {ensureTracker, calls} = recordingTracker();
 	const {engineCount, ...rest} = overrides;
@@ -141,6 +153,7 @@ const baseInput = (
 		launched: plans,
 		order,
 		targetSessions,
+		intoWindows,
 		resolveCalls,
 		trackerCalls: calls,
 		input: {
@@ -183,7 +196,7 @@ const bridgeRoles = CREW_ROLES.filter((r) => kindOf(r) === "bridge");
 
 describe("standup/orchestrate — the one stand-up command (issue #3299)", () => {
 	it.effect(
-		"stands up tracker + one window per bridge + N engine sessions, in roster order (AC1,AC2)",
+		"stands up tracker + one pane per bridge + N engine panes, in roster order (AC1,AC2)",
 		() =>
 			Effect.gen(function* () {
 				const N = 3;
@@ -205,14 +218,36 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 					assert.strictEqual(p.bind.role, p.session.role);
 					assert.match(p.session.address, /^inbox:\/\//);
 				}
-				// bridges placed on windows derived from their role slug, engines on their generated ids.
+				// bridges labelled by their role slug, engines by their generated ids.
 				const cos = launchedBridges.find((p) => p.session.role === "chief-of-staff");
-				assert.strictEqual(cos?.placement.window, "chief-of-staff");
-				assert.deepStrictEqual(launchedEngines.map((p) => p.placement.window).sort(), [
+				assert.strictEqual(cos?.placement.paneLabel, "chief-of-staff");
+				assert.deepStrictEqual(launchedEngines.map((p) => p.placement.paneLabel).sort(), [
 					"e0",
 					"e1",
 					"e2",
 				]);
+			}),
+	);
+
+	it.effect(
+		"launches the crew as PANES of ONE window: first opens it, every later pane splits into that id (#3424 AC1,AC2)",
+		() =>
+			Effect.gen(function* () {
+				const {input, intoWindows, launched} = baseInput({engineCount: 2});
+				const result = yield* runStandUp(input);
+
+				// exactly one session opens the crew window (intoWindow undefined); every later one splits into it.
+				assert.strictEqual(intoWindows.length, launched.length);
+				assert.strictEqual(intoWindows[0], undefined, "the first session opens the crew window");
+				for (const w of intoWindows.slice(1)) {
+					assert.strictEqual(
+						w,
+						RECORDED_CREW_WINDOW,
+						"every later pane splits into the opened window id",
+					);
+				}
+				// every launched session reports the one shared crew window.
+				for (const s of result.launched) assert.strictEqual(s.window, RECORDED_CREW_WINDOW);
 			}),
 	);
 
@@ -330,13 +365,13 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 	);
 
 	it.effect(
-		"resolves the target session BEFORE placing any window, and opens every window into it (#3418 AC1)",
+		"resolves the target session BEFORE placing any pane, and opens every pane into it (#3418 AC1)",
 		() =>
 			Effect.gen(function* () {
 				const {input, order, targetSessions} = baseInput({engineCount: 2});
 				yield* runStandUp(input);
 
-				// the target session is resolved before any launch, and every window is opened into it.
+				// the target session is resolved before any launch, and every pane is opened into it.
 				const firstLaunch = order.findIndex((e) => e.startsWith("launch:"));
 				const lastResolve = order.lastIndexOf("resolve");
 				assert.isBelow(lastResolve, firstLaunch);
@@ -369,11 +404,11 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 			Effect.gen(function* () {
 				const {input} = baseInput({
 					engineCount: 1,
-					launch: (plan, _targetSession) =>
+					launch: (plan, _targetSession, _intoWindow) =>
 						Effect.fail(
 							new StandUpLaunchError({
 								role: plan.session.role,
-								window: plan.placement.window,
+								pane: plan.placement.paneLabel,
 								reason: "tmux new-window exited 1 (no live pane)",
 							}),
 						),
@@ -400,37 +435,100 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 
 	const TARGET = "operator-session";
 
-	it.effect("launchSessionInTmux opens the window into the resolved target session on exit-0", () =>
-		Effect.gen(function* () {
-			const plan = yield* captureOnePlan;
-			const {runner, argvLog} = scriptedTmux([exited(0)]);
-			const result = yield* launchSessionInTmux(plan, TARGET, runner);
+	it.effect(
+		"launchSessionInTmux (first pane) opens the crew window into the resolved session and captures its id (#3424)",
+		() =>
+			Effect.gen(function* () {
+				const plan = yield* captureOnePlan;
+				// the first pane runs `new-window -P -F '#{window_id}'`; its stdout is the crew window id.
+				const {runner, argvLog} = scriptedTmux([exited(0, {stdout: "@7\n"})]);
+				const result = yield* launchSessionInTmux(plan, TARGET, undefined, runner);
 
-			assert.strictEqual(result.window, plan.placement.window);
-			assert.strictEqual(result.pid, 4242);
-			// the window opens into the RESOLVED session (the caller's, #3418), not a hardcoded one.
-			assert.deepStrictEqual(argvLog[0]?.slice(0, 6), [
-				"new-window",
-				"-t",
-				TARGET,
-				"-n",
-				plan.placement.window,
-				"claude",
-			]);
-		}),
+				assert.strictEqual(
+					result.window,
+					"@7",
+					"the captured crew window id threads to later panes",
+				);
+				assert.strictEqual(result.pane, plan.placement.paneLabel);
+				assert.strictEqual(result.pid, 4242);
+				// the crew window opens into the RESOLVED session (the caller's, #3418), not a hardcoded one.
+				assert.deepStrictEqual(argvLog[0], [
+					"new-window",
+					"-t",
+					TARGET,
+					"-n",
+					CREW_WINDOW,
+					"-P",
+					"-F",
+					"#{window_id}",
+					"claude",
+					...plan.bind.argv,
+				]);
+			}),
 	);
 
 	it.effect(
-		"launchSessionInTmux fails closed on an async non-zero exit — the swallowed failure #3418",
+		"launchSessionInTmux (later pane) splits into the crew window and re-tiles on exit-0 (#3424 AC1,AC2)",
+		() =>
+			Effect.gen(function* () {
+				const plan = yield* captureOnePlan;
+				// split-window then select-layout tiled — two tmux clients, both must exit 0.
+				const {runner, argvLog} = scriptedTmux([exited(0), exited(0)]);
+				const result = yield* launchSessionInTmux(plan, TARGET, "@7", runner);
+
+				assert.strictEqual(result.window, "@7", "a later pane rides the threaded crew window id");
+				assert.strictEqual(result.pane, plan.placement.paneLabel);
+				assert.deepStrictEqual(argvLog[0], [
+					"split-window",
+					"-t",
+					"@7",
+					"claude",
+					...plan.bind.argv,
+				]);
+				assert.deepStrictEqual(argvLog[1], ["select-layout", "-t", "@7", "tiled"]);
+			}),
+	);
+
+	it.effect(
+		"launchSessionInTmux (first pane) fails closed on an async non-zero exit — the swallowed failure #3418",
 		() =>
 			Effect.gen(function* () {
 				const plan = yield* captureOnePlan;
 				const {runner} = scriptedTmux([exited(1)]);
-				const err = yield* Effect.flip(launchSessionInTmux(plan, TARGET, runner));
+				const err = yield* Effect.flip(launchSessionInTmux(plan, TARGET, undefined, runner));
 
 				assert.instanceOf(err, StandUpLaunchError);
-				assert.strictEqual(err.window, plan.placement.window);
+				assert.strictEqual(err.pane, plan.placement.paneLabel);
 				assert.strictEqual(err.role, plan.session.role);
+			}),
+	);
+
+	it.effect(
+		"launchSessionInTmux (later pane) fails closed when the split-window exits non-zero (#3424 AC3)",
+		() =>
+			Effect.gen(function* () {
+				const plan = yield* captureOnePlan;
+				const {runner} = scriptedTmux([exited(1)]);
+				const err = yield* Effect.flip(launchSessionInTmux(plan, TARGET, "@7", runner));
+
+				assert.instanceOf(err, StandUpLaunchError);
+				assert.strictEqual(err.pane, plan.placement.paneLabel);
+				assert.strictEqual(err.role, plan.session.role);
+				assert.include(err.reason, "split-window");
+			}),
+	);
+
+	it.effect(
+		"launchSessionInTmux (later pane) fails closed when select-layout exits non-zero (#3424 AC3)",
+		() =>
+			Effect.gen(function* () {
+				const plan = yield* captureOnePlan;
+				// split-window succeeds, but the re-tile does not — still fails loud, no silently-untiled crew.
+				const {runner} = scriptedTmux([exited(0), exited(1)]);
+				const err = yield* Effect.flip(launchSessionInTmux(plan, TARGET, "@7", runner));
+
+				assert.instanceOf(err, StandUpLaunchError);
+				assert.include(err.reason, "select-layout tiled");
 			}),
 	);
 
@@ -438,7 +536,7 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 		Effect.gen(function* () {
 			const plan = yield* captureOnePlan;
 			const {runner} = scriptedTmux([exited(null, {spawnError: "spawn tmux ENOENT"})]);
-			const err = yield* Effect.flip(launchSessionInTmux(plan, TARGET, runner));
+			const err = yield* Effect.flip(launchSessionInTmux(plan, TARGET, undefined, runner));
 
 			assert.instanceOf(err, StandUpLaunchError);
 			assert.include(err.reason, "ENOENT");

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -10,9 +10,10 @@
  * roster session set → build EVERY per-session bind + compute ALL tmux placements → launch. Every
  * bind and every placement is resolved (and validated) BEFORE the first session launches, so any
  * precondition failure — a drifted CLI pin, a missing config dimension, an inert channel, a colliding
- * tmux window — aborts with a named error while zero sessions are up, never a half-launched
+ * pane label — aborts with a named error while zero sessions are up, never a half-launched
  * crew. No session is hand-launched: the launch of each `claude` session, bound to its role lease, is
- * the injected `launch` step the orchestration drives for the whole derived set.
+ * the injected `launch` step the orchestration drives for the whole derived set (all panes of one
+ * tiled crew window, founder ruling #3424).
  *
  * The side-effecting steps are injected (defaulting to production) so the composition is pure over
  * its inputs and unit-testable end to end — the same injection idiom version-assert (its version
@@ -40,7 +41,7 @@ import {
 	computeTmuxPlacement,
 	type PlacementTarget,
 	type RosterSession,
-	type TmuxWindowCollisionError,
+	type TmuxPaneCollisionError,
 } from "./tmux-placement.ts";
 import {
 	assertPinnedCliVersion,
@@ -48,12 +49,12 @@ import {
 	readInstalledCliVersionOutput,
 } from "./version-assert.ts";
 
-/** A `claude` session that could not be launched into its tmux window — carries the window + role it named. */
+/** A `claude` session that could not be launched into its pane of the crew window — carries the role + pane it named. */
 export class StandUpLaunchError extends Schema.TaggedErrorClass<StandUpLaunchError>()(
 	"@kampus/pipeline-crew-mcp/standup/StandUpLaunchError",
 	{
 		role: Schema.String,
-		window: Schema.String,
+		pane: Schema.String,
 		reason: Schema.String,
 	},
 ) {}
@@ -126,12 +127,15 @@ export interface LaunchPlan {
 	readonly placement: PlacementTarget;
 }
 
-/** A launched crew session: the role + lease it came up holding, the tmux window it lives in, and its pid. */
+/** A launched crew session: the role + lease it came up holding, the crew window + pane it lives in, and its pid. */
 export interface LaunchedSession {
 	readonly role: string;
 	/** The role-lease key inbox address the session-set minted (`inbox://<role>[/<instance>]`). */
 	readonly address: string;
+	/** The single tiled crew window every session shares — a tmux window id/target that later panes split into. */
 	readonly window: string;
+	/** This session's pane label within the crew window (its role slug or engine instance id). */
+	readonly pane: string;
 	readonly pid: number | undefined;
 }
 
@@ -143,7 +147,7 @@ export type StandUpError =
 	| CrewSessionBinUnresolvableError
 	| CrewServerNotRegisteredError
 	| ChannelPluginNotAllowedError
-	| TmuxWindowCollisionError
+	| TmuxPaneCollisionError
 	| TmuxSessionEnsureError
 	| StandUpLaunchError;
 
@@ -165,10 +169,13 @@ export interface StandUpInput {
 	/** Resolve the tmux session windows open into — the caller's current session, else a created fallback.
 	 * Default: `resolveTargetTmuxSession` (reads `$TMUX` + `display-message`). */
 	readonly resolveTargetSession?: () => Effect.Effect<string, TmuxSessionEnsureError>;
-	/** Launch one planned session into a window under `targetSession`, bound to its role lease. Default: `launchSessionInTmux`. */
+	/** Launch one planned session as a pane of the crew window under `targetSession`, bound to its role lease. The
+	 * first session (`intoWindow` undefined) opens the crew window and returns its id; every later session splits
+	 * into that window id. Default: `launchSessionInTmux`. */
 	readonly launch?: (
 		plan: LaunchPlan,
 		targetSession: string,
+		intoWindow: string | undefined,
 	) => Effect.Effect<LaunchedSession, StandUpLaunchError>;
 }
 
@@ -180,8 +187,8 @@ export interface StandUpResult {
 
 /**
  * Project a derived `CrewSession` onto the `RosterSession` tmux-placement consumes: a bridge places
- * on a window named by its role slug, an engine on its generated per-instance id (an operator cannot
- * name N dynamic engines). Both window names derive from identity — there is no config tmux dimension.
+ * on a pane labelled by its role slug, an engine on its generated per-instance id (an operator cannot
+ * name N dynamic engines). Both pane labels derive from identity — there is no config tmux dimension.
  */
 const toRosterSession = (session: CrewSession): RosterSession =>
 	session.kind === "engine"
@@ -250,42 +257,75 @@ const resolveTargetSessionDefault = (): Effect.Effect<string, TmuxSessionEnsureE
 		fallbackSession: FALLBACK_TMUX_SESSION,
 	});
 
+/** The single tiled window every crew pane opens into (founder ruling #3424): one window, all roles visible at once. */
+export const CREW_WINDOW = "crew";
+
+/** Map a non-zero exit / spawn error from one tmux step to the fail-loud `StandUpLaunchError` naming the role + pane. */
+const launchFailure = (
+	session: CrewSession,
+	pane: string,
+	run: TmuxRun,
+	what: string,
+): StandUpLaunchError =>
+	new StandUpLaunchError({
+		role: session.role,
+		pane,
+		reason:
+			run.spawnError !== undefined
+				? `cannot ${what} for pane "${pane}": ${run.spawnError}`
+				: `tmux ${what} for pane "${pane}" exited ${run.code ?? run.signal} (no live pane)`,
+	});
+
 /**
- * The production launcher: open a tmux window under `targetSession` (the resolved caller session) and run
- * `claude` there with the session's launch bind, then CONFIRM the window came up before counting it. `runTmux`
- * awaits the client's async exit, so a spawn failure or any non-zero exit — the swallowed failure of #3418 —
- * fails closed with `StandUpLaunchError` naming the role + window; a `LaunchedSession` therefore only ever
- * exists for a confirmed-live launch. The tmux runner is injected so the exit-code paths are unit-tested.
+ * The production launcher: place one `claude` session as a PANE of the single crew window under `targetSession`
+ * (the resolved caller session, #3418), then CONFIRM the pane came up before counting it. The first session
+ * (`intoWindow` undefined) opens the crew window with `new-window` and returns its id; every later session
+ * `split-window`s into that window id and re-`select-layout tiled`s so all roles stay evenly tiled and visible
+ * at once (founder ruling #3424, refining #3418). `runTmux` awaits each client's async exit, so a spawn failure
+ * or any non-zero exit — the swallowed failure #3418 closed — fails closed with `StandUpLaunchError` naming the
+ * role + pane; a `LaunchedSession` therefore only ever exists for a confirmed-live pane. The tmux runner is
+ * injected so the new-window / split-window / select-layout exit-code paths are unit-tested.
  */
 export const launchSessionInTmux = (
 	plan: LaunchPlan,
 	targetSession: string,
+	intoWindow: string | undefined,
 	runTmuxCommand: TmuxRunner = runTmux,
 ): Effect.Effect<LaunchedSession, StandUpLaunchError> =>
 	Effect.gen(function* () {
 		const {placement, bind, session} = plan;
-		const run = yield* runTmuxCommand([
-			"new-window",
-			"-t",
-			targetSession,
-			"-n",
-			placement.window,
-			"claude",
-			...bind.argv,
-		]);
-		if (run.spawnError !== undefined || run.code !== 0) {
-			return yield* Effect.fail(
-				new StandUpLaunchError({
-					role: session.role,
-					window: placement.window,
-					reason:
-						run.spawnError !== undefined
-							? `cannot launch claude into tmux window "${placement.window}": ${run.spawnError}`
-							: `tmux new-window for "${placement.window}" in session "${targetSession}" exited ${run.code ?? run.signal} (no live pane)`,
-				}),
-			);
+		const pane = placement.paneLabel;
+		if (intoWindow === undefined) {
+			// First session: open the crew window and capture its id (`-P -F '#{window_id}'`) so every later
+			// pane splits into exactly this window, never a stale same-named one.
+			const opened = yield* runTmuxCommand([
+				"new-window",
+				"-t",
+				targetSession,
+				"-n",
+				CREW_WINDOW,
+				"-P",
+				"-F",
+				"#{window_id}",
+				"claude",
+				...bind.argv,
+			]);
+			if (opened.spawnError !== undefined || opened.code !== 0) {
+				return yield* Effect.fail(launchFailure(session, pane, opened, "new-window"));
+			}
+			const window = opened.stdout.trim() || CREW_WINDOW;
+			return {role: session.role, address: session.address, window, pane, pid: opened.pid};
 		}
-		return {role: session.role, address: session.address, window: placement.window, pid: run.pid};
+		// Later session: split into the crew window, then re-tile so every pane is even and visible at once.
+		const split = yield* runTmuxCommand(["split-window", "-t", intoWindow, "claude", ...bind.argv]);
+		if (split.spawnError !== undefined || split.code !== 0) {
+			return yield* Effect.fail(launchFailure(session, pane, split, "split-window"));
+		}
+		const tiled = yield* runTmuxCommand(["select-layout", "-t", intoWindow, "tiled"]);
+		if (tiled.spawnError !== undefined || tiled.code !== 0) {
+			return yield* Effect.fail(launchFailure(session, pane, tiled, "select-layout tiled"));
+		}
+		return {role: session.role, address: session.address, window: intoWindow, pane, pid: split.pid};
 	});
 
 /**
@@ -339,11 +379,20 @@ export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, St
 				: Effect.die(`stand-up plan zip out of range for session "${session.role}"`);
 		});
 
-		// Resolve the target tmux session before placing any window: the caller's CURRENT session inside
+		// Resolve the target tmux session before placing any pane: the caller's CURRENT session inside
 		// tmux (which always exists — dissolving the fresh-machine "no crew session" failure), else a
 		// created fallback (founder ruling #3418). Last precondition before the no-partial-crew launch loop.
 		const targetSession = yield* resolveTargetSession();
-		// Wrap so `forEach`'s index arg never lands on the launcher's optional tmux-runner param.
-		const launched = yield* Effect.forEach(plans, (plan) => launch(plan, targetSession));
+		// Launch the whole crew into ONE tiled window (founder ruling #3424): the first session opens the
+		// crew window, and its resolved window id threads into every later session so they split into that
+		// exact window. Sequential (not `forEach`) because each pane splits the window the first one opened;
+		// any failed launch short-circuits fail-loud with no partial crew.
+		const launched: LaunchedSession[] = [];
+		let crewWindow: string | undefined;
+		for (const plan of plans) {
+			const session = yield* launch(plan, targetSession, crewWindow);
+			launched.push(session);
+			crewWindow ??= session.window;
+		}
 		return {tracker, launched};
 	});

--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.test.ts
@@ -1,21 +1,21 @@
 /**
  * The tmux placement mapping (AC 4): a sample roster session set — three bridges + N engines — maps to one
- * placement target per session, with each window name DERIVED from role identity (a bridge's role slug, an
+ * placement target per session, with each pane label DERIVED from role identity (a bridge's role slug, an
  * engine's per-instance id) rather than a config `tmux` dimension (which died with the one-role-map seam, ADR
- * 0189 / #3236). The SESSION windows open into is NOT this layer's concern — it is resolved at launch time to
- * the caller's current tmux session (founder ruling #3418), so a target carries no session field. Also pins
- * the one surviving fail-closed rejection: two sessions colliding on one window name.
+ * 0189 / #3236). The single crew window the panes tile in is named at launch, and the SESSION it opens under
+ * is resolved at launch to the caller's current tmux session (founder ruling #3418/#3424) — so a target carries
+ * neither. Also pins the one surviving fail-closed rejection: two sessions colliding on one pane label.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {
 	computeTmuxPlacement,
 	type RosterSession,
-	TmuxWindowCollisionError,
+	TmuxPaneCollisionError,
 } from "./tmux-placement.ts";
 
 // A sample roster: the three bridges + an engine count of N (here N = 3, each engine already
-// carrying its per-instance identity from #3297). Bridges name their window by role slug.
+// carrying its per-instance identity from #3297). Bridges label their pane by role slug.
 const BRIDGES: readonly RosterSession[] = [
 	{kind: "bridge", role: "chief-of-staff"},
 	{kind: "bridge", role: "cartographer"},
@@ -25,63 +25,66 @@ const engines = (n: number): readonly RosterSession[] =>
 	Array.from({length: n}, (_, i) => ({kind: "engine", id: `engine-${i + 1}`}) as const);
 
 describe("standup/tmux-placement — session set → placement targets (derived naming)", () => {
-	it.effect("places one window per bridge + one per engine (no session baked into a target)", () =>
-		Effect.gen(function* () {
-			const targets = yield* computeTmuxPlacement([...BRIDGES, ...engines(3)]);
-			assert.lengthOf(targets, 6, "3 bridges + 3 engines = 6 placement targets");
-			for (const t of targets) {
-				assert.notProperty(
-					t,
-					"session",
-					"the target carries no session — it is resolved at launch",
-				);
-			}
-		}),
+	it.effect(
+		"places one pane per bridge + one per engine (no session/window baked into a target)",
+		() =>
+			Effect.gen(function* () {
+				const targets = yield* computeTmuxPlacement([...BRIDGES, ...engines(3)]);
+				assert.lengthOf(targets, 6, "3 bridges + 3 engines = 6 placement targets");
+				for (const t of targets) {
+					assert.notProperty(
+						t,
+						"session",
+						"the target carries no session — it is resolved at launch",
+					);
+					assert.notProperty(t, "window", "the target carries no window — it is named at launch");
+				}
+			}),
 	);
 
-	it.effect("derives each bridge window from its role slug", () =>
+	it.effect("derives each bridge pane label from its role slug", () =>
 		Effect.gen(function* () {
 			const targets = yield* computeTmuxPlacement(BRIDGES);
 			assert.deepStrictEqual(
-				targets.map((t) => ({window: t.window, sessionRef: t.sessionRef, kind: t.kind})),
+				targets.map((t) => ({paneLabel: t.paneLabel, sessionRef: t.sessionRef, kind: t.kind})),
 				[
-					{window: "chief-of-staff", sessionRef: "chief-of-staff", kind: "bridge"},
-					{window: "cartographer", sessionRef: "cartographer", kind: "bridge"},
-					{window: "intake-desk", sessionRef: "intake-desk", kind: "bridge"},
+					{paneLabel: "chief-of-staff", sessionRef: "chief-of-staff", kind: "bridge"},
+					{paneLabel: "cartographer", sessionRef: "cartographer", kind: "bridge"},
+					{paneLabel: "intake-desk", sessionRef: "intake-desk", kind: "bridge"},
 				],
 			);
 		}),
 	);
 
-	it.effect("names each engine window from its per-instance id (distinct across the count)", () =>
+	it.effect("labels each engine pane from its per-instance id (distinct across the count)", () =>
 		Effect.gen(function* () {
 			const targets = yield* computeTmuxPlacement(engines(4));
 			assert.deepStrictEqual(
-				targets.map((t) => ({window: t.window, sessionRef: t.sessionRef, kind: t.kind})),
+				targets.map((t) => ({paneLabel: t.paneLabel, sessionRef: t.sessionRef, kind: t.kind})),
 				[
-					{window: "engine-1", sessionRef: "engine-1", kind: "engine"},
-					{window: "engine-2", sessionRef: "engine-2", kind: "engine"},
-					{window: "engine-3", sessionRef: "engine-3", kind: "engine"},
-					{window: "engine-4", sessionRef: "engine-4", kind: "engine"},
+					{paneLabel: "engine-1", sessionRef: "engine-1", kind: "engine"},
+					{paneLabel: "engine-2", sessionRef: "engine-2", kind: "engine"},
+					{paneLabel: "engine-3", sessionRef: "engine-3", kind: "engine"},
+					{paneLabel: "engine-4", sessionRef: "engine-4", kind: "engine"},
 				],
 			);
 			assert.strictEqual(
-				new Set(targets.map((t) => t.window)).size,
+				new Set(targets.map((t) => t.paneLabel)).size,
 				4,
-				"engine windows are distinct",
+				"engine pane labels are distinct",
 			);
 		}),
 	);
 
-	it.effect("fails closed when two sessions collide on one window", () =>
+	it.effect("fails closed when two sessions collide on one pane label", () =>
 		Effect.gen(function* () {
 			const failure = yield* computeTmuxPlacement([
 				{kind: "bridge", role: "chief-of-staff"},
-				// an engine whose id equals the already-placed bridge window name
+				// an engine whose id equals the already-placed bridge pane label
 				{kind: "engine", id: "chief-of-staff"},
 			]).pipe(Effect.flip);
-			assert.instanceOf(failure, TmuxWindowCollisionError);
-			assert.strictEqual(failure.window, "chief-of-staff");
+			assert.instanceOf(failure, TmuxPaneCollisionError);
+			assert.strictEqual(failure.paneLabel, "chief-of-staff");
 			assert.deepStrictEqual([...failure.sessionRefs], ["chief-of-staff", "chief-of-staff"]);
 		}),
 	);

--- a/packages/pipeline-crew-mcp/src/standup/tmux-placement.ts
+++ b/packages/pipeline-crew-mcp/src/standup/tmux-placement.ts
@@ -3,75 +3,77 @@
  * stand-up launcher (epic #3237) coordinates the crew over the channels substrate now, but
  * something must still put each launched session on the operator's screen — that is this layer.
  * It maps the roster session set (C6, #3297: one entry per bridge + one per engine instance) to
- * tmux placement targets, deriving each window name from the session's own role identity.
+ * tmux placement targets, deriving each pane label from the session's own role identity.
  *
- * The one non-obvious thing: this layer derives window NAMES only — it does NOT own the tmux SESSION.
- * Placement naming is DERIVED, not config-read: the old config `tmux` dimension (session + per-bridge
- * window names) died with the one-role-map seam (ADR 0189 / #3236) — post-MCP a role's address is a
- * lease, not a configured pane. A bridge's window is its role slug; an engine's window is its per-instance
- * id (an operator could never name N dynamic engines). The SESSION the windows open into is resolved at
- * LAUNCH time to the caller's current tmux session, not named here (founder ruling #3418: stand-up opens
- * windows in the operator's own session, never a hardcoded one) — so there is no session field on a target.
- * The layer stays thin: it does NOT register channels or mint identity (C5/C6 own those), and introduces NO
- * tmux-as-transport path (no pane-title discovery, no buffer-paste, no send-keys). Pure derivation (the
- * `registry-core` idiom).
+ * The one non-obvious thing: the whole crew lands as PANES of ONE tiled window, not a window per
+ * role (founder ruling #3424, refining #3418). So this layer derives per-pane LABELS only — never a
+ * window name, never the tmux SESSION. Placement naming is DERIVED, not config-read: the old config
+ * `tmux` dimension died with the one-role-map seam (ADR 0189 / #3236). A bridge's label is its role
+ * slug; an engine's is its per-instance id (an operator could never name N dynamic engines). The
+ * single crew window the panes open into is named at LAUNCH time (orchestrate's `CREW_WINDOW`), and
+ * the SESSION that window opens under is resolved at launch to the caller's current tmux session
+ * (founder ruling #3418) — so neither is a field on a target. The layer stays thin: no channel
+ * registration, no identity minting (C5/C6 own those), and NO tmux-as-transport path. Pure
+ * derivation (the `registry-core` idiom).
  */
 import {Effect, Schema} from "effect";
 
 /**
  * One session in the roster set (C6, #3297) that must be placed on the operator's screen. A bridge is
- * a singleton role window named by its role slug; an engine is one of N instances whose per-instance
- * identity (#3297 generates it) names its window — both derived from identity, never config.
+ * a singleton role pane labelled by its role slug; an engine is one of N instances whose per-instance
+ * identity (#3297 generates it) labels its pane — both derived from identity, never config.
  */
 export type RosterSession =
 	| {readonly kind: "bridge"; readonly role: string}
 	| {readonly kind: "engine"; readonly id: string};
 
-/** Where one session is placed: a named window (the session it opens into is resolved at launch time). */
+/** Where one session is placed: its pane label inside the single crew window (the window + session are resolved at launch). */
 export interface PlacementTarget {
-	/** The resolved tmux window name — a bridge's role slug or an engine's instance id. */
-	readonly window: string;
+	/** The resolved pane label — a bridge's role slug or an engine's instance id — identifying its pane in the crew window. */
+	readonly paneLabel: string;
 	/** The roster session this places — a bridge role slug or an engine instance id. */
 	readonly sessionRef: string;
 	readonly kind: "bridge" | "engine";
 }
 
 /**
- * Two sessions resolved to the same window under the tmux session — a placement that would stack
- * them invisibly on one window. The distinctness invariant is enforced here at its result site.
+ * Two sessions resolved to the same pane label under the crew window — a placement that would render
+ * two roles indistinguishable in the tiled layout. The distinctness invariant is enforced here at its
+ * result site.
  */
-export class TmuxWindowCollisionError extends Schema.TaggedErrorClass<TmuxWindowCollisionError>()(
-	"@kampus/pipeline-crew-mcp/standup/TmuxWindowCollisionError",
+export class TmuxPaneCollisionError extends Schema.TaggedErrorClass<TmuxPaneCollisionError>()(
+	"@kampus/pipeline-crew-mcp/standup/TmuxPaneCollisionError",
 	{
-		window: Schema.String,
+		paneLabel: Schema.String,
 		sessionRefs: Schema.Array(Schema.String),
 	},
 ) {}
 
 const placeOne = (session: RosterSession): PlacementTarget =>
 	session.kind === "engine"
-		? {window: session.id, sessionRef: session.id, kind: "engine"}
-		: {window: session.role, sessionRef: session.role, kind: "bridge"};
+		? {paneLabel: session.id, sessionRef: session.id, kind: "engine"}
+		: {paneLabel: session.role, sessionRef: session.role, kind: "bridge"};
 
 /**
- * Map the roster session set to tmux placement targets: one window per bridge (named by its role slug)
- * + one per engine instance (named by its id). Fails closed only on two sessions colliding on one window
- * name — the launch-time distinctness guard (the session they open into is resolved at launch, not here).
+ * Map the roster session set to tmux placement targets: one pane per bridge (labelled by its role slug)
+ * + one per engine instance (labelled by its id), all destined for the single tiled crew window. Fails
+ * closed only on two sessions colliding on one pane label — the distinctness guard (the window they open
+ * into is named at launch, the session it opens under is resolved at launch, neither here).
  */
 export const computeTmuxPlacement = (
 	sessions: readonly RosterSession[],
-): Effect.Effect<readonly PlacementTarget[], TmuxWindowCollisionError> =>
+): Effect.Effect<readonly PlacementTarget[], TmuxPaneCollisionError> =>
 	Effect.sync(() => sessions.map(placeOne)).pipe(
 		Effect.flatMap((targets) => {
-			const byWindow = new Map<string, string[]>();
+			const byLabel = new Map<string, string[]>();
 			for (const t of targets) {
-				const refs = byWindow.get(t.window) ?? [];
+				const refs = byLabel.get(t.paneLabel) ?? [];
 				refs.push(t.sessionRef);
-				byWindow.set(t.window, refs);
+				byLabel.set(t.paneLabel, refs);
 			}
-			for (const [window, sessionRefs] of byWindow) {
+			for (const [paneLabel, sessionRefs] of byLabel) {
 				if (sessionRefs.length > 1) {
-					return Effect.fail(new TmuxWindowCollisionError({window, sessionRefs}));
+					return Effect.fail(new TmuxPaneCollisionError({paneLabel, sessionRefs}));
 				}
 			}
 			return Effect.succeed(targets);


### PR DESCRIPTION
Fixes #3424

Founder layout refinement on #3418's launcher: the successor crew's sessions opened as **separate tmux windows** (one per role). Place them as **tiled PANES of a single window** instead, so the whole crew is visible at once during the parity trial — the way the existing crew's multi-pane role window works.

## What changed

- **`launchSessionInTmux` now takes an `intoWindow` arg.** The **first** session opens the crew window (`new-window -P -F '#{window_id}'`, capturing its id) and every **later** session `split-window`s into that exact window id, then re-`select-layout tiled`s so all role panes stay even and visible at once. The launch loop in `runStandUp` threads the first session's returned window id into the rest (sequential, not `forEach`, since each pane splits the window the first one opened).
- **Fail-loud with no partial crew preserved.** A non-zero exit / spawn error on the `new-window`, `split-window`, **or** `select-layout tiled` step surfaces `StandUpLaunchError` naming the role + pane.
- **`tmux-placement` now derives per-pane LABELS** (not window names) for the single crew window; `TmuxWindowCollisionError` → `TmuxPaneCollisionError`, the distinctness guard now runs on pane labels. Launch-time target-session resolution (caller's current session, #3418) is unchanged.
- **`StandUpLaunchError.window` → `.pane`;** `LaunchedSession` carries the shared crew window id + its pane label. The tmux runner injection is kept, so the split-window / select-layout exit-code paths are unit-tested the way `new-window` was.

## Acceptance criteria

- [x] Crew stand-up launches all roles as panes of one tiled window in the caller's current tmux session, not one window per role.
- [x] First session opens the window; each subsequent session splits into it; `select-layout tiled` is applied so every role pane is visible at once.
- [x] Launch stays fail-loud: a failed `split-window` (or `select-layout`) still surfaces `StandUpLaunchError` naming the role + pane, with no partial/invisible crew.
- [x] Launch-time target session resolution (caller's current session, #3418) unchanged.
- [x] The tmux runner injection stays unit-testable — new-window / split-window / select-layout exit-code paths covered.

## Verification

`pnpm typecheck` clean, `pnpm test` 189 passed (28 files), biome clean.

## Gate class

Touches only `packages/pipeline-crew-mcp/**` — **not §CP** (re-resolved `CONTROL_PLANE_RE` from origin/main does not match the crew-mcp package; ADR 0187 carve-out). Auto-ships on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)