### PR TITLE
feat(pasaport): Admin.over(platform)-gated user.setRole fate mutation (#3522)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -72,6 +72,7 @@ import {
 	sozlukStampWaveFlag,
 	userAdminFlag,
 	userBanFlag,
+	userRoleAssignFlag,
 } from "./worker/features/flagship/resources.ts";
 import {provisionEmailSending} from "./worker/features/pasaport/email-resources.ts";
 import PhoenixLive, {Phoenix} from "./worker/index.ts";
@@ -149,6 +150,10 @@ export default Alchemy.Stack(
 		// seam the ban mutations + admin read + moderator-UI controls gate behind, so an
 		// unreleased ban can never refuse a real user's session until a human release.
 		yield* userBanFlag(flagship.appId);
+		// The platform role-assign dark-ship flag, default-off (#3522, ADR 0107) — the single
+		// seam the `Admin.over(platform)`-gated `user.setRole` mutation gates behind, so an
+		// unreleased role-grant can never mint a moderator until a human release.
+		yield* userRoleAssignFlag(flagship.appId);
 		// The admin email-delivery (failing-address) surface dark-ship flag, default-off
 		// (#2692, epic #2687) — the single seam the emailDelivery.mark/clear mutations + the
 		// emailDelivery.failing admin roll-up gate behind until a human release.

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -247,6 +247,19 @@ export const PHOENIX_KARMA_GATES = "phoenix-karma-gates";
 export const PHOENIX_USER_BAN = "phoenix-user-ban";
 
 /**
+ * Platform-role assignment dark-ship flag (#3522, admin epic per ADR 0107). The SINGLE
+ * seam the `Admin.over(platform)`-gated `user.setRole` mutation gates behind — the writer
+ * for the `moderates` relation tuple #969/PR #1266's offline mint never gave the console.
+ * Default-off so the whole role-assign path reaches production dark until a human flips it
+ * at release (ADR 0083): with it off the mutation fails the invisible `Denied` (like a
+ * non-admin call), so an unreleased role-grant can never mint a moderator. Its OWN key,
+ * not the ban/email-admin seam — role-assign is a distinct admin capability with its own
+ * lifecycle (the `phoenix-user-ban` / `phoenix-email-delivery-admin` admin-surface
+ * precedent). The #3203 roster affordance wires onto this mutation later.
+ */
+export const PHOENIX_USER_ROLE_ASSIGN = "phoenix-user-role-assign";
+
+/**
  * Admin email-delivery (failing-address) surface dark-ship flag (#2692, email-bounce
  * epic #2687). The SINGLE seam the admin failing-address surface gates behind — the
  * `emailDelivery.mark` / `emailDelivery.clear` admin mutations AND the
@@ -379,6 +392,7 @@ export const DECLARED_FLAGS: readonly FlagDeclaration[] = [
 	{key: PHOENIX_REACTIONS, defaultValue: false},
 	{key: PHOENIX_KARMA_GATES, defaultValue: false},
 	{key: PHOENIX_USER_BAN, defaultValue: false},
+	{key: PHOENIX_USER_ROLE_ASSIGN, defaultValue: false},
 	{key: PHOENIX_EMAIL_DELIVERY_ADMIN, defaultValue: false},
 	{key: PHOENIX_EMAIL_DELIVERY_NOTICE, defaultValue: false},
 	{key: PHOENIX_NAV_IA, defaultValue: false},

--- a/apps/web/tests/integration/pasaport-set-role.test.ts
+++ b/apps/web/tests/integration/pasaport-set-role.test.ts
@@ -1,0 +1,202 @@
+/**
+ * `Pasaport.setRole` tuple-write fidelity against **real remote D1** (ADR 0082
+ * integration tier, #3522) — the security-critical branch the unit tier can't reach.
+ *
+ * `role-mutation.unit.test.ts` drives the WIRE authority (fail-closed for a non-admin,
+ * dark-ship inert) over a STUBBED `Pasaport`, so the domain write itself — the
+ * `role === "moderator" ? insert(moderatorTuple).onConflictDoNothing() : delete(...)`
+ * ternary inside `Pasaport.setRole` — never runs there, and an inverted ternary would
+ * ship green (AC5). This drives the REAL `Pasaport.setRole` over the shipped D1 REST
+ * transport and asserts the exact tuple the roster re-reads (`isModerator` /
+ * `moderatorsAmong`): `moderator` grants the `(user, "moderates", platform)` tuple
+ * (idempotently, `onConflictDoNothing`), `member` revokes it, and every change appends
+ * an audited `user_role_event` row.
+ *
+ * Mirrors `kunye-relation-store.test.ts` (the same real-D1 RelationStore primitive over
+ * `makeD1Rest` + `createDrizzle`) and `pasaport-ban.test.ts` (the sibling audit-log
+ * mutation). Runs on the run-scoped SHARED stage (ADR 0104); every id is `NS`-prefixed
+ * (this file's deterministic token) so its rows are its own and are cleaned up after.
+ */
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import type {RelationStore} from "@kampus/authz";
+import {makeD1Rest, readYourWrite} from "@kampus/d1-rest";
+import {and, eq, inArray} from "drizzle-orm";
+import {Effect, Layer} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {createDrizzle, type DrizzleDb, makeDrizzleLayer} from "../../worker/db/Drizzle.ts";
+import * as schema from "../../worker/db/drizzle/schema.ts";
+import {
+	isModerator,
+	moderatorTuple,
+	type PlatformRole,
+} from "../../worker/features/kunye/moderate.ts";
+import {RelationStoreLive} from "../../worker/features/kunye/RelationStore.ts";
+import {
+	type BetterAuthInstance,
+	makePasaportLive,
+	Pasaport,
+} from "../../worker/features/pasaport/Pasaport.ts";
+import {rateLimitRetryingFetch} from "./_d1-rest-retry.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
+
+const h = sharedStack();
+const NS = nsToken(import.meta.url);
+
+// The data-plane writes/reads cross this REST transport, so its `fetch` carries the same
+// 429-retry the sibling integration tests use (#3089): a transient CF 429 under
+// merge_group load is re-sent with backoff at the transport, not thrown into drizzle.
+const restLayer = Layer.merge(
+	CredentialsFromEnv,
+	FetchHttpClient.layer.pipe(
+		Layer.provide(
+			Layer.succeed(
+				FetchHttpClient.Fetch,
+				rateLimitRetryingFetch((input, init) => fetch(input, init)),
+			),
+		),
+	),
+);
+
+// `setRole` never touches better-auth (no session/DB use on this path), so an inert
+// instance satisfies the type — the same shape the Pasaport unit tests use.
+const inertAuth = {} as BetterAuthInstance;
+
+let db: DrizzleDb;
+let layer: Layer.Layer<Pasaport | RelationStore>;
+
+const userIds: string[] = [];
+
+// Insert the target directly (the offline mint path — like `kunye-relation-store`'s
+// `mint`): `setRole` rejects an unknown id up front, so the row must exist first.
+const createUser = async (id: string) => {
+	await db
+		.insert(schema.user)
+		.values({id, email: `${id}@test.local`, type: "human"})
+		.run();
+	userIds.push(id);
+};
+
+const runSetRole = (userId: string, role: PlatformRole) =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const pasaport = yield* Pasaport;
+			return yield* pasaport.setRole({userId, actorId: `${NS}-admin`, role});
+		}).pipe(Effect.provide(layer)),
+	);
+
+const runIsModerator = (userId: string) =>
+	Effect.runPromise(isModerator(userId).pipe(Effect.provide(layer)));
+
+// The exact `(user, "moderates", platform)` row `setRole` writes — count it directly to
+// prove the idempotent grant is a single row, not a duplicate.
+const tupleCount = async (userId: string): Promise<number> => {
+	const tuple = moderatorTuple(userId);
+	const rows = await db
+		.select({subject: schema.relationTuple.subject})
+		.from(schema.relationTuple)
+		.where(
+			and(
+				eq(schema.relationTuple.subject, tuple.subject),
+				eq(schema.relationTuple.relation, tuple.relation),
+				eq(schema.relationTuple.object, tuple.object),
+			),
+		)
+		.all();
+	return rows.length;
+};
+
+const auditRows = async (userId: string): Promise<Array<{role: string; actorId: string}>> => {
+	const rows = await db
+		.select({role: schema.userRoleEvent.role, actorId: schema.userRoleEvent.actorId})
+		.from(schema.userRoleEvent)
+		.where(eq(schema.userRoleEvent.userId, userId))
+		.all();
+	return rows;
+};
+
+// D1 REST carries no read-your-writes guarantee (replica lag), so poll the read to the
+// truth this test just wrote under a bounded budget rather than assert once and flake.
+const isModWhen = (userId: string, expected: boolean): Promise<boolean> =>
+	readYourWrite(
+		() => runIsModerator(userId),
+		(observed) => observed === expected,
+	);
+const tupleCountWhen = (userId: string, expected: number): Promise<number> =>
+	readYourWrite(
+		() => tupleCount(userId),
+		(observed) => observed === expected,
+	);
+const auditRowsWhen = (
+	userId: string,
+	predicate: (rows: Array<{role: string; actorId: string}>) => boolean,
+): Promise<Array<{role: string; actorId: string}>> =>
+	readYourWrite(() => auditRows(userId), predicate);
+
+beforeAll(async () => {
+	const {accountId, databaseId} = await h.d1Target();
+	db = createDrizzle(makeD1Rest({accountId, databaseId, layer: restLayer}));
+	const drizzleLayer = makeDrizzleLayer(db);
+	layer = Layer.mergeAll(
+		makePasaportLive(inertAuth).pipe(Layer.provide(drizzleLayer)),
+		RelationStoreLive.pipe(Layer.provide(drizzleLayer)),
+	);
+});
+
+afterAll(async () => {
+	if (userIds.length === 0) return;
+	// Tear down all three tables explicitly (the run is a direct REST transport — don't
+	// lean on ON DELETE cascade): audit rows, the moderates tuple, then the user rows.
+	await db.delete(schema.userRoleEvent).where(inArray(schema.userRoleEvent.userId, userIds)).run();
+	await db.delete(schema.relationTuple).where(inArray(schema.relationTuple.subject, userIds)).run();
+	await db.delete(schema.user).where(inArray(schema.user.id, userIds)).run();
+});
+
+describe("Pasaport.setRole — the real tuple write over real D1 (#3522 AC5)", () => {
+	it("moderator grants the (user, moderates, platform) tuple — and re-grant is an idempotent no-op", async () => {
+		const userId = `${NS}-grant`;
+		await createUser(userId);
+
+		// Before: not a moderator.
+		expect(await isModWhen(userId, false)).toBe(false);
+
+		const first = await runSetRole(userId, "moderator");
+		expect(first.role).toBe("moderator");
+		expect(await isModWhen(userId, true)).toBe(true);
+
+		// Re-grant: `onConflictDoNothing` must neither error nor duplicate the tuple.
+		const second = await runSetRole(userId, "moderator");
+		expect(second.role).toBe("moderator");
+		expect(await isModWhen(userId, true)).toBe(true);
+		expect(await tupleCountWhen(userId, 1)).toBe(1);
+	});
+
+	it("member revokes the tuple — the roster read flips back to non-moderator", async () => {
+		const userId = `${NS}-revoke`;
+		await createUser(userId);
+
+		await runSetRole(userId, "moderator");
+		expect(await isModWhen(userId, true)).toBe(true);
+
+		const revoked = await runSetRole(userId, "member");
+		expect(revoked.role).toBe("member");
+		expect(await isModWhen(userId, false)).toBe(false);
+		expect(await tupleCountWhen(userId, 0)).toBe(0);
+	});
+
+	it("every role change appends an audited user_role_event row (actor, target, new role)", async () => {
+		const userId = `${NS}-audit`;
+		await createUser(userId);
+
+		await runSetRole(userId, "moderator");
+		await runSetRole(userId, "member");
+
+		const rows = await auditRowsWhen(userId, (r) => r.length >= 2);
+		expect(rows.length).toBeGreaterThanOrEqual(2);
+		expect(rows.every((r) => r.actorId === `${NS}-admin`)).toBe(true);
+		const roles = rows.map((r) => r.role);
+		expect(roles).toContain("moderator");
+		expect(roles).toContain("member");
+	});
+});

--- a/apps/web/worker/db/drizzle/migrations/0032_user_role_event.sql
+++ b/apps/web/worker/db/drizzle/migrations/0032_user_role_event.sql
@@ -1,0 +1,18 @@
+-- #3522 (admin epic, ADR 0107) — the append-only platform-role assignment log. The
+-- audit trail for the `Admin.over(platform)`-gated `user.setRole` mutation, which
+-- writes the `moderates` relation tuple the console needs (#969/PR #1266 shipped only
+-- the offline mint). State is a projection of the latest row (`role`), mirroring
+-- `user_ban_event`, so the log can never drift from the `relation_tuple` write the
+-- mutation commits alongside it. The `(user_id, created_at DESC)` index serves the
+-- per-account latest-event read.
+
+CREATE TABLE `user_role_event` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`role` text NOT NULL,
+	`actor_id` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `user_role_event_user_created` ON `user_role_event` (`user_id`,"created_at" DESC);

--- a/apps/web/worker/db/drizzle/migrations/meta/0032_user_role_event_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0032_user_role_event_snapshot.json
@@ -1,0 +1,2507 @@
+{
+ "version": "6",
+ "dialect": "sqlite",
+ "id": "1c8aef63-0e1d-4745-918f-21120ab7dc38",
+ "prevId": "585e46b7-0f90-4f55-96b4-6211b4b18794",
+ "tables": {
+  "account": {
+   "name": "account",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "account_id": {
+     "name": "account_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "provider_id": {
+     "name": "provider_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "access_token": {
+     "name": "access_token",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "refresh_token": {
+     "name": "refresh_token",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "access_token_expires_at": {
+     "name": "access_token_expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "refresh_token_expires_at": {
+     "name": "refresh_token_expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "scope": {
+     "name": "scope",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "id_token": {
+     "name": "id_token",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "password": {
+     "name": "password",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {
+    "account_user_id_user_id_fk": {
+     "name": "account_user_id_user_id_fk",
+     "tableFrom": "account",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "apiKey": {
+   "name": "apiKey",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "config_id": {
+     "name": "config_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'default'"
+    },
+    "name": {
+     "name": "name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "start": {
+     "name": "start",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "prefix": {
+     "name": "prefix",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "key": {
+     "name": "key",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "refill_interval": {
+     "name": "refill_interval",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "refill_amount": {
+     "name": "refill_amount",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "last_refill_at": {
+     "name": "last_refill_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "enabled": {
+     "name": "enabled",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": true
+    },
+    "rate_limit_enabled": {
+     "name": "rate_limit_enabled",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": false
+    },
+    "rate_limit_time_window": {
+     "name": "rate_limit_time_window",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "rate_limit_max": {
+     "name": "rate_limit_max",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "request_count": {
+     "name": "request_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "remaining": {
+     "name": "remaining",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "last_request": {
+     "name": "last_request",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "expires_at": {
+     "name": "expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "permissions": {
+     "name": "permissions",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "metadata": {
+     "name": "metadata",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {
+    "apiKey_user_id_user_id_fk": {
+     "name": "apiKey_user_id_user_id_fk",
+     "tableFrom": "apiKey",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "comment_vote": {
+   "name": "comment_vote",
+   "columns": {
+    "comment_id": {
+     "name": "comment_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "voter_id": {
+     "name": "voter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "comment_vote_comment": {
+     "name": "comment_vote_comment",
+     "columns": [
+      "comment_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "comment_vote_comment_id_voter_id_pk": {
+     "columns": [
+      "comment_id",
+      "voter_id"
+     ],
+     "name": "comment_vote_comment_id_voter_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "definition_vote": {
+   "name": "definition_vote",
+   "columns": {
+    "definition_id": {
+     "name": "definition_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "voter_id": {
+     "name": "voter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "definition_vote_definition": {
+     "name": "definition_vote_definition",
+     "columns": [
+      "definition_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "definition_vote_definition_id_voter_id_pk": {
+     "columns": [
+      "definition_id",
+      "voter_id"
+     ],
+     "name": "definition_vote_definition_id_voter_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "pano_stats": {
+   "name": "pano_stats",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "integer",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 1
+    },
+    "total_posts": {
+     "name": "total_posts",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_comments": {
+     "name": "total_comments",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_authors": {
+     "name": "total_authors",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "post_record": {
+   "name": "post_record",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "slug": {
+     "name": "slug",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "title": {
+     "name": "title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "url": {
+     "name": "url",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "host": {
+     "name": "host",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "body": {
+     "name": "body",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "body_excerpt": {
+     "name": "body_excerpt",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_name": {
+     "name": "author_name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "tags": {
+     "name": "tags",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "score": {
+     "name": "score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "comment_count": {
+     "name": "comment_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "hot_score": {
+     "name": "hot_score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "last_activity_at": {
+     "name": "last_activity_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "is_draft": {
+     "name": "is_draft",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_at": {
+     "name": "removed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_by": {
+     "name": "removed_by",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_reason": {
+     "name": "removed_reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "sandboxed_at": {
+     "name": "sandboxed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "post_record_hot": {
+     "name": "post_record_hot",
+     "columns": [
+      "hot_score"
+     ],
+     "isUnique": false
+    },
+    "post_record_new": {
+     "name": "post_record_new",
+     "columns": [
+      "created_at"
+     ],
+     "isUnique": false
+    },
+    "post_record_top": {
+     "name": "post_record_top",
+     "columns": [
+      "score"
+     ],
+     "isUnique": false
+    },
+    "post_record_discuss": {
+     "name": "post_record_discuss",
+     "columns": [
+      "comment_count"
+     ],
+     "isUnique": false
+    },
+    "post_record_host": {
+     "name": "post_record_host",
+     "columns": [
+      "host"
+     ],
+     "isUnique": false
+    },
+    "post_record_author_created": {
+     "name": "post_record_author_created",
+     "columns": [
+      "author_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    },
+    "post_record_one_draft_per_author": {
+     "name": "post_record_one_draft_per_author",
+     "columns": [
+      "author_id"
+     ],
+     "isUnique": true,
+     "where": "`is_draft` = 1"
+    },
+    "post_record_sandboxed": {
+     "name": "post_record_sandboxed",
+     "columns": [
+      "sandboxed_at"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "post_vote": {
+   "name": "post_vote",
+   "columns": {
+    "post_id": {
+     "name": "post_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "voter_id": {
+     "name": "voter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "post_vote_post": {
+     "name": "post_vote_post",
+     "columns": [
+      "post_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "post_vote_post_id_voter_id_pk": {
+     "columns": [
+      "post_id",
+      "voter_id"
+     ],
+     "name": "post_vote_post_id_voter_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "session": {
+   "name": "session",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "expires_at": {
+     "name": "expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "token": {
+     "name": "token",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "ip_address": {
+     "name": "ip_address",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "user_agent": {
+     "name": "user_agent",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "session_token_unique": {
+     "name": "session_token_unique",
+     "columns": [
+      "token"
+     ],
+     "isUnique": true
+    }
+   },
+   "foreignKeys": {
+    "session_user_id_user_id_fk": {
+     "name": "session_user_id_user_id_fk",
+     "tableFrom": "session",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "sozluk_stats": {
+   "name": "sozluk_stats",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "integer",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 1
+    },
+    "total_definitions": {
+     "name": "total_definitions",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_terms": {
+     "name": "total_terms",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_authors": {
+     "name": "total_authors",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "term_record": {
+   "name": "term_record",
+   "columns": {
+    "slug": {
+     "name": "slug",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "title": {
+     "name": "title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "first_letter": {
+     "name": "first_letter",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "definition_count": {
+     "name": "definition_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "total_score": {
+     "name": "total_score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "excerpt": {
+     "name": "excerpt",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "top_definition_id": {
+     "name": "top_definition_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "first_at": {
+     "name": "first_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "last_activity_at": {
+     "name": "last_activity_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "last_edit_at": {
+     "name": "last_edit_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "term_record_recent": {
+     "name": "term_record_recent",
+     "columns": [
+      "last_activity_at"
+     ],
+     "isUnique": false
+    },
+    "term_record_popular": {
+     "name": "term_record_popular",
+     "columns": [
+      "total_score"
+     ],
+     "isUnique": false
+    },
+    "term_record_letter": {
+     "name": "term_record_letter",
+     "columns": [
+      "first_letter"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user": {
+   "name": "user",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "name": {
+     "name": "name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "email": {
+     "name": "email",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "image": {
+     "name": "image",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "type": {
+     "name": "type",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'human'"
+    },
+    "role": {
+     "name": "role",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'member'"
+    },
+    "tier": {
+     "name": "tier",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'\u00e7aylak'"
+    },
+    "promoted_at": {
+     "name": "promoted_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "email_verified": {
+     "name": "email_verified",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "username": {
+     "name": "username",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "deleted_at": {
+     "name": "deleted_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_username_unique": {
+     "name": "user_username_unique",
+     "columns": [
+      "username"
+     ],
+     "isUnique": true
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_profile": {
+   "name": "user_profile",
+   "columns": {
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "username": {
+     "name": "username",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "display_name": {
+     "name": "display_name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "image": {
+     "name": "image",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "total_karma": {
+     "name": "total_karma",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "definition_count": {
+     "name": "definition_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "post_count": {
+     "name": "post_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "comment_count": {
+     "name": "comment_count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_profile_username_unique": {
+     "name": "user_profile_username_unique",
+     "columns": [
+      "username"
+     ],
+     "isUnique": true
+    },
+    "user_profile_username": {
+     "name": "user_profile_username",
+     "columns": [
+      "username"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_vote": {
+   "name": "user_vote",
+   "columns": {
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_kind": {
+     "name": "target_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_id": {
+     "name": "target_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_vote_target": {
+     "name": "user_vote_target",
+     "columns": [
+      "target_kind",
+      "target_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "user_vote_user_id_target_kind_target_id_pk": {
+     "columns": [
+      "user_id",
+      "target_kind",
+      "target_id"
+     ],
+     "name": "user_vote_user_id_target_kind_target_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "verification": {
+   "name": "verification",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "identifier": {
+     "name": "identifier",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "value": {
+     "name": "value",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "expires_at": {
+     "name": "expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {},
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "content_report": {
+   "name": "content_report",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "reporter_id": {
+     "name": "reporter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_kind": {
+     "name": "target_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_id": {
+     "name": "target_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "reason": {
+     "name": "reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "status": {
+     "name": "status",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "'open'"
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "resolver_id": {
+     "name": "resolver_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "resolved_at": {
+     "name": "resolved_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "resolution": {
+     "name": "resolution",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "wave_id": {
+     "name": "wave_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "content_report_target": {
+     "name": "content_report_target",
+     "columns": [
+      "target_kind",
+      "target_id"
+     ],
+     "isUnique": false
+    },
+    "content_report_wave": {
+     "name": "content_report_wave",
+     "columns": [
+      "wave_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "content_report_pk": {
+     "name": "content_report_pk",
+     "columns": [
+      "reporter_id",
+      "target_kind",
+      "target_id"
+     ]
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "post_bookmark": {
+   "name": "post_bookmark",
+   "columns": {
+    "post_id": {
+     "name": "post_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "post_bookmark_user_created": {
+     "name": "post_bookmark_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "post_bookmark_pk": {
+     "name": "post_bookmark_pk",
+     "columns": [
+      "post_id",
+      "user_id"
+     ]
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "definition_record": {
+   "name": "definition_record",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_name": {
+     "name": "author_name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "term_slug": {
+     "name": "term_slug",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "term_title": {
+     "name": "term_title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "body": {
+     "name": "body",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "body_excerpt": {
+     "name": "body_excerpt",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "score": {
+     "name": "score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "removed_at": {
+     "name": "removed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_by": {
+     "name": "removed_by",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_reason": {
+     "name": "removed_reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "sandboxed_at": {
+     "name": "sandboxed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "definition_record_author_created": {
+     "name": "definition_record_author_created",
+     "columns": [
+      "author_id",
+      "created_at"
+     ],
+     "isUnique": false
+    },
+    "definition_record_term_score": {
+     "name": "definition_record_term_score",
+     "columns": [
+      "term_slug",
+      "score"
+     ],
+     "isUnique": false
+    },
+    "definition_record_sandboxed": {
+     "name": "definition_record_sandboxed",
+     "columns": [
+      "sandboxed_at"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "comment_record": {
+   "name": "comment_record",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "author_name": {
+     "name": "author_name",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "post_id": {
+     "name": "post_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "post_title": {
+     "name": "post_title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "parent_id": {
+     "name": "parent_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "body": {
+     "name": "body",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "body_excerpt": {
+     "name": "body_excerpt",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "score": {
+     "name": "score",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 0
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "removed_at": {
+     "name": "removed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_by": {
+     "name": "removed_by",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "removed_reason": {
+     "name": "removed_reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "sandboxed_at": {
+     "name": "sandboxed_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "comment_record_author_created": {
+     "name": "comment_record_author_created",
+     "columns": [
+      "author_id",
+      "created_at"
+     ],
+     "isUnique": false
+    },
+    "comment_record_post": {
+     "name": "comment_record_post",
+     "columns": [
+      "post_id"
+     ],
+     "isUnique": false
+    },
+    "comment_record_parent": {
+     "name": "comment_record_parent",
+     "columns": [
+      "parent_id"
+     ],
+     "isUnique": false
+    },
+    "comment_record_sandboxed": {
+     "name": "comment_record_sandboxed",
+     "columns": [
+      "sandboxed_at"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "relation_tuple": {
+   "name": "relation_tuple",
+   "columns": {
+    "subject": {
+     "name": "subject",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "relation": {
+     "name": "relation",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "object": {
+     "name": "object",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "relation_tuple_object": {
+     "name": "relation_tuple_object",
+     "columns": [
+      "object",
+      "relation"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "relation_tuple_subject_relation_object_pk": {
+     "name": "relation_tuple_subject_relation_object_pk",
+     "columns": [
+      "subject",
+      "relation",
+      "object"
+     ]
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "authorship_vouch": {
+   "name": "authorship_vouch",
+   "columns": {
+    "voucher_id": {
+     "name": "voucher_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "candidate_id": {
+     "name": "candidate_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "authorship_vouch_candidate": {
+     "name": "authorship_vouch_candidate",
+     "columns": [
+      "candidate_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "authorship_vouch_voucher_id_candidate_id_pk": {
+     "name": "authorship_vouch_voucher_id_candidate_id_pk",
+     "columns": [
+      "voucher_id",
+      "candidate_id"
+     ]
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "notification": {
+   "name": "notification",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "recipient_id": {
+     "name": "recipient_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "kind": {
+     "name": "kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_kind": {
+     "name": "target_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_id": {
+     "name": "target_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "actor_id": {
+     "name": "actor_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "count": {
+     "name": "count",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": 1
+    },
+    "read_at": {
+     "name": "read_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "notification_recipient_read": {
+     "name": "notification_recipient_read",
+     "columns": [
+      "recipient_id",
+      "read_at"
+     ],
+     "isUnique": false
+    },
+    "notification_recipient_created": {
+     "name": "notification_recipient_created",
+     "columns": [
+      "recipient_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_reaction": {
+   "name": "user_reaction",
+   "columns": {
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_kind": {
+     "name": "target_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "target_id": {
+     "name": "target_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "emoji": {
+     "name": "emoji",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_reaction_target": {
+     "name": "user_reaction_target",
+     "columns": [
+      "target_kind",
+      "target_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "user_reaction_user_id_target_kind_target_id_pk": {
+     "columns": [
+      "user_id",
+      "target_kind",
+      "target_id"
+     ],
+     "name": "user_reaction_user_id_target_kind_target_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_ban_event": {
+   "name": "user_ban_event",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "action": {
+     "name": "action",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "actor_id": {
+     "name": "actor_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "reason": {
+     "name": "reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "expires_at": {
+     "name": "expires_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_ban_event_user_created": {
+     "name": "user_ban_event_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {
+    "user_ban_event_user_id_user_id_fk": {
+     "name": "user_ban_event_user_id_user_id_fk",
+     "tableFrom": "user_ban_event",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "mecmua_post": {
+   "name": "mecmua_post",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "title": {
+     "name": "title",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "body": {
+     "name": "body",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false,
+     "default": "''"
+    },
+    "slug": {
+     "name": "slug",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "published_at": {
+     "name": "published_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "updated_at": {
+     "name": "updated_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "mecmua_post_author_created": {
+     "name": "mecmua_post_author_created",
+     "columns": [
+      "author_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "mecmua_subscription": {
+   "name": "mecmua_subscription",
+   "columns": {
+    "author_id": {
+     "name": "author_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "subscriber_id": {
+     "name": "subscriber_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "mecmua_subscription_subscriber": {
+     "name": "mecmua_subscription_subscriber",
+     "columns": [
+      "subscriber_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "mecmua_subscription_subscriber_id_author_id_pk": {
+     "columns": [
+      "subscriber_id",
+      "author_id"
+     ],
+     "name": "mecmua_subscription_subscriber_id_author_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "karma_event": {
+   "name": "karma_event",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "delta": {
+     "name": "delta",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "source_kind": {
+     "name": "source_kind",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "source_id": {
+     "name": "source_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "reason": {
+     "name": "reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "karma_event_user_created": {
+     "name": "karma_event_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {
+    "karma_event_user_id_user_id_fk": {
+     "name": "karma_event_user_id_user_id_fk",
+     "tableFrom": "karma_event",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "email_delivery_event": {
+   "name": "email_delivery_event",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "address": {
+     "name": "address",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "action": {
+     "name": "action",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "actor_id": {
+     "name": "actor_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "reason": {
+     "name": "reason",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": false,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "email_delivery_event_address_created": {
+     "name": "email_delivery_event_address_created",
+     "columns": [
+      "address",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    },
+    "email_delivery_event_user_created": {
+     "name": "email_delivery_event_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {
+    "email_delivery_event_user_id_user_id_fk": {
+     "name": "email_delivery_event_user_id_user_id_fk",
+     "tableFrom": "email_delivery_event",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "set null",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_mute": {
+   "name": "user_mute",
+   "columns": {
+    "muter_id": {
+     "name": "muter_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "muted_id": {
+     "name": "muted_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_mute_muted": {
+     "name": "user_mute_muted",
+     "columns": [
+      "muted_id"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {},
+   "compositePrimaryKeys": {
+    "user_mute_muter_id_muted_id_pk": {
+     "columns": [
+      "muter_id",
+      "muted_id"
+     ],
+     "name": "user_mute_muter_id_muted_id_pk"
+    }
+   },
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  },
+  "user_role_event": {
+   "name": "user_role_event",
+   "columns": {
+    "id": {
+     "name": "id",
+     "type": "text",
+     "primaryKey": true,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "user_id": {
+     "name": "user_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "role": {
+     "name": "role",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "actor_id": {
+     "name": "actor_id",
+     "type": "text",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    },
+    "created_at": {
+     "name": "created_at",
+     "type": "integer",
+     "primaryKey": false,
+     "notNull": true,
+     "autoincrement": false
+    }
+   },
+   "indexes": {
+    "user_role_event_user_created": {
+     "name": "user_role_event_user_created",
+     "columns": [
+      "user_id",
+      "\"created_at\" DESC"
+     ],
+     "isUnique": false
+    }
+   },
+   "foreignKeys": {
+    "user_role_event_user_id_user_id_fk": {
+     "name": "user_role_event_user_id_user_id_fk",
+     "tableFrom": "user_role_event",
+     "tableTo": "user",
+     "columnsFrom": [
+      "user_id"
+     ],
+     "columnsTo": [
+      "id"
+     ],
+     "onDelete": "cascade",
+     "onUpdate": "no action"
+    }
+   },
+   "compositePrimaryKeys": {},
+   "uniqueConstraints": {},
+   "checkConstraints": {}
+  }
+ },
+ "views": {},
+ "enums": {},
+ "_meta": {
+  "schemas": {},
+  "tables": {},
+  "columns": {}
+ },
+ "internal": {
+  "indexes": {
+   "post_record_author_created": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   },
+   "user_ban_event_user_created": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   },
+   "mecmua_post_author_created": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   },
+   "mecmua_subscription_subscriber": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   },
+   "user_role_event_user_created": {
+    "columns": {
+     "\"created_at\" DESC": {
+      "isExpression": true
+     }
+    }
+   }
+  }
+ }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
 			"when": 2496000000000,
 			"tag": "0031_user_mute",
 			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "6",
+			"when": 2596000000000,
+			"tag": "0032_user_role_event",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -235,6 +235,38 @@ export const emailDeliveryEvent = sqliteTable(
 );
 
 /**
+ * Append-only platform-role assignment log (#3522, admin epic per ADR 0107). The
+ * audit trail for the `Admin.over(platform)`-gated `user.setRole` mutation — the
+ * SPA-invokable writer for the `moderates` relation tuple that #969/PR #1266's
+ * offline mint never gave the console. Same append-only, latest-event-wins shape as
+ * {@link userBanEvent}: the newest event's `role` is the current assignment, so the
+ * log can never drift from the authoritative `relation_tuple` write the mutation
+ * commits alongside it. `role` is the NEW role the action set — `moderator` grants
+ * the `(user, "moderates", "platform")` tuple, `member` revokes it — so actor,
+ * target, new role, and time are all captured for the audit AC. The `(user_id,
+ * created_at DESC)` index serves the per-account latest-event read; `onDelete:
+ * cascade` ties the history to the account row (a kept tombstone survives account
+ * deletion, ADR 0097).
+ */
+export const userRoleEvent = sqliteTable(
+	"user_role_event",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, {onDelete: "cascade"}),
+		// The role this action assigned: `moderator` writes the `moderates` tuple,
+		// `member` clears it. The latest row projects to the account's current role.
+		role: text("role", {enum: ["member", "moderator"]}).notNull(),
+		// The admin who performed the action (a discharged `Admin` grant's account id),
+		// mirroring {@link userBanEvent}'s `actorId`.
+		actorId: text("actor_id").notNull(),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(t) => [index("user_role_event_user_created").on(t.userId, sql`${t.createdAt} DESC`)],
+);
+
+/**
  * Per-(definition, voter) up-vote presence row. `user_vote` and
  * `definition_record.score` (COUNT(*) under `WHERE definition_id = ?`) are both
  * denormalized off this, recomputed inline in the same D1 batch as the vote write.

--- a/apps/web/worker/features/fate-live/fanned-mutations.ts
+++ b/apps/web/worker/features/fate-live/fanned-mutations.ts
@@ -311,6 +311,12 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 		rationale: "appends an audited unban event on the identity surface — no fanned content entity",
 	},
 	{
+		key: "user.setRole",
+		fanned: false,
+		rationale:
+			"writes the `moderates` relation tuple + an audited role event on the identity/authority surface (#3522) — no Post/Comment/Definition in a subscribed content connection (mirrors user.banUser); the derived roster role re-reads the tuple through the gated UserAdmin view",
+	},
+	{
 		key: "emailDelivery.mark",
 		fanned: false,
 		rationale:

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -32,6 +32,7 @@ import type {
 	FailingAddressView,
 	ProfileView,
 	PromotionReceiptView,
+	RoleStateView,
 	UserView,
 } from "../pasaport/views.ts";
 import type {
@@ -88,6 +89,7 @@ export type {
 	FailingAddressEntity as FailingAddress,
 	Profile,
 	PromotionReceipt,
+	RoleStateEntity as RoleState,
 	User,
 } from "../pasaport/views.ts";
 export {
@@ -99,6 +101,7 @@ export {
 	failingAddressDataView,
 	profileDataView,
 	promotionReceiptDataView,
+	roleStateDataView,
 	userDataView,
 } from "../pasaport/views.ts";
 export type {
@@ -193,6 +196,7 @@ type _FateViewsFieldMapResolved = [
 	>,
 	AssertResolved<typeof PromotionReceiptView, AssertFieldMapResolved<typeof PromotionReceiptView>>,
 	AssertResolved<typeof BanStateView, AssertFieldMapResolved<typeof BanStateView>>,
+	AssertResolved<typeof RoleStateView, AssertFieldMapResolved<typeof RoleStateView>>,
 	AssertResolved<
 		typeof EmailDeliveryStateView,
 		AssertFieldMapResolved<typeof EmailDeliveryStateView>

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -40,6 +40,7 @@ import {
 	PHOENIX_SOZLUK_STAMP_WAVE,
 	PHOENIX_USER_ADMIN,
 	PHOENIX_USER_BAN,
+	PHOENIX_USER_ROLE_ASSIGN,
 	PROFILE_CANVAS,
 } from "../../../src/flags/keys.ts";
 import {AUDIT_ENVIRONMENT} from "../../environment.ts";
@@ -805,6 +806,37 @@ export const USER_BAN_FLAG = {
  */
 export const userBanFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_user_ban", {appId, ...USER_BAN_FLAG});
+
+/**
+ * The platform-role assignment dark-ship flag config (#3522, admin epic per ADR 0107).
+ * Default-OFF so the whole role-assign path reaches production dark: with it off the
+ * `Admin.over(platform)`-gated `user.setRole` mutation fails the invisible `Denied` (like
+ * a non-admin call), so an unreleased role-grant can never mint a moderator. Flipping it
+ * on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
+ * WITHOUT constructing the alchemy resource (mirrors `USER_BAN_FLAG`).
+ *
+ * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
+ *   - owner:           pasaport (the identity + authority surface)
+ *   - originating:     #3522 (epic: admin dashboard, per ADR 0107)
+ *   - removal trigger: once role-assign graduates to on at 100% and stable for one
+ *                      release, retire the flag and inline the now-permanent path.
+ */
+export const USER_ROLE_ASSIGN_FLAG = {
+	key: PHOENIX_USER_ROLE_ASSIGN,
+	description:
+		"platform role assign dark-ship (#3522, ADR 0107). owner: pasaport. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const userRoleAssignFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_user_role_assign", {appId, ...USER_ROLE_ASSIGN_FLAG});
 
 /**
  * The admin email-delivery (failing-address) surface dark-ship flag config (#2692,

--- a/apps/web/worker/features/flagship/user-role-assign.invariant.test.ts
+++ b/apps/web/worker/features/flagship/user-role-assign.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the platform role-assign surface
+ * (#3522, admin epic per ADR 0107). Inspected off the exported `USER_ROLE_ASSIGN_FLAG`
+ * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy resource
+ * is constructed — mirrors `email-delivery-admin.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_USER_ROLE_ASSIGN} from "../../../src/flags/keys.ts";
+import {USER_ROLE_ASSIGN_FLAG, userRoleAssignFlag} from "./resources.ts";
+
+describe("platform role-assign surface — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(USER_ROLE_ASSIGN_FLAG.defaultVariation, "off");
+		assert.strictEqual(USER_ROLE_ASSIGN_FLAG.variations.off, false);
+		assert.strictEqual(USER_ROLE_ASSIGN_FLAG.variations.on, true);
+		assert.strictEqual(USER_ROLE_ASSIGN_FLAG.key, "phoenix-user-role-assign");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(USER_ROLE_ASSIGN_FLAG.key, PHOENIX_USER_ROLE_ASSIGN);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof userRoleAssignFlag, "function");
+	});
+});

--- a/apps/web/worker/features/kunye/moderate.ts
+++ b/apps/web/worker/features/kunye/moderate.ts
@@ -11,18 +11,55 @@
  * invariant). The instance lives here — künye owns the kamp.us capability
  * instances; the vocab-free mechanism is `@kampus/authz`.
  */
-import {Capability, Grant, matchActor, platform, RelationStore} from "@kampus/authz";
+import {
+	Capability,
+	Grant,
+	matchActor,
+	key as objectKey,
+	platform,
+	RelationStore,
+} from "@kampus/authz";
 import {Effect} from "effect";
 import {UserId} from "../../lib/ids.ts";
 import {Denied} from "./errors.ts";
 
+/**
+ * The `relation_tuple.relation` verb the moderator role rides on — the SINGLE source
+ * every moderator read, discharge, and the `user.setRole` runtime write share, so the
+ * read/discharge key and the write key can't drift (#3522).
+ */
+export const MODERATES_RELATION = "moderates";
+
+/**
+ * The two platform roles the admin roster surfaces (#3200): `moderator` iff the
+ * `moderates` tuple is held, else `member`. The value `user.setRole` assigns (#3522).
+ */
+export type PlatformRole = "member" | "moderator";
+
 export class Moderate extends Capability.Relation<Moderate>()("kunye/Moderate", {
-	relation: "moderates",
+	relation: MODERATES_RELATION,
 	deny: () => new Denied({message: "Moderation authority required"}),
 }) {}
 
 // Re-export the platform scope so a moderation surface gates with one import.
 export {platform};
+
+/**
+ * The stored `relation_tuple` row for `(subject, "moderates", platform)` — the SAME
+ * key {@link isModerator} / {@link moderatorsAmong} read and `Moderate.over(platform)`
+ * discharges against, resolved through `@kampus/authz`'s canonical `objectKey` (as
+ * `RelationStoreLive` does). The `Admin.over(platform)`-gated `user.setRole` writer
+ * (#3522) inserts/deletes exactly this row, so the runtime WRITE of the moderator
+ * relation can never encode the tuple differently from the read — the read-key-can't-
+ * drift invariant, now extended to the write.
+ */
+export const moderatorTuple = (
+	subject: string,
+): {subject: string; relation: string; object: string} => ({
+	subject,
+	relation: MODERATES_RELATION,
+	object: objectKey(platform),
+});
 
 /**
  * Is `subject` a platform moderator? The SELF-status read behind the trusted `me`

--- a/apps/web/worker/features/pasaport/Pasaport.testing.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.testing.ts
@@ -37,6 +37,7 @@ const failOnContact: PasaportShape = {
 	getBanState: die("getBanState"),
 	banUser: die("banUser"),
 	unbanUser: die("unbanUser"),
+	setRole: die("setRole"),
 	getEmailDeliveryState: die("getEmailDeliveryState"),
 	markEmailFailing: die("markEmailFailing"),
 	clearEmailFailing: die("clearEmailFailing"),

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -21,6 +21,7 @@ import {
 	resolveCursor,
 } from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
+import {moderatorTuple, type PlatformRole} from "../kunye/moderate.ts";
 import type {StoredTier} from "../kunye/standing.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {
@@ -329,6 +330,19 @@ export class Pasaport extends Context.Service<
 			userId: string;
 			actorId: string;
 		}) => Effect.Effect<BanState, UserNotFound>;
+
+		// Assign a target account's platform role (#3522, admin epic per ADR 0107):
+		// `moderator` writes the `(userId, "moderates", platform)` relation tuple,
+		// `member` deletes it — the SPA-invokable writer #969/PR #1266's offline mint
+		// never gave the console. The tuple write IS the authority change (`isModerator`
+		// / `moderatorsAmong` re-read it), and an append to `user_role_event` records the
+		// actor + new role + time. Returns the assigned role. `UserNotFound` on an unknown
+		// target. The AUTHORITY is discharged at the resolver (`requireAdmin`), never here.
+		readonly setRole: (input: {
+			userId: string;
+			actorId: string;
+			role: PlatformRole;
+		}) => Effect.Effect<{readonly role: PlatformRole}, UserNotFound>;
 
 		// The target account's current email-delivery state, projected from the latest
 		// `email_delivery_event` row for its address (email-bounce epic #2687). A fresh
@@ -1172,6 +1186,48 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						}),
 					);
 					return yield* readBanState(input.userId);
+				}),
+
+				setRole: Effect.fn("Pasaport.setRole")(function* (input: {
+					userId: string;
+					actorId: string;
+					role: PlatformRole;
+				}) {
+					// Reject an unknown target up front so a role is never assigned to a
+					// non-existent id (mirrors `banUser`; the audit log stays meaningful).
+					const target = yield* run((db) => db.query.user.findFirst({where: {id: input.userId}}));
+					if (!target) return yield* new UserNotFound({message: "kullanıcı bulunamadı"});
+
+					// The `moderates` tuple IS the authority: `moderator` grants it (idempotent
+					// on re-grant), `member` revokes it. Encoded through kunye's `moderatorTuple`
+					// so the write can't drift from the `isModerator` / `moderatorsAmong` read.
+					const tuple = moderatorTuple(input.userId);
+					yield* run((db) =>
+						input.role === "moderator"
+							? db.insert(schema.relationTuple).values(tuple).onConflictDoNothing()
+							: db
+									.delete(schema.relationTuple)
+									.where(
+										and(
+											eq(schema.relationTuple.subject, tuple.subject),
+											eq(schema.relationTuple.relation, tuple.relation),
+											eq(schema.relationTuple.object, tuple.object),
+										),
+									),
+					);
+
+					// Audit the assignment (actor, target, new role, time) on the append-only
+					// `user_role_event` log — the same audit shape ban/email-delivery use.
+					yield* run((db) =>
+						db.insert(schema.userRoleEvent).values({
+							id: crypto.randomUUID(),
+							userId: input.userId,
+							role: input.role,
+							actorId: input.actorId,
+							createdAt: new Date(),
+						}),
+					);
+					return {role: input.role};
 				}),
 
 				getEmailDeliveryState: Effect.fn("Pasaport.getEmailDeliveryState")(function* (

--- a/apps/web/worker/features/pasaport/fate-module.ts
+++ b/apps/web/worker/features/pasaport/fate-module.ts
@@ -13,6 +13,7 @@ import {
 	failingAddressSource,
 	profileSource,
 	promotionReceiptSource,
+	roleStateSource,
 	userSource,
 } from "./sources.ts";
 import {
@@ -50,6 +51,7 @@ export const fateModule = {
 		promotionReceiptSource,
 		authorshipStandingSource,
 		banStateSource,
+		roleStateSource,
 		emailDeliveryStateSource,
 		failingAddressSource,
 	],

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -13,6 +13,7 @@ import {
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_EMAIL_DELIVERY_ADMIN,
 	PHOENIX_USER_BAN,
+	PHOENIX_USER_ROLE_ASSIGN,
 } from "../../../src/flags/keys.ts";
 import {UserId} from "../../lib/ids.ts";
 import {notifyKefil, notifyPromotion} from "../bildirim/rite-emitters.ts";
@@ -43,6 +44,7 @@ import {
 	toBanState,
 	toEmailDeliveryState,
 	toPromotionReceipt,
+	toRoleState,
 } from "./shapers.ts";
 import {resolveTandem} from "./tandem.ts";
 import {toTrustedUser} from "./trusted-user.ts";
@@ -51,6 +53,7 @@ import {
 	BanStateView,
 	EmailDeliveryStateView,
 	PromotionReceiptView,
+	RoleStateView,
 	UserView,
 } from "./views.ts";
 
@@ -74,6 +77,17 @@ const authorshipLoopOn = Effect.gen(function* () {
 const userBanOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_USER_BAN, false).pipe(provideRequestFlags);
+});
+
+/**
+ * Is the #3522 platform-role-assign dark-ship flag on for this request? Safe-default
+ * `false` (dark), the `userBanOn` idiom: with the flag off (default / Flagship outage)
+ * the `user.setRole` path fails the invisible `Denied` exactly like a non-admin call, so
+ * an unreleased role-grant can never mint a moderator (ADR 0083).
+ */
+const userRoleAssignOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(PHOENIX_USER_ROLE_ASSIGN, false).pipe(provideRequestFlags);
 });
 
 /**
@@ -137,6 +151,15 @@ const BanUserInput = Schema.Struct({
 
 const UnbanUserInput = Schema.Struct({
 	userId: UserId,
+});
+
+// Assign a target account's platform role by id: `role` is a `Schema.Literal` union, so a
+// value outside {member, moderator} is an input-DECODE failure — the body never runs on a
+// malformed request. No `actor` arg — the acting admin is the discharged `Admin` grant's
+// id, never client-supplied, so a role change is always audited against its real author.
+const SetRoleInput = Schema.Struct({
+	userId: UserId,
+	role: Schema.Literals(["member", "moderator"]),
 });
 
 // Mark a target account's address as failing: a `reason` (required — enforced non-empty
@@ -349,6 +372,29 @@ export const mutations = {
 		}),
 	),
 
+	// Assign a platform role (#3522, admin epic per ADR 0107) — `requireAdmin`-gated,
+	// behind the `phoenix-user-role-assign` dark-ship flag. With the flag off the mutation
+	// fails the invisible `Denied` (like a non-admin call), so an unreleased role-grant can
+	// never mint a moderator. The write is the `moderates` relation tuple (`moderator`
+	// grants it, `member` revokes it) — the SPA-invokable writer #969/PR #1266's offline
+	// mint never gave the console — plus an audited `user_role_event`. Not fanned
+	// (`fanned-mutations.ts`): the tuple/log are an identity/authority surface, not a
+	// subscribed content connection (mirrors `user.banUser`). The derived roster `role`
+	// cell re-reads the same tuple through the gated `UserAdmin` view.
+	"user.setRole": Fate.mutation(
+		{
+			input: SetRoleInput,
+			type: RoleStateView,
+			error: Schema.Union([Denied, UserNotFound]),
+		},
+		Effect.fn("user.setRole")(function* ({input}) {
+			if (!(yield* userRoleAssignOn)) {
+				return yield* Effect.fail(new Denied({message: "Bu işlem şu an kapalı."}));
+			}
+			return yield* requireAdmin(setRoleGated(input));
+		}),
+	),
+
 	// Manually mark a target account's address as failing (Child #2692, email-bounce epic
 	// #2687) — `requireAdmin`-gated, behind the `phoenix-email-delivery-admin` dark-ship
 	// flag. With the flag off the mutation fails the invisible `Denied` (like a non-admin
@@ -420,6 +466,19 @@ const unbanGated = Effect.fn("user.unbanGated")(function* (input: typeof UnbanUs
 	const pasaport = yield* Pasaport;
 	const state = yield* pasaport.unbanUser({userId: input.userId, actorId});
 	return toBanState(input.userId, state);
+});
+
+// The post-gate role-assign body — runnable only with an `Admin` `Grant` in R
+// (`requireAdmin` provides it); `yield* adminOf(grant)` reads the authority-checked actor
+// id the audit row is stamped with (mirroring `banGated`), so a role change is never
+// attributed to a client-supplied identity. `Pasaport.setRole` writes/clears the
+// `moderates` tuple and appends the audit event; `UserNotFound` on an unknown target.
+const setRoleGated = Effect.fn("user.setRoleGated")(function* (input: typeof SetRoleInput.Type) {
+	const grant = yield* Admin;
+	const actorId = yield* adminOf(grant);
+	const pasaport = yield* Pasaport;
+	const {role} = yield* pasaport.setRole({userId: input.userId, actorId, role: input.role});
+	return toRoleState(input.userId, role);
 });
 
 // The post-gate mark body — runnable only with an `Admin` `Grant` in R (`requireAdmin`

--- a/apps/web/worker/features/pasaport/role-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/role-mutation.unit.test.ts
@@ -1,0 +1,179 @@
+/**
+ * `user.setRole` WIRE-boundary coverage (#3522, admin epic per ADR 0107) — the
+ * authority + dark-ship decisions that are wrong-or-right with no database (ADR 0082),
+ * driven through the real external interface (`resolveWire`: decode + the
+ * `encodeWireError` class→wire-code seam), so a denial's wire `code` is what a client
+ * gets. Mirrors `ban-mutation.unit.test.ts`.
+ *
+ * The load-bearing AC (#3522): setRole FAILS CLOSED for a non-admin caller — a
+ * non-holder of the `admin` relation and the anonymous actor both get the invisible
+ * `UNAUTHORIZED` (they can't tell "not admin" from "not signed in", ADR 0098 §2), and
+ * neither reaches the write (the `Pasaport` stub is fail-on-contact). Plus the dark-ship:
+ * with the `phoenix-user-role-assign` flag OFF the path is inert (fails `Denied` before
+ * any authority check or write), so an unreleased role-grant never runs. The admin path
+ * reaches `Pasaport.setRole` and echoes the assigned role. The real-D1 tuple write→read
+ * round-trip (the roster re-reading the `moderates` tuple) is an integration concern.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type Actor,
+	AgentAuthority,
+	CurrentActor,
+	human,
+	RelationStore,
+	unauthenticated,
+} from "@kampus/authz";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {mutations} from "./mutations.ts";
+import {makePasaportStub} from "./Pasaport.testing.ts";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "role-test",
+	id: "role-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(
+		Flags,
+		// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised on this path.
+		{
+			getBoolean: () => Effect.succeed(on),
+			getString: () => Effect.die(new Error("unused")),
+			getNumber: () => Effect.die(new Error("unused")),
+			getObject: () => Effect.die(new Error("unused")),
+		} as unknown as typeof Flags.Service,
+	);
+
+const agentAuthorityStub = Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)});
+
+// A `RelationStore` where exactly `holders` hold the `admin` relation on platform.
+const adminStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
+	Layer.succeed(RelationStore, {
+		has: (tuple) => Effect.succeed(tuple.relation === "admin" && holders.includes(tuple.subject)),
+		hasSubjects: ({subjects, relation}) =>
+			Effect.succeed(
+				new Set(relation === "admin" ? subjects.filter((s) => holders.includes(s)) : []),
+			),
+		subjectsOf: ({relation}) => Effect.succeed(new Set(relation === "admin" ? holders : [])),
+	});
+
+const requestContext = (actor: Actor, on: boolean) =>
+	flagsStub(on).pipe(
+		Layer.provideMerge(Layer.succeed(CurrentUser, {user: undefined})),
+		Layer.provideMerge(Layer.succeed(CurrentActor, {actor})),
+		Layer.provideMerge(Layer.succeed(RuntimeContext, runtimeContextStub)),
+	);
+
+const setRole = (userId: string, role: "member" | "moderator") =>
+	resolveWire(mutations["user.setRole"], {
+		input: {userId, role},
+		select: ["id", "role"],
+	});
+
+const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
+	const error = Cause.findErrorOption(cause);
+	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
+};
+
+// A `Pasaport` that fails on ANY contact — proving a denied path never reached the write.
+const noWriteReached = Layer.mergeAll(makePasaportStub(), agentAuthorityStub);
+
+describe("user.setRole — admin authority (fail closed)", () => {
+	it.effect("an admin grants moderator; the write runs and echoes the assigned role", () =>
+		Effect.gen(function* () {
+			const receipt = yield* setRole("u-target", "moderator");
+			assert.strictEqual((receipt as {role: string}).role, "moderator");
+			assert.strictEqual((receipt as {id: string}).id, "u-target");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makePasaportStub({
+						setRole: (input) => Effect.succeed({role: input.role}),
+					}),
+					adminStoreOf(["u-admin"]),
+					agentAuthorityStub,
+					requestContext(human("u-admin"), true),
+				),
+			),
+		),
+	);
+
+	it.effect("an admin revokes moderator (role member); the write runs and echoes member", () =>
+		Effect.gen(function* () {
+			const receipt = yield* setRole("u-target", "member");
+			assert.strictEqual((receipt as {role: string}).role, "member");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makePasaportStub({
+						setRole: (input) => Effect.succeed({role: input.role}),
+					}),
+					adminStoreOf(["u-admin"]),
+					agentAuthorityStub,
+					requestContext(human("u-admin"), true),
+				),
+			),
+		),
+	);
+
+	it.effect("a non-admin gets the invisible UNAUTHORIZED — and never reaches the write", () =>
+		Effect.gen(function* () {
+			const exit = yield* setRole("u-target", "moderator").pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					noWriteReached,
+					adminStoreOf(["someone-else"]),
+					requestContext(human("u-rando"), true),
+				),
+			),
+		),
+	);
+
+	it.effect("the anonymous actor gets the SAME invisible UNAUTHORIZED", () =>
+		Effect.gen(function* () {
+			const exit = yield* setRole("u-target", "moderator").pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					noWriteReached,
+					adminStoreOf(["u-admin"]),
+					requestContext(unauthenticated, true),
+				),
+			),
+		),
+	);
+
+	it.effect("with the #3522 flag OFF the path is inert — no authority check, no write", () =>
+		Effect.gen(function* () {
+			const exit = yield* setRole("u-target", "moderator").pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			// Flag-off is the invisible Denied (UNAUTHORIZED), the same code a non-admin sees.
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					noWriteReached,
+					// Authority must NOT be consulted when the flag is off.
+					Layer.succeed(RelationStore, {
+						has: () => Effect.die(new Error("flag OFF must not check authority")),
+						hasSubjects: () => Effect.die(new Error("flag OFF must not check authority")),
+						subjectsOf: () => Effect.die(new Error("flag OFF must not check authority")),
+					}),
+					requestContext(human("u-admin"), false),
+				),
+			),
+		),
+	);
+});

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -4,6 +4,7 @@
  * (`.patterns/fate-effect-operations.md`).
  */
 
+import type {PlatformRole} from "../kunye/moderate.ts";
 import type {BanState} from "./ban.ts";
 import type {EmailDeliveryState, FailingAddress} from "./email-delivery.ts";
 import {
@@ -21,6 +22,7 @@ import type {
 	FailingAddressEntity,
 	Profile,
 	PromotionReceipt,
+	RoleStateEntity,
 	User,
 } from "./views.ts";
 
@@ -108,6 +110,15 @@ export const toBanState = (userId: string, state: BanState): BanStateEntity => (
 	banned: state.banned,
 	reason: state.reason,
 	expiresAt: state.expiresAt === null ? null : state.expiresAt.getTime(),
+});
+
+// The single spelling of the role-assignment ack (#3522) — keyed on the target user
+// id, so the `user.setRole` ack reconciles the SAME account the roster (`UserAdmin`)
+// lists. Carries only the newly-assigned `role`.
+export const toRoleState = (userId: string, role: PlatformRole): RoleStateEntity => ({
+	__typename: "RoleState",
+	id: userId,
+	role,
 });
 
 // The single spelling of the email-delivery-state ack (epic #2687) — the mark AND the

--- a/apps/web/worker/features/pasaport/sources.ts
+++ b/apps/web/worker/features/pasaport/sources.ts
@@ -19,6 +19,7 @@ import {
 	FailingAddressView,
 	ProfileView,
 	PromotionReceiptView,
+	RoleStateView,
 	UserView,
 } from "./views.ts";
 
@@ -86,6 +87,13 @@ export const authorshipStandingSource = Fate.syntheticSource(AuthorshipStandingV
 // source-completeness accepts the view-reachable result type; mirrors
 // `promotionReceiptSource`.
 export const banStateSource = Fate.syntheticSource(BanStateView);
+
+// `RoleState` has no by-id fetch path — it is produced ONLY past the `requireAdmin`
+// gate (#3522), by the `user.setRole` mutation ack, never a public by-id load (the
+// derived role IS re-readable via the gated `UserAdmin` roster). Registered with ZERO
+// capabilities so source-completeness accepts the view-reachable result type; mirrors
+// `banStateSource`.
+export const roleStateSource = Fate.syntheticSource(RoleStateView);
 
 // `EmailDeliveryState` has no by-id fetch path — it is produced ONLY past the
 // `requireAdmin` gate (epic #2687), by the `emailDelivery.mark` / `emailDelivery.clear`

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -8,6 +8,7 @@
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
+import type {PlatformRole} from "../kunye/moderate.ts";
 import {CONTRIBUTION_VIEW_ORDER_BY} from "./ordering.ts";
 import type {ContributionRow} from "./Pasaport.ts";
 import {type ProfileRow, profileViewFields} from "./profile-fields.ts";
@@ -173,6 +174,23 @@ export class FailingAddressView extends FateDataView<FailingAddressViewRow>()("F
 	since: true,
 } satisfies {[K in keyof FailingAddressViewRow]: true}) {}
 
+// The admin role-assignment ack (#3522, admin epic per ADR 0107) — the projected
+// role returned by the `user.setRole` mutation. `id` === the target user id (the
+// client normalization key), so the ack reconciles the SAME account the roster
+// (`UserAdmin`) lists; `role` is the newly-assigned platform role (`moderator` iff
+// the `moderates` tuple was granted, else `member`). It carries ONLY the role — no
+// session, no PII — and is only ever produced past the `requireAdmin` gate + the
+// dark-ship flag, so it never leaks. Mirrors `BanStateView`.
+export type RoleStateViewRow = ViewRow<{
+	id: string;
+	role: PlatformRole;
+}>;
+
+export class RoleStateView extends FateDataView<RoleStateViewRow>()("RoleState")({
+	id: true,
+	role: true,
+} satisfies {[K in keyof RoleStateViewRow]: true}) {}
+
 // The çaylak-SELF authorship-standing aggregate (#1316, epic #1202) — the
 // "yazarlığa giden yol" read the #1291 status block consumes about ITSELF. The
 // subject is always the authenticated çaylak (the `myAuthorshipStanding` resolver
@@ -213,6 +231,7 @@ export const accountDeletionReceiptDataView = AccountDeletionReceiptView.view;
 export const promotionReceiptDataView = PromotionReceiptView.view;
 export const authorshipStandingDataView = AuthorshipStandingView.view;
 export const banStateDataView = BanStateView.view;
+export const roleStateDataView = RoleStateView.view;
 export const emailDeliveryStateDataView = EmailDeliveryStateView.view;
 export const failingAddressDataView = FailingAddressView.view;
 
@@ -223,5 +242,6 @@ export type AccountDeletionReceipt = WorkerEntity<typeof AccountDeletionReceiptV
 export type PromotionReceipt = WorkerEntity<typeof PromotionReceiptView>;
 export type AuthorshipStanding = WorkerEntity<typeof AuthorshipStandingView>;
 export type BanStateEntity = WorkerEntity<typeof BanStateView>;
+export type RoleStateEntity = WorkerEntity<typeof RoleStateView>;
 export type EmailDeliveryStateEntity = WorkerEntity<typeof EmailDeliveryStateView>;
 export type FailingAddressEntity = WorkerEntity<typeof FailingAddressView>;


### PR DESCRIPTION
This adds the SPA-invokable role-assignment mutation the admin console needs. Today the phoenix worker has no way for the console to make someone a moderator: #969/PR #1266 shipped only the `Admin` capability plus an offline (D1/CLI) tuple mint, so the roster's `role` cell is derived from a `moderates` relation tuple that nothing writes from the app. This PR ships `user.setRole`, an `Admin.over(platform)`-gated fate mutation that grants or revokes that tuple, unblocking the platform-role half of #3203.

## What changed
- **`user.setRole` mutation** (`apps/web/worker/features/pasaport/mutations.ts`) — input `{userId, role: "member" | "moderator"}`, gated by `requireAdmin` (ADR 0107). A non-admin (or anonymous) caller gets the invisible `Denied` (`UNAUTHORIZED`), indistinguishable from "not signed in". Mirrors the `user.banUser` shape.
- **`Pasaport.setRole`** (`apps/web/worker/features/pasaport/Pasaport.ts`) — the domain write: `moderator` upserts the `(user, "moderates", "platform")` relation tuple (idempotent), `member` deletes it. The tuple encoding is single-sourced through kunye's new `moderatorTuple` helper (`apps/web/worker/features/kunye/moderate.ts`), co-located with the `isModerator`/`moderatorsAmong` read + the `Moderate` discharge, so the runtime write can't drift from the read key.
- **Audit log** — a new append-only `user_role_event` table (`apps/web/worker/db/drizzle/schema.ts` + migration `0032_user_role_event.sql`) records actor, target, new role, and time, mirroring the ban/email-delivery audit surface.
- **Fanout classification** — `user.setRole` is classified `fanned: false` in `apps/web/worker/features/fate-live/fanned-mutations.ts` (identity/authority surface, not a subscribed content connection); `fanout-guard` passes. The derived roster `role` cell re-reads the same tuple through the gated `UserAdmin` view, so it reflects the new value with no live publish needed.
- **Dark-ship flag** — ships behind the default-off `phoenix-user-role-assign` flag (ADR 0083), so the role-grant path reaches production dark until a human release; with it off the mutation fails the invisible `Denied`. Wired in `src/flags/keys.ts`, `worker/features/flagship/resources.ts`, and `alchemy.run.ts`.
- **Views/sources/wire** — `RoleStateView` ack (`{id, role}`) added and registered.

## Tests
- `apps/web/worker/features/pasaport/role-mutation.unit.test.ts` — the admin-gate refusal (non-admin + anonymous → `UNAUTHORIZED`, never reaching the write), the flag-off inert path, and the admin grant/revoke reaching the write and echoing the assigned role.
- `apps/web/worker/features/flagship/user-role-assign.invariant.test.ts` — the default-=-off dark-ship invariant.

`pnpm typecheck`, `pnpm lint:worktree`, `fanout-guard`, and `migrations-guard` all pass locally.

Fixes #3522
Flag: phoenix-user-role-assign