### PR TITLE
fix(pipeline-crew-mcp): decode a stringified channel_send body + surface the reject reason (#3486)

### DIFF
--- a/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
@@ -149,4 +149,47 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 			assert.isTrue(result.isError);
 		}),
 	);
+
+	// #3486: the MCP tools/call client serializes an unconstrained `body` as a JSON *string*, so a
+	// valid payload arrives stringified — every kind dead-lettered because the decode expected the
+	// struct. A stringified valid IntakePing must now decode and deliver just like the object form.
+	it.effect(
+		"channel_send decodes a STRINGIFIED valid body (the wire serializes body as JSON)",
+		() =>
+			Effect.gen(function* () {
+				const {client} = yield* makeInitializedClient;
+				const result = yield* client["tools/call"]({
+					name: "channel_send",
+					arguments: {
+						targetRole: "reviewer",
+						kind: "IntakePing",
+						// the body as the MCP client sends it for an unconstrained param: a JSON string
+						body: JSON.stringify({issue: "3057", from: "intake", at: "2026-07-16T10:00:00Z"}),
+					},
+				});
+				assert.isFalse(result.isError);
+				const ack = result.structuredContent as {by?: string; messageId?: string};
+				assert.strictEqual(ack.by, "peer-b");
+				assert.strictEqual(ack.messageId, "m-9");
+			}),
+	);
+
+	// #3486 AC#4: a genuine decode failure must surface InvalidMessageError.reason in the rendered
+	// tool error (Cause.pretty of the failure) — so a future mismatch is diagnosable from the tool
+	// output alone, not only by reading source.
+	it.effect("channel_send surfaces InvalidMessageError.reason in the rendered tool error", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				// missing IntakePing's required `from`/`at`, and not a JSON string either
+				arguments: {targetRole: "reviewer", kind: "IntakePing", body: {issue: "3057"}},
+			});
+			assert.isTrue(result.isError);
+			const rendered = (result.content as ReadonlyArray<{text?: string}>)
+				.map((c) => c.text ?? "")
+				.join("\n");
+			assert.include(rendered, `body does not match the "IntakePing" schema`);
+		}),
+	);
 });

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -25,7 +25,15 @@ export class InvalidMessageError extends Schema.TaggedErrorClass<InvalidMessageE
 		kind: Schema.String,
 		reason: Schema.String,
 	},
-) {}
+) {
+	// McpServer renders a failed tool call as `Cause.pretty(cause)` (effect-smol McpServer.ts),
+	// which prints an error's `message` — a bare TaggedError's is empty, so `reason` (the actual
+	// why) never reaches the tool output. Fold it into `message` so a decode failure is legible
+	// from the tool result alone, without reading source (#3486 AC#4).
+	override get message(): string {
+		return `${this.kind}: ${this.reason}`;
+	}
+}
 
 /** The outbound send capability: dial the live peer serving `targetRole` and deliver `kind`/`body`. */
 export class ChannelSend extends Context.Service<
@@ -58,7 +66,14 @@ const validateOutbound = (
 			}),
 		);
 	}
-	return Schema.decodeUnknownEffect(schema)(body).pipe(
+	// The MCP `tools/call` client serializes an unconstrained `body` (the tool's `Schema.Unknown`
+	// parameter has no object shape in the generated JSON schema) as a JSON *string*, so `body`
+	// arrives either as the struct itself OR as that struct stringified — the impedance mismatch
+	// that dead-lettered every kind (#3486). Accept both with a typed string→struct transform
+	// (`Schema.fromJsonString`, grounded in effect-smol Schema.ts) unioned with the raw struct, so
+	// the tolerance is one decode step, not a hand-rolled `typeof body === "string"` JSON.parse.
+	const tolerant = Schema.Union([schema, Schema.fromJsonString(schema)]);
+	return Schema.decodeUnknownEffect(tolerant)(body).pipe(
 		Effect.asVoid,
 		Effect.mapError(
 			(error) =>


### PR DESCRIPTION
Fixes #3486

## What & why

After #3484 made `channel_send` callable, no message of any kind delivered: the MCP `tools/call` client serializes an unconstrained `body` (the tool's `body` parameter is `Schema.Unknown`, which generates a JSON schema with no object shape) as a JSON **string**. Every message kind's payload is a `Schema.Struct`, so the per-kind decode in `validateOutbound` always failed on the stringified body — Claim/Release/DrainProgress/IntakePing/AnnouncePresence/LookupRole/Heartbeat all dead-lettered. Dead capability.

## The fix (two ACs, one PR)

**1 — decode a stringified body at the source of the mismatch.** The string appears because the wire client JSON-encodes an unconstrained tool-call argument; that is the true impedance mismatch, and it is on the receive/decode side (the caller is the LLM MCP client, not a phoenix send path — there is no internal `JSON.stringify` to remove). Fixed with a typed transform rather than a hand-rolled `typeof body === "string"` guard: `validateOutbound` decodes against `Schema.Union([schema, Schema.fromJsonString(schema)])`, so a body arriving as the struct **or** as that struct stringified is accepted in one make-invalid-states-unrepresentable step. `Schema.fromJsonString` (decodes a JSON string into an inner schema) is grounded in effect-smol `Schema.ts` at our pin (4.0.0-beta.92).

**2 — surface the reject reason (AC #4).** `McpServer` renders a failed tool call as `Cause.pretty(cause)`, which prints an error's `message` — a bare `TaggedError`'s message is empty, so `InvalidMessageError.reason` never reached the tool output (pre-fix, the rendered error was just the bare tag). `InvalidMessageError` now folds `reason` into `message`, so a future decode failure is diagnosable from the tool result alone.

## Tests (TDD)

- A **stringified** valid IntakePing now decodes and delivers (acks by the live peer), just like the object form.
- A genuinely-invalid body surfaces its `reason` (`body does not match the "IntakePing" schema`) in the rendered tool error.

Both new tests **fail on pre-fix `main`** (verified by restoring the pre-fix `send-tool.ts` and running the file) and pass on this branch.

## Gates

`@kampus/pipeline-crew-mcp` vitest (224 pass), `pnpm typecheck` (33/33), `biome check` clean on changed files, `pnpm install` up to date, leak-guard clean.