### PR TITLE
docs(roadmap): record 3 founder-approved campaigns (diataxis-docs #31, pipeline-cli-effect-migration #32, design-system-coverage #33)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,6 +36,9 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Mentor Audit | #27 | active |
 | Crew-MCP Finish — replace the tmux relay with crew-mcp | #28 | active |
 | Deterministic Crew Mechanics | #29 | active |
+| Diátaxis docs — pipeline-crew & -mcp | #31 | active |
+| pipeline-cli @effect/platform migration | #32 | active |
+| Agentic design-system coverage | #33 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Records 3 founder-approved campaigns onto the roadmap's `## Campaigns` section (the `/campaign` ritual's Step 4), each with its own milestone, wave label, and verified founder-approval trace.

| Campaign | Milestone | Wave label | Trace | Members |
|---|---|---|---|---|
| Diátaxis docs — pipeline-crew & -mcp | #31 | `diataxis-docs` | verified @ #3537 | 10 (#3537, #3559–3567) |
| pipeline-cli @effect/platform migration | #32 | `pipeline-cli-effect-migration` | verified @ #3462 | 7 (#3462, #3469–3474) |
| Agentic design-system coverage | #33 | `design-system-coverage` | verified @ #3150 | 5 (#3150, #3156/3158/3159/3160) |

All three passed `pipeline-cli campaign verify-trace` (founder-authored, wave-bound, ADR 0092 fail-closed). Milestones created, wave issues attached + repriced to p1 (platform-lane concurrency). This PR is the roadmap-visibility step only.

Recorded by chief-of-staff under the founder's explicit in-session authorization to run the ritual.