### PR TITLE
docs: Wave 3F — README/DEVELOPMENT light prose pass + DSM staleness de-stale

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Developing on phoenix
 
-phoenix is the opinionated stack the kamp.us products (sözlük, pano, vote, stats) are built on — a single Cloudflare Worker on alchemy + Effect + fate that serves the SPA, the data plane, and every backend route. It is not a general-purpose framework; it's this repo's engine, written down precisely enough that you can extend it without reverse-engineering the choices.
+phoenix is the opinionated stack the kamp.us products (sözlük, pano, mecmua) are built on — a single Cloudflare Worker on alchemy + Effect + fate that serves the SPA, the data plane, and every backend route. It is not a general-purpose framework; it's this repo's engine, written down precisely enough that you can extend it without reverse-engineering the choices.
 
 This is the builder's door. For what kamp.us *is* — the products and the ethos — see [README.md](./README.md).
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ kamp.us is a community built around two products:
 The door is open, but the right to speak is earned.
 
 - **kapı açık** — anyone can open an account.
-- **söz hakkı kazanılır** — what you first write goes up as a **çaylak** (newcomer), reviewed on the **divan** — the gated reviewer surface where a **yazar** (author) and a **moderatör** look over a newcomer's sandboxed work. As you contribute, a yazar vouches for you; you become a yazar yourself, and from then on what you write goes straight to publication.
+- **söz hakkı kazanılır** — what you first write goes up as a **çaylak** (newcomer), reviewed on the **divan** — the gated reviewer surface where a **yazar** (author) and a **moderatör** look over a newcomer's sandboxed work. As you contribute, a yazar vouches for you; you become a yazar yourself, and from then on your writing goes straight to publication.
 
 This earned-authorship rite is the spine of the community: it keeps the corner slow and the writing worth reading, instead of trading quality for reach. (See issues [#1202](https://github.com/kamp-us/phoenix/issues/1202) and [#1667](https://github.com/kamp-us/phoenix/issues/1667) for the framing.)
 
 ## The ethos
 
 - **Türkçe öncelikli** — Turkish-first for everything a person reads and writes.
-- **No ads, no follower counts, no sensation** — the incentives that make the rest of the internet loud are simply absent here.
+- **No ads, no follower counts, no sensation** — the incentives that make the rest of the internet loud are absent here.
 - **A slow corner** — depth over volume; a few hundred people who care over a crowd that doesn't.
 
 The full product/brand vocabulary — sözlük, pano, kampus, künye, divan, and the rest — lives in [`.glossary/LANGUAGE.md`](./.glossary/LANGUAGE.md).

--- a/design-system-manifest.md
+++ b/design-system-manifest.md
@@ -17,10 +17,7 @@ brand art and interface are one color system.
 The normative content is **founder-authored, not agent-invented**. It is the machine form of ADR
 [0162](https://github.com/kamp-us/phoenix/blob/main/.decisions/0162-four-pillars-design-law.md) —
 the ratify-root of the frontend audit wave (epic
-[#2168](https://github.com/kamp-us/phoenix/issues/2168)). ADR 0162 lands in parallel via
-[#2195](https://github.com/kamp-us/phoenix/pull/2195); this cross-ref uses its full GitHub URL
-(the ADR / skill cross-ref convention) because the target file is landing alongside this manifest,
-not yet on this branch's disk. An agent **transcribes** these
+[#2168](https://github.com/kamp-us/phoenix/issues/2168)). An agent **transcribes** these
 values into this artifact; it does **not** author design law. Where the ADR is silent, the gap is
 surfaced to the founder — it is never filled here.
 


### PR DESCRIPTION
## What

Class F (founder-approved on #3375) light-touch docs pass under the imported Strunk lean (`writing-clearly-and-concisely`) + Diátaxis doc-surface roles. Scoped to **prose tightening + de-stale only** — no restructuring, no new content.

### Changes
- **DEVELOPMENT.md** — line-3 product-list fix: the kamp.us products are **sözlük, pano, mecmua**. `vote` and `stats` are feature surfaces, not products (`.glossary/LANGUAGE.md` §3; the architecture tree already classes them under features, not products & product surfaces).
- **README.md** — minor Strunk tightenings: cut the magic adverb "simply"; active voice on the çaylak→yazar publication line.
- **design-system-manifest.md** — DSM staleness chore: drop the stale intro scaffolding claiming "ADR 0162 lands in parallel via #2195 / not yet on this branch's disk". ADR 0162 is now committed at `.decisions/0162-four-pillars-design-law.md`, so that justification is false. **The normative pillar/role-token law (the ADR-0162 firewall) is untouched** — prose/staleness only.

## Scope guard
- All three touched files re-checked against `pipeline-cli control-plane-paths` — none is a §CP path.
- README/DEVELOPMENT roles kept per CLAUDE.md doc-surfaces (README = product front door; DEVELOPMENT = builder state).
- No new content, no wholesale restructure (per #3375 Class F ruling).

## Acceptance criteria
- [x] README + DEVELOPMENT get a light Strunk prose pass; the line-3 product-list is corrected.
- [x] The DSM staleness chore is completed (stale content refreshed).
- [x] Each touched file re-checked against `control-plane-paths`.

Fixes #3396