### PR TITLE
feat(pipeline-cli): crew-fanout-guard — enforced allowlist for crew bridge spawn scoping (#3606)

### DIFF
--- a/.github/workflows/crew-fanout-guard.yml
+++ b/.github/workflows/crew-fanout-guard.yml
@@ -1,0 +1,43 @@
+name: crew-fanout-guard
+
+# CI gate for #3606 (residual from #3597/#3605): invert the crew read-only-fanout
+# per-bridge spawn DENYLIST into an ENFORCED ALLOWLIST. claude-code's permission model
+# only *subtracts* denied agent-types — there is no "spawn only X" primitive — so a
+# FUTURE mutating agent-type added to the roster is silently spawnable by every bridge
+# until someone remembers to extend each denylist (the "a future reader silently reopens
+# the deleted edge" risk ADR 0196 warns of). This job asserts every crew bridge
+# (chief-of-staff / cartographer / intake-desk) denies every mutating roster agent-type
+# NOT on its sanctioned allowlist, and fails closed on an uncovered agent-type or zero
+# scope (ADR 0092) — so a new un-denied mutating agent reds the build. Roster-law
+# boundary, ADR 0189/0196. The scan lives once in pipeline-cli's `crew-fanout-guard check`.
+on:
+  pull_request:
+
+# contents:read is all it needs; default-deny every other scope (CodeQL least-privilege).
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: every crew bridge denies non-allowlisted mutating agent-types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 on an uncovered bridge×agent-type pair, a missing bridge def, a stale
+      # allowlist, or zero scope (report on stderr, fail-closed). See #3606.
+      - name: Check crew bridge fanout scoping
+        run: node packages/pipeline-cli/src/bin.ts crew-fanout-guard check

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -24,6 +24,7 @@ import {commandsCommand} from "./tools/commands/command.ts";
 import {controlPlanePathsCommand} from "./tools/control-plane-paths/command.ts";
 import {cpCardinalityCommand} from "./tools/cp-cardinality/command.ts";
 import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
+import {crewFanoutGuardCommand} from "./tools/crew-fanout-guard/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {designInventoryCommand} from "./tools/design-inventory/command.ts";
 import {designTokenGuardCommand} from "./tools/design-token-guard/command.ts";
@@ -156,4 +157,9 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// inline-re-derives a tool-owned decision without citing the owning verb, so the verb
 	// sweep can't grow the unreferenced-tool pile. Fail-closed on zero scope (ADR 0092).
 	adoptionLintCommand,
+	// #3606 — inverts the crew read-only-fanout per-bridge spawn denylist into an ENFORCED
+	// allowlist: reds when a mutating roster agent-type is neither allowlisted nor denied by a
+	// crew bridge (chief-of-staff/cartographer/intake-desk), closing the future-agent hole ADR
+	// 0196 warns of. Fail-closed on zero scope (ADR 0092); roster-law boundary (ADR 0189/0196).
+	crewFanoutGuardCommand,
 ];

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/command.ts
@@ -1,0 +1,83 @@
+/**
+ * The `crew-fanout-guard` tool — `pipeline-cli crew-fanout-guard check [--root <d>]`.
+ *
+ * The CI surface for #3606: invert the crew read-only-fanout per-bridge spawn DENYLIST into
+ * an ENFORCED ALLOWLIST. For every crew bridge def (chief-of-staff / cartographer /
+ * intake-desk under `claude-plugins/pipeline-crew/agents/`), assert its `disallowedTools`
+ * denies every mutating roster agent-type NOT on that bridge's sanctioned allowlist — so a
+ * FUTURE mutating agent-type added to the roster (or a `Task(x)` deny silently removed) reds
+ * the build, closing the "a future reader silently reopens the deleted edge" hole ADR 0196
+ * warns about (roster-law boundary, ADR 0189/0196):
+ *
+ *   pipeline-cli crew-fanout-guard check            # CI gate: exit non-zero on an uncovered agent-type
+ *   pipeline-cli crew-fanout-guard check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * Fail-closed on zero scope, a missing bridge def, a stale allowlist, or any uncovered
+ * bridge×agent-type pair (ADR 0092). The scan/IO lives in `gate.ts`; this file wires it to
+ * the CLI (the thin-CLI-over-`gate.ts` idiom shared across the guards).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — both a gate failure (report on
+ * stderr) and an IO failure (fs unreadable) exit non-zero, undistinguished. `CheckFailed`
+ * is caught inside the handler (not at the bin's run boundary) so the contract survives
+ * folding into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../../find-root-dir.ts";
+import {type CheckFailed, checkCrewFanout} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repo root to scan the crew agent defs under (default: walk up for one)",
+	),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the default
+// error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkCrewFanout(resolveRoot(rootOpt)).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the build if a crew bridge fails to deny a non-allowlisted mutating roster agent-type",
+	),
+);
+
+export const crewFanoutGuardCommand = Command.make("crew-fanout-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: every crew bridge denies every non-allowlisted mutating roster agent-type (#3606, ADR 0189/0196)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts
@@ -1,0 +1,228 @@
+/**
+ * `crew-fanout-guard` pure core — invert the crew read-only-fanout per-bridge spawn
+ * DENYLIST into an ENFORCED ALLOWLIST (issue #3606, residual from #3597/#3605).
+ *
+ * The roster-law boundary (ADR 0189/0196) keeps a read-only fanout from drifting into a
+ * "bridge runs the pipeline" execution edge. claude-code's permission model only
+ * *subtracts* denied agent-types from the all-active spawnable set — there is no "spawn
+ * only X" positive primitive — so each bridge's `disallowedTools` must enumerate every
+ * mutating agent-type it may not spawn. The residual hole: a NEW mutating agent-type added
+ * to the roster is silently spawnable by every bridge until someone remembers to extend
+ * each denylist. This guard closes that structurally: it OWNS the per-bridge sanctioned
+ * allowlist and asserts every mutating roster agent-type NOT on a bridge's allowlist is
+ * denied — so a future un-allowlisted, un-denied agent-type reds the build.
+ *
+ * IO-free and total: every decision is a deterministic transform over already-gathered
+ * facts (the parsed agent defs). The filesystem boundary (enumerate the agent dirs, read
+ * each def) lives in `gate.ts`; this module never touches disk.
+ *
+ * Fail-closed by construction (ADR 0092): zero roster / zero bridges, a missing bridge
+ * def, a stale allowlist entry, or any uncovered mutating agent-type is a RED verdict —
+ * never a vacuous pass.
+ */
+import {parse as parseYaml} from "yaml";
+
+/**
+ * Read-only crew agent-types — write-tool-free by grant (ADR 0196). Excluded from the
+ * mutating roster: a bridge spawning one is context hygiene, not an execution edge. A NEW
+ * agent-type defaults to MUTATING (it is not on this set), so it must be explicitly
+ * allowlisted or denied — the fail-closed default that catches a future roster addition.
+ */
+export const READ_ONLY_AGENTS: ReadonlySet<string> = new Set(["crew-investigator"]);
+
+/** The three roster-law BRIDGE seats (ADR 0189) whose spawn scope this guard enforces. */
+export const BRIDGE_NAMES = [
+	"crew-cartographer",
+	"crew-chief-of-staff",
+	"crew-intake-desk",
+] as const;
+export type BridgeName = (typeof BRIDGE_NAMES)[number];
+
+/**
+ * Each bridge's SANCTIONED spawn allowlist — the enforced source of truth, NOT the def's
+ * denylist. Every mutating roster agent-type absent from a bridge's allowlist must appear
+ * in that bridge's `disallowedTools` `Task(...)`; a roster addition absent from BOTH reds
+ * the build. Encoding the allowlist here (rather than reading it back off the denylist) is
+ * what makes it *enforced*: removing a `Task(x)` deny from a bridge def without adding `x`
+ * here also reds the build.
+ *
+ * The allowlists track each bridge's charter: the cartographer keeps its Prototype-spike
+ * `coder` and ideation-legwork agents; the chief-of-staff spawns nothing (pure verify-and-
+ * carry); the intake-desk owns the planning/canon seam (planner/canon/adr) plus its
+ * report→triage loop (triager/reporter). See `claude-plugins/pipeline-crew/agents/`.
+ */
+export const BRIDGE_ALLOWLIST: Record<BridgeName, ReadonlyArray<string>> = {
+	"crew-cartographer": ["coder", "planner", "canon", "adr", "triager", "reporter"],
+	"crew-chief-of-staff": [],
+	"crew-intake-desk": ["planner", "canon", "adr", "triager", "reporter"],
+};
+
+/** One parsed agent def reduced to the two facts the decision needs. */
+export interface AgentDef {
+	/** The agent-type name (its `name:` frontmatter), e.g. `crew-cartographer`. */
+	readonly name: string;
+	/** Agent-types this def denies spawning, extracted from `disallowedTools` `Task(<type>)`. */
+	readonly disallowedTaskTypes: ReadonlyArray<string>;
+}
+
+/**
+ * The guard verdict. A discriminated union so an invalid state is unrepresentable: a pass
+ * never carries a gap list, and each failure shape carries exactly its evidence.
+ */
+export type CrewFanoutVerdict =
+	| {
+			readonly pass: true;
+			readonly mutatingRoster: ReadonlyArray<string>;
+			readonly bridges: ReadonlyArray<string>;
+	  }
+	/** No agent defs or no bridge defs in scope — fail closed, never a vacuous pass (ADR 0092). */
+	| {readonly pass: false; readonly reason: "zero-scope"; readonly detail: string}
+	/** An expected bridge def is absent — can't verify a bridge whose file vanished. */
+	| {
+			readonly pass: false;
+			readonly reason: "missing-bridge";
+			readonly missing: ReadonlyArray<string>;
+	  }
+	/** An allowlist entry names an agent-type not in the roster — policy drift, fail closed. */
+	| {
+			readonly pass: false;
+			readonly reason: "stale-allowlist";
+			readonly entries: ReadonlyArray<{readonly bridge: string; readonly agent: string}>;
+	  }
+	/** A mutating roster agent-type is neither allowlisted nor denied for a bridge — the hole. */
+	| {
+			readonly pass: false;
+			readonly reason: "uncovered";
+			readonly gaps: ReadonlyArray<{readonly bridge: string; readonly agent: string}>;
+	  };
+
+/** Extract the YAML frontmatter block (between the leading `---` fences) and parse it. */
+export const parseFrontmatter = (text: string): Record<string, unknown> | null => {
+	const m = /^---\r?\n([\s\S]*?)\r?\n---/.exec(text);
+	if (!m?.[1]) return null;
+	const parsed = parseYaml(m[1]);
+	return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+};
+
+/** Pull the agent-type names out of `disallowedTools` `Task(<type>)` entries. */
+export const disallowedTaskTypes = (disallowedTools: unknown): ReadonlyArray<string> => {
+	if (!Array.isArray(disallowedTools)) return [];
+	const out: Array<string> = [];
+	for (const entry of disallowedTools) {
+		if (typeof entry !== "string") continue;
+		const t = /^Task\(([^)]+)\)$/.exec(entry.trim());
+		if (t?.[1]) out.push(t[1].trim());
+	}
+	return out;
+};
+
+/** Parse one agent-def markdown into `{name, disallowedTaskTypes}`; null when it has no `name`. */
+export const parseAgentDef = (text: string): AgentDef | null => {
+	const fm = parseFrontmatter(text);
+	if (!fm || typeof fm.name !== "string") return null;
+	return {name: fm.name, disallowedTaskTypes: disallowedTaskTypes(fm.disallowedTools)};
+};
+
+/** The facts the pure verdict is computed over — gathered at the filesystem boundary. */
+export interface CrewFanoutInput {
+	/** Every discovered agent-type name across both agent dirs (the roster). */
+	readonly rosterAgents: ReadonlyArray<string>;
+	/** The bridge defs actually found on disk, parsed. */
+	readonly bridges: ReadonlyArray<AgentDef>;
+}
+
+/**
+ * Decide the verdict. Fails closed on zero scope, a missing bridge, a stale allowlist, or
+ * any mutating roster agent-type that a bridge neither allowlists nor denies.
+ */
+export const judge = (input: CrewFanoutInput): CrewFanoutVerdict => {
+	if (input.rosterAgents.length === 0) {
+		return {pass: false, reason: "zero-scope", detail: "no agent defs discovered"};
+	}
+	if (input.bridges.length === 0) {
+		return {pass: false, reason: "zero-scope", detail: "no bridge defs discovered"};
+	}
+
+	const found = new Set(input.bridges.map((b) => b.name));
+	const missing = BRIDGE_NAMES.filter((n) => !found.has(n));
+	if (missing.length > 0) {
+		return {pass: false, reason: "missing-bridge", missing};
+	}
+
+	const rosterSet = new Set(input.rosterAgents);
+	// A stale allowlist entry (an allowlisted agent-type no longer in the roster) means the
+	// policy drifted from reality — fail closed so a rename/removal forces an allowlist update.
+	const stale: Array<{bridge: string; agent: string}> = [];
+	for (const bridge of BRIDGE_NAMES) {
+		for (const agent of BRIDGE_ALLOWLIST[bridge]) {
+			if (!rosterSet.has(agent)) stale.push({bridge, agent});
+		}
+	}
+	if (stale.length > 0) {
+		return {pass: false, reason: "stale-allowlist", entries: stale};
+	}
+
+	const mutatingRoster = [...rosterSet].filter((a) => !READ_ONLY_AGENTS.has(a)).sort();
+
+	const gaps: Array<{bridge: string; agent: string}> = [];
+	for (const bridge of input.bridges) {
+		if (!(bridge.name in BRIDGE_ALLOWLIST)) continue;
+		const allow = new Set(BRIDGE_ALLOWLIST[bridge.name as BridgeName]);
+		const denied = new Set(bridge.disallowedTaskTypes);
+		for (const agent of mutatingRoster) {
+			if (allow.has(agent) || denied.has(agent)) continue;
+			gaps.push({bridge: bridge.name, agent});
+		}
+	}
+	if (gaps.length > 0) {
+		return {pass: false, reason: "uncovered", gaps};
+	}
+
+	return {pass: true, mutatingRoster, bridges: input.bridges.map((b) => b.name).sort()};
+};
+
+/** Render the human-readable report for a verdict (ADR 0092 §1 "emit what you scanned"). */
+export const renderReport = (verdict: CrewFanoutVerdict): string => {
+	if (verdict.pass) {
+		return (
+			`crew-fanout-guard: all ${verdict.bridges.length} crew bridge(s) [${verdict.bridges.join(", ")}] ` +
+			`deny every non-allowlisted mutating roster agent-type ` +
+			`(${verdict.mutatingRoster.length} in the mutating roster: ${verdict.mutatingRoster.join(", ")})`
+		);
+	}
+	if (verdict.reason === "zero-scope") {
+		return (
+			`crew-fanout-guard: ${verdict.detail} — fail-closed (ADR 0092). ` +
+			"Is the repo root correct, or did the crew agent-def layout change?"
+		);
+	}
+	if (verdict.reason === "missing-bridge") {
+		return (
+			`crew-fanout-guard: ${verdict.missing.length} expected crew bridge def(s) absent: ` +
+			`${verdict.missing.join(", ")} — fail-closed (a bridge whose def vanished can't be verified). ` +
+			"Restore the def or update BRIDGE_NAMES in crew-fanout-guard.ts."
+		);
+	}
+	if (verdict.reason === "stale-allowlist") {
+		const lines = verdict.entries.map(
+			(e) => `  ${e.bridge} allowlists "${e.agent}" (not in the roster)`,
+		);
+		return (
+			`crew-fanout-guard: ${verdict.entries.length} stale allowlist entr` +
+			`${verdict.entries.length === 1 ? "y" : "ies"} — an allowlisted agent-type is no longer a ` +
+			`known agent def:\n${lines.join("\n")}\n\n` +
+			"An allowlist must track the roster. Remove the stale entry from BRIDGE_ALLOWLIST, or restore\n" +
+			"the agent def it names."
+		);
+	}
+	const lines = verdict.gaps.map((g) => `  ${g.bridge} neither allowlists nor denies "${g.agent}"`);
+	return (
+		`crew-fanout-guard: ${verdict.gaps.length} uncovered bridge×agent-type pair` +
+		`${verdict.gaps.length === 1 ? "" : "s"} — a mutating roster agent-type is spawnable by a ` +
+		`bridge that should scope it out:\n${lines.join("\n")}\n\n` +
+		"Every mutating roster agent-type must be either on the bridge's sanctioned allowlist\n" +
+		"(BRIDGE_ALLOWLIST in crew-fanout-guard.ts) or denied in the bridge def's `disallowedTools`\n" +
+		"`Task(<type>)`. A newly-added mutating agent-type must be classified before it can ship\n" +
+		"(ADR 0189/0196 — keep the read-only fanout off the execution edge)."
+	);
+};

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Pure-core tests for `crew-fanout-guard` (#3606): the frontmatter/disallowedTools parse,
+ * the enforced-allowlist coverage decision, the future-agent fail-closed hole, and the
+ * zero-scope / missing-bridge / stale-allowlist fail-closed verdicts (ADR 0092). No IO —
+ * the filesystem seam is crossed in `gate.ts`.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {
+	type AgentDef,
+	BRIDGE_ALLOWLIST,
+	type CrewFanoutInput,
+	disallowedTaskTypes,
+	judge,
+	parseAgentDef,
+	parseFrontmatter,
+	renderReport,
+} from "./crew-fanout-guard.ts";
+
+// The full mutating roster the current crew ships (kampus-pipeline agents + the crew engine),
+// plus the read-only investigator and the three bridges. This mirrors the live agent defs.
+const PIPELINE_AGENTS = [
+	"coder",
+	"reviewer",
+	"shipper",
+	"planner",
+	"canon",
+	"adr",
+	"triager",
+	"reporter",
+];
+const CREW_AGENTS = [
+	"crew-cartographer",
+	"crew-chief-of-staff",
+	"crew-engineering-manager",
+	"crew-intake-desk",
+	"crew-investigator",
+];
+const FULL_ROSTER = [...PIPELINE_AGENTS, ...CREW_AGENTS];
+
+const bridge = (name: string, disallowedTaskTypes: ReadonlyArray<string>): AgentDef => ({
+	name,
+	disallowedTaskTypes,
+});
+
+// The three bridge defs, scoped to exactly cover their non-allowlisted mutating roster —
+// i.e. the live #3605 disallowedTools, expressed as agent-type names.
+const CARTOGRAPHER = bridge("crew-cartographer", [
+	"reviewer",
+	"shipper",
+	"crew-engineering-manager",
+	"crew-chief-of-staff",
+	"crew-intake-desk",
+	"crew-cartographer",
+]);
+const CHIEF = bridge("crew-chief-of-staff", [
+	"coder",
+	"reviewer",
+	"shipper",
+	"planner",
+	"canon",
+	"adr",
+	"triager",
+	"reporter",
+	"crew-engineering-manager",
+	"crew-cartographer",
+	"crew-intake-desk",
+	"crew-chief-of-staff",
+]);
+const INTAKE = bridge("crew-intake-desk", [
+	"coder",
+	"reviewer",
+	"shipper",
+	"crew-engineering-manager",
+	"crew-cartographer",
+	"crew-chief-of-staff",
+	"crew-intake-desk",
+]);
+
+const currentInput = (): CrewFanoutInput => ({
+	rosterAgents: FULL_ROSTER,
+	bridges: [CARTOGRAPHER, CHIEF, INTAKE],
+});
+
+describe("parseFrontmatter / parseAgentDef", () => {
+	it("extracts name + disallowedTools from a real bridge def's frontmatter", () => {
+		const md = [
+			"---",
+			"name: crew-cartographer",
+			"model: inherit",
+			'tools: ["Read", "Task"]',
+			'disallowedTools: ["Task(reviewer)", "Task(shipper)"]',
+			"---",
+			"",
+			"body text",
+		].join("\n");
+		expect(parseAgentDef(md)).toEqual({
+			name: "crew-cartographer",
+			disallowedTaskTypes: ["reviewer", "shipper"],
+		});
+	});
+
+	it("returns null for a def with no frontmatter or no name", () => {
+		expect(parseAgentDef("no frontmatter here")).toBeNull();
+		expect(parseAgentDef("---\nmodel: inherit\n---\nbody")).toBeNull();
+	});
+
+	it("parses a def with no disallowedTools as an empty deny list", () => {
+		const md = '---\nname: crew-engineering-manager\ntools: ["Task"]\n---\nbody';
+		expect(parseAgentDef(md)).toEqual({name: "crew-engineering-manager", disallowedTaskTypes: []});
+	});
+
+	it("parseFrontmatter tolerates CRLF fences", () => {
+		expect(parseFrontmatter("---\r\nname: x\r\n---\r\nbody")).toEqual({name: "x"});
+	});
+});
+
+describe("disallowedTaskTypes — extract agent-types from Task(...) denies only", () => {
+	it("keeps Task(x) entries, drops non-Task and malformed tokens", () => {
+		expect(
+			disallowedTaskTypes(["Task(reviewer)", "Task( shipper )", "Bash", "Task()", "Edit"]),
+		).toEqual(["reviewer", "shipper"]);
+	});
+
+	it("returns empty for a non-array", () => {
+		expect(disallowedTaskTypes(undefined)).toEqual([]);
+		expect(disallowedTaskTypes("Task(reviewer)")).toEqual([]);
+	});
+});
+
+describe("judge — the enforced-allowlist coverage decision", () => {
+	it("PASSES on the current, fully-scoped crew roster", () => {
+		const v = judge(currentInput());
+		expect(v.pass).toBe(true);
+		if (v.pass) {
+			// the read-only investigator is excluded from the mutating roster
+			expect(v.mutatingRoster).not.toContain("crew-investigator");
+			expect(v.mutatingRoster).toContain("coder");
+			expect(v.bridges).toEqual(["crew-cartographer", "crew-chief-of-staff", "crew-intake-desk"]);
+		}
+	});
+
+	it("FAILS CLOSED on a FUTURE mutating agent-type no bridge allowlists or denies (the #3606 hole)", () => {
+		const input: CrewFanoutInput = {
+			rosterAgents: [...FULL_ROSTER, "crew-auditor"],
+			bridges: [CARTOGRAPHER, CHIEF, INTAKE],
+		};
+		const v = judge(input);
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "uncovered") {
+			// every bridge is missing a deny for the new type, and none allowlists it
+			expect(v.gaps.map((g) => g.bridge).sort()).toEqual([
+				"crew-cartographer",
+				"crew-chief-of-staff",
+				"crew-intake-desk",
+			]);
+			expect(v.gaps.every((g) => g.agent === "crew-auditor")).toBe(true);
+		} else {
+			throw new Error(`expected an uncovered verdict, got ${v.pass ? "pass" : v.reason}`);
+		}
+	});
+
+	it("FAILS CLOSED when a bridge silently drops a Task(x) deny for a non-allowlisted type", () => {
+		// reviewer is NOT on the cartographer allowlist; removing its deny must red.
+		const weakened = bridge(
+			"crew-cartographer",
+			CARTOGRAPHER.disallowedTaskTypes.filter((t) => t !== "reviewer"),
+		);
+		const v = judge({rosterAgents: FULL_ROSTER, bridges: [weakened, CHIEF, INTAKE]});
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "uncovered") {
+			expect(v.gaps).toContainEqual({bridge: "crew-cartographer", agent: "reviewer"});
+		} else {
+			throw new Error("expected an uncovered verdict");
+		}
+	});
+
+	it("does NOT require a bridge to deny an agent-type on its own allowlist", () => {
+		// intake-desk allowlists planner/canon/adr — dropping those denies stays green.
+		const v = judge({rosterAgents: FULL_ROSTER, bridges: [CARTOGRAPHER, CHIEF, INTAKE]});
+		expect(v.pass).toBe(true);
+		expect(BRIDGE_ALLOWLIST["crew-intake-desk"]).toContain("planner");
+	});
+
+	it("fails closed on zero roster and on zero bridges (ADR 0092)", () => {
+		expect(judge({rosterAgents: [], bridges: [CARTOGRAPHER, CHIEF, INTAKE]})).toMatchObject({
+			pass: false,
+			reason: "zero-scope",
+		});
+		expect(judge({rosterAgents: FULL_ROSTER, bridges: []})).toMatchObject({
+			pass: false,
+			reason: "zero-scope",
+		});
+	});
+
+	it("fails closed when an expected bridge def is absent", () => {
+		const v = judge({rosterAgents: FULL_ROSTER, bridges: [CARTOGRAPHER, INTAKE]});
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "missing-bridge") {
+			expect(v.missing).toEqual(["crew-chief-of-staff"]);
+		} else {
+			throw new Error("expected a missing-bridge verdict");
+		}
+	});
+
+	it("fails closed on a stale allowlist entry (allowlists an agent not in the roster)", () => {
+		// drop `reporter` from the roster while an allowlist still names it.
+		const roster = FULL_ROSTER.filter((a) => a !== "reporter");
+		const v = judge({rosterAgents: roster, bridges: [CARTOGRAPHER, CHIEF, INTAKE]});
+		expect(v.pass).toBe(false);
+		if (!v.pass && v.reason === "stale-allowlist") {
+			expect(v.entries.map((e) => e.agent)).toContain("reporter");
+		} else {
+			throw new Error("expected a stale-allowlist verdict");
+		}
+	});
+});
+
+describe("renderReport", () => {
+	it("names the scanned bridges + mutating roster on a pass", () => {
+		const report = renderReport(judge(currentInput()));
+		expect(report).toContain("crew-cartographer");
+		expect(report).toContain("mutating roster");
+	});
+
+	it("names the offending bridge×agent pair on an uncovered fail", () => {
+		const v = judge({
+			rosterAgents: [...FULL_ROSTER, "crew-auditor"],
+			bridges: [CARTOGRAPHER, CHIEF, INTAKE],
+		});
+		const report = renderReport(v);
+		expect(report).toContain("crew-auditor");
+		expect(report).toContain("neither allowlists nor denies");
+	});
+});

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/gate.ts
@@ -1,0 +1,87 @@
+/**
+ * The `crew-fanout-guard` filesystem gate — the IO seam behind #3606's "every crew bridge
+ * denies every non-allowlisted mutating roster agent-type" check, split from `command.ts`
+ * so it is crossable in unit tests over a fake repo dir rather than only by spawning the
+ * bin (the core-in-its-own-file idiom).
+ *
+ * `checkCrewFanout` enumerates the two agent-def dirs (the kampus-pipeline roster + the
+ * pipeline-crew roster), parses each def's `name`/`disallowedTools`, resolves the three
+ * bridge defs, and delegates the verdict to the pure core (`crew-fanout-guard.ts`). It
+ * fails `CheckFailed` (exit non-zero) on any non-passing verdict — an uncovered agent-type,
+ * a missing bridge, a stale allowlist, or zero scope (fail-closed, ADR 0092). A directory/
+ * file IO failure is an `IoError` (also non-zero — both failures, undistinguished).
+ */
+import {existsSync, readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {
+	type AgentDef,
+	BRIDGE_NAMES,
+	judge,
+	parseAgentDef,
+	renderReport,
+} from "./crew-fanout-guard.ts";
+
+/** A directory/file IO failure: the run couldn't complete. */
+export class IoError extends Schema.TaggedErrorClass<IoError>()("IoError", {
+	path: Schema.String,
+	cause: Schema.Unknown,
+}) {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Schema.TaggedErrorClass<CheckFailed>()("CheckFailed", {
+	reason: Schema.String,
+}) {}
+
+/** The two agent-def dirs whose union is the crew's spawnable roster. */
+const AGENT_DIRS = [
+	"claude-plugins/kampus-pipeline/agents",
+	"claude-plugins/pipeline-crew/agents",
+] as const;
+
+/** Read + parse every `*.md` agent def under `<root>/<dir>` (tolerant of an absent dir). */
+const parseAgentDefsIn = (
+	root: string,
+	dir: string,
+): Effect.Effect<ReadonlyArray<AgentDef>, IoError> =>
+	Effect.try({
+		try: () => {
+			const base = join(root, dir);
+			// A moved/renamed dir surfaces as zero scope / missing-bridge downstream (fail-closed),
+			// not a crash — the verdict, not an ENOENT throw, carries the diagnosis.
+			if (!existsSync(base)) return [];
+			const out: Array<AgentDef> = [];
+			for (const entry of readdirSync(base, {withFileTypes: true})) {
+				if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+				const def = parseAgentDef(readFileSync(join(base, entry.name), "utf8"));
+				if (def) out.push(def);
+			}
+			return out;
+		},
+		catch: (cause) => new IoError({path: join(root, dir), cause}),
+	});
+
+/**
+ * The CI gate: succeed when every crew bridge def denies every non-allowlisted mutating
+ * roster agent-type, else `CheckFailed`. Fails closed on zero scope (ADR 0092).
+ */
+export const checkCrewFanout = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const perDir = yield* Effect.forEach(AGENT_DIRS, (dir) => parseAgentDefsIn(root, dir), {
+			concurrency: "unbounded",
+		});
+		const allDefs = perDir.flat();
+		const rosterAgents = allDefs.map((d) => d.name);
+		const byName = new Map(allDefs.map((d) => [d.name, d]));
+		const bridges = BRIDGE_NAMES.map((n) => byName.get(n)).filter(
+			(d): d is AgentDef => d !== undefined,
+		);
+
+		const verdict = judge({rosterAgents, bridges});
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});


### PR DESCRIPTION
## What

Adds `crew-fanout-guard`, a `pipeline-cli` CI guard that **inverts the crew read-only-fanout per-bridge spawn DENYLIST into an ENFORCED ALLOWLIST** — closing the residual future-agent hole from #3597/#3605.

claude-code's permission model only *subtracts* denied agent-types from the all-active spawnable set — there is no "spawn only X" primitive — so each crew bridge's `disallowedTools` must enumerate every mutating agent-type it may not spawn. The residual gap: a **future** mutating agent-type added to the roster is silently spawnable by every bridge until someone remembers to extend each denylist (the "a future reader silently reopens the deleted edge" risk ADR 0196 warns of). This is enforcement-hardening for the roster-law boundary (ADR 0189/0196) — the line that keeps a read-only fanout from drifting into a "bridge runs the pipeline" execution edge.

## How

The guard **owns** each bridge's sanctioned spawn allowlist (`BRIDGE_ALLOWLIST` in `crew-fanout-guard.ts`) and **discovers** the mutating roster from both agent-def dirs (`claude-plugins/kampus-pipeline/agents/` + `claude-plugins/pipeline-crew/agents/`; read-only agents like `crew-investigator` are excluded — a new agent-type defaults to *mutating*, the fail-closed default). For each crew bridge (chief-of-staff / cartographer / intake-desk) it asserts every mutating roster agent-type **not** on that bridge's allowlist appears in the bridge's `disallowedTools` `Task(...)` denies.

Fail-closed (ADR 0092) on:
- an **uncovered** mutating agent-type (neither allowlisted nor denied) — catches a future un-denied agent *and* a silently-removed `Task(x)` deny,
- a **missing** expected bridge def,
- a **stale** allowlist entry (allowlists an agent-type no longer in the roster),
- **zero scope** (no roster / no bridge defs).

Encoding the allowlist as the source of truth (rather than reading it back off the denylist) is what makes it *enforced*: a removed deny for a non-allowlisted type reds the build.

## Shape

- Pure, unit-tested core (`crew-fanout-guard.ts`) + thin Effect bin (`command.ts`) over an IO seam (`gate.ts`) — the `catalog-guard` / `readme-guard` idiom. Registered in the pipeline-cli router (`registry.ts`).
- CI job `.github/workflows/crew-fanout-guard.yml` runs `crew-fanout-guard check` on every PR.

## Verification

- 15 pure-core unit tests (parse, coverage decision, the future-agent hole, denylist-weakening, zero-scope / missing-bridge / stale-allowlist).
- `pipeline-cli crew-fanout-guard check` passes green against the live crew defs; full pipeline-cli suite (1522 tests) green; typecheck + biome clean; `commands check` documents all 53 tools.

## §CP

Touches `packages/pipeline-cli/**` and `.github/workflows/**` — this PR **banks for human merge** (expected).

## Scope note

The second residual gap from #3597/#3605 — `crew-investigator`'s `Bash`-surface read-only-ness (charter-level vs command-scoped) — is split out to #3614 and **not** touched here. This is the CI-guard unit only.

Fixes #3606

🤖 Generated with [Claude Code](https://claude.com/claude-code)