### PR TITLE
fix(pipeline-crew-mcp): stand-up abort surfaces the tagged error's rich fields (#3438)

### DIFF
--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -35,7 +35,7 @@ import {Cause, Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 
 import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
-import {CREW_WINDOW, runStandUp} from "./standup/index.ts";
+import {CREW_WINDOW, renderStandUpError, runStandUp} from "./standup/index.ts";
 import {isTrackerAddressInUse, launchTracker} from "./tracker/index.ts";
 import {VERSION} from "./version.ts";
 
@@ -105,9 +105,10 @@ const standUp = Command.make(
 				),
 			),
 			// Fail-loud, no partial crew: a bad config, a version drift, an unstartable tracker, an inert
-			// channel, or a colliding pane label aborts naming its cause — String(error) carries the tag.
-			Effect.catch((error: unknown) =>
-				Console.error(`stand-up aborted (no partial crew): ${String(error)}`).pipe(
+			// channel, or a colliding pane label aborts naming its cause — renderStandUpError surfaces the
+			// tagged error's rich fields (reason/role/pane), not just its tag (#3438).
+			Effect.catch((error) =>
+				Console.error(`stand-up aborted (no partial crew): ${renderStandUpError(error)}`).pipe(
 					Effect.andThen(Effect.sync(() => process.exit(1))),
 				),
 			),

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -50,6 +50,7 @@ export {
 	type LaunchedSession,
 	type LaunchPlan,
 	launchSessionInTmux,
+	renderStandUpError,
 	resolveTargetTmuxSession,
 	runStandUp,
 	type StandUpError,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -28,6 +28,7 @@ import {
 	type LaunchedSession,
 	type LaunchPlan,
 	launchSessionInTmux,
+	renderStandUpError,
 	resolveTargetTmuxSession,
 	runStandUp,
 	type StandUpInput,
@@ -618,4 +619,29 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 			assert.deepStrictEqual(argvLog, [["has-session", "-t", "crew"]]);
 		}),
 	);
+});
+
+// The abort render is the operator's whole diagnostic on a fail-closed boot — `String(error)` on a
+// TaggedError is tag-only, so both `reason`-carrying union members must surface their rich fields (#3438).
+describe("renderStandUpError", () => {
+	it("surfaces role, pane, and reason for a StandUpLaunchError", () => {
+		const reason = `tmux new-window for pane "triage" exited 127 (no live pane)`;
+		const rendered = renderStandUpError(
+			new StandUpLaunchError({role: "triage", pane: "triage", reason}),
+		);
+
+		assert.include(rendered, "StandUpLaunchError");
+		assert.include(rendered, "role=triage");
+		assert.include(rendered, "pane=triage");
+		assert.include(rendered, `reason=${reason}`);
+	});
+
+	it("surfaces session and reason for a TmuxSessionEnsureError", () => {
+		const reason = "has-session missed and new-session failed to come up";
+		const rendered = renderStandUpError(new TmuxSessionEnsureError({session: "crew", reason}));
+
+		assert.include(rendered, "TmuxSessionEnsureError");
+		assert.include(rendered, "session=crew");
+		assert.include(rendered, `reason=${reason}`);
+	});
 });

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -151,6 +151,23 @@ export type StandUpError =
 	| TmuxSessionEnsureError
 	| StandUpLaunchError;
 
+/**
+ * Render a stand-up abort for the operator: the error tag plus its diagnostic data fields. `String(error)` on a
+ * `Schema.TaggedErrorClass` prints only the tag and drops the fields — yet the fields are the payload an operator
+ * needs (which tmux step + exit code failed, in which role/pane), so surface every schema data field alongside
+ * the tag. Field-generic on purpose: every union member's diagnostic surfaces — including both `reason`-carriers,
+ * `StandUpLaunchError` (role/pane/reason) and `TmuxSessionEnsureError` (session/reason) — and a future member's
+ * fields can't silently regress to tag-only. `Cause.pretty` is not a substitute here: it prints tag + stack but
+ * not the schema fields (#3438).
+ */
+export const renderStandUpError = (error: StandUpError): string => {
+	const detail = Object.entries(error)
+		.filter(([key]) => key !== "_tag")
+		.map(([key, value]) => `${key}=${typeof value === "string" ? value : JSON.stringify(value)}`)
+		.join(", ");
+	return detail ? `${error._tag} (${detail})` : error._tag;
+};
+
 export interface StandUpInput {
 	/** The project root the tracker + every session join (the per-project socket key). */
 	readonly projectRoot: string;


### PR DESCRIPTION
Fixes #3438

## What

The `stand-up` command's fail-closed abort rendered `String(error)`, which on a `Schema.TaggedErrorClass` prints only the `_tag` and drops every field. An operator saw the failure *class* (`…/StandUpLaunchError`) but not the failing tmux step, exit code, role, or pane — so the boot failed loud but undiagnosable, forcing a by-hand reproduction to find the cause.

## Fix

- Add `renderStandUpError` next to the `StandUpError` union in `packages/pipeline-crew-mcp/src/standup/orchestrate.ts`: it renders the error tag plus every schema data field. It is **field-generic**, so both `reason`-carrying members surface their rich fields, not just the reporter-named one:
  - `StandUpLaunchError` → `role` / `pane` / `reason`
  - `TmuxSessionEnsureError` → `session` / `reason`
  - …and any future union member can't silently regress to tag-only.
- `packages/pipeline-crew-mcp/src/bin.ts` — the `stand-up` catch now calls `renderStandUpError(error)`. Fail-closed semantics are unchanged (still no partial crew, still exit 1).

**Grounding:** `Cause.pretty` was the issue's suggested path, but a local probe against the real error classes showed it prints only tag + stack and drops the schema fields — so it is *not* a substitute here. `Object.entries` on a `TaggedErrorClass` instance yields exactly `_tag` + the schema data fields (verified), which is what the render surfaces.

## Tests

`renderStandUpError` unit tests in `orchestrate.test.ts` assert that both members' `reason` (plus `role`/`pane` and `session`) appear in the rendered output. Full package suite green; `pnpm typecheck` + `pnpm lint` green.

## Scope

Confined to the observability gap. The underlying PATH-127 launcher-robustness cause (adjacent to #3419) is explicitly out of scope. Non-§CP (`packages/pipeline-crew-mcp/`, ADR 0187) → normal auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)