### PR TITLE
roadmap: close #28/#33 campaigns (done) + record Flag Retirement campaign (#34)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,11 +34,12 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | Campaign | Milestone | State |
 |----------|-----------|-------|
 | Mentor Audit | #27 | active |
-| Crew-MCP Finish — replace the tmux relay with crew-mcp | #28 | active |
+| Crew-MCP Finish — replace the tmux relay with crew-mcp | #28 | done |
 | Deterministic Crew Mechanics | #29 | active |
 | Diátaxis docs — pipeline-crew & -mcp | #31 | done |
 | pipeline-cli @effect/platform migration | #32 | active |
-| Agentic design-system coverage | #33 | active |
+| Agentic design-system coverage | #33 | done |
+| Flag Retirement (ADR 0136) | #34 | active |
 | Writing-Craft Import | #30 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:


### PR DESCRIPTION
Three ROADMAP `## Campaigns` changes, all milestone-synced:

- **Crew-MCP Finish #28 → done** — milestone already closed (0 open / 50 closed); row was stale-active (#3632).
- **Agentic design-system coverage #33 → done** — fully drained (0 open); milestone closed in this change-set. Last children #3150/#3158 closed earlier 2026-07-19.
- **+ Flag Retirement (ADR 0136) #34 → active** — NEW campaign. The founder-confirmed 17-flag serves:on retirement set (#3544 Gate 1 cleared 2026-07-19), decomposed by plan-epic into #3658–#3674, now milestone-backed. Founder-approval trace verified (`campaign verify-trace flag-retirement` PASS). ⚠ #3674 (phoenix-bildirim) gated on #3641 (live-hazard aggregation).

Keeps roadmap-guard in sync (done rows over closed milestones #28/#33; active row over open milestone #34).