### PR TITLE
feat(pipeline-cli): orphan-red-PR detector + heal-item emitter (boundary path, #3532)

### DIFF
--- a/.github/workflows/orphan-heal.yml
+++ b/.github/workflows/orphan-heal.yml
@@ -1,0 +1,74 @@
+name: orphan-heal
+
+# The orphan-red-PR detector + heal-item emitter — the #3532 boundary path, steps 1–2
+# (#3650). It ships BESIDE orphan-sweep.yml, not folded into it: that workflow sweeps orphan
+# Cloudflare stages (a resource leak), a wholly different "orphan" than a laneless red PR, so
+# conflating the two under one job would couple unrelated schedules and permissions.
+#
+# Engines self-drain and heal only lanes they OWN. An orphan red PR — open, non-draft, CI-red,
+# in no engine lane (hand-/conversation-authored, e.g. an ADR/ROADMAP PR that closes no triaged
+# issue) — is never healed, because no engine adopts a PR with no owned lane. Per the #3532
+# founder ruling this must be a BOUNDARY path: this job runs `pipeline-cli orphan-heal scan`,
+# which detects each such orphan and files one triaged, immediately-claimable "heal red CI on
+# PR #N" heal-item — idempotently (exactly one per PR). An engine then pulls the heal-item and
+# adopts the lane (steps 3–5, existing machinery). Engines never free-scan arbitrary red PRs.
+on:
+  schedule:
+    # Every 6 hours at :23 — off the top of the hour (the GitHub scheduler congests on-the-hour
+    # crons), spaced so an actively-worked red PR clears the grace window before it is flagged.
+    - cron: "23 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: "File the heal-items (true) or dry-run / print the plan only (false)"
+        type: boolean
+        default: false
+      grace-hours:
+        description: "Only flag a PR red at least this many hours"
+        type: string
+        default: "6"
+
+concurrency:
+  # Never let two scans race — a concurrent pair could file duplicate heal-items in the window
+  # before either's issue is visible to the other's idempotency read.
+  group: orphan-heal
+  cancel-in-progress: false
+
+permissions:
+  contents: read # checkout
+  pull-requests: read # list open PRs + read each head's checks / linked issues
+  issues: write # file the heal-items
+
+jobs:
+  scan:
+    name: detect orphan red PRs and emit heal-items
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # A scheduled run always --executes: the point is to convert orphans autonomously. A manual
+      # workflow_dispatch defaults to dry-run so a human can eyeball the plan (which PRs would be
+      # filed against) before opting into filing via the `execute` input.
+      - name: Scan for orphan red PRs and emit heal-items
+        env:
+          # The CLI resolves the repo from GITHUB_REPOSITORY (auto-set) and reads/writes via
+          # `gh api`; GH_TOKEN is what gh authenticates with.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          GRACE="${{ inputs.grace-hours || '6' }}"
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.execute }}" = "true" ]; then
+            echo "Running orphan-heal scan with --execute (filing heal-items; grace ${GRACE}h)."
+            node packages/pipeline-cli/src/bin.ts orphan-heal scan --execute --grace-hours "$GRACE"
+          else
+            echo "Running orphan-heal scan in dry-run mode (printing the plan only; grace ${GRACE}h)."
+            node packages/pipeline-cli/src/bin.ts orphan-heal scan --grace-hours "$GRACE"
+          fi

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -40,6 +40,7 @@ import {intakeDedupCommand} from "./tools/intake-dedup/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {mainSyncCommand} from "./tools/main-sync/command.ts";
 import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
+import {orphanHealCommand} from "./tools/orphan-heal/command.ts";
 import {patchGuardCommand} from "./tools/patch-guard/command.ts";
 import {pathFilterGuardCommand} from "./tools/path-filter-guard/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
@@ -164,4 +165,8 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// crew bridge (chief-of-staff/cartographer/intake-desk), closing the future-agent hole ADR
 	// 0196 warns of. Fail-closed on zero scope (ADR 0092); roster-law boundary (ADR 0189/0196).
 	crewFanoutGuardCommand,
+	// #3650 — the orphan-red-PR detector + heal-item emitter (the #3532 boundary path, steps
+	// 1–2): convert an open, CI-red, laneless PR into one idempotent triaged "heal red CI on
+	// PR #N" item so an engine adopts the lane, rather than free-scanning arbitrary red PRs.
+	orphanHealCommand,
 ];

--- a/packages/pipeline-cli/src/tools/orphan-heal/command.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/command.ts
@@ -1,0 +1,114 @@
+/**
+ * The `orphan-heal` tool — `pipeline-cli orphan-heal scan [flags]`.
+ *
+ *   node src/bin.ts orphan-heal scan                 # dry-run: print the plan, file nothing
+ *   node src/bin.ts orphan-heal scan --execute       # file one heal-item per detected orphan
+ *   node src/bin.ts orphan-heal scan --grace-hours 3 # override the red-for grace window
+ *
+ * The #3532 boundary path, steps 1–2 (#3650): the DETECTOR reads the open-PR set + each
+ * head's CI + lane state (all from existing state, REST only) and the EMITTER files one
+ * triaged, immediately-claimable "heal red CI on PR #N" issue per orphan — idempotently
+ * (skip if an open heal-item already targets the PR). It never mutates a PR and never lets an
+ * engine free-scan; an engine adopts the resulting lane downstream (steps 3–5, existing
+ * machinery). Dry-run by default so a human can eyeball the plan; the scheduled workflow
+ * passes `--execute`. `GithubLive` is baked in with `Command.provide(...)` so the registered
+ * command's residual requirement is the Node platform union (the registry seam, epic #994).
+ */
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {Github, GithubLive} from "./github.ts";
+import {healItemBody, healItemTitle, type PrSnapshot, planHealItems} from "./orphan-heal.ts";
+
+/** The source issue this tool implements — cited in each heal-item body for provenance. */
+const SOURCE_ISSUE = 3650;
+/** A heal-item is triaged (a type + priority + the triaged status) and unassigned ⇒ immediately claimable. */
+const HEAL_ITEM_LABELS = ["status:triaged", "type:chore", "p1"] as const;
+const DEFAULT_GRACE_HOURS = 6;
+
+const executeFlag = Flag.boolean("execute").pipe(
+	Flag.withDescription("file the heal-items (default: dry-run — print the plan, file nothing)"),
+);
+
+const graceHoursFlag = Flag.integer("grace-hours").pipe(
+	Flag.withDefault(DEFAULT_GRACE_HOURS),
+	Flag.withDescription(
+		`only flag a PR red at least this many hours (default: ${DEFAULT_GRACE_HOURS})`,
+	),
+);
+
+const scan = Command.make(
+	"scan",
+	{execute: executeFlag, graceHours: graceHoursFlag},
+	Effect.fn(function* ({execute, graceHours}) {
+		const gh = yield* Github;
+		const repo = yield* gh.repoName();
+		const graceMs = graceHours * 60 * 60 * 1000;
+
+		// Read once: the open-PR set + the existing heal-item targets (idempotency source).
+		const [prs, existingHealTargets] = yield* Effect.all(
+			[gh.listOpenPrs(), gh.existingHealTargets()],
+			{concurrency: "unbounded"},
+		);
+
+		// Resolve each PR's head-CI + lane state into a snapshot the pure core decides over.
+		const snapshots = yield* Effect.all(
+			prs.map((pr) =>
+				Effect.gen(function* () {
+					const [ci, laned] = yield* Effect.all([gh.headCi(pr.headSha), gh.inEngineLane(pr.body)], {
+						concurrency: "unbounded",
+					});
+					return {
+						number: pr.number,
+						isDraft: pr.isDraft,
+						ci: ci.conclusion,
+						redSince: ci.redSince,
+						inEngineLane: laned,
+						failingCheck: ci.failingCheck,
+					} satisfies PrSnapshot;
+				}),
+			),
+			{concurrency: 8},
+		);
+
+		const {emit, skip} = planHealItems(snapshots, {
+			graceMs,
+			now: Date.now(),
+			existingHealTargets,
+		});
+
+		process.stderr.write(
+			`orphan-heal: ${prs.length} open PR(s) scanned — ${emit.length} orphan(s) to heal, ${skip.length} skipped (grace ${graceHours}h)\n`,
+		);
+		for (const s of skip) process.stderr.write(`  skip #${s.number}: ${s.reason} — ${s.detail}\n`);
+
+		if (emit.length === 0) {
+			yield* Console.log("no orphan red PRs to heal");
+			return;
+		}
+
+		for (const item of emit) {
+			const title = healItemTitle(item.number);
+			if (!execute) {
+				yield* Console.log(
+					`[dry-run] would file: "${title}" (orphan-heal-target: #${item.number})`,
+				);
+				continue;
+			}
+			const body = healItemBody(item, {repo, sourceIssue: SOURCE_ISSUE});
+			const created = yield* gh.createHealItem({title, body, labels: [...HEAL_ITEM_LABELS]});
+			yield* Console.log(`filed #${created.number} → heals PR #${item.number}: ${created.url}`);
+		}
+	}),
+).pipe(
+	Command.withDescription(
+		"Detect orphan red PRs and emit one idempotent, triaged heal-item each (#3532 boundary path; #3650)",
+	),
+);
+
+export const orphanHealCommand = Command.make("orphan-heal").pipe(
+	Command.withSubcommands([scan]),
+	Command.withDescription(
+		"Orphan-red-PR detector + heal-item emitter — convert a laneless red PR into pullable board work (#3532)",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/orphan-heal/github.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/github.ts
@@ -1,0 +1,320 @@
+/**
+ * The GitHub boundary for `orphan-heal`: the live `Github` capability that reads the open-PR
+ * set, each head's CI conclusion, each PR's linked-issue lane state, and the existing
+ * heal-item set over `gh api` REST, and files a heal-item issue — feeding the IO-free
+ * `orphan-heal.ts` core.
+ *
+ * Same service pattern as the `intake-dedup` / `verdict` children (epic #994): a
+ * `Context.Service` on `ChildProcessSpawner`, REST only (GraphQL is broken on the kamp-us
+ * org), every infra failure a typed error in the `E` channel, untrusted REST JSON
+ * Schema-decoded at the boundary. All reads are from EXISTING state (open PRs, head
+ * check-runs, issue labels, open issues) — the #3650 AC forbids inventing a new lane store.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {type CiConclusion, extractHealTargets, parseClosingRefs} from "./orphan-heal.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/orphan-heal/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/orphan-heal/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/orphan-heal/RepoResolutionError",
+	{message: Schema.String},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/** Resolve the target repo (`owner/name`) per ADR 0062 §1: env override → `GITHUB_REPOSITORY` → `gh repo view`. */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/orphan-heal/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// The failing check-run conclusions that make a head CI-red (GitHub's check-run vocabulary).
+const RED_CONCLUSIONS = new Set([
+	"failure",
+	"timed_out",
+	"cancelled",
+	"action_required",
+	"startup_failure",
+]);
+
+/** An open PR row from the pulls endpoint (draft flag + head sha + body carry the gate inputs). */
+const RawPr = Schema.Struct({
+	number: Schema.Number,
+	draft: Schema.optionalKey(Schema.Boolean),
+	body: Schema.NullOr(Schema.String),
+	head: Schema.Struct({sha: Schema.String}),
+});
+const decodePrs = Schema.decodeUnknownEffect(Schema.Array(RawPr));
+
+/** A single head check-run (name + conclusion + when it completed — the red-since anchor). */
+const CheckRun = Schema.Struct({
+	name: Schema.String,
+	conclusion: Schema.NullOr(Schema.String),
+	completed_at: Schema.NullOr(Schema.String),
+});
+const CheckRuns = Schema.Struct({check_runs: Schema.Array(CheckRun)});
+const decodeCheckRuns = Schema.decodeUnknownEffect(CheckRuns);
+
+/** The legacy combined-status envelope — covers commit statuses that aren't check-runs. */
+const CombinedStatus = Schema.Struct({state: Schema.String});
+const decodeCombinedStatus = Schema.decodeUnknownEffect(CombinedStatus);
+
+const IssueLabels = Schema.Struct({labels: Schema.Array(Schema.Struct({name: Schema.String}))});
+const decodeIssueLabels = Schema.decodeUnknownEffect(IssueLabels);
+
+/** An open issue row (body carries the heal-target marker; a `pull_request` key means it's a PR — dropped). */
+const RawIssue = Schema.Struct({
+	number: Schema.Number,
+	body: Schema.NullOr(Schema.String),
+	pull_request: Schema.optionalKey(Schema.Unknown),
+});
+const decodeIssues = Schema.decodeUnknownEffect(Schema.Array(RawIssue));
+
+const CreatedIssue = Schema.Struct({number: Schema.Number, html_url: Schema.String});
+const decodeCreated = Schema.decodeUnknownEffect(CreatedIssue);
+
+/** A resolved open PR: the raw gate inputs the command turns into a `PrSnapshot`. */
+export interface OpenPr {
+	readonly number: number;
+	readonly isDraft: boolean;
+	readonly headSha: string;
+	readonly body: string;
+}
+
+/** The rolled-up head-CI verdict for one PR. */
+export interface HeadCi {
+	readonly conclusion: CiConclusion;
+	readonly redSince?: string | undefined;
+	readonly failingCheck?: string | undefined;
+}
+
+const listOpenPrs = Effect.fn("Github.listOpenPrs")(function* (repo: string) {
+	const args = ["api", "--paginate", `repos/${repo}/pulls?state=open&per_page=100`];
+	const rows = yield* decodePrs(yield* json(args));
+	return rows.map(
+		(r): OpenPr => ({
+			number: r.number,
+			isDraft: r.draft ?? false,
+			headSha: r.head.sha,
+			body: r.body ?? "",
+		}),
+	);
+});
+
+const headCi = Effect.fn("Github.headCi")(function* (repo: string, sha: string) {
+	const checkArgs = ["api", "--paginate", `repos/${repo}/commits/${sha}/check-runs?per_page=100`];
+	const {check_runs} = yield* decodeCheckRuns(yield* json(checkArgs));
+	const statusArgs = ["api", `repos/${repo}/commits/${sha}/status`];
+	const {state} = yield* decodeCombinedStatus(yield* json(statusArgs));
+
+	const failing = check_runs.filter(
+		(c) => c.conclusion !== null && RED_CONCLUSIONS.has(c.conclusion),
+	);
+	const isRed = failing.length > 0 || state === "failure";
+	if (!isRed) {
+		// pending ⇒ some check still running or the combined status is pending; else green.
+		const anyPending = state === "pending" || check_runs.some((c) => c.conclusion === null);
+		const conclusion: CiConclusion =
+			check_runs.length === 0 && state === "pending" ? "pending" : anyPending ? "pending" : "green";
+		return {conclusion} satisfies HeadCi;
+	}
+
+	// red-since: the LATEST failing completion — conservative, so a just-failed head waits the
+	// full grace window rather than being flagged the instant CI finishes red.
+	const completions = failing
+		.map((c) => c.completed_at)
+		.filter((t): t is string => typeof t === "string");
+	const redSince =
+		completions.length > 0
+			? completions.reduce((a, b) => (Date.parse(a) >= Date.parse(b) ? a : b))
+			: undefined;
+	return {
+		conclusion: "red",
+		redSince,
+		failingCheck: failing[0]?.name,
+	} satisfies HeadCi;
+});
+
+const issueIsTriaged = Effect.fn("Github.issueIsTriaged")(function* (repo: string, n: number) {
+	const args = ["api", `repos/${repo}/issues/${n}`];
+	// A closing ref may point at a nonexistent / other-repo number — treat any failed read (404,
+	// parse, decode) as "not a triaged lane" rather than aborting the whole sweep on one bad ref.
+	const read = Effect.gen(function* () {
+		const {labels} = yield* decodeIssueLabels(yield* json(args));
+		return labels.some((l) => l.name === "status:triaged");
+	});
+	return yield* read.pipe(Effect.orElseSucceed(() => false));
+});
+
+/**
+ * Is the PR in an engine lane? Derived from EXISTING state: it closes at least one
+ * `status:triaged` issue (engine-opened-from-a-triaged-issue). A PR that closes no triaged
+ * issue — a hand-/conversation-authored ADR/ROADMAP PR — is laneless (the orphan shape, #3532).
+ */
+const inEngineLane = Effect.fn("Github.inEngineLane")(function* (repo: string, body: string) {
+	const refs = parseClosingRefs(body);
+	if (refs.length === 0) return false;
+	const triagedFlags = yield* Effect.all(
+		refs.map((n) => issueIsTriaged(repo, n)),
+		{concurrency: "unbounded"},
+	);
+	return triagedFlags.some((t) => t);
+});
+
+const existingHealTargets = Effect.fn("Github.existingHealTargets")(function* (repo: string) {
+	const args = ["api", "--paginate", `repos/${repo}/issues?state=open&per_page=100`];
+	const rows = yield* decodeIssues(yield* json(args));
+	const targets = new Set<number>();
+	for (const r of rows) {
+		if (r.pull_request !== undefined) continue; // the issues endpoint returns PRs too
+		for (const t of extractHealTargets(r.body ?? "")) targets.add(t);
+	}
+	return targets as ReadonlySet<number>;
+});
+
+const createHealItem = Effect.fn("Github.createHealItem")(function* (
+	repo: string,
+	input: {readonly title: string; readonly body: string; readonly labels: ReadonlyArray<string>},
+) {
+	const labelArgs = input.labels.flatMap((l) => ["-f", `labels[]=${l}`]);
+	const args = [
+		"api",
+		"-X",
+		"POST",
+		`repos/${repo}/issues`,
+		"-f",
+		`title=${input.title}`,
+		"-f",
+		`body=${input.body}`,
+		...labelArgs,
+	];
+	const created = yield* decodeCreated(yield* json(args));
+	return {number: created.number, url: created.html_url};
+});
+
+type GhError = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
+
+/**
+ * `Github` — the IO shell over `gh api` REST for the orphan-heal reads + the heal-item write.
+ * Built by `GithubLive`, whose `R` is `ChildProcessSpawner`; repo resolution is cached and
+ * deferred to first use (ADR 0062 §1), so the layer build is side-effect-free.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly repoName: () => Effect.Effect<string, GhError>;
+		readonly listOpenPrs: () => Effect.Effect<ReadonlyArray<OpenPr>, GhError>;
+		readonly headCi: (sha: string) => Effect.Effect<HeadCi, GhError>;
+		readonly inEngineLane: (body: string) => Effect.Effect<boolean, GhError>;
+		readonly existingHealTargets: () => Effect.Effect<ReadonlySet<number>, GhError>;
+		readonly createHealItem: (input: {
+			readonly title: string;
+			readonly body: string;
+			readonly labels: ReadonlyArray<string>;
+		}) => Effect.Effect<{readonly number: number; readonly url: string}, GhError>;
+	}
+>()("@kampus/orphan-heal/Github") {}
+
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				repoName: () => repo,
+				listOpenPrs: () => repo.pipe(Effect.flatMap((r) => withSpawner(listOpenPrs(r)))),
+				headCi: (sha) => repo.pipe(Effect.flatMap((r) => withSpawner(headCi(r, sha)))),
+				inEngineLane: (body) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(inEngineLane(r, body)))),
+				existingHealTargets: () =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(existingHealTargets(r)))),
+				createHealItem: (input) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(createHealItem(r, input)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/orphan-heal/orphan-heal.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/orphan-heal.ts
@@ -1,0 +1,222 @@
+/**
+ * `orphan-heal` core — the pure, IO-free decision that turns a snapshot of open PRs into a
+ * plan of "heal red CI on PR #N" items to file (the #3532 boundary path, steps 1–2).
+ *
+ * Founder ruling on #3532: engines heal only lanes they OWN. An orphan red PR — open,
+ * CI-red, in no engine lane (hand-/conversation-authored, e.g. an ADR/ROADMAP PR that
+ * closes no triaged issue — #3501) — is never healed, because no engine adopts a PR with no
+ * owned lane. The ruling is BOUNDARY, not free-scan-adopt: convert the orphan into pullable
+ * board work first, and an engine adopts the resulting lane second. This core is that
+ * boundary — it decides which PRs are orphans-needing-heal and what heal-item to file; it
+ * never mutates a PR, and it never lets an engine free-scan.
+ *
+ * Default-deny toward NOT-orphan: a PR is flagged ONLY when every gate positively holds
+ * (open + non-draft, CI-red, laneless, red past the grace window, no existing heal-item).
+ * Any missing signal — an unknown CI conclusion, no red-since timestamp to measure grace
+ * against — leaves the PR un-flagged, so a miss can only ever under-file (a human still sees
+ * the red PR), never spuriously file a heal-item for a healthy or actively-worked lane.
+ *
+ * The IO lives in `github.ts` (the `gh api` REST shell that builds these snapshots and files
+ * the emitted issues); `command.ts` is the thin bin. This file holds only the decision over
+ * plain values and the heal-item string builders, so both are unit-tested without a network.
+ */
+
+/** The rolled-up head-CI conclusion. `unknown` is a real state (no checks reported) — default-deny treats it as not-red. */
+export type CiConclusion = "red" | "green" | "pending" | "unknown";
+
+/** A snapshot of one open PR — the gate inputs the plan decides over, all read from existing state. */
+export interface PrSnapshot {
+	readonly number: number;
+	readonly isDraft: boolean;
+	readonly ci: CiConclusion;
+	/** ISO-8601 timestamp the head CI first/last went red — the grace-window anchor. Absent ⇒ grace unmeasurable ⇒ not flagged. */
+	readonly redSince?: string | undefined;
+	/** True iff the PR is in an engine lane: it closes a triaged issue / that issue carries an active claim. */
+	readonly inEngineLane: boolean;
+	/** A failing check name carried into the heal-item for the engine to start from (diagnostic only, never decisive). */
+	readonly failingCheck?: string | undefined;
+}
+
+export interface HealPlanOptions {
+	/** The grace window: a PR must be red at least this long before it is flagged. */
+	readonly graceMs: number;
+	/** "Now" as epoch ms — injected so the decision is a pure function of its inputs (testable). */
+	readonly now: number;
+	/** PR numbers that already have an open heal-item — the idempotency set; a member is skipped, never re-filed. */
+	readonly existingHealTargets: ReadonlySet<number>;
+}
+
+/** Why a PR was passed over — each maps to exactly one failed gate, in evaluation order. */
+export type SkipReason =
+	| "draft"
+	| "ci-not-red"
+	| "in-engine-lane"
+	| "no-red-since"
+	| "within-grace"
+	| "heal-item-exists";
+
+/** A PR the plan will file a heal-item for. */
+export interface EmitItem {
+	readonly number: number;
+	readonly failingCheck?: string | undefined;
+	readonly redForMs: number;
+}
+
+/** A PR the plan passed over, with the deciding gate and a human-readable detail. */
+export interface SkipItem {
+	readonly number: number;
+	readonly reason: SkipReason;
+	readonly detail: string;
+}
+
+export interface HealPlan {
+	readonly emit: ReadonlyArray<EmitItem>;
+	readonly skip: ReadonlyArray<SkipItem>;
+}
+
+/** Render a ms duration as a compact `Nh Mm` / `Mm` string for the skip/emit detail lines. */
+export const formatDuration = (ms: number): string => {
+	const totalMinutes = Math.max(0, Math.floor(ms / 60000));
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	if (hours === 0) return `${minutes}m`;
+	return `${hours}h ${minutes}m`;
+};
+
+/**
+ * Decide, over a snapshot of open PRs, which to file a heal-item for and which to skip.
+ *
+ * The gates are evaluated in a fixed order so each skipped PR names the FIRST gate it failed
+ * — draft → not-red → in-lane → no-red-since → within-grace → already-has-heal-item — and a
+ * PR reaches `emit` only by clearing all of them. Idempotency is enforced here (the
+ * `existingHealTargets` gate), so re-running the detector never files a second heal-item for
+ * a PR that already has an open one (#3650 AC: idempotent emitter).
+ */
+export const planHealItems = (prs: ReadonlyArray<PrSnapshot>, opts: HealPlanOptions): HealPlan => {
+	const emit: Array<EmitItem> = [];
+	const skip: Array<SkipItem> = [];
+
+	for (const pr of prs) {
+		if (pr.isDraft) {
+			skip.push({number: pr.number, reason: "draft", detail: "PR is a draft"});
+			continue;
+		}
+		if (pr.ci !== "red") {
+			skip.push({number: pr.number, reason: "ci-not-red", detail: `head CI is ${pr.ci}, not red`});
+			continue;
+		}
+		if (pr.inEngineLane) {
+			skip.push({
+				number: pr.number,
+				reason: "in-engine-lane",
+				detail:
+					"PR is in an engine lane (closes a triaged issue / active claim) — the engine heals it",
+			});
+			continue;
+		}
+		// Red but with no measurable red-since anchor: cannot prove the grace window elapsed, so
+		// default-deny to not-flagged rather than file on an unbounded/unknown red duration.
+		const redAt = pr.redSince === undefined ? Number.NaN : Date.parse(pr.redSince);
+		if (Number.isNaN(redAt)) {
+			skip.push({
+				number: pr.number,
+				reason: "no-red-since",
+				detail:
+					"red, but no parseable red-since timestamp to measure the grace window (default-deny)",
+			});
+			continue;
+		}
+		const redForMs = opts.now - redAt;
+		if (redForMs < opts.graceMs) {
+			skip.push({
+				number: pr.number,
+				reason: "within-grace",
+				detail: `red for ${formatDuration(redForMs)} < grace ${formatDuration(opts.graceMs)}`,
+			});
+			continue;
+		}
+		if (opts.existingHealTargets.has(pr.number)) {
+			skip.push({
+				number: pr.number,
+				reason: "heal-item-exists",
+				detail: "an open heal-item already targets this PR — idempotent skip",
+			});
+			continue;
+		}
+		emit.push({number: pr.number, failingCheck: pr.failingCheck, redForMs});
+	}
+
+	return {emit, skip};
+};
+
+/**
+ * The heal-item idempotency marker. Each emitted issue carries one `orphan-heal-target: #<N>`
+ * line in its body; the detector reads it back off open issues to build `existingHealTargets`,
+ * so a re-run recognizes its own prior emission with no dedicated label or search-index round-trip.
+ */
+export const HEAL_TARGET_PREFIX = "orphan-heal-target:";
+
+export const healTargetMarker = (prNumber: number): string => `${HEAL_TARGET_PREFIX} #${prNumber}`;
+
+const HEAL_TARGET_RE = /orphan-heal-target:\s*#(\d+)/gi;
+
+/** Extract every PR number a heal-item body targets (usually one) — the read half of the marker. */
+export const extractHealTargets = (body: string): ReadonlyArray<number> => {
+	const out: Array<number> = [];
+	for (const m of body.matchAll(HEAL_TARGET_RE)) {
+		const n = Number.parseInt(m[1] ?? "", 10);
+		if (!Number.isNaN(n)) out.push(n);
+	}
+	return out;
+};
+
+const CLOSING_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s+#(\d+)/gi;
+
+/**
+ * Parse the GitHub closing-keyword references (`Fixes #N`, `Closes #N`, `Resolves: #N`, …)
+ * out of a PR body — the read the shell uses to find a PR's linked issues, from which
+ * engine-lane membership is derived (a PR that closes a triaged issue is in an owned lane).
+ */
+export const parseClosingRefs = (body: string): ReadonlyArray<number> => {
+	const out: Array<number> = [];
+	for (const m of body.matchAll(CLOSING_RE)) {
+		const n = Number.parseInt(m[1] ?? "", 10);
+		if (!Number.isNaN(n)) out.push(n);
+	}
+	return out;
+};
+
+export const healItemTitle = (prNumber: number): string => `heal red CI on PR #${prNumber}`;
+
+/**
+ * Build the heal-item body: the machine marker, a pointer at the failing check, and the
+ * boundary-ruling context an engine needs to adopt the lane (the #3532 boundary path).
+ */
+export const healItemBody = (
+	item: EmitItem,
+	ctx: {readonly repo: string; readonly sourceIssue: number},
+): string => {
+	const prUrl = `https://github.com/${ctx.repo}/pull/${item.number}`;
+	const checkLine = item.failingCheck
+		? `Failing check: \`${item.failingCheck}\`.`
+		: "Failing check: (see the PR's checks tab).";
+	return [
+		healTargetMarker(item.number),
+		"",
+		`PR ${prUrl} (#${item.number}) is an **orphan red PR** — open, non-draft, CI-red for`,
+		`${formatDuration(item.redForMs)}, and in no engine lane (it closes no triaged issue).`,
+		"",
+		checkLine,
+		"",
+		"## What to do",
+		`Adopt PR #${item.number} into an owned lane and repair its red CI: diagnose the failing`,
+		"check, push a fix on the PR's branch, and re-run until green.",
+		"",
+		"## Why this exists",
+		`Per the #3532 boundary ruling, engines heal only lanes they own — an orphan red PR is`,
+		"converted into this pullable heal-item first, then an engine adopts the lane. Engines do",
+		"not free-scan and mutate arbitrary red PRs.",
+		"",
+		`Emitted by \`pipeline-cli orphan-heal\` (#${ctx.sourceIssue}). Refs #3532.`,
+	].join("\n");
+};

--- a/packages/pipeline-cli/src/tools/orphan-heal/orphan-heal.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/orphan-heal.unit.test.ts
@@ -1,0 +1,180 @@
+import {describe, expect, it} from "vitest";
+import {
+	extractHealTargets,
+	formatDuration,
+	healItemBody,
+	healItemTitle,
+	healTargetMarker,
+	type PrSnapshot,
+	parseClosingRefs,
+	planHealItems,
+} from "./orphan-heal.ts";
+
+const HOUR = 60 * 60 * 1000;
+const NOW = Date.parse("2026-07-19T12:00:00Z");
+const GRACE = 6 * HOUR;
+
+const pr = (over: Partial<PrSnapshot> = {}): PrSnapshot => ({
+	number: over.number ?? 100,
+	isDraft: over.isDraft ?? false,
+	ci: over.ci ?? "red",
+	// default: red 8h ago (past a 6h grace)
+	redSince: "redSince" in over ? over.redSince : "2026-07-19T04:00:00Z",
+	inEngineLane: over.inEngineLane ?? false,
+	failingCheck: over.failingCheck,
+});
+
+const plan = (prs: ReadonlyArray<PrSnapshot>, targets: ReadonlyArray<number> = []) =>
+	planHealItems(prs, {graceMs: GRACE, now: NOW, existingHealTargets: new Set(targets)});
+
+describe("planHealItems — the orphan gate (all conditions must hold to emit)", () => {
+	it("flags an open, non-draft, CI-red, laneless PR red past the grace window", () => {
+		const {emit, skip} = plan([pr({number: 3501})]);
+		expect(skip).toHaveLength(0);
+		expect(emit).toHaveLength(1);
+		expect(emit[0]?.number).toBe(3501);
+		expect(emit[0]?.redForMs).toBe(8 * HOUR);
+	});
+
+	it("carries the failing check name into the emit item", () => {
+		const {emit} = plan([pr({failingCheck: "lint / format / typecheck"})]);
+		expect(emit[0]?.failingCheck).toBe("lint / format / typecheck");
+	});
+});
+
+describe("planHealItems — each gate skips with the FIRST failing reason", () => {
+	it("skips a draft PR", () => {
+		const {emit, skip} = plan([pr({isDraft: true})]);
+		expect(emit).toHaveLength(0);
+		expect(skip[0]?.reason).toBe("draft");
+	});
+
+	it("skips a green / pending / unknown PR (ci-not-red)", () => {
+		for (const ci of ["green", "pending", "unknown"] as const) {
+			const {emit, skip} = plan([pr({ci})]);
+			expect(emit).toHaveLength(0);
+			expect(skip[0]?.reason).toBe("ci-not-red");
+		}
+	});
+
+	it("skips a PR that is in an engine lane (the boundary — engines heal owned lanes)", () => {
+		const {emit, skip} = plan([pr({inEngineLane: true})]);
+		expect(emit).toHaveLength(0);
+		expect(skip[0]?.reason).toBe("in-engine-lane");
+	});
+
+	it("default-denies a red PR with no red-since anchor (grace unmeasurable)", () => {
+		const {emit, skip} = plan([pr({redSince: undefined})]);
+		expect(emit).toHaveLength(0);
+		expect(skip[0]?.reason).toBe("no-red-since");
+	});
+
+	it("default-denies a red PR with an unparseable red-since", () => {
+		const {skip} = plan([pr({redSince: "not-a-date"})]);
+		expect(skip[0]?.reason).toBe("no-red-since");
+	});
+
+	it("skips a PR red for less than the grace window", () => {
+		const {emit, skip} = plan([pr({redSince: "2026-07-19T09:00:00Z"})]); // red 3h < 6h grace
+		expect(emit).toHaveLength(0);
+		expect(skip[0]?.reason).toBe("within-grace");
+	});
+
+	it("gate order: a draft that is also green skips as draft (first gate wins)", () => {
+		const {skip} = plan([pr({isDraft: true, ci: "green"})]);
+		expect(skip[0]?.reason).toBe("draft");
+	});
+});
+
+describe("planHealItems — idempotency (never a second heal-item)", () => {
+	it("skips a PR that already has an open heal-item", () => {
+		const {emit, skip} = plan([pr({number: 3501})], [3501]);
+		expect(emit).toHaveLength(0);
+		expect(skip[0]?.reason).toBe("heal-item-exists");
+	});
+
+	it("re-running over the same orphan with its heal-item present emits nothing", () => {
+		const orphan = pr({number: 3501});
+		const first = plan([orphan]); // no existing item yet
+		expect(first.emit.map((e) => e.number)).toEqual([3501]);
+		const second = plan([orphan], [3501]); // item now exists
+		expect(second.emit).toHaveLength(0);
+	});
+
+	it("emits only the orphans without an existing heal-item across a mixed batch", () => {
+		const batch = [pr({number: 1}), pr({number: 2}), pr({number: 3})];
+		const {emit} = plan(batch, [2]);
+		expect(emit.map((e) => e.number)).toEqual([1, 3]);
+	});
+});
+
+describe("heal-item marker round-trip (the idempotency read/write pair)", () => {
+	it("healTargetMarker and extractHealTargets round-trip a PR number", () => {
+		expect(healTargetMarker(3501)).toBe("orphan-heal-target: #3501");
+		expect(extractHealTargets(healTargetMarker(3501))).toEqual([3501]);
+	});
+
+	it("extracts the target embedded in a full heal-item body", () => {
+		const body = healItemBody(
+			{number: 3501, failingCheck: "ci", redForMs: 8 * HOUR},
+			{repo: "kamp-us/phoenix", sourceIssue: 3650},
+		);
+		expect(extractHealTargets(body)).toEqual([3501]);
+	});
+
+	it("returns no targets for a body without the marker", () => {
+		expect(extractHealTargets("just some issue text about #3501")).toEqual([]);
+	});
+});
+
+describe("heal-item rendering", () => {
+	it("titles the heal-item deterministically", () => {
+		expect(healItemTitle(3501)).toBe("heal red CI on PR #3501");
+	});
+
+	it("body links the PR, names the failing check, and cites the boundary ruling", () => {
+		const body = healItemBody(
+			{number: 3501, failingCheck: "lint", redForMs: 8 * HOUR},
+			{repo: "kamp-us/phoenix", sourceIssue: 3650},
+		);
+		expect(body).toContain("https://github.com/kamp-us/phoenix/pull/3501");
+		expect(body).toContain("`lint`");
+		expect(body).toContain("#3532");
+	});
+
+	it("body degrades gracefully when no failing check is known", () => {
+		const body = healItemBody(
+			{number: 3501, redForMs: 8 * HOUR},
+			{repo: "kamp-us/phoenix", sourceIssue: 3650},
+		);
+		expect(body).toContain("see the PR's checks tab");
+	});
+});
+
+describe("parseClosingRefs — engine-lane derivation input", () => {
+	it("parses the standard closing keywords", () => {
+		expect(parseClosingRefs("Fixes #12")).toEqual([12]);
+		expect(parseClosingRefs("Closes #7 and resolves #8")).toEqual([7, 8]);
+		expect(parseClosingRefs("Resolved: #99")).toEqual([99]);
+	});
+
+	it("ignores a bare #ref without a closing keyword (a plain cross-link is not a lane)", () => {
+		expect(parseClosingRefs("see #12, related to #34")).toEqual([]);
+	});
+
+	it("returns empty for a body that closes nothing (the orphan shape)", () => {
+		expect(parseClosingRefs("docs(adr): 0195 amend 0189")).toEqual([]);
+	});
+});
+
+describe("formatDuration", () => {
+	it("renders sub-hour durations as minutes", () => {
+		expect(formatDuration(45 * 60 * 1000)).toBe("45m");
+	});
+	it("renders multi-hour durations as hours and minutes", () => {
+		expect(formatDuration(8 * HOUR + 30 * 60 * 1000)).toBe("8h 30m");
+	});
+	it("clamps a negative duration to 0m", () => {
+		expect(formatDuration(-1000)).toBe("0m");
+	});
+});


### PR DESCRIPTION
## What

Steps 1–2 of the #3532 boundary path (#3650): an **orphan-red-PR detector + heal-item emitter**.

- **New `pipeline-cli orphan-heal scan` verb** (`packages/pipeline-cli/src/tools/orphan-heal/`), registered in the router registry.
  - Pure, IO-free core (`orphan-heal.ts`): `planHealItems` decides, over a snapshot of open PRs, which are orphans-needing-heal. A PR is flagged **only** when every gate holds — open + non-draft, CI-red, laneless, red past a grace window — and no open heal-item already targets it. Default-deny toward NOT-orphan: any missing signal (unknown CI, no red-since anchor) leaves the PR un-flagged, so a miss can only under-file, never spuriously file.
  - IO shell (`github.ts`): reads the open-PR set, each head's CI conclusion + red-since, each PR's linked-issue lane state, and the existing heal-item set over `gh api` REST (GraphQL is broken on the org). Files the heal-item. All reads are from **existing state** (open PRs, head check-runs, issue labels, open issues) — no new lane-tracking store (per the AC).
  - Thin bin (`command.ts`): dry-run by default (prints the plan, files nothing); `--execute` files one triaged, immediately-claimable `heal red CI on PR #N` issue per orphan.
- **New scheduled `.github/workflows/orphan-heal.yml`** — runs the scan every 6h with `--execute`; `workflow_dispatch` defaults to dry-run so a human can eyeball the plan first. It ships **beside** `orphan-sweep.yml` (that sweeps orphan Cloudflare stages — a wholly different "orphan"), not folded into it.

## Boundary, not free-scan-adopt

Per the #3532 founder ruling: engines heal only lanes they **own**. An orphan red PR (hand-/conversation-authored, e.g. an ADR/ROADMAP PR that closes no triaged issue — #3501) is converted into a pullable heal-item **first**; an engine adopts the resulting lane **second** (steps 3–5 reuse the existing engine drain/repair loop). The detector never mutates a PR and never lets an engine free-scan.

## Lane membership + idempotency

- **Lane membership** is derived from existing state: a PR is in an engine lane iff it closes at least one `status:triaged` issue (engine-opened-from-a-triaged-issue). A PR that closes no triaged issue is laneless — the orphan shape.
- **Idempotency** is a body marker: each heal-item carries one `orphan-heal-target: #N` line, read back off open issues to build the skip set — so re-running never files a second heal-item for a PR that already has an open one. Enforced in the pure core and covered by a re-run test.

## Verification

- `pnpm typecheck` (full workspace) — clean
- `pnpm lint:worktree` — clean
- pipeline-cli suite — 1593 tests pass (24 new for the orphan-heal core: gate order, idempotency, marker round-trip, closing-ref parsing, rendering)
- Live dry-run against the repo: correctly classified the 3 open PRs (one in-engine-lane, two pending CI) → 0 orphans, filed nothing
- `catalog-guard` / `readme-guard` — clean

## §CP

Touches `packages/pipeline-cli/` and `.github/` (both control-plane paths) → §CP; banks at the code-owner, does not auto-merge.

Fixes #3650