### PR TITLE
fix(pipeline-crew-mcp): spawn crew panes through a login shell so the dev-channel dialog waits, not exits 1 (#3419)

### DIFF
--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -55,6 +55,7 @@ export {
 	launchSessionInTmux,
 	type ProjectScopeRegisterInput,
 	type ProjectScopeRegistrar,
+	paneClaudeCommand,
 	productionProjectScopeRegistrar,
 	renderStandUpError,
 	resolveTargetTmuxSession,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -31,6 +31,7 @@ import {
 	launchSessionInTmux,
 	type ProjectScopeRegistrar,
 	ProjectScopeWriteError,
+	paneClaudeCommand,
 	renderStandUpError,
 	resolveTargetTmuxSession,
 	runStandDown,
@@ -602,8 +603,7 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 					"-P",
 					"-F",
 					"#{window_id}",
-					"claude",
-					...plan.bind.argv,
+					...paneClaudeCommand(plan.bind.argv),
 				]);
 			}),
 	);
@@ -625,8 +625,7 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 					"@7",
 					"-c",
 					plan.cwd,
-					"claude",
-					...plan.bind.argv,
+					...paneClaudeCommand(plan.bind.argv),
 				]);
 				assert.deepStrictEqual(argvLog[1], ["select-layout", "-t", "@7", "tiled"]);
 			}),
@@ -761,6 +760,32 @@ describe("standup/orchestrate — launch-liveness + ensure-session (issue #3418)
 			assert.deepStrictEqual(argvLog, [["has-session", "-t", "crew"]]);
 		}),
 	);
+});
+
+// The dev-channel dialog fix (#3419): `claude` runs THROUGH an interactive login shell so the startup
+// confirmation dialog renders + waits (attended boot) instead of a direct exec exiting 1 at the dialog.
+describe("paneClaudeCommand — the dev-channel dialog shell-wrap (#3419)", () => {
+	it("wraps claude+argv as an interactive login shell command, argv re-parsed verbatim", () => {
+		const argv = ["--model", "opus", "--channels", "server:@kampus/pipeline-crew-mcp"];
+		const cmd = paneClaudeCommand(argv);
+
+		// shape: <shell> -lic '<single command string>' — a 3-token pane command, never a direct `claude`.
+		assert.strictEqual(cmd.length, 3);
+		assert.strictEqual(cmd[1], "-lic");
+		assert.notStrictEqual(cmd[0], "claude");
+		// the command string carries claude + every argv token, so the shell re-parses the exact same words.
+		const command = cmd[2] ?? "";
+		for (const token of ["claude", ...argv]) assert.include(command, token);
+	});
+
+	it("single-quotes each token so a value with shell metacharacters survives re-parsing", () => {
+		// a boot prompt carries spaces + an apostrophe — both must round-trip through the shell unchanged.
+		const cmd = paneClaudeCommand(["--name", "chief-of-staff", "Begin now: don't idle"]);
+		const command = cmd[2] ?? "";
+		// the apostrophe is escaped via the POSIX '\'' idiom, not left to split the quoted string.
+		assert.include(command, "'\\''");
+		assert.include(command, "'Begin now: don'\\''t idle'");
+	});
 });
 
 // The abort render is the operator's whole diagnostic on a fail-closed boot — `String(error)` on a

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -341,6 +341,30 @@ const resolveTargetSessionDefault = (): Effect.Effect<string, TmuxSessionEnsureE
 /** The single tiled window every crew pane opens into (founder ruling #3424): one window, all roles visible at once. */
 export const CREW_WINDOW = "crew";
 
+/** POSIX single-quote one argv token so the wrapping shell re-parses `claude <argv>` into the exact same words. */
+const shellQuote = (token: string): string => `'${token.replace(/'/g, "'\\''")}'`;
+
+/**
+ * The pane command tmux runs — `claude` spawned THROUGH an interactive login shell, not as the direct
+ * tmux pane process. Grounded on the live #3419 diagnosis against CLI 2.1.214: a recent CLI update added
+ * a startup confirmation dialog for `--dangerously-load-development-channels` (the crew channel flag
+ * config.ts's fail-closed cross-field check forces, since the crew's top-level `server:` ref only
+ * registers in development mode). Exec'd DIRECTLY as the tmux pane process, `claude` cannot set up its
+ * interactive raw-mode stdin for that dialog and the pane EXITS 1 immediately — collapsing the crew
+ * window and failing every sibling pane's split ("no live pane"). Spawned as a child of an interactive
+ * login shell (`-lic`), the dialog renders and the pane WAITS for the operator's accept — the
+ * founder-endorsed attended-boot interim (#3419, until the post-preview allowlist path via #3366 removes
+ * the dialog). Deliberately NOT a synthetic-keystroke auto-accept (the version-fragile anti-pattern the
+ * founder vetoed): it only restores the dialog to a state a human — or a `synchronize-panes` Enter —
+ * can accept. The operator's `$SHELL` runs it (falling back to `zsh`, the macOS default the workaround
+ * was proven on); every token is single-quoted so the shell re-parses the argv verbatim.
+ */
+export const paneClaudeCommand = (argv: readonly string[]): readonly string[] => {
+	const shell = process.env.SHELL || "zsh";
+	const command = ["claude", ...argv].map(shellQuote).join(" ");
+	return [shell, "-lic", command];
+};
+
 /** Map a non-zero exit / spawn error from one tmux step to the fail-loud `StandUpLaunchError` naming the role + pane. */
 const launchFailure = (
 	session: CrewSession,
@@ -380,6 +404,8 @@ export const launchSessionInTmux = (
 			// First session: open the crew window and capture its id (`-P -F '#{window_id}'`) so every later
 			// pane splits into exactly this window, never a stale same-named one. `-c <cwd>` boots the pane in
 			// its distinct launch cwd — the persisted-scope `projects[]` key its crew server is registered under (#3444).
+			// The pane runs `claude` THROUGH a login shell so the dev-channel startup dialog waits instead of
+			// exiting 1 (#3419, see paneClaudeCommand).
 			const opened = yield* runTmuxCommand([
 				"new-window",
 				"-t",
@@ -391,8 +417,7 @@ export const launchSessionInTmux = (
 				"-P",
 				"-F",
 				"#{window_id}",
-				"claude",
-				...bind.argv,
+				...paneClaudeCommand(bind.argv),
 			]);
 			if (opened.spawnError !== undefined || opened.code !== 0) {
 				return yield* Effect.fail(launchFailure(session, pane, opened, "new-window"));
@@ -401,14 +426,14 @@ export const launchSessionInTmux = (
 			return {role: session.role, address: session.address, window, pane, pid: opened.pid};
 		}
 		// Later session: split into the crew window in this pane's distinct launch cwd (`-c`), then re-tile.
+		// Same login-shell wrap as the first pane so the dev-channel dialog waits instead of exiting 1 (#3419).
 		const split = yield* runTmuxCommand([
 			"split-window",
 			"-t",
 			intoWindow,
 			"-c",
 			cwd,
-			"claude",
-			...bind.argv,
+			...paneClaudeCommand(bind.argv),
 		]);
 		if (split.spawnError !== undefined || split.code !== 0) {
 			return yield* Effect.fail(launchFailure(session, pane, split, "split-window"));


### PR DESCRIPTION
Fixes #3419

## Problem

The stand-up launcher (`packages/pipeline-crew-mcp/src/standup/orchestrate.ts`, `launchSessionInTmux`) exec'd `claude` **directly** as the tmux pane command (`new-window … claude …argv` / `split-window … claude …argv`). A recent CLI (2.1.214) added a startup **confirmation dialog** for `--dangerously-load-development-channels` — the channel flag `config.ts`'s fail-closed cross-field check forces, since the crew's top-level `server:` ref only registers in `development` mode.

Per the live diagnosis on #3419 (2026-07-18), exec'd directly `claude` cannot set up its interactive raw-mode stdin for that dialog, so the pane **EXITS 1 immediately** — collapsing the crew window and failing every sibling pane's split (the "no live pane" symptom). This is worse than the original "hangs" report: the crew never comes up at all.

## Fix

Spawn each pane's `claude` **through an interactive login shell** (`$SHELL -lic`, falling back to `zsh`) so the dialog renders and **waits** for the operator's accept — the founder-endorsed **attended-boot interim** (the dialog is dialog-free only via the post-preview allowlist path, #3366). The operator accepts once (or a `synchronize-panes` Enter accepts all panes at once) and every session self-starts.

This is deliberately **not** a synthetic-keystroke auto-accept (the version-fragile anti-pattern the founder vetoed in the #3419 ruling): it only restores the dialog to a state a human — or a synced Enter — can accept.

New pure helper `paneClaudeCommand(argv)` returns `[shell, "-lic", "<single-quoted claude + argv>"]`; every argv token is POSIX single-quoted so the wrapping shell re-parses it verbatim (spaces + apostrophes in the boot prompt survive).

## Grounding (per CLAUDE.md "ground falsifiable runtime claims in source")

The dialog + exit-1-on-direct-exec vs. wait-under-shell behaviors are the founder's live diagnosis reproduced against the installed CLI on #3419, not intuited. The `config.ts` fail-closed cross-field check that forces dev mode is left fully intact — the fix only changes *how the pane process is spawned*, not the channel-registration invariants.

## Scope / §CP

`packages/pipeline-crew-mcp/` is **not** control-plane (verified against the live `CONTROL_PLANE_RE`, deliberately un-§CP per ADR 0187) — this PR **auto-ships** on green, no `@kamp-us/control-plane` human-merge gate.

## Tests

- New `paneClaudeCommand` describe block: proves the interactive-login-shell shape and that a token with shell metacharacters (spaces + apostrophe) round-trips.
- The two existing `launchSessionInTmux` argvLog assertions now assert the shell-wrapped pane command.
- Full package suite green: 241/241. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)