### PR TITLE
feat(pipeline-cli): Tracker Effect service + GithubTrackerLive walking skeleton (claim + read-back)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -52,6 +52,7 @@ import {shipDigestCommand} from "./tools/ship-digest/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
 import {tokenSpendCommand} from "./tools/token-spend/command.ts";
+import {trackerCommand} from "./tools/tracker/command.ts";
 import {trivialDiffCommand} from "./tools/trivial-diff/command.ts";
 import {unresolvedThreadsGuardCommand} from "./tools/unresolved-threads-guard/command.ts";
 import {verdictCommand} from "./tools/verdict/command.ts";
@@ -118,6 +119,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	controlPlanePathsCommand,
 	cpCardinalityCommand,
 	tokenSpendCommand,
+	trackerCommand,
 	trivialDiffCommand,
 	classProbeCommand,
 	wayfinderMapCommand,

--- a/packages/pipeline-cli/src/tools/tracker/command.ts
+++ b/packages/pipeline-cli/src/tools/tracker/command.ts
@@ -1,0 +1,102 @@
+/**
+ * The `tracker` tool — `pipeline-cli tracker claim <target>` /
+ * `pipeline-cli tracker read-back <target>`.
+ *
+ * The seed surface of the Wave-1 `Tracker` service (ADR 0190): `claim` posts the ADR-0115
+ * agent-distinguishable claim and exits 0 only when the claim is ours; `read-back` resolves
+ * and prints the current owner. Judgment-as-parameter: the claiming identity is supplied,
+ * not decided by the tool — the session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only
+ * agent-distinguishable signal under the shared `usirin` login) and `--session` overrides it
+ * for the orchestrated/delegated-token path and for tests; an absent value fails closed.
+ *
+ * `GithubTrackerLive` is baked in with `Command.provide(...)` so the registered command's
+ * residual requirement is the Node platform union (the registry seam, epic #994).
+ */
+import {Console, Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {type ClaimResult, GithubTrackerLive, type ReadBackResult, Tracker} from "./tracker.ts";
+
+const BACKOFF_EXIT_CODE = 1;
+
+const targetArg = Argument.integer("target").pipe(
+	Argument.withDescription("the tracker entity (issue) number to claim / read back"),
+);
+
+const sessionFlag = Flag.string("session").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the claiming session id (default: $CLAUDE_CODE_SESSION_ID); the delegated token on the orchestrated path",
+	),
+);
+
+const resolveSession = (session: Option.Option<string>): string =>
+	Option.getOrElse(session, () => process.env.CLAUDE_CODE_SESSION_ID ?? "").trim();
+
+/** Print the back-off reason on stderr and exit non-zero — the "did not claim" signal. */
+const backOff = (reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stderr.write(`tracker: ${reason}\n`);
+		process.exit(BACKOFF_EXIT_CODE);
+	});
+
+const reportClaim = (target: number, result: ClaimResult): Effect.Effect<void> => {
+	switch (result._tag) {
+		case "claimed":
+			return Console.log(`tracker: claimed #${target} (session ${result.session}) — proceed.`);
+		case "held-by-other":
+			return backOff(
+				`#${target} is already claimed by another agent (session ${result.owner.session}, at ${result.owner.claimedAt}) — BACK OFF, do not mutate.`,
+			);
+		case "lost":
+			return backOff(
+				`lost the co-claim on #${target}` +
+					(result.owner !== null
+						? ` (earliest authorized claim is session ${result.owner.session})`
+						: " (our claim is not authorized — a write+ collaborator must post it)") +
+					" — BACK OFF, do not mutate.",
+			);
+	}
+};
+
+const claim = Command.make(
+	"claim",
+	{target: targetArg, session: sessionFlag},
+	Effect.fn(function* ({target, session}) {
+		const sessionId = resolveSession(session);
+		if (sessionId === "") {
+			return yield* backOff(
+				"no CLAUDE_CODE_SESSION_ID (and no --session) — cannot post an agent-distinguishable claim. BACK OFF, do not mutate.",
+			);
+		}
+		const result = yield* (yield* Tracker).claim(target, {session: sessionId});
+		yield* reportClaim(target, result);
+	}),
+).pipe(
+	Command.withDescription(
+		"Claim a tracker entity (exit 0 = held by us; non-zero = backed off, do not mutate)",
+	),
+);
+
+const reportReadBack = (target: number, result: ReadBackResult): Effect.Effect<void> =>
+	result._tag === "owned"
+		? Console.log(
+				`tracker: #${target} is claimed by session ${result.owner.session} (at ${result.owner.claimedAt}).`,
+			)
+		: Console.log(`tracker: #${target} is unclaimed.`);
+
+const readBack = Command.make(
+	"read-back",
+	{target: targetArg},
+	Effect.fn(function* ({target}) {
+		const result = yield* (yield* Tracker).readBack(target);
+		yield* reportReadBack(target, result);
+	}),
+).pipe(Command.withDescription("Read back and print the current claim owner of a tracker entity"));
+
+export const trackerCommand = Command.make("tracker").pipe(
+	Command.withSubcommands([claim, readBack]),
+	Command.withDescription(
+		"The crew tracker service (ADR 0190): claim a tracker entity + read back its owner",
+	),
+	Command.provide(GithubTrackerLive),
+);

--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -1,0 +1,344 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	GithubTrackerLive,
+	type RepoResolutionError,
+	Tracker,
+	TrackerNotImplementedError,
+} from "./tracker.ts";
+
+// The live layer resolves its repo lazily (ADR 0062 §1); pin the env override so the
+// fixtures keyed on `repos/kamp-us/phoenix/...` match without the ambient `gh repo view`.
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+const methodOf = (args: ReadonlyArray<string>): string => {
+	const i = args.indexOf("-X");
+	return i >= 0 ? (args[i + 1] ?? "GET") : "GET";
+};
+
+/**
+ * A `ChildProcessSpawner` answering `gh api` from a `${method} ${path}` fixture map
+ * (POST/GET/DELETE against the same REST path disambiguate by method). An unmapped key
+ * exits 1 (a not-found), the same shared shape the `epic-lock` github-service tests use.
+ */
+const mockSpawner = (
+	responses: Record<string, Response>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				const path = rawPath.replace(/\?.*$/, "");
+				const key = `${methodOf(args)} ${path}`;
+				const canned =
+					key in responses
+						? normalize(responses[key]!)
+						: {stdout: "", exitCode: 1, stderr: `not found: ${key}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Tracker>,
+	responses: Record<string, Response>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubTrackerLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const TARGET = 900;
+const P = `repos/kamp-us/phoenix`;
+const SID_MINE = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SID_OTHER = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const SID_FORGED = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const claimComment = (over: {
+	readonly id: number;
+	readonly login: string;
+	readonly session: string;
+	readonly at?: string;
+}) =>
+	({
+		id: over.id,
+		created_at: over.at ?? "2026-07-08T00:00:00Z",
+		user: {login: over.login},
+		body: `claim: ${over.session} · ${over.at ?? "2026-07-08T00:00:00Z"}`,
+	}) as const;
+
+describe("Tracker.claim — the ADR-0115 claim over a mock gh spawner", () => {
+	it.effect("no prior claim: we POST and our authorized claim is earliest → claimed", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.claim(TARGET, {session: SID_MINE});
+			assert.deepStrictEqual(result, {_tag: "claimed", session: SID_MINE});
+		}).pipe((effect) =>
+			provide(effect, {
+				// pre-check GET (empty), POST claim, checkpoint GET (our claim now present)
+				[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([
+					claimComment({id: 700, login: "usirin", session: SID_MINE}),
+				]),
+				[`POST ${P}/issues/${TARGET}/comments`]: "700",
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+			}),
+		),
+	);
+
+	it.effect(
+		"a pre-existing owner from another session → held-by-other (Rule 0, non-mutating)",
+		() =>
+			Effect.gen(function* () {
+				const tracker = yield* Tracker;
+				const result = yield* tracker.claim(TARGET, {session: SID_MINE});
+				assert.deepStrictEqual(result, {
+					_tag: "held-by-other",
+					owner: {session: SID_OTHER, claimedAt: "2026-07-08T00:00:00Z"},
+				});
+			}).pipe((effect) =>
+				provide(effect, {
+					[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([
+						claimComment({id: 500, login: "usirin", session: SID_OTHER}),
+					]),
+					[`GET ${P}/collaborators/usirin/permission`]: "write",
+				}),
+			),
+	);
+
+	it.effect("we already own it → claimed idempotently, no double-post", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.claim(TARGET, {session: SID_MINE});
+			assert.deepStrictEqual(result, {_tag: "claimed", session: SID_MINE});
+		}).pipe((effect) =>
+			provide(effect, {
+				// no POST fixture: an idempotent claim must NOT post a second comment
+				[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([
+					claimComment({id: 400, login: "usirin", session: SID_MINE}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+			}),
+		),
+	);
+
+	it.effect("lost co-race: an earlier authorized claim wins the checkpoint → lost + retract", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.claim(TARGET, {session: SID_MINE});
+			assert.deepStrictEqual(result, {
+				_tag: "lost",
+				owner: {session: SID_OTHER, claimedAt: "2026-07-08T00:00:01Z"},
+			});
+		}).pipe((effect) => {
+			let getCount = 0;
+			// pre-check sees no claim (we proceed to POST); the checkpoint GET then reveals an
+			// earlier authorized claim landed concurrently, so we lose and retract our own.
+			return effect.pipe(
+				Effect.provide(
+					GithubTrackerLive.pipe(
+						Layer.provide(
+							Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+								ChildProcessSpawner.make(
+									Effect.fnUntraced(function* (command) {
+										let cmd = command;
+										while (cmd._tag === "PipedCommand") cmd = cmd.left;
+										const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+										const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+										const path = rawPath.replace(/\?.*$/, "");
+										const method = methodOf(args);
+										let stdout = "";
+										let exitCode = 0;
+										if (method === "GET" && path === `${P}/issues/${TARGET}/comments`) {
+											getCount += 1;
+											stdout =
+												getCount === 1
+													? JSON.stringify([])
+													: JSON.stringify([
+															claimComment({
+																id: 500,
+																login: "usirin",
+																session: SID_OTHER,
+																at: "2026-07-08T00:00:01Z",
+															}),
+															claimComment({
+																id: 800,
+																login: "usirin",
+																session: SID_MINE,
+																at: "2026-07-08T00:00:02Z",
+															}),
+														]);
+										} else if (method === "POST" && path === `${P}/issues/${TARGET}/comments`) {
+											stdout = "800";
+										} else if (path === `${P}/collaborators/usirin/permission`) {
+											stdout = "write";
+										} else if (method === "DELETE" && path === `${P}/issues/comments/800`) {
+											stdout = "";
+										} else {
+											exitCode = 1;
+										}
+										return ChildProcessSpawner.makeHandle({
+											pid: ChildProcessSpawner.ProcessId(1),
+											stdin: Sink.drain,
+											stdout: Stream.fromIterable([enc.encode(stdout)]),
+											stderr: Stream.fromIterable([enc.encode("")]),
+											all: Stream.fromIterable([enc.encode(stdout)]),
+											exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+											isRunning: Effect.succeed(false),
+											kill: () => Effect.void,
+											getInputFd: () => Sink.drain,
+											getOutputFd: () => Stream.empty,
+											unref: Effect.succeed(Effect.void),
+										});
+									}),
+								),
+							),
+						),
+					),
+				),
+			);
+		}),
+	);
+
+	it.effect("a forged claim from a non-collaborator is ignored → our authorized claim wins", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.claim(TARGET, {session: SID_MINE});
+			assert.deepStrictEqual(result, {_tag: "claimed", session: SID_MINE});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([
+					// earliest, but forged (non-collaborator) — must be dropped before the tiebreak
+					claimComment({id: 10, login: "attacker", session: SID_FORGED}),
+					claimComment({
+						id: 900,
+						login: "usirin",
+						session: SID_MINE,
+						at: "2026-07-08T00:00:05Z",
+					}),
+				]),
+				[`POST ${P}/issues/${TARGET}/comments`]: "900",
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+				[`GET ${P}/collaborators/attacker/permission`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 404: Not Found",
+				},
+			}),
+		),
+	);
+});
+
+describe("Tracker.readBack — resolve the current owner", () => {
+	it.effect("an authorized claim present → owned", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.readBack(TARGET);
+			assert.deepStrictEqual(result, {
+				_tag: "owned",
+				owner: {session: SID_MINE, claimedAt: "2026-07-08T00:00:00Z"},
+			});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([
+					claimComment({id: 700, login: "usirin", session: SID_MINE}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+			}),
+		),
+	);
+
+	it.effect("no claim comments → unclaimed", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.readBack(TARGET);
+			assert.deepStrictEqual(result, {_tag: "unclaimed"});
+		}).pipe((effect) =>
+			provide(effect, {[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([])}),
+		),
+	);
+
+	it.effect("only a forged (non-collaborator) claim → unclaimed (fail-closed)", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.readBack(TARGET);
+			assert.deepStrictEqual(result, {_tag: "unclaimed"});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([
+					claimComment({id: 10, login: "attacker", session: SID_FORGED}),
+				]),
+				[`GET ${P}/collaborators/attacker/permission`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 404: Not Found",
+				},
+			}),
+		),
+	);
+});
+
+describe("Tracker — the declared-but-not-yet-built verbs fail closed", () => {
+	it.effect("applyTriage → TrackerNotImplementedError (never a silent no-op)", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const error = yield* Effect.flip(
+				tracker.applyTriage(TARGET, {type: "feature", priority: "p2"}),
+			);
+			assert.isTrue(error instanceof TrackerNotImplementedError);
+			assert.strictEqual(error.verb, "applyTriage");
+		}).pipe((effect) => provide(effect, {})),
+	);
+
+	it.effect("postVerdict → TrackerNotImplementedError", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const error = yield* Effect.flip(
+				tracker.postVerdict(TARGET, {gate: "review-code", passed: true, headRef: "deadbeef"}),
+			);
+			assert.isTrue(error instanceof TrackerNotImplementedError);
+			assert.strictEqual(error.verb, "postVerdict");
+		}).pipe((effect) => provide(effect, {})),
+	);
+
+	it.effect("graduate → TrackerNotImplementedError", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const error = yield* Effect.flip(tracker.graduate(TARGET, {stage: "triaged"}));
+			assert.isTrue(error instanceof TrackerNotImplementedError);
+			assert.strictEqual(error.verb, "graduate");
+		}).pipe((effect) => provide(effect, {})),
+	);
+});

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -1,0 +1,414 @@
+/**
+ * The `Tracker` service — the shared Effect capability over the crew's issue tracker
+ * surface (claims, triage, verdicts, graduation) with **domain-shaped** signatures.
+ *
+ * This is the walking skeleton of Wave 1 (epic #3258): a `Context.Service` `Tracker`
+ * tag plus its sole implementation `GithubTrackerLive`. It seeds one verb end to end —
+ * `claim` (the ADR-0115 agent-distinguishable claim) and a generic `readBack` — and
+ * *declares* the not-yet-built verbs (`applyTriage` / `postVerdict` / `graduate`) so the
+ * interface shape is complete before it locks; sibling Phase-3 children implement them.
+ *
+ * Two design rules bind every signature here and are the point of the skeleton:
+ *
+ *  - **Design against two backends, build one (ADR 0190).** `GithubTrackerLive` is the
+ *    only implementation now, but the interface must stay implementable over the two
+ *    downstream #3256 targets *without a reshape*: **Asana** (no sub-issues, no
+ *    GitHub-style label strings) and **local-markdown** (no ACL trust root). So no
+ *    signature carries a sub-issue id, a label string, or an ACL/REST idiom — those are
+ *    implementation details `GithubTrackerLive` hides. A `TargetId` is a bare domain
+ *    entity reference; a judgment carries the domain decision; a result carries a domain
+ *    owner (not a raw comment id). The GitHub ACL trust root (ADR 0055) lives entirely
+ *    inside the live impl, never in the interface — local-markdown has none.
+ *  - **Typed failures, never a throw (`.patterns/effect-errors.md`).** Every infra fault
+ *    is in the `E` channel — a non-zero `gh` exit is `GhCommandError`, malformed output
+ *    `GhParseError`, an unresolvable repo `RepoResolutionError`; untrusted REST JSON is
+ *    Schema-decoded at the boundary (`.patterns/effect-schema-validation.md`).
+ *
+ * The IO shell (`runGh` / `resolveRepo` / `authorizedAuthors`) mirrors the same idiom the
+ * `epic-lock` and `verdict` tools each carry (`epic-lock/github.ts`, `verdict/github.ts`);
+ * consolidating those consumers onto this one shared service is the same-commit-adoption
+ * follow-up (#3262 AC 5). The pure claim-resolution decision is reused from the existing
+ * IO-free, ADR-0040-tested core (`../epic-lock/claim-resolution.ts`) rather than
+ * re-derived — the single source of "who owns this claim" (gh-issue-intake-formats.md §7).
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {type ClaimComment, type ClaimWinner, resolveWinner} from "../epic-lock/claim-resolution.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/tracker/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/tracker/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/tracker/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/**
+ * A declared-but-not-yet-built verb was called. The skeleton ships `claim` + `readBack`
+ * live; `applyTriage` / `postVerdict` / `graduate` fail-closed with this typed error
+ * until a sibling Phase-3 child implements them — never a silent no-op or a throw.
+ */
+export class TrackerNotImplementedError extends Schema.TaggedErrorClass<TrackerNotImplementedError>()(
+	"@kampus/tracker/TrackerNotImplementedError",
+	{
+		verb: Schema.String,
+	},
+) {}
+
+/**
+ * A tracker entity reference — the domain id of the thing a verb acts on. Kept an opaque
+ * domain number so no backend's addressing leaks into a signature (ADR 0190): GitHub reads
+ * it as an issue number; an Asana/local-markdown adapter maps its own id at the boundary.
+ */
+export type TargetId = number;
+
+/** The resolved owner of a claim, domain-shaped: the winning session + when it claimed. */
+export interface ClaimOwner {
+	readonly session: string;
+	readonly claimedAt: string;
+}
+
+/** The agent-distinguishable claim decision (ADR 0115): who is claiming (the session id). */
+export interface ClaimJudgment {
+	readonly session: string;
+}
+
+/** The `claim` verdict — we own it, a pre-existing owner holds it, or we lost a co-race. */
+export type ClaimResult =
+	| {readonly _tag: "claimed"; readonly session: string}
+	| {readonly _tag: "held-by-other"; readonly owner: ClaimOwner}
+	| {readonly _tag: "lost"; readonly owner: ClaimOwner | null};
+
+/** The generic `readBack` verdict — the resolved owner, or that the target is unclaimed. */
+export type ReadBackResult =
+	| {readonly _tag: "owned"; readonly owner: ClaimOwner}
+	| {readonly _tag: "unclaimed"};
+
+// The declared (not-yet-built) verbs' domain judgments. Their exact shapes are owned by the
+// sibling Phase-3 children that implement them; declared here only so the interface is
+// complete before it locks (ADR 0190). Each stays domain-shaped — no label string, no
+// sub-issue id, no REST field — so a later Asana/local-markdown adapter needs no reshape.
+
+/** Triage classification: the domain type + priority a triage decision assigns. */
+export interface TriageJudgment {
+	readonly type: string;
+	readonly priority: string;
+}
+
+/** A gate verdict: which gate, whether it passed, and the head ref it is bound to. */
+export interface VerdictJudgment {
+	readonly gate: string;
+	readonly passed: boolean;
+	readonly headRef: string;
+}
+
+/** A lifecycle graduation: the stage the target moves to. */
+export interface GraduateJudgment {
+	readonly stage: string;
+}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the
+ * same direct-spawn shape `epic-lock`/`verdict` use so an exit code + stderr lower into a
+ * typed error rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` off PATH) folds
+ * into the same typed error as exit `-1`.
+ */
+const runGh = Effect.fn("Tracker.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Tracker.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
+ * defaults: with no env and no resolvable current repo it fails `RepoResolutionError`, so
+ * a foreign install can't accidentally operate on phoenix.
+ */
+const resolveRepo = Effect.fn("Tracker.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/tracker/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// REST-only arg builders — never GraphQL (broken on the kamp-us org).
+
+const listCommentsArgs = (repo: string, target: TargetId): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${target}/comments?per_page=100`,
+];
+
+const postClaimArgs = (repo: string, target: TargetId, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${target}/comments`,
+	"-f",
+	`body=${body}`,
+	"--jq",
+	".id",
+];
+
+const deleteCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"DELETE",
+	`repos/${repo}/issues/comments/${id}`,
+];
+
+const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/collaborators/${login}/permission`,
+	"--jq",
+	".permission",
+];
+
+/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
+const RawComment = Schema.Struct({
+	id: Schema.Number,
+	created_at: Schema.String,
+	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
+});
+const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+const toClaimComment = (raw: (typeof RawComment)["Type"]): ClaimComment => ({
+	id: raw.id,
+	author: raw.user?.login ?? "",
+	createdAt: raw.created_at,
+	body: raw.body ?? "",
+});
+
+const toOwner = (winner: ClaimWinner): ClaimOwner => ({
+	session: winner.session,
+	claimedAt: winner.createdAt,
+});
+
+const listClaimComments = Effect.fn("Tracker.listClaimComments")(function* (
+	repo: string,
+	target: TargetId,
+) {
+	const args = listCommentsArgs(repo, target);
+	const raw = yield* decodeComments(yield* json(args));
+	return raw.map(toClaimComment);
+});
+
+/**
+ * The write+ collaborator subset of `logins` — the ADR 0055 trust root, applied *inside*
+ * the live impl so it never leaks into the `Tracker` interface (local-markdown has no ACL).
+ * A non-`admin|maintain|write` permission, or any `gh` fault on the probe (a
+ * non-collaborator commonly 404s), drops the login — a forged claim never enters the set
+ * the pure core resolves over.
+ */
+const authorizedAuthors = Effect.fn("Tracker.authorizedAuthors")(function* (
+	repo: string,
+	logins: ReadonlyArray<string>,
+) {
+	const results = yield* Effect.forEach(
+		logins,
+		(login) =>
+			runGh(permissionArgs(repo, login)).pipe(
+				Effect.map((out) => ({login, permission: out.trim()})),
+				Effect.catchTag("@kampus/tracker/GhCommandError", () =>
+					Effect.succeed({login, permission: "none"}),
+				),
+			),
+		{concurrency: "unbounded"},
+	);
+	return results
+		.filter(
+			(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
+		)
+		.map((r) => r.login);
+});
+
+const resolveAuthorizedWinner = Effect.fn("Tracker.resolveAuthorizedWinner")(function* (
+	repo: string,
+	comments: ReadonlyArray<ClaimComment>,
+) {
+	const authors = [...new Set(comments.map((c) => c.author).filter((a) => a.length > 0))];
+	const authorized = yield* authorizedAuthors(repo, authors);
+	return resolveWinner(comments, authorized);
+});
+
+/**
+ * Claim `target` under `session` (ADR 0115). Rule-0 defer first: if an authorized claim
+ * from a *different* session already owns it, back off `held-by-other` without posting
+ * (a fresh arrival never evicts a pre-existing owner); if that owner is already us, return
+ * `claimed` idempotently rather than double-posting. Otherwise POST our claim comment and
+ * checkpoint-GET: we hold it only if the earliest authorized claim is ours, else retract
+ * our own claim and back off `lost` (never delete another agent's claim).
+ */
+const claim = Effect.fn("Tracker.claim")(function* (
+	repo: string,
+	target: TargetId,
+	session: string,
+) {
+	const mine = session.toLowerCase();
+	const before = yield* resolveAuthorizedWinner(repo, yield* listClaimComments(repo, target));
+	if (before !== null) {
+		return before.session === mine
+			? ({_tag: "claimed", session} satisfies ClaimResult)
+			: ({_tag: "held-by-other", owner: toOwner(before)} satisfies ClaimResult);
+	}
+	const now = new Date().toISOString();
+	const posted = yield* json(postClaimArgs(repo, target, `claim: ${session} · ${now}`));
+	const claimId = typeof posted === "number" ? posted : null;
+	const winner = yield* resolveAuthorizedWinner(repo, yield* listClaimComments(repo, target));
+	if (winner !== null && winner.session === mine) {
+		return {_tag: "claimed", session} satisfies ClaimResult;
+	}
+	if (claimId !== null) {
+		yield* runGh(deleteCommentArgs(repo, claimId)).pipe(Effect.ignore);
+	}
+	return {_tag: "lost", owner: winner !== null ? toOwner(winner) : null} satisfies ClaimResult;
+});
+
+/** Read back the current claim ownership of `target` — the verify leg of `claim`. */
+const readBack = Effect.fn("Tracker.readBack")(function* (repo: string, target: TargetId) {
+	const winner = yield* resolveAuthorizedWinner(repo, yield* listClaimComments(repo, target));
+	return winner !== null
+		? ({_tag: "owned", owner: toOwner(winner)} satisfies ReadBackResult)
+		: ({_tag: "unclaimed"} satisfies ReadBackResult);
+});
+
+type TrackerErrors = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
+
+/**
+ * `Tracker` — the shared crew tracker capability. `claim` and `readBack` are live; the
+ * three declared verbs fail `TrackerNotImplementedError` until a sibling child builds them
+ * (their success types are `never` by design — a not-yet-built verb produces no value).
+ * Built by `GithubTrackerLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Tracker extends Context.Service<
+	Tracker,
+	{
+		readonly claim: (
+			target: TargetId,
+			judgment: ClaimJudgment,
+		) => Effect.Effect<ClaimResult, TrackerErrors>;
+		readonly readBack: (target: TargetId) => Effect.Effect<ReadBackResult, TrackerErrors>;
+		readonly applyTriage: (
+			target: TargetId,
+			judgment: TriageJudgment,
+		) => Effect.Effect<never, TrackerNotImplementedError>;
+		readonly postVerdict: (
+			target: TargetId,
+			judgment: VerdictJudgment,
+		) => Effect.Effect<never, TrackerNotImplementedError>;
+		readonly graduate: (
+			target: TargetId,
+			judgment: GraduateJudgment,
+		) => Effect.Effect<never, TrackerNotImplementedError>;
+	}
+>()("@kampus/tracker/Tracker") {}
+
+const notImplemented = (verb: string): Effect.Effect<never, TrackerNotImplementedError> =>
+	new TrackerNotImplementedError({verb});
+
+/**
+ * The live `Tracker` layer over `gh api` REST. The `ChildProcessSpawner` dependency is
+ * captured once at construction and provided into each method body, so the public methods
+ * carry `R = never`. Repo resolution is deferred to first use (`Effect.cached`, ADR 0062
+ * §1): the layer build is side-effect-free, and `RepoResolutionError` lives in each verb's
+ * `E` channel, raised only when a verb actually reads or mutates.
+ */
+export const GithubTrackerLive: Layer.Layer<
+	Tracker,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> = Layer.effect(Tracker)(
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const withSpawner = <A, E>(
+			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+		const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+		return {
+			claim: (target, judgment) =>
+				repo.pipe(Effect.flatMap((r) => withSpawner(claim(r, target, judgment.session)))),
+			readBack: (target) => repo.pipe(Effect.flatMap((r) => withSpawner(readBack(r, target)))),
+			applyTriage: () => notImplemented("applyTriage"),
+			postVerdict: () => notImplemented("postVerdict"),
+			graduate: () => notImplemented("graduate"),
+		};
+	}),
+);


### PR DESCRIPTION
This lands the foundation for the deterministic-crew-mechanics Wave 1 (epic #3258): a shared `Tracker` Effect service that every later crew verb will extend, plus its one GitHub-backed implementation. It ships a single verb end to end — `claim` (post an agent-distinguishable claim and check it back) — proving the pattern before the interface locks. Anyone can drive it from the CLI: `pipeline-cli tracker claim <n>` / `pipeline-cli tracker read-back <n>`.

## What changed
- **`Tracker` `Context.Service` tag + `GithubTrackerLive` layer** (`packages/pipeline-cli/src/tools/tracker/tracker.ts`) — the sole implementation now. `claim` + `readBack` are live; `applyTriage` / `postVerdict` / `graduate` are **declared** so the interface is complete before it locks, and fail closed with a typed `TrackerNotImplementedError` until a sibling Phase-3 child builds them.
- **`pipeline-cli tracker` command** (`.../tracker/command.ts`) with judgment-as-parameter: the claiming session id is supplied (`--session`, default `$CLAUDE_CODE_SESSION_ID`), not decided by the tool. Registered in `registry.ts`.
- **Behavior tests** (`.../tracker/tracker.behavior.test.ts`, 11 cases) over a mock `gh` spawner: claim won / held-by-other (Rule-0 defer) / idempotent / lost-and-retract / forged-dropped; read-back owned / unclaimed / forged-dropped; and each declared verb failing closed.

## Design invariants (ADR 0190 — design against two backends, build one)
- **No GitHub semantics in any signature** — no sub-issue id, no label string, no REST idiom. A `TargetId` is a bare domain entity ref; judgments carry the domain decision; results carry a domain owner, not a raw comment id. The ADR-0055 ACL trust root lives entirely inside `GithubTrackerLive`, never in the interface. This keeps the interface implementable over #3256's Asana (no sub-issues / no label strings) and local-markdown (no ACL trust root) targets **without a reshape** — the portability design-check AC, recorded in ADR 0190.
- **Typed failures, never a throw** — every infra fault is in the `E` channel (`GhCommandError` / `GhParseError` / `RepoResolutionError`); untrusted REST JSON is Schema-decoded at the boundary. The pure claim-resolution decision is reused from the existing ADR-0040-tested core (`epic-lock/claim-resolution.ts`), not re-derived.

## Deferred (AC 5 — the sanctioned follow-up path)
Same-commit adoption of the claim/gh-IO consumers and the adoption lint are deferred to **#3572**: `epic-lock`'s `acquire` is a distinct verb (planning-lock + claim) on the gate-critical §CP path and deserves its own reviewed migration, and the adoption lint (the #3254 seam) does not exist yet.

§CP note: touches `packages/pipeline-cli/` — likely a §CP merge path per the issue; this stops at reviewed-ready.

Fixes #3262