### PR TITLE
feat(pipeline-crew-mcp): dynamic single-member crew ops — spawn-role / retire-role (#3519)

### DIFF
--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -7,6 +7,15 @@
  *   node src/bin.ts tracker                           # run a standalone per-project tracker
  *   node src/bin.ts stand-up                          # stand the whole crew up from the operator config
  *   node src/bin.ts stand-down                        # tear down the crew's project-scope .mcp.json + server approval
+ *   node src/bin.ts spawn-role <role>                 # add ONE member to the running crew (no whole-crew re-boot)
+ *   node src/bin.ts retire-role <role> [--instance]   # retire ONE member (kill its pane + reclaim its artifacts)
+ *
+ * The `spawn-role` / `retire-role` subcommands are the single-member membership ops (#3519): dynamic
+ * add/remove/respawn of ONE crew member without the whole-crew re-boot `stand-up`/`stand-down` force.
+ * `spawn-role` reuses the whole-crew per-role launch step but SPLITS the pane into the running crew
+ * window; `retire-role` kills one member's pane (its role lease frees by TTL) and reclaims its inbox
+ * socket + launcher cwd. The runtime already does the join/leave/discover (crew/session.ts + tracker.ts);
+ * these subcommands are the missing CLI surface over it. See `standup/single-role.ts`.
  *
  * The `session` subcommand is the runnable stdio MCP entry (#3062): it stands up one live crew
  * session's `McpServer` over stdio + its channel peer, so the crew's inter-session seams run over
@@ -40,10 +49,18 @@
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Cause, Console, Effect, Option} from "effect";
-import {Command, Flag} from "effect/unstable/cli";
+import {Argument, Command, Flag} from "effect/unstable/cli";
 
 import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
-import {CREW_WINDOW, renderStandUpError, runStandDown, runStandUp} from "./standup/index.ts";
+import {
+	CREW_WINDOW,
+	renderStandUpError,
+	renderTaggedError,
+	retireRole,
+	runStandDown,
+	runStandUp,
+	spawnRole,
+} from "./standup/index.ts";
 import {isTrackerAddressInUse, launchTracker} from "./tracker/index.ts";
 import {VERSION} from "./version.ts";
 
@@ -171,6 +188,79 @@ const standDown = Command.make(
 	),
 );
 
+// The positional role a single-member membership op targets — any roster role (the `session --role`
+// flag chooses from the SAME `CREW_ROLES` source; this is its positional twin for spawn/retire).
+const roleArg = Argument.choice("role", CREW_ROLES).pipe(
+	Argument.withDescription("the crew role to spawn/retire one member of (one of the CREW_ROLES)"),
+);
+// Which engine INSTANCE to retire — required for a cardinality-N engine, rejected for a singleton
+// bridge (retireRole enforces the kind rule). Optional at the CLI so a bridge omits it.
+const instanceFlagOptional = Flag.optional(Flag.string("instance")).pipe(
+	Flag.withDescription(
+		"the engine instance id to retire (required for an engine role, none for a bridge)",
+	),
+);
+
+const spawnRoleCmd = Command.make(
+	"spawn-role",
+	{projectRoot: projectRootFlag, role: roleArg},
+	Effect.fn(function* ({projectRoot, role}) {
+		yield* Console.error(
+			`pipeline-crew-mcp ${VERSION} — spawning one "${role}" member into the running crew (project ${projectRoot})`,
+		);
+		// Add ONE member to the running crew without a whole-crew re-boot (#3519): reuse the shared
+		// per-role launch step, split into the running crew window, fail-loud if no crew is up.
+		return yield* spawnRole({projectRoot, role}).pipe(
+			Effect.flatMap((result) =>
+				Console.error(
+					`crew member up: ${result.launched.role}→${result.launched.pane} in window ${result.launched.window} (pid ${result.launched.pid ?? "?"})`,
+				),
+			),
+			Effect.catch((error) =>
+				Console.error(`spawn-role aborted: ${renderTaggedError(error)}`).pipe(
+					Effect.andThen(Effect.sync(() => process.exit(1))),
+				),
+			),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Add ONE crew member to the running crew (split into the crew window), no whole-crew re-boot",
+	),
+);
+
+const retireRoleCmd = Command.make(
+	"retire-role",
+	{projectRoot: projectRootFlag, role: roleArg, instance: instanceFlagOptional},
+	Effect.fn(function* ({projectRoot, role, instance}) {
+		yield* Console.error(
+			`pipeline-crew-mcp ${VERSION} — retiring one "${role}" member from the running crew (project ${projectRoot})`,
+		);
+		// Tear ONE member down cleanly: kill its pane (its lease frees by TTL), reclaim its inbox socket +
+		// launcher cwd — leaving every other member running (#3519).
+		return yield* retireRole({
+			projectRoot,
+			role,
+			...(Option.isSome(instance) ? {instance: instance.value} : {}),
+		}).pipe(
+			Effect.flatMap((result) =>
+				Console.error(
+					`crew member retired: ${result.role}${result.instance ? `/${result.instance}` : ""} (killed pane ${result.paneId})`,
+				),
+			),
+			Effect.catch((error) =>
+				Console.error(`retire-role aborted: ${renderTaggedError(error)}`).pipe(
+					Effect.andThen(Effect.sync(() => process.exit(1))),
+				),
+			),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Retire ONE crew member (kill its pane + reclaim its artifacts), leaving the rest running",
+	),
+);
+
 const cli = Command.make(
 	"pipeline-crew-mcp",
 	{},
@@ -181,7 +271,7 @@ const cli = Command.make(
 	}),
 ).pipe(
 	Command.withDescription("The crew's channels-backed messaging substrate (epic #3045)"),
-	Command.withSubcommands([session, tracker, standUp, standDown]),
+	Command.withSubcommands([session, tracker, standUp, standDown, spawnRoleCmd, retireRoleCmd]),
 );
 
 cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -47,6 +47,7 @@ export {
 	tryBecomeTracker,
 } from "./ensure-tracker.ts";
 export {
+	buildLaunchPlan,
 	CREW_WINDOW,
 	ensureNamedTmuxSession,
 	FALLBACK_TMUX_SESSION,
@@ -58,9 +59,12 @@ export {
 	paneClaudeCommand,
 	productionProjectScopeRegistrar,
 	renderStandUpError,
+	renderTaggedError,
 	resolveTargetTmuxSession,
 	runStandDown,
 	runStandUp,
+	runTmux,
+	type SessionPlanContext,
 	type StandDownInput,
 	type StandUpError,
 	type StandUpInput,
@@ -69,6 +73,7 @@ export {
 	type TmuxRun,
 	type TmuxRunner,
 	TmuxSessionEnsureError,
+	toRosterSession,
 } from "./orchestrate.ts";
 export {
 	applyDisableApproval,
@@ -100,10 +105,29 @@ export {
 export {
 	type BridgeSession,
 	type CrewSession,
+	deriveOneSession,
 	deriveSessionSet,
 	type EngineSession,
 	type SessionSetInput,
 } from "./session-set.ts";
+export {
+	CrewPaneKillError,
+	CrewPaneNotFoundError,
+	CrewWindowNotRunningError,
+	findCrewPaneId,
+	productionRetireArtifacts,
+	type RetireArtifacts,
+	RetireRoleArgError,
+	type RetireRoleError,
+	type RetireRoleInput,
+	type RetireRoleResult,
+	resolveCrewWindowId,
+	retireRole,
+	type SpawnRoleError,
+	type SpawnRoleInput,
+	type SpawnRoleResult,
+	spawnRole,
+} from "./single-role.ts";
 export {
 	computeTmuxPlacement,
 	type PlacementTarget,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -106,7 +106,7 @@ export type TmuxRunner = (args: readonly string[]) => Effect.Effect<TmuxRun>;
  * `spawnError` data so each caller maps it to its own typed error (no raw try/catch: `spawn` reports
  * operational errors via `error`, not a throw). This mirrors ensure-tracker's `Effect.callback` node-event idiom.
  */
-const runTmux: TmuxRunner = (args) =>
+export const runTmux: TmuxRunner = (args) =>
 	Effect.callback<TmuxRun>((resume) => {
 		const child = spawn("tmux", [...args], {stdio: ["ignore", "pipe", "ignore"]});
 		let stdout = "";
@@ -167,21 +167,23 @@ export type StandUpError =
 	| StandUpLaunchError;
 
 /**
- * Render a stand-up abort for the operator: the error tag plus its diagnostic data fields. `String(error)` on a
+ * Render any crew tagged error for the operator: the tag plus its diagnostic data fields. `String(error)` on a
  * `Schema.TaggedErrorClass` prints only the tag and drops the fields — yet the fields are the payload an operator
  * needs (which tmux step + exit code failed, in which role/pane), so surface every schema data field alongside
- * the tag. Field-generic on purpose: every union member's diagnostic surfaces — including both `reason`-carriers,
- * `StandUpLaunchError` (role/pane/reason) and `TmuxSessionEnsureError` (session/reason) — and a future member's
- * fields can't silently regress to tag-only. `Cause.pretty` is not a substitute here: it prints tag + stack but
- * not the schema fields (#3438).
+ * the tag. Field-generic on purpose: every error's diagnostic surfaces regardless of its field shape, so a future
+ * member's fields can't silently regress to tag-only. `Cause.pretty` is not a substitute here: it prints tag +
+ * stack but not the schema fields (#3438). Shared by the stand-up path and the single-member membership ops (#3519).
  */
-export const renderStandUpError = (error: StandUpError): string => {
+export const renderTaggedError = (error: {readonly _tag: string}): string => {
 	const detail = Object.entries(error)
 		.filter(([key]) => key !== "_tag")
 		.map(([key, value]) => `${key}=${typeof value === "string" ? value : JSON.stringify(value)}`)
 		.join(", ");
 	return detail ? `${error._tag} (${detail})` : error._tag;
 };
+
+/** Render a stand-up abort — the `StandUpError`-typed alias over the shared field-generic renderer. */
+export const renderStandUpError = (error: StandUpError): string => renderTaggedError(error);
 
 /** What `register` commits in one shot: every pane's `.mcp.json` entry plus the run/project context the boot-gate seeds need. */
 export interface ProjectScopeRegisterInput {
@@ -267,11 +269,63 @@ export interface StandUpResult {
 }
 
 /**
+ * The already-resolved launch dimensions one session's plan is built against — the shared context
+ * both the whole-crew stand-up and a single-member `spawn-role` (#3519) hand `buildLaunchPlan`, so
+ * the per-session bind + cwd derivation is ONE code path (never forked between the two callers).
+ */
+export interface SessionPlanContext {
+	readonly projectRoot: string;
+	readonly serverName: string;
+	readonly config: LaunchConfig;
+	/** The id of the cwd-dir tree this session's launch cwd lands under (`<root>/.claude/crew-run/<runId>/`). */
+	readonly runId: string;
+	readonly localScope: ProjectScopeRegistrar;
+}
+
+/**
+ * Build ONE derived session's full launch plan: its launch bind (argv, #3296), its distinct git-valid
+ * launch cwd (where the pane's leaf `.mcp.json` lands, #3444), and its already-computed tmux placement.
+ * This is the per-role launch-plan step `runStandUp` runs for every roster session AND `spawn-role`
+ * (#3519) runs for one on-demand session — extracted, not forked, so single-role and whole-crew launch
+ * derive identically (a bridge binds its singleton address, an engine binds its per-instance identity).
+ */
+export const buildLaunchPlan = (
+	session: CrewSession,
+	placement: PlacementTarget,
+	ctx: SessionPlanContext,
+): Effect.Effect<
+	LaunchPlan,
+	| CrewSessionBinUnresolvableError
+	| CrewServerNotRegisteredError
+	| ChannelPluginNotAllowedError
+	| ProjectScopeWriteError,
+	FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const bind = yield* buildSessionBind({
+			role: session.role,
+			projectRoot: ctx.projectRoot,
+			serverName: ctx.serverName,
+			// Thread the session-set-derived per-instance identity so the launched engine binds it rather
+			// than re-minting its own (#3354 seam 3); a bridge is a singleton and has none.
+			instance: session.kind === "engine" ? session.instance : undefined,
+			// The role's configured model tier → the session's `--model` (#3423); undefined for a role that
+			// set none, so bind emits no `--model` and it boots on the CLI default.
+			tier: ctx.config.roleTiers[session.role],
+			channels: ctx.config.channels,
+		});
+		// The pane's distinct launch cwd — where its leaf `.mcp.json` lands (#3444). Resolved here so an
+		// unwritable cwd fails closed before the register/launch.
+		const cwd = yield* ctx.localScope.paneCwd(ctx.projectRoot, ctx.runId, placement.paneLabel);
+		return {session, bind, placement, cwd};
+	});
+
+/**
  * Project a derived `CrewSession` onto the `RosterSession` tmux-placement consumes: a bridge places
  * on a pane labelled by its role slug, an engine on its generated per-instance id (an operator cannot
  * name N dynamic engines). Both pane labels derive from identity — there is no config tmux dimension.
  */
-const toRosterSession = (session: CrewSession): RosterSession =>
+export const toRosterSession = (session: CrewSession): RosterSession =>
 	session.kind === "engine"
 		? {kind: "engine", id: session.instance}
 		: {kind: "bridge", role: session.role};
@@ -477,36 +531,25 @@ export const runStandUp = (
 
 		const sessions = deriveSessionSet({engineCount: config.engineCount, instanceId});
 
-		// Resolve EVERY bind + placement before launching anything — this is the no-partial-crew line:
-		// an inert channel or a colliding window fails here, while zero sessions are up.
-		const binds = yield* Effect.forEach(sessions, (session) =>
-			buildSessionBind({
-				role: session.role,
+		// Resolve EVERY bind + placement + cwd before launching anything — this is the no-partial-crew
+		// line: an inert channel or a colliding window fails here, while zero sessions are up.
+		const placements = yield* computeTmuxPlacement(sessions.map(toRosterSession));
+		// `placements` is derived from `sessions` in order, so the index is always populated; the die guard
+		// is the unreachable branch that satisfies noUncheckedIndexedAccess. Each session's full plan (bind,
+		// placement, distinct launch cwd) is built by the shared `buildLaunchPlan` — the same per-role step
+		// `spawn-role` runs for one on-demand session (#3519), never a forked launch path.
+		const plans = yield* Effect.forEach(sessions, (session, i) => {
+			const placement = placements[i];
+			if (placement === undefined) {
+				return Effect.die(`stand-up placement zip out of range for session "${session.role}"`);
+			}
+			return buildLaunchPlan(session, placement, {
 				projectRoot,
 				serverName,
-				// Thread the session-set-derived per-instance identity so the launched engine binds it
-				// rather than re-minting its own (#3354 seam 3); a bridge is a singleton and has none.
-				instance: session.kind === "engine" ? session.instance : undefined,
-				// The role's configured model tier → the session's `--model` (#3423); undefined for a
-				// role that set none, so bind emits no `--model` and it boots on the CLI default.
-				tier: config.roleTiers[session.role],
-				channels: config.channels,
-			}),
-		);
-		const placements = yield* computeTmuxPlacement(sessions.map(toRosterSession));
-		// `binds` and `placements` are each derived from `sessions` in order, so the index is always
-		// populated; the die guard is the unreachable branch that satisfies noUncheckedIndexedAccess. Each
-		// pane also gets a distinct git-valid launch cwd (where its leaf `.mcp.json` lands, #3444) — resolved
-		// here, before the register, so an unwritable cwd fails closed with zero panes up.
-		const plans = yield* Effect.forEach(sessions, (session, i) => {
-			const bind = binds[i];
-			const placement = placements[i];
-			if (bind === undefined || placement === undefined) {
-				return Effect.die(`stand-up plan zip out of range for session "${session.role}"`);
-			}
-			return localScope
-				.paneCwd(projectRoot, runId, placement.paneLabel)
-				.pipe(Effect.map((cwd): LaunchPlan => ({session, bind, placement, cwd})));
+				config,
+				runId,
+				localScope,
+			});
 		});
 
 		// Register every pane's crew server as a project-scope leaf `.mcp.json` + seed the two boot gates

--- a/packages/pipeline-crew-mcp/src/standup/session-set.ts
+++ b/packages/pipeline-crew-mcp/src/standup/session-set.ts
@@ -61,6 +61,32 @@ export interface SessionSetInput {
  * has no standing loop to run, so it is never stood up here (#3524). Total over the autobooted roles:
  * every one is kinded, so none is dropped or double-counted.
  */
+/**
+ * Derive ONE session for a single role — the on-demand membership op's session (#3519), the same
+ * `{role, address}` a stand-up session carries so a spawned member joins the tracker + channel over
+ * the identical runtime path. A bridge is its cardinality-1 singleton (`inbox://<role>`, no instance);
+ * an engine mints one fresh per-instance address (`inbox://<role>/<instance>`) so it deconflicts by
+ * resource claims exactly as a boot-from-stand-up engine does.
+ *
+ * Unlike `deriveSessionSet`, this is NOT gated on `isAutobooted`: `spawn-role` is the explicit human
+ * spawn of an on-demand role — the cartographer (human-in-the-loop) is precisely what it exists to
+ * launch — so the autoboot filter (which excludes HITL roles from the standing drain crew) must not
+ * apply here. The role's DRIVE still governs its boot turn downstream (bind.ts hands a HITL role no
+ * boot prompt, so it comes up idle waiting for the human), #3524.
+ */
+export const deriveOneSession = (input: {
+	readonly role: CrewRole;
+	/** Mints the engine instance's distinct id — injected so the derivation is pure/testable; production passes `randomUUID`. */
+	readonly instanceId: () => string;
+}): CrewSession => {
+	const {role, instanceId} = input;
+	if (kindOf(role) === "engine") {
+		const instance = instanceId();
+		return {kind: "engine", role, instance, address: inboxAddressFor(role, instance)};
+	}
+	return {kind: "bridge", role, address: inboxAddressFor(role, "")};
+};
+
 export const deriveSessionSet = (input: SessionSetInput): readonly CrewSession[] => {
 	const {engineCount, instanceId} = input;
 	const sessions: CrewSession[] = [];

--- a/packages/pipeline-crew-mcp/src/standup/single-role.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/single-role.test.ts
@@ -1,0 +1,430 @@
+/**
+ * standup/single-role — dynamic single-member membership ops (issue #3519). These tests pin the two
+ * commands' contracts with every side effect injected (no real tmux/filesystem/`claude`), the same idiom
+ * orchestrate.test.ts uses:
+ *   - `spawn-role` reuses the shared per-role launch step and SPLITS the new pane into the RUNNING crew
+ *     window (intoWindow defined) — never opens a new one — registering only its own pane's scope; it
+ *     spawns any roster role, including the on-demand human-in-the-loop cartographer (which boots idle,
+ *     no boot turn, #3524); it fails closed when no crew window is up.
+ *   - `retire-role` finds the one member's pane by its `--name` displayName, kills it, and reclaims its
+ *     inbox socket + launcher cwd — validating the instance against the role kind, and failing closed on
+ *     an ambiguous / absent pane or a failed kill (no half-teardown).
+ */
+import {NodeServices} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {inboxAddressFor} from "../crew/index.ts";
+import {
+	DEFAULT_CONFIG_PATH,
+	decodeLaunchConfig,
+	type LaunchConfig,
+	type LaunchConfigError,
+} from "./config.ts";
+import type {TrackerHandle, TrackerNotServingError} from "./ensure-tracker.ts";
+import {
+	type CrewMcpEntry,
+	CrewPaneKillError,
+	CrewPaneNotFoundError,
+	CrewWindowNotRunningError,
+	findCrewPaneId,
+	type LaunchedSession,
+	type LaunchPlan,
+	type ProjectScopeRegistrar,
+	type RetireArtifacts,
+	RetireRoleArgError,
+	resolveCrewWindowId,
+	retireRole,
+	type SpawnRoleInput,
+	spawnRole,
+	type TmuxRun,
+	type TmuxRunner,
+} from "./index.ts";
+
+const PINNED = "2.1.212";
+const SERVER = "@kampus/pipeline-crew-mcp";
+
+/** spawnRole reaches the platform through buildLaunchPlan's FileSystem/Path seam — provide the real Node platform. */
+const spawn = (input: SpawnRoleInput) => spawnRole(input).pipe(Effect.provide(NodeServices.layer));
+
+const rawConfigAt = (cliVersion: string): unknown => ({
+	cliVersion,
+	roles: {
+		"chief-of-staff": {tier: "opus"},
+		cartographer: {tier: "fable"},
+		"intake-desk": {tier: "fable"},
+		"engineering-manager": {tier: "opus", count: 2, wipCap: {productLanes: 1, platformLanes: 1}},
+	},
+	channels: {mode: "development", servers: [`server:${SERVER}`], allowedChannelPlugins: []},
+});
+
+const configAt = (cliVersion: string): Effect.Effect<LaunchConfig, LaunchConfigError> =>
+	decodeLaunchConfig(rawConfigAt(cliVersion), DEFAULT_CONFIG_PATH);
+
+const RESOLVED_SESSION = "operator-session";
+const CREW_WINDOW_ID = "@7";
+const RUN_ID = "spawn0";
+
+/** A recording launcher: captures the plan + intoWindow it was handed, and returns a fixed `LaunchedSession`. */
+const recordingLauncher = () => {
+	const calls: {plan: LaunchPlan; targetSession: string; intoWindow: string | undefined}[] = [];
+	const launch = (
+		plan: LaunchPlan,
+		targetSession: string,
+		intoWindow: string | undefined,
+	): Effect.Effect<LaunchedSession, never> => {
+		calls.push({plan, targetSession, intoWindow});
+		return Effect.succeed({
+			role: plan.session.role,
+			address: plan.session.address,
+			window: intoWindow ?? "@new",
+			pane: plan.placement.paneLabel,
+			pid: 5150,
+		});
+	};
+	return {calls, launch};
+};
+
+/** A recording project-scope registrar — captures the single pane entry spawn-role registers; touches no real config. */
+const recordingProjectScope = () => {
+	const registered: CrewMcpEntry[][] = [];
+	const cwdCalls: {runId: string; paneLabel: string}[] = [];
+	const registrar: ProjectScopeRegistrar = {
+		reap: () => Effect.void,
+		paneCwd: (_projectRoot, runId, paneLabel) =>
+			Effect.sync(() => {
+				cwdCalls.push({runId, paneLabel});
+				return `/fake-cwd/${runId}/${paneLabel}`;
+			}),
+		register: (input) =>
+			Effect.sync(() => {
+				registered.push(input.entries.map((e) => ({...e})));
+			}),
+	};
+	return {registrar, registered, cwdCalls};
+};
+
+const trackerHandle: TrackerHandle = {pid: 4242, socketPath: "/tmp/crew.sock"};
+const recordingTracker = (
+	result: Effect.Effect<TrackerHandle, TrackerNotServingError> = Effect.succeed(trackerHandle),
+) => {
+	let calls = 0;
+	const ensureTracker = (_r: string) => {
+		calls++;
+		return result;
+	};
+	return {ensureTracker, calls: () => calls};
+};
+
+/** A recording tmux runner: replays a scripted `TmuxRun` per call (repeating the last) and logs argv. */
+const scriptedTmux = (runs: readonly TmuxRun[]): {runner: TmuxRunner; argvLog: string[][]} => {
+	const argvLog: string[][] = [];
+	let i = 0;
+	const runner: TmuxRunner = (args) => {
+		argvLog.push([...args]);
+		const run = runs[Math.min(i, runs.length - 1)];
+		i++;
+		return run === undefined ? Effect.die("scriptedTmux: no run scripted") : Effect.succeed(run);
+	};
+	return {runner, argvLog};
+};
+
+const exited = (code: number | null, over: Partial<TmuxRun> = {}): TmuxRun => ({
+	pid: code === 0 ? 4242 : undefined,
+	code,
+	signal: null,
+	stdout: "",
+	spawnError: undefined,
+	...over,
+});
+
+/** A `list-windows` output that includes a live `crew` window — what spawn-role splits into. */
+const windowsWithCrew = (crewId: string): TmuxRun =>
+	exited(0, {stdout: `@0 main\n${crewId} crew\n@9 logs\n`});
+
+const baseSpawn = (
+	role: SpawnRoleInput["role"],
+	overrides: Partial<SpawnRoleInput> = {},
+): {
+	input: SpawnRoleInput;
+	launchCalls: {plan: LaunchPlan; targetSession: string; intoWindow: string | undefined}[];
+	registered: CrewMcpEntry[][];
+	trackerCalls: () => number;
+	argvLog: string[][];
+} => {
+	const {calls, launch} = recordingLauncher();
+	const {registrar, registered} = recordingProjectScope();
+	const {ensureTracker, calls: trackerCalls} = recordingTracker();
+	const {runner, argvLog} = scriptedTmux([windowsWithCrew(CREW_WINDOW_ID)]);
+	return {
+		launchCalls: calls,
+		registered,
+		trackerCalls,
+		argvLog,
+		input: {
+			projectRoot: "/repo",
+			role,
+			config: configAt(PINNED),
+			readVersionOutput: Effect.succeed(`${PINNED} (Claude Code)`),
+			instanceId: (() => {
+				let n = 0;
+				return () => `e${n++}`;
+			})(),
+			runId: () => RUN_ID,
+			localScope: registrar,
+			ensureTracker,
+			resolveTargetSession: () => Effect.succeed(RESOLVED_SESSION),
+			runTmux: runner,
+			launch,
+			...overrides,
+		},
+	};
+};
+
+describe("standup/single-role — spawn-role (issue #3519)", () => {
+	it.effect(
+		"spawns a bridge as a SPLIT into the running crew window, joining the tracker (AC1)",
+		() =>
+			Effect.gen(function* () {
+				const h = baseSpawn("chief-of-staff");
+				const result = yield* spawn(h.input);
+
+				// tracker reached (idempotent join), one member launched
+				assert.strictEqual(h.trackerCalls(), 1);
+				assert.strictEqual(result.launched.role, "chief-of-staff");
+				assert.strictEqual(result.launched.pane, "chief-of-staff");
+
+				// the pane SPLITS into the resolved crew window id (intoWindow DEFINED) — never a new window
+				assert.strictEqual(h.launchCalls.length, 1);
+				const call = h.launchCalls[0];
+				assert.strictEqual(call?.intoWindow, CREW_WINDOW_ID);
+				assert.strictEqual(call?.targetSession, RESOLVED_SESSION);
+
+				// exactly ONE pane's project scope is registered (the new member's), no sibling touched
+				assert.strictEqual(h.registered.length, 1);
+				assert.strictEqual(h.registered[0]?.length, 1);
+				assert.strictEqual(h.registered[0]?.[0]?.cwd, `/fake-cwd/${RUN_ID}/chief-of-staff`);
+
+				// the crew-window resolution probe ran list-windows against the resolved session
+				assert.deepStrictEqual(h.argvLog[0], [
+					"list-windows",
+					"-t",
+					RESOLVED_SESSION,
+					"-F",
+					"#{window_id} #{window_name}",
+				]);
+			}),
+	);
+
+	it.effect(
+		"spawns an engine with a fresh per-instance address that deconflicts by claims (AC4)",
+		() =>
+			Effect.gen(function* () {
+				const h = baseSpawn("engineering-manager");
+				const result = yield* spawn(h.input);
+
+				const plan = h.launchCalls[0]?.plan;
+				// engine → per-instance address (the same discriminator that keeps engine inboxes + resource
+				// claims collision-free), pane labelled by the instance id, split into the running window
+				assert.strictEqual(plan?.session.kind, "engine");
+				assert.strictEqual(result.launched.address, inboxAddressFor("engineering-manager", "e0"));
+				assert.strictEqual(result.launched.pane, "e0");
+				// a self-driving engine carries its boot turn (#3516) — one positional prompt
+				assert.strictEqual(plan?.bind.bootPromptArg.length, 1);
+			}),
+	);
+
+	it.effect(
+		"spawns the on-demand HITL cartographer (not autoboot-gated) and it boots idle (#3524)",
+		() =>
+			Effect.gen(function* () {
+				// the cartographer is human-in-the-loop — excluded from the STAND-UP set, but spawn-role is the
+				// explicit human spawn, so it IS launchable here; bind gives it NO boot turn (boots idle).
+				const h = baseSpawn("cartographer");
+				const result = yield* spawn(h.input);
+				assert.strictEqual(result.launched.role, "cartographer");
+				assert.strictEqual(h.launchCalls[0]?.plan.bind.bootPromptArg.length, 0);
+			}),
+	);
+
+	it.effect("fails closed when no crew window is running — run stand-up first", () =>
+		Effect.gen(function* () {
+			const {runner} = scriptedTmux([exited(0, {stdout: "@0 main\n@9 logs\n"})]); // no `crew` window
+			const h = baseSpawn("intake-desk", {runTmux: runner});
+			const error = yield* Effect.flip(spawn(h.input));
+			assert.instanceOf(error, CrewWindowNotRunningError);
+			// nothing launched — the split never happened
+			assert.strictEqual(h.launchCalls.length, 0);
+		}),
+	);
+
+	it.effect("aborts on a drifted CLI pin before ensuring the tracker or launching", () =>
+		Effect.gen(function* () {
+			const h = baseSpawn("chief-of-staff", {
+				readVersionOutput: Effect.succeed("2.0.0 (Claude Code)"),
+			});
+			yield* Effect.flip(spawn(h.input));
+			assert.strictEqual(h.trackerCalls(), 0);
+			assert.strictEqual(h.launchCalls.length, 0);
+		}),
+	);
+});
+
+describe("standup/single-role — resolveCrewWindowId", () => {
+	it.effect("returns the id of the crew window", () =>
+		Effect.gen(function* () {
+			const {runner} = scriptedTmux([windowsWithCrew("@42")]);
+			const id = yield* resolveCrewWindowId(RESOLVED_SESSION, runner);
+			assert.strictEqual(id, "@42");
+		}),
+	);
+
+	it.effect("fails closed when list-windows errors", () =>
+		Effect.gen(function* () {
+			const {runner} = scriptedTmux([exited(1)]);
+			const error = yield* Effect.flip(resolveCrewWindowId(RESOLVED_SESSION, runner));
+			assert.instanceOf(error, CrewWindowNotRunningError);
+		}),
+	);
+});
+
+// ── retire-role ────────────────────────────────────────────────────────────────────────────────
+
+/** A recording artifact cleanup — captures the inbox-socket + cwd removals without touching the filesystem. */
+const recordingArtifacts = () => {
+	const sockets: {role: string; instance: string}[] = [];
+	const cwds: {projectRoot: string; cwdLabel: string}[] = [];
+	const artifacts: RetireArtifacts = {
+		removeInboxSocket: (role, instance) => Effect.sync(() => void sockets.push({role, instance})),
+		removePaneCwd: (projectRoot, cwdLabel) =>
+			Effect.sync(() => void cwds.push({projectRoot, cwdLabel})),
+	};
+	return {artifacts, sockets, cwds};
+};
+
+/** A `list-panes` line for a crew member whose start command carries its `--name <displayName>` (the match key). */
+const paneLine = (paneId: string, displayName: string): string =>
+	`${paneId}::zsh -lic 'claude' '--agent' 'crew-role' '--name' '${displayName}'`;
+
+describe("standup/single-role — retire-role (issue #3519)", () => {
+	it.effect("retires a bridge: finds its pane, kills it, reclaims socket + cwd (AC2)", () =>
+		Effect.gen(function* () {
+			const {artifacts, sockets, cwds} = recordingArtifacts();
+			const {runner, argvLog} = scriptedTmux([
+				exited(0, {stdout: `%1::other pane\n${paneLine("%3", "chief-of-staff")}\n`}),
+				exited(0), // kill-pane
+			]);
+			const result = yield* retireRole({
+				projectRoot: "/repo",
+				role: "chief-of-staff",
+				runTmux: runner,
+				artifacts,
+			});
+
+			assert.strictEqual(result.paneId, "%3");
+			assert.deepStrictEqual(argvLog[1], ["kill-pane", "-t", "%3"]);
+			// lease frees by TTL (connection-is-lease); the launcher reclaims socket + cwd by the pane label
+			assert.deepStrictEqual(sockets, [{role: "chief-of-staff", instance: ""}]);
+			assert.deepStrictEqual(cwds, [{projectRoot: "/repo", cwdLabel: "chief-of-staff"}]);
+		}),
+	);
+
+	it.effect("retires ONE engine instance by id, leaving the others' leases intact (AC4)", () =>
+		Effect.gen(function* () {
+			const {artifacts, sockets, cwds} = recordingArtifacts();
+			const {runner} = scriptedTmux([
+				exited(0, {stdout: `${paneLine("%8", "engineering-manager-e0")}\n`}),
+				exited(0),
+			]);
+			const result = yield* retireRole({
+				projectRoot: "/repo",
+				role: "engineering-manager",
+				instance: "e0",
+				runTmux: runner,
+				artifacts,
+			});
+			assert.strictEqual(result.paneId, "%8");
+			assert.strictEqual(result.instance, "e0");
+			// socket + cwd keyed by the instance id — no sibling engine's artifacts touched
+			assert.deepStrictEqual(sockets, [{role: "engineering-manager", instance: "e0"}]);
+			assert.deepStrictEqual(cwds, [{projectRoot: "/repo", cwdLabel: "e0"}]);
+		}),
+	);
+
+	it.effect("rejects an engine retire with no instance (cardinality-N needs a name)", () =>
+		Effect.gen(function* () {
+			const {artifacts} = recordingArtifacts();
+			const error = yield* Effect.flip(
+				retireRole({projectRoot: "/repo", role: "engineering-manager", artifacts}),
+			);
+			assert.instanceOf(error, RetireRoleArgError);
+		}),
+	);
+
+	it.effect("rejects a bridge retire that carries an instance (a singleton takes none)", () =>
+		Effect.gen(function* () {
+			const {artifacts} = recordingArtifacts();
+			const error = yield* Effect.flip(
+				retireRole({projectRoot: "/repo", role: "intake-desk", instance: "x", artifacts}),
+			);
+			assert.instanceOf(error, RetireRoleArgError);
+		}),
+	);
+
+	it.effect("fails closed when no pane matches (already retired / crew down)", () =>
+		Effect.gen(function* () {
+			const {artifacts, sockets} = recordingArtifacts();
+			const {runner} = scriptedTmux([exited(0, {stdout: "%1::some unrelated pane\n"})]);
+			const error = yield* Effect.flip(
+				retireRole({projectRoot: "/repo", role: "cartographer", runTmux: runner, artifacts}),
+			);
+			assert.instanceOf(error, CrewPaneNotFoundError);
+			// no cleanup ran — nothing was killed
+			assert.strictEqual(sockets.length, 0);
+		}),
+	);
+
+	it.effect("fails closed (no kill) when the match is ambiguous", () =>
+		Effect.gen(function* () {
+			const {artifacts} = recordingArtifacts();
+			const {runner, argvLog} = scriptedTmux([
+				exited(0, {
+					stdout: `${paneLine("%2", "chief-of-staff")}\n${paneLine("%5", "chief-of-staff")}\n`,
+				}),
+			]);
+			const error = yield* Effect.flip(
+				retireRole({projectRoot: "/repo", role: "chief-of-staff", runTmux: runner, artifacts}),
+			);
+			assert.instanceOf(error, CrewPaneNotFoundError);
+			// only the list-panes probe ran — no kill-pane was attempted
+			assert.strictEqual(argvLog.length, 1);
+		}),
+	);
+
+	it.effect("fails closed and does NOT reclaim artifacts when kill-pane fails", () =>
+		Effect.gen(function* () {
+			const {artifacts, sockets, cwds} = recordingArtifacts();
+			const {runner} = scriptedTmux([
+				exited(0, {stdout: `${paneLine("%3", "chief-of-staff")}\n`}),
+				exited(1), // kill-pane fails
+			]);
+			const error = yield* Effect.flip(
+				retireRole({projectRoot: "/repo", role: "chief-of-staff", runTmux: runner, artifacts}),
+			);
+			assert.instanceOf(error, CrewPaneKillError);
+			assert.strictEqual(sockets.length, 0);
+			assert.strictEqual(cwds.length, 0);
+		}),
+	);
+});
+
+describe("standup/single-role — findCrewPaneId", () => {
+	it.effect("matches a crew pane on its displayName + claude marker", () =>
+		Effect.gen(function* () {
+			const {runner} = scriptedTmux([
+				exited(0, {stdout: `%1::vim\n${paneLine("%4", "engineering-manager-e1")}\n`}),
+			]);
+			const paneId = yield* findCrewPaneId("engineering-manager-e1", runner);
+			assert.strictEqual(paneId, "%4");
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/standup/single-role.ts
+++ b/packages/pipeline-crew-mcp/src/standup/single-role.ts
@@ -1,0 +1,479 @@
+/**
+ * standup/single-role — dynamic single-member membership ops (issue #3519): add, remove, or respawn
+ * ONE crew member without tearing the whole crew down and re-booting it. The whole-crew `stand-up` /
+ * `stand-down` are all-or-nothing; a single-member change through them costs a full re-boot that kills
+ * in-flight coder subagents, resets every standing session's context, and briefly leaves zero crew up.
+ *
+ * This is a CLI SURFACE over primitives that already exist — no new subsystem. The runtime already
+ * does dynamic membership: a booted session auto-joins the tracker + channel via `AnnouncePresence`
+ * (crew/session.ts), an engine deconflicts by resource claims, and a leaving member's presence/role
+ * lease frees by TTL once its heartbeat stops (connection-is-lease — the tracker has no wire release
+ * or disconnect hook, crew/tracker.ts). So the launcher's job is only the SCREEN + FILESYSTEM half:
+ *   - `spawnRole` runs the SAME per-role launch step the whole-crew boot runs (`buildLaunchPlan` +
+ *     `launchSessionInTmux`, extracted not forked, #3519 AC3), but SPLITS the pane into the RUNNING
+ *     crew window instead of opening a new one — so no other member is disturbed. The new session
+ *     announces its own presence + claims on boot; a HITL role (the cartographer) is spawnable here
+ *     precisely because this is the explicit human spawn, and bind.ts already boots it idle (#3524).
+ *   - `retireRole` kills the one member's pane (whose kill IS the connection-is-lease release), then
+ *     reclaims the filesystem artifacts that don't self-clean: its inbox socket + its launcher-owned cwd.
+ *     Every other member's lease + pane stays intact.
+ *
+ * The side-effecting seams (config, version, tracker, tmux runner, project scope, artifact cleanup) are
+ * injected, defaulting to production — so the whole flow is unit-tested with no real tmux/filesystem, the
+ * same idiom orchestrate.ts uses. A crew pane is identified by its `pane_start_command` (a documented tmux
+ * format, grounded against tmux 3.6a): the launch argv carries the member's `--name <displayName>` verbatim
+ * (the slug/uuid survives shell-quoting unmangled), so the displayName is the pane match key.
+ */
+import {randomUUID} from "node:crypto";
+import {existsSync, readdirSync, rmSync} from "node:fs";
+import {Effect, type FileSystem, type Path, Schema} from "effect";
+import {type CrewRole, inboxSocketFor, kindOf, SESSION_SERVER_NAME} from "../crew/index.ts";
+import type {
+	ChannelPluginNotAllowedError,
+	CrewServerNotRegisteredError,
+	CrewSessionBinUnresolvableError,
+} from "./bind.ts";
+import {type LaunchConfig, type LaunchConfigError, readLaunchConfig} from "./config.ts";
+import {
+	ensureTrackerRunning,
+	type TrackerHandle,
+	type TrackerNotServingError,
+} from "./ensure-tracker.ts";
+import {
+	buildLaunchPlan,
+	CREW_WINDOW,
+	FALLBACK_TMUX_SESSION,
+	type LaunchedSession,
+	type LaunchPlan,
+	launchSessionInTmux,
+	type ProjectScopeRegistrar,
+	productionProjectScopeRegistrar,
+	resolveTargetTmuxSession,
+	runTmux,
+	type StandUpLaunchError,
+	type TmuxRunner,
+	type TmuxSessionEnsureError,
+	toRosterSession,
+} from "./orchestrate.ts";
+import {crewRunRoot, ProjectScopeWriteError} from "./register-project-scope.ts";
+import {deriveOneSession} from "./session-set.ts";
+import {computeTmuxPlacement, type TmuxPaneCollisionError} from "./tmux-placement.ts";
+import {
+	assertPinnedCliVersion,
+	type CliVersionAssertError,
+	readInstalledCliVersionOutput,
+} from "./version-assert.ts";
+
+/** The `session --role`/`--name` display identity of one member — a bridge is its role slug, an engine is `role-<instance>`. */
+const displayNameOf = (role: CrewRole, instance: string): string =>
+	kindOf(role) === "engine" ? `${role}-${instance}` : role;
+
+// ── spawn-role ───────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `spawn-role` could not find a running `crew` window to split the new pane into. `spawn-role` ADDS a
+ * member to a RUNNING crew (respawn/scale-up), so an absent crew window is a fail-closed refusal — run
+ * `stand-up` first — never a silent new-window boot that would strand the member outside the crew view.
+ */
+export class CrewWindowNotRunningError extends Schema.TaggedErrorClass<CrewWindowNotRunningError>()(
+	"@kampus/pipeline-crew-mcp/standup/CrewWindowNotRunningError",
+	{
+		targetSession: Schema.String,
+		reason: Schema.String,
+	},
+) {}
+
+/** Every way `spawn-role` can abort — the launch-preconditions it shares with stand-up plus the missing-crew-window refusal. */
+export type SpawnRoleError =
+	| LaunchConfigError
+	| CliVersionAssertError
+	| TrackerNotServingError
+	| CrewSessionBinUnresolvableError
+	| CrewServerNotRegisteredError
+	| ChannelPluginNotAllowedError
+	| ProjectScopeWriteError
+	| TmuxPaneCollisionError
+	| TmuxSessionEnsureError
+	| CrewWindowNotRunningError
+	| StandUpLaunchError;
+
+export interface SpawnRoleInput {
+	/** The project root whose running tracker + crew window the new member joins. */
+	readonly projectRoot: string;
+	/** The role to spawn one member of — any roster role, including a human-in-the-loop one (the on-demand cartographer, #3524). */
+	readonly role: CrewRole;
+	/** The channel-ref name the member's crew MCP server registers under. Default: `SESSION_SERVER_NAME`. */
+	readonly serverName?: string;
+	/** Mints the id for this spawn's per-pane cwd dir (`<root>/.claude/crew-run/<runId>/`). Default: `randomUUID`. */
+	readonly runId?: () => string;
+	/** The project-scope collaborator (#3444). Default: `productionProjectScopeRegistrar`. */
+	readonly localScope?: ProjectScopeRegistrar;
+	/** The launch dimensions. Default: read the operator crew config. */
+	readonly config?: Effect.Effect<LaunchConfig, LaunchConfigError>;
+	/** The installed-CLI-version reader the pin is asserted against. Default: the real `claude --version`. */
+	readonly readVersionOutput?: Effect.Effect<string, unknown>;
+	/** Start-or-reuse the per-project tracker (idempotent — dials the running one). Default: `ensureTrackerRunning`. */
+	readonly ensureTracker?: (
+		projectRoot: string,
+	) => Effect.Effect<TrackerHandle, TrackerNotServingError>;
+	/** Mints the engine instance's distinct id. Default: `randomUUID`. */
+	readonly instanceId?: () => string;
+	/** Resolve the tmux session whose crew window the pane splits into. Default: the caller's current session, else the fallback. */
+	readonly resolveTargetSession?: () => Effect.Effect<string, TmuxSessionEnsureError>;
+	/** The tmux runner for the window-resolution probe. Default: `runTmux`. */
+	readonly runTmux?: TmuxRunner;
+	/** Launch one planned session as a pane. Default: `launchSessionInTmux`. */
+	readonly launch?: (
+		plan: LaunchPlan,
+		targetSession: string,
+		intoWindow: string | undefined,
+	) => Effect.Effect<LaunchedSession, StandUpLaunchError>;
+}
+
+/** What a completed `spawn-role` returns: the tracker it joined and the one member it launched. */
+export interface SpawnRoleResult {
+	readonly tracker: TrackerHandle;
+	readonly launched: LaunchedSession;
+}
+
+/** Resolve the tmux session windows open into — the caller's current session inside tmux, else the created fallback. */
+const resolveTargetSessionDefault = (
+	runTmuxCommand: TmuxRunner,
+): Effect.Effect<string, TmuxSessionEnsureError> =>
+	resolveTargetTmuxSession(
+		{inTmux: process.env.TMUX !== undefined, fallbackSession: FALLBACK_TMUX_SESSION},
+		runTmuxCommand,
+	);
+
+/**
+ * Resolve the id of the RUNNING `crew` window in `targetSession` — the window `spawn-role` splits the
+ * new pane into. Fails closed if the tmux probe errors or no `crew` window is up (run `stand-up` first).
+ * The tmux runner is injected so the found / absent branches are unit-tested without a real tmux.
+ */
+export const resolveCrewWindowId = (
+	targetSession: string,
+	runTmuxCommand: TmuxRunner = runTmux,
+): Effect.Effect<string, CrewWindowNotRunningError> =>
+	Effect.gen(function* () {
+		const listed = yield* runTmuxCommand([
+			"list-windows",
+			"-t",
+			targetSession,
+			"-F",
+			"#{window_id} #{window_name}",
+		]);
+		if (listed.spawnError !== undefined || listed.code !== 0) {
+			return yield* Effect.fail(
+				new CrewWindowNotRunningError({
+					targetSession,
+					reason:
+						listed.spawnError ??
+						`tmux list-windows for "${targetSession}" exited ${listed.code ?? listed.signal}`,
+				}),
+			);
+		}
+		for (const line of listed.stdout.split("\n")) {
+			const trimmed = line.trim();
+			if (trimmed.length === 0) continue;
+			const sep = trimmed.indexOf(" ");
+			const id = sep === -1 ? trimmed : trimmed.slice(0, sep);
+			const name = sep === -1 ? "" : trimmed.slice(sep + 1);
+			if (name === CREW_WINDOW) return id;
+		}
+		return yield* Effect.fail(
+			new CrewWindowNotRunningError({
+				targetSession,
+				reason: `no "${CREW_WINDOW}" window is running in tmux session "${targetSession}" — run stand-up first`,
+			}),
+		);
+	});
+
+/**
+ * Add ONE member to the running crew (issue #3519): assert the same launch preconditions stand-up does
+ * (config, pinned CLI version), ensure the tracker (idempotent — reuses the running one), derive the
+ * single session (a bridge singleton or one fresh-instance engine), build its launch plan through the
+ * SHARED `buildLaunchPlan` (never a forked launch path, AC3), register just this pane's project scope
+ * (idempotent boot gates, untouched siblings), then SPLIT it into the running crew window. The booted
+ * session auto-joins the tracker + channel via `AnnouncePresence` and (for an engine) deconflicts by
+ * resource claims — the launcher does none of that, it only puts the pane on screen.
+ */
+export const spawnRole = (
+	input: SpawnRoleInput,
+): Effect.Effect<SpawnRoleResult, SpawnRoleError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const {projectRoot, role} = input;
+		const serverName = input.serverName ?? SESSION_SERVER_NAME;
+		const instanceId = input.instanceId ?? randomUUID;
+		const runId = (input.runId ?? randomUUID)();
+		const localScope = input.localScope ?? productionProjectScopeRegistrar;
+		const ensureTracker = input.ensureTracker ?? ensureTrackerRunning;
+		const runTmuxCommand = input.runTmux ?? runTmux;
+		const resolveTargetSession =
+			input.resolveTargetSession ?? (() => resolveTargetSessionDefault(runTmuxCommand));
+		const launch = input.launch ?? launchSessionInTmux;
+
+		const config = yield* input.config ?? readLaunchConfig();
+		// Same fail-fast the whole-crew boot does: channels vary across CLI versions, so a drifted pin is
+		// a spawn to refuse before touching the tracker or launching (version-assert.ts / #3295).
+		yield* assertPinnedCliVersion(config, input.readVersionOutput ?? readInstalledCliVersionOutput);
+		const tracker = yield* ensureTracker(projectRoot);
+
+		const session = deriveOneSession({role, instanceId});
+		// One session ⇒ no pane-label collision is possible; computeTmuxPlacement is reused (not a
+		// re-implemented placeOne) so the pane label derivation stays the single stand-up code path.
+		const placements = yield* computeTmuxPlacement([toRosterSession(session)]);
+		const placement = placements[0];
+		if (placement === undefined) {
+			return yield* Effect.die(`spawn-role placement missing for role "${role}"`);
+		}
+		const plan = yield* buildLaunchPlan(session, placement, {
+			projectRoot,
+			serverName,
+			config,
+			runId,
+			localScope,
+		});
+
+		// Register just THIS pane's project scope (+ idempotent folder-trust / server-approval boot gates):
+		// adds one leaf `.mcp.json` in the pane's own cwd, on no running member's ancestor chain, so no
+		// sibling's channel isolation is disturbed (#3444).
+		yield* localScope.register({
+			projectRoot,
+			runId,
+			serverName,
+			entries: [
+				{cwd: plan.cwd, serverName: plan.bind.serverName, serverConfig: plan.bind.serverConfig},
+			],
+		});
+
+		const targetSession = yield* resolveTargetSession();
+		const crewWindow = yield* resolveCrewWindowId(targetSession, runTmuxCommand);
+		// `intoWindow` DEFINED ⇒ launchSessionInTmux splits into the existing crew window + re-tiles, never
+		// opens a new one — the "add a pane without disturbing any other member" path (AC1).
+		const launched = yield* launch(plan, targetSession, crewWindow);
+		return {tracker, launched};
+	});
+
+// ── retire-role ──────────────────────────────────────────────────────────────────────────────────
+
+/** `retire-role` was handed an instance argument inconsistent with the role's kind — an engine needs one, a bridge takes none. */
+export class RetireRoleArgError extends Schema.TaggedErrorClass<RetireRoleArgError>()(
+	"@kampus/pipeline-crew-mcp/standup/RetireRoleArgError",
+	{
+		role: Schema.String,
+		reason: Schema.String,
+	},
+) {}
+
+/** No single crew pane matched the member to retire — zero matches (already gone) or, defensively, more than one. */
+export class CrewPaneNotFoundError extends Schema.TaggedErrorClass<CrewPaneNotFoundError>()(
+	"@kampus/pipeline-crew-mcp/standup/CrewPaneNotFoundError",
+	{
+		displayName: Schema.String,
+		matched: Schema.Number,
+		reason: Schema.String,
+	},
+) {}
+
+/** The member's tmux pane was found but `kill-pane` did not succeed — the retire fails closed rather than half-tear-down. */
+export class CrewPaneKillError extends Schema.TaggedErrorClass<CrewPaneKillError>()(
+	"@kampus/pipeline-crew-mcp/standup/CrewPaneKillError",
+	{
+		paneId: Schema.String,
+		reason: Schema.String,
+	},
+) {}
+
+/** Every way `retire-role` can abort. */
+export type RetireRoleError =
+	| RetireRoleArgError
+	| CrewPaneNotFoundError
+	| CrewPaneKillError
+	| ProjectScopeWriteError;
+
+/**
+ * The filesystem artifacts a retired member leaves that don't self-reclaim: its inbox socket and its
+ * launcher-owned cwd dir(s). Injected so `retireRole` is unit-tested with no real filesystem, mirroring
+ * orchestrate.ts's `ProjectScopeRegistrar`.
+ */
+export interface RetireArtifacts {
+	/** Remove the member's inbox socket file (`inboxSocketFor(role, instance)`); a missing socket is a clean no-op. */
+	readonly removeInboxSocket: (
+		role: CrewRole,
+		instance: string,
+	) => Effect.Effect<void, ProjectScopeWriteError>;
+	/** Remove the member's launcher-owned pane cwd(s) — its `<cwdLabel>` dir under any crew-run id — leaving other members' dirs. */
+	readonly removePaneCwd: (
+		projectRoot: string,
+		cwdLabel: string,
+	) => Effect.Effect<void, ProjectScopeWriteError>;
+}
+
+/** Remove one path with `force` (a missing path is a no-op), wrapped as a fail-closed `ProjectScopeWriteError`. */
+const removePath = (path: string): Effect.Effect<void, ProjectScopeWriteError> =>
+	Effect.try({
+		try: () => rmSync(path, {recursive: true, force: true}),
+		catch: (cause) =>
+			new ProjectScopeWriteError({
+				configPath: path,
+				reason: `cannot remove ${path}: ${String(cause)}`,
+			}),
+	});
+
+/**
+ * The production artifact-cleanup: the inbox socket resolves to a deterministic path per member; the pane
+ * cwd is `<root>/.claude/crew-run/<runId>/<cwdLabel>` and `retire-role` does not know the (stand-up- or
+ * spawn-minted) runId, so it removes the `<cwdLabel>` dir under EVERY run dir — the label is unique to
+ * this member (a bridge's role slug / an engine's instance id), so no sibling's dir is touched.
+ */
+export const productionRetireArtifacts: RetireArtifacts = {
+	removeInboxSocket: (role, instance) => removePath(inboxSocketFor(role, instance)),
+	removePaneCwd: (projectRoot, cwdLabel) =>
+		Effect.gen(function* () {
+			const runRoot = crewRunRoot(projectRoot);
+			if (!existsSync(runRoot)) return;
+			const runDirs = yield* Effect.try({
+				try: () => readdirSync(runRoot, {withFileTypes: true}),
+				catch: (cause) =>
+					new ProjectScopeWriteError({
+						configPath: runRoot,
+						reason: `cannot read crew-run dir ${runRoot}: ${String(cause)}`,
+					}),
+			});
+			for (const entry of runDirs) {
+				if (!entry.isDirectory()) continue;
+				yield* removePath(`${runRoot}/${entry.name}/${cwdLabel}`);
+			}
+		}),
+};
+
+export interface RetireRoleInput {
+	/** The project root whose launcher-owned pane cwd is reclaimed. */
+	readonly projectRoot: string;
+	/** The role of the member to retire. */
+	readonly role: CrewRole;
+	/** The engine instance to retire (REQUIRED for an engine role, cardinality-N; a bridge is a singleton and takes none). */
+	readonly instance?: string | undefined;
+	/** The tmux runner for the list-panes / kill-pane calls. Default: `runTmux`. */
+	readonly runTmux?: TmuxRunner;
+	/** The filesystem artifact cleanup. Default: `productionRetireArtifacts`. */
+	readonly artifacts?: RetireArtifacts;
+}
+
+/** What a completed `retire-role` returns: which pane it killed and the member it identified. */
+export interface RetireRoleResult {
+	readonly paneId: string;
+	readonly role: CrewRole;
+	readonly instance: string;
+}
+
+/**
+ * Find the ONE crew pane for `displayName` by its `pane_start_command` — the launch argv carries
+ * `--name <displayName>` verbatim (the slug/uuid survives shell-quoting unmangled), and `claude` marks
+ * it a crew pane. Fails closed on zero matches (already gone) or, defensively, more than one. The tmux
+ * runner is injected so the found / absent / ambiguous branches are unit-tested without a real tmux.
+ */
+export const findCrewPaneId = (
+	displayName: string,
+	runTmuxCommand: TmuxRunner = runTmux,
+): Effect.Effect<string, CrewPaneNotFoundError> =>
+	Effect.gen(function* () {
+		const listed = yield* runTmuxCommand([
+			"list-panes",
+			"-a",
+			"-F",
+			"#{pane_id}::#{pane_start_command}",
+		]);
+		if (listed.spawnError !== undefined || listed.code !== 0) {
+			return yield* Effect.fail(
+				new CrewPaneNotFoundError({
+					displayName,
+					matched: 0,
+					reason: listed.spawnError ?? `tmux list-panes exited ${listed.code ?? listed.signal}`,
+				}),
+			);
+		}
+		const matches: string[] = [];
+		for (const line of listed.stdout.split("\n")) {
+			const trimmed = line.trim();
+			if (trimmed.length === 0) continue;
+			const sep = trimmed.indexOf("::");
+			if (sep === -1) continue;
+			const paneId = trimmed.slice(0, sep);
+			const command = trimmed.slice(sep + 2);
+			if (command.includes("claude") && command.includes(displayName)) matches.push(paneId);
+		}
+		if (matches.length !== 1 || matches[0] === undefined) {
+			return yield* Effect.fail(
+				new CrewPaneNotFoundError({
+					displayName,
+					matched: matches.length,
+					reason:
+						matches.length === 0
+							? `no running crew pane matches "${displayName}" — already retired, or the crew is down`
+							: `${matches.length} panes match "${displayName}" — refusing to kill ambiguously`,
+				}),
+			);
+		}
+		return matches[0];
+	});
+
+/**
+ * Retire ONE crew member (issue #3519): validate the instance against the role's kind, find its pane,
+ * `kill-pane` it, then reclaim its filesystem artifacts (inbox socket + launcher cwd). Killing the pane
+ * stops its heartbeat, so its presence/role lease frees by TTL (connection-is-lease — the tracker has no
+ * wire release; crew/tracker.ts) and, for an engine, so do its resource claims — leaving every OTHER
+ * member's lease + pane intact (AC4). The launcher never speaks to the tracker here; the runtime frees
+ * the lease on its own once the connection dies.
+ */
+export const retireRole = (
+	input: RetireRoleInput,
+): Effect.Effect<RetireRoleResult, RetireRoleError> =>
+	Effect.gen(function* () {
+		const {projectRoot, role} = input;
+		const runTmuxCommand = input.runTmux ?? runTmux;
+		const artifacts = input.artifacts ?? productionRetireArtifacts;
+		const kind = kindOf(role);
+
+		// Make the invalid states unrepresentable at the boundary: an engine is cardinality-N so it MUST
+		// be named by instance; a bridge is the singleton so an instance is meaningless.
+		if (kind === "engine" && (input.instance === undefined || input.instance.length === 0)) {
+			return yield* Effect.fail(
+				new RetireRoleArgError({
+					role,
+					reason: `"${role}" is a cardinality-N engine — pass the instance id of the member to retire`,
+				}),
+			);
+		}
+		if (kind === "bridge" && input.instance !== undefined) {
+			return yield* Effect.fail(
+				new RetireRoleArgError({
+					role,
+					reason: `"${role}" is a singleton bridge — it takes no instance`,
+				}),
+			);
+		}
+		const instance = input.instance ?? "";
+
+		// The pane is matched on the launch `--name` displayName; the cwd dir + inbox socket use the pane
+		// label (a bridge's role slug, an engine's instance id) — the two identities the launcher stamped.
+		const displayName = displayNameOf(role, instance);
+		const cwdLabel = kind === "engine" ? instance : role;
+
+		const paneId = yield* findCrewPaneId(displayName, runTmuxCommand);
+		const killed = yield* runTmuxCommand(["kill-pane", "-t", paneId]);
+		if (killed.spawnError !== undefined || killed.code !== 0) {
+			return yield* Effect.fail(
+				new CrewPaneKillError({
+					paneId,
+					reason:
+						killed.spawnError ??
+						`tmux kill-pane -t ${paneId} exited ${killed.code ?? killed.signal}`,
+				}),
+			);
+		}
+
+		yield* artifacts.removeInboxSocket(role, instance);
+		yield* artifacts.removePaneCwd(projectRoot, cwdLabel);
+		return {paneId, role, instance};
+	});


### PR DESCRIPTION
Today the crew can only be stood up or torn down whole — there's no way to add, drop, or restart a single member. That forces a full re-boot for any one-member change, which kills in-flight coder subagents, wipes every standing session's context, and briefly leaves zero crew running. This PR adds two CLI subcommands, `spawn-role <role>` and `retire-role <role>`, so one member can come and go while the rest keep running.

It's a CLI surface over primitives that already exist — the runtime already does dynamic membership (a booted session auto-joins the tracker + channel via `AnnouncePresence`, an engine deconflicts by resource claims, and a leaving member's presence/role lease frees by TTL once its heartbeat stops). The launcher only had to expose the screen + filesystem half.

## What changed
- Extracted `buildLaunchPlan` out of `runStandUp`, so single-member and whole-crew launch derive a session's plan (bind + cwd + placement) through **one** code path — not a forked launch (AC3). Generalized the stand-up error renderer to a shared `renderTaggedError`.
- Added `deriveOneSession(role)` — a single-role session derivation that is **not** autoboot-gated, so the on-demand human-in-the-loop cartographer is spawnable (it boots idle, no boot turn, per #3524); an engine mints a fresh per-instance address that deconflicts by resource claims like a boot-from-`stand-up` engine (AC4).
- `spawnRole` runs that shared launch step but **splits the pane into the running crew window** instead of opening a new one, and registers **only** its own pane's project scope (idempotent boot gates) so no other member is disturbed (AC1). It fails closed if no crew window is up (run `stand-up` first).
- `retireRole` kills the one member's pane — whose kill **is** the connection-is-lease release (the tracker has no wire release/disconnect hook, so the lease frees by TTL) — then reclaims the filesystem artifacts that don't self-clean: its inbox socket + its launcher-owned cwd, leaving every other member's lease + pane intact (AC2). An engine must be named by `--instance`; a bridge is a singleton and takes none — invalid combinations are rejected at the boundary.
- Unit tests cover both commands in the package's injected-side-effect bind/orchestrate idiom — no real tmux/filesystem/`claude` (AC5).

A crew pane is identified by its `pane_start_command` (a documented tmux format, grounded against the installed tmux 3.6a): the launch argv carries the member's `--name <displayName>` verbatim, and the slug/uuid survives shell-quoting unmangled, so it is the pane match key.

Scope: all changes are under `packages/pipeline-crew-mcp/` (NON-§CP, ADR 0187) — no `.github/CODEOWNERS` control-plane row, no crew agent-defs touched. The separate EM/chief-of-staff def vs ADR-0135 question (#3536) is out of scope here.

Fixes #3519