### PR TITLE
roadmap: claim milestone #30 Writing-Craft Import as active campaign

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Diátaxis docs — pipeline-crew & -mcp | #31 | done |
 | pipeline-cli @effect/platform migration | #32 | active |
 | Agentic design-system coverage | #33 | active |
+| Writing-Craft Import | #30 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Claims open milestone #30 (Writing-Craft Import) with a `## Campaigns` row — it was being worked (5 open, live campaign issue #3379) but unclaimed by any ROADMAP row, so `roadmap-guard check` was red on main. Adds `| Writing-Craft Import | #30 | active |`. Founder call 2026-07-19 (claim, not defer). Fixes #3633.