### PR TITLE
feat(pipeline-crew-mcp): resolve the crew rendezvous canonically per repo (#3627)

### DIFF
--- a/packages/pipeline-crew-mcp/README.md
+++ b/packages/pipeline-crew-mcp/README.md
@@ -75,6 +75,8 @@ pnpm --filter @kampus/pipeline-crew-mcp test       # @effect/vitest suite
 ```
 
 The `--role` is one of the four standing `CREW_ROLES` (`chief-of-staff`, `cartographer`,
-`intake-desk`, `engineering-manager`); the session joins the per-project tracker under
-`--project-root` (default: cwd) and runs until interrupted. See the [Tutorial](./docs/tutorial.md)
+`intake-desk`, `engineering-manager`); the session joins its repo's tracker at the canonical
+rendezvous (ADR 0197 — keyed on the repo's shared git dir, so the repo root, a nested subdir, and any
+linked worktree all meet at one registry). `--project-root` (default: cwd) only seeds git's repo
+discovery; it is never the rendezvous key. The session runs until interrupted. See the [Tutorial](./docs/tutorial.md)
 for the first-run walkthrough and the [Reference](./docs/reference.md) for the full CLI surface.

--- a/packages/pipeline-crew-mcp/docs/tutorial.md
+++ b/packages/pipeline-crew-mcp/docs/tutorial.md
@@ -56,20 +56,21 @@ import {
 } from "./src/crew/channel-server.ts";
 import {crewTrackerHostOrDialLayer, peerTrackerLayer} from "./src/crew/tracker.ts";
 import {Inbox} from "./src/peer/index.ts";
-import {socketPathFor} from "./src/tracker/index.ts";
-
-// A throwaway project root: its per-project tracker socket is the rendezvous both peers meet on.
-const PROJECT = "/tmp/kampus-crew-tutorial";
+import {resolveRendezvous} from "./src/tracker/index.ts";
 
 // Peer B is an engineering-manager engine instance; peer A is the intake-desk bridge.
 const B = "inbox://engineering-manager/tutorial";
 const A = "inbox://intake-desk";
 
-// One shared tracker for the project: the first peer to build this hosts the registry socket, a
-// racing peer catches EADDRINUSE and dials the existing one. Both peers reach the SAME registry.
-const tracker = crewTrackerHostOrDialLayer(socketPathFor(PROJECT)).pipe(
-	Layer.provide(NodeFileSystem.layer),
-);
+// One shared tracker for this repo, at its canonical rendezvous (ADR 0197) — keyed on the shared git
+// dir, so you get the same registry whether you run this from the repo root or a nested package dir.
+// The first peer to build this hosts the registry socket; a racing peer catches EADDRINUSE and dials
+// the existing one. Both peers reach the SAME registry.
+const tracker = Layer.unwrap(
+	resolveRendezvous(process.cwd()).pipe(
+		Effect.map((rendezvous) => crewTrackerHostOrDialLayer(rendezvous.socketPath)),
+	),
+).pipe(Layer.provide(NodeFileSystem.layer));
 
 // A peer's substrate: the tracker port (announce/lookup), its own inbox log, and the socket dialer.
 const substrate = (address: string) =>

--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -69,7 +69,9 @@ const roleFlag = Flag.choice("role", CREW_ROLES).pipe(
 );
 const projectRootFlag = Flag.string("project-root").pipe(
 	Flag.withDefault(process.cwd()),
-	Flag.withDescription("the project root whose per-project tracker socket this session joins"),
+	Flag.withDescription(
+		"a directory inside the repo whose tracker this session joins; seeds git repo discovery only — the rendezvous is the repo's canonical one (ADR 0197)",
+	),
 );
 // The launcher-assigned per-instance identity standup/bind.ts bakes into an engine's argv
 // (`CREW_SESSION_INSTANCE_FLAG`, #3297/#3354 seam 3). Optional: only engine roles carry it — a

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -51,7 +51,7 @@ import {
 	kindsToolHandlers,
 } from "../edge/index.ts";
 import {type Dialer, Inbox, type Tracker} from "../peer/index.ts";
-import {socketPathFor} from "../tracker/index.ts";
+import {resolveRendezvous} from "../tracker/index.ts";
 import {VERSION} from "../version.ts";
 import {
 	crewSocketDialerLayer,
@@ -70,7 +70,7 @@ export const SESSION_SERVER_NAME = "@kampus/pipeline-crew-mcp" as const;
 
 export interface CrewSessionConfig {
 	readonly role: CrewRole;
-	/** The project root whose per-project tracker socket this session rendezvous on. */
+	/** Seeds git repo discovery; the session meets at that repo's canonical rendezvous (ADR 0197). */
 	readonly projectRoot: string;
 	/** The MCP server name advertised over stdio (defaults to the package name). */
 	readonly name?: string;
@@ -126,7 +126,11 @@ export const peerSocketSubstrate = (
 	config: CrewSessionConfig,
 	address: string,
 ): Layer.Layer<CrewTracker | Tracker | Inbox | Dialer, unknown, FileSystem.FileSystem> => {
-	const crewTracker = crewTrackerHostOrDialLayer(socketPathFor(config.projectRoot));
+	const crewTracker = Layer.unwrap(
+		resolveRendezvous(config.projectRoot).pipe(
+			Effect.map((rendezvous) => crewTrackerHostOrDialLayer(rendezvous.socketPath)),
+		),
+	);
 	return Layer.mergeAll(
 		peerTrackerLayer.pipe(Layer.provideMerge(crewTracker)),
 		Inbox.layer(address),

--- a/packages/pipeline-crew-mcp/src/crew/tracker.rendezvous.socket.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.rendezvous.socket.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The end-to-end proof of ADR 0197 over the REAL socket: two peers of one repo seeded from DIFFERENT
+ * cwds — the repo root and a nested `apps/web` — meet at one live registry, so the peer announced by
+ * the first is discoverable by the second.
+ *
+ * This is the regression test for the failure the rewrite exists to kill. Under the old cwd-derived
+ * hashing these two seeds produced two sockets and two disjoint registries: each peer registered
+ * successfully, saw an empty lookup, and was indistinguishable from a peer that was simply alone.
+ *
+ * `it.live`, not `it.effect`: this binds a real unix socket and settles it with a real `Effect.sleep`,
+ * which the virtual TestClock would never advance.
+ */
+import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, realpathSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeFileSystem} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Context, Effect, Layer} from "effect";
+import {resolveRendezvous} from "../tracker/index.ts";
+import {CrewTracker, crewTrackerHostOrDialLayer} from "./tracker.ts";
+
+const hostOrDial = (socketPath: string) =>
+	crewTrackerHostOrDialLayer(socketPath).pipe(Layer.provide(NodeFileSystem.layer));
+
+describe("crew rendezvous — two cwds of one repo, one live registry", () => {
+	it.live("a peer announced from the repo root is discovered from a nested subdir", () =>
+		Effect.gen(function* () {
+			const root = realpathSync(mkdtempSync(join(tmpdir(), "rendezvous-e2e-")));
+			execFileSync("git", ["init", "-q", "-b", "main", root]);
+			const nested = join(root, "apps", "web");
+			mkdirSync(nested, {recursive: true});
+
+			const fromRoot = yield* resolveRendezvous(root);
+			const fromNested = yield* resolveRendezvous(nested);
+			assert.strictEqual(fromNested.socketPath, fromRoot.socketPath);
+
+			yield* Effect.scoped(
+				Effect.gen(function* () {
+					// The root-seeded peer wins the bind and hosts the registry for the repo.
+					const hostContext = yield* Layer.build(hostOrDial(fromRoot.socketPath));
+					yield* Effect.sleep("300 millis"); // let the socket server bind + listen
+					yield* Context.get(hostContext, CrewTracker).announce({
+						role: "engineering-manager",
+						peer: "inbox://engineering-manager",
+						address: "inbox://engineering-manager",
+					});
+
+					// The nested-seeded peer resolves the SAME socket, so its bind loses with EADDRINUSE and
+					// it dials the host — the convergence the old hashing broke.
+					const dialContext = yield* Layer.build(hostOrDial(fromNested.socketPath));
+					const found = yield* Context.get(dialContext, CrewTracker).lookup("engineering-manager");
+
+					assert.strictEqual(found.length, 1);
+					assert.strictEqual(found[0]?.address, "inbox://engineering-manager");
+				}),
+			);
+
+			rmSync(root, {recursive: true, force: true});
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/ensure-tracker.test.ts
@@ -4,15 +4,16 @@
  * `ensureTrackerRunning` spawns the standing tracker as a detached process that serves the socket and
  * survives a second stand-up (which reuses it via EADDRINUSE rather than double-binding).
  */
+import {execFileSync} from "node:child_process";
 import {randomUUID} from "node:crypto";
-import {mkdtempSync, rmSync} from "node:fs";
+import {mkdtempSync, realpathSync, rmSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {NodeFileSystem, NodeSocket} from "@effect/platform-node";
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
-import {socketPathFor, TrackerRegistry, trackerServerLayer} from "../tracker/index.ts";
+import {rendezvousSocketPathFor, TrackerRegistry, trackerServerLayer} from "../tracker/index.ts";
 import {ensureTrackerRunning, tryBecomeTracker} from "./ensure-tracker.ts";
 
 const freshSocketPath = () => join(tmpdir(), `ensure-tracker-${randomUUID().slice(0, 8)}.sock`);
@@ -74,8 +75,11 @@ describe("ensureTrackerRunning — the detached standing process", () => {
 	it.live(
 		"starts a detached tracker that serves the socket and reuses it on a second stand-up",
 		() => {
+			// A real git repo, because the rendezvous is keyed on the repo's shared git dir (ADR 0197) —
+			// a non-repo dir has no canonical rendezvous and resolution correctly errors instead.
 			const projectDir = mkdtempSync(join(tmpdir(), "ensure-tracker-proj-"));
-			const socketPath = socketPathFor(projectDir);
+			execFileSync("git", ["init", "-q", projectDir]);
+			const socketPath = rendezvousSocketPathFor(realpathSync(join(projectDir, ".git")));
 			return Effect.gen(function* () {
 				// First stand-up: no tracker running -> a detached child is spawned and serves the socket.
 				const started = yield* ensureTrackerRunning(projectDir);

--- a/packages/pipeline-crew-mcp/src/standup/ensure-tracker.ts
+++ b/packages/pipeline-crew-mcp/src/standup/ensure-tracker.ts
@@ -1,10 +1,10 @@
 /**
- * standup/ensure-tracker — the launcher's ensure-tracker-running step: guarantee the per-project
- * tracker is up as a standing process before any crew session is stood up.
+ * standup/ensure-tracker — the launcher's ensure-tracker-running step: guarantee the repo's tracker is
+ * up as a standing process, at the canonical rendezvous (ADR 0197), before any crew session is stood up.
  *
  * The one non-obvious thing is first-peer-spawn (see `../tracker/server.ts`): a successful bind on
- * the per-project socket means WE started the tracker; an `EADDRINUSE` means one is already serving
- * this project and we reuse it. `tryBecomeTracker` classifies that bind outcome (the unit-tested
+ * the rendezvous socket means WE started the tracker; an `EADDRINUSE` means one is already serving
+ * this repo and we reuse it. `tryBecomeTracker` classifies that bind outcome (the unit-tested
  * core); `ensureTrackerRunning` detaches the tracker into its own OS process so it outlives the
  * launcher and every session the launcher spawns — the open-peer-surface reason a non-Claude peer
  * can announce when no crew session is up. This module wraps `../tracker/`'s primitives read-only;
@@ -17,7 +17,11 @@ import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Effect, type FileSystem, Layer, type Scope} from "effect";
 import * as Schema from "effect/Schema";
 import type {SocketServerError} from "effect/unstable/socket/SocketServer";
-import {socketPathFor, trackerServerLayer} from "../tracker/index.ts";
+import {
+	type RendezvousResolutionError,
+	rendezvousSocketPath,
+	trackerServerLayer,
+} from "../tracker/index.ts";
 
 /** Which side of the first-peer-spawn race a stand-up landed on. */
 export type TrackerBindOutcome = "started" | "already-serving";
@@ -71,9 +75,14 @@ export const tryBecomeTracker = (
  */
 export const runStandingTracker = (
 	projectRoot: string,
-): Effect.Effect<TrackerBindOutcome, SocketServerError, FileSystem.FileSystem> =>
+): Effect.Effect<
+	TrackerBindOutcome,
+	SocketServerError | RendezvousResolutionError,
+	FileSystem.FileSystem
+> =>
 	Effect.scoped(
-		tryBecomeTracker(socketPathFor(projectRoot)).pipe(
+		rendezvousSocketPath(projectRoot).pipe(
+			Effect.flatMap(tryBecomeTracker),
 			Effect.tap((outcome) => (outcome === "started" ? Effect.never : Effect.void)),
 		),
 	);
@@ -112,17 +121,17 @@ const awaitSocketServing = (
 const SELF_PATH = fileURLToPath(import.meta.url);
 
 /**
- * Ensure a standing tracker for `projectRoot` before stand-up. Spawns the standing tracker as a
+ * Ensure a standing tracker for `projectRoot`'s repo before stand-up. Spawns the standing tracker as a
  * detached child (`detached` + `unref` + ignored stdio) so it outlives this launcher process and
- * every session it spawns, then waits until the per-project socket is confirmed serving — whether by
+ * every session it spawns, then waits until the rendezvous socket is confirmed serving — whether by
  * the child we just spawned (start-if-absent) or one that was already up (reuse-if-present, the child
  * exits on `EADDRINUSE`). Returns the child pid and the socket path peers dial.
  */
 export const ensureTrackerRunning = (
 	projectRoot: string,
-): Effect.Effect<TrackerHandle, TrackerNotServingError> =>
+): Effect.Effect<TrackerHandle, TrackerNotServingError | RendezvousResolutionError> =>
 	Effect.gen(function* () {
-		const socketPath = socketPathFor(projectRoot);
+		const socketPath = yield* rendezvousSocketPath(projectRoot);
 		const child = spawn(process.execPath, [SELF_PATH, projectRoot], {
 			detached: true,
 			stdio: "ignore",

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -23,6 +23,7 @@ import {spawn} from "node:child_process";
 import {randomUUID} from "node:crypto";
 import {Effect, type FileSystem, type Path, Schema} from "effect";
 import {SESSION_SERVER_NAME} from "../crew/index.ts";
+import type {RendezvousResolutionError} from "../tracker/index.ts";
 import {
 	buildSessionBind,
 	type ChannelPluginNotAllowedError,
@@ -158,6 +159,7 @@ export type StandUpError =
 	| LaunchConfigError
 	| CliVersionAssertError
 	| TrackerNotServingError
+	| RendezvousResolutionError
 	| CrewSessionBinUnresolvableError
 	| CrewServerNotRegisteredError
 	| ChannelPluginNotAllowedError
@@ -243,10 +245,10 @@ export interface StandUpInput {
 	readonly config?: Effect.Effect<LaunchConfig, LaunchConfigError>;
 	/** The installed-CLI-version reader the pin is asserted against. Default: the real `claude --version`. */
 	readonly readVersionOutput?: Effect.Effect<string, unknown>;
-	/** Start-or-reuse the per-project tracker. Default: `ensureTrackerRunning` (detached standing process). */
+	/** Start-or-reuse the repo's tracker at its canonical rendezvous. Default: `ensureTrackerRunning` (detached standing process). */
 	readonly ensureTracker?: (
 		projectRoot: string,
-	) => Effect.Effect<TrackerHandle, TrackerNotServingError>;
+	) => Effect.Effect<TrackerHandle, TrackerNotServingError | RendezvousResolutionError>;
 	/** Mints each engine instance's distinct id. Default: `randomUUID` (the generator sessions use at runtime). */
 	readonly instanceId?: () => string;
 	/** Resolve the tmux session windows open into — the caller's current session, else a created fallback.

--- a/packages/pipeline-crew-mcp/src/standup/single-role.ts
+++ b/packages/pipeline-crew-mcp/src/standup/single-role.ts
@@ -28,6 +28,7 @@ import {randomUUID} from "node:crypto";
 import {existsSync, readdirSync, rmSync} from "node:fs";
 import {Effect, type FileSystem, type Path, Schema} from "effect";
 import {type CrewRole, inboxSocketFor, kindOf, SESSION_SERVER_NAME} from "../crew/index.ts";
+import type {RendezvousResolutionError} from "../tracker/index.ts";
 import type {
 	ChannelPluginNotAllowedError,
 	CrewServerNotRegisteredError,
@@ -88,6 +89,7 @@ export type SpawnRoleError =
 	| LaunchConfigError
 	| CliVersionAssertError
 	| TrackerNotServingError
+	| RendezvousResolutionError
 	| CrewSessionBinUnresolvableError
 	| CrewServerNotRegisteredError
 	| ChannelPluginNotAllowedError
@@ -112,10 +114,10 @@ export interface SpawnRoleInput {
 	readonly config?: Effect.Effect<LaunchConfig, LaunchConfigError>;
 	/** The installed-CLI-version reader the pin is asserted against. Default: the real `claude --version`. */
 	readonly readVersionOutput?: Effect.Effect<string, unknown>;
-	/** Start-or-reuse the per-project tracker (idempotent — dials the running one). Default: `ensureTrackerRunning`. */
+	/** Start-or-reuse the repo's tracker at its canonical rendezvous (idempotent — dials the running one). Default: `ensureTrackerRunning`. */
 	readonly ensureTracker?: (
 		projectRoot: string,
-	) => Effect.Effect<TrackerHandle, TrackerNotServingError>;
+	) => Effect.Effect<TrackerHandle, TrackerNotServingError | RendezvousResolutionError>;
 	/** Mints the engine instance's distinct id. Default: `randomUUID`. */
 	readonly instanceId?: () => string;
 	/** Resolve the tmux session whose crew window the pane splits into. Default: the caller's current session, else the fallback. */

--- a/packages/pipeline-crew-mcp/src/tracker/index.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/index.ts
@@ -1,8 +1,9 @@
 /**
- * tracker/ — the control-plane registry: a standing `RpcServer` over a per-project unix socket
- * where peers announce their role + inbox, look each other up, and hold named role leases, all as
- * soft state that ages out on missed heartbeats. Registry only — it NEVER relays a message (that
- * is the peer/data-plane's job). Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ * tracker/ — the control-plane registry: a standing `RpcServer` at the canonical per-repo rendezvous
+ * (`./rendezvous.ts`, ADR 0197) where peers announce their role + inbox, look each other up, and hold
+ * named role leases, all as soft state that ages out on missed heartbeats. Registry only — it NEVER
+ * relays a message (that is the peer/data-plane's job). Generic (crew-agnostic); see the boundary note
+ * in `../index.ts`.
  */
 export {TrackerRegistry} from "./group.ts";
 export {TrackerHandlers} from "./handlers.ts";
@@ -14,9 +15,16 @@ export {
 	type RegistryState,
 } from "./registry-core.ts";
 export {
+	canonicalizeGitCommonDir,
+	type Rendezvous,
+	RendezvousResolutionError,
+	rendezvousSocketPath,
+	rendezvousSocketPathFor,
+	resolveRendezvous,
+} from "./rendezvous.ts";
+export {
 	isTrackerAddressInUse,
 	launchTracker,
 	reclaimStaleSocket,
-	socketPathFor,
 	trackerServerLayer,
 } from "./server.ts";

--- a/packages/pipeline-crew-mcp/src/tracker/rendezvous.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/rendezvous.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The canonical rendezvous (ADR 0197), proved against REAL git repos rather than a stubbed
+ * `rev-parse`: the whole decision rests on git's actual relative-vs-absolute `--git-common-dir`
+ * behavior across a main checkout, a nested subdirectory, and a linked worktree, so a fake would
+ * assert the belief instead of the platform.
+ *
+ * The convergence cases are the point. `repo` vs `repo/apps/web` is the literal split-bug scenario
+ * (`--git-common-dir` prints `../../.git` from the nested dir), and the linked worktree is the one
+ * that broke every prior candidate key — `--show-toplevel` and `--absolute-git-dir` both differ
+ * there, which is why ADR 0197 bans them.
+ */
+import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, realpathSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	canonicalizeGitCommonDir,
+	RendezvousResolutionError,
+	rendezvousSocketPathFor,
+	resolveRendezvous,
+} from "./rendezvous.ts";
+
+const git = (cwd: string, ...args: ReadonlyArray<string>): string =>
+	execFileSync("git", [...args], {cwd, encoding: "utf8"}).trim();
+
+/** A throwaway git repo with one commit — enough for `git worktree add` to have a base to branch from. */
+const makeRepo = (label: string): string => {
+	const root = realpathSync(mkdtempSync(join(tmpdir(), `rendezvous-${label}-`)));
+	execFileSync("git", ["init", "-q", "-b", "main", root]);
+	git(root, "config", "user.email", "test@example.invalid");
+	git(root, "config", "user.name", "Rendezvous Test");
+	git(root, "commit", "-q", "--allow-empty", "-m", "base");
+	return root;
+};
+
+describe("canonicalizeGitCommonDir — the relative-to-cwd trap (ADR 0197)", () => {
+	it("resolves the bare `.git` reading against the main checkout it was read from", () => {
+		assert.strictEqual(canonicalizeGitCommonDir(".git", "/repo"), "/repo/.git");
+	});
+	it("resolves a nested subdir's `../../.git` reading back to the SAME key", () => {
+		assert.strictEqual(canonicalizeGitCommonDir("../../.git", "/repo/apps/web"), "/repo/.git");
+	});
+	it("passes a worktree's already-absolute reading through unchanged", () => {
+		assert.strictEqual(canonicalizeGitCommonDir("/repo/.git", "/repo/.wt/lane-a"), "/repo/.git");
+	});
+});
+
+describe("resolveRendezvous — one repo, one rendezvous", () => {
+	it.effect("converges from the repo root, a nested subdir, and a linked worktree", () =>
+		Effect.gen(function* () {
+			const root = makeRepo("converge");
+			const nested = join(root, "apps", "web");
+			mkdirSync(nested, {recursive: true});
+			const worktree = join(root, ".wt", "lane-a");
+			git(root, "worktree", "add", "-q", "-b", "lane-a", worktree);
+
+			// The reading really is relative-to-cwd and really does differ — the trap this module handles.
+			assert.strictEqual(git(root, "rev-parse", "--git-common-dir"), ".git");
+			assert.strictEqual(git(nested, "rev-parse", "--git-common-dir"), "../../.git");
+
+			// …and `--absolute-git-dir` really does split in a worktree, which is why it is banned.
+			assert.notStrictEqual(
+				git(worktree, "rev-parse", "--absolute-git-dir"),
+				git(root, "rev-parse", "--absolute-git-dir"),
+			);
+
+			const fromRoot = yield* resolveRendezvous(root);
+			const fromNested = yield* resolveRendezvous(nested);
+			const fromWorktree = yield* resolveRendezvous(worktree);
+
+			assert.strictEqual(fromRoot.repoKey, realpathSync(join(root, ".git")));
+			assert.strictEqual(fromNested.repoKey, fromRoot.repoKey);
+			assert.strictEqual(fromWorktree.repoKey, fromRoot.repoKey);
+			assert.strictEqual(fromNested.socketPath, fromRoot.socketPath);
+			assert.strictEqual(fromWorktree.socketPath, fromRoot.socketPath);
+			assert.match(fromRoot.socketPath, /kampus-crew-[0-9a-f]{16}\.sock$/);
+
+			rmSync(root, {recursive: true, force: true});
+		}),
+	);
+
+	it.effect("keeps two different repos on different rendezvous", () =>
+		Effect.gen(function* () {
+			const a = makeRepo("iso-a");
+			const b = makeRepo("iso-b");
+
+			const rendezvousA = yield* resolveRendezvous(a);
+			const rendezvousB = yield* resolveRendezvous(b);
+
+			assert.notStrictEqual(rendezvousA.repoKey, rendezvousB.repoKey);
+			assert.notStrictEqual(rendezvousA.socketPath, rendezvousB.socketPath);
+
+			rmSync(a, {recursive: true, force: true});
+			rmSync(b, {recursive: true, force: true});
+		}),
+	);
+
+	it.effect("errors on a non-repo dir rather than falling back to a cwd-derived path", () =>
+		Effect.gen(function* () {
+			// `/` is outside any work tree on a test machine, so discovery has nothing to find.
+			const failure = yield* Effect.flip(resolveRendezvous("/"));
+			assert.instanceOf(failure, RendezvousResolutionError);
+			assert.strictEqual(failure.startDir, "/");
+		}),
+	);
+});
+
+describe("rendezvousSocketPathFor — the key is the only input", () => {
+	it("honors XDG_RUNTIME_DIR when set", () => {
+		const previous = process.env.XDG_RUNTIME_DIR;
+		process.env.XDG_RUNTIME_DIR = "/run/user/501";
+		const socketPath = rendezvousSocketPathFor("/repo/.git");
+		if (previous === undefined) delete process.env.XDG_RUNTIME_DIR;
+		else process.env.XDG_RUNTIME_DIR = previous;
+		assert.match(socketPath, /^\/run\/user\/501\/kampus-crew-[0-9a-f]{16}\.sock$/);
+	});
+});

--- a/packages/pipeline-crew-mcp/src/tracker/rendezvous.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/rendezvous.ts
@@ -1,0 +1,122 @@
+/**
+ * tracker/rendezvous — how a crew peer finds the ONE registry for its repo.
+ *
+ * The rendezvous is per-repo and canonical: keyed on the main checkout's SHARED git dir
+ * (`git rev-parse --git-common-dir`), so the main checkout, any nested subdirectory of it, and every
+ * `isolation:worktree` linked worktree of it all resolve to the same socket, while different repos on
+ * one machine stay isolated. See ADR 0197.
+ *
+ * The one non-obvious thing, and the trap the whole module is shaped around: `--git-common-dir` is
+ * printed RELATIVE TO THE CWD IT RAN IN. From the repo root it prints `.git`; from `repo/apps/web` it
+ * prints `../../.git`; from a linked worktree it prints an absolute path. So the raw string is not a
+ * key — it must be resolved against that same cwd and symlink-canonicalized before it is hashed, or
+ * the exact `repo` vs `repo/apps/web` split this module exists to kill comes straight back.
+ *
+ * ADR 0197 left open how much of the surrounding ceremony a canonical rendezvous retires. The finding
+ * is: only the cwd-derived hashing. First-peer host-or-dial and stale-socket reclaim (`./server.ts`)
+ * both SURVIVE, because neither was arbitrating *which* socket — they arbitrate a unix bind. Two
+ * panes still start concurrently and still contend for one now-agreed path (`EADDRINUSE` is what
+ * makes the second dial instead of die), and a SIGKILL'd host still strands its socket file. Canonical
+ * addressing makes that contention converge on one registry; it does not remove it.
+ */
+import {execFileSync} from "node:child_process";
+import {createHash} from "node:crypto";
+import {existsSync, realpathSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {isAbsolute, join, normalize, resolve} from "node:path";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+
+/** A repo has no canonical rendezvous when git can't name its shared dir — an error, never a fallback (ADR 0197). */
+export class RendezvousResolutionError extends Schema.TaggedErrorClass<RendezvousResolutionError>()(
+	"@kampus/pipeline-crew-mcp/tracker/RendezvousResolutionError",
+	{startDir: Schema.String, reason: Schema.String},
+) {}
+
+/** The canonical meeting point for one repo: the key every peer of it agrees on, and the socket it serves. */
+export interface Rendezvous {
+	/** The main checkout's shared git dir, absolute and symlink-resolved — the identity of the repo. */
+	readonly repoKey: string;
+	/** The unix socket derived from `repoKey` — where the tracker for this repo listens. */
+	readonly socketPath: string;
+}
+
+/**
+ * Turn a raw `git rev-parse --git-common-dir` reading into the canonical repo key: resolve it against
+ * the cwd git ran in (the reading is relative to exactly that dir), then follow symlinks so the main
+ * checkout and its worktrees land on one byte-identical string. A nonexistent path can't be
+ * `realpath`'d, so it degrades to a plain normalize rather than throwing — resolution failure is the
+ * caller's error channel, not this pure boundary's.
+ */
+export const canonicalizeGitCommonDir = (rawGitCommonDir: string, cwd: string): string => {
+	const absolute = isAbsolute(rawGitCommonDir) ? rawGitCommonDir : resolve(cwd, rawGitCommonDir);
+	return existsSync(absolute) ? realpathSync(absolute) : normalize(absolute);
+};
+
+/**
+ * The rendezvous socket for a canonical `repoKey`. Hashed rather than embedded so the path stays under
+ * the ~104-char unix socket limit; honors `XDG_RUNTIME_DIR`, falling back to the OS temp dir.
+ */
+export const rendezvousSocketPathFor = (repoKey: string): string => {
+	const digest = createHash("sha256").update(repoKey).digest("hex").slice(0, 16);
+	const base = process.env.XDG_RUNTIME_DIR ?? tmpdir();
+	return join(base, `kampus-crew-${digest}.sock`);
+};
+
+/** Ask git, from `startDir`, for this repo's shared git dir. */
+const readGitCommonDir = (startDir: string): Effect.Effect<string, RendezvousResolutionError> =>
+	Effect.try({
+		try: () =>
+			execFileSync("git", ["rev-parse", "--git-common-dir"], {
+				cwd: startDir,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+			}).trim(),
+		catch: (cause) =>
+			new RendezvousResolutionError({
+				startDir,
+				reason: `git rev-parse --git-common-dir failed: ${String(cause)}`,
+			}),
+	}).pipe(
+		Effect.flatMap((reading) =>
+			reading.length > 0
+				? Effect.succeed(reading)
+				: Effect.fail(
+						new RendezvousResolutionError({
+							startDir,
+							reason: "git rev-parse --git-common-dir printed nothing",
+						}),
+					),
+		),
+	);
+
+// Resolved once per start dir and held for the process lifetime (ADR 0197: resolve once, never
+// re-derive from a later cwd) — a crew process that later chdirs still rendezvous where it started.
+const resolvedRendezvous = new Map<string, Rendezvous>();
+
+/**
+ * Resolve the canonical rendezvous for the repo containing `startDir`. `startDir` seeds git's repo
+ * discovery only — it is never itself the key, so two callers passing `repo` and `repo/apps/web` (or a
+ * linked worktree of either) get the same `repoKey` and the same socket.
+ */
+export const resolveRendezvous = (
+	startDir: string,
+): Effect.Effect<Rendezvous, RendezvousResolutionError> =>
+	Effect.suspend(() => {
+		const cached = resolvedRendezvous.get(startDir);
+		if (cached !== undefined) return Effect.succeed(cached);
+		return readGitCommonDir(startDir).pipe(
+			Effect.map((reading) => {
+				const repoKey = canonicalizeGitCommonDir(reading, startDir);
+				const rendezvous: Rendezvous = {repoKey, socketPath: rendezvousSocketPathFor(repoKey)};
+				resolvedRendezvous.set(startDir, rendezvous);
+				return rendezvous;
+			}),
+		);
+	});
+
+/** The rendezvous socket for the repo containing `startDir` — the common case of `resolveRendezvous`. */
+export const rendezvousSocketPath = (
+	startDir: string,
+): Effect.Effect<string, RendezvousResolutionError> =>
+	resolveRendezvous(startDir).pipe(Effect.map((rendezvous) => rendezvous.socketPath));

--- a/packages/pipeline-crew-mcp/src/tracker/server.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.test.ts
@@ -14,20 +14,24 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
 import {TrackerRegistry} from "./group.ts";
-import {isTrackerAddressInUse, socketPathFor, trackerServerLayer} from "./server.ts";
+import {rendezvousSocketPathFor} from "./rendezvous.ts";
+import {isTrackerAddressInUse, trackerServerLayer} from "./server.ts";
 
 // trackerServerLayer's stale-socket reclaim now reaches disk through the FileSystem seam, so provide
 // the real Node FileSystem — the layer builds in-test exactly as under the bin's NodeServices.layer.
 const hostedTracker = (socketPath: string) =>
 	trackerServerLayer(socketPath).pipe(Layer.provide(NodeFileSystem.layer));
 
-describe("tracker socket path — per-project derivation", () => {
-	it("is deterministic and normalizes the root", () => {
-		assert.strictEqual(socketPathFor("/some/project"), socketPathFor("/some/project/"));
+describe("tracker socket path — derived from the canonical repo key", () => {
+	it("is deterministic in the repo key", () => {
+		assert.strictEqual(
+			rendezvousSocketPathFor("/repo/.git"),
+			rendezvousSocketPathFor("/repo/.git"),
+		);
 	});
-	it("differs across projects and is a well-formed .sock path", () => {
-		assert.notStrictEqual(socketPathFor("/project/a"), socketPathFor("/project/b"));
-		assert.match(socketPathFor("/project/a"), /kampus-crew-[0-9a-f]{16}\.sock$/);
+	it("differs across repos and is a well-formed .sock path", () => {
+		assert.notStrictEqual(rendezvousSocketPathFor("/a/.git"), rendezvousSocketPathFor("/b/.git"));
+		assert.match(rendezvousSocketPathFor("/a/.git"), /kampus-crew-[0-9a-f]{16}\.sock$/);
 	});
 });
 

--- a/packages/pipeline-crew-mcp/src/tracker/server.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/server.ts
@@ -3,9 +3,9 @@
  * `trackerServerLayer` bind (with stale-socket reclamation), the standalone `launchTracker` entry,
  * and the `EADDRINUSE` detector (`isTrackerAddressInUse`) the first-peer-spawn dial fallback keys on.
  *
- * The socket path is derived deterministically from the project root (`socketPathFor`), so every
- * peer of one project rendezvous on the same socket while different projects stay isolated — the
- * "per-project socket". The tracker is brought up by whichever peer needs it first (first-peer-
+ * The socket path is the canonical per-repo rendezvous (`./rendezvous.ts`, ADR 0197), so every peer of
+ * one repo — main checkout, nested subdir, or linked worktree — meets on the same socket while
+ * different repos stay isolated. The tracker is brought up by whichever peer needs it first (first-peer-
  * spawn): the first bind wins the socket; a later peer's bind gets `EADDRINUSE`, the signal that a
  * tracker is already serving this project, and it connects as a client instead. That host-or-dial
  * wiring — which combines this server layer with the crew's registry client — lives in
@@ -23,10 +23,7 @@
  * The served surface is `TrackerRegistry` — registry kinds only (see `./group.ts`); the tracker
  * has no handler for any message-relay kind, so it structurally cannot relay a message.
  */
-import {createHash} from "node:crypto";
 import {connect} from "node:net";
-import {tmpdir} from "node:os";
-import {join, resolve} from "node:path";
 import {NodeSocketServer} from "@effect/platform-node";
 import {Cause, Effect, FileSystem, Layer, Option} from "effect";
 import {RpcSerialization, RpcServer} from "effect/unstable/rpc";
@@ -34,23 +31,7 @@ import {SocketServerError} from "effect/unstable/socket/SocketServer";
 import {TrackerRegistry} from "./group.ts";
 import {TrackerHandlers} from "./handlers.ts";
 import {RegistryLive} from "./registry.ts";
-
-/**
- * The per-project unix socket path for `projectRoot`. Deterministic (same project ⇒ same socket)
- * yet collision-free across projects, and short enough to stay under the ~104-char unix socket
- * path limit by hashing the root rather than embedding it. Honors `XDG_RUNTIME_DIR` when set,
- * falling back to the OS temp dir.
- *
- * A pure synchronous boundary derivation, so its `node:os`/`node:path`/`node:crypto` calls stay raw
- * per the platform-access bright line (.patterns/effect-platform-access.md): `tmpdir()` is a temp-*path*
- * boundary read (never a created temp dir), and `createHash`/`join`/`resolve` operate on plain strings
- * here — none is woven through an Effect service method, so there is nothing to substitute.
- */
-export const socketPathFor = (projectRoot: string): string => {
-	const digest = createHash("sha256").update(resolve(projectRoot)).digest("hex").slice(0, 16);
-	const base = process.env.XDG_RUNTIME_DIR ?? tmpdir();
-	return join(base, `kampus-crew-${digest}.sock`);
-};
+import {resolveRendezvous} from "./rendezvous.ts";
 
 /**
  * Reclaim a *stale* unix socket at `socketPath` before a bind: unlink the file iff a connect to it
@@ -125,12 +106,13 @@ const boundTrackerServerLayer = (socketPath: string) =>
 	);
 
 /**
- * Standalone tracker entry: launch a dedicated tracker for `projectRoot` and keep it running until
- * interrupted (`Layer.launch` builds the server layer and blocks, closing it on teardown). Drives
- * the bin's `tracker` subcommand — the explicit way to stand a project's tracker up decoupled from
- * any role session. It fails fast with a `SocketServerError` when the socket is already bound
- * (`isTrackerAddressInUse`), the signal that a tracker is already up for this project; the caller
- * decides whether that is a clean no-op (the subcommand treats it as "already serving").
+ * Standalone tracker entry: launch a dedicated tracker at the canonical rendezvous for the repo
+ * containing `projectRoot` and keep it running until interrupted (`Layer.launch` builds the server
+ * layer and blocks, closing it on teardown). Drives the bin's `tracker` subcommand — the explicit way
+ * to stand a repo's tracker up decoupled from any role session. It fails fast with a
+ * `SocketServerError` when the socket is already bound (`isTrackerAddressInUse`), the signal that a
+ * tracker is already up for this repo; the caller decides whether that is a clean no-op (the
+ * subcommand treats it as "already serving").
  *
  * A live crew session does NOT use this blocking entry — it hosts the tracker as a scoped layer via
  * `crewTrackerHostOrDialLayer` (first-peer-spawn), so the server runs alongside the session rather
@@ -139,7 +121,9 @@ const boundTrackerServerLayer = (socketPath: string) =>
 export const launchTracker = (
 	projectRoot: string,
 ): Effect.Effect<never, unknown, FileSystem.FileSystem> =>
-	Layer.launch(trackerServerLayer(socketPathFor(projectRoot)));
+	resolveRendezvous(projectRoot).pipe(
+		Effect.flatMap((rendezvous) => Layer.launch(trackerServerLayer(rendezvous.socketPath))),
+	);
 
 /**
  * Is this cause a tracker-socket bind that lost the race — an `EADDRINUSE` raised while opening the


### PR DESCRIPTION
Fixes #3627.

Implements the binding constraints of **ADR 0197** — *the crew rendezvous is per-repo canonical, keyed on the main checkout's shared git dir* (the founder's Option B ruling on #3626, banked in #3747). Child of epic #3624.

## What changed

`socketPathFor(projectRoot)` hashed a **caller-supplied path**, so `socketPathFor(repo)` and `socketPathFor(repo/apps/web)` produced two different sockets and two disjoint registries. Each pane registered successfully, saw an empty lookup, and was indistinguishable from a pane that was simply alone — silently channel-deaf. That function is **retired outright**, not deprecated.

New module `packages/pipeline-crew-mcp/src/tracker/rendezvous.ts` resolves the rendezvous from `git rev-parse --git-common-dir`, normalized to an absolute symlink-resolved path, and derives the socket from **that** key. `projectRoot` survives only as a seed for git's repo discovery — it is never the key.

Every caller is migrated: `tracker/server.ts` (`launchTracker`), `tracker/index.ts`, `standup/ensure-tracker.ts`, `crew/session.ts` (`peerSocketSubstrate`), plus the `StandUpError` / `SpawnRoleError` unions and the `ensureTracker` injection seams in `standup/orchestrate.ts` and `standup/single-role.ts`. Docs follow: package README, `docs/tutorial.md`, and the `--project-root` flag description.

## The refinement the ADR's table alone under-specifies

`--git-common-dir` is **relative to the cwd it ran in**, not literally `.git`:

| run from | prints |
|---|---|
| repo root | `.git` |
| `repo/apps/web` | `../../.git` |
| linked worktree | absolute `/…/repo/.git` |

So the raw string is **not** a key. `canonicalizeGitCommonDir(raw, cwd)` resolves it against that same cwd and then `realpath`s it. A naive string comparison — or assuming the literal `.git` — reintroduces the exact `repo` vs `repo/apps/web` split this work exists to kill, which is why the nested-subdirectory case is covered explicitly in tests.

`--absolute-git-dir` is **not** used and is banned by ADR 0197: inside a worktree it returns that worktree's own private `.git/worktrees/<name>`, so it looks like a tidy fix for the relative-path problem while silently re-splitting every `isolation:worktree` lane. The test suite asserts that divergence directly, so the ban is enforced by a failing test rather than a comment.

Failure to resolve a repo is an explicit `RendezvousResolutionError` on the error channel — never a fallback to a cwd-derived or machine-global path.

## Tests — real git repos, not a stubbed `rev-parse`

The whole decision rests on git's actual behavior, so a fake would assert the belief instead of the platform. `tracker/rendezvous.test.ts` and `crew/tracker.rendezvous.socket.test.ts` create real repos with `git init` and real linked worktrees with `git worktree add`:

- repo root, nested `apps/web`, and a linked worktree all resolve to **one** `repoKey` and **one** socket;
- the readings really do differ (`.git` vs `../../.git`) and `--absolute-git-dir` really does split in a worktree;
- two different repos resolve to **different** rendezvous (cross-repo isolation);
- a non-repo dir errors instead of falling back;
- **end-to-end over the real unix socket:** a peer announced from the repo root is discovered by a peer seeded from `apps/web`, proving the two cwds share one live registry. This is the direct regression test for the original failure.

Package suite: 285 tests / 44 files green. Workspace `pnpm typecheck` and `pnpm lint:worktree` clean.

## Implementation finding — what the new topology does NOT retire

ADR 0197 retires the first-peer host-or-dial race and stale-socket reclaim *"to the extent the new topology allows"*, and explicitly leaves how much survives as a finding for this slice. **The finding: only the cwd-derived hashing is retired. Both of those survive, and removing them would be a regression.**

Neither was arbitrating *which* socket — they arbitrate a **unix bind**, which canonical addressing does not touch:

- **host-or-dial / `EADDRINUSE`** — two panes still start concurrently and still contend for one now-agreed path. `EADDRINUSE` is what makes the second peer dial instead of die. Canonical addressing makes that contention *converge on one registry*; it does not remove the contention.
- **stale-socket reclaim** — a `SIGKILL`'d host still strands its socket file on disk regardless of how the path was derived (node only unlinks on a clean `close()`). Unaffected by addressing.

This is recorded in the `rendezvous.ts` docblock so it is not re-opened as unexamined leftover ceremony. Reporting rather than forcing it, per the ADR.

## Sibling lanes

Not absorbed: #3628 (attached-inbox liveness), #3629 (reap orphaned procs), #3630 (channel doctor).

One note for **#3630 (channel doctor)**: `resolveRendezvous` gives the doctor a single canonical answer to "which rendezvous *should* this pane be on?", which previously had no well-defined answer. A doctor check comparing a live pane's socket against the resolved rendezvous is now trivial to express. It does not make #3630 redundant — liveness, orphan detection, and the operator-facing report are all still open.

## Follow-up recommendations (deliberately NOT done here)

- No file under `claude-plugins/*/skills/` or `claude-plugins/*/agents/` is touched — five PRs on those paths are banked and unmerged.
- ADR 0197's Records section routes a `.glossary/TERMS.md` entry for **crew rendezvous** to a follow-up `report`; that stays out of this diff.

Ships behind no flag — `**Containment:** exempt` (internal pipeline tooling, no kamp.us user surface).