### PR TITLE
fix(pipeline-crew-mcp): claim the peer BEFORE serving — win the channel_send build-order race (#3479)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -13,7 +13,7 @@
  */
 import {randomUUID} from "node:crypto";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Ref, Schema} from "effect";
+import {Deferred, Effect, Layer, Ref, Schema, Stdio, Stream} from "effect";
 import {McpSchema, McpServer} from "effect/unstable/ai";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
@@ -45,7 +45,7 @@ import {
 	inboxAddressFor,
 	sessionInstance,
 } from "./session.ts";
-import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
+import {CrewTracker, peerTrackerLayer, type TrackerRegistryClient} from "./tracker.ts";
 
 const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
 
@@ -286,6 +286,126 @@ const bootSessionClient = (address: string) =>
 		});
 		return {client, initialized};
 	});
+
+/**
+ * A substrate whose `CrewTracker.claim` BLOCKS on `gate` before granting — the in-memory stand-in for
+ * the slow unix-socket tracker handshake `makeCrewChannel` runs when it builds `ChannelSend`. It runs
+ * `onClaim` the instant it unblocks (past the gate), so a test can record WHEN the async `ChannelSend`
+ * resolves relative to the served transport. Everything else (announce/lookup/heartbeat) is the real
+ * in-memory registry, so `makeCrewChannel`'s presence announce + role-lease claim behave normally.
+ */
+const gatedRaceSubstrate = (
+	address: string,
+	gate: Deferred.Deferred<void>,
+	onClaim: Effect.Effect<void>,
+) => {
+	const tracker = Layer.unwrap(
+		RpcTest.makeClient(TrackerRegistry).pipe(
+			Effect.map((client) => {
+				const gatedClient: TrackerRegistryClient = {
+					Claim: (payload) =>
+						Deferred.await(gate).pipe(
+							Effect.andThen(onClaim),
+							Effect.andThen(client.Claim(payload)),
+						),
+					Release: (payload) => client.Release(payload),
+					AnnouncePresence: (payload) => client.AnnouncePresence(payload),
+					LookupRole: (payload) => client.LookupRole(payload),
+					Heartbeat: (payload) => client.Heartbeat(payload),
+				};
+				return CrewTracker.fromClient(gatedClient);
+			}),
+		),
+	).pipe(Layer.provide(registryHandlers));
+	return Layer.mergeAll(
+		tracker,
+		peerTrackerLayer.pipe(Layer.provide(tracker)),
+		Inbox.layer(address),
+		Dialer.layerFromConnect((addr) =>
+			Effect.fail(new PeerUnreachableError({target: addr, reason: "race-test stub dialer"})),
+		),
+	);
+};
+
+describe("crew/session — the session-mode server wins the async-ChannelSend build race (#3479 defect B)", () => {
+	// The advertisement guard below drives a synchronous in-memory ChannelSend, so registration wins the
+	// race and it passes EVEN with the pre-fix ordering — it cannot reproduce the live stdio symptom. This
+	// test injects an ASYNC ChannelSend (the gated tracker-claim) and asserts the toolkit registers BEFORE
+	// the forked stdio run-loop begins serving, so a client's `initialize` never sees `server.tools === []`.
+	// It FAILS on the old (transport-built-then-async-toolkit) ordering and PASSES on the claim-first fix.
+	// `it.live` (not `it.effect`): the race turns on REAL async scheduling — the forked run-loop, socket
+	// I/O, the timed gate release — so it must run on the live clock, not `it.effect`'s TestClock.
+	it.live(
+		"the channel_send toolkit registers before the forked run-loop serves, even with an async ChannelSend",
+		() =>
+			Effect.gen(function* () {
+				const address = `inbox://race-test-${randomUUID()}`;
+				const order = yield* Ref.make<ReadonlyArray<string>>([]);
+				const claimGate = yield* Deferred.make<void>();
+				// One Deferred per event, so the assertion waits for BOTH to land (no fixed-sleep guess): the
+				// event log records ORDER, the Deferreds record OCCURRENCE.
+				const servedAt = yield* Deferred.make<void>();
+				const resolvedAt = yield* Deferred.make<void>();
+				const mark = (label: string, at: Deferred.Deferred<void>) =>
+					Ref.update(order, (xs) => [...xs, label]).pipe(
+						Effect.andThen(Deferred.succeed(at, undefined)),
+						Effect.asVoid,
+					);
+
+				// The async ChannelSend: makeCrewChannel's tracker-claim blocks on claimGate (the slow socket
+				// handshake) and records "channel-resolved" the instant it unblocks — the point the toolkit can
+				// finally register channel_send.
+				const substrate = gatedRaceSubstrate(
+					address,
+					claimGate,
+					mark("channel-resolved", resolvedAt),
+				);
+
+				// A fake Stdio whose stdin records "serving-started" the instant the transport's run-loop begins
+				// consuming it, then blocks forever (Stream.never) so the run-loop stays live. This is the
+				// observable proxy for "the server is now able to answer initialize" — the exact moment
+				// channel_send must ALREADY be on server.tools (Effect gates capabilities.tools on tools.length).
+				const stdin = Stream.fromEffect(mark("serving-started", servedAt)).pipe(
+					Stream.drain,
+					Stream.concat(Stream.never),
+				);
+				const transport = McpServer.layerStdio({
+					name: "CrewRaceTestServer",
+					version: "0.0.0",
+					experimental: channelExperimentalCapability,
+				}).pipe(Layer.provide(Stdio.layerTest({stdin})));
+
+				const serverLayer = assembleCrewSession(
+					{role: CREW_ROLES[0], projectRoot: "/x"},
+					address,
+					substrate,
+					transport,
+				).pipe(Layer.orDie);
+
+				// Launch the live session on a scoped fiber. Claim-first (fixed): it blocks in the unwrap on the
+				// gated claim, so nothing serves until the gate opens. Old ordering: the transport builds and its
+				// run-loop starts serving while the toolkit still awaits the gated ChannelSend.
+				yield* Effect.forkScoped(Layer.launch(serverLayer));
+
+				// Give the OLD ordering's forked run-loop a window to record "serving-started" before the gate
+				// opens — so on the bug the order is [serving-started, channel-resolved]. The fix records nothing
+				// until the gate opens (the claim gates the whole build), then [channel-resolved, serving-started];
+				// on the fix channel-resolved ALWAYS precedes serving-started regardless of this delay.
+				yield* Effect.sleep("100 millis");
+				yield* Deferred.succeed(claimGate, undefined);
+
+				// Wait for BOTH events to occur, then read the order they landed in.
+				yield* Deferred.await(servedAt);
+				yield* Deferred.await(resolvedAt);
+				const recorded = yield* Ref.get(order);
+				assert.strictEqual(
+					recorded[0],
+					"channel-resolved",
+					"channel_send must be registered (ChannelSend resolved) BEFORE the run-loop serves initialize — else a client sees Capabilities: none and never lists the tool",
+				);
+			}),
+	);
+});
 
 describe("crew/session — the session-mode server advertises the channel edge (#3479 defect B)", () => {
 	it.effect(

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -13,11 +13,11 @@
  *   - inbound  — the peer-inbox socket server whose deliveries wake the session through
  *     `ChannelSink.layerFromMcpServer` (the same running server), rendered as a `<channel>` tag.
  * Both edges MUST land on ONE `McpServer` instance: the toolkit registers its tools on it and the
- * sink wakes through it. That single instance is achieved by MERGING the two registration layers
- * and providing the stdio transport ONCE (`assembleCrewSession`), so `McpServer.layer` memoizes to
- * a single instance across the toolkit registration, the sink, and the run loop. Providing the
- * transport per-registration instead splits the instance and the served server advertises no tools
- * (`/mcp` Capabilities: none) — the #3479 assembly defect. See `.patterns/mcp-server-effect.md`.
+ * sink wakes through it. `assembleCrewSession` achieves that AND wins the two build-order races that
+ * otherwise leave the served session advertising no tools (`/mcp` Capabilities: none, `channel_send`
+ * absent) — the #3479 assembly defect. See `assembleCrewSession` for the mechanism (merge the
+ * registrations + provide the transport once; claim the peer FIRST so `ChannelSend` is an instant
+ * binding when the toolkit registers) and `.patterns/mcp-server-effect.md` for the Effect idiom.
  *
  * The per-kind cardinality lease + presence announce ride the peer's scope (`makeCrewChannel`): a
  * second live session for a held BRIDGE role fails the build with `RoleUniquenessError`, an ENGINE
@@ -29,8 +29,9 @@
  * The binding is transport-injected: `channelSendFromPeer` takes the peer substrate as a
  * requirement (production supplies `peerSocketSubstrate` over unix sockets), so `session.test.ts`
  * drives the exact `ChannelSend`-from-peer binding fully in-memory (an `RpcTest` `CrewTracker` + an
- * in-memory `Connect`) — the same transport-free idiom `channel-server.test.ts` uses. The one seam
- * not exercised without a live MCP client is the stdio `McpServer` wake itself.
+ * in-memory `Connect`) — the same transport-free idiom `channel-server.test.ts` uses. A fake `Stdio`
+ * additionally drives the forked stdio run-loop's serve ordering (the Race-2 guard in
+ * `assembleCrewSession`); the one seam still not exercised is a full live-client stdio wake round-trip.
  */
 import {randomUUID} from "node:crypto";
 import {NodeStdio} from "@effect/platform-node";
@@ -127,10 +128,12 @@ export const peerSocketSubstrate = (
 };
 
 /**
- * The outbound binding: `ChannelSend` resolved to THIS session's peer `send` (`makeCrewChannel`).
- * Building the layer acquires the role-uniqueness lease and announces presence for the layer's
- * scope; a second live session for a held role fails the build with `RoleUniquenessError`. This is
- * the exact `ChannelSend` the `channel_send` MCP tool routes through — the tests drive it directly.
+ * The outbound binding as a standalone layer: `ChannelSend` resolved to THIS session's peer `send`
+ * (`makeCrewChannel`), acquiring the role-uniqueness lease + presence for the layer's scope (a held
+ * role fails the build with `RoleUniquenessError`). It yields the SAME `{send: channel.peer.send}`
+ * binding `assembleCrewSession` hoists inline — but as an ASYNC `Layer.effect`, so it is NOT used in
+ * the live assembly (that path resolves the peer first, then binds `ChannelSend` instantly, to win
+ * Race 2 above). `session.test.ts` drives THIS form directly to prove the send round-trips end to end.
  *
  * The peer substrate (`CrewTracker` + the peer ports) is a REQUIREMENT, not baked in, so the binding
  * is transport-injected: production supplies `peerSocketSubstrate`, the tests an in-memory substrate.
@@ -150,42 +153,58 @@ export const channelSendFromPeer = (
 /**
  * The two registrations that MUST land on the ONE served `McpServer` — outbound (the `channel_send`
  * toolkit) and inbound (the inbox-socket server whose `ChannelSink` wakes through the server) —
- * merged and provided their `transport` exactly ONCE.
+ * merged and provided their `transport` exactly ONCE. This is the load-bearing composition (#3479),
+ * and it must win TWO races or the live session advertises no tools (`/mcp` Capabilities: none).
  *
- * This is the load-bearing composition (#3479). `McpServer.toolkit` INTERNALLY self-provides its own
+ * Race 1 — the single instance (fixed #3480). `McpServer.toolkit` INTERNALLY self-provides its own
  * `McpServer.layer` (`toolkit = effectDiscard(registerToolkit(x)).pipe(Layer.provide(McpServer.layer))`),
- * so providing the transport *per registration* (the old `outbound.pipe(Layer.provide(server))` +
- * `inbound.pipe(Layer.provide(server))`) leaves the toolkit registering its tools into a throwaway
- * McpServer instance while the run loop serves a different one with `server.tools === []`. Effect's
- * initialize handler advertises `capabilities.tools` only `if (server.tools.length > 0)`, so the live
- * session advertised NOTHING — `/mcp` Capabilities: none, `channel_send` absent from the model's
- * toolset. Merging the registrations and providing the transport ONCE lets `McpServer.layer` memoize
- * to a single instance across the toolkit registration, the inbound sink, and the run loop — the
- * documented idiom (`.patterns/mcp-server-effect.md`: merge registrations, then `Layer.provide` the
- * transport once; grounded against the installed dist at the pin).
+ * so providing the transport *per registration* would leave the toolkit registering into a throwaway
+ * instance while the run loop serves a different one with `server.tools === []`. Merging the
+ * registrations and providing the transport ONCE lets `McpServer.layer` memoize to a single instance
+ * across the toolkit registration, the inbound sink, and the run loop.
+ *
+ * Race 2 — claim BEFORE serve (the live #3479 defect this build fixes). `McpServer.layerStdio` forks
+ * its serve/run-loop at layer-BUILD time and begins answering the client's `initialize` immediately;
+ * Effect's initialize handler sets `capabilities.tools` only `if (server.tools.length > 0)` AT THAT
+ * MOMENT, and a client that sees no `tools` capability never calls `tools/list` again. If the toolkit
+ * registration is still awaiting an async `ChannelSend` — the peer's tracker-`claim()` over a unix
+ * socket — when the run-loop answers `initialize`, `server.tools` is empty and `channel_send` is lost
+ * for the session's life. The fix runs `makeCrewChannel` (the claim + presence handshake) FIRST via
+ * `Layer.unwrap`, so `ChannelSend` is an instant `Layer.succeed` with the peer already resolved: the
+ * toolkit registers with no async gap, and by the time the forked run-loop serves `initialize` the
+ * tool is already on `server.tools`. `RoleUniquenessError` still fails the build fail-closed — the
+ * claim is on the critical path of the layer, so a held role slot aborts assembly before it serves.
  *
  * Transport-injected on purpose: production supplies the stdio transport, `session.test.ts` supplies
- * an in-process `McpServer.layerHttp` to drive the served server's `tools/list` + advertised
- * capabilities without a live stdio client.
+ * an in-process `McpServer.layerHttp` (advertised tools + capabilities) and a fake-`Stdio` forked
+ * run-loop (the async-`ChannelSend` race guard), both without a live stdio client.
  */
 export const assembleCrewSession = <RIn>(
 	config: CrewSessionConfig,
 	address: string,
 	substrate: Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown>,
 	transport: Layer.Layer<McpServer.McpServer | McpSchema.McpServerClient, never, RIn>,
-): Layer.Layer<never, unknown, RIn> => {
-	// outbound: the channel_send toolkit, its ChannelSend bound to this session's peer.
-	const outbound = McpServer.toolkit(ChannelToolkit).pipe(
-		Layer.provide(channelToolHandlers),
-		Layer.provide(channelSendFromPeer(config.role, address).pipe(Layer.provide(substrate))),
-	);
-	// inbound: the peer-inbox socket server, its deliveries waking THIS served server.
-	const inbound = inboxServerSocketLayer(address).pipe(
-		Layer.provide(ChannelSink.layerFromMcpServer),
-	);
-	// Provide the transport ONCE to the MERGED registrations — the single-instance memoization above.
-	return Layer.mergeAll(outbound, inbound).pipe(Layer.provide(transport));
-};
+): Layer.Layer<never, unknown, RIn> =>
+	// Claim FIRST (Race 2): the slow tracker-claim/presence handshake runs in the unwrap's effect,
+	// BEFORE the run-loop-forking transport is built, so ChannelSend below is a zero-async binding.
+	Layer.unwrap(
+		makeCrewChannel({role: config.role, address}).pipe(
+			Effect.map((channel) => {
+				// outbound: the channel_send toolkit, its ChannelSend an INSTANT bind to the already-resolved
+				// peer — the toolkit registers with no socket await in its build path (Race 2).
+				const outbound = McpServer.toolkit(ChannelToolkit).pipe(
+					Layer.provide(channelToolHandlers),
+					Layer.provide(Layer.succeed(ChannelSend, {send: channel.peer.send})),
+				);
+				// inbound: the peer-inbox socket server, its deliveries waking THIS served server.
+				const inbound = inboxServerSocketLayer(address).pipe(
+					Layer.provide(ChannelSink.layerFromMcpServer),
+				);
+				// Provide the transport ONCE to the MERGED registrations — the single-instance memo (Race 1).
+				return Layer.mergeAll(outbound, inbound).pipe(Layer.provide(transport));
+			}),
+		),
+	).pipe(Layer.provide(substrate));
 
 /**
  * The full runnable session layer: launch it (`Layer.launch`) to run one live crew session. The one


### PR DESCRIPTION
## Plain-language summary

The channel-native crew boots and receives messages, but the model never got a `channel_send` tool (`/mcp` showed `Capabilities: none`), so no session could dispatch or signal — the crew-cutover blocker (#3422). #3480 fixed the payload contract + a split-instance race; this PR fixes the **live** cause: a build-order race that answered the client's `initialize` with an empty tool list before `channel_send` finished registering. After this, a booted session lists `channel_send` and can send over a valid ADR-0189 edge.

## Root cause (Defect B — build-order race)

Grounded in the 2.1.214 client bundle + the patched `effect@4.0.0-beta.92`:

- `McpServer.layerStdio` **forks its serve/run-loop at layer-BUILD time** and answers the client's `initialize` immediately.
- Effect's initialize handler sets `capabilities.tools` **only** `if (server.tools.length > 0)` at that instant — and a client that sees no `tools` capability **never calls `tools/list` again**.
- The `channel_send` toolkit's `ChannelSend` was built by `channelSendFromPeer` → `makeCrewChannel` → `tracker.claim()` over a **unix socket** — a slow async handshake.
- So `initialize` was answered **during** the claim window, `server.tools` empty, `channel_send` lost for the session's life. (Inbound survived because `claude/channel` is a static `serverInfo` field advertised immediately — hence "connected + channel-gated but zero tools".)

## The fix — claim BEFORE serve

`assembleCrewSession` now runs `makeCrewChannel` (the claim + presence handshake) **first** via `Layer.unwrap`, then builds the `McpServer` + toolkit with the peer already resolved, so `ChannelSend` is an **instant** `Layer.succeed`. The toolkit registers with no async gap, and the tool is on `server.tools` before the forked run-loop serves `initialize`.

- Keeps #3480's **merge-registrations-then-provide-transport-once** idiom (single served instance).
- `RoleUniquenessError` stays a **fail-closed BUILD error** — the claim is on the layer's critical path, so a held role slot aborts assembly before it serves.
- Inbound (`claude/channel` capability + inbox socket) untouched (that was Defect A, landed in #3480).
- Grounded against effect-smol's Layer API (`Layer.unwrap` discharges the presence `Scope`) + `.patterns/mcp-server-effect.md`.

## Test — reproduces the race (the existing guard could not)

The #3480 advertisement guard drives a **synchronous** in-memory `ChannelSend` over `layerHttp`, so registration wins the race and it passes **even with the bug**. This PR adds an async-`ChannelSend` race guard that:

- drives the **real forked stdio run-loop** over a fake `Stdio`,
- gates the tracker-claim on a `Deferred` (the slow-socket simulation),
- asserts the toolkit registers **before** the run-loop begins serving.

Verified: it **FAILS on the old ordering** (`Received: "serving-started"`) and **PASSES on the fix**. The synchronous `layerHttp` advertisement guard is kept.

## Verification

- `@kampus/pipeline-crew-mcp` vitest: **222 passed** (incl. the new async-race test).
- `pnpm typecheck`: green (33/33).
- `pnpm lint:worktree`: clean.
- `pnpm install`: patch applies.

## Scope (all NON-§CP per ADR 0187)

- `packages/pipeline-crew-mcp/src/crew/session.ts` — the claim-first `assembleCrewSession` + docblocks.
- `packages/pipeline-crew-mcp/src/crew/session.test.ts` — the async-`ChannelSend` race guard.

`bind.ts` / `register-project-scope.ts` untouched (correct as-is per the diagnosis).

## Live validation (not in CI)

EA re-boots from this branch: `/mcp` must show `channel_send` with tool-count > 0 (flipping the long-standing `Capabilities: none`), then a board-pull round-trip over a valid ADR-0189 edge (CoS→intake-desk `IntakePing`, EM→intake-desk, or EM→chief-of-staff `DrainProgress` — no CoS→EM dispatch edge exists).

Fixes #3479

🤖 Generated with [Claude Code](https://claude.com/claude-code)