### PR TITLE
fix(pipeline): give every scratchpad write a per-run namespace (§SP) (#3718)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/adr.md
+++ b/claude-plugins/kampus-pipeline/agents/adr.md
@@ -72,6 +72,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** The ADR body, its links, and
   your return summary cite repo-relative paths only (`.decisions/NNNN-slug.md`, `apps/web/worker/…`) —
   never a `~/`, `/Users/…`, vault, or sibling-clone path, and no Obsidian `[[wikilinks]]`.
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
+  shared filename gets clobbered mid-run and reads back **another run's content with no
+  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
+  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
+  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal

--- a/claude-plugins/kampus-pipeline/agents/adr.md
+++ b/claude-plugins/kampus-pipeline/agents/adr.md
@@ -78,9 +78,19 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   shared filename gets clobbered mid-run and reads back **another run's content with no
   error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
-  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
-  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
+  needed, derive its path from a per-run namespace and name every leaf under it:
+  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
+  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
+  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
+  in the later call.** Your shell state does not survive between Bash calls, so a
+  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
+  yields a *new empty directory*, silently turning a read of your own earlier state into a
+  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
+  per agent run, and recomputable by any later call of that same run. Never park the path
+  itself in another file to carry it across — that just moves the collision onto that file.
+  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal

--- a/claude-plugins/kampus-pipeline/agents/canon.md
+++ b/claude-plugins/kampus-pipeline/agents/canon.md
@@ -77,6 +77,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   row, and your return summary cite repo-relative paths only (`.patterns/<name>.md`,
   `apps/web/worker/…`) — never a `~/`, `/Users/…`, vault, or sibling-clone path, and no Obsidian
   `[[wikilinks]]`.
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
+  shared filename gets clobbered mid-run and reads back **another run's content with no
+  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
+  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
+  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory. Resolve it with
   `git rev-parse --show-toplevel` and operate on `<root>/.patterns/`.
 

--- a/claude-plugins/kampus-pipeline/agents/canon.md
+++ b/claude-plugins/kampus-pipeline/agents/canon.md
@@ -83,9 +83,19 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   shared filename gets clobbered mid-run and reads back **another run's content with no
   error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
-  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
-  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
+  needed, derive its path from a per-run namespace and name every leaf under it:
+  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
+  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
+  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
+  in the later call.** Your shell state does not survive between Bash calls, so a
+  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
+  yields a *new empty directory*, silently turning a read of your own earlier state into a
+  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
+  per agent run, and recomputable by any later call of that same run. Never park the path
+  itself in another file to carry it across — that just moves the collision onto that file.
+  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory. Resolve it with
   `git rev-parse --show-toplevel` and operate on `<root>/.patterns/`.
 

--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -72,9 +72,19 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   shared filename gets clobbered mid-run and reads back **another run's content with no
   error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
-  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
-  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
+  needed, derive its path from a per-run namespace and name every leaf under it:
+  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
+  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
+  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
+  in the later call.** Your shell state does not survive between Bash calls, so a
+  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
+  yields a *new empty directory*, silently turning a read of your own earlier state into a
+  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
+  per agent run, and recomputable by any later call of that same run. Never park the path
+  itself in another file to carry it across — that just moves the collision onto that file.
+  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 - **State a *why* ONCE — collapse duplicated docblocks to a pointer.** In the code you
   generate, apply CLAUDE.md's "Comments earn their place or die" convention: state a

--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -66,6 +66,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** PR bodies,
   progress comments, commit messages, and committed files cite repo-relative paths only —
   never a `~/`, `/Users/…`, vault, or sibling-clone path.
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
+  shared filename gets clobbered mid-run and reads back **another run's content with no
+  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
+  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
+  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 - **State a *why* ONCE — collapse duplicated docblocks to a pointer.** In the code you
   generate, apply CLAUDE.md's "Comments earn their place or die" convention: state a

--- a/claude-plugins/kampus-pipeline/agents/planner.md
+++ b/claude-plugins/kampus-pipeline/agents/planner.md
@@ -91,9 +91,19 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   shared filename gets clobbered mid-run and reads back **another run's content with no
   error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
-  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
-  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
+  needed, derive its path from a per-run namespace and name every leaf under it:
+  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
+  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
+  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
+  in the later call.** Your shell state does not survive between Bash calls, so a
+  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
+  yields a *new empty directory*, silently turning a read of your own earlier state into a
+  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
+  per agent run, and recomputable by any later call of that same run. Never park the path
+  itself in another file to carry it across — that just moves the collision onto that file.
+  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 - **Plan only — never implement, review, or merge.** You write issues, never repo files (you
   carry no Edit/Write tool). You do not write code, do not run a review skill, do not flip a

--- a/claude-plugins/kampus-pipeline/agents/planner.md
+++ b/claude-plugins/kampus-pipeline/agents/planner.md
@@ -85,6 +85,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** The plan body, child
   bodies, journal notes, and progress comments cite repo-relative paths only — never a `~/`,
   `/Users/…`, vault, or sibling-clone path.
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
+  shared filename gets clobbered mid-run and reads back **another run's content with no
+  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
+  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
+  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 - **Plan only — never implement, review, or merge.** You write issues, never repo files (you
   carry no Edit/Write tool). You do not write code, do not run a review skill, do not flip a

--- a/claude-plugins/kampus-pipeline/agents/reporter.md
+++ b/claude-plugins/kampus-pipeline/agents/reporter.md
@@ -59,6 +59,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   / `user.name`. Never a `/Users/…`, `~/`, vault, or sibling-clone path — in the footer
   *or* in the body. Pointers cite repo-relative paths only. Generate the footer with
   `footer.sh`; if you ever assemble it by hand, scrub the same way.
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
+  shared filename gets clobbered mid-run and reads back **another run's content with no
+  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
+  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
+  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal

--- a/claude-plugins/kampus-pipeline/agents/reporter.md
+++ b/claude-plugins/kampus-pipeline/agents/reporter.md
@@ -65,9 +65,19 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   shared filename gets clobbered mid-run and reads back **another run's content with no
   error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
-  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
-  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
+  needed, derive its path from a per-run namespace and name every leaf under it:
+  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
+  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
+  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
+  in the later call.** Your shell state does not survive between Bash calls, so a
+  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
+  yields a *new empty directory*, silently turning a read of your own earlier state into a
+  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
+  per agent run, and recomputable by any later call of that same run. Never park the path
+  itself in another file to carry it across — that just moves the collision onto that file.
+  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -272,9 +272,19 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   shared filename gets clobbered mid-run and reads back **another run's content with no
   error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
-  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
-  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
+  needed, derive its path from a per-run namespace and name every leaf under it:
+  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
+  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
+  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
+  in the later call.** Your shell state does not survive between Bash calls, so a
+  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
+  yields a *new empty directory*, silently turning a read of your own earlier state into a
+  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
+  per agent run, and recomputable by any later call of that same run. Never park the path
+  itself in another file to carry it across — that just moves the collision onto that file.
+  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 - **Verify only — never edit, never merge, never review your own work.** You hold no
   Edit/Write tool by construction. You land a verdict; the merge is never yours — `ship-it`

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -266,6 +266,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** Verdict comments
   and any prose cite repo-relative paths only — never a `~/`, `/Users/…`, vault, or
   sibling-clone path.
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
+  shared filename gets clobbered mid-run and reads back **another run's content with no
+  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
+  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
+  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 - **Verify only — never edit, never merge, never review your own work.** You hold no
   Edit/Write tool by construction. You land a verdict; the merge is never yours — `ship-it`

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -108,9 +108,19 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   shared filename gets clobbered mid-run and reads back **another run's content with no
   error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
-  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
-  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
+  needed, derive its path from a per-run namespace and name every leaf under it:
+  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
+  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
+  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
+  in the later call.** Your shell state does not survive between Bash calls, so a
+  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
+  yields a *new empty directory*, silently turning a read of your own earlier state into a
+  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
+  per agent run, and recomputable by any later call of that same run. Never park the path
+  itself in another file to carry it across — that just moves the collision onto that file.
+  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal
 

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -102,6 +102,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** Progress comments and
   any text you post cite repo-relative paths only — never a `~/`, `/Users/…`, vault, or
   sibling-clone path.
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
+  shared filename gets clobbered mid-run and reads back **another run's content with no
+  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
+  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
+  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal
 

--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -90,6 +90,15 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **No home / local / absolute / sibling-repo paths in any artifact.** Issue bodies,
   comments, and labels cite repo-relative paths only — never a `~/`, `/Users/…`, vault,
   or sibling-clone path.
+- **Every intermediate file you write lives under a per-run scratch namespace (§SP).** Never
+  stash state in a fixed or work-item-keyed scratchpad path (`prref.txt`,
+  `/tmp/verdict-$PR.md`) — the pipeline runs several agents concurrently by design, so a
+  shared filename gets clobbered mid-run and reads back **another run's content with no
+  error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
+  Prefer passing the value in-process and writing no file at all; when a file is genuinely
+  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
+  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
+  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal

--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -96,9 +96,19 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   shared filename gets clobbered mid-run and reads back **another run's content with no
   error**: silent, and it routed a reviewer's `git diff` to the wrong PR's files (#3718).
   Prefer passing the value in-process and writing no file at all; when a file is genuinely
-  needed, allocate `RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")"` and name
-  every leaf under it. The rule, its fail-closed allocation, and the never-leak-the-path
-  corollary are single-sourced in the skills' `gh-issue-intake-formats.md` §SP.
+  needed, derive its path from a per-run namespace and name every leaf under it:
+  `RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?}/<skill>-<work-item>"`,
+  then `mkdir -p "$RUN_SCRATCH"` (fail closed — never fall back to a shared path).
+  **When the state must cross a Bash call, this recipe is the carrier: recompute the same line
+  in the later call.** Your shell state does not survive between Bash calls, so a
+  `RUN_SCRATCH` allocated by `mktemp -d` is unrecoverable afterwards — re-running `mktemp -d`
+  yields a *new empty directory*, silently turning a read of your own earlier state into a
+  read of nothing. Keying on `$CLAUDE_CODE_SESSION_ID` gives both properties at once: unique
+  per agent run, and recomputable by any later call of that same run. Never park the path
+  itself in another file to carry it across — that just moves the collision onto that file.
+  The rule, its fail-closed allocation, the single-Bash-call `mktemp` carve-out, and the
+  never-leak-the-path corollary are single-sourced in the skills'
+  `gh-issue-intake-formats.md` §SP.
 - **Work from the repo root**, not a nested app directory.
 
 ## Repo-agnostic — resolve `$REPO`, never hardcode a literal

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1849,6 +1849,114 @@ documented specialization of this same contract, not a fourth drifting copy.
 
 ---
 
+## SP. The per-run scratchpad namespace — one canonical definition (#3718)
+
+The pipeline runs several agents concurrently by design (the WIP cap is the whole point), and
+they share one `/tmp`. So an intermediate file written under a **fixed or work-item-keyed**
+name is a shared mutable surface: a second run clobbers it mid-flight and the first run reads
+back **the other run's content with no error**. In the live 2026-07-20 incident the file was
+`prref.txt` — one reviewer overwrote it while another was mid-run, and the victim's `git diff`
+silently returned the *wrong PR's* file list. Verdicts are the pipeline's routing gate, so that
+is a false PASS on unreviewed code.
+
+The class is **silent by construction**: a clobbered file reads back *successfully*, so there
+is no error to catch and no defensive "re-check after read" that reliably covers it. The only
+fix is structural — remove the shared namespace. This section states the rule **once** so every
+skill and agent cites *one* definition instead of re-deriving it (the §CP/§DOC/§ZS/§RO
+single-sourcing discipline, applied to scratch state).
+
+**A work-item id is not a run id.** Keying on `$PR` / `<EPIC>` / `#N` does *not* make a path
+unique: a re-review, a repair round, and a re-plan are all second runs over the same number,
+and the operator fans gates out in parallel over one PR routinely.
+
+### The namespace — deterministic *and* per-run
+
+Two requirements are both real, and a namespace that satisfies only one is broken:
+
+- **Per-run uniqueness** — concurrent runs must not be able to name each other's files.
+- **Deterministic re-derivability across Bash calls** — an agent's shell state does **not**
+  survive between Bash calls (`$$` differs call to call; every variable is gone), so a later
+  call must be able to recompute the same path *from scratch*. A namespace allocated by a bare
+  `mktemp -d` gives uniqueness and destroys this: re-running `mktemp -d` in a later call yields
+  a **new empty directory** and recovers nothing.
+
+`$CLAUDE_CODE_SESSION_ID` delivers both. It is the per-agent-run UUID the environment already
+exports — the same token ADR 0115's claim protocol stamps — and it is **stable across Bash
+calls** while **distinct per agent run** (sibling subagents of one pane each get their own).
+So it is a run identity any later call can recompute without carrying anything:
+
+The recipe is **one line, inlined at each site** — deliberately not a shell helper, because a
+helper is itself shell state that doesn't survive between Bash calls, so a later call could not
+call it. `<slug>` names the caller: the skill, plus the work item when one skill runs over
+several (`plan-epic-<EPIC>`, `write-code-<N>`, `review-skill-$PR`).
+
+**Open the run once, re-derive freely afterwards.** The distinction is load-bearing — getting
+it backwards re-creates the empty-directory bug it exists to prevent:
+
+```bash
+# OPEN — the skill's first step that writes state. Fail closed on a missing session id: never
+# fall back to a shared path, since a fallback resurrects the exact clobber (ADR 0092). The
+# `rm -rf` clears leftovers from an EARLIER run of this same slug in this same session, so a
+# re-run never reads its predecessor's files.
+[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || {
+  echo "§SP: CLAUDE_CODE_SESSION_ID unset — refusing to write run state to a shared scratch path (#3718)." >&2; exit 1; }
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/<slug>"
+rm -rf "$RUN_SCRATCH" && mkdir -p "$RUN_SCRATCH" || {
+  echo "§SP: could not create the per-run scratch dir $RUN_SCRATCH." >&2; exit 1; }
+
+# RE-DERIVE — every LATER Bash call. Same recipe ⇒ same directory ⇒ the files are still there.
+# NO `rm -rf` here: that is the open step's job, and repeating it would delete the very state
+# this call came to read. Assert what you expect to find, rather than reading a silent absence.
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/<slug>"
+[ -s "$RUN_SCRATCH/<file>" ] || { echo "§SP: $RUN_SCRATCH/<file> did not survive — re-run the opening step in THIS session." >&2; exit 1; }
+```
+
+**Assert presence, never let a test decide on an absent file.** A missing scratch file is not
+a neutral input: `[ existing -nt missing ]` is **true** in bash, so a freshness/staleness guard
+written as `if ! [ "$a" -nt "$b" ]` **passes silently** when `$b` is gone — the guard reads
+green precisely when its precondition is most broken. Check `-s` first (`plan-epic`'s Step-5
+splice guard is the live instance), so absence fails loud instead of waving work through.
+
+### The rules, in preference order
+
+1. **Prefer no file at all.** Pass the value in-process. `report` streams the issue body over
+   stdin rather than round-tripping a temp path (#2002), and `write-code` re-derives the branch
+   live from the worktree instead of caching it (#2038) — both satisfy §SP outright, with no
+   path to collide on and nothing to leak.
+2. **When a file is genuinely needed, derive its path from `$RUN_SCRATCH`.** Allocate it
+   fail-closed per the recipe above — never a bare `/tmp/<name>`, and never a path keyed only
+   on a work-item id. Leaf names then stay plain and readable (`deps.md`, not
+   `deps-$PR-$RANDOM.md`) because uniqueness lives in the **directory**, so a scratch write
+   added later *inherits* the guarantee instead of reintroducing the bug.
+3. **Never park a `$RUN_SCRATCH` path in another file to carry it across Bash calls** — that
+   just relocates the collision onto *that* file. You don't need to: **recompute it** from the
+   same `run_scratch` recipe, which is deterministic precisely so this rule costs nothing.
+4. **Carve-out — a raw `$(mktemp "${TMPDIR:-/tmp}/<name>.XXXXXX")` (or a throwaway
+   `$(mktemp -d)`) is §SP-compliant when it is allocated *and* consumed inside one Bash
+   call.** The kernel supplies the uniqueness, so there is no shared name to clobber, and a
+   path that never crosses a call needs no deterministic recipe. This is the right shape for a
+   verdict file written and immediately `cat`-ed into a `gh api` post (`review-code` /
+   `review-doc` / `review-skill` `VERDICT_FILE`, `ship-it`'s flag-const list), and for §RO's
+   throwaway head worktree (`git worktree add "$(mktemp -d)/…"`). It is a **deliberate second
+   form, not a tolerated exception** — stated here so it isn't re-bred as a competing
+   convention, and so a reader who meets both forms knows which one they are looking at.
+
+   The line between rule 4 and rules 2+3 is **lifetime, not file count**: the moment a path
+   has to survive into a *later* Bash call, the carve-out no longer applies and it belongs
+   under a session-derived `$RUN_SCRATCH`. Give a rule-4 temp a name that says what it holds
+   (`review-code-verdict.XXXXXX`), never the `kampus-run` prefix the rule-2 namespace uses —
+   the two forms should stay tellable apart at a glance.
+
+### Corollary — a scratch path is a local absolute path, so it never lands in a public artifact
+
+`$RUN_SCRATCH` expands to a machine-local absolute path. Quoting one into an issue body, PR
+body, comment, or commit message leaks the operator's filesystem layout — the leak `leak-guard`
+enforces against (#2683), and the reason a body is posted **by value** (`-f body="$(cat …)"`)
+rather than by `gh api -f body=@<path>` (#2002 / #754). Compose *through* the scratch file;
+never mention it in what you post.
+
+---
+
 ## HEAD. Review the PR head, never the launched checkout's working copy (#793)
 
 A review gate is frequently spawned with `isolation:worktree`, which lands it in a **fresh

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -222,15 +222,29 @@ stop to ask.)
 > hand-substitute with concrete issue numbers; `$VARS` (e.g. `$CHILD_ID`, `$BODY`)
 > are live shell variables the commands set and read.
 
+Every intermediate file below lives under `$RUN_SCRATCH`, the per-run scratch namespace defined
+once in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §SP — never a fixed or
+epic-keyed `/tmp` path. An epic number is **not** unique (a re-plan of the same epic is a second
+run over it), so re-rooting the whole family under one `mktemp -d` is what makes a cross-run
+clobber unrepresentable rather than merely unlikely (#3718). Open the run by allocating it, and
+re-derive it inside any later Bash call — shell state doesn't survive between calls, and §SP
+rule 3 forbids parking the path in another file to carry it across:
+
+```bash
+# §SP: the per-run scratch namespace — fail-closed, never a shared fallback
+RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+  echo "plan-epic: §SP could not create a per-run scratch dir — refusing to write plan state to a shared path (#3718)." >&2; exit 1; }
+```
+
 ```bash
 # the epic, its current body, its labels, and any children it already has
 gh api repos/$REPO/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
 # capture the body AND its revision marker from ONE GET — reading them in two calls lets a writer
 # land between them, yielding an updated_at newer than the captured body (TOCTOU skew); the Step 5
 # recheck would then either spuriously retry or trust a marker that doesn't match the captured body.
-gh api repos/$REPO/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-snap.json
-jq -r '.body'       /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-current.md
-jq -r '.updated_at' /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-updated-at.txt
+gh api repos/$REPO/issues/<EPIC> --jq '{body,updated_at}' > "$RUN_SCRATCH/snap.json"
+jq -r '.body'       "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/current.md"
+jq -r '.updated_at' "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/updated-at.txt"
 gh api 'repos/$REPO/issues/<EPIC>/sub_issues?per_page=100' \
   --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
 ```
@@ -440,13 +454,13 @@ later; #1968 and #2099 the same verdict-resolver work in two places).
 #    list is the source of truth for what the epic already spawned; on a mixed open/closed epic
 #    prefer it over sub_issues_summary (which undercounts).
 gh api "repos/$REPO/issues/<EPIC>/sub_issues?per_page=100" \
-  --jq '.[] | select(.state=="open") | .title' > /tmp/plan-epic-<EPIC>-existing-children.txt
+  --jq '.[] | select(.state=="open") | .title' > "$RUN_SCRATCH/existing-children.txt"
 
 # 2. The open backlog — the cross-backlog overlap set. A decomposition can re-mint work that
 #    already exists as an open standalone issue or another epic's child, so a proposed child that
 #    overlaps an open issue is surfaced/skipped, not minted. (REST issue list, not GraphQL.)
 gh api "repos/$REPO/issues?state=open&per_page=100" \
-  --jq '.[] | select(.pull_request | not) | "#\(.number)\t\(.title)"' > /tmp/plan-epic-<EPIC>-open-backlog.txt
+  --jq '.[] | select(.pull_request | not) | "#\(.number)\t\(.title)"' > "$RUN_SCRATCH/open-backlog.txt"
 ```
 
 **Then classify each proposed child before you create it:**
@@ -476,17 +490,18 @@ stdout, so multi-line markdown and backticks survive the shell without a `<<EOF`
 enforces the format-2 invariants (the ≥ 1-acceptance-criterion hard floor) and owns the
 leak-safe handoff — a stdout-only verb has no scratchpad file to `@`-reference, so the
 `gh api -f body=@<path>` machine-local-path leak (#2002 / #754 / PR #1567) is unreachable.
-Allocate the **spec** file with `mktemp` (every temp this skill uses is already epic-scoped —
-`/tmp/plan-epic-<EPIC>-*`), not a fixed `/tmp/plan-epic-child.json`: concurrent `plan-epic`
-runs on sibling epics share `/tmp`, so a fixed path lets one run's spec clobber another's
-before it is composed, filing a child under the right title but with a **sibling epic's
-`### What to build` + acceptance criteria** — a cross-epic body bleed the structural floor
-can't see (it checks markers, never body fidelity), caught only by `review-plan`'s
-non-blocking advisor (#754, same `/tmp` collision class as `report`'s per-run `mktemp`):
+Allocate the **spec** file with `mktemp` *inside* `$RUN_SCRATCH` (§SP), not a fixed
+`/tmp/plan-epic-child.json`: concurrent `plan-epic` runs on sibling epics share `/tmp`, so a
+fixed path lets one run's spec clobber another's before it is composed, filing a child under the
+right title but with a **sibling epic's `### What to build` + acceptance criteria** — a
+cross-epic body bleed the structural floor can't see (it checks markers, never body fidelity),
+caught only by `review-plan`'s non-blocking advisor (#754, the same silent-clobber class as
+#3718's `prref.txt`). The loop writes one spec per child, so the `mktemp` template matters here
+even within a single run:
 
 ```bash
 # write this child's spec into a per-run temp file, never a shared fixed path (#754)
-CHILD_SPEC_FILE="$(mktemp /tmp/plan-epic-<EPIC>-child.XXXXXX)"
+CHILD_SPEC_FILE="$(mktemp "$RUN_SCRATCH/child.XXXXXX")"
 cat > "$CHILD_SPEC_FILE" <<'EOF'
 {
   "stories": "<bare numbers, e.g. `1` or `1, 3` — no `S` prefix; or `none (pure infra — see What to build)`>",
@@ -769,7 +784,7 @@ The re-derive is the part that makes this honest, and it is **your action, not t
 The block below is a **skeleton you re-run per attempt, not a one-shot you launch once**: a
 `## Dependencies` block names concrete child numbers and phase topology, so when the recheck
 fires (a racer added/closed a child between your reads) you must **regenerate
-`/tmp/plan-epic-<EPIC>-deps.md` — and on a re-plan `/tmp/plan-epic-<EPIC>-plan.md` — against the
+`$RUN_SCRATCH/deps.md` — and on a re-plan `$RUN_SCRATCH/plan.md` — against the
 freshly-read body** (re-run Step 2's split + Step 5's section derivation) *before* you re-enter
 the loop. The script cannot do this for you inside one bash invocation; it can only **refuse to
 proceed** until you have. So the recheck branch stamps the fresh base and **breaks out** (it does
@@ -778,8 +793,8 @@ loudly** if `deps.md` was not regenerated since the base it splices onto was rea
 "re-derive" from a comment you might skip into a precondition the script enforces.
 
 ```bash
-# /tmp/plan-epic-<EPIC>-deps.md = the new `## Dependencies` block. On a RE-PLAN, also
-#   /tmp/plan-epic-<EPIC>-plan.md = the new `## Plan (plan-epic)` block (set REPLAN=1).
+# "$RUN_SCRATCH/deps.md" = the new `## Dependencies` block. On a RE-PLAN, also
+#   "$RUN_SCRATCH/plan.md" = the new `## Plan (plan-epic)` block (set REPLAN=1).
 #   Give each block a trailing blank line so the next spliced heading stays separated.
 # Landing is confirmed against the WHOLE `## Dependencies` block round-tripping byte-for-byte,
 # NOT a single line: two concurrent runs on the SAME epic likely both emit a given `- #<child>`
@@ -793,7 +808,7 @@ loudly** if `deps.md` was not regenerated since the base it splices onto was rea
 #
 # This block is a SKELETON you re-run per attempt, not a one-shot. When the recheck (step 2) fires
 # it stamps the fresh base, BREAKS, and hands back to you to re-derive `deps.md` (+ `plan.md` on a
-# re-plan) against `/tmp/plan-epic-<EPIC>-current.md` — then you re-invoke the block. The freshness
+# re-plan) against `$RUN_SCRATCH/current.md` — then you re-invoke the block. The freshness
 # guard (step 2.5) refuses to splice a `deps.md` older than the base it would splice onto, so a
 # stale block can never re-clobber a racer's legitimate topology.
 # Per attempt: re-read → recheck (verify unchanged) → freshness guard → epic-splice apply (guards + splice) → PATCH
@@ -804,10 +819,10 @@ loudly** if `deps.md` was not regenerated since the base it splices onto was rea
 landed=0; patched=0
 for attempt in 1 2 3; do
   # 1. re-read the LIVE body + its revision marker from ONE GET (coherent — no TOCTOU skew)
-  gh api repos/$REPO/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-live.json
-  jq -r '.body'       /tmp/plan-epic-<EPIC>-live.json > /tmp/plan-epic-<EPIC>-live.md
-  NOW=$(jq -r '.updated_at' /tmp/plan-epic-<EPIC>-live.json)
-  WAS=$(cat /tmp/plan-epic-<EPIC>-updated-at.txt)
+  gh api repos/$REPO/issues/<EPIC> --jq '{body,updated_at}' > "$RUN_SCRATCH/live.json"
+  jq -r '.body'       "$RUN_SCRATCH/live.json" > "$RUN_SCRATCH/live.md"
+  NOW=$(jq -r '.updated_at' "$RUN_SCRATCH/live.json")
+  WAS=$(cat "$RUN_SCRATCH/updated-at.txt")
 
   # 2. optimistic recheck — if the body moved since we last read it, stamp the fresh base and BREAK.
   #    Re-deriving the section is YOUR action (the script can't regenerate deps.md/plan.md inside one
@@ -816,8 +831,8 @@ for attempt in 1 2 3; do
   if [ "$NOW" != "$WAS" ]; then
     echo "epic body changed since read ($WAS -> $NOW) — RE-DERIVE deps.md (+ plan.md on a re-plan)"
     echo "  against the fresh base, then re-invoke this block. (Not auto-retried: the re-derive is an agent step.)"
-    cp /tmp/plan-epic-<EPIC>-live.md /tmp/plan-epic-<EPIC>-current.md   # fresh base to re-derive against
-    echo "$NOW" > /tmp/plan-epic-<EPIC>-updated-at.txt
+    cp "$RUN_SCRATCH/live.md" "$RUN_SCRATCH/current.md"   # fresh base to re-derive against
+    echo "$NOW" > "$RUN_SCRATCH/updated-at.txt"
     break
   fi
 
@@ -828,11 +843,11 @@ for attempt in 1 2 3; do
   #      re-derive precondition is unmet (you re-invoked without regenerating the block off the fresh
   #      base): a stale block that references the wrong child set. Abort loudly, don't write — this is
   #      what stops the `continue`-era footgun of re-splicing the originally-derived block (issue #261).
-  if ! [ /tmp/plan-epic-<EPIC>-deps.md -nt /tmp/plan-epic-<EPIC>-current.md ] \
-     || { [ "${REPLAN:-0}" = 1 ] && ! [ /tmp/plan-epic-<EPIC>-plan.md -nt /tmp/plan-epic-<EPIC>-current.md ]; }; then
+  if ! [ "$RUN_SCRATCH/deps.md" -nt "$RUN_SCRATCH/current.md" ] \
+     || { [ "${REPLAN:-0}" = 1 ] && ! [ "$RUN_SCRATCH/plan.md" -nt "$RUN_SCRATCH/current.md" ]; }; then
     echo "ABORT: deps.md (or plan.md on a re-plan) is NOT newer than the base it splices onto (-current.md) —"
     echo "       you re-invoked without re-deriving. Re-run Step 2's split + Step 5's section derivation"
-    echo "       against /tmp/plan-epic-<EPIC>-current.md, then re-invoke this block. Refusing to splice a stale block."
+    echo "       against "$RUN_SCRATCH/current.md", then re-invoke this block. Refusing to splice a stale block."
     break
   fi
 
@@ -846,21 +861,21 @@ for attempt in 1 2 3; do
   #    A corrupt/duplicated/drifted heading makes the verb exit non-zero — break loudly and inspect
   #    by hand rather than blind-write. The recheck/freshness/round-trip orchestration around it
   #    stays here (it is live-issue IO, not a text transform).
-  PLAN_ARG=(); [ "${REPLAN:-0}" = 1 ] && PLAN_ARG=(--plan-file /tmp/plan-epic-<EPIC>-plan.md)
+  PLAN_ARG=(); [ "${REPLAN:-0}" = 1 ] && PLAN_ARG=(--plan-file "$RUN_SCRATCH/plan.md")
   if ! node packages/pipeline-cli/src/bin.ts epic-splice apply \
-        --body-file /tmp/plan-epic-<EPIC>-live.md \
-        --deps-file /tmp/plan-epic-<EPIC>-deps.md \
-        "${PLAN_ARG[@]}" > /tmp/plan-epic-<EPIC>-body.md; then
+        --body-file "$RUN_SCRATCH/live.md" \
+        --deps-file "$RUN_SCRATCH/deps.md" \
+        "${PLAN_ARG[@]}" > "$RUN_SCRATCH/body.md"; then
     echo "ABORT: epic-splice refused (corrupt/duplicated/drifted heading — see its stderr) — refusing to splice; inspect by hand"
     break
   fi
-  BODY="$(cat /tmp/plan-epic-<EPIC>-body.md)"
+  BODY="$(cat "$RUN_SCRATCH/body.md")"
 
   # 5. extract THIS run's whole `## Dependencies` block (heading → EOF) from the body we're about
   #    to write — that exact multi-line block is what we'll confirm round-tripped, so a racer who
   #    happens to share a child number can't satisfy the check with one matching `- #` line.
-  awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' /tmp/plan-epic-<EPIC>-body.md \
-    > /tmp/plan-epic-<EPIC>-deps-expected.md
+  awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' "$RUN_SCRATCH/body.md" \
+    > "$RUN_SCRATCH/deps-expected.md"
 
   # 6. write, then re-confirm OUR WHOLE BLOCK landed — extract `## Dependencies`→EOF from the live
   #    post-write body and diff it against the block we just wrote. A racer's clobber differs
@@ -870,8 +885,8 @@ for attempt in 1 2 3; do
   #    that retries the loser.
   gh api -X PATCH repos/$REPO/issues/<EPIC> -f body="$BODY" >/dev/null; patched=1
   gh api repos/$REPO/issues/<EPIC> --jq '.body' \
-    | awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' > /tmp/plan-epic-<EPIC>-deps-live.md
-  if diff -q /tmp/plan-epic-<EPIC>-deps-expected.md /tmp/plan-epic-<EPIC>-deps-live.md >/dev/null; then
+    | awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' > "$RUN_SCRATCH/deps-live.md"
+  if diff -q "$RUN_SCRATCH/deps-expected.md" "$RUN_SCRATCH/deps-live.md" >/dev/null; then
     echo "epic body updated, our whole ## Dependencies block round-tripped"; landed=1; break
   else
     # A racer clobbered our write. Do NOT auto-re-splice the stale deps.md — that would
@@ -882,10 +897,10 @@ for attempt in 1 2 3; do
     # so a stale block can never re-clobber.
     echo "our ## Dependencies block is NOT the one in the post-write body — a racer clobbered it."
     echo "       Re-derive deps.md (and plan.md on a re-plan) against the refreshed"
-    echo "       /tmp/plan-epic-<EPIC>-current.md, then re-invoke this block. Refusing to re-splice the stale block."
-    gh api repos/$REPO/issues/<EPIC> > /tmp/plan-epic-<EPIC>-snap.json   # one snapshot, no TOCTOU between body+updated_at
-    jq -r '.body'       /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-current.md      # fresh base to re-derive against
-    jq -r '.updated_at' /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-updated-at.txt
+    echo "       "$RUN_SCRATCH/current.md", then re-invoke this block. Refusing to re-splice the stale block."
+    gh api repos/$REPO/issues/<EPIC> > "$RUN_SCRATCH/snap.json"   # one snapshot, no TOCTOU between body+updated_at
+    jq -r '.body'       "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/current.md"      # fresh base to re-derive against
+    jq -r '.updated_at' "$RUN_SCRATCH/snap.json" > "$RUN_SCRATCH/updated-at.txt"
     break
   fi
 done
@@ -955,7 +970,7 @@ close each source it names — but only a genuine `type:investigation` source, i
 # Extract every source the brief graduated from — tolerant of phrasing ("Emitted from resolved
 # investigation #N", "from resolved investigation #N"). The `resolved investigation` anchor is what
 # distinguishes a graduation provenance from an incidental `#N` cross-reference in the brief.
-SOURCES=$(grep -oiE 'resolved investigation #[0-9]+' /tmp/plan-epic-<EPIC>-current.md \
+SOURCES=$(grep -oiE 'resolved investigation #[0-9]+' "$RUN_SCRATCH/current.md" \
   | grep -oE '[0-9]+' | sort -u)
 for SRC in $SOURCES; do
   # Guard, fail-safe: close ONLY an open type:investigation — never a referenced epic/decision/bug,
@@ -1042,8 +1057,8 @@ Step 5** — surgical section splice + optimistic `updated_at` recheck, never a 
 whole-body `PATCH`. Re-plan is exactly the concurrency hot-spot the guard exists for: a
 re-plan loop racing a fresh `plan-epic` run or a `review-plan` child-flip is the
 lost-update case in issue #261. Write the fresh `## Plan (plan-epic)` block to
-`/tmp/plan-epic-<EPIC>-plan.md`, the fresh `## Dependencies` block to
-`/tmp/plan-epic-<EPIC>-deps.md`, and run the Step 5 loop with `REPLAN=1` so it splices
+`$RUN_SCRATCH/plan.md`, the fresh `## Dependencies` block to
+`$RUN_SCRATCH/deps.md`, and run the Step 5 loop with `REPLAN=1` so it splices
 **both** sections into the freshly-read live body in place (the live body already has exactly one
 `## Dependencies` heading and exactly one `## Plan (plan-epic)` heading to splice against — the
 loop's anchor guards abort if either drifted). When `updated_at` moved since your read, the loop

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -225,18 +225,27 @@ stop to ask.)
 Every intermediate file below lives under `$RUN_SCRATCH`, the per-run scratch namespace defined
 once in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §SP — never a fixed or
 epic-keyed `/tmp` path. An epic number is **not** unique (a re-plan of the same epic is a second
-run over it), so re-rooting the whole family under one `mktemp -d` is what makes a cross-run
-clobber unrepresentable rather than merely unlikely (#3718). Open the run by allocating it, and
-re-derive it inside any later Bash call — shell state doesn't survive between calls, and §SP
-rule 3 forbids parking the path in another file to carry it across:
+run over it), so re-rooting the whole family under one per-run directory is what makes a
+cross-run clobber unrepresentable rather than merely unlikely (#3718).
+
+Step 1 writes this state and **Step 5 reads it back from a different Bash call**, so the path
+must be *deterministic*, not randomly allocated: shell state doesn't survive between calls, and
+a re-run of `mktemp -d` would hand Step 5 a new empty directory instead of Step 1's files. §SP
+keys the namespace on `$CLAUDE_CODE_SESSION_ID` exactly so any later call can recompute it —
+**open** the run once here (the `rm -rf` clears a previous run of this same epic in this same
+session), then **re-derive** it with the same one-liner in every later block, per §SP rule 3:
 
 ```bash
-# §SP: the per-run scratch namespace — fail-closed, never a shared fallback
-RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
+[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || {
+  echo "plan-epic: §SP — CLAUDE_CODE_SESSION_ID unset; refusing to write plan state to a shared path (#3718)." >&2; exit 1; }
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/plan-epic-<EPIC>"
+rm -rf "$RUN_SCRATCH" && mkdir -p "$RUN_SCRATCH" || {
   echo "plan-epic: §SP could not create a per-run scratch dir — refusing to write plan state to a shared path (#3718)." >&2; exit 1; }
 ```
 
 ```bash
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
 # the epic, its current body, its labels, and any children it already has
 gh api repos/$REPO/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
 # capture the body AND its revision marker from ONE GET — reading them in two calls lets a writer
@@ -449,6 +458,7 @@ later; #1968 and #2099 the same verdict-resolver work in two places).
 **Read both sets once, before the create loop:**
 
 ```bash
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
 # 1. Already-emitted OPEN children of THIS epic — the re-dispatch idempotency set. A re-run must
 #    SKIP any proposed child that matches one of these (reconcile, don't re-create). The sub-issue
 #    list is the source of truth for what the epic already spawned; on a mixed open/closed epic
@@ -500,6 +510,8 @@ caught only by `review-plan`'s non-blocking advisor (#754, the same silent-clobb
 even within a single run:
 
 ```bash
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
+mkdir -p "$RUN_SCRATCH" || exit 1
 # write this child's spec into a per-run temp file, never a shared fixed path (#754)
 CHILD_SPEC_FILE="$(mktemp "$RUN_SCRATCH/child.XXXXXX")"
 cat > "$CHILD_SPEC_FILE" <<'EOF'
@@ -793,6 +805,22 @@ loudly** if `deps.md` was not regenerated since the base it splices onto was rea
 "re-derive" from a comment you might skip into a precondition the script enforces.
 
 ```bash
+# §SP: re-derive the per-run scratch namespace — this is a LATER Bash call, so Step 1's
+# $RUN_SCRATCH variable is gone. Same recipe ⇒ same directory ⇒ Step 1's files are still there.
+# NO `rm -rf` here (that is the OPEN step's job only): clearing it would delete exactly the
+# snapshot this step reads back, which is the whole failure §SP rule 3 exists to prevent.
+[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || {
+  echo "plan-epic: §SP — CLAUDE_CODE_SESSION_ID unset; cannot re-derive the Step 1 scratch namespace (#3718)." >&2; exit 1; }
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/plan-epic-<EPIC>"
+# Fail closed if Step 1's state isn't there: the freshness guard below compares file mtimes, and
+# `[ existing -nt missing ]` is TRUE in bash — so a missing base would let a STALE block splice
+# through silently. Assert presence first; never let the guard decide on absent files (#3718).
+for f in current.md updated-at.txt; do
+  [ -s "$RUN_SCRATCH/$f" ] || {
+    echo "plan-epic: §SP — $RUN_SCRATCH/$f is missing/empty; Step 1's snapshot did not survive." >&2
+    echo "  Re-run Step 1 in THIS session before splicing. Refusing to evaluate the freshness guard against absent state." >&2; exit 1; }
+done
+
 # "$RUN_SCRATCH/deps.md" = the new `## Dependencies` block. On a RE-PLAN, also
 #   "$RUN_SCRATCH/plan.md" = the new `## Plan (plan-epic)` block (set REPLAN=1).
 #   Give each block a trailing blank line so the next spliced heading stays separated.
@@ -843,8 +871,13 @@ for attempt in 1 2 3; do
   #      re-derive precondition is unmet (you re-invoked without regenerating the block off the fresh
   #      base): a stale block that references the wrong child set. Abort loudly, don't write — this is
   #      what stops the `continue`-era footgun of re-splicing the originally-derived block (issue #261).
-  if ! [ "$RUN_SCRATCH/deps.md" -nt "$RUN_SCRATCH/current.md" ] \
-     || { [ "${REPLAN:-0}" = 1 ] && ! [ "$RUN_SCRATCH/plan.md" -nt "$RUN_SCRATCH/current.md" ]; }; then
+  #      `-nt` alone CANNOT carry this check: `[ existing -nt missing ]` is TRUE in bash, so if the
+  #      derived block is absent the negation is false and the guard PASSES SILENTLY — a stale/no
+  #      block splices through. Assert the file exists and is non-empty FIRST, then compare mtimes.
+  if [ ! -s "$RUN_SCRATCH/deps.md" ] \
+     || ! [ "$RUN_SCRATCH/deps.md" -nt "$RUN_SCRATCH/current.md" ] \
+     || { [ "${REPLAN:-0}" = 1 ] && { [ ! -s "$RUN_SCRATCH/plan.md" ] \
+          || ! [ "$RUN_SCRATCH/plan.md" -nt "$RUN_SCRATCH/current.md" ]; }; }; then
     echo "ABORT: deps.md (or plan.md on a re-plan) is NOT newer than the base it splices onto (-current.md) —"
     echo "       you re-invoked without re-deriving. Re-run Step 2's split + Step 5's section derivation"
     echo "       against "$RUN_SCRATCH/current.md", then re-invoke this block. Refusing to splice a stale block."
@@ -967,6 +1000,8 @@ Scan the **brief** (the top section you read in Step 1) for the graduation-prove
 close each source it names — but only a genuine `type:investigation` source, idempotently:
 
 ```bash
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/plan-epic-<EPIC>"   # §SP re-derive (see the open step above)
+[ -s "$RUN_SCRATCH/current.md" ] || { echo "plan-epic: §SP — Step 1's current.md did not survive; re-run Step 1 in THIS session." >&2; exit 1; }
 # Extract every source the brief graduated from — tolerant of phrasing ("Emitted from resolved
 # investigation #N", "from resolved investigation #N"). The `resolved investigation` anchor is what
 # distinguishes a graduation provenance from an incidental `#N` cross-reference in the brief.

--- a/claude-plugins/kampus-pipeline/skills/report/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/report/SKILL.md
@@ -152,7 +152,10 @@ EOF
 } | pipeline-cli tracker create-issue --title "<title>"
 ```
 
-The body never lands on disk under a shared name and never round-trips through a variable, so the two named failure paths this hardening closes — "simplify" to a fixed `/tmp/report-body.md`, or reuse one `$BODY_FILE` across two creates — have no surface to occur on: there is no file path to fix and no variable to reuse.
+The body never lands on disk under a shared name and never round-trips through a variable, so the two named failure paths this hardening closes — "simplify" to a fixed `/tmp/report-body.md`, or reuse one `$BODY_FILE` across two creates — have no surface to occur on: there is no file path to fix and no variable to reuse. This is the
+first and strongest rule of the per-run scratchpad namespace — §SP of
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), *prefer no file at all* — and
+`report` is the idiom the rest of the pipeline is measured against (#2002, generalized in #3718).
 
 5. Report back to the user in one line: the issue number and URL (`create-issue` prints them as `tracker: created #<n> — <url>`). Then return to your original task — don't expand into triaging or fixing what you just filed.
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1300,10 +1300,12 @@ merge. Two forms, either is valid — both must carry the per-criterion table as
 First, **resolve the head SHA you actually reviewed** and **write the verdict to a per-run
 temp file** (`VERDICT_FILE="$(mktemp /tmp/review-code-verdict.XXXXXX)"`) so multi-line markdown +
 backticks survive the shell — both forms below read it back via `cat`. Allocate it with
-`mktemp`, not a fixed `/tmp/review-code-verdict-${PR}.md`: the PR number alone isn't unique —
-two reviews of the *same* PR running concurrently (the operator fans review-* out in
-parallel) would collide on it, one run's unread verdict stalling the write or leaking into
-the other (#1465). The SHA goes into the marker's first
+`mktemp`, never a fixed or `${PR}`-keyed path — the per-run scratchpad namespace, §SP of
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). The PR number alone isn't
+unique (two reviews of the *same* PR running concurrently — the operator fans review-* out in
+parallel — collide on it, one run's unread verdict stalling the write or leaking into the
+other, #1465), and a clobbered temp reads back **successfully with the other run's content**,
+so there is no error to catch (#3718). The SHA goes into the marker's first
 line (`review-code: PASS @ <sha> — merge-ready`) — it is **load-bearing**: `ship-it` refuses
 any verdict not bound to the PR's current head (ADR
 [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258). See the

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -642,10 +642,12 @@ reference from the summary line (there is no issue to auto-close on merge).
 
 **Resolve the head SHA you reviewed** and write the verdict to a per-run temp file
 (`VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"`) so multi-line markdown + backticks
-survive the shell, then post it. Allocate it with `mktemp`, not a fixed
-`/tmp/review-doc-verdict-${PR}.md`: the PR number alone isn't unique — two reviews of the *same*
-PR running concurrently would collide on it, one run's unread verdict stalling the write or
-leaking into the other. The SHA goes into the marker's first line
+survive the shell, then post it. Allocate it with `mktemp`, never a fixed or `${PR}`-keyed
+path — the per-run scratchpad namespace, §SP of
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). The PR number alone isn't
+unique (two reviews of the *same* PR running concurrently collide on it), and a clobbered temp
+reads back **successfully with the other run's content**, so there is no error to catch
+(#3718). The SHA goes into the marker's first line
 (`review-doc: PASS @ <sha> — merge-ready`) and is **load-bearing**: `ship-it` refuses any
 verdict not bound to the PR's current head (ADR
 [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258).

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -81,8 +81,10 @@ git fetch origin "$BASE_REF"
 # to a per-run mktemp handle so they survive the harness cwd/shell reset between Bash calls (a shell
 # var is lost across calls); re-source them with `. "$WT_FILE"` at each later step — NEVER re-derive
 # from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING reviewer's tree and
-# reads the wrong head's skill text — the #1807 collision). Mirror the VERDICT_FILE (#1465) / report
-# BODY_FILE mktemp discipline; WT_FILE itself is `$(mktemp)`, never a fixed/PR-only path.
+# reads the wrong head's skill text — the #1807 collision). This is the §SP per-run scratchpad
+# namespace (gh-issue-intake-formats.md), the same rule VERDICT_FILE (#1465) / report BODY_FILE
+# follow: WT_FILE itself is `$(mktemp)`, never a fixed or PR-keyed path — a PR number is not
+# unique, and a clobbered file reads back cleanly with the other run's content (#3718).
 WT_FILE="$(mktemp /tmp/review-skill-wt.XXXXXX)"
 pipeline-cli review-head materialize --pr "$PR" --worktree \
   | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
@@ -519,9 +521,12 @@ rigor check must PASS. One miss anywhere → FAIL.
 
 **Resolve the head SHA you reviewed** and write the verdict to a per-run temp file
 (`VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"`) so multi-line markdown +
-backticks survive the shell, then post it. Allocate it with `mktemp`, not a fixed
-`/tmp/review-skill-verdict-${PR}.md`: the PR number alone isn't unique — two reviews of the
-same PR running concurrently would collide. The SHA goes into the marker's first line
+backticks survive the shell, then post it. Allocate it with `mktemp`, never a fixed or
+`${PR}`-keyed path — the per-run scratchpad namespace, §SP of
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). The PR number alone isn't
+unique (two reviews of the same PR running concurrently collide), and a clobbered temp reads
+back **successfully with the other run's content**, so there is no error to catch (#3718).
+The SHA goes into the marker's first line
 (`review-skill: PASS @ <sha> — merge-ready`) and is **load-bearing**: `ship-it` refuses any
 verdict not bound to the PR's current head (ADR
 [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258).

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -82,10 +82,15 @@ git fetch origin "$BASE_REF"
 # var is lost across calls); re-source them with `. "$WT_FILE"` at each later step — NEVER re-derive
 # from a shared leaf name (a `git worktree list` re-derivation matches a SIBLING reviewer's tree and
 # reads the wrong head's skill text — the #1807 collision). This is the §SP per-run scratchpad
-# namespace (gh-issue-intake-formats.md), the same rule VERDICT_FILE (#1465) / report BODY_FILE
-# follow: WT_FILE itself is `$(mktemp)`, never a fixed or PR-keyed path — a PR number is not
-# unique, and a clobbered file reads back cleanly with the other run's content (#3718).
-WT_FILE="$(mktemp /tmp/review-skill-wt.XXXXXX)"
+# namespace (gh-issue-intake-formats.md): a PR number is not unique, and a clobbered file reads
+# back cleanly with the other run's content (#3718). WT_FILE is a CROSS-CALL carrier — a later
+# step re-sources it — so §SP rules 2+3 apply, NOT the rule-4 single-file `mktemp` carve-out
+# (that one is for allocate-and-consume inside one call, like VERDICT_FILE below): the path is
+# derived deterministically from the session id, so each later step recomputes this same line
+# rather than inheriting a lost `$WT_FILE` variable.
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR"
+mkdir -p "$RUN_SCRATCH" || { echo "review-skill: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
+WT_FILE="$RUN_SCRATCH/wt.env"
 pipeline-cli review-head materialize --pr "$PR" --worktree \
   | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
 . "$WT_FILE"
@@ -322,9 +327,17 @@ For checks that need the file in context (a trigger phrase, a cross-skill refere
 shape of a step you're judging), read the changed skill at the PR head **from the isolated
 review worktree** (`$REVIEW_WT/skills/...`) the config-pin step set up — never by checking the
 head out into your session tree. Because the harness resets the shell between Bash calls,
-re-source the run-unique handle at the start of any later step that references `$REVIEW_WT`
-(`. "$WT_FILE"`), never re-deriving it from the shared `review-skill-head-${PR}` leaf — under a
-parallel fan-out that leaf name also matches a sibling's worktree (#1807).
+re-source the run-unique handle at the start of any later step that references `$REVIEW_WT`,
+never re-deriving it from the shared `review-skill-head-${PR}` leaf — under a parallel fan-out
+that leaf name also matches a sibling's worktree (#1807). `$WT_FILE` is itself a lost shell
+variable by then, so recompute its path from the same §SP recipe first — that is exactly why
+the namespace is session-derived rather than `mktemp`-allocated:
+
+```bash
+WT_FILE="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/review-skill-$PR/wt.env"
+[ -s "$WT_FILE" ] || { echo "review-skill: §SP — $WT_FILE missing; re-run the head-materialization step in THIS session." >&2; exit 1; }
+. "$WT_FILE"
+```
 
 ### Fetch the base fresh before any "is-it-shipped on main" check
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1305,9 +1305,10 @@ RUN_ID=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
 # the run-evidence artifact id, then the manifest bytes
 ART_ID=$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
   --jq '.artifacts[] | select(.name=="run-evidence") | .id' 2>/dev/null)
-# per-run bundle dir (mktemp -d), NOT a fixed /tmp/ship-it-bundle: concurrent §CP shippers
-# fan out, and a shared path lets two racing runs read each other's bundle — merge-safety must
-# not rest on Step 3.5's commit==head assertion catching the swap after the fact (#2281).
+# per-run bundle dir (mktemp -d), NOT a fixed /tmp/ship-it-bundle — the §SP per-run scratchpad
+# namespace (gh-issue-intake-formats.md): concurrent §CP shippers fan out, and a shared path lets
+# two racing runs read each other's bundle — merge-safety must not rest on Step 3.5's
+# commit==head assertion catching the swap after the fact (#2281; the #3718 silent-clobber class).
 BUNDLE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ship-it-bundle.XXXXXX")
 gh api "repos/$REPO/actions/artifacts/$ART_ID/zip" > "$BUNDLE_DIR/run-evidence.zip" 2>/dev/null \
   && unzip -oq "$BUNDLE_DIR/run-evidence.zip" -d "$BUNDLE_DIR"
@@ -1385,11 +1386,12 @@ clear — proceed to Step 4. Like Step 2's FAIL and Step 3's red, a bundle refus
 # against each (commit-mismatch and missing-bundle are the same passing manifest mutated):
 cd packages/pipeline-cli/src/tools/crabbox-manifest
 HEAD_SHA=deadbeef
+RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || exit 1   # §SP, even in a rehearsal
 node ../../bin.ts crabbox-manifest --run-summary <(node -e 'console.log(JSON.stringify(require("./fixtures.ts").passingRunSummary()))') \
-  --commit "$HEAD_SHA" --environment test --output /tmp/pass.json   # all checks pass → clears
+  --commit "$HEAD_SHA" --environment test --output "$RUN_SCRATCH/pass.json"   # all checks pass → clears
 node ../../bin.ts crabbox-manifest --run-summary <(node -e 'console.log(JSON.stringify(require("./fixtures.ts").failingRunSummary()))') \
-  --commit "$HEAD_SHA" --environment test --output /tmp/fail.json   # test exit 1 → assertion 4 refuses
-# /tmp/pass.json with commit != $HEAD_SHA → assertion 3 (stale); rm /tmp/pass.json → assertion 1
+  --commit "$HEAD_SHA" --environment test --output "$RUN_SCRATCH/fail.json"   # test exit 1 → assertion 4 refuses
+# pass.json with commit != $HEAD_SHA → assertion 3 (stale); rm it → assertion 1
 ```
 
 ---
@@ -1804,16 +1806,23 @@ if [ -n "$ISSUE" ] && gh api "repos/$REPO/contents/product-development-cycle.md"
   #     (1) the key is a REAL declared default-off flag — read the `key: <CONST>` list from the flag-IaC
   #     surface (resources.ts) on `main`, resolved to literals via apps/web/src/flags/keys.ts; AND (2) it
   #     appears in GATING context, not documentation/example prose (the FLAG_IN_PROSE scoping below).
+  # the const list round-trips through a file only because the two greps are separate streams;
+  # it lands under a per-run mktemp, never a shared /tmp leaf (§SP of gh-issue-intake-formats.md).
+  # `$$` alone is NOT the guarantee — an agent's Bash calls can share a shell, so two ship-it runs
+  # can carry the same PID-derived name, and a clobbered list reads back cleanly as another run's
+  # flag keys, silently mis-deciding the dark-ship branch (#3718).
+  CONSTS_FILE="$(mktemp "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+    echo "ship-it: §SP could not allocate a per-run temp — refusing to read flag consts through a shared path (#3718)." >&2; exit 1; }
   DECLARED_KEYS=$(
     gh api "repos/$REPO/contents/apps/web/worker/features/flagship/resources.ts?ref=main" \
         --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
-      | grep -oE 'key:[[:space:]]*[A-Z0-9_]+' | grep -oE '[A-Z0-9_]+$' | sort -u > /tmp/shipit-flag-consts.$$ || true
+      | grep -oE 'key:[[:space:]]*[A-Z0-9_]+' | grep -oE '[A-Z0-9_]+$' | sort -u > "$CONSTS_FILE" || true
     gh api "repos/$REPO/contents/apps/web/src/flags/keys.ts?ref=main" \
         --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
       | grep -oE '^export const [A-Z0-9_]+[[:space:]]*=[[:space:]]*"[a-z0-9]+(-[a-z0-9]+)+"' \
       | sed -E 's/^export const ([A-Z0-9_]+)[[:space:]]*=[[:space:]]*"([a-z0-9-]+)"/\1 \2/' \
-      | while read -r CONST LIT; do grep -qx "$CONST" /tmp/shipit-flag-consts.$$ 2>/dev/null && echo "$LIT"; done
-    rm -f /tmp/shipit-flag-consts.$$
+      | while read -r CONST LIT; do grep -qx "$CONST" "$CONSTS_FILE" 2>/dev/null && echo "$LIT"; done
+    rm -f "$CONSTS_FILE"
   )
   FLAG_IN_PROSE=no
   if [ -n "$DECLARED_KEYS" ]; then

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1386,7 +1386,7 @@ clear — proceed to Step 4. Like Step 2's FAIL and Step 3's red, a bundle refus
 # against each (commit-mismatch and missing-bundle are the same passing manifest mutated):
 cd packages/pipeline-cli/src/tools/crabbox-manifest
 HEAD_SHA=deadbeef
-RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || exit 1   # §SP, even in a rehearsal
+RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/ship-it-rehearsal.XXXXXX")" || exit 1   # §SP rule 4: allocated + consumed in THIS block
 node ../../bin.ts crabbox-manifest --run-summary <(node -e 'console.log(JSON.stringify(require("./fixtures.ts").passingRunSummary()))') \
   --commit "$HEAD_SHA" --environment test --output "$RUN_SCRATCH/pass.json"   # all checks pass → clears
 node ../../bin.ts crabbox-manifest --run-summary <(node -e 'console.log(JSON.stringify(require("./fixtures.ts").failingRunSummary()))') \
@@ -1810,8 +1810,10 @@ if [ -n "$ISSUE" ] && gh api "repos/$REPO/contents/product-development-cycle.md"
   # it lands under a per-run mktemp, never a shared /tmp leaf (§SP of gh-issue-intake-formats.md).
   # `$$` alone is NOT the guarantee — an agent's Bash calls can share a shell, so two ship-it runs
   # can carry the same PID-derived name, and a clobbered list reads back cleanly as another run's
-  # flag keys, silently mis-deciding the dark-ship branch (#3718).
-  CONSTS_FILE="$(mktemp "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+  # flag keys, silently mis-deciding the dark-ship branch (#3718). This is §SP's rule-4 carve-out:
+  # allocated and consumed inside THIS one Bash call, so the kernel's uniqueness is the whole
+  # guarantee and no deterministic path is needed (it never has to survive into a later call).
+  CONSTS_FILE="$(mktemp "${TMPDIR:-/tmp}/ship-it-flag-consts.XXXXXX")" || {
     echo "ship-it: §SP could not allocate a per-run temp — refusing to read flag consts through a shared path (#3718)." >&2; exit 1; }
   DECLARED_KEYS=$(
     gh api "repos/$REPO/contents/apps/web/worker/features/flagship/resources.ts?ref=main" \

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -379,19 +379,29 @@ original is passed through byte-for-byte unchanged, exactly as before.
 
 To get the original and redact any leak before preserving it:
 
+Every temp file below lives under `$RUN_SCRATCH`, the per-run scratchpad namespace defined once
+in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §SP. An issue number is
+**not** a unique key — two triage runs over the same issue (a sweep plus a re-triage) collide on
+`/tmp/triage-original-<N>.md`, and a clobbered file **reads back cleanly with the other run's
+body**, so triage would silently preserve the wrong original inside `<details>` (#3718):
+
 ```bash
-gh api "repos/$REPO/issues/<N>" --jq '.body' > /tmp/triage-original-<N>.md
+# §SP: the per-run scratch namespace — fail-closed, never a shared fallback
+RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+  echo "triage: §SP could not create a per-run scratch dir — refusing to write issue bodies to a shared path (#3718)." >&2; exit 1; }
+
+gh api "repos/$REPO/issues/<N>" --jq '.body' > "$RUN_SCRATCH/original.md"
 # redact any machine-local path leak in the ORIGINAL before it goes into <details>; leak-free
 # originals pass through byte-for-byte. Reuses the shared leak matcher — no divergent patterns.
-pipeline-cli redact-leaks --body-file /tmp/triage-original-<N>.md > /tmp/triage-original-<N>.redacted.md
+pipeline-cli redact-leaks --body-file "$RUN_SCRATCH/original.md" > "$RUN_SCRATCH/original.redacted.md"
 # assemble the <details> block from the REDACTED original, never the raw one
 ```
 
-Assemble the new body in a temp file and read it into `$BODY` so multi-line markdown,
-backticks, and the nested fences survive the shell:
+Assemble the new body in a temp file — under `$RUN_SCRATCH` for the same reason — and read it
+into `$BODY` so multi-line markdown, backticks, and the nested fences survive the shell:
 
 ```bash
-BODY="$(cat /tmp/triage-body-<N>.md)"
+BODY="$(cat "$RUN_SCRATCH/body.md")"
 gh api -X PATCH "repos/$REPO/issues/<N>" -f body="$BODY"
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -386,8 +386,13 @@ in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §SP. An iss
 body**, so triage would silently preserve the wrong original inside `<details>` (#3718):
 
 ```bash
-# §SP: the per-run scratch namespace — fail-closed, never a shared fallback
-RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
+# Keyed on the session id (not a bare `mktemp -d`) because the PATCH block below runs in a LATER
+# Bash call, where every shell variable is gone: it re-derives this same path to read body.md back.
+[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || {
+  echo "triage: §SP — CLAUDE_CODE_SESSION_ID unset; refusing to write issue bodies to a shared path (#3718)." >&2; exit 1; }
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/triage-<N>"
+rm -rf "$RUN_SCRATCH" && mkdir -p "$RUN_SCRATCH" || {
   echo "triage: §SP could not create a per-run scratch dir — refusing to write issue bodies to a shared path (#3718)." >&2; exit 1; }
 
 gh api "repos/$REPO/issues/<N>" --jq '.body' > "$RUN_SCRATCH/original.md"
@@ -401,6 +406,9 @@ Assemble the new body in a temp file — under `$RUN_SCRATCH` for the same reaso
 into `$BODY` so multi-line markdown, backticks, and the nested fences survive the shell:
 
 ```bash
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/triage-<N>"   # §SP re-derive — same recipe as the block above, NO reset
+[ -s "$RUN_SCRATCH/body.md" ] || {
+  echo "triage: §SP — $RUN_SCRATCH/body.md is missing/empty; refusing to PATCH the issue with an empty body." >&2; exit 1; }
 BODY="$(cat "$RUN_SCRATCH/body.md")"
 gh api -X PATCH "repos/$REPO/issues/<N>" -f body="$BODY"
 ```

--- a/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
@@ -29,9 +29,12 @@ Every kill is auditable and reversible. Always:
 4. Close as **not planned** (state `closed`, reason `not_planned`).
 
 ```bash
-# step 1 only when closing as a duplicate of #M:
-gh api "repos/$REPO/issues/<N>" --jq '.body' > /tmp/dup-<N>.md   # then wrap in <details> and:
-gh api "repos/$REPO/issues/<M>/comments" -f body="$(cat /tmp/dup-comment-<N>.md)"
+# step 1 only when closing as a duplicate of #M. Temps live under the §SP per-run scratch
+# namespace (gh-issue-intake-formats.md) — an issue number is NOT unique, and a clobbered file
+# reads back cleanly as another run's body, preserving the WRONG original (#3718):
+RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || { echo "§SP: no per-run scratch dir — refusing a shared path (#3718)." >&2; exit 1; }
+gh api "repos/$REPO/issues/<N>" --jq '.body' > "$RUN_SCRATCH/dup.md"   # then wrap in <details> and:
+gh api "repos/$REPO/issues/<M>/comments" -f body="$(cat "$RUN_SCRATCH/dup-comment.md")"
 # steps 2-4, every kill:
 gh api "repos/$REPO/issues/<N>/comments" -f body="Closing not-planned: <specific reason>."
 gh api "repos/$REPO/issues/<N>/labels" -f "labels[]=closed-by-triage"

--- a/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
@@ -31,8 +31,10 @@ Every kill is auditable and reversible. Always:
 ```bash
 # step 1 only when closing as a duplicate of #M. Temps live under the §SP per-run scratch
 # namespace (gh-issue-intake-formats.md) — an issue number is NOT unique, and a clobbered file
-# reads back cleanly as another run's body, preserving the WRONG original (#3718):
-RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || { echo "§SP: no per-run scratch dir — refusing a shared path (#3718)." >&2; exit 1; }
+# reads back cleanly as another run's body, preserving the WRONG original (#3718). Keyed on the
+# session id so composing dup-comment.md in a later Bash call still resolves this same directory:
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset — refusing a shared path (#3718)}/triage-close-<N>"
+mkdir -p "$RUN_SCRATCH" || { echo "§SP: no per-run scratch dir — refusing a shared path (#3718)." >&2; exit 1; }
 gh api "repos/$REPO/issues/<N>" --jq '.body' > "$RUN_SCRATCH/dup.md"   # then wrap in <details> and:
 gh api "repos/$REPO/issues/<M>/comments" -f body="$(cat "$RUN_SCRATCH/dup-comment.md")"
 # steps 2-4, every kill:

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -843,11 +843,14 @@ freshly-fetched `FETCH_HEAD` is the only flow that works — don't "fix" it back
 >
 > This is exactly the recovery the reported incident used to self-heal, promoted to the
 > standing rule. **Do NOT** persist the branch name to a scratchpad/`/tmp` file to carry it
-> across calls. If — and only if — a per-run cache is genuinely unavoidable, its filename
-> **MUST** be namespaced by the per-agent token (`$CLAUDE_CODE_SESSION_ID`) so two lanes
-> cannot collide (`branch-$CLAUDE_CODE_SESSION_ID.txt`, never a bare `branch.txt`) — but the
-> live `git -C "$WT" branch --show-current` re-derivation above is the preferred, simpler
-> fix and needs no file at all.
+> across calls. This is the local instance of the **per-run scratchpad namespace**, §SP of
+> [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) — and it is §SP's *first*
+> rule, "prefer no file at all," which the live re-derivation above satisfies outright. If — and
+> only if — a per-run cache is genuinely unavoidable, allocate it under `$RUN_SCRATCH` per §SP
+> (never a bare `branch.txt`, and never a path keyed only on the issue number). The reason this
+> matters beyond a mis-push: a clobbered scratchpad file **reads back successfully** with the
+> sibling lane's content, so nothing errors and the wrong ref looks right (#2038, and the #3718
+> reviewer that diffed the wrong PR).
 
 The prefix is **derived** from this checkout's `git config user.name`, not a copied literal —
 so the branch lands under *your* handle (`<your-handle>/…`), whoever runs the skill, instead
@@ -1561,8 +1564,19 @@ Next — see [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §
 is the per-issue ledger for the next agent (a successor write-code run, or
 `review-code`): what moved, what you decided and why, what bit, what's still open.
 
+Compose the comment into a file under `$RUN_SCRATCH` — the per-run scratchpad namespace
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §SP) — never a fixed
+`/tmp/write-code-progress.md`. Several coder lanes drain concurrently by design, so a fixed
+leaf gets clobbered mid-run and reads back **the sibling lane's progress comment with no
+error**, posting another issue's ledger onto yours (#3718, the same silent-clobber class as
+#2038's `branch.txt`):
+
 ```bash
-BODY="$(cat /tmp/write-code-progress.md)"   # the four-section comment
+# §SP: the per-run scratch namespace — fail-closed, never a shared fallback
+RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+  echo "write-code: §SP could not create a per-run scratch dir — refusing to compose a comment through a shared path (#3718)." >&2; exit 1; }
+# …write the four-section comment to "$RUN_SCRATCH/progress.md", then:
+BODY="$(cat "$RUN_SCRATCH/progress.md")"   # the four-section comment
 # gate the comment on the mis-attribution guard (Step 3.5) — only comment on an issue whose claim is mine
 claim_is_mine "<N>" && gh api repos/$REPO/issues/<N>/comments -f body="$BODY"
 ```
@@ -1622,7 +1636,11 @@ so the spawner re-dispatches with the clause, rather than dropping the cross-tas
 silently. A blocked handoff is a fail-loud condition, never a silent no-op.
 
 ```bash
-BODY="$(cat /tmp/write-code-handoff.md)"   # ### Handoff: #N — <title> + the three fields
+# compose under the per-run scratch namespace (§SP), never a fixed /tmp leaf — a concurrent
+# coder lane would clobber it and this posts ITS handoff onto your epic, silently (#3718)
+RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+  echo "write-code: §SP could not create a per-run scratch dir — refusing to compose a handoff through a shared path (#3718)." >&2; exit 1; }
+BODY="$(cat "$RUN_SCRATCH/handoff.md")"   # ### Handoff: #N — <title> + the three fields
 # the handoff to the parent epic is predicated on OWNING THE CHILD — gate on claim_is_mine <child>
 # (Step 3.5), not the epic (which you never claim): only hand off about work whose claim is mine.
 claim_is_mine "<N>" && gh api repos/$REPO/issues/<EPIC>/comments -f body="$BODY"
@@ -1958,7 +1976,10 @@ makes the **stateless** gate re-run — you do **not** re-trigger or self-approv
 # exactly as wt_preflight is before every git op; gate both the push and the progress comment.
 claim_is_mine "$N" || { echo "refusing to push/comment — PR #$PR linked issue #$N not my claim (Step 3.5)"; exit 1; }
 wt_preflight && git push --force-with-lease origin HEAD   # gate the push ([per-mutation preflight]); --force-with-lease because the R2 rebase onto origin/main moved the head
-gh api repos/$REPO/issues/$N/comments -f body="$(cat /tmp/write-code-repair-progress.md)"
+# compose the repair note under the §SP per-run scratch namespace, never a fixed /tmp leaf:
+# concurrent repair lanes clobber a shared name and this posts THEIR note onto your issue (#3718)
+RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || { echo "write-code: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
+gh api repos/$REPO/issues/$N/comments -f body="$(cat "$RUN_SCRATCH/repair-progress.md")"
 ```
 
 **Acknowledge the inline threads you addressed** so the loop is visible to the reviewer who

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1572,10 +1572,15 @@ error**, posting another issue's ledger onto yours (#3718, the same silent-clobb
 #2038's `branch.txt`):
 
 ```bash
-# §SP: the per-run scratch namespace — fail-closed, never a shared fallback
-RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+# §SP: the per-run scratch namespace — deterministic + fail-closed, never a shared fallback.
+# Keyed on the session id, so if you compose progress.md in one Bash call and post it in the
+# next, this same line re-derives the SAME directory (a bare `mktemp -d` would hand the second
+# call a new EMPTY dir and post an empty body).
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-<N>"
+mkdir -p "$RUN_SCRATCH" || {
   echo "write-code: §SP could not create a per-run scratch dir — refusing to compose a comment through a shared path (#3718)." >&2; exit 1; }
 # …write the four-section comment to "$RUN_SCRATCH/progress.md", then:
+[ -s "$RUN_SCRATCH/progress.md" ] || { echo "write-code: progress.md is missing/empty — refusing to post an empty comment." >&2; exit 1; }
 BODY="$(cat "$RUN_SCRATCH/progress.md")"   # the four-section comment
 # gate the comment on the mis-attribution guard (Step 3.5) — only comment on an issue whose claim is mine
 claim_is_mine "<N>" && gh api repos/$REPO/issues/<N>/comments -f body="$BODY"
@@ -1637,9 +1642,14 @@ silently. A blocked handoff is a fail-loud condition, never a silent no-op.
 
 ```bash
 # compose under the per-run scratch namespace (§SP), never a fixed /tmp leaf — a concurrent
-# coder lane would clobber it and this posts ITS handoff onto your epic, silently (#3718)
-RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || {
+# coder lane would clobber it and this posts ITS handoff onto your epic, silently (#3718).
+# Deterministic (session-keyed), so writing handoff.md in one Bash call and posting it here in
+# the next resolves the SAME directory — re-running `mktemp -d` would yield an empty one.
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-<N>"
+mkdir -p "$RUN_SCRATCH" || {
   echo "write-code: §SP could not create a per-run scratch dir — refusing to compose a handoff through a shared path (#3718)." >&2; exit 1; }
+# …write the handoff to "$RUN_SCRATCH/handoff.md" first, then:
+[ -s "$RUN_SCRATCH/handoff.md" ] || { echo "write-code: handoff.md is missing/empty — refusing to post an empty handoff." >&2; exit 1; }
 BODY="$(cat "$RUN_SCRATCH/handoff.md")"   # ### Handoff: #N — <title> + the three fields
 # the handoff to the parent epic is predicated on OWNING THE CHILD — gate on claim_is_mine <child>
 # (Step 3.5), not the epic (which you never claim): only hand off about work whose claim is mine.
@@ -1977,8 +1987,12 @@ makes the **stateless** gate re-run — you do **not** re-trigger or self-approv
 claim_is_mine "$N" || { echo "refusing to push/comment — PR #$PR linked issue #$N not my claim (Step 3.5)"; exit 1; }
 wt_preflight && git push --force-with-lease origin HEAD   # gate the push ([per-mutation preflight]); --force-with-lease because the R2 rebase onto origin/main moved the head
 # compose the repair note under the §SP per-run scratch namespace, never a fixed /tmp leaf:
-# concurrent repair lanes clobber a shared name and this posts THEIR note onto your issue (#3718)
-RUN_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kampus-run.XXXXXX")" || { echo "write-code: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
+# concurrent repair lanes clobber a shared name and this posts THEIR note onto your issue (#3718).
+# Session-keyed and deterministic, so the note you wrote in an earlier Bash call is still here.
+RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/${CLAUDE_CODE_SESSION_ID:?§SP: session id unset (#3718)}/write-code-$N"
+mkdir -p "$RUN_SCRATCH" || { echo "write-code: §SP could not create a per-run scratch dir (#3718)." >&2; exit 1; }
+# …write the format-3 repair note to "$RUN_SCRATCH/repair-progress.md" first, then:
+[ -s "$RUN_SCRATCH/repair-progress.md" ] || { echo "write-code: repair-progress.md is missing/empty — refusing to post an empty comment." >&2; exit 1; }
 gh api repos/$REPO/issues/$N/comments -f body="$(cat "$RUN_SCRATCH/repair-progress.md")"
 ```
 


### PR DESCRIPTION
Fixes #3718

## The defect

Two concurrent reviewers shared the scratchpad leaf `prref.txt`. The #3698 reviewer overwrote it mid-run, and the #3703 reviewer's `git diff` **silently returned #3698's file list**. Nothing errored — a clobbered file reads back successfully, just with another run's content — so a reviewer can post a verdict describing a diff it never looked at. Verdicts are the pipeline's routing gate, so that surfaces as a false PASS on unreviewed code. Silent by construction: there is no read error to catch, which is why a defensive "re-check after read" cannot cover it.

## The fix — the class, not the two filenames

New **§SP. The per-run scratchpad namespace** in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` — the single-sourced convention, sitting alongside §CP/§DOC/§ZS/§RO.

The namespace must satisfy **two** requirements, and a design that meets only one is broken:

1. **Per-run uniqueness** — concurrent agents must not be able to name each other's files. (The point of #3718.)
2. **Deterministic re-derivability across Bash calls** — an agent's shell state does not survive between Bash calls, so a later call must recompute the path *from scratch*.

So the namespace is keyed on **`$CLAUDE_CODE_SESSION_ID`**, not a `mktemp -d`:

```bash
RUN_SCRATCH="${TMPDIR:-/tmp}/kampus-run/$CLAUDE_CODE_SESSION_ID/<slug>"
```

A bare `mktemp -d` gives (1) and destroys (2) — re-running it in a later call yields a **new empty directory** and recovers nothing. The session id gives both: verified **stable across Bash calls**, and **distinct per agent run** (one pane's scratch tree holds many separate session dirs, so concurrent agents never share one). Skills **open** the namespace once, with a reset that clears a previous run of the same slug, and **re-derive** it with the same one-line recipe in every later call.

§SP states four numbered rules in preference order — (1) prefer no file at all, (2) derive from `$RUN_SCRATCH`, fail-closed, (3) never park the path in another file, recompute it, (4) the single-Bash-call `mktemp` carve-out — plus the never-leak-the-path corollary and the fail-open `-nt` hazard.

**Rule 4 is deliberate, not a tolerated exception.** A raw `$(mktemp …XXXXXX)` (or a throwaway `$(mktemp -d)`) is compliant *by construction* when allocated and consumed inside one Bash call — the kernel supplies the uniqueness and nothing has to survive. The line is **lifetime, not file count**. This also keeps §SP consistent with §RO, which mandates exactly that shape for a gate's throwaway head worktree.

The generative property is the point: uniqueness lives in the **directory**, so leaf names stay plain (`deps.md`) and a scratch write added later **inherits** the guarantee. Renaming `prref.txt` would not have done that.

## Same-commit adoption

§SP is authored and cited by its consumers in the same commit. Re-rooted onto the deterministic namespace: **`plan-epic`** (the whole `/tmp/plan-epic-<EPIC>-*` family, across 5 blocks), **`write-code`** (progress, epic handoff, repair-progress), **`triage`** + `close-not-planned`, **`review-skill`** (`WT_FILE`, a genuine cross-call carrier). Collapsed to a §SP citation: `review-code`, `review-doc`, `review-skill`, `report`, `ship-it`. Standing invariant added to all **8 crew agent definitions** — including what to do when state must cross a Bash call, which for an agent is the dominant case.

`ship-it`'s two sites are rule-4 (allocate-and-consume in one block) and stay that way, renamed off the `kampus-run` prefix so the two forms stay tellable apart.

### `plan-epic`'s splice guard failed open — fixed

`[ existing -nt missing ]` is **true** in bash, so `if ! [ "$deps" -nt "$current" ]` **passed silently** when the base was gone — the guard read green precisely when its precondition was most broken, letting a stale block splice into an epic body. Step 5 now re-derives the namespace, asserts Step 1's snapshot is present, and checks `-s` before comparing mtimes.

## Verification

- **Cross-call recovery, end to end:** call 1 opened the namespace and wrote state; a separate call 2 saw `$RUN_SCRATCH` empty (state loss confirmed) yet recovered every file via the re-derive recipe and evaluated the freshness guard correctly. The old `mktemp -d` form re-allocated an empty dir, recovering 0 files.
- **`$$` vs the session id:** `$$` changed between two Bash calls while `$CLAUDE_CODE_SESSION_ID` held — independently confirming the original `$$` diagnosis.
- **Splice guard table-tested across 7 cases:** trips on the missing-base case that previously passed silently, and on stale/empty blocks; proceeds only on the two legitimate ones.
- `validate-skills.sh` — OK, 26 skills valid. Pre-commit `leak-guard` clean.

## Follow-up

The `pipeline-cli` lint guard for fixed-name scratch writes is filed as **#3735** — not re-filed here.

## §CP — banks for human approval

This touches the control plane (pipeline skills + crew agent definitions), so it **will not auto-merge** and banks for human approval per ADR 0048's single-merge-authority. Not a candidate for the autonomous drain path.