### PR TITLE
feat(user-admin): wire the platform-role-assign affordance into the kullanıcılar roster (#3523)

### DIFF
--- a/apps/web/src/admin/kullanicilar/KullanicilarPanel.css
+++ b/apps/web/src/admin/kullanicilar/KullanicilarPanel.css
@@ -80,3 +80,22 @@
 	color: var(--text-muted);
 	font: var(--t-body-sm);
 }
+
+/* Per-row role-assign affordance (#3523). Text-only status (design law pillar 4: state as
+   words, never color); the Button primitive carries the 36px hit-area + focus ring. */
+.kp-role {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	align-items: flex-start;
+}
+
+.kp-role__btn {
+	min-height: var(--tap-min);
+	min-width: var(--tap-min);
+}
+
+.kp-role__message {
+	color: var(--text-muted);
+	font: var(--t-meta);
+}

--- a/apps/web/src/admin/kullanicilar/KullanicilarPanel.gating.test.tsx
+++ b/apps/web/src/admin/kullanicilar/KullanicilarPanel.gating.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Kullanıcılar role-assign gating (#3523) — the two-gate contract at the component tier:
+ * the panel is behind `phoenix-user-admin`, and the per-row role affordance is behind its
+ * own `phoenix-user-role-assign` dark-ship flag. Off ⇒ invisible, as a whole column (header
+ * + cells), never an empty one. The read-view dark-ship (whole panel off) is proven
+ * in-browser by `tests/e2e/31-kullanicilar-darkship.spec.ts`; this pins the role-column flag.
+ */
+import {render, screen} from "@testing-library/react";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import KullanicilarPanel from "./KullanicilarPanel";
+
+// Keyed flag mock — both the panel `FlagGate` (`phoenix-user-admin`) and the role column's
+// `useFlag` (`phoenix-user-role-assign`) read through this, so one map drives both gates.
+let flags: Record<string, boolean>;
+vi.mock("../../flags/useFlag", () => ({
+	useFlag: (key: string) => ({value: flags[key] ?? false, loading: false}),
+}));
+
+// Keep react-fate's real `view`; stub the read hooks to yield exactly one roster row and the
+// client so no transport is built. The row's derived `role` is what the affordance mutates.
+const ROW = {
+	id: "u-1",
+	username: "anka",
+	email: "anka@kamp.us",
+	role: "member" as const,
+	banned: false,
+	tier: "çaylak",
+	createdAt: 0,
+};
+vi.mock("react-fate", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-fate")>();
+	return {
+		...actual,
+		useRequest: () => ({"userAdmin.list": "conn-ref"}),
+		useListView: () => [[{node: "row-ref-1"}], null, null],
+		useView: () => ROW,
+		useFateClient: () => ({mutations: {user: {setRole: vi.fn()}}}) as never,
+	};
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("kullanıcılar role-assign gating (#3523)", () => {
+	it("the whole roster is dark while phoenix-user-admin is off", () => {
+		flags = {"phoenix-user-admin": false, "phoenix-user-role-assign": true};
+		render(<KullanicilarPanel />);
+		expect(screen.queryByTestId("kullanicilar-panel")).toBeNull();
+		expect(screen.queryByTestId("role-toggle-u-1")).toBeNull();
+	});
+
+	it("the roster renders but the role column is invisible while phoenix-user-role-assign is off", () => {
+		flags = {"phoenix-user-admin": true, "phoenix-user-role-assign": false};
+		render(<KullanicilarPanel />);
+		expect(screen.getByTestId("kullanicilar-table")).toBeTruthy();
+		expect(screen.queryByTestId("role-toggle-u-1")).toBeNull();
+		expect(screen.queryByText("rol işlemleri")).toBeNull();
+	});
+
+	it("the role column appears once both flags are on", () => {
+		flags = {"phoenix-user-admin": true, "phoenix-user-role-assign": true};
+		render(<KullanicilarPanel />);
+		expect(screen.getByTestId("role-toggle-u-1")).toBeTruthy();
+		expect(screen.getByText("rol işlemleri")).toBeTruthy();
+	});
+});

--- a/apps/web/src/admin/kullanicilar/KullanicilarPanel.tsx
+++ b/apps/web/src/admin/kullanicilar/KullanicilarPanel.tsx
@@ -9,10 +9,13 @@
  * ships dark until a human flips the flag (ADR 0083) — the client half of the two-gate
  * contract whose worker half fails the invisible `Denied`.
  *
- * READ-ONLY: the per-user actions (rol ata, yasakla/kaldır) are a sibling child that wires
- * the already-shipped mutations into these rows later — this slice lists + searches only.
+ * Per-row role affordance (#3523): the `rol işlemleri` column wires the `user.setRole`
+ * mutation (#3522) behind its OWN default-off `phoenix-user-role-assign` flag, so the whole
+ * column is invisible until both that flag and `phoenix-user-admin` are on. The remaining
+ * per-user action (yasakla/kaldır) is a sibling child, wired later.
  *
- * Render decisions live DOM-free in `kullanicilar.ts` (unit-tested); this is the thin shell.
+ * Render decisions live DOM-free in `kullanicilar.ts` / `role-controls.ts` (unit-tested);
+ * this is the thin shell.
  * a11y: a labelled region + table; search is a real `<form>`; every cell is text, never
  * color; lowercase Turkish copy per the design law.
  */
@@ -21,9 +24,11 @@ import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {UserAdmin} from "../../../worker/features/fate/views";
 import {Button} from "../../components/ui/Button";
 import {FlagGate} from "../../flags/FlagGate";
-import {PHOENIX_USER_ADMIN} from "../../flags/keys";
+import {PHOENIX_USER_ADMIN, PHOENIX_USER_ROLE_ASSIGN} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
 import "./KullanicilarPanel.css";
 import {banLabel, createdAtLabel, roleLabel, usernameLabel} from "./kullanicilar";
+import {RoleControls} from "./RoleControls";
 
 const ROSTER_PAGE_SIZE = 50;
 
@@ -52,6 +57,11 @@ function KullanicilarRoster() {
 	// roster — only submitting the form (or clearing it) changes the request args.
 	const [draft, setDraft] = useState("");
 	const [applied, setApplied] = useState("");
+	// Bumped after a role assignment to remount RosterList, forcing a fresh network-only
+	// re-read so the row's derived `role` re-resolves through the gated view (#3523). A
+	// `RoleState` write doesn't touch the `UserAdmin` entity in the store, so the row can't
+	// self-update — the re-read is what reflects it.
+	const [reloadNonce, setReloadNonce] = useState(0);
 
 	function onSubmit(event: React.FormEvent) {
 		event.preventDefault();
@@ -82,13 +92,29 @@ function KullanicilarRoster() {
 				</Button>
 			</form>
 			<Suspense fallback={<p className="kp-kullanicilar__loading">yükleniyor…</p>}>
-				<RosterList search={applied} />
+				<RosterList
+					key={reloadNonce}
+					search={applied}
+					onRoleChanged={() => setReloadNonce((n) => n + 1)}
+				/>
 			</Suspense>
 		</section>
 	);
 }
 
-function RosterList({search}: {readonly search: string}) {
+function RosterList({
+	search,
+	onRoleChanged,
+}: {
+	readonly search: string;
+	readonly onRoleChanged: () => void;
+}) {
+	// The role-assign column is gated on its OWN dark-ship flag (#3522), evaluated once
+	// here so the whole column — header + cells — appears or disappears as a unit: flag
+	// off ⇒ no action column at all (not an empty one), the invisible-Denied client half.
+	// The panel already sits inside the `phoenix-user-admin` FlagGate, so both flags must
+	// be on for the controls to render.
+	const {value: roleAssignOn} = useFlag(PHOENIX_USER_ROLE_ASSIGN, false);
 	const result = useRequest(
 		{
 			"userAdmin.list": {
@@ -119,18 +145,32 @@ function RosterList({search}: {readonly search: string}) {
 					<th scope="col">durum</th>
 					<th scope="col">seviye</th>
 					<th scope="col">kayıt</th>
+					{roleAssignOn ? <th scope="col">rol işlemleri</th> : null}
 				</tr>
 			</thead>
 			<tbody>
 				{items.map(({node}) => (
-					<RosterRow key={node.id} node={node} />
+					<RosterRow
+						key={node.id}
+						node={node}
+						roleAssignOn={roleAssignOn}
+						onRoleChanged={onRoleChanged}
+					/>
 				))}
 			</tbody>
 		</table>
 	);
 }
 
-function RosterRow({node}: {readonly node: ViewRef<"UserAdmin">}) {
+function RosterRow({
+	node,
+	roleAssignOn,
+	onRoleChanged,
+}: {
+	readonly node: ViewRef<"UserAdmin">;
+	readonly roleAssignOn: boolean;
+	readonly onRoleChanged: () => void;
+}) {
 	const data = useView(UserAdminRowView, node);
 	return (
 		<tr data-testid={`kullanicilar-row-${data.id}`}>
@@ -140,6 +180,11 @@ function RosterRow({node}: {readonly node: ViewRef<"UserAdmin">}) {
 			<td data-testid={`kullanicilar-ban-${data.id}`}>{banLabel(data.banned)}</td>
 			<td>{data.tier}</td>
 			<td>{createdAtLabel(data.createdAt)}</td>
+			{roleAssignOn ? (
+				<td className="kp-kullanicilar__actions">
+					<RoleControls userId={data.id} platformRole={data.role} onRoleChanged={onRoleChanged} />
+				</td>
+			) : null}
 		</tr>
 	);
 }

--- a/apps/web/src/admin/kullanicilar/RoleControls.test.tsx
+++ b/apps/web/src/admin/kullanicilar/RoleControls.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * `RoleControls` component contract (#3523) — the per-row role-assign affordance wires the
+ * `Admin.over(platform)`-gated `user.setRole` mutation (#3522). Pins: the toggle label per
+ * current role, that a click invokes `user.setRole` with the toggled role, that a success
+ * re-reads the roster (`onRoleChanged`) and shows the outcome, and that the invisible
+ * `Denied` (a non-admin / flag-off refusal) shows the no-authority line and re-reads nothing.
+ */
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {RoleControls} from "./RoleControls";
+
+// Keep react-fate's real `view` (used at module load for `RoleStateSelect`); stub the client
+// so no transport is built — `setRole` is the only mutation the affordance touches.
+let setRoleResult: {result?: {role: string}; error?: unknown};
+const setRoleCalls: {userId: string; role: string}[] = [];
+vi.mock("react-fate", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-fate")>();
+	return {
+		...actual,
+		useFateClient: () =>
+			({
+				mutations: {
+					user: {
+						setRole: async ({input}: {input: {userId: string; role: string}}) => {
+							setRoleCalls.push(input);
+							return setRoleResult;
+						},
+					},
+				},
+			}) as never,
+	};
+});
+
+afterEach(() => {
+	setRoleCalls.length = 0;
+	vi.clearAllMocks();
+});
+
+describe("RoleControls (#3523)", () => {
+	it("a üye row offers to grant moderatör and assigns the moderator role on click", async () => {
+		setRoleResult = {result: {role: "moderator"}};
+		const onRoleChanged = vi.fn();
+		render(<RoleControls userId="u-1" platformRole="member" onRoleChanged={onRoleChanged} />);
+
+		const toggle = screen.getByTestId("role-toggle-u-1");
+		expect(toggle.textContent).toBe("moderatör yap");
+
+		fireEvent.click(toggle);
+		await waitFor(() => expect(setRoleCalls).toHaveLength(1));
+		expect(setRoleCalls[0]).toEqual({userId: "u-1", role: "moderator"});
+		await waitFor(() =>
+			expect(screen.getByTestId("role-message-u-1").textContent).toBe(
+				"kullanıcı moderatör yapıldı.",
+			),
+		);
+		expect(onRoleChanged).toHaveBeenCalledOnce();
+	});
+
+	it("a moderatör row offers to revoke and assigns the member role on click", async () => {
+		setRoleResult = {result: {role: "member"}};
+		const onRoleChanged = vi.fn();
+		render(<RoleControls userId="u-2" platformRole="moderator" onRoleChanged={onRoleChanged} />);
+
+		const toggle = screen.getByTestId("role-toggle-u-2");
+		expect(toggle.textContent).toBe("moderatörlüğü al");
+
+		fireEvent.click(toggle);
+		await waitFor(() => expect(setRoleCalls[0]).toEqual({userId: "u-2", role: "member"}));
+		await waitFor(() =>
+			expect(screen.getByTestId("role-message-u-2").textContent).toBe("moderatörlük kaldırıldı."),
+		);
+		expect(onRoleChanged).toHaveBeenCalledOnce();
+	});
+
+	it("an invisible Denied shows the no-authority line and re-reads nothing", async () => {
+		setRoleResult = {error: {code: "UNAUTHORIZED"}};
+		const onRoleChanged = vi.fn();
+		render(<RoleControls userId="u-3" platformRole="member" onRoleChanged={onRoleChanged} />);
+
+		fireEvent.click(screen.getByTestId("role-toggle-u-3"));
+		await waitFor(() =>
+			expect(screen.getByTestId("role-message-u-3").textContent).toBe("bu işlem için yetkin yok."),
+		);
+		expect(onRoleChanged).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/admin/kullanicilar/RoleControls.tsx
+++ b/apps/web/src/admin/kullanicilar/RoleControls.tsx
@@ -1,0 +1,92 @@
+/**
+ * `RoleControls` — the per-row platform-role affordance for the kullanıcılar roster
+ * (#3523, split from #3203). One toggle that grants/revokes the moderatör role via the
+ * `Admin.over(platform)`-gated `user.setRole` mutation (#3522), which writes the
+ * `moderates` relation tuple. The server is the sole authority: a non-admin call comes
+ * back the invisible `Denied` and shows the no-authority line, minting nothing.
+ *
+ * The panel renders this only when BOTH the roster flag `PHOENIX_USER_ADMIN` (the panel's
+ * `FlagGate`) and the role-assign dark-ship flag `PHOENIX_USER_ROLE_ASSIGN` (the roster's
+ * per-column `useFlag`) are on — the client half of the two-gate ship-dark contract whose
+ * worker half fails the invisible `Denied` (ADR 0083).
+ *
+ * After a successful assignment `onRoleChanged` re-reads the roster through the gated
+ * view so the row's derived `role` cell reflects the new value (the `moderates` tuple is
+ * re-joined server-side; a `RoleState` write does not update the `UserAdmin` entity in the
+ * client store). Render decisions are DOM-free in `role-controls.ts` (unit-tested).
+ *
+ * a11y: the `Button` primitive (focus ring + 36px hit area from the shared styles); the
+ * outcome is a `role="status" aria-live="polite"` text region (state as words, never
+ * color); copy is lowercase Turkish.
+ */
+import {useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {RoleState, UserAdminRole} from "../../../worker/features/fate/views";
+import {Button} from "../../components/ui/Button";
+import {codeOf} from "../../fate/wire";
+import {nextRole, roleActionLabel, roleOutcomeMessage} from "./role-controls";
+
+const RoleStateSelect = view<RoleState>()({
+	id: true,
+	role: true,
+});
+
+interface RoleControlsProps {
+	readonly userId: string;
+	// Named `platformRole`, not `role`, so the JSX prop doesn't collide with the ARIA `role`
+	// attribute the a11y lint keys on (a custom-component `role=` string trips it, #3523).
+	readonly platformRole: UserAdminRole;
+	/** Re-read the roster through the gated view so the row's `role` cell reflects the write. */
+	readonly onRoleChanged: () => void;
+}
+
+export function RoleControls({userId, platformRole, onRoleChanged}: RoleControlsProps) {
+	const fate = useFateClient();
+	const [busy, setBusy] = useState(false);
+	const [message, setMessage] = useState("");
+
+	async function onToggle() {
+		if (busy) return;
+		setBusy(true);
+		setMessage("");
+		try {
+			const {result, error} = await fate.mutations.user.setRole({
+				input: {userId, role: nextRole(platformRole)},
+				view: RoleStateSelect,
+			});
+			setMessage(
+				roleOutcomeMessage(error ? null : (result?.role ?? null), error ? codeOf(error) : null),
+			);
+			if (!error) onRoleChanged();
+		} catch (caught) {
+			setMessage(roleOutcomeMessage(null, codeOf(caught)));
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	return (
+		<div className="kp-role" data-testid={`kullanicilar-role-controls-${userId}`}>
+			<Button
+				variant="secondary"
+				size="sm"
+				className="kp-role__btn"
+				onClick={onToggle}
+				disabled={busy}
+				data-testid={`role-toggle-${userId}`}
+			>
+				{roleActionLabel(platformRole, busy)}
+			</Button>
+			{message ? (
+				<p
+					className="kp-role__message"
+					role="status"
+					aria-live="polite"
+					data-testid={`role-message-${userId}`}
+				>
+					{message}
+				</p>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/admin/kullanicilar/role-controls.test.ts
+++ b/apps/web/src/admin/kullanicilar/role-controls.test.ts
@@ -1,0 +1,50 @@
+/**
+ * `role-controls` pure-logic coverage (#3523) — the toggle target, its label, and the
+ * outcome-message mapping, DOM-free (the `ban-controls.ts` idiom). Turkish user-facing
+ * copy; English technical wire values.
+ */
+import {describe, expect, it} from "vitest";
+import {nextRole, roleActionLabel, roleOutcomeMessage} from "./role-controls";
+
+describe("nextRole", () => {
+	it("grants moderatör to a üye", () => {
+		expect(nextRole("member")).toBe("moderator");
+	});
+	it("revokes moderatör from a moderatör", () => {
+		expect(nextRole("moderator")).toBe("member");
+	});
+});
+
+describe("roleActionLabel", () => {
+	it("a üye row offers to grant the role", () => {
+		expect(roleActionLabel("member", false)).toBe("moderatör yap");
+	});
+	it("a moderatör row offers to revoke the role", () => {
+		expect(roleActionLabel("moderator", false)).toBe("moderatörlüğü al");
+	});
+	it("reflects the in-flight state per direction", () => {
+		expect(roleActionLabel("member", true)).toBe("yapılıyor…");
+		expect(roleActionLabel("moderator", true)).toBe("alınıyor…");
+	});
+});
+
+describe("roleOutcomeMessage", () => {
+	it("a granted moderatör confirms the promotion", () => {
+		expect(roleOutcomeMessage("moderator", null)).toBe("kullanıcı moderatör yapıldı.");
+	});
+	it("a revoked role confirms the removal", () => {
+		expect(roleOutcomeMessage("member", null)).toBe("moderatörlük kaldırıldı.");
+	});
+	it("the invisible Denied (both codes) reads as no-authority, leaking neither cause", () => {
+		expect(roleOutcomeMessage(null, "UNAUTHORIZED")).toBe("bu işlem için yetkin yok.");
+		expect(roleOutcomeMessage(null, "FORBIDDEN")).toBe("bu işlem için yetkin yok.");
+	});
+	it("a missing target reads not-found", () => {
+		expect(roleOutcomeMessage(null, "USER_NOT_FOUND")).toBe("kullanıcı bulunamadı.");
+	});
+	it("any other code falls back to the generic failure", () => {
+		expect(roleOutcomeMessage(null, "INTERNAL_SERVER_ERROR")).toBe(
+			"bir şeyler ters gitti, lütfen tekrar dene.",
+		);
+	});
+});

--- a/apps/web/src/admin/kullanicilar/role-controls.ts
+++ b/apps/web/src/admin/kullanicilar/role-controls.ts
@@ -1,0 +1,48 @@
+/**
+ * DOM-free render logic for the kullanıcılar role-assign affordance (#3523) — the
+ * grant/revoke toggle target, its label, and the outcome message, pure so they are
+ * unit-testable without a DOM (the `ban-controls.ts` idiom). `RoleControls.tsx` is the
+ * thin shell. Turkish user-facing copy per the language rule (`.glossary/LANGUAGE.md`);
+ * the wire role values stay English technical tokens (`member` / `moderator`).
+ *
+ * The two platform roles are `member` / `moderator` only — the `user.setRole` mutation's
+ * `SetRoleInput` (#3522) writes the `moderates` tuple, so the toggle grants or revokes the
+ * moderatör role; there is no SPA-assignable `admin` role.
+ */
+import type {UserAdminRole} from "../../../worker/features/user-admin/views";
+import type {FateWireCode} from "../../lib/fateWireCodes";
+
+/** The role the toggle assigns next — grant moderatör to a üye, revoke it from a moderatör. */
+export const nextRole = (current: UserAdminRole): UserAdminRole =>
+	current === "moderator" ? "member" : "moderator";
+
+/** The toggle's Turkish label, keyed on the current role and the in-flight state. */
+export const roleActionLabel = (current: UserAdminRole, busy: boolean): string => {
+	if (current === "moderator") return busy ? "alınıyor…" : "moderatörlüğü al";
+	return busy ? "yapılıyor…" : "moderatör yap";
+};
+
+/**
+ * Turkish feedback for a `user.setRole` outcome. On success (`code === null`) the
+ * message is keyed on the newly-assigned role the mutation returns; on failure it is
+ * keyed on the wire code — the invisible `Denied` (`UNAUTHORIZED`/`FORBIDDEN`, i.e. a
+ * non-admin call OR the flag off) reads as a plain no-authority line, never leaking
+ * which of the two it was.
+ */
+export const roleOutcomeMessage = (
+	assigned: UserAdminRole | null,
+	code: FateWireCode | null,
+): string => {
+	if (code === null && assigned !== null) {
+		return assigned === "moderator" ? "kullanıcı moderatör yapıldı." : "moderatörlük kaldırıldı.";
+	}
+	switch (code) {
+		case "UNAUTHORIZED":
+		case "FORBIDDEN":
+			return "bu işlem için yetkin yok.";
+		case "USER_NOT_FOUND":
+			return "kullanıcı bulunamadı.";
+		default:
+			return "bir şeyler ters gitti, lütfen tekrar dene.";
+	}
+};


### PR DESCRIPTION
Admins can now grant or revoke a user's moderatör role straight from a row of the kullanıcılar roster console, instead of only through the offline D1/CLI path. Each row gets a "rol işlemleri" toggle — "moderatör yap" for a üye, "moderatörlüğü al" for a moderatör — and the row updates to show the new role once the change lands. The whole thing stays hidden until a human turns it on, so it can ship without being live.

## What changed
- New `RoleControls` per-row affordance that calls the `Admin.over(platform)`-gated `user.setRole` mutation (#3522), which writes the `moderates` relation tuple. The server stays the sole authority: a non-admin (or flag-off) call returns the invisible `Denied` and shows the no-authority line, minting nothing.
- The affordance ships dark behind its own default-off `phoenix-user-role-assign` flag (declared in #3522). The action column — header + cells — is gated as a unit: with either that flag or the roster's `phoenix-user-admin` flag off, the column is invisible (never an empty column).
- After a successful assignment the roster re-reads network-only, so the row's derived `role` cell reflects the write (a `RoleState` write doesn't touch the `UserAdmin` entity in the store).
- Render decisions are DOM-free in `role-controls.ts` (unit-tested); `RoleControls.tsx` is the thin shell mirroring the shipped `BanControls` / `PromotionActions` pattern. New tests: pure-logic (`role-controls.test.ts`), the component mutation wiring + outcomes (`RoleControls.test.tsx`), and the two-flag gating (`KullanicilarPanel.gating.test.tsx`).

No new server-side privileged endpoint — this wires the #3522 mutation only. The platform roles the mutation assigns are `member` / `moderator` (there is no SPA-assignable `admin` role).

The composed-render self-check (Step 4d) was not run: the surface requires release plumbing to render (both default-off flags on + a discharged `Admin` grant + a populated roster). The off-path is covered in-browser by `tests/e2e/31-kullanicilar-darkship.spec.ts`; the column reuses the shipped roster table + the `Button` primitive.

Fixes #3523
Flag: phoenix-user-role-assign