### PR TITLE
fix(pipeline): a probe that could not execute resolves to UNKNOWN, never a definite answer (#3715, #3701)

### DIFF
--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -209,6 +209,30 @@ it adds no engine→engine and no human-facing edge.
   green. The §CP unblock logic lives once — in ship-it / `cp-cardinality` — and both the watcher and
   the shipper read that single source, so the trigger fires exactly when the enqueue would discharge
   and no second copy of the §CP discharge forks into this def.
+- **An unreadable review query resolves to UNKNOWN — never to an approval (fail closed).** The poll
+  reads live GitHub, so it must assume the response may not be review data at all. **Validate the
+  payload's shape before interpreting it**, and treat every non-conforming response — a 503/error
+  body, a non-array payload, a parse failure, a non-zero `gh` exit — as **UNKNOWN → do not fire,
+  re-arm**, never as a definite answer. A bare non-empty test on the response is the defect: during a
+  live GitHub partial outage an error body read as an approver's login and declared two unapproved §CP
+  PRs approved (#3715). Three rules make the positive branch fail closed:
+
+  ```bash
+  # 1. SHAPE FIRST: interpret nothing until the payload is proven to be the expected JSON array.
+  #    `jq -e 'type=="array"'` is the assertion — a 503 body is an object, so it exits non-zero.
+  REVIEWS="$(gh api --paginate "repos/$REPO/pulls/$PR/reviews?per_page=100" 2>/dev/null)" \
+    && printf '%s' "$REVIEWS" | jq -e 'type == "array"' >/dev/null 2>&1 \
+    || { echo "approval-watcher #$PR: reviews READ FAILED (unreadable payload) — UNKNOWN, re-arming; NOT 'no approval'"; return 0; }
+  # 2. EXACT MEMBERSHIP: an approver counts only if their login matches an actual control-plane
+  #    team member exactly (`--jq '.state'` == active), never a substring or non-empty test.
+  # 3. VERIFIED HEAD: require `.commit_id == $HEAD` on this proven-array read (ADR 0058).
+  ```
+
+  **Log "read failed" distinctly from "no approval."** They are different facts with the same
+  non-firing outcome, and collapsing them makes a GitHub outage look like a human who simply hasn't
+  approved yet — a silent stall nobody can see. The watcher's non-firing line must name which one it
+  was. The durable authority is still `cp-cardinality` and the shipper's own re-check at enqueue; this
+  rule is defense in depth on the trigger, so a hiccup can never *start* a §CP enqueue.
 - **Approved at the current head + green → wake and spawn the shipper.** When the predicate discharges
   — a non-author control-plane approval bound to the PR's *current* head, machine gates green — the
   watcher wakes you to spawn the approval-aware `shipper` on that head. The shipper re-runs the same

--- a/packages/pipeline-cli/src/tools/orphan-heal/command.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/command.ts
@@ -54,15 +54,16 @@ const scan = Command.make(
 		const snapshots = yield* Effect.all(
 			prs.map((pr) =>
 				Effect.gen(function* () {
-					const [ci, laned] = yield* Effect.all([gh.headCi(pr.headSha), gh.inEngineLane(pr.body)], {
-						concurrency: "unbounded",
-					});
+					const [ci, laneState] = yield* Effect.all(
+						[gh.headCi(pr.headSha), gh.inEngineLane(pr.body)],
+						{concurrency: "unbounded"},
+					);
 					return {
 						number: pr.number,
 						isDraft: pr.isDraft,
 						ci: ci.conclusion,
 						redSince: ci.redSince,
-						inEngineLane: laned,
+						laneState,
 						failingCheck: ci.failingCheck,
 					} satisfies PrSnapshot;
 				}),

--- a/packages/pipeline-cli/src/tools/orphan-heal/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/github-service.unit.test.ts
@@ -1,0 +1,145 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Github, GithubLive, type RepoResolutionError} from "./github.ts";
+
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+/** A `ChildProcessSpawner` answering `gh api` from a REST-path fixture map. */
+const mockSpawner = (
+	responses: Record<string, Response>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const path = (args.find((a) => a.startsWith("repos/")) ?? "").replace(/\?.*$/, "");
+				const canned =
+					path in responses
+						? normalize(responses[path]!)
+						: {stdout: "", exitCode: 1, stderr: `gh: Not Found (HTTP 404) ${path}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	responses: Record<string, Response>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const issuePath = (n: number) => `repos/${PINNED_REPO}/issues/${n}`;
+const triaged = JSON.stringify({labels: [{name: "status:triaged"}, {name: "p1"}]});
+const untriaged = JSON.stringify({labels: [{name: "status:needs-triage"}]});
+const notFound = {stdout: "", exitCode: 1, stderr: "gh: Not Found (HTTP 404)"} as const;
+const serverError = {
+	stdout: "",
+	exitCode: 1,
+	stderr: "gh: No server is currently available to service your request. (HTTP 503)",
+} as const;
+
+const laneOf = (body: string, responses: Record<string, Response>) =>
+	provide(
+		Effect.flatMap(Github, (gh) => gh.inEngineLane(body)),
+		responses,
+	);
+
+describe("Github.inEngineLane — a read that could not execute is `unknown`, never `laneless` (#3701)", () => {
+	it.effect("a transient 5xx on the only closing ref defers instead of reading laneless", () =>
+		Effect.gen(function* () {
+			const lane = yield* laneOf("Fixes #10", {[issuePath(10)]: serverError});
+			assert.strictEqual(lane, "unknown");
+		}),
+	);
+
+	it.effect("a genuine 404 closing ref still resolves laneless without aborting the sweep", () =>
+		Effect.gen(function* () {
+			const lane = yield* laneOf("Fixes #10", {[issuePath(10)]: notFound});
+			assert.strictEqual(lane, "laneless");
+		}),
+	);
+
+	it.effect("an undecodable payload resolves laneless (a bad ref, not an outage)", () =>
+		Effect.gen(function* () {
+			const lane = yield* laneOf("Fixes #10", {[issuePath(10)]: "{not json"});
+			assert.strictEqual(lane, "laneless");
+		}),
+	);
+
+	it.effect("a triaged closing ref is laned", () =>
+		Effect.gen(function* () {
+			const lane = yield* laneOf("Fixes #10", {[issuePath(10)]: triaged});
+			assert.strictEqual(lane, "laned");
+		}),
+	);
+
+	it.effect("a read that found no triaged label is confirmed laneless", () =>
+		Effect.gen(function* () {
+			const lane = yield* laneOf("Fixes #10", {[issuePath(10)]: untriaged});
+			assert.strictEqual(lane, "laneless");
+		}),
+	);
+
+	it.effect("a PR with no closing refs is laneless — nothing was read, nothing to defer on", () =>
+		Effect.gen(function* () {
+			const lane = yield* laneOf("no closing keyword here", {});
+			assert.strictEqual(lane, "laneless");
+		}),
+	);
+
+	// Precedence: `laned` is provable from one ref, `laneless` is not — it needs every ref read.
+	it.effect("one confirmed triaged ref wins over an unreadable sibling ref", () =>
+		Effect.gen(function* () {
+			const lane = yield* laneOf("Fixes #10, fixes #11", {
+				[issuePath(10)]: triaged,
+				[issuePath(11)]: serverError,
+			});
+			assert.strictEqual(lane, "laned");
+		}),
+	);
+
+	it.effect("an unreadable ref alongside a confirmed-untriaged ref still defers", () =>
+		Effect.gen(function* () {
+			const lane = yield* laneOf("Fixes #10, fixes #11", {
+				[issuePath(10)]: untriaged,
+				[issuePath(11)]: serverError,
+			});
+			assert.strictEqual(lane, "unknown");
+		}),
+	);
+});

--- a/packages/pipeline-cli/src/tools/orphan-heal/github.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/github.ts
@@ -13,7 +13,12 @@
 import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
-import {type CiConclusion, extractHealTargets, parseClosingRefs} from "./orphan-heal.ts";
+import {
+	type CiConclusion,
+	extractHealTargets,
+	type LaneState,
+	parseClosingRefs,
+} from "./orphan-heal.ts";
 
 /** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
 export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
@@ -217,30 +222,53 @@ const headCi = Effect.fn("Github.headCi")(function* (repo: string, sha: string) 
 	} satisfies HeadCi;
 });
 
+/** One closing ref's lane reading. `unknown` ⇒ the read could not execute, so it decides nothing. */
+type LaneProbe = "triaged" | "laneless" | "unknown";
+
+/**
+ * Did this `gh` failure prove the issue is not there (a definite answer), or merely prevent the
+ * read (no answer)? Only a 404 proves absence — a nonexistent or other-repo closing ref. A 5xx,
+ * an auth/rate-limit rejection, or a transport failure (`exitCode: -1`) all mean the probe never
+ * executed, which is `unknown`, never a negative that drives a file (#3701).
+ */
+const provesAbsent = (error: GhCommandError): boolean => /HTTP 404|not found/i.test(error.stderr);
+
 const issueIsTriaged = Effect.fn("Github.issueIsTriaged")(function* (repo: string, n: number) {
 	const args = ["api", `repos/${repo}/issues/${n}`];
-	// A closing ref may point at a nonexistent / other-repo number — treat any failed read (404,
-	// parse, decode) as "not a triaged lane" rather than aborting the whole sweep on one bad ref.
 	const read = Effect.gen(function* () {
 		const {labels} = yield* decodeIssueLabels(yield* json(args));
-		return labels.some((l) => l.name === "status:triaged");
+		return (labels.some((l) => l.name === "status:triaged") ? "triaged" : "laneless") as LaneProbe;
 	});
-	return yield* read.pipe(Effect.orElseSucceed(() => false));
+	return yield* read.pipe(
+		Effect.catchTag(
+			"@kampus/orphan-heal/GhCommandError",
+			(error): Effect.Effect<LaneProbe> =>
+				Effect.succeed(provesAbsent(error) ? "laneless" : "unknown"),
+		),
+		// A payload that won't parse/decode is a bad ref, not an outage — laneless, and the sweep
+		// carries on rather than aborting on one ref (the #3532 non-aborting behavior).
+		Effect.orElseSucceed((): LaneProbe => "laneless"),
+	);
 });
 
 /**
  * Is the PR in an engine lane? Derived from EXISTING state: it closes at least one
  * `status:triaged` issue (engine-opened-from-a-triaged-issue). A PR that closes no triaged
  * issue — a hand-/conversation-authored ADR/ROADMAP PR — is laneless (the orphan shape, #3532).
+ *
+ * Tri-state, and the precedence is what keeps it fail-closed: one confirmed triaged ref proves
+ * `laned` outright, but concluding `laneless` requires every ref to have actually been read — a
+ * single `unknown` among them means the evidence is incomplete, so the whole PR defers (#3701).
  */
 const inEngineLane = Effect.fn("Github.inEngineLane")(function* (repo: string, body: string) {
 	const refs = parseClosingRefs(body);
-	if (refs.length === 0) return false;
-	const triagedFlags = yield* Effect.all(
+	if (refs.length === 0) return "laneless" as LaneState;
+	const probes = yield* Effect.all(
 		refs.map((n) => issueIsTriaged(repo, n)),
 		{concurrency: "unbounded"},
 	);
-	return triagedFlags.some((t) => t);
+	if (probes.some((p) => p === "triaged")) return "laned" as LaneState;
+	return (probes.some((p) => p === "unknown") ? "unknown" : "laneless") as LaneState;
 });
 
 const existingHealTargets = Effect.fn("Github.existingHealTargets")(function* (repo: string) {
@@ -287,7 +315,7 @@ export class Github extends Context.Service<
 		readonly repoName: () => Effect.Effect<string, GhError>;
 		readonly listOpenPrs: () => Effect.Effect<ReadonlyArray<OpenPr>, GhError>;
 		readonly headCi: (sha: string) => Effect.Effect<HeadCi, GhError>;
-		readonly inEngineLane: (body: string) => Effect.Effect<boolean, GhError>;
+		readonly inEngineLane: (body: string) => Effect.Effect<LaneState, GhError>;
 		readonly existingHealTargets: () => Effect.Effect<ReadonlySet<number>, GhError>;
 		readonly createHealItem: (input: {
 			readonly title: string;

--- a/packages/pipeline-cli/src/tools/orphan-heal/orphan-heal.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/orphan-heal.ts
@@ -24,6 +24,14 @@
 /** The rolled-up head-CI conclusion. `unknown` is a real state (no checks reported) — default-deny treats it as not-red. */
 export type CiConclusion = "red" | "green" | "pending" | "unknown";
 
+/**
+ * Whether a PR sits in an engine lane. `unknown` is a first-class outcome, not a shade of
+ * `laneless`: it means the lane probe COULD NOT EXECUTE (a transient GitHub 5xx / transport
+ * failure), which says nothing about lane state. Folding that into `laneless` would let a blip
+ * read a healthy laned PR as an orphan and over-file against it (#3701).
+ */
+export type LaneState = "laned" | "laneless" | "unknown";
+
 /** A snapshot of one open PR — the gate inputs the plan decides over, all read from existing state. */
 export interface PrSnapshot {
 	readonly number: number;
@@ -31,8 +39,8 @@ export interface PrSnapshot {
 	readonly ci: CiConclusion;
 	/** ISO-8601 timestamp the head CI first/last went red — the grace-window anchor. Absent ⇒ grace unmeasurable ⇒ not flagged. */
 	readonly redSince?: string | undefined;
-	/** True iff the PR is in an engine lane: it closes a triaged issue / that issue carries an active claim. */
-	readonly inEngineLane: boolean;
+	/** Engine-lane membership, tri-state: only a confirmed `laneless` is flaggable (`unknown` defers). */
+	readonly laneState: LaneState;
 	/** A failing check name carried into the heal-item for the engine to start from (diagnostic only, never decisive). */
 	readonly failingCheck?: string | undefined;
 }
@@ -51,6 +59,7 @@ export type SkipReason =
 	| "draft"
 	| "ci-not-red"
 	| "in-engine-lane"
+	| "lane-state-unknown"
 	| "no-red-since"
 	| "within-grace"
 	| "heal-item-exists";
@@ -105,12 +114,22 @@ export const planHealItems = (prs: ReadonlyArray<PrSnapshot>, opts: HealPlanOpti
 			skip.push({number: pr.number, reason: "ci-not-red", detail: `head CI is ${pr.ci}, not red`});
 			continue;
 		}
-		if (pr.inEngineLane) {
+		if (pr.laneState === "laned") {
 			skip.push({
 				number: pr.number,
 				reason: "in-engine-lane",
 				detail:
 					"PR is in an engine lane (closes a triaged issue / active claim) — the engine heals it",
+			});
+			continue;
+		}
+		// The lane probe could not execute (transient GitHub failure). Defer to the next cadence
+		// pass rather than treat un-read as laneless and file against a possibly-healthy lane (#3701).
+		if (pr.laneState === "unknown") {
+			skip.push({
+				number: pr.number,
+				reason: "lane-state-unknown",
+				detail: "lane state unreadable (transient GitHub failure) — deferring to the next pass",
 			});
 			continue;
 		}

--- a/packages/pipeline-cli/src/tools/orphan-heal/orphan-heal.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/orphan-heal.unit.test.ts
@@ -20,7 +20,7 @@ const pr = (over: Partial<PrSnapshot> = {}): PrSnapshot => ({
 	ci: over.ci ?? "red",
 	// default: red 8h ago (past a 6h grace)
 	redSince: "redSince" in over ? over.redSince : "2026-07-19T04:00:00Z",
-	inEngineLane: over.inEngineLane ?? false,
+	laneState: over.laneState ?? "laneless",
 	failingCheck: over.failingCheck,
 });
 
@@ -58,9 +58,15 @@ describe("planHealItems — each gate skips with the FIRST failing reason", () =
 	});
 
 	it("skips a PR that is in an engine lane (the boundary — engines heal owned lanes)", () => {
-		const {emit, skip} = plan([pr({inEngineLane: true})]);
+		const {emit, skip} = plan([pr({laneState: "laned"})]);
 		expect(emit).toHaveLength(0);
 		expect(skip[0]?.reason).toBe("in-engine-lane");
+	});
+
+	it("defers a PR whose lane state could not be read, rather than filing against it", () => {
+		const {emit, skip} = plan([pr({laneState: "unknown"})]);
+		expect(emit).toHaveLength(0);
+		expect(skip[0]?.reason).toBe("lane-state-unknown");
 	});
 
 	it("default-denies a red PR with no red-since anchor (grace unmeasurable)", () => {


### PR DESCRIPTION
Two pipeline probes could report a definite answer when they had actually failed to read anything at all. The §CP approval-watcher could read a GitHub error body as an approver's login, and orphan-heal could read a transient read failure as "this PR is in no engine lane." Both now tell the difference between "I looked and the answer is no" and "I could not look," and both decline to act on the second.

They ship together because they are one defect, found twice.

## The unifying invariant

**A probe that could not execute resolves to UNKNOWN, never to a definite answer that drives an action.**

Each site broke that invariant in the opposite direction, which is exactly why they are the same bug:

- **#3715 fails OPEN toward a positive** — an unreadable read became "approved," which would *start* a §CP enqueue.
- **#3701 fails OPEN toward a negative** — an unreadable read became "laneless," which would *file* a heal-item against a healthy PR.

The fix in both is the same move: stop collapsing "no answer" into an answer.

## #3715 — §CP approval-watcher fails closed on an unreadable review query

`claude-plugins/pipeline-crew/agents/crew-engineering-manager.md`

The watcher's positive branch interpreted the reviews response without first proving it was review data. During a live GitHub partial outage a 503 body read as an approver's login and two unapproved §CP PRs were declared approved.

The watcher's poll now:

1. asserts the payload is a JSON array (`jq -e 'type=="array"'`) before interpreting it — any non-conforming response (503 body, non-array, parse failure, non-zero `gh` exit) resolves to **UNKNOWN → do not fire, re-arm**;
2. matches an approver login **exactly** against `@kamp-us/control-plane` membership rather than accepting any non-empty string;
3. requires `commit_id == head` on that proven read (ADR 0058);
4. logs "read failed" distinctly from "no approval", so an outage is visible instead of looking like a human who simply hasn't approved yet.

**Severity, stated plainly: this is defense in depth, not a live exploit.** The durable design already delegates the authoritative discharge to `cp-cardinality`, and the shipper re-checks approval at enqueue time. The observed failure was in an ad-hoc watcher. This hardens the *trigger* so a hiccup can never start a §CP enqueue in the first place — it is not closing an open hole in the merge gate. A severity correction to this effect was already posted on the issue.

## #3701 — orphan-heal: a failed lane read is UNKNOWN, not laneless

`packages/pipeline-cli/src/tools/orphan-heal/`

`Github.issueIsTriaged` folded every failed issue-labels read into `false` via `orElseSucceed`. `false` means "not a triaged lane", so a transient 5xx made a genuinely-laned PR read as laneless and the detector could over-file against it.

- `issueIsTriaged` returns a tri-state. A 404 (nonexistent / other-repo ref) or an undecodable payload is still a confirmed `laneless` that never aborts the sweep — the #3532 behavior is preserved. Any *other* `gh` failure (5xx, auth, rate-limit, transport) is `unknown`, because the probe never executed.
- `inEngineLane` carries the tri-state up with fail-closed precedence: one triaged ref proves `laned` outright, but concluding `laneless` requires *every* ref to have been read, so a single `unknown` defers the whole PR.
- The pure core gates on `laneState` and skips an unreadable PR under its own `lane-state-unknown` reason, so the defer shows up in the scan log rather than being indistinguishable from a confirmed orphan.
- Unit coverage for both branches — transient-failure → defer, genuine-404 → laneless — plus the precedence cases, in a new `github-service.unit.test.ts` built on the existing mock-spawner pattern.

## Shape of the PR

Two serial commits, one per issue, deliberately grouped: both issues are the same defect class on adjacent surfaces, so shipping them separately would have meant two lanes conflicting over the same invariant. Each commit stands alone and each issue's acceptance criteria are fully delivered, hence two closing keywords rather than a `Part of`.

`pnpm typecheck` and `pnpm lint:worktree` are green; the orphan-heal suite passes (33 tests).

## Control-plane

This PR touches `claude-plugins/**`, so it is **§CP** (ADR 0053): it banks for human control-plane approval and does **not** auto-merge on a green gate.

Fixes #3715
Fixes #3701
