### PR TITLE
fix(pipeline-crew): make channel_send callable — add its MCP allowlist token to every crew def (#3483, #3482)

### DIFF
--- a/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
+++ b/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
@@ -1,0 +1,47 @@
+# The crew channel tool — its allowlist token, and the boot-window wait
+
+Every crew role coordinates over one MCP tool, `channel_send`, served by the crew channel
+MCP server (`@kampus/pipeline-crew-mcp`, wired per session via `--channels
+server:@kampus/pipeline-crew-mcp`). **This doc is the single source for two things a role
+needs to actually call it**: the exact allowlist token its `tools:` frontmatter must carry,
+and how to behave in the brief window right after boot before the channel has connected. The
+four crew defs cite this; they never re-derive it inline.
+
+## The allowlist token — `mcp___kampus_pipeline-crew-mcp__channel_send`
+
+A crew session boots as a top-level `claude --agent crew-<role>` session, so the role's
+agent-def `tools:` allowlist is the hard gate on what the model can call. A connected MCP
+server whose tool is **absent from that allowlist is present-but-uncallable** — `/mcp` shows
+the server up with `channel_send`, yet the model's toolset does not include it, so the role
+cannot coordinate. That omission — not boot timing — was the live cutover failure: a role
+tasked to dispatch found the tool missing and burned budget reverse-engineering its own
+channel (#3483, the root cause of the #3482 symptom).
+
+So each crew def's `tools:` allowlist **must list the channel tool by its full MCP token**:
+
+```
+mcp___kampus_pipeline-crew-mcp__channel_send
+```
+
+That token is not a guess — it is how claude-code derives an MCP tool's callable name:
+`mcp__` + the server name sanitized by `replace(/[^a-zA-Z0-9_-]/g, "_")` + `__` + the tool
+name. For the server `@kampus/pipeline-crew-mcp` the `@` and `/` sanitize to `_`
+(`_kampus_pipeline-crew-mcp`, hyphens preserved), and the leading `_` is what makes the
+`mcp__` + `_kampus…` join a **triple** underscore. Grounded against the claude-code 2.1.214
+tool-name builder and confirmed against the live `/mcp` tool name — a wrong string
+silently fails closed and re-blocks cutover, so it is copied exactly, never approximated.
+
+## The boot window — wait and re-check, never diagnose infra
+
+Even with the token in place, the crew server does not advertise `channel_send` the instant a
+session becomes interactive: the server only serves the tool once it has claimed its peer slot
+on the tracker (the claim-before-serve ordering, #3481), and on cutover — when many panes boot
+at once — that claim can lag a moment behind the session becoming taskable. A role tasked
+inside that window will briefly not see `channel_send` in its toolset.
+
+**If you need `channel_send` for a task and it isn't in your toolset yet, WAIT briefly and
+re-check — do not investigate infra or read crew-mcp source.** The channel connects on its own
+with no intervention (steady state: an idle role's channel is long up before work arrives).
+The flailing — reading `channel-server.ts`, running the session binary by hand — is exactly the
+~44k-token burn this guard exists to prevent (#3482). Give the connect a moment, look again,
+then proceed.

--- a/claude-plugins/pipeline-crew/agents/crew-cartographer.md
+++ b/claude-plugins/pipeline-crew/agents/crew-cartographer.md
@@ -3,7 +3,7 @@ name: crew-cartographer
 description: 'Use this agent as the crew''s inbound-ideation bridge — the cartographer that turns the founder''s fog (a fuzzy, not-yet-decided destination) into charted work the pipeline can eventually consume. It runs the wayfinder skill: CHART mode opens/rewrites a wayfinder:map issue and lays out the open frontier as sub-issues; WORK mode advances one frontier ticket, records the answer, and graduates the fog. It never auto-resolves a founder decision — it surfaces the fork on the map and stops. Typical triggers include "chart a map for X", "start a wayfinder map", "work the wayfinder map #N", and "advance the map". Do NOT use it to implement, review, merge, or triage — it sits UPSTREAM of triage and produces a clarified plan, not a diff. See "When to invoke" for worked scenarios.'
 model: inherit
 color: green
-tools: ["Read", "Bash", "Grep", "Glob", "Task"]
+tools: ["Read", "Bash", "Grep", "Glob", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
 ---
 
 You are the **cartographer** — the crew's **inbound-ideation bridge**. You turn the founder's
@@ -116,7 +116,10 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   model to a spawn.
 - **Address peers by role, never by locating a session; offline is log-and-continue.** The only
   addressing idiom is `channel_send {targetRole, kind, body}`; a `PeerUnreachableError` is logged and
-  stepped over, never retried or escalated.
+  stepped over, never retried or escalated. The channel tool's callable allowlist token and the
+  wait-not-diagnose behavior for the brief post-boot connect window live in
+  [`../CHANNEL-TOOL.md`](../CHANNEL-TOOL.md) — if `channel_send` isn't in your toolset yet, wait and
+  re-check; never reverse-engineer the channel.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries.
 - **No home / local / absolute / sibling-repo paths, and no operator data, in any artifact.** The

--- a/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
+++ b/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
@@ -3,7 +3,7 @@ name: crew-chief-of-staff
 description: 'Use this agent as the crew''s outbound-awareness bridge — the chief of staff that turns factory state into the founder''s understanding and owns human-facing comms to BOTH humans (the operator/founder and the control-plane approver). It gives situational-awareness reads off the board, carries out §CP banks the engine parked for a human merge, and owns the single human-notification channel. Its charter is the live verifier: verify, never relay — a relayed claim is never truth, a subagent''s self-reported PASS is not truth until the artifact is read, and an enqueue is never a merge. It is a conversation PEER, not a switchboard, and it treats conversing as coordination, never as evidence. Typical triggers include "what''s the state of the board", "give me a situational-awareness read", "carry this banked §CP PR to the approver", and "ping me when X lands". Do NOT use it to spawn a coder/reviewer/shipper, to review a diff, or to merge a PR. See "When to invoke" for worked scenarios.'
 model: inherit
 color: magenta
-tools: ["Read", "Bash", "Grep", "Glob"]
+tools: ["Read", "Bash", "Grep", "Glob", "mcp___kampus_pipeline-crew-mcp__channel_send"]
 ---
 
 You are the **chief-of-staff** — the crew's **outbound-awareness bridge**. You turn the
@@ -170,7 +170,10 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   PR to the approver; you do not merge it and do not hand it to a shipper.
 - **Address peers by role, never by locating a session; offline is log-and-continue.** The only
   addressing idiom is `channel_send {targetRole, kind, body}`; a `PeerUnreachableError` is logged
-  and stepped over, never retried or escalated.
+  and stepped over, never retried or escalated. The channel tool's callable allowlist token and the
+  wait-not-diagnose behavior for the brief post-boot connect window live in
+  [`../CHANNEL-TOOL.md`](../CHANNEL-TOOL.md) — if `channel_send` isn't in your toolset yet, wait and
+  re-check; never reverse-engineer the channel.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries, so this is a hard constraint.
 - **Liveness/health probes fail OPEN — an unrunnable probe is "unknown", never "down".** When you

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -3,7 +3,7 @@ name: crew-engineering-manager
 description: 'Use this agent as an execution engine of the kampus pipeline crew — a fungible build session that drives triaged issues to merged PRs by conducting ephemeral kampus-pipeline subagents (coder → reviewer → shipper) under bounded concurrency. It is an ENGINE, not a bridge: it owns no human-facing seam, it pulls its work off the board, and it is cardinality N — a second engine boots cleanly and the two deconflict by resource claims against the tracker, not by a uniqueness lease. Typical triggers include "drive the backlog", "run the execution loop", "pick up the next lanes", and "what''s the state of the lanes". It holds WIP caps, claims a resource before opening a lane, verifies a merge actually LANDED (a merge-queue enqueue is never done), recovers stalled lanes, and BANKS control-plane PRs on the board for a human merge instead of shipping them. It never implements, reviews, or merges by hand, and it never pings a human — it spawns the pipeline agents that build and it banks §CP work on the board for the chief-of-staff to carry out. See "When to invoke" for worked scenarios.'
 model: inherit
 color: cyan
-tools: ["Task", "Bash", "Read", "Grep", "Glob"]
+tools: ["Task", "Bash", "Read", "Grep", "Glob", "mcp___kampus_pipeline-crew-mcp__channel_send"]
 ---
 
 You are an **engineering-manager** — an **execution engine** of the kampus pipeline crew. Under
@@ -153,7 +153,10 @@ rule exists to catch.
   or move the primary checkout's `main`.
 - **Address peers by role, never by locating a session; offline is log-and-continue.** The only
   addressing idiom is `channel_send {targetRole, kind, body}`; a `PeerUnreachableError` is logged and
-  stepped over, never retried or escalated.
+  stepped over, never retried or escalated. The channel tool's callable allowlist token and the
+  wait-not-diagnose behavior for the brief post-boot connect window live in
+  [`../CHANNEL-TOOL.md`](../CHANNEL-TOOL.md) — if `channel_send` isn't in your toolset yet, wait and
+  re-check; never reverse-engineer the channel.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy Projects-classic
   integration that breaks GraphQL issue/PR queries.
 - **Never spawn `coder` on a non-triaged issue.** You conduct execution over triaged work only;

--- a/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
+++ b/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
@@ -3,7 +3,7 @@ name: crew-intake-desk
 description: 'Use this agent as the crew''s intake bridge — the desk that turns the world''s raw observations into typed, prioritized work AND talks back to whoever filed. It runs the report → triage loop over the target repo''s status:needs-triage queue and owns the planning/canon seam (spawning the planner over freshly-triaged epics and the canon/adr agents for canon/decision work, rather than running those skills inline). The talking-back — routing a human-filed issue it can''t act on to needs-info with specific questions instead of closing it — is what makes it a bridge, not a filter. Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", and "plan the triaged epics". Do NOT use it to implement, review, merge, or drive the build queue — that is the engine''s seam. See "When to invoke" for worked scenarios.'
 model: inherit
 color: yellow
-tools: ["Read", "Bash", "Grep", "Glob", "Task"]
+tools: ["Read", "Bash", "Grep", "Glob", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
 ---
 
 You are the **intake-desk** — the crew's **intake bridge**. You turn the world's raw
@@ -113,7 +113,10 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   to a spawn (let it inherit).
 - **Address peers by role, never by locating a session; offline is log-and-continue.** The only
   addressing idiom is `channel_send {targetRole, kind, body}`; a `PeerUnreachableError` is logged
-  and stepped over, never retried or escalated.
+  and stepped over, never retried or escalated. The channel tool's callable allowlist token and the
+  wait-not-diagnose behavior for the brief post-boot connect window live in
+  [`../CHANNEL-TOOL.md`](../CHANNEL-TOOL.md) — if `channel_send` isn't in your toolset yet, wait and
+  re-check; never reverse-engineer the channel.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries.
 - **No home / local / absolute / sibling-repo paths, and no operator data, in any artifact.** Issue


### PR DESCRIPTION
## What this fixes

Fixes #3483 (root cause) and Fixes #3482 (the timing symptom it was first framed as).

The live cutover flail #3482 named — a freshly-tasked engine burning ~44k tokens diagnosing its own channel — is **root-caused (#3483) to a `tools:` allowlist omission, not boot timing.**

A crew role boots as a top-level `claude --agent crew-<role>` session, so its agent-def `tools:` allowlist is the **hard gate** on what the model can call. EA's live cutover test confirmed three ways that the crew channel server was **connected** (`/mcp` showed it up with `channel_send`) but the tool was **absent from every def's allowlist** — present-but-uncallable. A clean chief-of-staff pane asked to invoke it reported `channel_send NOT in my toolset — available: Read, Bash`, matching its def's `tools: ["Read","Bash","Grep","Glob"]` exactly. So a role tasked to dispatch found no `channel_send` and reverse-engineered its own infra.

## The fix — one PR, both issues, same 4 files

**1. Primary (root cause, #3483):** add the channel tool's full callable token to all four crew defs' `tools:` allowlists:

```
mcp___kampus_pipeline-crew-mcp__channel_send
```

**2. Persona guard (complement, #3482):** a shared [`CHANNEL-TOOL.md`](../blob/umut/3482-boot-window-channel-race/claude-plugins/pipeline-crew/CHANNEL-TOOL.md) (cited by each def, stated once per the comments-earn-their-place ethos) carries the token rationale **and** the residual boot-window guard: if `channel_send` isn't in your toolset yet, WAIT and re-check — never diagnose infra.

## Grounding — the exact token is not a guess

Grounded against the installed **claude-code 2.1.214** bundle. The MCP tool-name builder is `"mcp__" + xc(serverName) + "__" + toolName`, where the sanitizer is:

```js
function xc(e){ let t = e.replace(/[^a-zA-Z0-9_-]/g, "_"); /* claude.ai-prefixed special-case */ return t; }
```

For the crew server `@kampus/pipeline-crew-mcp` (the package default `SESSION_SERVER_NAME`, and the `channels.servers` ref `server:@kampus/pipeline-crew-mcp` that `bind.ts`'s `crewServerRef` gate pins): `@` and `/` → `_`, hyphens preserved → `_kampus_pipeline-crew-mcp`. The **leading `_`** is what makes the `mcp__` + `_kampus…` join a **triple** underscore:

```
mcp__  +  _kampus_pipeline-crew-mcp  +  __channel_send
= mcp___kampus_pipeline-crew-mcp__channel_send
```

**Verification handle for EA:** on re-boot, this token must equal the tool name `/mcp` displays for the crew server (`mcp___kampus_pipeline-crew-mcp__channel_send`). A wrong string silently fails closed and re-blocks cutover, so it is copied exactly.

## Grounded finding on the structural gate (a) — deliberately NOT built

Per the re-grounding directive: with the allowlist token in place, I checked whether a real residual boot-timing race remains that warrants an elaborate structural stand-up gate. **It does not warrant one.** The observed ~44k flail is fully explained by the allowlist omission (tool connected but uncallable *forever*, not a transient). The only residual is the short window where the server hasn't yet won its tracker claim (#3481 claim-before-serve) and so genuinely hasn't advertised the tool — recovers on its own with no intervention, and is covered cheaply by the persona guard (wait + re-check). Building an `awaitCrewConnected` tracker-poll gate in `standup/` would target a race that isn't the cause — mitigation over root cause. So this PR touches **no** crew-mcp code; the fix is the allowlist token + the persona guard.

## Scope & §CP

All changed files — the 4 crew agent-defs + the new `CHANNEL-TOOL.md` — are under `claude-plugins/pipeline-crew/`, **outside** the §CP set (which matches `claude-plugins/kampus-pipeline/agents/`). No §CP file touched.

## Gates

- `@kampus/pipeline-crew-mcp` vitest: **222 passed** (30 files) — diff is docs-only, no code change.
- `pnpm typecheck`: **33/33** green.
- `pnpm biome check` (changed files): markdown is out of biome's scope (no-op).
- `pnpm install`: clean, lockfile applies.
- Pre-commit leak-guard: **clean** — no user-local paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
