### PR TITLE
chore(flags): retire the `pano-draft-save` flag — rip the gate, fallback, and IaC declaration (#3673)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -53,7 +53,6 @@ import {
 	memberMuteFlag,
 	navIaFlag,
 	optimisticDefinitionDeleteFlag,
-	panoDraftSaveFlag,
 	panoStampWaveFlag,
 	profileCanvasFlag,
 	reactionsFlag,
@@ -79,8 +78,6 @@ export default Alchemy.Stack(
 		// Yielding the same app resource the worker `bind()`s is idempotent.
 		const flagship = yield* Flagship;
 		yield* demoTargetingFlag(flagship.appId);
-		// The pano taslak (draft-save) dark-ship flag, default-off (#746).
-		yield* panoDraftSaveFlag(flagship.appId);
 		// The mecmua write-path dark-ship flag, default-off (#2497, epic #2467) — the
 		// single seam mecmua.publish + mecmua.saveDraft gate behind until a human release.
 		yield* mecmuaWriteFlag(flagship.appId);

--- a/apps/web/src/admin/flags/flag-overrides.test.ts
+++ b/apps/web/src/admin/flags/flag-overrides.test.ts
@@ -29,11 +29,11 @@ describe("parseOverridesFromCookie", () => {
 
 	it("decodes the URL-encoded JSON map, picking the cookie out of a multi-cookie string", () => {
 		const value = encodeURIComponent(
-			JSON.stringify({"pano-draft-save": true, "phoenix-reactions": false}),
+			JSON.stringify({"mecmua-write": true, "phoenix-reactions": false}),
 		);
 		const cookie = `session=abc; ${FLAG_OVERRIDE_COOKIE}=${value}; theme=dark`;
 		expect(parseOverridesFromCookie(cookie)).toEqual({
-			"pano-draft-save": true,
+			"mecmua-write": true,
 			"phoenix-reactions": false,
 		});
 	});
@@ -86,7 +86,7 @@ describe("overrideStateOf / effectiveValue", () => {
 
 describe("serializeOverrideCookie — the write side", () => {
 	it("writes a path-scoped, SameSite=Lax cookie whose value round-trips back through the parser", () => {
-		const map = {"pano-draft-save": true, "phoenix-user-ban": false};
+		const map = {"mecmua-write": true, "phoenix-user-ban": false};
 		const cookie = serializeOverrideCookie(map);
 		expect(cookie).toContain(`${FLAG_OVERRIDE_COOKIE}=`);
 		expect(cookie).toContain("path=/");
@@ -122,15 +122,13 @@ describe("render decisions — lowercase Turkish, text-only", () => {
 	});
 
 	it("confirms each toggle outcome and names the control", () => {
-		expect(overrideOutcomeMessage({key: "pano-draft-save", state: "on"})).toContain(
+		expect(overrideOutcomeMessage({key: "mecmua-write", state: "on"})).toContain(
 			"açık olarak geçersiz",
 		);
-		expect(overrideOutcomeMessage({key: "pano-draft-save", state: "off"})).toContain(
+		expect(overrideOutcomeMessage({key: "mecmua-write", state: "off"})).toContain(
 			"kapalı olarak geçersiz",
 		);
-		expect(overrideOutcomeMessage({key: "pano-draft-save", state: "clear"})).toContain(
-			"temizlendi",
-		);
+		expect(overrideOutcomeMessage({key: "mecmua-write", state: "clear"})).toContain("temizlendi");
 		expect(actionButtonLabel("on")).toBe("aç");
 		expect(actionButtonLabel("off")).toBe("kapat");
 		expect(actionButtonLabel("clear")).toBe("temizle");

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -43,7 +43,6 @@ export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	URL_INVALID: "geçersiz bağlantı",
 	TAGS_REQUIRED: "en az bir etiket seç",
 	TAG_INVALID: "geçersiz etiket",
-	DRAFTS_DISABLED: "taslaklar şu an devre dışı",
 	PARENT_NOT_FOUND: "yanıtlanan içerik bulunamadı",
 	INVALID_FORMAT: "geçersiz biçim",
 	TOO_SHORT: "çok kısa",

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -8,9 +8,6 @@
  * strings.
  */
 
-/** Pano taslak (draft-save) dark-ship flag (#746). */
-export const PANO_DRAFT_SAVE = "pano-draft-save";
-
 /**
  * Sözlük parallel-stamp-wave containment flag (#2709, epic #2567). Default-off. The
  * sözlük definition reads (`getDefinitionsByIds` / `listDefinitionsKeyset`) always
@@ -242,7 +239,6 @@ export interface FlagDeclaration {
  * docblock above; the server default lives in `worker/features/flagship/resources.ts`).
  */
 export const DECLARED_FLAGS: readonly FlagDeclaration[] = [
-	{key: PANO_DRAFT_SAVE, defaultValue: false},
 	{key: PHOENIX_SOZLUK_STAMP_WAVE, defaultValue: false},
 	{key: PHOENIX_PANO_STAMP_WAVE, defaultValue: false},
 	{key: MECMUA_WRITE, defaultValue: false},

--- a/apps/web/src/flags/useFlag.test.ts
+++ b/apps/web/src/flags/useFlag.test.ts
@@ -71,7 +71,7 @@ describe("resolveBootFlag — the synchronous __BOOT__ member resolution", () =>
 
 	it("returns undefined for a non-member key regardless of __BOOT__ (always the fetch path)", () => {
 		// A non-member key never resolves synchronously even if __BOOT__ happens to carry it.
-		expect(resolveBootFlag({"pano-draft-save": true} as never, "pano-draft-save")).toBeUndefined();
-		expect(resolveBootFlag(undefined, "pano-draft-save")).toBeUndefined();
+		expect(resolveBootFlag({"mecmua-write": true} as never, "mecmua-write")).toBeUndefined();
+		expect(resolveBootFlag(undefined, "mecmua-write")).toBeUndefined();
 	});
 });

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -67,9 +67,6 @@ export const FATE_WIRE_CODES = [
 	"URL_INVALID",
 	"TAGS_REQUIRED",
 	"TAG_INVALID",
-	// Pano taslak (draft-save) is gated on the `pano-draft-save` flag; the server
-	// raises this when a draft mutation runs with the flag off (#746).
-	"DRAFTS_DISABLED",
 	"PARENT_NOT_FOUND",
 	"INVALID_FORMAT",
 	"TOO_SHORT",

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -9,8 +9,6 @@ import {Button} from "../components/ui/Button";
 import {DraftRestoreBanner} from "../components/ui/DraftRestoreBanner";
 import {useDraftSubmit} from "../fate/useDraftSubmit";
 import type {WireMessageOverrides} from "../fate/wireMessages";
-import {FlagGate} from "../flags/FlagGate";
-import {PANO_DRAFT_SAVE} from "../flags/keys";
 import {panoSubmitGate} from "../lib/panoSubmitGate";
 import {POST_TAG_KINDS, tagClass, tagLabel} from "../lib/panoTags";
 import {authRedirectPath} from "../lib/returnTo";
@@ -74,7 +72,6 @@ const PANO_SUBMIT_OVERRIDES: WireMessageOverrides = {
 	TAG_INVALID: "geçersiz etiket",
 	URL_INVALID: "geçersiz bağlantı",
 	TOO_SHORT: `başlık en az ${TITLE_MIN} karakter olmalı`,
-	DRAFTS_DISABLED: "taslaklar şu an devre dışı",
 	VALIDATION_ERROR: "girdiğin bilgiler geçersiz",
 	USER_NOT_FOUND: "kullanıcı bulunamadı",
 	BAD_REQUEST: "geçersiz istek",
@@ -416,17 +413,15 @@ export function PanoSubmitPage() {
 						) : null}
 
 						<div className="kp-pano-submit__form-actions">
-							<FlagGate flag={PANO_DRAFT_SAVE}>
-								<Button
-									type="button"
-									variant="tertiary"
-									data-testid="pano-submit-draft"
-									disabled={isInFlight}
-									onClick={onSaveDraft}
-								>
-									taslak
-								</Button>
-							</FlagGate>
+							<Button
+								type="button"
+								variant="tertiary"
+								data-testid="pano-submit-draft"
+								disabled={isInFlight}
+								onClick={onSaveDraft}
+							>
+								taslak
+							</Button>
 							<Button
 								type="submit"
 								variant="primary"

--- a/apps/web/tests/e2e/26-pano-draft-save.spec.ts
+++ b/apps/web/tests/e2e/26-pano-draft-save.spec.ts
@@ -3,23 +3,18 @@ import {signUp} from "./_helpers/auth";
 import {randomSuffix} from "./_helpers/rand";
 
 /**
- * Pano taslak (draft-save) dark-ship invariant — the off-path proven in-browser.
+ * Pano taslak (draft-save) — the live path proven in-browser.
  *
- * The `pano-draft-save` flag defaults OFF (IaC, #746), so the `FlagGate` around the
- * taslak button renders nothing: the new-post page is byte-identical to today and
- * the `pano-submit-draft` button is ABSENT. This is the dark-ship invariant — it
- * does NOT depend on fate-live, so it is stable to run on the default-off flag.
- *
- * The on-path (flag flipped → button appears → save persists a draft with
- * isDraft: true) is covered by the unit test
- * `worker/features/pano/draft-save.invariant.test.ts` (the flag-on path needs
- * release plumbing landing separately), so this e2e stays on the off-path.
+ * The taslak button used to sit behind a `FlagGate` on the draft-save dark-ship
+ * flag (#746); that flag graduated and was retired (ADR 0136), so the button now
+ * renders unconditionally on the new-post page. This spec does NOT depend on
+ * fate-live, so it is stable to run standalone.
  *
  * Mirrors the signUp + bootstrap + goto `/pano/yeni` pattern of
  * tests/e2e/14-pano-submit-post.spec.ts.
  */
-test.describe("Pano draft-save (dark-ship, flag default off)", () => {
-	test("the taslak draft button is absent while the flag defaults off", async ({page}) => {
+test.describe("Pano draft-save", () => {
+	test("the taslak draft button renders on the new-post form", async ({page}) => {
 		const localPart = `pd${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
 		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -30,11 +25,9 @@ test.describe("Pano draft-save (dark-ship, flag default off)", () => {
 		});
 
 		await page.goto("/pano/yeni");
-		// The submit button proves the form rendered…
 		await expect(page.locator('[data-testid="pano-submit-submit"]')).toBeVisible({
 			timeout: 5_000,
 		});
-		// …and the flag-gated draft button is absent (FlagGate hides it when off).
-		await expect(page.locator('[data-testid="pano-submit-draft"]')).toHaveCount(0);
+		await expect(page.locator('[data-testid="pano-submit-draft"]')).toBeVisible();
 	});
 });

--- a/apps/web/tests/e2e/28-reaction-bar-darkship.spec.ts
+++ b/apps/web/tests/e2e/28-reaction-bar-darkship.spec.ts
@@ -15,8 +15,7 @@ import {expect, test} from "@playwright/test";
  * the optimistic-then-reconcile loop) is covered by the unit tests
  * `src/components/reaction/reactionModel.test.ts` +
  * `reactionDispatch.test.ts` (the flag-on path needs release plumbing / a
- * seeded reaction, landing at release), so this e2e stays on the off-path — the
- * same split as `26-pano-draft-save.spec.ts`.
+ * seeded reaction, landing at release), so this e2e stays on the off-path.
  */
 // @journey:phoenix-reactions — the registered reachability journey for the reactions
 // vertical (ADR 0173 §2). reachability-guard asserts this tag exists; the e2e job runs it.

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -42,7 +42,6 @@ import {
 	CommentBodyRequired,
 	CommentBodyTooLong,
 	CommentNotFound,
-	DraftsDisabled,
 	ParentCommentNotFound,
 	PostBodyTooLong,
 	PostDeleteFailed,
@@ -100,7 +99,6 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	[CommentNotFound, "COMMENT_NOT_FOUND"],
 	[UnauthorizedPostMutation, "UNAUTHORIZED"],
 	[UnauthorizedCommentMutation, "UNAUTHORIZED"],
-	[DraftsDisabled, "DRAFTS_DISABLED"],
 	// mecmua write path (#2497) — reachable from fateConfig via `mecmua.publish` /
 	// `mecmua.saveDraft`. All message-only, so also round-trip representatives below;
 	// `MecmuaTitleRequired` shares the `TITLE_REQUIRED` code with pano's `TitleRequired`.
@@ -178,7 +176,6 @@ const ROUND_TRIP_CLASSES = [
 	CommentBodyTooLong,
 	ParentCommentNotFound,
 	PostDeleteFailed,
-	DraftsDisabled,
 	MecmuaDisabled,
 	MecmuaPostNotFound,
 	BodyRequired,

--- a/apps/web/worker/features/flagship/dev-override.ts
+++ b/apps/web/worker/features/flagship/dev-override.ts
@@ -20,7 +20,6 @@
  * never reaches Flagship or another request's state.
  */
 
-import {PANO_DRAFT_SAVE} from "../../../src/flags/keys.ts";
 import {DEMO_TARGETING_FLAG_KEY} from "./resources.ts";
 
 /** The cookie the dev override map travels in. Dev-only; never set in any deployed stage. */
@@ -40,7 +39,6 @@ export const emptyOverrides: FlagOverrides = {};
  * (the wrapper short-circuits any key), the list only seeds the UI.
  */
 export const DEV_OVERRIDABLE_FLAGS: readonly string[] = [
-	PANO_DRAFT_SAVE,
 	DEMO_TARGETING_FLAG_KEY,
 	"phoenix-flags-probe",
 ];

--- a/apps/web/worker/features/flagship/dev-override.unit.test.ts
+++ b/apps/web/worker/features/flagship/dev-override.unit.test.ts
@@ -31,9 +31,9 @@ describe("parseOverrideCookie", () => {
 	});
 
 	it("parses a well-formed boolean override map", () => {
-		const value = encodeOverrideCookieValue({"pano-draft-save": true, "demo-flag": false});
+		const value = encodeOverrideCookieValue({"mecmua-write": true, "demo-flag": false});
 		expect(parseOverrideCookie(cookie(value))).toEqual({
-			"pano-draft-save": true,
+			"mecmua-write": true,
 			"demo-flag": false,
 		});
 	});
@@ -107,7 +107,7 @@ describe("parseOverrideAction", () => {
 
 describe("override cookie round-trip", () => {
 	it("encode → parse is identity for a boolean map", () => {
-		const map = {"pano-draft-save": true, "phoenix-flags-probe": false};
+		const map = {"mecmua-write": true, "phoenix-flags-probe": false};
 		expect(parseOverrideCookie(cookie(encodeOverrideCookieValue(map)))).toEqual(map);
 	});
 });

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -15,7 +15,6 @@ import {
 	MECMUA_PUBLIC_READ,
 	MECMUA_WRITE,
 	MEMBER_MUTE,
-	PANO_DRAFT_SAVE,
 	PHOENIX_BILDIRIM,
 	PHOENIX_EDGE_SHELL_BOOT,
 	PHOENIX_EMAIL_DELIVERY_ADMIN,
@@ -88,39 +87,7 @@ export const demoTargetingFlag = (appId: Input<string>) =>
 		],
 	});
 
-export {PANO_DRAFT_SAVE, PHOENIX_BILDIRIM, PHOENIX_KARMA_GATES};
-
-/**
- * The pano `taslak` (draft-save) dark-ship flag config (#746) — the feature-flag
- * substrate's first real consumer (ADR 0091/0093). Default-OFF so it reaches
- * production dark; flipping it on is the human release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is
- * unit-inspectable WITHOUT constructing the alchemy resource (#746): the factory
- * spreads it into `FlagshipFlag`; the test asserts `defaultVariation`/
- * `variations.off` here, the same record the deploy ships.
- *
- * Per-flag metadata (the IaC ownership record `feature-flags-agent-workflow.md`
- * asks for):
- *   - owner:           pano
- *   - originating:     #746 (epic: feature-flag substrate, #488)
- *   - removal trigger: once draft-save graduates to 100% on, retire the flag and
- *                      delete its gate (the dark-ship is over).
- */
-export const PANO_DRAFT_SAVE_FLAG = {
-	key: PANO_DRAFT_SAVE,
-	description:
-		"pano taslak (draft-save) dark-ship (#746). owner: pano. removal: retire once on at 100%.",
-	defaultVariation: "off",
-	variations: {off: false, on: true},
-} as const;
-
-/**
- * No targeting rules — a plain boolean kill-switch. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
-export const panoDraftSaveFlag = (appId: Input<string>) =>
-	Cloudflare.Flagship.Flag("pano_draft_save", {appId, ...PANO_DRAFT_SAVE_FLAG});
+export {PHOENIX_BILDIRIM, PHOENIX_KARMA_GATES};
 
 /**
  * The mecmua write-path dark-ship flag config (#2497, epic #2467). The SINGLE seam
@@ -129,9 +96,9 @@ export const panoDraftSaveFlag = (appId: Input<string>) =>
  * it on is the human release act (ADR 0083).
  *
  * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `PANO_DRAFT_SAVE_FLAG`, #746): the
- * factory spreads it into `FlagshipFlag`; the test asserts `defaultVariation`/
- * `variations.off` on this same record.
+ * WITHOUT constructing the alchemy resource: the factory spreads it into `FlagshipFlag`;
+ * the test asserts `defaultVariation`/`variations.off` on this same record. Every flag
+ * config below is exported the same way for the same reason.
  *
  * Per-flag metadata (`.patterns/feature-flags-schema-lifecycle.md`):
  *   - owner:           mecmua
@@ -148,8 +115,7 @@ export const MECMUA_WRITE_FLAG = {
 } as const;
 
 /**
- * No targeting rules — a plain boolean kill-switch (`panoDraftSaveFlag` shape). `appId`
- * is resolved at deploy.
+ * No targeting rules — a plain boolean kill-switch. `appId` is resolved at deploy.
  */
 export const mecmuaWriteFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("mecmua_write", {appId, ...MECMUA_WRITE_FLAG});
@@ -196,7 +162,7 @@ export const mecmuaFeedFlag = (appId: Input<string>) =>
  *
  * Exported as a plain object so the default-=-safe-state invariant is
  * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
- * `PANO_DRAFT_SAVE_FLAG`, #746).
+ * `MECMUA_WRITE_FLAG`).
  *
  * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
  * asks for):
@@ -269,7 +235,7 @@ export const optimisticDefinitionDeleteFlag = (appId: Input<string>) =>
  *
  * Exported as a plain object so the default-=-safe-state invariant is
  * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
- * `PANO_DRAFT_SAVE_FLAG`, #746).
+ * `MECMUA_WRITE_FLAG`).
  *
  * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
  * asks for):
@@ -340,7 +306,7 @@ export const karmaGatesFlag = (appId: Input<string>) =>
  * the human release act (ADR 0083).
  *
  * Exported as a plain object so the default-=-safe-state invariant is
- * unit-inspectable WITHOUT constructing the alchemy resource (mirrors `PANO_DRAFT_SAVE_FLAG`).
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
  *
  * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
  *   - owner:           pasaport (the identity + session-boundary surface)
@@ -467,7 +433,7 @@ export const emailDeliveryNoticeFlag = (appId: Input<string>) =>
  * the authoring/publish path (#2497) ships behind its own seam.
  *
  * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `PANO_DRAFT_SAVE_FLAG`).
+ * WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
  *
  * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
  *   - owner:           mecmua (the long-form read surface)
@@ -531,7 +497,7 @@ export const navIaFlag = (appId: Input<string>) =>
  * Flipping it on is the human release act (ADR 0083).
  *
  * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `PANO_DRAFT_SAVE_FLAG`).
+ * WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
  *
  * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
  *   - owner:           sözlük (the definition read path)
@@ -565,7 +531,7 @@ export const sozlukStampWaveFlag = (appId: Input<string>) =>
  * not the pano feed (the #2322 base/overlay split).
  *
  * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `PANO_DRAFT_SAVE_FLAG`).
+ * WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
  *
  * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
  *   - owner:           pano (the thread/comment read path)

--- a/apps/web/worker/features/pano/draft-save.invariant.test.ts
+++ b/apps/web/worker/features/pano/draft-save.invariant.test.ts
@@ -1,32 +1,20 @@
 /**
- * The dark-ship default-=-safe-state invariant for pano taslak (draft-save), #746.
- * Two proofs the AC names:
+ * `post.saveDraft` returns a `Post` carrying `isDraft: true` — the taslak write's
+ * wire contract (#746; the dark-ship flag that once gated it is retired, ADR 0136).
  *
- *   (a) IaC default-off — the `panoDraftSaveFlag` config ships `defaultVariation:
- *       "off"` and `variations.off === false`. Inspected off the exported
- *       `PANO_DRAFT_SAVE_FLAG` record (the same object the factory spreads into
- *       `FlagshipFlag`), so no alchemy resource is constructed.
- *
- *   (b) Mutation gate — with `Flags` stubbed OFF, `post.saveDraft` fails the wire
- *       `DRAFTS_DISABLED` and NEVER touches the service (the dark path is
- *       unreachable even if a client bypasses the UI). With `Flags` stubbed ON, it
- *       calls `Pano.saveDraft` and returns a `Post` carrying `isDraft: true`.
- *
- * Wire-boundary unit test (ADR 0082): the `Pano`/`Flags`/`LivePublisher` seams are
+ * Wire-boundary unit test (ADR 0082): the `Pano`/`LivePublisher` seams are
  * substituted directly — no DB, no Flagship binding. The mutation runs through
  * `resolveWire` (its real external interface — `resolve` decode + the
- * `encodeWireError` class→wire-code seam), so the OFF path is proven by the WIRE
- * `code`. Mirrors `report-mutation.unit.test.ts` (`resolveWire` + `CurrentUser`)
- * and `Flags.unit.test.ts` (Flagship-free `Flags` stub).
+ * `encodeWireError` class→wire-code seam) rather than `.handler`, so the decode
+ * of the returned selection is part of what's proven. Mirrors
+ * `report-mutation.unit.test.ts` (`resolveWire` + `CurrentUser`).
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
-import {Cause, Effect, Layer} from "effect";
+import {Effect, Layer} from "effect";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
-import {Flags} from "../flagship/Flags.ts";
-import {PANO_DRAFT_SAVE_FLAG, panoDraftSaveFlag} from "../flagship/resources.ts";
 import {mutations} from "./mutations.ts";
 import {Pano, type SaveDraftResult} from "./Pano.ts";
 
@@ -40,24 +28,14 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// A `Flags` whose `getBoolean` returns a fixed value — the only method the gate
-// calls. Every typed read dies so an accidental call is loud.
-const flagsStub = (value: boolean): Layer.Layer<Flags> =>
-	Layer.succeed(Flags, {
-		getBoolean: () => Effect.succeed(value),
-		getString: () => Effect.die("getString not exercised"),
-		getNumber: () => Effect.die("getNumber not exercised"),
-		getObject: () => Effect.die("getObject not exercised"),
-	} as typeof Flags.Service);
-
 // A `LivePublisher` that records nothing — the publish is fire-and-forget and its
 // error channel is `never`, so it can never fail the mutation.
 const liveStub = Layer.succeed(LivePublisher)(
 	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
 );
 
-// A `Pano` stub whose `saveDraft` is scripted; every other method dies. Cast to the
-// full service tag — the gate path only ever reaches `saveDraft`.
+// A `Pano` stub whose `saveDraft` is scripted; every other method dies, so an
+// unexpected service call is loud rather than silently satisfied.
 const panoStub = (saveDraft: (typeof Pano.Service)["saveDraft"]): Layer.Layer<Pano> =>
 	Layer.succeed(
 		Pano,
@@ -84,63 +62,20 @@ const draftRow: SaveDraftResult = {
 	isDraft: true,
 };
 
-// Drive the op through its real external interface (`resolveWire`: `resolve`
-// decode + the `encodeWireError` class→wire-code seam), not `.handler` — so the
-// OFF-path assertion sees the WIRE `DRAFTS_DISABLED` code and a mis-annotated
-// `[FateWireCode]` on `DraftsDisabled` is a unit failure.
-const saveDraft = (
-	pano: Layer.Layer<Pano>,
-	flags: Layer.Layer<Flags>,
-	user: typeof AUTHOR | undefined = AUTHOR,
-) =>
+const saveDraft = (pano: Layer.Layer<Pano>, user: typeof AUTHOR | undefined = AUTHOR) =>
 	resolveWire(mutations["post.saveDraft"], {
 		input: {title: "yarım kalmış"},
 		select: ["id", "title", "isDraft"],
 	}).pipe(
-		Effect.provide(Layer.mergeAll(pano, flags, liveStub)),
+		Effect.provide(Layer.mergeAll(pano, liveStub)),
 		Effect.provideService(CurrentUser, {user}),
 		Effect.provideService(RuntimeContext, runtimeContextStub),
 	);
 
-describe("pano draft-save — (a) IaC default is the safe (off) state", () => {
-	it("the flag config ships defaultVariation off and variations.off === false", () => {
-		assert.strictEqual(PANO_DRAFT_SAVE_FLAG.defaultVariation, "off");
-		assert.strictEqual(PANO_DRAFT_SAVE_FLAG.variations.off, false);
-		assert.strictEqual(PANO_DRAFT_SAVE_FLAG.variations.on, true);
-		assert.strictEqual(PANO_DRAFT_SAVE_FLAG.key, "pano-draft-save");
-	});
-
-	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
-		assert.strictEqual(typeof panoDraftSaveFlag, "function");
-	});
-});
-
-describe("pano draft-save — (b) the mutation gate is the safe default", () => {
-	it.effect("flag OFF → the wire DRAFTS_DISABLED, and Pano.saveDraft is never called", () =>
+describe("pano draft-save", () => {
+	it.effect("Pano.saveDraft runs and the returned Post carries isDraft: true", () =>
 		Effect.gen(function* () {
-			const exit = yield* Effect.exit(
-				saveDraft(
-					panoStub(() => Effect.die("Pano.saveDraft ran with the flag off")),
-					flagsStub(false),
-				),
-			);
-			assert.isTrue(exit._tag === "Failure", "off-path fails");
-			if (exit._tag === "Failure") {
-				const error = Cause.findErrorOption(exit.cause);
-				assert.isTrue(error._tag === "Some");
-				if (error._tag === "Some") {
-					assert.strictEqual((error.value as {code?: unknown}).code, "DRAFTS_DISABLED");
-				}
-			}
-		}),
-	);
-
-	it.effect("flag ON → Pano.saveDraft runs and the returned Post carries isDraft: true", () =>
-		Effect.gen(function* () {
-			const post = yield* saveDraft(
-				panoStub(() => Effect.succeed(draftRow)),
-				flagsStub(true),
-			);
+			const post = yield* saveDraft(panoStub(() => Effect.succeed(draftRow)));
 			assert.strictEqual((post as {isDraft?: boolean}).isDraft, true);
 			assert.strictEqual((post as {id?: string}).id, "post_draft1");
 		}),

--- a/apps/web/worker/features/pano/errors.ts
+++ b/apps/web/worker/features/pano/errors.ts
@@ -138,14 +138,3 @@ export class PostDeleteFailed extends Schema.TaggedErrorClass<PostDeleteFailed>(
 	{message: Schema.String},
 	{[FateWireCode]: "POST_DELETE_FAILED"},
 ) {}
-
-/**
- * Drafts (taslak) are reachable only when the `pano-draft-save` flag is on. The
- * server-side gate raises this when a draft mutation runs with the flag off, so the
- * dark path is unreachable even if a client bypasses the UI. See issue #746.
- */
-export class DraftsDisabled extends Schema.TaggedErrorClass<DraftsDisabled>()(
-	"pano/DraftsDisabled",
-	{message: Schema.String},
-	{[FateWireCode]: "DRAFTS_DISABLED"},
-) {}

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -24,7 +24,6 @@ import {notifyContentVote} from "../bildirim/vote-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
-import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
 import {InsufficientKarma} from "../kunye/errors.ts";
 import {gateContentOnKarma} from "../kunye/privilege.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
@@ -34,7 +33,6 @@ import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentNotFound,
 	CommentValidationErrors,
-	DraftsDisabled,
 	PostDeleteFailed,
 	PostNotFound,
 	PostValidationErrors,
@@ -228,24 +226,14 @@ export const mutations = {
 			return yield* gateContentOnKarma(submit());
 		}),
 	),
-	// `post.saveDraft` / `post.discardDraft` are the dark-shipped taslak path (#746),
-	// gated server-side on `pano-draft-save` (default-off). The gate is load-bearing:
-	// with the flag off both fail `DraftsDisabled` so the path is unreachable even if a
-	// client bypasses the UI. The flag context is derived from the signed-in user (the
-	// `CurrentUser.required` identity), so a flip can target by user/percentage later.
 	"post.saveDraft": Fate.mutation(
 		{
 			input: SaveDraftInput,
 			type: PostView,
-			error: Schema.Union([Unauthorized, DraftsDisabled, ...PostValidationErrors]),
+			error: Schema.Union([Unauthorized, ...PostValidationErrors]),
 		},
 		Effect.fn("post.saveDraft")(function* ({input}) {
 			const user = yield* CurrentUser.required;
-			const flags = yield* Flags;
-			const on = yield* flags.getBoolean(PANO_DRAFT_SAVE, false).pipe(provideRequestFlags);
-			if (!on) {
-				return yield* new DraftsDisabled({message: "taslak özelliği şu an kapalı"});
-			}
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const r = yield* pano.saveDraft({
@@ -270,15 +258,10 @@ export const mutations = {
 		{
 			input: DiscardDraftInput,
 			type: PostView,
-			error: Schema.Union([Unauthorized, DraftsDisabled]),
+			error: Unauthorized,
 		},
 		Effect.fn("post.discardDraft")(function* () {
 			const user = yield* CurrentUser.required;
-			const flags = yield* Flags;
-			const on = yield* flags.getBoolean(PANO_DRAFT_SAVE, false).pipe(provideRequestFlags);
-			if (!on) {
-				return yield* new DraftsDisabled({message: "taslak özelliği şu an kapalı"});
-			}
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const r = yield* pano.discardDraft({authorId: UserId.make(user.id)});

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -248,8 +248,8 @@ export default Phoenix.make(
 		const telemetryLayer = Layer.succeed(TelemetryClient)(telemetryClient);
 
 		// The worker's ambient `RuntimeContext`, resolved once. The fate runtime needs
-		// it because the pano draft-save gate (#746) reads `Flags` (a `RuntimeContext`
-		// per-call requirement); `makeAppLive` reuses it for the `/api/auth/*` route.
+		// it because every flag gate reads `Flags` (a `RuntimeContext` per-call
+		// requirement); `makeAppLive` reuses it for the `/api/auth/*` route.
 		const runtimeContext = yield* RuntimeContext;
 
 		// The one worker-level runtime (ADR 0041/0043 — init-only wiring): exactly


### PR DESCRIPTION
The pano taslak (draft-save) dark-ship flag (#746) graduated, so only the served-ON branch is real behavior. This retires it per ADR 0136 — the flag, its gate, and everything that existed only to keep the OFF branch reachable come out. Behavior-preserving.

### What changed

**The gate + the dead OFF branch**
- `apps/web/src/pages/PanoSubmitPage.tsx` — the `FlagGate` around the taslak button is gone; the button renders inline. The `DRAFTS_DISABLED` copy override goes with it.
- `apps/web/worker/features/pano/mutations.ts` — `post.saveDraft` / `post.discardDraft` lose their `Flags.getBoolean` read and the `DraftsDisabled` early-return. `post.discardDraft`'s error narrows from a one-member `Schema.Union` to the bare `Unauthorized`.
- `apps/web/worker/features/pano/errors.ts` — `pano/DraftsDisabled` is deleted; it was reachable only from the OFF branch. Its `DRAFTS_DISABLED` wire code leaves `src/lib/fateWireCodes.ts` and its Turkish copy leaves `src/fate/wireMessages.ts`.

**The IaC declaration (all three shared files)**
- `apps/web/src/flags/keys.ts` — the `PANO_DRAFT_SAVE` constant and its `DECLARED_FLAGS` row.
- `apps/web/worker/features/flagship/resources.ts` — `PANO_DRAFT_SAVE_FLAG`, the `panoDraftSaveFlag` factory, and the import/re-export.
- `apps/web/alchemy.run.ts` — the import and the `yield* panoDraftSaveFlag(...)` wiring.
- `apps/web/worker/features/flagship/dev-override.ts` — the key's `DEV_OVERRIDABLE_FLAGS` entry.

No other flag's declaration is touched.

**One knock-on worth calling out:** eight sibling flag docblocks in `resources.ts` cited `PANO_DRAFT_SAVE_FLAG` as the exemplar for *why* each config is exported as a plain object (unit-inspectable without constructing the alchemy resource). Deleting it would have left eight dangling pointers, so `MECMUA_WRITE_FLAG` takes over as the anchor that states that rationale once, and the siblings now point at it.

**Tests**
- `worker/features/pano/draft-save.invariant.test.ts` — the OFF-world half (the IaC default-off assertions and the `DRAFTS_DISABLED` wire assertion) is removed; the ON-world `isDraft: true` wire assertion stays, still driven through `resolveWire`.
- `tests/e2e/26-pano-draft-save.spec.ts` — was purely a dark-ship "the button is absent" assertion. Inverted to assert the taslak button now renders, so the vertical keeps in-browser coverage rather than losing it.
- `worker/features/fate/wireCodes-per-class.unit.test.ts` — the `DraftsDisabled` registry rows.
- Fixtures that used the retired key as an arbitrary sample string (`useFlag.test.ts`, `flag-overrides.test.ts`, `dev-override.unit.test.ts`) moved to `mecmua-write`, a still-declared key.

### Verification

- `pnpm typecheck --force` — 33/33 successful, **0 cached** (forced so no sibling-worktree FULL TURBO green is replayed).
- `pnpm lint` — clean.
- `vitest run --project unit` — 286 files / 2351 tests pass.
- `vitest run --project client` — 53 files / 270 tests pass.
- `grep -rn 'pano-draft-save|PANO_DRAFT_SAVE|panoDraftSave|DraftsDisabled|DRAFTS_DISABLED' apps/` — no matches. Grep-clean, including the historical docblock mentions.

Committed through the full pre-commit hook stack (biome, leak-guard, primary-index-guard, ref-guard); no `--no-verify`.

Closes #3673

🤖 Generated with [Claude Code](https://claude.com/claude-code)