### PR TITLE
feat(pipeline-cli): adoption corpus-lint — flag inline re-derivations of tool-owned decisions, fail-closed in CI (#3261)

### DIFF
--- a/.github/workflows/adoption-lint.yml
+++ b/.github/workflows/adoption-lint.yml
@@ -1,0 +1,56 @@
+name: adoption-lint
+
+# The #3254 adoption corpus-lint (epic #3258, governing AC): reds a crew-corpus file
+# that inline-re-derives a tool-owned decision — the hand-copied ~50-line procedure that
+# duplicates a shipped `pipeline-cli` verb's logic — instead of citing the owning verb.
+# It lands FIRST so the verb-extraction sweep cannot grow the unreferenced-tool pile
+# (the `verdict read` divergent-copy class, #3254 / #2102). The match logic + the declared
+# decisions/exemptions live once in the tool (adoption-lint.ts / manifest.ts), never
+# re-grepped here.
+#
+# Scans the FULL corpus (not just changed files) so a re-derivation anywhere is caught
+# regardless of which PR introduced it, and FAILS CLOSED on zero scope per ADR 0092: a
+# lint that scanned nothing, or a manifest with no decision, is a broken lint (exit 3).
+# The corpus is the plugin's skills/** + agents/** (all .md/.sh) PLUS the orchestrator
+# runtime surface .claude/workflows/drive-issue.js — the sole declared mirror, in scope so
+# its exemption is itself linted (it must exist, not a blanket skip).
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: lint crew corpus for inline re-derivations of tool-owned decisions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Hand the CLI the whole corpus: every .md/.sh under the plugin dir plus the
+      # orchestrator's drive-issue.js (the declared mirror, in scope so its exemption is
+      # linted). The tool self-scopes against the manifest and fails closed (exit 3) on an
+      # empty corpus or an empty decision set (ADR 0092).
+      - name: Lint crew corpus for un-cited re-derivations
+        run: |
+          set -euo pipefail
+          {
+            find claude-plugins/kampus-pipeline -type f \( -name '*.md' -o -name '*.sh' \)
+            [ -f .claude/workflows/drive-issue.js ] && echo .claude/workflows/drive-issue.js
+          } | sort -u \
+            | xargs node packages/pipeline-cli/src/bin.ts adoption-lint check

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -12,6 +12,7 @@
  */
 import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
+import {adoptionLintCommand} from "./tools/adoption-lint/command.ts";
 import {campaignCommand} from "./tools/campaign/command.ts";
 import {catalogGuardCommand} from "./tools/catalog-guard/command.ts";
 import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
@@ -145,4 +146,8 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// reds a PR when a substantive unresolved review thread is unaccounted-for in the
 	// review-code verdict, covering the §CP manual-merge path ship-it Step 3.6 never sees.
 	unresolvedThreadsGuardCommand,
+	// The #3254 adoption corpus-lint (epic #3258, governing AC): reds a corpus file that
+	// inline-re-derives a tool-owned decision without citing the owning verb, so the verb
+	// sweep can't grow the unreferenced-tool pile. Fail-closed on zero scope (ADR 0092).
+	adoptionLintCommand,
 ];

--- a/packages/pipeline-cli/src/tools/adoption-lint/adoption-lint.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/adoption-lint.ts
@@ -1,0 +1,209 @@
+/**
+ * `adoption-lint` core — the pure, IO-free matcher behind the #3254 adoption
+ * corpus-lint. It flags a crew-corpus file (a SKILL.md, an agent def, an
+ * orchestrator surface) that **inline-re-derives a tool-owned decision** — the
+ * hand-copied ~50-line procedure that duplicates a shipped `pipeline-cli` verb's
+ * logic — **instead of citing the owning verb**. This is the governing AC of epic
+ * #3258: the lint lands FIRST so the verb-extraction sweep cannot grow the
+ * unreferenced-tool pile (the `verdict read` / `merge-queue-classify` divergent-copy
+ * class named in #3254 / #2102).
+ *
+ * A finding = a corpus file that matches a decision's re-derivation `signature`
+ * AND does NOT match its `citation` AND is not covered by a declared exemption.
+ * The declared exemptions are themselves linted (never a blanket skip, #3254):
+ *  - a `mirror` exemption admits a genuinely non-importable execution surface
+ *    (`.claude/workflows/drive-issue.js` cannot import the verb core at runtime);
+ *    the lint verifies it exists in scope AND is structurally non-importable (not a
+ *    `.md` doc, which has no excuse — it can cite the verb by contract).
+ *  - a `grandfathered` exemption records an EXISTING re-derivation awaiting its
+ *    sibling verb-child's same-commit migration; the lint verifies it *still*
+ *    re-derives-without-citing, so once migrated the entry goes stale and FAILS,
+ *    forcing its removal — the pile draws down and cannot silently rot.
+ *
+ * Fail-closed on zero scope (ADR 0092): the caller pairs this with `isZeroScope`,
+ * which reports when no corpus file was scanned OR the manifest declares no
+ * decision — either is a broken lint, a FAIL, never a silent PASS. The IO (reading
+ * the corpus files) is the caller's; contents are handed in, keeping this core
+ * pure and unit-testable. Signatures are non-global `RegExp`s used only with
+ * `.test()`, so there is no shared-`lastIndex` statefulness to reset.
+ */
+
+/** A decision a registered `pipeline-cli` verb owns, and how to detect an inline copy of it. */
+export interface OwnedDecision {
+	/** The owning verb selector, e.g. `verdict read` — what a compliant file cites. */
+	readonly verb: string;
+	/**
+	 * The re-derivation fingerprint: EVERY pattern must match the file (AND
+	 * semantics) for it to count as an inline copy of the verb's procedure. An
+	 * array (not one regex) so a fingerprint is the co-occurrence of several tells
+	 * — precise enough that an incidental mention of one tell isn't a false finding.
+	 */
+	readonly signature: ReadonlyArray<RegExp>;
+	/** What counts as citing the verb by contract — a match here clears the file. */
+	readonly citation: RegExp;
+	/** Why a signature-match-without-citation is a re-derivation (the report line). */
+	readonly reason: string;
+}
+
+/** A declared, self-linted exemption from a re-derivation finding (never a blanket skip). */
+export type Exemption =
+	| {
+			/** A genuinely non-importable execution surface, verb-agnostic (it mirrors whatever it must). */
+			readonly kind: "mirror";
+			readonly path: string;
+			readonly reason: string;
+	  }
+	| {
+			/** An EXISTING re-derivation of one verb, awaiting its sibling child's same-commit migration. */
+			readonly kind: "grandfathered";
+			readonly path: string;
+			readonly verb: string;
+			readonly reason: string;
+	  };
+
+export interface ScanFile {
+	readonly file: string;
+	readonly content: string;
+}
+
+/** A corpus file that inline-re-derives a tool-owned decision without citing the verb. */
+export interface AdoptionFinding {
+	readonly file: string;
+	readonly verb: string;
+	readonly reason: string;
+}
+
+/** A declared exemption that failed its own lint (stale / unjustified) — never a silent skip. */
+export interface ExemptionFinding {
+	readonly path: string;
+	readonly kind: Exemption["kind"];
+	readonly reason: string;
+}
+
+export interface AdoptionResult {
+	/** Re-derivation-without-citation findings across the corpus. */
+	readonly findings: ReadonlyArray<AdoptionFinding>;
+	/** Declared exemptions that failed their own lint (stale mirror / migrated grandfather). */
+	readonly exemptionFindings: ReadonlyArray<ExemptionFinding>;
+	/** Every corpus file the lint considered — its scope (ADR 0092). */
+	readonly scanned: ReadonlyArray<string>;
+	/** Files a valid exemption cleared (reported for observability, not a failure). */
+	readonly exempted: ReadonlyArray<string>;
+	/** The number of tool-owned decisions the manifest declares — zero is a broken scope. */
+	readonly decisionCount: number;
+}
+
+const normalize = (path: string): string => `/${path.replace(/\\/g, "/").replace(/^\/+/, "")}`;
+
+/** A path matches an exemption/decision path when it ends with the declared (normalized) suffix. */
+const pathMatches = (file: string, declared: string): boolean =>
+	normalize(file).endsWith(normalize(declared));
+
+/** A `.md` is importable-by-citation: it can name the verb by contract, so it can never be a mirror. */
+export const isImportableDoc = (path: string): boolean => normalize(path).endsWith(".md");
+
+/** True iff the file inline-re-derives the decision (every signature tell matches) and never cites it. */
+export const isReDerivedWithoutCitation = (content: string, decision: OwnedDecision): boolean =>
+	decision.signature.every((re) => re.test(content)) && !decision.citation.test(content);
+
+/**
+ * The exemption (if any) that clears `file` for `verb`: a verb-agnostic `mirror`
+ * whose path matches, or a `grandfathered` entry for exactly this verb whose path
+ * matches. A grandfather for a *different* verb does not clear this one.
+ */
+export const exemptionFor = (
+	file: string,
+	verb: string,
+	exemptions: ReadonlyArray<Exemption>,
+): Exemption | null =>
+	exemptions.find((e) => pathMatches(file, e.path) && (e.kind === "mirror" || e.verb === verb)) ??
+	null;
+
+/** Lint one declared exemption in isolation — returns the finding when it fails its own lint. */
+const lintExemption = (
+	exemption: Exemption,
+	files: ReadonlyArray<ScanFile>,
+	decisions: ReadonlyArray<OwnedDecision>,
+): ExemptionFinding | null => {
+	const target = files.find((f) => pathMatches(f.file, exemption.path));
+	if (target === undefined) {
+		return {
+			path: exemption.path,
+			kind: exemption.kind,
+			reason: `declared ${exemption.kind} exemption names a file not in scope — stale, remove it`,
+		};
+	}
+	if (exemption.kind === "mirror") {
+		// The carve-out is only for genuinely non-importable execution surfaces; a doc can cite.
+		if (isImportableDoc(exemption.path)) {
+			return {
+				path: exemption.path,
+				kind: exemption.kind,
+				reason:
+					"mirror exemption must be a non-importable execution surface — a .md doc can cite the verb by contract, so it has no excuse",
+			};
+		}
+		return null;
+	}
+	// grandfathered: it must STILL genuinely re-derive its verb without citing — else the sibling
+	// migration already fixed it and this entry is stale, so fail to force its removal (#3254).
+	const decision = decisions.find((d) => d.verb === exemption.verb);
+	if (decision === undefined) {
+		return {
+			path: exemption.path,
+			kind: exemption.kind,
+			reason: `grandfathers verb '${exemption.verb}' but no decision in the manifest owns it`,
+		};
+	}
+	if (!isReDerivedWithoutCitation(target.content, decision)) {
+		return {
+			path: exemption.path,
+			kind: exemption.kind,
+			reason: `grandfathered re-derivation of '${exemption.verb}' is gone (migrated, or the file now cites the verb) — remove this stale entry so the pile draws down`,
+		};
+	}
+	return null;
+};
+
+/**
+ * Scan the handed-in corpus for inline re-derivations of tool-owned decisions, and
+ * lint the declared exemptions themselves. Returns findings, exemption findings,
+ * and the two scopes the caller fails-closed on (ADR 0092).
+ */
+export const lintAdoption = (
+	files: ReadonlyArray<ScanFile>,
+	decisions: ReadonlyArray<OwnedDecision>,
+	exemptions: ReadonlyArray<Exemption>,
+): AdoptionResult => {
+	const scanned: string[] = [];
+	const exempted: string[] = [];
+	const findings: AdoptionFinding[] = [];
+
+	for (const {file, content} of files) {
+		scanned.push(file);
+		for (const decision of decisions) {
+			if (!isReDerivedWithoutCitation(content, decision)) continue;
+			if (exemptionFor(file, decision.verb, exemptions) !== null) {
+				exempted.push(file);
+				continue;
+			}
+			findings.push({file, verb: decision.verb, reason: decision.reason});
+		}
+	}
+
+	const exemptionFindings: ExemptionFinding[] = [];
+	for (const exemption of exemptions) {
+		const finding = lintExemption(exemption, files, decisions);
+		if (finding !== null) exemptionFindings.push(finding);
+	}
+
+	return {findings, exemptionFindings, scanned, exempted, decisionCount: decisions.length};
+};
+
+/**
+ * Zero-scope test (ADR 0092): a lint that looked at NO corpus file, or a manifest
+ * that declares NO decision, protects nothing — a FAIL, never a silent PASS. The
+ * caller maps `true` to a distinct non-zero exit.
+ */
+export const isZeroScope = (result: AdoptionResult): boolean =>
+	result.scanned.length === 0 || result.decisionCount === 0;

--- a/packages/pipeline-cli/src/tools/adoption-lint/adoption-lint.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/adoption-lint.unit.test.ts
@@ -1,0 +1,150 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type Exemption,
+	isReDerivedWithoutCitation,
+	isZeroScope,
+	lintAdoption,
+	type OwnedDecision,
+	type ScanFile,
+} from "./adoption-lint.ts";
+
+// A representative tool-owned decision: the `verdict read` fingerprint is the
+// co-occurrence of the gate-marker regex, the write+ ACL loop, and a latest-wins
+// resolution; a compliant file cites `pipeline-cli verdict`.
+const VERDICT: OwnedDecision = {
+	verb: "verdict read",
+	signature: [/review-\((?:code|doc|skill)/, /collaborators\//, /sort_by\(|\blast\b/],
+	citation: /pipeline-cli\s+verdict\b/,
+	reason: "re-derives the verdict-marker resolution `pipeline-cli verdict read` owns",
+};
+
+// A file that hand-copies the whole procedure inline (all three tells present).
+const RE_DERIVATION = [
+	"gh api repos/$REPO/issues/$PR/comments",
+	"  --jq '.[] | select(.body | test(\"review-(code|doc|skill): (PASS|FAIL)\"))'",
+	"perm=$(gh api repos/$REPO/collaborators/$a/permission --jq .permission)",
+	"latest=$(echo \"$markers\" | jq 'sort_by(.created_at) | last')",
+].join("\n");
+
+// The same procedure, but the file cites the owning verb by contract.
+const CITES = `${RE_DERIVATION}\n# see \`pipeline-cli verdict read --pr N --gate g\` — the owning verb`;
+
+// Only one tell present — an incidental mention, not a full re-derivation.
+const INCIDENTAL = "a note about a review-(code|doc) marker, nothing else";
+
+describe("isReDerivedWithoutCitation — the AND-of-tells fingerprint", () => {
+	it("is true when every signature tell matches and the verb is not cited", () => {
+		assert.isTrue(isReDerivedWithoutCitation(RE_DERIVATION, VERDICT));
+	});
+
+	it("is false when the file cites the owning verb by contract", () => {
+		assert.isFalse(isReDerivedWithoutCitation(CITES, VERDICT));
+	});
+
+	it("is false when only some tells match (an incidental mention, not a copy)", () => {
+		assert.isFalse(isReDerivedWithoutCitation(INCIDENTAL, VERDICT));
+	});
+});
+
+describe("lintAdoption — findings, exemptions, zero scope", () => {
+	it("flags a corpus file that inline-re-derives a tool-owned decision without citing it", () => {
+		const files: ScanFile[] = [{file: "skills/a/SKILL.md", content: RE_DERIVATION}];
+		const result = lintAdoption(files, [VERDICT], []);
+		assert.lengthOf(result.findings, 1);
+		assert.strictEqual(result.findings[0]?.verb, "verdict read");
+		assert.deepStrictEqual(result.scanned, ["skills/a/SKILL.md"]);
+	});
+
+	it("passes a file that cites the verb by contract", () => {
+		const files: ScanFile[] = [{file: "skills/b/SKILL.md", content: CITES}];
+		const result = lintAdoption(files, [VERDICT], []);
+		assert.lengthOf(result.findings, 0);
+		assert.lengthOf(result.exemptionFindings, 0);
+	});
+
+	it("clears a re-derivation covered by a valid grandfathered exemption, and reports it as exempted", () => {
+		const files: ScanFile[] = [{file: "skills/heal-ci/SKILL.md", content: RE_DERIVATION}];
+		const exemptions: Exemption[] = [
+			{
+				kind: "grandfathered",
+				path: "skills/heal-ci/SKILL.md",
+				verb: "verdict read",
+				reason: "existing copy — migrate with #3265",
+			},
+		];
+		const result = lintAdoption(files, [VERDICT], exemptions);
+		assert.lengthOf(result.findings, 0);
+		assert.lengthOf(result.exemptionFindings, 0);
+		assert.deepStrictEqual(result.exempted, ["skills/heal-ci/SKILL.md"]);
+	});
+
+	it("fails a grandfathered exemption that no longer re-derives (migrated) — forces its removal", () => {
+		// The file now cites the verb, so the grandfather entry is stale.
+		const files: ScanFile[] = [{file: "skills/heal-ci/SKILL.md", content: CITES}];
+		const exemptions: Exemption[] = [
+			{
+				kind: "grandfathered",
+				path: "skills/heal-ci/SKILL.md",
+				verb: "verdict read",
+				reason: "existing copy — migrate with #3265",
+			},
+		];
+		const result = lintAdoption(files, [VERDICT], exemptions);
+		assert.lengthOf(result.findings, 0);
+		assert.lengthOf(result.exemptionFindings, 1);
+		assert.strictEqual(result.exemptionFindings[0]?.kind, "grandfathered");
+	});
+
+	it("admits a mirror only for a non-importable execution surface, not a .md doc", () => {
+		const files: ScanFile[] = [
+			{file: ".claude/workflows/drive-issue.js", content: RE_DERIVATION},
+			{file: "skills/x/SKILL.md", content: RE_DERIVATION},
+		];
+		const good: Exemption[] = [
+			{kind: "mirror", path: ".claude/workflows/drive-issue.js", reason: "non-importable"},
+		];
+		const goodResult = lintAdoption(files, [VERDICT], good);
+		// the .js mirror clears its finding; the .md still reds (no exemption)
+		assert.lengthOf(goodResult.exemptionFindings, 0);
+		assert.deepStrictEqual(
+			goodResult.findings.map((f) => f.file),
+			["skills/x/SKILL.md"],
+		);
+
+		const bad: Exemption[] = [
+			{kind: "mirror", path: "skills/x/SKILL.md", reason: "a doc cannot be a mirror"},
+		];
+		const badResult = lintAdoption(files, [VERDICT], bad);
+		assert.lengthOf(badResult.exemptionFindings, 1);
+		assert.strictEqual(badResult.exemptionFindings[0]?.kind, "mirror");
+	});
+
+	it("fails a declared exemption that names a file not in scope (stale path)", () => {
+		const files: ScanFile[] = [{file: "skills/present/SKILL.md", content: CITES}];
+		const exemptions: Exemption[] = [
+			{kind: "mirror", path: ".claude/workflows/gone.js", reason: "moved away"},
+		];
+		const result = lintAdoption(files, [VERDICT], exemptions);
+		assert.lengthOf(result.exemptionFindings, 1);
+		assert.include(result.exemptionFindings[0]?.reason ?? "", "not in scope");
+	});
+});
+
+describe("isZeroScope — fail closed on either empty axis (ADR 0092)", () => {
+	it("is true when no corpus file was scanned", () => {
+		const result = lintAdoption([], [VERDICT], []);
+		assert.isTrue(isZeroScope(result));
+	});
+
+	it("is true when the manifest declares no decision", () => {
+		const files: ScanFile[] = [{file: "skills/a/SKILL.md", content: CITES}];
+		const result = lintAdoption(files, [], []);
+		assert.isTrue(isZeroScope(result));
+	});
+
+	it("is false when both axes are non-empty", () => {
+		const files: ScanFile[] = [{file: "skills/a/SKILL.md", content: CITES}];
+		const result = lintAdoption(files, [VERDICT], []);
+		assert.isFalse(isZeroScope(result));
+	});
+});

--- a/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/command.test.ts
@@ -1,0 +1,106 @@
+import {execFile} from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+// The fail-closed exit contract of `pipeline-cli adoption-lint check` over the shared bin.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+// Repo root: this file is packages/pipeline-cli/src/tools/adoption-lint/command.test.ts.
+const REPO_ROOT = fileURLToPath(new URL("../../../../../", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (args: ReadonlyArray<string>): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile("node", [BIN, "adoption-lint", ...args], (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+	});
+
+// A full inline re-derivation of the seeded `verdict read` decision (all three tells),
+// with no `pipeline-cli verdict` citation — the finding case.
+const RE_DERIVATION = [
+	'select(.body | test("review-(code|doc|skill): (PASS|FAIL)"))',
+	"gh api repos/$REPO/collaborators/$a/permission",
+	"jq 'sort_by(.created_at) | last'",
+].join("\n");
+
+// The full live corpus the adoption-lint.yml job scans: every .md/.sh under the plugin
+// dir plus the orchestrator's drive-issue.js (the declared mirror).
+const corpusFiles = (): string[] => {
+	const out: string[] = [];
+	const walk = (dir: string): void => {
+		for (const entry of readdirSync(dir, {withFileTypes: true})) {
+			const abs = join(dir, entry.name);
+			if (statSync(abs).isDirectory()) walk(abs);
+			else if (/\.(?:md|sh)$/.test(entry.name)) out.push(abs);
+		}
+	};
+	walk(join(REPO_ROOT, "claude-plugins", "kampus-pipeline"));
+	const orchestrator = join(REPO_ROOT, ".claude", "workflows", "drive-issue.js");
+	if (existsSync(orchestrator)) out.push(orchestrator);
+	return out;
+};
+
+describe("adoption-lint check — fail-closed exit contract (ADR 0092)", () => {
+	let dir: string;
+	const writeCorpus = (name: string, content: string): string => {
+		const d = join(dir, "skills", name);
+		mkdirSync(d, {recursive: true});
+		const p = join(d, "SKILL.md");
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "adoption-lint-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("exits 2 and reports the finding on an un-cited re-derivation", async () => {
+		const f = writeCorpus("dirty", RE_DERIVATION);
+		const {code, stdout, stderr} = await run(["check", f]);
+		assert.strictEqual(code, 2);
+		assert.include(stdout, "scanned 1 corpus file");
+		assert.include(stderr, "inline re-derivation");
+	}, 30_000);
+
+	// The green-corpus assertion CI depends on: over the FULL live corpus (the exact set
+	// the adoption-lint.yml job hands the tool), the seeded manifest is clean — every
+	// re-derivation is either cited or covered by a valid declared exemption. This is what
+	// lets the lint land green while armed against new drift; a migrated grandfather entry
+	// or a new un-cited re-derivation would flip it to exit 2 here.
+	it("exits 0 over the full live corpus (the CI scope)", async () => {
+		const corpus = corpusFiles();
+		assert.isAbove(corpus.length, 1, "expected a non-empty live corpus");
+		const {code, stdout, stderr} = await run(["check", ...corpus]);
+		assert.strictEqual(code, 0, `adoption-lint red on the live corpus:\n${stdout}\n${stderr}`);
+		assert.include(stdout, "clean");
+	}, 60_000);
+
+	it("exits 3 (zero-scope FAIL) when every handed file is unreadable/missing", async () => {
+		const {code, stderr} = await run(["check", join(dir, "does-not-exist.md")]);
+		assert.strictEqual(code, 3);
+		assert.include(stderr, "zero scope");
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/adoption-lint/command.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/command.ts
@@ -1,0 +1,126 @@
+/**
+ * The `adoption-lint` tool — `pipeline-cli adoption-lint check <file>…`.
+ *
+ * The #3254 adoption corpus-lint: flags a crew-corpus file that inline-re-derives a
+ * tool-owned decision instead of citing the owning `pipeline-cli` verb, the governing
+ * AC of epic #3258 (it lands first so the verb sweep can't grow the unreferenced-tool
+ * pile). Follows the `gh-phoenix lint-skills` shape — an IO-free core (`lintAdoption`)
+ * over a declared manifest, with a thin CLI that reads the handed corpus files and
+ * maps the verdict to a fail-closed exit contract (ADR 0092):
+ *
+ *   exit 0 — clean (no un-cited re-derivations, every declared exemption valid)
+ *   exit 2 — one or more findings (a re-derivation OR a stale/unjustified exemption)
+ *   exit 3 — zero scope (no corpus file scanned OR no decision declared)
+ *
+ * The exit mapping is caught inside this handler (not at the shared bin's run
+ * boundary, which provides only `NodeServices.layer` and no per-tool catch), so the
+ * contract survives the fold into `pipeline-cli` — mirrors `gh-phoenix` / `decisions-index`.
+ */
+import {readFileSync} from "node:fs";
+import {Console, Effect, Result} from "effect";
+import * as Schema from "effect/Schema";
+import {Argument, Command} from "effect/unstable/cli";
+import {type AdoptionResult, isZeroScope, lintAdoption, type ScanFile} from "./adoption-lint.ts";
+import {DECISIONS, EXEMPTIONS} from "./manifest.ts";
+
+const FINDING_EXIT_CODE = 2;
+const ZERO_SCOPE_EXIT_CODE = 3;
+
+class FindingsFound extends Schema.TaggedErrorClass<FindingsFound>()("FindingsFound", {
+	count: Schema.Number,
+}) {}
+class ZeroScope extends Schema.TaggedErrorClass<ZeroScope>()("ZeroScope", {}) {}
+
+const readFileOrSkip = (file: string): string | null =>
+	Result.getOrElse(
+		Result.try(() => readFileSync(file, "utf8")),
+		() => null,
+	);
+
+const fileArg = Argument.string("file").pipe(
+	Argument.atLeast(1),
+	Argument.withDescription(
+		"one or more crew-corpus file paths (SKILL.md / agent defs / orchestrator surfaces) to lint for inline re-derivations of tool-owned decisions",
+	),
+);
+
+/** The lint verdict: zero scope → ZeroScope, any finding → FindingsFound, else clean. */
+const judge = (result: AdoptionResult): Effect.Effect<void, ZeroScope | FindingsFound> =>
+	Effect.gen(function* () {
+		// ADR 0092: zero scope is a FAIL, never a silent PASS.
+		if (isZeroScope(result)) {
+			yield* Console.error(
+				`adoption-lint: FAIL — scanned ${result.scanned.length} file(s) against ${result.decisionCount} declared decision(s); a zero scope on either axis is fail-closed (ADR 0092).`,
+			);
+			return yield* Effect.fail(new ZeroScope());
+		}
+
+		const total = result.findings.length + result.exemptionFindings.length;
+		if (total === 0) {
+			yield* Console.log(
+				"adoption-lint: clean — no un-cited re-derivations of a tool-owned decision, and every declared exemption is valid.",
+			);
+			return;
+		}
+
+		if (result.findings.length > 0) {
+			yield* Console.error(
+				`adoption-lint: FAIL — ${result.findings.length} inline re-derivation(s) of a tool-owned decision that never cite the owning verb (#3254):`,
+			);
+			for (const f of result.findings) {
+				yield* Console.error(`  ${f.file}: ${f.reason}`);
+			}
+		}
+
+		if (result.exemptionFindings.length > 0) {
+			yield* Console.error(
+				`adoption-lint: FAIL — ${result.exemptionFindings.length} declared exemption(s) failed their own lint (stale or unjustified — #3254 forbids a blanket skip):`,
+			);
+			for (const f of result.exemptionFindings) {
+				yield* Console.error(`  [${f.kind}] ${f.path}: ${f.reason}`);
+			}
+		}
+
+		return yield* Effect.fail(new FindingsFound({count: total}));
+	});
+
+const onZeroScope = (_e: ZeroScope) => Effect.sync(() => process.exit(ZERO_SCOPE_EXIT_CODE));
+const onFindingsFound = (_e: FindingsFound) => Effect.sync(() => process.exit(FINDING_EXIT_CODE));
+
+const check = Command.make(
+	"check",
+	{files: fileArg},
+	Effect.fn(function* ({files}) {
+		const scanInput: ScanFile[] = [];
+		for (const file of files) {
+			const content = readFileOrSkip(file);
+			if (content !== null) scanInput.push({file, content});
+		}
+
+		const result = lintAdoption(scanInput, DECISIONS, EXEMPTIONS);
+
+		// ADR 0092: emit what was scanned (scope is observable), THEN judge.
+		yield* Console.log(
+			`adoption-lint: scanned ${result.scanned.length} corpus file(s) against ${result.decisionCount} declared decision(s)` +
+				(result.scanned.length > 0 ? `:` : ` (zero scope)`),
+		);
+		for (const f of result.scanned) yield* Console.log(`  scanned: ${f}`);
+		for (const f of result.exempted) yield* Console.log(`  exempted (declared + linted): ${f}`);
+
+		yield* judge(result).pipe(
+			Effect.catchTag("ZeroScope", onZeroScope),
+			Effect.catchTag("FindingsFound", onFindingsFound),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Flag corpus files that inline-re-derive a tool-owned decision without citing the owning verb (fails closed on zero scope)",
+	),
+);
+
+export const adoptionLintCommand = Command.make("adoption-lint").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Adoption corpus-lint: every extraction's decision must be cited, not re-derived (#3254 / epic #3258)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -1,0 +1,74 @@
+/**
+ * The declared manifest for `adoption-lint` — the tool-owned decisions the crew
+ * corpus must CITE rather than re-derive, plus the self-linted exemptions.
+ *
+ * This is the extension seam for epic #3258: each sibling verb-child that extracts
+ * a recurring envelope into a shared verb appends its decision here AND migrates
+ * its consumers same-commit (the #3254 rule), drawing the corresponding
+ * `grandfathered` entries below down to zero. The lint refuses to let that pile
+ * GROW — a NEW file re-deriving a declared decision without citing the verb and
+ * without a declared exemption reds the build.
+ *
+ * Seeded with the canonical #3254 example — `verdict read`, whose ADR-0058
+ * SHA-bound marker-resolution three skills hand-copy (#2102). The remaining
+ * envelope decisions (claim, apply-triage, create, post-verdict, graduate) arrive
+ * with their sibling children (#3262–#3266), each with its own consumer migration.
+ */
+import type {Exemption, OwnedDecision} from "./adoption-lint.ts";
+
+/**
+ * The tool-owned decisions the corpus must cite by contract.
+ *
+ * `verdict read` owns the ADR-0058 SHA-bound verdict-marker resolution — resolve
+ * the latest (PR, gate) verdict, author-gated to write+ collaborators (ADR 0055),
+ * bound to the PR's current head. Its fingerprint is the co-occurrence of the
+ * marker regex, the write+ ACL permission loop, and a latest-wins resolution — the
+ * three tells that mark a hand-copy of the procedure rather than an incidental
+ * mention. A file that cites `pipeline-cli verdict` is compliant.
+ */
+export const DECISIONS: ReadonlyArray<OwnedDecision> = [
+	{
+		verb: "verdict read",
+		signature: [
+			/review-\((?:code|doc|skill)/, // the gate-marker namespace regex
+			/collaborators\/[^/]*\/?permission|collaborators\//, // the write+ ACL loop (ADR 0055)
+			/sort_by\(|\blast\b/, // the latest-wins resolution
+		],
+		citation: /pipeline-cli\s+verdict\b/,
+		reason:
+			"re-derives the ADR-0058 SHA-bound verdict-marker resolution that `pipeline-cli verdict read` owns, instead of citing the verb (#3254 / #2102)",
+	},
+];
+
+/**
+ * The self-linted exemptions. Not a blanket skip (#3254): a `mirror` must be a real,
+ * non-importable execution surface still in scope; a `grandfathered` entry must
+ * *still* re-derive its verb (once its sibling child migrates the consumer, the
+ * entry goes stale and the lint fails until it is removed).
+ *
+ * `drive-issue.js` is the sole legitimate mirror: the orchestrator is a runtime
+ * `.js` surface that cannot import the TS verb core, so it must inline what a
+ * skill would cite. `heal-ci` and `write-code` are the two current `verdict read`
+ * re-derivers named in #3254 — grandfathered here until #3265 (post-verdict)
+ * extracts the verb and migrates them same-commit.
+ */
+export const EXEMPTIONS: ReadonlyArray<Exemption> = [
+	{
+		kind: "mirror",
+		path: ".claude/workflows/drive-issue.js",
+		reason:
+			"the orchestrator is a runtime .js surface that cannot import the TS verb core — it mirrors by necessity (#3254; the sole legitimate mirror)",
+	},
+	{
+		kind: "grandfathered",
+		path: "skills/heal-ci/SKILL.md",
+		verb: "verdict read",
+		reason: "existing `verdict read` re-derivation — migrate to `pipeline-cli verdict` with #3265",
+	},
+	{
+		kind: "grandfathered",
+		path: "skills/write-code/SKILL.md",
+		verb: "verdict read",
+		reason: "existing `verdict read` re-derivation — migrate to `pipeline-cli verdict` with #3265",
+	},
+];


### PR DESCRIPTION
## What & why

The **#3254 adoption corpus-lint**, the **governing AC of epic #3258** (Deterministic crew mechanics Wave 1). It lands **first** so the later verb-extraction sweep cannot grow the unreferenced-tool pile — the `verdict read` divergent-copy class named in #3254 / #2102, where a shipped CLI verb sits uncited while skills each carry a divergent ~50-line inline copy of its decision.

The lint flags a crew-corpus file that **inline-re-derives a tool-owned decision** (the hand-copied procedure that duplicates a shipped `pipeline-cli` verb's logic) **instead of citing the owning verb**, and fails closed in CI.

## How it works

- **New `pipeline-cli adoption-lint check <file>…` verb** over an IO-free core (`lintAdoption`) + a declared manifest, following the existing `gh-phoenix lint-skills` shape (a new, distinct check — not an edit to it). Registered in `registry.ts`.
- **Fail-closed exit contract (ADR 0092):** `0` clean · `2` findings · `3` zero scope (no corpus file scanned **or** no declared decision — either is a broken lint).
- **A finding** = a corpus file that matches a decision's re-derivation `signature` (co-occurrence of several tells — precise enough that an incidental mention isn't a false finding) **and** does not match its `citation` **and** is not covered by a declared exemption.
- **Declared-AND-linted exemptions, never a blanket skip:**
  - a `mirror` for the sole genuinely non-importable execution surface — `.claude/workflows/drive-issue.js` (the orchestrator can't import the TS verb core at runtime). The lint verifies it exists in scope **and** is structurally non-importable (a `.md` doc can cite, so it can never be a mirror).
  - self-cleaning `grandfathered` entries for the **existing** pile (`heal-ci` / `write-code` re-derive `verdict read`). Each must *still* re-derive-without-citing; once its sibling child (#3265) migrates it, the entry goes stale and the lint **fails until it is removed** — so the pile draws down and can't silently rot.
- **`.github/workflows/adoption-lint.yml`** guard job over the full corpus (plugin `skills/**` + `agents/**` plus `drive-issue.js`), following the `fanout-guard` / `skill-gh-lint` pattern; fails closed on zero scope.

## Scope

Seeds the manifest with **`verdict read` only** — the canonical #3254 example. The remaining envelope decisions (claim, apply-triage, create, post-verdict, graduate) arrive with their **sibling children (#3262–#3266)**, each with its own same-commit consumer migration that draws down the grandfathered entries. Out of scope here: the `Tracker` service and the envelope verbs.

## §CP note

Touches `packages/pipeline-cli/` and adds a `.github/` CI job → a likely **§CP merge path**. Stopping at reviewed-ready for cansirin approval at merge time (§CP is a merge-time PR-path property, not a label; none applied).

## Verification

- `adoption-lint` unit + CLI tests green (15 passed): re-derivation finding, compliant citation, zero-scope fail, the exemption self-lint (mirror non-importability, stale-grandfather, stale-path), and the exit contract.
- The CLI test also asserts the tool is **green over the full live corpus** (the exact set the CI job scans) — the lint lands green while armed against new drift.
- `tsgo` typecheck clean; biome clean; `commands` registry tool still green and lists `adoption-lint`.

Fixes #3261

🤖 Generated with [Claude Code](https://claude.com/claude-code)