### PR TITLE
refactor(pipeline-cli): migrate dependency & index guards to v4 @effect/platform seam (#3469) (§CP)

### DIFF
--- a/packages/pipeline-cli/src/tools/catalog-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/command.ts
@@ -27,26 +27,35 @@
  * bin's run boundary) so the contract survives folding into the shared `pipeline-cli`
  * bin, which provides only `NodeServices.layer` and no per-tool catch.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkCatalog} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each
+// marker through the `FileSystem`/`Path` seam so the resolver is testable off real
+// disk (.patterns/effect-platform-access.md). Mirrors `findRootDir`'s pure upward walk
+// (dirname to the fixpoint, then fall back to the start), but the marker check is the
+// fs seam — `fs.exists` yields an Effect, so the walk lives here rather than in the
+// pure helper. Marker-existence faults fall through as false, matching `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
@@ -55,8 +64,10 @@ const rootFlag = Flag.string("root").pipe(
 	),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
@@ -71,7 +82,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkCatalog(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkCatalog(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(

--- a/packages/pipeline-cli/src/tools/catalog-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/gate.ts
@@ -12,9 +12,7 @@
  * manifests are in scope (fail-closed, ADR 0092). A directory/file IO failure is an
  * `IoError` (also non-zero — both failures, undistinguished, per the bin's contract).
  */
-import {existsSync, readdirSync, readFileSync, statSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {
 	type AllowlistEntry,
@@ -42,57 +40,83 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
  * the root manifest. Each glob is either a `<dir>/*` member glob (enumerate immediate
  * subdirs that carry a `package.json`) or a literal member path. The root
  * `package.json` is always in scope — its deps are governed by the catalog rule too.
+ *
+ * All directory/path IO goes through the Effect `FileSystem`/`Path` seam (over the
+ * bin's `NodeServices.layer`), so a gate `unit` test substitutes an in-memory fs for
+ * the real disk (.patterns/effect-platform-access.md); a fs fault folds `PlatformError`
+ * → the `IoError` this gate already carries. This is the one why-note for the file's
+ * platform-seam migration — the other IO helpers below follow the same shape.
  */
 const enumerateManifestPaths = (
 	root: string,
 	globs: ReadonlyArray<string>,
-): Effect.Effect<ReadonlyArray<string>, IoError> =>
-	Effect.try({
-		try: () => {
-			const paths = new Set<string>();
-			if (existsSync(join(root, "package.json"))) paths.add("package.json");
-			for (const glob of globs) {
-				if (glob.endsWith("/*")) {
-					const parent = glob.slice(0, -2);
-					const base = join(root, parent);
-					if (!existsSync(base)) continue;
-					for (const entry of readdirSync(base, {withFileTypes: true})) {
-						const abs = join(base, entry.name);
-						if (!statSync(abs).isDirectory()) continue;
-						if (existsSync(join(abs, "package.json")))
-							paths.add(`${parent}/${entry.name}/package.json`);
-					}
-				} else if (existsSync(join(root, glob, "package.json"))) {
-					paths.add(`${glob}/package.json`);
+): Effect.Effect<ReadonlyArray<string>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const paths = new Set<string>();
+		if (yield* fs.exists(path.join(root, "package.json"))) paths.add("package.json");
+		for (const glob of globs) {
+			if (glob.endsWith("/*")) {
+				const parent = glob.slice(0, -2);
+				const base = path.join(root, parent);
+				if (!(yield* fs.exists(base))) continue;
+				for (const name of yield* fs.readDirectory(base)) {
+					const abs = path.join(base, name);
+					if ((yield* fs.stat(abs)).type !== "Directory") continue;
+					if (yield* fs.exists(path.join(abs, "package.json")))
+						paths.add(`${parent}/${name}/package.json`);
 				}
+			} else if (yield* fs.exists(path.join(root, glob, "package.json"))) {
+				paths.add(`${glob}/package.json`);
 			}
-			return [...paths].sort();
-		},
-		catch: (cause) => new IoError({path: root, cause}),
-	});
+		}
+		return [...paths].sort();
+	}).pipe(Effect.mapError((cause) => new IoError({path: root, cause})));
 
 /** Read + parse each manifest path into the pure core's `PackageManifest` shape. */
 const readManifests = (
 	root: string,
 	paths: ReadonlyArray<string>,
-): Effect.Effect<ReadonlyArray<PackageManifest>, IoError> =>
-	Effect.forEach(
-		paths,
-		(path) =>
-			Effect.try({
-				try: (): PackageManifest => {
-					const pkg = JSON.parse(readFileSync(join(root, path), "utf8")) as Record<string, unknown>;
-					return {path, deps: manifestDeps(pkg)};
-				},
-				catch: (cause) => new IoError({path: join(root, path), cause}),
-			}),
-		{concurrency: 1},
-	);
+): Effect.Effect<ReadonlyArray<PackageManifest>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		return yield* Effect.forEach(
+			paths,
+			(rel) => {
+				const abs = path.join(root, rel);
+				return fs.readFileString(abs, "utf8").pipe(
+					Effect.mapError((cause) => new IoError({path: abs, cause})),
+					Effect.flatMap((text) =>
+						Effect.try({
+							try: (): PackageManifest => ({
+								path: rel,
+								deps: manifestDeps(JSON.parse(text) as Record<string, unknown>),
+							}),
+							catch: (cause) => new IoError({path: abs, cause}),
+						}),
+					),
+				);
+			},
+			{concurrency: 1},
+		);
+	});
 
-const readWorkspaceGlobs = (root: string): Effect.Effect<ReadonlyArray<string>, IoError> =>
-	Effect.try({
-		try: () => parseWorkspacePackageGlobs(readFileSync(join(root, "pnpm-workspace.yaml"), "utf8")),
-		catch: (cause) => new IoError({path: join(root, "pnpm-workspace.yaml"), cause}),
+const readWorkspaceGlobs = (
+	root: string,
+): Effect.Effect<ReadonlyArray<string>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const target = path.join(root, "pnpm-workspace.yaml");
+		const text = yield* fs
+			.readFileString(target, "utf8")
+			.pipe(Effect.mapError((cause) => new IoError({path: target, cause})));
+		return yield* Effect.try({
+			try: () => parseWorkspacePackageGlobs(text),
+			catch: (cause) => new IoError({path: target, cause}),
+		});
 	});
 
 /**
@@ -103,7 +127,7 @@ const readWorkspaceGlobs = (root: string): Effect.Effect<ReadonlyArray<string>, 
 export const checkCatalog = (
 	root: string,
 	allowlist: ReadonlyArray<AllowlistEntry> = DEFAULT_ALLOWLIST,
-): Effect.Effect<void, IoError | CheckFailed> =>
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const globs = yield* readWorkspaceGlobs(root);
 		const paths = yield* enumerateManifestPaths(root, globs);

--- a/packages/pipeline-cli/src/tools/catalog-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/catalog-guard/gate.unit.test.ts
@@ -8,8 +8,9 @@
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {CheckFailed, checkCatalog} from "./gate.ts";
 
 let root: string;
@@ -36,7 +37,11 @@ const mkPackage = (name: string, pkg: Record<string, unknown> | null) => {
 	if (pkg) writeFileSync(join(dir, "package.json"), JSON.stringify(pkg), "utf8");
 };
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3469);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 
 const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
 	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/command.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/command.ts
@@ -18,8 +18,7 @@
  * seam, a tool self-contains its services. Only the `Command.run`/`Effect.provide`/
  * `runMain` wiring is dropped — the shared `pipeline-cli` bin owns the run boundary.
  */
-import {readFileSync, writeFileSync} from "node:fs";
-import {Console, Effect, Schema} from "effect";
+import {Console, Effect, FileSystem, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {buildManifest} from "./adapter.ts";
 import {Git, GitLive} from "./commit.ts";
@@ -45,17 +44,39 @@ const parseExtraChecks = (text: string): Effect.Effect<ReadonlyArray<Check>, Cra
 			new CrabboxParseError({message: `malformed --extra-checks: ${String(cause)}`}),
 	});
 
-/** Read a file as UTF-8, lowering an IO fault into the adapter's typed parse error. */
-const readText = (path: string): Effect.Effect<string, CrabboxParseError> =>
-	Effect.try({
-		try: () => readFileSync(path, "utf8"),
-		catch: (cause) => new CrabboxParseError({message: `cannot read ${path}: ${String(cause)}`}),
+/**
+ * Read a file as UTF-8, lowering an IO fault into the adapter's typed parse error.
+ *
+ * The read/write route through the Effect `FileSystem` seam (over the bin's
+ * `NodeServices.layer`), so this stays testable off real disk
+ * (.patterns/effect-platform-access.md); a fs fault folds `PlatformError` → the
+ * `CrabboxParseError` the CLI's exit contract already carries.
+ */
+const readText = (path: string): Effect.Effect<string, CrabboxParseError, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		return yield* fs
+			.readFileString(path, "utf8")
+			.pipe(
+				Effect.mapError(
+					(cause) => new CrabboxParseError({message: `cannot read ${path}: ${String(cause)}`}),
+				),
+			);
 	});
 
-const writeText = (path: string, contents: string): Effect.Effect<void, CrabboxParseError> =>
-	Effect.try({
-		try: () => writeFileSync(path, contents),
-		catch: (cause) => new CrabboxParseError({message: `cannot write ${path}: ${String(cause)}`}),
+const writeText = (
+	path: string,
+	contents: string,
+): Effect.Effect<void, CrabboxParseError, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		yield* fs
+			.writeFileString(path, contents)
+			.pipe(
+				Effect.mapError(
+					(cause) => new CrabboxParseError({message: `cannot write ${path}: ${String(cause)}`}),
+				),
+			);
 	});
 
 const runSummaryFlag = Flag.string("run-summary").pipe(

--- a/packages/pipeline-cli/src/tools/decisions-index/command.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/command.ts
@@ -32,11 +32,8 @@
  * each subcommand's handler so the contract survives folding into the shared
  * `pipeline-cli` bin (which provides only `NodeServices.layer`, no per-tool catch).
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "./decisions-index.ts";
 import type {CheckFailed} from "./gate.ts";
 import {checkIndex, compactIndex, generateIndex, nextIndex, validateAdrs} from "./gate.ts";
 
@@ -55,16 +52,28 @@ const ROOT_MARKERS = [DECISIONS_DIR, "pnpm-workspace.yaml", ".git"] as const;
  * `.decisions` there; this is foreign-repo-safe (no phoenix path hardcoded) and
  * keeps CI working (it runs from the root, where cwd === root). If no marker is
  * found we fall back to cwd's `.decisions` — the pre-fix behavior.
+ *
+ * The marker probes go through the `FileSystem`/`Path` seam (over the bin's
+ * `NodeServices.layer`), so this resolver is testable off real disk
+ * (.patterns/effect-platform-access.md). Mirrors the pure upward walk (dirname to the
+ * fixpoint), but `fs.exists` yields an Effect so the walk lives here; a probe fault
+ * falls through as false, matching the former `existsSync`.
  */
-const defaultDecisionsDir = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return join(root ?? start, DECISIONS_DIR);
-};
+const defaultDecisionsDir = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return path.join(dir, DECISIONS_DIR);
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return path.join(start, DECISIONS_DIR);
+		dir = parent;
+	}
+});
 
 // Optional, not defaulted: an absent --dir resolves to the repo-root `.decisions`
 // (see `defaultDecisionsDir`); a passed --dir is honored verbatim, relative to cwd.
@@ -75,8 +84,10 @@ const dirFlag = Flag.string("dir").pipe(
 	),
 );
 
-const resolveDir = (dir: Option.Option<string>): string =>
-	Option.getOrElse(dir, () => defaultDecisionsDir());
+const resolveDir = (
+	dir: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(dir, {onNone: () => defaultDecisionsDir(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
@@ -93,7 +104,8 @@ const compact = Command.make(
 	"compact",
 	{dir: dirFlag},
 	Effect.fn(function* ({dir: dirOpt}) {
-		yield* compactIndex(resolveDir(dirOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const dir = yield* resolveDir(dirOpt);
+		yield* compactIndex(dir).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(
@@ -105,7 +117,8 @@ const next = Command.make(
 	"next",
 	{dir: dirFlag},
 	Effect.fn(function* ({dir: dirOpt}) {
-		yield* nextIndex(resolveDir(dirOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const dir = yield* resolveDir(dirOpt);
+		yield* nextIndex(dir).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(
@@ -117,7 +130,8 @@ const generate = Command.make(
 	"generate",
 	{dir: dirFlag},
 	Effect.fn(function* ({dir: dirOpt}) {
-		yield* generateIndex(resolveDir(dirOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const dir = yield* resolveDir(dirOpt);
+		yield* generateIndex(dir).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(Command.withDescription("Regenerate .decisions/index.md from the ADR files"));
 
@@ -125,7 +139,8 @@ const validate = Command.make(
 	"validate",
 	{dir: dirFlag},
 	Effect.fn(function* ({dir: dirOpt}) {
-		yield* validateAdrs(resolveDir(dirOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const dir = yield* resolveDir(dirOpt);
+		yield* validateAdrs(dir).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription(
@@ -137,7 +152,8 @@ const check = Command.make(
 	"check",
 	{dir: dirFlag},
 	Effect.fn(function* ({dir: dirOpt}) {
-		yield* checkIndex(resolveDir(dirOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const dir = yield* resolveDir(dirOpt);
+		yield* checkIndex(dir).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(
 	Command.withDescription("Verify the committed index.md is fresh and has no duplicate ADR id"),

--- a/packages/pipeline-cli/src/tools/decisions-index/gate.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/gate.ts
@@ -13,9 +13,7 @@
  * rewrites the index. A directory/file IO failure is an `IoError` (also non-zero —
  * both failures, undistinguished, per the bin's contract).
  */
-import {readdirSync, readFileSync, writeFileSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
 import {
 	type AdrFile,
@@ -39,16 +37,28 @@ export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFa
 	reason: Schema.String,
 }) {}
 
-/** Read every ADR file (NNNN[a]-slug.md) in `dir`, excluding the generated index. */
-export const readAdrFiles = (dir: string): Effect.Effect<ReadonlyArray<AdrFile>, IoError> =>
-	Effect.try({
-		try: () =>
-			readdirSync(dir)
-				.filter((f) => f !== INDEX_FILE && ADR_FILE.test(f))
-				.sort()
-				.map((file) => ({file, text: readFileSync(join(dir, file), "utf8")})),
-		catch: (cause) => new IoError({path: dir, cause}),
-	});
+/**
+ * Read every ADR file (NNNN[a]-slug.md) in `dir`, excluding the generated index.
+ *
+ * The directory list + reads go through the Effect `FileSystem`/`Path` seam (over the
+ * bin's `NodeServices.layer`), so a gate `unit` test scripts an in-memory `.decisions`
+ * dir instead of touching real disk (.patterns/effect-platform-access.md); a fs fault
+ * folds `PlatformError` → the `IoError` this gate carries. This is the one why-note for
+ * the file's platform-seam migration — the writers/readers below follow the same shape.
+ */
+export const readAdrFiles = (
+	dir: string,
+): Effect.Effect<ReadonlyArray<AdrFile>, IoError, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const files = (yield* fs.readDirectory(dir))
+			.filter((f) => f !== INDEX_FILE && ADR_FILE.test(f))
+			.sort();
+		return yield* Effect.forEach(files, (file) =>
+			fs.readFileString(path.join(dir, file), "utf8").pipe(Effect.map((text) => ({file, text}))),
+		);
+	}).pipe(Effect.mapError((cause) => new IoError({path: dir, cause})));
 
 /** Fold a builder's throw (a duplicate id or a malformed file) into a CheckFailed. */
 const toGateFail = (build: () => string): Effect.Effect<string, CheckFailed> =>
@@ -84,21 +94,26 @@ export const buildNextNumber = (
  * index is regenerated and committed on merge to main instead (the `decisions-index`
  * workflow's push job). The built markdown is discarded — validation is the only effect.
  */
-export const validateAdrs = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const validateAdrs = (
+	dir: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
 		yield* Console.log("decisions-index: ADR files valid (no duplicate or mismatched id)");
 	});
 
 /** Rewrite `<dir>/index.md` from the ADR files. */
-export const generateIndex = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const generateIndex = (
+	dir: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
 		const markdown = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
-		const target = join(dir, INDEX_FILE);
-		yield* Effect.try({
-			try: () => writeFileSync(target, markdown),
-			catch: (cause) => new IoError({path: target, cause}),
-		});
+		const target = path.join(dir, INDEX_FILE);
+		yield* fs
+			.writeFileString(target, markdown)
+			.pipe(Effect.mapError((cause) => new IoError({path: target, cause})));
 		yield* Console.log(`decisions-index: wrote ${target}`);
 	});
 
@@ -108,7 +123,9 @@ export const generateIndex = (dir: string): Effect.Effect<void, IoError | CheckF
  * derives from the ADR frontmatter with no committed-file dependency, so it never
  * drifts and needs no regenerate step. `Console.log` writes the map to stdout.
  */
-export const compactIndex = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const compactIndex = (
+	dir: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const map = yield* readAdrFiles(dir).pipe(Effect.flatMap(buildCompactMap));
 		yield* Console.log(map);
@@ -121,7 +138,9 @@ export const compactIndex = (dir: string): Effect.Effect<void, IoError | CheckFa
  * on an already-broken tree (duplicate / mismatched id) rather than allocate over it —
  * the same fold `validate` uses, so `next` and `validate` never disagree.
  */
-export const nextIndex = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const nextIndex = (
+	dir: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const next = yield* readAdrFiles(dir).pipe(Effect.flatMap(buildNextNumber));
 		yield* Console.log(next);
@@ -132,14 +151,15 @@ export const nextIndex = (dir: string): Effect.Effect<void, IoError | CheckFaile
  * (stale index or duplicate id). A missing/unreadable committed index reads as
  * empty, so it never matches a non-empty build → stale.
  */
-export const checkIndex = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkIndex = (
+	dir: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
 		const expected = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
-		const target = join(dir, INDEX_FILE);
-		const committed = yield* Effect.try({
-			try: () => readFileSync(target, "utf8"),
-			catch: () => "",
-		}).pipe(Effect.orElseSucceed(() => ""));
+		const target = path.join(dir, INDEX_FILE);
+		const committed = yield* fs.readFileString(target, "utf8").pipe(Effect.orElseSucceed(() => ""));
 		if (committed === expected) {
 			yield* Console.log("decisions-index: index.md is up to date");
 			return;

--- a/packages/pipeline-cli/src/tools/decisions-index/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/gate.unit.test.ts
@@ -12,8 +12,9 @@
 import {mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {afterEach, assert, beforeEach, describe, it} from "@effect/vitest";
-import {Cause, Effect, Exit} from "effect";
+import {Cause, Effect, Exit, type FileSystem, type Path} from "effect";
 import {buildIndex} from "./decisions-index.ts";
 import {CheckFailed, checkIndex, generateIndex, nextIndex, validateAdrs} from "./gate.ts";
 
@@ -34,7 +35,11 @@ const writeAdr = (a: {name: string; text: string}) =>
 	writeFileSync(join(dir, a.name), a.text, "utf8");
 const writeIndex = (content: string) => writeFileSync(join(dir, "index.md"), content, "utf8");
 
-const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3469);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-temp-dir IO tests exercise the actual disk path they assert over.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 
 describe("checkIndex — the CI exit-code gate over a fake .decisions dir (ADR 0066)", () => {
 	it("PASSES (exit 0) when the committed index.md matches the build", async () => {

--- a/packages/pipeline-cli/src/tools/pointer-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/command.ts
@@ -24,34 +24,44 @@
  * bin's run boundary) so the contract survives folding into the shared `pipeline-cli`
  * bin, which provides only `NodeServices.layer` and no per-tool catch.
  */
-import {existsSync} from "node:fs";
-import {dirname, join, resolve} from "node:path";
-import {Effect, Option} from "effect";
+import {Effect, FileSystem, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {findRootDir} from "../../find-root-dir.ts";
 import {type CheckFailed, checkPointers} from "./gate.ts";
 
 const GATE_FAIL_EXIT_CODE = 1;
 // Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
 const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
 
-const defaultRoot = (from: string = process.cwd()): string => {
-	const start = resolve(from);
-	const root = findRootDir(
-		start,
-		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
-		dirname,
-	);
-	return root ?? start;
-};
+// Walk up from cwd for the first ancestor bearing a repo-root marker, probing each
+// marker through the `FileSystem`/`Path` seam so the resolver is testable off real
+// disk (.patterns/effect-platform-access.md). Mirrors `findRootDir`'s pure upward walk
+// (dirname to the fixpoint, then fall back to the start); `fs.exists` yields an Effect,
+// so the walk lives here, and a probe fault falls through as false like `existsSync`.
+const defaultRoot = Effect.fn(function* (from: string = process.cwd()) {
+	const fs = yield* FileSystem.FileSystem;
+	const path = yield* Path.Path;
+	const start = path.resolve(from);
+	let dir = start;
+	for (;;) {
+		for (const marker of ROOT_MARKERS) {
+			if (yield* fs.exists(path.join(dir, marker)).pipe(Effect.orElseSucceed(() => false)))
+				return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return start;
+		dir = parent;
+	}
+});
 
 const rootFlag = Flag.string("root").pipe(
 	Flag.optional,
 	Flag.withDescription("the repo root to scan CLAUDE.md files under (default: walk up for one)"),
 );
 
-const resolveRoot = (root: Option.Option<string>): string =>
-	Option.getOrElse(root, () => defaultRoot());
+const resolveRoot = (
+	root: Option.Option<string>,
+): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
+	Option.match(root, {onNone: () => defaultRoot(), onSome: Effect.succeed});
 
 // CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 // non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
@@ -66,7 +76,8 @@ const check = Command.make(
 	"check",
 	{root: rootFlag},
 	Effect.fn(function* ({root: rootOpt}) {
-		yield* checkPointers(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+		const root = yield* resolveRoot(rootOpt);
+		yield* checkPointers(root).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
 	}),
 ).pipe(Command.withDescription("Fail the build if any backticked CLAUDE.md path pointer is stale"));
 

--- a/packages/pipeline-cli/src/tools/pointer-guard/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/gate.test.ts
@@ -10,9 +10,18 @@ import {execFileSync} from "node:child_process";
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Exit} from "effect";
+import {Effect, Exit, type FileSystem, type Path} from "effect";
 import {type CheckFailed, checkPointers, scanStalePointers} from "./gate.ts";
+
+// The gate Effects require the `FileSystem | Path` seam (v4 platform migration, #3469);
+// provide the live Node layer — the same NodeServices.layer run.ts gives the bin — so these
+// real-git-repo IO tests exercise the actual disk path they assert over.
+const runP = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromise(Effect.provide(effect, NodeServices.layer));
+const runExit = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+	Effect.runPromiseExit(Effect.provide(effect, NodeServices.layer));
 
 /** A throwaway git repo so `git ls-files` has something to enumerate. */
 const makeRepo = (files: Record<string, string>): string => {
@@ -38,7 +47,7 @@ describe("scanStalePointers", () => {
 			"apps/web/real.ts": "ok",
 		});
 		try {
-			const stale = await Effect.runPromise(scanStalePointers(dir));
+			const stale = await runP(scanStalePointers(dir));
 			assert.deepStrictEqual(
 				stale.map((s) => ({file: s.file, path: s.path})),
 				[{file: "CLAUDE.md", path: "apps/web/gone.ts"}],
@@ -55,7 +64,7 @@ describe("scanStalePointers", () => {
 			"apps/web/CLAUDE.md": "nested dead: `apps/web/missing.ts`",
 		});
 		try {
-			const stale = await Effect.runPromise(scanStalePointers(dir));
+			const stale = await runP(scanStalePointers(dir));
 			assert.deepStrictEqual(
 				stale.map((s) => s.path),
 				["apps/web/missing.ts"],
@@ -72,7 +81,7 @@ describe("scanStalePointers", () => {
 			"CLAUDE.md": "create `apps/web/secret.env` from the example",
 		});
 		try {
-			const stale = await Effect.runPromise(scanStalePointers(dir));
+			const stale = await runP(scanStalePointers(dir));
 			assert.deepStrictEqual(stale, []);
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
@@ -83,7 +92,7 @@ describe("scanStalePointers", () => {
 		const dir = makeRepo({"CLAUDE.md": "ok `apps/web/real.ts`", "apps/web/real.ts": "ok"});
 		try {
 			writeFileSync(join(dir, "apps", "web", "CLAUDE.md"), "dead `apps/web/nope.ts`", "utf8");
-			const stale = await Effect.runPromise(scanStalePointers(dir));
+			const stale = await runP(scanStalePointers(dir));
 			assert.deepStrictEqual(stale, []);
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
@@ -95,7 +104,7 @@ describe("checkPointers", () => {
 	it("succeeds (no failure) on a clean repo", async () => {
 		const dir = makeRepo({"CLAUDE.md": "`apps/web/real.ts`", "apps/web/real.ts": "ok"});
 		try {
-			const exit = await Effect.runPromiseExit(checkPointers(dir));
+			const exit = await runExit(checkPointers(dir));
 			assert.isTrue(Exit.isSuccess(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});
@@ -105,7 +114,7 @@ describe("checkPointers", () => {
 	it("fails CheckFailed with a report on a stale pointer", async () => {
 		const dir = makeRepo({"CLAUDE.md": "dead `apps/web/gone.ts`"});
 		try {
-			const reason = await Effect.runPromise(
+			const reason = await runP(
 				checkPointers(dir).pipe(
 					Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
 				),
@@ -120,7 +129,7 @@ describe("checkPointers", () => {
 	it("fails CheckFailed (fail-closed, ADR 0092) when zero CLAUDE.md are in scope", async () => {
 		const dir = makeRepo({"README.md": "no CLAUDE.md here `apps/web/gone.ts`"});
 		try {
-			const exit = await Effect.runPromiseExit(checkPointers(dir));
+			const exit = await runExit(checkPointers(dir));
 			assert.isTrue(Exit.isFailure(exit));
 		} finally {
 			rmSync(dir, {recursive: true, force: true});

--- a/packages/pipeline-cli/src/tools/pointer-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/gate.ts
@@ -26,11 +26,14 @@
  * an `IoError` (also non-zero — both failures, undistinguished, per the bin's contract).
  */
 import {execFileSync} from "node:child_process";
-import {existsSync, readFileSync} from "node:fs";
-import {join} from "node:path";
-import {Console, Effect} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import * as Schema from "effect/Schema";
-import {findStalePointersIn, renderReport, type StalePointer} from "./pointer-guard.ts";
+import {
+	extractPathRefs,
+	findStalePointersIn,
+	renderReport,
+	type StalePointer,
+} from "./pointer-guard.ts";
 
 /** A directory/file/git IO failure: the run couldn't complete. */
 export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
@@ -75,21 +78,40 @@ const isGitIgnored = (root: string, path: string): boolean => {
 	}
 };
 
-/** Scan every git-tracked `CLAUDE.md` under `root` and collect the stale pointers. */
+/**
+ * Scan every git-tracked `CLAUDE.md` under `root` and collect the stale pointers.
+ *
+ * File reads + on-disk probes route through the Effect `FileSystem`/`Path` seam (over
+ * the bin's `NodeServices.layer`), so a gate `unit` test scripts an in-memory repo
+ * instead of touching real disk (.patterns/effect-platform-access.md); a read fault
+ * folds `PlatformError` → `IoError`. The pure scanner (`findStalePointersIn`) filters
+ * by a *synchronous* `exists` predicate, which the async fs seam can't be inline — so
+ * existence is precomputed per referenced path here and fed to the scanner as a lookup.
+ * A pointer resolves when it exists OR is gitignored (a deliberately-absent
+ * generated/runtime path like `apps/web/.env`); git IO stays a raw subprocess (the
+ * subprocess seam is a separate migration — `.patterns/effect-process-cli-shell.md`).
+ */
 export const scanStalePointers = (
 	root: string,
-): Effect.Effect<ReadonlyArray<StalePointer>, IoError> =>
+): Effect.Effect<ReadonlyArray<StalePointer>, IoError, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
 		const files = yield* listClaudeMdFiles(root);
-		const exists = (path: string): boolean =>
-			existsSync(join(root, path)) || isGitIgnored(root, path);
 		const stale: StalePointer[] = [];
 		for (const file of files) {
-			const text = yield* Effect.try({
-				try: () => readFileSync(join(root, file), "utf8"),
-				catch: (cause) => new IoError({path: file, cause}),
-			});
-			stale.push(...findStalePointersIn(file, text, exists));
+			const text = yield* fs
+				.readFileString(path.join(root, file), "utf8")
+				.pipe(Effect.mapError((cause) => new IoError({path: file, cause})));
+			const resolved = new Map<string, boolean>();
+			for (const ref of extractPathRefs(text)) {
+				if (resolved.has(ref.path)) continue;
+				const onDisk = yield* fs
+					.exists(path.join(root, ref.path))
+					.pipe(Effect.orElseSucceed(() => false));
+				resolved.set(ref.path, onDisk || isGitIgnored(root, ref.path));
+			}
+			stale.push(...findStalePointersIn(file, text, (p) => resolved.get(p) ?? false));
 		}
 		return stale;
 	});
@@ -99,7 +121,9 @@ export const scanStalePointers = (
  * else `CheckFailed` with the per-pointer report. Fails closed on zero CLAUDE.md in
  * scope (ADR 0092) — never a vacuous green on a mis-rooted scan.
  */
-export const checkPointers = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+export const checkPointers = (
+	root: string,
+): Effect.Effect<void, IoError | CheckFailed, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
 		const files = yield* listClaudeMdFiles(root);
 		if (files.length === 0) {

--- a/packages/pipeline-cli/src/tools/primary-index-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/primary-index-guard/command.ts
@@ -21,9 +21,8 @@
  * clean allow.
  */
 import {execFileSync} from "node:child_process";
-import {resolve} from "node:path";
 import {appendRecord, defaultLogPath, parseNameStatus} from "@kampus/primary-index-tripwire";
-import {Console, Effect, Option} from "effect";
+import {Console, Effect, Option, Path} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {decidePrimaryIndexCommit, MASS_DELETION_BLOCK_THRESHOLD} from "./primary-index-guard.ts";
 
@@ -54,16 +53,21 @@ const stagedDeletions = (): string => {
  * shared git-common-dir on the primary, differs in a linked worktree (the same signal write-code's
  * worktree preflight and ref-guard use). Indeterminate ⇒ `false` (fail-OPEN: a checkout we cannot
  * prove is the primary is not blocked, so a worktree agent is never false-refused).
+ *
+ * Path normalization goes through the Effect `Path` seam (over the bin's `NodeServices.layer`);
+ * git IO stays a raw read-only subprocess (the subprocess seam is a separate migration —
+ * `.patterns/effect-platform-access.md` / `.patterns/effect-process-cli-shell.md`).
  */
-const resolvePrimaryCheckout = (): boolean => {
+const resolvePrimaryCheckout = Effect.fn(function* () {
+	const path = yield* Path.Path;
 	const gd = runGit(["rev-parse", "--path-format=absolute", "--git-dir"]);
 	const cd = runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
 	if (!gd.ok || !cd.ok) return false;
 	const gitDir = gd.stdout.trim();
 	const commonDir = cd.stdout.trim();
 	if (gitDir === "" || commonDir === "") return false;
-	return resolve(gitDir) === resolve(commonDir);
-};
+	return path.resolve(gitDir) === path.resolve(commonDir);
+});
 
 const thresholdFlag = Flag.integer("threshold").pipe(
 	Flag.withDefault(MASS_DELETION_BLOCK_THRESHOLD),
@@ -82,7 +86,7 @@ const preCommit = Command.make(
 	{threshold: thresholdFlag, log: logFlag},
 	Effect.fn(function* ({threshold, log}) {
 		const decision = decidePrimaryIndexCommit({
-			onPrimaryCheckout: resolvePrimaryCheckout(),
+			onPrimaryCheckout: yield* resolvePrimaryCheckout(),
 			staged: parseNameStatus(stagedDeletions()),
 			cwd: process.cwd(),
 			agentType: process.env.CLAUDE_CODE_AGENT ?? "",


### PR DESCRIPTION
Fixes #3469

## What

Phase-2 §CP child of epic #3462 — migrates the raw `node:fs` / `node:path` production imports in the **dependency & index guard** cluster to the Effect v4 platform idiom (`.patterns/effect-platform-access.md`), mirroring the walking-skeleton crew-mcp migration (#3468 / PR #3485).

Tools migrated (8 files):
- `catalog-guard/command.ts`, `catalog-guard/gate.ts`
- `decisions-index/command.ts`, `decisions-index/gate.ts`
- `pointer-guard/command.ts`, `pointer-guard/gate.ts`
- `crabbox-manifest/command.ts`
- `primary-index-guard/command.ts`

## How

- File/dir/path IO now yields `FileSystem.FileSystem` / `Path.Path` from `effect`; the requirement discharges through the `NodeServices.layer` **already provided by `run.ts`** — no new layer wiring.
- Each gate core's `PlatformError` folds onto the domain error it already carries (`IoError` / `CheckFailed` / `CrabboxParseError`) via `Effect.mapError`, preserving the exit-code contract.
- The shared `defaultRoot` / `defaultDecisionsDir` upward-walk becomes an Effect that probes markers through `fs.exists` (mirrors the pure `findRootDir` walk; probe faults fall through as `false`, matching `existsSync`).
- `pointer-guard`'s pure scanner keeps its **synchronous** `exists` predicate — existence is precomputed per referenced path through the fs seam and fed to the scanner as a lookup, so `pointer-guard.ts` is untouched.

## Bright line preserved (per the doc)
- Git subprocess IO (`node:child_process` `execFileSync`) stays raw — the subprocess seam is a separate migration.
- `proper-lockfile` / `os` / `bin.ts` bootstrap untouched.
- No `.test.ts` real-fs code changed.

## Behavior unchanged (refactor, not a capability change)
- `pnpm --filter @kampus/pipeline-cli typecheck` passes.
- All 127 tests across the 5 migrated tools pass; biome clean on the slice.
- End-to-end smoke: `catalog-guard check`, `pointer-guard check`, `decisions-index next|compact` produce identical output + exit codes.
- Note: the repo-wide suite has one **pre-existing, out-of-slice** failure in `worktree-guard/command.hook.test.ts` (an environmental subprocess/git-state test in a different tool, child #3473) that fails identically on `origin/main` — unrelated to this diff.

## §CP
This PR touches `packages/pipeline-cli/**`, which **is** control-plane. It **banks for a human merge by @kamp-us/control-plane** and does **not** auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)