### PR TITLE
feat(pipeline-cli): Tracker graduate verb — map/investigation graduation-close envelope (#3266)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -987,10 +987,14 @@ for SRC in $SOURCES; do
     open:*type:investigation*) ;;
     *) echo "plan-epic: source #$SRC is $STATE ($TYPES) — not an open investigation, skipping close."; continue ;;
   esac
-  # Audit trail (AC): a reason comment recording source → artifact, so a reader can trace the
-  # graduation, then close as completed (the work graduated, it wasn't abandoned).
-  gh api repos/$REPO/issues/$SRC/comments -f body="Graduated into epic #<EPIC> (planned by plan-epic) — closing this investigation as the durable \`graduated into #<EPIC>\` record. Its diagnosis is carried forward by the epic and its planned children." >/dev/null
-  gh api -X PATCH repos/$REPO/issues/$SRC -f state=closed -f state_reason=completed >/dev/null
+  # Audit trail (AC): the `tracker graduate` verb owns the graduation-close envelope (ADR 0190,
+  # #3266) — it posts the source → artifact provenance record so a reader can trace the graduation,
+  # then closes the source as completed (the work graduated, it wasn't abandoned — distinct from
+  # triage's not_planned). Don't hand-roll the comment + `state_reason=completed` PATCH; that inline
+  # re-derivation is what the adoption lint (#3254) flags.
+  pipeline-cli tracker graduate "$SRC" \
+    --artifact "epic #<EPIC> (planned by plan-epic)" \
+    --note "closing this investigation as the durable \`graduated into #<EPIC>\` record. Its diagnosis is carried forward by the epic and its planned children." >/dev/null
   echo "plan-epic: closed graduated source investigation #$SRC → epic #<EPIC>."
 done
 ```

--- a/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md
@@ -539,9 +539,14 @@ Make the ideation→execution handoff traceable from both ends, then close:
 ```bash
 # Name every artifact the map graduated into (epics and/or ADR and/or roadmap), then close it
 # IFF the destination is FULLY graduated. A partial graduation is annotated but stays open.
-BODY="Graduated into: #$E1, #$E2 → triage → plan-epic → write-code; ADR 0176; ROADMAP.md v1. Frontier cleared — closing this map as the durable record of how the plan was discovered."
-gh api repos/$REPO/issues/$MAP/comments -f body="$BODY"
-gh api -X PATCH repos/$REPO/issues/$MAP -f state=closed -f state_reason=completed   # fully-graduated only; a partial graduation stays open
+# The `tracker graduate` verb owns this graduation-close envelope (ADR 0190, #3266): it posts
+# the `Graduated into <artifact>` source → artifact provenance record and closes the source as
+# completed. Don't hand-roll the comment + `state_reason=completed` PATCH — that inline
+# re-derivation is what the adoption lint (#3254) flags.
+pipeline-cli tracker graduate "$MAP" \
+  --artifact "#$E1, #$E2 → triage → plan-epic → write-code; ADR 0176; ROADMAP.md v1" \
+  --note "Frontier cleared — closing this map as the durable record of how the plan was discovered."
+# fully-graduated only; a partial graduation is annotated (a plain comment) but stays open.
 ```
 
 ### What emission is not

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -11,9 +11,9 @@
  *
  * Seeded with the canonical #3254 example — `verdict read`, whose ADR-0058
  * SHA-bound marker-resolution three skills hand-copy (#2102). `tracker apply-triage`
- * (#3263) and `tracker post-verdict` (#3265) have since landed; the remaining envelope
- * decisions (claim, graduate) arrive with their sibling children, each with its own
- * consumer migration.
+ * (#3263), `tracker post-verdict` (#3265), and `tracker graduate` (#3266) have since
+ * landed with their consumer migrations; the remaining envelope decision (claim) arrives
+ * with its sibling child.
  */
 import type {Exemption, OwnedDecision} from "./adoption-lint.ts";
 
@@ -88,6 +88,24 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		citation: /pipeline-cli\s+(?:tracker\s+post-verdict|verdict\s+post)\b/,
 		reason:
 			"re-derives the ADR-0058 verdict/comment-post + read-back envelope that `pipeline-cli tracker post-verdict` owns (compose the SHA-bound marker, PATCH-own-prior-else-POST, self-verify the landed body), instead of citing the verb (#3265 / #3254)",
+	},
+	{
+		// `tracker graduate` owns the map/investigation graduation-close envelope (#3266): post the
+		// `Graduated into <artifact>` source → artifact provenance record, then close the source as
+		// COMPLETED (graduated, not abandoned). The fingerprint is the co-occurrence of all three
+		// tells — the `Graduated into` provenance record, a comment POST that carries it, and the
+		// close-as-completed PATCH (`state=closed` + `state_reason=completed`, distinct from triage's
+		// `not_planned`) — so the many incidental prose mentions of "graduated" fog in wayfinder are
+		// not a false finding. A file that cites `pipeline-cli tracker graduate` is compliant.
+		verb: "tracker graduate",
+		signature: [
+			/Graduated into/, // the source → artifact provenance record
+			/\/comments\s+-f\s+body=/, // the audit-comment POST leg
+			/state=closed\s+-f\s+state_reason=completed/, // close as completed (not not_planned)
+		],
+		citation: /pipeline-cli\s+tracker\s+graduate\b/,
+		reason:
+			"re-derives the graduation-close envelope that `pipeline-cli tracker graduate` owns (post the source → artifact provenance record, close the source as completed), instead of citing the verb (#3266 / #3254)",
 	},
 ];
 

--- a/packages/pipeline-cli/src/tools/tracker/command.ts
+++ b/packages/pipeline-cli/src/tools/tracker/command.ts
@@ -2,16 +2,18 @@
  * The `tracker` tool — `pipeline-cli tracker claim <target>` /
  * `pipeline-cli tracker read-back <target>` / `pipeline-cli tracker apply-triage <target>` /
  * `pipeline-cli tracker create-issue` / `pipeline-cli tracker create-comment <target>` /
- * `pipeline-cli tracker post-verdict <target>`.
+ * `pipeline-cli tracker post-verdict <target>` / `pipeline-cli tracker graduate <target>`.
  *
  * The CLI surface of the Wave-1 `Tracker` service (ADR 0190): `claim` posts the ADR-0115
  * agent-distinguishable claim and exits 0 only when the claim is ours; `read-back` resolves
  * and prints the current owner; `apply-triage` applies a type/priority/status classification
  * and drops the entity out of the needs-triage queue (#3263); `create-issue` files a new
  * issue and `create-comment` adds a note (#3264); `post-verdict` upserts a SHA-bound
- * ADR-0058 gate verdict comment and reads it back (#3265). Judgment-as-parameter: the
- * claiming identity, the classification, the created content, and the verdict (gate /
- * PASS|FAIL / bound head / prose) are supplied, not decided by the tool — the claim session
+ * ADR-0058 gate verdict comment and reads it back (#3265); `graduate` posts the
+ * source → artifact provenance record and closes the source as completed (#3266).
+ * Judgment-as-parameter: the claiming identity, the classification, the created content, the
+ * verdict (gate / PASS|FAIL / bound head / prose), and the graduation artifact are supplied,
+ * not decided by the tool — the claim session
  * id defaults to `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable signal under the
  * shared `usirin` login) and `--session` overrides it for the orchestrated/delegated-token
  * path and for tests; an absent value fails closed. A create `--body` defaults to stdin, so
@@ -29,6 +31,7 @@ import {
 	type CommentResult,
 	type CreateIssueResult,
 	GithubTrackerLive,
+	type GraduateResult,
 	type ReadBackResult,
 	Tracker,
 	type TriageResult,
@@ -289,10 +292,60 @@ const postVerdict = Command.make(
 	),
 );
 
-export const trackerCommand = Command.make("tracker").pipe(
-	Command.withSubcommands([claim, readBack, applyTriage, createIssue, createComment, postVerdict]),
+// Judgment-as-parameter (#3252): what the source graduated into (`--artifact`) and an optional
+// closing note (`--note`) are supplied; the verb composes the `Graduated into <artifact>`
+// provenance record and does the two-step close-as-completed — no caller hand-rolls it.
+const artifactFlag = Flag.string("artifact").pipe(
+	Flag.withDescription(
+		"a domain reference to what the source graduated into (epic(s) / ADR / roadmap entry, prose)",
+	),
+);
+
+const noteFlag = Flag.string("note").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"optional closing prose appended after the `Graduated into <artifact>` record",
+	),
+);
+
+const reportGraduated = (target: number, result: GraduateResult): Effect.Effect<void> =>
+	Console.log(
+		`tracker: graduated #${target} into ${result.artifact} — closed as completed (state ${result.state}).`,
+	);
+
+const graduate = Command.make(
+	"graduate",
+	{target: targetArg, artifact: artifactFlag, note: noteFlag},
+	Effect.fn(function* ({target, artifact, note}) {
+		// Only carry `note` when present — `exactOptionalPropertyTypes` forbids `note: undefined`.
+		const judgment = Option.match(note, {
+			onNone: () => ({artifact}),
+			onSome: (n) => ({artifact, note: n}),
+		});
+		const result = yield* (yield* Tracker).graduate(target, judgment).pipe(
+			// A close that did not land `state=closed` fails loud, never a false graduation.
+			Effect.catchTag("@kampus/tracker/TrackerVerifyError", (error) => backOff(error.message)),
+		);
+		yield* reportGraduated(target, result);
+	}),
+).pipe(
 	Command.withDescription(
-		"The crew tracker service (ADR 0190): claim a tracker entity, read back its owner, apply a triage classification, create an issue or a comment, post a gate verdict",
+		"Graduate a source (map/investigation): post the source → artifact provenance record and close the source as completed (#3266)",
+	),
+);
+
+export const trackerCommand = Command.make("tracker").pipe(
+	Command.withSubcommands([
+		claim,
+		readBack,
+		applyTriage,
+		createIssue,
+		createComment,
+		postVerdict,
+		graduate,
+	]),
+	Command.withDescription(
+		"The crew tracker service (ADR 0190): claim a tracker entity, read back its owner, apply a triage classification, create an issue or a comment, post a gate verdict, graduate a source into its artifact",
 	),
 	Command.provide(GithubTrackerLive),
 );

--- a/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.behavior.test.ts
@@ -7,7 +7,6 @@ import {
 	type RepoResolutionError,
 	Tracker,
 	TrackerInputError,
-	TrackerNotImplementedError,
 	TrackerVerifyError,
 } from "./tracker.ts";
 
@@ -618,13 +617,76 @@ describe("Tracker.createComment — add a note over a mock gh spawner", () => {
 	);
 });
 
-describe("Tracker — the declared-but-not-yet-built verbs fail closed", () => {
-	it.effect("graduate → TrackerNotImplementedError", () =>
+describe("Tracker.graduate — the map/investigation graduation-close envelope", () => {
+	it.effect(
+		"posts the source → artifact provenance record, closes as completed, reads back → graduated",
+		() =>
+			Effect.gen(function* () {
+				const tracker = yield* Tracker;
+				const result = yield* tracker.graduate(TARGET, {
+					artifact: "epic #4242 (planned by plan-epic)",
+					note: "its diagnosis is carried forward by the epic.",
+				});
+				assert.deepStrictEqual(result, {
+					_tag: "graduated",
+					source: TARGET,
+					artifact: "epic #4242 (planned by plan-epic)",
+					state: "closed",
+				});
+			}).pipe((effect) =>
+				provide(effect, {
+					[`POST ${P}/issues/${TARGET}/comments`]: JSON.stringify({id: 6060}),
+					[`PATCH ${P}/issues/${TARGET}`]: JSON.stringify({
+						state: "closed",
+						state_reason: "completed",
+					}),
+				}),
+			),
+	);
+
+	it.effect("composes `Graduated into <artifact>` with no note when none is given", () =>
 		Effect.gen(function* () {
 			const tracker = yield* Tracker;
-			const error = yield* Effect.flip(tracker.graduate(TARGET, {stage: "triaged"}));
-			assert.isTrue(error instanceof TrackerNotImplementedError);
-			assert.strictEqual(error.verb, "graduate");
+			const result = yield* tracker.graduate(TARGET, {artifact: "#1, #2 → triage; ADR 0176"});
+			assert.deepStrictEqual(result, {
+				_tag: "graduated",
+				source: TARGET,
+				artifact: "#1, #2 → triage; ADR 0176",
+				state: "closed",
+			});
+		}).pipe((effect) =>
+			provide(effect, {
+				[`POST ${P}/issues/${TARGET}/comments`]: JSON.stringify({id: 6061}),
+				[`PATCH ${P}/issues/${TARGET}`]: JSON.stringify({
+					state: "closed",
+					state_reason: "completed",
+				}),
+			}),
+		),
+	);
+
+	it.effect(
+		"the close read-back is not `closed` → TrackerVerifyError (never a false graduation)",
+		() =>
+			Effect.gen(function* () {
+				const tracker = yield* Tracker;
+				const error = yield* Effect.flip(tracker.graduate(TARGET, {artifact: "epic #99"}));
+				assert.isTrue(error instanceof TrackerVerifyError);
+			}).pipe((effect) =>
+				provide(effect, {
+					[`POST ${P}/issues/${TARGET}/comments`]: JSON.stringify({id: 6062}),
+					// the PATCH came back still open — the folded-in read-back rejects the graduation
+					[`PATCH ${P}/issues/${TARGET}`]: JSON.stringify({state: "open", state_reason: null}),
+				}),
+			),
+	);
+
+	it.effect("a non-zero gh exit on the provenance comment → GhCommandError in the E channel", () =>
+		Effect.gen(function* () {
+			const tracker = yield* Tracker;
+			// no POST fixture → the comment call exits 1 → GhCommandError before any close, never a throw
+			const error = yield* Effect.flip(tracker.graduate(TARGET, {artifact: "epic #99"}));
+			assert.isTrue(error instanceof GhCommandError);
 		}).pipe((effect) => provide(effect, {})),
 	);
 });

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -6,9 +6,9 @@
  * tag plus its sole implementation `GithubTrackerLive`. `claim` (the ADR-0115
  * agent-distinguishable claim), a generic `readBack`, `applyTriage` (the label-transition
  * envelope, #3263), `createIssue` / `createComment` (the issue/comment create envelope,
- * #3264), and `postVerdict` (the ADR-0058 verdict/comment-post + read-back envelope, #3265)
- * are live; only `graduate` is still *declared* — its interface shape is fixed so the tag
- * locks before its remaining sibling Phase-3 child implements it.
+ * #3264), `postVerdict` (the ADR-0058 verdict/comment-post + read-back envelope, #3265),
+ * and `graduate` (the map/investigation graduation-close envelope, #3266) are all live —
+ * every Phase-3 verb has landed.
  *
  * Two design rules bind every signature here and are the point of the skeleton:
  *
@@ -77,19 +77,6 @@ export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionE
 ) {}
 
 /**
- * A declared-but-not-yet-built verb was called. `claim` / `readBack` / `applyTriage` /
- * `createIssue` / `createComment` / `postVerdict` are live; only `graduate` fails-closed
- * with this typed error until its sibling Phase-3 child implements it — never a silent
- * no-op or a throw.
- */
-export class TrackerNotImplementedError extends Schema.TaggedErrorClass<TrackerNotImplementedError>()(
-	"@kampus/tracker/TrackerNotImplementedError",
-	{
-		verb: Schema.String,
-	},
-) {}
-
-/**
  * A malformed verb judgment the caller must fix — e.g. `postVerdict` handed an unknown gate, or a
  * composed verdict body that trips `emissionDefect` (a polarity with no bindable `@ <sha>`, a
  * non-40-hex head, a machine-local path). A caller error, not an infra fault: it is raised before
@@ -103,9 +90,11 @@ export class TrackerInputError extends Schema.TaggedErrorClass<TrackerInputError
 ) {}
 
 /**
- * A verb's post-write self-verify failed: after `postVerdict` upserted the comment it re-fetched it
- * and the landed body is not a clean, in-namespace, leak-free marker. The read-back folded INTO the
- * write so a bypassed/hand-rolled body can't report a false success (ADR 0058 read-back, #3019).
+ * A verb's post-write self-verify failed: `postVerdict` re-fetched the comment it upserted and the
+ * landed body is not a clean, in-namespace, leak-free marker, or `graduate` closed the source and
+ * the read-back did not come back `state=closed`. The read-back folds INTO the write so a
+ * bypassed/hand-rolled body — or a close that silently didn't land — can't report a false success
+ * (ADR 0058 read-back, #3019).
  */
 export class TrackerVerifyError extends Schema.TaggedErrorClass<TrackerVerifyError>()(
 	"@kampus/tracker/TrackerVerifyError",
@@ -235,10 +224,31 @@ export type VerdictResult = {
 	readonly headRef: string;
 };
 
-/** A lifecycle graduation: the stage the target moves to. */
+/**
+ * A graduation-close judgment (#3266): what the source graduated into (`artifact`, a domain
+ * reference to the durable artifact(s) — an epic, an ADR, a roadmap entry, in prose) and an
+ * optional closing `note`. Domain vocabulary only — no issue-number-as-string, no REST field:
+ * the verb composes the `Graduated into <artifact>` provenance record and does the two-step
+ * close-as-completed at the boundary. Kept prose because a graduation targets *artifacts of many
+ * kinds* (an ADR / a ROADMAP entry are not tracker entities), so `artifact` is a human-readable
+ * reference, not a `TargetId`.
+ */
 export interface GraduateJudgment {
-	readonly stage: string;
+	readonly artifact: string;
+	readonly note?: string;
 }
+
+/**
+ * The `graduate` verdict — the source is now closed as completed, carrying the artifact it
+ * graduated into and the lifecycle `state` read back from the entity (so the caller sees the
+ * close that actually landed). A domain result, never a raw REST issue payload (ADR 0190).
+ */
+export type GraduateResult = {
+	readonly _tag: "graduated";
+	readonly source: TargetId;
+	readonly artifact: string;
+	readonly state: string;
+};
 
 const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
 	Stream.decodeText(stream).pipe(
@@ -401,6 +411,20 @@ const createCommentArgs = (repo: string, target: TargetId, body: string): Readon
 	`body=${body}`,
 ];
 
+// Close an issue as *completed* (the graduation-close, #3266) — distinct from triage's
+// `state_reason=not_planned`: the source graduated, it wasn't abandoned. Returns the updated
+// issue JSON so the landed close state is read back at the boundary.
+const closeCompletedArgs = (repo: string, target: TargetId): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"PATCH",
+	`repos/${repo}/issues/${target}`,
+	"-f",
+	"state=closed",
+	"-f",
+	"state_reason=completed",
+];
+
 const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
 	"api",
 	`repos/${repo}/collaborators/${login}/permission`,
@@ -455,6 +479,13 @@ const decodeCreatedIssue = Schema.decodeUnknownEffect(RawCreatedIssue);
 /** The created comment as the create endpoint returns it; only its ref is read. */
 const RawCreatedComment = Schema.Struct({id: Schema.Number});
 const decodeCreatedComment = Schema.decodeUnknownEffect(RawCreatedComment);
+
+/** The closed issue as the PATCH endpoint returns it; only the landed close state is read. */
+const RawClosedIssue = Schema.Struct({
+	state: Schema.String,
+	state_reason: Schema.optionalKey(Schema.NullOr(Schema.String)),
+});
+const decodeClosedIssue = Schema.decodeUnknownEffect(RawClosedIssue);
 
 const LABEL_STATUS_PREFIX = "status:";
 const QUEUE_STATUS = "needs-triage";
@@ -739,16 +770,58 @@ const createComment = Effect.fn("Tracker.createComment")(function* (
 	return {_tag: "commented", ref: created.id} satisfies CommentResult;
 });
 
+/**
+ * Compose the graduation-provenance record from the judgment: the `Graduated into <artifact>`
+ * prefix the verb OWNS (the audit line that records source → artifact), followed by the caller's
+ * optional closing note. Owning this composition is what lets the adoption-lint (#3254) forbid the
+ * wayfinder/plan skills from hand-rolling the close — they supply only the domain reference + note.
+ */
+const composeGraduationRecord = (artifact: string, note?: string): string => {
+	const trimmed = note?.trim();
+	return trimmed ? `Graduated into ${artifact} — ${trimmed}` : `Graduated into ${artifact}`;
+};
+
+/**
+ * Graduate `target` into its durable artifact(s) and close it as completed (ADR 0190, #3266) — the
+ * map/investigation graduation-close envelope the wayfinder/plan skills hand-rolled, now one
+ * domain-shaped verb. Post the `Graduated into <artifact>` provenance comment (the source → artifact
+ * audit record), then PATCH the source closed with `state_reason=completed` (graduated, not
+ * abandoned — distinct from triage's `not_planned`). The close read-back is Schema-decoded at the
+ * boundary and folded into the write: a close that did not land `state=closed` fails
+ * `TrackerVerifyError` rather than reporting a false graduation (#3019).
+ */
+const graduate = Effect.fn("Tracker.graduate")(function* (
+	repo: string,
+	target: TargetId,
+	judgment: GraduateJudgment,
+) {
+	const record = composeGraduationRecord(judgment.artifact, judgment.note);
+	yield* runGh(createCommentArgs(repo, target, record));
+	const closed = yield* decodeClosedIssue(yield* json(closeCompletedArgs(repo, target)));
+	if (closed.state !== "closed") {
+		return yield* new TrackerVerifyError({
+			message: `graduation-close of #${target} did not land: the source read back state='${closed.state}', not 'closed' — refusing to report a graduation that didn't take (#3019)`,
+		});
+	}
+	return {
+		_tag: "graduated",
+		source: target,
+		artifact: judgment.artifact,
+		state: closed.state,
+	} satisfies GraduateResult;
+});
+
 type TrackerErrors = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
 
 type PostVerdictErrors = TrackerErrors | TrackerInputError | TrackerVerifyError;
 
+type GraduateErrors = TrackerErrors | TrackerVerifyError;
+
 /**
- * `Tracker` — the shared crew tracker capability. `claim`, `readBack`, `applyTriage`,
- * `createIssue`, `createComment`, and `postVerdict` are live; only the still-declared
- * `graduate` fails `TrackerNotImplementedError` until its sibling child builds it (its
- * success type is `never` by design — a not-yet-built verb produces no value). Built by
- * `GithubTrackerLive`, whose `R` is `ChildProcessSpawner`.
+ * `Tracker` — the shared crew tracker capability. Every verb is live: `claim`, `readBack`,
+ * `applyTriage`, `createIssue`, `createComment`, `postVerdict`, and `graduate` (the
+ * map/investigation graduation-close, #3266). Built by `GithubTrackerLive`, whose `R` is
+ * `ChildProcessSpawner`.
  */
 export class Tracker extends Context.Service<
 	Tracker,
@@ -776,12 +849,9 @@ export class Tracker extends Context.Service<
 		readonly graduate: (
 			target: TargetId,
 			judgment: GraduateJudgment,
-		) => Effect.Effect<never, TrackerNotImplementedError>;
+		) => Effect.Effect<GraduateResult, GraduateErrors>;
 	}
 >()("@kampus/tracker/Tracker") {}
-
-const notImplemented = (verb: string): Effect.Effect<never, TrackerNotImplementedError> =>
-	new TrackerNotImplementedError({verb});
 
 /**
  * The live `Tracker` layer over `gh api` REST. The `ChildProcessSpawner` dependency is
@@ -813,7 +883,8 @@ export const GithubTrackerLive: Layer.Layer<
 				repo.pipe(Effect.flatMap((r) => withSpawner(createComment(r, target, judgment.body)))),
 			postVerdict: (target, judgment) =>
 				repo.pipe(Effect.flatMap((r) => withSpawner(postVerdict(r, target, judgment)))),
-			graduate: () => notImplemented("graduate"),
+			graduate: (target, judgment) =>
+				repo.pipe(Effect.flatMap((r) => withSpawner(graduate(r, target, judgment)))),
 		};
 	}),
 );


### PR DESCRIPTION
The final Phase-3 Tracker verb (epic #3258). Extracts the **map/investigation graduation-close** envelope into `Tracker.graduate`.

## What it does
`Tracker.graduate(source, {artifact, note?})` performs the graduation-close: posts the `Graduated into <artifact>` source → artifact provenance record, then closes the source as **completed** (graduated, not abandoned — distinct from triage's `not_planned`).

- **Domain-shaped signature** — a bare `TargetId` source plus a `{artifact, note}` judgment. No issue-number-as-string, no label string, no REST idiom leaks; the verb composes the provenance record and does the two-step close at the boundary (ADR 0190). `artifact` is prose because a graduation targets artifacts of many kinds (an ADR / a ROADMAP entry are not tracker entities).
- **Typed failures in the E channel** — infra faults are `GhCommandError` / `GhParseError` / `RepoResolutionError`; the close read-back is Schema-decoded (`RawClosedIssue`) at the boundary and folded into the write, so a close that didn't land `state=closed` fails `TrackerVerifyError` rather than reporting a false graduation (#3019).
- **CLI** — `pipeline-cli tracker graduate <target> --artifact <ref> [--note <prose>]`, judgment-as-parameter (#3252), registered in `withSubcommands`.

## Same-commit adoption (#3254, governing AC)
The inline graduation-close re-derivation is deleted from both consumers and each now cites the verb:
- wayfinder emission close (map graduation)
- plan-epic Step 6 (source-investigation close-on-graduation)

The `adoption-lint` manifest gains the `tracker graduate` decision (fingerprint: the `Graduated into` provenance record + the audit-comment POST + the `state_reason=completed` close). Adoption-lint is green over the full corpus.

`TrackerNotImplementedError` + the `notImplemented` helper are retired — every Phase-3 verb has now landed.

## Tests (ADR 0040)
Behavior tests cover the happy path, the no-note composition, the not-closed read-back → `TrackerVerifyError`, and the gh-fault → `GhCommandError` path. Full `pipeline-cli` suite: 1530 passing; typecheck + biome clean.

## §CP
Touches `packages/pipeline-cli/**` + gate-critical skills → §CP merge path. Stops at reviewed-ready for cansirin approval at merge time.

Fixes #3266

🤖 Generated with [Claude Code](https://claude.com/claude-code)