### PR TITLE
feat(pipeline-cli): issue-scoped `claim is-mine` resolver verb (default-deny)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -2430,6 +2430,14 @@ comment (§The `status:planning` epic-lock; `plan-epic`/`review-plan`). The
 mis-attribution guard (`write-code` #1456) reads this same surface to prove a target is its
 own before mutating it. Every consumer cites the `CLAIM_RE` and tiebreak defined **here**.
 
+The **resolution** side of this contract — resolve one owner by the earliest authorized
+claim and decide "is it mine?", default-deny — is implemented once as the shared verb
+`pipeline-cli claim is-mine --issue <N>` (#3687, reusing the epic-lock `resolveClaim` core);
+a consumer runs the verb rather than hand-rolling the resolution `jq`, exactly as §5/§6 route
+every marker emit through `pipeline-cli verdict post`. The bash resolution shown below is the
+canonical *reference* the verb implements — read it to understand the tiebreak, run the verb
+to make the decision.
+
 ### Why the bare assignee login cannot be the claim
 
 `write-code` claims by **self-assigning** and the picker's "skip assigned issues" rule

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -539,53 +539,26 @@ is the **only** sanctioned path to a mutation that names `<N>`, no bypass:
 ```bash
 # claim_is_mine <N>: resolve the EARLIEST AUTHORIZED claim marker on #N (issue or PR) and assert
 # its embedded session id == MY_CLAIM. Returns 0 only on a proven-own claim; non-zero (REFUSE) on
-# an absent OR a foreign claim. Reuses the ADR 0115 §1/§2 marker read — no second claim mechanism.
+# an absent OR a foreign claim. The ADR-0115 §2 resolution — CLAIM_RE + the write+ ACL trust root
+# (ADR 0055) + the earliest-(created_at, comment id) tiebreak — is owned once by the shared verb
+# `pipeline-cli claim is-mine`; CITE it, never hand-roll the jq (#3687, the same envelope
+# extraction the shipped review-verdict and tracker verbs underwent). The verb is default-deny: an absent claim, an
+# unauthorized-only claim, a foreign owner, and a missing session all resolve NOT-mine (exit
+# non-zero) — exactly this guard's fail-closed refusal, so the exit-status contract is preserved.
 claim_is_mine() {
-  local N="$1" cf am authorized winner perm a
-  cf=$(mktemp)
-  gh api "repos/$REPO/issues/$N/comments?per_page=100" > "$cf"   # PR comments share the issues endpoint
-  # claim grammar + matcher are SINGLE-SOURCED from gh-issue-intake-formats.md §7 (ADR 0115 §1/§2):
-  # the canonical marker `claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC>` and the ONE `CLAIM_RE`
-  # every consumer shares — cited verbatim here, NEVER re-derived (don't reintroduce a broader
-  # inline grammar; the §7 matcher is the single source the Step-3 write and §7 resolver also use).
-  CLAIM_RE='(?i)^\s*\**\s*claim:\s*[0-9a-f-]{36}\b'   # the §7 single source — cited, not re-derived
-  # AUTHORIZED authors only — write+ collaborators (ADR 0055 trust root, same set ship-it Step 2 /
-  # the repair scan build). A forged claim from a non-collaborator is ignored; an EMPTY authorized
-  # set resolves NO claim ⇒ the guard refuses — fail-closed, never a false win.
-  am=$(jq -r --arg re "$CLAIM_RE" '[.[] | select(.body | test($re)) | .user.login] | unique | .[]' "$cf")
-  authorized='[]'
-  while IFS= read -r a; do
-    [ -z "$a" ] && continue
-    perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
-    case "$perm" in admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;; esac
-  done <<<"$am"
-  # WINNER = the EARLIEST authorized claim — min (created_at, comment id), the server-assigned
-  # ordering (ADR 0115 §2), NOT lexicographic-min(session). Extract its embedded session id with
-  # §7's paired capture form (group `s`) — the same single source, no second grammar.
-  winner=$(jq -r --argjson authorized "$authorized" --arg re "$CLAIM_RE" \
-    '[.[] | select(.user.login | IN($authorized[])) | select(.body | test($re))]
-     | sort_by([.created_at, .id]) | first
-     | (.body // "" | (capture("(?i)^\\s*\\**\\s*claim:\\s*(?<s>[0-9a-f-]{36})") // {s:null}).s) // ""' "$cf")
-  if [ -z "$winner" ]; then
-    echo "mis-attribution guard FAILED (fail-closed): #$N carries no authorized claim marker — refusing to mutate (ADR 0115 §1/§2: absent ⇒ no owner, never a false win)." >&2
-    return 1
-  fi
-  if [ "$winner" != "$MY_CLAIM" ]; then
-    echo "mis-attribution guard FAILED (fail-closed): #$N is claimed by ANOTHER agent (earliest authorized claim session=$winner ≠ mine=$MY_CLAIM) — refusing to push/comment/close work I did not claim (ADR 0115 §4 / #1456; the #1404 near-miss)." >&2
-    return 1
-  fi
-  echo "mis-attribution guard: #$N earliest authorized claim == mine ($MY_CLAIM) — proceeding."
+  pipeline-cli claim is-mine --issue "$1" --session "$MY_CLAIM"   # exit 0 = mine; non-zero = REFUSE (default-deny)
 }
 
 claim_is_mine "<N>" && gh api repos/$REPO/issues/<N>/comments -f body="…"   # the guard gates the mutation; never run it ungated
 ```
 
-The guard is **fail-closed by construction** — it proceeds **only** on positive evidence of an
-authorized claim whose session is `MY_CLAIM`; an absent claim, an unauthorized-only claim, and a
-foreign claim all **refuse**. It is **observable** (it prints the resolved owner vs `MY_CLAIM`) and
-**idempotent** (a read-only GET). **Never** route around it by widening the comparison or treating
-the bare assignee as the owner — the assignee is a coarse availability gate only (ADR 0115 §1), and
-a login-keyed ownership check is the degeneracy this guard exists to remove.
+The guard is **fail-closed by construction** — the verb proceeds (exit 0) **only** on positive
+evidence of an authorized claim whose session is `MY_CLAIM`; an absent claim, an unauthorized-only
+claim, and a foreign claim all resolve not-mine and **refuse** (exit non-zero). It is **observable**
+(the verb prints the resolved owner vs `MY_CLAIM` and the outcome reason) and **idempotent** (a
+read-only GET). **Never** route around it by widening the comparison or treating the bare assignee
+as the owner — the assignee is a coarse availability gate only (ADR 0115 §1), and a login-keyed
+ownership check is the degeneracy this guard exists to remove.
 
 > **Which `<N>` to guard at each site.** The guarded number is the **work-target whose mutation
 > could clobber another agent**: Step 5 guards the **issue** you open the PR against; Step 6 the

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -18,6 +18,7 @@ import {catalogGuardCommand} from "./tools/catalog-guard/command.ts";
 import {changeDetectGuardCommand} from "./tools/change-detect-guard/command.ts";
 import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
 import {ciRequiredCommand} from "./tools/ci-required/command.ts";
+import {claimCommand} from "./tools/claim/command.ts";
 import {classProbeCommand} from "./tools/class-probe/command.ts";
 import {codeownersCpCommand} from "./tools/codeowners-cp/command.ts";
 import {commandsCommand} from "./tools/commands/command.ts";
@@ -169,6 +170,10 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// reds a PR when a substantive unresolved review thread is unaccounted-for in the
 	// review-code verdict, covering the §CP manual-merge path ship-it Step 3.6 never sees.
 	unresolvedThreadsGuardCommand,
+	// The #3687 issue-scoped claim resolver (epic #3258 verb wave): resolves the ADR-0115
+	// earliest-authorized-claim decision — "is this claim mine?" — default-deny, reusing
+	// epic-lock's pure `resolveClaim` core rather than a second copy.
+	claimCommand,
 	// The #3254 adoption corpus-lint (epic #3258, governing AC): reds a corpus file that
 	// inline-re-derives a tool-owned decision without citing the owning verb, so the verb
 	// sweep can't grow the unreferenced-tool pile. Fail-closed on zero scope (ADR 0092).

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -159,6 +159,25 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		reason:
 			"re-derives the §HEAD PR-head-checkout that `pipeline-cli review-head materialize` owns (fetch pull/<pr>/head into a per-run ref, check it out detached), instead of citing the verb (#3690 / #793 / #1807 / #3254)",
 	},
+	{
+		// `claim is-mine` owns the ADR-0115 earliest-authorized-claim RESOLUTION (#3687): resolve
+		// one owner among an issue's claim comments — the earliest write+-authored `claim: <sid>`
+		// marker (ADR 0055 trust root) — and decide "is it mine?", default-deny. The fingerprint is
+		// the co-occurrence of all three tells — the CLAIM_RE UUID-body grammar, the write+ ACL
+		// permission loop, and the earliest-(created_at, id) tiebreak — so an incidental prose
+		// mention of "claim" (the many in triage/ship-it) is not a false finding. The single-source
+		// GRAMMAR contract (gh-issue-intake-formats.md §7) and any consuming skill are compliant by
+		// citing `pipeline-cli claim` (as the verdict contract cites `pipeline-cli verdict post`).
+		verb: "claim is-mine",
+		signature: [
+			/\[0-9a-f-\]\{36\}/, // the CLAIM_RE UUID-body grammar (a session-id claim marker)
+			/collaborators\/[^/]*\/?permission|collaborators\//, // the write+ ACL loop (ADR 0055)
+			/sort_by\(\[?\.(?:created_at|at)|earliest authorized claim/, // the earliest-authorized tiebreak
+		],
+		citation: /pipeline-cli\s+claim\b/,
+		reason:
+			"re-derives the ADR-0115 earliest-authorized-claim resolution that `pipeline-cli claim is-mine` owns (resolve one owner by earliest authorized claim, default-deny), instead of citing the verb (#3687 / #3254)",
+	},
 ];
 
 /**

--- a/packages/pipeline-cli/src/tools/claim/claim-is-mine.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-is-mine.ts
@@ -1,0 +1,55 @@
+/**
+ * The pure "is this claim mine?" decision — the issue-scoped resolver verb's core,
+ * IO-free and total. It answers the one question `write-code`'s Step-3.5 guard and
+ * the orchestrator's pre-spawn check each hand-rolled inline: given an issue's claim
+ * comments, the write+ authorized-author set, and our own session id, is the earliest
+ * authorized claim *ours*?
+ *
+ * It **reuses** epic-lock's `resolveClaim` (the earliest-authorized-claim resolution,
+ * ADR 0115 §2 / gh-issue-intake-formats.md §7) rather than shipping a second copy —
+ * the AC of #3687 — and adds one projection on top: **default-deny**. Only a `won`
+ * outcome is ours; every un-resolvable outcome (`no-session`, `no-winner`, `lost`)
+ * answers **not-mine**, so a caller that cannot prove ownership backs off toward the
+ * expensive-but-correct path rather than mutating on an unproven claim (the #3250
+ * fail-safe license). This makes the mis-attribution guard fail-closed by
+ * construction, not by a caller remembering to check.
+ */
+import {
+	type ClaimResolutionInput,
+	type ClaimWinner,
+	resolveClaim,
+} from "../epic-lock/claim-resolution.ts";
+
+/** Why the decision resolved the way it did — the `resolveClaim` outcome tag, surfaced for observability. */
+export type ClaimReason = "won" | "lost" | "no-winner" | "no-session";
+
+/** The issue-scoped resolver verdict: is the claim ours, and (for a report) the resolved earliest owner. */
+export interface ClaimVerdict {
+	/** Ours iff the earliest authorized claim's session is ours — false on every un-resolvable outcome (default-deny). */
+	readonly mine: boolean;
+	/** The `resolveClaim` outcome that decided it — the audit trail for a caller's log/back-off message. */
+	readonly reason: ClaimReason;
+	/** The resolved earliest authorized claim, when one exists (`won`/`lost`); `null` when none resolved. */
+	readonly winner: ClaimWinner | null;
+}
+
+/**
+ * Resolve whether the earliest authorized claim on an issue is ours, **default-deny**.
+ * Delegates the resolution to the shared `resolveClaim` core and collapses its
+ * four-way outcome to a mine/not-mine answer: `won` ⇒ mine; `lost`, `no-winner`, and
+ * `no-session` all ⇒ not-mine. The un-resolvable outcomes are the fail-safe path —
+ * an absent claim, a foreign owner, or a missing session id can never read as ours.
+ */
+export const claimIsMine = (input: ClaimResolutionInput): ClaimVerdict => {
+	const outcome = resolveClaim(input);
+	switch (outcome._tag) {
+		case "won":
+			return {mine: true, reason: "won", winner: outcome.winner};
+		case "lost":
+			return {mine: false, reason: "lost", winner: outcome.winner};
+		case "no-winner":
+			return {mine: false, reason: "no-winner", winner: null};
+		case "no-session":
+			return {mine: false, reason: "no-session", winner: null};
+	}
+};

--- a/packages/pipeline-cli/src/tools/claim/claim-is-mine.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/claim/claim-is-mine.unit.test.ts
@@ -1,0 +1,112 @@
+import {assert, describe, it} from "@effect/vitest";
+import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
+import {type ClaimVerdict, claimIsMine} from "./claim-is-mine.ts";
+
+const SID_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SID_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const SID_C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const claim = (session: string): string => `claim: ${session} · 2026-07-08T00:00:00Z`;
+
+const comment = (over: Partial<ClaimComment> & {readonly id: number}): ClaimComment => ({
+	author: "usirin",
+	createdAt: "2026-07-08T00:00:00Z",
+	body: claim(SID_A),
+	...over,
+});
+
+describe("claimIsMine — the issue-scoped default-deny resolver decision", () => {
+	const cases: ReadonlyArray<{
+		readonly name: string;
+		readonly comments: ReadonlyArray<ClaimComment>;
+		readonly authorized: ReadonlyArray<string>;
+		readonly sessionId: string | null | undefined;
+		readonly expected: ClaimVerdict;
+	}> = [
+		{
+			name: "the earliest authorized claim is ours → mine",
+			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
+			authorized: ["usirin"],
+			sessionId: SID_A,
+			expected: {
+				mine: true,
+				reason: "won",
+				winner: {session: SID_A, id: 1, createdAt: "2026-07-08T00:00:00Z"},
+			},
+		},
+		{
+			name: "a foreign earliest claim owns the issue → not-mine (lost, defer to the holder)",
+			comments: [
+				comment({id: 10, author: "usirin", createdAt: "2026-07-08T00:00:01Z", body: claim(SID_A)}),
+				comment({id: 20, author: "usirin", createdAt: "2026-07-08T00:00:02Z", body: claim(SID_B)}),
+			],
+			authorized: ["usirin"],
+			sessionId: SID_B,
+			expected: {
+				mine: false,
+				reason: "lost",
+				winner: {session: SID_A, id: 10, createdAt: "2026-07-08T00:00:01Z"},
+			},
+		},
+		{
+			name: "FAIL-SAFE: no authorized claim resolves (only a forged non-collaborator claim) → not-mine (default-deny)",
+			comments: [comment({id: 5, author: "attacker", body: claim(SID_C)})],
+			authorized: ["usirin"],
+			sessionId: SID_A,
+			expected: {mine: false, reason: "no-winner", winner: null},
+		},
+		{
+			name: "FAIL-SAFE: empty authorized set resolves no owner → not-mine (default-deny, never a false win)",
+			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
+			authorized: [],
+			sessionId: SID_A,
+			expected: {mine: false, reason: "no-winner", winner: null},
+		},
+		{
+			name: "FAIL-SAFE: missing session id → not-mine (default-deny) even with our own claim present",
+			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
+			authorized: ["usirin"],
+			sessionId: undefined,
+			expected: {mine: false, reason: "no-session", winner: null},
+		},
+		{
+			name: "FAIL-SAFE: empty-string session id → not-mine (default-deny)",
+			comments: [comment({id: 1, author: "usirin", body: claim(SID_A)})],
+			authorized: ["usirin"],
+			sessionId: "",
+			expected: {mine: false, reason: "no-session", winner: null},
+		},
+		{
+			name: "FAIL-SAFE: no claim comments at all → not-mine (default-deny)",
+			comments: [],
+			authorized: ["usirin"],
+			sessionId: SID_A,
+			expected: {mine: false, reason: "no-winner", winner: null},
+		},
+	];
+
+	for (const {name, comments, authorized, sessionId, expected} of cases) {
+		it(name, () => {
+			assert.deepStrictEqual(
+				claimIsMine({comments, authorizedAuthors: authorized, sessionId}),
+				expected,
+			);
+		});
+	}
+
+	it("is default-deny for EVERY non-won outcome — the only true answer is a proven-own claim", () => {
+		// Property: across the un-resolvable inputs, `mine` is never true. A caller that
+		// cannot prove ownership always backs off (the #3250 fail-safe license).
+		const denials: ReadonlyArray<ClaimVerdict> = [
+			claimIsMine({comments: [], authorizedAuthors: ["usirin"], sessionId: SID_A}),
+			claimIsMine({
+				comments: [comment({id: 1, author: "attacker"})],
+				authorizedAuthors: ["usirin"],
+				sessionId: SID_A,
+			}),
+			claimIsMine({comments: [comment({id: 1})], authorizedAuthors: [], sessionId: SID_A}),
+			claimIsMine({comments: [comment({id: 1})], authorizedAuthors: ["usirin"], sessionId: null}),
+		];
+		for (const verdict of denials) assert.strictEqual(verdict.mine, false);
+	});
+});

--- a/packages/pipeline-cli/src/tools/claim/command.ts
+++ b/packages/pipeline-cli/src/tools/claim/command.ts
@@ -1,0 +1,89 @@
+/**
+ * The `claim` tool — `pipeline-cli claim is-mine --issue <N> [--session <sid>]`.
+ *
+ * The issue-scoped "is this claim mine?" resolver (#3687): resolve the earliest
+ * authorized claim on an arbitrary issue (ADR 0115 §2 / gh-issue-intake-formats.md
+ * §7) and decide whether it is ours — the decision `write-code`'s Step-3.5
+ * mis-attribution guard and the orchestrator's pre-spawn check each hand-rolled
+ * inline. The pure resolution core is epic-lock's `resolveClaim`, reused, not copied;
+ * this verb adds the **default-deny** projection over it (`claim-is-mine.ts`).
+ *
+ * `is-mine` **exits 0 only when the earliest authorized claim is ours** — every
+ * un-resolvable outcome (no authorized claim, a foreign owner, a missing session id)
+ * prints its reason on stderr and **exits non-zero**, so a caller branches on exit
+ * status (`pipeline-cli claim is-mine --issue N && <mutate>`) and backs off fail-safe
+ * toward the expensive-but-correct path (the #3250 license) rather than parsing
+ * prose. The resolved verdict is printed as JSON on stdout for a caller that wants
+ * the detail (the resolved owner, the outcome reason).
+ *
+ * The session id defaults to `$CLAUDE_CODE_SESSION_ID` (the only agent-distinguishable
+ * signal under the shared `usirin` login); `--session` overrides it for the
+ * orchestrated/delegated-token path (`MY_CLAIM`) and for tests. An absent session id
+ * is itself a default-deny outcome — not-mine — never a false win.
+ *
+ * `GithubLive` is baked in with `Command.provide(...)` so the registered command's
+ * residual requirement is the Node platform union (the registry seam, epic #994).
+ */
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import type {ClaimVerdict} from "./claim-is-mine.ts";
+import {Github, GithubLive} from "./github.ts";
+
+const NOT_MINE_EXIT_CODE = 1;
+
+const issueFlag = Flag.integer("issue").pipe(
+	Flag.withDescription("the issue (or PR) number whose claim to resolve"),
+);
+
+const sessionFlag = Flag.string("session").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the session id to resolve ownership against (default: $CLAUDE_CODE_SESSION_ID); the delegated MY_CLAIM token on the orchestrated path",
+	),
+);
+
+/** The resolving session id: `--session` if given, else `$CLAUDE_CODE_SESSION_ID`, else null (a default-deny input). */
+const resolveSession = (session: Option.Option<string>): string | null => {
+	const raw = Option.getOrElse(session, () => process.env.CLAUDE_CODE_SESSION_ID ?? "").trim();
+	return raw === "" ? null : raw;
+};
+
+/** The stderr reason line for a resolved verdict — the human-readable "why" a caller logs. */
+const reasonLine = (issue: number, verdict: ClaimVerdict): string => {
+	switch (verdict.reason) {
+		case "won":
+			return `#${issue}: earliest authorized claim is mine (${verdict.winner?.session}) — proceeding.`;
+		case "lost":
+			return `#${issue}: claimed by another agent (earliest authorized claim ${verdict.winner?.session}) — NOT mine, back off.`;
+		case "no-winner":
+			return `#${issue}: no authorized claim resolves — NOT mine, back off (default-deny, never a false win).`;
+		case "no-session":
+			return `#${issue}: no session id to resolve ownership under (CLAUDE_CODE_SESSION_ID absent and no --session) — NOT mine, back off (default-deny).`;
+	}
+};
+
+const isMine = Command.make(
+	"is-mine",
+	{issue: issueFlag, session: sessionFlag},
+	Effect.fn(function* ({issue, session}) {
+		const sessionId = resolveSession(session);
+		const verdict = yield* (yield* Github).isMine(issue, sessionId);
+		// The resolved detail goes to stdout as JSON (a caller may want the owner / reason);
+		// the human-readable verdict + back-off reason goes to stderr, mirroring verdict/epic-lock.
+		yield* Console.log(JSON.stringify({issue, ...verdict}));
+		process.stderr.write(`claim: ${reasonLine(issue, verdict)}\n`);
+		if (!verdict.mine) process.exit(NOT_MINE_EXIT_CODE);
+	}),
+).pipe(
+	Command.withDescription(
+		"Resolve whether an issue's earliest authorized claim is mine (exit 0 = mine; non-zero = not-mine, default-deny)",
+	),
+);
+
+export const claimCommand = Command.make("claim").pipe(
+	Command.withSubcommands([isMine]),
+	Command.withDescription(
+		"Resolve issue-claim ownership (ADR 0115 earliest-authorized-claim) — the default-deny 'is this claim mine' verb",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/claim/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/claim/github-service.unit.test.ts
@@ -1,0 +1,178 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Github, GithubLive, type RepoResolutionError} from "./github.ts";
+
+// The live layer resolves its repo lazily (ADR 0062 §1); pin the env override so the
+// fixtures keyed on `repos/kamp-us/phoenix/...` match without the ambient `gh repo view`.
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+const methodOf = (args: ReadonlyArray<string>): string => {
+	const i = args.indexOf("-X");
+	return i >= 0 ? (args[i + 1] ?? "GET") : "GET";
+};
+
+/**
+ * A `ChildProcessSpawner` answering `gh api` from a `${method} ${path}` fixture map.
+ * An unmapped key exits 1 (a not-found) — which is how a non-collaborator's
+ * `collaborators/<login>/permission` 404 is modelled.
+ */
+const mockSpawner = (
+	responses: Record<string, Response>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				const path = rawPath.replace(/\?.*$/, "");
+				const key = `${methodOf(args)} ${path}`;
+				const canned =
+					key in responses
+						? normalize(responses[key]!)
+						: {stdout: "", exitCode: 1, stderr: `not found: ${key}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	responses: Record<string, Response>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const ISSUE = 3687;
+const P = `repos/kamp-us/phoenix`;
+const SID_MINE = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SID_OTHER = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const SID_FORGED = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const claimComment = (over: {
+	readonly id: number;
+	readonly login: string;
+	readonly session: string;
+	readonly at?: string;
+}) =>
+	({
+		id: over.id,
+		created_at: over.at ?? "2026-07-08T00:00:00Z",
+		user: {login: over.login},
+		body: `claim: ${over.session} · ${over.at ?? "2026-07-08T00:00:00Z"}`,
+	}) as const;
+
+describe("Github.isMine — the issue-scoped default-deny resolver over a mock gh spawner", () => {
+	it.effect("earliest authorized claim is ours → mine", () =>
+		Effect.gen(function* () {
+			const verdict = yield* (yield* Github).isMine(ISSUE, SID_MINE);
+			assert.strictEqual(verdict.mine, true);
+			assert.strictEqual(verdict.reason, "won");
+			assert.strictEqual(verdict.winner?.session, SID_MINE);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+					claimComment({id: 700, login: "usirin", session: SID_MINE}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+			}),
+		),
+	);
+
+	it.effect("a foreign earlier authorized claim owns the issue → not-mine (lost)", () =>
+		Effect.gen(function* () {
+			const verdict = yield* (yield* Github).isMine(ISSUE, SID_MINE);
+			assert.strictEqual(verdict.mine, false);
+			assert.strictEqual(verdict.reason, "lost");
+			assert.strictEqual(verdict.winner?.session, SID_OTHER);
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+					claimComment({id: 500, login: "usirin", session: SID_OTHER, at: "2026-07-08T00:00:01Z"}),
+					claimComment({id: 800, login: "usirin", session: SID_MINE, at: "2026-07-08T00:00:02Z"}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+			}),
+		),
+	);
+
+	it.effect(
+		"FAIL-SAFE: only a forged non-collaborator claim exists → not-mine (default-deny, no-winner)",
+		() =>
+			Effect.gen(function* () {
+				const verdict = yield* (yield* Github).isMine(ISSUE, SID_MINE);
+				assert.strictEqual(verdict.mine, false);
+				assert.strictEqual(verdict.reason, "no-winner");
+			}).pipe((effect) =>
+				provide(effect, {
+					[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+						claimComment({id: 10, login: "attacker", session: SID_FORGED}),
+					]),
+					// a non-collaborator's permission probe 404s → dropped from the authorized set
+					[`GET ${P}/collaborators/attacker/permission`]: {
+						stdout: "",
+						exitCode: 1,
+						stderr: "HTTP 404: Not Found",
+					},
+				}),
+			),
+	);
+
+	it.effect("FAIL-SAFE: an unclaimed issue (no claim comments) → not-mine (default-deny)", () =>
+		Effect.gen(function* () {
+			const verdict = yield* (yield* Github).isMine(ISSUE, SID_MINE);
+			assert.strictEqual(verdict.mine, false);
+			assert.strictEqual(verdict.reason, "no-winner");
+		}).pipe((effect) =>
+			provide(effect, {[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([])}),
+		),
+	);
+
+	it.effect("FAIL-SAFE: a null session id → not-mine (default-deny, no-session)", () =>
+		Effect.gen(function* () {
+			const verdict = yield* (yield* Github).isMine(ISSUE, null);
+			assert.strictEqual(verdict.mine, false);
+			assert.strictEqual(verdict.reason, "no-session");
+		}).pipe((effect) =>
+			provide(effect, {
+				[`GET ${P}/issues/${ISSUE}/comments`]: JSON.stringify([
+					claimComment({id: 700, login: "usirin", session: SID_MINE}),
+				]),
+				[`GET ${P}/collaborators/usirin/permission`]: "write",
+			}),
+		),
+	);
+});

--- a/packages/pipeline-cli/src/tools/claim/github.ts
+++ b/packages/pipeline-cli/src/tools/claim/github.ts
@@ -1,0 +1,254 @@
+/**
+ * The GitHub boundary for the `claim` verb: a read-only `Github` capability that
+ * resolves "is this issue's claim mine?" over `gh api` REST, driving the IO-free
+ * `claim-is-mine.ts` decision (which itself reuses epic-lock's `resolveClaim` core).
+ *
+ * Same `Context.Service`-on-`ChildProcessSpawner` shape as epic-lock's `github.ts`
+ * (the epic #994 template child): REST only (GraphQL is broken on the kamp-us org),
+ * every infra failure a typed error in the `E` channel (`.patterns/effect-errors.md`)
+ * — a non-zero `gh` exit is `GhCommandError`, malformed output is `GhParseError`, an
+ * unresolvable repo is `RepoResolutionError` — and Schema-decoded untrusted REST JSON
+ * at the boundary. Unlike epic-lock this verb only READS: it lists the issue's
+ * comments, resolves the write+ authorized-author set (ADR 0055), and resolves the
+ * earliest authorized claim against our session id. No label, no comment write.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {ClaimComment} from "../epic-lock/claim-resolution.ts";
+import {type ClaimVerdict, claimIsMine} from "./claim-is-mine.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/claim/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/claim/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/claim/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit.
+ * `ChildProcess.make` is spawned directly to read `exitCode` + `stderr` and lower a
+ * non-zero exit into a typed error; a spawn/IO `PlatformError` (e.g. `gh` not on
+ * PATH) folds into the same `GhCommandError` (exit code `-1`).
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
+ * defaults: with no env and no resolvable current repo it fails `RepoResolutionError`.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/claim/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// REST-only arg builders — never GraphQL.
+
+const listCommentsArgs = (repo: string, issue: number): ReadonlyArray<string> => [
+	"api",
+	"--paginate",
+	`repos/${repo}/issues/${issue}/comments?per_page=100`,
+];
+
+const permissionArgs = (repo: string, login: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/collaborators/${login}/permission`,
+	"--jq",
+	".permission",
+];
+
+/** A raw comment as the issues/comments endpoint returns it; only these fields are read. */
+const RawComment = Schema.Struct({
+	id: Schema.Number,
+	created_at: Schema.String,
+	body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	user: Schema.NullOr(Schema.Struct({login: Schema.String})),
+});
+const decodeComments = Schema.decodeUnknownEffect(Schema.Array(RawComment));
+
+const toClaimComment = (raw: (typeof RawComment)["Type"]): ClaimComment => ({
+	id: raw.id,
+	author: raw.user?.login ?? "",
+	createdAt: raw.created_at,
+	body: raw.body ?? "",
+});
+
+const listClaimComments = Effect.fn("Github.listClaimComments")(function* (
+	repo: string,
+	issue: number,
+) {
+	const raw = yield* decodeComments(yield* json(listCommentsArgs(repo, issue)));
+	return raw.map(toClaimComment);
+});
+
+/**
+ * The write+ collaborator subset of `logins` — the ADR 0055 trust root. Each login is
+ * probed with `collaborators/<login>/permission`; a non-`admin|maintain|write`
+ * permission, or any `gh` fault on the probe (a non-collaborator commonly 404s),
+ * drops the login. A forged claim from a non-collaborator therefore never enters the
+ * authorized set the decision resolves over.
+ */
+const authorizedAuthors = Effect.fn("Github.authorizedAuthors")(function* (
+	repo: string,
+	logins: ReadonlyArray<string>,
+) {
+	const results = yield* Effect.forEach(
+		logins,
+		(login) =>
+			runGh(permissionArgs(repo, login)).pipe(
+				Effect.map((out) => ({login, permission: out.trim()})),
+				Effect.catchTag("@kampus/claim/GhCommandError", () =>
+					Effect.succeed({login, permission: "none"}),
+				),
+			),
+		{concurrency: "unbounded"},
+	);
+	return results
+		.filter(
+			(r) => r.permission === "admin" || r.permission === "maintain" || r.permission === "write",
+		)
+		.map((r) => r.login);
+});
+
+/**
+ * Resolve whether the earliest authorized claim on `issue` is ours, default-deny.
+ * Lists the issue's comments, resolves the write+ authorized-author set from the
+ * distinct claim-marker authors, then hands both plus our session id to the pure
+ * `claimIsMine` decision. Every un-resolvable state (no authorized claim, foreign
+ * owner, missing session) answers not-mine — the fail-safe the decision guarantees.
+ */
+const isMine = Effect.fn("Github.isMine")(function* (
+	repo: string,
+	issue: number,
+	sessionId: string | null,
+) {
+	const comments = yield* listClaimComments(repo, issue);
+	const authors = [...new Set(comments.map((c) => c.author).filter((a) => a.length > 0))];
+	const authorized = yield* authorizedAuthors(repo, authors);
+	return claimIsMine({comments, authorizedAuthors: authorized, sessionId});
+});
+
+/**
+ * `Github` — the read-only IO shell over `gh api` REST. `isMine` is the one verb the
+ * `claim` tool exposes: it takes the issue number and the resolving session id and
+ * returns the default-deny `ClaimVerdict`. Built by `GithubLive`, whose `R` is
+ * `ChildProcessSpawner`: provide the platform spawner (`NodeServices.layer`) in
+ * production; a test provides a mock spawner via `ChildProcessSpawner.make`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly isMine: (
+			issue: number,
+			sessionId: string | null,
+		) => Effect.Effect<
+			ClaimVerdict,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/claim/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at
+ * construction and provided *into* the method body, so the public method carries
+ * `R = never`. Repo resolution is deferred to first use (`Effect.cached`, ADR 0062
+ * §1): the layer build is side-effect-free, and `RepoResolutionError` lives in the
+ * method's `E` channel, raised only when `isMine` actually reads.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				isMine: (issue: number, sessionId: string | null) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(isMine(r, issue, sessionId)))),
+			};
+		}),
+	);


### PR DESCRIPTION
This adds a small `pipeline-cli claim is-mine --issue <N>` command that answers one question: is the claim on this issue mine? Agents draining the backlog stamp a session-id claim comment on the issue they pick up, and several of them (most notably write-code's mis-attribution guard) each hand-rolled ~40 lines of `jq` to re-resolve "who owns this?" before mutating an issue or PR. This collapses that decision into one shared verb, reusing the exact resolution core epic-lock already ships, and — crucially — it is default-deny: if ownership can't be proven, the answer is "not mine", so a caller backs off toward the safe path instead of acting on an unproven claim.

## What changed
- **New `claim is-mine` verb** (`packages/pipeline-cli/src/tools/claim/`): resolves the earliest authorized claim (write+ ACL trust root, ADR 0055) on an arbitrary issue and exits 0 only when it is ours; every un-resolvable outcome exits non-zero. The resolved verdict prints as JSON on stdout; the reason prints on stderr.
- **Pure core reuses epic-lock, not a second copy** (AC 3): `claim-is-mine.ts` imports `resolveClaim` from `tools/epic-lock/claim-resolution.ts` and adds one projection on top — the default-deny mapping (`won` ⇒ mine; `lost`/`no-winner`/`no-session` ⇒ not-mine).
- **Default-deny is unit-tested** (AC 2): `claim-is-mine.unit.test.ts` asserts each fail-safe path (no authorized claim, empty authorized set, missing/empty session, no comments) resolves not-mine, plus a property test that no un-resolvable input ever reads as mine. `github-service.unit.test.ts` covers the IO path over a mock `gh` spawner.
- **Consumers cite the verb, same-commit** (AC 3, #3254): write-code's Step-3.5 `claim_is_mine` guard now delegates to the verb instead of inlining the resolution `jq`; `gh-issue-intake-formats.md` §7 names the verb as the resolution implementation (mirroring how §5/§6 route emits through `verdict post`). The `adoption-lint` manifest gains a `claim is-mine` decision so a future un-cited re-derivation reds the build. `adoption-lint check` is clean.

## Verification
- `pnpm typecheck` (full workspace, 33/33) and `pnpm lint:worktree` clean.
- 13 unit tests pass; `adoption-lint` clean over the full corpus.
- Live end-to-end against this very issue: `claim is-mine --issue 3687` exits 0 for my session, non-zero for a foreign session.

Out of scope: the coarse-label lock acquire/release lifecycle stays in epic-lock; this is the resolver decision only.

Fixes #3687