### PR TITLE
test(e2e): make the sözlük create-flow submit survive the Base UI portal re-render (#3583)

### DIFF
--- a/apps/web/tests/e2e/06-sozluk-home.spec.ts
+++ b/apps/web/tests/e2e/06-sozluk-home.spec.ts
@@ -83,27 +83,24 @@ test.describe("SozlukHome create-flow (+ yeni tanım → composer)", () => {
 
 		await page.getByRole("button", {name: /yeni tanım/i}).click();
 
-		// Gate on the composer's `Terim` input becoming actionable rather than settling the
-		// dialog's `kp-dialog-pop` entry animation. The old settle awaited every animation's
-		// `finished` promise, but the Web Animations API REJECTS `finished` with an AbortError
-		// when an animation is cancelled — and the Base UI portal re-render cancels the entry
-		// animation mid-flight, so `Promise.all` fail-fast rejected and the spec died. That
-		// settle relocated the #3517 portal-re-render race into a hard rejection instead of
-		// removing it (#3526 → #3583). Playwright's built-in actionability on the fill/click
-		// below already waits for the popup to be visible, stable, and hit-testable and
-		// auto-retries a control the re-render detaches mid-action — the real fix for the #3517
-		// detach-mid-click flake.
+		// The Base UI dialog portal re-renders shortly after open (a transition-status flip
+		// that detaches the popup subtree — the #3517 race), so a single fill→submit loses its
+		// target: the `oluştur` button detaches faster than Playwright's per-action auto-retry
+		// can outlast (#3585 only moved the failure here from the cancelled-animation
+		// AbortError), and a remount clears the uncontrolled `Terim` input. Retry the whole
+		// fill→submit→navigate as one unit until it sticks — each poll re-fills (idempotent)
+		// and re-clicks, and the block passes only once the submit's navigation actually lands,
+		// so a mid-interaction detach is absorbed instead of failing the test. The app-side
+		// portal re-render is tracked as a follow-up off #3583.
 		const dialog = page.locator(".kp-dialog__popup");
 		await expect(dialog).toBeVisible();
-		const termInput = page.getByLabel("Terim");
-		await termInput.waitFor({state: "visible"});
-
-		// The dialog collects the term name (the composer is slug-addressed).
-		await termInput.fill(term);
-		await page.getByRole("button", {name: /^oluştur$/i}).click();
-
-		// The dialog slugifies + navigates to the fresh-slug composer route.
-		await expect(page).toHaveURL(new RegExp(`/sozluk/${slug}$`));
+		await expect(async () => {
+			// The dialog collects the term name (the composer is slug-addressed).
+			await page.getByLabel("Terim").fill(term);
+			await page.getByRole("button", {name: /^oluştur$/i}).click({timeout: 2_000});
+			// The dialog slugifies + navigates to the fresh-slug composer route.
+			await expect(page).toHaveURL(new RegExp(`/sozluk/${slug}$`), {timeout: 2_000});
+		}).toPass({timeout: 9_000});
 		// Signed-in fresh slug → NewTermComposer: term head + composer body.
 		await expect(page.locator(".kp-sozluk-term__head")).toBeVisible({timeout: 10_000});
 		await expect(page.locator('[data-testid="sozluk-composer-body"]')).toBeVisible();


### PR DESCRIPTION
## What & why

Fixes #3583 — the `+ yeni tanım` create-flow e2e spec (`apps/web/tests/e2e/06-sozluk-home.spec.ts`) fails deterministically whenever the e2e gate actually runs. **Unblocks #3578**, whose `e2e (reads + authed + flows, blocking)` job reds solely on this spec.

The previous fix (#3585) removed the cancelled-animation `AbortError` (it dropped the `getAnimations().finished` settle for an actionability wait) but only **relocated the underlying #3517 race one step later**: the Base UI dialog portal re-renders shortly after open and **detaches the `oluştur` submit button** faster than Playwright's ~5s per-action click auto-retry can outlast, so the click timed out with "element was detached from the DOM, retrying" on both attempts.

## The fix (test-side, robust)

Retry the whole **fill → submit → navigate** as one unit via `expect(async () => { … }).toPass({timeout: 9_000})`:

- Each poll re-fills the (uncontrolled, remount-clearable) `Terim` input, re-clicks the submit (`click({timeout: 2_000})`), and only passes once the submit's navigation to `/sozluk/<slug>` actually lands (`toHaveURL(…, {timeout: 2_000})`).
- A mid-interaction portal detach is therefore **absorbed and retried** instead of failing the test — the whole interaction survives the re-render, not just an individual auto-retried action.
- Sized to fit the 15s per-test timeout (Playwright config); in the settled case it passes on the first or second poll.

**Coverage preserved** — all existing assertions are unchanged: the fresh term routes to `/sozluk/<slug>`, and the signed-in fresh slug lands on `NewTermComposer` (`.kp-sozluk-term__head` + `[data-testid="sozluk-composer-body"]`).

## Root cause (app-side) — assessed, tracked as a follow-up

The real symptom is app-side: **the Base UI dialog popup subtree re-renders/remounts after it is already open**, which cancels the entry animation (#3517 → #3526 → #3583's first round) and detaches controls mid-interaction (this round). Whether that remount originates in Base UI's transition-status handling or in a host re-render reconciling our `Dialog.Popup` wrapper (`apps/web/src/components/ui/Dialog.tsx`, which re-creates `<Portal><Backdrop/><Popup>` each render) needs an isolated repro — not a clean, low-risk one-line fix from here, and a wrong "stabilize the portal" change risks regressing the dialog's animation/focus behavior. I filed **#3600** to investigate and fix the re-render at its source; this PR makes the gate green in the meantime.

## Test

- `pnpm biome check` clean on the spec.
- The retry loop is the standard Playwright remedy for a detach-mid-action control; it converges as soon as the post-open re-render settles.

Fixes #3583