### PR TITLE
fix(triage): make the split step idempotent — key child-create on the split-from-#<parent> back-reference (#3464) [§CP]

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -253,16 +253,37 @@ How to split:
    If an existing issue already covers it, enrich/triage that one instead of filing
    a twin. (This rule exists because a triage run once filed a duplicate of an issue
    that had landed in the queue minutes earlier.)
-3. **Create one new issue per extra unit** via REST, each labeled
-   `status:needs-triage` so it re-enters the queue (you'll triage the new ones on a
-   later pass — or this same run — like any other). Give each a sharp single-unit
-   title and a body that states the one problem, following the report skill's
-   5-section shape where it fits (see [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)
-   for the surrounding format conventions).
-4. **Cross-link.** Each new issue references the original (`split from #N`), and you
-   add a comment on the original listing the children (`split into #A, #B`). The
-   reader can always trace a unit back to where it came from.
-5. **Resolve the original.** Either keep it as one of the units (triage it normally,
+3. **Create-once guard — key the child-create on the parent back-reference (#3464).**
+   The child-create is otherwise **non-idempotent**: a retry or a re-emit of the same
+   split fires a second byte-identical twin (the #3462/#3463 double-fire — two children
+   5s apart). Before every split-child POST, ask `split-guard` whether a child that
+   already covers *this* `(parent, title)` unit exists — keyed on the durable
+   `split from #<parent>` back-reference each split child carries (item 5 below), **not**
+   body byte-equality, so a twin re-emitted with a slightly different body is still caught:
+
+   ```bash
+   EXISTING=$(node packages/pipeline-cli/src/bin.ts split-guard check \
+     --parent <original #N> --title "<the split-child title>")
+   ```
+
+   It prints the existing child's `#<n>` (⇒ **reuse it, skip the POST**) or nothing
+   (⇒ safe to create). It reads the read-after-write `needs-triage` queue, so a twin
+   created seconds ago is caught where the eventually-consistent search index would miss
+   it. This closes the sequential re-emit hole; the Step-0 claim still guards a concurrent
+   sibling sweep, and Step 3.2's `intake-dedup` still guards a report-agent twin.
+4. **Create one new issue per extra unit** via REST — **only when the create-once guard
+   found no existing child** — each labeled `status:needs-triage` so it re-enters the
+   queue (you'll triage the new ones on a later pass — or this same run — like any other).
+   Give each a sharp single-unit title and a body that states the one problem, following
+   the report skill's 5-section shape where it fits (see
+   [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) for the surrounding
+   format conventions).
+5. **Cross-link.** Each new issue references the original (`split from #N`) — this
+   back-reference is the create-once key the guard in item 3 reads, so it is
+   **load-bearing, not decorative** — and you add a comment on the original listing the
+   children (`split into #A, #B`). The reader can always trace a unit back to where it
+   came from.
+6. **Resolve the original.** Either keep it as one of the units (triage it normally,
    having spun the *other* units off) or, if it was purely a container with nothing
    left after splitting, close it not-planned with a `closed-by-triage` reason
    comment pointing at the children (the full close-out protocol — reason comment +
@@ -270,11 +291,19 @@ How to split:
    empty husk open.
 
 ```bash
-gh api "repos/$REPO/issues" \
-  -f title="<single-unit title>" \
-  -f body="$BODY" \
-  -f "labels[]=status:needs-triage"
-# then cross-link via a comment on the original (Step 6 shows the comment call)
+# 1. Create-once guard: skip the POST if a child already covers this (parent, title) unit (#3464).
+EXISTING=$(node packages/pipeline-cli/src/bin.ts split-guard check \
+  --parent "$N" --title "<single-unit title>")
+if [ -n "$EXISTING" ]; then
+  echo "split-guard: $EXISTING already covers this unit — reusing, not creating a twin"
+else
+  # 2. Body MUST carry the `split from #<N>` back-reference — it is the guard's create-once key.
+  gh api "repos/$REPO/issues" \
+    -f title="<single-unit title>" \
+    -f body="$BODY" \
+    -f "labels[]=status:needs-triage"
+  # then cross-link via a comment on the original (Step 6 shows the comment call)
+fi
 ```
 
 ---

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -49,6 +49,7 @@ import {roadmapGuardCommand} from "./tools/roadmap-guard/command.ts";
 import {settingsEnvGuardCommand} from "./tools/settings-env-guard/command.ts";
 import {shipDigestCommand} from "./tools/ship-digest/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
+import {splitGuardCommand} from "./tools/split-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
 import {tokenSpendCommand} from "./tools/token-spend/command.ts";
 import {trivialDiffCommand} from "./tools/trivial-diff/command.ts";
@@ -137,6 +138,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	catalogGuardCommand,
 	patchGuardCommand,
 	intakeDedupCommand,
+	splitGuardCommand,
 	redactLeaksCommand,
 	commandsCommand,
 	// The ADR-0158 unresolved-inline-thread merge gate's fail-closed enforcement (#3331):

--- a/packages/pipeline-cli/src/tools/split-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/split-guard/command.ts
@@ -1,0 +1,61 @@
+/**
+ * The `split-guard` tool — `pipeline-cli split-guard check --parent <N> --title "<child title>"`.
+ *
+ * The create-once guard for the `triage` skill's Step-3 split (#3464). Before the skill POSTs a
+ * split child, it asks this tool whether a child that already covers `(parent, title)` exists —
+ * keyed on the durable `split from #<parent>` back-reference, NOT body byte-equality — so a second
+ * run of the split (a retry, or a re-emit) reuses the first child instead of firing a twin (the
+ * #3462/#3463 double-fire).
+ *
+ * `check` prints the existing child's `#<n>` to stdout when a duplicate exists (⇒ the skill reuses
+ * it, skips the POST), and prints nothing when none does (⇒ safe to create). It resolves the read
+ * against the read-after-write `needs-triage` queue so a twin created seconds ago is still caught.
+ * Exit 0 in both cases; the resolution goes to stderr. `GithubLive` is baked in with
+ * `Command.provide(...)` so the registered command's residual requirement is the Node platform union.
+ */
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {Github, GithubLive} from "./github.ts";
+import {findExistingChild} from "./split-match.ts";
+
+const QUEUE_LABEL = "status:needs-triage";
+
+const parentFlag = Flag.integer("parent").pipe(
+	Flag.withDescription("the parent issue number the split child would back-reference"),
+);
+
+const titleFlag = Flag.string("title").pipe(
+	Flag.withDescription("the proposed split-child title (its unit-key is the create-once key)"),
+);
+
+const check = Command.make(
+	"check",
+	{parent: parentFlag, title: titleFlag},
+	Effect.fn(function* ({parent, title}) {
+		const gh = yield* Github;
+		const existing = yield* gh.queue(QUEUE_LABEL);
+		const dup = findExistingChild(parent, title, existing);
+		if (dup === undefined) {
+			process.stderr.write(
+				`split-guard: no existing split-from-#${parent} child for this unit — safe to create\n`,
+			);
+			return;
+		}
+		yield* Console.log(`#${dup}`);
+		process.stderr.write(
+			`split-guard: #${dup} already covers this split of #${parent} — reuse it, do NOT create a twin\n`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Print the existing split child that already covers (parent, title), or nothing if safe to create",
+	),
+);
+
+export const splitGuardCommand = Command.make("split-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Idempotency guard for the triage split step — key child-create on the split-from-#<parent> back-reference (#3464)",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/split-guard/github.ts
+++ b/packages/pipeline-cli/src/tools/split-guard/github.ts
@@ -1,0 +1,183 @@
+/**
+ * The GitHub boundary for `split-guard` (#3464): the live `Github` capability that reads the
+ * open `status:needs-triage` queue — WITH bodies — over `gh api` REST, feeding the IO-free
+ * `split-match.ts` core.
+ *
+ * Why the needs-triage queue and not the search index: the double-fire the guard closes emits its
+ * twin seconds apart (a retry/re-emit of the same split), so the read that catches it must be
+ * read-after-write consistent. The issues LIST endpoint filtered by `status:needs-triage` is — a
+ * child created seconds ago is already visible there — whereas `search/issues` is eventually
+ * consistent and would miss the just-created twin. Split children are always created
+ * `status:needs-triage` (triage Step 3.3), so the queue is exactly where a fresh twin lives.
+ *
+ * Same service pattern as `intake-dedup` / `verdict` (epic #994): a `Context.Service` on
+ * `ChildProcessSpawner`, REST only (GraphQL is broken on the kamp-us org), every infra failure a
+ * typed error in the `E` channel, untrusted REST JSON Schema-decoded at the boundary.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {ChildRef} from "./split-match.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/split-guard/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/split-guard/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/split-guard/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently defaults.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/split-guard/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// REST-only arg builder — never GraphQL. Paginated so a queue past one page is fully read.
+const queueArgs = (repo: string, label: string): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues?state=open&labels=${label}&per_page=100`,
+];
+
+/**
+ * A raw issue row from the issues endpoint. `pull_request` present ⇒ it is a PR (the endpoint
+ * returns both) and never a split child, so it's dropped. `body` is nullable on the REST surface.
+ */
+const RawIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	body: Schema.NullOr(Schema.String),
+	pull_request: Schema.optionalKey(Schema.Unknown),
+});
+const decodeQueue = Schema.decodeUnknownEffect(Schema.Array(RawIssue));
+
+const queue = Effect.fn("Github.queue")(function* (repo: string, label: string) {
+	const args = queueArgs(repo, label);
+	const rows = yield* decodeQueue(yield* json(args));
+	return rows
+		.filter((r) => r.pull_request === undefined)
+		.map((r): ChildRef => ({number: r.number, title: r.title, body: r.body ?? ""}));
+});
+
+/**
+ * `Github` — the IO shell over `gh api` REST. `queue(label)` lists the open `needs-triage`
+ * queue (read-after-write consistent) with bodies, which the core scans for the `split from
+ * #<parent>` back-reference. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly queue: (
+			label: string,
+		) => Effect.Effect<
+			ReadonlyArray<ChildRef>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/split-guard/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at construction
+ * and provided into each method body, so the public method carries `R = never`. Repo resolution is
+ * deferred to first use (`Effect.cached`, ADR 0062 §1): the layer build is side-effect-free.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				queue: (label) => repo.pipe(Effect.flatMap((r) => withSpawner(queue(r, label)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/split-guard/split-match.ts
+++ b/packages/pipeline-cli/src/tools/split-guard/split-match.ts
@@ -1,0 +1,67 @@
+/**
+ * The pure match core for `split-guard` (#3464): the create-once key that makes the
+ * `triage` skill's Step-3 "Split bundled reports" child-create idempotent.
+ *
+ * The observed defect (#3462/#3463): a single split of a parent emitted two byte-identical
+ * children 5s apart because nothing keyed the child-create on a durable signal — a retry or a
+ * re-emit produced a redundant twin. The durable idempotency signal is the `split from #<parent>`
+ * back-reference every split child already carries (triage Step 3.4 "Cross-link"): a second run
+ * finds the first child by that back-ref and skips the POST.
+ *
+ * IO-free by construction. `referencesParent` tests the durable back-ref; `unitKey` normalizes a
+ * title into a stable slug so the match survives whitespace/case/punctuation churn WITHOUT relying
+ * on byte-equality of the body (#3464 AC2 — a twin emitted with a slightly different body is still
+ * caught, because the key is (parent back-ref + title slug), never the body text). `github.ts`
+ * feeds this raw REST rows from the read-after-write `needs-triage` queue.
+ */
+
+/** A minimal open-issue row — number + title + body, the three fields the match needs. */
+export interface ChildRef {
+	readonly number: number;
+	readonly title: string;
+	readonly body: string;
+}
+
+/**
+ * Does `body` carry a `split from #<parent>` back-reference to `parent`? This is the durable
+ * create-once key (triage Step 3.4 stamps it on every split child). Matched emphasis-/case-tolerant
+ * and only on the exact number (a `#12` boundary guard so `#12` never matches `#123`).
+ */
+export const referencesParent = (body: string, parent: number): boolean =>
+	new RegExp(`split\\s+from\\s+#${parent}(?![0-9])`, "i").test(body);
+
+/**
+ * Normalize a title into a stable unit-key: lowercase, split on any non-alphanumeric run, drop
+ * empties, join with `-`. Order-preserving so two genuinely different siblings of the same parent
+ * (`split from #N` on each, but distinct units) keep distinct keys and are never collapsed — the
+ * key only absorbs whitespace/case/punctuation churn, not a real change of unit. A byte-identical
+ * twin (the #3462/#3463 case) and a whitespace-/case-variant twin both map to the same key.
+ */
+export const unitKey = (title: string): string =>
+	title
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((t) => t.length > 0)
+		.join("-");
+
+/**
+ * The create-once decision: among `existing` open children, return the number of one that already
+ * covers `(parent, proposedTitle)` — it back-references `parent` AND shares the proposed title's
+ * unit-key — or `undefined` when none does (safe to create). The lowest such number is returned so
+ * the survivor is deterministic (the earliest-created child wins, mirroring the #3461→#3462 canonical
+ * survivor). A non-undefined result means "reuse this child, do NOT POST a second."
+ */
+export const findExistingChild = (
+	parent: number,
+	proposedTitle: string,
+	existing: ReadonlyArray<ChildRef>,
+): number | undefined => {
+	const key = unitKey(proposedTitle);
+	// An all-punctuation / empty proposed title has no discriminating key — refuse to match on it
+	// rather than collapse every keyless child together (fail-open to create, never a false reuse).
+	if (key.length === 0) return undefined;
+	return existing
+		.filter((c) => referencesParent(c.body, parent) && unitKey(c.title) === key)
+		.map((c) => c.number)
+		.sort((a, b) => a - b)[0];
+};

--- a/packages/pipeline-cli/src/tools/split-guard/split-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/split-guard/split-match.unit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the `split-guard` pure core (#3464): the create-once key that makes the triage
+ * split idempotent. IO-free — no `gh` boundary here. The headline invariant is
+ * "split runs twice → one child" (the #3462/#3463 double-fire).
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {type ChildRef, findExistingChild, referencesParent, unitKey} from "./split-match.ts";
+
+describe("referencesParent", () => {
+	it("matches the canonical `split from #<parent>` back-reference", () => {
+		expect(referencesParent("... \n\nsplit from #3461\n", 3461)).toBe(true);
+	});
+
+	it("is case- and whitespace-tolerant", () => {
+		expect(referencesParent("Split  From   #3461", 3461)).toBe(true);
+	});
+
+	it("does not match a different parent, and guards the number boundary", () => {
+		expect(referencesParent("split from #3461", 3462)).toBe(false);
+		// #3461 must not match when the parent is #346 (prefix boundary).
+		expect(referencesParent("split from #3461", 346)).toBe(false);
+	});
+
+	it("is false when there is no back-reference", () => {
+		expect(referencesParent("a body with no split marker", 3461)).toBe(false);
+	});
+});
+
+describe("unitKey", () => {
+	it("normalizes case, punctuation, and whitespace to a stable slug", () => {
+		expect(unitKey("Migrate node:fs call sites to @effect/platform")).toBe(
+			unitKey("migrate   node/fs call-sites to @effect/platform"),
+		);
+	});
+
+	it("keeps genuinely different titles distinct", () => {
+		expect(unitKey("Migrate node:fs call sites")).not.toBe(unitKey("Add a moderation backend"));
+	});
+
+	it("is empty for an all-punctuation title", () => {
+		expect(unitKey("--- !!! ---")).toBe("");
+	});
+});
+
+describe("findExistingChild — the create-once decision", () => {
+	const parent = 3461;
+	const proposed =
+		"Migrate raw node:fs/os/path call sites in pipeline packages to @effect/platform layers";
+	const firstChild: ChildRef = {
+		number: 3462,
+		title: proposed,
+		body: `### What to build\n...\n\nsplit from #${parent}\n`,
+	};
+
+	it("returns undefined on the FIRST run (no existing child) — safe to create", () => {
+		expect(findExistingChild(parent, proposed, [])).toBeUndefined();
+	});
+
+	it("split runs twice → one child: the SECOND run finds the first child and skips the POST", () => {
+		// After the first emit, the read-after-write needs-triage queue carries #3462. A second run
+		// of the split with the same (parent, title) must resolve to #3462 — never a #3463 twin.
+		expect(findExistingChild(parent, proposed, [firstChild])).toBe(3462);
+	});
+
+	it("is robust to a body that differs slightly from the first emit (#3464 AC2)", () => {
+		// A twin re-emitted with a reworded body still carries `split from #<parent>`; the key is the
+		// back-ref + title-slug, not the body text — so byte-different bodies are still deduped.
+		const rewordedBody: ChildRef = {
+			number: 3462,
+			title: proposed,
+			body: `Slightly reworded lead paragraph.\n\nsplit from #${parent}`,
+		};
+		expect(findExistingChild(parent, proposed, [rewordedBody])).toBe(3462);
+	});
+
+	it("is robust to a title that differs only in case/whitespace/punctuation", () => {
+		const variantTitle: ChildRef = {
+			number: 3462,
+			title:
+				"migrate RAW node:fs / os / path call-sites in pipeline packages to @effect/platform layers",
+			body: `split from #${parent}`,
+		};
+		expect(findExistingChild(parent, proposed, [variantTitle])).toBe(3462);
+	});
+
+	it("does NOT collapse a genuinely different sibling of the same parent", () => {
+		// A parent legitimately splits into distinct units; a different-unit child must not suppress
+		// creation of this one.
+		const differentSibling: ChildRef = {
+			number: 3470,
+			title: "Add a create-once guard to the plan-epic child spawner",
+			body: `split from #${parent}`,
+		};
+		expect(findExistingChild(parent, proposed, [differentSibling])).toBeUndefined();
+	});
+
+	it("ignores a same-title child that back-references a DIFFERENT parent", () => {
+		const otherParentChild: ChildRef = {
+			number: 3480,
+			title: proposed,
+			body: "split from #9999",
+		};
+		expect(findExistingChild(parent, proposed, [otherParentChild])).toBeUndefined();
+	});
+
+	it("returns the lowest number when several twins already leaked (deterministic survivor)", () => {
+		const twinA: ChildRef = {number: 3462, title: proposed, body: `split from #${parent}`};
+		const twinB: ChildRef = {number: 3463, title: proposed, body: `split from #${parent}`};
+		expect(findExistingChild(parent, proposed, [twinB, twinA])).toBe(3462);
+	});
+
+	it("fails open (undefined) on an empty/keyless proposed title rather than a false reuse", () => {
+		const keyless: ChildRef = {number: 3462, title: "!!!", body: `split from #${parent}`};
+		expect(findExistingChild(parent, "!!!", [keyless])).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What & why

The triage skill's Step-3 "Split bundled reports" child-create was **non-idempotent**: a retry or a re-emit of one split fired a second byte-identical twin. Observed as the #3462/#3463 double-fire — two children of #3461 created 5s apart with identical bodies. Nothing keyed child creation on a durable signal, so a second pass produced a redundant twin that polluted the `status:needs-triage` queue and risked two parallel plans/builds for one sweep.

Fixes #3464.

## The fix

A focused new `pipeline-cli split-guard` tool that resolves the **create-once decision** before the split-child POST, keyed on the durable `split from #<parent>` back-reference every split child already carries (triage Step 3 "Cross-link") — **not** body byte-equality.

- **`split-match.ts`** — the IO-free pure core: `referencesParent` (the durable back-ref, number-boundary-guarded), `unitKey` (a normalized title slug tolerant of case/whitespace/punctuation churn), and `findExistingChild` (returns the existing child that already covers `(parent, title)`, else `undefined`).
- **`github.ts`** — the `gh api` REST boundary. It reads the **read-after-write `status:needs-triage` queue** (with bodies), so a twin created seconds ago is caught — where the eventually-consistent `search/issues` index would miss it. Same `Context.Service` pattern as `intake-dedup`/`verdict`.
- **`command.ts`** — `pipeline-cli split-guard check --parent <N> --title "<child title>"`: prints the existing child's `#<n>` (reuse it, skip the POST) or nothing (safe to create).
- **`triage/SKILL.md` Step 3** — wired to consult the guard before the child-create, and the `split from #<parent>` cross-link is now documented as the load-bearing create-once key.

## Acceptance criteria

- [x] Splitting a parent is idempotent: a second run for the same parent+child-brief does not create a second child — guarded by the existing `split from #<parent>` child before the POST.
- [x] Robust to a child body that differs slightly from a prior emit — the key is `(parent back-ref + title unit-key)`, never body byte-equality.
- [x] A regression test covers the "split runs twice → one child" invariant (`split-match.unit.test.ts`), per the repo's Node/Effect-CLI tooling convention.

## Honest boundary

This closes the **sequential re-emit** hole (the documented cause: a retry / re-emit). The Step-0 claim still guards a concurrent sibling sweep, and Step 3.2's `intake-dedup` still guards a report-agent twin. A genuinely simultaneous two-run TOCTOU (both read the queue before either creates) is inherent to check-then-create without a lock and out of scope here.

## §CP — control-plane

Both changed surfaces (`claude-plugins/kampus-pipeline/skills/triage/SKILL.md` and `packages/pipeline-cli/`) match `CONTROL_PLANE_RE`. This PR requires **@kamp-us/control-plane** team review and is banked for control-plane approval, not auto-shipped.

## Verification

- `pipeline-cli split-guard/` unit tests: 15 passed.
- `pnpm typecheck` (pipeline-cli): clean.
- `biome check`: clean.
- `gh-phoenix lint-skills` on the edited skill: clean (REST-only, valid frontmatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)