### PR TITLE
docs(ops): Diátaxis+Strunk dual-lens audit of ops/ runbooks (#3398)

### DIFF
--- a/ops/runbook-cf-down.md
+++ b/ops/runbook-cf-down.md
@@ -1,98 +1,96 @@
 # Runbook: Cloudflare down
 
-A Cloudflare-provider incident hits phoenix on **two surfaces at once**, and the response
-differs by surface. The whole running system rides Cloudflare — the `apps/web` worker, its
-production D1, and the `LiveDO` SSE fan-out are all Cloudflare primitives on one per-app
-stack (ADR [0057](../.decisions/0057-multi-app-multi-worker-repo.md)) — so a CF outage is a
-full app outage with **nothing to recover at our layer**. The agent pipeline is coupled to
-real Cloudflare too: the CI-only integration tier and the merge-queue/preview e2e run against
-a live deploy (ADR [0154](../.decisions/0154-integration-tier-is-ci-only.md)), so they red or
-hang for the duration. The load-bearing posture for that second surface is **hold, don't
-force-merge** — deploy is the agent boundary, release is a human act (ADR
-[0083](../.decisions/0083-agents-deploy-humans-release.md)) — so a CF-caused red is waited
-out, never bypassed.
+A Cloudflare incident hits phoenix on **two surfaces at once**, and the response differs by
+surface. The whole running system rides Cloudflare: the `apps/web` worker, its production D1,
+and the `LiveDO` SSE fan-out are Cloudflare primitives on one per-app stack (ADR
+[0057](../.decisions/0057-multi-app-multi-worker-repo.md)), so a CF outage is a full app
+outage with **nothing to recover at our layer**. The agent pipeline is coupled to real
+Cloudflare too: the CI-only integration tier and the merge-queue/preview e2e run against a
+live deploy (ADR [0154](../.decisions/0154-integration-tier-is-ci-only.md)), so they red or
+hang for the duration. On that second surface the posture is **hold, don't force-merge**:
+deploy is the agent boundary and release is a human act (ADR
+[0083](../.decisions/0083-agents-deploy-humans-release.md)), so you wait a CF-caused red out
+rather than bypass it.
 
 ## Symptoms
 
-Two symptom clusters; a CF incident usually shows **both** at once. Confirm against the
-external signal (see [Preconditions](#preconditions)) before assuming CF is the cause — the
-same signatures can come from a bad deploy, so the status page is what distinguishes a
-provider outage from our own regression.
+A CF incident usually shows **both** clusters below at once. Confirm against the external
+signal (see [Preconditions](#preconditions)) before assuming CF is the cause: a bad deploy
+produces the same signatures, and the status page is what tells a provider outage apart from
+our own regression.
 
 **Production app**
 
-- The site is unreachable or 5xx-ing broadly across routes (not one feature) — the worker,
-  its `assets` binding (the SPA), and the API are all down together because they are one
-  worker.
-- `GET /api/health` fails to respond at all, or every request path errors — distinct from a
-  Flagship-only degrade, which is the *typed 503* of ADR
+- The site is unreachable or 5xx-ing broadly across routes, not one feature. The worker, its
+  `assets` binding (the SPA), and the API are down together because they are one worker.
+- `GET /api/health` fails to respond at all, or every request path errors. This is distinct
+  from a Flagship-only degrade, which is the *typed 503* of ADR
   [0156](../.decisions/0156-health-probe-flagship-unreachable-is-typed-503.md) with the rest
   of the worker still serving. A whole-worker outage is CF; a lone `flagshipReachable:false`
   on an otherwise-200 probe is not this runbook.
-- Reads and writes both fail: D1 is unreachable, so nothing degrades to read-only — it's dark.
-- Live views are stale or 503 with `LIVE_UNAVAILABLE`; but unlike the isolated live-plane
-  degrade ([live plane degraded](./runbook-live-plane-degraded.md)), here the *rest* of the
-  app is down too. If only the live plane is affected, use that runbook, not this one.
+- Reads and writes both fail: D1 is unreachable, so nothing degrades to read-only.
+- Live views are stale or 503 with `LIVE_UNAVAILABLE`. Unlike the isolated
+  [live-plane degrade](./runbook-live-plane-degraded.md), here the *rest* of the app is down
+  too. If only the live plane is affected, use that runbook.
 
 **Agent pipeline**
 
 - The **integration** CI job (the CI-only tier, ADR
   [0154](../.decisions/0154-integration-tier-is-ci-only.md)) fails at its deploy step or its
-  black-box HTTP assertions — it deploys the real worker to real Cloudflare, so a CF outage
-  either blocks the deploy or makes every over-the-network assertion fail.
+  black-box HTTP assertions. It deploys the real worker to real Cloudflare, so a CF outage
+  either blocks the deploy or fails every over-the-network assertion.
 - The **merge queue** stalls: the required checks re-run the same real-CF-coupled jobs, so
-  enqueued PRs sit unmerged, and preview (`pr-<n>`) e2e red-or-hangs — a preview stage is a
+  enqueued PRs sit unmerged, and preview (`pr-<n>`) e2e reds or hangs. A preview stage is a
   full isolated worker + D1 + DOs on the same provider (ADR
   [0088](../.decisions/0088-preview-deploy-environment.md)).
-- The failure signature is a **timeout / connection error**, not a domain assertion — a green
-  test suite that only fails to reach Cloudflare. This is the tell that the red is
-  infrastructure, not the diff under review.
+- The failure signature is a **timeout or connection error**, not a domain assertion: a green
+  test suite that only fails to reach Cloudflare. This tells you the red is infrastructure,
+  not the diff under review.
 
 ## Preconditions
 
 - **Confirm it's Cloudflare, not us.** The authoritative external signal is the Cloudflare
-  status page, <https://www.cloudflarestatus.com> — check it (and CF's status posts) before
+  status page, <https://www.cloudflarestatus.com>. Check it (and CF's status posts) before
   running any procedure. A recent merge to `main` deploying a broken worker produces
-  overlapping symptoms; the status page is what tells a provider outage apart from our own
-  bad deploy. If the status page is green, this is likely **not** a CF incident — suspect a
-  recent deploy and treat it as an app regression instead.
-- **Know your access boundary.** Nothing in this runbook requires — or grants — the ability to
+  overlapping symptoms; the status page distinguishes a provider outage from our own bad
+  deploy. If the status page is green, this is likely **not** a CF incident: suspect a recent
+  deploy and treat it as an app regression.
+- **Know your access boundary.** Nothing in this runbook requires or grants the ability to
   *fix* Cloudflare; recovery is on Cloudflare's side. The only privileged action available is
-  a **human release/rollback** decision (a flag flip or a revert), which is infra-admin-only
-  by ADR [0083](../.decisions/0083-agents-deploy-humans-release.md). Agents do not hold deploy
+  a **human release/rollback** decision (a flag flip or a revert), infra-admin-only by ADR
+  [0083](../.decisions/0083-agents-deploy-humans-release.md). Agents do not hold deploy
   credentials (ADR [0154](../.decisions/0154-integration-tier-is-ci-only.md)), so an agent's
-  role during a CF incident is **observe, hold, and hand back**, never force through.
-- **Capture the blast radius first.** Before acting, note which surfaces are affected (app,
-  integration CI, merge queue, previews) and the incident's start time from the status page —
-  this is what the verification step compares against on recovery.
+  role during a CF incident is **observe, hold, and hand back**.
+- **Capture the blast radius first.** Note which surfaces are affected (app, integration CI,
+  merge queue, previews) and the incident's start time from the status page. The verification
+  step compares against this on recovery.
 
 ## Procedure
 
-There is no phoenix-side lever that restores Cloudflare; the procedure is to **classify,
-hold, and avoid making it worse** until CF recovers.
+No phoenix-side lever restores Cloudflare; the procedure is to **classify, hold, and avoid
+making it worse** until CF recovers.
 
 1. **Confirm the provider outage.** Open <https://www.cloudflarestatus.com>. If the incident
    is listed, proceed; if not, stop and treat the symptoms as a possible bad deploy (revisit
    [Preconditions](#preconditions)).
 
 2. **Production app — accept, don't thrash.** There is nothing to deploy around a provider
-   outage: the worker, D1, and `LiveDO` all ride CF, so redeploying lands nowhere and a
-   redeploy attempt can itself fail against the down provider. Do **not** attempt an
-   `alchemy deploy` to "refresh" the worker during the incident. Leave production as-is and
-   wait; the app returns when CF does, no action required.
+   outage: the worker, D1, and `LiveDO` all ride CF, so a redeploy lands nowhere and can
+   itself fail against the down provider. Do **not** run `alchemy deploy` to "refresh" the
+   worker during the incident. Leave production as-is and wait; the app returns when CF does.
 
 3. **Agent pipeline — HOLD the merge queue, do not force-merge.** A CF-caused red on the
-   integration job or a merge-queue stall is **expected** and is **not a signal about the PR's
-   diff**. The correct posture is to wait it out:
+   integration job or a merge-queue stall is **expected** and says nothing about the PR's
+   diff. Wait it out:
    - Do **not** force-merge, admin-merge, or bypass required checks to get past a CF-caused
      red. Deploy is the agent boundary; a merge that skips the real-CF gate ships past the
      safety line ADR [0083](../.decisions/0083-agents-deploy-humans-release.md) draws.
-   - Do **not** re-run the integration/e2e jobs in a tight loop hoping for green — they will
-     keep failing until CF is back, burning CI minutes and obscuring the real signal.
+   - Do **not** re-run the integration/e2e jobs in a tight loop hoping for green. They keep
+     failing until CF is back, burning CI minutes and obscuring the real signal.
    - Leave enqueued PRs enqueued; the queue drains itself once checks can pass again.
 
 4. **Hand back / annotate.** If you are an agent mid-task and your PR's red is CF-caused, stop
-   and hand back rather than escalating a fix — leave a short note on the PR that the red is a
+   and hand back rather than escalate a fix. Leave a short note on the PR that the red is a
    Cloudflare incident (link the status-page incident), not the diff, so the next actor
    doesn't rediscover it mid-incident. A human decides any release/rollback action per ADR
    [0083](../.decisions/0083-agents-deploy-humans-release.md).
@@ -104,37 +102,36 @@ hold, and avoid making it worse** until CF recovers.
 ## Verification
 
 Verify recovery in **surface order** — the app first (it unblocks users), the pipeline second
-(it unblocks merges) — and confirm against the same signals you captured in the preconditions.
+(it unblocks merges) — against the same signals you captured in the preconditions.
 
 1. **Cloudflare status is green.** The status page shows the incident resolved. This is the
    precondition for everything below; a partial provider recovery can still red the pipeline.
 
-2. **Production app is serving.** `GET /api/health` returns `200` with
-   `status:"ok"` (a typed body per ADR
+2. **Production app is serving.** `GET /api/health` returns `200` with `status:"ok"` (a typed
+   body per ADR
    [0156](../.decisions/0156-health-probe-flagship-unreachable-is-typed-503.md)); spot-check a
-   read route and a live view. Reads and a write both succeed — D1 is reachable again, not
-   just the worker.
+   read route and a live view. A read and a write both succeed, confirming D1 is reachable
+   again, not just the worker.
 
 3. **Agent pipeline is green.** Re-run (or let re-run) the integration job on a pending PR: it
    now deploys and its HTTP assertions pass. The merge queue resumes draining, and a `pr-<n>`
    preview e2e goes green. A CF-caused red clears on its own once the deploy step can reach
-   Cloudflare — no PR change is needed to make it pass, which is itself the confirmation the
-   red was infrastructure, not the diff.
+   Cloudflare, with no PR change needed to make it pass — itself the confirmation that the red
+   was infrastructure.
 
 ## Rollback / escalation
 
 - **Nothing to roll back at the provider layer.** The incident is Cloudflare's to resolve;
-  there is no phoenix-side rollback that recovers a down provider. "Rollback" here means only:
-  if, on recovery, the app is still broken, suspect a **bad deploy** that coincided with (or
-  was masked by) the outage, and treat it as an app regression — a human infra-admin reverts
-  the offending merge or holds the release (ADR
+  no phoenix-side rollback recovers a down provider. "Rollback" here means only this: if the
+  app is still broken on recovery, suspect a **bad deploy** that coincided with (or was masked
+  by) the outage, and treat it as an app regression. A human infra-admin reverts the offending
+  merge or holds the release (ADR
   [0083](../.decisions/0083-agents-deploy-humans-release.md)).
 - **Escalate a decision, not a bypass.** Escalation goes to a human with infra-admin
-  authority, and only to make a **release/rollback** call — never to force a merge past a
-  CF-caused red. Building a CF-independent CI fallback is explicitly out of scope (ADR
-  [0154](../.decisions/0154-integration-tier-is-ci-only.md) shuts that door): the integration
-  tier is CI-only against real Cloudflare by design, and the response to its unavailability is
-  to hold, not to fake it.
+  authority, and only to make a **release/rollback** call, never to force a merge past a
+  CF-caused red. Building a CF-independent CI fallback is out of scope: ADR
+  [0154](../.decisions/0154-integration-tier-is-ci-only.md) makes the integration tier CI-only
+  against real Cloudflare by design, and the response to its unavailability is to hold.
 - **When to widen.** If the outage is prolonged and a release is genuinely time-critical, the
   decision to wait vs. take a manual path is a human infra-admin's, made against the real
-  trade-offs — this runbook's standing default is **hold and wait**.
+  trade-offs. This runbook's standing default is **hold and wait**.

--- a/ops/runbook-d1-restore.md
+++ b/ops/runbook-d1-restore.md
@@ -1,68 +1,70 @@
 # Runbook: D1 export / restore
 
-Recover the single production D1 from a bad migration or accidental data loss by exporting a
-known-good snapshot and restoring it into a fresh stage. Grounded in phoenix's real stack — the
+Recover the single production D1 from a bad migration or accidental data loss: export a
+known-good snapshot and restore it into a fresh stage. Grounded in phoenix's real stack — the
 alchemy-managed D1 (one per app/stage, ADR
 [0057](../.decisions/0057-multi-app-multi-worker-repo.md)), the hand-authored flat migrations
 tree applied on deploy (ADR
 [0108](../.decisions/0108-hand-authored-flat-d1-migrations.md)), and the deploy-infra-to-cloud
-dev model (ADR [0032](../.decisions/0032-alchemy-beta45-and-dev-model.md)) — not generic SQLite
-advice.
+dev model (ADR [0032](../.decisions/0032-alchemy-beta45-and-dev-model.md)) — not generic
+SQLite advice.
 
-The one non-obvious hazard this runbook exists to handle: the **FTS5 export tax**. The site-search
+The one non-obvious hazard this runbook handles is the **FTS5 export tax**: the site-search
 FTS5 virtual tables block a naive whole-database D1 export, so the procedure exports the base
 tables only and rebuilds the search index on restore (ADR
 [0080](../.decisions/0080-site-search-lexical-bar-semantic-discovery.md)).
 
 ## Symptoms
 
-Reach for this runbook when the production D1 is corrupt or wrong and rolling *forward* won't fix
-it — you need a point-in-time restore, not another migration:
+Reach for this runbook when the production D1 is corrupt or wrong and rolling *forward* won't
+fix it — you need a point-in-time restore, not another migration:
 
 - A migration applied bad data or dropped/altered a column, and the loss is already live (a
   forward migration can't recover deleted rows).
-- Product reads return wrong or missing rows that trace to the store, not the read path — sözlük
-  terms / pano posts absent or truncated across clients, not just one stale live view (a stale
-  live view is the [live-plane-degraded](./runbook-live-plane-degraded.md) runbook, not this one).
+- Product reads return wrong or missing rows that trace to the store, not the read path:
+  sözlük terms / pano posts absent or truncated across clients, not just one stale live view
+  (one stale live view is the [live-plane-degraded](./runbook-live-plane-degraded.md)
+  runbook).
 - You need a verified backup of production D1 before a risky migration or bulk operation — the
   export half of this runbook, run proactively.
 
 ## Preconditions
 
-- **Cloudflare credentials with D1 access.** Export/restore uses the Cloudflare CLI against the
-  real remote D1; `alchemy dev`/`deploy` and the CLI both need account auth (ADR 0032 — dev and
-  prod resources are both real CF D1, there is no offline D1 emulator). The CLI is not a repo
-  dependency; invoke it with `pnpm dlx wrangler` (never `npx`).
+- **Cloudflare credentials with D1 access.** Export/restore uses the Cloudflare CLI against
+  the real remote D1; `alchemy dev`/`deploy` and the CLI both need account auth (ADR 0032 —
+  dev and prod resources are both real CF D1, there is no offline D1 emulator). The CLI is not
+  a repo dependency; invoke it with `pnpm dlx wrangler` (never `npx`).
 - **The physical D1 name for the stage you are acting on.** alchemy generates the production
   database name; read it from the deployed stack (the `phoenix_db` resource in
   [`apps/web/worker/db/resources.ts`](../apps/web/worker/db/resources.ts), applied by
   `alchemy deploy`). Never guess the name.
 - **A scratch stage to restore into — never restore over production first.** `alchemy deploy
-  --stage <scratch>` yields an isolated worker + D1 + DOs (ADR 0057), with all migrations applied
-  (so the schema, including the FTS5 virtual tables from migration
-  [`0002_search_fts.sql`](../apps/web/worker/db/drizzle/migrations/0002_search_fts.sql), already
-  exists). Restore into the scratch stage, verify, and only then decide on the production cutover.
+  --stage <scratch>` yields an isolated worker + D1 + DOs (ADR 0057), with all migrations
+  applied, so the schema — including the FTS5 virtual tables from migration
+  [`0002_search_fts.sql`](../apps/web/worker/db/drizzle/migrations/0002_search_fts.sql) —
+  already exists. Restore into the scratch stage, verify, then decide on the production
+  cutover.
 - **Capture the current state first.** Record the failing migration id and the current
-  `drizzle_migrations` applied set before you touch anything, so you know exactly which snapshot
-  you are restoring to.
+  `drizzle_migrations` applied set before you touch anything, so you know exactly which
+  snapshot you are restoring to.
 
 ## The FTS5 export tax — why a naive export fails
 
-Site search (ADR 0080) is two FTS5 **virtual** tables, `term_search` and `post_search`, declared
-by hand in migration
-[`0002_search_fts.sql`](../apps/web/worker/db/drizzle/migrations/0002_search_fts.sql) (drizzle's
-DSL cannot express a virtual table). Each FTS5 virtual table is backed by a set of **shadow
-tables** SQLite creates under the hood — `<name>_data`, `<name>_idx`, `<name>_content`,
-`<name>_docsize`, `<name>_config`. **D1 cannot export a database that contains virtual tables**
-(ADR 0080 §Sync/Trade-offs, and the export caveat recorded inline in the migration): a whole-DB
-export chokes on the virtual-table + shadow-table schema.
+Site search (ADR 0080) is two FTS5 **virtual** tables, `term_search` and `post_search`,
+declared by hand in migration
+[`0002_search_fts.sql`](../apps/web/worker/db/drizzle/migrations/0002_search_fts.sql)
+(drizzle's DSL cannot express a virtual table). SQLite backs each FTS5 virtual table with a
+set of **shadow tables** under the hood: `<name>_data`, `<name>_idx`, `<name>_content`,
+`<name>_docsize`, `<name>_config`. **D1 cannot export a database that contains virtual
+tables** (ADR 0080 §Sync/Trade-offs, and the export caveat recorded inline in the migration):
+a whole-DB export chokes on the virtual-table + shadow-table schema.
 
-The rows in the FTS tables are **derived, not primary**: they are an app-side dual-write of the
+The rows in the FTS tables are **derived, not primary**: an app-side dual-write of the
 Turkish-normalized title, kept in lockstep with `term_record` / `post_record` by
-[`features/search/fts-sync.ts`](../apps/web/worker/features/search/fts-sync.ts) (the `norm` column
-is computed by `normalize.ts`, not stored in the base row). So the FTS index is **reconstructable
-from the base tables** and never needs to be in the backup — which is exactly what makes the
-workaround safe: export the base tables, skip the virtual tables, rebuild the index on restore.
+[`features/search/fts-sync.ts`](../apps/web/worker/features/search/fts-sync.ts) (the `norm`
+column is computed by `normalize.ts`, not stored in the base row). So the FTS index rebuilds
+from the base tables and never needs to be in the backup — which is what makes the workaround
+safe: export the base tables, skip the virtual tables, rebuild the index on restore.
 
 ## Procedure
 
@@ -85,13 +87,14 @@ pnpm dlx wrangler d1 export <prod-d1-name> --remote --no-schema \
 Enumerate the real base-table set from the applied schema
 ([`apps/web/worker/db/drizzle/schema.ts`](../apps/web/worker/db/drizzle/schema.ts)); the two
 tables you must **omit** are `term_search` and `post_search` (and, implicitly, their shadow
-tables). If you prefer a full whole-DB export instead of an enumerated one, the alternative is to
-`DROP` the two virtual tables first and recreate them after — but that is a destructive change
-against the live database, so the non-destructive `--table` enumeration above is the default; the
-drop/recreate path is only for a one-time full migration-out.
+tables). To take a full whole-DB export instead, the alternative is to `DROP` the two virtual
+tables first and recreate them after — but that is a destructive change against the live
+database, so the non-destructive `--table` enumeration above is the default; use the
+drop/recreate path only for a one-time full migration-out.
 
-**2 — Restore the base data into the scratch stage.** Deploy the scratch stage (which applies all
-migrations, creating every base table plus the empty FTS5 virtual tables), then execute the dump:
+**2 — Restore the base data into the scratch stage.** Deploy the scratch stage (which applies
+all migrations, creating every base table plus the empty FTS5 virtual tables), then execute
+the dump:
 
 ```bash
 alchemy deploy --stage <scratch>
@@ -99,20 +102,21 @@ pnpm dlx wrangler d1 execute <scratch-d1-name> --remote --file ops-export.sql
 ```
 
 **3 — Rebuild the FTS5 index from the restored base tables.** The virtual tables exist (from
-migration 0002) but are empty, because the FTS rows were intentionally excluded from the export.
-Rebuild them by re-deriving each `norm` from the restored base rows the same way the write path
-does — through the app's Turkish fold in
+migration 0002) but are empty, because the export intentionally excluded the FTS rows. Rebuild
+them by re-deriving each `norm` from the restored base rows the same way the write path does —
+through the app's Turkish fold in
 [`features/search/normalize.ts`](../apps/web/worker/features/search/normalize.ts) and the
-dual-write shape in [`features/search/fts-sync.ts`](../apps/web/worker/features/search/fts-sync.ts)
-(`term_search(slug, norm)` from `term_record`, `post_search(id, norm)` from `post_record`). The
-`norm` value is app-computed (not a pure-SQL `lower()`), so the rebuild must run the app
+dual-write shape in
+[`features/search/fts-sync.ts`](../apps/web/worker/features/search/fts-sync.ts)
+(`term_search(slug, norm)` from `term_record`, `post_search(id, norm)` from `post_record`).
+The `norm` value is app-computed, not a pure-SQL `lower()`, so the rebuild must run the app
 normalizer, not a raw SQL projection.
 
-> **Known gap (follow-up).** There is no standing backfill route to rebuild the FTS index today —
-> the write path only syncs on individual mutations, and the security guard forbids resurrecting
-> an admin/seeder route (see CLAUDE.md §"Sözlük seed"). Until a sanctioned one-off backfill exists,
-> the rebuild is a manual maintenance execution deriving `norm` via `normalize.ts`. This gap is
-> tracked as a follow-up issue.
+> **Known gap (follow-up).** There is no standing backfill route to rebuild the FTS index
+> today — the write path only syncs on individual mutations, and the security guard forbids
+> resurrecting an admin/seeder route (see CLAUDE.md §"Sözlük seed"). Until a sanctioned one-off
+> backfill exists, the rebuild is a manual maintenance execution deriving `norm` via
+> `normalize.ts`. This gap is tracked as a follow-up issue.
 
 ## Verification
 
@@ -144,29 +148,29 @@ cutover.
 
 ## Rollback / escalation
 
-- **The scratch restore is the rollback surface.** Because you restore into an isolated scratch
-  stage (ADR 0057), a bad restore never touches production — tear the scratch stage down
-  (`alchemy` destroy for that stage) and re-run from a different export. Production is only ever
-  cut over *after* the scratch verification passes.
-- **If the export itself fails on virtual tables**, you skipped the `--table` enumeration or named
-  a virtual table — re-run step 1 with the base-table set only (this is the FTS5 export tax, not a
-  D1 outage).
-- **If the FTS rebuild can't be run** (no backfill path yet — see the known gap), the base data is
-  still fully restored and correct; search is degraded until the index is rebuilt. Escalate the
-  backfill as a product/infra task rather than blocking the data restore on it.
-- **If D1 itself is unavailable** (not a data problem — the store is down), this is a Cloudflare
-  incident: switch to the [Cloudflare-down runbook](./runbook-cf-down.md).
+- **The scratch restore is the rollback surface.** Because you restore into an isolated
+  scratch stage (ADR 0057), a bad restore never touches production: tear the scratch stage
+  down (`alchemy` destroy for that stage) and re-run from a different export. Cut over
+  production only *after* the scratch verification passes.
+- **If the export itself fails on virtual tables**, you skipped the `--table` enumeration or
+  named a virtual table — re-run step 1 with the base-table set only (this is the FTS5 export
+  tax, not a D1 outage).
+- **If the FTS rebuild can't be run** (no backfill path yet — see the known gap), the base
+  data is still fully restored and correct; search is degraded until the index is rebuilt.
+  Escalate the backfill as a product/infra task rather than block the data restore on it.
+- **If D1 itself is unavailable** (not a data problem — the store is down), this is a
+  Cloudflare incident: switch to the [Cloudflare-down runbook](./runbook-cf-down.md).
 
 ## Rehearsal
 
-The load-bearing, non-obvious mechanic — the **FTS5 export-tax workaround** (exclude the virtual
-tables → export base only → reimport → recreate the FTS5 tables from the migration DDL → rebuild
-the index → verify counts + working search) — was rehearsed once locally against SQLite 3.43.2
-(FTS5-enabled), using the **verbatim DDL** from migration `0002_search_fts.sql`. This proves the
-rebuild sequence and that search works after restore.
+The load-bearing, non-obvious mechanic — the **FTS5 export-tax workaround** (exclude the
+virtual tables → export base only → reimport → recreate the FTS5 tables from the migration DDL
+→ rebuild the index → verify counts + working search) — was rehearsed once locally against
+SQLite 3.43.2 (FTS5-enabled), using the **verbatim DDL** from migration `0002_search_fts.sql`.
+This proves the rebuild sequence and that search works after restore.
 
-Fixture: base tables `term_record` / `post_record` plus the two FTS5 virtual tables from the real
-migration DDL, seeded so search matches before restore.
+Fixture: base tables `term_record` / `post_record` plus the two FTS5 virtual tables from the
+real migration DDL, seeded so search matches before restore.
 
 ```
 # source: base counts + FTS search works, plus the shadow tables the export tax comes from
@@ -187,18 +191,18 @@ restored term MATCH mer*|1        # prefix index (prefix='2 3 4') works post-res
 restored PRAGMA integrity_check|ok
 ```
 
-Result: after excluding the FTS virtual tables from the export, reimporting the base tables, and
-recreating + rebuilding the FTS5 index from the migration DDL, both exact and prefix search return
-the expected rows and the database passes `integrity_check`.
+Result: after excluding the FTS virtual tables from the export, reimporting the base tables,
+and recreating + rebuilding the FTS5 index from the migration DDL, both exact and prefix
+search return the expected rows and the database passes `integrity_check`.
 
 **Scope of this rehearsal — read before trusting it.** It validates the FTS5 export-tax
-*mechanics* against a local FTS5 SQLite, which is where the real risk lives. It does **not**
-exercise the full production round-trip: `wrangler d1 export --remote` against the production D1
-and `alchemy deploy --stage <scratch>` require Cloudflare credentials (ADR 0032) and were not run
-here. A note on fidelity: the "naive whole-DB export is blocked by virtual tables" claim is a
-**D1-platform** behavior recorded by ADR 0080 and the migration's inline caveat — the local
+*mechanics* against a local FTS5 SQLite, where the real risk lives. It does **not** exercise
+the full production round-trip: `wrangler d1 export --remote` against the production D1 and
+`alchemy deploy --stage <scratch>` require Cloudflare credentials (ADR 0032) and were not run
+here. One note on fidelity: the "naive whole-DB export is blocked by virtual tables" claim is
+a **D1-platform** behavior recorded by ADR 0080 and the migration's inline caveat. The local
 `sqlite3` shell can round-trip virtual tables via its `writable_schema` path, so this specific
 tax was *not* reproduced locally and is cited from the D1 record, not re-derived. Before this
-runbook is relied on for a real production restore, the full remote round-trip should be rehearsed
-once against a scratch stage by an operator with Cloudflare access, and the observed remote
-evidence appended here.
+runbook is relied on for a real production restore, an operator with Cloudflare access should
+rehearse the full remote round-trip once against a scratch stage and append the observed
+remote evidence here.

--- a/ops/runbook-live-plane-degraded.md
+++ b/ops/runbook-live-plane-degraded.md
@@ -4,46 +4,45 @@ The live plane is phoenix's real-time push path: the unified `LiveDO` fans a mut
 invalidation out over SSE so every open view updates without a refresh (ADRs
 [0023](../.decisions/0023-live-views-sse-livedo.md) →
 [0025](../.decisions/0025-split-livedo-connection-topic.md) →
-[0037](../.decisions/0037-unified-void-aligned-live-do.md), on fate's native SSE +
-POST protocol, ADR [0034](../.decisions/0034-fate-native-sse-protocol.md)). One `LiveDO`
-class plays **two roles** — a `connection:` instance owns a client's held SSE stream, a
-`topic:` instance owns a subscriber set and fans a publish to it. Live is a **core UX
-tenet**, not a nice-to-have (ADR [0157](../.decisions/0157-realtime-is-a-core-ux-tenet.md)):
-"degraded" here means views that others can change stop updating live, which users read as
-staleness, not an outage.
+[0037](../.decisions/0037-unified-void-aligned-live-do.md), on fate's native SSE + POST
+protocol, ADR [0034](../.decisions/0034-fate-native-sse-protocol.md)). One `LiveDO` class
+plays **two roles**: a `connection:` instance owns a client's held SSE stream, a `topic:`
+instance owns a subscriber set and fans a publish to it. Live is a **core UX tenet** (ADR
+[0157](../.decisions/0157-realtime-is-a-core-ux-tenet.md)): "degraded" here means views that
+others can change stop updating live, which users read as staleness rather than an outage.
 
 This runbook covers **the live plane being degraded while the app is otherwise up** — stale
-views and `LIVE_UNAVAILABLE` 503s from `/fate/live`. If the *whole* app is unreachable
-(assets 5xx, `/fate` data reads failing, the worker itself down), that is a different
-failure — reach for [Cloudflare down](./runbook-cf-down.md) instead. How the live code is
-shaped is [`.patterns/fate-live-views.md`](../.patterns/fate-live-views.md) and
+views and `LIVE_UNAVAILABLE` 503s from `/fate/live`. If the *whole* app is unreachable (assets
+5xx, `/fate` data reads failing, the worker itself down), reach for
+[Cloudflare down](./runbook-cf-down.md) instead. How the live code is shaped is
+[`.patterns/fate-live-views.md`](../.patterns/fate-live-views.md) and
 [`.patterns/effect-sse-externally-driven.md`](../.patterns/effect-sse-externally-driven.md);
-this is how to operate it when it breaks. When this runbook and the source disagree, the
-source wins — fix the runbook.
+this runbook is how to operate it when it breaks. When this runbook and the source disagree,
+the source wins — fix the runbook.
 
 ## Symptoms
 
-Two distinct signals select this runbook. Which one you see narrows the cause before you
-touch anything:
+Two distinct signals select this runbook. Which one you see narrows the cause before you touch
+anything:
 
 - **Stale live views, *no* errors.** A row another client just created (a pano post, a
-  comment, a sözlük definition) does not appear until the reader manually refreshes; the
-  page is otherwise healthy — data reads (`/fate`) return, navigation works, nothing 500s.
-  The live *push* is missing, not the data. This is the more common and more insidious
-  symptom because nothing errors — see [triage](#triage) for the candidate causes.
+  comment, a sözlük definition) does not appear until the reader manually refreshes; the page
+  is otherwise healthy — data reads (`/fate`) return, navigation works, nothing 500s. The live
+  *push* is missing, not the data. This is the more common and more insidious symptom because
+  nothing errors — see [triage](#triage) for the candidate causes.
 - **`LIVE_UNAVAILABLE` 503 from `/fate/live`.** A `GET`/`POST /fate/live` returns the fate
   error envelope `{"error":{"code":"LIVE_UNAVAILABLE", …}}` with HTTP **503**. This is the
   route's *graceful* degradation path (`apps/web/worker/features/fate-live/route.ts`), not a
-  crash: a cold-DO transport failure that survived the bounded worker-seam retry surfaces as
-  a typed `LiveTransportError` → 503, by design, because the client's live pin retries the
-  whole connect on the next mount
-  ([`cold-start-retry.ts`](../apps/web/worker/features/fate-live/cold-start-retry.ts)). A
-  raw **500** from `/fate/live` is *not* this path — that is an unhandled defect, escalate it.
+  crash: a cold-DO transport failure that survived the bounded worker-seam retry surfaces as a
+  typed `LiveTransportError` → 503, by design, because the client's live pin retries the whole
+  connect on the next mount
+  ([`cold-start-retry.ts`](../apps/web/worker/features/fate-live/cold-start-retry.ts)). A raw
+  **500** from `/fate/live` is *not* this path — that is an unhandled defect, escalate it.
 
-Distinguishing **degraded live fan-out** from **app down**: the live plane is degraded when
+To distinguish **degraded live fan-out** from **app down**: the live plane is degraded when
 `/fate` data reads and asset loads still work and only the live push is stale or 503-ing. If
-`/fate` reads themselves fail, or the SPA won't load, the worker or Cloudflare is down —
-that is [Cloudflare down](./runbook-cf-down.md), not this runbook.
+`/fate` reads themselves fail, or the SPA won't load, the worker or Cloudflare is down — that
+is [Cloudflare down](./runbook-cf-down.md), not this runbook.
 
 ## Preconditions
 
@@ -57,12 +56,12 @@ that is [Cloudflare down](./runbook-cf-down.md), not this runbook.
 - **Know whether Sentry is live.** Worker/SPA error capture only activates when a DSN is
   provisioned at deploy — the integration ships **inert without a DSN**
   ([`.patterns/sentry.md`](../.patterns/sentry.md), ADR
-  [0118](../.decisions/0118-error-crash-monitoring-sentry-saas.md)). If no DSN is set,
-  Sentry will be silent and worker log-tail is your only live signal; don't wait on a
-  Sentry issue that will never arrive.
+  [0118](../.decisions/0118-error-crash-monitoring-sentry-saas.md)). With no DSN set, Sentry
+  is silent and worker log-tail is your only live signal; don't wait on a Sentry issue that
+  will never arrive.
 - **Capture the symptom first.** Note whether you see stale-without-503 or `LIVE_UNAVAILABLE`
-  503s, and a concrete reproduction (which entity, which view) before you change anything —
-  the two symptoms route to different causes.
+  503s, and a concrete reproduction (which entity, which view) before you change anything: the
+  two symptoms route to different causes.
 
 ## Procedure
 
@@ -74,10 +73,10 @@ Branch on the symptom captured above.
 instance was cold or briefly unreachable and the bounded cold-start retry (~1.5s worst case)
 was exhausted, so the route returned the graceful 503
 ([`cold-start-retry.ts`](../apps/web/worker/features/fate-live/cold-start-retry.ts)). A
-*transient* burst around a deploy or an idle-eviction warm-up is **expected** and
-self-heals — the live pin re-opens on the next mount. Escalate only when 503s are
-**sustained** (not clearing as clients remount) or you see raw **500s** from `/fate/live`
-(an unhandled defect, outside the graceful path).
+*transient* burst around a deploy or an idle-eviction warm-up is **expected** and self-heals —
+the live pin re-opens on the next mount. Escalate only when 503s are **sustained** (not
+clearing as clients remount) or you see raw **500s** from `/fate/live` (an unhandled defect,
+outside the graceful path).
 
 **Stale views without 503s** is the fan-out channel — the stream is up but a publish never
 reached it. Rank the candidates:
@@ -86,20 +85,20 @@ reached it. Rank the candidates:
    fanned entity (`Post` / `Comment` / `Definition`) must publish the invalidation through
    `WorkerLivePublisher` after its write; omitting it is **invisible at the mutation site**
    (the publisher's error channel is `never`) and silently staleness-breaks every other
-   client's view — the exact failure mode ADR
-   [0155](../.decisions/0155-fanned-mutation-publish-guard.md) and the `fanout-guard` CI
-   check exist to stop. If stale-without-503 is scoped to **one mutation** (e.g. only new
-   comments go stale, everything else updates live), suspect a fanned mutation that shipped
-   without its publish — cross-check
+   client's view — the failure mode ADR
+   [0155](../.decisions/0155-fanned-mutation-publish-guard.md) and the `fanout-guard` CI check
+   exist to stop. If stale-without-503 is scoped to **one mutation** (e.g. only new comments
+   go stale, everything else updates live), suspect a fanned mutation that shipped without its
+   publish — cross-check
    [`apps/web/worker/features/fate-live/fanned-mutations.ts`](../apps/web/worker/features/fate-live/fanned-mutations.ts).
    This is a **code defect**, not an operational one: the fix is the missing publish, not a
    runbook lever (see [rollback / escalation](#rollback--escalation)).
-2. **The publish/register race under load.** A create-mutation's fire-and-forget publish
-   lists the topic's subscribers **once**; if a subscriber's `register` RPC hasn't persisted
-   yet, the fan-out set is empty and the event delivers to nobody (v1 live is best-effort, no
-   replay). Under load `register` slows and the publish loses the race — the mutator's own
-   view waits on a push that never arrives (`.patterns/fate-live-views.md` §the register
-   race; #711/#714). This looks like *intermittent* staleness that worsens with traffic.
+2. **The publish/register race under load.** A create-mutation's fire-and-forget publish lists
+   the topic's subscribers **once**; if a subscriber's `register` RPC hasn't persisted yet,
+   the fan-out set is empty and the event delivers to nobody (v1 live is best-effort, no
+   replay). Under load `register` slows and the publish loses the race — the mutator's own view
+   waits on a push that never arrives (`.patterns/fate-live-views.md` §the register race;
+   #711/#714). This looks like *intermittent* staleness that worsens with traffic.
 3. **A torn-down live pin.** One always-on subscription (the global live pin, ADR
    [0094](../.decisions/0094-app-lifetime-global-live-pin.md)) keeps the shared `EventSource`
    alive across mutation churn; if it isn't mounted (anonymous client, a regression in
@@ -112,42 +111,42 @@ reached it. Rank the candidates:
   watch `/fate/live`: `LIVE_UNAVAILABLE` lines confirm the transport channel; their absence
   during a stale-view report points at the fan-out channel (an omitted/lost publish), not a
   transport failure.
-- **Sentry** — if a DSN is provisioned, an unhandled `/fate/live` **500** (not the graceful
+- **Sentry** — with a DSN provisioned, an unhandled `/fate/live` **500** (not the graceful
   503) surfaces as a captured issue at the worker request boundary
-  ([`.patterns/sentry.md`](../.patterns/sentry.md)). Remember it is inert without a DSN.
+  ([`.patterns/sentry.md`](../.patterns/sentry.md)). It is inert without a DSN.
 - **The `LiveDO`** — the connection role owns the held SSE stream and the subscription map;
   the topic role owns the subscriber set it fans to (`.patterns/fate-live-views.md`
   §topology). A `topic:` instance is not pinned by an open stream, so it evicts between a
-  publish and a later register — the storage-backed replay buffer, not an in-memory one, is
+  publish and a later register; the storage-backed replay buffer, not an in-memory one, is
   what closes that gap.
 
 ### The levers that exist today
 
-Be honest about the toolkit — it is deliberately small, and inventing controls that don't
-exist would make this runbook lie:
+The toolkit is deliberately small, and inventing controls that don't exist would make this
+runbook lie:
 
 - **Redeploy the `web` worker.** `pnpm deploy` (`alchemy deploy`, production stage) replaces
   the running worker, which recreates the isolate and its `LiveDO` bindings and clears any
   wedged warm state. This is the one blunt operational lever for a genuinely stuck transport
   channel (sustained 503s not clearing on remount).
 - **Let the live pin re-open.** By design the client re-opens the whole connect on the next
-  session mount, so a **client refresh** re-establishes a stream that hit a transient 503.
-  For a transient warm-up burst this is the *only* action needed — no operator lever at all.
+  session mount, so a **client refresh** re-establishes a stream that hit a transient 503. For
+  a transient warm-up burst this is the *only* action needed — no operator lever at all.
 
 **Levers that do not exist yet — state this plainly, do not improvise.** There is **no**
 per-`LiveDO`-instance restart, **no** live-plane feature flag or kill-switch, **no** fan-out
 circuit breaker, and **no** publish-replay/backfill lever. A stale-without-503 caused by an
 omitted publish is **not recoverable by any operational lever** — it is a code bug, and the
 fix is code (the missing publish), routed as below. Building finer live-plane recovery levers
-is out of scope for this runbook; if the incident shows one is needed, file it (see
+is out of scope for this runbook; if an incident shows one is needed, file it (see
 [escalation](#rollback--escalation)).
 
 ## Verification
 
 You've recovered when:
 
-- **A live view updates without a manual refresh.** Open the affected view in one client,
-  make the triggering change in another, and confirm the row appears with no refresh — the
+- **A live view updates without a manual refresh.** Open the affected view in one client, make
+  the triggering change in another, and confirm the row appears with no refresh — the
   end-to-end fan-out is the real check, not a proxy metric.
 - **`GET /fate/live?connectionId=…` returns `text/event-stream`, not 503.** A fresh connect
   opens the stream (the `: connected` frame) instead of the `LIVE_UNAVAILABLE` envelope.
@@ -155,22 +154,22 @@ You've recovered when:
   lingering line from before the fix is not a regression — confirm by timestamp).
 
 If the symptom was stale-without-503 from an omitted publish, verification is **the code
-fix's** review + the `fanout-guard` check going green, not a redeploy — nothing to verify
-operationally because there was no operational fault.
+fix's** review + the `fanout-guard` check going green, not a redeploy: there is nothing to
+verify operationally because there was no operational fault.
 
 ## Rollback / escalation
 
-- **Back out a redeploy.** If a redeploy makes things worse, roll the worker back to the
-  prior known-good version via the alchemy deploy model (ADR 0032) — a redeploy is
-  reversible, it does not mutate data.
+- **Back out a redeploy.** If a redeploy makes things worse, roll the worker back to the prior
+  known-good version via the alchemy deploy model (ADR 0032) — a redeploy is reversible, it
+  does not mutate data.
 - **A cause in code, not ops → route it as code.** If triage lands on an omitted `/fate/live`
-  publish (candidate 1) or the register race (candidate 2), there is no operational fix:
-  file a `report`-skill issue against the specific mutation/feature so it enters triage,
-  and — for an omitted publish — flag that `fanout-guard` should have caught it, so the gap
-  in the guard (or a mutation missing from the manifest) is investigated too. Do not paper
-  over a fan-out bug with repeated redeploys.
+  publish (candidate 1) or the register race (candidate 2), there is no operational fix: file
+  a `report`-skill issue against the specific mutation/feature so it enters triage, and — for
+  an omitted publish — flag that `fanout-guard` should have caught it, so the gap in the guard
+  (or a mutation missing from the manifest) is investigated too. Do not paper over a fan-out
+  bug with repeated redeploys.
 - **Escalate the platform substrate.** The fate/`LiveDO` substrate is platform/infra, where
-  engineering leads (ADR [0078](../.decisions/0078-product-driven-decisions-by-default.md)) —
-  sustained `LIVE_UNAVAILABLE` 503s that a redeploy doesn't clear, raw 500s from
-  `/fate/live`, or a suspected `LiveDO` topology/eviction fault (the connection/topic role
-  seam) is beyond this runbook's levers and belongs with whoever owns the live substrate.
+  engineering leads (ADR [0078](../.decisions/0078-product-driven-decisions-by-default.md)):
+  sustained `LIVE_UNAVAILABLE` 503s that a redeploy doesn't clear, raw 500s from `/fate/live`,
+  or a suspected `LiveDO` topology/eviction fault (the connection/topic role seam) is beyond
+  this runbook's levers and belongs with whoever owns the live substrate.


### PR DESCRIPTION
Fixes #3398

## What

Wave 3H — a Diátaxis + Strunk dual-lens audit of the three `ops/` runbooks:

- `ops/runbook-cf-down.md`
- `ops/runbook-d1-restore.md`
- `ops/runbook-live-plane-degraded.md`

## Lens applied

**Diátaxis (single-mode how-to).** A runbook is a how-to. Trimmed explanation-mode
intrusion where the prose re-derived an ADR's *why* at length, so each page reads as an
ordered recipe to a real result rather than a walkthrough that stops to teach.

**Strunk / writing-clearly.** Reduced em-dash density, cut negative-parallelism ("not X —
it's Y") and stakes-inflation AI-tells, moved passive constructions to active voice, and
omitted needless words.

## Operational accuracy preserved

The procedures are unchanged — only structure and prose moved:

- Every fenced command block is **byte-identical** to `origin/main` (verified by extracting
  and diffing all fenced content per file).
- Every relative/ADR link set is **identical** per file.
- No local/home/vault paths introduced (leak-guard clean in pre-commit).

## Acceptance criteria

- [x] The `ops/` runbooks are audited and corrected under the Diátaxis how-to + Strunk lens.
- [x] Operational accuracy is preserved (structure/prose fixed, procedures unchanged).
- [x] Each touched file re-checked against `control-plane-paths` — none match (not §CP).