### PR TITLE
ci(design-inventory): self-update freshness + descriptive/normative firewall guard (#3156) [§CP]

### DIFF
--- a/.github/workflows/design-inventory-guard.yml
+++ b/.github/workflows/design-inventory-guard.yml
@@ -1,0 +1,57 @@
+name: design-inventory-guard
+
+# CI gate for #3156 (epic #3150, ADR 0194 — the descriptive/normative firewall): closes the
+# self-updating loop for the DESCRIPTIVE component inventory and ENFORCES the firewall, so both
+# are gated at merge rather than merely intended. Two fail-closed checks:
+#
+#   1. Self-update freshness — re-run the extractor and red when the committed
+#      `design-system-inventory.md` is stale vs the live JSDoc on the annotated
+#      `apps/web/src/components/ui/*` primitives (drift = red; fresh = green). This keeps
+#      agent-facing coverage current without founder re-transcription.
+#   2. Descriptive/normative firewall — regenerate through the extractor (which writes ONLY the
+#      descriptive inventory) and red if the founder-authored `design-system-manifest.md` moved.
+#      A change to normative law must come from a human, never the extraction path.
+#
+# Both fail closed on zero scope (ADR 0092): zero annotated primitives reds the extractor. The
+# scan lives once in `pipeline-cli design-inventory` (the readme-guard / design-token-guard idiom).
+on:
+  pull_request:
+
+# Least-privilege GITHUB_TOKEN: the job checks out + reads the repo and runs the guard, which
+# fails via exit code — it posts no check-run/status/PR comment — so contents:read is all it needs.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: descriptive inventory is fresh and the normative manifest is untouched
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # AC1 — self-update freshness. Exit 1 when the committed inventory drifts from a fresh
+      # extraction, or when zero primitives are in scope (fail-closed). Report on stderr.
+      - name: Check the committed descriptive inventory is fresh
+        run: node packages/pipeline-cli/src/bin.ts design-inventory check
+
+      # AC2 — the descriptive/normative firewall. Run the real extraction path (it writes ONLY
+      # the descriptive inventory, structurally — gate.ts's writeDescriptiveArtifact refuses any
+      # other target) and assert the founder-authored normative manifest is byte-unchanged. A
+      # descriptive-only regeneration greens; any auto-mutation of design-system-manifest.md reds.
+      - name: Check the extraction path never mutates the normative manifest (firewall)
+        run: |
+          node packages/pipeline-cli/src/bin.ts design-inventory generate
+          git diff --exit-code -- design-system-manifest.md

--- a/packages/pipeline-cli/src/tools/design-inventory/README.md
+++ b/packages/pipeline-cli/src/tools/design-inventory/README.md
@@ -36,13 +36,33 @@ write at the manifest path is a `FirewallViolation`, proven by test.
 ```bash
 pipeline-cli design-inventory generate            # write design-system-inventory.md from the primitives' JSDoc
 pipeline-cli design-inventory generate --stdout   # print the index instead of writing it
-pipeline-cli design-inventory generate --check    # red on drift (freshness signal; CI wiring is #3156)
+pipeline-cli design-inventory generate --check    # red on drift (freshness signal, no write)
 pipeline-cli design-inventory generate --root <d> # point at a specific repo root (else: walk up for one)
+pipeline-cli design-inventory check               # the CI guard: red on a stale committed inventory
 ```
 
 Fail-closed on zero scope (ADR
 [0092](../../../../../.decisions/0092-gates-fail-closed-on-zero-scope.md)): zero annotated
 primitives discovered is a broken scope assumption, not a vacuous empty index.
+
+## The CI guard (self-update + firewall enforcement)
+
+`.github/workflows/design-inventory-guard.yml` runs on every PR
+([#3156](https://github.com/kamp-us/phoenix/issues/3156)) and reds — fail-closed — on either
+of two conditions, so the loop is genuinely self-updating and the firewall is _enforced_, not
+merely intended:
+
+- **Self-update freshness.** `design-inventory check` re-extracts and reds when the committed
+  `design-system-inventory.md` is stale vs the live JSDoc. Green means the committed inventory
+  matches a fresh extraction — agent-facing coverage stays current without founder
+  re-transcription. Regenerate + commit with `pipeline-cli design-inventory generate`.
+- **Descriptive/normative firewall.** The job regenerates through the extractor (which writes
+  _only_ the descriptive inventory) and asserts `design-system-manifest.md` is byte-unchanged.
+  A descriptive-only regeneration greens; any auto-mutation of the founder-authored normative
+  manifest reds. This is the CI-observable belt over the structural refusal in `gate.ts`.
+
+Both reds fail closed on zero scope (ADR 0092): zero annotated primitives reds the extractor
+rather than passing vacuously.
 
 ## Shape
 
@@ -52,13 +72,14 @@ The `pipeline-cli` guard idiom — a pure IO-free core, a thin filesystem gate, 
   inventory (fail-closed on zero), render the index, and the firewall predicate.
 - `gate.ts` — the filesystem seam: read the primitives, write the artifact through the
   firewall, or `--check` for drift.
-- `command.ts` — wires the gate to `pipeline-cli design-inventory generate`.
+- `command.ts` — wires the gate to `pipeline-cli design-inventory generate` and the CI-guard
+  `pipeline-cli design-inventory check`.
 - `*.unit.test.ts` — pure-core and gate-seam tests (T0/T1, ADR
-  [0040](../../../../../.decisions/0040-testing-taxonomy-and-seam-graduation.md)).
+  [0040](../../../../../.decisions/0040-testing-taxonomy-and-seam-graduation.md)): the freshness
+  fixtures (a drift reds, a fresh inventory greens) and the firewall fixtures (a write at the
+  manifest path is a `FirewallViolation`; a full generate never touches the manifest).
 
 ## Out of scope
 
-The CI wiring that runs `--check` on every diff and enforces the firewall as a merge gate
-is the next child ([#3156](https://github.com/kamp-us/phoenix/issues/3156)); on-demand
-per-component contract delivery is the deferred child
+On-demand per-component contract delivery is the deferred child
 ([#3158](https://github.com/kamp-us/phoenix/issues/3158)).

--- a/packages/pipeline-cli/src/tools/design-inventory/command.ts
+++ b/packages/pipeline-cli/src/tools/design-inventory/command.ts
@@ -8,8 +8,9 @@
  *
  *   pipeline-cli design-inventory generate            # write design-system-inventory.md from the primitives' JSDoc
  *   pipeline-cli design-inventory generate --stdout   # print the index instead of writing it
- *   pipeline-cli design-inventory generate --check     # red on drift (freshness signal; CI wiring is #3156)
+ *   pipeline-cli design-inventory generate --check     # red on drift (freshness signal)
  *   pipeline-cli design-inventory generate --root <d> # point at a specific repo root (else: walk up for one)
+ *   pipeline-cli design-inventory check               # the CI guard: red on a stale inventory (#3156)
  *
  * FIREWALL (ADR 0194): the tool writes ONLY the descriptive inventory artifact; the
  * normative manifest (four pillars / prohibitions / role-token values) is founder-authored
@@ -83,8 +84,28 @@ const generate = Command.make(
 	),
 );
 
+// The canonical guard entrypoint (`pipeline-cli <tool> check`, mirroring readme-guard /
+// design-token-guard) the CI job invokes — the self-update freshness rung of #3156. It reds
+// when the committed inventory drifts from a fresh extraction and fails closed on zero scope;
+// no write, so it's safe on a read-only checkout. It reuses the gate's `--check` path so the
+// scan lives once. The firewall half of #3156 is a git-diff belt in the workflow (a mutation
+// check has no home in a read-only pure gate) backed by the structural refusal in `gate.ts`.
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* generateInventory(resolveRoot(rootOpt), {stdout: false, check: true}).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"CI guard: fail closed when the committed descriptive inventory is stale vs the primitives' JSDoc",
+	),
+);
+
 export const designInventoryCommand = Command.make("design-inventory").pipe(
-	Command.withSubcommands([generate]),
+	Command.withSubcommands([generate, check]),
 	Command.withDescription(
 		"Self-updating descriptive component inventory from components/ui JSDoc (issue #3155, ADR 0194)",
 	),


### PR DESCRIPTION
Fixes #3156

Wires the already-shipped `design-inventory` extractor (#3155 / #3546) into CI as a **fail-closed guard**, closing the self-updating loop and _enforcing_ the descriptive/normative firewall (ADR 0194) at merge — not merely intending it.

## What lands

`.github/workflows/design-inventory-guard.yml` runs on every PR with two fail-closed checks, plus the canonical `pipeline-cli design-inventory check` guard subcommand (the `readme-guard` / `design-token-guard` `<tool> check` idiom):

1. **Self-update freshness (AC1).** `design-inventory check` re-runs the extractor and reds when the committed `design-system-inventory.md` is stale vs the live JSDoc on the annotated `apps/web/src/components/ui/*` primitives (drift = red; a fresh inventory = green). Keeps agent-facing coverage current without founder re-transcription.
2. **Descriptive/normative firewall (AC2).** The job regenerates through the extractor — which writes _only_ the descriptive inventory (`gate.ts`'s `writeDescriptiveArtifact` structurally refuses any other target) — then asserts `design-system-manifest.md` is byte-unchanged. Any auto-mutation of the founder-authored normative manifest reds; a descriptive-only regeneration greens. This is the CI-observable belt over the structural refusal.

Both fail closed on **zero scope** (ADR 0092): zero annotated primitives reds the extractor rather than passing vacuously.

## Verification

- Both checks green on `main` (33 primitives; manifest byte-unchanged after a real `generate`).
- Negative-tested both reds: a stale inventory reds `check` (exit 1); a mutated manifest reds the firewall git-diff (exit 1).
- The pure gate's red/green fixtures already cover all four cases (drift reds, fresh greens, a `FirewallViolation` at the manifest path, a full generate never touching the manifest) — `packages/pipeline-cli/src/tools/design-inventory/*.unit.test.ts`.
- `pnpm typecheck` + tool + router tests green; biome clean.

## §CP — control-plane

This PR lands on control-plane paths — `.github/workflows/**` and `packages/pipeline-cli/**` — so it is **§CP**: it merges via the **human control-plane merge gate**, not the autonomous path. Paths touched:

- `.github/workflows/design-inventory-guard.yml` (new)
- `packages/pipeline-cli/src/tools/design-inventory/command.ts` (added `check` subcommand)
- `packages/pipeline-cli/src/tools/design-inventory/README.md` (documents the guard — AC4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)