### PR TITLE
feat(pipeline-cli): intake-compose verb for the format-2 sub-issue body — one composer, not N re-derivations (#3688)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -468,30 +468,36 @@ query reads for an existing issue before filing. When in doubt on the epic's own
 reconcile (skip/Amend) over a second create; when in doubt on a backlog issue, reference it in the
 rationale and let `review-plan` weigh in.
 
-Create each child via REST, assembling its body from a temp file so multi-line
-markdown and backticks survive the shell. Allocate the body file with `mktemp`
-(every other temp this skill uses is already epic-scoped — `/tmp/plan-epic-<EPIC>-*`),
-not a fixed `/tmp/plan-epic-child.md`: concurrent `plan-epic` runs on sibling epics
-share `/tmp`, so a fixed path lets one run's child body clobber another's between the
-write and this `cat`, filing a child under the right title but with a **sibling epic's
-`### What to build` + acceptance criteria** — a cross-epic body bleed the structural
-floor can't see (it checks markers, never body fidelity), caught only by `review-plan`'s
+Create each child via REST. **Compose its format-2 body with
+`pipeline-cli intake-compose sub-issue`** — the one tested composer for the intake-formats
+prose contract §2 — rather than hand-re-deriving the format here (the #3254 cite-the-verb
+rule). Hand it the child's fields as a spec JSON and it emits the body **by value** on
+stdout, so multi-line markdown and backticks survive the shell without a `<<EOF` heredoc; it
+enforces the format-2 invariants (the ≥ 1-acceptance-criterion hard floor) and owns the
+leak-safe handoff — a stdout-only verb has no scratchpad file to `@`-reference, so the
+`gh api -f body=@<path>` machine-local-path leak (#2002 / #754 / PR #1567) is unreachable.
+Allocate the **spec** file with `mktemp` (every temp this skill uses is already epic-scoped —
+`/tmp/plan-epic-<EPIC>-*`), not a fixed `/tmp/plan-epic-child.json`: concurrent `plan-epic`
+runs on sibling epics share `/tmp`, so a fixed path lets one run's spec clobber another's
+before it is composed, filing a child under the right title but with a **sibling epic's
+`### What to build` + acceptance criteria** — a cross-epic body bleed the structural floor
+can't see (it checks markers, never body fidelity), caught only by `review-plan`'s
 non-blocking advisor (#754, same `/tmp` collision class as `report`'s per-run `mktemp`):
 
 ```bash
-# write this child's body into a per-run temp file, never a shared fixed path (#754)
-CHILD_BODY_FILE="$(mktemp /tmp/plan-epic-<EPIC>-child.XXXXXX)"
-cat > "$CHILD_BODY_FILE" <<'EOF'
-**Stories:** <bare numbers, e.g. `1` or `1, 3` — no `S` prefix, no parenthetical digits>
-**TDD:** yes | no
-
-### What to build
-<…>
-
-### Acceptance criteria
-- [ ] <…>
+# write this child's spec into a per-run temp file, never a shared fixed path (#754)
+CHILD_SPEC_FILE="$(mktemp /tmp/plan-epic-<EPIC>-child.XXXXXX)"
+cat > "$CHILD_SPEC_FILE" <<'EOF'
+{
+  "stories": "<bare numbers, e.g. `1` or `1, 3` — no `S` prefix; or `none (pure infra — see What to build)`>",
+  "tdd": "yes",
+  "whatToBuild": "<the prose spec>",
+  "acceptanceCriteria": ["<observable, checkable criterion>"]
+}
 EOF
-BODY="$(cat "$CHILD_BODY_FILE")"
+# The verb composes the format-2 body per the contract and emits it BY VALUE to stdout — no
+# hand-re-derived `### What to build` / `### Acceptance criteria`, no `-f body=@file` leak.
+BODY="$(pipeline-cli intake-compose sub-issue --spec "$CHILD_SPEC_FILE")"
 # ATOMIC create — body AND its type/priority/status:planned labels in ONE REST write. `POST /issues`
 # accepts `labels` inline, so an interrupted run can never leave a label-less child: the create
 # either lands the issue WITH its labels or creates nothing. (Values chosen per the paragraph below.)

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -37,6 +37,7 @@ import {fanoutGuardCommand} from "./tools/fanout-guard/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
 import {guardContentProbeCommand} from "./tools/guard-content-probe/command.ts";
+import {intakeComposeCommand} from "./tools/intake-compose/command.ts";
 import {intakeDedupCommand} from "./tools/intake-dedup/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {mainSyncCommand} from "./tools/main-sync/command.ts";
@@ -151,6 +152,11 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	changeDetectGuardCommand,
 	patchGuardCommand,
 	intakeDedupCommand,
+	// The #3688 intake-body composer (epic #3258): one tested verb that emits the
+	// format-2 sub-issue body of the gh-issue-intake-formats.md prose contract, so a
+	// filer cites it instead of re-deriving the format — and owns the by-value handoff
+	// that keeps the `-f body=@file` leak class (#2002 / #754) unreachable.
+	intakeComposeCommand,
 	splitGuardCommand,
 	redactLeaksCommand,
 	commandsCommand,

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -124,6 +124,24 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		reason:
 			"re-derives the epic-body splice (anchor guards + first-time-append / re-plan-in-place) that `pipeline-cli epic-splice apply` owns, instead of citing the verb (#3689 / #261 / #3254)",
 	},
+	{
+		// `intake-compose sub-issue` owns the format-2 sub-issue body of the intake-formats prose
+		// contract (§2, #3688). The fingerprint is the co-occurrence of the two format-2 section
+		// headings AND a bare `POST /issues` create (the ` \`/` -f` tell right after `/issues`,
+		// never `/issues/<N>`) — i.e. a file that actually FILES a composed format-2 body, not one
+		// that merely documents or reads the format. That create discriminator keeps the contract
+		// file (defines the format, no create) and write-code (reads format-2, creates PRs not
+		// issues) out of scope. A file that cites `pipeline-cli intake-compose` is compliant.
+		verb: "intake-compose sub-issue",
+		signature: [
+			/### What to build/, // the format-2 spec heading
+			/### Acceptance criteria/, // the format-2 acceptance-criteria heading
+			/gh api repos\/\$REPO\/issues(?: \\|\s+-f)/, // a bare POST /issues create (not /issues/<N>)
+		],
+		citation: /pipeline-cli\s+intake-compose\b/,
+		reason:
+			"re-derives the format-2 sub-issue body that `pipeline-cli intake-compose sub-issue` owns (the gh-issue-intake-formats.md prose contract §2), instead of citing the verb (#3688 / #3254)",
+	},
 ];
 
 /**

--- a/packages/pipeline-cli/src/tools/intake-compose/command.test.ts
+++ b/packages/pipeline-cli/src/tools/intake-compose/command.test.ts
@@ -1,0 +1,86 @@
+import {spawnSync} from "node:child_process";
+import {mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+// The exit + stdout contract of `pipeline-cli intake-compose sub-issue` over the shared bin.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (args: ReadonlyArray<string>, input?: string): RunResult => {
+	const r = spawnSync("node", [BIN, "intake-compose", ...args], {
+		encoding: "utf8",
+		input: input ?? "",
+	});
+	return {code: r.status ?? 0, stdout: r.stdout ?? "", stderr: r.stderr ?? ""};
+};
+
+const validSpec = {
+	stories: "4, 9",
+	tdd: "yes",
+	containment: "exempt (internal pipeline tooling — no user-facing surface)",
+	whatToBuild: "Add a pipeline-cli intake composer verb.",
+	acceptanceCriteria: ["A verb emits a format-2 body.", "Consumers cite the verb."],
+};
+
+describe("intake-compose sub-issue — leak-safe stdout handoff (AC3)", () => {
+	let dir: string;
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "intake-compose-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("emits the composed format-2 body to stdout and exits 0 (spec from a file)", () => {
+		const f = join(dir, "spec.json");
+		writeFileSync(f, JSON.stringify(validSpec), "utf8");
+		const {code, stdout} = run(["sub-issue", "--spec", f]);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "**Stories:** 4, 9");
+		assert.include(stdout, "**TDD:** yes");
+		assert.include(stdout, "### What to build");
+		assert.include(stdout, "### Acceptance criteria");
+		assert.include(stdout, "- [ ] A verb emits a format-2 body.");
+	}, 30_000);
+
+	it("reads the spec from stdin when --spec is omitted", () => {
+		const {code, stdout} = run(["sub-issue"], JSON.stringify(validSpec));
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "### Acceptance criteria");
+	}, 30_000);
+
+	// The whole point: the body is emitted BY VALUE to stdout, so a caller passes it
+	// as `-f body="$BODY"` — no file path is ever handed back to `@`-reference.
+	it("the emitted body carries no machine-local filesystem path (no @file leak surface)", () => {
+		const f = join(dir, "spec2.json");
+		writeFileSync(f, JSON.stringify(validSpec), "utf8");
+		const {stdout} = run(["sub-issue", "--spec", f]);
+		assert.notMatch(stdout, /(^|\s)@[/~]/);
+		// The spec file path itself must not appear in the emitted body.
+		assert.notInclude(stdout, f);
+	}, 30_000);
+
+	it("exits 2 on zero acceptance criteria (the format-2 hard floor)", () => {
+		const f = join(dir, "no-ac.json");
+		writeFileSync(f, JSON.stringify({...validSpec, acceptanceCriteria: []}), "utf8");
+		const {code, stderr} = run(["sub-issue", "--spec", f]);
+		assert.strictEqual(code, 2);
+		assert.include(stderr, "acceptance criterion");
+	}, 30_000);
+
+	it("exits 2 on malformed JSON", () => {
+		const f = join(dir, "bad.json");
+		writeFileSync(f, "{not json", "utf8");
+		const {code, stderr} = run(["sub-issue", "--spec", f]);
+		assert.strictEqual(code, 2);
+		assert.include(stderr, "valid JSON");
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/intake-compose/command.ts
+++ b/packages/pipeline-cli/src/tools/intake-compose/command.ts
@@ -1,0 +1,134 @@
+/**
+ * The `intake-compose` tool — `pipeline-cli intake-compose sub-issue`.
+ *
+ * The one composer for the format-2 sub-issue body of the intake-formats prose
+ * contract (`gh-issue-intake-formats.md` §2), so the skills that file a sub-issue
+ * cite this verb instead of re-deriving the format by hand (#3254 / epic #3258):
+ *
+ *   pipeline-cli intake-compose sub-issue [--spec <file>]   # spec JSON via file or stdin
+ *
+ * Reads a structured spec JSON (stories / tdd / containment / whatToBuild /
+ * acceptanceCriteria) from `--spec` or stdin, decodes it at this trust boundary
+ * with Schema (per `.patterns/effect-schema-validation.md`), enforces the format-2
+ * invariants (the ≥1-acceptance-criterion hard floor), and emits the composed body
+ * to **stdout only**.
+ *
+ * Stdout-only is the leak-safe handoff (AC3): the caller captures the body by value
+ * — `BODY="$(pipeline-cli intake-compose sub-issue --spec s.json)"` then
+ * `gh api … -f body="$BODY"` — so there is no scratchpad file to `@`-reference and
+ * the `gh api -f body=@<path>` machine-local-path leak (contract §"Posting a comment
+ * body"; #2002 / #754 / PR #1567) is structurally unreachable. There is deliberately
+ * no `--out <file>` flag — a file output would reopen exactly that `@file` path.
+ *
+ *   exit 0 — a well-formed body emitted to stdout
+ *   exit 2 — the spec is unreadable, not valid JSON, or violates a format-2 invariant
+ *
+ * The exit mapping is caught inside this handler (not at the shared bin's run
+ * boundary, which provides only NodeServices and no per-tool catch), mirroring
+ * `adoption-lint` / `changelog-derive`.
+ */
+import {readFileSync} from "node:fs";
+import {Console, Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {Command, Flag} from "effect/unstable/cli";
+import {composeSubIssueBody, type SubIssueSpec, validateSubIssueSpec} from "./compose.ts";
+
+const SPEC_ERROR_EXIT_CODE = 2;
+
+class SpecError extends Schema.TaggedErrorClass<SpecError>()("SpecError", {
+	message: Schema.String,
+}) {}
+
+/** The untrusted spec JSON, decoded at this boundary into the total `SubIssueSpec`. */
+const SpecSchema = Schema.Struct({
+	stories: Schema.String,
+	tdd: Schema.Literals(["yes", "no"]),
+	containment: Schema.optional(Schema.String),
+	whatToBuild: Schema.String,
+	acceptanceCriteria: Schema.Array(Schema.String),
+});
+
+const decodeSpec = Schema.decodeUnknownEffect(SpecSchema);
+
+const specFlag = Flag.string("spec").pipe(
+	Flag.optional,
+	Flag.withDescription("path to the spec JSON; defaults to reading the spec from stdin"),
+);
+
+/** Read the raw spec text from `--spec <file>` or stdin (fd 0), any IO failure typed. */
+const readSpec = (
+	spec: {readonly _tag: "Some"; readonly value: string} | {readonly _tag: "None"},
+) =>
+	Effect.try({
+		try: () => readFileSync(spec._tag === "Some" ? spec.value : 0, "utf8"),
+		catch: (cause) =>
+			new SpecError({
+				message: `cannot read spec from ${spec._tag === "Some" ? spec.value : "stdin"}: ${String(cause)}`,
+			}),
+	});
+
+const loadSpec = (
+	specFlagValue: {readonly _tag: "Some"; readonly value: string} | {readonly _tag: "None"},
+): Effect.Effect<SubIssueSpec, SpecError> =>
+	readSpec(specFlagValue).pipe(
+		Effect.flatMap((raw) =>
+			Effect.try({
+				try: () => JSON.parse(raw) as unknown,
+				catch: (cause) => new SpecError({message: `spec is not valid JSON: ${String(cause)}`}),
+			}),
+		),
+		Effect.flatMap((json) =>
+			decodeSpec(json).pipe(
+				Effect.mapError(
+					(cause) =>
+						new SpecError({message: `spec does not match the format-2 shape: ${String(cause)}`}),
+				),
+			),
+		),
+		Effect.map(
+			(decoded): SubIssueSpec => ({
+				stories: decoded.stories,
+				tdd: decoded.tdd,
+				...(decoded.containment !== undefined ? {containment: decoded.containment} : {}),
+				whatToBuild: decoded.whatToBuild,
+				acceptanceCriteria: decoded.acceptanceCriteria,
+			}),
+		),
+	);
+
+const onSpecError = (e: SpecError) =>
+	Console.error(`intake-compose: ${e.message}`).pipe(
+		Effect.flatMap(() => Effect.sync(() => process.exit(SPEC_ERROR_EXIT_CODE))),
+	);
+
+const subIssue = Command.make(
+	"sub-issue",
+	{spec: specFlag},
+	Effect.fn(function* ({spec}) {
+		const run = Effect.gen(function* () {
+			const parsed = yield* loadSpec(spec);
+			const violations = validateSubIssueSpec(parsed);
+			if (violations.length > 0) {
+				return yield* Effect.fail(
+					new SpecError({
+						message: `spec violates the format-2 contract:\n${violations.map((v) => `  - ${v}`).join("\n")}`,
+					}),
+				);
+			}
+			// The body goes to STDOUT by value — the leak-safe handoff (AC3). No `--out` file.
+			yield* Console.log(composeSubIssueBody(parsed));
+		});
+		yield* run.pipe(Effect.catchTag("SpecError", onSpecError));
+	}),
+).pipe(
+	Command.withDescription(
+		"Compose a format-2 sub-issue body from a spec JSON and emit it to stdout (the leak-safe by-value handoff)",
+	),
+);
+
+export const intakeComposeCommand = Command.make("intake-compose").pipe(
+	Command.withSubcommands([subIssue]),
+	Command.withDescription(
+		"Compose an intake body per the gh-issue-intake-formats.md prose contract — one composer, not N re-derivations (#3254 / epic #3258)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/intake-compose/compose.ts
+++ b/packages/pipeline-cli/src/tools/intake-compose/compose.ts
@@ -1,0 +1,98 @@
+/**
+ * `intake-compose` core — the pure, IO-free composer for the **format-2 sub-issue
+ * body** of the intake-formats prose contract (`gh-issue-intake-formats.md` §2).
+ * One tested composer so the skills that file a sub-issue (plan-epic, and any future
+ * filer) stop re-deriving the format by hand — the #3254 "cite the verb, don't
+ * re-derive" rule (epic #3258).
+ *
+ * `composeSubIssueBody` returns the body **by value** — never a file path — which is
+ * what makes the caller's handoff leak-safe; that design and its rationale live at
+ * the one site that enforces it, the stdout-only CLI in `command.ts`.
+ *
+ * `validateSubIssueSpec` enforces the format-2 invariants (contract §2) — non-empty
+ * `Stories` / `What to build`, a `yes|no` TDD flag, and the ≥ 1-acceptance-criterion
+ * hard floor — separately from composition so both are pure and unit-testable.
+ */
+
+/** The `**TDD:**` flag values the format-2 header admits. */
+export type TddFlag = "yes" | "no";
+
+/** The structured inputs a format-2 sub-issue body is composed from (contract §2 Shape). */
+export interface SubIssueSpec {
+	/** `**Stories:**` — bare story back-references, or the `none (pure infra …)` marker. Required, non-empty. */
+	readonly stories: string;
+	/** `**TDD:**` — test-first advice to write-code. */
+	readonly tdd: TddFlag;
+	/**
+	 * `**Containment:**` — the per-child cycle-containment marker. Omitted when the
+	 * child needs none; a missing line reads as `none` per the contract's tolerant read.
+	 */
+	readonly containment?: string;
+	/** `### What to build` — the prose spec. Required, non-empty. */
+	readonly whatToBuild: string;
+	/** `### Acceptance criteria` — the checklist review-code verifies. The hard floor: ≥ 1. */
+	readonly acceptanceCriteria: ReadonlyArray<string>;
+}
+
+/**
+ * Validate the format-2 invariants (contract §2). Returns the list of violation
+ * messages — an empty list means the spec is well-formed. Pure: no IO, no throw.
+ */
+export const validateSubIssueSpec = (spec: SubIssueSpec): ReadonlyArray<string> => {
+	const violations: string[] = [];
+	if (spec.stories.trim() === "") {
+		violations.push(
+			"`Stories` is required — a bare story back-reference, or `none (pure infra — see What to build)`",
+		);
+	}
+	if (spec.tdd !== "yes" && spec.tdd !== "no") {
+		violations.push("`TDD` must be `yes` or `no`");
+	}
+	if (spec.whatToBuild.trim() === "") {
+		violations.push("`What to build` is required — the prose spec cannot be empty");
+	}
+	// The contract's hard floor: a body with zero acceptance criteria is malformed —
+	// write-code has no "done" and review-code has nothing to verify (contract §2 Invariant).
+	const criteria = spec.acceptanceCriteria.filter((c) => c.trim() !== "");
+	if (criteria.length === 0) {
+		violations.push(
+			"at least one non-empty acceptance criterion is required (contract §2 hard floor)",
+		);
+	}
+	return violations;
+};
+
+/**
+ * Compose the format-2 sub-issue body from a validated spec — deterministic and
+ * total. Header lines (`Stories` / `TDD` / optional `Containment`) are consecutive,
+ * then the `### What to build` and `### Acceptance criteria` sections, each
+ * criterion an unchecked checkbox bullet. Trailing whitespace is trimmed so the
+ * output is byte-stable for a given spec.
+ *
+ * Callers should run `validateSubIssueSpec` first; composition itself is total and
+ * will emit whatever it is handed (an empty criteria list yields no bullets), which
+ * is why the invariant check is the caller's gate, not a silent drop here.
+ */
+export const composeSubIssueBody = (spec: SubIssueSpec): string => {
+	const header = [`**Stories:** ${spec.stories.trim()}`, `**TDD:** ${spec.tdd}`];
+	if (spec.containment !== undefined && spec.containment.trim() !== "") {
+		header.push(`**Containment:** ${spec.containment.trim()}`);
+	}
+
+	const criteria = spec.acceptanceCriteria
+		.map((c) => c.trim())
+		.filter((c) => c !== "")
+		.map((c) => `- [ ] ${c}`);
+
+	const sections = [
+		header.join("\n"),
+		"",
+		"### What to build",
+		spec.whatToBuild.trim(),
+		"",
+		"### Acceptance criteria",
+		criteria.join("\n"),
+	];
+
+	return `${sections.join("\n")}\n`;
+};

--- a/packages/pipeline-cli/src/tools/intake-compose/compose.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/intake-compose/compose.unit.test.ts
@@ -1,0 +1,105 @@
+import {assert, describe, it} from "@effect/vitest";
+import {composeSubIssueBody, type SubIssueSpec, validateSubIssueSpec} from "./compose.ts";
+
+const wellFormed: SubIssueSpec = {
+	stories: "4, 9",
+	tdd: "yes",
+	containment: "exempt (internal pipeline tooling — no user-facing surface)",
+	whatToBuild: "Add a pipeline-cli verb that composes an intake body.",
+	acceptanceCriteria: ["A verb emits a format-2 body.", "Consumers cite the verb."],
+};
+
+describe("composeSubIssueBody — deterministic format-2 emission (contract §2)", () => {
+	it("emits the header block, both sections, and checkbox bullets in order", () => {
+		const body = composeSubIssueBody(wellFormed);
+		assert.strictEqual(
+			body,
+			[
+				"**Stories:** 4, 9",
+				"**TDD:** yes",
+				"**Containment:** exempt (internal pipeline tooling — no user-facing surface)",
+				"",
+				"### What to build",
+				"Add a pipeline-cli verb that composes an intake body.",
+				"",
+				"### Acceptance criteria",
+				"- [ ] A verb emits a format-2 body.",
+				"- [ ] Consumers cite the verb.",
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("is deterministic — same spec, byte-identical output", () => {
+		assert.strictEqual(composeSubIssueBody(wellFormed), composeSubIssueBody(wellFormed));
+	});
+
+	it("omits the Containment line when no marker is given (missing reads as none)", () => {
+		const {containment: _omit, ...rest} = wellFormed;
+		const body = composeSubIssueBody(rest);
+		assert.notInclude(body, "**Containment:**");
+		assert.include(body, "**TDD:** yes\n\n### What to build");
+	});
+
+	it("trims trailing whitespace and blank criteria for a stable body", () => {
+		const body = composeSubIssueBody({
+			...wellFormed,
+			whatToBuild: "  spec with padding  ",
+			acceptanceCriteria: ["  a  ", "", "   ", "b"],
+		});
+		assert.include(body, "### What to build\nspec with padding\n");
+		assert.include(body, "- [ ] a\n- [ ] b");
+		assert.notInclude(body, "- [ ] \n");
+	});
+});
+
+describe("validateSubIssueSpec — the format-2 invariants (contract §2)", () => {
+	it("accepts a well-formed spec", () => {
+		assert.deepStrictEqual(validateSubIssueSpec(wellFormed), []);
+	});
+
+	it("rejects zero acceptance criteria (the hard floor)", () => {
+		const v = validateSubIssueSpec({...wellFormed, acceptanceCriteria: []});
+		assert.strictEqual(v.length, 1);
+		assert.include(v[0] ?? "", "acceptance criterion");
+	});
+
+	it("rejects an all-blank acceptance list (no checkable criterion survives the trim)", () => {
+		const v = validateSubIssueSpec({...wellFormed, acceptanceCriteria: ["", "   "]});
+		assert.include(v[0] ?? "", "acceptance criterion");
+	});
+
+	it("rejects an empty Stories back-reference", () => {
+		const v = validateSubIssueSpec({...wellFormed, stories: "   "});
+		assert.include(v.join(" "), "Stories");
+	});
+
+	it("rejects an empty What to build", () => {
+		const v = validateSubIssueSpec({...wellFormed, whatToBuild: ""});
+		assert.include(v.join(" "), "What to build");
+	});
+
+	it("rejects a non yes|no TDD flag", () => {
+		const v = validateSubIssueSpec({...wellFormed, tdd: "maybe" as SubIssueSpec["tdd"]});
+		assert.include(v.join(" "), "TDD");
+	});
+});
+
+// AC3 — the safe body handoff cannot reintroduce the `-f body=@file` leak. The
+// composer emits the body BY VALUE, so a caller captures it into `$BODY` and passes
+// `-f body="$BODY"`; there is no file path to `@`-reference. This asserts the emitted
+// body is pure markdown that carries no machine-local filesystem path — a body a
+// filer can post by value with no leak. (These are placeholder path shapes, not real
+// paths, so this test file itself stays leak-clean.)
+describe("intake-compose body handoff is leak-safe (AC3, #2002 / #754 / PR #1567)", () => {
+	it("emits a by-value markdown body carrying no local filesystem path", () => {
+		const body = composeSubIssueBody({
+			...wellFormed,
+			whatToBuild: "Prose that mentions no scratchpad file.",
+		});
+		assert.match(body, /^\*\*Stories:\*\*/);
+		// No `@`-prefixed path and no machine-local absolute-path root leaked into the body.
+		assert.notMatch(body, /(^|\s)@[/~]/);
+		assert.notMatch(body, /\/(?:tmp|var\/folders|Users|home|private)\//);
+	});
+});


### PR DESCRIPTION
Fixes #3688

## What
Adds `pipeline-cli intake-compose sub-issue` — one tested composer that emits the **format-2 sub-issue body** of the `gh-issue-intake-formats.md` prose contract (§2) from a structured spec JSON, so a filer cites the verb instead of re-deriving the format by hand (#3254 / epic #3258).

## How
- **Pure, unit-tested core** (`packages/pipeline-cli/src/tools/intake-compose/compose.ts`): `composeSubIssueBody` emits the body deterministically; `validateSubIssueSpec` enforces the format-2 invariants (the ≥1-acceptance-criterion hard floor, `yes|no` TDD flag, non-empty Stories / What-to-build).
- **Leak-safe by-value handoff** (`command.ts`): the verb emits the body to **stdout only** (there is deliberately no `--out <file>` flag), so a caller captures it into `$BODY` and posts `-f body="$BODY"`. The `gh api -f body=@<path>` machine-local-path leak class (#2002 / #754 / PR #1567) is structurally unreachable — there is no file to `@`-reference. A `command.test.ts` case covers the safe path (asserts the emitted body carries no filesystem path).
- **Registered** in `packages/pipeline-cli/src/registry.ts`.
- **Adopted same-commit** (#3254): migrated `plan-epic`'s child-body composition to call the verb and cite it, and added the `intake-compose sub-issue` decision to the adoption-lint manifest (`packages/pipeline-cli/src/tools/adoption-lint/manifest.ts`). Its signature isolates a real format-2 *filer* via the bare `POST /issues` create tell, keeping the contract file (defines the format, no create) and format-readers (`write-code`) out of scope. Verified: over the full live corpus adoption-lint stays green (`plan-epic` matches the signature and is now cited → 0 findings).

Out of scope (per the issue): changing the prose contract's format itself, or the §CP path regex.

## Acceptance criteria
- [x] A pipeline-cli intake-composer verb emits a format-2 body from structured inputs, with a pure unit-tested core.
- [x] The consumers that re-derive the format cite the verb; adoption-lint passes (full-corpus green test).
- [x] The composer's body handoff cannot reintroduce the `-f body=@file` leak (stdout-only, no `--out`; a command test covers the safe path).

## Note
This is a **§CP change** (`packages/pipeline-cli` + the intake-format contract's consumer) — it banks for human approval, it does not auto-merge. The §CP path regex (`CONTROL_PLANE_RE`) and the format contract's meaning are unchanged; this is an extract-and-adopt only.

## Guards run locally
`pnpm typecheck` (pipeline-cli, incl. new test files) clean · `pnpm lint:worktree` clean · pipeline-cli tests green (intake-compose 16, adoption-lint full-corpus 15, router/commands 13) · `leak-guard scan` clean on the diff · pre-commit + pre-push hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)