### PR TITLE
docs(pipeline): plain-language human-first summary block in report/write-code/plan-epic

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -251,6 +251,7 @@ Below the untouched brief, write the plan a `write-code` fleet needs, as a
 ```markdown
 ## Plan (plan-epic)
 
+### Summary
 ### Problem & who has it
 ### What changes
 ### User stories
@@ -267,6 +268,11 @@ of this plan block.) What each section holds:
 
 **Product layer — lead with this.**
 
+- **Summary** — a plain-language, human-first lead: **2–3 sentences a reader grasps on a
+  skim** — what this epic delivers and why it matters, in prose, no jargon — before the
+  structured plan below. It **precedes, never replaces**, the product/engineering layers
+  that follow (the human-first-summary mandate from
+  [#3374](https://github.com/kamp-us/phoenix/issues/3374)).
 - **Problem & who has it** — the problem from the user's perspective: who is affected
   (include automated agents — kamp.us is a human-*and*-agent surface), and why it matters
   now. Grounded in the brief + the existing product, not invented. This is the section

--- a/claude-plugins/kampus-pipeline/skills/report/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/report/SKILL.md
@@ -17,11 +17,22 @@ File autonomously. Do **not** propose-first or ask for permission — the whole 
 
 You apply exactly one label: `status:needs-triage`. Nothing else. Typing or prioritizing here would poison the triage queue — a hand-applied type looks identical to a triaged one, and triage can no longer trust the signal.
 
+## Lead with a plain-language summary
+
+Before the structured sections, open the body with a **plain-language, human-first
+summary — 2–3 sentences a reader grasps on a skim**: what you observed and why it's worth
+tracking, in prose, no jargon. It **precedes, never replaces**, the structured body below —
+a triager skimming the queue reads it first (the human-first-summary mandate from
+[#3374](https://github.com/kamp-us/phoenix/issues/3374)). Give it the heading `## Summary`.
+
 ## The 5-section body template
 
-The body is **type-blind** by design: the same five sections fit a bug, a refactor, a question, or an investigation, so you never have to classify to file. Use these exact section headings:
+The body is **type-blind** by design: the same five sections fit a bug, a refactor, a question, or an investigation, so you never have to classify to file. Under the `## Summary` lead above, use these exact section headings:
 
 ```markdown
+## Summary
+<2–3 plain-language sentences a reader grasps on a skim: what you observed and why it's worth tracking. The human-first lead, before the structured sections below.>
+
 ## What I was doing
 <The task in flight when this surfaced. One or two sentences. Concrete: what file, what feature, what command.>
 
@@ -79,7 +90,7 @@ REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOw
 ```
 
 1. Write the title: a short, specific, type-neutral summary of the observation (≤ ~70 chars). Good: "Retry helper in http worker swallows the abort reason". Bad: "Bug in worker" or "BUG: fix retry".
-2. Build the body: the five sections, then a blank line, then the footer block from `footer.sh`.
+2. Build the body: the `## Summary` lead, then the five sections, then a blank line, then the footer block from `footer.sh`.
 3. **Re-query for an existing issue — always, and last.** Report agents run
    concurrently (several people run them at once), so the same observation may have
    been filed minutes ago. Run this check *after* composing the body, as the final
@@ -117,6 +128,9 @@ Stream the composed body **straight into the create call over stdin** — there 
 # never touches the markdown, so backticks and nested ``` fences file intact.
 {
   cat <<'EOF'
+## Summary
+…
+
 ## What I was doing
 …
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1284,6 +1284,16 @@ Open the PR with **`Fixes #N` in the body** so merging auto-closes the issue (th
 the seam `review-code` relies on: pass → merge → `Fixes #N` closes it). Use the issue
 number you're implementing.
 
+**Lead the body with a plain-language, human-first summary.** Before any technical
+detail — the what-changed rundown, the `Fixes #N` seam, a `Flag:` line — open the body
+with **2–3 plain sentences a reviewer or a passer-by can grasp on a skim**: what this PR
+changes and why it matters, in prose, no jargon. The summary **precedes, never replaces**,
+the technical body below it. This is the human-first-summary mandate from
+[#3374](https://github.com/kamp-us/phoenix/issues/3374) — the same wired-in writing-craft
+integration Step 4e authors to, so write the summary to
+[`../writing-clearly-and-concisely/SKILL.md`](../writing-clearly-and-concisely/SKILL.md)
+(clear, concrete, no AI tells).
+
 **The AC-completeness gate — decide `Fixes #N` vs `Part of #N` from whether the diff satisfies
 EVERY acceptance criterion (run this BEFORE you write the keyword).** The closing keyword is a
 **scope claim**, not a formality: `Fixes #N` auto-closes the *whole* issue on merge, so it is
@@ -1412,7 +1422,7 @@ gh pr create \
   --base main \
   --title "<concise PR title>" \
   --body "$(cat <<'EOF'
-<short summary of what changed and why>
+<2–3 plain-language sentences: what changed and why, for a human skimming — the human-first summary that leads the body, before any technical detail>
 
 Fixes #<N>
 Flag: <FLAG_KEY>


### PR DESCRIPTION
This teaches three pipeline skills to open their output with a short, plain-English summary a human can grasp at a glance — before any structured or technical detail. `report` now leads issue bodies with a `## Summary`, `write-code` leads PR descriptions with a 2–3 sentence summary, and `plan-epic` leads epic plans with a `### Summary`. It only adds a lead-in; the existing body formats are untouched, so nothing downstream has to change.

Wave 2 of the #3374 writing-craft integration (the last §CP child). The summary block **precedes, never replaces** the technical body in each skill, and each mandate points back at #3374 rather than re-deriving the rationale.

**§CP:** this PR edits control-plane skill dirs (`claude-plugins/kampus-pipeline/skills/write-code/` and `.../plan-epic/`), so it is human-merge-only via **@kamp-us/control-plane** — do not auto-merge. (`report/` is not a control-plane dir on its own, but rides along in this PR.)

Fixes #3390