### PR TITLE
docs(patterns): canon-refresh the two GraphQL-era Effect docs to the fate boundary

### DIFF
--- a/.patterns/effect-error-operators.md
+++ b/.patterns/effect-error-operators.md
@@ -4,13 +4,13 @@ How to catch, inspect, and recover from errors in Effect. Covers `Effect.catchTa
 
 ## When to catch
 
-Default: **don't catch.** Let errors propagate to the resolver wrapper, where they map to wire codes. Catching mid-flow usually means hiding a failure that the caller would want to know about.
+Default: **don't catch.** Let errors propagate to the fate boundary, where `encodeWireError` maps them to wire codes. Catching mid-flow usually means hiding a failure that the caller would want to know about.
 
 Real reasons to catch in product code:
 
 - Recovering from an *expected* failure with a fallback value (`TermNotFound → empty page` for the resolver that handles "create term on first definition").
 - Wrapping a lower-layer error in a domain error (`DrizzleError → SozlukTermPersistenceError` if Sozluk wants to surface its own tag).
-- Boundary translation in the resolver wrapper itself (converting tagged errors to `GraphQLError`).
+- Boundary translation at the fate interpreter itself — encoding a tagged error to its wire code via the `FateWireCode` annotation ([fate-effect-wire-errors.md](./fate-effect-wire-errors.md)).
 
 Catching infra errors (`DrizzleError`) inside domain methods almost always means hiding a real problem. Let it fall through.
 
@@ -81,14 +81,7 @@ if (Exit.isSuccess(exit)) {
 }
 ```
 
-Used when you need to inspect both branches in the same code path. The resolver wrapper does this:
-
-```ts
-// worker/graphql/resolver.ts
-const exit = await context.runtime.runPromiseExit(Effect.gen(...));
-if (Exit.isSuccess(exit)) return exit.value;
-// ... handle failure cause
-```
+Used when you need to inspect both branches in the same code path — most often a test asserting on a failure ([effect-testing.md](./effect-testing.md)). At the serving boundary you rarely reach for `Effect.exit` directly: the fate interpreter runs each operation on the request fiber and, on failure, pulls the value off the `Cause` (see below) and hands it to `encodeWireError`. There is no per-request runtime and no `Effect`→`Promise` hop on the serving path (ADR 0043 — the lone `runtime.runPromise` survives only in the oracle baseline's `Executor.ts`). See [fate-effect-interpreter.md](./fate-effect-interpreter.md).
 
 ## `Exit` and `Cause` — the failure model
 
@@ -106,13 +99,13 @@ import {Cause, Exit} from "effect";
 
 const exit = yield* Effect.exit(operation);
 if (Exit.isFailure(exit)) {
-  const failure = Cause.failureOption(exit.cause);
-  // failure: Option<E> — the typed error if present
-  // If the failure is a defect, Option.none() — use Cause.dieOption(cause) for that.
+  const failure = Cause.findErrorOption(exit.cause);
+  // failure: Option<E> — the first typed error if present, else Option.none()
+  // for a pure-defect cause. `Cause.squash(cause)` collapses a cause to one value.
 }
 ```
 
-`Cause.findError` (used by the resolver wrapper) traverses the cause tree for the first typed failure:
+`Cause.findError` traverses the cause tree for the first typed failure, returning a `Result` whose `_tag === "Success"` carries the typed error on `.success`:
 
 ```ts
 const errResult = Cause.findError(exit.cause);
@@ -120,6 +113,8 @@ if (errResult._tag === "Success") {
   const e = errResult.success;  // the typed error
 }
 ```
+
+At the fate boundary this extraction is packaged once as `failureOf(cause)` (`packages/fate-effect/src/WireError.ts`): the typed failure if one exists (`Cause.findErrorOption`), otherwise the squashed defect (`Cause.squash`) — whatever it returns feeds straight into `encodeWireError` ([fate-effect-wire-errors.md](./fate-effect-wire-errors.md)).
 
 For phoenix-level work you rarely need to construct or compose Causes — the operators above hide them. Just remember: when you see `Cause` in a signature, it's the full failure-tree model.
 
@@ -132,44 +127,35 @@ throw new Error("boom")               // defect — bypasses E channel, lives in
 Effect.die(new Error("boom"))         // explicit defect
 ```
 
-**In product code, only produce typed failures.** Throwing inside an `Effect.gen` makes the error a defect, which won't show up in your `E` channel signature and won't be caught by `Effect.catchTag`. The resolver wrapper will still catch it via `Cause.squash` but you've lost type safety.
+**In product code, only produce typed failures.** Throwing inside an `Effect.gen` makes the error a defect, which won't show up in your `E` channel signature and won't be caught by `Effect.catchTag`. `encodeWireError` will still collapse it via `Cause.squash` at the boundary, but you've lost type safety.
 
-## How the resolver wrapper uses these
+## How the fate boundary uses these
 
-`worker/graphql/resolver.ts` is the canonical pattern for "consume an Effect at a system boundary":
+`FateInterpreter.handleRequest` (the `POST /fate` serving plane, ADR 0043 — [fate-effect-interpreter.md](./fate-effect-interpreter.md)) is the canonical pattern for "consume an Effect at a system boundary". Its dispatch loop runs each operation on the request fiber and maps a failed operation onto fate's protocol error shape:
 
 ```ts
-const exit = await context.runtime.runPromiseExit(Effect.gen(() => body(source, args)));
-if (Exit.isSuccess(exit)) return exit.value;
-
-const errResult = Cause.findError(exit.cause);
-if (errResult._tag === "Success") {
-  const e = errResult.success;
-  if (e instanceof GraphQLError) throw e;
-  throw encodeMutationError(e);
-}
-// defect path
-throw encodeMutationError(Cause.squash(exit.cause));
+// packages/fate-effect — dispatch (paraphrased)
+const value = failureOf(cause);        // typed failure, else squashed defect
+const wire = encodeWireError(value);   // → FateRequestError { code, message }
 ```
 
 What this does:
 
-1. Run the resolver Effect, getting an `Exit` back. Never throws.
-2. Success → return the value.
-3. Typed failure → find it in the cause tree, route through `encodeMutationError` (which switches on `_tag`).
-4. Defect → squash the cause to a single error, route through the same encoder.
+1. Run each operation on the request fiber — no `runPromiseExit`, no per-request runtime; the caller owns the one run boundary (ADR 0043).
+2. Success → the value is serialized into the operation's result.
+3. Failure → `failureOf(cause)` pulls the failed/thrown value off the `Cause`, then `encodeWireError` maps it to a wire code: an error class carrying a `FateWireCode` annotation encodes to that code plus its own `message`; anything un-annotated (or a defect) collapses to `INTERNAL_SERVER_ERROR` with a fixed message, so defect details never reach the wire ([fate-effect-wire-errors.md](./fate-effect-wire-errors.md)).
 
-If you find yourself writing similar boundary-handling code elsewhere (e.g., a typed-JSON `HttpApi` group), use this as the template.
+`encodeWireError` is total — it never throws, whatever the failed/thrown value — so the boundary always produces a well-formed protocol error. If you write similar boundary-handling code elsewhere (e.g., a typed-JSON `HttpApi` group), reach for the same `failureOf` → `encodeWireError` shape rather than re-deriving it.
 
 ## Anti-patterns
 
 - **`Effect.catchAll` to convert errors into a generic "operation failed" string.** You've thrown away the diagnostic value. Use `catchTags` to handle the cases you know, let the rest propagate.
-- **Catching `DrizzleError` inside a feature method.** Drizzle errors indicate infrastructure failure. Hiding them produces silent corruption. Let them propagate; the resolver maps to `INTERNAL_SERVER_ERROR`.
+- **Catching `DrizzleError` inside a feature method.** Drizzle errors indicate infrastructure failure. Hiding them produces silent corruption. Let them propagate; `encodeWireError` maps the un-annotated failure to `INTERNAL_SERVER_ERROR` at the boundary.
 - **Throwing inside an `Effect.gen` to "fail fast."** Use `return yield* new MyError({})` instead. Throws become defects, which TS can't reason about.
-- **Using `Effect.exit` everywhere just to be safe.** Most code should propagate failures naturally. Reach for `exit` only at boundaries (resolver wrapper, tests asserting on failures).
+- **Using `Effect.exit` everywhere just to be safe.** Most code should propagate failures naturally. Reach for `exit` only at boundaries (the fate interpreter, tests asserting on failures).
 
 ## See also
 
 - [effect-errors.md](./effect-errors.md) — defining tagged errors
 - [effect-testing.md](./effect-testing.md) — using `Effect.exit` and `Cause` in tests
-- `worker/graphql/resolver.ts` — production usage of the boundary pattern
+- [fate-effect-wire-errors.md](./fate-effect-wire-errors.md), [fate-effect-interpreter.md](./fate-effect-interpreter.md) — the fate boundary's error encoding + dispatch

--- a/.patterns/effect-fn-tracing.md
+++ b/.patterns/effect-fn-tracing.md
@@ -67,7 +67,7 @@ Without `return`, the next statement is unreachable but TypeScript won't catch i
 
 ```ts
 const addDefinition = Effect.fn("Sozluk.addDefinition")(function*(input) {
-  yield* run("addDefinition.insert", () => db.insert(...));
+  yield* run((db) => db.insert(definitionRecord).values(...));
   yield* recomputeTermSummary(input.termSlug, input.title, new Date());
   return {/* ... */};
 });
@@ -83,7 +83,7 @@ Both spans appear in the trace, nested. Helpers stay inside the layer's closure 
 
 - **Not a class.** It's a function constructor. Don't try to `new` it or extend it.
 - **Not for top-level Effects.** If you have a single Effect at module scope (no args), just write it as `const program = Effect.gen(function*() {...})` — `Effect.fn` is for argument-taking functions.
-- **Not a replacement for `Effect.gen` inline.** Inside a resolver body, `resolver(function*(_source, args) {...})` is `Generator`, not `Effect.fn`. The resolver wrapper handles the gen lifecycle. `Effect.fn` is for service methods you define separately and call multiple times.
+- **Not reserved for service methods — a fate resolver is one too.** A fate query/mutation resolver *is* an `Effect.fn`, named after its operation key: `Fate.mutation(schema, Effect.fn("definition.add")(function*({input}) {...}))` (`apps/web/worker/features/sozluk/mutations.ts`). The body destructures the decoded `{input}` (mutations) / `{args}` (queries), not a GraphQL `(_source, args)` pair, and the span surfaces the operation in the trace. So `Effect.fn` wraps both the resolver and the service methods it calls; a single no-arg top-level Effect stays plain `Effect.gen` (above).
 
 ## Naming spans well
 
@@ -91,7 +91,7 @@ The span name shows up in OTLP traces. Good names:
 
 - `Sozluk.addDefinition` — service + method
 - `Sozluk.recomputeTermSummary` — service + helper (private to the layer but still useful in traces)
-- `addDefinition.insert` — sub-operation inside a method (used as the `operation` argument to `Drizzle.run`, which uses it for the DB-level span)
+- `definition.addBody` — a sub-step wrapped in its own nested `Effect.fn` inside a resolver or method (`apps/web/worker/features/sozluk/mutations.ts`), so the step gets its own span in the trace
 
 Avoid:
 
@@ -101,19 +101,17 @@ Avoid:
 
 ## Layered tracing in practice
 
-For one resolver call (`addDefinitionMutation`), you'll see a trace like:
+For one fate mutation (`definition.add`), you'll see a trace like:
 
 ```
-graphql.mutation                                  150ms
-  Sozluk.addDefinition                            148ms
-    addDefinition.checkSlug (Drizzle.run)          5ms
-    addDefinition.insert (Drizzle.run)            42ms
-    Sozluk.recomputeTermSummary                    98ms
-      recomputeTermSummary.selectDefs (Drizzle.run) 12ms
-      recomputeTermSummary.upsert (Drizzle.run)   84ms
+POST /fate                                        150ms   ← the router request span (HttpEffect tracer)
+  definition.add                                  149ms   ← the resolver Effect.fn
+    definition.addBody                            148ms   ←   a nested sub-step Effect.fn
+      Sozluk.addDefinition                        140ms   ←   the service method
+        Sozluk.recomputeTermSummary                98ms
 ```
 
-Every span has a clear owner. When something is slow, the trace tells you whether it's the SQL, the orchestration, or the resolver wrapper.
+Handler and service `Effect.fn` spans parent to the router's request span because everything runs on the request fiber's tree (the `HttpEffect.toHandled` tracer middleware; pinned in `Interpreter.batch.test.ts` § observability — [fate-effect-interpreter.md](./fate-effect-interpreter.md)). `Drizzle.run` itself opens no span, so a DB call's time shows under the enclosing method's span. When something is slow, the trace tells you which resolver, method, or sub-step owns it.
 
 ## See also
 


### PR DESCRIPTION
Fixes #3393

## What

Wave 3C, Class C (founder-approved on #3375): canon-refresh the two GraphQL-era stale `.patterns/` docs to the current reality. Phoenix serves its data layer through fate's native interpreter (ADR 0043), not GraphQL — both docs still described a GraphQL resolver wrapper that no longer exists in the tree.

### `.patterns/effect-error-operators.md`
- Boundary error handling now flows through `FateInterpreter.handleRequest` → `failureOf(cause)` → `encodeWireError` (the `FateWireCode` annotation), replacing the `worker/graphql/resolver.ts` wrapper (`GraphQLError`, `encodeMutationError`, per-request `runtime.runPromiseExit`) that no longer exists.
- Corrected stale Effect API: `Cause.failureOption` → `Cause.findErrorOption` (grounded in effect-smol `Cause.ts`); `failureOf` grounded in `packages/fate-effect/src/WireError.ts`.
- "resolver wrapper" phrasings → the fate boundary / `encodeWireError`.

### `.patterns/effect-fn-tracing.md`
- The `Effect.fn` service-method convention (`Service.method`) is unchanged and stays — only the GraphQL-era framing was refreshed.
- Rooted the example trace at the router request span (not `graphql.mutation`); named the fate resolver `Effect.fn` (`{input}`/`{args}`, not a GraphQL `(_source, args)` pair).
- Dropped the false `Drizzle.run(operation, fn)` DB-span form: `Drizzle.run` takes one fn and opens no span (grounded in `apps/web/worker/db/Drizzle.ts`).

## Grounding
Every behavior claim verified against source: `apps/web/worker/features/fate/route.ts`, `features/sozluk/{mutations,errors,Sozluk}.ts`, `worker/db/Drizzle.ts`, `packages/fate-effect/src/WireError.ts`, `.patterns/fate-effect-{interpreter,wire-errors}.md`, and effect-smol `Cause.ts`.

## Scope / checks
- Docs-only (`.patterns/`), no user-facing surface. TDD: no (per issue).
- Both touched files re-checked against `pipeline-cli control-plane-paths` — neither matches the §CP regex.
- No leaked local/absolute paths (added-lines grep clean; leak-guard green at commit).