### PR TITLE
fix(pipeline): bump pipeline-cli pin to 0.2.0 so republish delivers worktree-sweep (#3451)

### DIFF
--- a/claude-plugins/kampus-pipeline/hooks/install.sh
+++ b/claude-plugins/kampus-pipeline/hooks/install.sh
@@ -17,7 +17,7 @@ set -u
 
 # The one version pin (single source: also read by guard.sh's data dir; the
 # skills' published-fallback pins must match). Bump to reinstall on next SessionStart.
-PIN="0.1.0"
+PIN="0.2.0"
 PKG="@kampus/pipeline-cli"
 
 . "$(dirname "${BASH_SOURCE[0]}")/resolve-data-dir.sh"

--- a/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
@@ -31,7 +31,7 @@ Capture one decision per file in `.decisions/`. There is no committed index (ADR
    if [ -f packages/pipeline-cli/src/bin.ts ]; then
      node packages/pipeline-cli/src/bin.ts decisions-index compact   # phoenix-local: the in-repo consolidated bin
    else
-     pnpm dlx @kampus/pipeline-cli@0.1.0 decisions-index compact      # foreign install: the published consolidated CLI (single-source pin)
+     pnpm dlx @kampus/pipeline-cli@0.2.0 decisions-index compact      # foreign install: the published consolidated CLI (single-source pin)
    fi
    ```
    The published CLI operates on the local `.decisions/` filesystem (no GitHub target), so there is no `$REPO`/`$CLAUDE_PIPELINE_REPO` resolution here — it is purely the in-repo-vs-published invocation swap.
@@ -123,4 +123,4 @@ On a **PR**, `.github/workflows/decisions-index.yml` runs `decisions-index valid
 - Date is today (`date` command if unsure).
 - Never edit an accepted ADR's decision text after the fact — supersede instead.
 - **Always resolve the vocabulary-impact outcome** (Step 5 / [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source)): every ADR ends with *either* a term surfaced to `.glossary/TERMS.md` *or* an explicit recorded "no vocabulary impact." Never leave it unstated — the explicit "none" is a real outcome, not a skip.
-- Your PR adds only the ADR file (plus the superseded file's status edit); there is no committed index. Optional local render of the on-demand compact map (nothing to stage): `node packages/pipeline-cli/src/bin.ts decisions-index compact` when the consolidated bin is on disk, else `pnpm dlx @kampus/pipeline-cli@0.1.0 decisions-index compact`.
+- Your PR adds only the ADR file (plus the superseded file's status edit); there is no committed index. Optional local render of the on-demand compact map (nothing to stage): `node packages/pipeline-cli/src/bin.ts decisions-index compact` when the consolidated bin is on disk, else `pnpm dlx @kampus/pipeline-cli@0.2.0 decisions-index compact`.

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -144,7 +144,7 @@ re-implementing ~50 lines of `jq` inline. Resolve the tool in-repo first, publis
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   LOCK="node packages/pipeline-cli/src/bin.ts epic-lock"   # phoenix-local: the in-repo consolidated bin
 else
-  LOCK="pnpm dlx @kampus/pipeline-cli@0.1.0 epic-lock"     # foreign install: the published CLI
+  LOCK="pnpm dlx @kampus/pipeline-cli@0.2.0 epic-lock"     # foreign install: the published CLI
 fi
 
 # Acquire the two-layer lock. `epic-lock acquire` runs the WHOLE ADR-0115 protocol over $CLAUDE_CODE_SESSION_ID

--- a/claude-plugins/kampus-pipeline/skills/release/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/release/SKILL.md
@@ -176,7 +176,7 @@ missing. Run it for the resolved key **before the dry-run flip**:
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   REACH="node packages/pipeline-cli/src/bin.ts reachability-guard check"
 else
-  REACH="pnpm dlx @kampus/pipeline-cli@0.1.0 reachability-guard check"
+  REACH="pnpm dlx @kampus/pipeline-cli@0.2.0 reachability-guard check"
 fi
 
 # HARD-REFUSE the flip on a non-zero exit — the report (on stderr) names which assertion failed

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1338,7 +1338,7 @@ genuinely unavoidable, the body **MUST** first pass `pipeline-cli leak-guard sca
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin
 else
-  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"     # foreign install: the published CLI
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.2.0 verdict"     # foreign install: the published CLI
 fi
 
 VERDICT_FILE="$(mktemp /tmp/review-code-verdict.XXXXXX)"
@@ -1520,7 +1520,7 @@ straddle a head move:
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   VERDICT="node packages/pipeline-cli/src/bin.ts verdict"
 else
-  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.2.0 verdict"
 fi
 HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # resolve ONCE, before authoring the verdict file (mirror the PASS path)
 VERDICT_FILE="$(mktemp /tmp/review-code-verdict.XXXXXX)"   # per-run temp, not a fixed/PR-namespaced path (#1465)

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -577,7 +577,7 @@ GitHub-hosted screenshot URLs so a human can see what you judged.
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin
 else
-  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"     # foreign install: the published CLI
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.2.0 verdict"     # foreign install: the published CLI
 fi
 upsert() {   # $1 = path to the composed verdict body → prints the upserted comment id; fails loud on a malformed marker
   local out

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -657,7 +657,7 @@ your composed verdict body by file:
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin
 else
-  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"     # foreign install: the published CLI
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.2.0 verdict"     # foreign install: the published CLI
 fi
 
 VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -128,7 +128,7 @@ in-repo first, published fallback (ADR 0064) — then branch on its exit status:
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   LOCK="node packages/pipeline-cli/src/bin.ts epic-lock"   # phoenix-local: the in-repo consolidated bin
 else
-  LOCK="pnpm dlx @kampus/pipeline-cli@0.1.0 epic-lock"     # foreign install: the published CLI (same pin as $GATE)
+  LOCK="pnpm dlx @kampus/pipeline-cli@0.2.0 epic-lock"     # foreign install: the published CLI (same pin as $GATE)
 fi
 
 # Acquire the two-layer lock. `epic-lock acquire` runs the WHOLE ADR-0115 protocol over $CLAUDE_CODE_SESSION_ID
@@ -221,7 +221,7 @@ else
   # foreign install: run the PUBLISHED consolidated CLI. The pin is the single source-of-truth
   # version (`install.sh`'s PIN + the other skills' published-fallback share it; epic #994 / #1003);
   # bump all in lockstep when pipeline-cli releases. Pin a concrete `@<version>` to reproduce a verdict.
-  GATE="pnpm dlx @kampus/pipeline-cli@0.1.0 epic-ledger"
+  GATE="pnpm dlx @kampus/pipeline-cli@0.2.0 epic-ledger"
 fi
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -558,7 +558,7 @@ the post. This is the single-source rule in
 if [ -f packages/pipeline-cli/src/bin.ts ]; then
   VERDICT="node packages/pipeline-cli/src/bin.ts verdict"   # phoenix-local: the in-repo consolidated bin
 else
-  VERDICT="pnpm dlx @kampus/pipeline-cli@0.1.0 verdict"     # foreign install: the published CLI
+  VERDICT="pnpm dlx @kampus/pipeline-cli@0.2.0 verdict"     # foreign install: the published CLI
 fi
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md
@@ -45,7 +45,7 @@ if [ -f packages/pipeline-cli/src/bin.ts ]; then
 else
   # foreign install: the PUBLISHED consolidated CLI; the pin is the single source-of-truth version
   # shared with the other skills' published-fallback (epic #994) — bump in lockstep on release.
-  DIGEST="pnpm dlx @kampus/pipeline-cli@0.1.0 ship-digest"
+  DIGEST="pnpm dlx @kampus/pipeline-cli@0.2.0 ship-digest"
 fi
 ```
 

--- a/packages/pipeline-cli/package.json
+++ b/packages/pipeline-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kampus/pipeline-cli",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "pipeline-cli — the single subcommand-router home all pipeline tooling folds into; `pipeline-cli <tool> …` dispatches to a registered tool (epic #994)",
 	"license": "MIT",
 	"repository": {

--- a/packages/pipeline-cli/src/version.ts
+++ b/packages/pipeline-cli/src/version.ts
@@ -11,7 +11,7 @@ import {Console, Effect} from "effect";
 import {Command} from "effect/unstable/cli";
 
 /** The pipeline-cli version string, surfaced both at the root `--version` and here. */
-export const VERSION = "0.1.0";
+export const VERSION = "0.2.0";
 
 export const versionCommand = Command.make(
 	"version",


### PR DESCRIPTION
## What

Fixes the SessionStart error hitting every phoenix-root session (#3451).

`.claude/settings.json`'s SessionStart runs `guard.sh worktree-sweep --execute`. The subcommand exists in-repo (`packages/pipeline-cli/src/registry.ts` → `worktreeSweepCommand`), but the **published** `@kampus/pipeline-cli@0.1.0` dist carries **zero** worktree-sweep files (verified: `npm view` tarball has 47 `.js` files, none named worktree-sweep). `install.sh` pins `PIN=0.1.0` with a `marker==PIN → skip reinstall` short-circuit, so it installs the stale 0.1.0 CLI; the hook execs it and every session errors `Unknown subcommand "worktree-sweep"` (exit 1, non-blocking) — the orphaned-worktree sweeper is silently disabled.

## Fix — root, not band-aid

Per the founder/EA ruling and ADR 0103 reinstall discipline: **move the version pin so a republish actually delivers a CLI containing worktree-sweep.** Not the band-aid of gating the hook on subcommand presence (that leaves the sweeper disabled until some future republish; #3452 is the separate CI-guard follow-up that must land *after* this).

- `packages/pipeline-cli/package.json` version `0.1.0 → 0.2.0` (minor: new `worktree-sweep` subcommand delivered)
- `src/version.ts` `VERSION 0.1.0 → 0.2.0` (self-report matches package.json)
- `claude-plugins/kampus-pipeline/hooks/install.sh` `PIN 0.1.0 → 0.2.0` — makes `marker != PIN` true on the next SessionStart, triggering the reinstall that pulls 0.2.0-with-worktree-sweep
- The 9 skills' `pnpm dlx @kampus/pipeline-cli@0.1.0` foreign-fallback pins `→ 0.2.0`, honoring install.sh's documented single-source lockstep ("the skills' published-fallback pins must match"). The `@kampus/cf-utils@0.1.0` pin in `what-shipped` is a **different package** and is untouched.

`CHANGELOG.md` is release-generated (ADR 0069) and correctly left untouched.

## Publish mechanism — grounded, requires a human follow-up

`.github/workflows/publish.yml` publishes `@kampus/pipeline-cli` via `pnpm publish` (OIDC trusted publishing) **only on `release: published`** with a tag `pipeline-cli-v<version>` that must equal `package.json` version (a guard fails the run otherwise). This is **NOT automatic on merge** (ADR 0103 — a human-cut GitHub Release).

**So after this PR merges, a human must cut a GitHub Release tagged `pipeline-cli-v0.2.0`** to actually publish the CLI-with-worktree-sweep. The version bumps here are the *precondition* for that release; they do not themselves publish. Once 0.2.0 is on npm, the next SessionStart's `marker != PIN` reinstall delivers worktree-sweep everywhere and the error clears.

> Ordering note: between merge and the release cut, the bumped `dlx @…@0.2.0` foreign-fallback resolves to a not-yet-published version. In-repo pipeline agents use the local bin (already has worktree-sweep), so only a genuinely foreign install in that window is affected — cut the release promptly after merge.

## §CP / human-merge-only

Touches `packages/pipeline-cli/`, `claude-plugins/kampus-pipeline/hooks/install.sh`, and `claude-plugins/kampus-pipeline/skills/*` — all match the canonical `CONTROL_PLANE_RE` (`^packages/pipeline-cli/`, `^claude-plugins/kampus-pipeline/hooks(/|\.json$)`, the enumerated review/plan/release skills). **This is §CP: human-merge-only via @kamp-us/control-plane. Do not auto-ship.**

## Checks

- `pnpm --filter @kampus/pipeline-cli typecheck` — clean
- `pnpm --filter @kampus/pipeline-cli test` — 99 files / 1368 tests pass
- `pnpm lint` — clean
- pre-commit guards (biome, leak-guard, primary-index, ref-guard) — clean

Fixes #3451

🤖 Generated with [Claude Code](https://claude.com/claude-code)