### PR TITLE
docs(glossary): coin "⌘K command palette (single search contract)" (#3097)

### DIFF
--- a/.glossary/TERMS.md
+++ b/.glossary/TERMS.md
@@ -206,6 +206,7 @@ time, correctness over milliseconds). This names the nouns.
 | site search | v1 is a **lexical search bar** (`/search?q=`), not semantic discovery — ADR 0080 splits the two. | semantic search (a separate product) |
 | term_search / post_search | The SQLite **FTS5** virtual tables backing sözlük/pano search; kept current by a dual-write sync path off `term_record` / `post_record`. | |
 | fts-backfill | Direct-D1 one-time CLI re-indexing existing summary rows into the FTS5 tables through the dual-write path (`packages/fts-backfill`). | a runtime backfill route |
+| ⌘K command palette (single search contract) | The single search entry point on kamp.us — "the one search contract made physical" (ADR [0186](../.decisions/0186-command-palette-single-search-contract.md)). One ⌘K palette, one affordance, over the global search contract: the three legacy "ara" surfaces (topbar / subnav / inline) collapse into it. The collapse is incremental, surface-by-surface, with [#2995](https://github.com/kamp-us/phoenix/issues/2995) (sözlük search → ⌘K) as fold step 1; each remaining surface folds toward the end-state the ADR fixes. v1 is search-only. | a **command runner** (v1 is search-only; a command-runner evolution is out of scope); a per-surface search reimplementation (a11y — keyboard / AT / reduced-motion — is code-authoritative via the a11y-spine contract, not redone per fold); a deferred big-bang (the collapse is incremental, surface-by-surface, each fold toward the ADR-fixed end-state) |
 
 ## Run-evidence / CI gating (ADRs 0054/0056/0058/0092)
 


### PR DESCRIPTION
Search on kamp.us was scattered across three separate "ara" surfaces (topbar, subnav, inline), and there was no shared name for the single entry point that replaces them. This adds one canonical glossary row for the ⌘K command palette so every future issue, PR, and ADR names that surface the same way instead of reinventing a label for it.

Adds a single `Term | Definition | Not` row to `.glossary/TERMS.md`, in the **Search (FTS)** section (the search-surface neighborhood):

- **Term:** ⌘K command palette (single search contract)
- **Definition:** the single search entry point on kamp.us — "the one search contract made physical" — cross-referencing ADR 0186 by its committed path, naming the collapse of the three legacy "ara" surfaces (topbar / subnav / inline) into the one palette, and pointing at #2995 as fold step 1.
- **Not:** the three disambiguations from the ADR brief — not a command runner (v1 is search-only), not a per-surface a11y reimplementation (a11y is code-authoritative via the a11y-spine contract), not a deferred big-bang (the collapse is incremental, surface-by-surface).

Docs-only, non-control-plane. ADR 0186 is committed on `main` (`.decisions/0186-command-palette-single-search-contract.md`), so the cross-reference is a live link, not a dangling one. Repo-relative paths only.

Fixes #3097