### PR TITLE
docs(codeowners): reference the @kamp-us/control-plane team, not named members + a stale count

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Control-plane: control-plane-team approval required (ADR 0053, 0065, 0071, 0135).
-# Owner is the @kamp-us/control-plane team (usirin + cansirin) — a two-human team so
-# `require_code_owner_review` is SATISFIABLE (a single operator cannot self-approve;
-# GitHub blocks self-approval, so a §CP PR needs the OTHER team member — a deliberate
-# two-person control). The team is humans-only: never an agent/bot, else an ADR-0055
-# agent approval would defeat the human-judgment property (ADR 0135, amending 0071).
+# Owner is the @kamp-us/control-plane team. `require_code_owner_review` is SATISFIABLE
+# because GitHub blocks self-approval: a §CP PR needs a DIFFERENT @kamp-us/control-plane
+# member to approve — a deliberate multi-person control. The team is humans-only: never
+# an agent/bot, else an ADR-0055 agent approval would defeat the human-judgment property
+# (ADR 0135, amending 0071).
 #
 # This file is INERT until the `main` ruleset enables `require_code_owner_review`
 # (a human governance action — the Phase-3 ruleset flip after this PR merges; see


### PR DESCRIPTION
This PR cleans up the header comment at the top of `.github/CODEOWNERS`. The comment used to list the control-plane owners by individual GitHub login and describe it as "a two-human team," but that team now has more than two members — so the note was both stale and needlessly person-level. It now just says the owner is the `@kamp-us/control-plane` team, with no individual names and no headcount. Nothing about who actually owns which paths changes.

This is a comment-only edit: every `@kamp-us/control-plane` assignment line below the header is byte-for-byte untouched, so ownership behavior is identical before and after.

Note (§CP): the diff touches `.github/CODEOWNERS`, a control-plane path — so this is an approval-gated merge (ADR 0135), not an auto-ship, even though the change is comment-only. The path is what classifies it §CP, regardless of the diff being a comment.

Fixes #3521