### PR TITLE
feat(pipeline-crew): /spawn-role — on-demand single-role launch gesture (#3576)

### DIFF
--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -185,6 +185,13 @@ table, and how the crew boots from that one config (the tracker + the three brid
 engines the config declares), are the [personalization seam](PERSONALIZATION.md)'s scope; read
 it there rather than duplicating the key list here.
 
+`/stand-up` boots the whole self-driving roster and *excludes* the human-in-the-loop
+cartographer (ADR [0189](../../.decisions/0189-crew-roster-law.md), #3524). To bring up **one**
+on-demand role — the cartographer for a `wayfinder chart`, or a scaled-up extra engine — run
+[`/spawn-role <role>`](commands/spawn-role.md): it adds a single member to the running crew with
+the full launcher bind (so the channel is never inert) and boots a HITL role idle. It fails
+closed if no crew is up — `/stand-up` first.
+
 ## Layout
 
 ```
@@ -195,6 +202,9 @@ pipeline-crew/
 │   ├── intake-desk.md            # intake bridge (report → triage → plan)
 │   ├── engineering-manager.md    # execution engine (coder → reviewer → shipper), ×N
 │   └── chief-of-staff.md         # outbound-awareness bridge (live verifier, human comms)
+├── commands/
+│   ├── stand-up.md               # boot the whole crew from the operator config
+│   └── spawn-role.md             # launch ONE on-demand role (the HITL cartographer, a scaled-up engine)
 ├── PERSONALIZATION.md            # the personalization seam — the config contract + dimensions
 ├── PROBES.md                     # probe discipline — fail-open liveness/health probes (#3411)
 ├── crew.config.template.jsonc    # placeholder-only per-install config template

--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -186,7 +186,7 @@ engines the config declares), are the [personalization seam](PERSONALIZATION.md)
 it there rather than duplicating the key list here.
 
 `/stand-up` boots the whole self-driving roster and *excludes* the human-in-the-loop
-cartographer (ADR [0189](../../.decisions/0189-crew-roster-law.md), #3524). To bring up **one**
+cartographer (ADR [0189](../../.decisions/0189-crew-roster-law-bridges-engines.md), #3524). To bring up **one**
 on-demand role — the cartographer for a `wayfinder chart`, or a scaled-up extra engine — run
 [`/spawn-role <role>`](commands/spawn-role.md): it adds a single member to the running crew with
 the full launcher bind (so the channel is never inert) and boots a HITL role idle. It fails

--- a/claude-plugins/pipeline-crew/commands/spawn-role.md
+++ b/claude-plugins/pipeline-crew/commands/spawn-role.md
@@ -1,0 +1,65 @@
+---
+description: Launch ONE on-demand crew role into the already-running crew — including the human-in-the-loop cartographer, which boots idle — doing the full launcher bind (per-pane channel scope, tmux placement, tier model, agent def), no whole-crew re-boot.
+argument-hint: "<role> [--project-root <path>]"
+allowed-tools: ["Bash"]
+---
+
+# Spawn one on-demand crew role
+
+This is the **on-demand launch gesture** for a single crew role. `stand-up` boots the
+whole self-driving roster and deliberately *excludes* the human-in-the-loop cartographer
+(ADR 0189, #3524); this command is how you bring up **one** role when you want it — the
+cartographer to run a `wayfinder chart`, or a scaled-up extra engine. It is a thin front for
+the substrate: the launcher logic (version assert, tracker ensure, single-session derivation,
+the per-session channel bind, screen placement) lives in the `@kampus/pipeline-crew-mcp`
+substrate's `spawn-role` subcommand (ADR 0192), never in this plugin.
+
+**Never hand-launch a role instead.** A hand-rolled `claude …` misses the per-pane leaf
+`.mcp.json` project scope that binds the session to `session --role <role>`, so on claude
+2.1.212+ the crew channel resolves against nothing and the session comes up channel-inert —
+you can't tell a bound member from a deaf one without probing (#3444). This command does the
+full bind, so a spawned member is always live on the channel. That is the whole reason it
+exists.
+
+## Preconditions
+
+A **crew must already be running** — this command *adds* a member to the running crew and
+splits its pane into the existing `crew` tmux window, so it fails closed if no crew window is
+up. Run [`/stand-up`](stand-up.md) first if the crew is down.
+
+It relies on the same filled operator config as stand-up (`$CREW_CONFIG`, else the working
+repo's `.claude/crew.config.jsonc`) for the launch dimensions — the role's model tier, the
+pinned CLI version, the channel policy. If you have not filled it yet, follow the
+[PERSONALIZATION.md](../PERSONALIZATION.md) steps first.
+
+## Run it
+
+Invoke the substrate's `spawn-role` subcommand with the role to launch (pass through
+`$ARGUMENTS`, e.g. a trailing `--project-root <path>`; it defaults to the current working
+directory):
+
+```bash
+pipeline-crew-mcp spawn-role $ARGUMENTS
+```
+
+For example, to bring up the cartographer:
+
+```bash
+pipeline-crew-mcp spawn-role cartographer
+```
+
+The launcher runs, **in order**: assert the pinned CLI version → ensure the per-project
+tracker is up (idempotent — reuses the running one) → derive the single session (a bridge
+singleton, or one fresh-instance engine) → build its channel bind + screen placement through
+the *same* primitives the whole-crew boot uses → register just this pane's leaf project scope
+→ split it into the running `crew` window. The new session announces its own presence and
+claims on boot, so no other member is disturbed.
+
+A **human-in-the-loop role (the cartographer) boots idle** — it is handed no self-driving boot
+prompt, because a role with no standing loop would confabulate work if told to "start your loop"
+(the drive is a roster law in the substrate bind, #3524). It comes up waiting for you to give it
+a turn.
+
+Report the launched role, its pane, and the tracker on success, or the named abort cause on
+failure. Do not hand-launch a session to route around a failure — re-run this command once the
+named precondition (crew up, config filled, CLI pin matched) is fixed.


### PR DESCRIPTION
Standing up a single on-demand crew role — today the human-in-the-loop cartographer — had no one-command gesture. `/stand-up` boots the whole self-driving roster and deliberately leaves the cartographer out (it boots idle, no self-driving prompt), so bringing one up meant hand-rolling the full launcher bind by hand — which the stand-up contract forbids and which risks a channel-inert session a human can't tell apart from a live one. This adds the missing gesture.

The `/spawn-role <role>` plugin command fronts the substrate's `pipeline-crew-mcp spawn-role` subcommand, mirroring `/stand-up`: run it and one member joins the running crew with the full bind, or the HITL cartographer comes up idle waiting for a turn.

## What changed
- **`claude-plugins/pipeline-crew/commands/spawn-role.md`** — a thin plugin command fronting `pipeline-crew-mcp spawn-role $ARGUMENTS`, mirroring `commands/stand-up.md`. Documents the crew-must-be-running precondition (it fails closed if no `crew` window is up), the full bind (per-pane leaf `.mcp.json` project scope, tmux placement in the `crew` window, tier `--model`, `--agent crew-<role>`), and that a HITL role boots idle. Never hand-launch — the note names the #3444 channel-inert failure the bind prevents.
- **`claude-plugins/pipeline-crew/README.md`** — a short discoverability note under the stand-up section pointing at `/spawn-role`, and the previously-missing `commands/` entry in the Layout block.

## Why the substrate isn't touched
The substrate on-demand launcher already exists: `pipeline-crew-mcp spawn-role <role>` (commit 15dd07e0, #3519) stands up ONE role reusing the exact primitives `runStandUp` composes — `deriveOneSession` (session-set.ts, deliberately NOT autoboot-gated so the HITL cartographer is launchable), `buildLaunchPlan` → `buildSessionBind` (bind.ts; the `selfDriving`/`bootPromptArg` drive law hands a HITL role no boot prompt on any launch path, #3524), `register-project-scope` (the per-pane leaf `.mcp.json`), and `computeTmuxPlacement`. It landed after #3576 was filed and subsumes the substrate half; re-implementing a parallel `stand-up --role`/`launch-role` would duplicate it and reintroduce the drift risk the shared-primitive reuse exists to prevent. #3576's remaining gap was purely the human-facing launch gesture — the plugin command front — which this PR adds.

## Tests
No new substrate code, so no new unit test. The launch path (including the HITL cartographer spawning and booting idle) is already covered by `packages/pipeline-crew-mcp/src/standup/single-role.test.ts` (`spawns the on-demand HITL cartographer (not autoboot-gated) and it boots idle (#3524)`, asserting `bootPromptArg.length === 0` + crew-window placement). `pnpm typecheck` green (no TS delta); `pnpm lint:worktree` clean skip (markdown-only).

Grounded in ADR 0189 (roster law) and ADR 0192 (substrate launcher: launcher logic lives in the substrate, the plugin carries only a thin front).

Follow-up (not in scope): a symmetric `/retire-role` front for the existing `pipeline-crew-mcp retire-role` teardown op.

Fixes #3576