### PR TITLE
feat(pipeline-cli): Tracker create verb — issue/comment create envelope + same-commit adoption (#3264)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/architecture-audit/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/architecture-audit/SKILL.md
@@ -228,14 +228,16 @@ call). Map the finding into the report template:
   seam), explicitly labeled a guess, never a mandate.
 
 ```bash
-# one finding, one issue — only status:needs-triage, exactly like report
+# one finding, one issue — only status:needs-triage, exactly like report. The
+# `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
+# `packages/pipeline-cli/src/tools/tracker/`) and enters the needs-triage queue by default;
+# don't hand-roll the `gh api repos/$REPO/issues` create — the adoption lint (#3254) flags it.
 BODY_FILE="$(mktemp /tmp/arch-audit-body.XXXXXX)"   # per-run temp file (concurrent runs share /tmp)
 # … write the five sections + footer into "$BODY_FILE" …
 BODY="$(cat "$BODY_FILE")"
-gh api repos/$REPO/issues \
-  -f title="<short, type-neutral finding summary (≤ ~70 chars)>" \
-  -f body="$BODY" \
-  -f "labels[]=status:needs-triage"
+pipeline-cli tracker create-issue \
+  --title "<short, type-neutral finding summary (≤ ~70 chars)>" \
+  --body "$BODY"
 ```
 
 Use the `report` footer helper for the metadata block so it stays free of PII and local paths

--- a/claude-plugins/kampus-pipeline/skills/report/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/report/SKILL.md
@@ -118,14 +118,15 @@ REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOw
    you know that it lacks as a comment there, and return to your task.
 4. File it, applying only `status:needs-triage`.
 
-Stream the composed body **straight into the create call over stdin** — there is no named temp file to collide on and no shell variable to reuse stale, so two concurrent `report` runs cannot interleave bodies (the cross-filing hazard is structurally unrepresentable, not merely warned against — #2002). `-F body=@-` reads the `body` field verbatim from stdin, and the **quoted** heredoc (`<<'EOF'`) passes the markdown through untouched — so multi-line markdown, backticks, and nested fences survive intact, the "backticks survive the shell" guarantee with no round-trip through a variable:
+Stream the composed body **straight into the create call over stdin** — there is no named temp file to collide on and no shell variable to reuse stale, so two concurrent `report` runs cannot interleave bodies (the cross-filing hazard is structurally unrepresentable, not merely warned against — #2002). The `tracker create-issue` verb reads its `--body` from stdin when the flag is absent, so the **quoted** heredoc (`<<'EOF'`) passes the markdown through untouched — multi-line markdown, backticks, and nested fences survive intact, the "backticks survive the shell" guarantee with no round-trip through a variable. Don't hand-roll the `gh api repos/$REPO/issues` create — that inline envelope is exactly what the adoption lint (#3254) flags; the verb owns it (ADR 0190; `packages/pipeline-cli/src/tools/tracker/`) and enters the needs-triage queue by default:
 
 ```bash
 # The five sections + a blank line + the footer.sh block, piped straight into the
-# REST create over stdin. No mktemp, no $BODY_FILE, no `$(cat …)` — nothing shared to
-# collide on. `-F body=@-` consumes the whole stream as the body field; `-f title`/
-# `-f labels[]` stay ordinary POST fields. The quoted `<<'EOF'` heredoc means the shell
-# never touches the markdown, so backticks and nested ``` fences file intact.
+# create verb over stdin. No mktemp, no $BODY_FILE, no `$(cat …)` — nothing shared to
+# collide on. `create-issue` consumes the whole stream as the body; the quoted `<<'EOF'`
+# heredoc means the shell never touches the markdown, so backticks and nested ``` fences
+# file intact. The verb passes the body by-value through a direct spawn (no `-f body=@file`),
+# so the local-path leak class is gone too.
 {
   cat <<'EOF'
 ## Summary
@@ -148,15 +149,12 @@ Stream the composed body **straight into the create call over stdin** — there 
 EOF
   echo   # blank line before the footer block
   claude-plugins/kampus-pipeline/skills/report/footer.sh   # emits its own `---` + <sub>… line
-} | gh api repos/$REPO/issues \
-  -f title="<title>" \
-  -F body=@- \
-  -f "labels[]=status:needs-triage"
+} | pipeline-cli tracker create-issue --title "<title>"
 ```
 
 The body never lands on disk under a shared name and never round-trips through a variable, so the two named failure paths this hardening closes — "simplify" to a fixed `/tmp/report-body.md`, or reuse one `$BODY_FILE` across two creates — have no surface to occur on: there is no file path to fix and no variable to reuse.
 
-5. Report back to the user in one line: the issue number and URL (`gh api` returns them as `.number` and `.html_url`). Then return to your original task — don't expand into triaging or fixing what you just filed.
+5. Report back to the user in one line: the issue number and URL (`create-issue` prints them as `tracker: created #<n> — <url>`). Then return to your original task — don't expand into triaging or fixing what you just filed.
 
 ## Conventions
 

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -298,10 +298,10 @@ if [ -n "$EXISTING" ]; then
   echo "split-guard: $EXISTING already covers this unit — reusing, not creating a twin"
 else
   # 2. Body MUST carry the `split from #<N>` back-reference — it is the guard's create-once key.
-  gh api "repos/$REPO/issues" \
-    -f title="<single-unit title>" \
-    -f body="$BODY" \
-    -f "labels[]=status:needs-triage"
+  #    The `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
+  #    `packages/pipeline-cli/src/tools/tracker/`), filing a status:needs-triage issue — don't
+  #    hand-roll the `gh api repos/$REPO/issues` create (the adoption lint (#3254) flags it).
+  pipeline-cli tracker create-issue --title "<single-unit title>" --body "$BODY"
   # then cross-link via a comment on the original (Step 6 shows the comment call)
 fi
 ```

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
@@ -500,11 +500,13 @@ Charted and cleared on wayfinder:map #<MAP>. Downstream is the existing pipeline
 EOF
   echo   # blank line before the footer block
   claude-plugins/kampus-pipeline/skills/report/footer.sh   # emits its own `---` + <sub>… line
-} | gh api repos/$REPO/issues \
-  -f title="<the epic, as one concrete deliverable>" \
-  -F body=@- \
-  -f "labels[]=status:needs-triage"
+} | pipeline-cli tracker create-issue --title "<the epic, as one concrete deliverable>"
 ```
+
+The `tracker create-issue` verb owns this intake-create envelope (ADR 0190;
+`packages/pipeline-cli/src/tools/tracker/`): it files a `status:needs-triage` issue, reading the
+body from stdin so the composed heredoc streams straight in. Don't hand-roll the
+`gh api repos/$REPO/issues` create — that inline envelope is what the adoption lint (#3254) flags.
 
 ### Close the map on graduation — the close-on-source forcing function
 

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -55,6 +55,22 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		reason:
 			"re-derives the label-transition envelope that `pipeline-cli tracker apply-triage` owns (add type/priority/status, remove needs-triage), instead of citing the verb (#3263 / #3254)",
 	},
+	{
+		// `tracker create-issue` owns the intake-create envelope (#3264): file a new issue with a
+		// title/body that enters the needs-triage queue. The fingerprint is the co-occurrence of
+		// both tells — a `-f title=` create field AND the `labels[]=status:needs-triage` intake
+		// label — so an incidental issue read (`/issues/<N>`), or a create at a different stage
+		// (plan-epic's `status:planned` child, wayfinder's `wayfinder:map`), is not a false finding.
+		// A file that cites `pipeline-cli tracker create-issue` is compliant.
+		verb: "tracker create-issue",
+		signature: [
+			/-f\s+"?title=/, // sets a title (a create, not a read)
+			/labels\[\]=status:needs-triage/, // enters the needs-triage intake queue
+		],
+		citation: /pipeline-cli\s+tracker\s+create-issue\b/,
+		reason:
+			"re-derives the intake-create envelope that `pipeline-cli tracker create-issue` owns (POST a titled needs-triage issue), instead of citing the verb (#3264 / #3254)",
+	},
 ];
 
 /**

--- a/packages/pipeline-cli/src/tools/tracker/command.ts
+++ b/packages/pipeline-cli/src/tools/tracker/command.ts
@@ -1,23 +1,30 @@
 /**
  * The `tracker` tool — `pipeline-cli tracker claim <target>` /
- * `pipeline-cli tracker read-back <target>` / `pipeline-cli tracker apply-triage <target>`.
+ * `pipeline-cli tracker read-back <target>` / `pipeline-cli tracker apply-triage <target>` /
+ * `pipeline-cli tracker create-issue` / `pipeline-cli tracker create-comment <target>`.
  *
  * The CLI surface of the Wave-1 `Tracker` service (ADR 0190): `claim` posts the ADR-0115
  * agent-distinguishable claim and exits 0 only when the claim is ours; `read-back` resolves
  * and prints the current owner; `apply-triage` applies a type/priority/status classification
- * and drops the entity out of the needs-triage queue (#3263). Judgment-as-parameter: the
- * claiming identity and the classification are supplied, not decided by the tool — the claim
- * session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable signal
- * under the shared `usirin` login) and `--session` overrides it for the orchestrated/
- * delegated-token path and for tests; an absent value fails closed.
+ * and drops the entity out of the needs-triage queue (#3263); `create-issue` files a new
+ * issue and `create-comment` adds a note (#3264). Judgment-as-parameter: the claiming
+ * identity, the classification, and the created content are supplied, not decided by the tool
+ * — the claim session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable
+ * signal under the shared `usirin` login) and `--session` overrides it for the orchestrated/
+ * delegated-token path and for tests; an absent value fails closed. A create `--body` defaults
+ * to stdin, so a composed markdown body streams straight in (no shared temp file, no
+ * `-f body=@file` local-path leak — the #2002 hazard class is gone, not hand-guarded).
  *
  * `GithubTrackerLive` is baked in with `Command.provide(...)` so the registered command's
  * residual requirement is the Node platform union (the registry seam, epic #994).
  */
+import {readFileSync} from "node:fs";
 import {Console, Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {
 	type ClaimResult,
+	type CommentResult,
+	type CreateIssueResult,
 	GithubTrackerLive,
 	type ReadBackResult,
 	Tracker,
@@ -138,10 +145,76 @@ const applyTriage = Command.make(
 	),
 );
 
-export const trackerCommand = Command.make("tracker").pipe(
-	Command.withSubcommands([claim, readBack, applyTriage]),
+// The create envelope (#3264): title/body/stage as parameters. `--body` defaults to stdin so
+// a composed markdown body streams straight in — the report/wayfinder/architecture-audit
+// intake flows pipe their heredoc into the verb, keeping the #2002 no-shared-temp-file property.
+const titleFlag = Flag.string("title").pipe(Flag.withDescription("the new issue's title"));
+
+const bodyFlag = Flag.string("body").pipe(
+	Flag.optional,
+	Flag.withDescription("the issue/comment body (default: read from stdin)"),
+);
+
+const stageFlag = Flag.string("stage").pipe(
+	Flag.optional,
+	Flag.withDescription("the lifecycle stage the new issue enters at (default: needs-triage)"),
+);
+
+/** The body from `--body`, else streamed from stdin (fd 0); an unreadable stream ⇒ empty. */
+const resolveBody = (body: Option.Option<string>): string => {
+	// biome-ignore lint/plugin: best-effort stdin read — a failed/absent stream is an empty body (the CLI's pre-verb input marshalling), never the E channel; a total helper, not Effect-cosplay. Mirrors trivial-diff's readDiff.
+	try {
+		return Option.match(body, {
+			onSome: (b) => b,
+			onNone: () => readFileSync(0, "utf8"),
+		});
+	} catch {
+		return "";
+	}
+};
+
+const reportCreated = (result: CreateIssueResult): Effect.Effect<void> =>
+	Console.log(`tracker: created #${result.target} — ${result.url}`);
+
+const createIssue = Command.make(
+	"create-issue",
+	{title: titleFlag, body: bodyFlag, stage: stageFlag},
+	Effect.fn(function* ({title, body, stage}) {
+		const result = yield* (yield* Tracker).createIssue({
+			title,
+			body: resolveBody(body),
+			stage: Option.getOrElse(stage, () => "needs-triage"),
+		});
+		yield* reportCreated(result);
+	}),
+).pipe(
 	Command.withDescription(
-		"The crew tracker service (ADR 0190): claim a tracker entity, read back its owner, apply a triage classification",
+		"File a new issue (title/body/stage) — enters the needs-triage queue by default; body from --body or stdin",
+	),
+);
+
+const commentTargetArg = Argument.integer("target").pipe(
+	Argument.withDescription("the tracker entity (issue) number to comment on"),
+);
+
+const reportCommented = (target: number, result: CommentResult): Effect.Effect<void> =>
+	Console.log(`tracker: commented on #${target} (ref ${result.ref}).`);
+
+const createComment = Command.make(
+	"create-comment",
+	{target: commentTargetArg, body: bodyFlag},
+	Effect.fn(function* ({target, body}) {
+		const result = yield* (yield* Tracker).createComment(target, {body: resolveBody(body)});
+		yield* reportCommented(target, result);
+	}),
+).pipe(
+	Command.withDescription("Add a comment (note) to a tracker entity; body from --body or stdin"),
+);
+
+export const trackerCommand = Command.make("tracker").pipe(
+	Command.withSubcommands([claim, readBack, applyTriage, createIssue, createComment]),
+	Command.withDescription(
+		"The crew tracker service (ADR 0190): claim a tracker entity, read back its owner, apply a triage classification, create an issue or a comment",
 	),
 	Command.provide(GithubTrackerLive),
 );

--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -407,6 +407,86 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 	);
 });
 
+describe("Tracker.createIssue — the intake-create envelope over a mock gh spawner", () => {
+	it.effect("files a needs-triage issue by default → created with its ref + url", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.createIssue({
+				title: "a new finding",
+				body: "## Summary\n…",
+			});
+			assert.deepStrictEqual(result, {
+				_tag: "created",
+				target: 4242,
+				url: "https://github.com/kamp-us/phoenix/issues/4242",
+			});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`POST ${P}/issues`]: JSON.stringify({
+					number: 4242,
+					html_url: "https://github.com/kamp-us/phoenix/issues/4242",
+				}),
+			}),
+		),
+	);
+
+	it.effect("honors an explicit --stage lifecycle stage", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.createIssue({
+				title: "a planned child",
+				body: "…",
+				stage: "planned",
+			});
+			assert.deepStrictEqual(result, {
+				_tag: "created",
+				target: 77,
+				url: "https://github.com/kamp-us/phoenix/issues/77",
+			});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`POST ${P}/issues`]: JSON.stringify({
+					number: 77,
+					html_url: "https://github.com/kamp-us/phoenix/issues/77",
+				}),
+			}),
+		),
+	);
+
+	it.effect("a non-zero gh create exit → GhCommandError in the E channel", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const error = yield* Effect.flip(tracker.createIssue({title: "t", body: "b"}));
+			assert.isTrue(error instanceof GhCommandError);
+		}).pipe((effect) =>
+			// no POST fixture → the create call exits 1 → GhCommandError, never a throw.
+			provide(effect, {}),
+		),
+	);
+});
+
+describe("Tracker.createComment — add a note over a mock gh spawner", () => {
+	it.effect("posts a note to the entity → commented with its ref", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.createComment(TARGET, {body: "a handoff note"});
+			assert.deepStrictEqual(result, {_tag: "commented", ref: 5150});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`POST ${P}/issues/${TARGET}/comments`]: JSON.stringify({id: 5150}),
+			}),
+		),
+	);
+
+	it.effect("a non-zero gh comment exit → GhCommandError in the E channel", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const error = yield* Effect.flip(tracker.createComment(TARGET, {body: "b"}));
+			assert.isTrue(error instanceof GhCommandError);
+		}).pipe((effect) => provide(effect, {})),
+	);
+});
+
 describe("Tracker — the declared-but-not-yet-built verbs fail closed", () => {
 	it.effect("postVerdict → TrackerNotImplementedError", () =>
 		Effect.gen(function* () {

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -4,8 +4,9 @@
  *
  * Grown from the Wave-1 walking skeleton (epic #3258): a `Context.Service` `Tracker`
  * tag plus its sole implementation `GithubTrackerLive`. `claim` (the ADR-0115
- * agent-distinguishable claim), a generic `readBack`, and `applyTriage` (the
- * label-transition envelope, #3263) are live; `postVerdict` / `graduate` are still
+ * agent-distinguishable claim), a generic `readBack`, `applyTriage` (the
+ * label-transition envelope, #3263), and `createIssue` / `createComment` (the
+ * issue/comment create envelope, #3264) are live; `postVerdict` / `graduate` are still
  * *declared* — their interface shape is fixed so the tag locks before its remaining
  * sibling Phase-3 children implement them.
  *
@@ -65,9 +66,10 @@ export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionE
 ) {}
 
 /**
- * A declared-but-not-yet-built verb was called. `claim` / `readBack` / `applyTriage`
- * are live; `postVerdict` / `graduate` fail-closed with this typed error until a sibling
- * Phase-3 child implements them — never a silent no-op or a throw.
+ * A declared-but-not-yet-built verb was called. `claim` / `readBack` / `applyTriage` /
+ * `createIssue` / `createComment` are live; `postVerdict` / `graduate` fail-closed with
+ * this typed error until a sibling Phase-3 child implements them — never a silent no-op
+ * or a throw.
  */
 export class TrackerNotImplementedError extends Schema.TaggedErrorClass<TrackerNotImplementedError>()(
 	"@kampus/tracker/TrackerNotImplementedError",
@@ -133,6 +135,41 @@ export type TriageResult = {
 	readonly type: string;
 	readonly priority: string;
 	readonly status: string;
+};
+
+/**
+ * A create-issue judgment (#3264): the `title` + `body` of the new entity, and the
+ * lifecycle `stage` it enters at (default `needs-triage` — the intake queue). Domain
+ * vocabulary only — `stage` maps to a `status:<stage>` label inside `GithubTrackerLive`,
+ * so no label string or REST field leaks into the signature (ADR 0190). The judgment
+ * carries the *content*; the queue/label plumbing is the verb's.
+ */
+export interface CreateIssueJudgment {
+	readonly title: string;
+	readonly body: string;
+	readonly stage?: string;
+}
+
+/**
+ * The `createIssue` result — the new entity's domain reference (`target`, a `TargetId`
+ * a later verb can act on) and a `url` locator to report. A domain entity ref, never a
+ * raw REST issue payload.
+ */
+export type CreateIssueResult = {
+	readonly _tag: "created";
+	readonly target: TargetId;
+	readonly url: string;
+};
+
+/** A create-comment judgment (#3264): the note `body` to add to an entity. */
+export interface CommentJudgment {
+	readonly body: string;
+}
+
+/** The `createComment` result — the created note's `ref` (its domain reference). */
+export type CommentResult = {
+	readonly _tag: "commented";
+	readonly ref: number;
 };
 
 /** A gate verdict: which gate, whether it passed, and the head ref it is bound to. */
@@ -254,6 +291,36 @@ const deleteCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
 	`repos/${repo}/issues/comments/${id}`,
 ];
 
+// Create a new issue. `title` / `body` / each `label` pass as by-value POST fields through
+// the direct `gh` spawn — no shell, no heredoc, no `-f body=@file`, so the whole local-path
+// leak / concurrent-body-collision class the skills hand-guard against (#2002) is structurally
+// absent here, not merely warned against.
+const createIssueArgs = (
+	repo: string,
+	title: string,
+	body: string,
+	labels: ReadonlyArray<string>,
+): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues`,
+	"-f",
+	`title=${title}`,
+	"-f",
+	`body=${body}`,
+	...labels.flatMap((label) => ["-f", `labels[]=${label}`]),
+];
+
+const createCommentArgs = (repo: string, target: TargetId, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${target}/comments`,
+	"-f",
+	`body=${body}`,
+];
+
 const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
 	"api",
 	`repos/${repo}/collaborators/${login}/permission`,
@@ -300,6 +367,14 @@ const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
 /** A raw label as the issues/labels endpoint returns it; only the name is read. */
 const RawLabel = Schema.Struct({name: Schema.String});
 const decodeLabels = Schema.decodeUnknownEffect(Schema.Array(RawLabel));
+
+/** The created issue as the create endpoint returns it; only the ref + locator are read. */
+const RawCreatedIssue = Schema.Struct({number: Schema.Number, html_url: Schema.String});
+const decodeCreatedIssue = Schema.decodeUnknownEffect(RawCreatedIssue);
+
+/** The created comment as the create endpoint returns it; only its ref is read. */
+const RawCreatedComment = Schema.Struct({id: Schema.Number});
+const decodeCreatedComment = Schema.decodeUnknownEffect(RawCreatedComment);
 
 const LABEL_STATUS_PREFIX = "status:";
 const QUEUE_STATUS = "needs-triage";
@@ -438,13 +513,47 @@ const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
 	} satisfies TriageResult;
 });
 
+/**
+ * Create a new issue (ADR 0190) — the intake-create envelope the report / wayfinder /
+ * architecture-audit / triage skills hand-composed, now one verb with the content as a
+ * parameter. The `stage` maps to the single `status:<stage>` label the new entity enters
+ * with (default `needs-triage`, the intake queue); the created ref + locator are
+ * Schema-decoded at the REST boundary and returned domain-shaped.
+ */
+const createIssue = Effect.fn("Tracker.createIssue")(function* (
+	repo: string,
+	judgment: CreateIssueJudgment,
+) {
+	const stage = judgment.stage ?? QUEUE_STATUS;
+	const labels = [`${LABEL_STATUS_PREFIX}${stage}`];
+	const created = yield* decodeCreatedIssue(
+		yield* json(createIssueArgs(repo, judgment.title, judgment.body, labels)),
+	);
+	return {
+		_tag: "created",
+		target: created.number,
+		url: created.html_url,
+	} satisfies CreateIssueResult;
+});
+
+/** Add a comment (note) to `target` (ADR 0190); the created note's ref is decoded back. */
+const createComment = Effect.fn("Tracker.createComment")(function* (
+	repo: string,
+	target: TargetId,
+	body: string,
+) {
+	const created = yield* decodeCreatedComment(yield* json(createCommentArgs(repo, target, body)));
+	return {_tag: "commented", ref: created.id} satisfies CommentResult;
+});
+
 type TrackerErrors = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
 
 /**
- * `Tracker` — the shared crew tracker capability. `claim`, `readBack`, and `applyTriage`
- * are live; the two still-declared verbs fail `TrackerNotImplementedError` until a sibling
- * child builds them (their success types are `never` by design — a not-yet-built verb
- * produces no value). Built by `GithubTrackerLive`, whose `R` is `ChildProcessSpawner`.
+ * `Tracker` — the shared crew tracker capability. `claim`, `readBack`, `applyTriage`,
+ * `createIssue`, and `createComment` are live; the two still-declared verbs fail
+ * `TrackerNotImplementedError` until a sibling child builds them (their success types are
+ * `never` by design — a not-yet-built verb produces no value). Built by `GithubTrackerLive`,
+ * whose `R` is `ChildProcessSpawner`.
  */
 export class Tracker extends Context.Service<
 	Tracker,
@@ -458,6 +567,13 @@ export class Tracker extends Context.Service<
 			target: TargetId,
 			judgment: TriageJudgment,
 		) => Effect.Effect<TriageResult, TrackerErrors>;
+		readonly createIssue: (
+			judgment: CreateIssueJudgment,
+		) => Effect.Effect<CreateIssueResult, TrackerErrors>;
+		readonly createComment: (
+			target: TargetId,
+			judgment: CommentJudgment,
+		) => Effect.Effect<CommentResult, TrackerErrors>;
 		readonly postVerdict: (
 			target: TargetId,
 			judgment: VerdictJudgment,
@@ -496,6 +612,10 @@ export const GithubTrackerLive: Layer.Layer<
 			readBack: (target) => repo.pipe(Effect.flatMap((r) => withSpawner(readBack(r, target)))),
 			applyTriage: (target, judgment) =>
 				repo.pipe(Effect.flatMap((r) => withSpawner(applyTriage(r, target, judgment)))),
+			createIssue: (judgment) =>
+				repo.pipe(Effect.flatMap((r) => withSpawner(createIssue(r, judgment)))),
+			createComment: (target, judgment) =>
+				repo.pipe(Effect.flatMap((r) => withSpawner(createComment(r, target, judgment.body)))),
 			postVerdict: () => notImplemented("postVerdict"),
 			graduate: () => notImplemented("graduate"),
 		};


### PR DESCRIPTION
Fixes #3264. Advances epic #3258 (Wave 1).

## What

Implements the `Tracker` **create** verbs over `GithubTrackerLive` (the sole impl), replacing the fail-closed skeleton coverage:

- **`createIssue`** — files a new issue from a `title` / `body`, entering the `needs-triage` intake queue by default (an optional `stage` targets another lifecycle stage). Returns the new entity's domain `target` ref + `url` locator.
- **`createComment`** — adds a note to an entity; returns the created note's `ref`.

Judgment-as-parameter (#3252): the content is supplied, not decided by the tool. Infra faults stay typed in the `E` channel (`GhCommandError` etc.); the create read-backs are Schema-decoded at the REST boundary. Signatures stay **domain-shaped** — `stage` maps to a `status:<stage>` label *inside* the live impl, so no label string or REST idiom leaks into the interface (ADR 0190).

Because the verb passes the body **by-value through a direct `gh` spawn** (no shell, no heredoc, no `-f body=@file`), the whole local-path-leak / concurrent-body-collision class the skills hand-guard against (#2002) is structurally absent, not merely warned against.

## CLI

- `pipeline-cli tracker create-issue --title <t> [--body <b>] [--stage <s>]`
- `pipeline-cli tracker create-comment <target> [--body <b>]`

`--body` defaults to **stdin**, so a composed markdown body streams straight in (the report/wayfinder heredoc pipes into the verb, keeping the #2002 no-shared-temp-file property).

## Same-commit adoption (#3254 / #3254 governing AC)

Migrated the four intake-create envelopes to cite the verb and added the `tracker create-issue` decision to the adoption-lint manifest (fingerprint: a `-f title=` create field co-occurring with `labels[]=status:needs-triage`, so plan-epic's `status:planned` child-create and wayfinder's `wayfinder:map` create are not false findings):

- `report/SKILL.md`, `wayfinder/SKILL.md` (epic create), `architecture-audit/SKILL.md`, `triage/SKILL.md` (split-filing)

`pipeline-cli adoption-lint check` is clean over the full corpus.

## Tests / checks

- `tracker.behavior.test.ts`: `createIssue` happy path + explicit `stage` + `GhCommandError` error path; `createComment` happy path + `GhCommandError` error path (ADR 0040). 34 tests pass.
- `tsc --noEmit` clean; `biome check` clean; adoption-lint clean over the corpus.

## §CP note

Touches `packages/pipeline-cli/**` and gate-critical skills → §CP merge path. Stops at reviewed-ready; banks for human (cansirin) approval at merge time. Do not merge on green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
