### PR TITLE
fix(ci): API-free git-mode change detection so a transient GitHub-API-HTML blip can't red ci-required (#3245)

### DIFF
--- a/.github/workflows/change-detect-guard.yml
+++ b/.github/workflows/change-detect-guard.yml
@@ -1,0 +1,46 @@
+name: change-detect-guard
+
+# CI gate for #3245: ci.yml's `changes` (detect changed areas) job must run API-free
+# git-mode change detection — its `dorny/paths-filter` step must set `token: ''`. dorny
+# reads changed files via the GitHub REST API (`pulls.listFiles`) whenever a token is set
+# (and the action defaults it to `${{ github.token }}`), falling back to a pure `git diff`
+# only when the token is empty. That live API read is the sole flake surface of the step: a
+# transient GitHub-API-HTML blip (`invalid character '<'`) hard-fails it and reds the
+# `ci-required` aggregate on a defect-free PR (#3244). This runs
+# `pipeline-cli change-detect-guard check` so a regression back to the API mode cannot merge.
+# It fails closed on zero scope — a missing job/step/`with:` block (ADR 0092). The scan lives
+# once in the tool.
+on:
+  pull_request:
+
+# Least-privilege GITHUB_TOKEN: the job only checks out + reads the repo and runs the
+# guard, which fails via exit code — it posts no check-run/status/PR comment — so
+# contents:read is all it needs; default-deny every other scope (CodeQL least-privilege).
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: check ci.yml changes job stays API-free git-mode
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 when ci.yml's changes-job dorny/paths-filter step isn't in API-free git-mode
+      # (a set/defaulted token), or on zero scope (a missing job/step/with, fail-closed).
+      # Report on stderr. See #3245.
+      - name: Check the ci.yml change-detection API-free git-mode invariant
+        run: node packages/pipeline-cli/src/bin.ts change-detect-guard check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,9 +149,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      # API-free git-mode change detection (#3245). dorny/paths-filter reads the changed
+      # file set two ways: on a `pull_request` event it calls the GitHub REST API
+      # (`pulls.listFiles`) WHEN a `token` is set, and ONLY when the token is empty does it
+      # fall back to a pure `git diff` against `pull_request.base.sha` (grounded in dorny
+      # v3.0.2 `src/main.ts` — the PR-event branch of `getChangedFiles`: `if (token) return
+      # getChangedFilesFromApi(...)`, else "Github token is not available - changes will be
+      # detected using git diff"). That live API read is the sole flake surface in this job:
+      # a transient GitHub-API-HTML blip served an error page where JSON was expected
+      # (`invalid character '<'`), hard-failing this step → `produce run-evidence bundle` →
+      # the `ci-required` aggregate went RED on a defect-free docs-only PR (#3244). Setting
+      # `token: ''` forces the git-diff path, removing the API read entirely so the transient
+      # CANNOT occur — a stronger fix than retrying a read we don't need to make. The
+      # `fetch-depth: 0` checkout above carries `base.sha`, so the diff resolves offline; the
+      # `merge_group`/`push` paths never used the API (they always git-diff via
+      # `getChangedFilesFromGit`, no token consumed) and are unaffected. A GENUINE git/detection
+      # error still hard-fails this step (fail-closed) — only the API-HTML transient is removed,
+      # never the real gate signal. `pipeline-cli change-detect-guard check` (change-detect-guard.yml)
+      # fails closed if this `token: ''` ever regresses back to the API mode.
       - uses: dorny/paths-filter@v3.0.2
         id: filter
         with:
+          token: ''
           filters: |
             # apps/**/… (not apps/web/…) so any app under apps/ is covered with no
             # filter edit — the discovery posture the package paths already have (ADR

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -15,6 +15,7 @@ import type {Command} from "effect/unstable/cli";
 import {adoptionLintCommand} from "./tools/adoption-lint/command.ts";
 import {campaignCommand} from "./tools/campaign/command.ts";
 import {catalogGuardCommand} from "./tools/catalog-guard/command.ts";
+import {changeDetectGuardCommand} from "./tools/change-detect-guard/command.ts";
 import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
 import {ciRequiredCommand} from "./tools/ci-required/command.ts";
 import {classProbeCommand} from "./tools/class-probe/command.ts";
@@ -141,6 +142,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	verdictCommand,
 	campaignCommand,
 	catalogGuardCommand,
+	changeDetectGuardCommand,
 	patchGuardCommand,
 	intakeDedupCommand,
 	splitGuardCommand,

--- a/packages/pipeline-cli/src/tools/change-detect-guard/README.md
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/README.md
@@ -1,0 +1,52 @@
+# change-detect-guard
+
+`pipeline-cli change-detect-guard check` — the mechanical enforcement that `ci.yml`'s
+`changes` job runs **API-free git-mode** change detection (issue
+[#3245](https://github.com/kamp-us/phoenix/issues/3245)).
+
+## What it enforces
+
+`ci.yml`'s `changes` (`detect changed areas`) job uses `dorny/paths-filter` to gate the
+cost-bearing CI jobs. On a `pull_request` event dorny reads the changed-file set **two
+ways**: it calls the GitHub REST API (`pulls.listFiles`) **whenever a `token` is set**, and
+falls back to a pure `git diff` against `pull_request.base.sha` **only when the token is
+empty** (grounded in dorny v3.0.2 `src/main.ts` — the PR-event branch of `getChangedFiles`:
+`if (token) return getChangedFilesFromApi(...)`, else _"Github token is not available -
+changes will be detected using git diff"_). dorny's `action.yml` **defaults** `token` to
+`${{ github.token }}`, so an **absent** `token:` still selects API mode.
+
+That live GitHub-API read is the **sole flake surface** of the change-detection step: a
+transient GitHub-API-HTML blip served an error page where JSON was expected (`invalid
+character '<'`), hard-failing the step → `produce run-evidence bundle` → the `ci-required`
+aggregate went **RED on a defect-free docs-only PR** ([#3244](https://github.com/kamp-us/phoenix/pull/3244)).
+`ci.yml` pins `token: ''` on the dorny step to force the API-free git path — removing the
+read entirely so the transient **cannot** occur. This guard fails closed if that ever
+regresses (an explicit non-empty token, or an absent `token:` falling back to the
+`github.token` default), which would reopen the flake.
+
+A genuine git/detection error still hard-fails the step (fail-closed) — only the API-HTML
+transient is removed, never the real gate signal.
+
+The core (`change-detect-guard.ts`) parses `ci.yml`, finds the `changes` job's
+`dorny/paths-filter` step, and asserts its `with.token` is present and empty (git-mode).
+
+Fail-closed on zero scope (ADR
+[0092](../../../../../.decisions/0092-gates-fail-closed-on-zero-scope.md)): a missing file,
+missing `changes` job or paths-filter step, or a missing `with:` block is a FAILURE — a
+guard that could not locate the step to check is broken, never a vacuous pass.
+
+## Usage
+
+```bash
+pipeline-cli change-detect-guard check              # the CI gate (exit non-zero on API mode / zero scope)
+pipeline-cli change-detect-guard check --root <dir> # read ci.yml under a specific root (default: walk up for one)
+```
+
+Wired as the always-on `.github/workflows/change-detect-guard.yml` gate (the
+`path-filter-guard` / `readme-guard` idiom). The pure core + IO seam live in
+`change-detect-guard.ts` / `gate.ts`; the pure verdict is unit-tested in
+`change-detect-guard.unit.test.ts`, the filesystem gate in `gate.unit.test.ts`.
+
+```bash
+pnpm --filter @kampus/pipeline-cli test    # vitest over the core + gate
+```

--- a/packages/pipeline-cli/src/tools/change-detect-guard/change-detect-guard.ts
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/change-detect-guard.ts
@@ -54,7 +54,11 @@ export const judge = (ciText: string): ChangeDetectVerdict => {
 	try {
 		doc = parse(ciText);
 	} catch (cause) {
-		return {pass: false, reason: "zero-scope", detail: `could not parse ci.yml YAML (${String(cause)})`};
+		return {
+			pass: false,
+			reason: "zero-scope",
+			detail: `could not parse ci.yml YAML (${String(cause)})`,
+		};
 	}
 	if (!isRecord(doc) || !isRecord(doc.jobs)) {
 		return {pass: false, reason: "zero-scope", detail: "ci.yml has no top-level 'jobs:' mapping"};

--- a/packages/pipeline-cli/src/tools/change-detect-guard/change-detect-guard.ts
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/change-detect-guard.ts
@@ -1,0 +1,127 @@
+/**
+ * `change-detect-guard` pure core (#3245) — assert ci.yml's `changes` job
+ * `dorny/paths-filter` step runs API-FREE git-mode change detection (`token: ''`).
+ *
+ * dorny/paths-filter reads the changed-file set two ways on a `pull_request` event: it
+ * calls the GitHub REST API (`pulls.listFiles`) WHENEVER a `token` is set, and falls back
+ * to a pure `git diff` against `pull_request.base.sha` ONLY when the token is empty (dorny
+ * v3.0.2 `src/main.ts`, the PR-event branch of `getChangedFiles`: `if (token) return
+ * getChangedFilesFromApi(...)`, else "Github token is not available - changes will be
+ * detected using git diff"). dorny's `action.yml` DEFAULTS `token` to `${{ github.token }}`,
+ * so an absent `token:` still selects API mode. That live API read is the sole flake surface
+ * in the job: a transient GitHub-API-HTML blip served an error page where JSON was expected
+ * (`invalid character '<'`), hard-failing the step and reddening the `ci-required` aggregate
+ * on a defect-free docs-only PR (#3244). ci.yml pins `token: ''` to force the API-free git
+ * path; this guard fails closed if that regresses (an explicit non-empty token, or an absent
+ * `token:` falling back to the `github.token` default), which would reopen the flake.
+ *
+ * IO-free and total: a deterministic transform over the ci.yml text. The filesystem seam
+ * (read the file) lives in `gate.ts`; this module never touches disk. Fail-closed on zero
+ * scope (ADR 0092): a missing job / paths-filter step / `with:` block — anything that leaves
+ * the invariant unverifiable — is a FAILURE, never a vacuous pass.
+ */
+import {parse} from "yaml";
+
+/** ci.yml's `changes` job → the `dorny/paths-filter` step whose `token` we assert. */
+export const CI_CHANGES_SOURCE = {
+	file: ".github/workflows/ci.yml",
+	job: "changes",
+} as const;
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+	typeof v === "object" && v !== null && !Array.isArray(v);
+
+/**
+ * The guard verdict — a discriminated union so an invalid state is unrepresentable: a pass
+ * carries no evidence, and each failure shape carries exactly its reason.
+ */
+export type ChangeDetectVerdict =
+	| {readonly pass: true}
+	/** A job/step/`with:` was missing — the invariant is unverifiable (fail closed, ADR 0092). */
+	| {readonly pass: false; readonly reason: "zero-scope"; readonly detail: string}
+	/** The dorny step selects the GitHub-API read (non-empty or defaulted token) — the flake path. */
+	| {readonly pass: false; readonly reason: "api-mode"; readonly detail: string};
+
+/**
+ * Decide the verdict over the ci.yml text. Parses the workflow, finds the `changes` job's
+ * first `uses: dorny/paths-filter@…` step, and asserts its `with.token` is present and
+ * empty (git-mode). Any structural gap is `zero-scope`; a missing or non-empty token is
+ * `api-mode`. `token.trim()` mirrors `@actions/core` `getInput`'s default trimming — the
+ * exact value dorny's `if (token)` branch sees.
+ */
+export const judge = (ciText: string): ChangeDetectVerdict => {
+	let doc: unknown;
+	try {
+		doc = parse(ciText);
+	} catch (cause) {
+		return {pass: false, reason: "zero-scope", detail: `could not parse ci.yml YAML (${String(cause)})`};
+	}
+	if (!isRecord(doc) || !isRecord(doc.jobs)) {
+		return {pass: false, reason: "zero-scope", detail: "ci.yml has no top-level 'jobs:' mapping"};
+	}
+	const job = doc.jobs[CI_CHANGES_SOURCE.job];
+	if (!isRecord(job) || !Array.isArray(job.steps)) {
+		return {
+			pass: false,
+			reason: "zero-scope",
+			detail: `ci.yml has no '${CI_CHANGES_SOURCE.job}' job with a 'steps:' list`,
+		};
+	}
+	const filterStep = job.steps.find(
+		(s) => isRecord(s) && typeof s.uses === "string" && s.uses.startsWith("dorny/paths-filter"),
+	);
+	if (!isRecord(filterStep) || !isRecord(filterStep.with)) {
+		return {
+			pass: false,
+			reason: "zero-scope",
+			detail: `ci.yml '${CI_CHANGES_SOURCE.job}' job has no dorny/paths-filter step with a 'with:' block`,
+		};
+	}
+	if (!("token" in filterStep.with)) {
+		return {
+			pass: false,
+			reason: "api-mode",
+			detail:
+				"the dorny/paths-filter step sets no 'token:' — it defaults to `${{ github.token }}`, which selects the " +
+				"GitHub-API (`pulls.listFiles`) change-detection path that flakes on a transient API-HTML blip (#3245). " +
+				"Set `token: ''` to force API-free git-mode detection.",
+		};
+	}
+	const token = filterStep.with.token;
+	if (typeof token !== "string" || token.trim() !== "") {
+		return {
+			pass: false,
+			reason: "api-mode",
+			detail:
+				`the dorny/paths-filter step's 'token:' is not the empty string (${JSON.stringify(token)}) — a set token ` +
+				"selects the GitHub-API (`pulls.listFiles`) change-detection path that flakes on a transient API-HTML blip " +
+				"(#3245). Set `token: ''` to force API-free git-mode detection.",
+		};
+	}
+	return {pass: true};
+};
+
+/** Render the human-readable report (ADR 0092 §1 "emit what you scanned"). */
+export const renderReport = (verdict: ChangeDetectVerdict): string => {
+	if (verdict.pass) {
+		return (
+			"change-detect-guard: ci.yml changes job's dorny/paths-filter step sets `token: ''` — " +
+			"API-free git-mode change detection is in force (the #3245 API-HTML flake path is closed)"
+		);
+	}
+	if (verdict.reason === "zero-scope") {
+		return (
+			`change-detect-guard: ${verdict.detail} — fail-closed (ADR 0092). Could not locate the ci.yml ` +
+			"changes-job dorny/paths-filter step, so the API-free git-mode invariant is unverifiable. Is the repo " +
+			"root correct, or did the changes job's paths-filter shape change?"
+		);
+	}
+	return (
+		"change-detect-guard: ci.yml's changes-job dorny/paths-filter step is in GitHub-API mode — " +
+		`${verdict.detail}\n\n` +
+		"That live GitHub-API read (`pulls.listFiles`) is the sole flake surface of the change-detection step: a " +
+		"transient GitHub-API-HTML blip (`invalid character '<'`) hard-fails the step and reds the `ci-required` " +
+		"aggregate on a defect-free PR (#3244/#3245). Restore `token: ''` on the dorny/paths-filter step so it " +
+		"detects changes with a pure `git diff` (no API read) — the `fetch-depth: 0` checkout carries the base commit."
+	);
+};

--- a/packages/pipeline-cli/src/tools/change-detect-guard/change-detect-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/change-detect-guard.unit.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The pure `change-detect-guard` verdict (#3245), over crafted ci.yml text — no disk. The
+ * IO exit-code gate is crossed in `gate.unit.test.ts`; here the decision itself is proven:
+ * `token: ''` passes, an explicit non-empty token fails (api-mode), an absent `token:` fails
+ * (api-mode, the `${{ github.token }}` default), and every structural gap fails closed.
+ *
+ * This is the transient-blip regression test: the flake fires ONLY through dorny's GitHub-API
+ * read path, which is selected by a set/defaulted token — so proving the guard reds on any
+ * token that reopens that path proves the #3244/#3245 flake surface stays closed.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {judge} from "./change-detect-guard.ts";
+
+/**
+ * Build a ci.yml with a `changes` job whose dorny/paths-filter step carries the given
+ * `with:` lines. Indentation matches ci.yml: step at 6 spaces, `with:` keys at 10.
+ */
+const mkCi = (withLines: ReadonlyArray<string>): string =>
+	[
+		"name: CI",
+		"on:",
+		"  pull_request:",
+		"jobs:",
+		"  changes:",
+		"    runs-on: ubuntu-latest",
+		"    steps:",
+		"      - uses: actions/checkout@v4.2.2",
+		"        with:",
+		"          fetch-depth: 0",
+		"      - uses: dorny/paths-filter@v3.0.2",
+		"        id: filter",
+		"        with:",
+		...withLines.map((l) => `          ${l}`),
+		"",
+	].join("\n");
+
+describe("judge — the API-free git-mode invariant on ci.yml's changes job", () => {
+	it("PASSES when the dorny step sets token: '' (single-quoted empty)", () => {
+		const ci = mkCi(["token: ''", "filters: |", "  code:", "    - 'packages/**'"]);
+		expect(judge(ci)).toEqual({pass: true});
+	});
+
+	it("PASSES when the dorny step sets token: \"\" (double-quoted empty)", () => {
+		const ci = mkCi(['token: ""', "filters: |", "  code:", "    - 'packages/**'"]);
+		expect(judge(ci)).toEqual({pass: true});
+	});
+
+	it("FAILS (api-mode) when the dorny step sets an explicit github.token", () => {
+		const ci = mkCi([
+			"token: ${{ github.token }}",
+			"filters: |",
+			"  code:",
+			"    - 'packages/**'",
+		]);
+		expect(judge(ci)).toMatchObject({pass: false, reason: "api-mode"});
+	});
+
+	it("FAILS (api-mode) when the dorny step omits token entirely (defaults to github.token)", () => {
+		const ci = mkCi(["filters: |", "  code:", "    - 'packages/**'"]);
+		expect(judge(ci)).toMatchObject({pass: false, reason: "api-mode"});
+	});
+
+	it("FAILS (api-mode) when token is null (bare `token:` → action.yml default)", () => {
+		const ci = mkCi(["token:", "filters: |", "  code:", "    - 'packages/**'"]);
+		expect(judge(ci)).toMatchObject({pass: false, reason: "api-mode"});
+	});
+
+	it("FAILS (zero-scope) when there is no dorny/paths-filter step", () => {
+		const ci = mkCi(["token: ''"]).replace(
+			"      - uses: dorny/paths-filter@v3.0.2",
+			"      - uses: some/other-action@v1",
+		);
+		expect(judge(ci)).toMatchObject({pass: false, reason: "zero-scope"});
+	});
+
+	it("FAILS (zero-scope) when the changes job is missing", () => {
+		const ci = mkCi(["token: ''", "filters: |", "  code:", "    - 'packages/**'"]).replace(
+			"  changes:",
+			"  other:",
+		);
+		expect(judge(ci)).toMatchObject({pass: false, reason: "zero-scope"});
+	});
+
+	it("FAILS (zero-scope) on unparseable ci.yml", () => {
+		expect(judge("name: [unterminated\n")).toMatchObject({pass: false, reason: "zero-scope"});
+	});
+
+	it("FAILS (zero-scope) when the dorny step has no with: block", () => {
+		const ci = [
+			"name: CI",
+			"on:",
+			"  pull_request:",
+			"jobs:",
+			"  changes:",
+			"    runs-on: ubuntu-latest",
+			"    steps:",
+			"      - uses: dorny/paths-filter@v3.0.2",
+			"        id: filter",
+			"",
+		].join("\n");
+		expect(judge(ci)).toMatchObject({pass: false, reason: "zero-scope"});
+	});
+});

--- a/packages/pipeline-cli/src/tools/change-detect-guard/change-detect-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/change-detect-guard.unit.test.ts
@@ -40,18 +40,13 @@ describe("judge — the API-free git-mode invariant on ci.yml's changes job", ()
 		expect(judge(ci)).toEqual({pass: true});
 	});
 
-	it("PASSES when the dorny step sets token: \"\" (double-quoted empty)", () => {
+	it('PASSES when the dorny step sets token: "" (double-quoted empty)', () => {
 		const ci = mkCi(['token: ""', "filters: |", "  code:", "    - 'packages/**'"]);
 		expect(judge(ci)).toEqual({pass: true});
 	});
 
 	it("FAILS (api-mode) when the dorny step sets an explicit github.token", () => {
-		const ci = mkCi([
-			"token: ${{ github.token }}",
-			"filters: |",
-			"  code:",
-			"    - 'packages/**'",
-		]);
+		const ci = mkCi(["token: ${{ github.token }}", "filters: |", "  code:", "    - 'packages/**'"]);
 		expect(judge(ci)).toMatchObject({pass: false, reason: "api-mode"});
 	});
 

--- a/packages/pipeline-cli/src/tools/change-detect-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/command.ts
@@ -1,0 +1,79 @@
+/**
+ * The `change-detect-guard` tool — `pipeline-cli change-detect-guard check [--root <d>]`
+ * (#3245).
+ *
+ * The CI surface for "ci.yml's `changes` job runs API-free git-mode change detection". The
+ * dorny/paths-filter step gates the cost-bearing jobs and, on a `pull_request` event, reads
+ * the changed-file set via the GitHub REST API (`pulls.listFiles`) unless `token: ''` forces
+ * a pure `git diff`. That live API read is the sole flake surface of the step: a transient
+ * GitHub-API-HTML blip reddens the whole `ci-required` aggregate on a defect-free PR. This
+ * guard makes the API-free posture mechanical so it can't silently regress:
+ *
+ *   pipeline-cli change-detect-guard check            # CI gate: exit non-zero on API mode / zero scope
+ *   pipeline-cli change-detect-guard check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * The scan/IO lives in `gate.ts`; this file wires it to the CLI (mirrors `path-filter-guard`/
+ * `readme-guard`/`fanout-guard`).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — a gate failure (report on stderr)
+ * and an IO failure exit non-zero, undistinguished. `CheckFailed` is caught inside the
+ * handler (not at the bin's run boundary) so the contract survives folding into the shared
+ * `pipeline-cli` bin, which provides only `NodeServices.layer`.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../../find-root-dir.ts";
+import {type CheckFailed, checkChangeDetect} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root to read ci.yml under (default: walk up for one)"),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
+// error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkChangeDetect(resolveRoot(rootOpt)).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the build if ci.yml's changes-job dorny/paths-filter step isn't in API-free git-mode (token: '')",
+	),
+);
+
+export const changeDetectGuardCommand = Command.make("change-detect-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: ci.yml's change-detection step stays API-free git-mode (no flaky GitHub-API read, #3245)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/change-detect-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/gate.ts
@@ -1,0 +1,49 @@
+/**
+ * The `change-detect-guard` filesystem gate (#3245) — the IO seam behind the ci.yml
+ * API-free-git-mode check, split from `command.ts` so it is crossable in unit tests over a
+ * fake repo dir rather than only by spawning the bin (the core-in-its-own-file idiom; #855).
+ *
+ * `checkChangeDetect` is the CI gate: it reads ci.yml and delegates the verdict to the pure
+ * core (`change-detect-guard.ts`). It fails `CheckFailed` (exit non-zero) when the dorny
+ * step is in GitHub-API mode (a set/defaulted token — the flake path) or on zero scope (a
+ * missing job/step/`with:` — fail-closed, ADR 0092). A file that cannot be read is an
+ * `IoError` (also non-zero — both failures, undistinguished, per the bin's contract).
+ */
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {CI_CHANGES_SOURCE, judge, renderReport} from "./change-detect-guard.ts";
+
+/** A file IO failure: the run couldn't complete. */
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
+
+const readWorkflow = (root: string, relPath: string): Effect.Effect<string, IoError> =>
+	Effect.try({
+		try: () => readFileSync(join(root, relPath), "utf8"),
+		catch: (cause) => new IoError({path: join(root, relPath), cause}),
+	});
+
+/**
+ * The CI gate: succeed when ci.yml's changes-job dorny/paths-filter step sets `token: ''`
+ * (API-free git-mode detection), else `CheckFailed`. Fails closed on any zero-scope gap
+ * (ADR 0092).
+ */
+export const checkChangeDetect = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const ciText = yield* readWorkflow(root, CI_CHANGES_SOURCE.file);
+		const verdict = judge(ciText);
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/change-detect-guard/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/change-detect-guard/gate.unit.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `checkChangeDetect` over a fake repo dir — the filesystem-seam test (#3245). The pure
+ * verdict is covered in `change-detect-guard.unit.test.ts`; this crosses the IO gate over a
+ * real temp dir, asserting the exit-code contract from observable outcomes — never by
+ * spawning the bin.
+ */
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, beforeEach, describe, expect, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import {CheckFailed, checkChangeDetect} from "./gate.ts";
+
+let root: string;
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "change-detect-guard-gate-"));
+});
+afterEach(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+
+const mkCi = (withLines: ReadonlyArray<string>): string =>
+	[
+		"name: CI",
+		"on:",
+		"  pull_request:",
+		"jobs:",
+		"  changes:",
+		"    runs-on: ubuntu-latest",
+		"    steps:",
+		"      - uses: dorny/paths-filter@v3.0.2",
+		"        id: filter",
+		"        with:",
+		...withLines.map((l) => `          ${l}`),
+		"",
+	].join("\n");
+
+const writeCi = (ci: string | null) => {
+	const dir = join(root, ".github", "workflows");
+	mkdirSync(dir, {recursive: true});
+	if (ci !== null) writeFileSync(join(dir, "ci.yml"), ci, "utf8");
+};
+
+const GIT_MODE = ["token: ''", "filters: |", "  code:", "    - 'packages/**'"];
+const API_MODE = ["token: ${{ github.token }}", "filters: |", "  code:", "    - 'packages/**'"];
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+const isCheckFailed = (exit: Exit.Exit<unknown, unknown>): boolean =>
+	Exit.isFailure(exit) && Cause.squash(exit.cause) instanceof CheckFailed;
+
+describe("checkChangeDetect — the CI exit-code gate over a fake repo dir", () => {
+	it("SUCCEEDS when the dorny step sets token: '' (the proof)", async () => {
+		writeCi(mkCi(GIT_MODE));
+		const exit = await run(checkChangeDetect(root));
+		expect(Exit.isSuccess(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed) when the dorny step is in GitHub-API mode (the falsification)", async () => {
+		writeCi(mkCi(API_MODE));
+		const exit = await run(checkChangeDetect(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+
+	it("FAILS (fail-closed) when ci.yml is missing (IoError)", async () => {
+		writeCi(null);
+		const exit = await run(checkChangeDetect(root));
+		expect(Exit.isFailure(exit)).toBe(true);
+	});
+
+	it("FAILS (CheckFailed, fail-closed) on zero scope (no dorny step)", async () => {
+		writeCi(
+			mkCi(GIT_MODE).replace(
+				"      - uses: dorny/paths-filter@v3.0.2",
+				"      - uses: some/other-action@v1",
+			),
+		);
+		const exit = await run(checkChangeDetect(root));
+		expect(isCheckFailed(exit)).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #3245

## Problem

The `changes` (`detect changed areas`) job's `dorny/paths-filter@v3.0.2` step read the PR's changed-file set via the GitHub REST API (`pulls.listFiles`) on `pull_request` events. A transient GitHub-API-HTML blip — an error page where JSON was expected (`invalid character '<'`) — hard-failed the step, cascading to `produce run-evidence bundle` → FAILURE and reddening the `ci-required` aggregate gate on a defect-free docs-only PR (#3244). A plain re-run cleared it, confirming a transient, not a content failure.

## Root cause + fix

Grounded in dorny/paths-filter v3.0.2 `src/main.ts` (the PR-event branch of `getChangedFiles`): dorny calls the GitHub API **whenever a `token` is set** (and `action.yml` defaults `token` to `${{ github.token }}`), and falls back to a **pure `git diff`** against `pull_request.base.sha` **only when the token is empty** ("Github token is not available - changes will be detected using git diff").

That live API read is the **sole flake surface** of the step. The fix sets **`token: ''`** on the dorny step, forcing the git-diff path and **removing the API read entirely** — so the transient API-HTML blip *cannot occur*, rather than retrying a read we don't need to make. Details:

- The job already checks out with `fetch-depth: 0`, so `base.sha` is present and the `git diff base.sha..HEAD` resolves offline.
- The `merge_group`/`push` code paths never used the API (they always git-diff via `getChangedFilesFromGit`, no token consumed) — **unaffected**.
- A **genuine** git/detection error still hard-fails the step (fail-closed) — only the API-HTML transient is removed, never the real gate signal. `ci-required` still reds on any real content/gate failure downstream (all gating jobs run their real checks).

## Regression guard

Adds `pipeline-cli change-detect-guard` (pure core + IO gate + unit tests) and an always-on `change-detect-guard.yml` job that **fails closed** if the dorny step ever regresses to API mode — a set token, an explicit `${{ github.token }}`, or an absent `token:` that falls back to the default. This is the "transient-blip path" test: the flake fires only through the API read, so proving the guard reds on any token that reopens that read keeps the flake surface closed.

## Acceptance criteria

- [x] A transient non-JSON/HTML GitHub-API response in `detect changed areas` no longer reds `ci-required` on a defect-free PR — the API read is removed at the root.
- [x] The detection step no longer makes the flake-prone API call; it detects changes with a pure `git diff` (a stronger outcome than retry/fail-soft, since there is no read to flake).
- [x] A genuine content/gate failure still reds `ci-required` — only the detection-infra transient is removed; a real git/detection error still hard-fails the step, and downstream job failures still red the aggregate.
- [x] Consistent with the existing full-jitter / rate-limit retry posture (#3089, #3099): those apply "where the GitHub-API reads apply" — this removes the GitHub-API read from the step, so no such read remains to retry.

## Notes

- Touches `.github/workflows/` + `packages/ci-required`-adjacent tooling (control-plane paths) → **§CP** at review/merge-time (expected; noting so the shipper banks for control-plane approval).
- The `changes` job's `permissions: pull-requests: read` is left as-is (now unused by the git-diff path) to keep the diff surgical; dropping it is a separate least-privilege cleanup.
- The worktree toolchain is currently broken (#3507: local pnpm 8.15.6 vs pinned 10.27.0, and a biome CLI/schema version mismatch), so `pnpm install`/`pnpm test`/the biome pre-commit couldn't run locally. The pure core + gate were smoke-validated with node's TS type-stripping over the real edited `ci.yml` (verdict `pass`) and all fixture cases; **CI is the authority** for the full vitest + biome run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)