### PR TITLE
fix(pipeline-crew-mcp): serve a spec-valid `channel_kinds` inputSchema + fence the shape at boot (#3753)

### DIFF
--- a/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
+++ b/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
@@ -64,3 +64,10 @@ with no intervention (steady state: an idle role's channel is long up before wor
 The flailing — reading `channel-server.ts`, running the session binary by hand — is exactly the
 ~44k-token burn this guard exists to prevent (#3482). Give the connect a moment, look again,
 then proceed.
+
+**The wait is bounded, and a still-empty toolset is a REPORT, not a longer wait.** A permanent
+failure looks identical to the boot window from a seat, so waiting patiently on one burns a whole
+session silently — that is exactly what #3753 did (one spec-invalid tool `inputSchema` made the
+CLI discard the server's entire `tools/list`, so no seat ever saw any channel tool). If the tools
+are still absent after a re-check or two, stop waiting and **file it** (the `report` skill) —
+still without diagnosing infra yourself.

--- a/packages/pipeline-crew-mcp/README.md
+++ b/packages/pipeline-crew-mcp/README.md
@@ -39,7 +39,10 @@ A small, layered substrate split into a **generic core** and one **crew-coupled*
   and the two-keyspace claim/lease store (presence leases keyed by peer, resource claims keyed
   by resource — ADR 0191).
 - **`src/peer/`** — a p2p participant: dials, holds connections, relays messages over the protocol.
-- **`src/edge/`** — the MCP channel edge: exposes the substrate to an MCP client as channels.
+- **`src/edge/`** — the MCP channel edge: exposes the substrate to an MCP client as channels, and
+  fences at boot that every tool it registers generates a spec-valid top-level `{"type":"object"}`
+  `inputSchema` — a client rejects the *whole* `tools/list` response on one bad schema, so without
+  the fence a single malformed tool silently zeroes every seat's channel tools (#3753).
 - **`src/crew/`** — the only crew-coupled module and the composition root: the Role enum (the
   four-role flat topology), the seam catalog (each role's crew interactions mapped over
   `protocol/`), the wiring that composes tracker + peer + edge into a per-role channel server

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -38,6 +38,7 @@ import {NodeStdio} from "@effect/platform-node";
 import {Effect, type FileSystem, Layer} from "effect";
 import {type McpSchema, McpServer} from "effect/unstable/ai";
 import {
+	assertToolSchemas,
 	ChannelClaim,
 	ChannelDescribe,
 	ChannelSend,
@@ -207,6 +208,10 @@ export const assembleCrewSession = <RIn, RSub = never>(
 	// BEFORE the run-loop-forking transport is built, so ChannelSend below is a zero-async binding.
 	Layer.unwrap(
 		Effect.gen(function* () {
+			// Startup invariant (#3753): every tool this session will register must generate a spec-valid
+			// top-level `{"type":"object"}` inputSchema. A client rejects the WHOLE tools/list response on
+			// one bad schema, so the failure mode without this fence is a silently tool-less session.
+			yield* assertToolSchemas([ChannelToolkit, ClaimToolkit, KindsToolkit]);
 			const channel = yield* makeCrewChannel({role: config.role, address});
 			// Startup invariant (#3622): resolve the full discoverable channel contract BEFORE serving.
 			// A shared kind set that can't be fully resolved to a shape fails the build HERE (on the boot

--- a/packages/pipeline-crew-mcp/src/edge/index.ts
+++ b/packages/pipeline-crew-mcp/src/edge/index.ts
@@ -40,3 +40,9 @@ export {
 	SendChannelMessage,
 } from "./send-tool.ts";
 export {channelServerLayer} from "./server.ts";
+export {
+	assertToolSchemas,
+	findInvalidToolSchemas,
+	InvalidToolSchemaError,
+	type ToolSchema,
+} from "./tool-schema-guard.ts";

--- a/packages/pipeline-crew-mcp/src/edge/kinds-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/kinds-tool.test.ts
@@ -96,6 +96,17 @@ describe("edge/kinds-tool — the channel_kinds discovery tool (#3622)", () => {
 		}),
 	);
 
+	// #3753: the SERVED inputSchema, read off the wire — a non-object top level makes a client discard
+	// the whole tools/list response, taking channel_send and channel_claim with it.
+	it.effect("serves channel_kinds with a spec-valid top-level object inputSchema", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const tools = yield* client["tools/list"]({});
+			const kinds = tools.tools.find((t) => t.name === "channel_kinds");
+			assert.deepStrictEqual(kinds?.inputSchema, {type: "object", additionalProperties: false});
+		}),
+	);
+
 	it.effect("channel_kinds returns the resolvable contract (kind shapes + role seams)", () =>
 		Effect.gen(function* () {
 			const {client} = yield* makeInitializedClient;

--- a/packages/pipeline-crew-mcp/src/edge/kinds-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/kinds-tool.ts
@@ -46,13 +46,23 @@ export class ChannelDescribe extends Context.Service<
 	}
 >()("@kampus/pipeline-crew-mcp/edge/ChannelDescribe") {}
 
-/** The one describe tool: no arguments in, the full discoverable channel contract out. */
+/**
+ * The one describe tool: no arguments in, the full discoverable channel contract out.
+ *
+ * `parameters` is effect-smol's `Tool.EmptyParams`, NOT `Schema.Struct({})`: the emitter renders an
+ * object representation with zero property AND zero index signatures as
+ * `{"anyOf":[{"type":"object"},{"type":"array"}]}` (`effect/src/internal/schema/representation.ts`,
+ * the `Objects` case), which is not the top-level `{"type":"object"}` the MCP spec requires — and the
+ * CLI rejects the WHOLE `ListToolsResult` on it, zeroing `channel_send`/`channel_claim` too (#3753).
+ * `Tool.EmptyParams` is the documented no-parameter schema (`effect/src/unstable/ai/Tool.ts`), a
+ * `Record(String, Never)` whose index signature emits `{"type":"object","additionalProperties":false}`.
+ */
 export const DescribeChannelKinds = Tool.make("channel_kinds", {
 	description:
 		"Resolve the crew channel contract BEFORE sending: every message kind's payload shape (JSON " +
 		"Schema) and each role's sanctioned send/receive kinds. Read this to build a valid `channel_send` " +
 		"body instead of discovering the shape from a send-time reject.",
-	parameters: Schema.Struct({}),
+	parameters: Tool.EmptyParams,
 	success: ChannelContractView,
 });
 

--- a/packages/pipeline-crew-mcp/src/edge/server.ts
+++ b/packages/pipeline-crew-mcp/src/edge/server.ts
@@ -13,10 +13,15 @@ import {Layer} from "effect";
 import {McpServer} from "effect/unstable/ai";
 import {channelExperimentalCapability} from "./mcp-channel.ts";
 import {ChannelToolkit, channelToolHandlers} from "./send-tool.ts";
+import {assertToolSchemas} from "./tool-schema-guard.ts";
 
 export const channelServerLayer = (options: {readonly name: string; readonly version: string}) =>
-	McpServer.toolkit(ChannelToolkit).pipe(
-		Layer.provide(channelToolHandlers),
+	Layer.mergeAll(
+		// Boot fence (#3753): a spec-invalid inputSchema makes the client discard the whole toolset, so
+		// assert the shape before the transport forks its serve loop rather than serve a dead toolset.
+		Layer.effectDiscard(assertToolSchemas([ChannelToolkit])),
+		McpServer.toolkit(ChannelToolkit).pipe(Layer.provide(channelToolHandlers)),
+	).pipe(
 		Layer.provide(
 			McpServer.layerStdio({
 				name: options.name,

--- a/packages/pipeline-crew-mcp/src/edge/tool-schema-guard.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/tool-schema-guard.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The boot fence over generated MCP `inputSchema` shapes (#3753): a tool whose schema is not a
+ * top-level `{"type":"object"}` is named and fails the build, because a client rejects the entire
+ * tools/list response on one bad schema and every other tool goes with it.
+ *
+ * The invalid fixture is `Schema.Struct({})` — the literal defect this fences: effect-smol renders an
+ * object with zero property AND zero index signatures as `{"anyOf":[{"type":"object"},{"type":"array"}]}`
+ * (`effect/src/internal/schema/representation.ts`, the `Objects` case), so the fixture stays honest
+ * against the real emitter instead of a hand-written schema the emitter would never produce.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Schema} from "effect";
+import {Tool, Toolkit} from "effect/unstable/ai";
+import {ClaimToolkit} from "./claim-tool.ts";
+import {KindsToolkit} from "./kinds-tool.ts";
+import {ChannelToolkit} from "./send-tool.ts";
+import {assertToolSchemas, findInvalidToolSchemas} from "./tool-schema-guard.ts";
+
+const InvalidToolkit = Toolkit.make(
+	Tool.make("spec_invalid_tool", {parameters: Schema.Struct({}), success: Schema.String}),
+);
+
+describe("edge/tool-schema-guard — the boot fence on generated inputSchema (#3753)", () => {
+	it("passes every tool the crew session registers", () => {
+		assert.deepStrictEqual(
+			findInvalidToolSchemas([ChannelToolkit, ClaimToolkit, KindsToolkit]),
+			[],
+		);
+	});
+
+	it("channel_kinds generates a top-level object schema", () => {
+		assert.deepStrictEqual(Tool.getJsonSchema(KindsToolkit.tools.channel_kinds), {
+			type: "object",
+			additionalProperties: false,
+		});
+	});
+
+	it("flags a tool whose generated schema is not a top-level object", () => {
+		const invalid = findInvalidToolSchemas([InvalidToolkit]);
+		assert.deepStrictEqual(
+			invalid.map(({tool}) => tool),
+			["spec_invalid_tool"],
+		);
+		assert.deepStrictEqual(invalid[0]?.inputSchema, {
+			anyOf: [{type: "object"}, {type: "array"}],
+		});
+	});
+
+	it.effect("fails loudly, naming the offending tool", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(assertToolSchemas([KindsToolkit, InvalidToolkit]));
+			assert.deepStrictEqual([...error.tools], ["spec_invalid_tool"]);
+			assert.include(error.message, "spec_invalid_tool");
+			assert.include(error.message, '{"anyOf":[{"type":"object"},{"type":"array"}]}');
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/edge/tool-schema-guard.ts
+++ b/packages/pipeline-crew-mcp/src/edge/tool-schema-guard.ts
@@ -1,0 +1,69 @@
+/**
+ * edge/tool-schema-guard — the boot fence over every registered tool's GENERATED `inputSchema`.
+ * Generic (crew-agnostic); see the boundary note in `../index.ts`.
+ *
+ * The MCP spec requires a tool's `inputSchema` to be a top-level `{"type":"object"}`, and the Claude
+ * Code CLI validates the entire `ListToolsResult`: ONE spec-invalid tool schema makes the client
+ * reject the whole response, so every OTHER tool on the server is zeroed as collateral and nothing
+ * fail-louds anywhere — the silent all-seats channel outage of #3753. This fence turns that class
+ * from "every seat silently boots with no channel tools" into "the server refuses to serve, naming
+ * the offending tool", and it asserts the SAME schema the server serves (`Tool.getJsonSchema`, the
+ * generator `McpServer` itself calls) rather than re-deriving the shape.
+ */
+import {Effect, Schema} from "effect";
+import {Tool, type Toolkit} from "effect/unstable/ai";
+
+/** One registered tool's generated `inputSchema`, as the fence read it. */
+export interface ToolSchema {
+	readonly tool: string;
+	readonly inputSchema: unknown;
+}
+
+/** One or more registered tools generate an `inputSchema` that is not a top-level object. */
+export class InvalidToolSchemaError extends Schema.TaggedErrorClass<InvalidToolSchemaError>()(
+	"@kampus/pipeline-crew-mcp/edge/InvalidToolSchemaError",
+	{
+		tools: Schema.Array(Schema.String),
+		detail: Schema.String,
+	},
+) {
+	override get message(): string {
+		return (
+			`spec-invalid MCP inputSchema on ${this.tools.join(", ")} — the MCP spec requires a ` +
+			`top-level {"type":"object"}, and a client rejects the WHOLE tools/list response on one bad ` +
+			`schema, zeroing every other tool (#3753). Generated: ${this.detail}`
+		);
+	}
+}
+
+/**
+ * The offending tools across `toolkits`, in registration order. Pure and reading the SAME generator
+ * the server serves (`Tool.getJsonSchema`) — so the fence is testable against a deliberately invalid
+ * tool without standing up a server or a transport.
+ */
+export const findInvalidToolSchemas = (
+	toolkits: ReadonlyArray<Toolkit.Any>,
+): ReadonlyArray<ToolSchema> =>
+	toolkits.flatMap((toolkit) =>
+		Object.values(toolkit.tools)
+			.map((tool) => ({tool: tool.name, inputSchema: Tool.getJsonSchema(tool)}))
+			.filter(({inputSchema}) => (inputSchema as {readonly type?: unknown}).type !== "object"),
+	);
+
+/**
+ * Assert every tool in `toolkits` serves a spec-valid `inputSchema`. Run on the boot critical path
+ * (before the transport forks its serve loop) so a violation aborts the build instead of shipping a
+ * server whose toolset the client will silently discard.
+ */
+export const assertToolSchemas = (
+	toolkits: ReadonlyArray<Toolkit.Any>,
+): Effect.Effect<void, InvalidToolSchemaError> => {
+	const invalid = findInvalidToolSchemas(toolkits);
+	if (invalid.length === 0) return Effect.void;
+	return Effect.fail(
+		new InvalidToolSchemaError({
+			tools: invalid.map(({tool}) => tool),
+			detail: invalid.map((v) => `${v.tool}=${JSON.stringify(v.inputSchema)}`).join(" · "),
+		}),
+	);
+};


### PR DESCRIPTION
Fixes #3753

## What broke

`DescribeChannelKinds` declared `parameters: Schema.Struct({})`. effect-smol's JSON-schema emitter
renders that as `{"anyOf":[{"type":"object"},{"type":"array"}]}` — not the top-level
`{"type":"object"}` the MCP spec requires — so the Claude Code CLI rejected the **whole**
`ListToolsResult` and `channel_send` / `channel_claim` were zeroed as collateral in every crew seat,
silently.

## The fix

1. **`channel_kinds` now declares `Tool.EmptyParams`** — effect-smol's documented no-parameter
   schema — so it emits `{"type":"object","additionalProperties":false}`.
2. **Boot fence (`packages/pipeline-crew-mcp/src/edge/tool-schema-guard.ts`)** — asserts at server
   boot that every registered tool's *generated* `inputSchema` (read through the same
   `Tool.getJsonSchema` the server serves) has top-level `type:"object"`, failing loudly and naming
   the offender. Wired into the crew session's boot critical path
   (`src/crew/session.ts`, alongside the existing #3622 contract-resolution invariant) and into the
   standalone channel server (`src/edge/server.ts`).
3. **`claude-plugins/pipeline-crew/CHANNEL-TOOL.md`** — the boot-window "wait and re-check" guidance
   is now bounded: a still-empty toolset after a re-check is a **report**, not a longer wait. That
   guidance is what let this read as connect lag for a whole session.

## effect-smol grounding (repo law: source, not intuition)

Both claims are read off the **pinned** dependency source (`effect@4.0.0-beta.92`), cited by package
+ in-package path:

- **Why `Schema.Struct({})` is invalid** — `effect/src/internal/schema/representation.ts`, the
  `Objects` case: an object representation with **zero property signatures AND zero index
  signatures** short-circuits to `return { anyOf: [{ type: "object" }, { type: "array" }] }` before
  the `{ type: "object" }` construction below it. (The same shape the `ObjectKeyword` case emits.)
- **What the server serves** — `effect/src/unstable/ai/McpServer.ts` builds each listed tool's
  `inputSchema: Tool.getJsonSchema(tool)`, which delegates to
  `Schema.toJsonSchemaDocument(tool.parametersSchema)` (`effect/src/unstable/ai/Tool.ts`). So the
  emitter output *is* the wire shape — no MCP-layer normalization sits in between.
- **The sanctioned no-parameter declaration** — `effect/src/unstable/ai/Tool.ts` documents it
  explicitly: *"If a tool accepts no parameters but still needs an explicit empty object schema, use
  `EmptyParams`"*, defined as `Schema.Record(Schema.String, Schema.Never)` and used as
  `Tool.make`'s own default when `parameters` is omitted. That index signature takes the
  `type: "object"` branch of the emitter, and its `Never` value collapses to
  `additionalProperties: false`.

Conclusion: effect-smol **can** emit a spec-valid empty-object schema through its own documented
API, so **no `pnpm patch` is needed** (ADR 0038 not engaged) and no fork is consumed.

Verified against the pinned emitter:

```
Struct({})  -> {"anyOf":[{"type":"object"},{"type":"array"}]}
EmptyParams -> {"type":"object","additionalProperties":false}
omitted     -> {"type":"object","additionalProperties":false}
```

## Wire evidence — raw JSON-RPC `initialize` + `tools/list`

Probed a real `node src/bin.ts session --role cartographer` over stdio (a throwaway git repo as
`--project-root`), same handshake the CLI performs.

**Before** (`parameters: Schema.Struct({})`):

```
initialize capabilities: {"experimental":{"claude/channel":{}},"completions":{},"tools":{"listChanged":true}}
TOOL channel_send  inputSchema={"type":"object","properties":{...},"required":[...],"additionalProperties":false}
TOOL channel_claim inputSchema={"type":"object","properties":{"resource":{...}},"required":["resource"],"additionalProperties":false}
TOOL channel_kinds inputSchema={"anyOf":[{"type":"object"},{"type":"array"}]}      <-- spec-invalid; CLI discards the whole result
```

**After** (`parameters: Tool.EmptyParams`):

```
initialize capabilities: {"experimental":{"claude/channel":{}},"completions":{},"tools":{"listChanged":true}}
TOOL channel_send  inputSchema={"type":"object","properties":{...},"required":[...],"additionalProperties":false}
TOOL channel_claim inputSchema={"type":"object","properties":{"resource":{...}},"required":["resource"],"additionalProperties":false}
TOOL channel_kinds inputSchema={"type":"object","additionalProperties":false}      <-- spec-valid top-level object
```

**Fence proven live** — re-running the probe with the fence armed and the defective schema restored,
the server refuses to boot instead of serving a toolset the client will discard:

```
[server] crew session failed to start: @kampus/pipeline-crew-mcp/edge/InvalidToolSchemaError:
  spec-invalid MCP inputSchema on channel_kinds — the MCP spec requires a top-level {"type":"object"},
  and a client rejects the WHOLE tools/list response on one bad schema, zeroing every other tool (#3753).
  Generated: channel_kinds={"anyOf":[{"type":"object"},{"type":"array"}]}
```

## Acceptance criteria

- [x] `channel_kinds`'s served `inputSchema` is a spec-valid top-level `{"type":"object"}` — raw
      JSON-RPC probe above, plus a wire-level assertion in
      `src/edge/kinds-tool.test.ts` (`tools/list` over a real `McpServer`).
- [x] The CLI's tools fetch succeeds for the crew server — the three tools are served with
      spec-valid schemas; the reproducer's A/B established the `anyOf` shape alone was sufficient to
      kill the fetch, and it is gone. (An operator seat check after stand-up is the final in-situ
      confirmation.)
- [x] The edge fail-louds at boot on any tool whose generated `inputSchema` lacks top-level
      `type:"object"` — `src/edge/tool-schema-guard.test.ts`, with an intentionally invalid tool
      built from the real emitter (`Schema.Struct({})`), asserting the offending tool is named.
- [x] The schema-emission choice is grounded in effect-smol source and cited above.

## Checks

- `pnpm vitest run` in `packages/pipeline-crew-mcp`: 45 files / 290 tests pass.
- `pnpm typecheck` (tsgo) clean; `biome check` clean.

## Merge-path note

This touches the crew coordination substrate (`packages/pipeline-crew-mcp/`), so it **likely banks
as §CP at merge time**. That is a merge-time PR property for the shipper to resolve, not a label
applied here.
