### PR TITLE
test(e2e): settle the sözlük composer dialog animation before submit (#3517)

### DIFF
--- a/apps/web/tests/e2e/06-sozluk-home.spec.ts
+++ b/apps/web/tests/e2e/06-sozluk-home.spec.ts
@@ -82,6 +82,19 @@ test.describe("SozlukHome create-flow (+ yeni tanım → composer)", () => {
 		expect(slug).not.toBe("");
 
 		await page.getByRole("button", {name: /yeni tanım/i}).click();
+
+		// Let the dialog's `kp-dialog-pop` entry animation (a translate+scale pop-in,
+		// Dialog.css) finish before touching its controls. Mid-animation the popup —
+		// and the `oluştur` submit inside it — is still moving, which trips
+		// Playwright's element-stability check and, on the retry, races a Base UI
+		// portal re-render that detaches the button mid-click (the #3517 flake). This
+		// awaits the actual CSS animation to settle, not a blanket sleep.
+		const dialog = page.locator(".kp-dialog__popup");
+		await expect(dialog).toBeVisible();
+		await dialog.evaluate((el) =>
+			Promise.all(el.getAnimations({subtree: true}).map((a) => a.finished)),
+		);
+
 		// The dialog collects the term name (the composer is slug-addressed).
 		await page.getByLabel("Terim").fill(term);
 		await page.getByRole("button", {name: /^oluştur$/i}).click();


### PR DESCRIPTION
Fixes #3517

## What

The `06-sozluk-home` create-flow spec (`apps/web/tests/e2e/06-sozluk-home.spec.ts:77`) flaked on the `oluştur` submit click — Playwright's `element is not stable` → `element was detached from the DOM, retrying` → timeout.

## Root cause (grounded in the observed mechanism)

`SozlukSubnavCta`'s dialog popup (`.kp-dialog__popup`) plays a `kp-dialog-pop` **entry animation** on mount (`translate(-50%, -48%) scale(0.97)` → `translate(-50%, -50%) scale(1)`, `apps/web/src/components/ui/Dialog.css`). Right after the dialog opens, the `oluştur` submit button is still **moving** as the popup animates in, so Playwright's actionability stability check fails; on the retry it races a Base UI portal re-render that **detaches** the button node mid-click. Warm preview, cleanly seeded — this is a dialog-stability race, not the preview-warm-gate class (#3179).

## Fix

Before filling and submitting, wait for the popup's CSS entry animation to actually finish:

```ts
const dialog = page.locator(".kp-dialog__popup");
await expect(dialog).toBeVisible();
await dialog.evaluate((el) =>
  Promise.all(el.getAnimations({subtree: true}).map((a) => a.finished)),
);
```

`getAnimations({subtree: true}).…finished` resolves the moment the pop-in animation settles (empty list ⇒ resolves immediately, never hangs), so the submit button is at rest when clicked. This targets the observed re-render race directly — **not** a blanket `waitForTimeout` sleep. All projects run Desktop Chrome (Chromium), where `getAnimations` is fully supported.

## Acceptance criteria

- [x] `06-sozluk-home.spec.ts:77` no longer flakes on the `oluştur` submit — the click now waits for the dialog's entry animation to settle so the button doesn't detach mid-click.
- [x] Grounded in the observed mechanism (button moves/detaches due to the dialog entry animation), not a blanket `waitForTimeout`.
- [x] Assertion coverage preserved — the test still verifies the fresh-slug route (`/sozluk/<slug>`) and that it lands on the composer (term head + composer body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)