### PR TITLE
fix(pipeline-cli): main-sync re-installs on a pulled dep-patch change or fails loud (#3498)

### DIFF
--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -17,6 +17,11 @@
  *      consistent with the #1494 incidents, which were always clean.
  *   2. The sync merge is `git merge --ff-only origin/main` — fast-forward only, so it
  *      never creates a merge commit and fails loudly rather than diverging the primary.
+ *   3. After a successful ff (either policy), if it pulled a dep input (`patches/**` or
+ *      `pnpm-lock.yaml`) the installed node_modules is stale, so re-install with the
+ *      REPO-PINNED pnpm before boot — or FAIL LOUD. See `runDepRefreshAfterFastForward` /
+ *      `dep-refresh.ts` (#3498); this closes the silent stale-runtime trap that inverts a
+ *      live re-test (a merged dep-patch fix reads as "still broken").
  *
  * TWO policies, one runnable surface:
  *   - default (drain-sync, #1494/#1573): AGGRESSIVE — reattaches a detached/off-`main`
@@ -37,9 +42,18 @@
  * provides.
  */
 import {execFileSync} from "node:child_process";
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
 import {isControlPlaneDeletion, parseNameStatus} from "@kampus/primary-index-tripwire";
 import {Console, Effect} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
+import {
+	decidePnpmVersionGuard,
+	depPathsForcingRefresh,
+	type PnpmVersion,
+	parsePackageManagerPnpm,
+	parsePnpmVersionOutput,
+} from "./dep-refresh.ts";
 import {decideMainRefresh, decideMainSync, type HeadState, MAIN_BRANCH} from "./main-sync.ts";
 
 interface GitResult {
@@ -48,10 +62,18 @@ interface GitResult {
 	readonly stderr: string;
 }
 
-const runGit = (args: ReadonlyArray<string>): GitResult => {
-	// biome-ignore lint/plugin: best-effort git shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
+const runGit = (args: ReadonlyArray<string>): GitResult => runTool("git", args);
+
+/**
+ * Best-effort external command — a non-zero exit AND a missing binary (ENOENT) both fold into
+ * a `{ok:false}` the caller branches on, never a thrown error. This is what lets a probe like
+ * `runTool("corepack", …).ok` double as an existence check (corepack is absent on a Volta box,
+ * #3498) without a separate `command -v`. A total helper, not Effect-cosplay.
+ */
+const runTool = (bin: string, args: ReadonlyArray<string>, cwd?: string): GitResult => {
+	// biome-ignore lint/plugin: total shell — exit code + ENOENT are absorbed into the GitResult, never the E channel.
 	try {
-		const stdout = execFileSync("git", [...args], {encoding: "utf8"});
+		const stdout = execFileSync(bin, [...args], cwd ? {encoding: "utf8", cwd} : {encoding: "utf8"});
 		return {ok: true, stdout, stderr: ""};
 	} catch (cause) {
 		const e = cause as {stdout?: Buffer | string; stderr?: Buffer | string};
@@ -104,6 +126,133 @@ const stagedControlPlaneDeletionCount = (): number => {
 	if (!r.ok) return 0;
 	return parseNameStatus(r.stdout).filter((e) => isControlPlaneDeletion(e.path)).length;
 };
+
+/** The repo-pinned pnpm major (from `packageManager`) used only to pin corepack; the guard still verifies it. */
+const PNPM_PIN_FALLBACK = "10.27.0";
+
+/**
+ * The resolved pnpm the install will run under: the argv to invoke it + the version we probed
+ * (or `null` when nothing resolved). Prefer corepack (it honors `packageManager`), then a
+ * bare-PATH pnpm — whose version the guard then rejects if it's the wrong major (#3498).
+ */
+interface ResolvedPnpm {
+	readonly bin: string;
+	readonly installArgv: ReadonlyArray<string>;
+	readonly resolved: PnpmVersion | null;
+	readonly pin: string;
+}
+
+const resolvePinnedPnpm = (required: PnpmVersion | null): ResolvedPnpm => {
+	const pin = required?.version ?? PNPM_PIN_FALLBACK;
+	// Prefer corepack — it downloads/runs the exact packageManager-pinned pnpm regardless of the
+	// stale per-machine pnpm on PATH (the bare pnpm@8 the lockfile rejects, #1256/ADR 0109).
+	if (runTool("corepack", ["--version"]).ok) {
+		runTool("corepack", ["prepare", `pnpm@${pin}`, "--activate"]); // best-effort activate; ignore result
+		const v = runTool("corepack", [`pnpm@${pin}`, "--version"]);
+		return {
+			bin: "corepack",
+			installArgv: [`pnpm@${pin}`, "install", "--frozen-lockfile"],
+			resolved: v.ok ? parsePnpmVersionOutput(v.stdout) : null,
+			pin,
+		};
+	}
+	if (runTool("pnpm", ["--version"]).ok) {
+		const v = runTool("pnpm", ["--version"]);
+		return {
+			bin: "pnpm",
+			installArgv: ["install", "--frozen-lockfile"],
+			resolved: v.ok ? parsePnpmVersionOutput(v.stdout) : null,
+			pin,
+		};
+	}
+	// Nothing on PATH — resolved stays null so the guard fail-closes (never a bare-PATH guess).
+	return {
+		bin: "corepack",
+		installArgv: [`pnpm@${pin}`, "install", "--frozen-lockfile"],
+		resolved: null,
+		pin,
+	};
+};
+
+/**
+ * After a successful `merge --ff-only`, re-install `node_modules` when the ff pulled a dep
+ * input — the #3498 fix. A ff that advances `patches/**` or `pnpm-lock.yaml` moves the SOURCE
+ * patch/lockfile but never the installed `.pnpm/…/patched` copy the runtime executes, so a
+ * re-booted crew silently runs the PRE-merge patched dep (a merged fix reads as "still broken").
+ *
+ * Fail-CLOSED, unlike the fail-open `bootstrap-deps` provisioning hook (ADR 0109): if the ff
+ * pulled a dep input but the pinned pnpm can't be resolved at the right major, this REFUSES
+ * (exit 1) rather than leave the runtime silently stale or install under a wrong-major pnpm.
+ * Only reached under `--execute` (the merge itself only runs there).
+ */
+const runDepRefreshAfterFastForward = Effect.fn(function* (oldHead: string) {
+	const diff = runGit(["diff", "--name-only", oldHead, "HEAD"]);
+	if (!diff.ok) {
+		yield* Console.error(
+			`main-sync REFUSED (fail-closed): could not diff ${oldHead}..HEAD to check what the fast-forward pulled — ${diff.stderr.trim() || "git diff failed"}. Refusing to leave a possibly-stale runtime unverified after a merge (#3498).`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+	const pulled = diff.stdout
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l !== "");
+	const forcing = depPathsForcingRefresh(pulled);
+	if (forcing.length === 0) return; // no dep input pulled — the installed node_modules stays valid
+
+	yield* Console.log(
+		`main-sync: fast-forward pulled dep input(s) [${forcing.join(", ")}] — the installed node_modules is now stale (source patch/lockfile advanced, but the .pnpm/…/patched copy the runtime executes did not). Re-installing with the repo-pinned pnpm before the runtime is used (#3498).`,
+	);
+
+	const root = runGit(["rev-parse", "--show-toplevel"]);
+	if (!root.ok) {
+		yield* Console.error(
+			`main-sync REFUSED (fail-closed): a fast-forward pulled dep input(s) [${forcing.join(", ")}] but the repo root could not be resolved (\`git rev-parse --show-toplevel\` failed) — cannot re-install. Resolve by hand before boot (#3498).`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+	const rootDir = root.stdout.trim();
+
+	let required: PnpmVersion | null = null;
+	// biome-ignore lint/plugin: total pre-runtime read — an unreadable/unparseable package.json folds to a null required version (guard fail-closes, #3498), never the E channel; same class as runTool above.
+	try {
+		const pkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as {
+			packageManager?: string;
+		};
+		required = parsePackageManagerPnpm(pkg.packageManager);
+	} catch {
+		required = null;
+	}
+
+	const {bin, installArgv, resolved, pin} = resolvePinnedPnpm(required);
+	const guard = decidePnpmVersionGuard(required, resolved);
+	if (!guard.ok) {
+		const detail =
+			guard.reason === "unresolved-required"
+				? "the root package.json `packageManager` pin could not be parsed, so the required pnpm version is unknown"
+				: guard.reason === "unresolved-pnpm"
+					? "no corepack/pnpm resolved on PATH to run the pinned install (never fall back to a bare-PATH pnpm of unknown major)"
+					: `the resolved pnpm ${guard.resolved.version} is the wrong major (need ${guard.required.major}.x — a pnpm@${guard.resolved.major} install silently leaves a stale patched dir)`;
+		yield* Console.error(
+			`main-sync REFUSED (fail-closed): a fast-forward pulled dep input(s) [${forcing.join(", ")}] so node_modules MUST be re-installed, but ${detail}. Refusing to (re-)boot on a silently-stale runtime (#3498). Provision with \`corepack pnpm@${pin} install --frozen-lockfile\` (repo-pinned pnpm; never bare-PATH), then re-run.`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+
+	yield* Console.log(
+		`main-sync: re-installing deps with pnpm ${guard.resolved.version} (repo-pinned major ${guard.resolved.major}) — \`${bin} ${installArgv.join(" ")}\``,
+	);
+	const installed = runTool(bin, installArgv, rootDir);
+	if (!installed.ok) {
+		yield* Console.error(
+			`main-sync REFUSED (fail-closed): dep re-install \`${bin} ${installArgv.join(" ")}\` failed — ${installed.stderr.trim() || "pnpm install exited non-zero"}. The runtime may be stale; resolve by hand before boot (#3498).`,
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}
+	yield* Console.log(
+		"main-sync: deps re-installed — the merged patched dep is now materialized in node_modules/.pnpm (#3498).",
+	);
+});
 
 /**
  * The gentle post-merge refresh (#2056) — the HEAD-preserving counterpart to the drain-sync
@@ -158,6 +307,9 @@ const runPostMergeRefresh = Effect.fn(function* (head: HeadState, execute: boole
 		return yield* Effect.sync(() => process.exit(1));
 	}
 
+	// The pre-merge tip: diff it against HEAD after the ff to see what the ff pulled (#3498).
+	const oldHead = runGit(["rev-parse", "HEAD"]).stdout.trim();
+
 	// --ff-only is the invariant that makes the refresh safe: it advances main to origin/main
 	// when it's a strict fast-forward and ABORTS on any divergence — never a merge commit,
 	// never a force. On a clean 'main' the worst case is a no-op, never a clobber (#2056).
@@ -171,6 +323,7 @@ const runPostMergeRefresh = Effect.fn(function* (head: HeadState, execute: boole
 	yield* Console.log(
 		`main-sync --post-merge: primary checkout fast-forwarded to origin/${MAIN_BRANCH}.`,
 	);
+	yield* runDepRefreshAfterFastForward(oldHead);
 });
 
 const executeFlag = Flag.boolean("execute").pipe(
@@ -257,6 +410,11 @@ const mainSync = Command.make(
 			return yield* Effect.sync(() => process.exit(1));
 		}
 
+		// The pre-merge tip: diff it against HEAD after the ff to see what the ff pulled (#3498).
+		// This is the crew re-boot/stand-up path (main-sync ff, then boot), so a pulled dep-patch
+		// change must re-install before the runtime is used, or the boot runs a stale node_modules.
+		const oldHead = runGit(["rev-parse", "HEAD"]).stdout.trim();
+
 		const merged = runGit(["merge", "--ff-only", `origin/${MAIN_BRANCH}`]);
 		if (!merged.ok) {
 			yield* Console.error(
@@ -265,6 +423,7 @@ const mainSync = Command.make(
 			return yield* Effect.sync(() => process.exit(1));
 		}
 		yield* Console.log(`main-sync: primary checkout synced to origin/${MAIN_BRANCH}.`);
+		yield* runDepRefreshAfterFastForward(oldHead);
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts
@@ -1,0 +1,105 @@
+/**
+ * `main-sync` dep-refresh pure core — decide, from the paths a fast-forward pulled,
+ * whether the installed `node_modules` is now stale and must be re-installed, and guard
+ * the pnpm version that install runs under. IO-free and total; the corepack/pnpm/git
+ * boundary (diff / --version / install) lives in `command.ts`. See #3498.
+ *
+ * The forcing hazard: a ff that advances `patches/**` or `pnpm-lock.yaml` moves the
+ * SOURCE patch/lockfile but never the installed `.pnpm/…/patched` copy the runtime
+ * executes — so a re-booted crew silently runs the PRE-merge patched dep (a merged fix
+ * reads as "still broken"). The fix re-installs with the REPO-PINNED pnpm on any such ff,
+ * or FAILS LOUD — never a bare-PATH pnpm (whose wrong major silently leaves a stale dir).
+ *
+ * Policy contrast with the `bootstrap-deps` post-checkout hook (ADR 0109): that hook is
+ * fail-OPEN (a clean SKIP when it can't resolve the pinned pnpm) because it is best-effort
+ * provisioning that re-provisions later. This core is fail-CLOSED: a forced refresh that
+ * can't run under the pinned pnpm must surface LOUD, never leave the runtime silently stale.
+ */
+
+/** A semver-ish pnpm version reduced to what the guard needs: the full string + its major. */
+export interface PnpmVersion {
+	readonly version: string;
+	readonly major: number;
+}
+
+/**
+ * A changed path forces a dep re-install iff it is the lockfile or lives under `patches/`.
+ * Both are inputs the installed `node_modules` is derived from, so a ff that moves either
+ * leaves the install stale until a re-install (#3498).
+ */
+export const pathForcesDepRefresh = (path: string): boolean =>
+	path === "pnpm-lock.yaml" || path.startsWith("patches/");
+
+/** The subset of `paths` that forces a dep refresh — the reportable "why" behind the decision. */
+export const depPathsForcingRefresh = (paths: ReadonlyArray<string>): ReadonlyArray<string> =>
+	paths.filter(pathForcesDepRefresh);
+
+/** True iff any pulled path forces a dep refresh. */
+export const changedPathsForceDepRefresh = (paths: ReadonlyArray<string>): boolean =>
+	paths.some(pathForcesDepRefresh);
+
+// A version tail may carry a corepack integrity hash (`10.27.0+sha512.…`) or a prerelease
+// (`10.27.0-rc.1`); the major/minor/patch triple is all the guard reads, so absorb the tail.
+const SEMVER_HEAD = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+/**
+ * Parse the root `packageManager` pin (`pnpm@10.27.0`) to the required pnpm version. Returns
+ * `null` when the field is absent, names a different package manager, or is malformed — the
+ * guard treats a `null` required version as unresolved (fail-closed), never a pass.
+ */
+export const parsePackageManagerPnpm = (packageManager: string | undefined): PnpmVersion | null => {
+	if (!packageManager) return null;
+	const m = packageManager.trim().match(/^pnpm@(\d+\.\d+\.\d+(?:[-+].*)?)$/);
+	if (!m) return null;
+	return parsePnpmVersionOutput(m[1] ?? "");
+};
+
+/**
+ * Parse `pnpm --version` stdout (a bare semver line) to a `PnpmVersion`. Returns `null` on
+ * empty/non-semver output — i.e. corepack/pnpm didn't resolve — which the guard fail-closes.
+ */
+export const parsePnpmVersionOutput = (output: string): PnpmVersion | null => {
+	const first = output.trim().split(/\s+/)[0] ?? "";
+	const m = first.match(SEMVER_HEAD);
+	if (!m) return null;
+	return {version: `${m[1]}.${m[2]}.${m[3]}`, major: Number(m[1])};
+};
+
+/**
+ * The pnpm-version guard outcome (candidate 3 of #3498, folded into the install path). Only
+ * `ok` authorizes the install; every other case is a fail-closed refusal with the reason a
+ * LOUD message reports — a crew-affecting install NEVER proceeds under an unknown/wrong major.
+ */
+export type PnpmGuardResult =
+	// The pinned pnpm resolved and its major matches the repo requirement — install may run.
+	| {readonly ok: true; readonly resolved: PnpmVersion}
+	// The `packageManager` pin was absent/unparseable — the required version is unknown.
+	| {readonly ok: false; readonly reason: "unresolved-required"}
+	// The pnpm probe didn't resolve (no corepack/pnpm on PATH) — never fall back to a
+	// bare-PATH pnpm of unknown major, the wrong-major hazard this whole fix exists to close.
+	| {readonly ok: false; readonly reason: "unresolved-pnpm"}
+	// Resolved pnpm's major differs from the repo requirement — a `pnpm@8` install silently
+	// leaves a stale patched dir (#3498), so fail closed instead of installing under it.
+	| {
+			readonly ok: false;
+			readonly reason: "major-mismatch";
+			readonly required: PnpmVersion;
+			readonly resolved: PnpmVersion;
+	  };
+
+/**
+ * Decide the pnpm-version guard. Total over the two nullable inputs (required = the parsed
+ * `packageManager` pin, resolved = the parsed `pnpm --version`): a `null` on either side is a
+ * fail-closed refusal, and only an equal-major pair authorizes the install.
+ */
+export const decidePnpmVersionGuard = (
+	required: PnpmVersion | null,
+	resolved: PnpmVersion | null,
+): PnpmGuardResult => {
+	if (required === null) return {ok: false, reason: "unresolved-required"};
+	if (resolved === null) return {ok: false, reason: "unresolved-pnpm"};
+	if (resolved.major !== required.major) {
+		return {ok: false, reason: "major-mismatch", required, resolved};
+	}
+	return {ok: true, resolved};
+};

--- a/packages/pipeline-cli/src/tools/main-sync/dep-refresh.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/dep-refresh.unit.test.ts
@@ -1,0 +1,163 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	changedPathsForceDepRefresh,
+	decidePnpmVersionGuard,
+	depPathsForcingRefresh,
+	type PnpmVersion,
+	parsePackageManagerPnpm,
+	parsePnpmVersionOutput,
+	pathForcesDepRefresh,
+} from "./dep-refresh.ts";
+
+describe("pathForcesDepRefresh — which pulled paths make node_modules stale", () => {
+	it("the lockfile forces a refresh", () => {
+		assert.strictEqual(pathForcesDepRefresh("pnpm-lock.yaml"), true);
+	});
+
+	it("any path under patches/ forces a refresh", () => {
+		assert.strictEqual(pathForcesDepRefresh("patches/effect@3.11.0.patch"), true);
+		assert.strictEqual(pathForcesDepRefresh("patches/@scope__pkg@1.0.0.patch"), true);
+	});
+
+	it("an unrelated source/doc path does NOT force a refresh", () => {
+		assert.strictEqual(pathForcesDepRefresh("apps/web/src/App.tsx"), false);
+		assert.strictEqual(pathForcesDepRefresh("README.md"), false);
+		assert.strictEqual(pathForcesDepRefresh("package.json"), false);
+	});
+
+	it("a nested lockfile is NOT the root lockfile — exact match only", () => {
+		// Only the root `pnpm-lock.yaml` drives the install; a same-named file elsewhere is not it.
+		assert.strictEqual(pathForcesDepRefresh("apps/web/pnpm-lock.yaml"), false);
+	});
+
+	it("a path merely containing 'patches' but not under patches/ does NOT force a refresh", () => {
+		assert.strictEqual(pathForcesDepRefresh("apps/web/src/patches.ts"), false);
+		assert.strictEqual(pathForcesDepRefresh("docs/patches/notes.md"), false);
+	});
+});
+
+describe("depPathsForcingRefresh / changedPathsForceDepRefresh — over a pulled set", () => {
+	it("returns only the dep-forcing subset (the reportable why)", () => {
+		const pulled = [
+			"apps/web/src/App.tsx",
+			"patches/effect@3.11.0.patch",
+			"README.md",
+			"pnpm-lock.yaml",
+		];
+		assert.deepStrictEqual(depPathsForcingRefresh(pulled), [
+			"patches/effect@3.11.0.patch",
+			"pnpm-lock.yaml",
+		]);
+		assert.strictEqual(changedPathsForceDepRefresh(pulled), true);
+	});
+
+	it("an empty pull (no-op ff) forces nothing", () => {
+		assert.deepStrictEqual(depPathsForcingRefresh([]), []);
+		assert.strictEqual(changedPathsForceDepRefresh([]), false);
+	});
+
+	it("a code-only pull forces nothing", () => {
+		const pulled = ["apps/web/src/App.tsx", "packages/pipeline-cli/src/x.ts"];
+		assert.deepStrictEqual(depPathsForcingRefresh(pulled), []);
+		assert.strictEqual(changedPathsForceDepRefresh(pulled), false);
+	});
+});
+
+describe("parsePackageManagerPnpm — the required version from the packageManager pin", () => {
+	it("parses `pnpm@10.27.0`", () => {
+		assert.deepStrictEqual(parsePackageManagerPnpm("pnpm@10.27.0"), {
+			version: "10.27.0",
+			major: 10,
+		});
+	});
+
+	it("absorbs a corepack integrity hash tail", () => {
+		assert.deepStrictEqual(parsePackageManagerPnpm("pnpm@10.27.0+sha512.abc123"), {
+			version: "10.27.0",
+			major: 10,
+		});
+	});
+
+	it("is null for a different package manager", () => {
+		assert.strictEqual(parsePackageManagerPnpm("yarn@4.0.0"), null);
+		assert.strictEqual(parsePackageManagerPnpm("npm@10.0.0"), null);
+	});
+
+	it("is null when absent or malformed (fail-closed: required unknown)", () => {
+		assert.strictEqual(parsePackageManagerPnpm(undefined), null);
+		assert.strictEqual(parsePackageManagerPnpm(""), null);
+		assert.strictEqual(parsePackageManagerPnpm("pnpm"), null);
+		assert.strictEqual(parsePackageManagerPnpm("pnpm@10"), null);
+	});
+});
+
+describe("parsePnpmVersionOutput — the resolved version from `pnpm --version`", () => {
+	it("parses a bare semver line", () => {
+		assert.deepStrictEqual(parsePnpmVersionOutput("10.27.0\n"), {version: "10.27.0", major: 10});
+	});
+
+	it("reads the wrong-major bare-PATH pnpm (the #3498 bug)", () => {
+		assert.deepStrictEqual(parsePnpmVersionOutput("8.15.6"), {version: "8.15.6", major: 8});
+	});
+
+	it("takes only the first whitespace-delimited token", () => {
+		assert.deepStrictEqual(parsePnpmVersionOutput("10.27.0 (extra noise)"), {
+			version: "10.27.0",
+			major: 10,
+		});
+	});
+
+	it("is null on empty / non-semver output (probe didn't resolve → fail-closed)", () => {
+		assert.strictEqual(parsePnpmVersionOutput(""), null);
+		assert.strictEqual(parsePnpmVersionOutput("command not found"), null);
+		assert.strictEqual(parsePnpmVersionOutput("\n\n"), null);
+	});
+});
+
+describe("decidePnpmVersionGuard — only an equal-major pair authorizes the install", () => {
+	const v = (version: string, major: number): PnpmVersion => ({version, major});
+
+	it("equal major → ok (install may run)", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(v("10.27.0", 10), v("10.27.0", 10)), {
+			ok: true,
+			resolved: v("10.27.0", 10),
+		});
+	});
+
+	it("equal major, different minor/patch → still ok (major is the compatibility axis)", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(v("10.27.0", 10), v("10.30.1", 10)), {
+			ok: true,
+			resolved: v("10.30.1", 10),
+		});
+	});
+
+	it("wrong major (pnpm@8 vs required 10) → fail-closed major-mismatch (the #3498 bug)", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(v("10.27.0", 10), v("8.15.6", 8)), {
+			ok: false,
+			reason: "major-mismatch",
+			required: v("10.27.0", 10),
+			resolved: v("8.15.6", 8),
+		});
+	});
+
+	it("required unresolved → fail-closed unresolved-required", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(null, v("10.27.0", 10)), {
+			ok: false,
+			reason: "unresolved-required",
+		});
+	});
+
+	it("pnpm probe unresolved (no corepack/pnpm) → fail-closed unresolved-pnpm", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(v("10.27.0", 10), null), {
+			ok: false,
+			reason: "unresolved-pnpm",
+		});
+	});
+
+	it("both unresolved → fail-closed on the required side first", () => {
+		assert.deepStrictEqual(decidePnpmVersionGuard(null, null), {
+			ok: false,
+			reason: "unresolved-required",
+		});
+	});
+});


### PR DESCRIPTION
When the crew re-boots, it runs `main-sync` (fast-forward to `origin/main`) and then boots. Before this change, that fast-forward advanced the source patch/lockfile on disk but never re-installed `node_modules`, so the crew kept running the pre-merge patched dependency — a merged fix silently read as "still broken" while CI (which installs fresh) was green. This change makes `main-sync` re-install with the repo-pinned pnpm whenever a fast-forward pulls a dependency input, or fail loudly if it can't — so a stale runtime can never pass silently again.

## What changed
- After a successful `merge --ff-only` (both the default drain-sync path and `--post-merge`), `main-sync` diffs what the fast-forward pulled. If it touched `patches/**` or `pnpm-lock.yaml`, the installed `node_modules` is stale and must be re-installed before the runtime is used.
- The re-install runs under the **repo-pinned pnpm** (`10.27.0`), resolved via **corepack** (`corepack pnpm@<pin> install --frozen-lockfile`) — **never** the bare-PATH pnpm. This mirrors the existing `bootstrap-deps` post-checkout hook (ADR 0109) but flips its fail-*open* skip to a fail-*closed* refusal, because a silently-stale crew runtime is exactly the trap this fixes.
- **pnpm-version guard folded in:** before installing, the resolved pnpm's major is checked against the `packageManager` pin. A wrong major (e.g. the bare `pnpm@8` that the observed crew ran), an unresolvable pnpm/corepack, or an unparseable pin all **fail closed** with a loud message + the manual provisioning command — never an install under the wrong toolchain (which is what silently leaves a stale patched dir).
- Pure decision core in `packages/pipeline-cli/src/tools/main-sync/dep-refresh.ts` (IO-free, unit-tested: 22 cases); the git/corepack/fs boundary in `command.ts`.

## Chosen candidate(s)
Candidates **2** (`main-sync` re-installs or fails loud on a `patches/**` / `pnpm-lock.yaml` fast-forward) **+ 3** (pnpm-version guard), folded into one install path. Candidate 1 (a crew-plugin re-boot procedure) was **not** chosen; this surface satisfies every acceptance criterion with the strongest, unit-tested enforcement.

## §CP status — needs @kamp-us/control-plane human merge
Re-verified at the actual fix surface with `pipeline-cli control-plane-paths`: all three changed files live under `packages/pipeline-cli/`, which the matcher classifies as **§CP (control-plane)**. This PR therefore does **NOT** auto-merge — it routes to the **@kamp-us/control-plane** team for human approval/merge. Nothing here touches the off-limits `claude-plugins/kampus-pipeline/` surface.

## Verification
- `pnpm typecheck` — clean (tsgo, full workspace)
- `pnpm lint:worktree` — clean
- `vitest run src/tools/main-sync/` — 42 passed (22 new dep-refresh cases + 20 existing)

Fixes #3498