### PR TITLE
feat(pipeline-crew-mcp): pass --name <role> per crew session for visible pane identity (#3443)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -22,6 +22,7 @@ import {
 	DEV_CHANNEL_FLAG,
 	MCP_CONFIG_FLAG,
 	MODEL_FLAG,
+	NAME_FLAG,
 } from "./bind.ts";
 import type {ChannelConfig} from "./config.ts";
 
@@ -69,13 +70,16 @@ describe("standup/bind — per-session bind constructor", () => {
 					"plugin:kampus:sozluk",
 				]);
 
-				// AC2: the full argv carries BOTH — the crew server is named in the flag, never .mcp.json alone.
+				// AC2: the full argv carries BOTH — the crew server is named in the flag, never .mcp.json alone —
+				// and closes with the visible-name flag (#3443); a bridge (no instance) names the bare role.
 				assert.deepStrictEqual(bind.argv, [
 					MCP_CONFIG_FLAG,
 					EXPECTED_MCP_JSON,
 					ALLOWLIST_CHANNEL_FLAG,
 					"server:pipeline-crew",
 					"plugin:kampus:sozluk",
+					NAME_FLAG,
+					ROLE,
 				]);
 			}),
 	);
@@ -104,7 +108,12 @@ describe("standup/bind — per-session bind constructor", () => {
 					"server:pipeline-crew",
 					"plugin:localdev:scratch",
 				]);
-				assert.deepStrictEqual(bind.argv, [MCP_CONFIG_FLAG, EXPECTED_MCP_JSON, ...bind.channelArg]);
+				assert.deepStrictEqual(bind.argv, [
+					MCP_CONFIG_FLAG,
+					EXPECTED_MCP_JSON,
+					...bind.channelArg,
+					...bind.nameArg,
+				]);
 			}),
 	);
 
@@ -257,10 +266,10 @@ describe("standup/bind — per-session bind constructor", () => {
 			// The tier boots the session's model — a family tier is a verbatim --model alias (config.ts
 			// Tier, grounded on the 2.1.212 bundle), so tier:opus yields `--model opus`.
 			assert.deepStrictEqual([...bind.modelArg], [MODEL_FLAG, "opus"]);
-			// --model leads the argv; the #3425 mcp-config + channel fragment follows it unchanged.
+			// --model leads the argv; the #3425 mcp-config + channel fragment follows it, then the name (#3443).
 			assert.deepStrictEqual(
 				[...bind.argv],
-				[MODEL_FLAG, "opus", ...bind.mcpConfigArg, ...bind.channelArg],
+				[MODEL_FLAG, "opus", ...bind.mcpConfigArg, ...bind.channelArg, ...bind.nameArg],
 			);
 		}),
 	);
@@ -302,8 +311,62 @@ describe("standup/bind — per-session bind constructor", () => {
 				});
 				assert.deepStrictEqual([...bind.modelArg], []);
 				assert.notInclude(bind.argv, MODEL_FLAG);
-				// argv is exactly the pre-#3423 fragment when no tier is set.
-				assert.deepStrictEqual([...bind.argv], [...bind.mcpConfigArg, ...bind.channelArg]);
+				// No tier ⇒ no --model; argv is the mcp-config + channel fragment closed by the name (#3443).
+				assert.deepStrictEqual(
+					[...bind.argv],
+					[...bind.mcpConfigArg, ...bind.channelArg, ...bind.nameArg],
+				);
+			}),
+	);
+
+	it.effect(
+		"emits --name <role> for a bridge (no instance) — the visible pane identity (#3443)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const bind = yield* buildSessionBind({
+					role: "chief-of-staff",
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+				assert.deepStrictEqual([...bind.nameArg], [NAME_FLAG, "chief-of-staff"]);
+				// the name flag rides the tail of the argv, after the channel fragment.
+				assert.deepStrictEqual([...bind.argv].slice(-2), [NAME_FLAG, "chief-of-staff"]);
+			}),
+	);
+
+	it.effect(
+		"engine sessions get --name <role>-<instance> so the N engine panes are distinctly named (AC2, #3443)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const engineOne = yield* buildSessionBind({
+					role: "engineering-manager",
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					instance: "e-1",
+					channels,
+				});
+				const engineTwo = yield* buildSessionBind({
+					role: "engineering-manager",
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					instance: "e-2",
+					channels,
+				});
+				assert.deepStrictEqual([...engineOne.nameArg], [NAME_FLAG, "engineering-manager-e-1"]);
+				assert.deepStrictEqual([...engineTwo.nameArg], [NAME_FLAG, "engineering-manager-e-2"]);
+				// the two engine panes come up with DISTINCT visible names, never two identical roles.
+				assert.notStrictEqual(engineOne.nameArg[1], engineTwo.nameArg[1]);
 			}),
 	);
 

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -50,6 +50,13 @@ export const CREW_SESSION_INSTANCE_FLAG = "--instance";
 export const MCP_CONFIG_FLAG = "--mcp-config";
 /** Sets the launched session's model to the role's configured tier (#3423); omitted when no tier. */
 export const MODEL_FLAG = "--model";
+/**
+ * Sets a visible per-session display name — shown in the prompt box, `/resume` picker, and terminal
+ * title (grounded against the installed CLI 2.1.214: `-n, --name <name>`). This is the on-screen
+ * role identity; `--agent` swaps the system prompt but is NOT visible, so it's the wrong flag for
+ * the operator-legibility symptom (#3443).
+ */
+export const NAME_FLAG = "--name";
 /** Allowlist mode: only servers named here load, gated by `allowedChannelPlugins` for plugin refs. */
 export const ALLOWLIST_CHANNEL_FLAG = "--channels";
 /** Dev mode: load channel servers not on the approved allowlist — local development only. */
@@ -97,7 +104,14 @@ export interface SessionBind {
 	readonly channelArg: readonly string[];
 	/** `["--model", "<alias>"]` when the role has a configured tier (#3423), else `[]` (CLI default). */
 	readonly modelArg: readonly string[];
-	/** The complete fragment `[...modelArg, ...mcpConfigArg, ...channelArg]` the launcher inlines for this session. */
+	/**
+	 * `["--name", "<display name>"]` — the visible per-session identity (#3443). A bridge is the
+	 * singleton `role`; an engine is `role-<instance>` so the N engine panes come up distinctly named
+	 * (AC2) rather than N identical `engineering-manager`s — the per-instance discriminator is the
+	 * same one that already keeps engine inboxes collision-free (session-set.ts).
+	 */
+	readonly nameArg: readonly [flag: string, name: string];
+	/** The complete fragment `[...modelArg, ...mcpConfigArg, ...channelArg, ...nameArg]` the launcher inlines for this session. */
 	readonly argv: readonly string[];
 }
 
@@ -229,6 +243,10 @@ export const buildSessionBind = (
 		// The role's tier boots the session on its `--model` (#3423); a role with no tier emits none,
 		// keeping the CLI-default boot rather than guessing. `tierModel` is total over the `Tier` enum.
 		const modelArg: readonly string[] = tier !== undefined ? [MODEL_FLAG, tierModel(tier)] : [];
+		// An engine appends its per-instance discriminator so the N engine panes are distinctly named
+		// (AC2); a bridge is the bare singleton role. Same instance that keeps engine inboxes distinct.
+		const displayName = instance !== undefined ? `${role}-${instance}` : role;
+		const nameArg: readonly [string, string] = [NAME_FLAG, displayName];
 
 		return {
 			role,
@@ -236,6 +254,7 @@ export const buildSessionBind = (
 			mcpConfigArg,
 			channelArg,
 			modelArg,
-			argv: [...modelArg, ...mcpConfigArg, ...channelArg],
+			nameArg,
+			argv: [...modelArg, ...mcpConfigArg, ...channelArg, ...nameArg],
 		};
 	});


### PR DESCRIPTION
## What

Crew stand-up boots N tiled tmux panes (chief-of-staff, cartographer, intake-desk, 2× engineering-manager), but every pane rendered identically as `✳ Claude Code` — no role identity on screen. The per-session bind argv (`packages/pipeline-crew-mcp/src/standup/bind.ts`) passed `--model`, `--mcp-config`, and the channel flags, but nothing that sets a visible session display name.

This adds a `nameArg` to the bind fragment and appends it to `argv`:

- **Bridge** (chief-of-staff / cartographer / intake-desk): `--name <role>` (the singleton role).
- **Engine** (engineering-manager): `--name <role>-<instance>`, so the N engine panes come up distinctly named (**AC2**) rather than N identical `engineering-manager`s — reusing the per-instance discriminator that already keeps engine inboxes collision-free (`session-set.ts`).

## Grounding (AC3)

The `-n, --name <name>` visible-title semantics are confirmed against the **installed Claude Code CLI 2.1.214** (`claude --help`): *"Set a display name for this session (shown in the prompt box, /resume picker, and terminal title)"*.

## AC4 — `--agent <role>` decision (deferred to #3447)

#3443's symptom is **visible** operator legibility: the panes all render identically as `✳ Claude Code`, so an operator can't tell which pane is which role. `--name` sets the on-screen display name and is the correct flag for that symptom.

`--agent <role>` is a different lever — it swaps the session's **invisible** system prompt / persona; it does not change the on-screen name. So `--agent` is the wrong flag for #3443's visible-legibility symptom and is **out of scope for this issue regardless of whether role agent-defs exist** (they do: `claude-plugins/pipeline-crew/agents/{cartographer,chief-of-staff,engineering-manager,intake-desk}.md` map 1:1 to the crew roles — the deferral rests on the visible-vs-invisible distinction, not on the defs' absence). Whether crew panes should *also* boot their role agent-def as the session persona via `--agent <role>` is a genuine boot-persona/behavioral decision (dogfood-relevant), distinct from this display-name fix — filed as **#3447** for triage/EM to decide, not settled inside this PR. The `NAME_FLAG` docblock in `bind.ts` records the same visible-vs-invisible rationale at the code.

## Scope

Strictly `bind.ts` + `bind.test.ts`. `orchestrate.ts` (`launchSessionInTmux`) forwards `...bind.argv` generically, so no edit there — it is untouched (in-flight in a separate PR).

## Tests

Updated the existing exact-argv assertions to reflect the appended `--name` flag, and added two dedicated tests: `--name <role>` for a bridge, and distinct `--name <role>-<instance>` for two engine instances. Full package `bind`/`orchestrate` suites (36 tests) pass; typecheck + biome clean.

Fixes #3443