### PR TITLE
docs(review-skills): reconcile stale §CP merge-model language with ADR 0135 (#3511)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -23,7 +23,8 @@ than from the implementer's say-so.
 **You do not merge. Not on a pass, not ever, not on your own authority.** Your output
 is a *verdict* — an approval signal the PR is merge-ready, or a fail comment listing
 what's missing. Merging is a separate, deliberate act performed by the **`ship-it`**
-skill (the one stage granted merge authority) — or a human. You signal merge-ready;
+skill (the one stage granted merge authority) — for the blocking set (§CP) too, only gated on a
+`@kamp-us/control-plane` approval at head that `ship-it` then enqueues on (ADR 0135). You signal merge-ready;
 `ship-it` is the consumer that asserts your PASS signal, confirms CI is green, and
 squash-merges. Your "you never merge" invariant holds precisely because `ship-it` is the
 single writer of the merge. Conflating "verified" with "merged" is exactly the
@@ -1273,8 +1274,9 @@ merge)`, no `@ <sha>` — the one advisory shape all three gates converge on (AD
 per-criterion evidence table, but it authorizes nothing on its first line — it stays *out* of
 `ship-it`'s auto-merge PASS namespace (no first-line `@ <sha>`), and it binds the reviewed head in
 the body's canonical `Reviewed-head: @ <sha>` line instead (ADR 0151). Under ADR 0135's
-approve-then-enqueue, a human merges the §CP PR by hand, **or** `ship-it` enqueues it once a
-`@kamp-us/control-plane` approval is present at head. Skip to **the blocking-set advisory path** below.
+approve-then-enqueue, a `@kamp-us/control-plane` member approves the §CP PR at its current head and
+`ship-it` then enqueues it (ADR 0048 single merge authority) — no human hand-merge. Skip to **the
+blocking-set advisory path** below.
 
 > **Why the advisory line, not "binding PASS + a caveat"?** The old shape — a real
 > `PASS @ <sha> — merge-ready` plus a control-plane warning — put a *binding* marker into
@@ -1448,9 +1450,10 @@ Every criterion passed but `CONTROL_PLANE_TOUCHED` (Step 2) is non-empty — the
 control plane (§CP). Post the **same evidence**, but the first line is the **canonical advisory
 line** (§6.6), **not** a binding merge-ready marker. Its **first line** carries **no `@ <sha>`** by
 design (it authorizes nothing on its first line, so it never enters `ship-it`'s auto-merge PASS
-namespace — ADR 0111); under ADR 0135's approve-then-enqueue a human merges it by hand, **or**
-`ship-it` enqueues it once a `@kamp-us/control-plane` approval is present at head (ADR 0135, amending
-0053). Upsert it exactly as the PASS path (one `review-code:` marker per PR), and — like the PASS
+namespace — ADR 0111); under ADR 0135's approve-then-enqueue a `@kamp-us/control-plane` member
+approves it at its current head and `ship-it` then enqueues it (ADR 0135, amending 0053; ADR 0048
+single merge authority) — no human hand-merge. Upsert it exactly as the PASS path (one `review-code:`
+marker per PR), and — like the PASS
 fallback — post it as a **comment**, not a native `APPROVE` (a native APPROVE would re-enter the
 code review namespace via its `commit_id`, defeating the advisory's purpose).
 
@@ -1472,8 +1475,9 @@ review-code: advisory — blocking-set PR (manual merge)
 
 PR #<PR> touches the control plane (`.claude/**`, `.github/**`, or a gate-critical skill — §CP):
 the agent control plane / pipeline gates (ADR 0053/0065). My verdict is **advisory only**: it
-does **not** authorize a merge. A maintainer merges this by hand, or `ship-it` enqueues it once a
-`@kamp-us/control-plane` approval is present at head (ADR 0135).
+does **not** authorize a merge. Under the §CP hard gate (ADR 0135), a `@kamp-us/control-plane`
+member approves this at its current head and `ship-it` then enqueues it (ADR 0048 single merge
+authority) — there is no human hand-merge in the §CP path.
 
 Reviewed-head: @ <HEAD_SHA>
 

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -178,8 +178,9 @@ dimension #2174 named **is** this skill's rubric (the six prohibitions above + t
 
 **You do not merge. Not on a pass, not ever, not on your own authority.** Your output is a *verdict*
 — a merge-ready signal (non-blocking) or advice (blocking) plus a fail comment naming the violated
-prohibition. Merging is the deliberate act of **`ship-it`** (the one stage granted merge authority),
-or, for the blocking set, a human. You signal merge-ready; `ship-it` asserts your PASS, confirms CI
+prohibition. Merging is the deliberate act of **`ship-it`** (the one stage granted merge authority) —
+for the blocking set (§CP) too, only gated on a `@kamp-us/control-plane` approval at head that
+`ship-it` then enqueues on (ADR 0135). You signal merge-ready; `ship-it` asserts your PASS, confirms CI
 is green, and squash-merges. Conflating "verified" with "merged" is the self-grading collapse this
 stage exists to prevent — the same invariant the sibling gates hold.
 
@@ -302,8 +303,9 @@ CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page
 - **Empty** (an ordinary product-UI PR — the common case for this gate) → **non-blocking**: your
   PASS marker binds `ship-it`.
 - **Non-empty** (the UI PR also touches a `.claude`/`.github` path or a gate-critical skill) →
-  **blocking** (§CP): you review it and post your findings, but **advisory only** — a maintainer
-  merges by hand. Say so in the verdict (Step 5, advisory path).
+  **blocking** (§CP): you review it and post your findings, but **advisory only** — a
+  `@kamp-us/control-plane` approval at head gates the merge and `ship-it` then enqueues it (ADR 0135
+  approve-then-enqueue; ADR 0048 single merge authority). Say so in the verdict (Step 5, advisory path).
 
 ---
 
@@ -627,15 +629,18 @@ Every check passed but Step 0 classified the PR **blocking** (§CP). Post the **
 the first line is the **canonical advisory line** — **not** a merge-ready go-ahead. The advisory line
 carries **no first-line `@ <sha>`** by design (ADR 0111 — it authorizes nothing, so it stays out of
 `ship-it`'s PASS namespace); the reviewed head is recorded once, in the body's canonical
-`Reviewed-head:` line (ADR 0151), which `ship-it`'s §CP enqueue reads. `ship-it` refuses this PR
-regardless; a human merges it.
+`Reviewed-head:` line (ADR 0151), which `ship-it`'s §CP enqueue reads. `ship-it` does not
+auto-merge this PR on machine gates alone — it enqueues only once a `@kamp-us/control-plane`
+approval is present at head (ADR 0135).
 
 ```markdown
 review-design: advisory — blocking-set PR (manual merge)
 
 PR #<PR> touches the control plane (§CP) — the agent control plane / pipeline gates (ADR
-0053/0065/0165). My verdict is **advisory only**: it does **not** authorize a merge. A maintainer
-merges this by hand.
+0053/0065/0165). My verdict is **advisory only**: it does **not** authorize a merge. Under the §CP
+hard gate (ADR 0135), a `@kamp-us/control-plane` member approves this at its current head and
+`ship-it` then enqueues it (ADR 0048 single merge authority) — there is no human hand-merge in the
+§CP path.
 
 Reviewed-head: @ <HEAD_SHA>
 

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -45,20 +45,25 @@ spec for this split, and it **supersedes** ADR
 
   Both are product or knowledge artifacts; gated for quality, but a human at the merge
   adds no security value.
-- **BLOCKING (manual merge).** Anything in the **canonical §CP set** (the single source in
+- **BLOCKING (§CP — approval-gated).** Anything in the **canonical §CP set** (the single source in
   [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `.claude/**`, `.github/**`,
   or one of the six **gate-critical skills** (`claude-plugins/kampus-pipeline/skills/ship-it/**`, `claude-plugins/kampus-pipeline/skills/review-code/**`,
   `claude-plugins/kampus-pipeline/skills/review-doc/**`, `claude-plugins/kampus-pipeline/skills/review-skill/**`, `claude-plugins/kampus-pipeline/skills/review-plan/**`,
   `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`) — the agent control plane (instructions, tools, hooks),
   CI enforcement, and the pipeline's own gates. A bad merge here is a serious security concern
-  (self-modification of guardrails; CI/secret exfiltration), so a **human merges these by hand**
-  and `ship-it` refuses them. The gate-critical skills were added to this set by ADR
+  (self-modification of guardrails; CI/secret exfiltration), so `ship-it` never auto-merges it on
+  machine gates alone: under the §CP hard gate (ADR
+  [0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md),
+  amending 0053) a `@kamp-us/control-plane` member must **approve** it at its current head, and only
+  then does `ship-it` enqueue it (ADR 0048 single merge authority) — there is no human hand-merge in
+  the §CP path. The gate-critical skills were added to this set by ADR
   [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md),
   with `review-skill/**` added by ADR
   [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md); **§CP is the
   authoritative source of the exact blocking set** (cite it, don't re-hard-code). For a doc PR
   that touches this set, you are **advisory only**: review it, post your findings, but say
-  plainly that your verdict does **not** authorize a merge — a maintainer does.
+  plainly that your verdict does **not** authorize a merge — the control-plane approval does (a
+  `@kamp-us/control-plane` member approves at head; `ship-it` then enqueues — ADR 0135).
 
 So before you verify anything, classify the diff (Step 0). The classification decides
 whether your marker binds `ship-it` or is merely advice.
@@ -68,7 +73,8 @@ whether your marker binds `ship-it` or is merely advice.
 **You do not merge. Not on a pass, not ever, not on your own authority.** Your output is
 a *verdict* — a merge-ready signal (non-blocking) or advice (blocking) plus a fail
 comment listing what's missing. Merging is the deliberate act of **`ship-it`** (the one
-stage granted merge authority) — or, for the blocking set, a human. You signal
+stage granted merge authority) — for the blocking set (§CP) too, only gated on a
+`@kamp-us/control-plane` approval at head that `ship-it` then enqueues on (ADR 0135). You signal
 merge-ready; `ship-it` is the consumer that asserts your PASS, confirms CI is green, and
 squash-merges. Conflating "verified" with "merged" is the self-grading collapse this
 stage exists to prevent — the same invariant `review-code` holds.
@@ -152,8 +158,9 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   `claude-plugins/kampus-pipeline/skills/review-doc/**`, `claude-plugins/kampus-pipeline/skills/review-skill/**`, `claude-plugins/kampus-pipeline/skills/review-plan/**`,
   `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`) — → the PR is in the **blocking set**. You review it and
   post your findings, but **advisory only** — your verdict does not authorize a merge; a
-  maintainer merges it by hand (ADR 0053, widened to the gate-critical skills by ADR 0065, with
-  `review-skill/**` added by ADR 0073). **§CP is the authoritative source — cite it, don't
+  `@kamp-us/control-plane` approval at head does, and `ship-it` then enqueues it (ADR 0135
+  approve-then-enqueue; ADR 0048 single merge authority — the §CP set is ADR 0053, widened to the
+  gate-critical skills by ADR 0065, with `review-skill/**` added by ADR 0073). **§CP is the authoritative source — cite it, don't
   re-hard-code the list** (the #375 drift class §CP closes). Say so explicitly in the verdict
   (Step 5). And — like `ship-it` Step 0 and `review-code` Step 2 — **resolve §CP from
   `origin/main` at run time, not from the copy embedded in this skill body** (this advisory flag
@@ -184,7 +191,7 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   # grep exit 1, an empty (non-control-plane) result, not a failure (#725).
   CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
     --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
-  # non-empty → blocking: advisory verdict only; a human merges (ADR 0053/0065/0073)
+  # non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
   ```
 - **Otherwise** → **non-blocking**, and the doc class — *which* `*.md`/knowledge files are
   yours — is the **canonical §DOC definition** in
@@ -711,8 +718,8 @@ false-fails the unconditional `verdict_post_verify … || exit 1`.
 
 Every check passed but Step 0 classified the PR **blocking** (it touches `.claude/**`,
 `.github/**`, or a gate-critical skill). Post the **same evidence**, but the first line is
-**not** a merge-ready go-ahead — it is advice. `ship-it` refuses this PR regardless; a human
-merges it.
+**not** a merge-ready go-ahead — it is advice. `ship-it` does not auto-merge this PR on machine
+gates alone — it enqueues only once a `@kamp-us/control-plane` approval is present at head (ADR 0135).
 
 > **The first-line `@ <sha>` is SHA-less by design; the SHA lives in the body; a delegated merge
 > actor confirms from the body, not the first-line marker (ADR
@@ -722,8 +729,10 @@ merges it.
 > It is *not* a dropped binding: you still record the reviewed head in the body's canonical
 > `Reviewed-head: @ <sha>` line + the per-AC PASS below. A delegated control-plane merge actor must
 > **not** try to bind your first-line marker (it would read as `unverified`); it confirms by reading
-> the body's `Reviewed-head: @ <sha>` line against the PR's current head + the per-AC PASS, then
-> applies `ship-it`'s just-in-time guards and merges by hand.
+> the body's `Reviewed-head: @ <sha>` line against the PR's current head + the per-AC PASS; then,
+> once a `@kamp-us/control-plane` approval is present at that head, `ship-it` applies its
+> just-in-time guards and **enqueues** it (ADR 0135 approve-then-enqueue; ADR 0048 single merge
+> authority) — not a human hand-merge.
 
 > **The body's `Reviewed-head:` line is canonical and load-bearing — emit it verbatim (ADR 0151).**
 > `ship-it`'s ADR-0135 approval-aware enqueue reads the reviewed head from **exactly** the
@@ -740,7 +749,9 @@ review-doc: advisory — blocking-set PR (manual merge)
 
 PR #<PR> touches the control plane (`.claude/`/`.github/` or a gate-critical skill) — the agent
 control plane / pipeline gates (ADR 0053/0065). My verdict is **advisory only**: it does **not**
-authorize a merge. A maintainer merges this by hand.
+authorize a merge. Under the §CP hard gate (ADR 0135), a `@kamp-us/control-plane` member approves
+this at its current head and `ship-it` then enqueues it (ADR 0048 single merge authority) — there
+is no human hand-merge in the §CP path.
 
 Reviewed-head: @ <HEAD_SHA>
 
@@ -779,7 +790,8 @@ Do **not** emit the `review-doc: PASS @ <sha> — merge-ready` marker for a bloc
 `ship-it` go-ahead, and `ship-it` must refuse the blocking set. The advisory line keeps
 your verdict out of `ship-it`'s PASS namespace while still recording the advisory verdict
 (as a comment, per ADR 0058 rule 4) — the advisory line carries no `@ <sha>` because no
-`ship-it` namespace consumes it; a human merges these (ADR 0053).
+`ship-it` namespace consumes it; a control-plane approval @head gates it and `ship-it` enqueues it
+(ADR 0135; §CP set ADR 0053).
 
 ### Fail path — any miss (non-blocking or blocking)
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -123,7 +123,8 @@ base.
 **You do not merge. Not on a pass, not ever, not on your own authority.** Your output is a
 *verdict* — a merge-ready signal (non-blocking) or advice (blocking) plus a fail comment
 listing what's missing. Merging is the deliberate act of **`ship-it`** (the one stage granted
-merge authority) — or, for the blocking set, a human. You signal merge-ready; `ship-it` is
+merge authority) — for the blocking set (§CP) too, only gated on a `@kamp-us/control-plane` approval
+at head that `ship-it` then enqueues on (ADR 0135). You signal merge-ready; `ship-it` is
 the consumer that asserts your PASS, confirms CI is green, and squash-merges. Conflating
 "verified" with "merged" is the self-grading collapse this stage exists to prevent — the same
 invariant `review-code`/`review-doc` hold.
@@ -223,15 +224,16 @@ fi
 # is grep exit 1, an empty (non-control-plane) result, not a failure (#725).
 CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
-# non-empty → blocking: advisory verdict only; a human merges (ADR 0053/0065/0073, §CP)
+# non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
 ```
 
 - **Non-empty** (the PR touches a `.claude`/`.github` path or a **gate-critical skill** —
   `claude-plugins/kampus-pipeline/skills/ship-it/**`, `claude-plugins/kampus-pipeline/skills/review-code/**`, `claude-plugins/kampus-pipeline/skills/review-doc/**`, `claude-plugins/kampus-pipeline/skills/review-skill/**`,
   `claude-plugins/kampus-pipeline/skills/review-plan/**`, `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`) → the PR is in the **blocking
   set** (§CP). You review it and post your findings, but **advisory only** — your verdict does
-  not authorize a merge; a maintainer merges it by hand. Say so explicitly in the verdict
-  (Step 5, advisory path). **This is the common case for a skill PR that edits a gate** —
+  not authorize a merge; a `@kamp-us/control-plane` approval at head does, and `ship-it` then
+  enqueues it (ADR 0135 approve-then-enqueue; ADR 0048 single merge authority). Say so explicitly
+  in the verdict (Step 5, advisory path). **This is the common case for a skill PR that edits a gate** —
   every gate skill is gate-critical, so a PR to `review-code`/`review-doc`/`review-skill`/
   `ship-it`/`review-plan`/this-formats-file lands here and your verdict is advisory.
 - **Empty** (only non-gate-critical `skills/**` — `triage`, `plan-epic`, `write-code`,
@@ -620,7 +622,8 @@ false-fails the unconditional `verdict_post_verify … || exit 1`.
 Every check passed but Step 0 classified the PR **blocking** (it touches a gate-critical skill
 or any §CP path — the common case for a skill PR that edits a gate). Post the **same
 evidence**, but the first line is the **canonical advisory line** (§6.6) — **not** a
-merge-ready go-ahead. `ship-it` refuses this PR regardless; a human merges it. The advisory
+merge-ready go-ahead. `ship-it` does not auto-merge this PR on machine gates alone — it enqueues
+only once a `@kamp-us/control-plane` approval is present at head (ADR 0135). The advisory
 line carries **no first-line `@ <sha>`** by design (it authorizes nothing, so there is nothing to
 bind), keeping your verdict out of `ship-it`'s PASS namespace.
 
@@ -632,8 +635,10 @@ bind), keeping your verdict out of `ship-it`'s PASS namespace.
 > It is *not* a dropped binding: you still record the reviewed head `@ <sha>` + the per-AC PASS in
 > the verdict **body** below. A delegated control-plane merge actor must **not** try to bind your
 > first-line marker (it would read as `unverified`); it confirms by reading the body's canonical
-> `Reviewed-head: @ <sha>` line against the PR's current head + the per-AC PASS, then applies
-> `ship-it`'s just-in-time guards and merges by hand.
+> `Reviewed-head: @ <sha>` line against the PR's current head + the per-AC PASS; then, once a
+> `@kamp-us/control-plane` approval is present at that head, `ship-it` applies its just-in-time
+> guards and **enqueues** it (ADR 0135 approve-then-enqueue; ADR 0048 single merge authority) — not
+> a human hand-merge.
 
 > **The body's `Reviewed-head:` line is canonical and load-bearing — emit it verbatim (ADR 0151).**
 > `ship-it`'s ADR-0135 approval-aware enqueue reads the reviewed head from **exactly** the
@@ -650,7 +655,9 @@ review-skill: advisory — blocking-set PR (manual merge)
 
 PR #<PR> touches the control plane (a gate-critical skill or a `.claude`/`.github` path — §CP) —
 the agent control plane / pipeline gates (ADR 0053/0065/0073). My verdict is **advisory only**:
-it does **not** authorize a merge. A maintainer merges this by hand.
+it does **not** authorize a merge. Under the §CP hard gate (ADR 0135), a `@kamp-us/control-plane`
+member approves this at its current head and `ship-it` then enqueues it (ADR 0048 single merge
+authority) — there is no human hand-merge in the §CP path.
 
 Reviewed-head: @ <HEAD_SHA>
 

--- a/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-trivial/SKILL.md
@@ -103,7 +103,8 @@ CONTROL_PLANE_RE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/
 
 - **A control-plane file is present** — any path matching the live `CONTROL_PLANE_RE`
   (`.claude/**`, `.github/**`, a gate-critical skill, the enforcement-guard packages). A
-  control-plane diff is **never** trivial; it takes the full path **and a human merge** (ADR
+  control-plane diff is **never** trivial; it takes the full path **and the §CP approve-then-enqueue
+  gate** — a `@kamp-us/control-plane` approval at head before `ship-it` enqueues it (ADR 0135; ADR
   0053 / 0065 / 0100). It must never have routed here.
 - **The boundary could not be read** — an empty/unresolvable `CONTROL_PLANE_RE`. With no
   boundary you cannot prove the diff is non-control-plane, so you must not treat it as trivial


### PR DESCRIPTION
Fixes #3511

## Problem

The §CP advisory/authority prose across the `review-*` skills still described the **pre-ADR-0135** merge model — "a maintainer merges this by hand" — which contradicts the model the pipeline actually ships. Under [ADR 0135](../blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md) (amending [0053](../blob/main/.decisions/0053-control-plane-boundary.md)) §CP is **approve-then-pipeline-enqueue**: a `@kamp-us/control-plane` member approves at the current head (machine gates green), then `ship-it` — the single merge authority ([ADR 0048](../blob/main/.decisions/0048-ship-it-merge-actor.md)) — enqueues the §CP PR exactly like a non-§CP PR. There is **no human hand-merge** in the documented §CP path. The stale text surfaced live on PR #3501's §CP advisory marker.

## Fix (prose/wording only — no machine behavior changed)

Reworded every stale §CP merge-model site across the review-* skills to the ADR-0135 approve-then-`ship-it`-enqueue model, grounded in ADR 0135/0048:

- **`review-doc/SKILL.md`** — Step-0 blocking bullet + header, the classification bullet, the §CP-touched comment, the "Authority limit" line, the delegated-merge-actor note, the advisory-verdict template body, and the "a human merges these" trailers.
- **`review-skill/SKILL.md`** — the §CP comment, the classification bullet, the "Authority limit" line, the advisory pass-path prose, the delegated-merge-actor note, and the advisory-verdict template body.
- **`review-design/SKILL.md`** — the classification bullet, the "Authority limit" line, the advisory pass-path prose, and the advisory-verdict template body.
- **`review-code/SKILL.md`** — the three half-stale sites (`:1276`/`:1451`/`:1475`) that led with "a human merges it by hand, **or** ship-it enqueues" now state approve-then-enqueue directly (dropped the hand-merge lead), plus the "Authority limit" line.
- **`review-trivial/SKILL.md`** — the "control-plane diff … takes a human merge" line now names the §CP approve-then-enqueue gate.

## Scope notes

- **Marker first line left verbatim.** The canonical advisory marker (`<gate>: advisory — blocking-set PR (manual merge)`) is single-sourced in `gh-issue-intake-formats.md` §6.6 and matched machine-side only on `<gate>: advisory` (the `(manual merge)` suffix is cosmetic). Editing it only here would drift the skills from their canonical source, so it is untouched — a follow-up will reconcile the formats contract's own stale §CP prose.
- **Crew defs already reconciled by #3569** (in this branch's base) — this PR does not touch them, staying disjoint from that fix.

## §CP

This PR edits gate-critical review-* skills, so it is itself a **control-plane PR**: it banks for a `@kamp-us/control-plane` approval at head and ships via `ship-it` on green (ADR 0135) — it dogfoods the very model it documents.

## Acceptance criteria

- [x] Every stale site states the ADR-0135 approve-then-`ship-it`-enqueue model; no surface leads with (or implies) a §CP human hand-merge as the normal path.
- [x] The review-code half-stale sites (`:1276`/`:1451`/`:1475`) no longer lead with hand-merge.
- [x] `crew-chief-of-staff.md`/`crew-engineering-manager.md` reconciled (by #3569, in base).
- [x] `grep -rn "merges this by hand\|approval + merge" .claude/skills/review-*/SKILL.md claude-plugins/pipeline-crew/agents/*.md` returns no stale §CP-path hits.
- [x] No new decision introduced — edits only reconcile prose to ADRs 0135/0053/0048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)