### PR TITLE
fix(pipeline-cli): stop self-heal pnpm install from purging node_modules (#3504)

### DIFF
--- a/packages/pipeline-cli/src/bin.ts
+++ b/packages/pipeline-cli/src/bin.ts
@@ -17,14 +17,16 @@
  * On the normal (installed) path this is a plain pass-through.
  */
 import {spawnSync} from "node:child_process";
-import {existsSync} from "node:fs";
+import {existsSync, lstatSync} from "node:fs";
 import {dirname, join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {findRootDir} from "./find-root-dir.ts";
 import {
+	assertSelfHealInstallSafe,
 	isUnlinkedDependencyError,
 	loadWithSelfHeal,
 	remediationMessage,
+	SELF_HEAL_INSTALL_ARGS,
 	shouldSelfHeal,
 } from "./module-load-guard.ts";
 
@@ -39,7 +41,15 @@ const install = async (): Promise<void> => {
 	console.error(
 		"pipeline-cli: an unlinked workspace dep — self-healing with a one-shot `pnpm install`…",
 	);
-	const result = spawnSync("pnpm", ["install"], {cwd: rootDir, stdio: "inherit"});
+	// Refuse before pnpm runs if rootDir/node_modules is a symlink — a hook-invoked
+	// destructive install would otherwise follow it into the shared primary and purge it (#3504).
+	assertSelfHealInstallSafe(rootDir, (p) => (existsSync(p) ? lstatSync(p) : null));
+	// Non-TTY stdin (`ignore`) so pnpm can never (auto-)confirm a purge prompt; with the
+	// armed `--config.confirm-modules-purge=true` it aborts on a purge instead (#3504).
+	const result = spawnSync("pnpm", [...SELF_HEAL_INSTALL_ARGS], {
+		cwd: rootDir,
+		stdio: ["ignore", "inherit", "inherit"],
+	});
 	if (result.status !== 0) {
 		throw new Error(
 			`pipeline-cli self-heal: \`pnpm install\` failed (exit ${result.status ?? `signal ${result.signal}`}) — cannot link deps`,

--- a/packages/pipeline-cli/src/module-load-guard.ts
+++ b/packages/pipeline-cli/src/module-load-guard.ts
@@ -13,8 +13,65 @@
  * module '/abs/path'`), which is a real code bug we must not mask.
  */
 
+import {join} from "node:path";
+
 /** The pnpm filter that links this package's own deps in isolation. */
 const FILTER_INSTALL = "pnpm --filter @kampus/pipeline-cli install";
+
+/**
+ * The argv the self-heal install runs pnpm with. `--config.confirm-modules-purge=true`
+ * keeps pnpm's destructive-purge guard ARMED, so a self-heal that would otherwise "remove
+ * and reinstall node_modules from scratch" instead **aborts** under a non-TTY stdin
+ * (`ABORTED_REMOVE_MODULES_DIR_NO_TTY`) rather than wiping the modules farm (#3504).
+ *
+ * Grounded in pnpm 10.27.0 (`purgeModulesDirsOfImporters` in its `dist/pnpm.mjs`), NOT
+ * intuition: the purge path is `if (confirmModulesPurge ?? true) { if (!stdin.isTTY) throw
+ * ABORTED_REMOVE_MODULES_DIR_NO_TTY; … }` — so `true` + no-TTY THROWS (safe), while the
+ * value the original report guessed, `=false`, takes the `else` branch and purges
+ * **silently**. Passing `=false` would be the exact opposite of the fix; we pass `=true`
+ * and the bin runs pnpm with a non-TTY stdin so the abort is guaranteed to fire.
+ */
+export const SELF_HEAL_INSTALL_ARGS: readonly string[] = [
+	"install",
+	"--config.confirm-modules-purge=true",
+];
+
+/**
+ * The refusal message when the self-heal install is asked to run over a symlinked
+ * repo-root `node_modules`. Named separately so the bin and the test share one string.
+ */
+export const selfHealSymlinkRefusal = (nodeModulesPath: string): string =>
+	[
+		`pipeline-cli self-heal: refusing to \`pnpm install\` — \`${nodeModulesPath}\` is a symlink.`,
+		"A destructive install here would follow the link and purge the symlink target's",
+		"node_modules (the shared primary checkout, when a worktree lane symlinks into it) —",
+		"the primary-checkout-corruption class (#2143/#2144/#2270) via the hook+pnpm path (#3504).",
+		"Provision a real per-worktree node_modules instead of symlinking into the primary.",
+	].join("\n");
+
+/** lstat shape the guard needs — just the symlink predicate; `null` when the path is absent. */
+export interface LstatLike {
+	isSymbolicLink(): boolean;
+}
+
+/**
+ * Fail-closed guard run immediately before the self-heal `pnpm install`: throw iff the
+ * repo-root `node_modules` is a **symlink**. That is the #3504 corruption vector — a
+ * worktree lane symlinks its `node_modules` into the shared primary checkout, and a
+ * destructive install follows the link and wipes the primary's farm. Version-robust (it
+ * does not rely on any particular pnpm's purge-confirmation behavior): a symlinked
+ * modules dir is never a path a mutating install may follow, on any pnpm. A real
+ * directory (the normal primary/`main-sync` self-heal) passes untouched.
+ */
+export const assertSelfHealInstallSafe = (
+	rootDir: string,
+	lstat: (path: string) => LstatLike | null,
+): void => {
+	const nodeModulesPath = join(rootDir, "node_modules");
+	if (lstat(nodeModulesPath)?.isSymbolicLink()) {
+		throw new Error(selfHealSymlinkRefusal(nodeModulesPath));
+	}
+};
 
 /**
  * True iff `err` is a Node `ERR_MODULE_NOT_FOUND` for an **unlinked package**

--- a/packages/pipeline-cli/src/module-load-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/module-load-guard.unit.test.ts
@@ -1,8 +1,11 @@
 import {describe, expect, it, vi} from "vitest";
 import {
+	assertSelfHealInstallSafe,
 	isUnlinkedDependencyError,
 	loadWithSelfHeal,
 	remediationMessage,
+	SELF_HEAL_INSTALL_ARGS,
+	selfHealSymlinkRefusal,
 	shouldSelfHeal,
 	unlinkedPackageName,
 } from "./module-load-guard.ts";
@@ -94,6 +97,44 @@ describe("shouldSelfHeal", () => {
 		expect(shouldSelfHeal({PIPELINE_CLI_NO_SELF_HEAL: ""})).toBe(true);
 		expect(shouldSelfHeal({PIPELINE_CLI_NO_SELF_HEAL: "0"})).toBe(true);
 		expect(shouldSelfHeal({PIPELINE_CLI_NO_SELF_HEAL: "false"})).toBe(true);
+	});
+});
+
+describe("SELF_HEAL_INSTALL_ARGS", () => {
+	it("keeps pnpm's purge guard ARMED (=true), never disarms it (=false)", () => {
+		// pnpm 10.27.0 `purgeModulesDirsOfImporters`: `confirmModulesPurge ?? true` + non-TTY
+		// THROWS ABORTED_REMOVE_MODULES_DIR_NO_TTY; `=false` purges silently. We must pass `=true`.
+		expect(SELF_HEAL_INSTALL_ARGS).toContain("--config.confirm-modules-purge=true");
+		expect(SELF_HEAL_INSTALL_ARGS).not.toContain("--config.confirm-modules-purge=false");
+		expect(SELF_HEAL_INSTALL_ARGS[0]).toBe("install");
+	});
+});
+
+describe("assertSelfHealInstallSafe", () => {
+	const symlink = {isSymbolicLink: () => true};
+	const realDir = {isSymbolicLink: () => false};
+
+	it("REFUSES when repo-root node_modules is a symlink (the #3504 corruption vector)", () => {
+		const lstat = vi.fn().mockReturnValue(symlink);
+		expect(() => assertSelfHealInstallSafe("/repo", lstat)).toThrow(/is a symlink/);
+		expect(lstat).toHaveBeenCalledWith("/repo/node_modules");
+	});
+
+	it("proceeds when node_modules is a real directory (the normal primary/main-sync self-heal)", () => {
+		expect(() =>
+			assertSelfHealInstallSafe("/repo", vi.fn().mockReturnValue(realDir)),
+		).not.toThrow();
+	});
+
+	it("proceeds when node_modules is absent (a fresh checkout — nothing to follow)", () => {
+		expect(() => assertSelfHealInstallSafe("/repo", vi.fn().mockReturnValue(null))).not.toThrow();
+	});
+
+	it("the refusal names the corruption class and the offending path", () => {
+		const msg = selfHealSymlinkRefusal("/repo/node_modules");
+		expect(msg).toContain("/repo/node_modules");
+		expect(msg).toContain("#3504");
+		expect(msg).toContain("symlink");
 	});
 });
 


### PR DESCRIPTION
Fixes #3504

## Root cause

`packages/pipeline-cli/src/bin.ts` `install()` (the #2459 self-heal) ran a **bare** `pnpm install` with an inherited TTY and no purge-confirmation config. On a lane whose repo-root `node_modules` is (or is symlinked to) the shared primary checkout's, a hook-invoked destructive "remove and reinstall node_modules from scratch" could follow that symlink and **wipe the primary's top-level symlink farm** mid-install — the primary-checkout-corruption class (#2143/#2144/#2270) reached through the hook+pnpm path.

## The pnpm behavior, grounded in source (not intuition)

Verified against pnpm 10.27.0's `purgeModulesDirsOfImporters` (its shipped `dist/pnpm.mjs`):

```
if (confirmModulesPurge ?? true) {          // default true
  if (!process.stdin.isTTY) throw ABORTED_REMOVE_MODULES_DIR_NO_TTY;   // non-TTY → ABORT (safe)
  … enquirer confirm prompt …               // TTY → prompt
}
// else (confirmModulesPurge === false) → purge SILENTLY, no confirmation
```

So `confirmModulesPurge=true` + a non-TTY stdin **aborts** rather than purging. The original report's suggested `--config.confirmModulesPurge=false` is **exactly backwards** — `false` takes the else branch and purges silently. The report's incident was on the worktree's stray pnpm 8.15.6, which predates the no-TTY abort guard.

## The fix (two guards)

- **Symlink refusal (version-robust, load-bearing).** `assertSelfHealInstallSafe(rootDir, lstat)` throws before pnpm runs if repo-root `node_modules` is a symlink, so a mutating install never follows a worktree's link into the primary — independent of any pnpm's purge behavior. A real directory (the normal primary / `main-sync` self-heal) passes untouched.
- **Armed purge guard + non-TTY stdin.** The install now runs `pnpm install --config.confirm-modules-purge=true` with `stdin: "ignore"`, so on pnpm >=10 a purge aborts (`ABORTED_REMOVE_MODULES_DIR_NO_TTY`) instead of wiping — pnpm can never (auto-)confirm a purge.

## Threat model (§CP corruption-guard, per #1961)

- **Asset protected:** the shared primary checkout's `node_modules` symlink farm (crew crown-jewel state).
- **Attack/failure surface:** a hook (`lefthook.yml` pre-commit/pre-push/reference-transaction) shells `node packages/pipeline-cli/src/bin.ts <tool>`; the self-heal fires non-interactively with no human to catch a purge prompt.
- **Before:** bare `pnpm install` + inherited stdin → a purge could be auto-confirmed and follow a symlink into the primary → catastrophic wipe.
- **After:** the symlink refusal makes the corruption vector unreachable regardless of pnpm version/config; the non-TTY + armed-confirm guard makes any purge on pnpm >=10 a loud abort. Both are fail-closed (throw/abort), never fail-open.
- **Residual:** on a pnpm that predates the no-TTY abort AND with a *non-symlinked* not-pnpm-managed `node_modules`, the second guard degrades — but that path can no longer touch the primary (no symlink to follow), so the catastrophic blast radius is closed. The enabling half (worktrees can't run the pinned pnpm) is tracked separately per triage's split.

## Verification

- `pnpm --filter @kampus/pipeline-cli` unit tests: 22 passed (4 new — symlink refuse / real-dir proceed / absent-node_modules proceed / args keep `=true` never `=false`).
- `typecheck` clean, `biome check` clean on the three changed files.

## Files

- `packages/pipeline-cli/src/module-load-guard.ts` — `SELF_HEAL_INSTALL_ARGS`, `assertSelfHealInstallSafe`, `selfHealSymlinkRefusal`.
- `packages/pipeline-cli/src/bin.ts` — wires the guard + non-TTY stdin into `install()`.
- `packages/pipeline-cli/src/module-load-guard.unit.test.ts` — the corruption-path tests.

> §CP: `packages/pipeline-cli/**` — routes to control-plane human merge; do not auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)