### PR TITLE
ci: gate merge_group integration on the backend path filter, consistent with PR head (#3514) [§CP]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,24 +80,33 @@ jobs:
       # The `feature-complete` forcing function still wins (it ORs with `backend`), and
       # since a feature-complete PR is by definition worker-affecting the worker-
       # relevance AND never strips a flagged full sweep in practice.
-      # `merge_group` now respects the SAME worker-relevance filter the `pull_request`
-      # path trusts (issue #3079), instead of ORing in FIRST to force the full suite on
-      # every batch — the old unconditional merge_group run let a flaky real-CF integration
-      # suite evict clean worker-IRRELEVANT PRs from the queue (#3075: #3067/#3073/#3074/
-      # #3064). The classify step below now runs on `merge_group` too, over the batch's
-      # real `base_sha...head_sha` range (ADR 0132) — the prospective merge of every queued
-      # PR, so a diff over it OR's ALL batched PRs: the batch is worker-relevant if ANY
-      # batched PR touches the worker, and integration is skipped ONLY when EVERY batched PR
-      # is provably worker-irrelevant (`worker_relevant == 'false'`). FAIL-SAFE TO RUNNING is
-      # preserved end to end — `|| 'true'` defaults an absent/empty output to running, the
-      # classify step emits `worker_relevant=true` on any missing base/head SHA or
-      # unresolvable diff, and the classifier core itself fails safe to running — so any
-      # doubt RUNS integration, never skips (the #3079 threat model: a mis-classified
-      # worker-relevant batch must never skip and merge broken). The batch still runs in the
-      # trusted base's context with repo secrets, so the PR-only fork/author guard does not
-      # apply.
+      # `merge_group` now respects the SAME two change-detection gates the `pull_request`
+      # path trusts, ANDed together — the `backend` path filter AND the worker-relevance
+      # classifier — instead of ORing in FIRST to force the full suite on every batch. The
+      # old unconditional merge_group run let a flaky real-CF integration suite evict clean
+      # worker-IRRELEVANT PRs from the queue (#3075: #3067/#3073/#3074/#3064; #3079 added the
+      # worker-relevance AND). But worker-relevance alone was still COARSER than the PR-head
+      # gate: it fail-safes any non-`packages/**` path (a docs/markdown/skills diff) to
+      # `relevant`, so a docs-only batch RAN integration on merge_group even though the
+      # `backend` path filter SKIPS it on the PR head — the two contexts disagreed, and a
+      # clean docs-only PR got dequeued when that gating run hit the teardown flake
+      # (#3514/#690/#813; PR #3512, run 29659047210). Fix: gate the merge_group branch on the
+      # SAME `backend` path filter the PR head uses, so the skip decision is consistent across
+      # PR head and merge_group. `steps.filter.outputs.backend` IS computed on merge_group —
+      # `dorny/paths-filter` diffs the merge_group ref against the default branch (`main...ref`
+      # merge-base), i.e. the batch's cumulative diff — so a docs-only batch has
+      # `backend == false` in BOTH contexts. The worker-relevance AND is retained: a
+      # lockfile-triggered-but-worker-irrelevant batch (`backend == true`, `worker_relevant ==
+      # false`) still skips, mirroring the PR head. FAIL-SAFE TO RUNNING is preserved end to
+      # end — `|| 'true'` defaults an absent/empty worker_relevant to running, the classify
+      # step emits `worker_relevant=true` on any missing base/head SHA or unresolvable diff,
+      # and dorny lists a superset of files on any diff ambiguity → `backend=true` → RUN; so
+      # any doubt RUNS integration, never skips (the #3079 threat model: a mis-classified
+      # batch must never skip and merge broken). The batch still runs in the trusted base's
+      # context with repo secrets, so the PR-only fork/author guard does not apply.
       integration_required: >-
         ${{ (github.event_name == 'merge_group' &&
+             steps.filter.outputs.backend == 'true' &&
              (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false') ||
             ((steps.filter.outputs.backend == 'true' ||
              contains(github.event.pull_request.labels.*.name, 'feature-complete')) &&


### PR DESCRIPTION
## What & why

The merge queue dequeues clean, docs-only PRs because the required `integration tests` job **runs and gates on the `merge_group` commit even though change-detection legitimately SKIPS it on the PR head** for a docs/markdown-only diff. The two evaluation contexts disagreed on *how* they detect change:

- **PR head:** `integration_required` gates on the `backend` **path filter** (`steps.filter.outputs.backend`), which excludes docs/markdown/skills — a docs-only diff SKIPS integration (green legit-skip).
- **merge_group:** `integration_required` gated **only** on the worker-relevance classifier, which fail-safes any non-`packages/**` path (a docs/markdown diff) to `relevant` — so a docs-only batch RAN integration, hit the known Cloudflare shared-stage teardown flake, and dequeued the PR without merging.

This is the structural (behavior-vs-intent) defect #3514 owns — independent of the flake itself.

## The fix (Option A — consistent change-detection)

AND the **same `backend` path filter** into the `merge_group` branch of `integration_required`, mirroring the PR-head skip logic:

```yaml
${{ (github.event_name == 'merge_group' &&
     steps.filter.outputs.backend == 'true' &&
     (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false') || ... }}
```

`steps.filter.outputs.backend` **is already computed on `merge_group`**: `dorny/paths-filter@v3.0.2` routes a `merge_group` event (not a PR event, base defaulted to the default branch) through `getChangedFilesFromGit` → `getChangesSinceMergeBase(defaultBranch, mergeGroupRef)`, i.e. a `main...<merge_group ref>` merge-base diff = the batch's cumulative diff. So a docs-only batch has `backend == false` in **both** contexts. The filter step already runs unconditionally on every merge_group today; this PR simply *uses* an output that was previously produced-but-unused for the integration gate — no new failure surface.

The worker-relevance `!= 'false'` AND is **retained**, so a lockfile-triggered-but-worker-irrelevant batch (`backend == true`, `worker_relevant == false`) still skips — exactly mirroring the PR head.

## Fail-safe / gate integrity

- **FAIL-SAFE TO RUNNING preserved.** Any diff ambiguity widens the file set → `backend == true` → RUN; `worker_relevant` defaults to `true` on any unresolvable diff. The #3079 threat model (a mis-classified batch must never skip and merge broken) holds.
- **No weakening of the real gate.** A batch whose diff *does* touch integration-relevant code (`backend == true`) still requires `integration tests`. The change only removes the run for a diff that legitimately skips it on its own PR head.
- Only the `merge_group` branch of one expression changed; e2e / check / packages / workflows gating is untouched. Path-filter lists are unchanged, so the `path-filter-guard` ci.yml↔deploy.yml sync invariant still holds (verified locally). `actionlint` passes locally.

## Cross-links (not duplicated)

- #690 (sweep) / #813 (durable fix) — the flake facet; this PR does not re-open or duplicate them.
- #3515 separately addresses the teardown flake itself (already landed).
- Incident: PR #3512, Actions run `29659047210`, merge_group head `b06b2a0cd78ca20a96cc8b5671f6bb9f6382c545`.

## §CP notice

This edits `.github/workflows/ci.yml` — a **§CP (control-plane) surface**. It banks for `@kamp-us/control-plane` approval and ships via `ship-it` (ADR 0135); it should **not** auto-ship.

Fixes #3514

🤖 Generated with [Claude Code](https://claude.com/claude-code)