### PR TITLE
fix(pipeline-crew-mcp): consume the --instance flag bind.ts bakes for engine sessions (#3445)

### DIFF
--- a/packages/pipeline-crew-mcp/src/bin.test.ts
+++ b/packages/pipeline-crew-mcp/src/bin.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The `session` subcommand's flag surface (#3445): the seam standup/bind.ts (the producer) bakes
+ * `--instance <uuid>` into every engine's argv, so `bin.ts session` (the consumer) MUST declare that
+ * flag or Effect-CLI rejects it and every engine session dies at parse before serving. Drives the
+ * real bin as a subprocess (the same `execFile` idiom worktree-guard's command test uses) — a
+ * declared flag is listed in `--help` and parses, an undeclared one is neither.
+ */
+import {execFile} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (...args: readonly string[]): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile("node", [BIN, ...args], (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+	});
+
+describe("bin.ts — the session subcommand declares --instance (#3445)", () => {
+	it("session --help lists --instance, so the flag bind.ts bakes parses instead of aborting", async () => {
+		const {code, stdout} = await run("session", "--help");
+		assert.strictEqual(code, 0, "session --help exits 0");
+		assert.match(
+			stdout,
+			/--instance/,
+			"the --instance flag is declared (bind.ts's producer now has a consumer)",
+		);
+		// the pre-existing flags still render — the additive change didn't drop them.
+		assert.match(stdout, /--role/, "the --role flag is still declared");
+		assert.match(stdout, /--project-root/, "the --project-root flag is still declared");
+	}, 30_000);
+});

--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -31,7 +31,7 @@
  * for the typed command, the Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Cause, Console, Effect} from "effect";
+import {Cause, Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 
 import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
@@ -46,15 +46,30 @@ const projectRootFlag = Flag.string("project-root").pipe(
 	Flag.withDefault(process.cwd()),
 	Flag.withDescription("the project root whose per-project tracker socket this session joins"),
 );
+// The launcher-assigned per-instance identity standup/bind.ts bakes into an engine's argv
+// (`CREW_SESSION_INSTANCE_FLAG`, #3297/#3354 seam 3). Optional: only engine roles carry it — a
+// bridge is a singleton and omits it, so the session mints its own (see `sessionInstance`). This is
+// the consumer the producer shipped without; without it Effect-CLI rejects `--instance` and every
+// engine session dies at parse (#3445).
+const instanceFlag = Flag.optional(Flag.string("instance")).pipe(
+	Flag.withDescription("the launcher-assigned per-instance identity an engine session binds"),
+);
 
 const session = Command.make(
 	"session",
-	{projectRoot: projectRootFlag, role: roleFlag},
-	Effect.fn(function* ({projectRoot, role}) {
+	{projectRoot: projectRootFlag, role: roleFlag, instance: instanceFlag},
+	Effect.fn(function* ({projectRoot, role, instance}) {
 		yield* Console.error(
 			`pipeline-crew-mcp ${VERSION} — crew session for role "${role}" (project ${projectRoot})`,
 		);
-		return yield* runCrewSession({projectRoot, role}).pipe(
+		// Thread the flag through as an EXACT-optional key: include `instance` only when the launcher
+		// passed one (an engine), omit it entirely otherwise (a bridge/singleton, or a direct run) so
+		// `CrewSessionConfig.instance`'s absent case stays absent — `sessionInstance` then mints one.
+		return yield* runCrewSession({
+			projectRoot,
+			role,
+			...(Option.isSome(instance) ? {instance: instance.value} : {}),
+		}).pipe(
 			Effect.catch((error: unknown) =>
 				Console.error(
 					error instanceof RoleUniquenessError

--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -28,7 +28,7 @@ import {TrackerRegistry} from "../tracker/group.ts";
 import {TrackerHandlers} from "../tracker/handlers.ts";
 import {RegistryLive} from "../tracker/registry.ts";
 import {CREW_ROLES, kindOf} from "./roles.ts";
-import {channelSendFromPeer, inboxAddressFor} from "./session.ts";
+import {channelSendFromPeer, inboxAddressFor, sessionInstance} from "./session.ts";
 import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
 
 const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
@@ -167,5 +167,32 @@ describe("crew/session — per-instance engine addressing (AC 1)", () => {
 		const two = inboxAddressFor(engineRole, "two");
 		assert.strictEqual(one, `inbox://${engineRole}/one`);
 		assert.notStrictEqual(one, two, "N engine instances never collapse onto a single address");
+	});
+});
+
+describe("crew/session — sessionInstance honors the launcher-assigned identity (#3445 AC 2)", () => {
+	const engineRole = CREW_ROLES.find((role) => kindOf(role) === "engine");
+	const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+	it("binds the passed instance when present, not a freshly minted one", () => {
+		assert(engineRole !== undefined, "the roster must carry an engine role");
+		const instance = "launcher-assigned-uuid";
+		assert.strictEqual(
+			sessionInstance({role: engineRole, projectRoot: "/x", instance}),
+			instance,
+			"the launcher-assigned instance is honored — the engine binds THAT address, not a self-mint",
+		);
+	});
+
+	it("mints a fresh UUID when absent (the bridge/singleton or direct-run case)", () => {
+		assert(engineRole !== undefined, "the roster must carry an engine role");
+		const config = {role: engineRole, projectRoot: "/x"};
+		const minted = sessionInstance(config);
+		assert.match(minted, UUID_RE, "absent ⇒ a minted UUID, preserving pre-#3445 behavior");
+		assert.notStrictEqual(
+			minted,
+			sessionInstance(config),
+			"each absent-instance resolution mints a distinct id",
+		);
 	});
 });

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -65,6 +65,13 @@ export interface CrewSessionConfig {
 	readonly name?: string;
 	/** The MCP server version advertised over stdio (defaults to the package `VERSION`). */
 	readonly version?: string;
+	/**
+	 * The launcher-assigned per-instance identity (#3297) an engine session binds, threaded from the
+	 * `session --instance <id>` flag (bin.ts) that standup/bind.ts bakes for engine roles. Exact-optional
+	 * (like `name`/`version`): present ⇒ the session comes up on THAT address; absent (a bridge/singleton,
+	 * or a direct run) ⇒ `sessionInstance` mints one. See `sessionInstance` (#3445).
+	 */
+	readonly instance?: string;
 }
 
 /**
@@ -74,7 +81,7 @@ export interface CrewSessionConfig {
  * discriminator `inbox://<role>/<instance>`, so N engine sessions hold N distinct presence leases
  * (keyed by peer in the registry) and resolve to N distinct inbox sockets — never overwriting each
  * other. `inboxSocketPathFor` hashes the whole address, so two engine instances get collision-free
- * sockets. The `instance` is a per-session id, generated once in `crewSessionLayer`.
+ * sockets. The `instance` is a per-session id, resolved once in `crewSessionLayer` (`sessionInstance`).
  */
 export const inboxAddressFor = (role: CrewRole, instance: string): string =>
 	kindOf(role) === "engine" ? `inbox://${role}/${instance}` : `inbox://${role}`;
@@ -82,6 +89,16 @@ export const inboxAddressFor = (role: CrewRole, instance: string): string =>
 /** The unix socket this session's peer inbox is served on — the address resolved to a socket path. */
 export const inboxSocketFor = (role: CrewRole, instance: string): string =>
 	inboxSocketPathFor(inboxAddressFor(role, instance));
+
+/**
+ * This session's per-instance id: the launcher-assigned `config.instance` when present (an engine
+ * bound by standup/bind.ts's `--instance`, #3297), else a freshly minted UUID. The fallback preserves
+ * the pre-#3445 behavior for the no-instance case — a bridge singleton, which folds no instance into
+ * its address anyway, or a direct `session` run — so honoring the launcher's identity never regresses
+ * the absent case. See `inboxAddressFor` for how the id enters the address.
+ */
+export const sessionInstance = (config: CrewSessionConfig): string =>
+	config.instance ?? randomUUID();
 
 /**
  * The peer substrate over real unix sockets: the first-peer-spawn `CrewTracker` (host the tracker
@@ -133,10 +150,11 @@ export const channelSendFromPeer = (
  * inbound socket server's `ChannelSink` wakes through it — memoized to a single running transport.
  */
 export const crewSessionLayer = (config: CrewSessionConfig) => {
-	// One per-session instance id, generated once here and threaded to every address derivation, so
-	// an engine session's inbox/announce/heartbeat all agree on the same per-instance address (a
-	// bridge ignores it and keeps its singleton address). See `inboxAddressFor`.
-	const address = inboxAddressFor(config.role, randomUUID());
+	// One per-session instance id, resolved once here and threaded to every address derivation, so an
+	// engine session's inbox/announce/heartbeat all agree on the same per-instance address (a bridge
+	// ignores it and keeps its singleton address). Honors the launcher-assigned `config.instance` when
+	// present, minting one only when absent. See `sessionInstance` / `inboxAddressFor`.
+	const address = inboxAddressFor(config.role, sessionInstance(config));
 	// The one running stdio McpServer + its channel capability; shared across both channel edges.
 	const server = McpServer.layerStdio({
 		name: config.name ?? SESSION_SERVER_NAME,


### PR DESCRIPTION
## What & why

The #3297/#3354 seam-3 work shipped a **producer without a consumer**: `standup/bind.ts` bakes `--instance <uuid>` into every engine role's session argv (`CREW_SESSION_INSTANCE_FLAG`), but `bin.ts`'s `session` `Command.make` declared only `{project-root, role}`. Effect-CLI rejects the unrecognized flag (`Unrecognized flag: --instance in command pipeline-crew-mcp session`), so every engineering-manager engine session **died at parse before serving** — the live 3/5-alive symptom (the three bridges carry no `--instance` and survived; engineering-manager is the only engine role, so both EM engines were dead on arrival).

## The fix

- **`bin.ts`** — declare an optional `--instance` flag on the `session` command (`Flag.optional(Flag.string("instance"))`, matching the existing `project-root`/`role` idiom) so the flag bind.ts emits parses. Thread it as an **exact-optional key** into `CrewSessionConfig`: included only when the launcher passed one (an engine), omitted otherwise (a bridge/singleton, or a direct run).
- **`crew/session.ts`** — add `CrewSessionConfig.instance` (exact-optional, like `name`/`version`) and `sessionInstance`, which **honors the launcher-assigned instance when present** and mints a UUID only when absent (preserving the pre-fix no-instance behavior). `crewSessionLayer` now derives its address from `sessionInstance` instead of always `randomUUID()`-ing.

## Acceptance criteria

- [x] `session` `Command.make` declares an optional `--instance` flag (bridges omit it; engines pass it) — an engine launched with `--instance <uuid>` now parses (`session --help` lists it) instead of aborting.
- [x] The parsed `instance` is threaded through `CrewSessionConfig` and honored by `crewSessionLayer` — binds the launcher-assigned identity when present, falls back to `randomUUID()` only when absent.
- [x] Engine sessions no longer abort at parse; bridges unchanged (they never carried `--instance`).
- [x] Tests cover the seam: `session --help` lists `--instance` (parses), and `sessionInstance` binds the passed instance / falls back to a minted UUID when absent — guarding the producer/consumer from drifting apart again.

## Scope

`bind.ts` (the producer, junior's #3446 lane) is **not touched**. Verified NON-§CP (ADR 0187 carve-out): all four paths are outside `CONTROL_PLANE_RE`. Branched off fresh `origin/main` (junior's #3441/#3438 bin.ts abort-catch present). `pnpm typecheck` + the package vitest (194 tests) green.

Fixes #3445

🤖 Generated with [Claude Code](https://claude.com/claude-code)