### PR TITLE
fix(pipeline): worktree lanes fetch fresh origin/main before branching (#3621)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,17 @@
 				]
 			}
 		],
+		"WorktreeCreate": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/create-worktree.sh\"",
+						"timeout": 600
+					}
+				]
+			}
+		],
 		"SessionStart": [
 			{
 				"matcher": "startup|resume",

--- a/.decisions/0178-worktreecreate-hook-provisioning.md
+++ b/.decisions/0178-worktreecreate-hook-provisioning.md
@@ -110,3 +110,34 @@ there is never a dep-less worktree presented as ready. An absent `worktree_path`
 - Sibling context: ADR 0109 (the install this reuses), #2924 (this durable fix), #2923 (the
   acute incident + empirical 13s measurement), #787/#788/#789 (the PATH-strip class defended
   against here).
+
+## Amendment (2026-07-19, #3621) — fetch fresh before branching, and re-register the corrected hook
+
+Two follow-ons close the loop this ADR opened:
+
+1. **Re-registration.** #2925's registration was reverted (#2938) because the handler was built
+   to a wrong inferred payload contract and fail-closed every spawn. #2936 corrected the script
+   against the captured golden payload (`{cwd, name}` → path constructed as
+   `<cwd>/.claude/worktrees/<name>`) and pinned it with `create-worktree.hook.test.ts`, but the
+   registration was never re-added — so the hook sat inert and the harness *default* provisioning
+   ran instead, branching each worktree off the primary checkout's local `main`. #3621 re-adds the
+   `WorktreeCreate` entry (timeout 600) to both `.claude/settings.json` and the plugin's
+   `hooks.json`, now that the golden-fixture gate (#2935/ADR 0180) has proven the corrected handler.
+
+2. **Fetch before branching (the #3621 root cause).** This ADR's original text assumed
+   `origin/main` was a fresh base. It is not: the primary checkout's `origin/main` remote-tracking
+   ref only advances on an explicit `git fetch`, and nothing fetches per-spawn — so a lane spawned
+   right after a sibling lane merged branched off a **stale** tip missing that merge. Two serialized
+   same-file lanes then both went green in isolation and collided only at ship time
+   (`mergeable_state=dirty`, #3620) — or, worse, a clean/green PR silently reverted the sibling's
+   merged work (#3678). The hook now runs `git fetch --quiet origin main` and branches off the
+   just-fetched `FETCH_HEAD` (freshness independent of any remote-tracking refspec), failing **loud**
+   (non-zero → blocks creation → coder fail-closes at its Step-4 preflight) if the fetch fails rather
+   than silently branching from a possibly-stale base.
+
+   **No new corruption surface.** The fetch advances only remote-tracking refs; it **never** moves
+   the primary's local `main` HEAD, so the #2143/#2144 primary-main-corruption class is not
+   reintroduced. A dirty or off-`main` primary is simply irrelevant here — the base is the fetched
+   remote tip, never local `main` — which is why this is preferred over any "sync/fast-forward local
+   main" approach (there is no local ref to clobber). The `--detach` rationale above is unchanged;
+   only the base commit-ish moves from the stale cached ref to the fresh `FETCH_HEAD`.

--- a/claude-plugins/kampus-pipeline/hooks.json
+++ b/claude-plugins/kampus-pipeline/hooks.json
@@ -69,6 +69,17 @@
 					}
 				]
 			}
+		],
+		"WorktreeCreate": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/create-worktree.sh",
+						"timeout": 600
+					}
+				]
+			}
 		]
 	}
 }

--- a/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
+++ b/claude-plugins/kampus-pipeline/hooks/create-worktree.sh
@@ -57,10 +57,6 @@ fi
 
 worktree_path="$cwd/.claude/worktrees/$name"
 
-# The WorktreeCreate payload carries no base ref; every coder re-branches off origin/main in
-# its Step-4 preflight regardless, so origin/main is the base to check out.
-base_ref="origin/main"
-
 # NOW ensure a full PATH for git + the post-checkout `pnpm install` it fires. The hook exec
 # env's PATH handling is UNDOCUMENTED (the sibling harness `git worktree add` strips PATH to
 # /usr/bin — #787/ADR 0109); if that stripping applies here too, `bootstrap-deps` finds no
@@ -76,13 +72,29 @@ if ! cd "$cwd" 2>/dev/null; then
 	exit 1
 fi
 
-# `--detach` deliberately: a linked worktree can't check out a base_ref that is a LOCAL
-# branch already checked out in the primary (`git worktree add <p> main` fatals with
-# 'main is already checked out') — and the coder re-branches off origin/main in its Step-4
-# preflight regardless, so the base HEAD is throwaway. A detached checkout at base_ref's
-# commit sidesteps the collision and still fires post-checkout (ADR 0109 provisioning).
-if ! git worktree add --detach "$worktree_path" "$base_ref" >&2; then
-	echo "create-worktree: git worktree add --detach '$worktree_path' '$base_ref' failed — refusing (fail-closed)." >&2
+# Freshen the remote tip BEFORE branching — the #3621 fix. The primary checkout's `origin/main`
+# remote-tracking ref only advances on an explicit fetch, and nothing fetches per-spawn; so
+# branching off the cached `origin/main` (or the harness default's local `main`) silently bases a
+# lane on a STALE tip, missing a sibling lane's just-merged commit. Two serialized same-file lanes
+# then both go green in isolation and collide only at ship time (mergeable_state=dirty) — or, worse,
+# a clean/green PR silently reverts the sibling's merged work (#3678). The fetch NEVER moves the
+# primary's local `main` HEAD (it advances only remote-tracking refs), so the #2143/#2144
+# primary-main-corruption class is not reintroduced — a dirty or off-`main` primary is irrelevant
+# here because the base is the freshly-fetched remote tip, never local `main`. Fail LOUD if the
+# fetch fails rather than silently branching from a possibly-stale base.
+if ! git fetch --quiet origin main >&2; then
+	echo "create-worktree: git fetch origin main failed — refusing to branch from a possibly-stale base (fail-closed, #3621)." >&2
+	exit 1
+fi
+
+# Branch off the just-fetched tip via FETCH_HEAD — guaranteeing freshness independent of whether a
+# remote-tracking refspec maps `main`→`origin/main` (FETCH_HEAD is exactly what the fetch above
+# just wrote). `--detach` deliberately: a linked worktree can't check out a base that is a LOCAL
+# branch already checked out in the primary (`git worktree add <p> main` fatals with 'main is
+# already checked out'), and the coder re-branches in its Step-4 preflight regardless, so the base
+# HEAD is throwaway. A detached checkout at FETCH_HEAD still fires post-checkout (ADR 0109).
+if ! git worktree add --detach "$worktree_path" FETCH_HEAD >&2; then
+	echo "create-worktree: git worktree add --detach '$worktree_path' FETCH_HEAD failed — refusing (fail-closed)." >&2
 	exit 1
 fi
 

--- a/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/create-worktree.hook.test.ts
@@ -186,9 +186,10 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 		assert.notStrictEqual(code, 0, "a payload with no cwd must be rejected");
 	});
 
-	it("fail-closes (non-zero) when git worktree add fails (unresolvable origin/main)", () => {
-		// A fresh repo with NO origin: the payload carries no base_ref, so the hook defaults to
-		// origin/main, which can't resolve here → `git worktree add` fails → fail-closed.
+	it("fail-closes (non-zero) when the fetch fails (no origin → possibly-stale base) — #3621", () => {
+		// A fresh repo with NO origin: the hook fetches origin/main BEFORE branching (#3621), so
+		// the missing origin makes `git fetch origin main` fail → the hook fail-closes at the fetch
+		// rather than silently branching from a possibly-stale base.
 		const bare = mkdtempSync(join(tmpdir(), "wtc-noorigin-"));
 		git(bare, "init", "-q", "-b", "main");
 		git(bare, "config", "user.email", "t@t.t");
@@ -199,7 +200,67 @@ describe("create-worktree.sh — WorktreeCreate hook against the golden real pay
 		const name = "agent-badbase01";
 		const {code} = run(bare, goldenPayloadFor(bare, name));
 		rmSync(bare, {recursive: true, force: true});
-		assert.notStrictEqual(code, 0, "an unresolvable base must fail-close, blocking creation");
+		assert.notStrictEqual(code, 0, "a failed fetch must fail-close, blocking creation");
+	});
+
+	// THE #3621 regression: reproduce the stale-local-main trap and prove the hook fetches fresh.
+	// A consumer whose cached origin/main AND local main both predate a sibling lane's merge must
+	// still base its new worktree on a tip that INCLUDES that merge — and must do so WITHOUT moving
+	// the primary's local main (the #2143/#2144 primary-main-corruption constraint).
+	it("fetches origin BEFORE branching so the base includes a sibling's just-merged commit, never moving local main (#3621)", () => {
+		const originRepo = mkdtempSync(join(tmpdir(), "wtc-origin-"));
+		git(originRepo, "init", "-q", "-b", "main");
+		git(originRepo, "config", "user.email", "t@t.t");
+		git(originRepo, "config", "user.name", "t");
+		writeFileSync(join(originRepo, "README.md"), "x");
+		git(originRepo, "add", ".");
+		git(originRepo, "commit", "-q", "-m", "init");
+
+		// Consumer tracks origin at the init commit — its origin/main AND local main both point there.
+		const consumer = mkdtempSync(join(tmpdir(), "wtc-consumer-"));
+		git(consumer, "init", "-q", "-b", "main");
+		git(consumer, "config", "user.email", "t@t.t");
+		git(consumer, "config", "user.name", "t");
+		git(consumer, "remote", "add", "origin", originRepo);
+		git(consumer, "fetch", "-q", "origin");
+		git(consumer, "checkout", "-q", "-B", "main", "origin/main");
+		const staleTip = git(consumer, "rev-parse", "main").trim();
+
+		// A sibling lane merges to origin AFTER the consumer last fetched — the exact stale window.
+		writeFileSync(join(originRepo, "sibling.txt"), "merged-by-sibling");
+		git(originRepo, "add", ".");
+		git(originRepo, "commit", "-q", "-m", "sibling merge");
+		const freshTip = git(originRepo, "rev-parse", "HEAD").trim();
+
+		const name = "agent-stale01";
+		const expected = join(consumer, ".claude", "worktrees", name);
+		const {code, stdout} = run(consumer, goldenPayloadFor(consumer, name));
+		assert.strictEqual(code, 0, "the hook must provision, fetching fresh");
+		assert.strictEqual(stdout.trim(), expected);
+
+		const wtHead = git(expected, "rev-parse", "HEAD").trim();
+		assert.strictEqual(
+			wtHead,
+			freshTip,
+			"the worktree base must be the FRESH remote tip (fetched), not the stale local/origin main",
+		);
+		assert.isTrue(
+			existsSync(join(expected, "sibling.txt")),
+			"the sibling's just-merged file must be present in the base",
+		);
+		assert.notStrictEqual(wtHead, staleTip, "the base must NOT be the pre-merge stale tip");
+
+		// The load-bearing no-corruption constraint: the fetch advances only remote-tracking refs,
+		// never the primary's local main HEAD (#2143/#2144).
+		const consumerLocalMain = git(consumer, "rev-parse", "main").trim();
+		assert.strictEqual(
+			consumerLocalMain,
+			staleTip,
+			"the hook must NOT move the primary's local main — only remote-tracking refs (#2143/#2144)",
+		);
+
+		rmSync(consumer, {recursive: true, force: true});
+		rmSync(originRepo, {recursive: true, force: true});
 	});
 
 	// Guard the anti-fabrication invariant directly: the raw fixture bytes fed to the handler


### PR DESCRIPTION
## What

Make the worktree-spawn substrate branch every `isolation:worktree` lane off a **freshly-fetched** remote main, so a lane spawned right after a sibling lane merged is based on a merge-base that **includes** that merge.

## Why (the bug)

The `WorktreeCreate` hook (ADR 0178) branched off the primary checkout's cached `origin/main` — a remote-tracking ref that only advances on an explicit `git fetch`, which nothing runs per-spawn. Worse, its registration had been reverted (#2938, after the #2925 wrong-payload handler; the handler was corrected in #2936 but never re-registered), so the harness *default* provisioning ran instead, branching each worktree off the primary's **local** `main`. Either path bases a lane on a **stale** tip when a sibling just merged:

- **#3620** — two serialized lanes on the same file (`tracker.ts`) both went green in isolation and collided only at ship time (`mergeable_state=dirty`), after a full coder+reviewer round-trip.
- **#3678** — worse: a clean, green, *mergeable* PR whose diff silently **reverted** merged §CP work, because the edit was applied over a stale base. Caught only because the review gate diffs against the correct merge-base.

## The fix (report candidate #1 — the substrate branches off fresh remote main)

- `create-worktree.sh` now runs `git fetch --quiet origin main` **before** branching, and checks out the just-fetched `FETCH_HEAD` (fresh independent of any remote-tracking refspec). It fails **loud** (non-zero → blocks creation → coder fail-closes at its Step-4 preflight) if the fetch fails, rather than silently branching from a possibly-stale base.
- Re-register the corrected `WorktreeCreate` hook (`timeout: 600`) in `.claude/settings.json` and the plugin's `hooks.json`, now that the golden-fixture gate (ADR 0180 / #2935) has proven the handler.

## No new corruption surface

The fetch advances **only** remote-tracking refs — it never moves the primary's local `main` HEAD — so the #2143/#2144 primary-main-corruption class is **not** reintroduced. A dirty or off-`main` primary is simply irrelevant: the base is the fetched remote tip, never local `main`. This is why the fetch-and-branch-off-`FETCH_HEAD` approach is preferred over any "sync/fast-forward local main" path — there is no local ref to clobber.

## Acceptance criteria

- [x] A worktree lane spawned right after a sibling merged to `origin/main` is based on a merge-base that **includes** that merge (fetch fresh; new regression test asserts the base == the sibling's just-merged commit).
- [x] The fix never force-moves / bare-gits the primary checkout's `main` (fetch touches only remote-tracking refs; test asserts local `main` is unmoved).
- [x] When the fresh base cannot be obtained, the sync fails **loud** rather than silently branching from a stale base (fetch failure → non-zero exit → blocked creation).
- [x] Two serialized lanes touching the same file no longer both come up green in isolation and collide at ship time (each lane now branches off the sibling's merged tip).

## Tests / guards

- `create-worktree.hook.test.ts`: adds the #3621 regression (stale-consumer reproduction proving the base includes a sibling's just-merged commit **and** local `main` is unmoved); updates the no-origin case to fail at the fetch. 57/57 worktree-sweep tests pass.
- `pnpm --filter @kampus/pipeline-cli typecheck`, biome, shellcheck, `settings-env-guard`, pre-commit (leak-guard / primary-index-guard / ref-guard) all green.

## Scope

**§CP / control-plane** — touches `.claude/settings.json`, the plugin `hooks.json`, the crew worktree-spawn hook, and `packages/pipeline-cli`. Human-merged (cansirin), not auto-shipped. Amends ADR 0178.

Fixes #3621