### PR TITLE
feat(pipeline-crew-mcp): boot crew panes AS their role persona via --plugin-dir + --agent (#3447)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -12,6 +12,7 @@ import {existsSync} from "node:fs";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {
+	AGENT_FLAG,
 	ALLOWLIST_CHANNEL_FLAG,
 	buildSessionBind,
 	ChannelPluginNotAllowedError,
@@ -24,12 +25,16 @@ import {
 	DEV_CHANNEL_FLAG,
 	MODEL_FLAG,
 	NAME_FLAG,
+	PLUGIN_DIR_FLAG,
 } from "./bind.ts";
 import type {ChannelConfig} from "./config.ts";
 
 const ROLE = "engineering-manager";
 const PROJECT_ROOT = "/work/phoenix";
 const SERVER_NAME = "pipeline-crew";
+// The pipeline-crew plugin root under PROJECT_ROOT — the dir `--plugin-dir` loads the role agent-defs
+// from so `--agent <role>` resolves the persona instead of general-purpose (#3447).
+const EXPECTED_PLUGIN_DIR = "/work/phoenix/claude-plugins/pipeline-crew";
 
 // The exact persisted-scope server config the launcher writes to `~/.claude.json` local scope: the
 // launcher's own node (`process.execPath`) running the ABSOLUTE bin.ts path — a resolvable invocation,
@@ -68,9 +73,14 @@ describe("standup/bind — per-session bind constructor", () => {
 					"plugin:kampus:sozluk",
 				]);
 
-				// AC2: the argv registers the channel + closes with the visible name (#3443) and carries NO
-				// `--mcp-config` — the crew server now registers via the persisted local scope (#3444).
+				// AC2: the argv boots the role persona (--plugin-dir + --agent, #3447), registers the channel,
+				// closes with the visible name (#3443), and carries NO `--mcp-config` — the crew server now
+				// registers via the persisted local scope (#3444).
 				assert.deepStrictEqual(bind.argv, [
+					PLUGIN_DIR_FLAG,
+					EXPECTED_PLUGIN_DIR,
+					AGENT_FLAG,
+					ROLE,
 					ALLOWLIST_CHANNEL_FLAG,
 					"server:pipeline-crew",
 					"plugin:kampus:sozluk",
@@ -105,8 +115,69 @@ describe("standup/bind — per-session bind constructor", () => {
 					"server:pipeline-crew",
 					"plugin:localdev:scratch",
 				]);
-				assert.deepStrictEqual(bind.argv, [...bind.channelArg, ...bind.nameArg]);
+				assert.deepStrictEqual(bind.argv, [
+					...bind.pluginDirArg,
+					...bind.agentArg,
+					...bind.channelArg,
+					...bind.nameArg,
+				]);
 			}),
+	);
+
+	it.effect(
+		"boots each pane AS its role persona: --plugin-dir <crew plugin> + --agent <role>, identity-mapped (#3447)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				// Each role's --agent target is the role verbatim — CREW_ROLES == the agent-defs' `name:`
+				// frontmatter (ADR 0189), so no translation table; --plugin-dir is what makes it resolvable.
+				for (const role of [
+					"chief-of-staff",
+					"cartographer",
+					"intake-desk",
+					"engineering-manager",
+				]) {
+					const bind = yield* buildSessionBind({
+						role,
+						projectRoot: PROJECT_ROOT,
+						serverName: SERVER_NAME,
+						channels,
+					});
+					assert.deepStrictEqual([...bind.pluginDirArg], [PLUGIN_DIR_FLAG, EXPECTED_PLUGIN_DIR]);
+					assert.deepStrictEqual([...bind.agentArg], [AGENT_FLAG, role]);
+					// the persona flags lead the argv (ahead of the channel fragment), after any --model.
+					assert.deepStrictEqual([...bind.argv].slice(0, 4), [
+						PLUGIN_DIR_FLAG,
+						EXPECTED_PLUGIN_DIR,
+						AGENT_FLAG,
+						role,
+					]);
+				}
+			}),
+	);
+
+	it.effect("derives --plugin-dir from the project root (never a hardcoded/home path)", () =>
+		Effect.gen(function* () {
+			const channels: ChannelConfig = {
+				mode: "development",
+				servers: ["server:pipeline-crew"],
+				allowedChannelPlugins: [],
+			};
+			const bind = yield* buildSessionBind({
+				role: ROLE,
+				projectRoot: "/some/other/root",
+				serverName: SERVER_NAME,
+				channels,
+			});
+			assert.deepStrictEqual(
+				[...bind.pluginDirArg],
+				[PLUGIN_DIR_FLAG, "/some/other/root/claude-plugins/pipeline-crew"],
+			);
+		}),
 	);
 
 	it.effect(
@@ -253,10 +324,18 @@ describe("standup/bind — per-session bind constructor", () => {
 			// The tier boots the session's model — a family tier is a verbatim --model alias (config.ts
 			// Tier, grounded on the 2.1.212 bundle), so tier:opus yields `--model opus`.
 			assert.deepStrictEqual([...bind.modelArg], [MODEL_FLAG, "opus"]);
-			// --model leads the argv; the channel fragment follows it, then the name (#3443). No --mcp-config.
+			// --model leads the argv; then the persona flags (#3447), the channel fragment, and the name
+			// (#3443). No --mcp-config.
 			assert.deepStrictEqual(
 				[...bind.argv],
-				[MODEL_FLAG, "opus", ...bind.channelArg, ...bind.nameArg],
+				[
+					MODEL_FLAG,
+					"opus",
+					...bind.pluginDirArg,
+					...bind.agentArg,
+					...bind.channelArg,
+					...bind.nameArg,
+				],
 			);
 		}),
 	);
@@ -298,8 +377,12 @@ describe("standup/bind — per-session bind constructor", () => {
 				});
 				assert.deepStrictEqual([...bind.modelArg], []);
 				assert.notInclude(bind.argv, MODEL_FLAG);
-				// No tier ⇒ no --model; argv is the channel fragment closed by the name (#3443).
-				assert.deepStrictEqual([...bind.argv], [...bind.channelArg, ...bind.nameArg]);
+				// No tier ⇒ no --model; argv is the persona flags (#3447) + the channel fragment closed by
+				// the name (#3443).
+				assert.deepStrictEqual(
+					[...bind.argv],
+					[...bind.pluginDirArg, ...bind.agentArg, ...bind.channelArg, ...bind.nameArg],
+				);
 			}),
 	);
 

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -30,6 +30,7 @@
  * fail-closed guard lives at that write (register-project-scope.ts / orchestrate.ts), not here.
  */
 import {existsSync} from "node:fs";
+import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {Effect, Schema} from "effect";
 import {type ChannelConfig, type Tier, tierModel} from "./config.ts";
@@ -58,6 +59,23 @@ export const MODEL_FLAG = "--model";
  * the operator-legibility symptom (#3443).
  */
 export const NAME_FLAG = "--name";
+/**
+ * Boots the crew session's plugin substrate so `--agent <role>` can resolve the role's agent-def as
+ * the session persona. `--agent` binds only an agent-def already in the launched session's resolver,
+ * and a pipeline-crew agent-def enters that resolver as a source:"plugin" def ONLY once the plugin is
+ * loaded — so without `--plugin-dir <…/claude-plugins/pipeline-crew>` the `--agent <role>` below falls
+ * through to the generic general-purpose default (the observed generic boot, #3447). The pipeline-crew
+ * plugin declares no MCP server (the crew channel MCP is wired separately via the channel flag), so a
+ * plain `--plugin-dir` adds only the agent-defs. Role → agent-def is an IDENTITY map — `CREW_ROLES`
+ * equals the agent-defs' `name:` frontmatter (ADR 0189) — so `--agent <role>` passes the role verbatim,
+ * no translation table.
+ */
+export const PLUGIN_DIR_FLAG = "--plugin-dir";
+/** Boots the session AS its role persona by resolving the plugin agent-def named `<role>` (see PLUGIN_DIR_FLAG, #3447). */
+export const AGENT_FLAG = "--agent";
+/** The pipeline-crew plugin root under a given project root — the dir `--plugin-dir` loads agent-defs from. */
+const crewPluginDir = (projectRoot: string): string =>
+	join(projectRoot, "claude-plugins/pipeline-crew");
 /** Allowlist mode: only servers named here load, gated by `allowedChannelPlugins` for plugin refs. */
 export const ALLOWLIST_CHANNEL_FLAG = "--channels";
 /** Dev mode: load channel servers not on the approved allowlist — local development only. */
@@ -120,8 +138,17 @@ export interface SessionBind {
 	 */
 	readonly nameArg: readonly [flag: string, name: string];
 	/**
-	 * The complete argv `[...modelArg, ...channelArg, ...nameArg]` the launcher passes to `claude`. It
-	 * no longer carries `--mcp-config`: the crew server now registers via the pane's project-scope
+	 * `["--plugin-dir", "<projectRoot>/claude-plugins/pipeline-crew"]` — loads the pipeline-crew plugin
+	 * so its agent-defs enter the launched session's resolver, the precondition `--agent` needs (see
+	 * PLUGIN_DIR_FLAG, #3447).
+	 */
+	readonly pluginDirArg: readonly [flag: string, dir: string];
+	/** `["--agent", "<role>"]` — boots the session AS its role persona (identity-mapped, #3447 / ADR 0189). */
+	readonly agentArg: readonly [flag: string, role: string];
+	/**
+	 * The complete argv `[...modelArg, ...pluginDirArg, ...agentArg, ...channelArg, ...nameArg]` the
+	 * launcher passes to `claude`. It boots the role persona (`--plugin-dir` + `--agent`, #3447) and no
+	 * longer carries `--mcp-config`: the crew server now registers via the pane's project-scope
 	 * `.mcp.json` (`serverConfig`), which is what the channel resolver actually reads (#3444).
 	 */
 	readonly argv: readonly string[];
@@ -258,6 +285,11 @@ export const buildSessionBind = (
 		// (AC2); a bridge is the bare singleton role. Same instance that keeps engine inboxes distinct.
 		const displayName = instance !== undefined ? `${role}-${instance}` : role;
 		const nameArg: readonly [string, string] = [NAME_FLAG, displayName];
+		// The persona boot (#3447): --plugin-dir loads the pipeline-crew plugin so --agent <role>
+		// resolves the role's agent-def instead of falling through to general-purpose. Role → agent-def
+		// is an identity map (CREW_ROLES == the agent-defs' `name:` frontmatter, ADR 0189), so pass verbatim.
+		const pluginDirArg: readonly [string, string] = [PLUGIN_DIR_FLAG, crewPluginDir(projectRoot)];
+		const agentArg: readonly [string, string] = [AGENT_FLAG, role];
 
 		return {
 			role,
@@ -267,6 +299,8 @@ export const buildSessionBind = (
 			channelArg,
 			modelArg,
 			nameArg,
-			argv: [...modelArg, ...channelArg, ...nameArg],
+			pluginDirArg,
+			agentArg,
+			argv: [...modelArg, ...pluginDirArg, ...agentArg, ...channelArg, ...nameArg],
 		};
 	});


### PR DESCRIPTION
## What

Wire the crew launcher so each pane boots **AS its role persona**, not the generic `general-purpose` default. The founder resolved decision #3447 to OPTION-A (boot the persona). This is the gate for the crew changeover.

`buildSessionBind` (`packages/pipeline-crew-mcp/src/standup/bind.ts`) assembled each pane's `claude` argv with no persona wiring, so every pane fell through `--agent` to `general-purpose`. Two flags are added to the per-pane argv:

1. `--plugin-dir <projectRoot>/claude-plugins/pipeline-crew` — loads the pipeline-crew plugin so its agent-defs enter the launched session's resolver as `source:"plugin"` defs (per-session, no marketplace/enable step). Without it, the agent-def isn't in `activeAgents` and `--agent` falls through to general-purpose.
2. `--agent <role>` — resolves that plugin agent-def by bare name.

Role → agent-def is an **identity map**: `CREW_ROLES` (`crew/roles.ts`) == the `name:` frontmatter of `claude-plugins/pipeline-crew/agents/*.md` (ADR 0189), so the role is passed verbatim — no translation table.

## Details

- The plugin dir is derived from the already-threaded `projectRoot` (`<projectRoot>/claude-plugins/pipeline-crew`), never an absolute/home path.
- The pipeline-crew plugin declares no MCP server, so plain `--plugin-dir` adds only the agent-defs; the crew channel MCP stays wired separately via the channel flag.
- New `SessionBind` fields `pluginDirArg` / `agentArg` mirror the existing `modelArg` / `channelArg` / `nameArg` idiom.

**Resulting per-pane argv** (post-S1 shape, `--mcp-config` already dropped in #3460):

```
[...modelArg, --plugin-dir <projectRoot>/claude-plugins/pipeline-crew, --agent <role>, ...channelArg, ...nameArg]
```

## §CP

Non-§CP. Changed paths are all under `packages/pipeline-crew-mcp/**`, which the live `control-plane-paths` matcher does not protect (its `agents/` clause anchors to `kampus-pipeline/agents/`, not `pipeline-crew/agents/`; ADR 0187). No code-owner gate applies.

## Tests

- `bind.test.ts`: argv assertions updated to include `--plugin-dir`/`--agent`; added a persona-boot test asserting each of the four roles gets `--agent <role>` identity-mapped + `--plugin-dir` derived from projectRoot (and a hardcoded-path-free derivation test).
- `orchestrate.test.ts` / `bin.test.ts` spread `plan.bind.argv` dynamically — unaffected structurally.
- Full package vitest: 220 passing. `pnpm typecheck` clean. `pnpm lint:worktree` clean.

Fixes #3447