### PR TITLE
test(e2e): stop sozluk create-flow dying on a cancelled dialog animation (#3583)

### DIFF
--- a/apps/web/tests/e2e/06-sozluk-home.spec.ts
+++ b/apps/web/tests/e2e/06-sozluk-home.spec.ts
@@ -83,20 +83,23 @@ test.describe("SozlukHome create-flow (+ yeni tanım → composer)", () => {
 
 		await page.getByRole("button", {name: /yeni tanım/i}).click();
 
-		// Let the dialog's `kp-dialog-pop` entry animation (a translate+scale pop-in,
-		// Dialog.css) finish before touching its controls. Mid-animation the popup —
-		// and the `oluştur` submit inside it — is still moving, which trips
-		// Playwright's element-stability check and, on the retry, races a Base UI
-		// portal re-render that detaches the button mid-click (the #3517 flake). This
-		// awaits the actual CSS animation to settle, not a blanket sleep.
+		// Gate on the composer's `Terim` input becoming actionable rather than settling the
+		// dialog's `kp-dialog-pop` entry animation. The old settle awaited every animation's
+		// `finished` promise, but the Web Animations API REJECTS `finished` with an AbortError
+		// when an animation is cancelled — and the Base UI portal re-render cancels the entry
+		// animation mid-flight, so `Promise.all` fail-fast rejected and the spec died. That
+		// settle relocated the #3517 portal-re-render race into a hard rejection instead of
+		// removing it (#3526 → #3583). Playwright's built-in actionability on the fill/click
+		// below already waits for the popup to be visible, stable, and hit-testable and
+		// auto-retries a control the re-render detaches mid-action — the real fix for the #3517
+		// detach-mid-click flake.
 		const dialog = page.locator(".kp-dialog__popup");
 		await expect(dialog).toBeVisible();
-		await dialog.evaluate((el) =>
-			Promise.all(el.getAnimations({subtree: true}).map((a) => a.finished)),
-		);
+		const termInput = page.getByLabel("Terim");
+		await termInput.waitFor({state: "visible"});
 
 		// The dialog collects the term name (the composer is slug-addressed).
-		await page.getByLabel("Terim").fill(term);
+		await termInput.fill(term);
 		await page.getByRole("button", {name: /^oluştur$/i}).click();
 
 		// The dialog slugifies + navigates to the fresh-slug composer route.


### PR DESCRIPTION
The sozluk `+ yeni tanım` create-flow e2e spec was dying with `AbortError: The user aborted a request` every time the e2e gate actually ran. This makes the test tolerant of the dialog's entry animation being cancelled, so it stops depending on a promise the dialog's own re-render throws away — while keeping every one of its assertions intact.

## What changed

`apps/web/tests/e2e/06-sozluk-home.spec.ts` — the "`+ yeni tanım` dialog routes a fresh term to /sozluk/<slug> and lands on the composer" test no longer awaits `Promise.all(el.getAnimations({subtree:true}).map((a) => a.finished))` to settle the popup. The Web Animations API rejects an animation's `finished` promise with an `AbortError` when the animation is **cancelled**, and the Base UI dialog portal re-render cancels the entry animation mid-flight — so `Promise.all` fail-fast rejected and the spec died. That settle (added in #3526 for #3517) relocated the portal-re-render race into a hard rejection rather than removing it.

The spec now waits for the composer's `Terim` input to be visible, then fills it and clicks `oluştur`. Playwright's built-in actionability on the fill/click already waits for the popup to be visible, stable, and hit-testable and auto-retries a control the re-render detaches mid-action — which is the real fix for the #3517 detach-mid-click flake. The test's intent and all assertions (fresh term routes to `/sozluk/<slug>`, lands on `NewTermComposer` with the term head + composer body) are unchanged.

Once merged, this unblocks PR #3578's `e2e` job, which was reding solely on this spec.

Fixes #3583