### PR TITLE
fix(run-evidence): retry crabbox download on transient GitHub 5xx (#3719)

### DIFF
--- a/.github/workflows/run-evidence.yml
+++ b/.github/workflows/run-evidence.yml
@@ -99,10 +99,41 @@ jobs:
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/crabbox"
           cd "$RUNNER_TEMP/crabbox"
-          gh release download "v${CRABBOX_VERSION}" -R openclaw/crabbox \
-            -p "crabbox_${CRABBOX_VERSION}_linux_amd64.tar.gz" -p "checksums.txt"
-          grep "crabbox_${CRABBOX_VERSION}_linux_amd64.tar.gz" checksums.txt | sha256sum -c -
-          tar -xzf "crabbox_${CRABBOX_VERSION}_linux_amd64.tar.gz"
+          TARBALL="crabbox_${CRABBOX_VERSION}_linux_amd64.tar.gz"
+          DOWNLOAD_LOG="$RUNNER_TEMP/crabbox-download.log"
+          # `gh release download` is an unretried API call, so one transient GitHub 5xx kills the
+          # producer and leaves that head with no run-evidence bundle for ship-it Step 3.5 to
+          # discharge (#3719: three runs died on `HTTP 503 … /releases/assets/447225790`, an asset
+          # that exists). Retry ONLY the transient class — a permanent error (a moved/yanked pin,
+          # auth) still fails on the first attempt, so a real break is never retried into a timeout.
+          downloaded=""
+          for attempt in 1 2 3 4 5; do
+            # gh refuses to overwrite an existing file, so clear any partial from a failed attempt —
+            # otherwise the retry fails "already exists" and misreads as a permanent error.
+            rm -f "$TARBALL" checksums.txt
+            if gh release download "v${CRABBOX_VERSION}" -R openclaw/crabbox \
+                 -p "$TARBALL" -p "checksums.txt" 2>"$DOWNLOAD_LOG"; then
+              downloaded=yes
+              break
+            fi
+            cat "$DOWNLOAD_LOG" >&2
+            # Unrecognized/empty stderr counts as non-transient: fail fast rather than retry an
+            # error we can't prove is recoverable.
+            if ! grep -qiE 'HTTP 5[0-9]{2}|timeout|timed out|connection reset|connection refused|TLS handshake|unexpected EOF|no such host|temporarily unavailable' "$DOWNLOAD_LOG"; then
+              echo "::error::crabbox v${CRABBOX_VERSION} download failed with a NON-transient error (see above) — the pin may be missing, renamed, or unauthorized. Not retrying." >&2
+              exit 1
+            fi
+            echo "attempt ${attempt}: transient GitHub error downloading crabbox v${CRABBOX_VERSION}; retrying"
+            sleep $((attempt * 5))
+          done
+          if [ -z "$downloaded" ]; then
+            echo "::error::crabbox v${CRABBOX_VERSION} download failed after 5 attempts against transient GitHub errors — failing red rather than yielding no run-evidence bundle" >&2
+            exit 1
+          fi
+          # Verified OUTSIDE the retry loop on purpose: a checksum mismatch means a tampered or
+          # corrupt artifact, never something to retry away — it fails red on the spot.
+          grep "$TARBALL" checksums.txt | sha256sum -c -
+          tar -xzf "$TARBALL"
           install -m 0755 crabbox "$RUNNER_TEMP/crabbox/bin-crabbox" 2>/dev/null || \
             install -m 0755 ./crabbox*/crabbox "$RUNNER_TEMP/crabbox/bin-crabbox" 2>/dev/null || \
             { chmod +x crabbox && cp crabbox "$RUNNER_TEMP/crabbox/bin-crabbox"; }


### PR DESCRIPTION
Fixes #3719

## Root cause — diagnosed from the failing runs' logs, not inferred

The `Install crabbox (pinned)` step called `gh release download` with **no retry**. Under `set -euo pipefail`, one transient GitHub 5xx failed the step, so the producer emitted **no run-evidence bundle** at that head — and ship-it Step 3.5 could not be discharged by its sanctioned path.

All three outage-window failures carry the identical signature:

```
HTTP 503: No server is currently available to service your request.
(https://api.github.com/repos/openclaw/crabbox/releases/assets/447225790)
```

| run | head | failing step | error |
| --- | --- | --- | --- |
| 29709833408 | `27e35d7f` | `Install crabbox (pinned)` | HTTP 503 on asset `447225790` |
| 29709359641 | `c55af6d9` | `Install crabbox (pinned)` | HTTP 503 on asset `447225790` |
| 29709257010 | `8947c6d5` | `Install crabbox (pinned)` | HTTP 503 on asset `447225888` |

**It is not a moved or yanked pin.** Asset `447225790` is `crabbox_0.31.0_linux_amd64.tar.gz` and `447225888` is `checksums.txt` — the exact two assets the step requests. Both still resolve today on release `v0.31.0` (`draft: false`, `prerelease: false`, published `2026-06-14`). The 503 came from the asset *download*, after the release and asset IDs had already resolved. So it is not a registry/auth change, not a lockfile mismatch, and not a runner-image change — it is an unretried network call against a degraded API.

Consistent with that, the producer is **currently green**: the 29 most recent `run-evidence.yml` runs all succeeded. The break self-healed with the outage; what is fixed here is the durable resilience gap it exposed.

## The fix

Retry the download on the transient class only, with increasing backoff — matching the existing repo idiom in `deploy.yml` and `pr-cleanup.yml` (`for attempt in 1 2 3 4 5` + `sleep $((attempt * N))` + fail-loud if it never succeeded).

Three properties keep this from becoming a way to paper over a real break:

- **Non-transient errors are not retried.** A 404/410/auth error fails on the **first** attempt with an explicit `::error::`. Only 5xx / timeout / connection reset / TLS handshake / DNS errors retry. Unrecognized or empty stderr counts as non-transient — fail fast rather than retry something unproven to be recoverable.
- **Exhausted retries fail red.** Five failed transient attempts exit 1 loudly; they never fall through to a partial or absent artifact.
- **Checksum verification stays outside the retry loop.** A mismatch is a tampered/corrupt artifact and fails immediately — it can never be retried away.

Also: each attempt clears the partial download first, because `gh release download` refuses to overwrite an existing file — without that, attempt 2 would fail `already exists` and misclassify as a permanent error.

## What was explicitly NOT done

- **The gate is not weakened.** No `continue-on-error`, no non-blocking job, no waiver path. ship-it Step 3.5 keeps its full teeth.
- **The pin is not skipped or moved.** `CRABBOX_VERSION` stays `0.31.0` — the pin is valid, so there was no reason to move it.
- Nothing was relaxed, so there is no tradeoff needing a founder call.

## Verification

Behavior-tested the step's real extracted shell against a stubbed `gh`:

| scenario | result |
| --- | --- |
| 503 twice, then success | exit 0, 3 attempts, 2 retries — **recovers** |
| permanent 404 | exit 1, **1 attempt, no retry** |
| persistent 503 | exit 1 after 5 attempts, fails red |
| checksum mismatch | exit 1, not retried away |
| clean success | exit 0, 1 attempt (no regression) |

Also green: workflow YAML parses, `bash -n` clean, `pipeline-cli workflow-contract check`, `pnpm lint:worktree`, `pnpm typecheck` (33/33).

## Control-plane note (§CP)

This diff touches `.github/workflows/**`, which is **control-plane** — it banks for human approval and will **not** auto-merge.
