### PR TITLE
fix(integration): make shared-stage teardown best-effort at the Promise boundary (#3515)

### DIFF
--- a/apps/web/tests/integration/_best-effort-teardown.ts
+++ b/apps/web/tests/integration/_best-effort-teardown.ts
@@ -1,0 +1,28 @@
+/**
+ * Best-effort teardown at the JS Promise boundary (#3515).
+ *
+ * The run-scoped shared-stage teardown attempts one `Core.destroy` per run and is meant to be
+ * STRICTLY best-effort: the leaked stage is swept out-of-band (#690), so a teardown failure must
+ * NEVER red a green `test:integration` run. Neutralizing failures INSIDE the destroy Effect
+ * (`Effect.catchCause`) is not enough — `Core.run` is `Effect.runPromise(toEffect(...))`, and
+ * `toEffect` provides the `Cloudflare.state()` / `providers()` layers, the config load, and
+ * `Effect.scoped(...)` finalization OUTSIDE that inner catch. A transient credential/network
+ * failure in layer acquisition, or a scope-finalization defect, therefore escapes the inner catch
+ * and rejects the returned teardown promise. A rejected vitest `globalSetup` teardown promise fails
+ * the whole run (`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`) and dequeues an otherwise-clean PR from the
+ * merge queue — the exact recurrence #3515 tracks. (#813's closed-PR `cleanup`-job "Verify
+ * teardown" guard in `deploy.yml` is a different surface and never covered this path.) Best-effort
+ * belongs at the boundary that actually gates the run — the returned Promise — not one Effect layer
+ * beneath it, which is the boundary this helper enforces. See #3514 for the sibling structural
+ * merge_group-vs-PR-head skip defect.
+ */
+export async function runBestEffortTeardown(
+	teardown: () => Promise<unknown>,
+	onLeak: (error: unknown) => void,
+): Promise<void> {
+	try {
+		await teardown();
+	} catch (error) {
+		onLeak(error);
+	}
+}

--- a/apps/web/tests/integration/_best-effort-teardown.unit.test.ts
+++ b/apps/web/tests/integration/_best-effort-teardown.unit.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Reproduces the #3515 recurrence condition at the unit level: a shared-stage teardown whose
+ * underlying `Core.run` REJECTS (the escape past the inner `Effect.catchCause` — layer acquisition
+ * or scope finalization) must not reject the caller. If it did, the vitest `globalSetup` teardown
+ * promise would reject and red a green `test:integration` run, dequeuing a clean PR (#3515). The
+ * wrapper's contract: swallow every rejection, report the leak once, always resolve.
+ */
+
+import {describe, expect, it, vi} from "vitest";
+import {runBestEffortTeardown} from "./_best-effort-teardown.ts";
+
+describe("runBestEffortTeardown", () => {
+	it("resolves and reports the leak when the teardown thunk rejects (the #3515 escape)", async () => {
+		const onLeak = vi.fn();
+		const boom = new Error("Core.run rejected: state layer acquisition failed");
+
+		await expect(
+			runBestEffortTeardown(() => Promise.reject(boom), onLeak),
+		).resolves.toBeUndefined();
+
+		expect(onLeak).toHaveBeenCalledTimes(1);
+		expect(onLeak).toHaveBeenCalledWith(boom);
+	});
+
+	it("resolves and never reports a leak when the teardown thunk succeeds (a clean run)", async () => {
+		const onLeak = vi.fn();
+
+		await expect(
+			runBestEffortTeardown(() => Promise.resolve("destroyed"), onLeak),
+		).resolves.toBeUndefined();
+
+		expect(onLeak).not.toHaveBeenCalled();
+	});
+
+	it("swallows a non-Error rejection too (a raw FiberFailure string never escapes)", async () => {
+		const onLeak = vi.fn();
+
+		await expect(
+			runBestEffortTeardown(() => Promise.reject("stage leaked"), onLeak),
+		).resolves.toBeUndefined();
+
+		expect(onLeak).toHaveBeenCalledWith("stage leaked");
+	});
+});

--- a/apps/web/tests/integration/_global-setup.ts
+++ b/apps/web/tests/integration/_global-setup.ts
@@ -19,10 +19,10 @@
 
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Core from "alchemy/Test/Core";
-import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import type {TestProject} from "vitest/node";
 import Stack from "../../alchemy.run.ts";
+import {runBestEffortTeardown} from "./_best-effort-teardown.ts";
 import {
 	awaitAuthRouteReady,
 	awaitWorkerReady,
@@ -108,20 +108,24 @@ export default async function setup(project: TestProject): Promise<() => Promise
 	// `ensureIntegrationEnv()` set this above (idempotent `??=`); a real `.env`/CI secret wins.
 	project.provide("integrationAuthSecret", process.env.BETTER_AUTH_SECRET ?? "");
 
-	// Best-effort teardown, ONE destroy per run (mirrors the per-file `afterAll(destroy)`):
-	// a CF delete-ordering Conflict / WorkerNotFound is CLEANUP, not an assertion, so catch +
-	// log loud (swept by #690) rather than letting it red a green run. See ADR 0104.
+	// Best-effort teardown, ONE destroy per run (mirrors the per-file `afterAll(destroy)`): a CF
+	// delete-ordering Conflict / WorkerNotFound is CLEANUP, not an assertion, so a failure here must
+	// never red a green run — the leaked stage is swept out-of-band (#690). Best-effort holds at the
+	// returned-Promise boundary via `runBestEffortTeardown`, NOT via an inner `Effect.catchCause`:
+	// `Core.run` (`runPromise(toEffect(...))`) acquires the `Cloudflare.state()`/`providers()` layers
+	// and runs `Effect.scoped` finalization OUTSIDE that inner catch, so a transient credential/scope
+	// failure escaped it and rejected this promise, failing the whole run (#3515 — distinct from
+	// #813's closed-PR `cleanup` guard). See ADR 0104 and `_best-effort-teardown.ts`.
 	return async () => {
 		if (NO_DESTROY) return;
-		await Core.run(
-			Core.destroy(MAKE_OPTIONS, Stack, {stage}).pipe(
-				Effect.catchCause((cause) =>
-					Effect.logWarning(
-						`[integration] best-effort shared-stage teardown failed for stage "${stage}" — stage leaked, sweep via #690 (durable fix #813):\n${Cause.pretty(cause)}`,
-					),
+		await runBestEffortTeardown(
+			() => Core.run(Core.destroy(MAKE_OPTIONS, Stack, {stage}), MAKE_OPTIONS),
+			(error) =>
+				console.warn(
+					`[integration] best-effort shared-stage teardown failed for stage "${stage}" — stage leaked, sweep via #690 (durable fix #813); made non-gating at the Promise boundary so it never reds a green run (#3515):\n${
+						error instanceof Error ? (error.stack ?? error.message) : String(error)
+					}`,
 				),
-			),
-			MAKE_OPTIONS,
 		);
 	};
 }


### PR DESCRIPTION
Fixes #3515

## Root cause — why #813's fix did not hold on this path

**#813 (PR #1296) never covered this path.** #813's "Verify teardown" guard was scoped to the *closed-PR* `cleanup` job in `.github/workflows/deploy.yml` — it verifies that preview-stack workers are actually gone after a PR closes. The recurrence here is a **different surface**: the integration test's own **in-run shared-stage teardown** in `apps/web/tests/integration/_global-setup.ts`. That path was never in scope of #813's guard, so it could not have prevented this flake.

**The real defect — best-effort at the wrong boundary.** The shared-stage teardown is meant to be strictly best-effort: the leaked stage is swept out-of-band (#690), so a teardown failure must never red a green `test:integration` run. It applied best-effort-ness with an inner `Effect.catchCause(logWarning)`. But `Core.run` is `Effect.runPromise(toEffect(...))`, and `toEffect` (alchemy `Test/Core.ts`) acquires the `Cloudflare.state()` / `providers()` layers, loads config, and runs `Effect.scoped(...)` finalization **outside** that inner catch. A transient credential/network failure in layer acquisition, or a scope-finalization defect, therefore **escapes** the `catchCause`, rejects the returned teardown promise, fails the whole vitest `globalSetup` teardown, and reds the run (`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`) — dequeuing an otherwise-clean PR from the merge queue. That is the recurrence on Actions run `29659047210` that took out #3512.

## The fix

Move best-effort-ness to the boundary that actually gates the run — the **returned Promise** — via a new `runBestEffortTeardown` helper. It wraps the whole `await Core.run(...)` so **every** rejection (Effect failure, layer acquisition, or scope finalization) is swallowed and the leak is logged **once** for #690's sweep. On a clean run nothing is emitted; a failing teardown logs but never reds the run.

- `apps/web/tests/integration/_best-effort-teardown.ts` — the helper (single load-bearing docblock explains the escape).
- `apps/web/tests/integration/_best-effort-teardown.unit.test.ts` — reproduces the rejecting-`Core.run` escape condition and asserts the wrapper resolves + reports the leak once.
- `apps/web/tests/integration/_global-setup.ts` — teardown rewired through the helper; the escapable inner `Effect.catchCause` removed.

## Acceptance criteria

- [x] **Root cause named** — #813's guard targeted the closed-PR `cleanup` job (worker survival), not the integration in-run shared-stage teardown; the escape past `Effect.catchCause` via `Core.run`'s layer/scope boundary is the actual mechanism.
- [x] **Teardown no longer reds a clean run** — best-effort now holds at the Promise boundary; unit test reproduces the rejecting-`Core.run` condition and proves the wrapper resolves (no `stage leaked` / `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL` propagation).
- [x] **Clean PR not ejected by this path** — a teardown-time failure can no longer reject the `globalSetup` teardown, so the `29659047210` failure mode (dequeue on shared-stage teardown) cannot recur.
- [x] **Cross-links preserved** — #690 (sweep), #813 (closed-PR cleanup guard — different surface), #3514 (sibling structural merge_group-vs-PR-head skip defect) referenced in code + commit.

## Scope note

Sibling **#3514** owns the *structural* `merge_group`-vs-PR-head skip inconsistency (a docs-only PR gating on an integration run it skips on head) — a distinct CI-config defect, not touched here. The per-file `integrationStack` teardown in `_integration.ts` shares the same Effect-boundary shape but was not the recurrence surface; a follow-up will assess it separately.

## §CP / gate-critical flag

This touches **gate-critical test-teardown infra** that gates the merge queue (`apps/web/tests/integration/_global-setup.ts` + the shared teardown helper). Flagging for human/control-plane approval — **should bank, not auto-ship**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
