### PR TITLE
chore(codeowners): reference @kamp-us/control-plane team only in §CP header comment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Control-plane: control-plane-team approval required (ADR 0053, 0065, 0071, 0135).
-# Owner is the @kamp-us/control-plane team (usirin + cansirin) — a two-human team so
-# `require_code_owner_review` is SATISFIABLE (a single operator cannot self-approve;
-# GitHub blocks self-approval, so a §CP PR needs the OTHER team member — a deliberate
-# two-person control). The team is humans-only: never an agent/bot, else an ADR-0055
-# agent approval would defeat the human-judgment property (ADR 0135, amending 0071).
+# Owner is the @kamp-us/control-plane team, so `require_code_owner_review` is SATISFIABLE
+# (a single operator cannot self-approve; GitHub blocks self-approval, so a §CP PR needs
+# ANOTHER team member — a deliberate multi-person control). The team is humans-only:
+# never an agent/bot, else an ADR-0055 agent approval would defeat the human-judgment
+# property (ADR 0135, amending 0071).
 #
 # This file is INERT until the `main` ruleset enables `require_code_owner_review`
 # (a human governance action — the Phase-3 ruleset flip after this PR merges; see


### PR DESCRIPTION
## What & why
Comment-only cleanup of the `.github/CODEOWNERS` control-plane header. The header named individual members and called the owner "a two-human team" — a stale count and a needless person-level detail in a committed artifact. Ownership is a team, so the comment now references the `@kamp-us/control-plane` team only: no individual logins, no member count. System behavior is identical before and after.

## Scope
- Edits **only** the header comment block (lines 2–6). Line 1 and every `@kamp-us/control-plane` ownership assignment row are **byte-for-byte unchanged** — the diff is 5 comment lines in / 5 out, all prefixed `#`.
- The rationale is preserved: `require_code_owner_review` is satisfiable because a single operator cannot self-approve, and the team is humans-only (an ADR-0055 agent approval would defeat the human-judgment property; ADR 0135, amending 0071).

## Verification
- `pipeline-cli codeowners-cp check` passes — all 22 §CP paths covered; the comment edit alters no covered-path row.
- Diff confirmed comment-only; no ownership assignment line changed.

## §CP note
This touches `.github/**`, a control-plane surface, so it is §CP regardless of being comment-only: it is **approval-gated at merge** by a `@kamp-us/control-plane` team member at the current head (ADR 0135) and does **not** auto-ship. Banked reviewed-ready for a human to carry to the approver.

Fixes #3521

🤖 Generated with [Claude Code](https://claude.com/claude-code)