### PR TITLE
docs(pipeline-crew-mcp): docs/ tree scaffold + README front-door index (#3559)

### DIFF
--- a/packages/pipeline-crew-mcp/README.md
+++ b/packages/pipeline-crew-mcp/README.md
@@ -2,54 +2,65 @@
 
 The crew's channels-backed messaging substrate — the peer-to-peer transport the pipeline
 crew talk over, exposed to each agent as MCP channels (epic #3045). The crew is a flat
-topology of five standing roles: `ea-chief-of-staff`, `engineering-manager`, `triage-guy`,
-`junior-engineer`, `cartographer` (the canonical agent-type slugs).
+topology of five standing roles (`ea-chief-of-staff`, `engineering-manager`, `triage-guy`,
+`junior-engineer`, `cartographer`), coordinating over a generic p2p tracker + peers with an
+MCP channel edge on top, so an agent joins a channel and sends/receives crew messages through
+its MCP client instead of an out-of-band tmux relay. Internal pipeline tooling, on no kamp.us
+user surface.
+
+This README is the **front door**: what the package is, why it exists, and an index into the
+[`docs/`](./docs/) tree. For anything deeper, follow the index — the docs are the source of
+truth for how to learn, operate, look up, and reason about the substrate.
+
+## Documentation
+
+The package docs are structured by [Diátaxis](https://diataxis.fr/) — one comprehension mode
+per file:
+
+| Doc | Mode | For |
+|---|---|---|
+| [Tutorial](./docs/tutorial.md) | learning | Bring up two peers, send a message, claim a resource — the end-to-end round-trip. |
+| [How-to](./docs/how-to.md) | tasks | Add a message kind, wire a tracker semantic, debug an offline peer, run stand-up under CI. |
+| [Reference](./docs/reference.md) | information | The message-kind catalog, tracker claim/lease semantics, the CLI surface, error types. |
+| [Explanation](./docs/explanation.md) | understanding | The coordination model — stigmergic claim map, pull-not-push, two-keyspace design (→ ADR 0191). |
+
+> **Surface separation (load-bearing).** This is the **package** substrate's docs home; its
+> index links **only** into this package's own `docs/` tree. The `pipeline-crew` **plugin** —
+> the crew itself (roles, roster law, §CP flow, personalization) — is a separate surface with
+> its own docs beside its agent defs. The two never cross-link: a reader asking "how do I add a
+> role" (plugin) must never land in "how does the claim map work" (package), and vice-versa.
 
 ## What it is
 
 A small, layered substrate split into a **generic core** and one **crew-coupled** module:
 
 - **`src/protocol/`** — the wire format: message envelopes and the codec every peer shares.
-- **`src/tracker/`** — the rendezvous registry where peers announce and discover each other.
+- **`src/tracker/`** — the rendezvous registry where peers announce and discover each other,
+  and the two-keyspace claim/lease store (presence leases keyed by peer, resource claims keyed
+  by resource — ADR 0191).
 - **`src/peer/`** — a p2p participant: dials, holds connections, relays messages over the protocol.
 - **`src/edge/`** — the MCP channel edge: exposes the substrate to an MCP client as channels.
-- **`src/crew/`** — the only crew-coupled module and the composition root: the Role enum
-  (the five-role flat topology, a single swap-in roster seam), the seam catalog (each role's
-  crew interactions mapped over `protocol/` — claim/collision-check, role-uniqueness lease,
-  epic handoff, drain tally, intake ping, discovery/presence), the wiring that composes
-  tracker + peer + edge into a per-role channel server (enforcing the role-uniqueness lease
-  the generic peer does not), and — the cutover (#3062) — the **runnable stdio session entry**
-  (`crew/session.ts`): one live session's stdio `McpServer` + `ChannelSend`-from-peer, driving
-  both channel edges (outbound the `channel_send` relay tool + the `channel_claim` resource-claim
-  tool, inbound inbox→channel wake) off one server. `channel_claim` (#3509) surfaces the tracker's
-  resource-keyed `Claim` so an engine can lock an issue before opening a lane — a second claimant on
-  a held resource gets a `collision`, not a second grant (the cross-engine mutual exclusion that a
-  peer-relayed `channel_send` cannot provide).
+- **`src/crew/`** — the only crew-coupled module and the composition root: the Role enum (the
+  five-role flat topology), the seam catalog (each role's crew interactions mapped over
+  `protocol/`), the wiring that composes tracker + peer + edge into a per-role channel server
+  (enforcing the role-uniqueness lease the generic peer does not, ADR 0189), and the runnable
+  stdio session entry (`crew/session.ts`).
+- **`src/standup/`** — the launch-time orchestration that stands the whole crew up from the
+  operator config, and the single-member `spawn-role` / `retire-role` ops.
 
 **The load-bearing boundary:** `protocol/`, `tracker/`, `peer/`, and `edge/` are the reusable
 channels substrate and never import `crew/`; `crew/` depends inward on the generic core, never
-the reverse. That one-way dependency is what keeps the substrate reusable beyond the crew — it
-is the reason the modules are split into directories rather than a flat file.
+the reverse. That one-way dependency is what keeps the substrate reusable beyond the crew.
 
 ## Why it exists
 
 The crew is a set of independent agent sessions that previously coordinated through out-of-band
-surfaces — filed issues plus a tmux relay convention (buffer-paste + staggered-submit, pane-title
-discovery, capture-pane identity verification). This package gives them a first-class, in-process
-messaging substrate — a generic p2p tracker + peers underneath, an MCP channel edge on top — so an
-agent joins a channel and sends/receives crew messages through its MCP client rather than a bespoke
-relay. It is internal pipeline tooling, on no kamp.us user surface. tmux is retained only as session
-host / stand-up topology; the seams no longer ride it.
-
-## Status
-
-The generic substrate (`protocol`/`tracker`/`peer`/`edge`), the `crew/` composition root (Role enum
-+ catalog + wiring), and the **cutover** (#3062) are landed: `crew/session.ts` binds the runnable
-stdio session entry, and the root barrel (`src/index.ts`) exposes the whole substrate onto the
-`crew/` composition. Every inter-session seam (claim/collision-check, planned-epic handoff, drain
-tally, intake pings, role discovery/presence, the role-uniqueness lease) routes over the channels
-protocol. Out of v1: the EA→operator human-notification channel (deferred) and removing tmux as
-session host.
+surfaces — filed issues plus a tmux relay convention. This package gives them a first-class,
+in-process messaging substrate so an agent joins a channel and sends/receives crew messages
+through its MCP client rather than a bespoke relay. tmux is retained only as session host /
+stand-up topology; the seams no longer ride it. The design rationale — stigmergic coordination
+through the shared claim map, claim-liveness riding presence, the two-keyspace split — is in the
+[Explanation](./docs/explanation.md), which points to ADR 0191.
 
 ## Usage
 
@@ -65,4 +76,5 @@ pnpm --filter @kampus/pipeline-crew-mcp test       # @effect/vitest suite
 
 The `--role` is one of the five standing `CREW_ROLES` (`ea-chief-of-staff`, `engineering-manager`,
 `triage-guy`, `junior-engineer`, `cartographer`); the session joins the per-project tracker under
-`--project-root` (default: cwd) and runs until interrupted.
+`--project-root` (default: cwd) and runs until interrupted. See the [Tutorial](./docs/tutorial.md)
+for the first-run walkthrough and the [Reference](./docs/reference.md) for the full CLI surface.

--- a/packages/pipeline-crew-mcp/docs/explanation.md
+++ b/packages/pipeline-crew-mcp/docs/explanation.md
@@ -1,0 +1,21 @@
+# Explanation — the coordination model
+
+> **Diátaxis mode: explanation** (understanding-oriented). One mode per doc — shape and
+> tradeoffs, not steps. Learn the substrate from zero in the [tutorial](./tutorial.md);
+> perform a specific task with the [how-to](./how-to.md); look up an exact contract in the
+> [reference](./reference.md).
+
+Why the substrate is shaped the way it is: stigmergic coordination through the shared claim
+map, pull-not-push messaging, claim-liveness riding presence, and the two-keyspace registry
+design. This quadrant **points to the governing ADR rather than re-deriving it**, so the docs
+can never drift from the decision (per CLAUDE.md's "collapse a docblock that re-derives an
+ADR's *why* to a pointer" rule).
+
+> **Status: scaffold.** This is the docs-home quadrant stub. The rationale body is authored in
+> [#3561](https://github.com/kamp-us/phoenix/issues/3561) (Phase 1).
+
+## Grounding
+
+- Claim lifecycle, two-keyspace design, claim-liveness-rides-presence:
+  [ADR 0191 — crew claim lifecycle](../../../.decisions/0191-crew-claim-lifecycle.md).
+- The registry model these facets fall out of: [`src/tracker/registry-core.ts`](../src/tracker/registry-core.ts).

--- a/packages/pipeline-crew-mcp/docs/how-to.md
+++ b/packages/pipeline-crew-mcp/docs/how-to.md
@@ -1,0 +1,21 @@
+# How-to — extend and operate the substrate
+
+> **Diátaxis mode: how-to** (task-oriented). One mode per doc — goal-focused recipes for a
+> reader who already knows the shape. Learn the substrate from zero in the
+> [tutorial](./tutorial.md); look up an exact contract in the [reference](./reference.md);
+> understand the design rationale in the [explanation](./explanation.md).
+
+Goal-focused recipes for the recurring package tasks: add a message kind, wire a new tracker
+semantic, debug an offline peer, and run stand-up under CI.
+
+> **Status: scaffold.** This is the docs-home quadrant stub. The recipes are authored in
+> [#3564](https://github.com/kamp-us/phoenix/issues/3564) (Phase 2), which builds on the
+> [reference](./reference.md) and [explanation](./explanation.md).
+
+## Grounding
+
+- Message kinds + codec: [`src/protocol/schema.ts`](../src/protocol/schema.ts).
+- Tracker claim/lease core: [`src/tracker/registry-core.ts`](../src/tracker/registry-core.ts).
+- Stand-up orchestration + per-session bind: [`src/standup/bind.ts`](../src/standup/bind.ts),
+  [`src/standup/orchestrate.ts`](../src/standup/orchestrate.ts).
+- CLI subcommands: [`src/bin.ts`](../src/bin.ts).

--- a/packages/pipeline-crew-mcp/docs/reference.md
+++ b/packages/pipeline-crew-mcp/docs/reference.md
@@ -1,0 +1,21 @@
+# Reference — substrate contracts
+
+> **Diátaxis mode: reference** (information-oriented). One mode per doc — exhaustive and
+> source-matching, no narrative. Learn the substrate from zero in the
+> [tutorial](./tutorial.md); perform a specific task with the [how-to](./how-to.md);
+> understand *why* the contracts are shaped this way in the [explanation](./explanation.md).
+
+The exact contracts an integrator codes against: the message-kind catalog, the tracker
+claim/lease semantics, the stand-up CLI surface, and the typed error catalog.
+
+> **Status: scaffold.** This is the docs-home quadrant stub. The contract catalog is authored
+> in [#3560](https://github.com/kamp-us/phoenix/issues/3560) (Phase 1), read directly off the
+> live modules so the signatures match source.
+
+## Grounding
+
+- Message-kind catalog + wire codec: [`src/protocol/schema.ts`](../src/protocol/schema.ts).
+- Tracker claim/lease semantics (two keyspaces): [`src/tracker/registry-core.ts`](../src/tracker/registry-core.ts).
+- CLI (`session` / `tracker` / `stand-up` / `stand-down` / `spawn-role` / `retire-role`):
+  [`src/bin.ts`](../src/bin.ts).
+- Error types: [`src/crew/errors.ts`](../src/crew/errors.ts), [`src/peer/errors.ts`](../src/peer/errors.ts).

--- a/packages/pipeline-crew-mcp/docs/tutorial.md
+++ b/packages/pipeline-crew-mcp/docs/tutorial.md
@@ -1,0 +1,22 @@
+# Tutorial — send your first message and claim a resource
+
+> **Diátaxis mode: tutorial** (learning-oriented). One mode per doc — a linear, hand-held
+> lesson to a guaranteed outcome. Look up an exact contract in the
+> [reference](./reference.md); perform a specific task with the [how-to](./how-to.md);
+> understand *why* the substrate is shaped this way in the [explanation](./explanation.md).
+
+A zero-to-working walkthrough: bring up two peers on one project's tracker, send a message
+across the channel, and claim a resource so the second peer sees a `collision` — the smallest
+end-to-end round-trip that exercises both the channel edge and the tracker before you extend
+either.
+
+> **Status: scaffold.** This is the docs-home quadrant stub. The lesson body is authored in
+> [#3565](https://github.com/kamp-us/phoenix/issues/3565) (Phase 2), which builds on the
+> settled contracts in the [reference](./reference.md).
+
+## Grounding
+
+- Session entry / CLI: [`src/bin.ts`](../src/bin.ts) (`session`, `tracker`).
+- The runnable session: [`src/crew/session.ts`](../src/crew/session.ts).
+- Message payloads: [`src/protocol/schema.ts`](../src/protocol/schema.ts).
+- Claim/lease semantics: [`src/tracker/registry-core.ts`](../src/tracker/registry-core.ts).


### PR DESCRIPTION
Fixes #3559

Phase-1 root of epic #3537 (milestone: Diátaxis docs — pipeline-crew & -mcp). Establishes the **package surface's docs home** that every quadrant sibling links into.

## What changed
- **`packages/pipeline-crew-mcp/docs/`** — new Diátaxis tree, one single-mode file per quadrant (house style: fate-live pattern split, #3392):
  - `tutorial.md` — learning: 2-peer send + resource-claim round-trip.
  - `how-to.md` — tasks: add a message kind, wire a tracker semantic, debug an offline peer, run stand-up under CI.
  - `reference.md` — information: message-kind catalog, tracker claim/lease semantics, CLI, error types.
  - `explanation.md` — understanding: the coordination model, **pointing to ADR 0191** rather than re-deriving it.
- **`packages/pipeline-crew-mcp/README.md`** — rewritten as a front-door index into `docs/`, condensing the what/why and adding the quadrant index table.

## Scope (per the issue)
This child creates the **scaffold + index + empty-but-headed quadrant files** only. The quadrant bodies land in the sibling children: Reference #3560, Explanation #3561 (Phase 1); How-to #3564, Tutorial #3565 (Phase 2). Each stub carries its single-mode framing, an authoring pointer to its issue, and grounded source/ADR pointers.

## Surface separation (load-bearing)
The package index links **only** into the package's own `docs/` tree — never into the `pipeline-crew` plugin docs. The README states the invariant explicitly: a "how do I add a role" (plugin) reader must never land in "how does the claim map work" (package).

## Verification
- `pipeline-cli readme-guard check` — green (all 28 members carry a README).
- `pnpm lint` — green (no biome-handled changed files; docs are markdown).
- Explanation quadrant points to [ADR 0191](.decisions/0191-crew-claim-lifecycle.md); grounding pointers cite `protocol/schema.ts`, `tracker/registry-core.ts`, `standup/bind.ts`, `bin.ts`, `crew/errors.ts`.

## Merge model
§CP-by-content (docs touch the crew package) — **banks for a human merge**. Not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)