### PR TITLE
feat(pipeline-cli): Tracker.postVerdict — ADR-0058 verdict/comment-post + read-back envelope (#3265)

### DIFF
--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -10,9 +10,10 @@
  * without a declared exemption reds the build.
  *
  * Seeded with the canonical #3254 example — `verdict read`, whose ADR-0058
- * SHA-bound marker-resolution three skills hand-copy (#2102). The remaining
- * envelope decisions (claim, apply-triage, create, post-verdict, graduate) arrive
- * with their sibling children (#3262–#3266), each with its own consumer migration.
+ * SHA-bound marker-resolution three skills hand-copy (#2102). `tracker apply-triage`
+ * (#3263) and `tracker post-verdict` (#3265) have since landed; the remaining envelope
+ * decisions (claim, graduate) arrive with their sibling children, each with its own
+ * consumer migration.
  */
 import type {Exemption, OwnedDecision} from "./adoption-lint.ts";
 
@@ -55,6 +56,23 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		reason:
 			"re-derives the label-transition envelope that `pipeline-cli tracker apply-triage` owns (add type/priority/status, remove needs-triage), instead of citing the verb (#3263 / #3254)",
 	},
+	{
+		// `tracker post-verdict` owns the ADR-0058 verdict/comment-post + read-back envelope (#3265):
+		// compose the SHA-bound `review-<gate>: <PASS|FAIL> @ <sha>` marker, PATCH our own prior marker
+		// in the namespace else POST, then re-fetch and self-verify the landed body (#3019). The
+		// fingerprint is the co-occurrence of emitting the marker AS a comment body (`body=review-…`)
+		// and the PATCH-own-prior upsert against the comments endpoint — so a mere DESCRIPTION of the
+		// marker format (which every review skill carries) is NOT a false finding. A file that cites
+		// `pipeline-cli tracker post-verdict` (or the equivalent `pipeline-cli verdict post`) is compliant.
+		verb: "tracker post-verdict",
+		signature: [
+			/body=[^"']{0,80}review-(?:code|doc|skill|design):/, // emits the verdict marker as a comment body
+			/-X\s+PATCH[^\n]*\/comments/, // the PATCH-own-prior upsert leg (else POST)
+		],
+		citation: /pipeline-cli\s+(?:tracker\s+post-verdict|verdict\s+post)\b/,
+		reason:
+			"re-derives the ADR-0058 verdict/comment-post + read-back envelope that `pipeline-cli tracker post-verdict` owns (compose the SHA-bound marker, PATCH-own-prior-else-POST, self-verify the landed body), instead of citing the verb (#3265 / #3254)",
+	},
 ];
 
 /**
@@ -66,8 +84,10 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
  * `drive-issue.js` is the sole legitimate mirror: the orchestrator is a runtime
  * `.js` surface that cannot import the TS verb core, so it must inline what a
  * skill would cite. `heal-ci` and `write-code` are the two current `verdict read`
- * re-derivers named in #3254 — grandfathered here until #3265 (post-verdict)
- * extracts the verb and migrates them same-commit.
+ * re-derivers named in #3254 — their conversion is a non-drop-in rewrite (both scans
+ * do more than a single (PR, gate) resolution: write-code also counts FAIL rounds for
+ * the N=3 repair cap), so #3265 deferred it to its own reviewable PR, tracked by #3619;
+ * they stay grandfathered here until that migration lands and draws them down.
  */
 export const EXEMPTIONS: ReadonlyArray<Exemption> = [
 	{
@@ -80,12 +100,14 @@ export const EXEMPTIONS: ReadonlyArray<Exemption> = [
 		kind: "grandfathered",
 		path: "skills/heal-ci/SKILL.md",
 		verb: "verdict read",
-		reason: "existing `verdict read` re-derivation — migrate to `pipeline-cli verdict` with #3265",
+		reason:
+			"existing `verdict read` re-derivation — migrate to `pipeline-cli verdict read` (deferred by #3265 to its own PR, #3619)",
 	},
 	{
 		kind: "grandfathered",
 		path: "skills/write-code/SKILL.md",
 		verb: "verdict read",
-		reason: "existing `verdict read` re-derivation — migrate to `pipeline-cli verdict` with #3265",
+		reason:
+			"existing `verdict read` re-derivation — migrate to `pipeline-cli verdict read` (deferred by #3265 to its own PR, #3619)",
 	},
 ];

--- a/packages/pipeline-cli/src/tools/tracker/command.ts
+++ b/packages/pipeline-cli/src/tools/tracker/command.ts
@@ -1,19 +1,23 @@
 /**
  * The `tracker` tool — `pipeline-cli tracker claim <target>` /
- * `pipeline-cli tracker read-back <target>` / `pipeline-cli tracker apply-triage <target>`.
+ * `pipeline-cli tracker read-back <target>` / `pipeline-cli tracker apply-triage <target>` /
+ * `pipeline-cli tracker post-verdict <target>`.
  *
  * The CLI surface of the Wave-1 `Tracker` service (ADR 0190): `claim` posts the ADR-0115
  * agent-distinguishable claim and exits 0 only when the claim is ours; `read-back` resolves
  * and prints the current owner; `apply-triage` applies a type/priority/status classification
- * and drops the entity out of the needs-triage queue (#3263). Judgment-as-parameter: the
- * claiming identity and the classification are supplied, not decided by the tool — the claim
- * session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable signal
- * under the shared `usirin` login) and `--session` overrides it for the orchestrated/
- * delegated-token path and for tests; an absent value fails closed.
+ * and drops the entity out of the needs-triage queue (#3263); `post-verdict` upserts a
+ * SHA-bound ADR-0058 gate verdict comment and reads it back (#3265). Judgment-as-parameter:
+ * the claiming identity, the classification, and the verdict (gate / PASS|FAIL / bound head /
+ * prose) are supplied, not decided by the tool — the claim session id defaults to
+ * `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable signal under the shared `usirin`
+ * login) and `--session` overrides it for the orchestrated/delegated-token path and for tests;
+ * an absent value fails closed.
  *
  * `GithubTrackerLive` is baked in with `Command.provide(...)` so the registered command's
  * residual requirement is the Node platform union (the registry seam, epic #994).
  */
+import {readFileSync} from "node:fs";
 import {Console, Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {
@@ -22,12 +26,13 @@ import {
 	type ReadBackResult,
 	Tracker,
 	type TriageResult,
+	type VerdictResult,
 } from "./tracker.ts";
 
 const BACKOFF_EXIT_CODE = 1;
 
 const targetArg = Argument.integer("target").pipe(
-	Argument.withDescription("the tracker entity (issue) number to claim / read back"),
+	Argument.withDescription("the tracker entity (issue / PR) number the verb acts on"),
 );
 
 const sessionFlag = Flag.string("session").pipe(
@@ -138,10 +143,84 @@ const applyTriage = Command.make(
 	),
 );
 
-export const trackerCommand = Command.make("tracker").pipe(
-	Command.withSubcommands([claim, readBack, applyTriage]),
+// Judgment-as-parameter (#3252): the verdict decision (gate / PASS|FAIL / bound head / prose body)
+// is supplied, never decided by the tool — the role vocabulary (which reviewer) lives in the agent
+// def, not here. The verb composes the ADR-0058 `review-<gate>:` marker from these parameters so no
+// caller hand-composes it.
+const verdictGateFlag = Flag.string("gate").pipe(
+	Flag.withDescription("the gate namespace: one of code | doc | skill | design (review-<gate>)"),
+);
+
+const resultFlag = Flag.string("result").pipe(
+	Flag.withDescription("the verdict polarity: PASS or FAIL"),
+);
+
+const headRefFlag = Flag.string("head").pipe(
+	Flag.withDescription("the full 40-hex head SHA the verdict binds to (ADR 0058)"),
+);
+
+const verdictBodyFileFlag = Flag.string("body-file").pipe(
+	Flag.optional,
+	Flag.withDescription("path to the verdict prose body (default: read the body from stdin)"),
+);
+
+const parsePassed = (raw: string): Effect.Effect<boolean, never> => {
+	const value = raw.trim().toUpperCase();
+	if (value === "PASS") return Effect.succeed(true);
+	if (value === "FAIL") return Effect.succeed(false);
+	return backOff(`invalid --result '${raw}' — expected PASS or FAIL`);
+};
+
+const readBody = (bodyFile: Option.Option<string>): Effect.Effect<string, never> =>
+	Effect.sync(() =>
+		Option.match(bodyFile, {
+			onNone: () => readFileSync(0, "utf8"),
+			onSome: (path) => readFileSync(path, "utf8"),
+		}),
+	);
+
+const reportVerdict = (target: number, result: VerdictResult): Effect.Effect<void> =>
+	Console.log(
+		`tracker: ${result._tag} ${result.gate} verdict on #${target} (${result.passed ? "PASS" : "FAIL"} @ ${result.headRef}).`,
+	);
+
+const postVerdict = Command.make(
+	"post-verdict",
+	{
+		target: targetArg,
+		gate: verdictGateFlag,
+		result: resultFlag,
+		head: headRefFlag,
+		bodyFile: verdictBodyFileFlag,
+	},
+	Effect.fn(function* ({target, gate, result, head, bodyFile}) {
+		const passed = yield* parsePassed(result);
+		const body = (yield* readBody(bodyFile)).replace(/\s+$/, "");
+		if (body.length === 0) {
+			return yield* backOff(
+				"empty verdict body — nothing to post (pass --body-file or pipe the prose on stdin)",
+			);
+		}
+		const posted = yield* (yield* Tracker)
+			.postVerdict(target, {gate, passed, headRef: head, body})
+			.pipe(
+				// A malformed judgment (unknown gate, unbindable/non-40-hex @ <sha>, a leaked local path)
+				// and a failed post-write self-verify both fail loud, never a false success.
+				Effect.catchTag("@kampus/tracker/TrackerInputError", (error) => backOff(error.message)),
+				Effect.catchTag("@kampus/tracker/TrackerVerifyError", (error) => backOff(error.message)),
+			);
+		yield* reportVerdict(target, posted);
+	}),
+).pipe(
 	Command.withDescription(
-		"The crew tracker service (ADR 0190): claim a tracker entity, read back its owner, apply a triage classification",
+		"Upsert a SHA-bound gate verdict comment for a tracker entity and read it back (PATCH own prior marker, else POST — one per gate, ADR 0058)",
+	),
+);
+
+export const trackerCommand = Command.make("tracker").pipe(
+	Command.withSubcommands([claim, readBack, applyTriage, postVerdict]),
+	Command.withDescription(
+		"The crew tracker service (ADR 0190): claim a tracker entity, read back its owner, apply a triage classification, post a gate verdict",
 	),
 	Command.provide(GithubTrackerLive),
 );

--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -6,7 +6,9 @@ import {
 	GithubTrackerLive,
 	type RepoResolutionError,
 	Tracker,
+	TrackerInputError,
 	TrackerNotImplementedError,
+	TrackerVerifyError,
 } from "./tracker.ts";
 
 // The live layer resolves its repo lazily (ADR 0062 §1); pin the env override so the
@@ -52,7 +54,10 @@ const mockSpawner = (
 				let cmd = command;
 				while (cmd._tag === "PipedCommand") cmd = cmd.left;
 				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
-				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				// route on the REST path when present, else on the `gh <sub> <verb>` shape (e.g. `api user`)
+				const rawPath =
+					args.find((a) => a.startsWith("repos/")) ??
+					(args[0] === "api" ? (args[1] ?? "") : args.slice(0, 2).join(" "));
 				const path = rawPath.replace(/\?.*$/, "");
 				const key = `${methodOf(args)} ${path}`;
 				const canned =
@@ -407,18 +412,133 @@ describe("Tracker.applyTriage — the label-transition envelope over a mock gh s
 	);
 });
 
-describe("Tracker — the declared-but-not-yet-built verbs fail closed", () => {
-	it.effect("postVerdict → TrackerNotImplementedError", () =>
+describe("Tracker.postVerdict — the ADR-0058 verdict/comment-post + read-back envelope", () => {
+	// A full 40-hex head SHA — the ONLY shape the tightened emission guard (#2683) accepts on a
+	// POSTed marker, so the composed `review-<gate>: PASS @ <sha>` first line is bindable.
+	const HEAD40 = `${"a1b2c3d4e5f6".repeat(3)}a1b2`; // 12*3 + 4 = 40 hex
+	const PROSE = "all acceptance criteria met — merge-ready.";
+	const LANDED_PASS = `review-code: PASS @ ${HEAD40}\n\n${PROSE}`;
+
+	const verdictComment = (over: {
+		readonly id: number;
+		readonly login: string;
+		readonly body: string;
+	}) =>
+		({
+			id: over.id,
+			created_at: "2026-07-11T00:00:00Z",
+			user: {login: over.login},
+			body: over.body,
+		}) as const;
+
+	it.effect(
+		"no prior own marker → POST a fresh verdict, self-verify the landed body → posted",
+		() =>
+			Effect.gen(function* () {
+				const tracker = yield* Tracker;
+				const result = yield* tracker.postVerdict(TARGET, {
+					gate: "code",
+					passed: true,
+					headRef: HEAD40,
+					body: PROSE,
+				});
+				assert.deepStrictEqual(result, {
+					_tag: "posted",
+					gate: "code",
+					passed: true,
+					headRef: HEAD40,
+				});
+			}).pipe((effect) =>
+				provide(effect, {
+					"GET user": "usirin",
+					[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([]),
+					[`POST ${P}/issues/${TARGET}/comments`]: "999",
+					// the #3019 read-back: postVerdict re-fetches the landed comment and re-runs emissionDefect
+					[`GET ${P}/issues/comments/999`]: LANDED_PASS,
+				}),
+			),
+	);
+
+	it.effect("our own prior marker in the namespace → PATCH it (upsert, not append) → patched", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const result = yield* tracker.postVerdict(TARGET, {
+				gate: "code",
+				passed: true,
+				headRef: HEAD40,
+				body: PROSE,
+			});
+			assert.deepStrictEqual(result, {
+				_tag: "patched",
+				gate: "code",
+				passed: true,
+				headRef: HEAD40,
+			});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				// our own prior review-code marker exists → the upsert PATCHes it, never a second POST
+				[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([
+					verdictComment({id: 42, login: "usirin", body: `review-code: FAIL @ ${HEAD40}\n\nstale`}),
+				]),
+				[`PATCH ${P}/issues/comments/42`]: "42",
+				[`GET ${P}/issues/comments/42`]: LANDED_PASS,
+			}),
+		),
+	);
+
+	it.effect("an unknown gate → TrackerInputError before any write", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;
 			const error = yield* Effect.flip(
-				tracker.postVerdict(TARGET, {gate: "review-code", passed: true, headRef: "deadbeef"}),
+				tracker.postVerdict(TARGET, {gate: "bogus", passed: true, headRef: HEAD40, body: PROSE}),
 			);
-			assert.isTrue(error instanceof TrackerNotImplementedError);
-			assert.strictEqual(error.verb, "postVerdict");
+			assert.isTrue(error instanceof TrackerInputError);
 		}).pipe((effect) => provide(effect, {})),
 	);
 
+	it.effect("a non-40-hex head → emission defect → TrackerInputError, no write", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			// no POST/PATCH fixture: the emission guard must refuse before any write reaches GitHub
+			const error = yield* Effect.flip(
+				tracker.postVerdict(TARGET, {gate: "code", passed: false, headRef: "abc123", body: PROSE}),
+			);
+			assert.isTrue(error instanceof TrackerInputError);
+		}).pipe((effect) => provide(effect, {"GET user": "usirin"})),
+	);
+
+	it.effect("the landed body fails self-verify → TrackerVerifyError (never a false success)", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			const error = yield* Effect.flip(
+				tracker.postVerdict(TARGET, {gate: "code", passed: true, headRef: HEAD40, body: PROSE}),
+			);
+			assert.isTrue(error instanceof TrackerVerifyError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${TARGET}/comments`]: JSON.stringify([]),
+				[`POST ${P}/issues/${TARGET}/comments`]: "999",
+				// the landed body is not a clean in-namespace marker — the folded-in read-back rejects it
+				[`GET ${P}/issues/comments/999`]: "oops — a hand-edited body with no marker",
+			}),
+		),
+	);
+
+	it.effect("a non-zero gh exit on whoami → GhCommandError in the E channel", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			// no `GET user` fixture → whoami exits 1 → GhCommandError, never a throw or a silent post
+			const error = yield* Effect.flip(
+				tracker.postVerdict(TARGET, {gate: "code", passed: true, headRef: HEAD40, body: PROSE}),
+			);
+			assert.isTrue(error instanceof GhCommandError);
+		}).pipe((effect) => provide(effect, {})),
+	);
+});
+
+describe("Tracker — the declared-but-not-yet-built verbs fail closed", () => {
 	it.effect("graduate → TrackerNotImplementedError", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -4,10 +4,10 @@
  *
  * Grown from the Wave-1 walking skeleton (epic #3258): a `Context.Service` `Tracker`
  * tag plus its sole implementation `GithubTrackerLive`. `claim` (the ADR-0115
- * agent-distinguishable claim), a generic `readBack`, and `applyTriage` (the
- * label-transition envelope, #3263) are live; `postVerdict` / `graduate` are still
- * *declared* — their interface shape is fixed so the tag locks before its remaining
- * sibling Phase-3 children implement them.
+ * agent-distinguishable claim), a generic `readBack`, `applyTriage` (the label-transition
+ * envelope, #3263), and `postVerdict` (the ADR-0058 verdict/comment-post + read-back
+ * envelope, #3265) are live; only `graduate` is still *declared* — its interface shape is
+ * fixed so the tag locks before its remaining sibling Phase-3 child implements it.
  *
  * Two design rules bind every signature here and are the point of the skeleton:
  *
@@ -36,6 +36,17 @@ import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import {type ClaimComment, type ClaimWinner, resolveWinner} from "../epic-lock/claim-resolution.ts";
+// The ADR-0058 verdict-marker grammar + emission guard is the SINGLE SOURCE — reused, never
+// re-derived, exactly as the claim decision reuses `epic-lock/claim-resolution.ts`. `postVerdict`
+// composes and self-verifies its comment through this pure core so the tool OWNS the decision the
+// adoption-lint (#3254) forbids the corpus from hand-copying.
+import {
+	emissionDefect,
+	GATE_KEYWORD,
+	GATES,
+	namespaceRe,
+	type VerdictGate,
+} from "../verdict/verdict-match.ts";
 
 /** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
 export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
@@ -65,14 +76,39 @@ export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionE
 ) {}
 
 /**
- * A declared-but-not-yet-built verb was called. `claim` / `readBack` / `applyTriage`
- * are live; `postVerdict` / `graduate` fail-closed with this typed error until a sibling
- * Phase-3 child implements them — never a silent no-op or a throw.
+ * A declared-but-not-yet-built verb was called. `claim` / `readBack` / `applyTriage` /
+ * `postVerdict` are live; only `graduate` fails-closed with this typed error until its sibling
+ * Phase-3 child implements it — never a silent no-op or a throw.
  */
 export class TrackerNotImplementedError extends Schema.TaggedErrorClass<TrackerNotImplementedError>()(
 	"@kampus/tracker/TrackerNotImplementedError",
 	{
 		verb: Schema.String,
+	},
+) {}
+
+/**
+ * A malformed verb judgment the caller must fix — e.g. `postVerdict` handed an unknown gate, or a
+ * composed verdict body that trips `emissionDefect` (a polarity with no bindable `@ <sha>`, a
+ * non-40-hex head, a machine-local path). A caller error, not an infra fault: it is raised before
+ * any write reaches the tracker.
+ */
+export class TrackerInputError extends Schema.TaggedErrorClass<TrackerInputError>()(
+	"@kampus/tracker/TrackerInputError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/**
+ * A verb's post-write self-verify failed: after `postVerdict` upserted the comment it re-fetched it
+ * and the landed body is not a clean, in-namespace, leak-free marker. The read-back folded INTO the
+ * write so a bypassed/hand-rolled body can't report a false success (ADR 0058 read-back, #3019).
+ */
+export class TrackerVerifyError extends Schema.TaggedErrorClass<TrackerVerifyError>()(
+	"@kampus/tracker/TrackerVerifyError",
+	{
+		message: Schema.String,
 	},
 ) {}
 
@@ -135,12 +171,32 @@ export type TriageResult = {
 	readonly status: string;
 };
 
-/** A gate verdict: which gate, whether it passed, and the head ref it is bound to. */
+/**
+ * A gate verdict (judgment-as-parameter, #3252): which `gate` it decides, whether it `passed`,
+ * the `headRef` the verdict binds to (ADR 0058), and the verdict `body` prose. Domain vocabulary
+ * only — `gate` is the crew's own gate name (`code`/`doc`/`skill`/`design`); the caller never
+ * hand-composes the `review-<gate>:` marker or its `@ <sha>` binding (the divergent-copy class
+ * #3254 names), so no GitHub marker string leaks into the signature. `GithubTrackerLive` composes
+ * the marker from this judgment at the boundary.
+ */
 export interface VerdictJudgment {
 	readonly gate: string;
 	readonly passed: boolean;
 	readonly headRef: string;
+	readonly body: string;
 }
+
+/**
+ * The `postVerdict` verdict: the landed verdict read back from the entity — whether it was a fresh
+ * comment (`posted`) or an upsert of our own prior marker in the namespace (`patched`), and the
+ * gate/passed/headRef it now carries. A domain result, never a raw REST comment id (ADR 0190).
+ */
+export type VerdictResult = {
+	readonly _tag: "posted" | "patched";
+	readonly gate: string;
+	readonly passed: boolean;
+	readonly headRef: string;
+};
 
 /** A lifecycle graduation: the stage the target moves to. */
 export interface GraduateJudgment {
@@ -236,7 +292,9 @@ const listCommentsArgs = (repo: string, target: TargetId): ReadonlyArray<string>
 	`repos/${repo}/issues/${target}/comments?per_page=100`,
 ];
 
-const postClaimArgs = (repo: string, target: TargetId, body: string): ReadonlyArray<string> => [
+// A generic comment POST — the claim marker and the verdict marker are both a body POST that
+// returns the new comment id; single-sourced so the two consumers can't drift.
+const postCommentArgs = (repo: string, target: TargetId, body: string): ReadonlyArray<string> => [
 	"api",
 	"-X",
 	"POST",
@@ -246,6 +304,28 @@ const postClaimArgs = (repo: string, target: TargetId, body: string): ReadonlyAr
 	"--jq",
 	".id",
 ];
+
+const patchCommentArgs = (repo: string, id: number, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"PATCH",
+	`repos/${repo}/issues/comments/${id}`,
+	"-f",
+	`body=${body}`,
+	"--jq",
+	".id",
+];
+
+// The read-back GET for `postVerdict`'s self-verify (#3019): re-fetch the single comment we just
+// upserted and return its LANDED body, so the marker/leak-clean shape is re-checked as it landed.
+const getCommentBodyArgs = (repo: string, id: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/comments/${id}`,
+	"--jq",
+	".body",
+];
+
+const whoAmIArgs: ReadonlyArray<string> = ["api", "user", "--jq", ".login"];
 
 const deleteCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
 	"api",
@@ -384,7 +464,7 @@ const claim = Effect.fn("Tracker.claim")(function* (
 			: ({_tag: "held-by-other", owner: toOwner(before)} satisfies ClaimResult);
 	}
 	const now = new Date().toISOString();
-	const posted = yield* json(postClaimArgs(repo, target, `claim: ${session} · ${now}`));
+	const posted = yield* json(postCommentArgs(repo, target, `claim: ${session} · ${now}`));
 	const claimId = typeof posted === "number" ? posted : null;
 	const winner = yield* resolveAuthorizedWinner(repo, yield* listClaimComments(repo, target));
 	if (winner !== null && winner.session === mine) {
@@ -438,12 +518,127 @@ const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
 	} satisfies TriageResult;
 });
 
-type TrackerErrors = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
+/** Map a domain gate name to the ADR-0058 `VerdictGate`, or `null` if it is not a known gate. */
+const asGate = (gate: string): VerdictGate | null => {
+	const g = gate.trim().toLowerCase();
+	return (GATES as ReadonlyArray<string>).includes(g) ? (g as VerdictGate) : null;
+};
 
 /**
- * `Tracker` — the shared crew tracker capability. `claim`, `readBack`, and `applyTriage`
- * are live; the two still-declared verbs fail `TrackerNotImplementedError` until a sibling
- * child builds them (their success types are `never` by design — a not-yet-built verb
+ * Compose the verdict comment body from the domain judgment: the ADR-0058 SHA-bound marker on line
+ * one (`review-<gate>: <PASS|FAIL> @ <headRef>`) followed by the verdict prose. The caller supplies
+ * only the domain decision (gate/passed/headRef) + prose — never the marker string — so the marker
+ * grammar lives in exactly one place (`verdict-match.ts`).
+ */
+const composeVerdictBody = (
+	gate: VerdictGate,
+	passed: boolean,
+	headRef: string,
+	prose: string,
+): string => `${GATE_KEYWORD[gate]}: ${passed ? "PASS" : "FAIL"} @ ${headRef}\n\n${prose}`;
+
+/**
+ * The post-write self-verify (#3019): re-fetch the comment `postVerdict` just upserted and assert
+ * its LANDED body passes the SAME `emissionDefect` gate the composed input passed — a marker on line
+ * one, a bindable `@ <sha>`, and no machine-local path anywhere. Folds the read-back INTO the write
+ * so a caller can't leave a `@path`/non-marker/leaking comment on a public PR while reporting
+ * success. Fail-closed: a failed re-fetch, or any landed defect, raises `TrackerVerifyError`.
+ */
+const verifyLanded = Effect.fn("Tracker.verifyLanded")(function* (
+	repo: string,
+	id: number,
+	gate: VerdictGate,
+) {
+	const landed = yield* runGh(getCommentBodyArgs(repo, id)).pipe(
+		Effect.catchTag(
+			"@kampus/tracker/GhCommandError",
+			(cause) =>
+				new TrackerVerifyError({
+					message: `could not re-fetch the just-posted verdict comment #${id} to self-verify it (${cause.stderr.trim() || `exit ${cause.exitCode}`}) — refusing to report success on an unverifiable post (#3019)`,
+				}),
+		),
+	);
+	const defect = emissionDefect(landed, gate);
+	if (defect !== null) {
+		return yield* new TrackerVerifyError({
+			message: `the landed verdict comment #${id} failed self-verify: ${defect} — a bypassed/hand-rolled body reached GitHub; the post is rejected rather than reported as success (#3019)`,
+		});
+	}
+});
+
+/**
+ * Upsert `target`'s `gate` verdict and read it back (ADR 0058 rule 2, ADR 0190) — the
+ * verdict/comment-post + read-back envelope the review/ship/heal skills hand-rolled, now one
+ * domain-shaped verb. Compose the SHA-bound marker + prose from the judgment, refuse fail-closed on
+ * any `emissionDefect` (wrong namespace, unbindable/non-40-hex `@ <sha>`, a machine-local path) as a
+ * `TrackerInputError` before any write, then scan our OWN prior marker in the namespace (newest by
+ * `(createdAt, id)`) and PATCH it if present else POST a fresh one — exactly one verdict comment per
+ * (entity, gate), and the own-authored scope means two reviewers never stomp each other's records.
+ * Finally `verifyLanded` re-fetches the upserted comment and re-runs the emission gate on its landed
+ * body. The untrusted comment list is Schema-decoded at the boundary (`listClaimComments`).
+ */
+const postVerdict = Effect.fn("Tracker.postVerdict")(function* (
+	repo: string,
+	target: TargetId,
+	judgment: VerdictJudgment,
+) {
+	const gate = asGate(judgment.gate);
+	if (gate === null) {
+		return yield* new TrackerInputError({
+			message: `unknown gate '${judgment.gate}' — expected one of ${GATES.join(" | ")}`,
+		});
+	}
+	const headRef = judgment.headRef.trim();
+	const body = composeVerdictBody(
+		gate,
+		judgment.passed,
+		headRef,
+		judgment.body.replace(/\s+$/, ""),
+	);
+	const defect = emissionDefect(body, gate);
+	if (defect !== null) {
+		return yield* new TrackerInputError({message: `refusing to post: ${defect}`});
+	}
+	const me = (yield* runGh(whoAmIArgs)).trim();
+	const re = namespaceRe(gate);
+	const mine = (yield* listClaimComments(repo, target))
+		.filter((c) => c.author === me && re.test(c.body))
+		.sort((a, b) => (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id));
+	const priorId = mine[mine.length - 1]?.id;
+	const upsert = yield* Effect.gen(function* () {
+		if (priorId !== undefined) {
+			const decoded = yield* json(patchCommentArgs(repo, priorId, body));
+			return {
+				_tag: "patched" as const,
+				id: typeof decoded === "number" ? decoded : priorId,
+			};
+		}
+		const decoded = yield* json(postCommentArgs(repo, target, body));
+		if (typeof decoded !== "number") {
+			return yield* new GhParseError({
+				args: postCommentArgs(repo, target, "<body>"),
+				message: "comment POST did not return a numeric id",
+			});
+		}
+		return {_tag: "posted" as const, id: decoded};
+	});
+	yield* verifyLanded(repo, upsert.id, gate);
+	return {
+		_tag: upsert._tag,
+		gate: judgment.gate,
+		passed: judgment.passed,
+		headRef,
+	} satisfies VerdictResult;
+});
+
+type TrackerErrors = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
+
+type PostVerdictErrors = TrackerErrors | TrackerInputError | TrackerVerifyError;
+
+/**
+ * `Tracker` — the shared crew tracker capability. `claim`, `readBack`, `applyTriage`, and
+ * `postVerdict` are live; only the still-declared `graduate` fails `TrackerNotImplementedError`
+ * until its sibling child builds it (its success type is `never` by design — a not-yet-built verb
  * produces no value). Built by `GithubTrackerLive`, whose `R` is `ChildProcessSpawner`.
  */
 export class Tracker extends Context.Service<
@@ -461,7 +656,7 @@ export class Tracker extends Context.Service<
 		readonly postVerdict: (
 			target: TargetId,
 			judgment: VerdictJudgment,
-		) => Effect.Effect<never, TrackerNotImplementedError>;
+		) => Effect.Effect<VerdictResult, PostVerdictErrors>;
 		readonly graduate: (
 			target: TargetId,
 			judgment: GraduateJudgment,
@@ -496,7 +691,8 @@ export const GithubTrackerLive: Layer.Layer<
 			readBack: (target) => repo.pipe(Effect.flatMap((r) => withSpawner(readBack(r, target)))),
 			applyTriage: (target, judgment) =>
 				repo.pipe(Effect.flatMap((r) => withSpawner(applyTriage(r, target, judgment)))),
-			postVerdict: () => notImplemented("postVerdict"),
+			postVerdict: (target, judgment) =>
+				repo.pipe(Effect.flatMap((r) => withSpawner(postVerdict(r, target, judgment)))),
 			graduate: () => notImplemented("graduate"),
 		};
 	}),


### PR DESCRIPTION
Fixes #3265

## What

Add the `postVerdict` verb to the `Tracker` service (ADR 0190, epic #3258) — the ADR-0058 verdict/comment-post + read-back envelope, extracted domain-shaped.

- **Domain method** on the `Tracker` interface + implemented in `GithubTrackerLive` (sole impl). The signature is domain-shaped: `VerdictJudgment = { gate, passed, headRef, body }` — no `review-<gate>:` marker string, sub-issue id, label string, or REST idiom leaks in. The GitHub marker grammar lives entirely inside the live impl.
- **Upsert + read-back**: composes the SHA-bound `review-<gate>: <PASS|FAIL> @ <sha>` marker from the judgment, refuses fail-closed on any `emissionDefect` (wrong namespace, unbindable/non-40-hex `@ <sha>`, machine-local path leak) as a typed `TrackerInputError` before any write, then PATCHes our own prior marker in the namespace else POSTs (one comment per (entity, gate)), and finally re-fetches + self-verifies the landed body (#3019) — a bad landed marker fails `TrackerVerifyError`, never a false success.
- **Single-source reuse**: the marker grammar + `emissionDefect` come from `verdict-match.ts`'s pure core (not re-derived), exactly as the claim verb reuses `claim-resolution.ts`.
- **Typed E-channel** (ADR 0040): `RepoResolutionError | GhCommandError | GhParseError | TrackerInputError | TrackerVerifyError | SchemaError`; the untrusted comment list is Schema-decoded at the boundary.
- **CLI verb** `pipeline-cli tracker post-verdict <target> --gate <g> --result PASS|FAIL --head <sha> [--body-file <f>]` — judgment-as-parameter (#3252), never per-role; role vocabulary stays in the agent def.

## Adoption (#3254, governing AC)

- Appended the `tracker post-verdict` decision to the adoption-lint manifest so a future inline hand-roll of the verdict-post envelope reds the build. The signature keys on emitting the marker AS a comment body (`body=review-…`) + the PATCH-own-prior upsert — a mere *description* of the marker format (which every review skill carries) is not a false finding.
- No consumer currently re-derives this envelope: every review skill already cites `pipeline-cli verdict post`. The adoption-lint is green over the full corpus.
- The two grandfathered `verdict read` re-derivers (`write-code` / `heal-ci`) are a **non-drop-in** rewrite — both scans do more than a single (PR, gate) resolution (write-code also counts FAIL rounds for the N=3 repair cap), so converting them safely deserves its own reviewable PR. Deferred to **#3619** to keep this §CP diff scoped; they stay grandfathered and the lint stays green.

## Tests (ADR 0040)

New behavior tests over a mock `gh` spawner: happy POST + happy PATCH-upsert, plus error/back-off paths — unknown gate → `TrackerInputError`, non-40-hex head (emission defect) → `TrackerInputError` with no write, landed-body self-verify failure → `TrackerVerifyError`, and a non-zero `gh` exit → `GhCommandError` in the E channel.

Full `pipeline-cli` suite green (1494 tests), `tsc` + biome clean, adoption-lint clean over the CI corpus.

## §CP note

Touches `packages/pipeline-cli/**` + the gate-critical adoption-lint manifest → §CP merge path. Stops at reviewed-ready for cansirin approval at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)