### PR TITLE
fix(deps): patch alchemy Test.make to honor config.hookTimeout, not the 120s clamp (#3168)

### DIFF
--- a/apps/web/tests/integration/alchemy-hook-timeout.unit.test.ts
+++ b/apps/web/tests/integration/alchemy-hook-timeout.unit.test.ts
@@ -1,0 +1,74 @@
+// @patch-pin: alchemy@2.0.0-beta.59
+/**
+ * Regression pin for the alchemy `Test.make` hook-timeout patch (#3168, ADR 0038).
+ *
+ * Unpatched, alchemy's `Test.make` hook registrars pass `timeoutOf(opts) ?? 120_000`
+ * as the explicit second arg to vitest's `beforeAll`/`afterAll`. `@vitest/runner`
+ * honors that arg verbatim (`beforeAll(fn, timeout = getDefaultHookTimeout())`), so an
+ * un-annotated hook is silently clamped to 120s and the project's `config.hookTimeout`
+ * never applies — the #3146 merge-queue eviction root cause. The patch drops the
+ * `?? DEFAULT_TIMEOUT` fallback so an un-annotated hook passes `undefined`, which lets
+ * the runner's default parameter resolve `config.hookTimeout` instead.
+ *
+ * The pin reads the timeout `@vitest/runner` actually resolved for a registered hook,
+ * which it stores on the hook fn under the `VITEST_CLEANUP_TIMEOUT` symbol. It
+ * self-calibrates against a plain vitest `beforeAll` (whose resolved timeout IS
+ * `config.hookTimeout`), so it holds at whatever this project's hook timeout is rather
+ * than a hard-coded number: an un-annotated `Test.make` hook must resolve to the same
+ * default a plain hook does, and specifically must NOT be the 120000 clamp — while an
+ * explicit `{timeout}` override still threads through unchanged.
+ */
+import * as Test from "alchemy/Test/Vitest";
+import {Effect, Layer} from "effect";
+import {describe, expect, it, beforeAll as vitestBeforeAll} from "vitest";
+import {getCurrentSuite, getHooks} from "vitest/suite";
+
+// `@vitest/runner` stashes each hook's resolved timeout on the registered hook fn under
+// this symbol (see `beforeAll` in @vitest/runner's chunk-artifact). Read it back to see
+// exactly what timeout the runner resolved — the observable the clamp lives in.
+const resolvedTimeoutOfLastBeforeAll = (): number | undefined => {
+	const suite = getCurrentSuite().suite;
+	if (suite === undefined) return undefined;
+	const hooks = getHooks(suite).beforeAll as ReadonlyArray<object>;
+	const last = hooks[hooks.length - 1];
+	if (last === undefined) return undefined;
+	const sym = Object.getOwnPropertySymbols(last).find(
+		(s) => s.description === "VITEST_CLEANUP_TIMEOUT",
+	);
+	const value = sym === undefined ? undefined : (last as Record<symbol, unknown>)[sym];
+	return typeof value === "number" ? value : undefined;
+};
+
+const CLAMP = 120_000;
+
+// Hooks are registered at collection time (outside any `it`), then asserted inside the
+// tests below. `Test.make({providers: Layer.empty})` needs no cloud wiring here — the
+// registrar closures are captured, not run for their effect, so this stays offline.
+describe("alchemy Test.make honors config.hookTimeout (patch pin, #3168)", () => {
+	// A plain vitest hook with no explicit timeout resolves to config.hookTimeout — the
+	// calibration baseline an un-annotated Test.make hook must match.
+	vitestBeforeAll(() => {});
+	const configDefault = resolvedTimeoutOfLastBeforeAll();
+
+	const api = Test.make({providers: Layer.empty});
+	// `beforeAll` returns an accessor Effect we register only for its side effect (the
+	// vitest hook it installs); `void` it, matching `_integration.ts`'s `void stack`.
+	const unannotatedHook = api.beforeAll(Effect.void);
+	const unannotated = resolvedTimeoutOfLastBeforeAll();
+	void unannotatedHook;
+
+	const overriddenHook = api.beforeAll(Effect.void, {timeout: 300_000});
+	const overridden = resolvedTimeoutOfLastBeforeAll();
+	void overriddenHook;
+
+	it("resolves an un-annotated hook to config.hookTimeout, not the 120s clamp", () => {
+		expect(typeof configDefault).toBe("number");
+		expect(configDefault).not.toBe(CLAMP);
+		expect(unannotated).toBe(configDefault);
+		expect(unannotated).not.toBe(CLAMP);
+	});
+
+	it("threads an explicit {timeout} override (>120s) through unchanged", () => {
+		expect(overridden).toBe(300_000);
+	});
+});

--- a/patches/alchemy@2.0.0-beta.59.patch
+++ b/patches/alchemy@2.0.0-beta.59.patch
@@ -125,3 +125,39 @@ index 5a3a52dccf3fa3cc5e21ac2190027801fc646b53..d3d9c6762a8b4a04e8ed3bd1c0b0b882
              tags: metadataTags,
              tailConsumers: undefined,
              usageModel: undefined,
+diff --git a/lib/Test/Vitest.js b/lib/Test/Vitest.js
+index a16382c..5e4bba2 100644
+--- a/lib/Test/Vitest.js
++++ b/lib/Test/Vitest.js
+@@ -69,19 +69,19 @@ export const make = (options) => {
+     test.provider = provider;
+     const beforeAll = (eff, hookOptions) => {
+         let result;
+-        vitestBeforeAll(() => runEff(eff).then((v) => (result = v)), timeoutOf(hookOptions) ?? DEFAULT_TIMEOUT);
++        vitestBeforeAll(() => runEff(eff).then((v) => (result = v)), timeoutOf(hookOptions));
+         return Effect.sync(() => result);
+     };
+     const beforeEach = (eff, hookOptions) => {
+         vitestBeforeEach(() => runEff(eff), timeoutOf(hookOptions));
+     };
+     const afterAll = ((eff, hookOptions) => {
+-        vitestAfterAll(() => runEff(eff), timeoutOf(hookOptions) ?? DEFAULT_TIMEOUT);
++        vitestAfterAll(() => runEff(eff), timeoutOf(hookOptions));
+     });
+     afterAll.skipIf = (predicate) => (eff, hookOptions) => {
+         if (predicate)
+             return;
+-        vitestAfterAll(() => runEff(eff), timeoutOf(hookOptions) ?? DEFAULT_TIMEOUT);
++        vitestAfterAll(() => runEff(eff), timeoutOf(hookOptions));
+     };
+     const afterEach = (eff, hookOptions) => {
+         vitestAfterEach(() => runEff(eff), timeoutOf(hookOptions));
+@@ -97,7 +97,7 @@ export const make = (options) => {
+     // user-registered `afterAll` (including `destroy(Stack)`); vitest runs
+     // afterAll hooks in registration order.
+     queueMicrotask(() => {
+-        vitestAfterAll(() => Effect.runPromise(closeScope), DEFAULT_TIMEOUT);
++        vitestAfterAll(() => Effect.runPromise(closeScope));
+     });
+     return {
+         test,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ patchedDependencies:
     hash: e0af930dd67d32efc5463f43c35824fc35d9b9558716831f9cec3764017cf40c
     path: patches/@nkzw__fate@1.3.1.patch
   alchemy@2.0.0-beta.59:
-    hash: f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1
+    hash: 204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc
     path: patches/alchemy@2.0.0-beta.59.patch
   effect@4.0.0-beta.92:
     hash: 86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4
@@ -276,7 +276,7 @@ importers:
         version: 0.2.0
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+        version: 2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe)
       better-auth:
         specifier: 'catalog:'
         version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
@@ -385,7 +385,7 @@ importers:
     dependencies:
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+        version: 2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
@@ -419,7 +419,7 @@ importers:
         version: 1.6.23(d638c0c4fe1d54f9d6f4939b1f8c5473)
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+        version: 2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe)
       better-auth:
         specifier: 'catalog:'
         version: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
@@ -490,7 +490,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+        version: 2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1024,7 +1024,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+        version: 2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1206,7 +1206,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+        version: 2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1363,7 +1363,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+        version: 2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -4734,7 +4734,7 @@ snapshots:
 
   '@alchemy.run/better-auth@2.0.0-beta.59(d88aca205a308eb6da45241210d87429)':
     dependencies:
-      alchemy: 2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe)
+      alchemy: 2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe)
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       effect: 4.0.0-beta.92(patch_hash=86156a90a2a601313cb88e7bbd19ae0e42065a114c44806c2e303167eb7528a4)
     transitivePeerDependencies:
@@ -6342,7 +6342,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  alchemy@2.0.0-beta.59(patch_hash=f2f5ae9651ffc7f4cef5c3ff244d46f9371a404b5b0bdb5828aedf20d91acca1)(f5887e258d9cc412fb2b9d8b16e32cfe):
+  alchemy@2.0.0-beta.59(patch_hash=204bf3117812a8a49610d2657951bba0c304d2b712f5767e02dcbd2c5536e8bc)(f5887e258d9cc412fb2b9d8b16e32cfe):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1053.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -92,7 +92,7 @@ onlyBuiltDependencies:
 # Local patches (policy: patch deps locally, don't depend on an upstream/fork
 # release — ADR 0038). Re-key each on that dep's next version bump.
 #
-# alchemy — two patches on beta.59:
+# alchemy — three patches on beta.59:
 # 1. Cloudflare/Flagship/Flag.js — `FlagshipFlag.reconcile` UPDATE path reconciles
 #    only the schema/metadata IaC owns ({variations, description}) and preserves the
 #    live serving the dashboard owns ({defaultVariation, rules, enabled}); the no-op
@@ -103,6 +103,13 @@ onlyBuiltDependencies:
 #    thread it through the provider as the script-upload metadata's `cache_options`
 #    field, sent only when set. Implements ADR 0170; beta.59 predates the native
 #    knob. Retire both hunks when a future alchemy release ships the field natively.
+# 3. Test/Vitest.js — `Test.make`'s `beforeAll`/`afterAll`/`afterAll.skipIf`/scope-close
+#    hooks drop the `?? DEFAULT_TIMEOUT` (120s) fallback, passing `undefined` when no
+#    `{timeout}` override is given so @vitest/runner resolves `config.hookTimeout`
+#    instead of the hard-coded clamp. The clamp silently shadowed `vitest.config.ts`'s
+#    `hookTimeout` and was the #3146 merge-queue eviction root cause (#3168). Regression
+#    test: apps/web/tests/integration/alchemy-hook-timeout.unit.test.ts. Retire when a
+#    future alchemy release honors the configured hook timeout natively.
 #
 # The prior beta.56 second hunk (DurableObjectNamespace.d.ts — adding
 # `DurableObjectNamespaceScope` to the `DurableObjectServices` union) was DROPPED:


### PR DESCRIPTION
alchemy's `Test.make` was quietly forcing every deploy/setup hook to a 120-second timeout, ignoring the hook timeout we configure in `vitest.config.ts`. That hidden clamp is what ejected clean product PRs from the merge queue in #3146. This PR extends our local alchemy patch so those hooks fall back to the configured `config.hookTimeout` instead of the hardcoded 120s, removing the trap for every current and future `Test.make` hook — not just the call sites #3167 worked around.

## What changed

- **`patches/alchemy@2.0.0-beta.59.patch`** — new hunk on `lib/Test/Vitest.js`. The four hook sites (`beforeAll`, `afterAll`, `afterAll.skipIf`, and the scope-close fallback) drop the `?? DEFAULT_TIMEOUT` / bare-`DEFAULT_TIMEOUT` fallback and pass `timeoutOf(hookOptions)` (i.e. `undefined` when no `{timeout}` override). `@vitest/runner` then resolves `config.hookTimeout` via its default parameter. An explicit `{timeout}` override still threads through unchanged. Local pnpm patch per ADR 0038 — not an upstream/fork source.
- **`pnpm-workspace.yaml`** — the alchemy patch-pin comment now documents the third hunk (what it changes, why, and the regression test), under the two-layer patch-pin discipline (#3051/#3053). The `patchedDependencies` entry is unchanged.
- **`apps/web/tests/integration/alchemy-hook-timeout.unit.test.ts`** — `@patch-pin`ed regression test. It reads the timeout `@vitest/runner` actually resolved for a registered hook (stored on the hook fn under the `VITEST_CLEANUP_TIMEOUT` symbol) and self-calibrates against a plain vitest `beforeAll` (whose resolved timeout is `config.hookTimeout`). An un-annotated `Test.make` hook must resolve to that same default and specifically must not be `120000`; an override of `300000` (>120s) must thread through unchanged. Verified to fail against unpatched alchemy (`120000`) and pass with the patch applied.

## Acceptance criteria

- [x] `patches/alchemy@2.0.0-beta.59.patch` gains a `lib/Test/Vitest.js` hunk so the hooks no longer pass the hardcoded `120_000` when no `{timeout}` override is given — `config.hookTimeout` is honored instead.
- [x] Registered under the two-layer patch-pin discipline: `patchedDependencies` entry stays, and a `@patch-pin` comment documents the new hunk.
- [x] A regression test proves a `Test.make` hook honors the configured `hookTimeout` (a >120s hook is not clamped to `120000`).
- [x] With the patch applied, integration deploy hooks respect `vitest.config.ts`'s `hookTimeout` without the per-call-site `{timeout}` workaround. Simplifying/removing the #3167 workaround is tracked as a follow-up, not done here.

Root cause of #3146 (p0); relates to workaround PR #3167.

Fixes #3168