### PR TITLE
fix(sozluk): mask the /sozluk term lists on viewer-visible definitions (#3724)

### DIFF
--- a/.patterns/caylak-content-containment.md
+++ b/.patterns/caylak-content-containment.md
@@ -64,3 +64,26 @@ triage by the #1705 investigation:
 
 When adding a new çaylak-reachable write path, place it in the table above: contained via
 the sandbox seam, inert (private / own-content / no public topic), or a new gap to file.
+
+## The read side's blind spot — derived summary rows
+
+`sandboxVisibleWhere` / `publicLiveWhere` mask a **content** table, keyed off the
+`sandboxed_at` / `removed_at` / `author_id` columns the row itself carries. A **derived
+summary** row has none of them: `term_record` is a recomputable aggregate of a term's
+definitions (ADR 0011), so nothing on it says "this term is sandboxed" — yet the row is
+created, and its user-authored `title` becomes readable, the moment a çaylak writes their
+first definition. A list that selects the summary table directly is therefore **unmasked by
+construction**, even in a codebase where every content read is masked (#3724: a newcomer's
+term reached the top of the anonymous /sozluk list and its page rendered zero definitions —
+a dead-end public page *and* a title-level containment leak).
+
+The rule: **a read over a derived summary table derives its visibility from the content it
+summarizes, viewer-aware** — an `EXISTS` over the content table carrying `publicLiveWhere`
+for the requesting viewer, applied to the page query **and** any `count(*)` beside it, so an
+author still finds their own not-yet-public row. Both sözlük term lists take this shape:
+`termHasVisibleDefinitionWhere` (`apps/web/worker/features/sozluk/TermVisibility.ts`) for
+the paginated lists, and the live-definition ranking inside `Sozluk.getLandingTerms` for the
+landing column.
+
+When adding a read over any table whose rows are *derived* rather than authored, ask which
+content table owns its lifecycle, and mask through that.

--- a/apps/web/tests/e2e/07-sozluk-term.spec.ts
+++ b/apps/web/tests/e2e/07-sozluk-term.spec.ts
@@ -2,15 +2,14 @@ import {expect, test} from "@playwright/test";
 
 /**
  * The term page's render contract, reached by a real click-through as an
- * unauthenticated visitor.
+ * unauthenticated visitor — from BOTH public entry points into a term.
  *
- * Entry is the LANDING "son eklenenler" column, not /sozluk's: only `landingTerms`
- * masks its ranking on live definitions (`Sozluk.getLandingTerms` — #1205/#1424), so
- * every term it links to is guaranteed to have at least one definition this viewer can
- * read. /sozluk's own `recentTerms` selects `term_record` unmasked, so its first row can
- * be a term whose only definitions are a newcomer's sandboxed ones — a public page that
- * renders empty. That is a live product defect, filed as #3724, NOT something this spec
- * should absorb; /sozluk's list rendering stays covered by 06-sozluk-home.
+ * The second test is the direct assertion of the sandbox-containment invariant #3724
+ * restored: every public term list now masks `term_record` on definitions the viewer can
+ * actually read (`landingTerms` via `getLandingTerms`, `recentTerms`/`popularTerms` via
+ * `termHasVisibleDefinitionWhere` — #1205/#1424), so the first /sozluk row can no longer
+ * be a newcomer's sandbox-only term that renders a dead-end page. /sozluk's list
+ * rendering itself stays covered by 06-sozluk-home.
  */
 test.describe("SozlukTermPage", () => {
 	test("from / → click first term → /sozluk/<slug>", async ({page}) => {
@@ -40,5 +39,21 @@ test.describe("SozlukTermPage", () => {
 
 		// Top definition has the --top modifier
 		await expect(page.locator(".kp-sozluk-definition--top")).toBeVisible();
+	});
+
+	test("from /sozluk → click first row → a term page with at least one definition", async ({
+		page,
+	}) => {
+		await page.goto("/sozluk");
+		const firstRow = page.locator("a.kp-sozluk-term-row").first();
+		await expect(firstRow).toBeVisible({timeout: 10_000});
+		const href = await firstRow.getAttribute("href");
+		expect(href).toMatch(/^\/sozluk\/.+/);
+		await firstRow.click();
+		await expect(page).toHaveURL(href ?? "");
+
+		// The invariant: the first row of the public /sozluk list always leads to a term
+		// page carrying at least one definition an anonymous viewer can read.
+		await expect(page.locator(".kp-sozluk-definition").first()).toBeVisible();
 	});
 });

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -52,6 +52,7 @@ import {
 	UnauthorizedDefinitionMutation,
 } from "./errors.ts";
 import {DEFINITION_ORDERING, TERM_SUMMARY_ORDERING, type TermSummarySort} from "./ordering.ts";
+import {termHasVisibleDefinitionWhere} from "./TermVisibility.ts";
 import {
 	type TermConnectionPage,
 	type TermSummaryRow,
@@ -400,10 +401,19 @@ export class Sozluk extends Context.Service<
 			limit?: number;
 		}) => Effect.Effect<TermSummaryRow[]>;
 
+		/**
+		 * The paginated term lists behind `terms` / `recentTerms` / `popularTerms`.
+		 * Viewer-masked: a term surfaces only when the viewer can read at least one of
+		 * its definitions (`termHasVisibleDefinitionWhere`, #3724) — the same live-content
+		 * gate `getLandingTerms` carries, so a çaylak's sandbox-only term never reaches
+		 * the public /sozluk front door as a dead-end page.
+		 */
 		readonly listTermSummariesConnection: (opts?: {
 			sort?: ListSort;
 			first?: number;
 			after?: string | null;
+			viewerId?: string | null | undefined;
+			sandboxViewer?: SandboxViewer | undefined;
 		}) => Effect.Effect<TermConnectionPage>;
 
 		/**
@@ -955,21 +965,35 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		});
 
 		const listTermSummariesConnection = Effect.fn("Sozluk.listTermSummariesConnection")(function* (
-			opts: {sort?: ListSort; first?: number; after?: string | null} = {},
+			opts: {
+				sort?: ListSort;
+				first?: number;
+				after?: string | null;
+				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
+			} = {},
 		) {
 			const sort = opts.sort ?? "recent";
 			const first = Math.max(1, Math.min(opts.first ?? 20, 100));
 			const after = opts.after ?? null;
+			const viewer = resolveSandboxViewer(opts);
 
+			// The count carries the SAME mask as the page below: an unmasked `count(*)`
+			// would report terms the page can never yield, so the connection would claim
+			// pages that don't exist.
 			const totalCount = yield* run((db) =>
 				db
 					.select({n: sql<number>`count(*)`})
 					.from(schema.termRecord)
+					.where(termHasVisibleDefinitionWhere(db, viewer))
 					.get()
 					.then((r) => r?.n ?? 0),
 			);
 
 			type CursorRow = {slug: string; totalScore: number; lastActivityAt: Date | null};
+			// Deliberately UNMASKED: this read only recovers the cursor's keyset position,
+			// it never yields a row. Masking it would turn a cursor whose term went
+			// sandboxed mid-scroll into a cursor miss and truncate the rest of the list.
 			const resolvedRow = after
 				? ((yield* run((db) =>
 						db
@@ -1004,7 +1028,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				db
 					.select(termSummaryColumns)
 					.from(schema.termRecord)
-					.where(cursorPredicate)
+					.where(and(cursorPredicate, termHasVisibleDefinitionWhere(db, viewer)))
 					.orderBy(...orderByColumns(ordering))
 					.limit(first + 1),
 			);

--- a/apps/web/worker/features/sozluk/TermVisibility.ts
+++ b/apps/web/worker/features/sozluk/TermVisibility.ts
@@ -1,0 +1,48 @@
+/**
+ * The sözlük term-list read mask: a `term_record` row is visible to a viewer only when
+ * at least one of its definitions is (#3724).
+ *
+ * `term_record` is a recomputable summary cache, not content — it carries no lifecycle
+ * columns of its own, so it cannot be masked directly. Visibility is therefore *derived*
+ * from the definitions the row summarizes, which is where the çaylak sandbox (#1205) and
+ * the ADR 0096 removal guard actually live. `Sozluk.getLandingTerms` derives the same fact
+ * by ranking on live definitions; this is the reusable, viewer-aware form the paginated
+ * term lists apply.
+ */
+import {and, eq, exists, type SQL, sql} from "drizzle-orm";
+import type {DrizzleDb} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {publicLiveWhere} from "../lifecycle/SandboxVisibility.ts";
+
+/**
+ * `EXISTS (SELECT 1 FROM definition_record WHERE term_slug = term_record.slug AND
+ * <publicLiveWhere>)` — the correlated existence probe that gates a `term_record` row on
+ * the viewer's own definition visibility, sourced from the shared `publicLiveWhere` seam
+ * (#1359/#1407) rather than a re-derived mask.
+ *
+ * Viewer-aware by construction, which is the load-bearing property: an anonymous visitor
+ * never reaches a term whose only definitions are a newcomer's sandboxed ones (both a
+ * dead-end public page and a partial sandbox-containment leak — the term title escapes),
+ * while the author still finds their own not-yet-public term, and a moderator sees the
+ * full backlog.
+ */
+export const termHasVisibleDefinitionWhere = (db: DrizzleDb, viewer: SandboxViewer): SQL =>
+	exists(
+		db
+			.select({one: sql`1`})
+			.from(schema.definitionRecord)
+			.where(
+				and(
+					eq(schema.definitionRecord.termSlug, schema.termRecord.slug),
+					publicLiveWhere(
+						{
+							removedAt: schema.definitionRecord.removedAt,
+							sandboxedAt: schema.definitionRecord.sandboxedAt,
+							authorId: schema.definitionRecord.authorId,
+						},
+						viewer,
+					),
+				),
+			),
+	);

--- a/apps/web/worker/features/sozluk/lists.ts
+++ b/apps/web/worker/features/sozluk/lists.ts
@@ -14,6 +14,7 @@ import {Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {type KeysetPage, toConnection} from "../fate/connection.ts";
+import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {type ListSort, Sozluk} from "./Sozluk.ts";
 import {toTerm} from "./shapers.ts";
 import type {TermSummaryRow} from "./term-fields.ts";
@@ -42,8 +43,12 @@ const listTerms = (
 ) =>
 	Effect.gen(function* () {
 		const sozluk = yield* Sozluk;
+		// Resolve the sandbox viewer (identity + moderator probe) so the list hides terms
+		// whose only definitions this viewer can't read (#3724).
+		const sandboxViewer = yield* currentSandboxViewer;
 		const page = yield* sozluk.listTermSummariesConnection({
 			sort,
+			sandboxViewer,
 			...(args.first !== undefined ? {first: args.first} : {}),
 			...(args.after !== undefined ? {after: args.after} : {}),
 		});

--- a/apps/web/worker/features/sozluk/term-list-sandbox.unit.test.ts
+++ b/apps/web/worker/features/sozluk/term-list-sandbox.unit.test.ts
@@ -1,0 +1,196 @@
+/**
+ * `Sozluk.listTermSummariesConnection` sandbox-visibility wiring (#3724) — the security
+ * fix for the /sozluk root lists (`terms` / `recentTerms` / `popularTerms`). The list
+ * selects from `term_record`, a summary cache with no lifecycle columns of its own, so
+ * visibility must be derived from the definitions it summarizes: BOTH the page query and
+ * `totalCount` carry an `EXISTS` over `definition_record` masked by `publicLiveWhere`.
+ * Without it a çaylak's sandbox-only term lands at the top of the anonymous /sozluk front
+ * door and its term page renders zero definition cards (#1205/#1424).
+ *
+ * Unit-tier per ADR 0082: row-level filtering is integration's job; what THIS proves is
+ * that both reads WIRE the mask in, and that it is viewer-aware (the author's own arm
+ * appears only for a signed-in viewer, and a moderator drops the sandbox arm entirely).
+ * The compiled SQL is captured off a substituted `Drizzle` seam that renders each
+ * builder's `.toSQL()` (the `Sozluk.connection.unit.test.ts` scripted-access idiom).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
+import {ReactionStub} from "../reaction/Reaction.testing.ts";
+import {Vote} from "../vote/Vote.ts";
+import {type ListSort, Sozluk, SozlukLive} from "./Sozluk.ts";
+
+const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
+	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
+
+/**
+ * The two reads land on DIFFERENT capture surfaces, which is why this harness has two.
+ * The page read hands `run` the un-awaited builder, so it renders via `.toSQL()`. The
+ * `totalCount` read finalizes inside the callback (`.get().then(…)`), so `run` only ever
+ * sees a promise — its SQL is recoverable solely at the D1 binding, off `prepare`/`bind`.
+ */
+function scriptedAccess(results: ReadonlyArray<unknown>): {
+	access: DrizzleAccess;
+	builders: {sql: string; params: unknown[]}[];
+	prepared: {sql: string; params: unknown[]}[];
+} {
+	const state = {i: 0};
+	const builders: {sql: string; params: unknown[]}[] = [];
+	const prepared: {sql: string; params: unknown[]}[] = [];
+	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only `prepare`/`batch` are exercised and every result is scripted.
+	const capturingD1 = {
+		prepare: (sql: string) => {
+			const entry = {sql, params: [] as unknown[]};
+			prepared.push(entry);
+			return {
+				bind(...params: unknown[]) {
+					entry.params = params;
+					return this;
+				},
+				async all() {
+					return {results: []};
+				},
+				async first() {
+					return null;
+				},
+				async run() {
+					return {};
+				},
+				async raw() {
+					return [];
+				},
+			};
+		},
+		async batch() {
+			return [];
+		},
+	} as unknown as D1Database;
+	const renderDb = drizzle(capturingD1, {relations});
+
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			const built = fn(renderDb) as unknown;
+			if (hasToSQL(built)) builders.push(built.toSQL());
+			const value = results[state.i++] as A;
+			return Effect.succeed(value);
+		},
+		batch: () => Effect.die(new Error("the term list must not batch")),
+	};
+	return {access, builders, prepared};
+}
+
+// biome-ignore lint/plugin: a service double — the term list never reaches the Vote service.
+const VoteStub = Layer.succeed(Vote, {
+	cast: () => Effect.die(new Error("the term list must not cast a vote")),
+	readMine: () => Effect.succeed(new Set<string>()),
+	clearTarget: () => Effect.void,
+} as unknown as typeof Vote.Service);
+
+const sozlukLayer = (access: DrizzleAccess) =>
+	SozlukLive.pipe(
+		Layer.provide(VoteStub),
+		Layer.provide(ReactionStub),
+		Layer.provide(PasaportIdentityStub),
+		Layer.provide(Layer.succeed(Drizzle, access)),
+	);
+
+/** The connection's two rendered reads: the masked `totalCount` and the masked page. */
+const runList = (opts: {
+	sort?: ListSort;
+	after?: string;
+	viewerId?: string | null;
+	sandboxViewer?: SandboxViewer;
+}): Effect.Effect<{count: string; page: string; pageParams: unknown[]}> =>
+	Effect.gen(function* () {
+		const cursorRow = {slug: "onceki-terim", totalScore: 3, lastActivityAt: new Date(0)};
+		const {access, builders, prepared} = scriptedAccess(
+			opts.after === undefined
+				? [0 /* count */, [] /* page */]
+				: [0 /* count */, cursorRow, [] /* page */],
+		);
+		yield* Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			yield* sozluk.listTermSummariesConnection(opts);
+		}).pipe(Effect.provide(sozlukLayer(access)));
+
+		const count = prepared[0];
+		const page = builders[0];
+		assert.isDefined(count, "the totalCount read reached the D1 binding");
+		assert.isDefined(page, "the page read rendered off the seam");
+		return {
+			count: count.sql.toLowerCase(),
+			page: page.sql.toLowerCase(),
+			pageParams: page.params,
+		};
+	});
+
+const EXISTS_OVER_DEFINITIONS =
+	/exists \(select 1 from "definition_record" where .*"definition_record"\."term_slug" = "term_record"\."slug"/;
+
+describe("Sozluk.listTermSummariesConnection — the /sozluk lists exclude sandbox-only terms (#3724)", () => {
+	it.effect("the page query gates term_record on an EXISTS over live definitions", () =>
+		Effect.gen(function* () {
+			const {page} = yield* runList({sort: "recent"});
+			assert.match(page, EXISTS_OVER_DEFINITIONS, "correlated EXISTS over definition_record");
+			assert.match(page, /"definition_record"\."removed_at" is null/, "removal guard present");
+			assert.match(page, /"definition_record"\."sandboxed_at" is null/, "sandbox mask present");
+			// Never the inverted mask — that would show ONLY the sandboxed terms.
+			assert.notMatch(page, /sandboxed_at" is not null/, "mask is IS NULL, never IS NOT NULL");
+		}),
+	);
+
+	it.effect("totalCount carries the identical mask — never an unfiltered count(*)", () =>
+		Effect.gen(function* () {
+			const {count} = yield* runList({sort: "recent"});
+			assert.match(count, EXISTS_OVER_DEFINITIONS, "the count is masked, not a bare count(*)");
+			assert.match(count, /"definition_record"\."removed_at" is null/, "removal guard present");
+			assert.match(count, /"definition_record"\."sandboxed_at" is null/, "sandbox mask present");
+		}),
+	);
+
+	it.effect("an anonymous viewer gets the public mask only — no author arm", () =>
+		Effect.gen(function* () {
+			const {page, count} = yield* runList({sort: "recent"});
+			for (const sql of [page, count]) {
+				assert.notMatch(sql, /"definition_record"\."author_id" =/, "no author arm when anonymous");
+			}
+		}),
+	);
+
+	it.effect("a signed-in viewer additionally sees their OWN not-yet-public term", () =>
+		Effect.gen(function* () {
+			const {page, count, pageParams} = yield* runList({sort: "recent", viewerId: "u-caylak"});
+			for (const rendered of [page, count]) {
+				assert.include(
+					rendered,
+					'"definition_record"."sandboxed_at" is null)) or ("definition_record"."author_id" = ?)',
+					"the sandbox arm widens to the viewer's own definitions",
+				);
+			}
+			assert.include(pageParams, "u-caylak", "the viewer id is bound into the mask");
+		}),
+	);
+
+	it.effect("a cursor page keeps BOTH the keyset predicate and the mask", () =>
+		Effect.gen(function* () {
+			const {page} = yield* runList({sort: "recent", after: "onceki-terim"});
+			assert.match(page, EXISTS_OVER_DEFINITIONS, "the mask survives pagination");
+			assert.match(page, /"term_record"\."last_activity_at" </, "the keyset predicate survives");
+		}),
+	);
+
+	it.effect("a moderator sees every not-removed term — the sandbox arm drops", () =>
+		Effect.gen(function* () {
+			const {page} = yield* runList({
+				sort: "recent",
+				sandboxViewer: {viewerId: "u-mod", canSeeSandboxed: true},
+			});
+			assert.match(page, EXISTS_OVER_DEFINITIONS, "still gated on having a readable definition");
+			assert.match(page, /"definition_record"\."removed_at" is null/, "removal guard stays");
+			assert.notMatch(page, /sandboxed_at/, "no sandbox restriction for a moderator");
+		}),
+	);
+});


### PR DESCRIPTION
A brand-new member's first sözlük term was showing up on the public /sozluk list even though the definition inside it was still held back for review — so an anonymous visitor saw the term's title at the top of the page, clicked it, and landed on a term page with no definitions at all. This PR gives the /sozluk term lists the same rule the homepage column already had: a term only appears if the person looking at it can actually read at least one of its definitions. Authors still see their own in-review terms, and moderators still see everything.

## What changed

- **`apps/web/worker/features/sozluk/TermVisibility.ts`** (new) — `termHasVisibleDefinitionWhere(db, viewer)`: an `EXISTS` over `definition_record` correlated on `term_slug`, carrying the shared `publicLiveWhere` (removal guard + sandbox mask) for the requesting viewer. `term_record` is a derived summary with no lifecycle columns of its own, so its visibility has to come from the content it summarizes.
- **`Sozluk.listTermSummariesConnection`** — takes `viewerId` / `sandboxViewer`, resolves the viewer through `resolveSandboxViewer`, and applies the mask to **both** the page query and `totalCount` (previously an unfiltered `count(*)`). The cursor-resolve read stays deliberately unmasked: it recovers a keyset position and yields no rows, so masking it would truncate a list whose cursor term went sandboxed mid-scroll.
- **`features/sozluk/lists.ts`** — `terms` / `recentTerms` / `popularTerms` resolve `currentSandboxViewer` and thread it in, the same way `queries.ts`'s `term` resolver already does.
- **`term-list-sandbox.unit.test.ts`** (new, 6 cases) — asserts the wiring off the substituted `Drizzle` seam: the mask is on the page query and on `totalCount`, it is `IS NULL` and never inverted, anonymous gets no author arm, a signed-in viewer's own `author_id` arm appears and binds the viewer id, a moderator drops the sandbox arm but keeps the removal guard, and a cursor page keeps both the keyset predicate and the mask.
- **`tests/e2e/07-sozluk-term.spec.ts`** — adds the direct invariant test (first public /sozluk row → term page with at least one anonymous-visible definition) and drops the stale docblock that described the defect as live.
- **`.patterns/caylak-content-containment.md`** — new "read side's blind spot" section: a read over a *derived* summary table must derive visibility from the content table that owns its lifecycle.

## Product call

The issue flagged an embedded micro-decision — invisible vs visible-but-marked for a term whose only content is sandboxed. Matched the `getLandingTerms` precedent: **invisible** to third parties, still visible to its author.

## Verification

- `pnpm typecheck` — clean (33/33 tasks)
- `pnpm lint:worktree` — clean
- `pnpm test:unit` — 2344 passed / 283 files, including the 6 new cases

Integration seeding is unaffected: `h.seedTerm` authors as a yazar, so seeded definitions are live and stay visible through the mask.

Fixes #3724
