### PR TITLE
fix(pipeline-crew): rename crew agent-defs to collision-free crew-<role> names (#3447)

### DIFF
--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -50,23 +50,23 @@ personal config. Every operator-specific value enters through the
 The four roles, each owning one accountability:
 
 - **cartographer — the inbound-ideation bridge**
-  ([`agents/cartographer.md`](agents/cartographer.md)). Turns the founder's *fog* — a fuzzy,
+  ([`agents/crew-cartographer.md`](agents/crew-cartographer.md)). Turns the founder's *fog* — a fuzzy,
   not-yet-decided destination — into charted work by running the `wayfinder` skill (the
   `wayfinder:map` / `wayfinder:backlog` label contract). It sits one stage upstream of triage
   and never auto-resolves a founder decision — it surfaces the fork on the map and stops.
-- **intake-desk — the intake bridge** ([`agents/intake-desk.md`](agents/intake-desk.md)).
+- **intake-desk — the intake bridge** ([`agents/crew-intake-desk.md`](agents/crew-intake-desk.md)).
   Turns the world's raw observations into typed, prioritized work *and talks back to whoever
   filed* (the talking-back is what makes it a bridge, not a filter). Runs the report → triage
   loop and owns the planning/canon seam (spawns the `planner` / `canon` / `adr` agents). A
   *desk* is a standing seat staffed by whoever is on shift (renamed from `triage-guy`, which
   named a person, not a seat).
 - **engineering-manager — the execution engine**
-  ([`agents/engineering-manager.md`](agents/engineering-manager.md)). Pure throughput,
+  ([`agents/crew-engineering-manager.md`](agents/crew-engineering-manager.md)). Pure throughput,
   cardinality N: pulls ready work off the board, claims each resource against the tracker to
   deconflict, and drives coder → reviewer → shipper to a *landed* merge under bounded WIP
   caps. It owns **no** human-facing seam — it banks §CP PRs on the board, never pings a human.
 - **chief-of-staff — the outbound-awareness bridge**
-  ([`agents/chief-of-staff.md`](agents/chief-of-staff.md)). Turns factory state into the
+  ([`agents/crew-chief-of-staff.md`](agents/crew-chief-of-staff.md)). Turns factory state into the
   founder's understanding and owns human-facing comms to **both** humans (the founder and the
   §CP approver). Its charter is the **live verifier**: verify, never relay — a relayed claim
   is never truth, a self-reported PASS is not truth until the artifact is read, an enqueue is

--- a/claude-plugins/pipeline-crew/agents/crew-cartographer.md
+++ b/claude-plugins/pipeline-crew/agents/crew-cartographer.md
@@ -1,5 +1,5 @@
 ---
-name: cartographer
+name: crew-cartographer
 description: 'Use this agent as the crew''s inbound-ideation bridge — the cartographer that turns the founder''s fog (a fuzzy, not-yet-decided destination) into charted work the pipeline can eventually consume. It runs the wayfinder skill: CHART mode opens/rewrites a wayfinder:map issue and lays out the open frontier as sub-issues; WORK mode advances one frontier ticket, records the answer, and graduates the fog. It never auto-resolves a founder decision — it surfaces the fork on the map and stops. Typical triggers include "chart a map for X", "start a wayfinder map", "work the wayfinder map #N", and "advance the map". Do NOT use it to implement, review, merge, or triage — it sits UPSTREAM of triage and produces a clarified plan, not a diff. See "When to invoke" for worked scenarios.'
 model: inherit
 color: green

--- a/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
+++ b/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
@@ -1,5 +1,5 @@
 ---
-name: chief-of-staff
+name: crew-chief-of-staff
 description: 'Use this agent as the crew''s outbound-awareness bridge — the chief of staff that turns factory state into the founder''s understanding and owns human-facing comms to BOTH humans (the operator/founder and the control-plane approver). It gives situational-awareness reads off the board, carries out §CP banks the engine parked for a human merge, and owns the single human-notification channel. Its charter is the live verifier: verify, never relay — a relayed claim is never truth, a subagent''s self-reported PASS is not truth until the artifact is read, and an enqueue is never a merge. It is a conversation PEER, not a switchboard, and it treats conversing as coordination, never as evidence. Typical triggers include "what''s the state of the board", "give me a situational-awareness read", "carry this banked §CP PR to the approver", and "ping me when X lands". Do NOT use it to spawn a coder/reviewer/shipper, to review a diff, or to merge a PR. See "When to invoke" for worked scenarios.'
 model: inherit
 color: magenta

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -1,5 +1,5 @@
 ---
-name: engineering-manager
+name: crew-engineering-manager
 description: 'Use this agent as an execution engine of the kampus pipeline crew — a fungible build session that drives triaged issues to merged PRs by conducting ephemeral kampus-pipeline subagents (coder → reviewer → shipper) under bounded concurrency. It is an ENGINE, not a bridge: it owns no human-facing seam, it pulls its work off the board, and it is cardinality N — a second engine boots cleanly and the two deconflict by resource claims against the tracker, not by a uniqueness lease. Typical triggers include "drive the backlog", "run the execution loop", "pick up the next lanes", and "what''s the state of the lanes". It holds WIP caps, claims a resource before opening a lane, verifies a merge actually LANDED (a merge-queue enqueue is never done), recovers stalled lanes, and BANKS control-plane PRs on the board for a human merge instead of shipping them. It never implements, reviews, or merges by hand, and it never pings a human — it spawns the pipeline agents that build and it banks §CP work on the board for the chief-of-staff to carry out. See "When to invoke" for worked scenarios.'
 model: inherit
 color: cyan

--- a/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
+++ b/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
@@ -1,5 +1,5 @@
 ---
-name: intake-desk
+name: crew-intake-desk
 description: 'Use this agent as the crew''s intake bridge — the desk that turns the world''s raw observations into typed, prioritized work AND talks back to whoever filed. It runs the report → triage loop over the target repo''s status:needs-triage queue and owns the planning/canon seam (spawning the planner over freshly-triaged epics and the canon/adr agents for canon/decision work, rather than running those skills inline). The talking-back — routing a human-filed issue it can''t act on to needs-info with specific questions instead of closing it — is what makes it a bridge, not a filter. Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", and "plan the triaged epics". Do NOT use it to implement, review, merge, or drive the build queue — that is the engine''s seam. See "When to invoke" for worked scenarios.'
 model: inherit
 color: yellow

--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -80,7 +80,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					PLUGIN_DIR_FLAG,
 					EXPECTED_PLUGIN_DIR,
 					AGENT_FLAG,
-					ROLE,
+					`crew-${ROLE}`,
 					ALLOWLIST_CHANNEL_FLAG,
 					"server:pipeline-crew",
 					"plugin:kampus:sozluk",
@@ -125,7 +125,7 @@ describe("standup/bind — per-session bind constructor", () => {
 	);
 
 	it.effect(
-		"boots each pane AS its role persona: --plugin-dir <crew plugin> + --agent <role>, identity-mapped (#3447)",
+		"boots each pane AS its role persona: --plugin-dir <crew plugin> + --agent crew-<role>, collision-free (#3447)",
 		() =>
 			Effect.gen(function* () {
 				const channels: ChannelConfig = {
@@ -133,8 +133,9 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				// Each role's --agent target is the role verbatim — CREW_ROLES == the agent-defs' `name:`
-				// frontmatter (ADR 0189), so no translation table; --plugin-dir is what makes it resolvable.
+				// Each role's --agent target is the collision-free `crew-<role>` plugin agent-def name (not
+				// the bare role), so a personal `~/.claude/agents/<role>.md` def can't shadow it (#3447
+				// Option B); the bare role stays the key everywhere else. --plugin-dir makes it resolvable.
 				for (const role of [
 					"chief-of-staff",
 					"cartographer",
@@ -148,13 +149,13 @@ describe("standup/bind — per-session bind constructor", () => {
 						channels,
 					});
 					assert.deepStrictEqual([...bind.pluginDirArg], [PLUGIN_DIR_FLAG, EXPECTED_PLUGIN_DIR]);
-					assert.deepStrictEqual([...bind.agentArg], [AGENT_FLAG, role]);
+					assert.deepStrictEqual([...bind.agentArg], [AGENT_FLAG, `crew-${role}`]);
 					// the persona flags lead the argv (ahead of the channel fragment), after any --model.
 					assert.deepStrictEqual([...bind.argv].slice(0, 4), [
 						PLUGIN_DIR_FLAG,
 						EXPECTED_PLUGIN_DIR,
 						AGENT_FLAG,
-						role,
+						`crew-${role}`,
 					]);
 				}
 			}),

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -66,12 +66,16 @@ export const NAME_FLAG = "--name";
  * loaded — so without `--plugin-dir <…/claude-plugins/pipeline-crew>` the `--agent <role>` below falls
  * through to the generic general-purpose default (the observed generic boot, #3447). The pipeline-crew
  * plugin declares no MCP server (the crew channel MCP is wired separately via the channel flag), so a
- * plain `--plugin-dir` adds only the agent-defs. Role → agent-def is an IDENTITY map — `CREW_ROLES`
- * equals the agent-defs' `name:` frontmatter (ADR 0189) — so `--agent <role>` passes the role verbatim,
- * no translation table.
+ * plain `--plugin-dir` adds only the agent-defs. The plugin agent-defs are named `crew-<role>`, not
+ * the bare role: a bare `name:` frontmatter becomes the def's `agentType` verbatim with no plugin
+ * namespacing, and the agent pool is last-write-wins with personal `~/.claude/agents/` iterated after
+ * plugins — so a same-named personal def would SHADOW the plugin def and `--agent <role>` would boot
+ * the personal persona instead (the #3447 collision). The `crew-<role>` names are collision-free, so
+ * `--agent` passes `crew-<role>` (the bare role mapped at the argv site below); the bare role stays the
+ * key everywhere else — `CREW_ROLES`, the channel role map, model tiering, `--name` (ADR 0189, #3447).
  */
 export const PLUGIN_DIR_FLAG = "--plugin-dir";
-/** Boots the session AS its role persona by resolving the plugin agent-def named `<role>` (see PLUGIN_DIR_FLAG, #3447). */
+/** Boots the session AS its role persona by resolving the plugin agent-def named `crew-<role>` (see PLUGIN_DIR_FLAG, #3447). */
 export const AGENT_FLAG = "--agent";
 /** The pipeline-crew plugin root under a given project root — the dir `--plugin-dir` loads agent-defs from. */
 const crewPluginDir = (projectRoot: string): string =>
@@ -143,8 +147,8 @@ export interface SessionBind {
 	 * PLUGIN_DIR_FLAG, #3447).
 	 */
 	readonly pluginDirArg: readonly [flag: string, dir: string];
-	/** `["--agent", "<role>"]` — boots the session AS its role persona (identity-mapped, #3447 / ADR 0189). */
-	readonly agentArg: readonly [flag: string, role: string];
+	/** `["--agent", "crew-<role>"]` — boots the session AS its role persona (collision-free name, see AGENT_FLAG). */
+	readonly agentArg: readonly [flag: string, agentName: string];
 	/**
 	 * The complete argv `[...modelArg, ...pluginDirArg, ...agentArg, ...channelArg, ...nameArg]` the
 	 * launcher passes to `claude`. It boots the role persona (`--plugin-dir` + `--agent`, #3447) and no
@@ -285,11 +289,11 @@ export const buildSessionBind = (
 		// (AC2); a bridge is the bare singleton role. Same instance that keeps engine inboxes distinct.
 		const displayName = instance !== undefined ? `${role}-${instance}` : role;
 		const nameArg: readonly [string, string] = [NAME_FLAG, displayName];
-		// The persona boot (#3447): --plugin-dir loads the pipeline-crew plugin so --agent <role>
-		// resolves the role's agent-def instead of falling through to general-purpose. Role → agent-def
-		// is an identity map (CREW_ROLES == the agent-defs' `name:` frontmatter, ADR 0189), so pass verbatim.
+		// The persona boot (#3447): --plugin-dir loads the pipeline-crew plugin so --agent resolves the
+		// role's agent-def instead of falling through to general-purpose. The agent-def name is the
+		// collision-free `crew-<role>`, so map the bare role at this argv site (see AGENT_FLAG for why).
 		const pluginDirArg: readonly [string, string] = [PLUGIN_DIR_FLAG, crewPluginDir(projectRoot)];
-		const agentArg: readonly [string, string] = [AGENT_FLAG, role];
+		const agentArg: readonly [string, string] = [AGENT_FLAG, `crew-${role}`];
 
 		return {
 			role,


### PR DESCRIPTION
## What

Completes #3447 (reopened) via **Option B**: rename the pipeline-crew plugin agent-defs to collision-free `crew-<role>` names so a personal `~/.claude/agents/<role>.md` def can never shadow them.

## Why Option B (not a qualified `--agent` flag)

A read-only 2.1.214 bundle decompile proved the shadowing is unwinnable from the plugin tier:
1. A plugin agent-def's **bare** `name:` frontmatter becomes its `agentType` verbatim — no plugin namespacing.
2. `--agent` matches on raw `agentType === value` equality — there is **no** `:`-qualifier parsing, so `--agent pipeline-crew:cartographer` matches nothing and falls through to `general-purpose`.
3. The agent-pool dedup is a last-write-wins Map, and personal `~/.claude/agents/` is iterated **after** plugins — so a same-named personal def shadows the plugin def.

A name collision therefore can't be won and the qualified flag doesn't exist. The only robust fix is **unique plugin names**.

## The change (surgical — exactly two surfaces carry `crew-`)

- **Frontmatter `name:` of the four agent-defs** (`claude-plugins/pipeline-crew/agents/*.md`) → `crew-<role>`; files renamed to match.
- **Launcher `--agent` argv value** (`packages/pipeline-crew-mcp/src/standup/bind.ts`) → `crew-${role}`, mapped at the argv site only. `--plugin-dir` unchanged.

**Everything else stays keyed on the bare role name**: `CREW_ROLES` (`crew/roles.ts`, untouched), the channel role map, model tiering, and the `--name`/session identity. No repo-wide rename.

## Class / §CP

- `packages/pipeline-crew-mcp/**` and `claude-plugins/pipeline-crew/agents/**` are both **NON-§CP** — the live `CONTROL_PLANE_RE` agents clause anchors to `claude-plugins/kampus-pipeline/agents/`, not `pipeline-crew`, and `packages/pipeline-cli/` (not `pipeline-crew-mcp`).
- class-probe: `has-code`, `has-skills` (review-code + review-skill).

## Tests

Full `@kampus/pipeline-crew-mcp` vitest green (220 passing), typecheck clean, biome clean. `bind.test.ts` now asserts each pane's argv carries `--agent crew-<role>` while `--name` stays the bare role.

## Follow-up (not in scope here)

ADR 0189 governs the pipeline-crew roster but documents role names as bare slugs (`chief-of-staff`, etc.) — those are the **CREW_ROLES**, still correct. The one stale claim is the "`--agent <role>` verbatim / CREW_ROLES == agent-def `name:` frontmatter" identity, now a `crew-<role>` transform. An ADR touch-up recording the collision-free plugin-name convention is a fast-follow.

Fixes #3447