### PR TITLE
fix(crew-channel): emit server notifications — arm the McpServer drain's initializedClients gate (#3499)

### DIFF
--- a/packages/pipeline-crew-mcp/src/edge/notif-drain-emit.repro.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/notif-drain-emit.repro.test.ts
@@ -1,0 +1,123 @@
+// @patch-pin: effect@4.0.0-beta.92
+/**
+ * Behavior pin for the (#3499) hunk of `patches/effect@4.0.0-beta.92.patch` (ADR 0038): the McpServer
+ * notification-routing branch arms `server.initializedClients` when a client sends
+ * `notifications/initialized` — the Set the run-loop notification drain gates every server->client
+ * notification on.
+ *
+ * The 0-delivery defect: `server.initializedClients` is otherwise NEVER populated (two compounding
+ * upstream bugs — the `notifications/initialized` handler is a no-op AND is unreachable, since the
+ * router dispatches client notifications by `handlers.mapUnsafe.get(request.tag)` but handlers are
+ * keyed by `rpc.key` = `effect/rpc/Rpc/<tag>`, so the bare-tag lookup always misses). The drain's
+ * `for (const clientId of server.initializedClients.keys())` then iterates an empty Set and emits
+ * nothing — a channel wake (and `tools/list_changed`) is dequeued and dropped, so the recipient client
+ * gets 0 tokens despite the InboxAck (which returns on enqueue, not emit). The fix arms the gate at
+ * the routing point with the same numeric `clientId` the drain iterates; the client sends
+ * `notifications/initialized` after the initialize response per the MCP lifecycle (claude-code
+ * v2.1.214's client does — its handshake ends `await this.notification({method:"notifications/initialized"})`).
+ *
+ * Faithful LIVE-path pin: boots the real `McpServer.layerStdio` (the exact transport `bin.ts session`
+ * serves) over a fake Stdio, feeds a raw NDJSON-RPC `initialize` + `notifications/initialized` into
+ * stdin, fires a `notifications/claude/channel` wake through the running server, and asserts the wire
+ * line reaches stdout. RED on current effect (empty Set ⇒ no line), GREEN on the fix. A SECOND wake to
+ * the same client must ALSO emit — the drain only `.delete()`s a member once it leaves the live
+ * `clientIds` (disconnect), never after a send, so an armed client keeps receiving. `it.live` (not
+ * `it.effect`): the forked run-loop + stdin/stdout streaming turn on REAL async scheduling, not the
+ * TestClock. Retire when effect ships a populated initialized-clients set and the patch is removed.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Deferred, Effect, Layer, Ref, Sink, Stdio, Stream} from "effect";
+import {McpServer} from "effect/unstable/ai";
+import {CHANNEL_NOTIFICATION_METHOD, channelExperimentalCapability} from "./mcp-channel.ts";
+
+const decoder = new TextDecoder();
+const ndjson = (message: unknown): Uint8Array =>
+	new TextEncoder().encode(`${JSON.stringify(message)}\n`);
+
+// The client handshake pair, in stdin order: the server processes `initialize` (storing the client
+// session) before `notifications/initialized` (which the fix uses to arm the drain gate).
+const INITIALIZE = ndjson({
+	jsonrpc: "2.0",
+	id: 1,
+	method: "initialize",
+	params: {
+		protocolVersion: "9999-01-01",
+		capabilities: {},
+		clientInfo: {name: "TestClient", version: "0.0.0"},
+	},
+});
+const INITIALIZED = ndjson({jsonrpc: "2.0", method: "notifications/initialized"});
+
+describe("effect McpServer drain patch (#3499) — a wake reaches an initialized client", () => {
+	it.live(
+		"after initialize + notifications/initialized, a channel wake emits to stdout — and a second wake to the same client also emits",
+		() =>
+			Effect.gen(function* () {
+				const out = yield* Ref.make("");
+				const stdin = Stream.fromIterable([INITIALIZE, INITIALIZED]).pipe(
+					Stream.concat(Stream.never),
+				);
+				// biome-ignore lint/suspicious/useIterableCallbackReturn: Sink.forEach's callback returns an Effect (the per-chunk write), not an Array.forEach callback.
+				const capturingStdout = Sink.forEach((chunk: string | Uint8Array) =>
+					Ref.update(
+						out,
+						(acc) => acc + (typeof chunk === "string" ? chunk : decoder.decode(chunk)),
+					),
+				);
+
+				// Launch the live stdio server on a forked scoped fiber (so a teardown interrupt never fails
+				// the test body) and hand a `wake` closure out through a Deferred — resolved inside the layer
+				// where `McpServer` is in scope — so the body fires wakes against the same running instance the
+				// transport serves.
+				const ready = yield* Deferred.make<(content: string) => Effect.Effect<void>>();
+				const serverLayer = Layer.effectDiscard(
+					Effect.flatMap(McpServer.McpServer, (server) =>
+						Deferred.succeed(ready, (content: string) =>
+							server.notifications[CHANNEL_NOTIFICATION_METHOD]({content}).pipe(Effect.asVoid),
+						),
+					),
+				).pipe(
+					Layer.provideMerge(
+						McpServer.layerStdio({
+							name: "DrainReproServer",
+							version: "0.0.0",
+							experimental: channelExperimentalCapability,
+						}),
+					),
+					Layer.provide(Stdio.layerTest({stdin, stdout: () => capturingStdout})),
+				);
+				yield* Effect.forkScoped(Layer.launch(serverLayer));
+				const wake = yield* Deferred.await(ready);
+
+				// Let the forked run-loop consume the handshake pair so `initializedClients` is armed BEFORE
+				// the wake enqueues — a wake drained before the client registers is lost (that is the bug, not
+				// a race in the fix). A generous fixed window, since polling the Set would deadlock the RED run
+				// (on the unfixed router it never populates).
+				yield* Effect.sleep("1 second");
+
+				yield* wake("wake-1");
+				yield* Effect.sleep("500 millis");
+				const afterFirst = yield* Ref.get(out);
+				assert.include(
+					afterFirst,
+					CHANNEL_NOTIFICATION_METHOD,
+					"the wake must be emitted to the initialized client — an empty initializedClients Set drops it (0 tokens)",
+				);
+				assert.include(
+					afterFirst,
+					"wake-1",
+					"the emitted notification must carry the wake content",
+				);
+
+				yield* wake("wake-2");
+				yield* Effect.sleep("500 millis");
+				const afterSecond = yield* Ref.get(out);
+				assert.include(
+					afterSecond,
+					"wake-2",
+					"a SECOND wake to the same client must ALSO emit — the drain must not drop a client after one send",
+				);
+			}).pipe(Effect.scoped),
+		{timeout: 20000},
+	);
+});

--- a/patches/effect@4.0.0-beta.92.patch
+++ b/patches/effect@4.0.0-beta.92.patch
@@ -81,10 +81,34 @@ index 87a6f7acdd3d7f89b41fac68e575d80a09748f64..978ddb8206b27201c26fb2ff189dfad1
  /**
   * Registers a `Toolkit` with the `McpServer`.
 diff --git a/dist/unstable/ai/McpServer.js b/dist/unstable/ai/McpServer.js
-index 4cb198b928a5538737af01c0d18a03c7d28eb445..60b2749fc62890cbe01cb103f1c15fce8d71a270 100644
+index 4cb198b928a5538737af01c0d18a03c7d28eb445..61e2bf1044a334b96832b2851757751240ff77a4 100644
 --- a/dist/unstable/ai/McpServer.js
 +++ b/dist/unstable/ai/McpServer.js
-@@ -329,9 +329,14 @@ export const run = /*#__PURE__*/Effect.fnUntraced(function* (options) {
+@@ -303,6 +303,23 @@ export const run = /*#__PURE__*/Effect.fnUntraced(function* (options) {
+                   requestId: String(request.payload.requestId)
+                 });
+               }
++              // phoenix patch (#3499): arm the notification drain's client gate. The run-loop drain
++              // fans every server->client notification (a crew channel wake AND tools/list_changed) by
++              // iterating `server.initializedClients` — a Set that is otherwise NEVER populated, so the
++              // drain iterates nothing and emits nothing (0 tokens delivered despite a returned ack).
++              // Two upstream defects compound: the `notifications/initialized` handler is a no-op, AND
++              // this branch would never reach it anyway — it dispatches client notifications by
++              // `handlers.mapUnsafe.get(request.tag)`, but the handler Context is keyed by `rpc.key`
++              // (`effect/rpc/Rpc/<tag>`), so the bare-tag lookup always misses and returns Effect.void.
++              // Arm the gate at the routing point instead, with the SAME numeric `clientId` the drain
++              // iterates (`clientIds`) and sends to — guaranteeing identity match. The client sends
++              // `notifications/initialized` after the initialize response per the MCP lifecycle
++              // (claude-code v2.1.214's client does). The drain only .delete()s a member once it leaves
++              // the live clientIds (disconnect), never after a send, so a repeat wake still emits. See
++              // ADR 0038.
++              if (request.tag === "notifications/initialized") {
++                server.initializedClients.add(clientId);
++              }
+               const handler = handlers.mapUnsafe.get(request.tag);
+               return handler ? handler.handler(request.payload, {
+                 rpc,
+@@ -329,9 +346,14 @@ export const run = /*#__PURE__*/Effect.fnUntraced(function* (options) {
        }
      })
    });
@@ -101,7 +125,7 @@ index 4cb198b928a5538737af01c0d18a03c7d28eb445..60b2749fc62890cbe01cb103f1c15fce
      const message = {
        _tag: "Request",
        tag: request.tag,
-@@ -850,6 +855,12 @@ const layerHandlers = (serverInfo, options) => ClientRpcs.toLayer(Effect.gen(fun
+@@ -850,6 +872,12 @@ const layerHandlers = (serverInfo, options) => ClientRpcs.toLayer(Effect.gen(fun
        if (serverInfo.extensions) {
          capabilities.extensions = serverInfo.extensions;
        }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ patchedDependencies:
     hash: f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1
     path: patches/alchemy@2.0.0-beta.59.patch
   effect@4.0.0-beta.92:
-    hash: 606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c
+    hash: 86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4
     path: patches/effect@4.0.0-beta.92.patch
   react-fate@1.3.1:
     hash: 6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b
@@ -225,28 +225,28 @@ importers:
     dependencies:
       '@alchemy.run/better-auth':
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(28c7faf2239d1bcd26a70fa2349ca6dc)
+        version: 2.0.0-beta.59(d88aca205a308eb6da45241210d87429)
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(0221deb0aa4032bbd6f0e38a2de6fbaa)
+        version: 1.6.23(d638c0c4fe1d54f9d6f4939b1f8c5473)
       '@better-auth/core':
         specifier: 'catalog:'
         version: 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@effect/sql-d1':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/sql-pg':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@kampus/authz':
         specifier: workspace:*
         version: link:../../packages/authz
@@ -261,13 +261,13 @@ importers:
         version: link:../../packages/fate-effect
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@sentry/cloudflare':
         specifier: 'catalog:'
         version: 10.62.0(@cloudflare/workers-types@4.20260629.1)
       '@sentry/effect':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@sentry/react':
         specifier: 'catalog:'
         version: 10.62.0(react@19.2.6)
@@ -276,19 +276,19 @@ importers:
         version: 0.2.0
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call:
         specifier: 'catalog:'
         version: 1.3.7(zod@4.4.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       lucide-react:
         specifier: 'catalog:'
         version: 1.23.0(react@19.2.6)
@@ -300,7 +300,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-fate:
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react-router:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -313,13 +313,13 @@ importers:
         version: 4.20260629.1
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@fontsource/ibm-plex-sans':
         specifier: 'catalog:'
         version: 5.2.8
@@ -385,10 +385,10 @@ importers:
     dependencies:
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -398,7 +398,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -416,19 +416,19 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: 'catalog:'
-        version: 1.6.23(0221deb0aa4032bbd6f0e38a2de6fbaa)
+        version: 1.6.23(d638c0c4fe1d54f9d6f4939b1f8c5473)
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -438,7 +438,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -456,10 +456,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -468,10 +468,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -481,7 +481,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -490,7 +490,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -502,10 +502,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -514,7 +514,7 @@ importers:
         version: link:../cf-utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -524,7 +524,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -542,7 +542,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/audit-stage':
         specifier: workspace:*
         version: link:../audit-stage
@@ -551,7 +551,7 @@ importers:
         version: link:../audit-verdict
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -561,7 +561,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -579,7 +579,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -591,7 +591,7 @@ importers:
         version: link:../preview-seed
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -601,7 +601,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -619,17 +619,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -647,7 +647,7 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -669,10 +669,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -682,7 +682,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -700,10 +700,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
@@ -715,10 +715,10 @@ importers:
         version: link:../db-schema
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -728,7 +728,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -749,7 +749,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -822,10 +822,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -835,7 +835,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -853,7 +853,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -875,17 +875,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -903,7 +903,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/depo':
         specifier: workspace:*
         version: link:../depo
@@ -912,14 +912,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -937,10 +937,10 @@ importers:
     dependencies:
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -962,17 +962,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -990,10 +990,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -1002,10 +1002,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1015,7 +1015,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1024,7 +1024,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1036,10 +1036,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1051,10 +1051,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1064,7 +1064,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1082,10 +1082,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       yaml:
         specifier: 'catalog:'
         version: 2.9.0
@@ -1095,7 +1095,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1113,7 +1113,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/design-capture':
         specifier: workspace:*
         version: link:../design-capture
@@ -1122,14 +1122,14 @@ importers:
         version: 1.59.1
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1147,17 +1147,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1175,19 +1175,19 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1197,7 +1197,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1206,7 +1206,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1218,20 +1218,20 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/cf-credentials':
         specifier: workspace:*
         version: link:../cf-credentials
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1249,7 +1249,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/ci-required':
         specifier: workspace:*
         version: link:../ci-required
@@ -1261,7 +1261,7 @@ importers:
         version: link:../primary-index-tripwire
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       fast-xml-parser:
         specifier: 'catalog:'
         version: 5.8.0
@@ -1274,7 +1274,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1292,10 +1292,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       proper-lockfile:
         specifier: 'catalog:'
         version: 4.1.2
@@ -1305,7 +1305,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1326,10 +1326,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+        version: 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -1341,10 +1341,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -1354,7 +1354,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1363,7 +1363,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
+        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1375,17 +1375,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+        version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -1406,7 +1406,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -4732,11 +4732,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@alchemy.run/better-auth@2.0.0-beta.59(28c7faf2239d1bcd26a70fa2349ca6dc)':
+  '@alchemy.run/better-auth@2.0.0-beta.59(d88aca205a308eb6da45241210d87429)':
     dependencies:
-      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7)
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     transitivePeerDependencies:
       - '@effect/platform-bun'
       - '@effect/platform-node'
@@ -5013,11 +5013,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.6.23(0221deb0aa4032bbd6f0e38a2de6fbaa)':
+  '@better-auth/api-key@1.6.23(d638c0c4fe1d54f9d6f4939b1f8c5473)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -5036,12 +5036,12 @@ snapshots:
       '@cloudflare/workers-types': 4.20260629.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
 
   '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -5166,24 +5166,24 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1053.0
       '@aws-sdk/types': 3.973.9
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@smithy/shared-ini-file-loader': 4.5.4
       '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.4.4
       aws4fetch: 1.0.20
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
 
   '@distilled.cloud/cloudflare-rolldown-plugin@0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
     dependencies:
@@ -5196,74 +5196,74 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       workerd: 1.20260617.1
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(3ed4a2fe42fad8cbf74266c67140aab9)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(92b9c4fcbafa5211c1ae2d6175ddf9cc)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
     transitivePeerDependencies:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
 
-  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
 
-  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
 
-  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
 
   '@drizzle-team/brocli@0.12.0': {}
 
   '@effect/language-service@0.85.1': {}
 
-  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.3.0
@@ -5271,14 +5271,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
 
-  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       pg: 8.21.0
       pg-connection-string: 2.12.0
       pg-cursor: 2.20.0(pg@8.21.0)
@@ -5318,9 +5318,9 @@ snapshots:
       '@effect/tsgo-win32-arm64': 0.5.2
       '@effect/tsgo-win32-x64': 0.5.2
 
-  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -5609,13 +5609,13 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nkzw/fate@1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
       superjson: 2.2.6
       zod: 4.4.3
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@noble/ciphers@2.2.0': {}
@@ -5865,12 +5865,12 @@ snapshots:
 
   '@sentry/core@10.62.0': {}
 
-  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))':
+  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
       '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -6342,21 +6342,21 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(1ad6c9879d1ee320572840a52db2b1a7):
+  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1053.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(3ed4a2fe42fad8cbf74266c67140aab9)
-      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1))(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(92b9c4fcbafa5211c1ae2d6175ddf9cc)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1
       '@octokit/webhooks': 14.2.0
@@ -6366,7 +6366,7 @@ snapshots:
       '@types/aws-lambda': 8.10.161
       aws4fetch: 1.0.20
       capnweb: 0.6.1
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       fast-glob: 3.3.3
       fast-xml-parser: 5.8.0
       ink: 6.8.0(@types/react@19.2.14)(react@19.2.6)
@@ -6382,11 +6382,11 @@ snapshots:
       undici: 7.24.8
       yaml: 2.9.0
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(ioredis@5.10.1)
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(ioredis@5.10.1)
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       ws: 8.21.0
     transitivePeerDependencies:
@@ -6427,10 +6427,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
+  better-auth@1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -6448,7 +6448,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       react: 19.2.6
@@ -6550,19 +6550,19 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
-      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))
+      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))
       '@libsql/client': 0.17.3
       '@opentelemetry/api': 1.9.1
-      effect: 4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)
+      effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       zod: 4.4.3
 
-  effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c):
+  effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4):
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0
@@ -7312,9 +7312,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=606fa916b6fae40b09b12ee8fabc171ac95f7eee73caf9c43e2d81cf34f4ce4c))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nkzw/fate': 1.3.1(patch_hash=e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:


### PR DESCRIPTION
Fixes #3499

## What was broken
After the four send-side crew-channel fixes landed (#3489/#3491/#3493/#3495/#3497), a crew channel round-trip returned an `InboxAck` but the recipient session received **zero tokens**. The recipient's `McpServer` run-loop drain dequeued the `notifications/claude/channel` wake but **emitted it to nobody**: the drain fans every server→client notification (the channel wake AND `tools/list_changed`) by iterating `server.initializedClients`, a `Set<number>` that was **never populated**. Empty Set ⇒ the drain iterates nothing ⇒ no notification is ever written to the client (0 tokens), while the ack — which returns on *enqueue*, not *emit* — makes the round-trip look healthy.

## Root cause (grounded, two compounding upstream defects)
Instrumenting the drain loop confirmed `[DRAIN] initializedClients= []` while the live client id was `[0]`. Tracing *why* the Set stays empty surfaced **two** upstream bugs in `effect@4.0.0-beta.92`'s `McpServer`, not one:

1. The `notifications/initialized` handler is a **no-op** (`_ => Effect.void`).
2. **That handler is never even reached.** The notification router dispatches client notifications with `handlers.mapUnsafe.get(request.tag)`, but the handler `Context` is keyed by `rpc.key` = `` `effect/rpc/Rpc/<tag>` ``. So the bare-tag lookup **always misses** and returns `Effect.void`. Verified live: for `notifications/initialized`, `byTag=false byKey=true`.

So the issue's proposed C1 as written (patch the no-op handler) is **provably insufficient** — I confirmed the handler edit alone leaves the pin RED, because the handler is dead code under the tag-vs-key dispatch bug.

## The fix (empirical fork resolved → engineering-led, ADR 0078)
**Grounding the fork — does claude-code v2.1.214 send `notifications/initialized`?** YES. Confirmed from the claude-code v2.1.214 bundle: its MCP client handshake ends with `await this.notification({method:"notifications/initialized"})` after processing the initialize response. So the spec-faithful, handshake-gated approach (C1's intent) is valid.

**Chosen fix:** arm the drain gate at the **notification routing point**, with `server.initializedClients.add(clientId)` when `request.tag === "notifications/initialized"`. This realizes C1's intent (preserve handshake-gating) while sidestepping the dead-handler dispatch bug, and uses the **same numeric `clientId`** the drain iterates (`clientIds`) and sends to (`patchedProtocol.send(clientId, …)`) — guaranteeing identity match, no `client.id`-vs-`clientId` ambiguity. It does **not** touch request/response handling or any other notification (`tools/list_changed` emission is unaffected; `notifications/cancelled` is intercepted earlier). It is **not** the C2 fallback (iterate live `clientIds`, drop the gate) — that loosens handshake-gating and wasn't needed since the client provably handshakes.

The drain only `.delete()`s a Set member once it leaves the live `clientIds` (a disconnect), **never after a send** — so a second wake to the same client still emits (guarded by the test below).

## §CP scope
NON-control-plane: the fix is a hunk added to `patches/effect@4.0.0-beta.92.patch` (`patches/**`, verified outside `CONTROL_PLANE_RE`), stacking sequentially on the prior send-side hunks in the same file — no conflict. Same classification as #3491/#3495.

## Test (@patch-pin, ADR 0038 — edits the effect pnpm patch)
`packages/pipeline-crew-mcp/src/edge/notif-drain-emit.repro.test.ts` boots the **real** `McpServer.layerStdio` (the exact transport `bin.ts session` serves) over a fake Stdio, feeds a raw NDJSON-RPC `initialize` + `notifications/initialized` into stdin, fires a `notifications/claude/channel` wake through the running server, and asserts the wire line reaches stdout.
- **RED** on current effect (empty Set ⇒ no line) — verified by stripping the fix: `AssertionError … expected '{"jsonrpc":"2.0","id":1,"result":…}' to include 'notifications/claude/channel'`.
- **GREEN** on the fix.
- A **second wake** to the same client also emits (guards the `.delete()`-drops-subsequent hazard).
- Constraints honored: `it.live` (not `it.effect`); no `Effect.timeoutFail`/`tapErrorCause` (absent in this beta).

## Gates
- `@kampus/pipeline-crew-mcp` vitest: **236/236 pass** (incl. the new pin).
- `pnpm typecheck`, `pnpm biome check`: clean.
- `pnpm install --frozen-lockfile` re-applies the patch; `pipeline-cli patch-guard check` passes (9 @patch-pin markers).

## ⚠️ DEPLOY GATE (CRITICAL — links #3498)
**On merge, the crew re-boot MUST run a pinned-pnpm 10.27.0 `pnpm install --frozen-lockfile` before re-testing.** `main-sync` (ff-merge) alone will **NOT** install the patched effect — and a stale runtime **silently reproduces this exact bug**, so a green fix reads as still-broken if the runtime isn't re-installed. Whoever re-tests must be told this explicitly (this is the #3498 trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
