### PR TITLE
fix(pipeline-crew-mcp): don't autoboot the cartographer (HITL role) with a self-driving boot prompt (#3524)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -24,13 +24,17 @@ export {
 export {RoleUniquenessError} from "./errors.ts";
 export {
 	type CardinalityOf,
+	CREW_DRIVE,
 	CREW_ROLES,
 	CREW_ROSTER,
 	CrewRole,
 	type CrewRoleCardinality,
+	type CrewRoleDrive,
 	type CrewRoleKind,
 	cardinalityOf,
 	cardinalityOfKind,
+	driveOf,
+	isAutobooted,
 	isCrewRole,
 	kindOf,
 } from "./roles.ts";

--- a/packages/pipeline-crew-mcp/src/crew/roles.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/roles.test.ts
@@ -7,11 +7,14 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Schema} from "effect";
 import {
+	CREW_DRIVE,
 	CREW_ROLES,
 	CREW_ROSTER,
 	CrewRole,
 	cardinalityOf,
 	cardinalityOfKind,
+	driveOf,
+	isAutobooted,
 	isCrewRole,
 	kindOf,
 } from "./roles.ts";
@@ -66,6 +69,33 @@ describe("crew/roles — the kind-typed roster (ADR 0189)", () => {
 		for (const role of CREW_ROLES) {
 			assert.strictEqual(cardinalityOf(role), kindOf(role) === "bridge" ? 1 : "N");
 		}
+	});
+
+	it("kinds each role's drive: cartographer is human-in-the-loop, the rest self-drive (#3524)", () => {
+		assert.deepStrictEqual(CREW_DRIVE, {
+			"chief-of-staff": "self-driving",
+			cartographer: "human-in-the-loop",
+			"intake-desk": "self-driving",
+			"engineering-manager": "self-driving",
+		});
+		// driveOf is total over the roster and reads straight off CREW_DRIVE.
+		for (const role of CREW_ROLES) {
+			assert.strictEqual(driveOf(role), CREW_DRIVE[role]);
+		}
+		assert.strictEqual(driveOf("cartographer"), "human-in-the-loop");
+		assert.strictEqual(driveOf("engineering-manager"), "self-driving");
+	});
+
+	it("isAutobooted is exactly the self-driving roster — the cartographer is on-demand (#3524)", () => {
+		for (const role of CREW_ROLES) {
+			assert.strictEqual(isAutobooted(role), driveOf(role) === "self-driving");
+		}
+		// the cartographer stays a known/addressable roster role but is NOT autobooted (AC4).
+		assert.isFalse(isAutobooted("cartographer"));
+		assert.isTrue(new Set<string>(CREW_ROLES).has("cartographer"));
+		assert.isTrue(isAutobooted("chief-of-staff"));
+		assert.isTrue(isAutobooted("intake-desk"));
+		assert.isTrue(isAutobooted("engineering-manager"));
 	});
 
 	it("a bridge cardinality is the literal 1 at the type level (2 is unrepresentable)", () => {

--- a/packages/pipeline-crew-mcp/src/crew/roles.ts
+++ b/packages/pipeline-crew-mcp/src/crew/roles.ts
@@ -51,6 +51,38 @@ export const CREW_ROSTER = {
 export const kindOf = (role: CrewRole): CrewRoleKind => CREW_ROSTER[role];
 
 /**
+ * A role's DRIVE governs how it STARTS — orthogonal to its kind (which governs cardinality). A
+ * self-driving role runs a standing work loop under its own power, so it is autobooted on every
+ * stand-up and takes a cold-start boot turn. A human-in-the-loop role has NO standing loop: it is an
+ * on-demand, per-session partner a human spawns when they want it (the cartographer's charting
+ * session), so it is never autobooted and, if launched, comes up idle waiting for the human rather
+ * than confabulating work. See ADR 0189 (roster law) + #3524.
+ */
+export type CrewRoleDrive = "self-driving" | "human-in-the-loop";
+
+/**
+ * The drive of each roster role — the single source of which roles self-drive a standing loop.
+ * `satisfies Record<CrewRole, CrewRoleDrive>` makes it TOTAL over the roster: add a role to
+ * `CREW_ROLES` without kinding its drive here and this stops compiling. The cartographer is the one
+ * human-in-the-loop role (a HITL ideation partner with nothing to autorun, #3524); the rest self-drive.
+ */
+export const CREW_DRIVE = {
+	"chief-of-staff": "self-driving",
+	cartographer: "human-in-the-loop",
+	"intake-desk": "self-driving",
+	"engineering-manager": "self-driving",
+} as const satisfies Record<CrewRole, CrewRoleDrive>;
+
+/** Total: the drive of any crew role, read straight off the roster map. */
+export const driveOf = (role: CrewRole): CrewRoleDrive => CREW_DRIVE[role];
+
+/**
+ * Whether a role is autobooted on stand-up: exactly the self-driving roles. A human-in-the-loop role
+ * is on-demand — spawned by a human when wanted — and is never part of the standing drain crew (#3524).
+ */
+export const isAutobooted = (role: CrewRole): boolean => driveOf(role) === "self-driving";
+
+/**
  * Cardinality is a FUNCTION of kind, never a free field — a bridge is exactly one (nobody else
  * owns its seam), an engine is an unbounded pool (`"N"`). Because the only way to name a
  * cardinality is through the kind, a bridge with cardinality 2 does not typecheck. See ADR 0189.

--- a/packages/pipeline-crew-mcp/src/standup/bind.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.test.ts
@@ -483,33 +483,63 @@ describe("standup/bind — per-session bind constructor", () => {
 			}),
 	);
 
-	it.effect("every crew role (bridge + engine) gets the same role-agnostic boot turn (#3516)", () =>
-		Effect.gen(function* () {
-			const channels: ChannelConfig = {
-				mode: "development",
-				servers: ["server:pipeline-crew"],
-				allowedChannelPlugins: [],
-			};
-			// A bridge (no instance) and an engine (with instance) both receive the boot prompt — the def
-			// each boots as carries its own cold-start, so the launcher's turn is deliberately generic.
-			const bridge = yield* buildSessionBind({
-				role: "chief-of-staff",
-				projectRoot: PROJECT_ROOT,
-				serverName: SERVER_NAME,
-				channels,
-			});
-			const engine = yield* buildSessionBind({
-				role: "engineering-manager",
-				projectRoot: PROJECT_ROOT,
-				serverName: SERVER_NAME,
-				instance: "e-1",
-				channels,
-			});
-			assert.deepStrictEqual([...bridge.bootPromptArg], [BOOT_PROMPT]);
-			assert.deepStrictEqual([...engine.bootPromptArg], [BOOT_PROMPT]);
-			assert.strictEqual(bridge.argv[bridge.argv.length - 1], BOOT_PROMPT);
-			assert.strictEqual(engine.argv[engine.argv.length - 1], BOOT_PROMPT);
-		}),
+	it.effect(
+		"every SELF-DRIVING role (bridge + engine) gets the same role-agnostic boot turn (#3516)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				// A self-driving bridge (no instance) and an engine (with instance) both receive the boot
+				// prompt — the def each boots as carries its own cold-start, so the launcher's turn is generic.
+				const bridge = yield* buildSessionBind({
+					role: "chief-of-staff",
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+				const engine = yield* buildSessionBind({
+					role: "engineering-manager",
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					instance: "e-1",
+					channels,
+				});
+				assert.deepStrictEqual([...bridge.bootPromptArg], [BOOT_PROMPT]);
+				assert.deepStrictEqual([...engine.bootPromptArg], [BOOT_PROMPT]);
+				assert.strictEqual(bridge.argv[bridge.argv.length - 1], BOOT_PROMPT);
+				assert.strictEqual(engine.argv[engine.argv.length - 1], BOOT_PROMPT);
+			}),
+	);
+
+	it.effect(
+		"a human-in-the-loop role (the cartographer) gets NO boot turn — it boots idle (#3524)",
+		() =>
+			Effect.gen(function* () {
+				const channels: ChannelConfig = {
+					mode: "development",
+					servers: ["server:pipeline-crew"],
+					allowedChannelPlugins: [],
+				};
+				// The cartographer has no standing loop, so it must NOT be handed the self-driving BOOT_PROMPT
+				// — that is what made it confabulate work. Even launched on-demand, its argv carries no
+				// positional prompt, so the CLI opens an interactive session that idles waiting for the human.
+				const bind = yield* buildSessionBind({
+					role: "cartographer",
+					projectRoot: PROJECT_ROOT,
+					serverName: SERVER_NAME,
+					channels,
+				});
+				assert.deepStrictEqual([...bind.bootPromptArg], []);
+				assert.notInclude(bind.argv, BOOT_PROMPT);
+				// Interactive and idle: still no -p/--print (an interactive session), and the argv ends at the
+				// visible --name pair rather than a boot-turn prompt — it waits for the human, not a loop.
+				assert.notInclude(bind.argv, "-p");
+				assert.notInclude(bind.argv, "--print");
+				assert.deepStrictEqual([...bind.argv].slice(-2), [...bind.nameArg]);
+			}),
 	);
 
 	it.effect("allowlist mode fails closed on a plugin channel whose plugin is not allowlisted", () =>

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -33,6 +33,7 @@ import {existsSync} from "node:fs";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {Effect, Schema} from "effect";
+import {driveOf, isCrewRole} from "../crew/index.ts";
 import {type ChannelConfig, type Tier, tierModel} from "./config.ts";
 
 /**
@@ -87,9 +88,12 @@ export const AGENT_FLAG = "--agent";
  * `[prompt]` argument and — with NO `-p`/`--print` — keeps the session INTERACTIVE, i.e. it runs this
  * turn and stays alive to self-drain (grounded on the installed CLI 2.1.214:
  * `Usage: claude [options] [command] [prompt]` — "starts an interactive session by default, use
- * -p/--print for non-interactive output"). Role-agnostic on purpose: it nudges the session to run
- * whatever cold-start its own def defines, so it fits every crew role (bridge + engine) without the
- * launcher re-encoding each persona's boot behavior.
+ * -p/--print for non-interactive output"). Role-agnostic on purpose within its scope: it nudges the
+ * session to run whatever cold-start its own def defines, so it fits every SELF-DRIVING role (the
+ * bridges + engines that run a standing loop) without the launcher re-encoding each persona's boot
+ * behavior. It is NOT handed to a human-in-the-loop role (the cartographer): a HITL role has no
+ * standing loop, so "start your loop under your own power" would make it confabulate work — it boots
+ * idle with no prompt instead (the drive branch in `buildSessionBind`, #3524).
  */
 export const BOOT_PROMPT =
 	"Begin now. Run your role's on-boot cold-start behavior as defined by your agent instructions: announce your presence on the channel, then start your standing work loop under your own power. Do not wait to be pinged, relayed to, or told to start.";
@@ -166,12 +170,14 @@ export interface SessionBind {
 	/** `["--agent", "crew-<role>"]` — boots the session AS its role persona (collision-free name, see AGENT_FLAG). */
 	readonly agentArg: readonly [flag: string, agentName: string];
 	/**
-	 * `[BOOT_PROMPT]` — the single positional initial prompt that hands the spawned session its first
-	 * turn so its def's on-boot cold-start fires from launch, not on a hand-kick (#3516; see BOOT_PROMPT).
-	 * It rides the argv TAIL, after the non-variadic `--name <name>`, so it lands as the CLI's `[prompt]`
-	 * positional rather than being swallowed by the variadic `--channels`/dev-channel option ahead of it.
+	 * A self-driving role's boot turn: `[BOOT_PROMPT]` — the single positional initial prompt that hands
+	 * the spawned session its first turn so its def's on-boot cold-start fires from launch, not on a
+	 * hand-kick (#3516; see BOOT_PROMPT). It rides the argv TAIL, after the non-variadic `--name <name>`,
+	 * so it lands as the CLI's `[prompt]` positional rather than being swallowed by the variadic
+	 * `--channels`/dev-channel option ahead of it. A human-in-the-loop role emits `[]` (no boot turn) so
+	 * it comes up idle waiting for the human rather than manufacturing work (the drive branch, #3524).
 	 */
-	readonly bootPromptArg: readonly [prompt: string];
+	readonly bootPromptArg: readonly [] | readonly [prompt: string];
 	/**
 	 * The complete argv
 	 * `[...modelArg, ...pluginDirArg, ...agentArg, ...channelArg, ...nameArg, ...bootPromptArg]` the
@@ -322,7 +328,13 @@ export const buildSessionBind = (
 		// The launcher's boot turn (#3516): a tail positional prompt so the spawned session fires its
 		// def's cold-start instead of idling. Tail placement (after the non-variadic --name) keeps it out
 		// of the variadic channel option's reach; no -p/--print keeps the session interactive to self-drain.
-		const bootPromptArg: readonly [string] = [BOOT_PROMPT];
+		// A HITL role (the cartographer) gets NO boot turn — "start your loop under your own power" makes a
+		// role with no standing loop confabulate work, so it boots idle instead (#3524). The drive is a
+		// roster law, derived here (not a per-launch input like tier), so a HITL role can never be handed
+		// the self-driving prompt on any launch path — autoboot or the on-demand spawn. A non-roster role
+		// (never expected) defaults self-driving, preserving today's boot-turn behavior.
+		const selfDriving = !isCrewRole(role) || driveOf(role) === "self-driving";
+		const bootPromptArg: readonly [] | readonly [string] = selfDriving ? [BOOT_PROMPT] : [];
 
 		return {
 			role,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -10,7 +10,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {CREW_ROLES, kindOf} from "../crew/index.ts";
+import {CREW_ROLES, isAutobooted, kindOf} from "../crew/index.ts";
 import {CREW_SESSION_INSTANCE_FLAG} from "./bind.ts";
 import {
 	DEFAULT_CONFIG_PATH,
@@ -257,7 +257,8 @@ const exited = (code: number | null, over: Partial<TmuxRun> = {}): TmuxRun => ({
 	...over,
 });
 
-const bridgeRoles = CREW_ROLES.filter((r) => kindOf(r) === "bridge");
+// The autobooted bridges — a HITL bridge (the cartographer) is on-demand, not stood up (#3524).
+const bridgeRoles = CREW_ROLES.filter((r) => kindOf(r) === "bridge" && isAutobooted(r));
 
 describe("standup/orchestrate — the one stand-up command (issue #3299)", () => {
 	it.effect(
@@ -484,14 +485,17 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 	it.effect("threads each role's config tier into its launch --model (#3423, end to end)", () =>
 		Effect.gen(function* () {
 			// rawConfigAt sets the founder ruling — cartographer=fable, the rest=opus — so the boot
-			// proves each session comes up on its configured tier's model, not the CLI default.
+			// proves each session comes up on its configured tier's model, not the CLI default. The
+			// cartographer is not autobooted (#3524), so it never launches here; its tier is asserted at the
+			// on-demand spawn path, not the stand-up. intake-desk carries the fable tier among the autobooted.
 			const {input, launched} = baseInput({engineCount: 2});
 			yield* runStandUp(input);
 
 			const modelOf = (role: string): readonly string[] | undefined =>
 				launched.find((p) => p.session.role === role)?.bind.modelArg;
 			assert.deepStrictEqual([...(modelOf("chief-of-staff") ?? [])], ["--model", "opus"]);
-			assert.deepStrictEqual([...(modelOf("cartographer") ?? [])], ["--model", "fable"]);
+			// the cartographer is on-demand, never in the standing stand-up — no launched session for it.
+			assert.isUndefined(launched.find((p) => p.session.role === "cartographer"));
 			assert.deepStrictEqual([...(modelOf("intake-desk") ?? [])], ["--model", "fable"]);
 			// every engine boots on the engineering-manager tier (opus).
 			for (const p of launched.filter((x) => x.session.kind === "engine")) {

--- a/packages/pipeline-crew-mcp/src/standup/session-set.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/session-set.test.ts
@@ -1,14 +1,19 @@
 /**
- * standup/session-set — the roster-driven session set (AC 1–4, ADR 0189). These tests pin the
- * derivation against the confirmed roster (three bridges + the engine pool) and a sample engine
- * count: bridge cardinality 1, engine cardinality N, distinct per-instance engine identities, and
- * that the set is derived from the kind-typed roster contract rather than a re-declared role list.
+ * standup/session-set — the roster-driven session set (AC 1–4, ADR 0189; #3524). These tests pin the
+ * derivation against the AUTOBOOTED roster (the self-driving roles — the two self-driving bridges +
+ * the engine pool) and a sample engine count: bridge cardinality 1, engine cardinality N, distinct
+ * per-instance engine identities, that the set is derived from the kind-typed roster contract rather
+ * than a re-declared role list, and that a human-in-the-loop role (the cartographer) is NOT stood up.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Schema} from "effect";
-import {CREW_ROLES, kindOf} from "../crew/index.ts";
+import {CREW_ROLES, isAutobooted, kindOf} from "../crew/index.ts";
 import {EngineCount} from "./config.ts";
 import {type CrewSession, deriveSessionSet} from "./session-set.ts";
+
+// The autobooted roster — the self-driving roles the stand-up brings up. A human-in-the-loop role
+// (the cartographer) is excluded: on-demand, never in the standing drain crew (#3524).
+const AUTOBOOTED = CREW_ROLES.filter(isAutobooted);
 
 // N as the real branded EngineCount (≥1) the launcher hands the derivation, not a bare cast.
 const n = (count: number): EngineCount => Schema.decodeUnknownSync(EngineCount)(count);
@@ -23,12 +28,12 @@ const bridges = (set: readonly CrewSession[]) => set.filter((s) => s.kind === "b
 const engines = (set: readonly CrewSession[]) => set.filter((s) => s.kind === "engine");
 
 describe("standup/session-set — roster-driven session set (ADR 0189)", () => {
-	it("stands up exactly one instance per bridge kind and N of the engine kind (AC1)", () => {
+	it("stands up exactly one instance per autobooted bridge kind and N of the engine kind (AC1)", () => {
 		const N = 3;
 		const set = deriveSessionSet({engineCount: n(N), instanceId: counter()});
 
-		const bridgeRoles = CREW_ROLES.filter((r) => kindOf(r) === "bridge");
-		const engineRoles = CREW_ROLES.filter((r) => kindOf(r) === "engine");
+		const bridgeRoles = AUTOBOOTED.filter((r) => kindOf(r) === "bridge");
+		const engineRoles = AUTOBOOTED.filter((r) => kindOf(r) === "engine");
 
 		// one session per bridge kind — the exact confirmed bridges, each cardinality 1.
 		assert.deepStrictEqual(
@@ -70,10 +75,10 @@ describe("standup/session-set — roster-driven session set (ADR 0189)", () => {
 		}
 	});
 
-	it("derives from the kind-typed roster, not a re-declared list — every role is present (AC3)", () => {
+	it("derives from the kind-typed roster, not a re-declared list — every autobooted role is present (AC3)", () => {
 		const set = deriveSessionSet({engineCount: n(1), instanceId: counter()});
-		// every roster role appears at least once, kinded exactly as the roster says.
-		for (const role of CREW_ROLES) {
+		// every AUTOBOOTED (self-driving) roster role appears at least once, kinded exactly as the roster says.
+		for (const role of AUTOBOOTED) {
 			const forRole = set.filter((s) => s.role === role);
 			assert.isTrue(forRole.length >= 1, `role ${role} missing from the session set`);
 			for (const s of forRole) {
@@ -86,8 +91,19 @@ describe("standup/session-set — roster-driven session set (ADR 0189)", () => {
 		}
 	});
 
+	it("excludes a human-in-the-loop role (the cartographer) from the stand-up set (#3524)", () => {
+		const set = deriveSessionSet({engineCount: n(3), instanceId: counter()});
+		const roles = new Set(set.map((s) => s.role));
+		// the cartographer is a known/addressable roster role but NOT autobooted — on-demand only.
+		assert.isFalse(roles.has("cartographer"), "cartographer must not be autobooted (#3524)");
+		// exactly the self-driving roster is stood up — no HITL role sneaks in.
+		for (const s of set) {
+			assert.isTrue(isAutobooted(s.role), `${s.role} is not autobooted but appears in the set`);
+		}
+	});
+
 	it("scales the engine pool with the config engine count, bridges fixed at 1 (AC1,AC4)", () => {
-		const bridgeCount = CREW_ROLES.filter((r) => kindOf(r) === "bridge").length;
+		const bridgeCount = AUTOBOOTED.filter((r) => kindOf(r) === "bridge").length;
 		for (const N of [1, 2, 5, 10]) {
 			const set = deriveSessionSet({engineCount: n(N), instanceId: counter()});
 			assert.strictEqual(bridges(set).length, bridgeCount);

--- a/packages/pipeline-crew-mcp/src/standup/session-set.ts
+++ b/packages/pipeline-crew-mcp/src/standup/session-set.ts
@@ -5,6 +5,11 @@
  * process spawn, no argv (the bind constructor #3296 turns each `{role, address}` into argv, the
  * orchestration child spawns them).
  *
+ * The stand-up set is the AUTOBOOTED roles only — the self-driving roster (`isAutobooted`). A
+ * human-in-the-loop role (the cartographer) has no standing loop to autorun, so it is skipped here
+ * and spawned on demand instead; it stays a known/addressable roster role, just not an autobooted one
+ * (#3524, ADR 0189).
+ *
  * The set is derived by iterating the roster (`CREW_ROLES` + `kindOf`), never a re-declared role
  * list, so a roster change flows through here with no edit. Each session carries the `address`
  * `inboxAddressFor` mints — which IS its role-lease key: a bridge's singleton `inbox://<role>` (its
@@ -13,7 +18,7 @@
  * carry no instance because a bridge-with-an-instance is meaningless — the discriminated union makes
  * that state unrepresentable, mirroring `inboxAddressFor`'s own kind branch.
  */
-import {CREW_ROLES, type CrewRole, inboxAddressFor, kindOf} from "../crew/index.ts";
+import {CREW_ROLES, type CrewRole, inboxAddressFor, isAutobooted, kindOf} from "../crew/index.ts";
 import type {EngineCount} from "./config.ts";
 
 /**
@@ -51,13 +56,18 @@ export interface SessionSetInput {
 
 /**
  * Derive the stand-up's session set from the roster-law contract: exactly one bridge session per
- * bridge role and `engineCount` sessions per engine role, each engine instance addressed distinctly.
- * Total by construction — every roster role is kinded, so no role is dropped or double-counted.
+ * autobooted bridge role and `engineCount` sessions per autobooted engine role, each engine instance
+ * addressed distinctly. Scoped to the self-driving roster (`isAutobooted`) — a human-in-the-loop role
+ * has no standing loop to run, so it is never stood up here (#3524). Total over the autobooted roles:
+ * every one is kinded, so none is dropped or double-counted.
  */
 export const deriveSessionSet = (input: SessionSetInput): readonly CrewSession[] => {
 	const {engineCount, instanceId} = input;
 	const sessions: CrewSession[] = [];
 	for (const role of CREW_ROLES) {
+		// Only self-driving roles are autobooted into the stand-up set; a human-in-the-loop role (the
+		// cartographer) is on-demand — spawned by a human when wanted — so it is skipped here (#3524).
+		if (!isAutobooted(role)) continue;
 		if (kindOf(role) === "engine") {
 			for (let i = 0; i < engineCount; i++) {
 				const instance = instanceId();


### PR DESCRIPTION
Fixes #3524

## What changed

The `cartographer` is a human-in-the-loop ideation partner (the wayfinder CHART/WORK facilitator) with **no standing work loop**, but it sat in the autobooted roster and received the universal self-driving `BOOT_PROMPT` — so every `stand-up` spun up a cartographer that confabulated work for itself (observed: grepping `.glossary/LANGUAGE.md` for an invented Turkish-copy requirement, ~88k Fable tokens burned). Founder ruling 2026-07-18: *"we should not autoboot a cartographer — it's a HITL helper, there is nothing to autorun."*

The fix adds a **DRIVE** dimension to the roster, orthogonal to `kind` (which governs cardinality):

- **`packages/pipeline-crew-mcp/src/crew/roles.ts`** — new `CrewRoleDrive` (`self-driving` | `human-in-the-loop`), a total `CREW_DRIVE` map (`cartographer` → `human-in-the-loop`, the rest → `self-driving`), `driveOf`, and `isAutobooted`. `satisfies Record<CrewRole, CrewRoleDrive>` keeps it total over the roster (add a role without a drive and it stops compiling). Cartographer **stays** in `CREW_ROLES` / `CREW_ROSTER` — still a known, addressable, kinded (`bridge`) channel role.
- **`packages/pipeline-crew-mcp/src/standup/session-set.ts`** — `deriveSessionSet` now stands up only `isAutobooted` roles, so a standing `stand-up` brings up `chief-of-staff` + `intake-desk` + N engines and **not** the cartographer.
- **`packages/pipeline-crew-mcp/src/standup/bind.ts`** — the bind constructor derives the role's drive from the roster and hands the self-driving `BOOT_PROMPT` **only** to self-driving roles. A HITL role (even launched on demand, e.g. via the #3519 dynamic-membership lever) gets an empty `bootPromptArg` and comes up **idle** waiting for the human, never manufacturing work. Deriving from the roster (not a per-launch input like `tier`) makes it impossible to hand a HITL role the self-driving prompt on any launch path.
- **`packages/pipeline-crew-mcp/src/crew/index.ts`** — re-exports the new roster symbols.

## Acceptance criteria

- [x] A standing `stand-up` boots only self-driving roles (chief-of-staff + intake-desk + N engines) — cartographer is not in the autobooted session set.
- [x] Cartographer stays spawnable on demand as a single-role session; the bind path launches it idle (the #3519 lever consumes this).
- [x] No autobooted session receives a self-driving `BOOT_PROMPT` for a role with no standing loop — a HITL role boots idle.
- [x] The `CREW_ROLES` roster-law invariants (ADR 0189) remain coherent — cartographer is still a known/addressable channel role, just not an autobooted one.

## Tests

Added coverage for `CREW_DRIVE` / `driveOf` / `isAutobooted` (roles.test.ts), cartographer-excluded-from-the-set (session-set.test.ts), and HITL-boots-idle / self-driving-gets-boot-turn (bind.test.ts); updated orchestrate.test.ts to the autobooted roster. Full package suite green (243 tests), typecheck clean.

## Routing

**Not §CP** — `packages/pipeline-crew-mcp/**` is outside `CONTROL_PLANE_RE` (ADR 0187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)