### PR TITLE
fix(pipeline-crew-mcp): reclaim a stale inbox socket before bind so the crew session survives restart (#3489)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.socket.test.ts
@@ -1,0 +1,159 @@
+/**
+ * crew/channel-server — the REAL unix-socket transport of the inbox server, the seam the
+ * in-memory `RpcTest`/in-process-`Connect` tests never exercise. Covers:
+ *   - a real IntakePing round-trip: production `inboxServerSocketLayer` (NDJSON over a unix
+ *     socket) driven by the production `crewSocketDialerLayer`, asserting the InboxAck returns
+ *     and the recipient wakes with the {content, meta} contract;
+ *   - the stale-socket bind (#3489): a crashed prior process's orphaned socket file at
+ *     `inboxSocketPathFor(address)` is reclaimed (`reclaimStaleSocket`, #3280), so the server
+ *     still binds instead of dying with `SocketServerError: Open`;
+ *   - the guard: a genuinely LIVE listener at the path is NOT reclaimed — a second bind fails.
+ *
+ * Uses `it.live`, not `it.effect`: `it.effect` runs under a virtual TestClock where `Effect.sleep`
+ * (the server-boot settle) never advances and the test hangs; the stale case also spawns a real
+ * child + SIGKILL, which needs real time.
+ */
+import {spawn} from "node:child_process";
+import {existsSync} from "node:fs";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit, Layer, Ref} from "effect";
+import {type ChannelNotificationPayload, ChannelSink} from "../edge/index.ts";
+import {Dialer, type InboxEnvelope} from "../peer/index.ts";
+import {
+	crewSocketDialerLayer,
+	inboxServerSocketLayer,
+	inboxSocketPathFor,
+} from "./channel-server.ts";
+
+const freshAddress = () => `inbox://engine/${Math.random().toString(36).slice(2)}`;
+
+// A sink that records every wake, so the round-trip can assert the delivery reached the edge.
+const recordingSink = (wakes: Ref.Ref<ReadonlyArray<ChannelNotificationPayload>>) =>
+	Layer.succeed(ChannelSink, {
+		wake: (payload) => Ref.update(wakes, (xs) => [...xs, payload]),
+	});
+
+const discardingSink = Layer.succeed(ChannelSink, {wake: () => Effect.void});
+
+/**
+ * Faithfully reproduce a crashed process's orphaned inbox socket: a child binds `socketPath`, then
+ * `SIGKILL` leaves the `.sock` file on disk with no listener (node only unlinks on a CLEAN close).
+ * The stranded file refuses a connect with `ECONNREFUSED` — the stale signal `reclaimStaleSocket`
+ * keys on (#3280). Mirrors `tracker/server.test.ts`'s `leaveStaleSocket`.
+ */
+const leaveStaleSocket = (socketPath: string): Effect.Effect<void> =>
+	Effect.callback<void>((resume) => {
+		const source = `const net=require("node:net");const s=net.createServer();s.listen(${JSON.stringify(
+			socketPath,
+		)},()=>process.stdout.write("L"));setInterval(()=>{},1000);`;
+		const child = spawn(process.execPath, ["-e", source]);
+		child.stdout.on("data", (chunk) => {
+			if (String(chunk).includes("L")) {
+				child.once("exit", () => resume(Effect.void));
+				child.kill("SIGKILL");
+			}
+		});
+	});
+
+describe("crew/channel-server — REAL unix-socket inbox transport", () => {
+	it.live(
+		"a valid IntakePing crosses the socket, returns an InboxAck, and wakes the recipient",
+		() =>
+			Effect.gen(function* () {
+				const address = freshAddress();
+				const socketPath = inboxSocketPathFor(address);
+				const wakes = yield* Ref.make<ReadonlyArray<ChannelNotificationPayload>>([]);
+				const serverLayer = inboxServerSocketLayer(address).pipe(
+					Layer.provide(recordingSink(wakes)),
+				);
+
+				const result = yield* Effect.gen(function* () {
+					yield* Effect.sleep("400 millis"); // let the socket server bind + listen
+					assert.isTrue(existsSync(socketPath), "inbox socket must be listening");
+
+					const envelope: InboxEnvelope = {
+						messageId: "m-roundtrip-1",
+						from: "inbox://engineering-manager/1",
+						kind: "IntakePing",
+						body: {issue: "3489", from: "engineering-manager", at: new Date().toISOString()},
+						at: new Date().toISOString(),
+					};
+					const dialer = yield* Dialer;
+					const ack = yield* dialer.send(address, envelope).pipe(Effect.timeout("6 seconds"));
+					return {ack, wakes: yield* Ref.get(wakes)};
+				}).pipe(Effect.scoped, Effect.provide(Layer.mergeAll(crewSocketDialerLayer, serverLayer)));
+
+				assert.strictEqual(result.ack.by, address, "the ack is stamped by the recipient inbox");
+				assert.strictEqual(result.ack.messageId, "m-roundtrip-1", "the ack echoes the messageId");
+				assert.lengthOf(result.wakes, 1, "the recipient inbox woke exactly once");
+				assert.match(result.wakes[0]?.content ?? "", /IntakePing/, "the wake carries the kind");
+				assert.strictEqual(
+					result.wakes[0]?.meta?.from,
+					"inbox://engineering-manager/1",
+					"the wake meta.from echoes the sender ({content, meta} contract)",
+				);
+			}),
+		{timeout: 20000},
+	);
+
+	it.live(
+		"reclaims a crashed prior process's STALE socket and still binds (not SocketServerError: Open, #3489)",
+		() =>
+			Effect.gen(function* () {
+				const address = freshAddress();
+				const socketPath = inboxSocketPathFor(address);
+				// Strand the stale socket BEFORE the layer builds — the reclaim runs at build time, so the
+				// bind must observe the crashed process's orphaned file, not a clean path.
+				yield* leaveStaleSocket(socketPath);
+				assert.isTrue(
+					existsSync(socketPath),
+					"precondition: a stale inbox socket occupies the path",
+				);
+
+				const exit = yield* Effect.scoped(
+					Effect.gen(function* () {
+						const built = yield* Layer.build(
+							inboxServerSocketLayer(address).pipe(Layer.provide(discardingSink)),
+						).pipe(Effect.exit);
+						assert.isTrue(
+							existsSync(socketPath),
+							"the inbox socket is listening after the reclaim + bind",
+						);
+						return built;
+					}),
+				);
+				assert.isTrue(Exit.isSuccess(exit), "a stale socket file must not crash the bind");
+			}),
+		{timeout: 20000},
+	);
+
+	it.live(
+		"does NOT reclaim a genuinely-live listener at the path — a second bind fails (#3489 guard)",
+		() =>
+			Effect.gen(function* () {
+				const address = freshAddress();
+				const socketPath = inboxSocketPathFor(address);
+
+				yield* Effect.scoped(
+					Effect.gen(function* () {
+						// Stand up a LIVE inbox server first, held for this scope.
+						yield* Layer.build(inboxServerSocketLayer(address).pipe(Layer.provide(discardingSink)));
+						yield* Effect.sleep("300 millis");
+						assert.isTrue(existsSync(socketPath), "the live listener is bound");
+
+						// A second bind at the same (live) path must FAIL — reclaim skips the unlink when the
+						// connect succeeds, so the raw bind rejects with EADDRINUSE (the live socket is untouched).
+						const second = yield* Layer.build(
+							inboxServerSocketLayer(address).pipe(Layer.provide(discardingSink)),
+						).pipe(Effect.exit);
+						assert.isTrue(
+							Exit.isFailure(second),
+							"a live listener must not be reclaimed — the second bind fails closed",
+						);
+						assert.isTrue(existsSync(socketPath), "the live listener's socket file is untouched");
+					}),
+				);
+			}),
+		{timeout: 20000},
+	);
+});

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.ts
@@ -31,6 +31,7 @@ import {
 	PeerUnreachableError,
 	type RolePresence,
 } from "../peer/index.ts";
+import {reclaimStaleSocket} from "../tracker/index.ts";
 import {RoleUniquenessError} from "./errors.ts";
 import {type CrewRole, kindOf} from "./roles.ts";
 import {type ClaimReply, CrewTracker} from "./tracker.ts";
@@ -147,6 +148,14 @@ export const crewSocketDialerLayer: Layer.Layer<Dialer> = Layer.succeed(Dialer, 
  * The peer-inbox `RpcServer` over a unix socket at `address`, serving `PeerInbox` with the
  * channel-bridging inbox (`edge`) so each delivery wakes the session — mirrors the tracker's
  * socket server. Requires a `ChannelSink` (the edge's last-mile wake port).
+ *
+ * The socket transport is reclamation-guarded exactly like the tracker's (`reclaimStaleSocket`,
+ * #3280): the deterministic per-instance path is unlinked before bind IFF a connect proves it a
+ * crashed process's orphaned socket (`ECONNREFUSED`) — `NodeSocketServer` only unlinks on CLEAN
+ * scope teardown, so a crash/SIGKILL leaves the file, and a raw bind over it dies with
+ * `SocketServerError: Open`, crashing the whole crew session (#3489). A genuinely-live listener is
+ * never reclaimed (connect succeeds ⇒ not stale), so the raw bind still fails closed on a real
+ * competitor. `Layer.unwrap` sequences the reclaim ahead of the bind.
  */
 export const inboxServerSocketLayer = (address: string): Layer.Layer<never, unknown, ChannelSink> =>
 	RpcServer.layer(PeerInbox).pipe(
@@ -155,7 +164,11 @@ export const inboxServerSocketLayer = (address: string): Layer.Layer<never, unkn
 			RpcServer.layerProtocolSocketServer.pipe(
 				Layer.provide([
 					RpcSerialization.layerNdjson,
-					NodeSocketServer.layer({path: inboxSocketPathFor(address)}),
+					Layer.unwrap(
+						reclaimStaleSocket(inboxSocketPathFor(address)).pipe(
+							Effect.as(NodeSocketServer.layer({path: inboxSocketPathFor(address)})),
+						),
+					),
 				]),
 			),
 		),

--- a/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
@@ -1,0 +1,98 @@
+/**
+ * crew/session — the forked-stdio live-wake round-trip, closing the seam `session.ts` flags
+ * unexercised (docblock line 34: "a full live-client stdio wake round-trip"). The REAL live
+ * assembly (`assembleCrewSession`, the exact layer `bin.ts session --role` serves) over
+ * `McpServer.layerStdio` (the forked run-loop — the live-crew transport, NOT the in-process HTTP
+ * harness the other tests use) both binds the inbound peer-inbox socket AND wakes the session: a
+ * dial to that socket returns an InboxAck, and `bridge.deliver` returns the ack only after
+ * `sink.wake` completes through the live `ChannelSink.layerFromMcpServer` emit path, so a returned
+ * ack proves the whole inbound wake fired end to end over the real stdio server.
+ *
+ * Uses `it.live`, not `it.effect`: `it.effect`'s virtual TestClock freezes `Effect.sleep` (the
+ * forked run-loop + socket-bind settle) and the test hangs.
+ */
+import {randomUUID} from "node:crypto";
+import {existsSync} from "node:fs";
+import {assert, describe, it} from "@effect/vitest";
+import {Cause, Effect, Exit, Layer, Stdio, Stream} from "effect";
+import {McpServer} from "effect/unstable/ai";
+import {RpcTest} from "effect/unstable/rpc";
+import {channelExperimentalCapability} from "../edge/index.ts";
+import {Dialer, Inbox, PeerUnreachableError} from "../peer/index.ts";
+import {TrackerRegistry} from "../tracker/group.ts";
+import {TrackerHandlers} from "../tracker/handlers.ts";
+import {RegistryLive} from "../tracker/registry.ts";
+import {crewSocketDialerLayer, inboxSocketPathFor} from "./channel-server.ts";
+import {assembleCrewSession} from "./session.ts";
+import {CrewTracker, peerTrackerLayer} from "./tracker.ts";
+
+const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+const inMemoryCrewTracker = Layer.unwrap(
+	RpcTest.makeClient(TrackerRegistry).pipe(Effect.map(CrewTracker.fromClient)),
+).pipe(Layer.provide(registryHandlers));
+
+// The sender's Dialer is stubbed to unreachable — the DIAL under test is driven separately over the
+// production `crewSocketDialerLayer`, so the substrate's own dialer is never the path exercised.
+const inMemorySubstrate = (address: string) =>
+	Layer.mergeAll(
+		inMemoryCrewTracker,
+		peerTrackerLayer.pipe(Layer.provide(inMemoryCrewTracker)),
+		Inbox.layer(address),
+		Dialer.layerFromConnect((addr) =>
+			Effect.fail(new PeerUnreachableError({target: addr, reason: "test stub dialer"})),
+		),
+	);
+
+describe("crew/session — forked-stdio live-wake round-trip (session.ts:34 seam)", () => {
+	it.live(
+		"assembleCrewSession over layerStdio binds the inbox socket and a dial round-trips a wake back to an ack",
+		() =>
+			Effect.gen(function* () {
+				const address = `inbox://intake-desk-stdio-${randomUUID().slice(0, 8)}`;
+				const socketPath = inboxSocketPathFor(address);
+
+				// A stdin that stays open so the forked run-loop keeps serving (the live stdio transport).
+				const transport = McpServer.layerStdio({
+					name: "CrewStdioTestServer",
+					version: "0.0.0",
+					experimental: channelExperimentalCapability,
+				}).pipe(Layer.provide(Stdio.layerTest({stdin: Stream.never})));
+
+				const serverLayer = assembleCrewSession(
+					{role: "intake-desk", projectRoot: "/x"},
+					address,
+					inMemorySubstrate(address),
+					transport,
+				).pipe(Layer.orDie);
+
+				yield* Effect.forkScoped(Layer.launch(serverLayer));
+				yield* Effect.sleep("1500 millis"); // window for the forked run-loop + socket bind
+
+				assert.isTrue(
+					existsSync(socketPath),
+					`the LIVE stdio assembly must bind the inbox socket at ${socketPath}`,
+				);
+
+				const ackExit = yield* Effect.gen(function* () {
+					const dialer = yield* Dialer;
+					return yield* dialer
+						.send(address, {
+							messageId: "m-stdio-1",
+							from: "inbox://engineering-manager/1",
+							kind: "IntakePing",
+							body: {issue: "3489", from: "engineering-manager", at: new Date().toISOString()},
+							at: new Date().toISOString(),
+						})
+						.pipe(Effect.timeout("6 seconds"));
+				}).pipe(Effect.provide(crewSocketDialerLayer), Effect.exit);
+
+				assert.isTrue(
+					Exit.isSuccess(ackExit),
+					`the ack must return through the live stdio layerFromMcpServer sink: ${
+						Exit.isFailure(ackExit) ? Cause.pretty(ackExit.cause) : ""
+					}`,
+				);
+			}).pipe(Effect.scoped),
+		{timeout: 20000},
+	);
+});

--- a/packages/pipeline-crew-mcp/src/tracker/index.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/index.ts
@@ -16,6 +16,7 @@ export {
 export {
 	isTrackerAddressInUse,
 	launchTracker,
+	reclaimStaleSocket,
 	socketPathFor,
 	trackerServerLayer,
 } from "./server.ts";

--- a/packages/pipeline-crew-mcp/src/tracker/server.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.ts
@@ -58,7 +58,7 @@ export const socketPathFor = (projectRoot: string): string => {
  * unlink is best-effort — if a concurrent peer reclaimed+rebound in the probe→unlink window, our
  * bind then loses the race with `EADDRINUSE` and the caller dials, the same convergence as a live host.
  */
-const reclaimStaleSocket = (socketPath: string): Effect.Effect<void> =>
+export const reclaimStaleSocket = (socketPath: string): Effect.Effect<void> =>
 	probeStaleSocket(socketPath).pipe(
 		Effect.flatMap((isStale) =>
 			isStale


### PR DESCRIPTION
Fixes #3489

## Problem
The crew session MCP server crashes on startup with `SocketServerError: Open`, so an affected instance delivers **zero** messages. The inbound inbox socket server bound a raw `NodeSocketServer.layer({path: inboxSocketPathFor(address)})` with no unlink-before-bind. `NodeSocketServer` only unlinks the socket file on a CLEAN scope teardown, so a prior process that crashed/SIGKILLed leaves a **stale socket file** at the deterministic per-instance path — the next start hits `EADDRINUSE`, the whole session dies, and (because `bridge.ts` returns the `InboxAck` only after `sink.wake` completes) the sender gets no ack AND the recipient gets 0 tokens. Intermittent because it only fails when the path is occupied.

The address is per-instance-unique (`inboxSocketPathFor` is a sha256 of the full address), so an occupied path is a stale file, not a live competitor.

## Fix
Guard the inbox socket bind with the tracker's **existing, source-verified `reclaimStaleSocket` (#3280)** rather than a second copy of the same logic: probe the path first and unlink **only** on a proven-refused connect (`ECONNREFUSED` = a crashed process's orphan). A genuinely-live listener (connect succeeds) is never reclaimed — it's left for the raw bind to reject fail-closed, so a real competitor can't be clobbered (the AC's explicit requirement). `reclaimStaleSocket` is now exported from `tracker/` and reused by the crew inbox socket via the established crew→tracker dependency. Scope semantics (`Layer.unwrap` sequencing the reclaim ahead of the bind) mirror `trackerServerLayer`; `session.ts` claim-first/merge-once wiring is untouched.

Fix surface: `packages/pipeline-crew-mcp/src/crew/channel-server.ts` (NON-§CP, ADR 0187).

## Tests (`it.live` — `it.effect`'s TestClock freezes `Effect.sleep` and hangs)
- **Stale-socket bind** (`channel-server.socket.test.ts`): a SIGKILLed child's orphaned socket is reclaimed and the server still binds. This test **fails `SocketServerError: Open` on pre-fix `main`**, passes on the fix (verified).
- **Live-listener guard**: a second bind on a live socket fails closed; the live socket file is untouched.
- **Real unix-socket wake round-trip**: a production `inboxServerSocketLayer` + `crewSocketDialerLayer` IntakePing returns an ack and wakes the recipient with the `{content, meta}` contract.
- **Forked-stdio live-wake round-trip** (`session.assembly.test.ts`): the real `assembleCrewSession` over `McpServer.layerStdio` binds the inbox socket and a dial round-trips a wake back to an ack — closing the seam flagged unexercised in `session.ts` docblock line 34.

## Gates
`@kampus/pipeline-crew-mcp` vitest: 228 passed. `pnpm typecheck`: clean. `biome check` on changed files: clean. `pnpm install`: clean (lockfile up to date).