### PR TITLE
feat(pipeline-crew): wire the engine self-drain loop into the EM def (#3510)

### DIFF
--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -71,6 +71,39 @@ session; the substrate resolves the target role's inbox for you:
 
 These hold on every run regardless of what the spawn prompt remembered to say.
 
+### Cold-start — boot straight into the drain, zero external nudge
+
+On boot, once the channel is reachable, do two things before you wait for anything: send
+**`AnnouncePresence`** over the channel (you are live and pulling), then run **one initial board
+sweep** — read the tracker for claimable triaged lanes and open as many as your WIP caps allow. A
+freshly-booted engine therefore begins draining under its own power; you do **not** wait to be
+pinged, relayed to, or told to start. That first sweep seeds the self-drain loop below, which carries
+you from boot to a dry board.
+
+### The self-drain loop — a background coder's completion is your next wake
+
+You are a **standing, self-sustaining loop**, not a one-shot turn: under the roster law
+([ADR 0189](../../../.decisions/0189-crew-roster-law-bridges-engines.md)) you are N-instance
+throughput, and throughput that idles after a single lane is not throughput. Because the board is
+**pull**, nothing external wakes you between lanes — so you wake **yourself**, by riding subagent
+completion:
+
+- **Dispatch every `coder` as a background task.** A backgrounded Task hands control back and the
+  harness re-invokes you when it finishes — that completion **is** your next wake (the pull-side
+  equivalent of the retired crew's push-wake).
+- **On each wake, pull the next claimed lane.** When a background coder (or any lane subagent)
+  completes, advance that lane through the lane loop below, then immediately re-sweep the board and
+  open the next claimable lane your WIP caps allow. Do not idle at the prompt. Repeat until the board
+  is dry.
+- **A dry board is the only rest state.** With no claimable lane left and no lane in flight you have
+  drained the board — only then do you stop pulling. You **never** sit idle beside a claimable board
+  item with a free slot; that idle-beside-work state is the exact gap this loop closes.
+
+The loop rides **your own** background-task completions — it introduces **no** engine→engine and
+**no** intake→engine edge, and reverses no ADR-0189 invariant: you still pull from the board and
+`Claim` against the tracker, never take work handed by a peer. It is also distinct from `Heartbeat`
+presence keepalive — a self-drain wake *drives* work, whereas `Heartbeat` only attests you are alive.
+
 ### WIP caps — bounded concurrency, lane-partitioned
 
 Run at most your configured product-lane and platform/pipeline-lane counts concurrently; classify


### PR DESCRIPTION
## What & why

The successor (channel-native) crew's **engine** sessions (ADR [0189](https://github.com/kamp-us/phoenix/blob/main/.decisions/0189-crew-roster-law-bridges-engines.md) — the N-instance throughput role) did **not self-sustain their board-pull loop**: a booted engine ran one turn (pull board → dispatch one lane) then idled at the prompt, so the board drained only at operator-nudge speed. Observed live during the milestone #28 parity run (engine B idle beside two claimable items). This wires the missing loop driver into the engine role def so a fresh boot self-drains.

Fixes #3510

## Scope — NON-§CP, Tier 1 ONLY (founder-directed)

Amends `claude-plugins/pipeline-crew/agents/crew-engineering-manager.md` **only** — the crew plugin, **NON-§CP per ADR 0187** (verified via `pipeline-cli control-plane-paths`), so this **auto-ships on green** through the normal non-§CP pipeline path.

Two behaviors added to the engine's execution contract:

1. **Cold-start** — on boot, `AnnouncePresence` + one initial board sweep, so a freshly-booted engine begins draining with zero external nudge.
2. **Self-drain loop** — dispatch every `coder` as a **background task**, treat its completion as the next **wake**, and on wake pull the next claimable lane until the board is dry (the pull-side equivalent of the retired crew's push-wake). A dry board with no in-flight lane is the only rest state; the engine never idles beside claimable work with a free slot.

**Out of scope (held for umut/EM):** Tier 2 (the intake→engine work-arrival wake edge) and Tier 3 (the cadence backstop). This edit introduces **no** engine→engine and **no** intake→engine edge and reverses no ADR-0189 invariant — the wakes are the engine's own background-task completions, and the loop remains board-pull + `Claim`-against-the-tracker. It is kept distinct from `Heartbeat` presence keepalive.

The new sections extend (do not contradict) the existing WIP-cap, claim, §CP-bank, and QUEUED≠MERGED sections and cite ADR 0189 rather than re-derive it.

## Acceptance (Tier 1)

The def, once loaded on a fresh boot, makes an engine self-drain a non-empty board to merged/banked with **zero nudges** — cold-start sweep + background-completion-driven loop until the board is dry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)