### PR TITLE
fix(crew-channel): restore delivery — by-tag notification encode + single-encoded body (#3491)

### DIFF
--- a/packages/pipeline-crew-mcp/src/edge/defect-a-double-encode.repro.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/defect-a-double-encode.repro.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Defect (a) — the send-tool boundary normalizes `body` to a struct once (#3491). The MCP
+ * `tools/call` client serializes an unconstrained `body` as a JSON *string*; the handler must
+ * forward the DECODED struct (what `validateOutbound` returns) to `ChannelSend.send`, not the raw
+ * string. Forwarding the string double-encodes it downstream: `bridge.formatChannelTag` does
+ * `JSON.stringify(envelope.body)`, so a string body becomes a JSON-string-of-a-JSON-string
+ * (`"{…}"` with a leading quote) — the live 0-delivery symptom.
+ *
+ * Driven through the REAL `channel_send` handler over an in-memory `McpServer`, with a
+ * `ChannelSend` that captures the body it receives — so this pins the boundary, not a stub.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Ref, Schema} from "effect";
+import {McpSchema, McpServer} from "effect/unstable/ai";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import {RpcSerialization} from "effect/unstable/rpc";
+import * as RpcClient from "effect/unstable/rpc/RpcClient";
+import type {InboxAck, InboxEnvelope} from "../peer/index.ts";
+import {formatChannelTag} from "./bridge.ts";
+import {channelExperimentalCapability} from "./mcp-channel.ts";
+import {ChannelSend, ChannelToolkit, channelToolHandlers} from "./send-tool.ts";
+
+class DisposeError extends Schema.TaggedErrorClass<DisposeError>()(
+	"@kampus/pipeline-crew-mcp/DisposeError",
+	{cause: Schema.Unknown},
+) {}
+
+const baseEnvelope = (body: unknown): InboxEnvelope => ({
+	messageId: "m-1",
+	from: "inbox://engineering-manager/1",
+	kind: "IntakePing",
+	body,
+	at: "2026-07-18T00:00:00Z",
+});
+
+// A ChannelSend that records the exact `body` the handler forwards, so the test can assert the
+// boundary handed it the decoded struct (not the raw JSON string the wire delivered).
+const makeCapturingClient = Effect.gen(function* () {
+	const captured = yield* Ref.make<unknown>(undefined);
+	const capturingSend = Layer.succeed(ChannelSend, {
+		send: (_targetRole, _kind, body) =>
+			Ref.set(captured, body).pipe(
+				Effect.as<InboxAck>({messageId: "m-9", by: "peer-b", at: "2026-07-18T00:00:00Z"}),
+			),
+	});
+
+	const serverLayer = McpServer.toolkit(ChannelToolkit).pipe(
+		Layer.provide(channelToolHandlers),
+		Layer.provide(capturingSend),
+		Layer.provide(
+			McpServer.layerHttp({
+				name: "ChannelEdgeDoubleEncodeTestServer",
+				version: "0.0.0",
+				path: "/mcp",
+				experimental: channelExperimentalCapability,
+			}),
+		),
+	);
+	const {dispose, handler} = HttpRouter.toWebHandler(serverLayer, {disableLogger: true});
+	yield* Effect.addFinalizer(() =>
+		Effect.tryPromise({try: () => dispose(), catch: (cause) => new DisposeError({cause})}).pipe(
+			Effect.ignore,
+		),
+	);
+
+	let sessionId: string | null = null;
+	const customFetch: typeof fetch = async (input, init) => {
+		const request = input instanceof Request ? input : new Request(input, init);
+		if (sessionId) request.headers.set("Mcp-Session-Id", sessionId);
+		const response = await handler(request);
+		sessionId = response.headers.get("Mcp-Session-Id");
+		return response;
+	};
+
+	const clientLayer = RpcClient.layerProtocolHttp({url: "http://localhost/mcp"}).pipe(
+		Layer.provideMerge([FetchHttpClient.layer, RpcSerialization.layerJsonRpc()]),
+		Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch)),
+	);
+	const client = yield* RpcClient.make(McpSchema.ClientRpcs).pipe(Effect.provide(clientLayer));
+	yield* client.initialize({
+		protocolVersion: "9999-01-01",
+		capabilities: {},
+		clientInfo: {name: "TestClient", version: "0.0.0"},
+	});
+	return {client, captured};
+});
+
+describe("defect(a): channel_send normalizes body to a struct at the boundary (#3491)", () => {
+	it("a STRUCT body renders single-encoded through formatChannelTag (baseline)", () => {
+		const tag = formatChannelTag(baseEnvelope({issue: "3486", from: "engineering-manager"}));
+		const inner = tag.slice(tag.indexOf(">") + 1, tag.lastIndexOf("<"));
+		assert.strictEqual(inner, '{"issue":"3486","from":"engineering-manager"}');
+	});
+
+	// The fix: even when the wire delivers `body` as a JSON STRING, the handler forwards the decoded
+	// struct, so the downstream render is single-encoded. Before the fix the raw string rode through
+	// and formatChannelTag double-quoted it (`"{…}"`).
+	it.live("a STRING body arrives at ChannelSend as a decoded struct → single-encoded render", () =>
+		Effect.gen(function* () {
+			const {client, captured} = yield* makeCapturingClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				arguments: {
+					targetRole: "reviewer",
+					kind: "IntakePing",
+					body: JSON.stringify({
+						issue: "3486",
+						from: "engineering-manager",
+						at: "2026-07-18T00:00:00Z",
+					}),
+				},
+			});
+			assert.isFalse(result.isError);
+
+			const forwarded = yield* Ref.get(captured);
+			assert.typeOf(
+				forwarded,
+				"object",
+				"handler must forward the DECODED struct, not the raw JSON string",
+			);
+			assert.deepInclude(forwarded as object, {issue: "3486", from: "engineering-manager"});
+
+			const inner = ((tag) => tag.slice(tag.indexOf(">") + 1, tag.lastIndexOf("<")))(
+				formatChannelTag(baseEnvelope(forwarded)),
+			);
+			assert.notMatch(
+				inner,
+				/^"/,
+				"single-encoded body must not start with a quote (that is the double-encode symptom)",
+			);
+			assert.strictEqual(
+				inner,
+				'{"issue":"3486","from":"engineering-manager","at":"2026-07-18T00:00:00Z"}',
+			);
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/edge/notif-encode.repro.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/notif-encode.repro.test.ts
@@ -1,0 +1,58 @@
+// @patch-pin: effect@4.0.0-beta.92
+/**
+ * Behavior pin for the (b1) hunk of `patches/effect@4.0.0-beta.92.patch` (#3491, ADR 0038): the
+ * `McpServer.js` run-loop encodes each outgoing notification against ITS OWN rpc `payloadSchema`
+ * keyed by `request.tag`, NOT a blind `Schema.Union` of every notification payload schema.
+ *
+ * Why the union was wrong (the 0-delivery defect this pins against): three members —
+ * `notifications/{resources,tools,prompts}/list_changed` — have all-optional payloads that accept
+ * ANY object and strip unknown keys, and they sit before `claude/channel` in the union. So a
+ * `{content, meta}` channel payload matches a `list_changed` member FIRST and encodes to `{}` — the
+ * wake ships with empty params and the recipient drops it (0 tokens). This test pins the ENCODING
+ * STRATEGY the run-loop uses (by-tag, not union), reading the real patched `ServerNotificationRpcs`
+ * schemas; the run-loop hunk itself is reviewed in the patch diff. Retire when effect ships a native
+ * custom-notification passthrough and the patch is removed.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Schema} from "effect";
+import {McpSchema} from "effect/unstable/ai";
+import {CHANNEL_NOTIFICATION_METHOD} from "./mcp-channel.ts";
+
+const requests = McpSchema.ServerNotificationRpcs.requests;
+const channelPayload = {content: "wake", meta: {from: "inbox://engineering-manager/1"}};
+
+describe("effect notification encode patch (b1) — by-tag, not blind union (#3491)", () => {
+	// The pre-fix run-loop strategy, reproduced verbatim: a union over every payload schema. An
+	// earlier all-optional member wins and strips {content, meta} to {} — the defect the patch routes
+	// around. Kept as the pin's teeth: it documents WHY the run-loop must not encode against the union.
+	it("the blind union strips a {content, meta} channel payload to {} (the defect)", () => {
+		const union = Schema.Union(Array.from(requests.values(), (rpc) => rpc.payloadSchema));
+		const encoded = Schema.encodeUnknownSync(union)(channelPayload) as Record<string, unknown>;
+		assert.notProperty(
+			encoded,
+			"content",
+			"the blind union strips content — this is the 0-delivery defect the by-tag fix avoids",
+		);
+	});
+
+	// The fix's strategy: encode against the SPECIFIC rpc payloadSchema keyed by tag. The channel
+	// member preserves {content, meta} intact.
+	it("by-tag encode preserves {content, meta} for claude/channel", () => {
+		const rpc = requests.get(CHANNEL_NOTIFICATION_METHOD);
+		assert.isDefined(rpc);
+		const encoded = Schema.encodeUnknownSync(rpc!.payloadSchema)(channelPayload) as Record<
+			string,
+			unknown
+		>;
+		assert.strictEqual(encoded.content, "wake");
+		assert.deepEqual(encoded.meta, {from: "inbox://engineering-manager/1"});
+	});
+
+	// No regression: the other notifications still encode correctly under their own tag — a
+	// list_changed carries no payload and encodes to {}, which is exactly right for it.
+	it("by-tag encode still correctly encodes a list_changed (no regression)", () => {
+		const rpc = requests.get("notifications/tools/list_changed");
+		assert.isDefined(rpc);
+		assert.deepEqual(Schema.encodeUnknownSync(rpc!.payloadSchema)({}), {});
+	});
+});

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -48,15 +48,20 @@ export class ChannelSend extends Context.Service<
 >()("@kampus/pipeline-crew-mcp/edge/ChannelSend") {}
 
 /**
- * Decode `body` against the catalog schema for `kind` before anything is dialed. An unknown
- * kind or a body that fails its kind's schema short-circuits with an `InvalidMessageError`, so
- * the send never reaches `ChannelSend.send` and the sender never sees a delivered-to-inbox ack
- * for a malformed message (#3229). A valid body passes through unchanged.
+ * Decode `body` against the catalog schema for `kind` and RETURN the decoded struct — the single
+ * boundary normalization for the send path. An unknown kind or a body that fails its kind's schema
+ * short-circuits with an `InvalidMessageError`, so the send never reaches `ChannelSend.send` and the
+ * sender never sees a delivered-to-inbox ack for a malformed message (#3229).
+ *
+ * Returning the decoded value (not `void`) is load-bearing: the handler forwards THIS struct, so a
+ * body that arrived JSON-stringified is normalized to a struct exactly once here — `bridge`'s
+ * `formatChannelTag` then `JSON.stringify`s a struct, not a string, and the wire is single-encoded.
+ * Forwarding the raw `body` instead double-encoded a string body (#3491 defect a).
  */
 const validateOutbound = (
 	kind: string,
 	body: unknown,
-): Effect.Effect<void, InvalidMessageError> => {
+): Effect.Effect<unknown, InvalidMessageError> => {
 	const schema = payloadSchemaForKind(kind);
 	if (schema === undefined) {
 		return Effect.fail(
@@ -74,7 +79,6 @@ const validateOutbound = (
 	// the tolerance is one decode step, not a hand-rolled `typeof body === "string"` JSON.parse.
 	const tolerant = Schema.Union([schema, Schema.fromJsonString(schema)]);
 	return Schema.decodeUnknownEffect(tolerant)(body).pipe(
-		Effect.asVoid,
 		Effect.mapError(
 			(error) =>
 				new InvalidMessageError({
@@ -106,7 +110,9 @@ export const channelToolHandlers = ChannelToolkit.toLayer(
 		const sender = yield* ChannelSend;
 		return {
 			channel_send: ({body, kind, targetRole}) =>
-				validateOutbound(kind, body).pipe(Effect.andThen(sender.send(targetRole, kind, body))),
+				validateOutbound(kind, body).pipe(
+					Effect.flatMap((decoded) => sender.send(targetRole, kind, decoded)),
+				),
 		};
 	}),
 );

--- a/patches/effect@4.0.0-beta.92.patch
+++ b/patches/effect@4.0.0-beta.92.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/unstable/ai/McpSchema.d.ts b/dist/unstable/ai/McpSchema.d.ts
-index 06fff42d7f240698b9388524f874367c494242e6..8421cf06c7dee8215b690772df8a06a75284d679 100644
+index 06fff42d7f240698b9388524f874367c494242e6..87d21c376458a4bf05befd752865a78be916ebc4 100644
 --- a/dist/unstable/ai/McpSchema.d.ts
 +++ b/dist/unstable/ai/McpSchema.d.ts
 @@ -3329,7 +3329,17 @@ export declare class ServerRequestRpcs extends ServerRequestRpcs_base {
@@ -22,7 +22,7 @@ index 06fff42d7f240698b9388524f874367c494242e6..8421cf06c7dee8215b690772df8a06a7
   * RPC group for notifications that an MCP server can send to a client,
   * including cancellation, progress, logging, and list or resource update
 diff --git a/dist/unstable/ai/McpSchema.js b/dist/unstable/ai/McpSchema.js
-index 909ac602a249610fdd9a1f72ae207d8813ebc28a..3f8339d619cf06c6ec1c5686c701dfbb0dbdfdf4 100644
+index 909ac602a249610fdd9a1f72ae207d8813ebc28a..fed03caaab728239c6335973e509a867ecd7029f 100644
 --- a/dist/unstable/ai/McpSchema.js
 +++ b/dist/unstable/ai/McpSchema.js
 @@ -1961,7 +1961,17 @@ export class ServerRequestRpcs extends /*#__PURE__*/RpcGroup.make(Ping, CreateMe
@@ -81,10 +81,27 @@ index 87a6f7acdd3d7f89b41fac68e575d80a09748f64..978ddb8206b27201c26fb2ff189dfad1
  /**
   * Registers a `Toolkit` with the `McpServer`.
 diff --git a/dist/unstable/ai/McpServer.js b/dist/unstable/ai/McpServer.js
-index 4cb198b928a5538737af01c0d18a03c7d28eb445..d19e7f7992f437bec6a7b64ed512e3ae5bc90204 100644
+index 4cb198b928a5538737af01c0d18a03c7d28eb445..60b2749fc62890cbe01cb103f1c15fce8d71a270 100644
 --- a/dist/unstable/ai/McpServer.js
 +++ b/dist/unstable/ai/McpServer.js
-@@ -850,6 +850,12 @@ const layerHandlers = (serverInfo, options) => ClientRpcs.toLayer(Effect.gen(fun
+@@ -329,9 +329,14 @@ export const run = /*#__PURE__*/Effect.fnUntraced(function* (options) {
+       }
+     })
+   });
+-  const encodeNotification = Schema.encodeUnknownEffect(Schema.Union(Array.from(ServerNotificationRpcs.requests.values(), rpc => rpc.payloadSchema)));
++  // phoenix patch (#3491, b1): encode each outgoing notification against ITS OWN rpc payloadSchema,
++  // keyed by request.tag — NOT a blind Schema.Union of every payload schema. In the union the
++  // all-optional `*_list_changed` members accept any object and strip unknown keys, and they sit
++  // before `claude/channel`, so a {content, meta} channel payload matches list_changed first and
++  // encodes to {} — the wake ships with empty params and the recipient drops it (0 tokens). See ADR 0038.
++  const encodeNotificationByTag = new Map(Array.from(ServerNotificationRpcs.requests, ([tag, rpc]) => [tag, Schema.encodeUnknownEffect(rpc.payloadSchema)]));
+   yield* Queue.take(server.notificationsQueue).pipe(Effect.flatMap(Effect.fnUntraced(function* (request) {
+-    const encoded = yield* encodeNotification(request.payload);
++    const encoded = yield* encodeNotificationByTag.get(request.tag)(request.payload);
+     const message = {
+       _tag: "Request",
+       tag: request.tag,
+@@ -850,6 +855,12 @@ const layerHandlers = (serverInfo, options) => ClientRpcs.toLayer(Effect.gen(fun
        if (serverInfo.extensions) {
          capabilities.extensions = serverInfo.extensions;
        }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ patchedDependencies:
     hash: f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1
     path: patches/alchemy@2.0.0-beta.59.patch
   effect@4.0.0-beta.92:
-    hash: 47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875
+    hash: 64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7
     path: patches/effect@4.0.0-beta.92.patch
   react-fate@1.3.1:
     hash: 6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b
@@ -225,28 +225,28 @@ importers:
     dependencies:
       '@alchemy.run/better-auth':
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(ba1bc25de2a84253ab7c1679b51bc9df)
+        version: 2.0.0-beta.59(be406d9deb1a54d01497e90e80c83ab8)
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(61729f46701d199bceb0183b264a7e40)
+        version: 1.6.23(a7c8e4e41b3d7e389906c8252c5e2b38)
       '@better-auth/core':
         specifier: 'catalog:'
         version: 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@effect/sql-d1':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/sql-pg':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@kampus/authz':
         specifier: workspace:*
         version: link:../../packages/authz
@@ -261,13 +261,13 @@ importers:
         version: link:../../packages/fate-effect
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@sentry/cloudflare':
         specifier: 'catalog:'
         version: 10.62.0(@cloudflare/workers-types@4.20260629.1)
       '@sentry/effect':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@sentry/react':
         specifier: 'catalog:'
         version: 10.62.0(react@19.2.6)
@@ -276,19 +276,19 @@ importers:
         version: 0.2.0
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call:
         specifier: 'catalog:'
         version: 1.3.7(zod@4.4.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@19.2.6)
@@ -300,7 +300,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-fate:
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react-router:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -313,13 +313,13 @@ importers:
         version: 4.20260629.1
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@fontsource/ibm-plex-sans':
         specifier: 'catalog:'
         version: 5.2.8
@@ -385,10 +385,10 @@ importers:
     dependencies:
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -398,7 +398,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -416,19 +416,19 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(61729f46701d199bceb0183b264a7e40)
+        version: 1.6.23(a7c8e4e41b3d7e389906c8252c5e2b38)
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -438,7 +438,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -456,10 +456,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -468,10 +468,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -481,7 +481,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -490,7 +490,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -502,10 +502,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -514,7 +514,7 @@ importers:
         version: link:../cf-utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -524,7 +524,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -542,7 +542,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/audit-stage':
         specifier: workspace:*
         version: link:../audit-stage
@@ -551,7 +551,7 @@ importers:
         version: link:../audit-verdict
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -561,7 +561,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -579,7 +579,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -591,7 +591,7 @@ importers:
         version: link:../preview-seed
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -601,7 +601,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -619,17 +619,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -647,7 +647,7 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -669,10 +669,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -682,7 +682,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -700,10 +700,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -715,10 +715,10 @@ importers:
         version: link:../db-schema
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -728,7 +728,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -749,7 +749,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -822,10 +822,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -835,7 +835,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -853,7 +853,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -875,17 +875,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -903,7 +903,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/depo':
         specifier: workspace:*
         version: link:../depo
@@ -912,14 +912,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -937,10 +937,10 @@ importers:
     dependencies:
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -962,17 +962,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -990,10 +990,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -1002,10 +1002,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1015,7 +1015,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1024,7 +1024,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1036,10 +1036,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1051,10 +1051,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1064,7 +1064,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1082,10 +1082,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       yaml:
         specifier: 'catalog:'
         version: 2.9.0
@@ -1095,7 +1095,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1113,7 +1113,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/design-capture':
         specifier: workspace:*
         version: link:../design-capture
@@ -1122,14 +1122,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1147,17 +1147,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1175,19 +1175,19 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1197,7 +1197,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1206,7 +1206,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1218,20 +1218,20 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1249,7 +1249,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/ci-required':
         specifier: workspace:*
         version: link:../ci-required
@@ -1261,7 +1261,7 @@ importers:
         version: link:../primary-index-tripwire
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       fast-xml-parser:
         specifier: 'catalog:'
         version: 5.8.0
@@ -1274,7 +1274,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1292,10 +1292,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       proper-lockfile:
         specifier: 'catalog:'
         version: 4.1.2
@@ -1305,7 +1305,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1326,10 +1326,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1341,10 +1341,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1354,7 +1354,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1363,7 +1363,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1375,17 +1375,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1406,7 +1406,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -4732,11 +4732,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@alchemy.run/better-auth@2.0.0-beta.59(ba1bc25de2a84253ab7c1679b51bc9df)':
+  '@alchemy.run/better-auth@2.0.0-beta.59(be406d9deb1a54d01497e90e80c83ab8)':
     dependencies:
-      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010)
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     transitivePeerDependencies:
       - '@effect/platform-bun'
       - '@effect/platform-node'
@@ -5013,11 +5013,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.6.23(61729f46701d199bceb0183b264a7e40)':
+  '@better-auth/api-key@1.6.23(a7c8e4e41b3d7e389906c8252c5e2b38)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -5036,12 +5036,12 @@ snapshots:
       '@cloudflare/workers-types': 4.20260629.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
 
   '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -5166,24 +5166,24 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1053.0
       '@aws-sdk/types': 3.973.9
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@smithy/shared-ini-file-loader': 4.5.4
       '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.4.4
       aws4fetch: 1.0.20
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
 
   '@distilled.cloud/cloudflare-rolldown-plugin@0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
     dependencies:
@@ -5196,74 +5196,74 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       workerd: 1.20260617.1
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(65a33d4814a6fc29095b657dfc60b6ea)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(bffeadfa3860de8cc67d37b8f261927c)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
     transitivePeerDependencies:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
 
-  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
 
-  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
 
-  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
 
   '@drizzle-team/brocli@0.12.0': {}
 
   '@effect/language-service@0.85.1': {}
 
-  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.3.0
@@ -5271,14 +5271,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
 
-  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       pg: 8.21.0
       pg-connection-string: 2.12.0
       pg-cursor: 2.20.0(pg@8.21.0)
@@ -5318,9 +5318,9 @@ snapshots:
       '@effect/tsgo-win32-arm64': 0.5.2
       '@effect/tsgo-win32-x64': 0.5.2
 
-  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -5609,13 +5609,13 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
       superjson: 2.2.6
       zod: 4.4.3
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@noble/ciphers@2.2.0': {}
@@ -5865,12 +5865,12 @@ snapshots:
 
   '@sentry/core@10.62.0': {}
 
-  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))':
+  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
       '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -6342,21 +6342,21 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(648105f9071363f67c1886ece62a0010):
+  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1053.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(65a33d4814a6fc29095b657dfc60b6ea)
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(bffeadfa3860de8cc67d37b8f261927c)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1
       '@octokit/webhooks': 14.2.0
@@ -6366,7 +6366,7 @@ snapshots:
       '@types/aws-lambda': 8.10.161
       aws4fetch: 1.0.20
       capnweb: 0.6.1
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       fast-glob: 3.3.3
       fast-xml-parser: 5.8.0
       ink: 6.8.0(@types/react@19.2.14)(react@19.2.6)
@@ -6382,11 +6382,11 @@ snapshots:
       undici: 7.24.8
       yaml: 2.9.0
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(ioredis@5.10.1)
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       ws: 8.21.0
     transitivePeerDependencies:
@@ -6427,10 +6427,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
+  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -6448,7 +6448,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       react: 19.2.6
@@ -6550,19 +6550,19 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))
+      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
       '@libsql/client': 0.17.3
       '@opentelemetry/api': 1.9.1
-      effect: 4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)
+      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       zod: 4.4.3
 
-  effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875):
+  effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7):
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0
@@ -7312,9 +7312,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=47190f7ec0f2fe0b3bfd9a64fb8b13267c10c25d36a52195cb6f225a06586875))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:


### PR DESCRIPTION
Fixes #3491

Restores crew-channel delivery (0% even with sockets bound) by fixing two independent, sequenced defects on the send→wire path. Both were reproduced RED on `main`; both land here in one PR. Coordinate with #3489 (socket-bind) — all three of #3489 / #3486 / this are required for end-to-end delivery.

## (b1) run-loop notification encode — by-tag, not blind union [UPSTREAM]

`effect`'s `McpServer.js` run-loop encoded every outgoing notification against `Schema.Union(Array.from(ServerNotificationRpcs.requests.values(), rpc => rpc.payloadSchema))`. The three `*_list_changed` members have all-optional payloads that accept any object and strip unknown keys, and sit before `claude/channel` in the union — so a `{content, meta}` channel payload matched `list_changed` first and encoded to `{}`. The wake shipped with empty params and the recipient dropped it (0 tokens).

The (b1) hunk of `patches/effect@4.0.0-beta.92.patch` now builds a per-tag encoder map and encodes each notification against **its own** rpc `payloadSchema` keyed by `request.tag`. Other notifications still encode correctly under their own tag. Regenerated via `pnpm patch` (ADR 0038); `pnpm install --frozen-lockfile` re-applies cleanly and the lockfile patch hash is updated.

## (a) double-encoded body — normalize once at the boundary

`channel_send` forwarded the model's raw `body` to `sender.send`. The MCP client passes `body` as a JSON **string**; `#3486`'s `validateOutbound` only validated it, so the handler forwarded the untouched string, and `bridge.formatChannelTag` then `JSON.stringify`'d it again → a JSON-string-of-a-JSON-string.

`validateOutbound` now **returns** the decoded struct (it already decodes via `Union([schema, fromJsonString(schema)])`), and the handler forwards that decoded struct to `sender.send`. The body is normalized once at the send-tool boundary, so `formatChannelTag` renders it single-encoded — no downstream band-aid.

## Tests

- `packages/pipeline-crew-mcp/src/edge/notif-encode.repro.test.ts` — the `@patch-pin: effect@4.0.0-beta.92` behavior pin (ADR 0038): the blind union strips `{content, meta}` to `{}` (the defect), by-tag encode preserves it, and a `list_changed` still encodes correctly.
- `packages/pipeline-crew-mcp/src/edge/defect-a-double-encode.repro.test.ts` — drives the real `channel_send` handler over an in-memory `McpServer` with a capturing `ChannelSend`; asserts a JSON-string body arrives as a decoded struct and renders single-encoded.

## Gates

- `@kampus/pipeline-crew-mcp` vitest: 32 files / 229 tests green.
- `pnpm typecheck`: clean.
- `biome check` on changed files: clean.
- `pipeline-cli patch-guard check`: green (7 `@patch-pin` markers).
- `pnpm install --frozen-lockfile`: patch re-applies.

§CP: both surfaces are NON-§CP (`patches/**` has no `CONTROL_PLANE_RE` alternation; `pipeline-crew-mcp` ≠ the §CP `packages/pipeline-cli/`, ADR 0187). Out-of-scope (b2), the `message`-decoder client-contract question, is intentionally not touched — it's a contingent follow-up to verify after this + #3489 land and a re-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)