### PR TITLE
feat(pipeline-cli): review-head materialization verb — de-quadruplicate the gate skills' PR-head checkout (#3690)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1869,19 +1869,26 @@ ad hoc.
 **The invariant — a review gate MUST source ALL code/prose under review from the PR head, and
 assert it did:**
 
-1. **Resolve the live head SHA up front, via REST/porcelain — never GraphQL** (§Target repo
-   resolution / the all-`gh api` rule). This is the SHA the verdict binds to (§5/ADR 0058):
+1. **Resolve + materialize the head via the shared `pipeline-cli review-head` verb — never
+   re-derive it inline** (#3690 / #793 / #1807; `packages/pipeline-cli/src/tools/review-head/`).
+   The verb owns the deterministic mechanism this section used to spell out inline: it resolves the
+   live head SHA up front via REST (never GraphQL — the SHA the verdict binds to, §5/ADR 0058),
+   fetches the head into a per-run ref (never the launched checkout — the §RO read-only path), and
+   **asserts the fetched ref resolves to exactly that SHA before you review** — aborting on a moved
+   head rather than binding a stale verdict. Two modes, same core:
    ```bash
-   HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
+   # ref-only (review-doc reads via `git show "$PR_REF:<path>"`):
+   eval "$(pipeline-cli review-head materialize --pr "$PR" | jq -r '"PR_REF=\(.prRef); HEAD_SHA=\(.headSha)"')"
+   # full detached head worktree (review-code / review-skill), emitted as `.worktreeDir`:
+   pipeline-cli review-head materialize --pr "$PR" --worktree | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
    ```
-2. **Materialize the head into a per-run ref (never the launched checkout)** — the §RO
-   read-only path — and confirm it resolves to exactly that SHA before reviewing:
-   ```bash
-   PR_REF="refs/pr/$PR-$(uuidgen)"
-   git fetch origin "pull/$PR/head:$PR_REF"
-   FETCHED="$(git rev-parse "$PR_REF")"
-   [ "$FETCHED" = "$HEAD_SHA" ] || { echo "FATAL: fetched head $FETCHED != resolved $HEAD_SHA — aborting" >&2; exit 1; }
-   ```
+   `pull/<pr>/head` resolves same-repo AND cross-fork, and the checkout is always DETACHED onto the
+   per-run ref — never `gh pr checkout` / `git checkout` / `git switch`, which would land the head in
+   the shared PRIMARY the harness resets a subagent's cwd to and detach the human's `main`
+   (#2270/#1103; the verb refuses this outright). Run `iso_preflight` (§RO-iso) BEFORE the verb.
+2. **(owned by the verb, step 1)** — the per-run-ref fetch + the fetched-ref-IS-the-head assertion
+   are the verb's, not a step each gate re-derives; `review-design` reviews a preview URL rather than
+   a tree, so it uses the lighter `pipeline-cli review-head resolve --pr "$PR"` (the head SHA only).
 3. **Read every file under review FROM THE HEAD, never from CWD.** Route full-file reads
    through `git show "$PR_REF:<path>"` (or read from the throwaway head worktree the gate
    already materializes — `git worktree add "$(mktemp -d)/…" "$PR_REF"`, `$REVIEW_WT`), and

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -322,36 +322,28 @@ BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
 # whose consumers had merged minutes earlier was FAILed against a stale local main.)
 git fetch origin "$BASE_REF"
 
-# Fetch the PR head into a dedicated ref WITHOUT touching the session tree. pull/$PR/head
-# resolves for same-repo AND cross-fork PRs, so there is no separate cross-fork branch to
-# check out into your own tree (the trust inversion ADR 0052 closes — never run
-# `gh pr checkout` / `git checkout` / `git switch`, which materialize the head into a working
-# tree: the harness resets this cwd to the shared PRIMARY between Bash calls, so a bare checkout
-# lands there and detaches the human's `main` (#2270/#1103 detach class) — §RO forbids it outright).
-# Per-run ref: the PR number alone is shared, so a second review of the same PR would
-# overwrite the ref mid-review and you'd verify the wrong SHA — uniquify it per invocation.
-PR_REF="refs/pr/$PR-$(uuidgen)"
-git fetch origin "pull/$PR/head:$PR_REF"
-
-REVIEW_WT="$(mktemp -d)/review-head-${PR}"
-# Persist the run-unique worktree path to a per-run mktemp handle so it survives the harness
-# cwd/shell reset between Bash calls — $REVIEW_WT is a shell var lost across calls, and the leaf
-# `review-head-${PR}` is PR-namespaced, so a later step re-deriving it from `git worktree list`
-# would match a SIBLING reviewer's `review-head-<otherPR>` and pin the wrong head (the collision
-# #1807: a reviewer re-read a shared pointer and found it flipped to a sibling's worktree). Mirror
-# the VERDICT_FILE (#1465) / report BODY_FILE mktemp discipline: `. "$WT_FILE"` at the start of
-# each later step re-sources $REVIEW_WT/$PR_REF from the run-unique handle, NEVER from
-# the shared leaf name. WT_FILE itself is `$(mktemp)` — never a fixed/PR-only path. HEAD_SHA is
-# NOT persisted here: it is re-resolved fresh against the live head at each later step (§HEAD),
-# so only the run-unique tree/ref handles need to survive.
+# §HEAD steps 1–3 (resolve the live head SHA, fetch pull/$PR/head into a per-run ref WITHOUT
+# touching the session tree, assert the fetched ref IS that head, add a throwaway DETACHED head
+# worktree) are the shared `pipeline-cli review-head materialize` verb (#3690 / #793 / #1807) —
+# cite it, don't re-derive it. `pull/<pr>/head` resolves for same-repo AND cross-fork PRs, so there
+# is no separate cross-fork branch to check out (the trust inversion ADR 0052 closes); the verb
+# never runs `gh pr checkout` / `git checkout` / `git switch` (which would land the head in the
+# shared PRIMARY the harness resets this cwd to and detach the human's `main` — #2270/#1103), and it
+# nonce-uniques the ref per invocation so a concurrent review of the same PR can't overwrite it
+# (#1807). It emits the resolved head + ref + worktree as JSON. Persist those to a per-run mktemp
+# handle so they survive the harness cwd/shell reset between Bash calls (a shell var is lost across
+# calls); re-source them with `. "$WT_FILE"` at each later step — NEVER re-derive from a shared leaf
+# name (a `git worktree list` re-derivation matches a SIBLING reviewer's tree and pins the wrong head).
+# The `--worktree` tree is a FULL checkout (ADR 0067): biome.jsonc + biome-plugins/, patches/, the
+# catalog/lockfile, and everything `fate generate` needs are present, so the typecheck bootstrap is
+# whole. A full checkout also lands the head's root CLAUDE.md + .claude/.decisions/.patterns — that
+# leak is closed by the explicit denylist removal + absence-assert below, NOT by any pattern set.
 WT_FILE="$(mktemp /tmp/review-code-wt.XXXXXX)"
-{ echo "REVIEW_WT='$REVIEW_WT'"; echo "PR_REF='$PR_REF'"; } > "$WT_FILE"
-# Cone-mode-minus-denylist (ADR 0067): a FULL checkout materializes the head's whole tree, so
-# biome.jsonc + biome-plugins/, patches/, the catalog/lockfile, and everything `fate generate`
-# needs are present — the typecheck bootstrap is whole. A full checkout (like cone mode) also
-# lands the head's root CLAUDE.md + .claude/.decisions/.patterns — that leak is closed by the
-# explicit denylist removal + absence-assert below, NOT by any include/cone pattern set.
-git worktree add "$REVIEW_WT" "$PR_REF"
+pipeline-cli review-head materialize --pr "$PR" --worktree \
+  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
+. "$WT_FILE"
+[ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
+  echo "FATAL: review-head materialize did not yield a head worktree — aborting (never review the base tree; §HEAD)." >&2; exit 1; }
 
 # LAYER-2 containment (#2666): a freshly materialized worktree MUST come up pristine — assert it
 # clean NOW, before the denylist `rm --cached` below deliberately dirties it. A dirty materialization

--- a/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-design/SKILL.md
@@ -314,7 +314,10 @@ CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page
 ```bash
 gh api repos/$REPO/pulls/$PR \
   --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head your verdict binds to (ADR 0058)
+# Resolve the current head SHA the verdict binds to (ADR 0058) via the shared
+# `pipeline-cli review-head` verb (#3690 / #793 / #1807) — `resolve` is REST-only (this gate
+# reviews the preview URL, not a checked-out tree), fail-safe on a missing/closed/partial head:
+HEAD_SHA="$(pipeline-cli review-head resolve --pr "$PR" | jq -r .headSha)"
 ```
 
 Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `write-code` writes) —

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -340,13 +340,13 @@ branch cut from `origin/main` (the **base**) — so a plain full-file `Read`/`ca
 reads the **pre-PR base**, and you would review the wrong file version while binding the verdict
 to the right head SHA (issue [#793](https://github.com/kamp-us/phoenix/issues/793); the
 false-PASS hazard). Obey [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §HEAD
-**before** verifying any criterion — cite it, don't re-derive the steps: resolve the live head
-via REST (`gh pr view $PR --repo "$REPO" --json headRefOid -q .headRefOid`), fetch it into the
-per-run `$PR_REF` + assert `git rev-parse "$PR_REF"` equals it, read every full file from the
-head (`git show "$PR_REF:<path>"`) and **never** from CWD, and re-check the live head before
-posting (§HEAD #4). The fetch-into-a-ref read mechanism below *is* §HEAD's read path for this
-diff-only gate; the verdict (§5) must bind to the SHA whose files you actually read and assert
-it read the PR head.
+**before** verifying any criterion — cite it, don't re-derive the steps: run
+`pipeline-cli review-head materialize --pr "$PR"` (the shared verb, #3690 / #793 / #1807) to
+resolve the live head SHA via REST, fetch it into the per-run `$PR_REF`, and assert the fetched
+ref IS that head; then read every full file from the head (`git show "$PR_REF:<path>"`) and
+**never** from CWD, and re-check the live head before posting (§HEAD #4). The verb's
+fetch-into-a-ref is §HEAD's read path for this diff-only gate; the verdict (§5) must bind to the
+SHA whose files you actually read and assert it read the PR head.
 
 Verification is grounded in the **diff**, not the PR's self-description. There is **no
 test-running here** — a doc PR has no behavior to exercise; the artifact *is* the prose,
@@ -364,12 +364,15 @@ the hunk alone — and read it **read-only**, without ever switching the checkou
 **Read-only on git working state** below). Fetch the head into a ref and read off that ref:
 
 ```bash
-# Land the head in a per-run ref WITHOUT touching the working tree (resolves for same-repo
-# AND cross-fork PRs — never `gh pr checkout` / `git checkout` / `git switch`: the harness
-# resets this cwd to the shared PRIMARY between Bash calls, so a checkout lands there and
-# detaches the human's `main` (#2270/#1103), and §RO forbids switching your tree outright):
-PR_REF="refs/pr/$PR-$(uuidgen)"
-git fetch origin "pull/$PR/head:$PR_REF"
+# Land the head in a per-run ref via the shared `pipeline-cli review-head materialize` verb
+# (#3690 / #793 / #1807) — cite it, don't re-derive it. Ref-only mode (no `--worktree`): it
+# resolves the live head SHA (REST), fetches `pull/<pr>/head` into a nonce-uniqued per-run ref
+# WITHOUT touching the working tree, and asserts the fetched ref IS that head. It never runs
+# `gh pr checkout` / `git checkout` / `git switch` (which would land the head in the shared PRIMARY
+# the harness resets this cwd to and detach the human's `main` — #2270/#1103; §RO). It emits the
+# head + ref as JSON:
+eval "$(pipeline-cli review-head materialize --pr "$PR" \
+  | jq -r '"PR_REF=\(.prRef); HEAD_SHA=\(.headSha)"')"
 
 # Read the head's files off the ref — read-only, no checkout:
 git show "$PR_REF:<path>"            # the file's content at the PR head
@@ -378,18 +381,18 @@ git grep -n "<pattern>" "$PR_REF"    # search the head tree without checking it 
 git update-ref -d "$PR_REF"          # drop the throwaway ref when done
 ```
 
-If a check genuinely needs a materialized tree (rare for a doc PR), add a **throwaway
-worktree** from `$PR_REF` and **persist its run-unique path to a per-run `mktemp` handle**
-so a later step recovers the exact own tree rather than re-deriving it from the shared,
-PR-namespaced `review-doc-head-$PR` leaf (which would match a sibling reviewer's
-`review-doc-head-<otherPR>` under a parallel fan-out and pin the wrong head — the #1807
-collision; mirror the `VERDICT_FILE` (#1465) / report `BODY_FILE` `mktemp` discipline):
+If a check genuinely needs a materialized tree (rare for a doc PR), pass `--worktree` to the
+same verb — it adds a throwaway DETACHED head worktree (named `review-head-<pr>-*`) and emits
+its path. **Persist that path to a per-run `mktemp` handle** so a later step recovers the exact
+own tree rather than re-deriving it from a shared, PR-namespaced leaf (which would match a
+sibling reviewer's tree under a parallel fan-out and pin the wrong head — the #1807 collision;
+mirror the `VERDICT_FILE` (#1465) / report `BODY_FILE` `mktemp` discipline):
 
 ```bash
-REVIEW_WT="$(mktemp -d)/review-doc-head-$PR"
 WT_FILE="$(mktemp /tmp/review-doc-wt.XXXXXX)"          # run-unique handle, never a fixed/PR-only path
-{ echo "REVIEW_WT='$REVIEW_WT'"; echo "PR_REF='$PR_REF'"; } > "$WT_FILE"
-git worktree add "$REVIEW_WT" "$PR_REF"
+pipeline-cli review-head materialize --pr "$PR" --worktree \
+  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)"' > "$WT_FILE"
+. "$WT_FILE"
 # Register teardown as a trap so a mid-block error still tears the throwaway tree down:
 trap 'rm -rf "$REVIEW_WT"; git worktree prune' EXIT
 # … later steps: `. "$WT_FILE"` re-sources $REVIEW_WT/$PR_REF after a between-call reset,

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -70,31 +70,25 @@ reviewing (below), read all skill text from the head, and re-check the live head
 BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main — your trusted config
 git fetch origin "$BASE_REF"
 
-# §HEAD: resolve the live head via REST (never GraphQL) — the SHA the verdict binds to (ADR 0058).
-HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
-
-# Fetch the PR head into a dedicated ref WITHOUT touching the session tree (same-repo AND
-# cross-fork; never `gh pr checkout` / `git checkout` / `git switch`, which materialize the head
-# into a working tree — the harness resets this cwd to the shared PRIMARY between Bash calls, so a
-# bare checkout lands there and detaches the human's `main` (#2270/#1103), and §RO forbids it).
-PR_REF="refs/pr/$PR-$(uuidgen)"
-git fetch origin "pull/$PR/head:$PR_REF"
-# §HEAD #2: confirm the fetched ref IS the resolved head before reviewing — else you'd review a
-# different SHA than the verdict claims. Abort on mismatch rather than bind a stale verdict.
-[ "$(git rev-parse "$PR_REF")" = "$HEAD_SHA" ] || { echo "FATAL: fetched head != resolved $HEAD_SHA — aborting" >&2; exit 1; }
-
-REVIEW_WT="$(mktemp -d)/review-skill-head-${PR}"
-# Persist the run-unique worktree path to a per-run mktemp handle so it survives the harness
-# cwd/shell reset between Bash calls — $REVIEW_WT is a shell var lost across calls, and the leaf
-# `review-skill-head-${PR}` is PR-namespaced, so a later step re-deriving it from `git worktree
-# list` would match a SIBLING reviewer's `review-skill-head-<otherPR>` and read the wrong head's
-# skill text (the #1807 collision: a reviewer re-read a shared pointer and found it flipped to a
-# sibling's worktree). Mirror the VERDICT_FILE (#1465) / report BODY_FILE mktemp discipline:
-# `. "$WT_FILE"` at the start of each later step re-sources these from the run-unique handle,
-# NEVER from the shared leaf name. WT_FILE itself is `$(mktemp)` — never a fixed/PR-only path.
+# §HEAD steps 1–3 (resolve the live head SHA via REST, fetch pull/$PR/head into a nonce-uniqued
+# per-run ref WITHOUT touching the session tree, assert the fetched ref IS that head, add a
+# throwaway DETACHED head worktree) are the shared `pipeline-cli review-head materialize` verb
+# (#3690 / #793 / #1807) — cite it, don't re-derive it. `pull/<pr>/head` resolves same-repo AND
+# cross-fork; the verb never runs `gh pr checkout` / `git checkout` / `git switch` (which would land
+# the head in the shared PRIMARY the harness resets this cwd to and detach the human's `main` —
+# #2270/#1103; §RO), and it internally aborts on a fetched-ref ≠ resolved-head mismatch (§HEAD #2)
+# so you never review a different SHA than the verdict claims. Persist its emitted head/ref/worktree
+# to a per-run mktemp handle so they survive the harness cwd/shell reset between Bash calls (a shell
+# var is lost across calls); re-source them with `. "$WT_FILE"` at each later step — NEVER re-derive
+# from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING reviewer's tree and
+# reads the wrong head's skill text — the #1807 collision). Mirror the VERDICT_FILE (#1465) / report
+# BODY_FILE mktemp discipline; WT_FILE itself is `$(mktemp)`, never a fixed/PR-only path.
 WT_FILE="$(mktemp /tmp/review-skill-wt.XXXXXX)"
-{ echo "REVIEW_WT='$REVIEW_WT'"; echo "PR_REF='$PR_REF'"; echo "HEAD_SHA='$HEAD_SHA'"; } > "$WT_FILE"
-git worktree add "$REVIEW_WT" "$PR_REF"
+pipeline-cli review-head materialize --pr "$PR" --worktree \
+  | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
+. "$WT_FILE"
+[ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {
+  echo "FATAL: review-head materialize did not yield a head worktree — aborting (never review the base tree; §HEAD)." >&2; exit 1; }
 
 # Enforce the instruction denylist EXPLICITLY (a full checkout lands the head's root CLAUDE.md
 # + .claude/.decisions/.patterns): remove them, then ASSERT absent — the load-bearing isolation

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -52,6 +52,7 @@ import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {redactLeaksCommand} from "./tools/redact-leaks/command.ts";
 import {refGuardCommand} from "./tools/ref-guard/command.ts";
 import {resumePolicyCommand} from "./tools/resume-policy/command.ts";
+import {reviewHeadCommand} from "./tools/review-head/command.ts";
 import {roadmapCommand} from "./tools/roadmap/command.ts";
 import {roadmapGuardCommand} from "./tools/roadmap-guard/command.ts";
 import {settingsEnvGuardCommand} from "./tools/settings-env-guard/command.ts";
@@ -141,6 +142,10 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	designTokenGuardCommand,
 	designInventoryCommand,
 	resumePolicyCommand,
+	// The shared PR-head-checkout the review gates cite instead of hand-copying the §HEAD
+	// materialization (#793 / #1807): resolve + fetch the PR's current head into a per-run ref
+	// (+ optional detached worktree), asserting the fetched ref IS the resolved head (ADR 0058).
+	reviewHeadCommand,
 	evalHarnessCommand,
 	mainSyncCommand,
 	refGuardCommand,

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -11,7 +11,8 @@
  *
  * Seeded with the canonical #3254 example — `verdict read`, whose ADR-0058
  * SHA-bound marker-resolution three skills hand-copy (#2102). `tracker apply-triage`
- * (#3263), `tracker post-verdict` (#3265), and `tracker graduate` (#3266) have since
+ * (#3263), `tracker post-verdict` (#3265), `tracker graduate` (#3266), and
+ * `review-head materialize` (#3690, the §HEAD PR-head-checkout of #793 / #1807) have since
  * landed with their consumer migrations; the remaining envelope decision (claim) arrives
  * with its sibling child.
  */
@@ -141,6 +142,22 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		citation: /pipeline-cli\s+intake-compose\b/,
 		reason:
 			"re-derives the format-2 sub-issue body that `pipeline-cli intake-compose sub-issue` owns (the gh-issue-intake-formats.md prose contract §2), instead of citing the verb (#3688 / #3254)",
+	},
+	{
+		// `review-head materialize` owns the §HEAD PR-head-checkout the review-code / review-doc /
+		// review-skill gates each hand-copied (#793 / #1807): fetch `pull/<pr>/head` into a per-run
+		// `refs/pr/` ref (never the launched tree) and check it out DETACHED for review. The fingerprint
+		// is the co-occurrence of both tells — the `pull/<pr>/head:` fetch refspec AND the per-run
+		// `refs/pr/` ref — so an incidental mention of a head SHA (review-design resolves `.head.sha`
+		// only, no checkout) is not a false finding. A file that cites `pipeline-cli review-head` is compliant.
+		verb: "review-head materialize",
+		signature: [
+			/pull\/\$\{?PR\}?\/head:/, // the head-fetch refspec into a per-run ref
+			/refs\/pr\//, // the per-run ref namespace the head lands in
+		],
+		citation: /pipeline-cli\s+review-head\b/,
+		reason:
+			"re-derives the §HEAD PR-head-checkout that `pipeline-cli review-head materialize` owns (fetch pull/<pr>/head into a per-run ref, check it out detached), instead of citing the verb (#3690 / #793 / #1807 / #3254)",
 	},
 ];
 

--- a/packages/pipeline-cli/src/tools/review-head/command.ts
+++ b/packages/pipeline-cli/src/tools/review-head/command.ts
@@ -1,0 +1,88 @@
+/**
+ * The `review-head` tool — `pipeline-cli review-head resolve` / `materialize`.
+ *
+ * The shared, tested owner of "materialize the PR's current review head for review" (#793 / #1807),
+ * extracted from the inline copies the review-code / review-doc / review-skill gates each hand-rolled
+ * and the head-SHA resolution review-design binds its verdict to. A pure resolution core
+ * (`resolve-head.ts`) + the checkout step the verb owns (`materialize.ts`).
+ *
+ *   resolve --pr N         — print the current head SHA + ref as JSON (REST only). review-design.
+ *   materialize --pr N      — resolve, fetch `pull/N/head` into a per-run ref, assert it IS the head,
+ *     [--worktree]            and (with --worktree) add a throwaway DETACHED worktree. Prints the
+ *                             resolved head + prRef (+ worktreeDir) as JSON on stdout for the caller
+ *                             to `eval`/read; every refusal prints its reason on stderr and exits non-zero.
+ *
+ * The caller runs the §RO-iso primary-checkout preflight (gh-issue-intake-formats.md) BEFORE
+ * `materialize` — this verb is the deterministic mechanism, not the isolation gate. `ReviewHeadLive`
+ * is baked in with `Command.provide(...)` so the residual requirement is the Node platform union.
+ */
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {ReviewHead, ReviewHeadLive} from "./materialize.ts";
+
+const FAIL_EXIT_CODE = 1;
+
+const prFlag = Flag.integer("pr").pipe(Flag.withDescription("the pull request number"));
+
+const worktreeFlag = Flag.boolean("worktree").pipe(
+	Flag.withDescription(
+		"also add a throwaway DETACHED worktree on the fetched head (code/skill gates); default is ref-only (review-doc reads via `git show`)",
+	),
+);
+
+/** Print `reason` on stderr and exit non-zero — the refusal signal a caller branches on. */
+const fail = (reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stderr.write(`review-head: ${reason}\n`);
+		process.exit(FAIL_EXIT_CODE);
+	});
+
+const resolve = Command.make(
+	"resolve",
+	{pr: prFlag},
+	Effect.fn(function* ({pr}) {
+		const head = yield* (yield* ReviewHead).resolve(pr).pipe(
+			Effect.catchTag("@kampus/review-head/UnresolvableHeadError", (e) => fail(e.message)),
+			// A 404 from `gh api pulls/<pr>` is the missing-PR fail-safe at the IO edge (the null-head
+			// case is caught in the core): a clean refusal + non-zero exit, not a raw stack trace.
+			Effect.catchTag("@kampus/gh-io/GhCommandError", (e) =>
+				fail(`could not read PR #${pr} (gh exit ${e.exitCode}): ${e.stderr.trim() || "not found"}`),
+			),
+		);
+		yield* Console.log(JSON.stringify({pr, ...head}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Resolve a PR's current head SHA + ref via REST (exit 0 = a bindable head; non-zero = missing/closed/partial head)",
+	),
+);
+
+const materialize = Command.make(
+	"materialize",
+	{pr: prFlag, worktree: worktreeFlag},
+	Effect.fn(function* ({pr, worktree}) {
+		const result = yield* (yield* ReviewHead).materialize(pr, worktree).pipe(
+			Effect.catchTag("@kampus/review-head/UnresolvableHeadError", (e) => fail(e.message)),
+			Effect.catchTag("@kampus/review-head/HeadMismatchError", (e) => fail(e.message)),
+			Effect.catchTag("@kampus/review-head/GitCommandError", (e) =>
+				fail(`git ${e.args.join(" ")} failed (exit ${e.exitCode}): ${e.stderr.trim()}`),
+			),
+			Effect.catchTag("@kampus/gh-io/GhCommandError", (e) =>
+				fail(`could not read PR #${pr} (gh exit ${e.exitCode}): ${e.stderr.trim() || "not found"}`),
+			),
+		);
+		yield* Console.log(JSON.stringify(result));
+	}),
+).pipe(
+	Command.withDescription(
+		"Materialize a PR's current head into a per-run ref (+ optional detached worktree), asserting the fetched ref IS the resolved head (§HEAD)",
+	),
+);
+
+export const reviewHeadCommand = Command.make("review-head").pipe(
+	Command.withSubcommands([resolve, materialize]),
+	Command.withDescription(
+		"Resolve + materialize a PR's current review head deterministically — the shared PR-head-checkout the gate skills cite (#793 / #1807)",
+	),
+	Command.provide(ReviewHeadLive),
+);

--- a/packages/pipeline-cli/src/tools/review-head/git-io.ts
+++ b/packages/pipeline-cli/src/tools/review-head/git-io.ts
@@ -1,0 +1,52 @@
+/**
+ * The `git` IO seam for `review-head` — the sibling of the tracker `gh-io.ts` `runGh`, for the
+ * head-materialization git ops (`fetch` into a per-run ref, `rev-parse` the fetched ref, `worktree
+ * add --detach`). `gh` head resolution reuses the shared `../tracker/gh-io.ts` seam; the git ops are
+ * review-head-local, so their runner lives here rather than widening the shared gh seam with a `git`
+ * verb. Same discipline: REST/porcelain only, a non-zero exit is a typed `GitCommandError`, never a throw.
+ */
+import {Effect, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess} from "effect/unstable/process";
+
+/** A `git` invocation exited non-zero (an unreachable ref, a worktree-add collision, a detached-primary refusal, …). */
+export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()(
+	"@kampus/review-head/GitCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `git <args>` and return stdout, failing `GitCommandError` on a non-zero exit. Mirrors the
+ * `gh-io.ts` `runGh` structure exactly (spawn directly to read `exitCode` + `stderr`, lower a
+ * non-zero exit and any spawn/IO `PlatformError` into one typed error) so the two runners can't drift.
+ */
+export const runGit = Effect.fn("ReviewHead.runGit")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("git", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GitCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GitCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);

--- a/packages/pipeline-cli/src/tools/review-head/materialize.ts
+++ b/packages/pipeline-cli/src/tools/review-head/materialize.ts
@@ -1,0 +1,206 @@
+/**
+ * The GitHub + git boundary for `review-head`: the live `ReviewHead` capability that resolves and
+ * materializes a PR's current review head deterministically over `gh api` REST + `git`, driving the
+ * IO-free `resolve-head.ts` core. The single owner of the "materialize the PR head for review" step
+ * the review-code / review-doc / review-skill gates each hand-copied inline (#793 / #1807), and the
+ * head-SHA resolution review-design binds its verdict to.
+ *
+ * Two verbs, sharing the `resolveHead` core:
+ *  - `resolve(pr)` — REST-only: the current head SHA + ref, fail-safe on a missing/closed PR. What
+ *    review-design needs (it reviews a preview URL, not a checked-out tree).
+ *  - `materialize(pr, {worktree})` — the §HEAD read path: resolve, then fetch `pull/<pr>/head` into a
+ *    per-run ref (never the launched tree), assert the fetched ref IS the resolved head SHA, and —
+ *    with `--worktree` — add a throwaway DETACHED worktree on that ref (never a branch switch, §RO).
+ *
+ * REST only (GraphQL is broken on the kamp-us org); every infra failure is a typed error. The caller
+ * is responsible for the §RO-iso primary-checkout preflight BEFORE calling `materialize` — this verb
+ * is the deterministic mechanism, not the isolation gate.
+ */
+import {randomUUID} from "node:crypto";
+import {mkdtempSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {Context, Effect, Layer} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	type GhCommandError,
+	type GhParseError,
+	json,
+	type RepoResolutionError,
+	resolveRepo,
+} from "../tracker/gh-io.ts";
+import {type GitCommandError, runGit} from "./git-io.ts";
+import {
+	type MaterializePlan,
+	type PullHeadPayload,
+	planMaterialization,
+	type ResolvedHead,
+	resolveHead,
+} from "./resolve-head.ts";
+
+/** The PR could not be resolved to a bindable head (missing/closed PR, deleted/partial head SHA). */
+export class UnresolvableHeadError extends Schema.TaggedErrorClass<UnresolvableHeadError>()(
+	"@kampus/review-head/UnresolvableHeadError",
+	{message: Schema.String},
+) {}
+
+/** The fetched per-run ref did not resolve to the head SHA REST reported — a moved/raced head; abort rather than review the wrong tree. */
+export class HeadMismatchError extends Schema.TaggedErrorClass<HeadMismatchError>()(
+	"@kampus/review-head/HeadMismatchError",
+	{message: Schema.String},
+) {}
+
+export {GitCommandError} from "./git-io.ts";
+
+/** The result of a `materialize` — the resolved head plus the per-run ref (and worktree, when requested). */
+export interface MaterializeResult {
+	readonly pr: number;
+	readonly headSha: string;
+	readonly headRef: string;
+	readonly crossFork: boolean;
+	readonly prRef: string;
+	/** The throwaway detached worktree path, or `null` for a ref-only materialization. */
+	readonly worktreeDir: string | null;
+}
+
+// Only the fields review-head reads; head/head.repo are NullOr for a deleted head / deleted fork.
+const RawPull = Schema.Struct({
+	number: Schema.Number,
+	state: Schema.String,
+	head: Schema.NullOr(
+		Schema.Struct({
+			sha: Schema.NullOr(Schema.String),
+			ref: Schema.NullOr(Schema.String),
+			repo: Schema.NullOr(Schema.Struct({full_name: Schema.String})),
+		}),
+	),
+	base: Schema.Struct({repo: Schema.Struct({full_name: Schema.String})}),
+});
+const decodePull = Schema.decodeUnknownEffect(RawPull);
+
+const toPayload = (raw: (typeof RawPull)["Type"]): PullHeadPayload => ({
+	number: raw.number,
+	state: raw.state,
+	head:
+		raw.head === null
+			? null
+			: {
+					sha: raw.head.sha,
+					ref: raw.head.ref,
+					repoFullName: raw.head.repo?.full_name ?? null,
+				},
+	baseRepoFullName: raw.base.repo.full_name,
+});
+
+const pullArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/pulls/${pr}`,
+];
+
+/** REST-resolve the PR's current head, decode it, and run the pure `resolveHead` — the shared front half of both verbs. */
+const resolve = Effect.fn("ReviewHead.resolve")(function* (repo: string, pr: number) {
+	const raw = yield* decodePull(yield* json(pullArgs(repo, pr)));
+	const resolution = resolveHead(toPayload(raw));
+	if (resolution._tag === "unresolvable") {
+		return yield* new UnresolvableHeadError({message: resolution.reason});
+	}
+	return resolution satisfies ResolvedHead;
+});
+
+/**
+ * Materialize the head per the plan: fetch `pull/<pr>/head` into the per-run ref (the head reaches a
+ * ref, never the launched working tree — §RO), assert the fetched ref IS the resolved head SHA (a
+ * moved head between resolve and fetch aborts rather than reviewing a stale tree — §HEAD #2), then —
+ * when `worktree` — `git worktree add --detach` a throwaway tree on that ref. Detached by construction
+ * (the `resolve-head` plan's `detach: true`): never `git checkout <headRef>`, safe for cross-fork heads.
+ */
+const materialize = Effect.fn("ReviewHead.materialize")(function* (
+	repo: string,
+	pr: number,
+	worktree: boolean,
+) {
+	const head = yield* resolve(repo, pr);
+	const plan: MaterializePlan = planMaterialization(head, {pr, nonce: randomUUID()});
+
+	yield* runGit(["fetch", "origin", plan.fetchRefspec]);
+	const fetched = (yield* runGit(["rev-parse", plan.prRef])).trim().toLowerCase();
+	if (fetched !== plan.headSha) {
+		return yield* new HeadMismatchError({
+			message: `fetched head ${fetched} != resolved ${plan.headSha} for PR #${pr} — the head moved under the review; aborting rather than binding a verdict to a tree I did not fetch (§HEAD #2)`,
+		});
+	}
+
+	let worktreeDir: string | null = null;
+	if (worktree) {
+		worktreeDir = mkdtempSync(join(tmpdir(), `review-head-${pr}-`));
+		yield* runGit(["worktree", "add", "--detach", worktreeDir, plan.prRef]);
+	}
+
+	return {
+		pr,
+		headSha: plan.headSha,
+		headRef: plan.headRef,
+		crossFork: plan.crossFork,
+		prRef: plan.prRef,
+		worktreeDir,
+	} satisfies MaterializeResult;
+});
+
+/**
+ * `ReviewHead` — the IO shell over `gh api` REST + `git` for the §HEAD head materialization.
+ * `resolve` gives the current head SHA/ref (review-design); `materialize` fetches it into a per-run
+ * ref and optionally a detached throwaway worktree (review-code/doc/skill). Built by `ReviewHeadLive`.
+ */
+export class ReviewHead extends Context.Service<
+	ReviewHead,
+	{
+		readonly resolve: (
+			pr: number,
+		) => Effect.Effect<
+			ResolvedHead,
+			| RepoResolutionError
+			| GhCommandError
+			| GhParseError
+			| UnresolvableHeadError
+			| Schema.SchemaError
+		>;
+		readonly materialize: (
+			pr: number,
+			worktree: boolean,
+		) => Effect.Effect<
+			MaterializeResult,
+			| RepoResolutionError
+			| GhCommandError
+			| GhParseError
+			| GitCommandError
+			| UnresolvableHeadError
+			| HeadMismatchError
+			| Schema.SchemaError
+		>;
+	}
+>()("@kampus/review-head/ReviewHead") {}
+
+/**
+ * The live `ReviewHead` layer. The `ChildProcessSpawner` dependency is captured once and provided
+ * into each method body (public methods carry `R = never`); repo resolution is deferred to first use
+ * (`Effect.cached`, ADR 0062 §1) so the layer build is side-effect-free.
+ */
+export const ReviewHeadLive: Layer.Layer<
+	ReviewHead,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> = Layer.effect(ReviewHead)(
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const withSpawner = <A, E>(
+			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+		const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+		return {
+			resolve: (pr) => repo.pipe(Effect.flatMap((r) => withSpawner(resolve(r, pr)))),
+			materialize: (pr, worktree) =>
+				repo.pipe(Effect.flatMap((r) => withSpawner(materialize(r, pr, worktree)))),
+		};
+	}),
+);

--- a/packages/pipeline-cli/src/tools/review-head/resolve-head.ts
+++ b/packages/pipeline-cli/src/tools/review-head/resolve-head.ts
@@ -1,0 +1,126 @@
+/**
+ * The IO-free head-resolution core for `review-head` — the deterministic decision a
+ * review gate makes when it materializes "the PR's current review head" for review
+ * (#793 / #1807). It answers two things from the untrusted `repos/:repo/pulls/:pr`
+ * REST payload, with no git or `gh` IO of its own:
+ *
+ *  1. `resolveHead` — WHICH head. Extract the PR's current (latest) head SHA + ref from
+ *     the payload, fail-safe to `unresolvable` when there is no bindable head (a missing
+ *     / closed PR, a deleted head branch, a non-40-hex sha) rather than let a gate
+ *     materialize a head it cannot bind a verdict to.
+ *  2. `planMaterialization` — HOW to check it out. The per-run ref + `pull/<pr>/head`
+ *     refspec, and — load-bearing — that the checkout is ALWAYS **detached** onto that ref,
+ *     never a `git checkout <headRef>` of the branch: §RO (gh-issue-intake-formats.md)
+ *     forbids a gate switching the launched tree onto the head branch, and `pull/<pr>/head`
+ *     resolves for same-repo AND cross-fork PRs so there is never a branch to switch to.
+ *
+ * The IO shell (`materialize.ts`) decodes the REST JSON at the boundary and drives this
+ * core; keeping the decision here is what makes "latest head / detached-vs-branch /
+ * missing-PR fail-safe" unit-testable without a live repo or PR.
+ */
+
+/** The head fields `review-head` reads off the decoded `repos/:repo/pulls/:pr` payload. */
+export interface PullHeadPayload {
+	readonly number: number;
+	readonly state: string;
+	/** `null` when GitHub reports no head object (a deleted head, some closed-PR shapes). */
+	readonly head: {
+		readonly sha: string | null;
+		readonly ref: string | null;
+		/** `head.repo.full_name` — `null` when the head fork was deleted. */
+		readonly repoFullName: string | null;
+	} | null;
+	/** `base.repo.full_name` — the merge-target repo, to classify a cross-fork head. */
+	readonly baseRepoFullName: string;
+}
+
+/** A resolved, bindable head — a full-40-hex SHA plus the branch name and fork classification. */
+export interface ResolvedHead {
+	readonly headSha: string;
+	/** The head branch name; `""` when the head branch was already deleted (SHA still bindable). */
+	readonly headRef: string;
+	/** True when the head lives on a fork of the base repo (still fetched via `pull/<pr>/head`). */
+	readonly crossFork: boolean;
+}
+
+export type HeadResolution =
+	| ({readonly _tag: "resolved"} & ResolvedHead)
+	| {readonly _tag: "unresolvable"; readonly reason: string};
+
+const FULL_SHA_RE = /^[0-9a-f]{40}$/;
+
+/**
+ * Resolve the PR's current review head from the REST payload. REST always returns the
+ * PR's *latest* head, so `.head.sha` is the current head with no history to walk. Fail-safe:
+ * a `null` head, an empty/non-40-hex SHA all resolve to `unresolvable` — a gate must not
+ * materialize (and bind a verdict to) a head it cannot name (ADR 0058 §5).
+ */
+export const resolveHead = (pull: PullHeadPayload): HeadResolution => {
+	if (pull.head === null || pull.head.sha === null) {
+		return {
+			_tag: "unresolvable",
+			reason: `PR #${pull.number} (state=${pull.state}) has no head SHA — a missing/closed PR or a deleted head; refusing to materialize a head no verdict can bind to`,
+		};
+	}
+	const headSha = pull.head.sha.trim().toLowerCase();
+	if (!FULL_SHA_RE.test(headSha)) {
+		return {
+			_tag: "unresolvable",
+			reason: `PR #${pull.number} head SHA '${pull.head.sha}' is not a full 40-hex commit — refusing to bind a verdict to a partial/malformed head (ADR 0058 §5)`,
+		};
+	}
+	return {
+		_tag: "resolved",
+		headSha,
+		headRef: pull.head.ref ?? "",
+		crossFork: pull.head.repoFullName !== null && pull.head.repoFullName !== pull.baseRepoFullName,
+	};
+};
+
+/** The per-run ref a gate fetches the head into — PR-namespaced AND nonce-uniqued so two concurrent reviews of the same PR never collide on the ref (#1807). */
+export const perRunRef = (pr: number, nonce: string): string => `refs/pr/${pr}-${nonce}`;
+
+/** The refspec that fetches the PR head into `prRef` — `pull/<pr>/head` resolves same-repo AND cross-fork. */
+export const fetchRefspec = (pr: number, prRef: string): string => `pull/${pr}/head:${prRef}`;
+
+/** The deterministic checkout plan `review-head materialize` executes for a resolved head. */
+export interface MaterializePlan {
+	readonly headSha: string;
+	readonly headRef: string;
+	readonly crossFork: boolean;
+	/** The per-run ref the head is fetched into and (optionally) worktree-checked-out from. */
+	readonly prRef: string;
+	/** `pull/<pr>/head:<prRef>` — the fetch that lands the head in `prRef` without touching the working tree. */
+	readonly fetchRefspec: string;
+	/**
+	 * ALWAYS true: the head is checked out DETACHED onto `prRef`, never `git checkout <headRef>`.
+	 * §RO forbids a gate switching the launched tree onto the head branch, and a cross-fork head
+	 * has no local branch to switch to — a detached per-run ref is the one shape safe for both.
+	 */
+	readonly detach: true;
+	/** The throwaway worktree path when a full tree is materialized (`--worktree`), else `null` (ref-only). */
+	readonly worktreeDir: string | null;
+}
+
+/**
+ * Build the checkout plan for a resolved head. The plan is detached-only by construction
+ * (`detach: true`, target `prRef`) — the "detached, never the branch" §RO decision made
+ * once here rather than re-derived per gate. `worktreeDir` is set only when the caller
+ * asked for a full materialized tree (the code/skill gates); a ref-only gate (review-doc)
+ * leaves it `null` and reads the head via `git show "$prRef:<path>"`.
+ */
+export const planMaterialization = (
+	head: ResolvedHead,
+	opts: {readonly pr: number; readonly nonce: string; readonly worktreeDir?: string},
+): MaterializePlan => {
+	const prRef = perRunRef(opts.pr, opts.nonce);
+	return {
+		headSha: head.headSha,
+		headRef: head.headRef,
+		crossFork: head.crossFork,
+		prRef,
+		fetchRefspec: fetchRefspec(opts.pr, prRef),
+		detach: true,
+		worktreeDir: opts.worktreeDir ?? null,
+	};
+};

--- a/packages/pipeline-cli/src/tools/review-head/resolve-head.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/review-head/resolve-head.unit.test.ts
@@ -1,0 +1,114 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	fetchRefspec,
+	type HeadResolution,
+	type PullHeadPayload,
+	perRunRef,
+	planMaterialization,
+	type ResolvedHead,
+	resolveHead,
+} from "./resolve-head.ts";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+
+const pull = (over: Partial<PullHeadPayload> = {}): PullHeadPayload => ({
+	number: 42,
+	state: "open",
+	head: {sha: SHA, ref: "usirin/feature", repoFullName: "kamp-us/phoenix"},
+	baseRepoFullName: "kamp-us/phoenix",
+	...over,
+});
+
+const asResolved = (r: HeadResolution): ResolvedHead => {
+	assert.strictEqual(r._tag, "resolved");
+	if (r._tag !== "resolved") throw new Error("unreachable");
+	return r;
+};
+
+describe("resolveHead — the latest head from the REST payload", () => {
+	it("resolves the current head SHA (lowercased) and ref for a same-repo PR", () => {
+		const r = resolveHead(pull());
+		assert.deepStrictEqual(r, {
+			_tag: "resolved",
+			headSha: SHA,
+			headRef: "usirin/feature",
+			crossFork: false,
+		});
+	});
+
+	it("takes REST's `.head.sha` verbatim as the latest head — no history to walk", () => {
+		// REST always returns the PR's current head, so a second, newer push just shows up as a
+		// different `.head.sha` on the next read; the core has no stale-head branch to guard.
+		const newer = "fedcba9876543210fedcba9876543210fedcba98";
+		const r = asResolved(
+			resolveHead(pull({head: {sha: newer, ref: "b", repoFullName: "kamp-us/phoenix"}})),
+		);
+		assert.strictEqual(r.headSha, newer);
+	});
+
+	it("flags a cross-fork head (head repo != base repo) while still resolving it", () => {
+		const r = asResolved(
+			resolveHead(pull({head: {sha: SHA, ref: "patch-1", repoFullName: "someone/phoenix"}})),
+		);
+		assert.isTrue(r.crossFork);
+	});
+
+	it("resolves a head whose branch was deleted (SHA still bindable, ref empty)", () => {
+		const r = asResolved(resolveHead(pull({head: {sha: SHA, ref: null, repoFullName: null}})));
+		assert.strictEqual(r.headRef, "");
+		assert.strictEqual(r.headSha, SHA);
+	});
+});
+
+describe("resolveHead — missing-PR fail-safe", () => {
+	it("is unresolvable when the head object is absent (missing/closed PR)", () => {
+		const r = resolveHead(pull({number: 7, state: "closed", head: null}));
+		assert.strictEqual(r._tag, "unresolvable");
+		if (r._tag === "unresolvable") assert.match(r.reason, /#7.*no head SHA/);
+	});
+
+	it("is unresolvable when the head SHA is null", () => {
+		const r = resolveHead(pull({head: {sha: null, ref: "x", repoFullName: "kamp-us/phoenix"}}));
+		assert.strictEqual(r._tag, "unresolvable");
+	});
+
+	it("is unresolvable when the head SHA is not a full 40-hex commit", () => {
+		const r = resolveHead(
+			pull({head: {sha: "0123abc", ref: "x", repoFullName: "kamp-us/phoenix"}}),
+		);
+		assert.strictEqual(r._tag, "unresolvable");
+		if (r._tag === "unresolvable") assert.match(r.reason, /not a full 40-hex/);
+	});
+});
+
+describe("planMaterialization — detached-vs-branch (never switch onto the head branch)", () => {
+	const head = asResolved(resolveHead(pull()));
+
+	it("checks out the head DETACHED onto the per-run ref, never `git checkout <headRef>`", () => {
+		const plan = planMaterialization(head, {pr: 42, nonce: "abc123"});
+		assert.isTrue(plan.detach);
+		assert.strictEqual(plan.prRef, "refs/pr/42-abc123");
+		// The checkout target is the per-run REF, not the head BRANCH — §RO forbids a branch switch.
+		assert.notStrictEqual(plan.prRef, head.headRef);
+		assert.strictEqual(plan.fetchRefspec, "pull/42/head:refs/pr/42-abc123");
+	});
+
+	it("PR-namespaces AND nonce-uniques the ref so concurrent reviews of one PR never collide (#1807)", () => {
+		const a = planMaterialization(head, {pr: 42, nonce: "run-a"});
+		const b = planMaterialization(head, {pr: 42, nonce: "run-b"});
+		assert.notStrictEqual(a.prRef, b.prRef);
+		assert.strictEqual(perRunRef(42, "run-a"), a.prRef);
+	});
+
+	it("carries a worktree dir only when a full tree is requested (else ref-only, null)", () => {
+		assert.strictEqual(planMaterialization(head, {pr: 42, nonce: "n"}).worktreeDir, null);
+		assert.strictEqual(
+			planMaterialization(head, {pr: 42, nonce: "n", worktreeDir: "/tmp/rh-42"}).worktreeDir,
+			"/tmp/rh-42",
+		);
+	});
+
+	it("fetchRefspec resolves same-repo and cross-fork identically (pull/<pr>/head)", () => {
+		assert.strictEqual(fetchRefspec(7, "refs/pr/7-x"), "pull/7/head:refs/pr/7-x");
+	});
+});


### PR DESCRIPTION
## What

Extract the quadruplicated "materialize the PR's current review head" logic the gate skills each hand-copied (#793 / #1807) into one tested `pipeline-cli review-head` verb, and adopt it across the four gate skills **same-commit** (#3254 same-commit adoption).

## The verb (`packages/pipeline-cli/src/tools/review-head/`)

- **`resolve-head.ts`** — the IO-free resolution core: extract the latest head SHA + ref from the REST pull payload (fail-safe to `unresolvable` on a missing/closed PR, a null head, or a non-40-hex SHA), plus the deterministic **detached-only** checkout plan (per-run `refs/pr/<pr>-<nonce>` ref, `detach: true`, never a `git checkout <headRef>` branch switch — §RO). Unit-tested for the three AC cases: **latest head**, **detached-vs-branch**, **missing-PR fail-safe**.
- **`materialize.ts` + `git-io.ts`** — the `gh` REST + `git` IO shell (`ReviewHead` service, `ReviewHeadLive` layer):
  - `pipeline-cli review-head resolve --pr N` — the current head SHA/ref only (review-design reviews a preview URL, not a tree).
  - `pipeline-cli review-head materialize --pr N [--worktree]` — fetch `pull/<pr>/head` into a per-run ref (never the launched tree), **assert the fetched ref IS the resolved head** (§HEAD #2, aborts on a moved head), and with `--worktree` add a throwaway **detached** worktree (`review-head-<pr>-*`, the shape `worktree-sweep` reclaims).
- Registered in the tool registry; shows up in `pipeline-cli commands compact`.

## Adoption, same-commit (#3254)

- `adoption-lint/manifest.ts` declares the `review-head materialize` decision (fingerprint: the `pull/<pr>/head:` fetch refspec **AND** the per-run `refs/pr/` ref — narrow enough that review-design's SHA-only `.head.sha` read isn't a false finding).
- All four gate skills + the `gh-issue-intake-formats.md` §HEAD contract migrated to **cite the verb** in the same commit — so **no `review-head` grandfathered entry is needed** (born drawn-down to zero). `adoption-lint check` over the full corpus is clean.

## Out of scope

Verdict resolution (`verdict read`, story 1) and any per-gate review judgment (must-not-cross #3251) — untouched.

## Guards

`pnpm typecheck` clean · `biome check` clean · `adoption-lint check` clean (8 decisions, full 62-file CI corpus) · 1580 pipeline-cli tests green · live end-to-end verified (`resolve`/`materialize --worktree` against a real PR, plus the missing-PR fail-safe).

This is a **§CP change** (packages/pipeline-cli + the gate skills) — it banks for human approval, not auto-merge.

Fixes #3690

🤖 Generated with [Claude Code](https://claude.com/claude-code)