### PR TITLE
fix(pipeline-crew-mcp): channel dispatch — payload contract + session assembly (#3479)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -11,11 +11,22 @@
  *   - `inboxAddressFor` addresses every standing role distinctly (no role orphaned — the
  *     cartographer included).
  */
+import {randomUUID} from "node:crypto";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Ref} from "effect";
-import {RpcTest} from "effect/unstable/rpc";
+import {Effect, Layer, Ref, Schema} from "effect";
+import {McpSchema, McpServer} from "effect/unstable/ai";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import {RpcSerialization, RpcTest} from "effect/unstable/rpc";
+import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import type {ChannelNotificationPayload} from "../edge/index.ts";
-import {ChannelSend, ChannelSink, channelInboxLayer} from "../edge/index.ts";
+import {
+	CHANNEL_CAPABILITY,
+	ChannelSend,
+	ChannelSink,
+	channelExperimentalCapability,
+	channelInboxLayer,
+} from "../edge/index.ts";
 import {
 	type Connect,
 	Dialer,
@@ -28,7 +39,12 @@ import {TrackerRegistry} from "../tracker/group.ts";
 import {TrackerHandlers} from "../tracker/handlers.ts";
 import {RegistryLive} from "../tracker/registry.ts";
 import {CREW_ROLES, kindOf} from "./roles.ts";
-import {channelSendFromPeer, inboxAddressFor, sessionInstance} from "./session.ts";
+import {
+	assembleCrewSession,
+	channelSendFromPeer,
+	inboxAddressFor,
+	sessionInstance,
+} from "./session.ts";
 import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
 
 const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
@@ -98,8 +114,8 @@ describe("crew/session — cutover: the ChannelSend-from-peer binding round-trip
 			assert.strictEqual(ack.by, receiverAddress, "acked by the receiver's inbox ⇒ it went to it");
 			const recorded = yield* Ref.get(wakes);
 			assert.lengthOf(recorded, 1);
-			assert.match(recorded[0]?.message ?? "", /IntakePing/, "the seam rode a channel wake");
-			assert.strictEqual(recorded[0]?._meta?.from, senderAddress);
+			assert.match(recorded[0]?.content ?? "", /IntakePing/, "the seam rode a channel wake");
+			assert.strictEqual(recorded[0]?.meta?.from, senderAddress);
 		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
 	);
 
@@ -195,4 +211,114 @@ describe("crew/session — sessionInstance honors the launcher-assigned identity
 			"each absent-instance resolution mints a distinct id",
 		);
 	});
+});
+
+// A dispose() rejection is irrelevant to teardown; surface it as a typed failure and swallow it
+// (never Effect.promise, whose rejection escapes as an uncatchable defect — .patterns/index.md #2736).
+class DisposeError extends Schema.TaggedErrorClass<DisposeError>()(
+	"@kampus/pipeline-crew-mcp/crew/DisposeError",
+	{cause: Schema.Unknown},
+) {}
+
+/**
+ * The in-memory substrate for the outbound `ChannelSend` binding: an `RpcTest`-backed `CrewTracker`
+ * (so `makeCrewChannel`'s role-lease claim + presence announce succeed when the outbound layer is
+ * BUILT) + the peer ports + a stub dialer. `channel_send` is only REGISTERED here, never called
+ * during `tools/list`, so the dialer need only exist.
+ */
+const inMemoryCrewTracker = Layer.unwrap(
+	RpcTest.makeClient(TrackerRegistry).pipe(Effect.map(CrewTracker.fromClient)),
+).pipe(Layer.provide(registryHandlers));
+const inMemorySubstrate = (address: string) =>
+	Layer.mergeAll(
+		inMemoryCrewTracker,
+		peerTrackerLayer.pipe(Layer.provide(inMemoryCrewTracker)),
+		Inbox.layer(address),
+		Dialer.layerFromConnect((addr) =>
+			Effect.fail(new PeerUnreachableError({target: addr, reason: "test stub dialer"})),
+		),
+	);
+
+/**
+ * Boot the SESSION-MODE server assembly (`assembleCrewSession`) in-process over `McpServer.layerHttp`
+ * — the same assembly `bin.ts session --role` serves over stdio, minus the stdio transport — and
+ * return an initialized MCP client of it. Mirrors the in-memory harness in `edge/mcp-channel.test.ts`:
+ * a `HttpRouter.toWebHandler` + a session-replaying `customFetch` drive the real served server, so the
+ * advertised `tools/list` + `capabilities.experimental` are observable without a live stdio client.
+ */
+const bootSessionClient = (address: string) =>
+	Effect.gen(function* () {
+		const serverLayer = assembleCrewSession(
+			{role: CREW_ROLES[0], projectRoot: "/x"},
+			address,
+			inMemorySubstrate(address),
+			McpServer.layerHttp({
+				name: "CrewSessionTestServer",
+				version: "0.0.0",
+				path: "/mcp",
+				experimental: channelExperimentalCapability,
+			}),
+		).pipe(Layer.orDie);
+		const {dispose, handler} = HttpRouter.toWebHandler(serverLayer, {disableLogger: true});
+		yield* Effect.addFinalizer(() =>
+			Effect.tryPromise({try: () => dispose(), catch: (cause) => new DisposeError({cause})}).pipe(
+				Effect.ignore,
+			),
+		);
+
+		let sessionId: string | null = null;
+		const customFetch: typeof fetch = async (input, init) => {
+			const request = input instanceof Request ? input : new Request(input, init);
+			if (sessionId) request.headers.set("Mcp-Session-Id", sessionId);
+			const response = await handler(request);
+			sessionId = response.headers.get("Mcp-Session-Id");
+			return response;
+		};
+		const clientLayer = RpcClient.layerProtocolHttp({url: "http://localhost/mcp"}).pipe(
+			Layer.provideMerge([FetchHttpClient.layer, RpcSerialization.layerJsonRpc()]),
+			Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch)),
+		);
+		const client = yield* RpcClient.make(McpSchema.ClientRpcs).pipe(Effect.provide(clientLayer));
+		const initialized = yield* client.initialize({
+			protocolVersion: "9999-01-01",
+			capabilities: {},
+			clientInfo: {name: "TestClient", version: "0.0.0"},
+		});
+		return {client, initialized};
+	});
+
+describe("crew/session — the session-mode server advertises the channel edge (#3479 defect B)", () => {
+	it.effect(
+		"its tools/list exposes channel_send AND it advertises the claude/channel capability",
+		() =>
+			Effect.gen(function* () {
+				// Unique address ⇒ a collision-free inbox socket path, so parallel test files never clash.
+				const address = `inbox://session-mode-test-${randomUUID()}`;
+				const {client, initialized} = yield* bootSessionClient(address);
+
+				// The `claude/channel` experimental capability rides the initialize response (from the one
+				// served McpServer's serverInfo.experimental).
+				assert.isDefined(
+					initialized.capabilities.experimental,
+					"the served server must advertise an experimental capability set",
+				);
+				assert.deepEqual(
+					initialized.capabilities.experimental?.[CHANNEL_CAPABILITY],
+					{},
+					"the served session must advertise the claude/channel capability",
+				);
+
+				// channel_send must be in the served server's tools/list — the outbound toolkit registered
+				// on the same instance the transport serves. Regression guard for the #3479 completing bar
+				// ("a session can call channel_send"): it pins that `assembleCrewSession` advertises the tool
+				// over a real served transport, so a future recomposition that splits the served instance
+				// from the toolkit's is caught in-process. NB: this in-process HTTP harness advertises under
+				// BOTH the merge-once and the old per-registration provide (McpServer.layer memoizes across
+				// the single build), so it does NOT by itself reproduce the live stdio `/mcp` Capabilities:
+				// none symptom — that final check is EA's live re-boot (see PR notes).
+				const listed = yield* client["tools/list"]({});
+				const names = listed.tools.map((tool) => tool.name);
+				assert.include(names, "channel_send", "the model must be able to call channel_send");
+			}).pipe(Effect.scoped),
+	);
 });

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -12,9 +12,12 @@
  *     so a role addresses a peer by role (never a tmux window/pane) and the send dials it directly,
  *   - inbound  — the peer-inbox socket server whose deliveries wake the session through
  *     `ChannelSink.layerFromMcpServer` (the same running server), rendered as a `<channel>` tag.
- * Both edges share one `McpServer` instance by layer memoization (the shared `server` value), so
- * the toolkit registers on, and the sink wakes through, the exact transport serving stdio — the
- * same memoization the edge server (#3162) relies on when it provides `layerStdio` to the toolkit.
+ * Both edges MUST land on ONE `McpServer` instance: the toolkit registers its tools on it and the
+ * sink wakes through it. That single instance is achieved by MERGING the two registration layers
+ * and providing the stdio transport ONCE (`assembleCrewSession`), so `McpServer.layer` memoizes to
+ * a single instance across the toolkit registration, the sink, and the run loop. Providing the
+ * transport per-registration instead splits the instance and the served server advertises no tools
+ * (`/mcp` Capabilities: none) — the #3479 assembly defect. See `.patterns/mcp-server-effect.md`.
  *
  * The per-kind cardinality lease + presence announce ride the peer's scope (`makeCrewChannel`): a
  * second live session for a held BRIDGE role fails the build with `RoleUniquenessError`, an ENGINE
@@ -32,7 +35,7 @@
 import {randomUUID} from "node:crypto";
 import {NodeStdio} from "@effect/platform-node";
 import {Effect, Layer} from "effect";
-import {McpServer} from "effect/unstable/ai";
+import {type McpSchema, McpServer} from "effect/unstable/ai";
 import {
 	ChannelSend,
 	ChannelSink,
@@ -145,9 +148,50 @@ export const channelSendFromPeer = (
 	);
 
 /**
- * The full runnable session layer: launch it (`Layer.launch`) to run one live crew session. The
- * one stdio `McpServer` (`server`) is provided to BOTH edges — the toolkit registers on it, the
- * inbound socket server's `ChannelSink` wakes through it — memoized to a single running transport.
+ * The two registrations that MUST land on the ONE served `McpServer` — outbound (the `channel_send`
+ * toolkit) and inbound (the inbox-socket server whose `ChannelSink` wakes through the server) —
+ * merged and provided their `transport` exactly ONCE.
+ *
+ * This is the load-bearing composition (#3479). `McpServer.toolkit` INTERNALLY self-provides its own
+ * `McpServer.layer` (`toolkit = effectDiscard(registerToolkit(x)).pipe(Layer.provide(McpServer.layer))`),
+ * so providing the transport *per registration* (the old `outbound.pipe(Layer.provide(server))` +
+ * `inbound.pipe(Layer.provide(server))`) leaves the toolkit registering its tools into a throwaway
+ * McpServer instance while the run loop serves a different one with `server.tools === []`. Effect's
+ * initialize handler advertises `capabilities.tools` only `if (server.tools.length > 0)`, so the live
+ * session advertised NOTHING — `/mcp` Capabilities: none, `channel_send` absent from the model's
+ * toolset. Merging the registrations and providing the transport ONCE lets `McpServer.layer` memoize
+ * to a single instance across the toolkit registration, the inbound sink, and the run loop — the
+ * documented idiom (`.patterns/mcp-server-effect.md`: merge registrations, then `Layer.provide` the
+ * transport once; grounded against the installed dist at the pin).
+ *
+ * Transport-injected on purpose: production supplies the stdio transport, `session.test.ts` supplies
+ * an in-process `McpServer.layerHttp` to drive the served server's `tools/list` + advertised
+ * capabilities without a live stdio client.
+ */
+export const assembleCrewSession = <RIn>(
+	config: CrewSessionConfig,
+	address: string,
+	substrate: Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown>,
+	transport: Layer.Layer<McpServer.McpServer | McpSchema.McpServerClient, never, RIn>,
+): Layer.Layer<never, unknown, RIn> => {
+	// outbound: the channel_send toolkit, its ChannelSend bound to this session's peer.
+	const outbound = McpServer.toolkit(ChannelToolkit).pipe(
+		Layer.provide(channelToolHandlers),
+		Layer.provide(channelSendFromPeer(config.role, address).pipe(Layer.provide(substrate))),
+	);
+	// inbound: the peer-inbox socket server, its deliveries waking THIS served server.
+	const inbound = inboxServerSocketLayer(address).pipe(
+		Layer.provide(ChannelSink.layerFromMcpServer),
+	);
+	// Provide the transport ONCE to the MERGED registrations — the single-instance memoization above.
+	return Layer.mergeAll(outbound, inbound).pipe(Layer.provide(transport));
+};
+
+/**
+ * The full runnable session layer: launch it (`Layer.launch`) to run one live crew session. The one
+ * stdio `McpServer` is provided to the merged registrations exactly once (`assembleCrewSession`), so
+ * the served server advertises the `channel_send` tool + the `claude/channel` capability; the
+ * heartbeat rides the same `substrate` the outbound binding announces on.
  */
 export const crewSessionLayer = (config: CrewSessionConfig) => {
 	// One per-session instance id, resolved once here and threaded to every address derivation, so an
@@ -155,7 +199,7 @@ export const crewSessionLayer = (config: CrewSessionConfig) => {
 	// ignores it and keeps its singleton address). Honors the launcher-assigned `config.instance` when
 	// present, minting one only when absent. See `sessionInstance` / `inboxAddressFor`.
 	const address = inboxAddressFor(config.role, sessionInstance(config));
-	// The one running stdio McpServer + its channel capability; shared across both channel edges.
+	// The one running stdio McpServer + its channel capability; the served transport for both edges.
 	const server = McpServer.layerStdio({
 		name: config.name ?? SESSION_SERVER_NAME,
 		version: config.version ?? VERSION,
@@ -166,24 +210,11 @@ export const crewSessionLayer = (config: CrewSessionConfig) => {
 	// heartbeat loop, so both drive the one hosted tracker / registry this session announces on.
 	const substrate = peerSocketSubstrate(config, address);
 
-	// outbound: the channel_send toolkit, its ChannelSend bound to this session's peer.
-	const outbound = McpServer.toolkit(ChannelToolkit).pipe(
-		Layer.provide(channelToolHandlers),
-		Layer.provide(channelSendFromPeer(config.role, address).pipe(Layer.provide(substrate))),
-		Layer.provide(server),
-	);
-
 	// keepalive: refresh this session's presence + role lease under the TTL so it never ages out while
 	// the session is live (#3218). Shares `substrate`, so the beats reach the registry announced on.
 	const heartbeat = crewHeartbeatLayer(address).pipe(Layer.provide(substrate));
 
-	// inbound: the peer-inbox socket server, its deliveries waking THIS running server.
-	const inbound = inboxServerSocketLayer(address).pipe(
-		Layer.provide(ChannelSink.layerFromMcpServer),
-		Layer.provide(server),
-	);
-
-	return Layer.mergeAll(outbound, heartbeat, inbound);
+	return Layer.mergeAll(assembleCrewSession(config, address, substrate, server), heartbeat);
 };
 
 /**

--- a/packages/pipeline-crew-mcp/src/edge/bridge.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/bridge.test.ts
@@ -1,7 +1,7 @@
 /**
  * Inbound bridge behavior (AC 2): a delivery to the channel-bridging `Inbox` wakes the
  * session over the `ChannelSink`, carrying the message as a structured `<channel>` tag with
- * the sender in `_meta.from`, and returns a delivered-to-inbox ack stamped by this edge peer.
+ * the sender in `meta.from`, and returns a delivered-to-inbox ack stamped by this edge peer.
  * Driven against a capturing `ChannelSink`, so the bridge logic is under test without a live
  * MCP transport (the real emit-through-the-patched-notification path is `channel-sink.test.ts`).
  */
@@ -38,8 +38,8 @@ describe("edge/bridge — inbound peer-inbox message wakes the session (AC2)", (
 
 				const wakes = yield* Ref.get(captured);
 				assert.strictEqual(wakes.length, 1);
-				assert.strictEqual(wakes[0]?.message, formatChannelTag(envelope({messageId: "m-7"})));
-				assert.strictEqual(wakes[0]?._meta?.from, "peer-a");
+				assert.strictEqual(wakes[0]?.content, formatChannelTag(envelope({messageId: "m-7"})));
+				assert.strictEqual(wakes[0]?.meta?.from, "peer-a");
 			}).pipe(Effect.provide(channelInboxLayer("edge-a").pipe(Layer.provide(CapturingSink))));
 		}),
 	);

--- a/packages/pipeline-crew-mcp/src/edge/bridge.ts
+++ b/packages/pipeline-crew-mcp/src/edge/bridge.ts
@@ -16,7 +16,7 @@ import {ChannelSink} from "./channel-sink.ts";
 /**
  * Render a delivered envelope as the `<channel>` tag the session reads: `from`/`kind` as
  * attributes, the body as content. Identity rides in the tag because the channel carries
- * no addressing (`_meta.from` on the notification is the wire-level echo of the same).
+ * no addressing (`meta.from` on the notification is the wire-level echo of the same).
  */
 export const formatChannelTag = (envelope: InboxEnvelope): string =>
 	`<channel from=${JSON.stringify(envelope.from)} kind=${JSON.stringify(envelope.kind)}>${JSON.stringify(envelope.body)}</channel>`;
@@ -34,7 +34,7 @@ export const channelInboxLayer = (self: string): Layer.Layer<Inbox, never, Chann
 			const log = yield* Ref.make<ReadonlyArray<InboxEnvelope>>([]);
 			return {
 				deliver: (envelope) =>
-					sink.wake({message: formatChannelTag(envelope), _meta: {from: envelope.from}}).pipe(
+					sink.wake({content: formatChannelTag(envelope), meta: {from: envelope.from}}).pipe(
 						Effect.andThen(Ref.update(log, (xs) => [...xs, envelope])),
 						Effect.as<InboxAck>({
 							messageId: envelope.messageId,

--- a/packages/pipeline-crew-mcp/src/edge/channel-sink.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/channel-sink.test.ts
@@ -1,7 +1,7 @@
 /**
  * Channel-sink emit against the patched base (AC 2): `layerFromMcpServer.wake` enqueues a
  * `notifications/claude/channel` request onto the running `McpServer`'s outgoing-notification
- * queue, carrying the `{message, _meta.from}` payload. The notification method is a
+ * queue, carrying the `{content, meta.from}` payload. The notification method is a
  * `ServerNotificationRpcs` member ONLY under the effect patch (ADR 0038) — so emitting it
  * through a real `McpServer` pins the bridge's last-mile emit to the actual patched wire
  * contract, not a stub. No transport is installed, so the queue isn't drained and the emitted
@@ -19,16 +19,16 @@ const TestServer = Layer.effect(McpServer.McpServer, McpServer.McpServer.make);
 describe("edge/channel-sink — wake emits notifications/claude/channel (AC2, patched base)", () => {
 	it.effect("a wake enqueues a claude/channel notification carrying the payload", () =>
 		Effect.gen(function* () {
-			const message = '<channel from="peer-a" kind="IntakePing">{}</channel>';
+			const content = '<channel from="peer-a" kind="IntakePing">{}</channel>';
 			const sink = yield* ChannelSink;
-			yield* sink.wake({message, _meta: {from: "peer-a"}});
+			yield* sink.wake({content, meta: {from: "peer-a"}});
 
 			const server = yield* McpServer.McpServer;
 			const request = yield* Queue.take(server.notificationsQueue);
 			assert.strictEqual(request.tag, CHANNEL_NOTIFICATION_METHOD);
-			const payload = request.payload as {message: string; _meta?: {from?: string}};
-			assert.strictEqual(payload.message, message);
-			assert.strictEqual(payload._meta?.from, "peer-a");
+			const payload = request.payload as {content: string; meta?: {from?: string}};
+			assert.strictEqual(payload.content, content);
+			assert.strictEqual(payload.meta?.from, "peer-a");
 		}).pipe(Effect.provide(ChannelSink.layerFromMcpServer.pipe(Layer.provideMerge(TestServer)))),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/edge/mcp-channel.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/mcp-channel.test.ts
@@ -112,14 +112,29 @@ describe("effect MCP edge patch — behavior pin (claude/channel capability + no
 		assert.isTrue(McpSchema.ServerNotificationRpcs.requests.has(CHANNEL_NOTIFICATION_METHOD));
 	});
 
-	it("a channel payload encodes through the exact schema the run-loop uses", () => {
+	// Pin the 2.1.214 CLIENT contract, not just server union membership (#3479). The Claude Code
+	// channel handler validates params as `{ content: string (REQUIRED), meta?: record<string,string> }`
+	// — a `{message, _meta}` payload fails that validation and the inbound wake is DROPPED at the
+	// recipient. The prior pin asserted the old `{message, _meta}` shape, so the drift went undetected;
+	// this asserts the wire keys the client actually requires and that the legacy keys do NOT ride.
+	it("a channel payload encodes to the 2.1.214 client contract {content, meta}", () => {
 		const rpc = McpSchema.ServerNotificationRpcs.requests.get(CHANNEL_NOTIFICATION_METHOD);
 		assert.isDefined(rpc);
 		const encoded = Schema.encodeUnknownSync(rpc!.payloadSchema)({
-			message: "wake",
-			_meta: {from: "a"},
-		}) as {message: string; _meta?: {from?: string}};
-		assert.strictEqual(encoded.message, "wake");
-		assert.strictEqual(encoded._meta?.from, "a");
+			content: "wake",
+			meta: {from: "a"},
+		}) as Record<string, unknown>;
+		assert.strictEqual(encoded.content, "wake");
+		assert.deepEqual(encoded.meta, {from: "a"});
+		assert.notProperty(
+			encoded,
+			"message",
+			"legacy `message` key must not ride the wire — 2.1.214 drops it",
+		);
+		assert.notProperty(
+			encoded,
+			"_meta",
+			"legacy `_meta` key must not ride the wire — 2.1.214 wants `meta`",
+		);
 	});
 });

--- a/packages/pipeline-crew-mcp/src/edge/mcp-channel.ts
+++ b/packages/pipeline-crew-mcp/src/edge/mcp-channel.ts
@@ -23,11 +23,14 @@ export const channelExperimentalCapability: Record<string, Record<string, never>
 };
 
 /**
- * Shape of a `notifications/claude/channel` payload. `_meta.from` carries the
- * originating peer (the raw-SDK contract proven by spike #3034); `message` is the
- * channel body.
+ * Shape of a `notifications/claude/channel` payload — the exact params the 2.1.214 Claude
+ * Code channel handler validates: `content` (required string) is the channel body, `meta`
+ * (optional `record<string,string>`) carries the originating peer in `meta.from`. The wake
+ * is DROPPED at the recipient if `content` is absent, so this contract is load-bearing, not
+ * cosmetic (#3479 — the crew emitted `{message, _meta}` and every inbound wake failed the
+ * client's param validation).
  */
 export interface ChannelNotificationPayload {
-	readonly message: string;
-	readonly _meta?: Record<string, unknown> & {readonly from?: string};
+	readonly content: string;
+	readonly meta?: Record<string, string>;
 }

--- a/patches/effect@4.0.0-beta.92.patch
+++ b/patches/effect@4.0.0-beta.92.patch
@@ -8,8 +8,8 @@ index 06fff42d7f240698b9388524f874367c494242e6..8421cf06c7dee8215b690772df8a06a7
  export type ServerRequestEncoded = RequestEncoded<typeof ServerRequestRpcs>;
 -declare const ServerNotificationRpcs_base: RpcGroup.RpcGroup<typeof CancelledNotification | typeof ProgressNotification | typeof ResourceListChangedNotification | typeof ResourceUpdatedNotification | typeof PromptListChangedNotification | typeof ToolListChangedNotification | typeof LoggingMessageNotification>;
 +declare const ChannelNotification_base: Rpc.Rpc<"notifications/claude/channel", Schema.Struct<{
-+    message: Schema.String;
-+    _meta: Schema.decodeTo<Schema.optional<Schema.$Record<Schema.String, Schema.Codec<Schema.Json, Schema.Json, never, never>>>, Schema.optionalKey<Schema.$Record<Schema.String, Schema.Codec<Schema.Json, Schema.Json, never, never>>>, never, never>;
++    content: Schema.String;
++    meta: Schema.optionalKey<Schema.$Record<Schema.String, Schema.String>>;
 +}>, Schema.Void, Schema.Never, never, never>;
 +/**
 + * phoenix patch (#3053): custom, non-allowlisted server->client channel notification.
@@ -30,14 +30,14 @@ index 909ac602a249610fdd9a1f72ae207d8813ebc28a..3f8339d619cf06c6ec1c5686c701dfbb
   * @since 4.0.0
   */
 -export class ServerNotificationRpcs extends /*#__PURE__*/RpcGroup.make(CancelledNotification, ProgressNotification, LoggingMessageNotification, ResourceUpdatedNotification, ResourceListChangedNotification, ToolListChangedNotification, PromptListChangedNotification) {}
-+// phoenix patch (#3053): custom, non-allowlisted server->client channel notification.
++// phoenix patch (#3053, #3479): custom, non-allowlisted server->client channel notification.
 +// The MCP spec allows arbitrary `notifications/*` methods; upstream's ServerNotificationRpcs
-+// union is fixed, so the run-loop's encode union (built from this group's payload schemas)
-+// and the McpServer.notifications client both gain this member by adding it here.
++// union is fixed. Payload is the 2.1.214 Claude Code channel contract `{content, meta}` (NOT
++// `{message, _meta}`, which the client drops); run-loop encode union + notifications client gain it.
 +export class ChannelNotification extends /*#__PURE__*/Rpc.make("notifications/claude/channel", {
 +  payload: {
-+    ...NotificationMeta.fields,
-+    message: Schema.String
++    content: Schema.String,
++    meta: /*#__PURE__*/Schema.optionalKey(/*#__PURE__*/Schema.Record(Schema.String, Schema.String))
 +  }
 +}) {}
 +export class ServerNotificationRpcs extends /*#__PURE__*/RpcGroup.make(CancelledNotification, ProgressNotification, LoggingMessageNotification, ResourceUpdatedNotification, ResourceListChangedNotification, ToolListChangedNotification, PromptListChangedNotification, ChannelNotification) {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ patchedDependencies:
     hash: f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1
     path: patches/alchemy@2.0.0-beta.59.patch
   effect@4.0.0-beta.92:
-    hash: 3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade
+    hash: 47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875
     path: patches/effect@4.0.0-beta.92.patch
   react-fate@1.3.1:
     hash: 6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b
@@ -225,28 +225,28 @@ importers:
     dependencies:
       '@alchemy.run/better-auth':
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(9a95b5cea7a55f9918de6e649971c2ea)
+        version: 2.0.0-beta.59(ba1bc25de2a84253ab7c1679b51bc9df)
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(456558883cb20d24e53ea36eb8a82f55)
+        version: 1.6.23(61729f46701d199bceb0183b264a7e40)
       '@better-auth/core':
         specifier: 'catalog:'
         version: 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@effect/sql-d1':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/sql-pg':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@kampus/authz':
         specifier: workspace:*
         version: link:../../packages/authz
@@ -261,13 +261,13 @@ importers:
         version: link:../../packages/fate-effect
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@sentry/cloudflare':
         specifier: 'catalog:'
         version: 10.62.0(@cloudflare/workers-types@4.20260629.1)
       '@sentry/effect':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@sentry/react':
         specifier: 'catalog:'
         version: 10.62.0(react@19.2.6)
@@ -276,19 +276,19 @@ importers:
         version: 0.2.0
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call:
         specifier: 'catalog:'
         version: 1.3.7(zod@4.4.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@19.2.6)
@@ -300,7 +300,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-fate:
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react-router:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -313,13 +313,13 @@ importers:
         version: 4.20260629.1
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@fontsource/ibm-plex-sans':
         specifier: 'catalog:'
         version: 5.2.8
@@ -385,10 +385,10 @@ importers:
     dependencies:
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -398,7 +398,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -416,19 +416,19 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(456558883cb20d24e53ea36eb8a82f55)
+        version: 1.6.23(61729f46701d199bceb0183b264a7e40)
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -438,7 +438,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -456,10 +456,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -468,10 +468,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -481,7 +481,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -490,7 +490,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -502,10 +502,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -514,7 +514,7 @@ importers:
         version: link:../cf-utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -524,7 +524,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -542,7 +542,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/audit-stage':
         specifier: workspace:*
         version: link:../audit-stage
@@ -551,7 +551,7 @@ importers:
         version: link:../audit-verdict
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -561,7 +561,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -579,7 +579,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -591,7 +591,7 @@ importers:
         version: link:../preview-seed
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -601,7 +601,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -619,17 +619,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -647,7 +647,7 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -669,10 +669,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -682,7 +682,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -700,10 +700,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -715,10 +715,10 @@ importers:
         version: link:../db-schema
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -728,7 +728,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -749,7 +749,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -822,10 +822,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -835,7 +835,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -853,7 +853,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -875,17 +875,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -903,7 +903,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/depo':
         specifier: workspace:*
         version: link:../depo
@@ -912,14 +912,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -937,10 +937,10 @@ importers:
     dependencies:
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -962,17 +962,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -990,10 +990,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -1002,10 +1002,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1015,7 +1015,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1024,7 +1024,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1036,10 +1036,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1051,10 +1051,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1064,7 +1064,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1082,10 +1082,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       yaml:
         specifier: 'catalog:'
         version: 2.9.0
@@ -1095,7 +1095,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1113,7 +1113,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/design-capture':
         specifier: workspace:*
         version: link:../design-capture
@@ -1122,14 +1122,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1147,17 +1147,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1175,19 +1175,19 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1197,7 +1197,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1206,7 +1206,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1218,20 +1218,20 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1249,7 +1249,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/ci-required':
         specifier: workspace:*
         version: link:../ci-required
@@ -1261,7 +1261,7 @@ importers:
         version: link:../primary-index-tripwire
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       fast-xml-parser:
         specifier: 'catalog:'
         version: 5.8.0
@@ -1274,7 +1274,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1292,10 +1292,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       proper-lockfile:
         specifier: 'catalog:'
         version: 4.1.2
@@ -1305,7 +1305,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1326,10 +1326,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1341,10 +1341,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1354,7 +1354,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1363,7 +1363,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1375,17 +1375,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1406,7 +1406,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -4732,11 +4732,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@alchemy.run/better-auth@2.0.0-beta.59(9a95b5cea7a55f9918de6e649971c2ea)':
+  '@alchemy.run/better-auth@2.0.0-beta.59(ba1bc25de2a84253ab7c1679b51bc9df)':
     dependencies:
-      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d)
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     transitivePeerDependencies:
       - '@effect/platform-bun'
       - '@effect/platform-node'
@@ -5013,11 +5013,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.6.23(456558883cb20d24e53ea36eb8a82f55)':
+  '@better-auth/api-key@1.6.23(61729f46701d199bceb0183b264a7e40)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -5036,12 +5036,12 @@ snapshots:
       '@cloudflare/workers-types': 4.20260629.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
 
   '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -5166,24 +5166,24 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1053.0
       '@aws-sdk/types': 3.973.9
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@smithy/shared-ini-file-loader': 4.5.4
       '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.4.4
       aws4fetch: 1.0.20
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
 
   '@distilled.cloud/cloudflare-rolldown-plugin@0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
     dependencies:
@@ -5196,74 +5196,74 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       workerd: 1.20260617.1
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(b7a52a79e2a9b18230ffd28d8c5f26e6)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(65a33d4814a6fc29095b657dfc60b6ea)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
     transitivePeerDependencies:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
 
-  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
 
-  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
 
-  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
 
   '@drizzle-team/brocli@0.12.0': {}
 
   '@effect/language-service@0.85.1': {}
 
-  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.3.0
@@ -5271,14 +5271,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
 
-  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       pg: 8.21.0
       pg-connection-string: 2.12.0
       pg-cursor: 2.20.0(pg@8.21.0)
@@ -5318,9 +5318,9 @@ snapshots:
       '@effect/tsgo-win32-arm64': 0.5.2
       '@effect/tsgo-win32-x64': 0.5.2
 
-  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -5609,13 +5609,13 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
       superjson: 2.2.6
       zod: 4.4.3
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@noble/ciphers@2.2.0': {}
@@ -5865,12 +5865,12 @@ snapshots:
 
   '@sentry/core@10.62.0': {}
 
-  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))':
+  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
       '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -6342,21 +6342,21 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(8b66631a37c8fc827b8b84667dc6559d):
+  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1053.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(b7a52a79e2a9b18230ffd28d8c5f26e6)
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(65a33d4814a6fc29095b657dfc60b6ea)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1
       '@octokit/webhooks': 14.2.0
@@ -6366,7 +6366,7 @@ snapshots:
       '@types/aws-lambda': 8.10.161
       aws4fetch: 1.0.20
       capnweb: 0.6.1
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       fast-glob: 3.3.3
       fast-xml-parser: 5.8.0
       ink: 6.8.0(@types/react@19.2.14)(react@19.2.6)
@@ -6382,11 +6382,11 @@ snapshots:
       undici: 7.24.8
       yaml: 2.9.0
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(ioredis@5.10.1)
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       ws: 8.21.0
     transitivePeerDependencies:
@@ -6427,10 +6427,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
+  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -6448,7 +6448,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       react: 19.2.6
@@ -6550,19 +6550,19 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))
+      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
       '@libsql/client': 0.17.3
       '@opentelemetry/api': 1.9.1
-      effect: 4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)
+      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       zod: 4.4.3
 
-  effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade):
+  effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875):
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0
@@ -7312,9 +7312,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=3285226dd6fbb4f9b5bdaa53768681e3af65198c733ad4a338f79be9d1a0bade))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:


### PR DESCRIPTION
> ⚠️ SCOPE (EM): this PR lands **Defect A** (inbound payload rename `message/_meta`→`content/meta`, a genuine inbound-drop fix) + the **Defect B idiom-alignment** (session.ts merge-registrations recompose — a correct idiom-alignment + advertisement regression-guard, but a LIVE /mcp on this branch confirmed it does NOT fix the `Capabilities: none` symptom). The real Defect B fix (`--channels` client-side tool-suppression) is a FOLLOW-UP PR that will land as a follow-up for #3479 (kept open). This PR **Refs #3479**, does not close it.

Refs #3479

Two confirmed defects in the crew channel **signal** layer (the ADR 0189 valid edges only — CoS→intake-desk `IntakePing`, EM→intake-desk, EM→chief-of-staff `DrainProgress`; **no** CoS→EM task-dispatch edge is added, the EM pulls off the board). All changed paths are **NON-§CP**.

## Defect A — inbound payload schema drift (grounded against the 2.1.214 CLI bundle)
2.1.214's `notifications/claude/channel` handler validates params as `{ content: string (REQUIRED), meta?: record<string,string> }`. The crew emitted `{ message, _meta }`, so `content` was absent → the notification failed the client's validation → **every inbound wake was dropped**. Renamed the emit path `message`→`content`, `_meta`→`meta` across all surfaces:

- `patches/effect@4.0.0-beta.92.patch` — the `ChannelNotification` Rpc payload schema is now `{ content: Schema.String, meta: Schema.optionalKey(Schema.Record(String, String)) }` (both the `.js` and `.d.ts` hunks). `pnpm install` re-applies cleanly (lockfile patch-hash bumped).
- `packages/pipeline-crew-mcp/src/edge/mcp-channel.ts` — `ChannelNotificationPayload` → `{ content, meta? }`.
- `packages/pipeline-crew-mcp/src/edge/bridge.ts` — `channelInboxLayer` wakes with `{ content, meta:{from} }`.
- `packages/pipeline-crew-mcp/src/edge/mcp-channel.test.ts` — the drift-pin now asserts the **2.1.214 CLIENT contract** (`{content, meta}` encodes, and the legacy `message`/`_meta` keys do NOT ride the wire). The prior pin asserted the server/patch shape, which is exactly why the drift went undetected.
- Field references in `channel-sink.test.ts` / `bridge.test.ts` / `session.test.ts` updated to the new shape.

## Defect B — session assembly (composed per the documented idiom)
`crewSessionLayer` is recomposed via a transport-injected `assembleCrewSession`: **merge** the outbound `channel_send` toolkit + the inbound sink registrations and provide the stdio transport **once**, rather than per-registration — the `.patterns/mcp-server-effect.md` Rule ("merge registrations, then `Layer.provide` the transport once"). A new in-process test boots the session-mode assembly over `McpServer.layerHttp` and asserts the served `tools/list` includes `channel_send` **and** `capabilities.experimental` includes `claude/channel`.

**Honest caveat (ground-truth from my own test — please read before merge):** the in-process HTTP harness advertises `channel_send` under **both** the merge-once form and the old per-registration form (`McpServer.layer` memoizes to a single instance across the single build), so this test does **not** by itself reproduce the live stdio `/mcp` **Capabilities: none** symptom. The merge-once change is the correct documented idiom and is behavior-preserving/​improving, but I could not prove in-process that it is *the* fix for the live symptom. **The real completing gate is EA's live re-boot** (`/mcp` must show `channel_send` + a tool count > 0, then a board-pull round-trip over a valid ADR 0189 edge). If the live boot still shows `Capabilities: none`, the residual cause is client-side channel-vs-`mcpServers` handling in `standup/bind.ts` (the original triage diagnosis), which this PR's scope explicitly excluded.

## Verify
- `pnpm install` succeeds (patch applies; lockfile updated).
- `@kampus/pipeline-crew-mcp` vitest: **221 passed** (incl. the new B advertisement test + the A client-contract pin).
- Full-workspace `pnpm typecheck`: **33/33**.
- `biome check`: clean.
- All changed paths NON-§CP (re-resolved live `CONTROL_PLANE_RE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
