### PR TITLE
feat(ui): roll the JSDoc metadata convention across the remaining ui primitives (#3154)

### DIFF
--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -37,6 +37,15 @@ export interface SurfaceProps extends React.HTMLAttributes<HTMLElement> {
 	border?: boolean;
 }
 
+/**
+ * @component Surface
+ * @whenToUse The parameterized surface shell — background/border/radius/padding/
+ *   elevation driven entirely by role-token props. Reach for it (over `Card`) only
+ *   to reproduce an existing shell's exact look during a migration; for a new
+ *   surface prefer `Card`'s opinionated default (the selection rule is the
+ *   manifest's, referenced not restated — see `design-system-manifest.md`).
+ * @slot children The surface's content.
+ */
 export function Surface({
 	as,
 	tone = "default",

--- a/apps/web/src/components/ui/Collapsible.tsx
+++ b/apps/web/src/components/ui/Collapsible.tsx
@@ -11,7 +11,10 @@ export function Trigger({
 	open,
 	className = "",
 	...rest
-}: React.ComponentProps<typeof BaseCollapsible.Trigger> & {open?: boolean}) {
+}: React.ComponentProps<typeof BaseCollapsible.Trigger> & {
+	/** Current open state — drives the +/– glyph and the expand/collapse aria-label. */
+	open?: boolean;
+}) {
 	return (
 		<BaseCollapsible.Trigger
 			className={`${styles.trigger} ${className}`.trim()}
@@ -31,4 +34,14 @@ export function Panel({children, ...rest}: React.ComponentProps<typeof BaseColla
 	);
 }
 
+/**
+ * @component Collapsible
+ * @whenToUse The show/hide disclosure compound (base-ui). Compose from its parts to
+ *   toggle a region's visibility inline — a "show more" body, an expandable detail.
+ *   `Trigger` supplies its own genişlet/daralt aria-label, so reach for it rather
+ *   than a hand-wired button + hidden div.
+ * @slot Root The open/close state provider wrapping the trigger + panel.
+ * @slot Trigger The +/– toggle control that opens/closes the panel.
+ * @slot Panel The collapsible content region.
+ */
 export const Collapsible = {Root, Trigger, Panel};

--- a/apps/web/src/components/ui/CopyLinkButton.tsx
+++ b/apps/web/src/components/ui/CopyLinkButton.tsx
@@ -89,11 +89,21 @@ export function shareFeedbackLabel(
 export interface CopyLinkButtonProps {
 	/** Canonical path of the item, e.g. `/pano/:id` or `/pano/:id#comment-<id>`. */
 	path: string;
+	/** Resting label; defaults to `paylaş`. Feedback states replace it transiently. */
 	label?: string;
 	testId?: string;
 	className?: string;
 }
 
+/**
+ * @component CopyLinkButton
+ * @whenToUse The shared paylaş (share/copy-link) control. Reach for it on any
+ *   shareable item (pano post/comment, sözlük definition) — pass the canonical
+ *   `path` and it resolves the absolute URL, copies it, and flashes inline
+ *   kopyalandı/kopyalanamadı feedback (native share sheet only on coarse-pointer
+ *   surfaces). Don't hand-roll per-page link logic.
+ * @slot none Renders its own label; no children slot.
+ */
 export function CopyLinkButton({path, label = "paylaş", testId, className}: CopyLinkButtonProps) {
 	const [feedback, setFeedback] = React.useState<"copied" | "error" | null>(null);
 	const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/apps/web/src/components/ui/DraftRestoreBanner.tsx
+++ b/apps/web/src/components/ui/DraftRestoreBanner.tsx
@@ -7,12 +7,21 @@ import "./DraftRestoreBanner.css";
  * the user explicitly restores or discards it. Real semantics — a labelled `<section>`
  * landmark with two native buttons (full keyboard path + visible focus from `kp-btn`);
  * state is conveyed by text, not color alone. Copy is lowercase Turkish.
+ *
+ * @component DraftRestoreBanner
+ * @whenToUse The saved-draft restore prompt. Reach for it after a flow that may have
+ *   stashed a draft across the auth round-trip — it OFFERS restore/discard rather
+ *   than silently re-injecting (#1214). Wire `onRestore`/`onDismiss` to the caller's
+ *   draft store.
+ * @slot none Fixed copy + two actions; no children slot.
  */
 export function DraftRestoreBanner({
 	onRestore,
 	onDismiss,
 }: {
+	/** Called when the user accepts — restore the stashed draft. */
 	onRestore: () => void;
+	/** Called when the user declines — discard/ignore the stashed draft. */
 	onDismiss: () => void;
 }) {
 	return (

--- a/apps/web/src/components/ui/EditedIndicator.tsx
+++ b/apps/web/src/components/ui/EditedIndicator.tsx
@@ -1,13 +1,24 @@
 import {editedAfter, formatEditedTooltipTR} from "../../lib/datetime";
 import {Tooltip} from "./Tooltip";
 
-// Returns null when `updatedAt` is missing or within the grace window, so callers
-// can render it unconditionally without gating on edit state themselves.
+/**
+ * The muted "düzenlendi" edit marker with an edited-at tooltip. Returns null when
+ * `updatedAt` is missing or within the grace window, so callers can render it
+ * unconditionally without gating on edit state themselves.
+ *
+ * @component EditedIndicator
+ * @whenToUse The edited-marker glyph. Reach for it on any editable entity's meta row
+ *   (post, comment, definition) to signal an edit — render it unconditionally and
+ *   let it self-suppress when the item is unedited or still within the grace window.
+ * @slot none Fixed copy + tooltip; no children slot.
+ */
 export function EditedIndicator({
 	createdAt,
 	updatedAt,
 }: {
+	/** The entity's creation timestamp — the baseline the edit is measured against. */
 	createdAt: string | null | undefined;
+	/** The entity's last-update timestamp; drives visibility and the tooltip text. */
 	updatedAt: string | null | undefined;
 }) {
 	if (!editedAfter(createdAt, updatedAt)) return null;

--- a/apps/web/src/components/ui/EmptyState.tsx
+++ b/apps/web/src/components/ui/EmptyState.tsx
@@ -10,6 +10,16 @@ import "./EmptyState.css";
  * Slots, not law: an `icon` glyph slot, a required `title`, an optional
  * `description`, and an `action` CTA slot. Composed from existing spacing/text
  * tokens only — it defines no new design-system primitive.
+ *
+ * @component EmptyState
+ * @whenToUse The inline empty-state block. Reach for it to fill a sparse region
+ *   within a page (an empty feed, a zero-count list, a contribution-less profile)
+ *   so the void reads as intentional. For a full-page miss use `NotFoundPage`, its
+ *   404 sibling, instead.
+ * @slot icon Optional decorative glyph above the title (aria-hidden).
+ * @slot title The required headline for the empty state.
+ * @slot description Optional supporting line under the title.
+ * @slot action Optional CTA (e.g. a Button) below the copy.
  */
 export function EmptyState({
 	icon,
@@ -18,9 +28,13 @@ export function EmptyState({
 	action,
 	className = "",
 }: {
+	/** Decorative glyph above the title. */
 	icon?: React.ReactNode;
+	/** The required headline. */
 	title: React.ReactNode;
+	/** Optional supporting line under the title. */
 	description?: React.ReactNode;
+	/** Optional CTA below the copy. */
 	action?: React.ReactNode;
 	className?: string;
 }) {

--- a/apps/web/src/components/ui/Form.tsx
+++ b/apps/web/src/components/ui/Form.tsx
@@ -8,6 +8,14 @@ import "./Form.css";
 const styles = bem("kp-form", []);
 const fieldStyles = bem("kp-field", ["label", "hint", "error"]);
 
+/**
+ * @component Form
+ * @whenToUse The form shell (base-ui) — the outermost element for any input form,
+ *   wiring native submit + validation. Compose the field family (`Field`, `Label`,
+ *   `Hint`, `FieldError`, `Input`, `Textarea`) inside it rather than hand-rolling a
+ *   `<form>`.
+ * @slot children The form's fields and controls.
+ */
 export function Form({className = "", children, ...rest}: React.ComponentProps<typeof BaseForm>) {
 	return (
 		<BaseForm className={`${styles.root} ${className}`.trim()} {...rest}>
@@ -16,6 +24,13 @@ export function Form({className = "", children, ...rest}: React.ComponentProps<t
 	);
 }
 
+/**
+ * @component Field
+ * @whenToUse The single-field grouping (base-ui) — wraps one `Label` + control +
+ *   `Hint`/`FieldError`, wiring their aria relationships. Reach for it once per input
+ *   inside a `Form` so label/error association is automatic.
+ * @slot children The field's `Label`, control, and hint/error parts.
+ */
 export function Field({
 	className = "",
 	children,
@@ -28,6 +43,13 @@ export function Field({
 	);
 }
 
+/**
+ * @component Label
+ * @whenToUse The field label (base-ui) — the accessible name for its `Field`'s
+ *   control. Reach for it inside every `Field`; it associates to the control
+ *   automatically, so never substitute a bare `<label>` or placeholder text.
+ * @slot children The label text.
+ */
 export function Label({children, ...rest}: React.ComponentProps<typeof BaseField.Label>) {
 	return (
 		<BaseField.Label className={fieldStyles.label} {...rest}>
@@ -36,6 +58,13 @@ export function Label({children, ...rest}: React.ComponentProps<typeof BaseField
 	);
 }
 
+/**
+ * @component Hint
+ * @whenToUse The field helper text (base-ui) — a persistent description under a
+ *   control, wired to `aria-describedby`. Reach for it for guidance that always
+ *   shows; use `FieldError` for validation messages instead.
+ * @slot children The hint text.
+ */
 export function Hint({children, ...rest}: React.ComponentProps<typeof BaseField.Description>) {
 	return (
 		<BaseField.Description className={fieldStyles.hint} {...rest}>
@@ -44,6 +73,13 @@ export function Hint({children, ...rest}: React.ComponentProps<typeof BaseField.
 	);
 }
 
+/**
+ * @component FieldError
+ * @whenToUse The field validation message (base-ui) — the error line for its
+ *   `Field`'s control, wired to the control and shown on invalid state. Reach for it
+ *   for validation feedback; use `Hint` for always-on guidance.
+ * @slot children The error text.
+ */
 export function FieldError({children, ...rest}: React.ComponentProps<typeof BaseField.Error>) {
 	return (
 		<BaseField.Error className={fieldStyles.error} {...rest}>
@@ -52,15 +88,31 @@ export function FieldError({children, ...rest}: React.ComponentProps<typeof Base
 	);
 }
 
+/**
+ * @component Input
+ * @whenToUse The single-line text control (base-ui). Reach for it inside a `Field`
+ *   for any one-line input; for multi-line text use `Textarea`.
+ * @slot none A leaf control; no children slot.
+ */
 export function Input({className = "", ...rest}: React.ComponentProps<typeof BaseInput>) {
 	return <BaseInput className={`kp-input ${className}`.trim()} {...rest} />;
 }
 
+/**
+ * @component Textarea
+ * @whenToUse The multi-line text control. Reach for it inside a `Field` for
+ *   free-form text (a comment body, a definition); pass `mono` for code/preformatted
+ *   input. For a single line use `Input`.
+ * @slot none A leaf control; no children slot.
+ */
 export function Textarea({
 	className = "",
 	mono = false,
 	...rest
-}: React.TextareaHTMLAttributes<HTMLTextAreaElement> & {mono?: boolean}) {
+}: React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+	/** Render in a monospace face for code/preformatted input. */
+	mono?: boolean;
+}) {
 	const cls = `kp-textarea ${mono ? "kp-textarea--mono" : ""} ${className}`.trim();
 	return <BaseField.Control render={<textarea className={cls} {...rest} />} />;
 }

--- a/apps/web/src/components/ui/ReportButton.tsx
+++ b/apps/web/src/components/ui/ReportButton.tsx
@@ -18,6 +18,14 @@ export interface ReportButtonProps {
 	className?: string;
 }
 
+/**
+ * @component ReportButton
+ * @whenToUse The shared bildir (report) control. Reach for it on any reportable item
+ *   (pano post/comment, sözlük definition) — pass `onReport` to perform the mutation
+ *   and it owns the in-flight lock plus the bildirildi/zaten bildirildi feedback,
+ *   locking once confirmed. Don't hand-roll per-page report logic.
+ * @slot none Renders its own label; no children slot.
+ */
 export function ReportButton({onReport, testId, className}: ReportButtonProps) {
 	const [state, setState] = React.useState<"idle" | "busy" | "reported" | "already">("idle");
 

--- a/apps/web/src/components/ui/ReviewBadge.tsx
+++ b/apps/web/src/components/ui/ReviewBadge.tsx
@@ -5,6 +5,14 @@
 // badge). State is carried by the word, not color alone (the AA-contrast tokens).
 import "./ReviewBadge.css";
 
+/**
+ * @component ReviewBadge
+ * @whenToUse The incelemede in-review badge. Reach for it on a çaylak's OWN
+ *   sandboxed content (post-detail, definition) to signal it is pending review —
+ *   the `sandboxed` wire flag is owner-scoped, so only the author sees it. The
+ *   profile katkıların list has its own #1291 badge; don't reuse this there.
+ * @slot none Fixed copy; no children slot.
+ */
 export function ReviewBadge() {
 	return (
 		<span className="kp-review-badge" data-testid="incelemede-badge">

--- a/apps/web/src/components/ui/Tabs.tsx
+++ b/apps/web/src/components/ui/Tabs.tsx
@@ -11,6 +11,7 @@ export function Root({
 	children,
 	...rest
 }: React.ComponentProps<typeof BaseTabs.Root> & {
+	/** Visual style of the tab list: `underline` (default) or `pill`. */
 	variant?: "underline" | "pill";
 }) {
 	const cls = `${styles.root} ${variant === "pill" ? "kp-tabs--pill" : ""} ${className}`.trim();
@@ -45,4 +46,15 @@ export function Panel({children, ...rest}: React.ComponentProps<typeof BaseTabs.
 	);
 }
 
+/**
+ * @component Tabs
+ * @whenToUse The tabbed-panels compound (base-ui). Compose from its parts to switch
+ *   between sibling views within one region; supports an `underline` or `pill`
+ *   `variant`. Reach for it over hand-wired show/hide so keyboard + aria roles come
+ *   for free.
+ * @slot Root The selection-state provider wrapping the list + panels.
+ * @slot List The tab strip holding the `Tab` triggers.
+ * @slot Tab A single tab trigger; its text child is its accessible name.
+ * @slot Panel The content region shown for the matching tab.
+ */
 export const Tabs = {Root, List, Tab, Panel};

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -22,6 +22,14 @@ const ToastContext = React.createContext<ToastContextValue | null>(null);
 
 let nextId = 0;
 
+/**
+ * @component ToastProvider
+ * @whenToUse The transient-notification host. Mount it once near the app root; child
+ *   surfaces raise toasts via the `useToast` hook (`show`/`dismiss`). Reach for it
+ *   for ephemeral status messages (a saved confirmation, a session-expired notice) —
+ *   re-showing the same id replaces rather than stacks.
+ * @slot children The subtree that can raise toasts via `useToast`.
+ */
 export function ToastProvider({children}: {children: React.ReactNode}) {
 	const [toasts, setToasts] = React.useState<ToastDescriptor[]>([]);
 

--- a/apps/web/src/components/ui/ToggleGroup.tsx
+++ b/apps/web/src/components/ui/ToggleGroup.tsx
@@ -14,6 +14,7 @@ export function Root({
 	children,
 	...rest
 }: React.ComponentProps<typeof BaseToggleGroup> & {
+	/** Visual style of the group: `pill` (default) · `segmented` · `square` · `swatch`. */
 	variant?: ToggleVariant;
 }) {
 	const variantCls = variant === "pill" ? "" : `kp-toggle-group--${variant}`;
@@ -31,6 +32,7 @@ export function Item({
 	children,
 	...rest
 }: React.ComponentProps<typeof Toggle> & {
+	/** For the `swatch` variant: the color rendered as the item's fill (`--swatch-color`). */
 	swatchColor?: string;
 }) {
 	// `--swatch-color` is a CSS custom property; React 19's `CSSProperties` only
@@ -53,4 +55,14 @@ export function Item({
 	);
 }
 
+/**
+ * @component ToggleGroup
+ * @whenToUse The single/multi-select toggle set (base-ui). Compose `Root` + `Item`s
+ *   for a segmented control, a filter set, or a swatch picker (`variant="swatch"`
+ *   with `swatchColor`). Reach for it when a small fixed set of options toggles in
+ *   place; for a binary on/off use `Switch`.
+ * @slot Root The selection-state provider wrapping the items.
+ * @slot Item A single toggle option; text child is its accessible name (or set
+ *   `aria-label` for an icon/swatch-only item).
+ */
 export const ToggleGroup = {Root, Item};

--- a/apps/web/src/components/ui/Tooltip.tsx
+++ b/apps/web/src/components/ui/Tooltip.tsx
@@ -5,17 +5,36 @@ import "./Tooltip.css";
 
 const styles = bem("kp-tooltip", ["positioner", "popup"]);
 
+/**
+ * @component TooltipProvider
+ * @whenToUse The tooltip timing/context host (base-ui). Mount it once high in the
+ *   tree so grouped tooltips share open/close delays; every `Tooltip` renders under
+ *   it. Reach for it at the app/shell level, not per tooltip.
+ * @slot children The subtree whose `Tooltip`s share this provider's timing.
+ */
 export const Provider = BaseTooltip.Provider;
 
+/**
+ * @component Tooltip
+ * @whenToUse The hover/focus tooltip (base-ui). Wrap a trigger element to attach a
+ *   short supplementary hint. It is supplementary only — never put essential
+ *   information solely in a tooltip; its z-index is tuned to clear the sticky Subnav
+ *   (#2046). Requires a `TooltipProvider` ancestor.
+ * @slot children The trigger element the tooltip is attached to.
+ */
 export function Tooltip({
 	content,
 	children,
 	side = "top",
 	defaultOpen,
 }: {
+	/** The tooltip's content shown in the popup. */
 	content: React.ReactNode;
+	/** The trigger element the tooltip attaches to. */
 	children: React.ReactNode;
+	/** Which edge of the trigger the popup opens from. Defaults to `top`. */
 	side?: "top" | "right" | "bottom" | "left";
+	/** Render open on mount (e.g. for a one-shot coach-mark). */
 	defaultOpen?: boolean;
 }) {
 	return (

--- a/apps/web/src/components/ui/atoms.tsx
+++ b/apps/web/src/components/ui/atoms.tsx
@@ -33,24 +33,54 @@ export function Tag({
 	);
 }
 
+/**
+ * @component Kbd
+ * @whenToUse The keyboard-key glyph — renders a `<kbd>` for a shortcut key or key
+ *   combo mentioned in running text (e.g. a `⌘K` hint). Reach for it over a styled
+ *   span so the key reads as a key semantically, not just visually.
+ * @slot children The key label (a single key or a combo).
+ */
 export function Kbd({children}: {children: React.ReactNode}) {
 	return <kbd className="kp-kbd">{children}</kbd>;
 }
 
+/**
+ * @component Mark
+ * @whenToUse The highlight glyph — renders a `<mark>` to emphasize a run of text
+ *   (a search-match hit, a called-out term). Reach for it over a colored span so
+ *   the highlight carries the native highlight semantics.
+ * @slot children The highlighted text.
+ */
 export function Mark({children}: {children: React.ReactNode}) {
 	return <mark className="kp-mark">{children}</mark>;
 }
 
+/**
+ * @component Code
+ * @whenToUse The inline-code glyph — renders a `<code>` for an identifier, path, or
+ *   short literal inside running prose. Reach for it over a styled span so the code
+ *   run is semantic; for a multi-line block use a `<pre>`, not this inline atom.
+ * @slot children The code text.
+ */
 export function Code({children}: {children: React.ReactNode}) {
 	return <code className="kp-code">{children}</code>;
 }
 
+/**
+ * @component Skeleton
+ * @whenToUse The loading-placeholder block — a shimmering box that reserves space
+ *   for content still in flight. Reach for it to hold layout during a fetch instead
+ *   of a spinner or a collapsing void; size it to the content it stands in for.
+ * @slot none Presentational; renders no children.
+ */
 export function Skeleton({
 	width,
 	height = 12,
 	className = "",
 }: {
+	/** Placeholder width; a bare number is treated as pixels. */
 	width?: number | string;
+	/** Placeholder height; a bare number is treated as pixels. Defaults to 12. */
 	height?: number | string;
 	className?: string;
 }) {


### PR DESCRIPTION
Fixes #3154

Mechanical rollout of the ratified descriptive-only JSDoc component-metadata schema (ADR 0194, seeded on the a11y-registry primitives in #3153 / PR #3437) to **every remaining primitive** under `apps/web/src/components/ui/`. No new convention — the pilot's shape is copied verbatim (`@component` + `@whenToUse` + `@slot` per composition point + prop-level JSDoc; one block on the compound-object export for compounds).

### Primitives covered (this PR)
- **atoms.tsx:** `Code`, `Kbd`, `Mark`, `Skeleton` (`Tag` was the pilot)
- **Card.tsx:** `Surface` (`Card` was the pilot)
- **Compound objects:** `Collapsible`, `Tabs`, `ToggleGroup`, `Tooltip` (+ `TooltipProvider`)
- **Form family:** `Form`, `Field`, `Label`, `Hint`, `FieldError`, `Input`, `Textarea`
- **Standalone:** `CopyLinkButton`, `ReportButton`, `EmptyState`, `DraftRestoreBanner`, `EditedIndicator`, `ReviewBadge`, `ToastProvider`

That is every `index.ts`-exported primitive not covered by the pilot, plus the three issue-named non-index primitives (`ReviewBadge`, `EditedIndicator`, `Toast`).

### Firewall (ADR 0194)
Descriptive fields only. `@whenToUse` references `design-system-manifest.md` law by pointer, never mints a rule. `design-system-manifest.md` is **untouched**. No §CP surface touched — `apps/web/src/**` only.

### Verification
- `pnpm typecheck` — pass (33/33)
- `pnpm lint` — pass (only pre-existing warnings in `packages/pipeline-cli`, unrelated files)

### Notes for review
- The Form family's parts are separately-exported functions (not a compound object), so each carries its own `@component` block — consistent with how the pilot gave each `atoms.tsx` export its own block, and required for the extractor to key on every exported name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)