### PR TITLE
refactor(pipeline-cli): single-source the gh-IO seam — migrate verdict + epic-lock onto shared Tracker seam (#3572)

### DIFF
--- a/packages/pipeline-cli/src/tools/epic-lock/github.ts
+++ b/packages/pipeline-cli/src/tools/epic-lock/github.ts
@@ -21,40 +21,34 @@
  * post, a lost co-acquire — is an observable outcome the command prints, never an
  * exception. See ADR 0059 (the epic-plan lock) and ADR 0115 (the claim marker).
  */
-import {Context, Effect, Layer, Stream} from "effect";
+import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
-import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {ChildProcessSpawner} from "effect/unstable/process";
+// The `gh api` REST IO seam (runGh / resolveRepo / authorizedAuthors / RawComment) is the SINGLE
+// SOURCE shared with the `Tracker` service and `verdict` — no longer re-copied here (#3262 AC 5).
+// The error types are re-exported below so callers/tests keep importing them from this module.
+import {
+	authorizedAuthors,
+	decodeComments,
+	deleteCommentArgs,
+	type GhCommandError,
+	type GhParseError,
+	json,
+	listCommentsArgs,
+	postCommentArgs,
+	type RawComment,
+	type RepoResolutionError,
+	resolveRepo,
+	runGh,
+} from "../tracker/gh-io.ts";
 import {type ClaimComment, ownClaimCommentIds, resolveWinner} from "./claim-resolution.ts";
+
+// Re-export the shared IO seam's typed failures so callers/tests keep importing them from this
+// module — the single-source classes now live in `../tracker/gh-io.ts` (#3262 AC 5).
+export {GhCommandError, GhParseError, RepoResolutionError} from "../tracker/gh-io.ts";
 
 /** The canonical epic-plan lock label (ADR 0059). */
 export const LOCK_LABEL = "status:planning";
-
-/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, 422 missing label, …). */
-export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
-	"@kampus/epic-lock/GhCommandError",
-	{
-		args: Schema.Array(Schema.String),
-		exitCode: Schema.Number,
-		stderr: Schema.String,
-	},
-) {}
-
-/** `gh` output was not the JSON the loader expected. */
-export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
-	"@kampus/epic-lock/GhParseError",
-	{
-		args: Schema.Array(Schema.String),
-		message: Schema.String,
-	},
-) {}
-
-/** No `owner/name` target repo could be resolved (no env override, no current repo). */
-export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
-	"@kampus/epic-lock/RepoResolutionError",
-	{
-		message: Schema.String,
-	},
-) {}
 
 /** The `acquire` verdict — exactly one holder, or one of four fail-closed back-offs. */
 export type AcquireResult =
@@ -71,89 +65,9 @@ export type ReleaseResult = {
 	readonly labelRemoved: boolean;
 };
 
-const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
-	Stream.decodeText(stream).pipe(
-		Stream.mkString,
-		Effect.orElseSucceed(() => ""),
-	);
-
-/**
- * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit.
- * `ChildProcessSpawner.string` surfaces only spawn/IO faults, not the process's own
- * exit code — so the handle is spawned directly to read `exitCode` + `stderr` and
- * lower a non-zero exit into a typed error. A spawn/IO `PlatformError` (e.g. `gh`
- * not on PATH) folds into the same typed `GhCommandError` (exit code `-1`).
- */
-const runGh = Effect.fn("Github.runGh")(
-	function* (args: ReadonlyArray<string>) {
-		const handle = yield* ChildProcess.make("gh", args);
-		const [stdout, stderr, exitCode] = yield* Effect.all(
-			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
-			{concurrency: "unbounded"},
-		);
-		if (exitCode !== 0) {
-			return yield* new GhCommandError({args, exitCode, stderr});
-		}
-		return stdout;
-	},
-	Effect.scoped,
-	(effect, args) =>
-		Effect.catchTag(
-			effect,
-			"PlatformError",
-			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
-		),
-);
-
-const parseJson = (
-	args: ReadonlyArray<string>,
-	raw: string,
-): Effect.Effect<unknown, GhParseError> =>
-	Effect.try({
-		try: () => JSON.parse(raw) as unknown,
-		catch: (cause) =>
-			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
-	});
-
-const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
-	return yield* parseJson(args, yield* runGh(args));
-});
-
-const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
-
-/**
- * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
- * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
- * defaults to a repo: with no env and no resolvable current repo it fails
- * `RepoResolutionError`, so a foreign install can't accidentally operate on phoenix.
- */
-const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
-	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
-	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
-		return fromEnv.trim();
-	}
-	const viewed = yield* runGh([
-		"repo",
-		"view",
-		"--json",
-		"nameWithOwner",
-		"-q",
-		".nameWithOwner",
-	]).pipe(
-		Effect.map((out) => out.trim()),
-		Effect.catchTag("@kampus/epic-lock/GhCommandError", () => Effect.succeed("")),
-	);
-	if (REPO_RE.test(viewed)) {
-		return viewed;
-	}
-	return yield* new RepoResolutionError({
-		message:
-			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
-			"or run inside a git repo whose origin `gh repo view` can read",
-	});
-});
-
-// REST-only arg builders — never GraphQL.
+// The epic-lock label envelope (the ADR-0059 `status:planning` read/add/remove) is the arg-builder
+// set unique to this lock; the generic comment IO (list/post/delete) is the shared
+// `../tracker/gh-io.ts` seam, so only these three label builders live here — never GraphQL.
 
 const issueArgs = (repo: string, epic: number): ReadonlyArray<string> => [
 	"api",
@@ -178,48 +92,8 @@ const removeLabelArgs = (repo: string, epic: number): ReadonlyArray<string> => [
 	`repos/${repo}/issues/${epic}/labels/${LOCK_LABEL}`,
 ];
 
-const postClaimArgs = (repo: string, epic: number, body: string): ReadonlyArray<string> => [
-	"api",
-	"-X",
-	"POST",
-	`repos/${repo}/issues/${epic}/comments`,
-	"-f",
-	`body=${body}`,
-	"--jq",
-	".id",
-];
-
-const listCommentsArgs = (repo: string, epic: number): ReadonlyArray<string> => [
-	"api",
-	"--paginate",
-	`repos/${repo}/issues/${epic}/comments?per_page=100`,
-];
-
-const deleteCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
-	"api",
-	"-X",
-	"DELETE",
-	`repos/${repo}/issues/comments/${id}`,
-];
-
-const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
-	"api",
-	`repos/${repo}/collaborators/${login}/permission`,
-	"--jq",
-	".permission",
-];
-
 /** The issue-label array `[.labels[].name]` returns. */
 const decodeLabels = Schema.decodeUnknownEffect(Schema.Array(Schema.String));
-
-/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
-const RawComment = Schema.Struct({
-	id: Schema.Number,
-	created_at: Schema.String,
-	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
-	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
-});
-const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
 
 const toClaimComment = (raw: (typeof RawComment)["Type"]): ClaimComment => ({
 	id: raw.id,
@@ -244,35 +118,6 @@ const listClaimComments = Effect.fn("Github.listClaimComments")(function* (
 	const args = listCommentsArgs(repo, epic);
 	const raw = yield* decodeComments(yield* json(args));
 	return raw.map(toClaimComment);
-});
-
-/**
- * The write+ collaborator subset of `logins` — the ADR 0055 trust root. Each login
- * is probed with `collaborators/<login>/permission`; a non-`admin|maintain|write`
- * permission, or any `gh` fault on the probe (a non-collaborator commonly 404s),
- * drops the login. A forged claim from a non-collaborator therefore never enters the
- * authorized set the core resolves over.
- */
-const authorizedAuthors = Effect.fn("Github.authorizedAuthors")(function* (
-	repo: string,
-	logins: ReadonlyArray<string>,
-) {
-	const results = yield* Effect.forEach(
-		logins,
-		(login) =>
-			runGh(permissionArgs(repo, login)).pipe(
-				Effect.map((out) => ({login, permission: out.trim()})),
-				Effect.catchTag("@kampus/epic-lock/GhCommandError", () =>
-					Effect.succeed({login, permission: "none"}),
-				),
-			),
-		{concurrency: "unbounded"},
-	);
-	return results
-		.filter(
-			(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
-		)
-		.map((r) => r.login);
 });
 
 const resolveAuthorizedWinner = Effect.fn("Github.resolveAuthorizedWinner")(function* (
@@ -305,20 +150,20 @@ const acquire = Effect.fn("Github.acquire")(function* (
 	// "ok" is the label-landed sentinel; a GhCommandError lowers to the label-missing back-off.
 	const labelResult = yield* runGh(addLabelArgs(repo, epic)).pipe(
 		Effect.as<AcquireResult | "ok">("ok"),
-		Effect.catchTag("@kampus/epic-lock/GhCommandError", (error) =>
+		Effect.catchTag("@kampus/gh-io/GhCommandError", (error) =>
 			Effect.succeed<AcquireResult | "ok">({_tag: "label-missing", stderr: error.stderr}),
 		),
 	);
 	if (labelResult !== "ok") return labelResult;
 
 	const now = new Date().toISOString();
-	const claimResult = yield* json(postClaimArgs(repo, epic, `claim: ${sessionId} · ${now}`)).pipe(
+	const claimResult = yield* json(postCommentArgs(repo, epic, `claim: ${sessionId} · ${now}`)).pipe(
 		Effect.map((v): number | AcquireResult =>
 			typeof v === "number"
 				? v
 				: {_tag: "claim-post-failed", stderr: "claim POST did not return a comment id"},
 		),
-		Effect.catchTag("@kampus/epic-lock/GhCommandError", (error) =>
+		Effect.catchTag("@kampus/gh-io/GhCommandError", (error) =>
 			Effect.succeed<number | AcquireResult>({_tag: "claim-post-failed", stderr: error.stderr}),
 		),
 	);
@@ -354,7 +199,7 @@ const release = Effect.fn("Github.release")(function* (
 		mine,
 		(id) =>
 			runGh(deleteCommentArgs(repo, id)).pipe(
-				Effect.catchTag("@kampus/epic-lock/GhCommandError", (error) =>
+				Effect.catchTag("@kampus/gh-io/GhCommandError", (error) =>
 					is404(error.stderr) ? Effect.void : Effect.fail(error),
 				),
 			),
@@ -362,7 +207,7 @@ const release = Effect.fn("Github.release")(function* (
 	);
 	const labelRemoved = yield* runGh(removeLabelArgs(repo, epic)).pipe(
 		Effect.as(true),
-		Effect.catchTag("@kampus/epic-lock/GhCommandError", (error) =>
+		Effect.catchTag("@kampus/gh-io/GhCommandError", (error) =>
 			is404(error.stderr) ? Effect.succeed(false) : Effect.fail(error),
 		),
 	);

--- a/packages/pipeline-cli/src/tools/tracker/gh-io.ts
+++ b/packages/pipeline-cli/src/tools/tracker/gh-io.ts
@@ -1,0 +1,229 @@
+/**
+ * The shared `gh api` REST IO seam for the crew's tracker consumers — the single source of the
+ * `runGh` / `resolveRepo` / `authorizedAuthors` / `RawComment` idiom the `Tracker` service, the
+ * `epic-lock` lock, and the `verdict` gate each used to re-copy (#3262 AC 5, the same-commit
+ * adoption follow-up). Consolidating it here is what makes those three consumers stop drifting
+ * their own copies of the same procedure.
+ *
+ * The seam is deliberately domain-free: it is the `gh`-over-REST plumbing (spawn, JSON parse,
+ * repo resolution, the ADR 0055 write+ ACL gate, the raw comment shape), NOT the claim/verdict
+ * decision. Each consumer keeps its own domain core (`claim-resolution.ts`, `verdict-match.ts`)
+ * and maps the `RawComment` boundary type into its own domain comment. Two rules bind it, the
+ * same two that bound the copies:
+ *
+ *  - **REST only** — GraphQL is broken on the kamp-us org, so every call is `gh api …`.
+ *  - **Typed failures, never a throw (`.patterns/effect-errors.md`).** A non-zero `gh` exit is
+ *    `GhCommandError`, malformed output `GhParseError`, an unresolvable repo `RepoResolutionError`;
+ *    untrusted REST JSON is Schema-decoded at the boundary (`.patterns/effect-schema-validation.md`).
+ */
+import {Effect, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess} from "effect/unstable/process";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, 422 missing label, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/gh-io/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/gh-io/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/gh-io/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit.
+ * `ChildProcessSpawner.string` surfaces only spawn/IO faults, not the process's own exit code —
+ * so the handle is spawned directly to read `exitCode` + `stderr` and lower a non-zero exit into a
+ * typed error rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` off PATH) folds into the
+ * same typed error as exit `-1`.
+ */
+export const runGh = Effect.fn("GhIo.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+/** Run `gh <args>` and JSON-parse its stdout, lowering a parse failure into `GhParseError`. */
+export const json = Effect.fn("GhIo.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently defaults to a
+ * repo: with no env and no resolvable current repo it fails `RepoResolutionError`, so a foreign
+ * install can't accidentally operate on phoenix.
+ */
+export const resolveRepo = Effect.fn("GhIo.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/gh-io/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// REST-only arg builders shared across the tracker consumers — never GraphQL.
+
+export const listCommentsArgs = (repo: string, target: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${target}/comments?per_page=100`,
+];
+
+// A comment POST that returns the new comment id — the claim marker and the verdict marker are
+// both a body POST that reads back `.id`, single-sourced so the consumers can't drift.
+export const postCommentArgs = (
+	repo: string,
+	target: number,
+	body: string,
+): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${target}/comments`,
+	"-f",
+	`body=${body}`,
+	"--jq",
+	".id",
+];
+
+export const patchCommentArgs = (repo: string, id: number, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"PATCH",
+	`repos/${repo}/issues/comments/${id}`,
+	"-f",
+	`body=${body}`,
+	"--jq",
+	".id",
+];
+
+export const deleteCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"DELETE",
+	`repos/${repo}/issues/comments/${id}`,
+];
+
+// The read-back GET for a post's self-verify (#3019): re-fetch the single comment we just upserted
+// and return its LANDED body, so the marker/leak-clean shape is re-checked as it actually landed.
+export const getCommentBodyArgs = (repo: string, id: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/comments/${id}`,
+	"--jq",
+	".body",
+];
+
+export const whoAmIArgs: ReadonlyArray<string> = ["api", "user", "--jq", ".login"];
+
+const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/collaborators/${login}/permission`,
+	"--jq",
+	".permission",
+];
+
+/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
+export const RawComment = Schema.Struct({
+	id: Schema.Number,
+	created_at: Schema.String,
+	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
+});
+export const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+/**
+ * The write+ collaborator subset of `logins` — the ADR 0055 trust root. Each login is probed with
+ * `collaborators/<login>/permission`; a non-`admin|maintain|write` permission, or any `gh` fault on
+ * the probe (a non-collaborator commonly 404s), drops the login. A forged claim/marker from a
+ * non-collaborator therefore never enters the authorized set a consumer's core resolves over.
+ */
+export const authorizedAuthors = Effect.fn("GhIo.authorizedAuthors")(function* (
+	repo: string,
+	logins: ReadonlyArray<string>,
+) {
+	const results = yield* Effect.forEach(
+		logins,
+		(login) =>
+			runGh(permissionArgs(repo, login)).pipe(
+				Effect.map((out) => ({login, permission: out.trim()})),
+				Effect.catchTag("@kampus/gh-io/GhCommandError", () =>
+					Effect.succeed({login, permission: "none"}),
+				),
+			),
+		{concurrency: "unbounded"},
+	);
+	return results
+		.filter(
+			(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
+		)
+		.map((r) => r.login);
+});

--- a/packages/pipeline-cli/src/tools/tracker/tracker.ts
+++ b/packages/pipeline-cli/src/tools/tracker/tracker.ts
@@ -33,9 +33,9 @@
  * IO-free, ADR-0040-tested core (`../epic-lock/claim-resolution.ts`) rather than
  * re-derived — the single source of "who owns this claim" (gh-issue-intake-formats.md §7).
  */
-import {Context, Effect, Layer, Stream} from "effect";
+import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
-import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {ChildProcessSpawner} from "effect/unstable/process";
 import {type ClaimComment, type ClaimWinner, resolveWinner} from "../epic-lock/claim-resolution.ts";
 // The ADR-0058 verdict-marker grammar + emission guard is the SINGLE SOURCE — reused, never
 // re-derived, exactly as the claim decision reuses `epic-lock/claim-resolution.ts`. `postVerdict`
@@ -48,33 +48,31 @@ import {
 	namespaceRe,
 	type VerdictGate,
 } from "../verdict/verdict-match.ts";
+// The `gh api` REST IO seam (runGh / resolveRepo / authorizedAuthors / RawComment) is the SINGLE
+// SOURCE this service, `epic-lock/github.ts`, and `verdict/github.ts` share — no longer re-copied
+// per consumer (#3262 AC 5). The error types are re-exported below so callers/tests keep importing
+// them from this module.
+import {
+	authorizedAuthors,
+	decodeComments,
+	deleteCommentArgs,
+	type GhCommandError,
+	GhParseError,
+	getCommentBodyArgs,
+	json,
+	listCommentsArgs,
+	patchCommentArgs,
+	postCommentArgs,
+	type RawComment,
+	type RepoResolutionError,
+	resolveRepo,
+	runGh,
+	whoAmIArgs,
+} from "./gh-io.ts";
 
-/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
-export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
-	"@kampus/tracker/GhCommandError",
-	{
-		args: Schema.Array(Schema.String),
-		exitCode: Schema.Number,
-		stderr: Schema.String,
-	},
-) {}
-
-/** `gh` output was not the JSON the loader expected. */
-export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
-	"@kampus/tracker/GhParseError",
-	{
-		args: Schema.Array(Schema.String),
-		message: Schema.String,
-	},
-) {}
-
-/** No `owner/name` target repo could be resolved (no env override, no current repo). */
-export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
-	"@kampus/tracker/RepoResolutionError",
-	{
-		message: Schema.String,
-	},
-) {}
+// Re-export the shared IO seam's typed failures so callers/tests keep importing them from this
+// service module — the single-source classes now live in `gh-io.ts` (#3262 AC 5).
+export {GhCommandError, GhParseError, RepoResolutionError} from "./gh-io.ts";
 
 /**
  * A malformed verb judgment the caller must fix — e.g. `postVerdict` handed an unknown gate, or a
@@ -250,136 +248,9 @@ export type GraduateResult = {
 	readonly state: string;
 };
 
-const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
-	Stream.decodeText(stream).pipe(
-		Stream.mkString,
-		Effect.orElseSucceed(() => ""),
-	);
-
-/**
- * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the
- * same direct-spawn shape `epic-lock`/`verdict` use so an exit code + stderr lower into a
- * typed error rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` off PATH) folds
- * into the same typed error as exit `-1`.
- */
-const runGh = Effect.fn("Tracker.runGh")(
-	function* (args: ReadonlyArray<string>) {
-		const handle = yield* ChildProcess.make("gh", args);
-		const [stdout, stderr, exitCode] = yield* Effect.all(
-			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
-			{concurrency: "unbounded"},
-		);
-		if (exitCode !== 0) {
-			return yield* new GhCommandError({args, exitCode, stderr});
-		}
-		return stdout;
-	},
-	Effect.scoped,
-	(effect, args) =>
-		Effect.catchTag(
-			effect,
-			"PlatformError",
-			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
-		),
-);
-
-const parseJson = (
-	args: ReadonlyArray<string>,
-	raw: string,
-): Effect.Effect<unknown, GhParseError> =>
-	Effect.try({
-		try: () => JSON.parse(raw) as unknown,
-		catch: (cause) =>
-			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
-	});
-
-const json = Effect.fn("Tracker.json")(function* (args: ReadonlyArray<string>) {
-	return yield* parseJson(args, yield* runGh(args));
-});
-
-const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
-
-/**
- * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
- * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
- * defaults: with no env and no resolvable current repo it fails `RepoResolutionError`, so
- * a foreign install can't accidentally operate on phoenix.
- */
-const resolveRepo = Effect.fn("Tracker.resolveRepo")(function* () {
-	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
-	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
-		return fromEnv.trim();
-	}
-	const viewed = yield* runGh([
-		"repo",
-		"view",
-		"--json",
-		"nameWithOwner",
-		"-q",
-		".nameWithOwner",
-	]).pipe(
-		Effect.map((out) => out.trim()),
-		Effect.catchTag("@kampus/tracker/GhCommandError", () => Effect.succeed("")),
-	);
-	if (REPO_RE.test(viewed)) {
-		return viewed;
-	}
-	return yield* new RepoResolutionError({
-		message:
-			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
-			"or run inside a git repo whose origin `gh repo view` can read",
-	});
-});
-
-// REST-only arg builders — never GraphQL (broken on the kamp-us org).
-
-const listCommentsArgs = (repo: string, target: TargetId): ReadonlyArray<string> => [
-	"api",
-	"--paginate",
-	`repos/${repo}/issues/${target}/comments?per_page=100`,
-];
-
-// A generic comment POST — the claim marker and the verdict marker are both a body POST that
-// returns the new comment id; single-sourced so the two consumers can't drift.
-const postCommentArgs = (repo: string, target: TargetId, body: string): ReadonlyArray<string> => [
-	"api",
-	"-X",
-	"POST",
-	`repos/${repo}/issues/${target}/comments`,
-	"-f",
-	`body=${body}`,
-	"--jq",
-	".id",
-];
-
-const patchCommentArgs = (repo: string, id: number, body: string): ReadonlyArray<string> => [
-	"api",
-	"-X",
-	"PATCH",
-	`repos/${repo}/issues/comments/${id}`,
-	"-f",
-	`body=${body}`,
-	"--jq",
-	".id",
-];
-
-// The read-back GET for `postVerdict`'s self-verify (#3019): re-fetch the single comment we just
-// upserted and return its LANDED body, so the marker/leak-clean shape is re-checked as it landed.
-const getCommentBodyArgs = (repo: string, id: number): ReadonlyArray<string> => [
-	"api",
-	`repos/${repo}/issues/comments/${id}`,
-	"--jq",
-	".body",
-];
-
-const whoAmIArgs: ReadonlyArray<string> = ["api", "user", "--jq", ".login"];
-
-const deleteCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
-	"api",
-	"-X",
-	"DELETE",
-	`repos/${repo}/issues/comments/${id}`,
-];
+// Tracker-specific REST arg builders — never GraphQL (broken on the kamp-us org). The generic
+// comment IO (list/post/patch/delete/get-body) and the `whoami` probe are the shared `gh-io.ts`
+// seam; only the create/label/close envelopes unique to the tracker's verbs live here.
 
 // Create a new issue. `title` / `body` / each `label` pass as by-value POST fields through
 // the direct `gh` spawn — no shell, no heredoc, no `-f body=@file`, so the whole local-path
@@ -425,13 +296,6 @@ const closeCompletedArgs = (repo: string, target: TargetId): ReadonlyArray<strin
 	"state_reason=completed",
 ];
 
-const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
-	"api",
-	`repos/${repo}/collaborators/${login}/permission`,
-	"--jq",
-	".permission",
-];
-
 const addLabelsArgs = (
 	repo: string,
 	target: TargetId,
@@ -458,15 +322,6 @@ const listLabelsArgs = (repo: string, target: TargetId): ReadonlyArray<string> =
 	"--paginate",
 	`repos/${repo}/issues/${target}/labels?per_page=100`,
 ];
-
-/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
-const RawComment = Schema.Struct({
-	id: Schema.Number,
-	created_at: Schema.String,
-	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
-	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
-});
-const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
 
 /** A raw label as the issues/labels endpoint returns it; only the name is read. */
 const RawLabel = Schema.Struct({name: Schema.String});
@@ -509,35 +364,6 @@ const listClaimComments = Effect.fn("Tracker.listClaimComments")(function* (
 	const args = listCommentsArgs(repo, target);
 	const raw = yield* decodeComments(yield* json(args));
 	return raw.map(toClaimComment);
-});
-
-/**
- * The write+ collaborator subset of `logins` — the ADR 0055 trust root, applied *inside*
- * the live impl so it never leaks into the `Tracker` interface (local-markdown has no ACL).
- * A non-`admin|maintain|write` permission, or any `gh` fault on the probe (a
- * non-collaborator commonly 404s), drops the login — a forged claim never enters the set
- * the pure core resolves over.
- */
-const authorizedAuthors = Effect.fn("Tracker.authorizedAuthors")(function* (
-	repo: string,
-	logins: ReadonlyArray<string>,
-) {
-	const results = yield* Effect.forEach(
-		logins,
-		(login) =>
-			runGh(permissionArgs(repo, login)).pipe(
-				Effect.map((out) => ({login, permission: out.trim()})),
-				Effect.catchTag("@kampus/tracker/GhCommandError", () =>
-					Effect.succeed({login, permission: "none"}),
-				),
-			),
-		{concurrency: "unbounded"},
-	);
-	return results
-		.filter(
-			(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
-		)
-		.map((r) => r.login);
 });
 
 const resolveAuthorizedWinner = Effect.fn("Tracker.resolveAuthorizedWinner")(function* (
@@ -608,7 +434,7 @@ const applyTriage = Effect.fn("Tracker.applyTriage")(function* (
 	const add = [`type:${judgment.type}`, judgment.priority, `${LABEL_STATUS_PREFIX}${status}`];
 	yield* runGh(addLabelsArgs(repo, target, add));
 	yield* runGh(removeLabelArgs(repo, target, `${LABEL_STATUS_PREFIX}${QUEUE_STATUS}`)).pipe(
-		Effect.catchTag("@kampus/tracker/GhCommandError", () => Effect.succeed("")),
+		Effect.catchTag("@kampus/gh-io/GhCommandError", () => Effect.succeed("")),
 	);
 	const labels = yield* decodeLabels(yield* json(listLabelsArgs(repo, target)));
 	const landedStatus = labels
@@ -657,7 +483,7 @@ const verifyLanded = Effect.fn("Tracker.verifyLanded")(function* (
 ) {
 	const landed = yield* runGh(getCommentBodyArgs(repo, id)).pipe(
 		Effect.catchTag(
-			"@kampus/tracker/GhCommandError",
+			"@kampus/gh-io/GhCommandError",
 			(cause) =>
 				new TrackerVerifyError({
 					message: `could not re-fetch the just-posted verdict comment #${id} to self-verify it (${cause.stderr.trim() || `exit ${cause.exitCode}`}) — refusing to report success on an unverifiable post (#3019)`,

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -17,9 +17,28 @@
  *    gate's marker (fail-closed on a cross-namespace body), then PATCH our own prior marker in
  *    the namespace if one exists, else POST a fresh one — exactly one verdict comment per (PR, gate).
  */
-import {Context, Effect, Layer, Stream} from "effect";
+import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
-import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {ChildProcessSpawner} from "effect/unstable/process";
+// The `gh api` REST IO seam (runGh / resolveRepo / authorizedAuthors / RawComment) is the SINGLE
+// SOURCE shared with the `Tracker` service and `epic-lock` — no longer re-copied here (#3262 AC 5).
+// The error types are re-exported below so callers/tests keep importing them from this module.
+import {
+	authorizedAuthors,
+	decodeComments,
+	type GhCommandError,
+	GhParseError,
+	getCommentBodyArgs,
+	json,
+	listCommentsArgs,
+	patchCommentArgs,
+	postCommentArgs,
+	type RawComment,
+	type RepoResolutionError,
+	resolveRepo,
+	runGh,
+	whoAmIArgs,
+} from "../tracker/gh-io.ts";
 import {
 	emissionDefect,
 	namespaceRe,
@@ -30,32 +49,9 @@ import {
 	type VerdictOutcome,
 } from "./verdict-match.ts";
 
-/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
-export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
-	"@kampus/verdict/GhCommandError",
-	{
-		args: Schema.Array(Schema.String),
-		exitCode: Schema.Number,
-		stderr: Schema.String,
-	},
-) {}
-
-/** `gh` output was not the JSON the loader expected. */
-export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
-	"@kampus/verdict/GhParseError",
-	{
-		args: Schema.Array(Schema.String),
-		message: Schema.String,
-	},
-) {}
-
-/** No `owner/name` target repo could be resolved (no env override, no current repo). */
-export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
-	"@kampus/verdict/RepoResolutionError",
-	{
-		message: Schema.String,
-	},
-) {}
+// Re-export the shared IO seam's typed failures so callers/tests keep importing them from this
+// module — the single-source classes now live in `../tracker/gh-io.ts` (#3262 AC 5).
+export {GhCommandError, GhParseError, RepoResolutionError} from "../tracker/gh-io.ts";
 
 /** A malformed request the caller must fix — e.g. a `post` body whose first line is the wrong gate's marker. */
 export class VerdictInputError extends Schema.TaggedErrorClass<VerdictInputError>()(
@@ -95,149 +91,15 @@ export interface PostResult {
 	readonly commentId: number;
 }
 
-const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
-	Stream.decodeText(stream).pipe(
-		Stream.mkString,
-		Effect.orElseSucceed(() => ""),
-	);
-
-/**
- * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit — the same
- * direct-spawn shape `epic-lock` uses so a non-zero exit + stderr lower into a typed error
- * rather than a throw. A spawn/IO `PlatformError` (e.g. `gh` not on PATH) folds in as exit `-1`.
- */
-const runGh = Effect.fn("Github.runGh")(
-	function* (args: ReadonlyArray<string>) {
-		const handle = yield* ChildProcess.make("gh", args);
-		const [stdout, stderr, exitCode] = yield* Effect.all(
-			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
-			{concurrency: "unbounded"},
-		);
-		if (exitCode !== 0) {
-			return yield* new GhCommandError({args, exitCode, stderr});
-		}
-		return stdout;
-	},
-	Effect.scoped,
-	(effect, args) =>
-		Effect.catchTag(
-			effect,
-			"PlatformError",
-			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
-		),
-);
-
-const parseJson = (
-	args: ReadonlyArray<string>,
-	raw: string,
-): Effect.Effect<unknown, GhParseError> =>
-	Effect.try({
-		try: () => JSON.parse(raw) as unknown,
-		catch: (cause) =>
-			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
-	});
-
-const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
-	return yield* parseJson(args, yield* runGh(args));
-});
-
-const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
-
-/**
- * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
- * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently defaults —
- * with no env and no resolvable current repo it fails `RepoResolutionError`.
- */
-const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
-	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
-	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
-		return fromEnv.trim();
-	}
-	const viewed = yield* runGh([
-		"repo",
-		"view",
-		"--json",
-		"nameWithOwner",
-		"-q",
-		".nameWithOwner",
-	]).pipe(
-		Effect.map((out) => out.trim()),
-		Effect.catchTag("@kampus/verdict/GhCommandError", () => Effect.succeed("")),
-	);
-	if (REPO_RE.test(viewed)) {
-		return viewed;
-	}
-	return yield* new RepoResolutionError({
-		message:
-			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
-			"or run inside a git repo whose origin `gh repo view` can read",
-	});
-});
-
-// REST-only arg builders — never GraphQL.
-
+// The PR head-SHA read is the one arg builder unique to `verdict` (the ADR-0058 head binding);
+// the generic comment IO (list/post/patch/get-body) and the `whoami` probe are the shared
+// `../tracker/gh-io.ts` seam.
 const headShaArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 	"api",
 	`repos/${repo}/pulls/${pr}`,
 	"--jq",
 	".head.sha",
 ];
-
-const listCommentsArgs = (repo: string, pr: number): ReadonlyArray<string> => [
-	"api",
-	"--paginate",
-	`repos/${repo}/issues/${pr}/comments?per_page=100`,
-];
-
-const whoAmIArgs: ReadonlyArray<string> = ["api", "user", "--jq", ".login"];
-
-const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
-	"api",
-	`repos/${repo}/collaborators/${login}/permission`,
-	"--jq",
-	".permission",
-];
-
-const postCommentArgs = (repo: string, pr: number, body: string): ReadonlyArray<string> => [
-	"api",
-	"-X",
-	"POST",
-	`repos/${repo}/issues/${pr}/comments`,
-	"-f",
-	`body=${body}`,
-	"--jq",
-	".id",
-];
-
-const patchCommentArgs = (repo: string, id: number, body: string): ReadonlyArray<string> => [
-	"api",
-	"-X",
-	"PATCH",
-	`repos/${repo}/issues/comments/${id}`,
-	"-f",
-	`body=${body}`,
-	"--jq",
-	".id",
-];
-
-// The read-back GET for the post self-verify (#3019): fetch the single comment we just upserted and
-// return its LANDED body, so `emissionDefect` re-checks the marker/leak-clean shape as it actually
-// landed — the same issues/comments/<id> endpoint PATCH targets.
-const getCommentArgs = (repo: string, id: number): ReadonlyArray<string> => [
-	"api",
-	`repos/${repo}/issues/comments/${id}`,
-	"--jq",
-	".body",
-];
-
-/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
-const RawComment = Schema.Struct({
-	id: Schema.Number,
-	created_at: Schema.String,
-	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
-	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
-});
-const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
 
 const toVerdictComment = (raw: (typeof RawComment)["Type"]): VerdictComment => ({
 	id: raw.id,
@@ -263,9 +125,9 @@ const verifyLanded = Effect.fn("Github.verifyLanded")(function* (
 	id: number,
 	gate: VerdictGate,
 ) {
-	const landed = yield* runGh(getCommentArgs(repo, id)).pipe(
+	const landed = yield* runGh(getCommentBodyArgs(repo, id)).pipe(
 		Effect.catchTag(
-			"@kampus/verdict/GhCommandError",
+			"@kampus/gh-io/GhCommandError",
 			(cause) =>
 				new VerdictVerifyError({
 					message: `could not re-fetch the just-posted verdict comment #${id} to self-verify it (${cause.stderr.trim() || `exit ${cause.exitCode}`}) — refusing to report success on an unverifiable post (#3019)`,
@@ -284,34 +146,6 @@ const listComments = Effect.fn("Github.listComments")(function* (repo: string, p
 	const args = listCommentsArgs(repo, pr);
 	const raw = yield* decodeComments(yield* json(args));
 	return raw.map(toVerdictComment);
-});
-
-/**
- * The write+ collaborator subset of `logins` — the ADR 0055 trust root. Each login is probed
- * with `collaborators/<login>/permission`; a non-`admin|maintain|write` permission, or any `gh`
- * fault on the probe (a non-collaborator commonly 404s), drops the login. A forged marker from a
- * non-collaborator therefore never enters the authorized set the core resolves over.
- */
-const authorizedAuthors = Effect.fn("Github.authorizedAuthors")(function* (
-	repo: string,
-	logins: ReadonlyArray<string>,
-) {
-	const results = yield* Effect.forEach(
-		logins,
-		(login) =>
-			runGh(permissionArgs(repo, login)).pipe(
-				Effect.map((out) => ({login, permission: out.trim()})),
-				Effect.catchTag("@kampus/verdict/GhCommandError", () =>
-					Effect.succeed({login, permission: "none"}),
-				),
-			),
-		{concurrency: "unbounded"},
-	);
-	return results
-		.filter(
-			(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
-		)
-		.map((r) => r.login);
 });
 
 /**


### PR DESCRIPTION
Fixes #3572

## What & why

Single-sources the `runGh` / `resolveRepo` / `authorizedAuthors` / `RawComment` idiom that the `Tracker` service, `epic-lock`, and `verdict` each re-copied, per #3262 AC 5 (the same-commit-adoption follow-up, ADR 0190). The three consumers now share **one** IO seam instead of drifting private copies. **No observable behavior change** — a pure refactor; all existing tests pass unchanged.

## Approach

New shared seam `packages/pipeline-cli/src/tools/tracker/gh-io.ts` (the tracker is the owning "one shared service" the issue names). It carries the gh-over-REST plumbing only — spawn, JSON parse, ADR 0062 repo resolution, the ADR 0055 write+ ACL gate (`authorizedAuthors`), the `RawComment` boundary shape, and the generic comment arg builders (list/post/patch/delete/get-body + whoami). It is deliberately **domain-free**: each consumer keeps its own domain core (`claim-resolution.ts`, `verdict-match.ts`) and maps the `RawComment` boundary into its own domain comment.

The three typed failures (`GhCommandError` / `GhParseError` / `RepoResolutionError`) collapse from three per-module namespaces into one `@kampus/gh-io/*` namespace, **re-exported** from each consumer module so every caller and test keeps importing them from the same place unchanged.

Commit 1 extracts the seam and migrates `tracker.ts` + `verdict/github.ts`. Commit 2 migrates the gate-critical §CP `epic-lock/github.ts` as its **own** reviewed change (per the issue's sequencing guidance) — only the ADR-0059 `status:planning` label envelope stays local (unique to the lock); the two-layer label+claim `acquire`/`release` semantics are preserved exactly.

## Acceptance criteria

- [x] `verdict/github.ts` consumes the shared seam; its inline `runGh`/`resolveRepo`/`authorizedAuthors`/`RawComment` copy is deleted.
- [x] `epic-lock/github.ts` migrated in its **own** commit (gate-critical §CP path); planning-lock + claim `acquire` semantics preserved exactly.
- [x] No observable behavior change — existing unit/behavior tests still pass (147 in the touched dirs; 1530 across the package).
- [x] Adoption lint (#3615) stays green — `adoption-lint check` over the full corpus exits 0; no manifest change (this migration retires no grandfathered entry — the two grandfathers are `verdict read`, owned by #3619).
- [ ] **Skills-claim AC — deliberately out of scope, flagged for the reviewer.** There is no inline *claim* re-derivation in skills to migrate here: the claim protocol in `gh-issue-intake-formats.md` §7 is the canonical single-source that `tracker.ts` itself cites (not a re-derivation to eliminate), and the adoption manifest declares **no** `tracker claim` decision — its own note says "the remaining envelope decision (claim) arrives with its sibling child." Wiring a `tracker claim` adoption decision + routing the gate-critical `write-code`/§7 claim prose through the CLI verb is separate, higher-risk skill work that should not ride this code refactor. Left to the human §CP reviewer to confirm.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` (pipeline-cli) — 109 files, 1530 tests pass
- `pnpm biome check` on the touched dirs — clean
- `adoption-lint check` over the corpus — clean (exit 0)

This is §CP (`packages/pipeline-cli/**`) → banks for human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)