### PR TITLE
refactor(leak-guard): shared machine-local-path matcher + /tmp socket-glob carve-out (#3506, #3492)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1413,6 +1413,15 @@ that **review-code does not merge** — `ship-it` is the authorized merge step. 
 a PR rests on the non-AC sub-gates alone; this is exactly the `review-doc` Step 5 no-link shape,
 mirrored for the code lane.
 
+### Reviewer discipline — never write a bare `/tmp/…` in the verdict body (#3492)
+
+When a verdict must reference the crew inbox socket, write it as the bare name
+`kampus-crew-inbox-*.sock` (no `/tmp/` prefix) or inside a code fence. leak-guard fail-closes on
+ANY bare `/tmp/…` literal in a landed comment (ship-it Step 3.7 `leak-guard scan-pr`), and that is
+correct — the guard's zero-`/tmp` invariant stays strict (#3492 Option 1; there is deliberately no
+socket carve-out in the shared matcher). A bare `/tmp/kampus-crew-inbox-*.sock` in your prose blocks
+the ship; the bare-name or fenced form conveys the same thing without tripping the guard.
+
 ### The marker is the contract — emit the canonical line, never a freelance form (governs 4a *and* 4b)
 
 The first line is **the contract `ship-it` consumes**, not a stylistic choice — it must match

--- a/packages/pipeline-cli/src/tools/leak-guard/crew-leak.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/crew-leak.ts
@@ -19,11 +19,16 @@
  * fictional `Robin`/`Sam` seam examples), so it is intentionally dropped. Do not add
  * name-literal matching back in any form.
  *
- * The path class mirrors leak-guard's precise deny-list (the specific machine-local home
- * dirs), not a bare-`~/` catch-all — the crew ships `${CLAUDE_PLUGIN_ROOT}` and relative
- * `../../.decisions/...` paths, which are not machine-local and must pass. Every match
- * class is unit-tested in `crew-leak.unit.test.ts`, class by class, on FICTIONAL fixtures.
+ * The `"path"` class is the SHARED `MACHINE_LOCAL_PATH_PATTERNS` from `path-matcher.ts`
+ * (the single source both detectors import, per the #3506 ruling) — so its config-file and
+ * `/tmp` shape carve-outs can never drift from leak-guard's, which was the root bug #3506
+ * records. Layered on top of the shared arm are the crew-only classes this sanitizer adds:
+ * an absolute Linux `/home/<name>` path (stricter than leak-guard's macOS-only home arm),
+ * plus emails, tmux pane ids, and personal auto-memory refs. `${CLAUDE_PLUGIN_ROOT}` and
+ * relative `../../.decisions/...` paths are not machine-local and must pass. Every class is
+ * unit-tested in `crew-leak.unit.test.ts`, class by class, on FICTIONAL fixtures.
  */
+import {MACHINE_LOCAL_PATH_PATTERNS} from "./path-matcher.ts";
 
 export type LeakClass = "path" | "email" | "tmux-id" | "memory-ref";
 
@@ -43,33 +48,16 @@ interface ClassPattern {
 }
 
 // Order = report order. Every pattern carries the global flag for the per-match scan.
+// The `"path"` class is the shared `MACHINE_LOCAL_PATH_PATTERNS` tagged with the class, then the
+// crew-only Linux `/home/<name>` arm and the three non-path classes layered on top (see docblock).
 const CLASS_PATTERNS: ReadonlyArray<ClassPattern> = [
-	{
-		class: "path",
-		// Drive-letter carve-out — see leak-guard.ts LEAK_PATTERNS (#3070): exempts only a
-		// Windows `C:/Users/...` prefix, keeps the bare POSIX `/Users/<name>/` true positive.
-		pattern: /(?<![A-Za-z]:)\/Users\/[A-Za-z0-9._-]+/g,
-		reason: "absolute macOS home path (/Users/<name>/...)",
-	},
+	...MACHINE_LOCAL_PATH_PATTERNS.map(
+		(p): ClassPattern => ({class: "path", pattern: p.pattern, reason: p.reason}),
+	),
 	{
 		class: "path",
 		pattern: /\/home\/[A-Za-z0-9._-]+/g,
 		reason: "absolute Linux home path (/home/<name>/...)",
-	},
-	{
-		class: "path",
-		pattern: /(?<![\w.])~\/\.(?:claude|usirin|agent)\b/g,
-		reason: "agent/tool home dir (~/.claude, ~/.usirin, ~/.agent)",
-	},
-	{
-		class: "path",
-		pattern: /(?<![\w.])~\/code\//g,
-		reason: "home-dir sibling-repo clone (~/code/...)",
-	},
-	{
-		class: "path",
-		pattern: /(?<![\w/])\/vault\//g,
-		reason: "vault path (/vault/...)",
 	},
 	{
 		class: "email",

--- a/packages/pipeline-cli/src/tools/leak-guard/crew-leak.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/crew-leak.unit.test.ts
@@ -37,6 +37,18 @@ describe("findCrewLeaks — match classes", () => {
 			expect(classes(findCrewLeaks("cd ~/.usirin"))).toContain("path");
 			expect(classes(findCrewLeaks("cd ~/.agent"))).toContain("path");
 		});
+		// #3506 — the shared path-matcher's config-file carve-out now applies HERE too (it used to
+		// only be on leak-guard's copy — the drift this ticket fixes). The two public claude CLI
+		// config files pass; a ~/.claude directory-internal still flags.
+		it("exempts the public ~/.claude.json / ~/.claude/settings.json config files (#3506, shared carve-out)", () => {
+			expect(findCrewLeaks("registers the server into ~/.claude.json")).toEqual([]);
+			expect(findCrewLeaks("edit ~/.claude/settings.json to add the crew server")).toEqual([]);
+		});
+		it("still flags a ~/.claude directory-internal path (#3506 — carve-out is leaf-pinned)", () => {
+			expect(classes(findCrewLeaks("session log at ~/.claude/projects/x/y.jsonl"))).toContain(
+				"path",
+			);
+		});
 		it("flags ~/code/ sibling clones", () => {
 			expect(classes(findCrewLeaks("~/code/github.com/x/y"))).toContain("path");
 		});

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
@@ -10,10 +10,11 @@
  * empty list. No regex over arbitrary source — the match is scoped to doc surfaces
  * exactly as the AC requires.
  *
- * The machine-local-path shapes themselves — the generic deny-list design, the
- * `~/.claude` config-file carve-out (#3475/#3505), and the `/tmp/…-*.sock` glob
- * carve-out (#3492) — live in the single shared `path-matcher.ts` module that both
- * this doc/comment scanner and `crew-leak.ts` import, so the two detectors can never
+ * The machine-local-path shapes themselves — the generic deny-list design and the
+ * `~/.claude` config-file carve-out (#3475/#3505); the `/tmp` arm carries no carve-out,
+ * so it fail-closes on any bare `/tmp/…` (#3492 Option 1) — live in the single shared
+ * `path-matcher.ts` module that both this doc/comment scanner and `crew-leak.ts` import,
+ * so the two detectors can never
  * drift (the #3506 root bug). This module owns only the doc-surface scoping (which
  * files get scanned) and the self-exempt list; the path shapes are imported, not
  * re-declared. See `path-matcher.ts` for the pattern rationale.
@@ -111,7 +112,7 @@ export const findLeaks = (filePath: string, text: string): ReadonlyArray<Leak> =
  * mktemp path onto public PRs (#2796/#2822/#2683/#2772). A comment body is UNCONDITIONALLY a
  * shared public artifact, so there is no doc-surface gate and no self-exempt list — it scans
  * the shared `MACHINE_LOCAL_PATH_PATTERNS` AND the stricter comment-body-only `TEMP_PATH_PATTERNS`
- * (which carries the `/tmp/…-*.sock` glob carve-out, #3492). Generic path shapes only (#2393).
+ * (which fail-closes on any bare `/tmp/…`, no carve-out — #3492 Option 1). Generic path shapes only (#2393).
  */
 export const findCommentLeaks = (text: string): ReadonlyArray<Leak> => {
 	if (!text) return [];

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
@@ -10,18 +10,15 @@
  * empty list. No regex over arbitrary source — the match is scoped to doc surfaces
  * exactly as the AC requires.
  *
- * The non-obvious part is the deny-list design: it matches ONLY the specific #158
- * leak dirs (`/Users/<name>`, `~/.claude|.usirin|.agent`, `~/code/`, `/vault/`),
- * NOT a general bare-`~/` catch-all. So any other `~/<x>` — `~/.config`,
- * `~/.alchemy` (a documented tool dir; see .patterns/alchemy-ci-cd.md),
- * `~/Documents` — PASSES, because it leaks no identity of this machine. Plus the
- * `/tmp` scratch carve-out and the path-hygiene self-exempt files. That precise
- * allowlist is the load-bearing false-positive safety, encoded in
- * `leak-guard.unit.test.ts`. The `~/.claude` arm is further NARROWED BY SHAPE (#3475)
- * to exempt the two public, machine-agnostic config *files* `~/.claude.json` and
- * `~/.claude/settings.json` while still flagging `~/.claude/`-directory internals — the
- * carve-out lives at the pattern (LEAK_PATTERNS), not in a named allow-list (#2393).
+ * The machine-local-path shapes themselves — the generic deny-list design, the
+ * `~/.claude` config-file carve-out (#3475/#3505), and the `/tmp/…-*.sock` glob
+ * carve-out (#3492) — live in the single shared `path-matcher.ts` module that both
+ * this doc/comment scanner and `crew-leak.ts` import, so the two detectors can never
+ * drift (the #3506 root bug). This module owns only the doc-surface scoping (which
+ * files get scanned) and the self-exempt list; the path shapes are imported, not
+ * re-declared. See `path-matcher.ts` for the pattern rationale.
  */
+import {MACHINE_LOCAL_PATH_PATTERNS, type PathPattern, TEMP_PATH_PATTERNS} from "./path-matcher.ts";
 
 export interface Leak {
 	/** The exact substring that matched a leak pattern. */
@@ -43,6 +40,10 @@ const DOC_SELF_EXEMPT = [
 	"/packages/leak-guard/README.md",
 	"/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts",
 	"/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts",
+	// The shared machine-local-path matcher spells the forbidden token shapes out as
+	// patterns (moved out of leak-guard.ts per #3506), so it is exempt like its host was.
+	"/packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts",
+	"/packages/pipeline-cli/src/tools/leak-guard/path-matcher.unit.test.ts",
 	"/packages/pipeline-cli/src/tools/leak-guard/command.ts",
 	// Documents the leak-guard deny-list patterns (the ~/.claude / ~/code/ / /vault
 	// example shapes), so it must spell the forbidden tokens out — exempt like the
@@ -61,81 +62,10 @@ const DOC_SELF_EXEMPT = [
 	"/CLAUDE.md",
 ] as const;
 
-interface LeakPattern {
-	readonly pattern: RegExp;
-	readonly reason: string;
-}
-
-// Order = report order. Each `g` flag is required for the per-match scan in findLeaks.
-const LEAK_PATTERNS: ReadonlyArray<LeakPattern> = [
-	{
-		// The `(?<![A-Za-z]:)` drive-letter carve-out keeps this a GENERIC structural check
-		// while dropping the Windows-file-URL false positive: a bare POSIX `/Users/<name>/`
-		// still matches (real macOS-home leak), but a drive-prefixed `C:/Users/...` (e.g.
-		// `file:///C:/Users/ci/...`) does not — that substring is not a macOS home path and
-		// carries no operator PII, yet its FP fail-closed-blocked legitimate PRs (#3070).
-		pattern: /(?<![A-Za-z]:)\/Users\/[A-Za-z0-9._-]+/g,
-		reason: "absolute macOS home path (/Users/<name>/...)",
-	},
-	{
-		pattern: /(?<![\w.])~\/\.(usirin|agent)\b/g,
-		reason: "agent/tool home dir (~/.usirin, ~/.agent)",
-	},
-	{
-		// The `~/.claude` home-dir detector, NARROWED by shape (not a named allow-list; #2393
-		// and #3475): it still flags any descent into the private agent home tree
-		// (`~/.claude/projects/…`, `~/.claude/todos/…`) and bare `~/.claude`, but the two
-		// negative lookaheads carve out the claude CLI's public, machine-agnostic config *files*
-		// — `~/.claude.json` (a sibling dotfile config, `~/.claude` + a `.json` extension, NOT
-		// the directory) and `~/.claude/settings.json` (the one documented settings file). Those
-		// two are identical on every machine and reveal nothing operator-specific, and they are
-		// the literal subject of packages/pipeline-crew-mcp, so flagging them was a chronic
-		// false positive. The carve-out is SHAPE, not a membership list: the exclusion is a
-		// property of this one generic pattern (a config-file leaf on the marker), so a longer
-		// name (`~/.claude.json.bak`, `~/.claude/settings.local.json`, `~/.claude/settings.jsonc`)
-		// or any deeper path still trips it — the `(?![\w.])` tail pins each carve-out to the
-		// exact public leaf. See the threat-model note on #3475 for what this can no longer catch.
-		pattern: /(?<![\w.])~\/\.claude(?!\.json(?![\w.]))(?!\/settings\.json(?![\w.]))\b/g,
-		reason:
-			"agent/tool home dir (~/.claude internals; public config files ~/.claude.json, ~/.claude/settings.json exempt)",
-	},
-	{
-		pattern: /(?<![\w.])~\/code\//g,
-		reason: "home-dir sibling-repo clone (~/code/...)",
-	},
-	{
-		pattern: /(?<![\w/])\/vault\//g,
-		reason: "vault path (/vault/...)",
-	},
-];
-
-// Machine-local temp/scratch roots — a PR/issue COMMENT (or verdict) body must never carry
-// one (the #2796/#2822 scratchpad-`@filepath` and #2683/#2772 mktemp-in-`@sha` leaks). This is
-// deliberately STRICTER than the doc-surface `findLeaks`, which carves out a bare `/tmp` for
-// illustrative examples in docs — a public PR comment has no such legitimate use, so these are
-// scanned by `findCommentLeaks` only, never by the file-surface path. Generic path shapes, NOT
-// a named deny-list (#2393): the macOS mktemp dirs and a bare `/tmp` scratch path. The
-// `(?<![\w.])` lookbehind stops a `/private/tmp/...` match from also double-firing the `/tmp/`
-// pattern (its preceding char is a word char), so each leak reports once.
-const TEMP_PATTERNS: ReadonlyArray<LeakPattern> = [
-	{
-		pattern: /(?<![\w.])\/var\/folders\/[A-Za-z0-9._/-]+/g,
-		reason: "macOS per-user mktemp dir (/var/folders/...)",
-	},
-	{
-		pattern: /(?<![\w.])\/private\/(?:tmp|var)\/[A-Za-z0-9._/-]+/g,
-		reason: "macOS resolved temp root (/private/tmp/..., /private/var/...)",
-	},
-	{
-		pattern: /(?<![\w.])\/tmp\/[A-Za-z0-9._/-]+/g,
-		reason: "machine-local temp/scratch path (/tmp/...)",
-	},
-];
-
 const normalize = (path: string): string => path.replace(/\\/g, "/");
 
 /** Every leak in `text` for `patterns`, deduped on matched+reason (report order = pattern order). */
-const scanPatterns = (text: string, patterns: ReadonlyArray<LeakPattern>): ReadonlyArray<Leak> => {
+const scanPatterns = (text: string, patterns: ReadonlyArray<PathPattern>): ReadonlyArray<Leak> => {
 	const seen = new Set<string>();
 	const leaks: Leak[] = [];
 	for (const {pattern, reason} of patterns) {
@@ -171,7 +101,7 @@ export const findLeaks = (filePath: string, text: string): ReadonlyArray<Leak> =
 	if (!filePath || !text) return [];
 	if (!isSharedArtifact(filePath)) return [];
 	if (isSelfExempt(filePath)) return [];
-	return scanPatterns(text, LEAK_PATTERNS);
+	return scanPatterns(text, MACHINE_LOCAL_PATH_PATTERNS);
 };
 
 /**
@@ -180,9 +110,10 @@ export const findLeaks = (filePath: string, text: string): ReadonlyArray<Leak> =
  * `/private/tmp/.../scratchpad/verdict.md` scratchpad ref and a `@/var/folders/.../tmp.XXXX`
  * mktemp path onto public PRs (#2796/#2822/#2683/#2772). A comment body is UNCONDITIONALLY a
  * shared public artifact, so there is no doc-surface gate and no self-exempt list — it scans
- * the home-dir `LEAK_PATTERNS` AND the stricter `TEMP_PATTERNS`. Generic path shapes only (#2393).
+ * the shared `MACHINE_LOCAL_PATH_PATTERNS` AND the stricter comment-body-only `TEMP_PATH_PATTERNS`
+ * (which carries the `/tmp/…-*.sock` glob carve-out, #3492). Generic path shapes only (#2393).
  */
 export const findCommentLeaks = (text: string): ReadonlyArray<Leak> => {
 	if (!text) return [];
-	return scanPatterns(text, [...LEAK_PATTERNS, ...TEMP_PATTERNS]);
+	return scanPatterns(text, [...MACHINE_LOCAL_PATH_PATTERNS, ...TEMP_PATH_PATTERNS]);
 };

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
@@ -163,16 +163,17 @@ describe("findCommentLeaks — PR/issue comment body scan (#2796, stricter than 
 		assert.strictEqual(leaks.length, 1);
 	});
 
-	// #3492 — the /tmp/…-*.sock glob carve-out reaches the landed-comment surface (scan-pr Step 3.7):
-	// a reviewer verdict narrating the machine-agnostic socket glob no longer fail-closed-blocks the
-	// ship, while a real machine-local /tmp scratch path in a comment still does.
-	it("allows a *-globbed /tmp/…-*.sock socket name in a verdict comment (#3492)", () =>
-		assert.isFalse(
+	// #3492 (Option 1) — the /tmp arm has NO socket carve-out: the comment surface fail-closes on
+	// ANY bare /tmp/…, including the crew-inbox socket glob. The false positive is fixed emit-side
+	// (review-code reviewers write the socket as a bare `kampus-crew-inbox-*.sock` name or fenced),
+	// never by weakening scan-pr Step 3.7.
+	it("blocks a bare /tmp/…-*.sock socket glob in a verdict comment (#3492 — guard stays strict)", () =>
+		assert.isTrue(
 			hasCommentLeak(
-				"review-code: PASS — the /tmp/kampus-crew-inbox-*.sock runtime path is a legit socket-path domain, not a home path",
+				"review-code: PASS — the /tmp/kampus-crew-inbox-*.sock runtime path is the crew inbox socket",
 			),
 		));
-	it("still blocks a concrete /tmp scratch path in a verdict comment (#3492 — no glob)", () =>
+	it("blocks a concrete /tmp scratch path in a verdict comment (#3492)", () =>
 		assert.isTrue(hasCommentLeak("review-code: notes staged at /tmp/reviewer-scratch/verdict.md")));
 });
 

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
@@ -162,6 +162,18 @@ describe("findCommentLeaks — PR/issue comment body scan (#2796, stricter than 
 		const leaks = findCommentLeaks("staged at /private/tmp/claude/scratchpad/verdict.md");
 		assert.strictEqual(leaks.length, 1);
 	});
+
+	// #3492 — the /tmp/…-*.sock glob carve-out reaches the landed-comment surface (scan-pr Step 3.7):
+	// a reviewer verdict narrating the machine-agnostic socket glob no longer fail-closed-blocks the
+	// ship, while a real machine-local /tmp scratch path in a comment still does.
+	it("allows a *-globbed /tmp/…-*.sock socket name in a verdict comment (#3492)", () =>
+		assert.isFalse(
+			hasCommentLeak(
+				"review-code: PASS — the /tmp/kampus-crew-inbox-*.sock runtime path is a legit socket-path domain, not a home path",
+			),
+		));
+	it("still blocks a concrete /tmp scratch path in a verdict comment (#3492 — no glob)", () =>
+		assert.isTrue(hasCommentLeak("review-code: notes staged at /tmp/reviewer-scratch/verdict.md")));
 });
 
 describe("findLeaks — file surface keeps its /tmp carve-out (unchanged by the comment scan)", () => {

--- a/packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts
@@ -1,0 +1,106 @@
+/**
+ * The single machine-local-path matcher shared by BOTH leak-guard detectors — the doc/comment
+ * scanner (`leak-guard.ts`) and the crew-plugin sanitizer (`crew-leak.ts`). Extracted per the
+ * founder ruling on #3506 (Option C — extract, don't copy): the two detectors each carried their
+ * own copy of the same path arm, and #3505's `~/.claude` shape carve-out landed on leak-guard's
+ * copy only — so the copies drifted, which is the exact root bug #3506 records. With the arm (and
+ * every path-shape carve-out) living HERE once, the two-detectors-drift class of bug is structurally
+ * impossible rather than fixed one instance at a time.
+ *
+ * Two arms, both GENERIC structural shapes and never a named operator allow-list (#2393):
+ *
+ *  - `MACHINE_LOCAL_PATH_PATTERNS` — the home/absolute path arm (`/Users/<name>`, `~/.usirin`,
+ *    `~/.claude` internals, `~/code/`, `/vault/`). Used by every leak-guard surface and by
+ *    crew-leak's `"path"` class.
+ *  - `TEMP_PATH_PATTERNS` — the stricter temp/scratch roots (`/var/folders/…`, `/private/tmp|var/…`,
+ *    `/tmp/…`). leak-guard scans these on the PR/issue-COMMENT surface only (a public comment has no
+ *    legitimate bare-`/tmp` example the way a doc does); crew-leak does not scan temp roots.
+ *
+ * Carve-outs live at the pattern (a property of the shape), not in a membership list:
+ *  - `~/.claude.json` and `~/.claude/settings.json` — the two public, machine-agnostic claude CLI
+ *    config *files* — pass, while any `~/.claude/`-directory descent still flags (#3475/#3505).
+ *  - a username-free, `*`-globbed `/tmp/…-*.sock` (e.g. `/tmp/kampus-crew-inbox-*.sock`) passes: it
+ *    is a well-known socket's glob NAME, not a machine-local instance, the same public-token class as
+ *    the config-file carve-out above (#3492 founder ruling — Option A). A concrete `/tmp/<name>/…`
+ *    scratch path (no glob) still flags — the exemption REQUIRES the `*`, so nothing machine-local
+ *    is let through.
+ */
+
+export interface PathPattern {
+	readonly pattern: RegExp;
+	readonly reason: string;
+}
+
+// Order = report order. Each `g` flag is required for the per-match `matchAll` scan the consumers run.
+export const MACHINE_LOCAL_PATH_PATTERNS: ReadonlyArray<PathPattern> = [
+	{
+		// The `(?<![A-Za-z]:)` drive-letter carve-out keeps this a GENERIC structural check
+		// while dropping the Windows-file-URL false positive: a bare POSIX `/Users/<name>/`
+		// still matches (real macOS-home leak), but a drive-prefixed `C:/Users/...` (e.g.
+		// `file:///C:/Users/ci/...`) does not — that substring is not a macOS home path and
+		// carries no operator PII, yet its FP fail-closed-blocked legitimate PRs (#3070).
+		pattern: /(?<![A-Za-z]:)\/Users\/[A-Za-z0-9._-]+/g,
+		reason: "absolute macOS home path (/Users/<name>/...)",
+	},
+	{
+		pattern: /(?<![\w.])~\/\.(usirin|agent)\b/g,
+		reason: "agent/tool home dir (~/.usirin, ~/.agent)",
+	},
+	{
+		// The `~/.claude` home-dir detector, NARROWED by shape (not a named allow-list; #2393
+		// and #3475): it still flags any descent into the private agent home tree
+		// (`~/.claude/projects/…`, `~/.claude/todos/…`) and bare `~/.claude`, but the two
+		// negative lookaheads carve out the claude CLI's public, machine-agnostic config *files*
+		// — `~/.claude.json` (a sibling dotfile config, `~/.claude` + a `.json` extension, NOT
+		// the directory) and `~/.claude/settings.json` (the one documented settings file). Those
+		// two are identical on every machine and reveal nothing operator-specific, and they are
+		// the literal subject of packages/pipeline-crew-mcp, so flagging them was a chronic
+		// false positive. The carve-out is SHAPE, not a membership list: the exclusion is a
+		// property of this one generic pattern (a config-file leaf on the marker), so a longer
+		// name (`~/.claude.json.bak`, `~/.claude/settings.local.json`, `~/.claude/settings.jsonc`)
+		// or any deeper path still trips it — the `(?![\w.])` tail pins each carve-out to the
+		// exact public leaf. See the threat-model note on #3475 for what this can no longer catch.
+		pattern: /(?<![\w.])~\/\.claude(?!\.json(?![\w.]))(?!\/settings\.json(?![\w.]))\b/g,
+		reason:
+			"agent/tool home dir (~/.claude internals; public config files ~/.claude.json, ~/.claude/settings.json exempt)",
+	},
+	{
+		pattern: /(?<![\w.])~\/code\//g,
+		reason: "home-dir sibling-repo clone (~/code/...)",
+	},
+	{
+		pattern: /(?<![\w/])\/vault\//g,
+		reason: "vault path (/vault/...)",
+	},
+];
+
+// Machine-local temp/scratch roots — a PR/issue COMMENT (or verdict) body must never carry one
+// (the #2796/#2822 scratchpad-`@filepath` and #2683/#2772 mktemp-in-`@sha` leaks). Generic path
+// shapes, NOT a named deny-list (#2393). The `(?<![\w.])` lookbehind stops a `/private/tmp/...`
+// match from also double-firing the `/tmp/` pattern (its preceding char is a word char), so each
+// leak reports once.
+export const TEMP_PATH_PATTERNS: ReadonlyArray<PathPattern> = [
+	{
+		pattern: /(?<![\w.])\/var\/folders\/[A-Za-z0-9._/-]+/g,
+		reason: "macOS per-user mktemp dir (/var/folders/...)",
+	},
+	{
+		pattern: /(?<![\w.])\/private\/(?:tmp|var)\/[A-Za-z0-9._/-]+/g,
+		reason: "macOS resolved temp root (/private/tmp/..., /private/var/...)",
+	},
+	{
+		// The `/tmp/` scratch detector, NARROWED by shape (#3492 founder ruling — Option A, the
+		// same by-shape idiom as the `~/.claude` config-file carve-out above, never a named token
+		// list; #2393). The negative lookahead exempts a username-free, `*`-globbed socket NAME —
+		// `/tmp/kampus-crew-inbox-*.sock` — because a glob is a well-known socket's name, not a
+		// machine-local instance, and reviewer verdicts whose SUBJECT is that socket predictably
+		// narrate it in prose (which was fail-closed-blocking crew-mcp ships at scan-pr Step 3.7).
+		// The exemption REQUIRES the `*` and a single terminal `.sock` leaf with no `/` descent, so
+		// a concrete scratch path (`/tmp/<user>-scratch/…`, any `/tmp/<name>/…`) — which has no glob
+		// or descends into a dir that could hide a username — still flags. A `.sock` backup
+		// (`…-*.sock.bak`) still flags too (the `(?![\w.])` tail pins the exemption to the leaf).
+		pattern:
+			/(?<![\w.])\/tmp\/(?![A-Za-z0-9._-]*\*[A-Za-z0-9._*-]*\.sock(?![\w.]))[A-Za-z0-9._/-]+/g,
+		reason: "machine-local temp/scratch path (/tmp/...)",
+	},
+];

--- a/packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts
@@ -19,11 +19,12 @@
  * Carve-outs live at the pattern (a property of the shape), not in a membership list:
  *  - `~/.claude.json` and `~/.claude/settings.json` — the two public, machine-agnostic claude CLI
  *    config *files* — pass, while any `~/.claude/`-directory descent still flags (#3475/#3505).
- *  - a username-free, `*`-globbed `/tmp/…-*.sock` (e.g. `/tmp/kampus-crew-inbox-*.sock`) passes: it
- *    is a well-known socket's glob NAME, not a machine-local instance, the same public-token class as
- *    the config-file carve-out above (#3492 founder ruling — Option A). A concrete `/tmp/<name>/…`
- *    scratch path (no glob) still flags — the exemption REQUIRES the `*`, so nothing machine-local
- *    is let through.
+ *
+ * There is deliberately NO `/tmp` carve-out: the `TEMP_PATH_PATTERNS` arm fail-closes on ANY bare
+ * `/tmp/…` in a landed comment (including a `/tmp/kampus-crew-inbox-*.sock` socket glob). `/tmp` is
+ * exactly the machine-local category the guard exists to catch, so the reviewer-verdict false
+ * positive is fixed emit-side (review-code reviewers write the socket as the bare `kampus-crew-inbox-*.sock`
+ * name or inside a code fence), never by weakening the guard (#3492 founder ruling — Option 1).
  */
 
 export interface PathPattern {
@@ -89,18 +90,11 @@ export const TEMP_PATH_PATTERNS: ReadonlyArray<PathPattern> = [
 		reason: "macOS resolved temp root (/private/tmp/..., /private/var/...)",
 	},
 	{
-		// The `/tmp/` scratch detector, NARROWED by shape (#3492 founder ruling — Option A, the
-		// same by-shape idiom as the `~/.claude` config-file carve-out above, never a named token
-		// list; #2393). The negative lookahead exempts a username-free, `*`-globbed socket NAME —
-		// `/tmp/kampus-crew-inbox-*.sock` — because a glob is a well-known socket's name, not a
-		// machine-local instance, and reviewer verdicts whose SUBJECT is that socket predictably
-		// narrate it in prose (which was fail-closed-blocking crew-mcp ships at scan-pr Step 3.7).
-		// The exemption REQUIRES the `*` and a single terminal `.sock` leaf with no `/` descent, so
-		// a concrete scratch path (`/tmp/<user>-scratch/…`, any `/tmp/<name>/…`) — which has no glob
-		// or descends into a dir that could hide a username — still flags. A `.sock` backup
-		// (`…-*.sock.bak`) still flags too (the `(?![\w.])` tail pins the exemption to the leaf).
-		pattern:
-			/(?<![\w.])\/tmp\/(?![A-Za-z0-9._-]*\*[A-Za-z0-9._*-]*\.sock(?![\w.]))[A-Za-z0-9._/-]+/g,
+		// The `/tmp/` scratch detector fail-closes on ANY bare `/tmp/…` — including a
+		// `/tmp/kampus-crew-inbox-*.sock` socket glob. `/tmp` is the machine-local category the
+		// guard exists to catch; the reviewer-verdict false positive is fixed emit-side, never by a
+		// guard carve-out (#3492 founder ruling — Option 1). No exemption here by design.
+		pattern: /(?<![\w.])\/tmp\/[A-Za-z0-9._/-]+/g,
 		reason: "machine-local temp/scratch path (/tmp/...)",
 	},
 ];

--- a/packages/pipeline-cli/src/tools/leak-guard/path-matcher.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/path-matcher.unit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `path-matcher` unit tests — the single source both leak-guard detectors import (#3506). These
+ * pin the two SHAPE carve-outs that must apply uniformly to every consumer: the `~/.claude` public
+ * config-file exemption (#3475/#3505) and the `/tmp/…-*.sock` machine-agnostic socket-glob
+ * exemption (#3492). The detector-level tests (leak-guard.unit.test.ts / crew-leak.unit.test.ts)
+ * assert the carve-outs reach their surfaces; these assert the shared shapes directly.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {MACHINE_LOCAL_PATH_PATTERNS, TEMP_PATH_PATTERNS} from "./path-matcher.ts";
+
+// A minimal any-pattern scan over an arm — mirrors what the consumers' scanners do (matchAll per
+// pattern), reduced to a boolean for the assertions here.
+const hits = (patterns: ReadonlyArray<{pattern: RegExp}>, text: string): boolean =>
+	patterns.some((p) => text.match(p.pattern) !== null);
+
+const hitsHome = (text: string): boolean => hits(MACHINE_LOCAL_PATH_PATTERNS, text);
+const hitsTemp = (text: string): boolean => hits(TEMP_PATH_PATTERNS, text);
+
+describe("MACHINE_LOCAL_PATH_PATTERNS — home/absolute arm", () => {
+	describe("~/.claude public config-file carve-out (#3475/#3505)", () => {
+		it("exempts the ~/.claude.json sibling dotfile", () =>
+			assert.isFalse(hitsHome("registers the server into ~/.claude.json")));
+		it("exempts the ~/.claude/settings.json config file", () =>
+			assert.isFalse(hitsHome("edit ~/.claude/settings.json to add the crew server")));
+
+		it("still flags a ~/.claude directory-internal path", () =>
+			assert.isTrue(hitsHome("session log at ~/.claude/projects/foo/bar.jsonl")));
+		it("still flags a bare ~/.claude directory reference", () =>
+			assert.isTrue(hitsHome("the ~/.claude directory holds machine state")));
+		it("still flags a config-file-lookalike leaf (settings.local.json / .claude.json.bak)", () => {
+			assert.isTrue(hitsHome("local override at ~/.claude/settings.local.json"));
+			assert.isTrue(hitsHome("backup at ~/.claude.json.bak"));
+		});
+	});
+
+	describe("the rest of the arm is unchanged", () => {
+		it("flags /Users/<name>, ~/.usirin, ~/.agent, ~/code/, /vault/", () => {
+			assert.isTrue(hitsHome("see /Users/someone/code/x"));
+			assert.isTrue(hitsHome("the vault lives at ~/.usirin/vault"));
+			assert.isTrue(hitsHome("agent home ~/.agent/state"));
+			assert.isTrue(hitsHome("rebuilt from ~/code/github.com/kamp-us/kampus"));
+			assert.isTrue(hitsHome("stored under /vault/secrets"));
+		});
+		it("does NOT flag a Windows drive-prefixed C:/Users/... URL (#3070)", () =>
+			assert.isFalse(hitsHome("file:///C:/Users/ci/proj/x")));
+		it("does NOT flag benign ~/.config or ~/Documents", () => {
+			assert.isFalse(hitsHome("credentials in ~/.config/kampus/creds"));
+			assert.isFalse(hitsHome("saved to ~/Documents/report.pdf"));
+		});
+	});
+});
+
+describe("TEMP_PATH_PATTERNS — /tmp/…-*.sock glob carve-out (#3492)", () => {
+	it("exempts a username-free, *-globbed socket name", () => {
+		assert.isFalse(hitsTemp("the inbox is /tmp/kampus-crew-inbox-*.sock"));
+		assert.isFalse(hitsTemp("bind /tmp/some-service-*.sock for the fan-out"));
+	});
+
+	it("still flags a concrete /tmp/<name> scratch path (no glob)", () => {
+		assert.isTrue(hitsTemp("staged at /tmp/alice-scratch/verdict.md"));
+		assert.isTrue(hitsTemp("wrote /tmp/write-code-progress.md"));
+		// a concrete socket without a glob is machine-local — still flags
+		assert.isTrue(hitsTemp("bound /tmp/kampus-crew-inbox.sock"));
+	});
+	it("still flags a globbed path that descends into a directory (could hide a username)", () =>
+		assert.isTrue(hitsTemp("under /tmp/alice/*.sock")));
+	it("still flags a .sock backup leaf (the exemption is pinned to the terminal leaf)", () =>
+		assert.isTrue(hitsTemp("stale /tmp/kampus-crew-inbox-*.sock.bak")));
+	it("still flags the mktemp roots (/var/folders, /private/tmp)", () => {
+		assert.isTrue(hitsTemp("/var/folders/8f/T/tmp.abc"));
+		assert.isTrue(hitsTemp("/private/tmp/claude/scratchpad/verdict.md"));
+	});
+});

--- a/packages/pipeline-cli/src/tools/leak-guard/path-matcher.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/path-matcher.unit.test.ts
@@ -1,9 +1,10 @@
 /**
  * `path-matcher` unit tests — the single source both leak-guard detectors import (#3506). These
- * pin the two SHAPE carve-outs that must apply uniformly to every consumer: the `~/.claude` public
- * config-file exemption (#3475/#3505) and the `/tmp/…-*.sock` machine-agnostic socket-glob
- * exemption (#3492). The detector-level tests (leak-guard.unit.test.ts / crew-leak.unit.test.ts)
- * assert the carve-outs reach their surfaces; these assert the shared shapes directly.
+ * pin the one SHAPE carve-out that must apply uniformly to every consumer: the `~/.claude` public
+ * config-file exemption (#3475/#3505). The `/tmp` arm has NO carve-out (#3492 Option 1 — the socket
+ * false positive is fixed emit-side, not by weakening the guard), so it fail-closes on ANY bare
+ * `/tmp/…`. The detector-level tests (leak-guard.unit.test.ts / crew-leak.unit.test.ts) assert the
+ * carve-out reaches their surfaces; these assert the shared shapes directly.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {MACHINE_LOCAL_PATH_PATTERNS, TEMP_PATH_PATTERNS} from "./path-matcher.ts";
@@ -50,23 +51,17 @@ describe("MACHINE_LOCAL_PATH_PATTERNS — home/absolute arm", () => {
 	});
 });
 
-describe("TEMP_PATH_PATTERNS — /tmp/…-*.sock glob carve-out (#3492)", () => {
-	it("exempts a username-free, *-globbed socket name", () => {
-		assert.isFalse(hitsTemp("the inbox is /tmp/kampus-crew-inbox-*.sock"));
-		assert.isFalse(hitsTemp("bind /tmp/some-service-*.sock for the fan-out"));
+describe("TEMP_PATH_PATTERNS — fail-close on ANY bare /tmp (no carve-out, #3492 Option 1)", () => {
+	it("flags the socket glob (#3492 — the fix is emit-side, the guard stays strict)", () => {
+		assert.isTrue(hitsTemp("the inbox is /tmp/kampus-crew-inbox-*.sock"));
+		assert.isTrue(hitsTemp("bind /tmp/some-service-*.sock for the fan-out"));
 	});
-
-	it("still flags a concrete /tmp/<name> scratch path (no glob)", () => {
+	it("flags a concrete /tmp/<name> scratch path", () => {
 		assert.isTrue(hitsTemp("staged at /tmp/alice-scratch/verdict.md"));
 		assert.isTrue(hitsTemp("wrote /tmp/write-code-progress.md"));
-		// a concrete socket without a glob is machine-local — still flags
 		assert.isTrue(hitsTemp("bound /tmp/kampus-crew-inbox.sock"));
 	});
-	it("still flags a globbed path that descends into a directory (could hide a username)", () =>
-		assert.isTrue(hitsTemp("under /tmp/alice/*.sock")));
-	it("still flags a .sock backup leaf (the exemption is pinned to the terminal leaf)", () =>
-		assert.isTrue(hitsTemp("stale /tmp/kampus-crew-inbox-*.sock.bak")));
-	it("still flags the mktemp roots (/var/folders, /private/tmp)", () => {
+	it("flags the mktemp roots (/var/folders, /private/tmp)", () => {
 		assert.isTrue(hitsTemp("/var/folders/8f/T/tmp.abc"));
 		assert.isTrue(hitsTemp("/private/tmp/claude/scratchpad/verdict.md"));
 	});


### PR DESCRIPTION
## What & why

Two founder-ruled §CP leak-guard decisions, shipped in ONE PR because they share the same module (splitting them would re-introduce the exact drift #3506 fixes).

**Root bug (#3506):** the two leak-guard detectors each carried their own copy of the machine-local-path arm — `leak-guard.ts` (`findLeaks` doc/comment scanner) and `crew-leak.ts` (`findCrewLeaks` crew-plugin sanitizer). #3505's `~/.claude` config-file carve-out landed on `leak-guard.ts`'s copy only, so `crew-leak.ts` drifted. Fixing one copy at a time is how this class of bug keeps recurring.

### #3506 — Option C (extract, don't copy)

Extract the shared machine-local-path matcher into one new module, `packages/pipeline-cli/src/tools/leak-guard/path-matcher.ts`, that BOTH detectors import:

- `MACHINE_LOCAL_PATH_PATTERNS` — the home/absolute arm (`/Users/<name>`, `~/.usirin`, `~/.claude` internals, `~/code/`, `/vault/`) with the `~/.claude.json` / `~/.claude/settings.json` shape carve-out (#3475/#3505) living in exactly ONE place now — it applies to both detectors uniformly.
- `TEMP_PATH_PATTERNS` — the stricter comment-body-only temp roots.

`crew-leak.ts` keeps its extra classes layered on top of the shared path arm (Linux `/home/<name>`, email, tmux-id, memory-ref). `leak-guard.ts` keeps its doc-surface scoping + self-exempt list. Neither detector's scope changes — only the duplicated path arm is de-duplicated. The two-detectors-drift class of bug is now structurally impossible, not fixed one instance at a time.

### #3492 — Option 1 (emit-side reviewer discipline; the guard stays strict)

**Corrected per the founder's authoritative 2026-07-19 ruling** (superseding the earlier mis-recorded "Option A" guard carve-out). The shared matcher's zero-`/tmp` invariant is load-bearing and stays intact: there is **no** `/tmp/…-*.sock` carve-out. leak-guard fail-closes on ANY bare `/tmp/…` in a landed comment again — including `/tmp/kampus-crew-inbox-*.sock` — because `/tmp` is exactly the machine-local category the guard exists to catch. The shared matcher carries ONLY #3505's proven-safe config-file carve-out.

The reviewer-verdict false positive is fixed on the **emit side** instead: a tight reviewer-discipline note in `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`, at the point reviewers author the verdict body, instructing them to reference the crew inbox socket as the bare name `kampus-crew-inbox-*.sock` (no `/tmp/` prefix) or inside a code fence — so a landed verdict never carries a bare `/tmp/…` literal for ship-it Step 3.7 to (correctly) block.

Carve-outs stay generic shape-based patterns, never a named allow-list (#2393).

## Tests

- `path-matcher.unit.test.ts`: the `~/.claude.json` / `settings.json` config-file carve-out passes, a `~/.claude/`-internal still flags; the `/tmp` arm fail-closes on ANY bare `/tmp/…` — the socket glob, a concrete scratch path, and the mktemp roots all flag.
- `leak-guard.unit.test.ts`: a bare `/tmp/…-*.sock` socket glob AND a concrete `/tmp` scratch path both block on the `findCommentLeaks` (scan-pr) surface.
- `crew-leak.unit.test.ts`: the #3506 de-drift assertion — the shared config-file carve-out now applies to `findCrewLeaks`.
- Full `@kampus/pipeline-cli` suite: 1545 passed. Typecheck + biome clean; pre-commit leak-guard clean; adoption-lint clean.

## §CP note

This is MIXED code + a gate-critical skill: it touches `packages/pipeline-cli/**` (control-plane) AND `review-code/SKILL.md`, so it banks for human control-plane merge and needs both `review-code` and `review-skill` verdicts at re-review. No guard capability is removed — #3492 Option 1 keeps the guard strict; #3506 de-duplicates and keeps the one proven config-file carve-out that lets through only public, machine-agnostic tokens carrying zero operator data.

Fixes #3506
Fixes #3492