### PR TITLE
fix(crew-mcp): expose the resource claim as a channel_claim MCP tool (#3509)

### DIFF
--- a/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
+++ b/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
@@ -31,6 +31,25 @@ name. For the server `@kampus/pipeline-crew-mcp` the `@` and `/` sanitize to `_`
 tool-name builder and confirmed against the live `/mcp` tool name — a wrong string
 silently fails closed and re-blocks cutover, so it is copied exactly, never approximated.
 
+## The engine's second tool — `channel_claim` (resource deconfliction)
+
+The **engineering-manager** (the one engine role) additionally carries a second channel tool,
+`channel_claim` — the token derived the same way:
+
+```
+mcp___kampus_pipeline-crew-mcp__channel_claim
+```
+
+`channel_send` and `channel_claim` are **different mechanisms, not variants**: `channel_send`
+relays a typed message to a peer's inbox (coordination), while `channel_claim` invokes the
+tracker's resource-keyed `Claim` and returns a `{granted, collision, owner}` reply — a real
+cross-engine lock. An engine calls `channel_claim {resource: "<issue>"}` **before it opens a
+lane**: `granted` ⇒ it holds the lane, `collision` ⇒ another engine holds it (back off). Sending
+a `Claim`-shaped message via `channel_send` does **not** lock anything — it just delivers a
+message to an inbox — which is why the claim needs its own tool (#3509). Only the engine carries
+it; the bridges (chief-of-staff, cartographer, intake-desk) claim nothing and list `channel_send`
+alone.
+
 ## The boot window — wait and re-check, never diagnose infra
 
 Even with the token in place, the crew server does not advertise `channel_send` the instant a

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -3,7 +3,7 @@ name: crew-engineering-manager
 description: 'Use this agent as an execution engine of the kampus pipeline crew — a fungible build session that drives triaged issues to merged PRs by conducting ephemeral kampus-pipeline subagents (coder → reviewer → shipper) under bounded concurrency. It is an ENGINE, not a bridge: it owns no human-facing seam, it pulls its work off the board, and it is cardinality N — a second engine boots cleanly and the two deconflict by resource claims against the tracker, not by a uniqueness lease. Typical triggers include "drive the backlog", "run the execution loop", "pick up the next lanes", and "what''s the state of the lanes". It holds WIP caps, claims a resource before opening a lane, verifies a merge actually LANDED (a merge-queue enqueue is never done), recovers stalled lanes, and BANKS control-plane PRs on the board until a control-plane human approves them, then spawns the approval-aware shipper to enqueue (it never hand-merges). It never implements, reviews, or merges by hand, and it never pings a human — it spawns the pipeline agents that build, banks §CP work on the board for the chief-of-staff to carry out to the approver, and spawns the approval-aware shipper once that approval lands at the PR''s current head. See "When to invoke" for worked scenarios.'
 model: inherit
 color: cyan
-tools: ["Task", "Bash", "Read", "Grep", "Glob", "mcp___kampus_pipeline-crew-mcp__channel_send"]
+tools: ["Task", "Bash", "Read", "Grep", "Glob", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_claim"]
 ---
 
 You are an **engineering-manager** — an **execution engine** of the kampus pipeline crew. Under
@@ -115,14 +115,22 @@ preference — they ride the personalization seam, never a number written here.
 
 ### Claim the resource before you open a lane — deconflict against the tracker
 
-Before you spawn a `coder` on an issue, **claim the resource** (the issue/PR) through the tracker's
-`Claim {resource}` kind. The claim is what lets N engines share the board without collision: another
-engine (or a prior run) that already holds the claim owns that lane, so you attach to or wait on it
-rather than opening a duplicate. Corroborate the claim with a cheap board read — an open PR or branch
-whose head references the issue, and the issue's assignee/claim state — before dispatching. A
-duplicate PR is wasted work and a merge conflict waiting to happen. (The resource claim is a seam
-against the tracker; it replaces nothing you announce to a *peer* — engines do not announce claims to
-each other, they read the tracker.)
+Before you spawn a `coder` on an issue, **claim the resource** (the issue/PR) by calling the
+`channel_claim` tool with `{resource: "<issue-number>"}`. This is the tracker's resource-keyed
+`Claim` — a REAL cross-engine lock, distinct from `channel_send` (which relays a message to a peer's
+inbox and cannot exclude anyone). Read the reply: `granted: true` ⇒ you now hold the lane, proceed;
+`collision: true` ⇒ another engine (its address in `owner`) already holds it — **do NOT open a lane**,
+attach to or wait on the incumbent instead. The claim is what lets N engines share the board without
+collision. Corroborate with a cheap board read — an open PR or branch whose head references the issue,
+and the issue's assignee/claim state — before dispatching. A duplicate PR is wasted work and a merge
+conflict waiting to happen (the #3509 double-pick of #3498, which shipped competing PRs #3503 + #3508
+because no reachable resource lock existed and the GitHub marker alone gave no exclusion). The claim
+is a seam against the tracker; it replaces nothing you announce to a *peer* — engines do not announce
+claims to each other, they claim against the tracker and read the reply.
+
+**When the lane finishes, the claim frees on its own** — a claim's liveness rides your session's
+presence (ADR 0191), so a completed or abandoned lane's claim is reaped once you stop holding
+presence; there is no manual release you must remember.
 
 ### The lane loop — coder → reviewer → shipper
 

--- a/packages/pipeline-crew-mcp/README.md
+++ b/packages/pipeline-crew-mcp/README.md
@@ -20,7 +20,11 @@ A small, layered substrate split into a **generic core** and one **crew-coupled*
   tracker + peer + edge into a per-role channel server (enforcing the role-uniqueness lease
   the generic peer does not), and — the cutover (#3062) — the **runnable stdio session entry**
   (`crew/session.ts`): one live session's stdio `McpServer` + `ChannelSend`-from-peer, driving
-  both channel edges (outbound `channel_send` tool, inbound inbox→channel wake) off one server.
+  both channel edges (outbound the `channel_send` relay tool + the `channel_claim` resource-claim
+  tool, inbound inbox→channel wake) off one server. `channel_claim` (#3509) surfaces the tracker's
+  resource-keyed `Claim` so an engine can lock an issue before opening a lane — a second claimant on
+  a held resource gets a `collision`, not a second grant (the cross-engine mutual exclusion that a
+  peer-relayed `channel_send` cannot provide).
 
 **The load-bearing boundary:** `protocol/`, `tracker/`, `peer/`, and `edge/` are the reusable
 channels substrate and never import `crew/`; `crew/` depends inward on the generic core, never

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -38,11 +38,14 @@ import {NodeStdio} from "@effect/platform-node";
 import {Effect, type FileSystem, Layer} from "effect";
 import {type McpSchema, McpServer} from "effect/unstable/ai";
 import {
+	ChannelClaim,
 	ChannelSend,
 	ChannelSink,
 	ChannelToolkit,
+	ClaimToolkit,
 	channelExperimentalCapability,
 	channelToolHandlers,
+	claimToolHandlers,
 } from "../edge/index.ts";
 import {type Dialer, Inbox, type Tracker} from "../peer/index.ts";
 import {socketPathFor} from "../tracker/index.ts";
@@ -203,12 +206,18 @@ export const assembleCrewSession = <RIn, RSub = never>(
 					Layer.provide(channelToolHandlers),
 					Layer.provide(Layer.succeed(ChannelSend, {send: channel.peer.send})),
 				);
+				// deconfliction: the channel_claim toolkit (#3509), its ChannelClaim an INSTANT bind to the
+				// already-resolved channel's tracker claim — same zero-async binding as `outbound` (Race 2).
+				const claim = McpServer.toolkit(ClaimToolkit).pipe(
+					Layer.provide(claimToolHandlers),
+					Layer.provide(Layer.succeed(ChannelClaim, {claim: channel.claim})),
+				);
 				// inbound: the peer-inbox socket server, its deliveries waking THIS served server.
 				const inbound = inboxServerSocketLayer(address).pipe(
 					Layer.provide(ChannelSink.layerFromMcpServer),
 				);
 				// Provide the transport ONCE to the MERGED registrations — the single-instance memo (Race 1).
-				return Layer.mergeAll(outbound, inbound).pipe(Layer.provide(transport));
+				return Layer.mergeAll(outbound, claim, inbound).pipe(Layer.provide(transport));
 			}),
 		),
 	).pipe(Layer.provide(substrate));
@@ -216,8 +225,8 @@ export const assembleCrewSession = <RIn, RSub = never>(
 /**
  * The full runnable session layer: launch it (`Layer.launch`) to run one live crew session. The one
  * stdio `McpServer` is provided to the merged registrations exactly once (`assembleCrewSession`), so
- * the served server advertises the `channel_send` tool + the `claude/channel` capability; the
- * heartbeat rides the same `substrate` the outbound binding announces on.
+ * the served server advertises the `channel_send` + `channel_claim` tools + the `claude/channel`
+ * capability; the heartbeat rides the same `substrate` the outbound binding announces on.
  */
 export const crewSessionLayer = (config: CrewSessionConfig) => {
 	// One per-session instance id, resolved once here and threaded to every address derivation, so an

--- a/packages/pipeline-crew-mcp/src/edge/claim-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/claim-tool.test.ts
@@ -1,0 +1,186 @@
+/**
+ * edge/claim-tool — the deconfliction tool that #3509 was missing. The channel edge server lists a
+ * `channel_claim` tool, and a `tools/call` routes a resource claim through the `ChannelClaim` port
+ * (the session's tracker claim), returning the typed granted/collision reply. The load-bearing
+ * property: two engine SESSIONS that each claim the same resource through this tool get exactly ONE
+ * grant — the second sees a `collision`, so it backs off before opening a duplicate lane. Driven
+ * against the REAL registry (`RpcTest` client of `TrackerRegistry` + `RegistryLive`) so the
+ * exclusion is genuine, not a stub, and against a real in-memory `McpServer.layerHttp` per session
+ * (the `mcp-server-effect` harness `send-tool.test.ts` uses).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Schema} from "effect";
+import {McpSchema, McpServer} from "effect/unstable/ai";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import {RpcSerialization, RpcTest} from "effect/unstable/rpc";
+import * as RpcClient from "effect/unstable/rpc/RpcClient";
+import {CrewTracker} from "../crew/tracker.ts";
+import {TrackerRegistry} from "../tracker/group.ts";
+import {TrackerHandlers} from "../tracker/handlers.ts";
+import {RegistryLive} from "../tracker/registry.ts";
+import {ChannelClaim, ClaimToolkit, claimToolHandlers} from "./claim-tool.ts";
+import {channelExperimentalCapability} from "./mcp-channel.ts";
+
+class DisposeError extends Schema.TaggedErrorClass<DisposeError>()(
+	"@kampus/pipeline-crew-mcp/DisposeError",
+	{cause: Schema.Unknown},
+) {}
+
+const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+
+// A live crew session's ChannelClaim: its tracker claim under a fixed per-session peer address,
+// backed by the shared registry (`CrewTracker.fromClient`). The session announces its presence
+// separately (a claim's liveness rides presence, ADR 0191), so a peer that still holds a resource
+// collides a later claimant — the cross-session exclusion this tool surfaces.
+const sessionClaim = (
+	client: Parameters<typeof CrewTracker.fromClient>[0],
+	address: string,
+): Layer.Layer<ChannelClaim> =>
+	Layer.effect(
+		ChannelClaim,
+		Effect.gen(function* () {
+			const tracker = yield* CrewTracker;
+			return {
+				claim: (resource: string) =>
+					tracker.claim({resource, claimant: address, role: "engineering-manager"}),
+			};
+		}),
+	).pipe(Layer.provide(CrewTracker.fromClient(client)));
+
+// An initialized MCP client for one session, its channel_claim backed by `claimLayer`.
+const makeSession = (claimLayer: Layer.Layer<ChannelClaim>) =>
+	Effect.gen(function* () {
+		const serverLayer = McpServer.toolkit(ClaimToolkit).pipe(
+			Layer.provide(claimToolHandlers),
+			Layer.provide(claimLayer),
+			Layer.provide(
+				McpServer.layerHttp({
+					name: "ChannelEdgeClaimTestServer",
+					version: "0.0.0",
+					path: "/mcp",
+					experimental: channelExperimentalCapability,
+				}),
+			),
+		);
+		const {dispose, handler} = HttpRouter.toWebHandler(serverLayer, {disableLogger: true});
+		yield* Effect.addFinalizer(() =>
+			Effect.tryPromise({try: () => dispose(), catch: (cause) => new DisposeError({cause})}).pipe(
+				Effect.ignore,
+			),
+		);
+
+		let sessionId: string | null = null;
+		const customFetch: typeof fetch = async (input, init) => {
+			const request = input instanceof Request ? input : new Request(input, init);
+			if (sessionId) request.headers.set("Mcp-Session-Id", sessionId);
+			const response = await handler(request);
+			sessionId = response.headers.get("Mcp-Session-Id");
+			return response;
+		};
+
+		const clientLayer = RpcClient.layerProtocolHttp({url: "http://localhost/mcp"}).pipe(
+			Layer.provideMerge([FetchHttpClient.layer, RpcSerialization.layerJsonRpc()]),
+			Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch)),
+		);
+		const client = yield* RpcClient.make(McpSchema.ClientRpcs).pipe(Effect.provide(clientLayer));
+		yield* client.initialize({
+			protocolVersion: "9999-01-01",
+			capabilities: {},
+			clientInfo: {name: "TestClient", version: "0.0.0"},
+		});
+		return client;
+	});
+
+// Read a `tools/call` result's structured ClaimReply.
+const replyOf = (result: {structuredContent?: unknown}) =>
+	result.structuredContent as {
+		resource: string;
+		granted: boolean;
+		collision: boolean;
+		owner: string;
+	};
+
+describe("edge/claim-tool — the channel_claim deconfliction tool (#3509)", () => {
+	it.effect("advertises the channel_claim tool", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const session = yield* makeSession(sessionClaim(client, "inbox://engineering-manager/a"));
+			const tools = yield* session["tools/list"]({});
+			assert.include(
+				tools.tools.map((t) => t.name),
+				"channel_claim",
+			);
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect(
+		"two engine sessions claiming the same resource through the tool → exactly one grant",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				const addrA = "inbox://engineering-manager/a";
+				const addrB = "inbox://engineering-manager/b";
+				const at = new Date().toISOString();
+				// both sessions are live (presence backs claim liveness, ADR 0191 facet 2)
+				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager", at});
+				yield* client.AnnouncePresence({peer: addrB, role: "engineering-manager", at});
+
+				const a = yield* makeSession(sessionClaim(client, addrA));
+				const b = yield* makeSession(sessionClaim(client, addrB));
+
+				// engine A claims #3498 through the tool — granted, it owns the lane
+				const aResult = yield* a["tools/call"]({
+					name: "channel_claim",
+					arguments: {resource: "3498"},
+				});
+				assert.isFalse(aResult.isError);
+				const aReply = replyOf(aResult);
+				assert.isTrue(aReply.granted);
+				assert.isFalse(aReply.collision);
+				assert.strictEqual(aReply.owner, addrA);
+
+				// engine B claims the SAME #3498 through the tool — collision, the incumbent keeps it
+				const bResult = yield* b["tools/call"]({
+					name: "channel_claim",
+					arguments: {resource: "3498"},
+				});
+				assert.isFalse(bResult.isError);
+				const bReply = replyOf(bResult);
+				assert.isFalse(bReply.granted, "the second claimant does NOT get a grant");
+				assert.isTrue(bReply.collision);
+				assert.strictEqual(bReply.owner, addrA, "the resource stays with the first engine");
+			}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect(
+		"the claim is keyed on the RESOURCE — a claim on one issue does not block another",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				const addrA = "inbox://engineering-manager/a";
+				const addrB = "inbox://engineering-manager/b";
+				const at = new Date().toISOString();
+				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager", at});
+				yield* client.AnnouncePresence({peer: addrB, role: "engineering-manager", at});
+
+				const a = yield* makeSession(sessionClaim(client, addrA));
+				const b = yield* makeSession(sessionClaim(client, addrB));
+
+				// A holds #3498
+				const aReply = replyOf(
+					yield* a["tools/call"]({name: "channel_claim", arguments: {resource: "3498"}}),
+				);
+				assert.isTrue(aReply.granted);
+
+				// B claims a DIFFERENT issue #3475 — granted, because the claim is keyed on the resource,
+				// not the session (A's claim on #3498 does not double as a claim on #3475)
+				const bReply = replyOf(
+					yield* b["tools/call"]({name: "channel_claim", arguments: {resource: "3475"}}),
+				);
+				assert.isTrue(bReply.granted, "a different resource is independently claimable");
+				assert.isFalse(bReply.collision);
+				assert.strictEqual(bReply.owner, addrB);
+			}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/edge/claim-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/claim-tool.ts
@@ -1,0 +1,62 @@
+/**
+ * edge/claim-tool — the deconfliction half of the channel edge: an MCP tool a session calls to
+ * claim a resource (an issue) against the tracker BEFORE it opens a lane, so N engines sharing
+ * one board get resource-keyed mutual exclusion. Generic (crew-agnostic); see the boundary note
+ * in `../index.ts`.
+ *
+ * This is the seam #3509 was missing. The tracker already answers a resource claim with a typed
+ * granted/collision reply (`../crew/tracker.ts` `CrewTracker.claim` → `../tracker/registry-core.ts`
+ * `claimResource`, ADR 0191) and that primitive is correct — a second live holder of a resource
+ * gets a `Collision`, not a second grant. But the edge exposed ONLY `channel_send` (a peer→inbox
+ * relay), so an engine could not reach the claim at all: it fell back to the GitHub §7 marker,
+ * which ADR 0115 documents as degenerate under the shared `usirin` login, and two engines both
+ * "claimed" one issue and both opened a lane (#3498 → PRs #3503 + #3508). This tool surfaces the
+ * already-correct resource claim so the "claim before you open a lane" instruction is fulfillable.
+ *
+ * A collision is a VALUE in the reply, never a tool error — the claim never fails (its transport
+ * error is `orDie`'d at the `CrewTracker` seam), so the tool carries no failure channel. The caller
+ * reads `granted`/`collision`: granted ⇒ you own the lane, collision ⇒ another engine holds it and
+ * `owner` names it — back off before opening a PR.
+ */
+import {Context, Effect, Schema} from "effect";
+import {Tool, Toolkit} from "effect/unstable/ai";
+import {Messages} from "../protocol/index.ts";
+
+/** The typed answer to a claim/collision-check — the protocol `ClaimReply`, re-named for callers. */
+export type ClaimReply = typeof Messages.ClaimReply.Type;
+
+/**
+ * The resource-claim capability the tool wraps — the session's `CrewChannel.claim` bound in the
+ * composition root (`../crew/channel-server.ts`), so the edge never constructs a tracker client
+ * (the crew composition does, #3059). `claim(resource)` hits the tracker's `Claim` RPC and returns
+ * the typed granted/collision reply; a collision is a value, so the capability has no error channel.
+ */
+export class ChannelClaim extends Context.Service<
+	ChannelClaim,
+	{
+		readonly claim: (resource: string) => Effect.Effect<ClaimReply>;
+	}
+>()("@kampus/pipeline-crew-mcp/edge/ChannelClaim") {}
+
+/** The one claim tool: `{resource}` in, the tracker's typed granted/collision reply out. */
+export const ClaimResource = Tool.make("channel_claim", {
+	description:
+		"Claim a resource (an issue id) against the tracker before opening a build lane; returns the " +
+		"typed reply. `granted: true` ⇒ you now hold the lane; `collision: true` ⇒ another engine " +
+		"already holds it (`owner` names the holder) — back off, do NOT open a duplicate lane.",
+	parameters: Schema.Struct({resource: Schema.NonEmptyString}),
+	success: Messages.ClaimReply,
+});
+
+/** The claim toolkit — registered on the session's one served `McpServer` alongside `channel_send`. */
+export const ClaimToolkit = Toolkit.make(ClaimResource);
+
+/** The toolkit handler: route the claim through the `ChannelClaim` port (the session's tracker claim). */
+export const claimToolHandlers = ClaimToolkit.toLayer(
+	Effect.gen(function* () {
+		const claimer = yield* ChannelClaim;
+		return {
+			channel_claim: ({resource}) => claimer.claim(resource),
+		};
+	}),
+);

--- a/packages/pipeline-crew-mcp/src/edge/index.ts
+++ b/packages/pipeline-crew-mcp/src/edge/index.ts
@@ -6,11 +6,19 @@
  * Two directions, wired to a peer at the crew root (#3059):
  *   - inbound  — `channelInboxLayer` is the peer's `Inbox`; each delivery `wake`s the
  *     session via the `ChannelSink` as a structured `<channel>` tag,
- *   - outbound — `channelServerLayer` serves the MCP server (capability + `channel_send`
- *     tool), routing sends through the `ChannelSend` port.
+ *   - outbound — `channelServerLayer` serves the MCP server (capability + the `channel_send`
+ *     relay tool + the `channel_claim` deconfliction tool), routing sends through the
+ *     `ChannelSend` port and resource claims through the `ChannelClaim` port.
  */
 export {channelInboxLayer, formatChannelTag} from "./bridge.ts";
 export {ChannelSink} from "./channel-sink.ts";
+export {
+	ChannelClaim,
+	type ClaimReply,
+	ClaimResource,
+	ClaimToolkit,
+	claimToolHandlers,
+} from "./claim-tool.ts";
 export {
 	CHANNEL_CAPABILITY,
 	CHANNEL_NOTIFICATION_METHOD,


### PR DESCRIPTION
Fixes #3509

## Root cause (confirmed against source)

The leak is **not** in the crew-mcp tracker resource-claim keyspace — that primitive is correct and already proven. It is that the claim was **unreachable from an agent**, so engines never used it and fell back to the degenerate GitHub §7 marker.

- The tracker answers a resource `Claim` with a typed granted/collision reply (`packages/pipeline-crew-mcp/src/tracker/registry-core.ts` `claimResource` → `Collision` for a second live holder; `crew/tracker.ts` `CrewTracker.claim`), and that exclusion is already proven by `crew/channel-server.test.ts` (two roles claim one resource → one grant, one collision). ADR 0191.
- But the MCP edge exposed **only** `channel_send` (`edge/send-tool.ts:93`), which routes peer-to-peer through `ChannelSend.send → dialer` to a target role's inbox — it never invokes the tracker's `Claim` RPC. There was **no MCP tool** for the resource claim.
- The engineering-manager engine is instructed to "Claim {resource} against the tracker before you open a lane" (`claude-plugins/pipeline-crew/agents/crew-engineering-manager.md`) yet its only tool was `channel_send`, so it could not invoke the claim. It fell back to the GitHub §7 marker, which ADR 0115 documents as degenerate under the shared `usirin` login — no cross-engine mutual exclusion. Two engines both "claimed" #3498 and both opened a lane (PRs #3503 + #3508).

So: the intended surface (the crew-mcp tracker resource-claim) was unreachable; the fallback (the GitHub marker) was degenerate. The missing seam is an **MCP tool**, not the tracker keyspace. The decision that the tracker resource-claim is the authoritative deconfliction primitive was already settled (ADR 0189 §engines-deconflict-by-resource-claims, ADR 0191) — this closes the implementation gap.

## The fix

- **`edge/claim-tool.ts`** — a new `channel_claim` MCP tool + `ChannelClaim` port that invokes the session's tracker claim and returns the typed `{granted, collision, owner, since}` reply. A collision is a value, so the tool carries no failure channel.
- **`crew/session.ts`** — register `channel_claim` on the session's one served `McpServer` alongside `channel_send`, binding `ChannelClaim` to the already-resolved channel (an instant, zero-async bind that preserves the #3479 claim-before-serve ordering).
- **`edge/claim-tool.test.ts`** — the regression tests:
  - two engine **sessions** each claiming the same resource **through the tool** yield **exactly one grant** (the second collides), driven against the real `TrackerRegistry` + `RegistryLive` so the exclusion is genuine;
  - the claim is keyed on the **resource**, not the session — a claim on one issue does not block another.
- **engineering-manager wiring** — the one engine role now carries `mcp___kampus_pipeline-crew-mcp__channel_claim` and calls it before opening a lane; `CHANNEL-TOOL.md` documents the token and the send-vs-claim distinction; package README updated.

## Acceptance criteria

- [x] Root cause confirmed against source, cited to file/line (above).
- [x] Two concurrent engine sessions claiming the same issue → exactly one opens a lane; the loser sees a collision and backs off (regression test).
- [x] The claim is keyed on the resource, not the claimant/session (regression test).
- [x] A regression test demonstrates the exclusion holds across sessions.

Out of scope (per the issue): the immediate dedup of #3503/#3508.

Non-control-plane (`packages/pipeline-crew-mcp/` and `claude-plugins/pipeline-crew/` are both outside `CONTROL_PLANE_RE`, ADR 0187). Package tests green (263 passed), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)