### PR TITLE
fix(main-sync): re-install with the pinned pnpm on a ff that pulls patches/lockfile — stale-runtime guard (#3498)

### DIFF
--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -37,9 +37,19 @@
  * provides.
  */
 import {execFileSync} from "node:child_process";
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
 import {isControlPlaneDeletion, parseNameStatus} from "@kampus/primary-index-tripwire";
 import {Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {
+	changedPathsForceDepRefresh,
+	decidePnpmVersionGuard,
+	depPathsForcingRefresh,
+	type PnpmVersion,
+	parsePackageManagerPnpm,
+	parsePnpmVersionOutput,
+} from "./dep-refresh.ts";
 import {decideMainRefresh, decideMainSync, type HeadState, MAIN_BRANCH} from "./main-sync.ts";
 
 interface GitResult {
@@ -48,16 +58,20 @@ interface GitResult {
 	readonly stderr: string;
 }
 
-const runGit = (args: ReadonlyArray<string>): GitResult => {
-	// biome-ignore lint/plugin: best-effort git shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
+// A best-effort captured-output runner: a non-zero exit is fully absorbed into a {ok:false}
+// GitResult the caller branches on, never the E channel — a total helper, not Effect-cosplay.
+const runCaptured = (cmd: string, args: ReadonlyArray<string>, cwd?: string): GitResult => {
+	// biome-ignore lint/plugin: see the note above — total by construction, the E channel is never used.
 	try {
-		const stdout = execFileSync("git", [...args], {encoding: "utf8"});
+		const stdout = execFileSync(cmd, [...args], {encoding: "utf8", ...(cwd ? {cwd} : {})});
 		return {ok: true, stdout, stderr: ""};
 	} catch (cause) {
 		const e = cause as {stdout?: Buffer | string; stderr?: Buffer | string};
 		return {ok: false, stdout: String(e.stdout ?? ""), stderr: String(e.stderr ?? "")};
 	}
 };
+
+const runGit = (args: ReadonlyArray<string>): GitResult => runCaptured("git", args);
 
 /**
  * The short branch the primary HEAD points at, or `null` for a detached HEAD.
@@ -105,6 +119,107 @@ const stagedControlPlaneDeletionCount = (): number => {
 	return parseNameStatus(r.stdout).filter((e) => isControlPlaneDeletion(e.path)).length;
 };
 
+/** The primary checkout's toplevel — where package.json lives and the install must run. `null` if git can't resolve it. */
+const repoRoot = (): string | null => {
+	const r = runGit(["rev-parse", "--show-toplevel"]);
+	return r.ok && r.stdout.trim() !== "" ? r.stdout.trim() : null;
+};
+
+/** The `packageManager` pin from the root package.json, or `undefined` if unreadable/absent. */
+const readPackageManagerPin = (root: string): string | undefined => {
+	// biome-ignore lint/plugin: total pre-runtime helper — a missing file / bad JSON maps to `undefined`, which the guard treats as unresolved-required (fail-closed); no E channel to model.
+	try {
+		const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+			packageManager?: string;
+		};
+		return pkg.packageManager;
+	} catch {
+		return undefined;
+	}
+};
+
+/**
+ * Re-install deps after a ff merge IFF the merge pulled a `patches/**`/`pnpm-lock.yaml`
+ * change — the #3498 fix. Without it the ff advances the SOURCE patch/lockfile but not the
+ * installed `.pnpm/…/patched` copy the runtime executes, so a re-booted crew silently runs
+ * the PRE-merge patched dep (a merged fix reads as "still broken"). Resolves pnpm via corepack
+ * against the repo's `packageManager` pin — NEVER a bare-PATH pnpm, whose wrong major silently
+ * leaves a stale patched dir — and FAILS LOUD (exit 1) if it can't resolve the pinned pnpm, the
+ * resolved major mismatches the repo requirement, or the frozen install fails. `preSha` is HEAD
+ * captured immediately before the merge, so `preSha..HEAD` is exactly what the ff pulled.
+ */
+const refreshDepsAfterMerge = Effect.fn(function* (preSha: string) {
+	const diff = runGit(["diff", "--name-only", preSha, "HEAD"]);
+	const changed = diff.ok
+		? diff.stdout
+				.split("\n")
+				.map((s) => s.trim())
+				.filter((s) => s !== "")
+		: [];
+	const forcing = depPathsForcingRefresh(changed);
+	if (!changedPathsForceDepRefresh(changed)) {
+		yield* Console.log(
+			"  dep refresh: the merge pulled no patches/** or pnpm-lock.yaml change — installed node_modules is current, nothing to re-install.",
+		);
+		return;
+	}
+
+	yield* Console.log(
+		`  dep refresh: the merge pulled ${forcing.length} dep-input change(s) (${forcing.join(", ")}) — installed node_modules is now STALE, re-installing with the repo-pinned pnpm.`,
+	);
+
+	const root = repoRoot();
+	if (root === null) {
+		yield* Console.error(
+			`main-sync dep refresh FAILED (fail-closed): the merge changed ${forcing.join(", ")} but the repo root is unresolvable — refusing to install under an unknown root. node_modules is STALE (#3498); provision the pinned pnpm and re-run.`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+
+	const required = parsePackageManagerPnpm(readPackageManagerPin(root));
+	// Resolve pnpm via corepack AGAINST THE PIN (`corepack pnpm@<version> …`), never the bare-PATH
+	// pnpm — the wrong-major hazard #3498 exists to close. A failed probe ⇒ unresolved ⇒ fail-closed.
+	let resolved: PnpmVersion | null = null;
+	if (required !== null) {
+		const ver = runCaptured("corepack", [`pnpm@${required.version}`, "--version"], root);
+		resolved = ver.ok ? parsePnpmVersionOutput(ver.stdout) : null;
+	}
+	const guard = decidePnpmVersionGuard(required, resolved);
+	if (!guard.ok) {
+		const detail =
+			guard.reason === "unresolved-required"
+				? "the root package.json `packageManager` pin is absent or unparseable — cannot determine the required pnpm major"
+				: guard.reason === "unresolved-pnpm"
+					? "could not resolve the repo-pinned pnpm via corepack (corepack absent or errored) — refusing to fall back to a bare-PATH pnpm, whose wrong major silently leaves a stale patched dir"
+					: `resolved pnpm ${guard.resolved.version} (major ${guard.resolved.major}) does NOT match the repo-required major ${guard.required.major} (${guard.required.version}) — a wrong-major install silently leaves a stale patched dir`;
+		const provision = required
+			? `corepack pnpm@${required.version} install --frozen-lockfile`
+			: "corepack pnpm install --frozen-lockfile";
+		yield* Console.error(
+			`main-sync dep refresh FAILED (fail-closed): the merge changed ${forcing.join(", ")} but ${detail}. node_modules is STALE and a re-booted crew would run the PRE-merge patched dep (#3498). Provision with the pinned pnpm (\`${provision}\`) and re-run.`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+
+	yield* Console.log(
+		`  dep refresh: resolved pnpm ${guard.resolved.version} via corepack (matches the pinned major ${guard.resolved.major}) — running the frozen-lockfile install.`,
+	);
+	const installed = runCaptured(
+		"corepack",
+		[`pnpm@${guard.resolved.version}`, "install", "--frozen-lockfile"],
+		root,
+	);
+	if (!installed.ok) {
+		yield* Console.error(
+			`main-sync dep refresh FAILED (fail-closed): \`corepack pnpm@${guard.resolved.version} install --frozen-lockfile\` exited non-zero — ${installed.stderr.trim() || "install error"}. node_modules may be STALE (#3498). Resolve the install by hand before booting the crew.`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+	yield* Console.log(
+		"  dep refresh: re-installed with the pinned pnpm — installed node_modules now matches the merged patches/lockfile.",
+	);
+});
+
 /**
  * The gentle post-merge refresh (#2056) — the HEAD-preserving counterpart to the drain-sync
  * below. `decideMainRefresh` is the safety policy; this runs it. A `leave-alone` plan is a
@@ -146,6 +261,9 @@ const runPostMergeRefresh = Effect.fn(function* (head: HeadState, execute: boole
 		yield* Console.log(
 			`  would refresh: git fetch origin ${MAIN_BRANCH} && git merge --ff-only origin/${MAIN_BRANCH}`,
 		);
+		yield* Console.log(
+			"  would then, IF the ff pulls a patches/** or pnpm-lock.yaml change: re-install with the repo-pinned pnpm via corepack (or fail loud) — #3498",
+		);
 		yield* Console.log("  (dry-run — pass --execute to run; nothing touched)");
 		return;
 	}
@@ -158,6 +276,8 @@ const runPostMergeRefresh = Effect.fn(function* (head: HeadState, execute: boole
 		return yield* Effect.sync(() => process.exit(1));
 	}
 
+	// HEAD before the merge, so refreshDepsAfterMerge diffs exactly what the ff pulled (#3498).
+	const preSha = runGit(["rev-parse", "HEAD"]).stdout.trim();
 	// --ff-only is the invariant that makes the refresh safe: it advances main to origin/main
 	// when it's a strict fast-forward and ABORTS on any divergence — never a merge commit,
 	// never a force. On a clean 'main' the worst case is a no-op, never a clobber (#2056).
@@ -171,6 +291,7 @@ const runPostMergeRefresh = Effect.fn(function* (head: HeadState, execute: boole
 	yield* Console.log(
 		`main-sync --post-merge: primary checkout fast-forwarded to origin/${MAIN_BRANCH}.`,
 	);
+	yield* refreshDepsAfterMerge(preSha);
 });
 
 const executeFlag = Flag.boolean("execute").pipe(
@@ -234,6 +355,9 @@ const mainSync = Command.make(
 					`  would sync: git fetch origin ${MAIN_BRANCH} && git merge --ff-only origin/${MAIN_BRANCH}`,
 				);
 			}
+			yield* Console.log(
+				"  would then, IF the ff pulls a patches/** or pnpm-lock.yaml change: re-install with the repo-pinned pnpm via corepack (or fail loud) — #3498",
+			);
 			yield* Console.log("  (dry-run — pass --execute to run; nothing touched)");
 			return;
 		}
@@ -257,6 +381,8 @@ const mainSync = Command.make(
 			return yield* Effect.sync(() => process.exit(1));
 		}
 
+		// HEAD before the merge, so refreshDepsAfterMerge diffs exactly what the ff pulled (#3498).
+		const preSha = runGit(["rev-parse", "HEAD"]).stdout.trim();
 		const merged = runGit(["merge", "--ff-only", `origin/${MAIN_BRANCH}`]);
 		if (!merged.ok) {
 			yield* Console.error(
@@ -265,6 +391,7 @@ const mainSync = Command.make(
 			return yield* Effect.sync(() => process.exit(1));
 		}
 		yield* Console.log(`main-sync: primary checkout synced to origin/${MAIN_BRANCH}.`);
+		yield* refreshDepsAfterMerge(preSha);
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts
@@ -1,0 +1,100 @@
+/**
+ * `main-sync` dep-refresh pure core — decide, from the paths a fast-forward pulled,
+ * whether the installed `node_modules` is now stale and must be re-installed, and guard
+ * the pnpm version that install runs under. IO-free and total; the corepack/pnpm/git
+ * boundary (diff / --version / install) lives in `command.ts`. See #3498.
+ *
+ * The forcing hazard: a ff that advances `patches/**` or `pnpm-lock.yaml` moves the
+ * SOURCE patch/lockfile but never the installed `.pnpm/…/patched` copy the runtime
+ * executes — so a re-booted crew silently runs the PRE-merge patched dep (a merged fix
+ * reads as "still broken"). The fix re-installs with the REPO-PINNED pnpm on any such ff,
+ * or FAILS LOUD — never a bare-PATH pnpm (whose wrong major silently leaves a stale dir).
+ */
+
+/** A semver-ish pnpm version reduced to what the guard needs: the full string + its major. */
+export interface PnpmVersion {
+	readonly version: string;
+	readonly major: number;
+}
+
+/**
+ * A changed path forces a dep re-install iff it is the lockfile or lives under `patches/`.
+ * Both are inputs the installed `node_modules` is derived from, so a ff that moves either
+ * leaves the install stale until a re-install (#3498).
+ */
+export const pathForcesDepRefresh = (path: string): boolean =>
+	path === "pnpm-lock.yaml" || path.startsWith("patches/");
+
+/** The subset of `paths` that forces a dep refresh — the reportable "why" behind the decision. */
+export const depPathsForcingRefresh = (paths: ReadonlyArray<string>): ReadonlyArray<string> =>
+	paths.filter(pathForcesDepRefresh);
+
+/** True iff any pulled path forces a dep refresh. */
+export const changedPathsForceDepRefresh = (paths: ReadonlyArray<string>): boolean =>
+	paths.some(pathForcesDepRefresh);
+
+// A version tail may carry a corepack integrity hash (`10.27.0+sha512.…`) or a prerelease
+// (`10.27.0-rc.1`); the major/minor/patch triple is all the guard reads, so absorb the tail.
+const SEMVER_HEAD = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+/**
+ * Parse the root `packageManager` pin (`pnpm@10.27.0`) to the required pnpm version. Returns
+ * `null` when the field is absent, names a different package manager, or is malformed — the
+ * guard treats a `null` required version as unresolved (fail-closed), never a pass.
+ */
+export const parsePackageManagerPnpm = (packageManager: string | undefined): PnpmVersion | null => {
+	if (!packageManager) return null;
+	const m = packageManager.trim().match(/^pnpm@(\d+\.\d+\.\d+(?:[-+].*)?)$/);
+	if (!m) return null;
+	return parsePnpmVersionOutput(m[1] ?? "");
+};
+
+/**
+ * Parse `pnpm --version` stdout (a bare semver line) to a `PnpmVersion`. Returns `null` on
+ * empty/non-semver output — i.e. corepack/pnpm didn't resolve — which the guard fail-closes.
+ */
+export const parsePnpmVersionOutput = (output: string): PnpmVersion | null => {
+	const first = output.trim().split(/\s+/)[0] ?? "";
+	const m = first.match(SEMVER_HEAD);
+	if (!m) return null;
+	return {version: `${m[1]}.${m[2]}.${m[3]}`, major: Number(m[1])};
+};
+
+/**
+ * The pnpm-version guard outcome (candidate 3 of #3498, folded into the install path). Only
+ * `ok` authorizes the install; every other case is a fail-closed refusal with the reason a
+ * LOUD message reports — a crew-affecting install NEVER proceeds under an unknown/wrong major.
+ */
+export type PnpmGuardResult =
+	// The pinned pnpm resolved and its major matches the repo requirement — install may run.
+	| {readonly ok: true; readonly resolved: PnpmVersion}
+	// The `packageManager` pin was absent/unparseable — the required version is unknown.
+	| {readonly ok: false; readonly reason: "unresolved-required"}
+	// `corepack pnpm --version` didn't resolve (corepack absent / errored) — never fall back to
+	// a bare-PATH pnpm, which is the wrong-major hazard this whole fix exists to close.
+	| {readonly ok: false; readonly reason: "unresolved-pnpm"}
+	// Resolved pnpm's major differs from the repo requirement — a `pnpm@8` install silently
+	// leaves a stale patched dir (#3498), so fail closed instead of installing under it.
+	| {
+			readonly ok: false;
+			readonly reason: "major-mismatch";
+			readonly required: PnpmVersion;
+			readonly resolved: PnpmVersion;
+	  };
+
+/**
+ * Decide the pnpm-version guard. Total over the two nullable inputs (required = the parsed
+ * `packageManager` pin, resolved = the parsed `corepack pnpm --version`): a `null` on either
+ * side is a fail-closed refusal, and only an equal-major pair authorizes the install.
+ */
+export const decidePnpmVersionGuard = (
+	required: PnpmVersion | null,
+	resolved: PnpmVersion | null,
+): PnpmGuardResult => {
+	if (required === null) return {ok: false, reason: "unresolved-required"};
+	if (resolved === null) return {ok: false, reason: "unresolved-pnpm"};
+	if (resolved.major !== required.major) {
+		return {ok: false, reason: "major-mismatch", required, resolved};
+	}
+	return {ok: true, resolved};
+};

--- a/packages/pipeline-cli/src/tools/main-sync/dep-refresh.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/dep-refresh.unit.test.ts
@@ -1,0 +1,140 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	changedPathsForceDepRefresh,
+	decidePnpmVersionGuard,
+	depPathsForcingRefresh,
+	type PnpmVersion,
+	parsePackageManagerPnpm,
+	parsePnpmVersionOutput,
+	pathForcesDepRefresh,
+} from "./dep-refresh.ts";
+
+describe("pathForcesDepRefresh — the lockfile + patches/ are dep inputs", () => {
+	it("pnpm-lock.yaml forces a refresh", () => {
+		assert.isTrue(pathForcesDepRefresh("pnpm-lock.yaml"));
+	});
+
+	it("any patches/** file forces a refresh (the #3498 patched-dep hazard)", () => {
+		assert.isTrue(pathForcesDepRefresh("patches/effect@4.0.0-beta.92.patch"));
+		assert.isTrue(pathForcesDepRefresh("patches/@nkzw__fate@1.3.1.patch"));
+	});
+
+	it("unrelated source/doc changes do NOT force a refresh", () => {
+		assert.isFalse(pathForcesDepRefresh("apps/web/worker/index.ts"));
+		assert.isFalse(pathForcesDepRefresh("README.md"));
+		// a lookalike that is NOT the lockfile nor under patches/ is not a dep input
+		assert.isFalse(pathForcesDepRefresh("docs/pnpm-lock.yaml.md"));
+		assert.isFalse(pathForcesDepRefresh("patches-notes.md"));
+	});
+});
+
+describe("depPathsForcingRefresh / changedPathsForceDepRefresh", () => {
+	it("returns exactly the forcing subset, order-preserving", () => {
+		const changed = [
+			"apps/web/worker/index.ts",
+			"patches/effect@4.0.0-beta.92.patch",
+			"README.md",
+			"pnpm-lock.yaml",
+		];
+		assert.deepStrictEqual(depPathsForcingRefresh(changed), [
+			"patches/effect@4.0.0-beta.92.patch",
+			"pnpm-lock.yaml",
+		]);
+		assert.isTrue(changedPathsForceDepRefresh(changed));
+	});
+
+	it("a merge with no dep-input change does not force a refresh", () => {
+		const changed = ["apps/web/src/App.tsx", ".decisions/0200-foo.md"];
+		assert.deepStrictEqual(depPathsForcingRefresh(changed), []);
+		assert.isFalse(changedPathsForceDepRefresh(changed));
+	});
+
+	it("an empty diff (no files) does not force a refresh", () => {
+		assert.isFalse(changedPathsForceDepRefresh([]));
+	});
+});
+
+describe("parsePackageManagerPnpm — the packageManager pin", () => {
+	it("parses `pnpm@10.27.0` to version + major", () => {
+		assert.deepStrictEqual(parsePackageManagerPnpm("pnpm@10.27.0"), {
+			version: "10.27.0",
+			major: 10,
+		});
+	});
+
+	it("absorbs a corepack integrity-hash suffix", () => {
+		assert.deepStrictEqual(parsePackageManagerPnpm("pnpm@10.27.0+sha512.abc"), {
+			version: "10.27.0",
+			major: 10,
+		});
+	});
+
+	it("returns null for a different package manager, absent, or malformed pin", () => {
+		assert.isNull(parsePackageManagerPnpm("yarn@4.1.0"));
+		assert.isNull(parsePackageManagerPnpm(undefined));
+		assert.isNull(parsePackageManagerPnpm(""));
+		assert.isNull(parsePackageManagerPnpm("pnpm"));
+		assert.isNull(parsePackageManagerPnpm("pnpm@10"));
+	});
+});
+
+describe("parsePnpmVersionOutput — `pnpm --version` stdout", () => {
+	it("parses a bare semver line", () => {
+		assert.deepStrictEqual(parsePnpmVersionOutput("10.27.0\n"), {version: "10.27.0", major: 10});
+	});
+
+	it("parses the wrong-major bare-PATH pnpm (8.15.6) — so the guard can reject it", () => {
+		assert.deepStrictEqual(parsePnpmVersionOutput("8.15.6"), {version: "8.15.6", major: 8});
+	});
+
+	it("returns null for empty / non-semver output (corepack didn't resolve)", () => {
+		assert.isNull(parsePnpmVersionOutput(""));
+		assert.isNull(parsePnpmVersionOutput("   "));
+		assert.isNull(parsePnpmVersionOutput("command not found"));
+	});
+});
+
+describe("decidePnpmVersionGuard — candidate 3, folded into the install path", () => {
+	const v = (version: string, major: number): PnpmVersion => ({version, major});
+
+	it("matching major → ok (the install is authorized)", () => {
+		const g = decidePnpmVersionGuard(v("10.27.0", 10), v("10.27.0", 10));
+		assert.deepStrictEqual(g, {ok: true, resolved: v("10.27.0", 10)});
+	});
+
+	it("matching major with a differing patch/minor still passes (major is the guard axis)", () => {
+		const g = decidePnpmVersionGuard(v("10.27.0", 10), v("10.28.1", 10));
+		assert.isTrue(g.ok);
+	});
+
+	it("wrong major → fail-closed major-mismatch (the 8.x-vs-10.x #3498 case)", () => {
+		const g = decidePnpmVersionGuard(v("10.27.0", 10), v("8.15.6", 8));
+		assert.deepStrictEqual(g, {
+			ok: false,
+			reason: "major-mismatch",
+			required: v("10.27.0", 10),
+			resolved: v("8.15.6", 8),
+		});
+	});
+
+	it("unparseable pin → fail-closed unresolved-required", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(null, v("10.27.0", 10)), {
+			ok: false,
+			reason: "unresolved-required",
+		});
+	});
+
+	it("unresolved pnpm (corepack absent/errored) → fail-closed unresolved-pnpm, NEVER a bare-PATH fallback", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(v("10.27.0", 10), null), {
+			ok: false,
+			reason: "unresolved-pnpm",
+		});
+	});
+
+	it("both null → unresolved-required (required is checked first)", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(null, null), {
+			ok: false,
+			reason: "unresolved-required",
+		});
+	});
+});


### PR DESCRIPTION
Closes #3498

## The defect
A re-booted crew silently ran STALE `node_modules` after a merged pnpm-patch change. `main-sync`'s `git merge --ff-only` advanced the source patch FILE / `pnpm-lock.yaml` but never re-installed, so the installed `node_modules/.pnpm/…/patched` copy the runtime executes stayed pre-merge — a merged fix read as "still broken", and the failure was SILENT. Compounded by a bare-PATH pnpm of the wrong major (8.x vs the repo-pinned `10.27.0`) silently leaving a stale patched dir.

## The fix (EM directive: candidates 2 + 3, folded into `main-sync`)
After a fast-forward (both the default drain-sync path and `--post-merge`) that pulls a change under `patches/**` or `pnpm-lock.yaml`, `main-sync` now re-installs the deps before boot can proceed — using the **repo-pinned pnpm resolved via corepack** against the `packageManager` pin (`pnpm@10.27.0`), **never a bare-PATH pnpm** — or **FAILS LOUD** (exit 1).

Candidate 3's pnpm-version guard is folded into that install path: an unparseable `packageManager` pin, an unresolved corepack pnpm (corepack absent/errored), or a resolved-major mismatch all **fail closed** rather than install under a wrong toolchain and silently leave a stale patched dir.

## Fix surface
- `packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts` — IO-free pure core: the path→dep-input classification (`patches/**` + `pnpm-lock.yaml`) and the pnpm-version guard decision (`decidePnpmVersionGuard`).
- `packages/pipeline-cli/src/tools/main-sync/dep-refresh.unit.test.ts` — unit tests for the core (path forcing, pin/version parsing, guard totality incl. the 8.x-vs-10.x mismatch and the fail-closed branches).
- `packages/pipeline-cli/src/tools/main-sync/command.ts` — the git/corepack boundary: capture `preSha` before the ff, `diff preSha..HEAD` after it, and on a dep-input change resolve+guard pnpm and run `corepack pnpm@<pin> install --frozen-lockfile`. Wired into both the drain-sync and `--post-merge` paths; dry-run mentions the step.

## Acceptance criteria
- [x] After a PR changing `patches/**` or `pnpm-lock.yaml` merges, the re-boot ff triggers a frozen re-install with the pinned pnpm — the installed `…/patched` matches post-merge, not pre-merge.
- [x] The re-boot path can no longer SILENTLY leave a stale runtime: on a patches/lockfile change it re-installs with the pinned pnpm, or FAILS LOUD.
- [x] A wrong-major pnpm fails closed (`major-mismatch`) — never a silent stale patched dir.
- [x] Any install uses the repo-pinned pnpm via corepack against the `packageManager` pin, never bare-PATH.

## §CP
`packages/pipeline-cli/` matches the control-plane-paths matcher, so this is **§CP**. Routes to @kamp-us/control-plane for HUMAN merge — not auto-ship.

## Validation
`pipeline-cli` unit suite green for the touched core (`main-sync/` = 38 tests, incl. the new `dep-refresh` cases); biome + tsgo clean on the changed files. (The one unrelated failure in the local sandbox is `worktree-guard/command.hook.test.ts`, a hook-subprocess test sensitive to the sandbox's pnpm/corepack gap — outside this diff's scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)