### PR TITLE
fix(ci): give e2e and deploy one diff basis so a skipped deploy can't wedge a PR (#3722)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      # MERGE-BASE DIFF BASIS (issue #3722) — the second half of the change-detection
+      # contract, as load-bearing as the `token: ''` mode below. In git mode dorny diffs
+      # TWO-DOT from `pull_request.base.sha` to the checked-out ref (v3.0.2 `src/main.ts`:
+      # `git.getChanges(base || baseSha || defaultBranch, currentRef)`; `src/git.ts`
+      # `getChanges` runs `git diff --name-status <base>..<head>`). `base.sha` is the base
+      # BRANCH TIP at event time, while the checked-out `refs/pull/N/merge` is built on the
+      # tip as of when GitHub last regenerated it — so the moment main advances past a PR's
+      # merge ref, every file main changed in between is reported as changed HERE, in
+      # reverse. deploy.yml's filter reads the same globs off the same diff basis, so both
+      # must be anchored to the true common ancestor or they classify the same PR differently.
+      # That divergence wedged PR #3713: 22 phantom `e2e:` hits (apps/web/src, worker, …)
+      # from main's drift set `e2e_required=true` while deploy correctly skipped, so e2e
+      # polled 10 min for a preview comment that could never arrive and permanently redded a
+      # 4-file skills/pipeline-cli PR. Passing the true merge base as `base` makes the
+      # two-dot diff equal the PR's own three-dot diff. Fail-safe: on any failure the output
+      # is empty, dorny falls back to today's `base.sha` basis, and detection stays wide (it
+      # over-reports, never under-reports) — a doubt always RUNS a gate, never skips one.
+      - id: mergebase
+        if: github.event_name == 'pull_request'
+        run: |
+          set -uo pipefail
+          if sha=$(git merge-base "${{ github.event.pull_request.base.sha }}" HEAD 2>/dev/null); then
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            echo "::notice::change-detection diff basis = merge base $sha (base.sha ${{ github.event.pull_request.base.sha }})"
+          else
+            echo "::warning::could not resolve a merge base — falling back to dorny's base.sha basis (detection stays wide, never narrower)"
+          fi
+
       # API-free git-mode change detection (#3245). dorny/paths-filter reads the changed
       # file set two ways: on a `pull_request` event it calls the GitHub REST API
       # (`pulls.listFiles`) WHEN a `token` is set, and ONLY when the token is empty does it
@@ -171,6 +199,10 @@ jobs:
         id: filter
         with:
           token: ''
+          # Empty on non-PR events, where dorny already merge-bases against the default
+          # branch itself — so `merge_group`/`push` behavior is untouched. `path-filter-guard`
+          # fails closed if this `token`/`base` pairing ever drifts from deploy.yml's.
+          base: ${{ steps.mergebase.outputs.sha }}
           filters: |
             # apps/**/… (not apps/web/…) so any app under apps/ is covered with no
             # filter edit — the discovery posture the package paths already have (ADR
@@ -207,6 +239,10 @@ jobs:
             # #2372) by `pipeline-cli path-filter-guard check` (the path-filter-guard.yml
             # job), which fails the build if this `e2e:` set and deploy.yml's `deploy:`
             # set drift apart — this comment documents the invariant; the guard defends it.
+            #
+            # Equal lists are only HALF the invariant (#3722): the two steps must also read
+            # the same changed-file set, which their `token`/`base` inputs decide. The guard
+            # now compares that pair too — see the `base:` input above.
             e2e:
               - 'apps/**/src/**'
               - 'apps/**/index.html'
@@ -760,6 +796,8 @@ jobs:
       - name: Await preview URL + D1 id + live /api from deploy.yml
         id: preview
         uses: actions/github-script@v7.0.1
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
             const marker = "<!-- preview-deploy -->";
@@ -772,6 +810,10 @@ jobs:
             // key set deploy.yml emits (issue #2951). Absent when no `preview-flag:<key>`
             // label forced anything, so it never gates the poll — only enriches the run env.
             const flagsRe = /<!-- preview-flags:([^>]*?) -->/;
+            // deploy.yml's NEGATIVE verdict (#3722): no preview stack was minted for this
+            // head, so there is nothing for e2e to run against. Bound to the head sha so a
+            // stale verdict from an earlier push can never satisfy a later head.
+            const noneRe = new RegExp(`<!-- preview-deploy:none head:${process.env.HEAD_SHA} -->`);
             const sleep = () => new Promise((r) => setTimeout(r, interval));
 
             // Phase 1 — discover the preview URL + D1 id from the sticky comment.
@@ -781,6 +823,25 @@ jobs:
                 ...context.repo, issue_number: context.issue.number, per_page: 100,
               });
               const c = comments.find((x) => x.body?.includes(marker));
+              // Read the negative verdict BEFORE the positive one: waiting out the deadline
+              // for a preview deploy.yml has already declined to mint can only end in a red
+              // `ci-required` on a PR with no defect in it (#3722, PR #3713). Exiting green
+              // here is the same legitimate not-applicable PASS the job gets when
+              // `e2e_required` is false — the only difference is that this PR reached the
+              // job before the two workflows agreed. That disagreement is a CI-config
+              // defect, so say so LOUDLY: this backstop must stay visible, never quietly
+              // absorb the drift it exists to survive.
+              if (c && noneRe.test(c.body)) {
+                core.warning(
+                  "deploy.yml published a NO-PREVIEW verdict for this head, yet e2e was required — " +
+                  "ci.yml's `e2e` filter and deploy.yml's `deploy` filter disagreed about this diff. " +
+                  "e2e is structurally not applicable (no preview URL will ever be posted), so this run " +
+                  "exits as a not-applicable PASS instead of timing out. The disagreement itself is a CI " +
+                  "config defect — fix the two `changes` jobs' filters/diff basis (#3722), don't rely on this exit.",
+                );
+                core.setOutput("skipped", "true");
+                return;
+              }
               const m = c && c.body.match(webRe);
               if (m) {
                 url = m[1];
@@ -829,7 +890,10 @@ jobs:
       # read specs assert on and the write/flow specs navigate from — e.g. the
       # `flows` specs that open "the first post/term" (#521). Idempotent upsert, so
       # a re-run is safe.
+      # `skipped` means the step above read deploy.yml's no-preview verdict, so there is no
+      # preview stack to seed or test — the remaining steps have no target (#3722).
       - name: Seed preview D1
+        if: steps.preview.outputs.skipped != 'true'
         run: node packages/preview-seed/src/bin.ts run --database-id "${{ steps.preview.outputs.db }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -843,6 +907,7 @@ jobs:
       # `--reporter=html,list` leaves a browsable report for the artifact below
       # (traces from the config's `trace: on-first-retry` + CI retry).
       - name: Run e2e specs (blocking — unauth + authed + flows)
+        if: steps.preview.outputs.skipped != 'true'
         run: >-
           pnpm --filter './apps/**' exec playwright test
           --reporter=html,list

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,18 +56,57 @@ jobs:
     name: detect deploy relevance
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read # dorny/paths-filter reads the PR's changed files via the API
+      # A job-level block REPLACES the workflow default, so `contents: read` must be
+      # restated here for the checkout the merge-base step needs. `pull-requests` is no
+      # longer read by dorny (it runs API-free now) but stays for the paths-filter action's
+      # own event-payload access.
+      contents: read
+      pull-requests: read
     outputs:
       deploy: ${{ steps.decide.outputs.deploy }}
     steps:
-      # dorny/paths-filter resolves the PR's changed files from the API (no checkout
-      # needed on a `pull_request` event). Run it only for a PR — `push` (prod) never
-      # consults it; the `decide` step below forces `deploy=true` for every non-PR
-      # event so prod always deploys.
+      # Full history so the merge-base below resolves; the default shallow checkout has no
+      # common ancestor to compute against.
+      - uses: actions/checkout@v4.2.2
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 0
+
+      # IDENTICAL CHANGE DETECTION TO ci.yml — same `token`, same `base`, same globs (#3722).
+      # This job and ci.yml's `changes` job must classify a PR's diff the SAME way or the
+      # deploy⊇e2e invariant is unenforceable in practice: equal glob lists over DIFFERENT
+      # changed-file sets still disagree. Two separate defects made them disagree, and both
+      # are fixed by pinning the pair here and in ci.yml:
+      #   1. MODE. This step defaulted `token` to `${{ github.token }}` → dorny's API read
+      #      (`pulls.listFiles`, GitHub's three-dot merge-base diff), while ci.yml pins
+      #      `token: ''` → a local `git diff`. Two different readers of "what changed".
+      #      `token: ''` also removes the transient GitHub-API-HTML blip that hard-failed the
+      #      equivalent ci.yml step and redded a defect-free PR (#3244/#3245).
+      #   2. BASIS. In git mode dorny diffs TWO-DOT from `pull_request.base.sha` — the base
+      #      BRANCH TIP at event time, not the common ancestor — so once main advances past
+      #      the PR's merge ref, main's own drift is reported as this PR's changes.
+      # Together those wedged PR #3713 (#3722): ci.yml saw 22 phantom `e2e:` hits from main's
+      # drift → `e2e_required=true`, this job saw the real 4 files → `deploy=false`, and e2e
+      # polled 10 min for a preview that structurally could never arrive.
+      - id: mergebase
+        if: github.event_name == 'pull_request'
+        run: |
+          set -uo pipefail
+          if sha=$(git merge-base "${{ github.event.pull_request.base.sha }}" HEAD 2>/dev/null); then
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            echo "::notice::deploy-relevance diff basis = merge base $sha (base.sha ${{ github.event.pull_request.base.sha }})"
+          else
+            echo "::warning::could not resolve a merge base — falling back to dorny's base.sha basis (detection stays wide, so this fails TOWARD deploying)"
+          fi
+
+      # Run it only for a PR — `push` (prod) never consults it; the `decide` step below
+      # forces `deploy=true` for every non-PR event so prod always deploys.
       - uses: dorny/paths-filter@v3.0.2
         id: filter
         if: github.event_name == 'pull_request'
         with:
+          token: ''
+          base: ${{ steps.mergebase.outputs.sha }}
           filters: |
             # Deploy-relevant paths = ci.yml's `changes.e2e` filter, EXACTLY (issue #2366).
             # Keep this list byte-for-byte in sync with the `e2e:` block in
@@ -76,6 +115,8 @@ jobs:
             # ENFORCED MECHANICALLY (issue #2372) by `pipeline-cli path-filter-guard check`
             # (the path-filter-guard.yml job): it fails the build if this `deploy:` set and
             # ci.yml's `e2e:` set drift apart — this comment documents it, the guard defends it.
+            # The guard also compares the two steps' `token`/`base` inputs, because equal
+            # globs read against different changed-file sets still disagree (#3722).
             deploy:
               - 'apps/**/src/**'
               - 'apps/**/index.html'
@@ -107,6 +148,57 @@ jobs:
             echo "deploy=false" >> "$GITHUB_OUTPUT"
             echo "::notice::no deploy-relevant paths changed → SKIP preview deploy (docs/canon/pipeline-only PR). e2e also skips (identical filter); PR-close teardown is a separate workflow (pr-cleanup.yml) and is unaffected."
           fi
+
+  # Publish the NEGATIVE preview verdict as a first-class artifact (#3722).
+  #
+  # ci.yml's `e2e` job cannot `needs:` a job in this workflow, so it synchronizes on the
+  # sticky `<!-- preview-deploy -->` comment. That seam only ever carried the POSITIVE
+  # answer, so "no preview is coming" was indistinguishable from "the preview hasn't been
+  # posted yet" — e2e could only wait out its 10-minute deadline and then red the PR. The
+  # `changes`/`e2e_required` fix above stops the two workflows from disagreeing in the
+  # first place; this job makes the failure mode UNREACHABLE rather than merely unlikely,
+  # by giving the poll a definitive negative to read.
+  #
+  # SHA-bound (ADR 0058's stance, applied to a deploy verdict): the marker names the PR head
+  # it was computed for, so e2e honors it only for the head it is actually running against —
+  # a stale verdict from an earlier push can never green a later head. The body is REPLACED,
+  # not upserted, so a previous head's live preview URL is cleared rather than left for e2e
+  # to probe. This job and the `deploy` matrix are mutually exclusive by construction (their
+  # `if:`s read the same `needs.changes.outputs.deploy`), so they never race on the comment.
+  no-preview:
+    name: report no preview deploy
+    needs: changes
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      needs.changes.outputs.deploy != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7.0.1
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const marker = "<!-- preview-deploy -->";
+            const headSha = process.env.HEAD_SHA;
+            const body = `${marker}\n### No preview deploy\n`
+              + `<!-- preview-deploy:none head:${headSha} -->\n`
+              + `- No preview deploy for this PR — its diff touches no deploy-relevant path, `
+              + `so no preview stack was minted and \`e2e\` is not applicable. `
+              + `<sub>(${headSha.slice(0, 7)})</sub>`;
+
+            const {data: comments} = await github.rest.issues.listComments({
+              ...context.repo, issue_number: context.issue.number, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({...context.repo, comment_id: existing.id, body});
+            } else {
+              await github.rest.issues.createComment({...context.repo, issue_number: context.issue.number, body});
+            }
+            core.info(`published no-preview verdict for head ${headSha}`);
 
   # Single source of the per-app roster (ADR 0057, #1434), declared ONCE in
   # .github/app-roster.json and consumed via `fromJSON(needs.app-roster.outputs.matrix)`

--- a/packages/pipeline-cli/src/tools/path-filter-guard/README.md
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/README.md
@@ -26,6 +26,29 @@ The core (`path-filter-guard.ts`) parses each workflow YAML, finds the `changes`
 the inline `#` comments are inert), reads the `e2e:` / `deploy:` key, and diffs the two
 as sets (order-independent).
 
+## Equal globs are only half the invariant — the diff basis must match too
+
+A glob list decides which paths matter. dorny's **`token`** and **`base`** inputs decide
+which *changed-file set* those globs are applied to, and the guard compares that pair as
+well (issue [#3722](https://github.com/kamp-us/phoenix/issues/3722)):
+
+- **`token`** picks the reader. Absent (it defaults to `${{ github.token }}`) or non-empty
+  ⇒ dorny calls `pulls.listFiles`, i.e. GitHub's three-dot **merge-base** diff. Empty ⇒ a
+  local `git diff`. (dorny v3.0.2 `src/main.ts`, the PR-event branch of `getChangedFiles`.)
+- **`base`** picks what that local diff is taken *from*. Absent ⇒ a **two-dot** diff from
+  `pull_request.base.sha`, the base *branch tip* at event time rather than the common
+  ancestor — so once `main` advances past the PR's merge ref, `main`'s own drift is
+  reported as this PR's changes.
+
+Those two inputs drifted while the glob lists stayed byte-identical, and this guard
+**passed** the resulting wedge. On PR
+[#3713](https://github.com/kamp-us/phoenix/pull/3713) `ci.yml` (git mode, no `base`) saw 22
+phantom `e2e:` hits from `main`'s post-branch drift while `deploy.yml` (API mode) saw only
+the PR's real four files: `e2e_required` went true, `deploy` correctly skipped, and the e2e
+poll waited out its deadline for a preview that could never arrive — reddening
+`ci-required` on a PR with no defect in it. Both steps now pin `token: ''` plus a
+merge-base `base:`, and a `basis-drift` verdict fires if that pairing ever diverges again.
+
 Fail-closed on zero scope (ADR
 [0092](../../../../../.decisions/0092-gates-fail-closed-on-zero-scope.md)): a missing
 file, missing `changes` job or paths-filter step, a missing `e2e:`/`deploy:` key, or an

--- a/packages/pipeline-cli/src/tools/path-filter-guard/path-filter-guard.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/path-filter-guard.ts
@@ -1,20 +1,30 @@
 /**
- * `path-filter-guard` pure core (issue #2372) — decide whether ci.yml's `changes.e2e`
- * dorny/paths-filter list and deploy.yml's `changes.deploy` dorny/paths-filter list are
- * the SAME set of glob entries. IO-free and total: every decision is a deterministic
- * transform over the two workflow-file texts. The filesystem boundary (read the two
- * files) lives in `gate.ts`; this module never touches disk.
+ * `path-filter-guard` pure core (issue #2372) — decide whether ci.yml's `changes.e2e` and
+ * deploy.yml's `changes.deploy` dorny/paths-filter steps classify a PR's diff the SAME way.
+ * IO-free and total: every decision is a deterministic transform over the two workflow-file
+ * texts. The filesystem boundary (read the two files) lives in `gate.ts`; this module never
+ * touches disk.
  *
  * The load-bearing invariant it mechanizes: deploy's RUN-set must be a SUPERSET of e2e's
  * RUN-set (deploy skips only where e2e also skips). ci.yml's `e2e` job polls deploy.yml's
  * sticky `<!-- preview-deploy -->` comment on a 10-minute deadline, so a PR that trips
  * e2e but skips its deploy makes the poll time out and wedge the required `ci-required`
- * check. Both files pin the invariant today with identical lists guarded ONLY by a
- * reciprocal human comment — nothing mechanical stops a future edit to one from drifting
- * the other. Set EQUALITY is the checkable form: equality ⇒ superset, and equality is
- * exactly what the two comments already pin (a general superset check would let deploy
- * grow entries e2e lacks, which the comments forbid). See ci.yml's `e2e:` block and
- * deploy.yml's `deploy:` block.
+ * check. Both files pin the invariant with identical lists guarded ONLY by a reciprocal
+ * human comment — nothing mechanical stops a future edit to one from drifting the other.
+ * Set EQUALITY is the checkable form: equality ⇒ superset, and equality is exactly what the
+ * two comments already pin (a general superset check would let deploy grow entries e2e
+ * lacks, which the comments forbid).
+ *
+ * EQUAL GLOBS ARE NOT ENOUGH — the DIFF BASIS must match too (#3722). A glob list only
+ * decides which paths matter; dorny's `token` and `base` inputs decide which changed-file
+ * set the globs are applied TO. Those inputs drifted while the lists stayed byte-identical:
+ * ci.yml pinned `token: ''` (a local two-dot `git diff` from `pull_request.base.sha`) while
+ * deploy.yml defaulted `token` to `github.token` (dorny's API read, GitHub's three-dot
+ * merge-base diff). Identical globs over different file sets still disagree — and did, on
+ * PR #3713, where main's post-branch drift showed up as 22 phantom `e2e:` hits in ci.yml
+ * only: `e2e_required` went true, `deploy` correctly skipped, and the e2e poll timed out and
+ * permanently redded a defect-free PR. This guard PASSED that PR, because it compared only
+ * the lists. It now compares both halves — the globs AND the `(token, base)` basis pair.
  *
  * Fail-closed on zero scope (ADR 0092): a missing file/job/paths-filter step, a missing
  * `e2e:`/`deploy:` key, or an empty list is a FAILURE — a guard that extracted nothing
@@ -50,11 +60,38 @@ export interface PathFilterFacts {
 }
 
 /**
- * Extracting one filter list either yields its entries or the reason it couldn't — every
- * `ok: false` arm is a zero-scope failure (ADR 0092), never treated as an empty pass.
+ * The changed-file set a dorny step resolves its globs against, read off the two inputs
+ * that decide it. `undefined` means the input is absent, which is NOT the same as empty:
+ * an absent `token` defaults to `${{ github.token }}` (API mode), an empty one forces git
+ * mode — the exact distinction that drifted in #3722.
+ */
+export interface DiffBasis {
+	readonly token: string | undefined;
+	readonly base: string | undefined;
+}
+
+/** Render a basis for a human report, naming the mode each input selects. */
+export const describeBasis = (basis: DiffBasis): string => {
+	const token =
+		basis.token === undefined
+			? "token: <absent> ⇒ defaults to github.token (API/listFiles mode)"
+			: basis.token.trim() === ""
+				? "token: '' (API-free git-diff mode)"
+				: `token: ${basis.token} (API/listFiles mode)`;
+	const base =
+		basis.base === undefined
+			? "base: <absent> ⇒ two-dot diff from pull_request.base.sha"
+			: `base: ${basis.base}`;
+	return `${token}; ${base}`;
+};
+
+/**
+ * Extracting one filter step either yields its glob entries plus its diff basis, or the
+ * reason it couldn't — every `ok: false` arm is a zero-scope failure (ADR 0092), never
+ * treated as an empty pass.
  */
 export type FilterExtraction =
-	| {readonly ok: true; readonly entries: ReadonlyArray<string>}
+	| {readonly ok: true; readonly entries: ReadonlyArray<string>; readonly basis: DiffBasis}
 	| {readonly ok: false; readonly detail: string};
 
 /**
@@ -73,6 +110,13 @@ export type PathFilterVerdict =
 			readonly onlyInE2e: ReadonlyArray<string>;
 			/** Entries in deploy.yml's `deploy` list absent from ci.yml's `e2e` list. */
 			readonly onlyInDeploy: ReadonlyArray<string>;
+	  }
+	/** Equal globs, but resolved against different changed-file sets (#3722). */
+	| {
+			readonly pass: false;
+			readonly reason: "basis-drift";
+			readonly ciBasis: DiffBasis;
+			readonly deployBasis: DiffBasis;
 	  };
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
@@ -146,13 +190,20 @@ export const extractFilterList = (workflowText: string, source: FilterSource): F
 	if (entries.length === 0) {
 		return {ok: false, detail: `${source.file}: '${source.key}:' is an empty list`};
 	}
-	return {ok: true, entries};
+	// A non-string `token`/`base` (a number, a null) is read as absent: it cannot be the
+	// string the other side pins, so the comparison below still catches it as drift.
+	const readInput = (name: string): string | undefined => {
+		const raw = (filterStep.with as Record<string, unknown>)[name];
+		return typeof raw === "string" ? raw : undefined;
+	};
+	return {ok: true, entries, basis: {token: readInput("token"), base: readInput("base")}};
 };
 
 /**
- * Decide the verdict over the two workflow texts. Order: extract each list (fail closed
- * on any zero-scope gap), then compare as SETS (order-independent). Set inequality —
- * an entry in one list absent from the other, in either direction — is drift.
+ * Decide the verdict over the two workflow texts. Order: extract each step (fail closed on
+ * any zero-scope gap), compare the globs as SETS (order-independent), then compare the diff
+ * basis. Set inequality — an entry in one list absent from the other, in either direction —
+ * is drift; equal globs read against a different `(token, base)` pair is basis-drift.
  */
 export const judge = (facts: PathFilterFacts): PathFilterVerdict => {
 	const e2e = extractFilterList(facts.ciText, CI_E2E_SOURCE);
@@ -167,6 +218,9 @@ export const judge = (facts: PathFilterFacts): PathFilterVerdict => {
 	if (onlyInE2e.length > 0 || onlyInDeploy.length > 0) {
 		return {pass: false, reason: "drift", onlyInE2e, onlyInDeploy};
 	}
+	if (e2e.basis.token !== deploy.basis.token || e2e.basis.base !== deploy.basis.base) {
+		return {pass: false, reason: "basis-drift", ciBasis: e2e.basis, deployBasis: deploy.basis};
+	}
 	return {pass: true, count: e2eSet.size};
 };
 
@@ -175,7 +229,8 @@ export const renderReport = (verdict: PathFilterVerdict): string => {
 	if (verdict.pass) {
 		return (
 			`path-filter-guard: ci.yml changes.e2e and deploy.yml changes.deploy are identical ` +
-			`(${verdict.count} glob entries) — the deploy⊇e2e sync invariant holds`
+			`(${verdict.count} glob entries, same token/base diff basis) — the deploy⊇e2e sync ` +
+			`invariant holds`
 		);
 	}
 	if (verdict.reason === "zero-scope") {
@@ -183,6 +238,20 @@ export const renderReport = (verdict: PathFilterVerdict): string => {
 			`path-filter-guard: ${verdict.detail} — fail-closed (ADR 0092). Could not extract both ` +
 			"the ci.yml changes.e2e and deploy.yml changes.deploy filter lists, so the sync invariant " +
 			"is unverifiable. Is the repo root correct, or did a workflow's paths-filter shape change?"
+		);
+	}
+	if (verdict.reason === "basis-drift") {
+		return (
+			"path-filter-guard: ci.yml's changes.e2e filter and deploy.yml's changes.deploy filter " +
+			"have the SAME globs but resolve them against a DIFFERENT changed-file set:\n" +
+			`  ci.yml     ${describeBasis(verdict.ciBasis)}\n` +
+			`  deploy.yml ${describeBasis(verdict.deployBasis)}\n\n` +
+			"dorny's `token` picks the reader (absent/non-empty ⇒ the API's three-dot merge-base " +
+			"diff; empty ⇒ a local git diff) and `base` picks what that diff is taken from. Equal " +
+			"globs over different file sets still disagree about the same PR — which is how a PR " +
+			"can trip e2e while its deploy skips, leaving e2e to poll 10 minutes for a preview that " +
+			"never arrives and permanently red `ci-required` (#3722, PR #3713). Give both steps the " +
+			"SAME `token:` and `base:` inputs."
 		);
 	}
 	const lines: Array<string> = [];

--- a/packages/pipeline-cli/src/tools/path-filter-guard/path-filter-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/path-filter-guard/path-filter-guard.unit.test.ts
@@ -17,9 +17,14 @@ const mkWorkflow = (
 	key: string,
 	globs: ReadonlyArray<string>,
 	extraLines: ReadonlyArray<string> = [],
+	/** The diff-basis inputs (#3722); omitted keys are absent from the `with:` block. */
+	inputs: {readonly token?: string; readonly base?: string} = {},
 ): string => {
 	const items = globs.map((g) => `              - '${g}'`);
 	const block = [`            ${key}:`, ...extraLines.map((l) => `            ${l}`), ...items];
+	const basisLines: Array<string> = [];
+	if (inputs.token !== undefined) basisLines.push(`          token: '${inputs.token}'`);
+	if (inputs.base !== undefined) basisLines.push(`          base: '${inputs.base}'`);
 	return [
 		"name: T",
 		"on:",
@@ -32,23 +37,27 @@ const mkWorkflow = (
 		"      - uses: dorny/paths-filter@v3.0.2",
 		"        id: filter",
 		"        with:",
+		...basisLines,
 		"          filters: |",
 		...block,
 		"",
 	].join("\n");
 };
 
+/** Stands in for the `${{ steps.mergebase.outputs.sha }}` expression the workflows pin. */
+const MERGE_BASE = "<merge-base-expression>";
+
 const SAMPLE = ["apps/**/src/**", "apps/**/worker/**", ".github/workflows/deploy.yml"];
 
 describe("extractFilterList — the pure extractor", () => {
 	it("extracts the e2e glob list from a well-formed ci.yml changes job", () => {
 		const res = extractFilterList(mkWorkflow("e2e", SAMPLE), CI_E2E_SOURCE);
-		expect(res).toEqual({ok: true, entries: SAMPLE});
+		expect(res).toEqual({ok: true, entries: SAMPLE, basis: {token: undefined, base: undefined}});
 	});
 
 	it("extracts the deploy glob list from a well-formed deploy.yml changes job", () => {
 		const res = extractFilterList(mkWorkflow("deploy", SAMPLE), DEPLOY_SOURCE);
-		expect(res).toEqual({ok: true, entries: SAMPLE});
+		expect(res).toEqual({ok: true, entries: SAMPLE, basis: {token: undefined, base: undefined}});
 	});
 
 	it("ignores inline # comments in the filters block (dorny parses it as YAML)", () => {
@@ -56,7 +65,7 @@ describe("extractFilterList — the pure extractor", () => {
 			mkWorkflow("e2e", SAMPLE, ["# SYNC INVARIANT: keep in lockstep with deploy.yml"]),
 			CI_E2E_SOURCE,
 		);
-		expect(res).toEqual({ok: true, entries: SAMPLE});
+		expect(res).toEqual({ok: true, entries: SAMPLE, basis: {token: undefined, base: undefined}});
 	});
 
 	it("fails closed on unparseable workflow YAML", () => {
@@ -149,5 +158,54 @@ describe("judge — set equality over the two filter lists", () => {
 			deployText: mkWorkflow("deploy", []),
 		});
 		expect(verdict).toMatchObject({pass: false, reason: "zero-scope"});
+	});
+});
+
+/**
+ * The #3722 regression: equal globs are not enough. The wedge that redded PR #3713 had
+ * byte-identical lists — it was the `token`/`base` inputs that diverged, so the two
+ * workflows applied the same globs to different changed-file sets. These cases pin the
+ * exact production shape of that bug and the shape that fixes it.
+ */
+describe("judge — diff-basis equality (#3722)", () => {
+	it("FAILS (basis-drift) on the production wedge: ci pins token '' while deploy defaults it", () => {
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", SAMPLE, [], {token: ""}),
+			deployText: mkWorkflow("deploy", SAMPLE),
+		});
+		expect(verdict).toMatchObject({
+			pass: false,
+			reason: "basis-drift",
+			ciBasis: {token: "", base: undefined},
+			deployBasis: {token: undefined, base: undefined},
+		});
+	});
+
+	it("FAILS (basis-drift) when only one side anchors the diff to a merge base", () => {
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", SAMPLE, [], {
+				token: "",
+				base: MERGE_BASE,
+			}),
+			deployText: mkWorkflow("deploy", SAMPLE, [], {token: ""}),
+		});
+		expect(verdict).toMatchObject({pass: false, reason: "basis-drift"});
+	});
+
+	it("PASSES when both steps pin the same token and base", () => {
+		const inputs = {token: "", base: MERGE_BASE};
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", SAMPLE, [], inputs),
+			deployText: mkWorkflow("deploy", SAMPLE, [], inputs),
+		});
+		expect(verdict).toEqual({pass: true, count: SAMPLE.length});
+	});
+
+	it("reports glob drift BEFORE basis drift when both have drifted", () => {
+		const verdict = judge({
+			ciText: mkWorkflow("e2e", [...SAMPLE, "apps/**/index.html"], [], {token: ""}),
+			deployText: mkWorkflow("deploy", SAMPLE),
+		});
+		expect(verdict).toMatchObject({pass: false, reason: "drift"});
 	});
 });


### PR DESCRIPTION
A PR that changes no app or worker code should skip both the preview deploy and the e2e suite. Sometimes only one of them skipped: the deploy correctly stood down, but e2e was still marked required, so it spent ten minutes waiting for a preview URL that was never going to be posted and then failed the PR — permanently, with nothing wrong in the diff. This makes the two workflows agree on what a PR actually changed, so that split can't happen.

Fixes #3722

## The root cause, recovered

The first acceptance criterion asks which filter made `e2e_required` true. It was not a filter list at all — the two lists are byte-identical and their sync guard was right to pass. The two workflows were reading **different changed-file sets**.

`dorny/paths-filter`'s `token` input picks how it reads a PR's changes (grounded in v3.0.2 `src/main.ts`, the PR-event branch of `getChangedFiles`, and `src/git.ts`):

| | `ci.yml` `changes` | `deploy.yml` `changes` |
|---|---|---|
| `token` | `''` (pinned by #3245) | absent → defaults to `${{ github.token }}` |
| reader | local `git diff` | `pulls.listFiles` (API) |
| basis | **two-dot** from `pull_request.base.sha` | GitHub's **three-dot** merge-base diff |

`pull_request.base.sha` is the base *branch tip* at event time, not the merge base. So the moment `main` advances past a PR's merge ref, a two-dot diff reports everything `main` changed in between — in reverse — as this PR's changes.

Reproduced against the wedged PR #3713:

| | base.sha | merge-base | files seen | `e2e:` hits |
|---|---|---|---|---|
| ci.yml (two-dot) | `11f0932d` | — | **58** | **22** (`apps/web/src/**`, `apps/web/worker/**`, `alchemy.run.ts`) |
| deploy.yml (three-dot) | — | `a0ddfee2` | **4** | **0** |

`e2e_required` went true off 22 files the PR never touched; `deploy` correctly saw the real four (3 `SKILL.md` + 1 `pipeline-cli` file) and skipped. Sibling PRs #3698/#3703 escaped only because their `base.sha` happened to *equal* their merge-base, making two-dot and three-dot identical — which is exactly why the bug looked like it struck one PR at random.

## The fix

**1. One diff basis for both workflows.** Each `changes` job now resolves the true merge base and hands it to dorny as `base:`, and both pin `token: ''`. A two-dot diff *from the merge base* is the three-dot diff, so the two jobs classify a PR identically.

**Why this cannot weaken e2e coverage.** The change only narrows the changed-file set to the PR's own diff. A file a PR genuinely changes is in its merge-base diff by definition, so every PR carrying real app/worker surface trips `e2e:` exactly as it does today — only the phantom entries contributed by `main`'s drift disappear. In the one edge case where the two differ for a genuinely-touched file (the PR changes X to the same content `main` did), merge-base semantics are *more* inclusive, not less. If merge-base resolution ever fails, the output is empty and dorny falls back to today's basis, so detection stays wide: any doubt runs a gate, never skips one.

This required no change to either glob list, so it also cannot prune real coverage by construction.

**2. "No preview" becomes a readable answer, not silence.** e2e can't `needs:` a job in another workflow, so it synchronizes on the sticky `<!-- preview-deploy -->` comment — which only ever carried the *positive* answer. "No preview is coming" was indistinguishable from "not posted yet", leaving the deadline as e2e's only exit. `deploy.yml` now publishes a SHA-bound `<!-- preview-deploy:none head:<sha> -->` marker when it declines to deploy, and e2e reads it and exits as a legitimate not-applicable PASS.

This is a backstop, not the fix, and it is deliberately loud: reaching it means the two workflows disagreed, so the step emits a `::warning::` naming that as a CI-config defect. It cannot mask a future regression into a silent green — the fix above is what stops the disagreement, this only stops the disagreement from being unrecoverable. Binding the marker to the head sha keeps a stale verdict from an earlier push from ever greening a later head.

**3. The sync guard now covers this class.** `path-filter-guard` passed the #3713 wedge because it only ever compared glob lists. It now also compares the two steps' `(token, base)` pair and fails closed with a `basis-drift` verdict — equal globs read against different file sets still disagree.

## Acceptance criteria

- [x] Paths-filter output on the reproducing PR recovered, identifying what made `e2e_required` true — the diff basis, not a filter entry (table above, computed from #3713's real SHAs).
- [x] A deploy-skipping PR can no longer be wedged red: both workflows now read one changed-file set, and the no-preview marker makes the deadlock unreachable even if they ever diverge again.
- [x] e2e on such a PR skips (basis parity) or resolves to a not-applicable PASS (marker), with no weakening of coverage for PRs carrying app/worker surface.
- [x] The sync-guard is strengthened to cover the divergence — `basis-drift`, with unit tests pinning the production shape of the bug.

## Verification

- `pipeline-cli path-filter-guard check` → pass (12 globs, same token/base basis); `change-detect-guard check` → pass (`token: ''` intact).
- `actionlint` clean on both workflows.
- `pnpm typecheck` (33/33), `pnpm lint:worktree` clean, `@kampus/pipeline-cli` suite 1650/1650 including 4 new `basis-drift` cases.

## Control-plane change

Touches `.github/**` — banks for human approval, no auto-merge.

## Reviewer notes

- `deploy.yml`'s `changes` job gains an `actions/checkout` (needed for the merge-base) and restates `contents: read`, since a job-level `permissions:` block replaces the workflow default. `fetch-depth: 0` makes `base.sha` resolvable locally — `actions/checkout` v4.2.2 fetches `+refs/heads/*:refs/remotes/origin/*` on `fetchDepth <= 0` (`src/ref-helper.ts` `getRefSpecForAllHistory`).
- `merge_group` and `push` are untouched: the merge-base step is PR-gated, so `base:` is empty there and dorny keeps merge-basing against the default branch itself.
- Pinning `token: ''` in `deploy.yml` also closes the transient GitHub-API-HTML flake (#3244) on that job, the same one #3245 removed from `ci.yml`.
- The `no-preview` job and the `deploy` matrix are mutually exclusive — their `if:`s read the same `needs.changes.outputs.deploy` — so they never race on the sticky comment.
