### PR TITLE
§CP: shared ADR-0164 guard-content probe verb — review gate + driver + ship-it (Fixes #3645)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -591,6 +591,20 @@ fi
 CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
 # non-empty → control-plane: emit the advisory line in the verdict (Step 4a) per ADR 0053/0065/0073
+# §CP by CONTENT (ADR 0164): a touched .decisions/** ADR is not path-§CP, but a guard-RELAXING one is
+# control-plane by nature. Probe each ADR's content at head with the SHARED `guard-content-probe` verb
+# — the SAME probe ship-it Step 0, review-doc, and the driver (via trivial-diff) call, so a guard-touching
+# ADR reads §CP consistently everywhere (issue #3645, founder ruling #3416). A mixed code+guard-ADR PR
+# fans BOTH gates; either flagging the ADR carries the §CP merge-authority hold. Fail-closed inside the verb.
+HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+GUARD_TOUCHING=""
+while IFS= read -r adr; do
+  [ -z "$adr" ] && continue
+  gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
+    | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null \
+    && GUARD_TOUCHING="$GUARD_TOUCHING $adr"
+done < <(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' | grep -E '^\.decisions/.*\.md$' || true)
+# non-empty $GUARD_TOUCHING → §CP-advisory, same as CONTROL_PLANE_TOUCHED above (Step 4a; ADR 0164/0135)
 ```
 
 ---
@@ -1265,8 +1279,10 @@ re-gates.
 ## Step 4a — Pass path: signal merge-ready (do NOT merge)
 
 Every criterion passed. **Branch on the control-plane class first** (the `CONTROL_PLANE_TOUCHED`
-flag from Step 2): a **blocking-set** PR (it touches `.claude/**`, `.github/**`, or a
-gate-critical skill — §CP) does **not** get a binding `PASS @ <sha> — merge-ready` marker. It
+flag from Step 2 — **or** a non-empty `GUARD_TOUCHING`, a guard-touching `.decisions/**` ADR that is
+§CP by content, ADR 0164 / #3645): a **blocking-set** PR (it touches `.claude/**`, `.github/**`, a
+gate-critical skill, or a guard-touching ADR — §CP) does **not** get a binding `PASS @ <sha> —
+merge-ready` marker. It
 gets the **canonical advisory line** instead — `review-code: advisory — blocking-set PR (manual
 merge)`, no `@ <sha>` — the one advisory shape all three gates converge on (ADR
 [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md) §5;
@@ -1455,8 +1471,10 @@ same forbidden forms — differing only in polarity (`FAIL @ <sha> — not merge
 
 ### Pass path — blocking-set PR (advisory only, the canonical advisory form)
 
-Every criterion passed but `CONTROL_PLANE_TOUCHED` (Step 2) is non-empty — the PR touches the
-control plane (§CP). Post the **same evidence**, but the first line is the **canonical advisory
+Every criterion passed but `CONTROL_PLANE_TOUCHED` **or** `GUARD_TOUCHING` (Step 2) is non-empty —
+the PR touches the control plane, or a guard-touching `.decisions/**` ADR that is §CP by content (ADR
+0164 / #3645; the shared `guard-content-probe` verb returned `guard-touching`). Post the **same
+evidence**, but the first line is the **canonical advisory
 line** (§6.6), **not** a binding merge-ready marker. Its **first line** carries **no `@ <sha>`** by
 design (it authorizes nothing on its first line, so it never enters `ship-it`'s auto-merge PASS
 namespace — ADR 0111); under ADR 0135's approve-then-enqueue a `@kamp-us/control-plane` member
@@ -1482,11 +1500,12 @@ code review namespace via its `commit_id`, defeating the advisory's purpose).
 ```markdown
 review-code: advisory — blocking-set PR (manual merge)
 
-PR #<PR> touches the control plane (`.claude/**`, `.github/**`, or a gate-critical skill — §CP):
-the agent control plane / pipeline gates (ADR 0053/0065). My verdict is **advisory only**: it
-does **not** authorize a merge. Under the §CP hard gate (ADR 0135), a `@kamp-us/control-plane`
-member approves this at its current head and `ship-it` then enqueues it (ADR 0048 single merge
-authority) — there is no human hand-merge in the §CP path.
+PR #<PR> is §CP — it touches the control plane (`.claude/**`, `.github/**`, or a gate-critical
+skill — ADR 0053/0065), OR a guard-touching `.decisions/**` ADR (§CP by content, ADR 0164 — the
+shared `guard-content-probe` verb flagged: `<the .decisions/** path(s)>`). My verdict is **advisory
+only**: it does **not** authorize a merge. Under the §CP hard gate (ADR 0135), a
+`@kamp-us/control-plane` member approves this at its current head and `ship-it` then enqueues it (ADR
+0048 single merge authority) — there is no human hand-merge in the §CP path.
 
 Reviewed-head: @ <HEAD_SHA>
 

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -193,6 +193,32 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
     --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
   # non-empty → blocking: advisory only; a control-plane approval @head → ship-it enqueues (ADR 0135; §CP set 0053/0065/0073)
   ```
+- **Any guard-touching `.decisions/**` ADR (§CP by CONTENT, ADR 0164)** — a `.decisions/**` ADR is
+  not path-§CP, but one that **relaxes, amends, or widens an exemption on a documented guard** is
+  control-plane by *nature* and its path can't tell it from an ordinary ADR (ADR
+  [0164](https://github.com/kamp-us/phoenix/blob/main/.decisions/0164-guard-relaxing-adr-cp-gate.md),
+  #2191). Classify it by CONTENT with the **shared `pipeline-cli guard-content-probe` verb** — the
+  SAME probe `ship-it` Step 0 and the driver (via `trivial-diff`) call, so a guard-touching ADR reads
+  §CP consistently at every stage, not only at `ship-it` (issue #3645, founder ruling #3416). Before
+  #3645 this gate classified §CP by path alone, so a guard-relaxing ADR (live: PR #3415 / ADR 0194)
+  read NON-§CP here and got a bindable PASS — the latent §CP-routing hole this closes. A guard-touching
+  ADR puts the PR in the **blocking set** exactly like a path-§CP file: you review it and post
+  findings, but **advisory only** (Step 5's blocking-set path). Fail-closed: an unreadable ADR body ⇒
+  §CP (the verb resolves this).
+
+  ```bash
+  # Probe each touched .decisions/** ADR's CONTENT at head with the shared verb (single source of the
+  # ADR-0164 guard vocabulary; #3645). Exit 0 ⇒ guard-touching ⇒ §CP-advisory. Fail-closed inside the verb.
+  HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+  GUARD_TOUCHING=""
+  while IFS= read -r adr; do
+    [ -z "$adr" ] && continue
+    gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
+      | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null \
+      && GUARD_TOUCHING="$GUARD_TOUCHING $adr"
+  done < <(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' | grep -E '^\.decisions/.*\.md$' || true)
+  # non-empty $GUARD_TOUCHING → blocking: §CP-advisory, same as a control-plane path above (ADR 0164/0135)
+  ```
 - **Otherwise** → **non-blocking**, and the doc class — *which* `*.md`/knowledge files are
   yours — is the **canonical §DOC definition** in
   [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md): cite it, don't re-derive
@@ -716,10 +742,15 @@ false-fails the unconditional `verdict_post_verify … || exit 1`.
 
 ### Pass path — blocking-set PR (advisory only)
 
-Every check passed but Step 0 classified the PR **blocking** (it touches `.claude/**`,
-`.github/**`, or a gate-critical skill). Post the **same evidence**, but the first line is
-**not** a merge-ready go-ahead — it is advice. `ship-it` does not auto-merge this PR on machine
-gates alone — it enqueues only once a `@kamp-us/control-plane` approval is present at head (ADR 0135).
+Every check passed but Step 0 classified the PR **blocking** — it touches `.claude/**`,
+`.github/**`, or a gate-critical skill, **OR** it touches a **guard-touching `.decisions/**` ADR**
+(§CP by content, ADR 0164 — the shared `guard-content-probe` verb returned `guard-touching`). Post
+the **same evidence**, but the first line is **not** a merge-ready go-ahead — it is advice. `ship-it`
+does not auto-merge this PR on machine gates alone — it enqueues only once a `@kamp-us/control-plane`
+approval is present at head (ADR 0135). A guard-touching ADR routes here — a **§CP-advisory** verdict,
+non-bindable, head recorded only in the body's `Reviewed-head:` line — instead of the bindable
+`review-doc: PASS @ <sha> — merge-ready` a non-guard ADR earns; its `review-doc` verdict routing is
+unchanged (it is still doc-class), only the merge-authority moves (ADR 0164 / #3645).
 
 > **The first-line `@ <sha>` is SHA-less by design; the SHA lives in the body; a delegated merge
 > actor confirms from the body, not the first-line marker (ADR
@@ -747,11 +778,12 @@ gates alone — it enqueues only once a `@kamp-us/control-plane` approval is pre
 ```markdown
 review-doc: advisory — blocking-set PR (manual merge)
 
-PR #<PR> touches the control plane (`.claude/`/`.github/` or a gate-critical skill) — the agent
-control plane / pipeline gates (ADR 0053/0065). My verdict is **advisory only**: it does **not**
-authorize a merge. Under the §CP hard gate (ADR 0135), a `@kamp-us/control-plane` member approves
-this at its current head and `ship-it` then enqueues it (ADR 0048 single merge authority) — there
-is no human hand-merge in the §CP path.
+PR #<PR> is §CP — it touches the control plane (`.claude/`/`.github/` or a gate-critical skill), OR
+it touches a **guard-touching `.decisions/**` ADR** (§CP by content, ADR 0164 — the shared
+`guard-content-probe` verb flagged it: `<the .decisions/** path(s)>`). My verdict is **advisory
+only**: it does **not** authorize a merge. Under the §CP hard gate (ADR 0135), a
+`@kamp-us/control-plane` member approves this at its current head and `ship-it` then enqueues it (ADR
+0048 single merge authority) — there is no human hand-merge in the §CP path.
 
 Reviewed-head: @ <HEAD_SHA>
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -276,20 +276,19 @@ echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plan
 # §CP CONTENT clause (ADR 0164/#2191): a .decisions/** ADR is §CP by PATH only if it also matches
 # CONTROL_PLANE_RE (it doesn't) — but a guard-RELAXING ADR is control-plane by NATURE and path can't
 # tell it from an ordinary one. So classify a touched .decisions/** ADR §CP when its CONTENT cites or
-# amends a documented guard. GUARD_ADR_RE is single-sourced in gh-issue-intake-formats.md §CP — the
-# literal below is the fail-closed reference + validate-gate-path-drift lockstep target, NOT the live
-# decision source: re-resolve it from origin/main (like CONTROL_PLANE_RE, #981), and read each ADR's
-# body at the PR head. FAIL CLOSED throughout: unreadable boundary ⇒ match-everything; unreadable ADR
-# (delete/404) ⇒ §CP — never auto-ship an ADR that couldn't be read and proven guard-free.
-GUARD_ADR_RE='guard|invariant|fail-closed|fail-open|fail closed|fail open|containment|control-plane|control plane|§cp|self-weakening|blocking set|adversarial review|must never|hard-gate|hard gate|enforcement|\bgat(e|es|ing|ed)\b|relax|loosen|weaken|soften|widen|broaden|waive|bypass|exempt|carve[ -]?out|opt[ -]?out'   # §CP canonical (ADR 0164) — drift-locked to gh-issue-intake-formats.md
-GA_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^GUARD_ADR_RE=' | head -n1 || true)"
-if [ -n "$GA_LIVE" ]; then GUARD_ADR_RE="$(printf '%s' "$GA_LIVE" | sed "s/^GUARD_ADR_RE='//; s/'$//")"; else GUARD_ADR_RE='.'; fi   # FAIL CLOSED: '.' ⇒ every ADR word matches ⇒ every touched .decisions/** file is §CP
+# amends a documented guard. This probe is the SHARED verb `pipeline-cli guard-content-probe` (issue
+# #3645, founder ruling #3416) — the ONE content probe the review gate and the driver (via
+# trivial-diff) ALSO call, so a guard-touching ADR classifies §CP consistently at every stage, not
+# only here. The GUARD_ADR_RE vocabulary stays single-sourced in gh-issue-intake-formats.md §CP; the
+# verb reads it from the local checkout (immune to the #981 injected-snapshot staleness — it reads
+# disk, not this skill's prompt copy). FAIL CLOSED: an unreadable ADR body (delete/404) ⇒ §CP —
+# never auto-ship an ADR that couldn't be read and proven guard-free (the verb resolves this itself).
 HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
 echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
   [ -z "$adr" ] && continue
-  body="$(gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null || true)"
-  if [ -z "$body" ]; then echo "BLOCKING ($adr — unreadable at head ⇒ §CP, fail-closed)"
-  elif printf '%s' "$body" | grep -Eiq "$GUARD_ADR_RE"; then echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"; fi
+  gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
+    | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" >/dev/null \
+    && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
 done
 # The has-code/has-docs/has-skills probes are single-sourced as canonical HAS_*_RE= lines in
 # gh-issue-intake-formats.md §CLASS and re-resolved from origin/main here (like CONTROL_PLANE_RE/

--- a/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
@@ -73,37 +73,20 @@ else
   formats: $FORMATS_RE"
 fi
 
-# Invariant 1b: GUARD_ADR_RE copy matches §CP (ADR 0164).
+# Invariant 1b: the §CP canonical GUARD_ADR_RE is present (ADR 0164, #3645).
 #
-# The guard-touching-ADR content predicate (ADR 0164, #2191) is single-sourced in §CP the
-# same way CONTROL_PLANE_RE is: one canonical GUARD_ADR_RE= line in gh-issue-intake-formats.md,
-# with ONE consumer copy in ship-it (its fail-closed reference literal). Lock the copy
-# byte-identical to §CP so the vocabulary can't drift between the source and ship-it.
+# The guard-touching-ADR content predicate (ADR 0164, #2191) is single-sourced in §CP as one
+# canonical GUARD_ADR_RE= line in gh-issue-intake-formats.md. Since #3645 there is NO
+# hand-copied consumer literal to drift-lock: ship-it Step 0, the review gate, and the driver
+# (via trivial-diff) all run the SHARED `pipeline-cli guard-content-probe` verb, whose core
+# parses this canonical line directly (like class-probe parses HAS_*_RE) — so the byte-compare
+# of a consumer copy is obsolete. This invariant now only asserts the canonical still EXISTS
+# (the single source the verb reads); a drift would be a same-file edit, not a copy skew.
 GA_CANONICAL=$(grep "^GUARD_ADR_RE=" "$FORMATS_MD" | head -n1 | sed 's/^GUARD_ADR_RE=//' || true)
 if [ -z "$GA_CANONICAL" ]; then
-	fail "§CP canonical GUARD_ADR_RE= not found in $FORMATS_MD — line must start with GUARD_ADR_RE= (ADR 0164)"
+	fail "§CP canonical GUARD_ADR_RE= not found in $FORMATS_MD — line must start with GUARD_ADR_RE= (ADR 0164; the guard-content-probe verb reads this single source)"
 else
-	ok "§CP canonical GUARD_ADR_RE extracted from gh-issue-intake-formats.md"
-	GA_MD="$skills_dir/ship-it/SKILL.md"
-	if [ ! -f "$GA_MD" ]; then
-		fail "ship-it/SKILL.md not found — cannot verify GUARD_ADR_RE copy"
-	else
-		GA_LINE=$(grep "GUARD_ADR_RE=" "$GA_MD" | head -n1 || true)
-		if [ -z "$GA_LINE" ]; then
-			fail "ship-it/SKILL.md: no GUARD_ADR_RE= line found — consumer must carry a copy matching §CP (ADR 0164)"
-		else
-			GA_STRIPPED="${GA_LINE#"${GA_LINE%%[![:space:]]*}"}"
-			GA_VAL="${GA_STRIPPED#GUARD_ADR_RE=}"
-			GA_VAL_CLEAN=$(printf '%s\n' "$GA_VAL" | sed "s/'[[:space:]]*#.*$/'/")
-			if [ "$GA_VAL_CLEAN" = "$GA_CANONICAL" ]; then
-				ok "ship-it/SKILL.md GUARD_ADR_RE matches §CP canonical"
-			else
-				fail "ship-it/SKILL.md GUARD_ADR_RE has drifted from §CP canonical
-  §CP:  $GA_CANONICAL
-  copy: $GA_VAL_CLEAN"
-			fi
-		fi
-	fi
+	ok "§CP canonical GUARD_ADR_RE present in gh-issue-intake-formats.md (read by pipeline-cli guard-content-probe)"
 fi
 
 # Invariant 1c: HAS_*_RE class-fan copies match §CP (issue #2488).

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -35,6 +35,7 @@ import {failureClassifierCommand} from "./tools/failure-classifier/command.ts";
 import {fanoutGuardCommand} from "./tools/fanout-guard/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
+import {guardContentProbeCommand} from "./tools/guard-content-probe/command.ts";
 import {intakeDedupCommand} from "./tools/intake-dedup/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {mainSyncCommand} from "./tools/main-sync/command.ts";
@@ -129,6 +130,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	wayfinderMapCommand,
 	shipDigestCommand,
 	glossaryDriftCommand,
+	guardContentProbeCommand,
 	failureClassifierCommand,
 	fanoutGuardCommand,
 	reachabilityGuardCommand,

--- a/packages/pipeline-cli/src/tools/guard-content-probe/README.md
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/README.md
@@ -1,0 +1,70 @@
+# guard-content-probe
+
+`pipeline-cli guard-content-probe classify` — the **shared ADR-0164 guard-touching-ADR
+content probe**. Classifies one `.decisions/**` ADR body as `guard-touching` (§CP by
+content) or `not-guard-touching`, so the **review gate**, the **driver**, and **ship-it
+Step 0** all reach the same §CP verdict for the same diff through one verb (issue
+[#3645](https://github.com/kamp-us/phoenix/issues/3645), founder ruling
+[#3416](https://github.com/kamp-us/phoenix/issues/3416)).
+
+## Why it exists
+
+`.decisions/**` is otherwise non-blocking — it auto-merges on a `review-doc` PASS. But an
+ADR that **relaxes, amends, or widens an exemption on a documented guard** is control-plane
+by *nature* (it weakens the pipeline's own guardrails), and its **path** is
+indistinguishable from an ordinary ADR's (ADR
+[0164](https://github.com/kamp-us/phoenix/blob/main/.decisions/0164-guard-relaxing-adr-cp-gate.md),
+[#2191](https://github.com/kamp-us/phoenix/issues/2191)).
+
+Before #3645, only **ship-it Step 0** re-classified such an ADR by content — the review gate
+and the driver classified §CP by **path regex alone**. A guard-relaxing ADR (live: PR
+[#3415](https://github.com/kamp-us/phoenix/pull/3415) / ADR 0194) therefore read NON-§CP at
+review and driver and was caught only at ship-it: a latent §CP-routing hole if ship-it is
+ever bypassed. This verb is the single content probe every stage now calls, so the
+classification is consistent.
+
+## Generic content-shape, never a named list
+
+The probe matches over **guard/fail-closed/enforcement vocabulary**, never a hardcoded
+ADR/name list — an author-declared tag is self-defeating (the agent that lacks the
+discipline to hold the guard also won't tag it; ADR 0164 MECHANISM), and a named deny-list
+is the [#2393](https://github.com/kamp-us/phoenix/issues/2393) prohibition. "You cannot
+relax a guard without naming it," so a probe over the guard vocabulary catches the class an
+author tag would let slip.
+
+## Single source
+
+The canonical `GUARD_ADR_RE` vocabulary is **not** re-declared here — it is parsed from
+`gh-issue-intake-formats.md` §CP, the one definition ship-it Step 0 and the reviewer fan
+re-resolve (exactly as `class-probe` parses `HAS_*_RE`). There is no second copy to drift.
+
+## Split of concerns
+
+IO in the thin bin (`command.ts`) — reading the ADR body from stdin and `GUARD_ADR_RE` from
+the local §CP; the whole predicate in the pure core (`guard-content-probe.ts`). The **caller**
+owns the `gh api` REST resolution of each `.decisions/**` file's body at the PR head.
+
+## Fail-closed (ADR 0164 / ADR 0092)
+
+Every ambiguity resolves to `guard-touching` (§CP): an unreadable §CP boundary defaults to
+`.` (match-everything), an uncompilable regex matches everything, and a null/empty ADR body
+(a delete/404/unreadable head) classifies guard-touching. The probe over-routes a
+merely-guard-*citing* ADR to a cheap human approval rather than risk missing a
+guard-*relaxer* that would auto-ship a weakened gate.
+
+## Usage
+
+```bash
+# ship-it Step 0 / review gate: read each touched .decisions/** ADR's body at head, probe it.
+HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+echo "$FILES" | grep -E '^\.decisions/.*\.md$' | while IFS= read -r adr; do
+  [ -z "$adr" ] && continue
+  gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' 2>/dev/null \
+    | node packages/pipeline-cli/src/bin.ts guard-content-probe classify --path "$adr" \
+    && echo "BLOCKING ($adr — guard-touching ADR ⇒ §CP, ADR 0164)"
+done
+```
+
+The decision word (`guard-touching` | `not-guard-touching`) goes to **stdout**; a human
+reason goes to **stderr**. Exit is **0 on `guard-touching`, 1 on `not-guard-touching`**, so
+the gate bash fails closed with `… && echo BLOCKING`.

--- a/packages/pipeline-cli/src/tools/guard-content-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/command.ts
@@ -1,0 +1,129 @@
+/**
+ * The `guard-content-probe` tool — `pipeline-cli guard-content-probe classify [flags]`
+ * (issue #3645, founder ruling #3416).
+ *
+ *   gh api "repos/$REPO/contents/$adr?ref=$HEAD_SHA" -H 'Accept: application/vnd.github.raw' \
+ *     | pipeline-cli guard-content-probe classify --path "$adr"
+ *   pipeline-cli guard-content-probe classify --body-file adr.md --path .decisions/0194-x.md
+ *
+ * The ADR-0164 guard-touching-ADR content probe, shared so the review gate (review-doc /
+ * review-code), the driver (via trivial-diff), and ship-it Step 0 classify a guard-touching
+ * `.decisions/**` change through ONE verb — not three copies of the grep. Reads ONE ADR's body
+ * from stdin (or `--body-file`), reads the canonical `GUARD_ADR_RE` from the local
+ * `gh-issue-intake-formats.md` §CP (the single source — never a second inline copy), and prints
+ * `guard-touching` / `not-guard-touching` to **stdout** — the word the caller branches on. A
+ * human reason goes to **stderr**. Exit code mirrors the decision: **0 on `guard-touching`, 1 on
+ * `not-guard-touching`**, so the gate bash can `… guard-content-probe classify && echo BLOCKING`
+ * and fail closed.
+ *
+ * IO here (the thin bin); the whole ADR-0164 predicate lives in `guard-content-probe.ts` (the
+ * pure, unit-tested core), the same split `class-probe` / `cp-cardinality` use. The caller owns
+ * the `gh api` REST resolution of each `.decisions/**` file's body at the PR head — the
+ * integration half this tool never touches. Fail-closed: an unreadable §CP boundary or an
+ * unreadable ADR body both classify `guard-touching` (over-route to a cheap human approval,
+ * never auto-ship an unproven guard-relaxer).
+ */
+import {existsSync, readFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../../find-root-dir.ts";
+import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
+import {
+	FAILCLOSED_GUARD_ADR_RE,
+	parseGuardAdrRe,
+	probeGuardContent,
+} from "./guard-content-probe.ts";
+
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const bodyFileFlag = Flag.string("body-file").pipe(
+	Flag.optional,
+	Flag.withDescription("read the ADR body from this file (default: stdin)"),
+);
+
+const pathFlag = Flag.string("path").pipe(
+	Flag.optional,
+	Flag.withDescription("the .decisions/** path being classified (labels the human reason only)"),
+);
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("repo root to read gh-issue-intake-formats.md §CP from (default: walk up)"),
+);
+
+/**
+ * Read the ADR body from `--body-file` or stdin. A failed read returns null, which the core
+ * classifies guard-touching (fail-closed) — the same posture as an unreadable ADR at head.
+ */
+const readBody = (bodyFile: Option.Option<string>): string | null => {
+	// biome-ignore lint/plugin: best-effort read — a failed read is absorbed into null (⇒ guard-touching, fail-closed), never the E channel; a total helper, not Effect-cosplay.
+	try {
+		return Option.match(bodyFile, {
+			onSome: (path) => readFileSync(path, "utf8"),
+			onNone: () => readFileSync(0, "utf8"),
+		});
+	} catch {
+		return null;
+	}
+};
+
+/** Read local §CP text; null (⇒ fail-closed `GUARD_ADR_RE`) if the file is unreadable. */
+const readFormats = (root: string): string | null => {
+	// biome-ignore lint/plugin: best-effort read — an unreadable file is absorbed into null (⇒ fail-closed GUARD_ADR_RE), never the E channel; a total helper, not Effect-cosplay.
+	try {
+		return readFileSync(join(root, FORMATS_PATH), "utf8");
+	} catch {
+		return null;
+	}
+};
+
+const classifyCmd = Command.make(
+	"classify",
+	{bodyFile: bodyFileFlag, path: pathFlag, root: rootFlag},
+	Effect.fn(function* ({bodyFile, path, root}) {
+		const rootDir = Option.getOrElse(root, () => defaultRoot());
+		const formats = readFormats(rootDir);
+		const guardRe = formats === null ? FAILCLOSED_GUARD_ADR_RE : parseGuardAdrRe(formats);
+		const body = readBody(bodyFile);
+		const result = probeGuardContent(body, guardRe);
+		const label = Option.getOrElse(path, () => "(stdin ADR)");
+
+		if (formats === null) {
+			yield* Effect.sync(() =>
+				process.stderr.write(
+					`guard-content-probe: could not read ${FORMATS_PATH} under ${rootDir} — using fail-closed GUARD_ADR_RE ('.', match-everything ⇒ §CP).\n`,
+				),
+			);
+		}
+		yield* Effect.sync(() =>
+			process.stderr.write(
+				`guard-content-probe: ${label} → ${result.guardTouching ? "guard-touching (§CP, ADR 0164)" : "not-guard-touching"} [${result.reason}]\n`,
+			),
+		);
+		yield* Console.log(result.guardTouching ? "guard-touching" : "not-guard-touching");
+		// Exit code mirrors the decision so the gate bash fails closed: 0 ⇒ §CP, 1 ⇒ ordinary.
+		if (!result.guardTouching) return yield* Effect.sync(() => process.exit(1));
+	}),
+).pipe(
+	Command.withDescription(
+		"Classify one .decisions/** ADR body as guard-touching (§CP) or not by content (ADR 0164, #3645)",
+	),
+);
+
+export const guardContentProbeCommand = Command.make("guard-content-probe").pipe(
+	Command.withSubcommands([classifyCmd]),
+	Command.withDescription(
+		"Shared ADR-0164 guard-touching-ADR content probe (review gate + driver + ship-it Step 0; #3645)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.ts
@@ -1,0 +1,87 @@
+/**
+ * `guard-content-probe` pure core — the ADR-0164 guard-touching-ADR content predicate,
+ * extracted so the review gate, the driver (via trivial-diff), and ship-it Step 0 all
+ * classify a guard-touching `.decisions/**` change through ONE shared function rather than
+ * three independently-eyeballed copies of the grep (issue #3645, founder ruling #3416).
+ *
+ * The classification RESULT was already correct at ship-it Step 0, yet the review gate and
+ * the driver classified §CP by PATH alone — so a guard-relaxing ADR (live: PR #3415 / ADR
+ * 0194) read NON-§CP at review + driver and was caught only at ship-it. If ship-it is ever
+ * bypassed, that guard-touching change routes as ordinary work — the latent §CP-routing hole
+ * this core closes by being the single content probe every stage calls.
+ *
+ * This is a GENERIC content-shape check over guard/fail-closed/enforcement vocabulary, NEVER
+ * a hardcoded ADR/name list — an author-declared tag is self-defeating (the agent that lacks
+ * the discipline to hold the guard also won't tag it; ADR 0164 MECHANISM), and a named
+ * deny-list is the #2393 prohibition. "You cannot relax a guard without naming it," so a
+ * probe over the guard vocabulary catches the class an author tag would let slip.
+ *
+ * Single source: the canonical `GUARD_ADR_RE` vocabulary is NOT re-declared here — it is
+ * parsed from `gh-issue-intake-formats.md` §CP, the one definition ship-it Step 0 and the
+ * reviewer fan re-resolve, exactly as `class-probe` parses `HAS_*_RE`. There is no second
+ * copy to drift.
+ *
+ * Fail-closed by construction (ADR 0164 / ADR 0092): an unreadable §CP boundary defaults to
+ * match-everything, an uncompilable regex matches everything, and a null/empty ADR body
+ * (a delete/404/unreadable head) classifies guard-touching — the probe over-matches a
+ * merely-guard-*citing* ADR to a cheap human approval rather than risk missing a
+ * guard-*relaxer* that would auto-ship a weakened gate.
+ */
+
+/**
+ * Fail-closed default: `.` matches every ADR word ⇒ every touched `.decisions/**` file is
+ * guard-touching ⇒ §CP. Byte-identical intent to ship-it Step 0's `GUARD_ADR_RE='.'` fallback:
+ * an unreadable/incomplete §CP over-classifies to §CP, never silently exempts.
+ */
+export const FAILCLOSED_GUARD_ADR_RE = ".";
+
+/**
+ * Parse the canonical `GUARD_ADR_RE='…'` line out of `gh-issue-intake-formats.md` §CP.
+ * Matches only the single-quoted canonical assignment (`GUARD_ADR_RE='…'`), never a
+ * double-quoted re-assignment. A missing line falls back to the fail-closed default — the
+ * source is single, so this only bites on a truncated read.
+ */
+export const parseGuardAdrRe = (formatsText: string): string =>
+	formatsText.match(/^GUARD_ADR_RE='([^']*)'/m)?.[1] ?? FAILCLOSED_GUARD_ADR_RE;
+
+/** Why the probe decided as it did — surfaced for the human reason line. */
+export type GuardProbeReason =
+	| "unreadable-body"
+	| "guard-vocabulary-match"
+	| "uncompilable-regex"
+	| "no-match";
+
+export interface GuardProbeResult {
+	/** True ⇒ the ADR content is guard-touching ⇒ §CP (merge-authority hold, ADR 0164). */
+	readonly guardTouching: boolean;
+	readonly reason: GuardProbeReason;
+}
+
+/**
+ * Is an ADR's content guard-touching (§CP by content, ADR 0164)? Pure and total.
+ *
+ * Fail-closed order, transcribing ship-it Step 0 exactly:
+ *   1. body null/empty ⇒ guard-touching (an ADR that couldn't be read at head is never
+ *      proven guard-free — the `[ -z "$body" ] → BLOCKING` clause).
+ *   2. `guardRe` won't compile ⇒ guard-touching (a broken boundary must never silently
+ *      match nothing).
+ *   3. body matches `guardRe` (case-insensitive, like `grep -Ei`) ⇒ guard-touching.
+ *   4. otherwise ⇒ not guard-touching.
+ */
+export const probeGuardContent = (
+	body: string | null | undefined,
+	guardRe: string,
+): GuardProbeResult => {
+	if (body === null || body === undefined || body.trim() === "") {
+		return {guardTouching: true, reason: "unreadable-body"};
+	}
+	let re: RegExp;
+	try {
+		re = new RegExp(guardRe, "i");
+	} catch {
+		return {guardTouching: true, reason: "uncompilable-regex"};
+	}
+	return re.test(body)
+		? {guardTouching: true, reason: "guard-vocabulary-match"}
+		: {guardTouching: false, reason: "no-match"};
+};

--- a/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.unit.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from "vitest";
+import {
+	FAILCLOSED_GUARD_ADR_RE,
+	parseGuardAdrRe,
+	probeGuardContent,
+} from "./guard-content-probe.ts";
+
+// A faithful slice of the canonical §CP source: the single-quoted GUARD_ADR_RE= line the
+// verb parses, plus the double-quoted re-assignment it must NOT capture (mirrors the real
+// gh-issue-intake-formats.md §CP block, ADR 0164).
+const FORMATS_SLICE = [
+	"Some prose about the guard-touching ADR predicate.",
+	"GUARD_ADR_RE='guard|invariant|fail-closed|enforcement|relax|loosen|weaken|widen|waive|bypass|exempt'",
+	'GUARD_ADR_RE="$(printf \'%s\' "$GA_LIVE" | sed ...)"',
+].join("\n");
+
+describe("parseGuardAdrRe — single-source the §CP vocabulary (ADR 0164)", () => {
+	it("parses the canonical single-quoted GUARD_ADR_RE= assignment", () => {
+		expect(parseGuardAdrRe(FORMATS_SLICE)).toBe(
+			"guard|invariant|fail-closed|enforcement|relax|loosen|weaken|widen|waive|bypass|exempt",
+		);
+	});
+
+	it("ignores the double-quoted re-assignment line (never cross-captures)", () => {
+		// The `^GUARD_ADR_RE='` anchor + `[^']*` value excludes the `GUARD_ADR_RE="$(...)"` line.
+		expect(parseGuardAdrRe(FORMATS_SLICE)).not.toContain("printf");
+	});
+
+	it("falls back to the fail-closed match-everything default on a truncated read", () => {
+		expect(parseGuardAdrRe("no assignment here")).toBe(FAILCLOSED_GUARD_ADR_RE);
+		expect(FAILCLOSED_GUARD_ADR_RE).toBe(".");
+	});
+});
+
+const GUARD_RE = parseGuardAdrRe(FORMATS_SLICE);
+
+describe("probeGuardContent — the ADR-0164 content-shape predicate (#3645)", () => {
+	describe("fail-closed: an unreadable ADR body is guard-touching", () => {
+		it("null body ⇒ guard-touching (delete/404/unreadable head)", () => {
+			const r = probeGuardContent(null, GUARD_RE);
+			expect(r.guardTouching).toBe(true);
+			expect(r.reason).toBe("unreadable-body");
+		});
+
+		it("undefined and whitespace-only bodies ⇒ guard-touching", () => {
+			expect(probeGuardContent(undefined, GUARD_RE).guardTouching).toBe(true);
+			expect(probeGuardContent("   \n\t ", GUARD_RE).guardTouching).toBe(true);
+		});
+	});
+
+	describe("fail-closed: an uncompilable boundary matches everything", () => {
+		it("a broken regex ⇒ guard-touching, never silently match nothing", () => {
+			const r = probeGuardContent("# ADR: an ordinary product decision", "(unterminated");
+			expect(r.guardTouching).toBe(true);
+			expect(r.reason).toBe("uncompilable-regex");
+		});
+
+		it("the fail-closed '.' default matches any non-empty body ⇒ guard-touching", () => {
+			expect(probeGuardContent("anything", FAILCLOSED_GUARD_ADR_RE).guardTouching).toBe(true);
+		});
+	});
+
+	describe("guard-vocabulary match (§CP, ADR 0164)", () => {
+		it("a guard-relaxing ADR is guard-touching", () => {
+			const body = "# ADR 0194\n\nThis decision relaxes the fail-closed enforcement guard.";
+			const r = probeGuardContent(body, GUARD_RE);
+			expect(r.guardTouching).toBe(true);
+			expect(r.reason).toBe("guard-vocabulary-match");
+		});
+
+		it("matches case-insensitively (grep -Ei parity)", () => {
+			const r = probeGuardContent("We must WEAKEN the INVARIANT here.", GUARD_RE);
+			expect(r.guardTouching).toBe(true);
+		});
+
+		it("a single vocabulary hit anywhere in the body is enough (conservative over-match)", () => {
+			const r = probeGuardContent("Long prose ... bypass ... more prose.", GUARD_RE);
+			expect(r.guardTouching).toBe(true);
+		});
+	});
+
+	describe("no match — an ordinary ADR is not guard-touching", () => {
+		it("a product decision with no guard vocabulary classifies not-guard-touching", () => {
+			const body = "# ADR 0200\n\nSözlük term pages sort entries by score, newest first.";
+			const r = probeGuardContent(body, GUARD_RE);
+			expect(r.guardTouching).toBe(false);
+			expect(r.reason).toBe("no-match");
+		});
+	});
+});

--- a/packages/pipeline-cli/src/tools/trivial-diff/command.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/command.ts
@@ -33,6 +33,7 @@ import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
 import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
+import {parseGuardAdrRe} from "../guard-content-probe/guard-content-probe.ts";
 import {classify} from "./trivial-diff.ts";
 
 /**
@@ -94,16 +95,17 @@ const resolveRepo = (repo: Option.Option<string>): string | null => {
 };
 
 /**
- * Re-resolve the live `CONTROL_PLANE_RE` from `origin/main` via the REST raw contents
- * endpoint (`?ref=main`), then parse it with the single-sourced `extractControlPlaneRe`.
- * Returns null on any failure (gh missing/unauth, repo unresolved, file absent, no
- * assignment line) — the core then fails closed.
+ * Fetch `gh-issue-intake-formats.md` raw from `origin/main` (`?ref=main`) — the single source
+ * for both the §CP boundary (`CONTROL_PLANE_RE`) and the guard-touching-ADR vocabulary
+ * (`GUARD_ADR_RE`, ADR 0164). Returns null on any failure (gh missing/unauth, repo unresolved,
+ * file absent); both bounds then fail closed. One fetch, both regexes — never a second network
+ * round-trip nor a second copy of the boundary grammar.
  */
-const resolveControlPlaneRe = (repo: string | null): string | null => {
+const fetchFormatsRaw = (repo: string | null): string | null => {
 	if (repo === null) return null;
-	// biome-ignore lint/plugin: best-effort probe — any failure (gh missing/unauth, repo unresolved, file absent) is absorbed into null (the core then fails closed), never the E channel; a total helper, not Effect-cosplay.
+	// biome-ignore lint/plugin: best-effort probe — any failure (gh missing/unauth, repo unresolved, file absent) is absorbed into null (both bounds then fail closed), never the E channel; a total helper, not Effect-cosplay.
 	try {
-		const raw = execFileSync(
+		return execFileSync(
 			"gh",
 			[
 				"api",
@@ -113,7 +115,6 @@ const resolveControlPlaneRe = (repo: string | null): string | null => {
 			],
 			{encoding: "utf8"},
 		);
-		return extractControlPlaneRe(raw);
 	} catch {
 		return null;
 	}
@@ -123,7 +124,9 @@ const classifyCmd = Command.make(
 	"classify",
 	{diffFile: diffFileFlag, maxLines: maxLinesFlag, repo: repoFlag},
 	Effect.fn(function* ({diffFile, maxLines, repo}) {
-		const controlPlaneRe = resolveControlPlaneRe(resolveRepo(repo));
+		const formatsRaw = fetchFormatsRaw(resolveRepo(repo));
+		const controlPlaneRe = formatsRaw === null ? null : extractControlPlaneRe(formatsRaw);
+		const guardAdrRe = formatsRaw === null ? null : parseGuardAdrRe(formatsRaw);
 		const diff = readDiff(diffFile);
 		if (diff === null) {
 			// Unreadable diff is itself fail-closed: classify as non-trivial.
@@ -133,7 +136,7 @@ const classifyCmd = Command.make(
 			yield* Console.log("non-trivial");
 			return;
 		}
-		const result = classify(diff, {controlPlaneRe, lineBudget: maxLines});
+		const result = classify(diff, {controlPlaneRe, lineBudget: maxLines, guardAdrRe});
 		yield* Effect.sync(() => process.stderr.write(`trivial-diff: ${result.reason}\n`));
 		yield* Console.log(result.verdict);
 	}),

--- a/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.ts
@@ -21,7 +21,12 @@
  *      under the line bound `N`.
  *   2. No new surface / code-path change — no dependency/manifest/migration/schema/
  *      config path, and no new module edge (`export` / `import` / `require(`).
- *   3. Not control-plane — no changed path matches the live `CONTROL_PLANE_RE`.
+ *   3. Not control-plane — no changed path matches the live `CONTROL_PLANE_RE`, AND no
+ *      touched `.decisions/**` ADR is guard-touching by content (ADR 0164 / #3645). A
+ *      guard-relaxing ADR is a doc by path — so without this bound it would ride the
+ *      single-doc-file trivial branch onto the lighter gate, exactly the §CP-routing hole
+ *      #3645 closes. The guard-touching content check is the SAME shared verb ship-it Step 0
+ *      and the review gate call — one probe, one classification.
  */
 
 /** One file's slice of a unified diff: its path + line counts + the added-line bodies. */
@@ -35,6 +40,8 @@ export interface ChangedFile {
 	/** The bodies of the added (`+`) content lines, sans the leading `+`. */
 	readonly addedLines: ReadonlyArray<string>;
 }
+
+import {probeGuardContent} from "../guard-content-probe/guard-content-probe.ts";
 
 /** The terminal verdict — two states only, never an "unknown" a caller could read as trivial. */
 export type Verdict = "trivial" | "non-trivial";
@@ -56,6 +63,13 @@ export interface ClassifyOptions {
 	readonly controlPlaneRe: string | null;
 	/** The single-file line bound `N` (added + removed) below which a non-doc file is trivial. */
 	readonly lineBudget: number;
+	/**
+	 * The live `GUARD_ADR_RE` (ADR 0164), re-resolved from `origin/main` by the bin — the SAME
+	 * canonical the shared `guard-content-probe` verb reads. `null` means it could not be read;
+	 * the core then treats every touched `.decisions/**` ADR as guard-touching (fail-closed,
+	 * mirroring the boundary's `CONTROL_PLANE_RE=null` posture).
+	 */
+	readonly guardAdrRe: string | null;
 }
 
 const trivial = (reason: string): Classification => ({verdict: "trivial", reason});
@@ -92,6 +106,9 @@ const isSurfacePath = (path: string): boolean => {
 	if (path.endsWith(".sql")) return true;
 	return /(^|\/)(migrations|drizzle)\//.test(path);
 };
+
+/** True for a `.decisions/**` ADR — the class the guard-touching content bound (ADR 0164) scopes to. */
+const isAdrPath = (path: string): boolean => path.startsWith(".decisions/");
 
 /** True for a doc/comment-only file: a doc extension or a path under a docs dir. */
 const isDocPath = (path: string): boolean => {
@@ -211,6 +228,20 @@ export const classify = (diff: string, opts: ClassifyOptions): Classification =>
 		return nonTrivial(
 			`new module edge added (export/import/require) in ${f.path} — not trivial (ADR 0120 §1.2).`,
 		);
+	}
+
+	// Bound 3 (content) — a guard-touching `.decisions/**` ADR is §CP by nature (ADR 0164) and
+	// must NEVER ride the single-doc-file trivial branch below onto the lighter gate (#3645). Probe
+	// its added content with the SAME shared verb ship-it Step 0 / the review gate call; fail-closed
+	// (null boundary ⇒ match-everything, empty added lines ⇒ guard-touching). Order is deliberate:
+	// this runs BEFORE the isDocPath trivial return, so a guard-relaxing ADR can't be masked as a doc.
+	if (isAdrPath(f.path)) {
+		const probe = probeGuardContent(f.addedLines.join("\n"), opts.guardAdrRe ?? ".");
+		if (probe.guardTouching) {
+			return nonTrivial(
+				`guard-touching .decisions/** ADR (${f.path}: ${probe.reason}) — §CP by content, never trivial (ADR 0164 / #3645).`,
+			);
+		}
 	}
 
 	// Bound 1 — small + single-concern. A doc/comment-only file is trivial at any size;

--- a/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.unit.test.ts
@@ -3,6 +3,7 @@ import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
 import {CONTROL_PLANE_RE} from "../control-plane-paths/control-plane-re.ts";
+import {parseGuardAdrRe} from "../guard-content-probe/guard-content-probe.ts";
 import {type ClassifyOptions, classify, parseUnifiedDiff} from "./trivial-diff.ts";
 
 // The live CONTROL_PLANE_RE, IMPORTED from its single source (#2761) — never re-literaled
@@ -11,9 +12,21 @@ import {type ClassifyOptions, classify, parseUnifiedDiff} from "./trivial-diff.t
 // string input. The lockstep test at the bottom re-checks the const against the formats-doc.
 const LIVE_RE = CONTROL_PLANE_RE;
 
+const FORMATS_ON_DISK = fileURLToPath(
+	new URL(
+		"../../../../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+		import.meta.url,
+	),
+);
+// The live GUARD_ADR_RE (ADR 0164), parsed from the same single source the shared
+// guard-content-probe verb reads — never re-literaled here, so the guard-touching bound cannot
+// drift from §CP. The bin re-resolves it from origin/main; the core takes it as a string.
+const LIVE_GUARD_RE = parseGuardAdrRe(readFileSync(FORMATS_ON_DISK, "utf8"));
+
 const opts = (over: Partial<ClassifyOptions> = {}): ClassifyOptions => ({
 	controlPlaneRe: LIVE_RE,
 	lineBudget: 20,
+	guardAdrRe: LIVE_GUARD_RE,
 	...over,
 });
 
@@ -142,6 +155,41 @@ describe("classify — §CP forces non-trivial (live boundary, checked first)", 
 	});
 });
 
+describe("classify — a guard-touching .decisions/** ADR forces non-trivial (ADR 0164 / #3645)", () => {
+	it("an ADR whose added content relaxes a guard → non-trivial (never the trivial doc branch)", () => {
+		const c = classify(
+			fileDiff(".decisions/0194-x.md", [
+				"This decision relaxes the fail-closed enforcement guard.",
+			]),
+			opts(),
+		);
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/guard-touching/);
+	});
+
+	it("an ordinary product ADR with no guard vocabulary stays trivial", () => {
+		const c = classify(
+			fileDiff(".decisions/0200-sozluk-sort.md", [
+				"Term pages sort entries by score, newest first.",
+			]),
+			opts(),
+		);
+		expect(c.verdict).toBe("trivial");
+	});
+
+	it("null guardAdrRe → fail-closed: any .decisions/** ADR is guard-touching → non-trivial", () => {
+		const c = classify(fileDiff(".decisions/0001-x.md", ["a tweak"]), opts({guardAdrRe: null}));
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/guard-touching/);
+	});
+
+	it("a pure-deletion ADR change (no added lines) → guard-touching (fail-closed)", () => {
+		const del =
+			"diff --git a/.decisions/0001-x.md b/.decisions/0001-x.md\n--- a/.decisions/0001-x.md\n+++ b/.decisions/0001-x.md\n@@ -1 +0,0 @@\n-the guard clause is here\n";
+		expect(classify(del, opts()).verdict).toBe("non-trivial");
+	});
+});
+
 describe("classify — unreadable / unparseable boundary forces non-trivial (fail-closed)", () => {
 	it("null boundary → non-trivial", () => {
 		const c = classify(fileDiff("README.md", ["x"]), opts({controlPlaneRe: null}));
@@ -172,15 +220,8 @@ describe("classify — unparseable / empty diff forces non-trivial (fail-closed)
 // gh-issue-intake-formats.md on disk — the const↔formats-doc drift check, redundant with
 // codeowners-cp + validate-gate-path-drift.sh but cheap belt-and-suspenders (#2761/#2343).
 describe("the §CP const stays in lockstep with the formats doc on disk", () => {
-	const FORMATS_PATH = fileURLToPath(
-		new URL(
-			"../../../../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
-			import.meta.url,
-		),
-	);
-
 	it("equals the canonical CONTROL_PLANE_RE extracted from the formats doc", () => {
-		const canonical = extractControlPlaneRe(readFileSync(FORMATS_PATH, "utf8"));
+		const canonical = extractControlPlaneRe(readFileSync(FORMATS_ON_DISK, "utf8"));
 		expect(canonical).not.toBeNull();
 		expect(LIVE_RE).toBe(canonical);
 	});


### PR DESCRIPTION
Fixes #3645. Implements founder ruling #3416 (2026-07-19).

## Problem
The review gate and the driver classified §CP by **path regex alone**, while only ship-it Step 0 re-classified a guard-touching `.decisions/**` ADR by **content**. A guard-relaxing ADR (live: PR #3415 / ADR 0194) therefore read NON-§CP at the review gate and the driver and was caught only at ship-it — a latent §CP-routing hole if ship-it is ever bypassed.

## Change (single source of truth)
- **New `pipeline-cli guard-content-probe` verb** — pure unit-tested core + thin bin, parity with `cp-cardinality` / `trivial-diff` / `class-probe`. A **generic** guard/fail-closed/enforcement content-shape check (NOT a named ADR list — the #2393 prohibition), single-sourcing the `GUARD_ADR_RE` vocabulary from `gh-issue-intake-formats.md` §CP (parsed like `HAS_*_RE`). Fail-closed: an unreadable ADR body or uncompilable regex ⇒ §CP.
- **Driver (via `trivial-diff`):** folds in the probe so a guard-touching `.decisions/**` change classifies **non-trivial** — the driver then routes it to the full gate + shipper bank instead of the lighter path. It **banks**, does not auto-ship.
- **`review-doc` / `review-code`:** Step 0 calls the verb; a guard-touching ADR emits the **§CP-advisory** verdict form (non-bindable, `Reviewed-head:` bound in the body) instead of a bindable `PASS @ <sha> — merge-ready`.
- **ship-it Step 0:** refactored to call the **same** verb; the inline `GUARD_ADR_RE` literal + its origin/main re-resolve are gone — no second copy of the probe logic remains.
- **`validate-gate-path-drift.sh`:** Invariant 1b drops the now-obsolete ship-it-copy byte-compare (the verb reads the canonical live) and asserts the §CP canonical still exists.

The probe's classification is now consistent across review gate, driver, and ship-it for the same diff, living in exactly one place.

## Acceptance criteria
- [x] New verb implements the ADR-0164 guard-content probe as a generic content-shape check (no hardcoded ADR/name list), pure unit-tested core.
- [x] The review gate (`review-doc` / `review-code`) invokes the verb and emits a §CP-advisory (non-bindable) verdict for a guard-touching `.decisions/**` change.
- [x] The driver banks — does not auto-ship — a guard-touching ADR (via `trivial-diff` → non-trivial → full gate + shipper bank).
- [x] ship-it Step 0 refactored to call the same shared verb; no second copy of the probe logic remains.
- [x] Classification is consistent across review gate, driver, and ship-it for the same diff.

## Verification
- `pipeline-cli guard-content-probe` + `trivial-diff` unit tests: 42 passed (guard-relaxing → guard-touching/non-trivial; ordinary ADR → not; empty body / null boundary → fail-closed §CP).
- `commands` / `router` / `readme-guard` tests pass (verb registered, carries a README).
- `validate-gate-path-drift.sh`: 17 checks OK.
- `tsc --noEmit` clean; biome clean.

## §CP
Edits `packages/pipeline-cli/**` + gate-critical skills → §CP; banks for control-plane human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)