### PR TITLE
fix(leak-guard): narrow ~/.claude detector by shape to exempt public config files (#3475) [§CP]

### DIFF
--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
@@ -17,7 +17,10 @@
  * `~/Documents` — PASSES, because it leaks no identity of this machine. Plus the
  * `/tmp` scratch carve-out and the path-hygiene self-exempt files. That precise
  * allowlist is the load-bearing false-positive safety, encoded in
- * `leak-guard.unit.test.ts`.
+ * `leak-guard.unit.test.ts`. The `~/.claude` arm is further NARROWED BY SHAPE (#3475)
+ * to exempt the two public, machine-agnostic config *files* `~/.claude.json` and
+ * `~/.claude/settings.json` while still flagging `~/.claude/`-directory internals — the
+ * carve-out lives at the pattern (LEAK_PATTERNS), not in a named allow-list (#2393).
  */
 
 export interface Leak {
@@ -75,8 +78,26 @@ const LEAK_PATTERNS: ReadonlyArray<LeakPattern> = [
 		reason: "absolute macOS home path (/Users/<name>/...)",
 	},
 	{
-		pattern: /(?<![\w.])~\/\.(claude|usirin|agent)\b/g,
-		reason: "agent/tool home dir (~/.claude, ~/.usirin, ~/.agent)",
+		pattern: /(?<![\w.])~\/\.(usirin|agent)\b/g,
+		reason: "agent/tool home dir (~/.usirin, ~/.agent)",
+	},
+	{
+		// The `~/.claude` home-dir detector, NARROWED by shape (not a named allow-list; #2393
+		// and #3475): it still flags any descent into the private agent home tree
+		// (`~/.claude/projects/…`, `~/.claude/todos/…`) and bare `~/.claude`, but the two
+		// negative lookaheads carve out the claude CLI's public, machine-agnostic config *files*
+		// — `~/.claude.json` (a sibling dotfile config, `~/.claude` + a `.json` extension, NOT
+		// the directory) and `~/.claude/settings.json` (the one documented settings file). Those
+		// two are identical on every machine and reveal nothing operator-specific, and they are
+		// the literal subject of packages/pipeline-crew-mcp, so flagging them was a chronic
+		// false positive. The carve-out is SHAPE, not a membership list: the exclusion is a
+		// property of this one generic pattern (a config-file leaf on the marker), so a longer
+		// name (`~/.claude.json.bak`, `~/.claude/settings.local.json`, `~/.claude/settings.jsonc`)
+		// or any deeper path still trips it — the `(?![\w.])` tail pins each carve-out to the
+		// exact public leaf. See the threat-model note on #3475 for what this can no longer catch.
+		pattern: /(?<![\w.])~\/\.claude(?!\.json(?![\w.]))(?!\/settings\.json(?![\w.]))\b/g,
+		reason:
+			"agent/tool home dir (~/.claude internals; public config files ~/.claude.json, ~/.claude/settings.json exempt)",
 	},
 	{
 		pattern: /(?<![\w.])~\/code\//g,

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
@@ -15,8 +15,8 @@ describe("findLeaks — BLOCK matrix (a real local path in a shared artifact)", 
 		assert.isTrue(hasLeak("README.md", "the vault lives at ~/.usirin/vault"));
 	});
 
-	it("blocks ~/.claude in a .md", () => {
-		assert.isTrue(hasLeak("guide.md", "edit ~/.claude/settings.json"));
+	it("blocks a ~/.claude directory-internal path in a .md (#3475 — internals stay flagged)", () => {
+		assert.isTrue(hasLeak("guide.md", "session log at ~/.claude/projects/foo/bar.jsonl"));
 	});
 
 	it("blocks ~/code sibling-repo clone in a .md", () => {
@@ -73,6 +73,48 @@ describe("findLeaks — ALLOW matrix (legitimate content must NOT be flagged)", 
 	it("allows a clean shared artifact with no local paths", () => {
 		assert.isFalse(hasLeak("README.md", "this is ordinary prose with no paths at all"));
 	});
+});
+
+describe("~/.claude public-config-file carve-out (#3475 — narrowed by shape, both surfaces)", () => {
+	// The three provably-safe public, machine-agnostic config FILES must PASS on BOTH the doc
+	// surface (findLeaks) and the guard-4 landed-comment surface (findCommentLeaks) — they are
+	// the literal subject of packages/pipeline-crew-mcp and reveal nothing operator-specific.
+	const PUBLIC_CONFIG_FILES = [
+		"registers the server into ~/.claude.json",
+		"edit ~/.claude/settings.json to add the crew server",
+		"the project MCP config lives in .mcp.json",
+	] as const;
+	// The directory internals + operator-specific / config-file-lookalike forms must STILL trip
+	// the detector — the carve-out is pinned to the two exact public leaves by shape.
+	const STILL_FLAGGED = [
+		"session log at ~/.claude/projects/foo/bar.jsonl",
+		"todo state at ~/.claude/todos/list.json",
+		"the ~/.claude directory holds machine state",
+		"local override at ~/.claude/settings.local.json",
+		"backup at ~/.claude.json.bak",
+		"vault at ~/.usirin/vault",
+		"agent home ~/.agent/state",
+		"a real machine path /Users/someone/code/x",
+	] as const;
+
+	for (const text of PUBLIC_CONFIG_FILES) {
+		it(`allows "${text}" on the doc surface`, () => assert.isFalse(hasLeak("guide.md", text)));
+		it(`allows "${text}" on the comment surface (guard-4)`, () =>
+			assert.isFalse(hasCommentLeak(text)));
+	}
+	// The end-to-end guard-4 case from #3475: one crew-mcp comment naming all three at once passes.
+	it("allows a crew-mcp comment naming all three config files at once (guard-4, #3475 e2e)", () =>
+		assert.isFalse(
+			hasCommentLeak(
+				"pipeline-crew-mcp registers servers into ~/.claude.json, ~/.claude/settings.json, and the project .mcp.json",
+			),
+		));
+
+	for (const text of STILL_FLAGGED) {
+		it(`still flags "${text}" on the doc surface`, () => assert.isTrue(hasLeak("guide.md", text)));
+		it(`still flags "${text}" on the comment surface (guard-4)`, () =>
+			assert.isTrue(hasCommentLeak(text)));
+	}
 });
 
 describe("findCommentLeaks — PR/issue comment body scan (#2796, stricter than the file surface)", () => {

--- a/packages/pipeline-cli/src/tools/redact-leaks/redact-leaks.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/redact-leaks/redact-leaks.unit.test.ts
@@ -33,9 +33,11 @@ describe("redactLeaks — REDACT matched leaks, preserving evidential shape (#30
 		assert.isTrue(isClean(out));
 	});
 
-	it("redacts an agent/tool home dir (~/.claude) down to ~, dropping the tool name", () => {
-		const out = redactLeaks("edit ~/.claude/settings.json please");
-		assert.strictEqual(out, "edit ~/<redacted>/settings.json please");
+	it("redacts a ~/.claude private-home internal down to ~, dropping the tool name", () => {
+		// A descent into the private agent-home tree is still a leak — only the two public
+		// config leaves were exempted by shape (#3475); ~/.claude/projects/... is not one.
+		const out = redactLeaks("edit ~/.claude/projects/foo/session.json please");
+		assert.strictEqual(out, "edit ~/<redacted>/projects/foo/session.json please");
 		assert.isTrue(isClean(out));
 	});
 
@@ -61,6 +63,20 @@ describe("redactLeaks — no regression for leak-free text (#3021 AC5)", () => {
 
 	it("preserves an empty string", () => {
 		assert.strictEqual(redactLeaks(""), "");
+	});
+
+	it("leaves the now-exempt public, machine-agnostic config leaves unredacted (#3475)", () => {
+		// The detector (leak-guard.ts) narrowed the ~/.claude arm by shape to exempt these
+		// public config files — they are no longer leaks, so the redactor, sharing the one
+		// findCommentLeaks source, must return them byte-for-byte (the private-home internals
+		// case above still redacts). Keeps redactor and detector contracts aligned.
+		for (const safe of [
+			"edit ~/.claude.json please",
+			"edit ~/.claude/settings.json please",
+			"see .mcp.json for the server list",
+		]) {
+			assert.strictEqual(redactLeaks(safe), safe);
+		}
 	});
 
 	it("leaves a leak-free multi-line body with code fences byte-for-byte", () => {


### PR DESCRIPTION
Fixes #3475

## ⚠️ §CP — control-plane guard change · human merge by @kamp-us/control-plane

This PR touches `packages/pipeline-cli/` (matches `CONTROL_PLANE_RE`), so it is **§CP**. It is **not** an autonomous product PR and must **not** enter the mechanical drain. It routes to **human control-plane approval by @kamp-us/control-plane** (the team, not an individual). It narrows a security guard, so per standing practice (#1961) it needs **adversarial review against the threat-model below** — a code-gate never vets the *security premise* of a guard change. **Do not auto-merge.**

## What changed

Guard-4 — `pipeline-cli leak-guard scan-pr`, the landed-comment scan (`packages/pipeline-cli/src/tools/leak-guard/scan-pr.ts`, detector in `leak-guard.ts`) — fail-closed **blocked** every crew-mcp PR/comment/ADR that named the claude CLI's public config files `~/.claude.json` and `~/.claude/settings.json`, because they tripped the `~/.claude` "agent/tool home dir" arm. Those two files are the literal subject of `packages/pipeline-crew-mcp/`, so the guard chronically blocked that whole line of work and forced a manual `redact-leaks` dance to merge provably-clean work (it blocked PR #3460, the S1 crew-channel fix for #3444).

The fix **narrows the `~/.claude` detector by shape**, in the single generic `LEAK_PATTERNS` regex:

- Split the `~/.claude` arm off from `~/.usirin` / `~/.agent` (those are unchanged — always flag).
- The `~/.claude` arm gains two negative lookaheads that carve out **only** the two public config-file leaves:
  `~\/\.claude(?!\.json(?![\w.]))(?!\/settings\.json(?![\w.]))\b`
  - `~/.claude.json` — the marker directly extended by a `.json` extension (a sibling dotfile config, **not** the `~/.claude` directory at all).
  - `~/.claude/settings.json` — the one documented public settings file.
- The `(?![\w.])` tail pins each carve-out to the **exact** public leaf, so a longer name or deeper path still trips: `~/.claude.json.bak`, `~/.claude/settings.local.json`, `~/.claude/settings.jsonc`, and every `~/.claude/<internal>` directory descent stay flagged.
- `.mcp.json` was never matched by any pattern (it has no `~/.` prefix); it stays clean — regression-covered.

This is a **narrowed generic pattern, not a named allow-list** (#2393): the exclusion is a property of the one detector regex describing the *config-file shape*, not a lookup table of literal full-path strings, and the home-dir detector is **not** removed.

## Threat-model note (mandatory input to the §CP adversarial review)

**What the narrowing can no longer catch.** After this change, the `~/.claude` detector will **no longer flag** exactly two string shapes:
1. `~/.claude` immediately followed by `.json` at a leaf boundary → `~/.claude.json`.
2. `~/.claude/settings.json` at a leaf boundary.

Nothing else is widened. Concretely, an author could now write `~/.claude.json` or `~/.claude/settings.json` into a shared artifact and the guard stays silent.

**Why the excluded subset is provably safe.** Both are the claude CLI's **canonical, documented, machine-agnostic config *files***: their paths and names are `$HOME`-relative and **identical on every machine**, and they encode no operator-specific token — no real `/Users/<login>/…`, no login, no vault or sibling-clone path, no machine-local temp root. `~/.claude.json` is moreover a *sibling file* of the `~/.claude` directory, a different filesystem entity than the private directory tree. They carry no PII and reveal nothing beyond "this machine runs the claude CLI," which is true of every machine in the org. They are also the literal domain subject of `packages/pipeline-crew-mcp/` (whose job is registering crew MCP servers into exactly these files), so naming them is unavoidable in that line of work.

**What is still caught (the detector's true target is intact).** Every operator-specific / machine-local shape still fails closed:
- `~/.claude/<internal>` directory descents (e.g. `projects/`, `todos/`, `history` — these encode the operator's filesystem layout and private session data).
- bare `~/.claude` used as a directory (conservatively kept flagged — it is not one of the two exempt files).
- config-file lookalikes that are not the exact public leaf: `~/.claude.json.bak`, `~/.claude/settings.local.json` (the gitignored machine-local override), `~/.claude/settings.jsonc`.
- `~/.usirin`, `~/.agent` (untouched arm).
- a real absolute `/Users/<login>/…` home path, `/vault/…`, `~/code/…` sibling-clone paths, and all the `/var/folders`, `/private/tmp`, `/tmp` comment-body temp patterns (untouched).

**Residual risk assessment.** The only new blind spot is the two exact public filenames. There is no shape by which an operator-specific path can be smuggled *through* the carve-out: any extra path segment or filename suffix re-arms the detector (the `(?![\w.])` tail), and `~/.usirin` / `~/.agent` / `/Users` / `/vault` / temp roots are entirely outside the narrowed arm. The narrowing is confined to `leak-guard.ts`'s `LEAK_PATTERNS`, which has **three** consumers: `findLeaks` (doc surfaces), `findCommentLeaks` (= guard-4), and — the third, easy-to-miss one — `packages/pipeline-cli/src/tools/redact-leaks/redact-leaks.ts`, which imports `findCommentLeaks` as its single detection source. Narrowing the shared pattern therefore also changed the **redactor's** behavior: `redactLeaks` no longer masks the two now-exempt public leaves (they are no longer detected as leaks). This is **intentional and correct** — the redactor's contract is deliberately kept aligned with the detector's new contract (redact exactly what is still a leak, leave the safe public config leaves byte-for-byte), and `redact-leaks.unit.test.ts` was updated to assert this: its `~/.claude` case retargets to a private-home internal (still redacted) and a new case asserts `~/.claude.json` / `~/.claude/settings.json` / `.mcp.json` pass through unredacted. The detector is **not** re-broadened to accommodate the redactor. `crew-leak.ts` — the separate "zero real operator data" detector for shipped `claude-plugins/pipeline-crew/` files — is a different contract and is **deliberately left unchanged**; this PR does not weaken it.

## Verification

- Real guard exercised both ways via `node src/bin.ts leak-guard scan-comment`: the three public config paths (and a combined crew-mcp comment naming all three) now exit 0 (pass); `~/.claude/projects/…`, `~/.claude/todos/…`, bare `~/.claude`, `~/.claude/settings.local.json`, `~/.claude.json.bak`, `~/.usirin`, `~/.agent`, `/Users/<login>/…` all still exit 2 (blocked).
- Bidirectional regression tests added in `leak-guard.unit.test.ts` covering **both** surfaces (`findLeaks` doc + `findCommentLeaks` guard-4); the pre-existing "blocks ~/.claude" test was flipped to a directory-internal so the block direction stays asserted.
- Third-consumer alignment: `redact-leaks.unit.test.ts` updated so the redactor no longer redacts the now-safe public leaves (`~/.claude.json`, `~/.claude/settings.json`, `.mcp.json`) while still redacting `~/.claude/`-internals and every real leak — detector and redactor contracts stay aligned. Full `packages/pipeline-cli` suite green (`pnpm vitest run`: 1392 tests, 99 files), fixing the earlier red on `redact-leaks` + `ci-required`.
- `tsgo -p tsconfig.json` (== `pnpm typecheck` for the package) clean; `biome check` clean; full leak-guard vitest suite green (92 tests, 6 files); pre-commit hooks (biome, leak-guard, primary-index) green.

## Acceptance criteria

- [x] Guard-4 scan no longer flags `~/.claude.json`, `~/.claude/settings.json`, `.mcp.json`.
- [x] Still flags `~/.claude/`-internals and operator-specific / machine-local paths.
- [x] Narrowed generic pattern by shape — not a named allow-list, home-dir detector retained (#2393).
- [x] Bidirectional regression tests (public paths pass; machine-local + `~/.claude/<internal>` trip).
- [x] Written threat-model note (above).
- [x] End-to-end: a crew-mcp-style comment naming the three config paths passes the real guard without the redact dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)