### PR TITLE
feat(pipeline-cli): extract plan-epic epic-body splice into an `epic-splice` verb (#3689)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -746,9 +746,12 @@ native compare-and-swap — so the write is made safe by **two layers**, in orde
 from your in-memory plan and overwrite the whole thing. Re-read the epic's **current** body
 immediately before the write, replace **only the section you changed** (the `## Dependencies`
 block, and — when re-planning — the `## Plan (plan-epic)` block), and leave every other byte of
-the live body exactly as you just read it. A concurrent edit to a *different* part of the body
-(the brief, a sibling's handoff note, a label-driven addition) then cannot collide with your
-write at all — you preserved it verbatim because you never reconstructed it.
+the live body exactly as you just read it. The deterministic splice itself — the heading-count
+guards, the first-time-append vs re-plan-in-place decision, and the byte-preserving section
+replacement — is the `pipeline-cli epic-splice apply` verb (#3689, extracted from #261); the
+block below calls it rather than hand-composing the transform. A concurrent edit to a *different*
+part of the body (the brief, a sibling's handoff note, a label-driven addition) then cannot
+collide with your write at all — the verb preserved it verbatim because it never reconstructed it.
 
 **Layer 2 — optimistic recheck (abort+retry on a same-section race).** Two writers editing the
 *same* section still race. So immediately before the `PATCH`, re-GET the epic's `updated_at` and
@@ -780,14 +783,14 @@ loudly** if `deps.md` was not regenerated since the base it splices onto was rea
 # derived against the body it's splicing onto, never a stale one.
 # A first-time plan has NO `## Dependencies` heading yet (Step 2 doesn't write one) — that case
 # APPENDS the block to EOF; a re-plan has exactly one and SPLICES it in place. Zero headings on a
-# re-plan, or more than one ever, is corruption: abort loudly (step 4).
+# re-plan, or more than one ever, is corruption: the `epic-splice` verb (step 3) exits non-zero.
 #
 # This block is a SKELETON you re-run per attempt, not a one-shot. When the recheck (step 2) fires
 # it stamps the fresh base, BREAKS, and hands back to you to re-derive `deps.md` (+ `plan.md` on a
 # re-plan) against `/tmp/plan-epic-<EPIC>-current.md` — then you re-invoke the block. The freshness
 # guard (step 2.5) refuses to splice a `deps.md` older than the base it would splice onto, so a
 # stale block can never re-clobber a racer's legitimate topology.
-# Per attempt: re-read → recheck (verify unchanged) → freshness guard → anchor guard → splice/append → PATCH
+# Per attempt: re-read → recheck (verify unchanged) → freshness guard → epic-splice apply (guards + splice) → PATCH
 # → re-verify our block landed. `landed=1` only after a pass confirms the round-trip; `patched=1`
 # records that a PATCH was actually issued (so the terminal verdict can tell "raced every time,
 # never wrote" from "wrote and lost"). The terminal check after the loop turns an
@@ -827,52 +830,23 @@ for attempt in 1 2 3; do
     break
   fi
 
-  # 3. anchor guard — the splice keys off the count of exact `## Dependencies` headings:
-  #      0 + first-time plan → no topology pinned yet (Step 2 omits it): APPEND to EOF (step 4a).
-  #      1                   → re-plan with an existing section: SPLICE it in place (step 4b).
-  #      0 + re-plan, or >1  → corruption (heading drifted to `## Dependencies (phased)`, was
-  #                            deleted, or duplicated): a blind splice/append would orphan or
-  #                            double the section. Abort loudly, leave `landed=0`.
-  DEPS_HEADINGS=$(grep -c '^## Dependencies[[:space:]]*$' /tmp/plan-epic-<EPIC>-live.md)
-  if [ "$DEPS_HEADINGS" -gt 1 ] || { [ "$DEPS_HEADINGS" -eq 0 ] && [ "${REPLAN:-0}" = 1 ]; }; then
-    echo "ABORT: live body has $DEPS_HEADINGS exact '## Dependencies' headings (want 0 on a first-time plan, 1 on a re-plan) — refusing to splice; inspect by hand"
+  # 3. splice/append the changed section(s) via the shared verb — `pipeline-cli epic-splice apply`
+  #    owns the deterministic transform (#3689, extracted from #261): the exact-`## Dependencies`
+  #    heading-count guards (0 + first-time → APPEND to EOF; exactly 1 → SPLICE in place; 0 on a
+  #    re-plan or >1 ever → corrupt, exit 1) and, on a re-plan, the in-place `## Plan (plan-epic)`
+  #    splice with its own exactly-one-heading guard. Everything OUTSIDE the replaced section(s) is
+  #    preserved byte-for-byte (the brief especially — layer 1). Pass `--plan-file` ONLY on a
+  #    re-plan: its presence IS the re-plan signal (both sections re-spliced); omit it first-time.
+  #    A corrupt/duplicated/drifted heading makes the verb exit non-zero — break loudly and inspect
+  #    by hand rather than blind-write. The recheck/freshness/round-trip orchestration around it
+  #    stays here (it is live-issue IO, not a text transform).
+  PLAN_ARG=(); [ "${REPLAN:-0}" = 1 ] && PLAN_ARG=(--plan-file /tmp/plan-epic-<EPIC>-plan.md)
+  if ! node packages/pipeline-cli/src/bin.ts epic-splice apply \
+        --body-file /tmp/plan-epic-<EPIC>-live.md \
+        --deps-file /tmp/plan-epic-<EPIC>-deps.md \
+        "${PLAN_ARG[@]}" > /tmp/plan-epic-<EPIC>-body.md; then
+    echo "ABORT: epic-splice refused (corrupt/duplicated/drifted heading — see its stderr) — refusing to splice; inspect by hand"
     break
-  fi
-
-  # 3b. on a re-plan, the Plan splice (step 4) keys off `## Plan (plan-epic)` the same way deps keys
-  #     off `## Dependencies` — and the same drift bites: 0 means the heading drifted (e.g. `## Plan`)
-  #     and the awk would splice NOTHING (the re-planned plan silently dropped); >1 means it'd double.
-  #     Want exactly 1 on a re-plan. (First-time plans don't splice the plan block, so skip the check.)
-  if [ "${REPLAN:-0}" = 1 ]; then
-    PLAN_HEADINGS=$(grep -c '^## Plan (plan-epic)[[:space:]]*$' /tmp/plan-epic-<EPIC>-live.md)
-    if [ "$PLAN_HEADINGS" -ne 1 ]; then
-      echo "ABORT: re-plan but live body has $PLAN_HEADINGS exact '## Plan (plan-epic)' headings (want exactly 1) — refusing to splice; inspect by hand"
-      break
-    fi
-  fi
-
-  # 4. surgical splice/append: write ONLY the changed section(s), keep every other byte verbatim.
-  if [ "$DEPS_HEADINGS" -eq 0 ]; then
-    # 4a. FIRST-TIME plan — no `## Dependencies` heading exists. Append the block to the END of a
-    #     byte-for-byte copy of the live body (the brief + plan above are preserved untouched).
-    cp /tmp/plan-epic-<EPIC>-live.md /tmp/plan-epic-<EPIC>-body.md
-    cat /tmp/plan-epic-<EPIC>-deps.md >> /tmp/plan-epic-<EPIC>-body.md
-  else
-    # 4b. RE-PLAN — `## Dependencies` is the pinned LAST section: cut from its heading to EOF,
-    #     append fresh deps. (DEPS_HEADINGS == 1 here.)
-    awk '/^## Dependencies[[:space:]]*$/{exit} {print}' /tmp/plan-epic-<EPIC>-live.md \
-      > /tmp/plan-epic-<EPIC>-body.md
-    cat /tmp/plan-epic-<EPIC>-deps.md >> /tmp/plan-epic-<EPIC>-body.md
-  fi
-  # On a RE-PLAN, `## Plan (plan-epic)` ALSO changed — splice it in place too: delete the inclusive
-  # `## Plan (plan-epic)`..next-`## ` range and re-insert the fresh plan block at that boundary.
-  if [ "${REPLAN:-0}" = 1 ]; then
-    awk -v plan="/tmp/plan-epic-<EPIC>-plan.md" '
-      /^## Plan \(plan-epic\)[[:space:]]*$/ { while ((getline l < plan) > 0) print l; skip=1; next }
-      skip && /^## / { skip=0 }
-      !skip { print }
-    ' /tmp/plan-epic-<EPIC>-body.md > /tmp/plan-epic-<EPIC>-body.2.md \
-      && mv /tmp/plan-epic-<EPIC>-body.2.md /tmp/plan-epic-<EPIC>-body.md
   fi
   BODY="$(cat /tmp/plan-epic-<EPIC>-body.md)"
 
@@ -927,13 +901,13 @@ if [ "$landed" != 1 ]; then
 fi
 ```
 
-**Keep the brief byte-for-byte.** With the surgical splice/append this is automatic: a first-time
-plan appends the `## Dependencies` block to a verbatim copy of the live body; a re-plan copies the
-live body up to the `## Dependencies` heading verbatim and re-appends the fresh block. Either way
-the brief above the plan is untouched bytes from the live read; on a re-plan the `## Plan
-(plan-epic)` block is itself re-spliced in place (step 4), and everything outside the two changed
-sections is verbatim — don't reflow the brief, don't "tidy" it, don't reconstruct it from memory —
-splice around it.
+**Keep the brief byte-for-byte.** With the `epic-splice` verb's surgical splice/append this is
+automatic: a first-time plan appends the `## Dependencies` block to a verbatim copy of the live
+body; a re-plan copies the live body up to the `## Dependencies` heading verbatim and re-appends
+the fresh block. Either way the brief above the plan is untouched bytes from the live read; on a
+re-plan the `## Plan (plan-epic)` block is itself re-spliced in place, and everything outside the
+two changed sections is verbatim — don't reflow the brief, don't "tidy" it, don't reconstruct it
+from memory — splice around it.
 
 **Honest residual — this narrows the window, it is not a lock.** The recheck (layer 2) only
 *detects* a race that completed before this run's read; a writer who edits **after** your

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -30,6 +30,7 @@ import {designInventoryCommand} from "./tools/design-inventory/command.ts";
 import {designTokenGuardCommand} from "./tools/design-token-guard/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
 import {epicLockCommand} from "./tools/epic-lock/command.ts";
+import {epicSpliceCommand} from "./tools/epic-splice/command.ts";
 import {evalHarnessCommand} from "./tools/eval-harness/command.ts";
 import {failureClassifierCommand} from "./tools/failure-classifier/command.ts";
 import {fanoutGuardCommand} from "./tools/fanout-guard/command.ts";
@@ -103,6 +104,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	versionCommand,
 	epicLedgerCommand,
 	epicLockCommand,
+	epicSpliceCommand,
 	decisionsIndexCommand,
 	readmeGuardCommand,
 	roadmapCommand,

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -107,6 +107,23 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		reason:
 			"re-derives the graduation-close envelope that `pipeline-cli tracker graduate` owns (post the source → artifact provenance record, close the source as completed), instead of citing the verb (#3266 / #3254)",
 	},
+	{
+		// `epic-splice apply` owns the deterministic epic-body splice (#3689): the anchor-count
+		// heading guards + first-time-append / re-plan-in-place section replacement `plan-epic`
+		// Step 5 used to hand-compose inline (#261). The fingerprint is the co-occurrence of the
+		// deps-heading anchor count, the surgical `## Dependencies`→EOF cut, and the in-place
+		// `## Plan (plan-epic)` splice — the three tells of a hand-copy of the whole splice, not an
+		// incidental `## Dependencies` mention. A file that cites `pipeline-cli epic-splice` is compliant.
+		verb: "epic-splice apply",
+		signature: [
+			/grep -c '\^## Dependencies/, // the deps-heading anchor count
+			/awk '\/\^## Dependencies\[\[:space:\]\]\*\$\/\{exit\}/, // the surgical deps-section cut
+			/\/\^## Plan \\\(plan-epic\\\)\[\[:space:\]\]\*\$\//, // the in-place plan splice
+		],
+		citation: /pipeline-cli\s+epic-splice\b/,
+		reason:
+			"re-derives the epic-body splice (anchor guards + first-time-append / re-plan-in-place) that `pipeline-cli epic-splice apply` owns, instead of citing the verb (#3689 / #261 / #3254)",
+	},
 ];
 
 /**

--- a/packages/pipeline-cli/src/tools/epic-splice/command.ts
+++ b/packages/pipeline-cli/src/tools/epic-splice/command.ts
@@ -1,0 +1,74 @@
+/**
+ * The `epic-splice` tool — `pipeline-cli epic-splice apply --body-file <f> --deps-file <f>
+ * [--plan-file <f>]`.
+ *
+ * The deterministic epic-body splice `plan-epic` Step 5 used to hand-compose inline (#261 / #3689):
+ * given the live epic body and a freshly-derived `## Dependencies` block (plus, on a re-plan, a
+ * `## Plan (plan-epic)` block via `--plan-file`), it prints the spliced body to stdout — a
+ * first-time APPEND or a re-plan in-place REPLACE — with the anchor-count guards. `--plan-file`
+ * present ⇒ re-plan mode; absent ⇒ first-time (or a deps-only re-splice).
+ *
+ * Exit 0 = a clean splice printed to stdout (raw bytes, no trailing newline added, so the caller's
+ * PATCH round-trips byte-for-byte). Exit 1 = a corrupt-heading refusal (the reason on stderr) — the
+ * caller must inspect by hand rather than blind-write. Pure text transform: no `gh` boundary, so it
+ * needs no `Github` layer — the optimistic `updated_at` recheck + PATCH orchestration stay in the
+ * skill prose (#3689 scope).
+ */
+import {readFileSync} from "node:fs";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {spliceEpicBody} from "./epic-splice.ts";
+
+const CORRUPT_EXIT_CODE = 1;
+
+const bodyFileFlag = Flag.string("body-file").pipe(
+	Flag.withDescription("path to the live epic body the splice preserves around"),
+);
+const depsFileFlag = Flag.string("deps-file").pipe(
+	Flag.withDescription(
+		"path to the freshly-derived `## Dependencies` block to append or splice in place",
+	),
+);
+const planFileFlag = Flag.string("plan-file").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"path to the freshly-derived `## Plan (plan-epic)` block — its presence marks a re-plan (both sections re-spliced)",
+	),
+);
+
+const apply = Command.make(
+	"apply",
+	{bodyFile: bodyFileFlag, depsFile: depsFileFlag, planFile: planFileFlag},
+	Effect.fn(function* ({bodyFile, depsFile, planFile}) {
+		const body = yield* Effect.sync(() => readFileSync(bodyFile, "utf8"));
+		const deps = yield* Effect.sync(() => readFileSync(depsFile, "utf8"));
+		const plan = yield* Effect.sync(() =>
+			Option.match(planFile, {
+				onNone: () => null,
+				onSome: (path) => readFileSync(path, "utf8"),
+			}),
+		);
+
+		const outcome = spliceEpicBody({body, deps, plan});
+		if (outcome._tag === "Corrupt") {
+			process.stderr.write(`epic-splice: ${outcome.reason}\n`);
+			return yield* Effect.sync(() => process.exit(CORRUPT_EXIT_CODE));
+		}
+		// Raw bytes, no trailing newline added — the caller PATCHes this verbatim (byte-preservation).
+		yield* Effect.sync(() => process.stdout.write(outcome.body));
+		process.stderr.write(
+			`epic-splice: ${outcome.mode === "append" ? "appended" : "spliced"} the section(s)\n`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Splice/append the `## Dependencies` (and, with --plan-file, `## Plan (plan-epic)`) block into the live epic body — exit 0 = printed, exit 1 = corrupt heading",
+	),
+);
+
+export const epicSpliceCommand = Command.make("epic-splice").pipe(
+	Command.withSubcommands([apply]),
+	Command.withDescription(
+		"Deterministic epic-body splice for plan-epic — first-time append vs re-plan in-place, with heading-count guards (#3689)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/epic-splice/epic-splice.ts
+++ b/packages/pipeline-cli/src/tools/epic-splice/epic-splice.ts
@@ -1,0 +1,141 @@
+/**
+ * `epic-splice` core — the pure, IO-free text transform behind `plan-epic`'s
+ * epic-body splice (#3689), extracted from the ~95-line hand-composed splice the
+ * skill's Step 5 carried inline (#261). Given the live epic body, a freshly-derived
+ * `## Dependencies` block, and — on a re-plan — a fresh `## Plan (plan-epic)` block,
+ * it produces the spliced body: a first-time APPEND of the deps block, or a re-plan
+ * in-place REPLACE of the deps (and plan) sections, with the anchor-count guards that
+ * refuse a corrupt-heading body rather than orphan or double a section.
+ *
+ * Only the deterministic text transform lives here. The optimistic `updated_at`
+ * recheck + the abort-retry PATCH orchestration around it stay in the skill prose —
+ * they are IO against the live GitHub issue, not a text function (#3689 scope).
+ *
+ * Byte-preservation is the load-bearing invariant: every byte OUTSIDE the replaced
+ * section(s) survives verbatim, because the transform slices the live body on the
+ * heading boundary rather than reconstructing it — so a concurrent edit to the brief
+ * (or any other section) can never be clobbered by this write (#261, the lost-update
+ * this splice exists to prevent).
+ */
+
+/** The re-plan mode is carried by the presence of a fresh plan block — a re-plan re-splices both sections. */
+export interface SpliceInput {
+	/** The live epic body, read immediately before the write (the base every splice preserves around). */
+	readonly body: string;
+	/** The freshly-derived `## Dependencies` block to append or splice in place. */
+	readonly deps: string;
+	/**
+	 * The freshly-derived `## Plan (plan-epic)` block, present iff this is a re-plan.
+	 * `null` ⇒ a first-time plan (only the deps block is written; the plan already sits
+	 * in the body from Step 2). Non-null ⇒ re-plan (both sections are re-spliced).
+	 */
+	readonly plan: string | null;
+}
+
+/** `append` — first-time plan (no deps heading yet); `replace` — a deps section spliced in place. */
+export type SpliceMode = "append" | "replace";
+
+/** A successful splice, or a corrupt-heading refusal naming what it saw (never a blind write). */
+export type SpliceOutcome =
+	| {readonly _tag: "Spliced"; readonly body: string; readonly mode: SpliceMode}
+	| {readonly _tag: "Corrupt"; readonly reason: string};
+
+// The exact `## Dependencies` / `## Plan (plan-epic)` heading lines — a heading line is the
+// literal text followed only by optional trailing whitespace (`[^\S\n]` = whitespace but not the
+// newline). This mirrors the skill's `grep -c '^## Dependencies[[:space:]]*$'` anchor: a drifted
+// heading (`## Dependencies (phased)`) has non-whitespace after the word, so it does NOT match —
+// which is exactly what surfaces as a heading-count-0 corruption on a re-plan.
+const DEPS_HEADING = /^## Dependencies[^\S\n]*$/m;
+const DEPS_HEADING_G = /^## Dependencies[^\S\n]*$/gm;
+const PLAN_HEADING = /^## Plan \(plan-epic\)[^\S\n]*$/m;
+const PLAN_HEADING_G = /^## Plan \(plan-epic\)[^\S\n]*$/gm;
+// The next top-level section boundary: a line starting with exactly `## ` (two hashes + space).
+// A `### Phase N` sub-heading has three hashes, so it is NOT a boundary — the plan block's own
+// `### ` sub-headings never terminate the replaced range (mirrors the skill's `/^## /` awk).
+const NEXT_H2 = /^## /m;
+
+const countHeadings = (body: string, re: RegExp): number => body.match(re)?.length ?? 0;
+
+/**
+ * Replace the inclusive range from `headingRe`'s first line up to (but excluding) the next
+ * top-level `## ` heading with `block`. When the section is the last one (no following `## `),
+ * replace through EOF. Mirrors the skill's in-place plan awk exactly.
+ */
+const spliceSection = (body: string, headingRe: RegExp, block: string): string => {
+	const start = body.search(headingRe);
+	// Start the next-boundary search AFTER the heading line so the heading itself (also `## `) is
+	// not read as its own boundary — the skill's awk skips the heading line via `next`.
+	const afterHeadingLine = body.indexOf("\n", start);
+	const searchFrom = afterHeadingLine === -1 ? body.length : afterHeadingLine + 1;
+	const rel = body.slice(searchFrom).search(NEXT_H2);
+	const next = rel === -1 ? -1 : searchFrom + rel;
+	return next === -1
+		? body.slice(0, start) + block
+		: body.slice(0, start) + block + body.slice(next);
+};
+
+/**
+ * Splice the fresh `## Dependencies` (and, on a re-plan, `## Plan (plan-epic)`) block(s) into the
+ * live body. The anchor-count guards decide first-time-append vs re-plan-replace vs corruption:
+ *
+ *   0 deps headings + first-time → APPEND the block to EOF (Step 2 hasn't pinned a topology yet)
+ *   1 deps heading               → REPLACE it in place (a re-plan of an existing section)
+ *   0 deps + re-plan, or >1 ever → corruption (heading drifted, deleted, or duplicated) → refuse
+ *
+ * On a re-plan the plan block is likewise required to have exactly one `## Plan (plan-epic)`
+ * anchor, else the splice would drop or double the section — refuse rather than write.
+ */
+export const spliceEpicBody = ({body, deps, plan}: SpliceInput): SpliceOutcome => {
+	const replan = plan !== null;
+
+	const depsCount = countHeadings(body, DEPS_HEADING_G);
+	if (depsCount > 1) {
+		return {
+			_tag: "Corrupt",
+			reason: `live body has ${depsCount} exact '## Dependencies' headings (want 0 on a first-time plan, 1 on a re-plan) — refusing to splice; inspect by hand`,
+		};
+	}
+	if (depsCount === 0 && replan) {
+		return {
+			_tag: "Corrupt",
+			reason:
+				"re-plan but live body has 0 exact '## Dependencies' headings (the pinned heading drifted or was deleted) — refusing to splice; inspect by hand",
+		};
+	}
+
+	if (replan) {
+		const planCount = countHeadings(body, PLAN_HEADING_G);
+		if (planCount !== 1) {
+			return {
+				_tag: "Corrupt",
+				reason: `re-plan but live body has ${planCount} exact '## Plan (plan-epic)' headings (want exactly 1) — refusing to splice; inspect by hand`,
+			};
+		}
+	}
+
+	// Splice the plan section FIRST (on the live body), then deps. In `plan-epic`'s canonical
+	// brief → plan → dependencies layout the two edits touch disjoint regions, so order is
+	// commutative and the output is byte-identical to the skill's deps-then-plan awk — but doing
+	// plan first keeps the plan anchor resolvable against the body the guard counted, rather than a
+	// body the deps splice may have already cut through.
+	let working = body;
+	if (plan !== null) {
+		working = spliceSection(working, PLAN_HEADING, plan);
+	}
+
+	let spliced: string;
+	let mode: SpliceMode;
+	if (depsCount === 0) {
+		// First-time: append to a verbatim copy of the live body — the brief + plan above are untouched.
+		spliced = working + deps;
+		mode = "append";
+	} else {
+		// Re-plan of deps: the pinned `## Dependencies` is the last section — cut from its heading to
+		// EOF and re-append the fresh block. Everything before the heading is verbatim live bytes.
+		const start = working.search(DEPS_HEADING);
+		spliced = working.slice(0, start) + deps;
+		mode = "replace";
+	}
+
+	return {_tag: "Spliced", body: spliced, mode};
+};

--- a/packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the `epic-splice` pure core (#3689): the epic-body splice extracted from
+ * `plan-epic`'s inline Step-5 splice (#261). IO-free — no `gh` boundary. The headline invariants:
+ * first-time APPEND vs re-plan in-place REPLACE, the heading-count corruption guards, and
+ * byte-for-byte preservation of everything outside the replaced section (the brief especially).
+ */
+import {assert, describe, expect, it} from "@effect/vitest";
+import {type SpliceOutcome, spliceEpicBody} from "./epic-splice.ts";
+
+// A brief with deliberately fragile bytes: trailing whitespace, a backtick span, a blank line —
+// exactly what a naive reconstruct-from-memory splice would "tidy" and thereby clobber (#261).
+const BRIEF = "## Problem\n\nThe brief.  trailing spaces:   \nA `code` span and a — dash.\n\n";
+const PLAN = "## Plan (plan-epic)\n\n### Product layer\n\nold plan prose.\n\n";
+const DEPS = "## Dependencies\n\n### Phase 1\n- #1 — a\n- #2 — b\n";
+
+const spliced = (o: SpliceOutcome): string => {
+	assert.strictEqual(o._tag, "Spliced");
+	return o._tag === "Spliced" ? o.body : "";
+};
+
+// Assert the outcome is a refusal and return its reason for an UNCONDITIONAL `expect` — so the
+// reason check never hides behind an `if` branch that might not run (the silent-pass shape).
+const corruptReason = (o: SpliceOutcome): string => {
+	assert.strictEqual(o._tag, "Corrupt");
+	return o._tag === "Corrupt" ? o.reason : "";
+};
+
+describe("first-time plan — APPEND (no `## Dependencies` heading yet)", () => {
+	const body = BRIEF + PLAN;
+	const deps = "## Dependencies\n\n### Phase 1\n- #10 — x\n";
+
+	it("appends the deps block to the verbatim live body", () => {
+		const out = spliceEpicBody({body, deps, plan: null});
+		assert.strictEqual(out._tag, "Spliced");
+		if (out._tag !== "Spliced") return;
+		expect(out.mode).toBe("append");
+		expect(out.body).toBe(body + deps);
+	});
+
+	it("preserves the brief and plan byte-for-byte", () => {
+		const out = spliced(spliceEpicBody({body, deps, plan: null}));
+		expect(out.startsWith(BRIEF + PLAN)).toBe(true);
+	});
+});
+
+describe("re-plan of deps only — REPLACE the pinned section in place (plan unchanged)", () => {
+	const body = BRIEF + PLAN + DEPS;
+	const newDeps = "## Dependencies\n\n### Phase 1\n- #99 — fresh\n";
+
+	it("cuts from the single `## Dependencies` heading to EOF and re-appends the fresh block", () => {
+		const out = spliceEpicBody({body, deps: newDeps, plan: null});
+		assert.strictEqual(out._tag, "Spliced");
+		if (out._tag !== "Spliced") return;
+		expect(out.mode).toBe("replace");
+		expect(out.body).toBe(BRIEF + PLAN + newDeps);
+	});
+
+	it("preserves the brief and the unchanged plan section verbatim", () => {
+		const out = spliced(spliceEpicBody({body, deps: newDeps, plan: null}));
+		expect(out.startsWith(BRIEF + PLAN)).toBe(true);
+		// the old deps line is gone, the fresh one is present
+		expect(out).not.toContain("- #1 — a");
+		expect(out).toContain("- #99 — fresh");
+	});
+});
+
+describe("re-plan of both sections — splice plan AND deps in place", () => {
+	const MIDDLE = "## Testing\n\nsome middle section.\n\n";
+	const body = BRIEF + PLAN + MIDDLE + DEPS;
+	const newPlan = "## Plan (plan-epic)\n\n### Product layer\n\nfresh plan prose.\n\n";
+	const newDeps = "## Dependencies\n\n### Phase 1\n- #7 — new\n";
+
+	it("replaces the plan section (up to the next `## `) and the deps section, keeping the middle", () => {
+		const out = spliceEpicBody({body, deps: newDeps, plan: newPlan});
+		assert.strictEqual(out._tag, "Spliced");
+		if (out._tag !== "Spliced") return;
+		expect(out.mode).toBe("replace");
+		expect(out.body).toBe(BRIEF + newPlan + MIDDLE + newDeps);
+	});
+
+	it("preserves the brief and the middle section byte-for-byte", () => {
+		const out = spliced(spliceEpicBody({body, deps: newDeps, plan: newPlan}));
+		expect(out.startsWith(BRIEF)).toBe(true);
+		expect(out).toContain(MIDDLE);
+		expect(out).not.toContain("old plan prose");
+	});
+
+	it("does not treat the plan block's own `### Phase` sub-headings as a section boundary", () => {
+		const planWithPhases = "## Plan (plan-epic)\n\n### Phase A\n\ntext\n\n### Phase B\n\nmore\n\n";
+		const out = spliced(spliceEpicBody({body, deps: newDeps, plan: planWithPhases}));
+		expect(out).toBe(BRIEF + planWithPhases + MIDDLE + newDeps);
+	});
+});
+
+describe("corrupt-heading guards — refuse rather than orphan or double a section", () => {
+	it("refuses a body with more than one `## Dependencies` heading", () => {
+		const body = `${BRIEF}${DEPS}\n${DEPS}`;
+		const reason = corruptReason(spliceEpicBody({body, deps: DEPS, plan: null}));
+		expect(reason).toContain("2 exact '## Dependencies' headings");
+	});
+
+	it("refuses a re-plan whose body has zero `## Dependencies` headings (drifted/deleted)", () => {
+		const body = BRIEF + PLAN; // no deps heading
+		const reason = corruptReason(spliceEpicBody({body, deps: DEPS, plan: PLAN}));
+		expect(reason).toContain("0 exact '## Dependencies' headings");
+	});
+
+	it("treats a drifted `## Dependencies (phased)` heading as zero (a re-plan then refuses)", () => {
+		const body = `${BRIEF}${PLAN}## Dependencies (phased)\n\n### Phase 1\n- #1 — a\n`;
+		const out = spliceEpicBody({body, deps: DEPS, plan: PLAN});
+		expect(out._tag).toBe("Corrupt");
+	});
+
+	it("refuses a re-plan whose body lacks exactly one `## Plan (plan-epic)` heading", () => {
+		const body = BRIEF + DEPS; // one deps heading, zero plan headings
+		const reason = corruptReason(spliceEpicBody({body, deps: DEPS, plan: PLAN}));
+		expect(reason).toContain("0 exact '## Plan (plan-epic)' headings");
+	});
+
+	it("refuses a re-plan whose body has two `## Plan (plan-epic)` headings", () => {
+		const body = BRIEF + PLAN + PLAN + DEPS;
+		const reason = corruptReason(spliceEpicBody({body, deps: DEPS, plan: PLAN}));
+		expect(reason).toContain("2 exact '## Plan (plan-epic)' headings");
+	});
+});


### PR DESCRIPTION
plan-epic used to hand-compose a ~95-line epic-body splice inline in its Step 5: the guards that count `## Dependencies` / `## Plan (plan-epic)` headings, the choice between appending the block on a first-time plan versus splicing it in place on a re-plan, and the surgical section replacement that keeps every other byte of the epic body untouched. This PR lifts that deterministic text transform out of the skill prose into a shared, unit-tested CLI verb — `pipeline-cli epic-splice apply` — and migrates plan-epic to call it in the same commit, so the recurring splice can no longer drift between a hand-copy in the skill and the logic it describes.

## What changed
- **New tool `packages/pipeline-cli/src/tools/epic-splice/`** — a pure, IO-free core (`epic-splice.ts`) that takes the live body + a fresh `## Dependencies` block (and, on a re-plan, a `## Plan (plan-epic)` block) and returns the spliced body, or a corrupt-heading refusal. A thin Effect CLI (`command.ts`) reads the files, prints the spliced body as raw bytes (no trailing newline added, so the caller's PATCH round-trips), and exits non-zero on a corrupt/duplicated/drifted heading.
- **Unit tests** over first-time append, deps-only re-plan, plan+deps re-plan, the corrupt-heading guards (>1 deps, 0 deps on a re-plan, a drifted `## Dependencies (phased)`, wrong plan-heading count), and **byte-for-byte preservation of the brief**.
- **plan-epic migrated same-commit** (#3254): Step 5's inline anchor-guards + splice/append are replaced by a call to `pipeline-cli epic-splice apply`. The optimistic `updated_at` recheck + PATCH-and-round-trip orchestration stays in the skill prose — it is live-issue IO, not a text transform.
- **adoption-lint manifest** gains the `epic-splice apply` decision, so a future inline re-derivation of the splice reds the build; plan-epic now cites the verb and adoption-lint passes clean.

## Guards
`pnpm typecheck` (33/33), `pnpm lint:worktree` (exit 0), full `pipeline-cli` suite (1581 pass), the new `epic-splice` tests (12 pass), and `adoption-lint` over the full corpus (clean) all green.

This is a §CP change (packages/pipeline-cli + the plan-epic skill) — it banks for human approval rather than auto-merging.

Fixes #3689