### PR TITLE
feat(pipeline-cli): Tracker apply-triage verb — label-transition envelope + same-commit adoption (#3263)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -547,32 +547,21 @@ bootstrap / formats contract ([`../gh-issue-intake-formats.md`](../gh-issue-inta
 triage *applies* labels from that existing set, and must never silently auto-mint an
 off-spec label via `POST .../labels`.
 
-A triaged issue carries: the one `type:*`, one `p*`, and `status:triaged`. Remove
-`status:needs-triage` so it leaves the queue. Do it in REST calls:
+A triaged issue carries the one `type:*`, one `p*`, and `status:triaged`, and leaves the
+queue (its `status:needs-triage` removed). Apply the whole transition with the `Tracker`
+verb — the classification is the parameter, the label plumbing is the verb's:
 
 ```bash
-# add the type, priority, and triaged status
-gh api "repos/$REPO/issues/<N>/labels" \
-  -f "labels[]=type:chore" -f "labels[]=p2" -f "labels[]=status:triaged"
-# remove the needs-triage label — pass the BARE name; gh api encodes the path segment
-# (don't pre-encode the colon as %3A, or gh double-encodes it to %253A → spurious 404)
-gh api -X DELETE "repos/$REPO/issues/<N>/labels/status:needs-triage"
+pipeline-cli tracker apply-triage <N> --type <type> --p <priority>
 ```
 
-A `404 "Label does not exist"` on that DELETE is harmless **only** in one known case:
-the issue never carried `status:needs-triage` to begin with — a pre-bootstrap backlog
-issue that predates the label, which you may triage directly by number. In that case
-the label is already absent, so the goal (issue out of the queue) is met. Do **not**
-blanket-`|| true` the call: a 404 on an issue that *did* carry the label means the
-removal silently failed and the issue is still in the needs-triage queue while looking
-triaged. So if you're not certain it's the pre-bootstrap case, verify the label is
-actually gone after the call rather than swallowing the error:
-
-```bash
-gh api "repos/$REPO/issues/<N>" \
-  --jq '[.labels[].name] | index("status:needs-triage") // "removed"'
-# expect "removed"; anything else means the label is still on the issue — investigate
-```
+The verb adds the `type:` / priority / `status:triaged` labels and drops the queue label
+in one envelope (ADR 0190; `packages/pipeline-cli/src/tools/tracker/`). Dropping the queue
+label is idempotent: a `404 "Label does not exist"` when the issue never carried
+`status:needs-triage` (a pre-bootstrap issue predating the label) is tolerated, since the
+goal — issue out of the queue — is met either way. Pass `--status <stage>` to target a
+different lifecycle stage (e.g. `needs-info`); it defaults to `triaged`. Don't hand-roll
+the REST label calls — that inline envelope is exactly what the adoption lint (#3254) flags.
 
 `status:triaged` is an explicit signature only *you* apply — it tells write-code the
 issue was actually reviewed. Never let a type label alone stand in for it; a

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -38,6 +38,23 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		reason:
 			"re-derives the ADR-0058 SHA-bound verdict-marker resolution that `pipeline-cli verdict read` owns, instead of citing the verb (#3254 / #2102)",
 	},
+	{
+		// `tracker apply-triage` owns the label-transition envelope (#3263): add the
+		// type/priority/status classification then remove the needs-triage queue label. The
+		// fingerprint is the co-occurrence of all three tells — adding a `type:` label, setting
+		// `status:triaged`, and deleting the `status:needs-triage` queue label — so an incidental
+		// `labels[]=type:` (e.g. creating a child issue in plan-epic) is not a false finding. A
+		// file that cites `pipeline-cli tracker apply-triage` is compliant.
+		verb: "tracker apply-triage",
+		signature: [
+			/labels\[\]=type:/, // adds a type label
+			/labels\[\]=status:triaged/, // sets the triaged status
+			/labels\/status:needs-triage/, // removes the needs-triage queue label
+		],
+		citation: /pipeline-cli\s+tracker\s+apply-triage\b/,
+		reason:
+			"re-derives the label-transition envelope that `pipeline-cli tracker apply-triage` owns (add type/priority/status, remove needs-triage), instead of citing the verb (#3263 / #3254)",
+	},
 ];
 
 /**

--- a/packages/pipeline-cli/src/tools/tracker/command.ts
+++ b/packages/pipeline-cli/src/tools/tracker/command.ts
@@ -1,20 +1,28 @@
 /**
  * The `tracker` tool — `pipeline-cli tracker claim <target>` /
- * `pipeline-cli tracker read-back <target>`.
+ * `pipeline-cli tracker read-back <target>` / `pipeline-cli tracker apply-triage <target>`.
  *
- * The seed surface of the Wave-1 `Tracker` service (ADR 0190): `claim` posts the ADR-0115
+ * The CLI surface of the Wave-1 `Tracker` service (ADR 0190): `claim` posts the ADR-0115
  * agent-distinguishable claim and exits 0 only when the claim is ours; `read-back` resolves
- * and prints the current owner. Judgment-as-parameter: the claiming identity is supplied,
- * not decided by the tool — the session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only
- * agent-distinguishable signal under the shared `usirin` login) and `--session` overrides it
- * for the orchestrated/delegated-token path and for tests; an absent value fails closed.
+ * and prints the current owner; `apply-triage` applies a type/priority/status classification
+ * and drops the entity out of the needs-triage queue (#3263). Judgment-as-parameter: the
+ * claiming identity and the classification are supplied, not decided by the tool — the claim
+ * session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable signal
+ * under the shared `usirin` login) and `--session` overrides it for the orchestrated/
+ * delegated-token path and for tests; an absent value fails closed.
  *
  * `GithubTrackerLive` is baked in with `Command.provide(...)` so the registered command's
  * residual requirement is the Node platform union (the registry seam, epic #994).
  */
 import {Console, Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
-import {type ClaimResult, GithubTrackerLive, type ReadBackResult, Tracker} from "./tracker.ts";
+import {
+	type ClaimResult,
+	GithubTrackerLive,
+	type ReadBackResult,
+	Tracker,
+	type TriageResult,
+} from "./tracker.ts";
 
 const BACKOFF_EXIT_CODE = 1;
 
@@ -93,10 +101,47 @@ const readBack = Command.make(
 	}),
 ).pipe(Command.withDescription("Read back and print the current claim owner of a tracker entity"));
 
-export const trackerCommand = Command.make("tracker").pipe(
-	Command.withSubcommands([claim, readBack]),
+// Judgment-as-parameter (#3252): the classification is supplied, not decided by the tool.
+// `--status` defaults to the `triaged` lifecycle stage — the common triage transition.
+const typeFlag = Flag.string("type").pipe(
+	Flag.withDescription("the domain type classification (e.g. feature, bug, chore)"),
+);
+
+const priorityFlag = Flag.string("p").pipe(
+	Flag.withDescription("the domain priority (e.g. p0, p1, p2)"),
+);
+
+const statusFlag = Flag.string("status").pipe(
+	Flag.optional,
+	Flag.withDescription("the target lifecycle stage (default: triaged)"),
+);
+
+const reportTriage = (target: number, result: TriageResult): Effect.Effect<void> =>
+	Console.log(
+		`tracker: triaged #${target} — type:${result.type} ${result.priority} status:${result.status}.`,
+	);
+
+const applyTriage = Command.make(
+	"apply-triage",
+	{target: targetArg, type: typeFlag, p: priorityFlag, status: statusFlag},
+	Effect.fn(function* ({target, type, p, status}) {
+		const result = yield* (yield* Tracker).applyTriage(target, {
+			type,
+			priority: p,
+			status: Option.getOrElse(status, () => "triaged"),
+		});
+		yield* reportTriage(target, result);
+	}),
+).pipe(
 	Command.withDescription(
-		"The crew tracker service (ADR 0190): claim a tracker entity + read back its owner",
+		"Apply a triage classification (type / priority / status) to a tracker entity, leaving the needs-triage queue",
+	),
+);
+
+export const trackerCommand = Command.make("tracker").pipe(
+	Command.withSubcommands([claim, readBack, applyTriage]),
+	Command.withDescription(
+		"The crew tracker service (ADR 0190): claim a tracker entity, read back its owner, apply a triage classification",
 	),
 	Command.provide(GithubTrackerLive),
 );

--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -2,6 +2,7 @@ import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
 import {Effect, Layer, Sink, Stream} from "effect";
 import {ChildProcessSpawner} from "effect/unstable/process";
 import {
+	GhCommandError,
 	GithubTrackerLive,
 	type RepoResolutionError,
 	Tracker,
@@ -310,18 +311,103 @@ describe("Tracker.readBack — resolve the current owner", () => {
 	);
 });
 
-describe("Tracker — the declared-but-not-yet-built verbs fail closed", () => {
-	it.effect("applyTriage → TrackerNotImplementedError (never a silent no-op)", () =>
+describe("Tracker.applyTriage — the label-transition envelope over a mock gh spawner", () => {
+	const L = `${P}/issues/${TARGET}/labels`;
+
+	it.effect("adds type/priority/status, removes needs-triage, reads back → triaged", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.applyTriage(TARGET, {type: "feature", priority: "p2"});
+			assert.deepStrictEqual(result, {
+				_tag: "triaged",
+				type: "feature",
+				priority: "p2",
+				status: "triaged",
+			});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`POST ${L}`]: JSON.stringify([{name: "type:feature"}, {name: "p2"}]),
+				[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`]: "",
+				// read-back reflects the post-transition state: the queue label is gone.
+				[`GET ${L}`]: JSON.stringify([
+					{name: "type:feature"},
+					{name: "p2"},
+					{name: "status:triaged"},
+				]),
+			}),
+		),
+	);
+
+	it.effect("honors an explicit --status stage and reports the stage that landed", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.applyTriage(TARGET, {
+				type: "bug",
+				priority: "p1",
+				status: "needs-info",
+			});
+			assert.deepStrictEqual(result, {
+				_tag: "triaged",
+				type: "bug",
+				priority: "p1",
+				status: "needs-info",
+			});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`POST ${L}`]: JSON.stringify([{name: "type:bug"}]),
+				[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`]: "",
+				[`GET ${L}`]: JSON.stringify([
+					{name: "type:bug"},
+					{name: "p1"},
+					{name: "status:needs-info"},
+				]),
+			}),
+		),
+	);
+
+	it.effect("the queue label already absent (404 on remove) → still triaged (idempotent)", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.applyTriage(TARGET, {type: "chore", priority: "p2"});
+			assert.deepStrictEqual(result, {
+				_tag: "triaged",
+				type: "chore",
+				priority: "p2",
+				status: "triaged",
+			});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`POST ${L}`]: JSON.stringify([{name: "type:chore"}]),
+				// a pre-bootstrap issue never carried the queue label → the remove 404s, tolerated.
+				[`DELETE ${P}/issues/${TARGET}/labels/status:needs-triage`]: {
+					stdout: "",
+					exitCode: 1,
+					stderr: "HTTP 404: Label does not exist",
+				},
+				[`GET ${L}`]: JSON.stringify([
+					{name: "type:chore"},
+					{name: "p2"},
+					{name: "status:triaged"},
+				]),
+			}),
+		),
+	);
+
+	it.effect("a non-zero gh add-labels exit → GhCommandError in the E channel", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;
 			const error = yield* Effect.flip(
 				tracker.applyTriage(TARGET, {type: "feature", priority: "p2"}),
 			);
-			assert.isTrue(error instanceof TrackerNotImplementedError);
-			assert.strictEqual(error.verb, "applyTriage");
-		}).pipe((effect) => provide(effect, {})),
+			assert.isTrue(error instanceof GhCommandError);
+		}).pipe((effect) =>
+			// no POST fixture → the add-labels call exits 1 → GhCommandError, never a throw.
+			provide(effect, {}),
+		),
 	);
+});
 
+describe("Tracker — the declared-but-not-yet-built verbs fail closed", () => {
 	it.effect("postVerdict → TrackerNotImplementedError", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -2,11 +2,12 @@
  * The `Tracker` service — the shared Effect capability over the crew's issue tracker
  * surface (claims, triage, verdicts, graduation) with **domain-shaped** signatures.
  *
- * This is the walking skeleton of Wave 1 (epic #3258): a `Context.Service` `Tracker`
- * tag plus its sole implementation `GithubTrackerLive`. It seeds one verb end to end —
- * `claim` (the ADR-0115 agent-distinguishable claim) and a generic `readBack` — and
- * *declares* the not-yet-built verbs (`applyTriage` / `postVerdict` / `graduate`) so the
- * interface shape is complete before it locks; sibling Phase-3 children implement them.
+ * Grown from the Wave-1 walking skeleton (epic #3258): a `Context.Service` `Tracker`
+ * tag plus its sole implementation `GithubTrackerLive`. `claim` (the ADR-0115
+ * agent-distinguishable claim), a generic `readBack`, and `applyTriage` (the
+ * label-transition envelope, #3263) are live; `postVerdict` / `graduate` are still
+ * *declared* — their interface shape is fixed so the tag locks before its remaining
+ * sibling Phase-3 children implement them.
  *
  * Two design rules bind every signature here and are the point of the skeleton:
  *
@@ -64,9 +65,9 @@ export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionE
 ) {}
 
 /**
- * A declared-but-not-yet-built verb was called. The skeleton ships `claim` + `readBack`
- * live; `applyTriage` / `postVerdict` / `graduate` fail-closed with this typed error
- * until a sibling Phase-3 child implements them — never a silent no-op or a throw.
+ * A declared-but-not-yet-built verb was called. `claim` / `readBack` / `applyTriage`
+ * are live; `postVerdict` / `graduate` fail-closed with this typed error until a sibling
+ * Phase-3 child implements them — never a silent no-op or a throw.
  */
 export class TrackerNotImplementedError extends Schema.TaggedErrorClass<TrackerNotImplementedError>()(
 	"@kampus/tracker/TrackerNotImplementedError",
@@ -109,11 +110,30 @@ export type ReadBackResult =
 // complete before it locks (ADR 0190). Each stays domain-shaped — no label string, no
 // sub-issue id, no REST field — so a later Asana/local-markdown adapter needs no reshape.
 
-/** Triage classification: the domain type + priority a triage decision assigns. */
+/**
+ * Triage classification (judgment-as-parameter, #3252): the domain type + priority a
+ * triage decision assigns, and the lifecycle stage it moves the entity to (`status`,
+ * default `triaged`). Domain vocabulary only — `type`/`priority`/`status` are the crew's
+ * own terms; `GithubTrackerLive` maps them to `type:` / `status:` label strings at the
+ * boundary, so no GitHub label string leaks into the signature (ADR 0190).
+ */
 export interface TriageJudgment {
 	readonly type: string;
 	readonly priority: string;
+	readonly status?: string;
 }
+
+/**
+ * The `applyTriage` verdict — the entity now carries the classification, with `status`
+ * read back from the entity (so the caller sees the stage that actually landed, not just
+ * the one requested). A domain owner, never a raw REST label payload.
+ */
+export type TriageResult = {
+	readonly _tag: "triaged";
+	readonly type: string;
+	readonly priority: string;
+	readonly status: string;
+};
 
 /** A gate verdict: which gate, whether it passed, and the head ref it is bound to. */
 export interface VerdictJudgment {
@@ -241,6 +261,33 @@ const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
 	".permission",
 ];
 
+const addLabelsArgs = (
+	repo: string,
+	target: TargetId,
+	labels: ReadonlyArray<string>,
+): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${target}/labels`,
+	...labels.flatMap((label) => ["-f", `labels[]=${label}`]),
+];
+
+// The bare label name is passed unencoded: gh encodes the path segment itself, so
+// pre-encoding the `:` would double-encode it (%253A) into a spurious 404.
+const removeLabelArgs = (repo: string, target: TargetId, label: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"DELETE",
+	`repos/${repo}/issues/${target}/labels/${label}`,
+];
+
+const listLabelsArgs = (repo: string, target: TargetId): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${target}/labels?per_page=100`,
+];
+
 /** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
 const RawComment = Schema.Struct({
 	id: Schema.Number,
@@ -249,6 +296,13 @@ const RawComment = Schema.Struct({
 	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
 });
 const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+/** A raw label as the issues/labels endpoint returns it; only the name is read. */
+const RawLabel = Schema.Struct({name: Schema.String});
+const decodeLabels = Schema.decodeUnknownEffect(Schema.Array(RawLabel));
+
+const LABEL_STATUS_PREFIX = "status:";
+const QUEUE_STATUS = "needs-triage";
 
 const toClaimComment = (raw: (typeof RawComment)["Type"]): ClaimComment => ({
 	id: raw.id,
@@ -350,13 +404,47 @@ const readBack = Effect.fn("Tracker.readBack")(function* (repo: string, target: 
 		: ({_tag: "unclaimed"} satisfies ReadBackResult);
 });
 
+/**
+ * Apply a triage classification to `target` (ADR 0190) — the label-transition envelope
+ * the triage skill hand-rolled, now one verb with the judgment as a parameter. Adds the
+ * `type:` / priority / `status:<stage>` labels, then removes the `status:needs-triage`
+ * queue label so the entity leaves the queue. The removal is idempotent: a `gh` 404 (the
+ * entity never carried the queue label — a pre-bootstrap issue) is not a failure of the
+ * transition, since the triaged end-state is reached either way. Reads the labels back and
+ * Schema-decodes them at the boundary, reporting the `status` stage that actually landed.
+ */
+const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
+	repo: string,
+	target: TargetId,
+	judgment: TriageJudgment,
+) {
+	const status = judgment.status ?? "triaged";
+	const add = [`type:${judgment.type}`, judgment.priority, `${LABEL_STATUS_PREFIX}${status}`];
+	yield* runGh(addLabelsArgs(repo, target, add));
+	yield* runGh(removeLabelArgs(repo, target, `${LABEL_STATUS_PREFIX}${QUEUE_STATUS}`)).pipe(
+		Effect.catchTag("@kampus/tracker/GhCommandError", () => Effect.succeed("")),
+	);
+	const labels = yield* decodeLabels(yield* json(listLabelsArgs(repo, target)));
+	const landedStatus = labels
+		.map((label) => label.name)
+		.filter((name) => name.startsWith(LABEL_STATUS_PREFIX))
+		.map((name) => name.slice(LABEL_STATUS_PREFIX.length))
+		.find((stage) => stage !== QUEUE_STATUS);
+	return {
+		_tag: "triaged",
+		type: judgment.type,
+		priority: judgment.priority,
+		status: landedStatus ?? status,
+	} satisfies TriageResult;
+});
+
 type TrackerErrors = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
 
 /**
- * `Tracker` — the shared crew tracker capability. `claim` and `readBack` are live; the
- * three declared verbs fail `TrackerNotImplementedError` until a sibling child builds them
- * (their success types are `never` by design — a not-yet-built verb produces no value).
- * Built by `GithubTrackerLive`, whose `R` is `ChildProcessSpawner`.
+ * `Tracker` — the shared crew tracker capability. `claim`, `readBack`, and `applyTriage`
+ * are live; the two still-declared verbs fail `TrackerNotImplementedError` until a sibling
+ * child builds them (their success types are `never` by design — a not-yet-built verb
+ * produces no value). Built by `GithubTrackerLive`, whose `R` is `ChildProcessSpawner`.
  */
 export class Tracker extends Context.Service<
 	Tracker,
@@ -369,7 +457,7 @@ export class Tracker extends Context.Service<
 		readonly applyTriage: (
 			target: TargetId,
 			judgment: TriageJudgment,
-		) => Effect.Effect<never, TrackerNotImplementedError>;
+		) => Effect.Effect<TriageResult, TrackerErrors>;
 		readonly postVerdict: (
 			target: TargetId,
 			judgment: VerdictJudgment,
@@ -406,7 +494,8 @@ export const GithubTrackerLive: Layer.Layer<
 			claim: (target, judgment) =>
 				repo.pipe(Effect.flatMap((r) => withSpawner(claim(r, target, judgment.session)))),
 			readBack: (target) => repo.pipe(Effect.flatMap((r) => withSpawner(readBack(r, target)))),
-			applyTriage: () => notImplemented("applyTriage"),
+			applyTriage: (target, judgment) =>
+				repo.pipe(Effect.flatMap((r) => withSpawner(applyTriage(r, target, judgment)))),
 			postVerdict: () => notImplemented("postVerdict"),
 			graduate: () => notImplemented("graduate"),
 		};


### PR DESCRIPTION
This adds the `apply-triage` verb to the shared `Tracker` service, so a triage/planner agent applies a type/priority/status classification through one CLI verb instead of hand-composing the label-transition `gh api` calls from memory. The classification is a parameter, not tool behavior; the label plumbing lives once, behind the verb. It also migrates the triage skill's inline envelope to cite the verb, so the crew corpus consumes what it extracts.

## What changed
- **`Tracker.applyTriage`** (`packages/pipeline-cli/src/tools/tracker/tracker.ts`) — replaces the fail-closed skeleton stub with a real implementation over `GithubTrackerLive`. It adds the `type:` / priority / `status:<stage>` labels then removes the `status:needs-triage` queue label in one envelope. The removal is idempotent: a `gh` 404 (a pre-bootstrap issue that never carried the queue label) is tolerated. The label read-back is Schema-decoded at the REST boundary and reports the stage that actually landed.
- **CLI** (`.../tracker/command.ts`) — `pipeline-cli tracker apply-triage <N> --type <t> --p <p> [--status <s>]`, judgment-as-parameter; `--status` defaults to `triaged`.
- **Behavior tests** (`.../tracker/tracker.behavior.test.ts`) — happy path, explicit `--status` stage, idempotent-404 back-off, and a `GhCommandError` error path (ADR 0040 style, over the mock `gh` spawner).
- **Same-commit adoption (#3254)** — the triage skill's inline label envelope (`claude-plugins/kampus-pipeline/skills/triage/SKILL.md`) is deleted and replaced with a citation to the verb; the `apply-triage` decision is added to the adoption-lint manifest (`.../adoption-lint/manifest.ts`) so future re-derivations are flagged. `adoption-lint` is clean over the full corpus.

## Design invariants (ADR 0190 — design against two backends, build one)
- No GitHub semantics in the signature — `TriageJudgment` carries domain `type` / `priority` / `status`; `GithubTrackerLive` maps them to label strings at the boundary. No label string or REST idiom leaks into the interface.
- Infra failures are typed in the E channel (`GhCommandError` / `GhParseError` / `RepoResolutionError` / `SchemaError`); untrusted REST JSON is Schema-decoded at the boundary.

Verified locally: `pnpm typecheck` clean, `pnpm lint:worktree` clean, tracker + adoption-lint suites pass (29 tests), `adoption-lint check` clean over the whole plugin corpus.

§CP note: touches `packages/pipeline-cli/**` and a gate-critical skill — stops at reviewed-ready for cansirin approval at merge time; not merged here.

Advances epic #3258 (Wave 1).

Fixes #3263