### PR TITLE
fix(pipeline-crew-mcp): give each engine its boot turn — launch with an initial prompt (#3516)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -14,6 +14,7 @@ import {Effect} from "effect";
 import {
 	AGENT_FLAG,
 	ALLOWLIST_CHANNEL_FLAG,
+	BOOT_PROMPT,
 	buildSessionBind,
 	ChannelPluginNotAllowedError,
 	CREW_SESSION_BIN_PATH,
@@ -74,8 +75,8 @@ describe("standup/bind — per-session bind constructor", () => {
 				]);
 
 				// AC2: the argv boots the role persona (--plugin-dir + --agent, #3447), registers the channel,
-				// closes with the visible name (#3443), and carries NO `--mcp-config` — the crew server now
-				// registers via the persisted local scope (#3444).
+				// carries the visible name (#3443), closes with the positional boot-turn prompt (#3516), and
+				// carries NO `--mcp-config` — the crew server now registers via the persisted local scope (#3444).
 				assert.deepStrictEqual(bind.argv, [
 					PLUGIN_DIR_FLAG,
 					EXPECTED_PLUGIN_DIR,
@@ -86,6 +87,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					"plugin:kampus:sozluk",
 					NAME_FLAG,
 					ROLE,
+					BOOT_PROMPT,
 				]);
 				assert.notInclude(bind.argv, "--mcp-config");
 			}),
@@ -120,6 +122,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					...bind.agentArg,
 					...bind.channelArg,
 					...bind.nameArg,
+					...bind.bootPromptArg,
 				]);
 			}),
 	);
@@ -325,8 +328,8 @@ describe("standup/bind — per-session bind constructor", () => {
 			// The tier boots the session's model — a family tier is a verbatim --model alias (config.ts
 			// Tier, grounded on the 2.1.212 bundle), so tier:opus yields `--model opus`.
 			assert.deepStrictEqual([...bind.modelArg], [MODEL_FLAG, "opus"]);
-			// --model leads the argv; then the persona flags (#3447), the channel fragment, and the name
-			// (#3443). No --mcp-config.
+			// --model leads the argv; then the persona flags (#3447), the channel fragment, the name
+			// (#3443), and the tail boot-turn prompt (#3516). No --mcp-config.
 			assert.deepStrictEqual(
 				[...bind.argv],
 				[
@@ -336,6 +339,7 @@ describe("standup/bind — per-session bind constructor", () => {
 					...bind.agentArg,
 					...bind.channelArg,
 					...bind.nameArg,
+					...bind.bootPromptArg,
 				],
 			);
 		}),
@@ -378,11 +382,17 @@ describe("standup/bind — per-session bind constructor", () => {
 				});
 				assert.deepStrictEqual([...bind.modelArg], []);
 				assert.notInclude(bind.argv, MODEL_FLAG);
-				// No tier ⇒ no --model; argv is the persona flags (#3447) + the channel fragment closed by
-				// the name (#3443).
+				// No tier ⇒ no --model; argv is the persona flags (#3447) + the channel fragment + the name
+				// (#3443), closed by the tail boot-turn prompt (#3516).
 				assert.deepStrictEqual(
 					[...bind.argv],
-					[...bind.pluginDirArg, ...bind.agentArg, ...bind.channelArg, ...bind.nameArg],
+					[
+						...bind.pluginDirArg,
+						...bind.agentArg,
+						...bind.channelArg,
+						...bind.nameArg,
+						...bind.bootPromptArg,
+					],
 				);
 			}),
 	);
@@ -403,8 +413,13 @@ describe("standup/bind — per-session bind constructor", () => {
 					channels,
 				});
 				assert.deepStrictEqual([...bind.nameArg], [NAME_FLAG, "chief-of-staff"]);
-				// the name flag rides the tail of the argv, after the channel fragment.
-				assert.deepStrictEqual([...bind.argv].slice(-2), [NAME_FLAG, "chief-of-staff"]);
+				// the name flag rides after the channel fragment, immediately before the tail boot-turn
+				// prompt (#3516) — so it's the last-but-one pair, with BOOT_PROMPT at the very tail.
+				assert.deepStrictEqual([...bind.argv].slice(-3), [
+					NAME_FLAG,
+					"chief-of-staff",
+					BOOT_PROMPT,
+				]);
 			}),
 	);
 
@@ -436,6 +451,65 @@ describe("standup/bind — per-session bind constructor", () => {
 				// the two engine panes come up with DISTINCT visible names, never two identical roles.
 				assert.notStrictEqual(engineOne.nameArg[1], engineTwo.nameArg[1]);
 			}),
+	);
+
+	it.effect(
+		"hands the session its boot turn: a single positional prompt at the argv tail, no -p/--print (#3516)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				const bind = yield* buildSessionBind({
+					role: ROLE,
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+
+				// The boot prompt is exactly one bare positional (no flag) carrying BOOT_PROMPT — that is
+				// the CLI's `[prompt]` argument, which gives the spawned session its first turn so its def's
+				// cold-start fires from boot instead of idling (#3516).
+				assert.deepStrictEqual([...bind.bootPromptArg], [BOOT_PROMPT]);
+				// It rides the very tail of the argv, after --name (the non-variadic option that stops the
+				// variadic channel flag), so it lands as the positional prompt and isn't swallowed.
+				assert.strictEqual(bind.argv[bind.argv.length - 1], BOOT_PROMPT);
+				// Interactive, not headless: no -p/--print means the session runs this turn AND stays alive
+				// to self-drain (grounded on CLI 2.1.214: interactive by default, -p/--print exits).
+				assert.notInclude(bind.argv, "-p");
+				assert.notInclude(bind.argv, "--print");
+			}),
+	);
+
+	it.effect("every crew role (bridge + engine) gets the same role-agnostic boot turn (#3516)", () =>
+		Effect.gen(function* () {
+			const channels: ChannelConfig = {
+				mode: "development",
+				servers: ["server:pipeline-crew"],
+				allowedChannelPlugins: [],
+			};
+			// A bridge (no instance) and an engine (with instance) both receive the boot prompt — the def
+			// each boots as carries its own cold-start, so the launcher's turn is deliberately generic.
+			const bridge = yield* buildSessionBind({
+				role: "chief-of-staff",
+				projectRoot: PROJECT_ROOT,
+				serverName: SERVER_NAME,
+				channels,
+			});
+			const engine = yield* buildSessionBind({
+				role: "engineering-manager",
+				projectRoot: PROJECT_ROOT,
+				serverName: SERVER_NAME,
+				instance: "e-1",
+				channels,
+			});
+			assert.deepStrictEqual([...bridge.bootPromptArg], [BOOT_PROMPT]);
+			assert.deepStrictEqual([...engine.bootPromptArg], [BOOT_PROMPT]);
+			assert.strictEqual(bridge.argv[bridge.argv.length - 1], BOOT_PROMPT);
+			assert.strictEqual(engine.argv[engine.argv.length - 1], BOOT_PROMPT);
+		}),
 	);
 
 	it.effect("allowlist mode fails closed on a plugin channel whose plugin is not allowlisted", () =>

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -77,6 +77,22 @@ export const NAME_FLAG = "--name";
 export const PLUGIN_DIR_FLAG = "--plugin-dir";
 /** Boots the session AS its role persona by resolving the plugin agent-def named `crew-<role>` (see PLUGIN_DIR_FLAG, #3447). */
 export const AGENT_FLAG = "--agent";
+/**
+ * The launcher's initial boot turn: a positional prompt handed to `claude` at launch so the freshly
+ * spawned session TAKES a first turn instead of loading its persona and sitting idle. This is the only
+ * missing piece for the crew engine's cold-start self-drain (#3516): the role def (#3512) already
+ * carries the "on boot, sweep the board and start the self-drain loop" behavior, but a persona-loaded
+ * session only reads that def — it never fires until it is given a turn, and a launcher that passes no
+ * initial prompt never gives it one. It is a bare positional (no flag) so it maps to the CLI's
+ * `[prompt]` argument and — with NO `-p`/`--print` — keeps the session INTERACTIVE, i.e. it runs this
+ * turn and stays alive to self-drain (grounded on the installed CLI 2.1.214:
+ * `Usage: claude [options] [command] [prompt]` — "starts an interactive session by default, use
+ * -p/--print for non-interactive output"). Role-agnostic on purpose: it nudges the session to run
+ * whatever cold-start its own def defines, so it fits every crew role (bridge + engine) without the
+ * launcher re-encoding each persona's boot behavior.
+ */
+export const BOOT_PROMPT =
+	"Begin now. Run your role's on-boot cold-start behavior as defined by your agent instructions: announce your presence on the channel, then start your standing work loop under your own power. Do not wait to be pinged, relayed to, or told to start.";
 /** The pipeline-crew plugin root under a given project root — the dir `--plugin-dir` loads agent-defs from. */
 const crewPluginDir = (projectRoot: string): string =>
 	join(projectRoot, "claude-plugins/pipeline-crew");
@@ -150,10 +166,19 @@ export interface SessionBind {
 	/** `["--agent", "crew-<role>"]` — boots the session AS its role persona (collision-free name, see AGENT_FLAG). */
 	readonly agentArg: readonly [flag: string, agentName: string];
 	/**
-	 * The complete argv `[...modelArg, ...pluginDirArg, ...agentArg, ...channelArg, ...nameArg]` the
-	 * launcher passes to `claude`. It boots the role persona (`--plugin-dir` + `--agent`, #3447) and no
-	 * longer carries `--mcp-config`: the crew server now registers via the pane's project-scope
-	 * `.mcp.json` (`serverConfig`), which is what the channel resolver actually reads (#3444).
+	 * `[BOOT_PROMPT]` — the single positional initial prompt that hands the spawned session its first
+	 * turn so its def's on-boot cold-start fires from launch, not on a hand-kick (#3516; see BOOT_PROMPT).
+	 * It rides the argv TAIL, after the non-variadic `--name <name>`, so it lands as the CLI's `[prompt]`
+	 * positional rather than being swallowed by the variadic `--channels`/dev-channel option ahead of it.
+	 */
+	readonly bootPromptArg: readonly [prompt: string];
+	/**
+	 * The complete argv
+	 * `[...modelArg, ...pluginDirArg, ...agentArg, ...channelArg, ...nameArg, ...bootPromptArg]` the
+	 * launcher passes to `claude`. It boots the role persona (`--plugin-dir` + `--agent`, #3447), then
+	 * gives the session its boot turn via the tail positional prompt (#3516), and no longer carries
+	 * `--mcp-config`: the crew server now registers via the pane's project-scope `.mcp.json`
+	 * (`serverConfig`), which is what the channel resolver actually reads (#3444).
 	 */
 	readonly argv: readonly string[];
 }
@@ -294,6 +319,10 @@ export const buildSessionBind = (
 		// collision-free `crew-<role>`, so map the bare role at this argv site (see AGENT_FLAG for why).
 		const pluginDirArg: readonly [string, string] = [PLUGIN_DIR_FLAG, crewPluginDir(projectRoot)];
 		const agentArg: readonly [string, string] = [AGENT_FLAG, `crew-${role}`];
+		// The launcher's boot turn (#3516): a tail positional prompt so the spawned session fires its
+		// def's cold-start instead of idling. Tail placement (after the non-variadic --name) keeps it out
+		// of the variadic channel option's reach; no -p/--print keeps the session interactive to self-drain.
+		const bootPromptArg: readonly [string] = [BOOT_PROMPT];
 
 		return {
 			role,
@@ -305,6 +334,14 @@ export const buildSessionBind = (
 			nameArg,
 			pluginDirArg,
 			agentArg,
-			argv: [...modelArg, ...pluginDirArg, ...agentArg, ...channelArg, ...nameArg],
+			bootPromptArg,
+			argv: [
+				...modelArg,
+				...pluginDirArg,
+				...agentArg,
+				...channelArg,
+				...nameArg,
+				...bootPromptArg,
+			],
 		};
 	});


### PR DESCRIPTION
Fixes #3516

## What & why

The launcher spawned each crew engine (`claude` session) with `--plugin-dir` + `--agent` but **no initial prompt**, so a persona-loaded session just loaded its def and waited — the EM def's "on boot, sweep the board" cold-start (shipped as #3512) could never fire. Engines booted IDLE and never self-drained until hand-kicked. The only missing piece is giving the spawned session its first turn.

## The fix — a positional boot-turn prompt (`packages/pipeline-crew-mcp/` only)

`buildSessionBind` now emits `BOOT_PROMPT` as a **positional initial prompt at the argv tail**, so the launched `claude` takes a first turn from boot and its def's cold-start fires under its own power. The def (#3512) carries the actual loop; the boot turn is the delta.

- **Placement:** the prompt rides the argv **tail, after the non-variadic `--name <name>`** — so it lands as the CLI's `[prompt]` positional rather than being swallowed by the variadic `--channels`/`--dangerously-load-development-channels` option ahead of it.
- **Interactive, not headless:** no `-p`/`--print`, so the session runs the boot turn and **stays alive to self-drain**.
- **Role-agnostic:** the prompt nudges the session to run whatever cold-start its own def defines, so it fits every crew role (bridge + engine) without the launcher re-encoding each persona's boot behavior.

## Grounding — the CLI's real initial-prompt shape

Verified against the installed CLI **2.1.214**: `Usage: claude [options] [command] [prompt]` — "starts an interactive session by default, use `-p/--print` for non-interactive output". A bare positional prompt (no `-p`) is exactly the interactive first-turn mechanism this needs; `-p/--print` would run once and exit (wrong — the engine must stay alive to self-drain).

## Acceptance criteria

1. Launcher gives each spawned engine its first turn from boot — positional boot prompt, matched to the real CLI invocation shape. ✅
2. A freshly-booted engine, zero external nudge, executes its def's cold-start (the #3512 loop carries it once triggered); the boot-turn is the delta. ✅
3. Change confined to `packages/pipeline-crew-mcp/`; touches no §CP surface (nothing under `.claude/`, `.github/`, or `claude-plugins/pipeline-crew/agents/`). ✅
4. Boot-turn mechanism covered by tests in `packages/pipeline-crew-mcp/` matching the existing bind-test idiom (two new `bind.test.ts` cases: exact tail-positional assembly with no `-p`/`--print`, and every role gets the same boot turn). ✅

## Verification

- `vitest run` (pipeline-crew-mcp): **239 passed** (2 new bind tests; existing argv assertions updated for the tail element).
- `tsgo -p tsconfig.json`: clean (exit 0).
- `biome check` on the two changed files: clean.

## Files changed (both under `packages/pipeline-crew-mcp/`)

- `packages/pipeline-crew-mcp/src/standup/bind.ts` — `BOOT_PROMPT` constant, `bootPromptArg` field on `SessionBind`, appended to `argv` tail.
- `packages/pipeline-crew-mcp/src/standup/bind.test.ts` — argv assertions updated for the tail element + two new boot-turn tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)