### PR TITLE
feat(pipeline-cli): reap gone-dir worktrees in worktree-sweep (#3654)

### DIFF
--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.hook.test.ts
@@ -148,4 +148,55 @@ describe("worktree-sweep --execute — SessionStart cadence against a REAL git r
 		assert.strictEqual(code, 0);
 		assert.isTrue(existsSync(keepWt), "dry-run must never remove a worktree");
 	}, 30_000);
+
+	// #3654: a tree whose working dir was cleaned out from under it (a dead session's temp root)
+	// leaves stale `.git/worktrees/<id>` metadata that `git worktree list` keeps surfacing. The
+	// sweep must prune it via `git worktree prune` (no `git worktree remove` — the path is gone),
+	// and leave a genuinely-present unmerged tree untouched.
+	// Match on the repo-relative tail: macOS git reports the realpath (`/private/var/…`) while
+	// `mainRepo` is the `/var/…` symlink alias, so only an endsWith on the sub-path is stable.
+	const listsPath = (p: string): boolean => {
+		const tail = p.slice(mainRepo.length);
+		return git(mainRepo, "worktree", "list", "--porcelain")
+			.split("\n")
+			.some((l) => l.startsWith("worktree ") && l.slice("worktree ".length).endsWith(tail));
+	};
+
+	it("prunes a gone-dir tree's stale metadata on --execute, but keeps a present unmerged tree", async () => {
+		const goneWt = join(mainRepo, ".claude", "worktrees", "wf_gone");
+		git(mainRepo, "worktree", "add", "-q", "--detach", goneWt, "HEAD");
+		// Remove the working dir out from under git — now only the admin metadata lingers (prunable).
+		rmSync(goneWt, {recursive: true, force: true});
+		assert.isTrue(
+			listsPath(goneWt),
+			"precondition: git still lists the gone tree's stale metadata",
+		);
+
+		// A present, clean, but genuinely UNMERGED tree — a commit past origin/main so its tip is
+		// neither ancestor-reachable nor content-equivalent — must survive (never reaped).
+		const liveWt = join(mainRepo, ".claude", "worktrees", "wf_gone_live");
+		git(mainRepo, "worktree", "add", "-q", "-b", "umut/unmerged-3654", liveWt, "HEAD");
+		writeFileSync(join(liveWt, "feature.txt"), "unmerged feature work");
+		git(liveWt, "add", ".");
+		git(liveWt, "commit", "-q", "-m", "unmerged feature");
+		backdate(liveWt);
+
+		const {stdout, code} = await runSweep(mainRepo, ["--execute"]);
+		assert.strictEqual(code, 0, stdout);
+		assert.isFalse(listsPath(goneWt), "gone-dir metadata must be pruned from git's worktree list");
+		assert.isTrue(existsSync(liveWt), "a present unmerged tree must be kept");
+		assert.isTrue(listsPath(liveWt), "the present unmerged tree stays registered");
+
+		git(mainRepo, "worktree", "remove", "--force", liveWt);
+	}, 30_000);
+
+	it("dry-run leaves gone-dir metadata in place (nothing pruned without --execute)", async () => {
+		const goneWt = join(mainRepo, ".claude", "worktrees", "wf_gone_dry");
+		git(mainRepo, "worktree", "add", "-q", "--detach", goneWt, "HEAD");
+		rmSync(goneWt, {recursive: true, force: true});
+		const {code} = await runSweep(mainRepo, []);
+		assert.strictEqual(code, 0);
+		assert.isTrue(listsPath(goneWt), "dry-run must not prune gone-dir metadata");
+		git(mainRepo, "worktree", "prune"); // clean up the fixture's stale metadata
+	}, 30_000);
 });

--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -2,13 +2,16 @@
  * The `worktree-sweep` tool — `pipeline-cli worktree-sweep [--execute]`.
  *
  * The sanctioned, safe-by-default bulk drain for accumulated agent worktrees (issue
- * #1243). It sweeps two leaked classes (#2785): the harness-provisioned build trees under
- * `.claude/worktrees/`, and the `$TMPDIR`-rooted `review-head-*` detached checkouts the
- * review gates materialize. The harness does not auto-remove a build tree that made commits,
- * and nothing at all reclaims a review-head tree, so both pile up without bound and slow every
- * git op. This command enumerates them, classifies each via the pure core (`worktree-sweep.ts`),
- * prints the plan, and — ONLY with `--execute` — runs `git worktree remove` (NEVER `--force`)
- * on the removable set.
+ * #1243). It sweeps three leaked classes (#2785, #3654): the harness-provisioned build trees
+ * under `.claude/worktrees/`, the `$TMPDIR`-rooted `review-head-*` detached checkouts the
+ * review gates materialize, and gone-dir trees — ANY tree whose working directory is already
+ * missing, leaving only stale `.git/worktrees/<id>` metadata (the cross-session pile). The
+ * harness does not auto-remove a build tree that made commits, nothing reclaims a review-head
+ * tree, and nothing prunes a tree whose session temp-root was cleaned out from under it, so all
+ * three pile up without bound and slow every git op. This command enumerates them, classifies
+ * each via the pure core (`worktree-sweep.ts`), prints the plan, and — ONLY with `--execute` —
+ * runs `git worktree remove` (NEVER `--force`) on the removable set and `git worktree prune`
+ * for the gone-dir metadata.
  *
  * Safe by construction (enforcement lines):
  *   1. The pure classifier only marks a worktree removable when it is CLEAN, reachable
@@ -205,6 +208,23 @@ const worktreeSweep = Command.make(
 		const records: ReadonlyArray<WorktreeRecord> = parsed
 			.filter((p) => !p.bare)
 			.map((p) => {
+				// A gone-dir tree's working directory is missing, so every probe below is either
+				// meaningless or actively errors (`git -C <gone> status` fails → fail-safe dirty,
+				// which would mis-KEEP it). Short-circuit to the safe-to-prune record: the classifier
+				// checks `prunable` first, so the other facts are never consulted for it (#3654).
+				if (p.prunable) {
+					return {
+						path: p.path,
+						branch: p.branch,
+						prunable: true,
+						isDirty: false,
+						reachableFromOriginMain: false,
+						squashMergedToOriginMain: false,
+						locked: p.locked,
+						recentlyActive: false,
+						hasOpenPr: false,
+					};
+				}
 				const managed = isManagedWorktree(p.path);
 				// A review-head tree is a swept candidate too (#2785), so its liveness (idle mtime)
 				// must be probed. Its detached HEAD carries no branch, so the open-PR probe below
@@ -225,6 +245,7 @@ const worktreeSweep = Command.make(
 				return {
 					path: p.path,
 					branch: p.branch,
+					prunable: false,
 					isDirty,
 					reachableFromOriginMain: reachable,
 					squashMergedToOriginMain: squashMerged,
@@ -254,9 +275,27 @@ const worktreeSweep = Command.make(
 			return;
 		}
 
+		// A gone-dir tree has no path to `git worktree remove`; a single `git worktree prune` reaps
+		// ALL prunable admin metadata at once, and every gone-dir record maps to exactly what prune
+		// clears (both keyed on the same `prunable` fact), so the plan and the prune stay consistent.
+		const goneDir = plan.toRemove.filter((r) => r.reason === "gone-dir");
+		const toRemovePaths = plan.toRemove.filter((r) => r.reason !== "gone-dir");
+
+		let pruned = 0;
+		if (goneDir.length > 0) {
+			const res = runGit(["worktree", "prune", "--verbose"]);
+			if (res.ok) {
+				pruned = goneDir.length;
+				for (const r of goneDir)
+					yield* Console.log(`  pruned (gone-dir metadata) ${r.worktree.path}`);
+			} else {
+				yield* Console.error(`  gone-dir prune failed — ${res.stderr.trim()}`);
+			}
+		}
+
 		let removed = 0;
 		let refused = 0;
-		for (const r of plan.toRemove) {
+		for (const r of toRemovePaths) {
 			// NEVER --force: git refuses a tree it judges unsafe, and we KEEP it (report, don't escalate).
 			const res = runGit(["worktree", "remove", r.worktree.path]);
 			if (res.ok) {
@@ -270,13 +309,13 @@ const worktreeSweep = Command.make(
 			}
 		}
 		yield* Console.log(
-			`worktree-sweep: removed ${removed}, kept ${plan.kept.length + refused}` +
+			`worktree-sweep: removed ${removed}, pruned ${pruned}, kept ${plan.kept.length + refused}` +
 				(refused > 0 ? ` (${refused} removable but refused by git → kept)` : ""),
 		);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Safe bulk drain of accumulated agent build worktrees + leaked review-head checkouts — clean+idle only, never --force (#1243/#2785)",
+		"Safe bulk drain of accumulated agent build worktrees + leaked review-head checkouts + gone-dir metadata — clean+idle only, never --force (#1243/#2785/#3654)",
 	),
 );
 

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
@@ -5,7 +5,7 @@
  * boundary (enumerate / status / ancestry / remove) lives in `command.ts`; this module
  * never runs a command and never removes anything.
  *
- * Two swept classes (#2785):
+ * Three swept classes (#2785, #3654):
  *   - **Build worktrees** under `.claude/worktrees/` — a harness-provisioned agent tree
  *     that carries a real branch and may hold unpushed work; removable ONLY when clean AND
  *     its branch's content already landed on `origin/main` (the merge gate below).
@@ -15,6 +15,12 @@
  *     head: they carry NO branch and no unpushed work, so they need no merge gate — a clean,
  *     idle, unlocked one holds nothing recoverable. Without this class they were `not-managed`
  *     and never reaped, so they leaked unbounded (562 accumulated before a manual sweep).
+ *   - **Gone-dir worktrees** (#3654) — ANY tree, managed or foreign, whose working directory
+ *     is already gone (`git worktree list --porcelain` flags it `prunable`). Only the stale
+ *     `.git/worktrees/<id>` admin metadata lingers; there is no on-disk tree to strand and the
+ *     branch ref survives a prune, so it is reaped unconditionally via `git worktree prune`
+ *     (never `git worktree remove`, whose path is missing). This is the bulk of a cross-session
+ *     pile: trees that outlived the sessions whose temp roots were cleaned from under them.
  *
  * The safety property is the whole point (MEMORY "Safe worktree prune", #1243 AC):
  * a worktree is removable ONLY when it is clean AND its branch's content has already
@@ -74,6 +80,15 @@ export const isSweptWorktree = (path: string): boolean =>
 export interface WorktreeRecord {
 	readonly path: string;
 	readonly branch: string | null;
+	/**
+	 * The tree's working directory is already gone — `git worktree list --porcelain`
+	 * flagged it `prunable` (its gitdir points at a non-existent location, #3654). Only
+	 * the stale `.git/worktrees/<id>` admin metadata survives; there is no on-disk working
+	 * tree to hold unpushed work, and the branch ref is untouched by a prune, so any
+	 * committed work stays in the object store. Checked FIRST in `classifyWorktree` —
+	 * before managed-ness or dirtiness — because it is unconditionally safe to reap.
+	 */
+	readonly prunable: boolean;
 	readonly isDirty: boolean;
 	/** HEAD is a commit-ancestor of `origin/main` (non-squash merge, or detached at a merged commit). */
 	readonly reachableFromOriginMain: boolean;
@@ -113,6 +128,14 @@ export type KeepReason =
 
 /** Why a worktree is REMOVABLE — a build tree clean AND on `origin/main`, or an idle review-head tree. */
 export type RemoveReason =
+	/**
+	 * The working directory is already gone — reap the stale `.git/worktrees/<id>` metadata
+	 * via `git worktree prune` (#3654). No `git worktree remove` (the path is missing); the
+	 * prune only clears admin metadata and never touches a branch ref, so nothing recoverable
+	 * is lost. This is the bulk of a cross-session pile: trees whose sessions' temp roots were
+	 * cleaned out from under them.
+	 */
+	| "gone-dir"
 	/** Clean, on a branch whose tip is reachable from `origin/main` (merged). */
 	| "merged-clean"
 	/** Clean, detached at a commit reachable from `origin/main`. */
@@ -151,8 +174,13 @@ export interface WorktreeSweepPlan {
 /**
  * Classify a single worktree. The order of checks IS the safety policy:
  *
+ *   0. Prunable (working dir already gone) → REMOVE (`gone-dir`), regardless of managed-ness
+ *      (#3654). Wins over everything, INCLUDING `not-managed`: a gone-dir tree — a foreign
+ *      `scratchpad/wt-*` from a dead session as much as a managed one — has no working tree to
+ *      strand and its branch ref survives the prune, so clearing the stale metadata is
+ *      unconditionally safe. This is what reaps the cross-session pile of orphaned trees.
  *   1. Neither swept class → KEEP (`not-managed`). The primary checkout and any foreign
- *      tree are never candidates, regardless of their other facts.
+ *      tree with a LIVE directory are never candidates, regardless of their other facts.
  *   2. Dirty → KEEP (`dirty`). Wins over every other signal for BOTH classes: a worktree
  *      with working-tree changes is never removed, even when its branch has merged.
  *   3. Liveness gates (#2240) — locked / recently-active → KEEP, for BOTH classes. A clean
@@ -173,6 +201,9 @@ export interface WorktreeSweepPlan {
  *   8. Otherwise → KEEP (`unmerged`). Genuinely unmerged work.
  */
 export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
+	if (wt.prunable) {
+		return {kind: "remove", reason: "gone-dir"};
+	}
 	const reviewHead = isReviewHeadWorktree(wt.path);
 	if (!isManagedWorktree(wt.path) && !reviewHead) {
 		return {kind: "keep", reason: "not-managed"};
@@ -228,6 +259,8 @@ export interface ParsedWorktree {
 	readonly branch: string | null;
 	readonly bare: boolean;
 	readonly locked: boolean;
+	/** `git worktree list --porcelain` flagged the tree `prunable` — its working dir is gone (#3654). */
+	readonly prunable: boolean;
 }
 
 /**
@@ -243,16 +276,18 @@ export const parseWorktreeList = (porcelain: string): ReadonlyArray<ParsedWorktr
 	let branch: string | null = null;
 	let bare = false;
 	let locked = false;
+	let prunable = false;
 
 	const flush = () => {
 		if (path !== null) {
-			out.push({path, head, branch, bare, locked});
+			out.push({path, head, branch, bare, locked, prunable});
 		}
 		path = null;
 		head = null;
 		branch = null;
 		bare = false;
 		locked = false;
+		prunable = false;
 	};
 
 	for (const raw of porcelain.split("\n")) {
@@ -275,6 +310,8 @@ export const parseWorktreeList = (porcelain: string): ReadonlyArray<ParsedWorktr
 			bare = true;
 		} else if (line.startsWith("locked")) {
 			locked = true;
+		} else if (line.startsWith("prunable")) {
+			prunable = true;
 		}
 	}
 	flush();

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
@@ -17,6 +17,7 @@ const reviewHeadPath = (leaf: string) => `/var/folders/8f/tmp.aBcD1234/${leaf}`;
 const reviewRecord = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	path: reviewHeadPath("review-head-2815"),
 	branch: null,
+	prunable: false,
 	isDirty: false,
 	// A detached review head is often NOT reachable/merged (an open PR's head, pre-squash) — the
 	// leaked class the merge gate can't reclaim. These fields are moot for review-head classification.
@@ -31,6 +32,7 @@ const reviewRecord = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 const record = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	path: wtPath("agent-clean"),
 	branch: "umut/1234-thing",
+	prunable: false,
 	isDirty: false,
 	reachableFromOriginMain: true,
 	squashMergedToOriginMain: false,
@@ -222,6 +224,36 @@ describe("classifyWorktree — REMOVE branches (clean AND reachable)", () => {
 	});
 });
 
+describe("classifyWorktree — gone-dir prune (#3654)", () => {
+	it("prunes a gone-dir MANAGED tree (working dir missing → reap the stale metadata)", () => {
+		const d = classifyWorktree(record({prunable: true}));
+		assert.deepStrictEqual(d, {kind: "remove", reason: "gone-dir"});
+	});
+
+	it("prunes a gone-dir FOREIGN tree too — prunable wins over not-managed (the cross-session pile)", () => {
+		const d = classifyWorktree(record({path: "/Users/dev/scratchpad/wt-3030", prunable: true}));
+		assert.deepStrictEqual(d, {kind: "remove", reason: "gone-dir"});
+	});
+
+	it("prunable wins over a fail-safe dirty flag (the working dir is gone — nothing on disk to strand)", () => {
+		// A gone-dir tree can't be `git status`ed, so the impure shell reads dirty=true fail-safe;
+		// prunable is checked FIRST so the metadata is still reaped (the branch ref survives a prune).
+		const d = classifyWorktree(record({prunable: true, isDirty: true}));
+		assert.deepStrictEqual(d, {kind: "remove", reason: "gone-dir"});
+	});
+
+	it("keeps a still-present (not-prunable) foreign tree — a live human worktree is never reaped", () => {
+		const d = classifyWorktree(
+			record({
+				path: "/Users/dev/scratchpad/wt-live",
+				prunable: false,
+				reachableFromOriginMain: true,
+			}),
+		);
+		assert.deepStrictEqual(d, {kind: "keep", reason: "not-managed"});
+	});
+});
+
 describe("computeWorktreeSweepPlan — partition", () => {
 	it("partitions a mixed pile into removable + kept-with-reason", () => {
 		const records: ReadonlyArray<WorktreeRecord> = [
@@ -272,6 +304,23 @@ describe("computeWorktreeSweepPlan — partition", () => {
 		assert.strictEqual(keepReason(reviewHeadPath("review-head-13")), "locked");
 	});
 
+	it("partitions gone-dir trees (managed + foreign) into removable alongside a merged build tree", () => {
+		const records: ReadonlyArray<WorktreeRecord> = [
+			record({path: wtPath("a"), branch: "umut/1-done"}), // merged-clean → remove
+			record({path: wtPath("gone-managed"), prunable: true}), // gone-dir → remove
+			record({path: "/Users/dev/scratchpad/wt-3030", prunable: true}), // gone-dir foreign → remove
+			record({path: wtPath("live"), reachableFromOriginMain: false}), // unmerged → keep
+		];
+		const plan = computeWorktreeSweepPlan(records);
+		const removeReason = (path: string) =>
+			plan.toRemove.find((r) => r.worktree.path === path)?.reason;
+		assert.strictEqual(removeReason(wtPath("gone-managed")), "gone-dir");
+		assert.strictEqual(removeReason("/Users/dev/scratchpad/wt-3030"), "gone-dir");
+		assert.strictEqual(removeReason(wtPath("a")), "merged-clean");
+		assert.strictEqual(plan.kept.length, 1);
+		assert.strictEqual(plan.kept[0]?.reason, "unmerged");
+	});
+
 	it("an empty list yields an empty plan", () => {
 		assert.deepStrictEqual(computeWorktreeSweepPlan([]), {toRemove: [], kept: []});
 	});
@@ -314,6 +363,7 @@ describe("parseWorktreeList", () => {
 			branch: "main",
 			bare: false,
 			locked: false,
+			prunable: false,
 		});
 		assert.strictEqual(parsed[1]?.branch, "umut/1234-thing");
 		assert.strictEqual(parsed[2]?.branch, null);
@@ -332,6 +382,27 @@ describe("parseWorktreeList", () => {
 		const parsed = parseWorktreeList(porcelain);
 		assert.strictEqual(parsed.length, 1);
 		assert.isTrue(parsed[0]?.locked);
+	});
+
+	it("captures a prunable (gone-dir) worktree — #3654", () => {
+		const porcelain = [
+			`worktree ${wtPath("gone")}`,
+			"HEAD eeee5555",
+			"detached",
+			"prunable gitdir file points to non-existent location",
+			"",
+		].join("\n");
+		const parsed = parseWorktreeList(porcelain);
+		assert.strictEqual(parsed.length, 1);
+		assert.isTrue(parsed[0]?.prunable);
+		assert.isFalse(parsed[0]?.locked);
+	});
+
+	it("a non-prunable block reads prunable=false", () => {
+		const parsed = parseWorktreeList(
+			[`worktree ${wtPath("live")}`, "HEAD ffff6666", "branch refs/heads/umut/9-x", ""].join("\n"),
+		);
+		assert.isFalse(parsed[0]?.prunable);
 	});
 
 	it("tolerates a trailing block with no terminating blank line", () => {


### PR DESCRIPTION
## What

Adds a third swept class to `worktree-sweep`: **gone-dir trees** — any worktree (managed or foreign) whose working directory is already gone, leaving only stale `.git/worktrees/<id>` metadata. This is the bulk of the cross-session pile #3654 describes: trees that outlived the sessions whose temp roots were cleaned out from under them.

## How

`git worktree list --porcelain` already flags such a tree `prunable`, so the change stays in the existing pure-core seam:

- `parseWorktreeList` captures the `prunable` line; `WorktreeRecord` gains a `prunable` fact.
- `classifyWorktree` gains a `gone-dir` `RemoveReason`, checked **FIRST** — before managed-ness or dirtiness. Reaping a gone-dir tree is unconditionally safe: there is no on-disk working tree to strand, and `git worktree prune` never touches a branch ref, so any committed work survives in the object store.
- The command runs a single `git worktree prune` for the gone-dir set (no `git worktree remove` — the path is missing) and keeps the existing no-`--force` removal for present clean+merged+idle trees.

## Acceptance criteria

- [x] A merged/closed + clean tree is removable non-force — existing `worktree-sweep` behavior (managed build trees), unchanged.
- [x] A dirty/uncommitted tree is never removed — existing guard, and gone-dir short-circuits before probing (fail-safe unaffected).
- [x] Trees whose directory is already gone are pruned via `git worktree prune`, clearing stale `.git/worktrees/` metadata — **new**.
- [x] Running the reaper leaves only genuinely-active / dirty / unmerged trees behind. A present *foreign* tree (a human's manual worktree) is deliberately KEPT — the conservative reading of the safety discipline; only gone-dir metadata is reaped unconditionally regardless of ownership.

## Safety

Never `git worktree remove --force`. Gone-dir trees are pruned (metadata-only; branch refs and committed objects survive); present trees still go through the no-`--force` remove that git itself refuses on dirty/locked/current, reported as KEPT.

## Tests

- Unit (pure core): gone-dir managed → prune, gone-dir foreign → prune, prunable-wins-over-dirty, present-foreign → keep; plus a `prunable` porcelain-parse case.
- Real-git hook test: gone-dir metadata pruned on `--execute`, a present unmerged tree kept + still registered, dry-run prunes nothing.

Fixes #3654

🤖 Generated with [Claude Code](https://claude.com/claude-code)