### PR TITLE
refactor(pipeline-crew-mcp): migrate node:* call sites to the v4 Effect platform idiom (#3468)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
@@ -116,7 +116,9 @@ describe("crew/channel-server — REAL unix-socket inbox transport", () => {
 				const exit = yield* Effect.scoped(
 					Effect.gen(function* () {
 						const built = yield* Layer.build(
-							inboxServerSocketLayer(address).pipe(Layer.provide([discardingSink, NodeFileSystem.layer])),
+							inboxServerSocketLayer(address).pipe(
+								Layer.provide([discardingSink, NodeFileSystem.layer]),
+							),
 						).pipe(Effect.exit);
 						assert.isTrue(
 							existsSync(socketPath),
@@ -140,14 +142,20 @@ describe("crew/channel-server — REAL unix-socket inbox transport", () => {
 				yield* Effect.scoped(
 					Effect.gen(function* () {
 						// Stand up a LIVE inbox server first, held for this scope.
-						yield* Layer.build(inboxServerSocketLayer(address).pipe(Layer.provide([discardingSink, NodeFileSystem.layer])));
+						yield* Layer.build(
+							inboxServerSocketLayer(address).pipe(
+								Layer.provide([discardingSink, NodeFileSystem.layer]),
+							),
+						);
 						yield* Effect.sleep("300 millis");
 						assert.isTrue(existsSync(socketPath), "the live listener is bound");
 
 						// A second bind at the same (live) path must FAIL — reclaim skips the unlink when the
 						// connect succeeds, so the raw bind rejects with EADDRINUSE (the live socket is untouched).
 						const second = yield* Layer.build(
-							inboxServerSocketLayer(address).pipe(Layer.provide([discardingSink, NodeFileSystem.layer])),
+							inboxServerSocketLayer(address).pipe(
+								Layer.provide([discardingSink, NodeFileSystem.layer]),
+							),
 						).pipe(Effect.exit);
 						assert.isTrue(
 							Exit.isFailure(second),

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
@@ -15,6 +15,7 @@
  */
 import {spawn} from "node:child_process";
 import {existsSync} from "node:fs";
+import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer, Ref} from "effect";
 import {type ChannelNotificationPayload, ChannelSink} from "../edge/index.ts";
@@ -63,8 +64,10 @@ describe("crew/channel-server — REAL unix-socket inbox transport", () => {
 				const address = freshAddress();
 				const socketPath = inboxSocketPathFor(address);
 				const wakes = yield* Ref.make<ReadonlyArray<ChannelNotificationPayload>>([]);
+				// The reclaim now reaches disk through the `FileSystem` seam, so provide the real Node
+				// FileSystem — the layer builds in-test exactly as under the bin's `NodeServices.layer`.
 				const serverLayer = inboxServerSocketLayer(address).pipe(
-					Layer.provide(recordingSink(wakes)),
+					Layer.provide([recordingSink(wakes), NodeFileSystem.layer]),
 				);
 
 				const result = yield* Effect.gen(function* () {
@@ -113,7 +116,7 @@ describe("crew/channel-server — REAL unix-socket inbox transport", () => {
 				const exit = yield* Effect.scoped(
 					Effect.gen(function* () {
 						const built = yield* Layer.build(
-							inboxServerSocketLayer(address).pipe(Layer.provide(discardingSink)),
+							inboxServerSocketLayer(address).pipe(Layer.provide([discardingSink, NodeFileSystem.layer])),
 						).pipe(Effect.exit);
 						assert.isTrue(
 							existsSync(socketPath),
@@ -137,14 +140,14 @@ describe("crew/channel-server — REAL unix-socket inbox transport", () => {
 				yield* Effect.scoped(
 					Effect.gen(function* () {
 						// Stand up a LIVE inbox server first, held for this scope.
-						yield* Layer.build(inboxServerSocketLayer(address).pipe(Layer.provide(discardingSink)));
+						yield* Layer.build(inboxServerSocketLayer(address).pipe(Layer.provide([discardingSink, NodeFileSystem.layer])));
 						yield* Effect.sleep("300 millis");
 						assert.isTrue(existsSync(socketPath), "the live listener is bound");
 
 						// A second bind at the same (live) path must FAIL — reclaim skips the unlink when the
 						// connect succeeds, so the raw bind rejects with EADDRINUSE (the live socket is untouched).
 						const second = yield* Layer.build(
-							inboxServerSocketLayer(address).pipe(Layer.provide(discardingSink)),
+							inboxServerSocketLayer(address).pipe(Layer.provide([discardingSink, NodeFileSystem.layer])),
 						).pipe(Effect.exit);
 						assert.isTrue(
 							Exit.isFailure(second),

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.ts
@@ -19,7 +19,7 @@
  */
 import {createHash} from "node:crypto";
 import {NodeSocket, NodeSocketServer} from "@effect/platform-node";
-import {Effect, Layer} from "effect";
+import {Effect, type FileSystem, Layer} from "effect";
 import {RpcClient, RpcSerialization, RpcServer} from "effect/unstable/rpc";
 import {type ChannelSink, channelInboxLayer} from "../edge/index.ts";
 import {
@@ -147,7 +147,9 @@ export const crewSocketDialerLayer: Layer.Layer<Dialer> = Layer.succeed(Dialer, 
 /**
  * The peer-inbox `RpcServer` over a unix socket at `address`, serving `PeerInbox` with the
  * channel-bridging inbox (`edge`) so each delivery wakes the session — mirrors the tracker's
- * socket server. Requires a `ChannelSink` (the edge's last-mile wake port).
+ * socket server. Requires a `ChannelSink` (the edge's last-mile wake port) and, since the reclaim
+ * now reaches disk through the `FileSystem` seam (`reclaimStaleSocket`), a `FileSystem` — discharged
+ * at the bin's `NodeServices.layer`, the same seam the tracker's reclaim threads to.
  *
  * The socket transport is reclamation-guarded exactly like the tracker's (`reclaimStaleSocket`,
  * #3280): the deterministic per-instance path is unlinked before bind IFF a connect proves it a
@@ -157,7 +159,9 @@ export const crewSocketDialerLayer: Layer.Layer<Dialer> = Layer.succeed(Dialer, 
  * never reclaimed (connect succeeds ⇒ not stale), so the raw bind still fails closed on a real
  * competitor. `Layer.unwrap` sequences the reclaim ahead of the bind.
  */
-export const inboxServerSocketLayer = (address: string): Layer.Layer<never, unknown, ChannelSink> =>
+export const inboxServerSocketLayer = (
+	address: string,
+): Layer.Layer<never, unknown, ChannelSink | FileSystem.FileSystem> =>
 	RpcServer.layer(PeerInbox).pipe(
 		Layer.provide(inboxHandlers.pipe(Layer.provide(channelInboxLayer(address)))),
 		Layer.provide(

--- a/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
@@ -14,6 +14,7 @@
 import {randomUUID} from "node:crypto";
 import {existsSync} from "node:fs";
 import {assert, describe, it} from "@effect/vitest";
+import {NodeFileSystem} from "@effect/platform-node";
 import {Cause, Effect, Exit, Layer, Stdio, Stream} from "effect";
 import {McpServer} from "effect/unstable/ai";
 import {RpcTest} from "effect/unstable/rpc";
@@ -58,12 +59,15 @@ describe("crew/session — forked-stdio live-wake round-trip (session.ts:34 seam
 					experimental: channelExperimentalCapability,
 				}).pipe(Layer.provide(Stdio.layerTest({stdin: Stream.never})));
 
+				// The inbound socket server's stale-socket reclaim reaches disk through the `FileSystem`
+				// seam; the in-memory substrate carries no `FileSystem`, so provide the real Node one —
+				// discharged here exactly as the bin's `NodeServices.layer` does in production.
 				const serverLayer = assembleCrewSession(
 					{role: "intake-desk", projectRoot: "/x"},
 					address,
 					inMemorySubstrate(address),
 					transport,
-				).pipe(Layer.orDie);
+				).pipe(Layer.provide(NodeFileSystem.layer), Layer.orDie);
 
 				yield* Effect.forkScoped(Layer.launch(serverLayer));
 				yield* Effect.sleep("1500 millis"); // window for the forked run-loop + socket bind

--- a/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
@@ -13,8 +13,8 @@
  */
 import {randomUUID} from "node:crypto";
 import {existsSync} from "node:fs";
-import {assert, describe, it} from "@effect/vitest";
 import {NodeFileSystem} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
 import {Cause, Effect, Exit, Layer, Stdio, Stream} from "effect";
 import {McpServer} from "effect/unstable/ai";
 import {RpcTest} from "effect/unstable/rpc";

--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -12,6 +12,7 @@
  *     cartographer included).
  */
 import {randomUUID} from "node:crypto";
+import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Deferred, Effect, Layer, Ref, Schema, Stdio, Stream} from "effect";
 import {McpSchema, McpServer} from "effect/unstable/ai";
@@ -258,7 +259,9 @@ const bootSessionClient = (address: string) =>
 				path: "/mcp",
 				experimental: channelExperimentalCapability,
 			}),
-		).pipe(Layer.orDie);
+			// The inbound socket server's stale-socket reclaim reaches disk through the `FileSystem`
+			// seam; the in-memory substrate carries none, so provide the real Node one (as the bin does).
+		).pipe(Layer.provide(NodeFileSystem.layer), Layer.orDie);
 		const {dispose, handler} = HttpRouter.toWebHandler(serverLayer, {disableLogger: true});
 		yield* Effect.addFinalizer(() =>
 			Effect.tryPromise({try: () => dispose(), catch: (cause) => new DisposeError({cause})}).pipe(
@@ -380,7 +383,8 @@ describe("crew/session — the session-mode server wins the async-ChannelSend bu
 					address,
 					substrate,
 					transport,
-				).pipe(Layer.orDie);
+					// Provide the real Node `FileSystem` for the inbound reclaim seam (as the bin does).
+				).pipe(Layer.provide(NodeFileSystem.layer), Layer.orDie);
 
 				// Launch the live session on a scoped fiber. Claim-first (fixed): it blocks in the unwrap on the
 				// gated claim, so nothing serves until the gate opens. Old ordering: the transport builds and its

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -35,7 +35,7 @@
  */
 import {randomUUID} from "node:crypto";
 import {NodeStdio} from "@effect/platform-node";
-import {Effect, Layer} from "effect";
+import {Effect, type FileSystem, Layer} from "effect";
 import {type McpSchema, McpServer} from "effect/unstable/ai";
 import {
 	ChannelSend,
@@ -118,7 +118,7 @@ export const sessionInstance = (config: CrewSessionConfig): string =>
 export const peerSocketSubstrate = (
 	config: CrewSessionConfig,
 	address: string,
-): Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown> => {
+): Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown, FileSystem.FileSystem> => {
 	const crewTracker = crewTrackerHostOrDialLayer(socketPathFor(config.projectRoot));
 	return Layer.mergeAll(
 		peerTrackerLayer.pipe(Layer.provideMerge(crewTracker)),
@@ -179,12 +179,19 @@ export const channelSendFromPeer = (
  * an in-process `McpServer.layerHttp` (advertised tools + capabilities) and a fake-`Stdio` forked
  * run-loop (the async-`ChannelSend` race guard), both without a live stdio client.
  */
-export const assembleCrewSession = <RIn>(
+export const assembleCrewSession = <RIn, RSub = never>(
 	config: CrewSessionConfig,
 	address: string,
-	substrate: Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown>,
+	// The substrate may carry its own requirement (`RSub`): production's `peerSocketSubstrate` needs
+	// `FileSystem` (the tracker's stale-socket reclaim seam), discharged with `RIn` at the bin's
+	// NodeServices.layer; the in-memory test substrate is `RSub = never`.
+	substrate: Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown, RSub>,
 	transport: Layer.Layer<McpServer.McpServer | McpSchema.McpServerClient, never, RIn>,
-): Layer.Layer<never, unknown, RIn> =>
+	// `FileSystem` is a standing requirement independent of the substrate: the inbound socket server
+	// (`inboxServerSocketLayer`) reclaims a stale inbox socket through the `FileSystem` seam (#3489),
+	// discharged with `RIn`/`RSub` at the bin's `NodeServices.layer` — production's `peerSocketSubstrate`
+	// already carries it in `RSub`, so this widens nothing for the live path.
+): Layer.Layer<never, unknown, RIn | RSub | FileSystem.FileSystem> =>
 	// Claim FIRST (Race 2): the slow tracker-claim/presence handshake runs in the unwrap's effect,
 	// BEFORE the run-loop-forking transport is built, so ChannelSend below is a zero-async binding.
 	Layer.unwrap(

--- a/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.test.ts
@@ -8,6 +8,7 @@
 import {randomUUID} from "node:crypto";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeFileSystem} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Cause, Context, Effect, Layer} from "effect";
 import {RpcTest} from "effect/unstable/rpc";
@@ -19,6 +20,11 @@ import {RegistryLive} from "../tracker/registry.ts";
 import {CrewTracker, crewTrackerHostOrDialLayer} from "./tracker.ts";
 
 const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+
+// The host layer's stale-socket reclaim reaches disk through the FileSystem seam; provide the real
+// Node FileSystem so the host-or-dial layer builds in-test as under the bin's NodeServices.layer.
+const hostOrDial = (socketPath: string) =>
+	crewTrackerHostOrDialLayer(socketPath).pipe(Layer.provide(NodeFileSystem.layer));
 const nowIso = () => new Date().toISOString();
 
 const errWithCode = (code: string): Error => Object.assign(new Error(code), {code});
@@ -29,8 +35,8 @@ describe("crew/tracker — first-peer-spawn: two sessions on one project root, o
 			const socketPath = join(tmpdir(), `crew-hostdial-${randomUUID().slice(0, 8)}.sock`);
 			// Two concurrent sessions on ONE socket: the first hosts, the second must dial the host —
 			// exactly one server binds. If two bound, they'd be two registries and the cross-lookup fails.
-			const ctxA = yield* Layer.build(crewTrackerHostOrDialLayer(socketPath));
-			const ctxB = yield* Layer.build(crewTrackerHostOrDialLayer(socketPath));
+			const ctxA = yield* Layer.build(hostOrDial(socketPath));
+			const ctxB = yield* Layer.build(hostOrDial(socketPath));
 			const trackerA = Context.get(ctxA, CrewTracker);
 			const trackerB = Context.get(ctxB, CrewTracker);
 			// A announces; B looks it up and finds it ⇒ both speak to the SAME registry ⇒ one tracker.
@@ -48,7 +54,7 @@ describe("crew/tracker — first-peer-spawn: two sessions on one project root, o
 	it.effect("a lone session hosts its own tracker (announce→lookup round-trips on one layer)", () =>
 		Effect.gen(function* () {
 			const socketPath = join(tmpdir(), `crew-solo-${randomUUID().slice(0, 8)}.sock`);
-			const ctx = yield* Layer.build(crewTrackerHostOrDialLayer(socketPath));
+			const ctx = yield* Layer.build(hostOrDial(socketPath));
 			const tracker = Context.get(ctx, CrewTracker);
 			yield* tracker.announce({
 				role: "reviewer",

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -13,7 +13,7 @@
  *     that address back out (matching the `inbox://…` convention the tracker socket test uses).
  */
 import {NodeSocket} from "@effect/platform-node";
-import {Array as Arr, Context, Effect, Layer, type Scope} from "effect";
+import {Array as Arr, Context, Effect, type FileSystem, Layer, type Scope} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
 import {type RolePresence, Tracker} from "../peer/index.ts";
 import type * as Schema from "../protocol/schema.ts";
@@ -177,7 +177,9 @@ export const crewTrackerSocketLayer = (socketPath: string) =>
  * is listening before the client connects) and keeps the hosted server scoped for the session's
  * lifetime. A non-`EADDRINUSE` bind failure is re-raised, never dialed over.
  */
-export const crewTrackerHostOrDialLayer = (socketPath: string): Layer.Layer<CrewTracker, unknown> =>
+export const crewTrackerHostOrDialLayer = (
+	socketPath: string,
+): Layer.Layer<CrewTracker, unknown, FileSystem.FileSystem> =>
 	crewTrackerSocketLayer(socketPath).pipe(
 		Layer.provide(trackerServerLayer(socketPath)),
 		Layer.catchCause((cause) =>

--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -477,7 +477,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -509,13 +509,13 @@ describe("standup/bind — per-session bind constructor", () => {
 				};
 				// A self-driving bridge (no instance) and an engine (with instance) both receive the boot
 				// prompt — the def each boots as carries its own cold-start, so the launcher's turn is generic.
-				const bridge = yield* buildSessionBind({
+				const bridge = yield* build({
 					role: "chief-of-staff",
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
 					channels,
 				});
-				const engine = yield* buildSessionBind({
+				const engine = yield* build({
 					role: "engineering-manager",
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -541,7 +541,7 @@ describe("standup/bind — per-session bind constructor", () => {
 				// The cartographer has no standing loop, so it must NOT be handed the self-driving BOOT_PROMPT
 				// — that is what made it confabulate work. Even launched on-demand, its argv carries no
 				// positional prompt, so the CLI opens an interactive session that idles waiting for the human.
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: "cartographer",
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,

--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -9,8 +9,9 @@
  * allowlist-mode plugin channel whose plugin the config's `allowedChannelPlugins` doesn't list.
  */
 import {existsSync} from "node:fs";
+import {NodePath, NodeServices} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect} from "effect";
+import {Effect, FileSystem, Layer} from "effect";
 import {
 	AGENT_FLAG,
 	ALLOWLIST_CHANNEL_FLAG,
@@ -33,6 +34,21 @@ import type {ChannelConfig} from "./config.ts";
 const ROLE = "engineering-manager";
 const PROJECT_ROOT = "/work/phoenix";
 const SERVER_NAME = "pipeline-crew";
+
+// The bind constructor reaches the platform through the `FileSystem`/`Path` seam
+// (.patterns/effect-platform-access.md), discharged in-test by the same NodeServices.layer the bin
+// provides — so `build` is the real-disk variant (bin.ts resolves), matching production.
+const build = (input: Parameters<typeof buildSessionBind>[0]) =>
+	buildSessionBind(input).pipe(Effect.provide(NodeServices.layer));
+
+// The seam is what makes the "bin absent" guard testable WITHOUT the old injected `binExists`: a fake
+// `FileSystem` whose `exists` answers false (the whole filesystem substituted, not just a probe fn).
+const buildWithBinAbsent = (input: Parameters<typeof buildSessionBind>[0]) =>
+	buildSessionBind(input).pipe(
+		Effect.provide(
+			Layer.mergeAll(FileSystem.layerNoop({exists: () => Effect.succeed(false)}), NodePath.layer),
+		),
+	);
 // The pipeline-crew plugin root under PROJECT_ROOT — the dir `--plugin-dir` loads the role agent-defs
 // from so `--agent <role>` resolves the persona instead of general-purpose (#3447).
 const EXPECTED_PLUGIN_DIR = "/work/phoenix/claude-plugins/pipeline-crew";
@@ -55,7 +71,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew", "plugin:kampus:sozluk"],
 					allowedChannelPlugins: ["kampus"],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -104,7 +120,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew", "plugin:localdev:scratch"],
 					allowedChannelPlugins: [],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -145,7 +161,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					"intake-desk",
 					"engineering-manager",
 				]) {
-					const bind = yield* buildSessionBind({
+					const bind = yield* build({
 						role,
 						projectRoot: PROJECT_ROOT,
 						serverName: SERVER_NAME,
@@ -171,7 +187,7 @@ describe("standup/bind — per-session bind constructor", () => {
 				servers: ["server:pipeline-crew"],
 				allowedChannelPlugins: [],
 			};
-			const bind = yield* buildSessionBind({
+			const bind = yield* build({
 				role: ROLE,
 				projectRoot: "/some/other/root",
 				serverName: SERVER_NAME,
@@ -193,7 +209,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:some-other"],
 					allowedChannelPlugins: [],
 				};
-				const error = yield* buildSessionBind({
+				const error = yield* build({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -216,7 +232,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -250,7 +266,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -269,7 +285,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -297,13 +313,12 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const error = yield* buildSessionBind({
+				const error = yield* buildWithBinAbsent({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
 					channels,
-					// The injected resolvability probe reports the bin absent — the launch must refuse.
-					binExists: () => false,
+					// The substituted FileSystem reports the bin absent (exists → false) — the launch must refuse.
 				}).pipe(Effect.flip);
 
 				assert.instanceOf(error, CrewSessionBinUnresolvableError);
@@ -318,7 +333,7 @@ describe("standup/bind — per-session bind constructor", () => {
 				servers: ["server:pipeline-crew"],
 				allowedChannelPlugins: [],
 			};
-			const bind = yield* buildSessionBind({
+			const bind = yield* build({
 				role: ROLE,
 				projectRoot: PROJECT_ROOT,
 				serverName: SERVER_NAME,
@@ -354,7 +369,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: "cartographer",
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -374,7 +389,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: ROLE,
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -406,7 +421,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const bind = yield* buildSessionBind({
+				const bind = yield* build({
 					role: "chief-of-staff",
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -432,14 +447,14 @@ describe("standup/bind — per-session bind constructor", () => {
 					servers: ["server:pipeline-crew"],
 					allowedChannelPlugins: [],
 				};
-				const engineOne = yield* buildSessionBind({
+				const engineOne = yield* build({
 					role: "engineering-manager",
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
 					instance: "e-1",
 					channels,
 				});
-				const engineTwo = yield* buildSessionBind({
+				const engineTwo = yield* build({
 					role: "engineering-manager",
 					projectRoot: PROJECT_ROOT,
 					serverName: SERVER_NAME,
@@ -549,7 +564,7 @@ describe("standup/bind — per-session bind constructor", () => {
 				servers: ["server:pipeline-crew", "plugin:untrusted:evil"],
 				allowedChannelPlugins: ["kampus"],
 			};
-			const error = yield* buildSessionBind({
+			const error = yield* build({
 				role: ROLE,
 				projectRoot: PROJECT_ROOT,
 				serverName: SERVER_NAME,

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -29,10 +29,8 @@
  * exact rejection the CLI raises). The project-scope WRITE is a launcher side effect, so its own
  * fail-closed guard lives at that write (register-project-scope.ts / orchestrate.ts), not here.
  */
-import {existsSync} from "node:fs";
-import {join} from "node:path";
 import {fileURLToPath} from "node:url";
-import {Effect, Schema} from "effect";
+import {Effect, FileSystem, Path, Schema} from "effect";
 import {driveOf, isCrewRole} from "../crew/index.ts";
 import {type ChannelConfig, type Tier, tierModel} from "./config.ts";
 
@@ -97,9 +95,8 @@ export const AGENT_FLAG = "--agent";
  */
 export const BOOT_PROMPT =
 	"Begin now. Run your role's on-boot cold-start behavior as defined by your agent instructions: announce your presence on the channel, then start your standing work loop under your own power. Do not wait to be pinged, relayed to, or told to start.";
-/** The pipeline-crew plugin root under a given project root — the dir `--plugin-dir` loads agent-defs from. */
-const crewPluginDir = (projectRoot: string): string =>
-	join(projectRoot, "claude-plugins/pipeline-crew");
+/** The pipeline-crew plugin root segment `--plugin-dir` joins onto a project root to load agent-defs from. */
+const CREW_PLUGIN_SUBDIR = "claude-plugins/pipeline-crew";
 /** Allowlist mode: only servers named here load, gated by `allowedChannelPlugins` for plugin refs. */
 export const ALLOWLIST_CHANNEL_FLAG = "--channels";
 /** Dev mode: load channel servers not on the approved allowlist — local development only. */
@@ -212,12 +209,6 @@ export interface SessionBindInput {
 	readonly tier?: Tier | undefined;
 	/** The resolved channels dimension of the crew `LaunchConfig` (#3293), consumed read-only. */
 	readonly channels: ChannelConfig;
-	/**
-	 * Whether the crew server's `bin.ts` resolves on disk — injected so the fail-closed
-	 * resolvability guard is unit-testable without moving the real file. Default: the real
-	 * `existsSync`, checked against `CREW_SESSION_BIN_PATH` (#3425).
-	 */
-	readonly binExists?: (binPath: string) => boolean;
 }
 
 /**
@@ -274,16 +265,27 @@ export const buildSessionBind = (
 	input: SessionBindInput,
 ): Effect.Effect<
 	SessionBind,
-	CrewSessionBinUnresolvableError | CrewServerNotRegisteredError | ChannelPluginNotAllowedError
+	CrewSessionBinUnresolvableError | CrewServerNotRegisteredError | ChannelPluginNotAllowedError,
+	FileSystem.FileSystem | Path.Path
 > =>
 	Effect.gen(function* () {
+		// The platform is the swappable seam (.patterns/effect-platform-access.md): `FileSystem` probes
+		// bin.ts resolvability (a `unit` test substitutes a fake FS instead of the old injected `binExists`),
+		// and `Path` builds the plugin dir. Both discharge from the crew-mcp bin's existing NodeServices.layer.
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
 		const {role, projectRoot, serverName, instance, tier, channels} = input;
-		const binExists = input.binExists ?? existsSync;
 		const servers = channels.servers;
 
 		// Resolvability before anything else: the bin the server command runs must exist on disk, else
-		// the launched `<node> <bin.ts>` fails to spawn and the channel is inert (#3425).
-		if (!binExists(CREW_SESSION_BIN_PATH)) {
+		// the launched `<node> <bin.ts>` fails to spawn and the channel is inert (#3425). A probe fault
+		// folds to "absent" (`orElseSucceed(false)`) so an fs error fails the launch closed under the
+		// existing named error, never leaking a `PlatformError` — matching the old `existsSync` (false on
+		// any fault), so this reader's E channel stays exactly its three launch-refusal errors.
+		const binExists = yield* fs
+			.exists(CREW_SESSION_BIN_PATH)
+			.pipe(Effect.orElseSucceed(() => false));
+		if (!binExists) {
 			return yield* Effect.fail(
 				new CrewSessionBinUnresolvableError({binPath: CREW_SESSION_BIN_PATH}),
 			);
@@ -323,7 +325,10 @@ export const buildSessionBind = (
 		// The persona boot (#3447): --plugin-dir loads the pipeline-crew plugin so --agent resolves the
 		// role's agent-def instead of falling through to general-purpose. The agent-def name is the
 		// collision-free `crew-<role>`, so map the bare role at this argv site (see AGENT_FLAG for why).
-		const pluginDirArg: readonly [string, string] = [PLUGIN_DIR_FLAG, crewPluginDir(projectRoot)];
+		const pluginDirArg: readonly [string, string] = [
+			PLUGIN_DIR_FLAG,
+			path.join(projectRoot, CREW_PLUGIN_SUBDIR),
+		];
 		const agentArg: readonly [string, string] = [AGENT_FLAG, `crew-${role}`];
 		// The launcher's boot turn (#3516): a tail positional prompt so the spawned session fires its
 		// def's cold-start instead of idling. Tail placement (after the non-variadic --name) keeps it out

--- a/packages/pipeline-crew-mcp/src/standup/config.ts
+++ b/packages/pipeline-crew-mcp/src/standup/config.ts
@@ -22,8 +22,7 @@
  * (operator/notification/wipCap/…) are ignored. There is no config-read tmux dimension —
  * tmux window placement now derives from role identity at launch (tmux-placement.ts), not config.
  */
-import {readFileSync} from "node:fs";
-import {Effect, Schema} from "effect";
+import {Effect, FileSystem, Schema} from "effect";
 import {CREW_ROLES} from "../crew/index.ts";
 
 /**
@@ -316,17 +315,26 @@ export const decodeLaunchConfig = (
  */
 const readParsedConfig = (env: {
 	readonly CREW_CONFIG?: string | undefined;
-}): Effect.Effect<{readonly parsed: unknown; readonly configPath: string}, LaunchConfigError> =>
+}): Effect.Effect<
+	{readonly parsed: unknown; readonly configPath: string},
+	LaunchConfigError,
+	FileSystem.FileSystem
+> =>
 	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
 		const configPath = resolveConfigPath(env);
-		const text = yield* Effect.try({
-			try: () => readFileSync(configPath, "utf8"),
-			catch: (cause) =>
-				new LaunchConfigError({
-					configPath,
-					reason: `cannot read crew config (run pipeline-crew stand-up first): ${String(cause)}`,
-				}),
-		});
+		// The `FileSystem` seam (over the bin's NodeServices.layer) reads the config, so a `unit` test
+		// substitutes it in place of the real disk (.patterns/effect-platform-access.md). A read fault is
+		// a typed `PlatformError` on E, folded to the dimension-naming LaunchConfigError this reader owns.
+		const text = yield* fs.readFileString(configPath, "utf8").pipe(
+			Effect.mapError(
+				(cause) =>
+					new LaunchConfigError({
+						configPath,
+						reason: `cannot read crew config (run pipeline-crew stand-up first): ${String(cause)}`,
+					}),
+			),
+		);
 		const parsed = yield* Effect.try({
 			try: () => parseJsonc(text),
 			catch: (cause) =>
@@ -342,7 +350,7 @@ const readParsedConfig = (env: {
  */
 export const readLaunchConfig = (
 	env: {readonly CREW_CONFIG?: string | undefined} = process.env,
-): Effect.Effect<LaunchConfig, LaunchConfigError> =>
+): Effect.Effect<LaunchConfig, LaunchConfigError, FileSystem.FileSystem> =>
 	readParsedConfig(env).pipe(
 		Effect.flatMap(({parsed, configPath}) => decodeLaunchConfig(parsed, configPath)),
 	);

--- a/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
@@ -8,7 +8,7 @@ import {randomUUID} from "node:crypto";
 import {mkdtempSync, rmSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
-import {NodeSocket} from "@effect/platform-node";
+import {NodeFileSystem, NodeSocket} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
@@ -16,6 +16,14 @@ import {socketPathFor, TrackerRegistry, trackerServerLayer} from "../tracker/ind
 import {ensureTrackerRunning, tryBecomeTracker} from "./ensure-tracker.ts";
 
 const freshSocketPath = () => join(tmpdir(), `ensure-tracker-${randomUUID().slice(0, 8)}.sock`);
+
+// The tracker layer's stale-socket reclaim reaches disk through the FileSystem seam; provide the real
+// Node FileSystem so both the direct host-layer build and `tryBecomeTracker` discharge it in-test
+// (leaving only Scope, which the outer `Effect.scoped` supplies) — as under the bin's NodeServices.layer.
+const hostedTracker = (socketPath: string) =>
+	trackerServerLayer(socketPath).pipe(Layer.provide(NodeFileSystem.layer));
+const attemptBecomeTracker = (socketPath: string) =>
+	tryBecomeTracker(socketPath).pipe(Effect.provide(NodeFileSystem.layer));
 
 const clientLayer = (socketPath: string) =>
 	RpcClient.layerProtocolSocket().pipe(
@@ -31,7 +39,7 @@ describe("tryBecomeTracker — the bind-outcome core", () => {
 	it.effect("start-if-absent: an unbound socket is won ('started') and served afterward", () => {
 		const socketPath = freshSocketPath();
 		return Effect.gen(function* () {
-			const outcome = yield* tryBecomeTracker(socketPath);
+			const outcome = yield* attemptBecomeTracker(socketPath);
 			assert.strictEqual(outcome, "started");
 			// served afterward: a client round-trips through the just-started tracker.
 			const client = yield* RpcClient.make(TrackerRegistry);
@@ -51,9 +59,9 @@ describe("tryBecomeTracker — the bind-outcome core", () => {
 			const socketPath = freshSocketPath();
 			return Effect.gen(function* () {
 				// A tracker is already serving this socket (built into the scope).
-				yield* Layer.build(trackerServerLayer(socketPath));
+				yield* Layer.build(hostedTracker(socketPath));
 				// The second attempt must not crash or double-bind — it reads the EADDRINUSE reuse signal.
-				const outcome = yield* tryBecomeTracker(socketPath);
+				const outcome = yield* attemptBecomeTracker(socketPath);
 				assert.strictEqual(outcome, "already-serving");
 			}).pipe(Effect.scoped);
 		},

--- a/packages/pipeline-crew-mcp/src/standup/ensure-tracker.ts
+++ b/packages/pipeline-crew-mcp/src/standup/ensure-tracker.ts
@@ -13,8 +13,8 @@
 import {spawn} from "node:child_process";
 import {connect} from "node:net";
 import {fileURLToPath} from "node:url";
-import {NodeRuntime} from "@effect/platform-node";
-import {Effect, Layer, type Scope} from "effect";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Effect, type FileSystem, Layer, type Scope} from "effect";
 import * as Schema from "effect/Schema";
 import type {SocketServerError} from "effect/unstable/socket/SocketServer";
 import {socketPathFor, trackerServerLayer} from "../tracker/index.ts";
@@ -53,7 +53,7 @@ const isAddressInUse = (error: SocketServerError): boolean => {
  */
 export const tryBecomeTracker = (
 	socketPath: string,
-): Effect.Effect<TrackerBindOutcome, SocketServerError, Scope.Scope> =>
+): Effect.Effect<TrackerBindOutcome, SocketServerError, Scope.Scope | FileSystem.FileSystem> =>
 	Layer.build(trackerServerLayer(socketPath)).pipe(
 		Effect.map((): TrackerBindOutcome => "started"),
 		Effect.catchTag("SocketServerError", (error) =>
@@ -71,7 +71,7 @@ export const tryBecomeTracker = (
  */
 export const runStandingTracker = (
 	projectRoot: string,
-): Effect.Effect<TrackerBindOutcome, SocketServerError> =>
+): Effect.Effect<TrackerBindOutcome, SocketServerError, FileSystem.FileSystem> =>
 	Effect.scoped(
 		tryBecomeTracker(socketPathFor(projectRoot)).pipe(
 			Effect.tap((outcome) => (outcome === "started" ? Effect.never : Effect.void)),
@@ -135,5 +135,10 @@ export const ensureTrackerRunning = (
 // Detached-child entry: when this module is the process entrypoint, run the standing tracker for the
 // project root passed as argv[2]. `ensureTrackerRunning` re-enters here in the spawned child.
 if (import.meta.main) {
-	NodeRuntime.runMain(runStandingTracker(process.argv[2] ?? process.cwd()));
+	// The detached-child entrypoint is a bin-level platform-composition boundary (the doc's bright
+	// line): provide the Node platform here so `runStandingTracker`'s `FileSystem` requirement — the
+	// stale-socket reclaim seam — discharges, exactly as bin.ts provides it for `launchTracker`.
+	NodeRuntime.runMain(
+		runStandingTracker(process.argv[2] ?? process.cwd()).pipe(Effect.provide(NodeServices.layer)),
+	);
 }

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -8,6 +8,7 @@
  * Every side-effecting step is injected — a version reader, a recording tracker, a recording launcher
  * — so the whole boot runs in a unit test with no real subprocess, tmux, or `claude`.
  */
+import {NodeServices} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {CREW_ROLES, isAutobooted, kindOf} from "../crew/index.ts";
@@ -45,6 +46,12 @@ import {
 
 const PINNED = "2.1.212";
 const SERVER = "@kampus/pipeline-crew-mcp";
+
+// The per-session bind reaches the platform through the FileSystem/Path seam; provide the real Node
+// platform (the bin's NodeServices.layer) so runStandUp discharges it in-test. These tests inject
+// every side-effecting step, so the only live platform touch is the bind's bin.ts resolvability probe.
+const standUp = (input: Parameters<typeof runStandUp>[0]) =>
+	runStandUp(input).pipe(Effect.provide(NodeServices.layer));
 
 /**
  * A post-#3236 one-role-map crew config (raw, on-disk shape): the engine count lives at
@@ -268,7 +275,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 			Effect.gen(function* () {
 				const N = 3;
 				const {input, launched, trackerCalls} = baseInput({engineCount: N});
-				const result = yield* runStandUp(input);
+				const result = yield* standUp(input);
 
 				assert.strictEqual(trackerCalls(), 1);
 				assert.strictEqual(result.tracker, trackerHandle);
@@ -301,7 +308,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 		() =>
 			Effect.gen(function* () {
 				const {input, intoWindows, launched} = baseInput({engineCount: 2});
-				const result = yield* runStandUp(input);
+				const result = yield* standUp(input);
 
 				// exactly one session opens the crew window (intoWindow undefined); every later one splits into it.
 				assert.strictEqual(intoWindows.length, launched.length);
@@ -322,7 +329,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 		Effect.gen(function* () {
 			for (const N of [1, 4]) {
 				const {input, launched} = baseInput({engineCount: N, instanceId: counter()});
-				yield* runStandUp(input);
+				yield* standUp(input);
 				assert.strictEqual(launched.filter((p) => p.session.kind === "engine").length, N);
 				assert.strictEqual(
 					launched.filter((p) => p.session.kind === "bridge").length,
@@ -339,7 +346,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 				const {input, launched, trackerCalls} = baseInput({
 					readVersionOutput: Effect.succeed("2.1.300 (Claude Code)"),
 				});
-				const err = yield* Effect.flip(runStandUp(input));
+				const err = yield* Effect.flip(standUp(input));
 
 				assert.instanceOf(err, CliVersionAssertError);
 				// version assert runs before ensure-tracker: the tracker was never reached, nothing launched.
@@ -355,7 +362,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 					new LaunchConfigError({configPath: ".claude/crew.config.jsonc", reason: "missing"}),
 				),
 			});
-			const err = yield* Effect.flip(runStandUp(input));
+			const err = yield* Effect.flip(standUp(input));
 
 			assert.instanceOf(err, LaunchConfigError);
 			assert.strictEqual(trackerCalls(), 0);
@@ -369,7 +376,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 				ensureTracker: (_root: string) =>
 					Effect.fail(new TrackerNotServingError({socketPath: "/tmp/crew.sock"})),
 			});
-			const err = yield* Effect.flip(runStandUp(input));
+			const err = yield* Effect.flip(standUp(input));
 
 			assert.instanceOf(err, TrackerNotServingError);
 			// derive/bind/placement/launch all sit after ensure-tracker — nothing launched.
@@ -382,7 +389,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 		() =>
 			Effect.gen(function* () {
 				const {input, launched} = baseInput({serverName: "not-in-servers"});
-				const err = yield* Effect.flip(runStandUp(input));
+				const err = yield* Effect.flip(standUp(input));
 
 				assert.instanceOf(err, CrewServerNotRegisteredError);
 				assert.strictEqual(launched.length, 0);
@@ -392,7 +399,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 	it.effect("threads each engine's per-instance identity into its launch argv (seam 3)", () =>
 		Effect.gen(function* () {
 			const {input, launched} = baseInput({engineCount: 3});
-			yield* runStandUp(input);
+			yield* standUp(input);
 
 			const engines = launched.filter((p) => p.session.kind === "engine");
 			assert.strictEqual(engines.length, 3);
@@ -418,7 +425,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 				const {input, launched, order, reaped, registered, registeredCtx, cwdCalls} = baseInput({
 					engineCount: N,
 				});
-				yield* runStandUp(input);
+				yield* standUp(input);
 
 				// The start-of-stand-up reaper swept once, keyed by the crew server name (the resolver's ref).
 				assert.strictEqual(reaped.length, 1);
@@ -475,7 +482,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 							),
 					},
 				});
-				const err = yield* Effect.flip(runStandUp(input));
+				const err = yield* Effect.flip(standUp(input));
 
 				assert.instanceOf(err, ProjectScopeWriteError);
 				// register sits before the launch loop — a failed registration launches nothing (no partial crew).
@@ -490,7 +497,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 			// cartographer is not autobooted (#3524), so it never launches here; its tier is asserted at the
 			// on-demand spawn path, not the stand-up. intake-desk carries the fable tier among the autobooted.
 			const {input, launched} = baseInput({engineCount: 2});
-			yield* runStandUp(input);
+			yield* standUp(input);
 
 			const modelOf = (role: string): readonly string[] | undefined =>
 				launched.find((p) => p.session.role === role)?.bind.modelArg;
@@ -512,7 +519,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 		() =>
 			Effect.gen(function* () {
 				const {input, order, targetSessions} = baseInput({engineCount: 2});
-				yield* runStandUp(input);
+				yield* standUp(input);
 
 				// the target session is resolved before any launch, and every pane is opened into it.
 				const firstLaunch = order.findIndex((e) => e.startsWith("launch:"));
@@ -533,7 +540,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 							new TmuxSessionEnsureError({session: "crew", reason: "new-session exited 1"}),
 						),
 				});
-				const err = yield* Effect.flip(runStandUp(input));
+				const err = yield* Effect.flip(standUp(input));
 
 				assert.instanceOf(err, TmuxSessionEnsureError);
 				// session resolution sits before the launch loop — nothing launched when it fails.
@@ -556,7 +563,7 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 							}),
 						),
 				});
-				const err = yield* Effect.flip(runStandUp(input));
+				const err = yield* Effect.flip(standUp(input));
 				assert.instanceOf(err, StandUpLaunchError);
 			}),
 	);
@@ -570,7 +577,7 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 	// Capture one real, fully-derived LaunchPlan by running a stand-up whose launcher just records it.
 	const captureOnePlan = Effect.gen(function* () {
 		const {input, launched} = baseInput({engineCount: 1});
-		yield* runStandUp(input);
+		yield* standUp(input);
 		const plan = launched[0];
 		assert.isDefined(plan);
 		return plan as LaunchPlan;

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -21,7 +21,7 @@
  */
 import {spawn} from "node:child_process";
 import {randomUUID} from "node:crypto";
-import {Effect, Schema} from "effect";
+import {Effect, type FileSystem, type Path, Schema} from "effect";
 import {SESSION_SERVER_NAME} from "../crew/index.ts";
 import {
 	buildSessionBind,
@@ -452,7 +452,9 @@ export const launchSessionInTmux = (
  * launch each session bound to its role lease. Every derivation and validation completes before the
  * first launch, so any precondition failure aborts (naming its cause) with zero sessions up.
  */
-export const runStandUp = (input: StandUpInput): Effect.Effect<StandUpResult, StandUpError> =>
+export const runStandUp = (
+	input: StandUpInput,
+): Effect.Effect<StandUpResult, StandUpError, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const {projectRoot} = input;
 		const serverName = input.serverName ?? SESSION_SERVER_NAME;

--- a/packages/pipeline-crew-mcp/src/tracker/server.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.test.ts
@@ -9,12 +9,17 @@ import {randomUUID} from "node:crypto";
 import {existsSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
-import {NodeSocket} from "@effect/platform-node";
+import {NodeFileSystem, NodeSocket} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
 import {TrackerRegistry} from "./group.ts";
 import {isTrackerAddressInUse, socketPathFor, trackerServerLayer} from "./server.ts";
+
+// trackerServerLayer's stale-socket reclaim now reaches disk through the FileSystem seam, so provide
+// the real Node FileSystem — the layer builds in-test exactly as under the bin's NodeServices.layer.
+const hostedTracker = (socketPath: string) =>
+	trackerServerLayer(socketPath).pipe(Layer.provide(NodeFileSystem.layer));
 
 describe("tracker socket path — per-project derivation", () => {
 	it("is deterministic and normalizes the root", () => {
@@ -64,7 +69,7 @@ describe("tracker over a unix socket — RpcServer round-trip", () => {
 			assert.lengthOf(result.peers, 1);
 			assert.strictEqual(result.peers[0]?.peer, "inbox://peer-a");
 		}).pipe(
-			Effect.provide(Layer.mergeAll(socketClientLayer(socketPath), trackerServerLayer(socketPath))),
+			Effect.provide(Layer.mergeAll(socketClientLayer(socketPath), hostedTracker(socketPath))),
 			Effect.scoped,
 		);
 	});
@@ -107,7 +112,7 @@ describe("tracker stale-socket crash recovery (#3280)", () => {
 				// Build the server FIRST so it reclaims the stale file and is listening, THEN dial a client
 				// (the production sequencing: `crewTrackerHostOrDialLayer` provides the client onto the
 				// hosted server). A successful round-trip proves the reclaim re-hosted the tracker.
-				yield* Layer.build(trackerServerLayer(socketPath));
+				yield* Layer.build(hostedTracker(socketPath));
 				const result = yield* Effect.gen(function* () {
 					const client = yield* RpcClient.make(TrackerRegistry);
 					yield* client.AnnouncePresence({
@@ -129,8 +134,8 @@ describe("tracker stale-socket crash recovery (#3280)", () => {
 			const socketPath = join(tmpdir(), `crew-live-${randomUUID().slice(0, 8)}.sock`);
 			return Effect.gen(function* () {
 				// host A is live for the scope; reclaim must NOT unlink it out from under the running host.
-				yield* Layer.build(trackerServerLayer(socketPath));
-				const exit = yield* Effect.exit(Layer.build(trackerServerLayer(socketPath)));
+				yield* Layer.build(hostedTracker(socketPath));
+				const exit = yield* Effect.exit(Layer.build(hostedTracker(socketPath)));
 				assert.isTrue(
 					Exit.isFailure(exit),
 					"a second bind on a LIVE socket must fail, not reclaim",

--- a/packages/pipeline-crew-mcp/src/tracker/server.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.ts
@@ -24,12 +24,11 @@
  * has no handler for any message-relay kind, so it structurally cannot relay a message.
  */
 import {createHash} from "node:crypto";
-import {unlink} from "node:fs";
 import {connect} from "node:net";
 import {tmpdir} from "node:os";
 import {join, resolve} from "node:path";
 import {NodeSocketServer} from "@effect/platform-node";
-import {Cause, Effect, Layer, Option} from "effect";
+import {Cause, Effect, FileSystem, Layer, Option} from "effect";
 import {RpcSerialization, RpcServer} from "effect/unstable/rpc";
 import {SocketServerError} from "effect/unstable/socket/SocketServer";
 import {TrackerRegistry} from "./group.ts";
@@ -41,6 +40,11 @@ import {RegistryLive} from "./registry.ts";
  * yet collision-free across projects, and short enough to stay under the ~104-char unix socket
  * path limit by hashing the root rather than embedding it. Honors `XDG_RUNTIME_DIR` when set,
  * falling back to the OS temp dir.
+ *
+ * A pure synchronous boundary derivation, so its `node:os`/`node:path`/`node:crypto` calls stay raw
+ * per the platform-access bright line (.patterns/effect-platform-access.md): `tmpdir()` is a temp-*path*
+ * boundary read (never a created temp dir), and `createHash`/`join`/`resolve` operate on plain strings
+ * here — none is woven through an Effect service method, so there is nothing to substitute.
  */
 export const socketPathFor = (projectRoot: string): string => {
 	const digest = createHash("sha256").update(resolve(projectRoot)).digest("hex").slice(0, 16);
@@ -58,12 +62,19 @@ export const socketPathFor = (projectRoot: string): string => {
  * unlink is best-effort — if a concurrent peer reclaimed+rebound in the probe→unlink window, our
  * bind then loses the race with `EADDRINUSE` and the caller dials, the same convergence as a live host.
  */
-export const reclaimStaleSocket = (socketPath: string): Effect.Effect<void> =>
+export const reclaimStaleSocket = (
+	socketPath: string,
+): Effect.Effect<void, never, FileSystem.FileSystem> =>
 	probeStaleSocket(socketPath).pipe(
 		Effect.flatMap((isStale) =>
 			isStale
-				? Effect.callback<void>((resume) => {
-						unlink(socketPath, () => resume(Effect.void));
+				? Effect.gen(function* () {
+						// Unlink via the `FileSystem` seam (.patterns/effect-platform-access.md), discharged by
+						// the crew-mcp bin's NodeServices.layer. Best-effort: `force` ignores an already-gone
+						// file, and `ignore` swallows any other fault so a lost probe→unlink race just falls back
+						// to the real bind losing `EADDRINUSE` and the caller dialing — the same convergence.
+						const fs = yield* FileSystem.FileSystem;
+						yield* Effect.ignore(fs.remove(socketPath, {force: true}));
 					})
 				: Effect.void,
 		),
@@ -125,7 +136,9 @@ const boundTrackerServerLayer = (socketPath: string) =>
  * `crewTrackerHostOrDialLayer` (first-peer-spawn), so the server runs alongside the session rather
  * than blocking it.
  */
-export const launchTracker = (projectRoot: string): Effect.Effect<never, unknown> =>
+export const launchTracker = (
+	projectRoot: string,
+): Effect.Effect<never, unknown, FileSystem.FileSystem> =>
 	Layer.launch(trackerServerLayer(socketPathFor(projectRoot)));
 
 /**


### PR DESCRIPTION
This PR routes the raw `node:*` filesystem calls in `pipeline-crew-mcp` through Effect's v4 platform seam, so the code depends on a swappable `FileSystem`/`Path` service instead of welding itself to the real disk. Nothing about how the crew boots changes — the same reads, writes, and unlinks happen — but the platform is now a service a `unit` test can substitute, which is the whole point of the migration. It also serves as the worked reference slice for `.patterns/effect-platform-access.md`.

### What changed (the three scoped files)

- **`standup/config.ts`** — `readFileSync` → `fs.readFileString` in the crew-config reader; the `PlatformError` is folded to the existing `LaunchConfigError`.
- **`standup/bind.ts`** — `existsSync` → `fs.exists` for the bin.ts resolvability probe (drops the old injected `binExists` function for the real `FileSystem` seam), and `node:path` `join` → `Path.Path.join` for the plugin dir. An fs fault on the probe folds to "absent" (`orElseSucceed(false)`) so the reader's `E` channel stays exactly its three launch-refusal errors, matching the old `existsSync`.
- **`tracker/server.ts`** — `unlink` (`node:fs`) → `fs.remove(path, {force: true})` in the stale-socket reclaim (best-effort, `Effect.ignore`).

The resulting `FileSystem`/`Path` requirement threads through `runStandUp`, the tracker layer stack (`trackerServerLayer` → `crewTrackerHostOrDialLayer` → `peerSocketSubstrate`/`assembleCrewSession`), and `tryBecomeTracker`/`runStandingTracker` — all discharged by the crew-mcp bin's **existing** `NodeServices.layer` (no new layer wiring). The one added platform provide is at the `ensure-tracker` detached-child entrypoint, a bin-level composition boundary (the doc's bright line), mirroring how `bin.ts` provides it for `launchTracker`.

Tests substitute the seam per the doc's Testing section: `NodeServices`/`NodeFileSystem.layer` for the real-disk cases, and a `FileSystem.layerNoop({exists: () => Effect.succeed(false)})` fake for the bin-absent guard (replacing the removed `binExists` injection).

### Bright-line boundaries kept raw (AC3)

- **`socketPathFor` is a pure synchronous boundary derivation**, so its `node:os` `tmpdir()` (temp-*path*, never a created temp dir), `node:crypto` `createHash`, and `node:path` `join`/`resolve` stay raw — none is woven through an Effect service method, so there is nothing to substitute (documented at the call site). Effect-ifying it would cascade `Path` through the whole tracker/session layer stack and break the synchronous `socketPathFor(a) === socketPathFor(b)` test assertions — out of this slice's scope.
- `fileURLToPath` (`node:url`) and `node:net` `connect` stay raw (no platform service), as does the deliberate real-fs `existsSync` assertion in `bind.test.ts`.

### Verification

- `pnpm --filter @kampus/pipeline-crew-mcp typecheck`: this migration adds **zero** new type errors.
- Package tests: every test in the migrated modules passes (220 passing).

**Pre-existing, unrelated red on `main` (NOT introduced here):** `src/edge/channel-sink.ts` (typecheck `Missing "message"`) and the two `edge/` tests (`channel-sink.test.ts`, `mcp-channel.test.ts`) fail identically on pristine `main` — those files are untouched by this PR and import none of the changed modules (verified by a clean-tree baseline). Filed separately for triage. The migrated modules are fully green.

Not §CP (ADR 0187) — auto-ships on green.

Fixes #3468
