### PR TITLE
fix(crew-channel): omit JSON-RPC id for notifications — spec-compliant emit unblocks delivery (#3495)

### DIFF
--- a/packages/pipeline-crew-mcp/src/edge/notif-id-omit.repro.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/notif-id-omit.repro.test.ts
@@ -1,0 +1,65 @@
+// @patch-pin: effect@4.0.0-beta.92
+/**
+ * Behavior pin for the (b2) hunk of `patches/effect@4.0.0-beta.92.patch` (#3495, ADR 0038): the
+ * JSON-RPC encoder (`RpcSerialization.js` `encodeJsonRpcMessage`, the "Request" case) omits the
+ * `id` member for a NOTIFICATION (nullish id) instead of coercing `Number(undefined)→NaN→null`.
+ *
+ * Why the coercion was the 0-delivery defect: the McpServer drain loop builds an outgoing
+ * notification as `{_tag:"Request", tag, payload}` with no `id`, so upstream's
+ * `id: response.id !== "" ? Number(response.id) : ""` emitted `Number(undefined)=NaN` → JSON
+ * `id:null`. A JSON-RPC notification MUST have no `id` member; the real MCP-SDK (zod) client routes
+ * notification-vs-request on `id`-member PRESENCE, so an `id:null` "notification" is never dispatched
+ * to the `claude/channel` handler → 0 tokens, and the malformed exchange stalls the InboxAck.
+ *
+ * Honest reproducibility caveat: the SDK-side rejection is NOT reproducible in-process — effect↔effect
+ * tolerates `id:null` (its own `decodeJsonRpcMessage` maps `id:null` → a Request with `id:""`), only
+ * the real zod client rejects it. So this pins at the SERIALIZATION boundary — the emitted JSON-RPC
+ * shape — not a full round-trip: RED on current (`id:null`), GREEN on the fix (member absent). Pure
+ * synchronous encoder assertions (no Effect run), so `it.effect` is intentionally not used. Retire
+ * when effect ships a native custom-notification passthrough and the patch is removed.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {RpcSerialization} from "effect/unstable/rpc";
+import {CHANNEL_NOTIFICATION_METHOD} from "./mcp-channel.ts";
+
+// The exact message the McpServer drain loop builds for an outgoing notification: `_tag:"Request"`,
+// a `notifications/*` method, and NO `id` member (a notification expects no response).
+const notificationMessage = {
+	_tag: "Request",
+	tag: CHANNEL_NOTIFICATION_METHOD,
+	payload: {content: "wake"},
+};
+
+// A genuine request carries its correlation `id` — the encoder must never drop it.
+const requestMessage = {
+	_tag: "Request",
+	id: "7",
+	tag: "some/request/method",
+	payload: {},
+};
+
+const encodeToWire = (message: unknown): Record<string, unknown> => {
+	const parser = RpcSerialization.jsonRpc().makeUnsafe();
+	const wire = parser.encode(message);
+	assert.isString(wire, "the jsonRpc encoder emits a JSON string for a single message");
+	return JSON.parse(wire as string) as Record<string, unknown>;
+};
+
+describe("effect notification encode patch (b2) — omit id for notifications (#3495)", () => {
+	it("a notifications/* message serializes with NO id member (member absent, not id:null)", () => {
+		const wire = encodeToWire(notificationMessage);
+		assert.notProperty(
+			wire,
+			"id",
+			"a JSON-RPC notification MUST carry no id member — id:null (the pre-fix coercion) is never dispatched by the MCP-SDK client",
+		);
+		assert.strictEqual(wire.method, CHANNEL_NOTIFICATION_METHOD);
+		assert.deepEqual(wire.params, {content: "wake"});
+	});
+
+	it("a real request still serializes WITH its id (no regression)", () => {
+		const wire = encodeToWire(requestMessage);
+		assert.property(wire, "id", "a JSON-RPC request MUST carry its correlation id");
+		assert.strictEqual(wire.id, 7);
+	});
+});

--- a/patches/effect@4.0.0-beta.92.patch
+++ b/patches/effect@4.0.0-beta.92.patch
@@ -114,3 +114,38 @@ index 4cb198b928a5538737af01c0d18a03c7d28eb445..60b2749fc62890cbe01cb103f1c15fce
        return Effect.withFiber(fiber => {
          const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest);
          if (httpRequest) {
+diff --git a/dist/unstable/rpc/RpcSerialization.js b/dist/unstable/rpc/RpcSerialization.js
+index 92e6608cda58cb4a325931a9be154ae86b2807b2..d596537dd79d204425310f276286114dcefcdf76 100644
+--- a/dist/unstable/rpc/RpcSerialization.js
++++ b/dist/unstable/rpc/RpcSerialization.js
+@@ -266,17 +266,27 @@ function encodeJsonRpcResponse(response, batches) {
+ }
+ function encodeJsonRpcMessage(response) {
+   switch (response._tag) {
+-    case "Request":
+-      return {
++    case "Request": {
++      // phoenix patch (#3495): a JSON-RPC notification MUST carry NO `id` member; a request MUST.
++      // The McpServer drain loop builds a notification as {_tag:"Request"} with no `id`, so a nullish
++      // `response.id` IS the notification case — omit the member. Upstream instead did
++      // `id: response.id !== "" ? Number(response.id) : ""`, coercing Number(undefined)→NaN→JSON null;
++      // that `id:null` reads as a malformed request to the MCP-SDK zod client (it routes on id-member
++      // presence) and is never dispatched → 0 delivery. Requests keep their id unchanged. See ADR 0038.
++      const encoded = {
+         jsonrpc: "2.0",
+         method: response.tag,
+         params: response.payload,
+-        id: response.id !== "" ? Number(response.id) : "",
+         headers: response.headers,
+         traceId: response.traceId,
+         spanId: response.spanId,
+         sampled: response.sampled
+       };
++      if (Predicate.isNotNullish(response.id)) {
++        encoded.id = response.id !== "" ? Number(response.id) : "";
++      }
++      return encoded;
++    }
+     case "Ping":
+     case "Pong":
+     case "Interrupt":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ patchedDependencies:
     hash: f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1
     path: patches/alchemy@2.0.0-beta.59.patch
   effect@4.0.0-beta.92:
-    hash: 64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7
+    hash: 606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c
     path: patches/effect@4.0.0-beta.92.patch
   react-fate@1.3.1:
     hash: 6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b
@@ -225,28 +225,28 @@ importers:
     dependencies:
       '@alchemy.run/better-auth':
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(be406d9deb1a54d01497e90e80c83ab8)
+        version: 2.0.0-beta.59(28c7faf2239d1bcd26a70fa2349ca6dc)
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(a7c8e4e41b3d7e389906c8252c5e2b38)
+        version: 1.6.23(0221deb0aa4032bbd6f0e38a2de6fbaa)
       '@better-auth/core':
         specifier: 'catalog:'
         version: 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@effect/sql-d1':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/sql-pg':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@kampus/authz':
         specifier: workspace:*
         version: link:../../packages/authz
@@ -261,13 +261,13 @@ importers:
         version: link:../../packages/fate-effect
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@sentry/cloudflare':
         specifier: 'catalog:'
         version: 10.62.0(@cloudflare/workers-types@4.20260629.1)
       '@sentry/effect':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@sentry/react':
         specifier: 'catalog:'
         version: 10.62.0(react@19.2.6)
@@ -276,19 +276,19 @@ importers:
         version: 0.2.0
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call:
         specifier: 'catalog:'
         version: 1.3.7(zod@4.4.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@19.2.6)
@@ -300,7 +300,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-fate:
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react-router:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -313,13 +313,13 @@ importers:
         version: 4.20260629.1
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@fontsource/ibm-plex-sans':
         specifier: 'catalog:'
         version: 5.2.8
@@ -385,10 +385,10 @@ importers:
     dependencies:
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -398,7 +398,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -416,19 +416,19 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(a7c8e4e41b3d7e389906c8252c5e2b38)
+        version: 1.6.23(0221deb0aa4032bbd6f0e38a2de6fbaa)
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -438,7 +438,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -456,10 +456,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -468,10 +468,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -481,7 +481,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -490,7 +490,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -502,10 +502,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -514,7 +514,7 @@ importers:
         version: link:../cf-utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -524,7 +524,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -542,7 +542,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/audit-stage':
         specifier: workspace:*
         version: link:../audit-stage
@@ -551,7 +551,7 @@ importers:
         version: link:../audit-verdict
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -561,7 +561,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -579,7 +579,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -591,7 +591,7 @@ importers:
         version: link:../preview-seed
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -601,7 +601,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -619,17 +619,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -647,7 +647,7 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -669,10 +669,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -682,7 +682,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -700,10 +700,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -715,10 +715,10 @@ importers:
         version: link:../db-schema
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -728,7 +728,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -749,7 +749,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -822,10 +822,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -835,7 +835,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -853,7 +853,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -875,17 +875,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -903,7 +903,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/depo':
         specifier: workspace:*
         version: link:../depo
@@ -912,14 +912,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -937,10 +937,10 @@ importers:
     dependencies:
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -962,17 +962,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -990,10 +990,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -1002,10 +1002,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1015,7 +1015,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1024,7 +1024,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1036,10 +1036,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1051,10 +1051,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1064,7 +1064,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1082,10 +1082,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       yaml:
         specifier: 'catalog:'
         version: 2.9.0
@@ -1095,7 +1095,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1113,7 +1113,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/design-capture':
         specifier: workspace:*
         version: link:../design-capture
@@ -1122,14 +1122,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1147,17 +1147,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1175,19 +1175,19 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1197,7 +1197,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1206,7 +1206,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1218,20 +1218,20 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1249,7 +1249,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/ci-required':
         specifier: workspace:*
         version: link:../ci-required
@@ -1261,7 +1261,7 @@ importers:
         version: link:../primary-index-tripwire
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       fast-xml-parser:
         specifier: 'catalog:'
         version: 5.8.0
@@ -1274,7 +1274,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1292,10 +1292,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       proper-lockfile:
         specifier: 'catalog:'
         version: 4.1.2
@@ -1305,7 +1305,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1326,10 +1326,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1341,10 +1341,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1354,7 +1354,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1363,7 +1363,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1375,17 +1375,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1406,7 +1406,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -4732,11 +4732,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@alchemy.run/better-auth@2.0.0-beta.59(be406d9deb1a54d01497e90e80c83ab8)':
+  '@alchemy.run/better-auth@2.0.0-beta.59(28c7faf2239d1bcd26a70fa2349ca6dc)':
     dependencies:
-      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a)
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     transitivePeerDependencies:
       - '@effect/platform-bun'
       - '@effect/platform-node'
@@ -5013,11 +5013,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.6.23(a7c8e4e41b3d7e389906c8252c5e2b38)':
+  '@better-auth/api-key@1.6.23(0221deb0aa4032bbd6f0e38a2de6fbaa)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -5036,12 +5036,12 @@ snapshots:
       '@cloudflare/workers-types': 4.20260629.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
 
   '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -5166,24 +5166,24 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1053.0
       '@aws-sdk/types': 3.973.9
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@smithy/shared-ini-file-loader': 4.5.4
       '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.4.4
       aws4fetch: 1.0.20
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
 
   '@distilled.cloud/cloudflare-rolldown-plugin@0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
     dependencies:
@@ -5196,74 +5196,74 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       workerd: 1.20260617.1
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(bffeadfa3860de8cc67d37b8f261927c)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(3ed4a2fe42fad8cbf74266c67140aab9)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
     transitivePeerDependencies:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
 
-  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
 
-  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
 
-  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
 
   '@drizzle-team/brocli@0.12.0': {}
 
   '@effect/language-service@0.85.1': {}
 
-  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.3.0
@@ -5271,14 +5271,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
 
-  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       pg: 8.21.0
       pg-connection-string: 2.12.0
       pg-cursor: 2.20.0(pg@8.21.0)
@@ -5318,9 +5318,9 @@ snapshots:
       '@effect/tsgo-win32-arm64': 0.5.2
       '@effect/tsgo-win32-x64': 0.5.2
 
-  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -5609,13 +5609,13 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
       superjson: 2.2.6
       zod: 4.4.3
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@noble/ciphers@2.2.0': {}
@@ -5865,12 +5865,12 @@ snapshots:
 
   '@sentry/core@10.62.0': {}
 
-  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))':
+  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
       '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -6342,21 +6342,21 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(271000ac678408cfe188abeef5fadd9a):
+  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1053.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(bffeadfa3860de8cc67d37b8f261927c)
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(3ed4a2fe42fad8cbf74266c67140aab9)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1
       '@octokit/webhooks': 14.2.0
@@ -6366,7 +6366,7 @@ snapshots:
       '@types/aws-lambda': 8.10.161
       aws4fetch: 1.0.20
       capnweb: 0.6.1
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       fast-glob: 3.3.3
       fast-xml-parser: 5.8.0
       ink: 6.8.0(@types/react@19.2.14)(react@19.2.6)
@@ -6382,11 +6382,11 @@ snapshots:
       undici: 7.24.8
       yaml: 2.9.0
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(ioredis@5.10.1)
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       ws: 8.21.0
     transitivePeerDependencies:
@@ -6427,10 +6427,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
+  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -6448,7 +6448,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       react: 19.2.6
@@ -6550,19 +6550,19 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))
+      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
       '@libsql/client': 0.17.3
       '@opentelemetry/api': 1.9.1
-      effect: 4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)
+      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       zod: 4.4.3
 
-  effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7):
+  effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c):
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0
@@ -7312,9 +7312,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=64b7619334bbc6564315e375fa274cdd8829851c471bd5d3dcb533efa97539b7))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:


### PR DESCRIPTION
## What

The crew channel delivered **0 tokens and 0 InboxAck end-to-end** even after the merged send-side fixes (#3489 socket-bind, #3491/#3493 by-tag single-encode + content). Root cause is one layer out from the payload: the effect JSON-RPC encoder emitted the `notifications/claude/channel` notification carrying **`id: null`** instead of **omitting** the `id` member. This is the 4th and final (b2) crew-channel cutover blocker.

## Root cause (source + node-proven)

- The `McpServer` drain loop builds an outgoing notification as `{_tag:"Request", tag, payload}` with **no `id`**.
- `RpcSerialization.encodeJsonRpcMessage` "Request" case did `id: response.id !== "" ? Number(response.id) : ""` → `response.id` is `undefined` → `Number(undefined) = NaN` → JSON `null`.
- A JSON-RPC notification MUST have no `id` member; the real MCP-SDK (zod) client routes notification-vs-request on `id`-member **presence**, so the malformed `id:null` "notification" is never dispatched to the client's `claude/channel` handler (0 tokens), and the exchange stalls the `McpErrorBase` decode / `sink.wake` (no InboxAck). Client is proven capable (claude-code v2.1.214 registers a capability-gated `claude/channel` handler) — this is our emit defect, in-package.

## The fix

Stacked as a new hunk on the merged #3491/#3493 state in the same patch file `patches/effect@4.0.0-beta.92.patch`. In the encoder's Request case, emit the `id` member **only when `response.id` is present** (`Predicate.isNotNullish`): a nullish id is exactly the notification case, so the member is omitted rather than coerced. This mirrors the JSON-RPC contract the SDK client routes on (id-member presence).

- **Notifications** now emit no `id` member (spec-compliant).
- **Requests keep their `id` unchanged** — verified by the pin (a request with `id:"7"` still serializes `"id":7`). The hard constraint (never drop a request's id) holds because a real request always carries a non-nullish id; only the notification/broken-nullish case changes.

Regenerated via the sanctioned `pnpm patch` flow; lockfile patch-hash bumped; `pnpm install --frozen-lockfile` re-applies; `pipeline-cli patch-guard check` passes.

## `@patch-pin` test (ADR 0038)

New `packages/pipeline-crew-mcp/src/edge/notif-id-omit.repro.test.ts` pins at the **serialization boundary**: encoding a `notifications/claude/channel` message yields a JSON-RPC object with the `id` member **absent** — RED on current (`id:null`), GREEN on the fix — plus a no-regression assertion that a real request still serializes with its `id`.

Honest caveat (baked into the test docblock): the full SDK-side rejection is **not** reproducible in-process — effect↔effect tolerates `id:null` (its own decoder maps `id:null` → a Request with `id:""`), only the real zod client rejects it. So the pin asserts the emitted JSON shape, not a full round-trip. `it.effect` intentionally not used (pure synchronous encoder assertions).

Pre-fix wire (node-proven): `{"jsonrpc":"2.0","method":"notifications/claude/channel","params":{"content":"wake"},"id":null}` → post-fix omits `id`.

## §CP

NON-control-plane. Changed files — `patches/effect@4.0.0-beta.92.patch`, `pnpm-lock.yaml`, and the new pin under `packages/pipeline-crew-mcp/` — were checked against `CONTROL_PLANE_RE`; none match (there is no `patches` alternation).

## Gates run locally

- `pipeline-cli patch-guard check` — 4 patches pinned, all green
- `@kampus/pipeline-crew-mcp` vitest — 235 passed (35 files)
- `pnpm --filter @kampus/pipeline-crew-mcp typecheck` — clean
- `biome check` on the new test — clean

Fixes #3495