### PR TITLE
roadmap: complete Diátaxis docs campaign (done)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Mentor Audit | #27 | active |
 | Crew-MCP Finish — replace the tmux relay with crew-mcp | #28 | active |
 | Deterministic Crew Mechanics | #29 | active |
-| Diátaxis docs — pipeline-crew & -mcp | #31 | active |
+| Diátaxis docs — pipeline-crew & -mcp | #31 | done |
 | pipeline-cli @effect/platform migration | #32 | active |
 | Agentic design-system coverage | #33 | active |
 


### PR DESCRIPTION
Completes the Diátaxis docs — pipeline-crew & -mcp audit wave (`diataxis-docs`) as a finished campaign — milestone #31 fully drained (0 open / 12 closed) and now closed. Flips the ROADMAP `## Campaigns` row #31 State `active → done`, paired with the milestone close so roadmap-guard I3 stays in sync (only *open* milestones must be claimed).

Founder-approval trace verified (`campaign verify-trace diataxis-docs` PASS — approved by usirin at 2026-07-19T03:47:28Z). Symmetric `done` path of the /campaign ritual.