### PR TITLE
fix(ci): constrain the preview-deploy sticky-comment lookups to the CI author

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -801,6 +801,18 @@ jobs:
         with:
           script: |
             const marker = "<!-- preview-deploy -->";
+            // phoenix is PUBLIC, so anyone can comment on a PR — but every lookup below reads
+            // a TRUSTED CI artifact (deploy.yml's sticky comment): the preview URL + D1 token
+            // e2e is pointed at, and the `:none` verdict that exits e2e as a not-applicable
+            // PASS. Matching on body alone let a third party pre-post a forged marker — `find`
+            // takes the FIRST match and deploy.yml posts ~43s in — and so steer e2e at an
+            // attacker-controlled URL or skip the gate outright (#3740). The author is
+            // verified against the live artifact, not assumed: deploy.yml comments through
+            // github-script's default GITHUB_TOKEN, i.e. `github-actions[bot]` (user.type
+            // `Bot`, id 41898282). GitHub rejects `[`/`]` in usernames, so no human account
+            // can hold that login.
+            const CI_COMMENT_AUTHOR = "github-actions[bot]";
+            const isTrustedCi = (x) => x.user?.login === CI_COMMENT_AUTHOR && x.user?.type === "Bot";
             const deadline = Date.now() + 10 * 60 * 1000;
             const interval = 15000;
             // Match the web app's block in the sticky comment, capturing the URL
@@ -818,11 +830,23 @@ jobs:
 
             // Phase 1 — discover the preview URL + D1 id from the sticky comment.
             let url, db, flags = "";
+            let sawUntrusted = false;
             while (Date.now() < deadline) {
               const {data: comments} = await github.rest.issues.listComments({
                 ...context.repo, issue_number: context.issue.number, per_page: 100,
               });
-              const c = comments.find((x) => x.body?.includes(marker));
+              const c = comments.find((x) => isTrustedCi(x) && x.body?.includes(marker));
+              // A marker-bearing comment we IGNORED is either a forgery attempt or drift in
+              // deploy.yml's posting identity. Either way the poll would otherwise just time
+              // out with an unexplained "no preview was posted" — say which it is, once.
+              if (!c && !sawUntrusted && comments.some((x) => x.body?.includes(marker))) {
+                sawUntrusted = true;
+                core.warning(
+                  `ignoring a \`${marker}\` comment not authored by ${CI_COMMENT_AUTHOR}: the e2e ` +
+                  "gate reads only the trusted CI identity's sticky comment (#3740). If deploy.yml " +
+                  "now posts under a different identity, update CI_COMMENT_AUTHOR in this step.",
+                );
+              }
               // Read the negative verdict BEFORE the positive one: waiting out the deadline
               // for a preview deploy.yml has already declined to mint can only end in a red
               // `ci-required` on a PR with no defect in it (#3722, PR #3713). Exiting green
@@ -855,7 +879,12 @@ jobs:
               await sleep();
             }
             if (!url) {
-              core.setFailed("timed out waiting for the preview deploy (URL + D1 id) from deploy.yml");
+              core.setFailed(
+                "timed out waiting for the preview deploy (URL + D1 id) from deploy.yml" +
+                (sawUntrusted
+                  ? ` — note: a \`${marker}\` comment WAS present but was ignored because ${CI_COMMENT_AUTHOR} did not author it (#3740)`
+                  : ""),
+              );
               return;
             }
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,10 +189,15 @@ jobs:
               + `so no preview stack was minted and \`e2e\` is not applicable. `
               + `<sub>(${headSha.slice(0, 7)})</sub>`;
 
+            // Upsert only OUR OWN sticky comment — see ci.yml's `Await preview URL` step for
+            // why every lookup on this seam is author-constrained (#3740). Without it a third
+            // party's forged marker is the comment this job edits, so the verdict e2e reads
+            // sits in an attacker-authored comment they can keep rewriting.
+            const isTrustedCi = (c) => c.user?.login === "github-actions[bot]" && c.user?.type === "Bot";
             const {data: comments} = await github.rest.issues.listComments({
               ...context.repo, issue_number: context.issue.number, per_page: 100,
             });
-            const existing = comments.find((c) => c.body?.includes(marker));
+            const existing = comments.find((c) => isTrustedCi(c) && c.body?.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({...context.repo, comment_id: existing.id, body});
             } else {
@@ -626,6 +631,9 @@ jobs:
 
             // Replace this app's block in the body (or append it), preserving any
             // other app's block another matrix job may have already written.
+            // Author-constrained like every other lookup on this seam (#3740).
+            const isTrustedCi = (c) => c.user?.login === "github-actions[bot]" && c.user?.type === "Bot";
+
             const upsert = (body) => {
               const header = `${marker}\n### 🚀 Preview deployed`;
               let b = body && body.includes(marker) ? body : header;
@@ -645,7 +653,7 @@ jobs:
                 const {data: comments} = await github.rest.issues.listComments({
                   ...context.repo, issue_number: context.issue.number, per_page: 100,
                 });
-                const existing = comments.find((c) => c.body?.includes(marker));
+                const existing = comments.find((c) => isTrustedCi(c) && c.body?.includes(marker));
                 if (existing) {
                   await github.rest.issues.updateComment({
                     ...context.repo, comment_id: existing.id, body: upsert(existing.body),


### PR DESCRIPTION
This repo is public, so anyone can comment on a pull request. The e2e gate found the
preview-deploy comment it trusts by searching for a marker in the comment text, without
ever checking who wrote it — so a stranger could post a lookalike comment and point the
test run at a server they control, or fake the "no preview was deployed" verdict and make
the gate pass without testing anything. Every lookup on that comment now also requires the
comment to be written by the CI bot.

## What changed

- **`.github/workflows/ci.yml`** — the `e2e` job's "Await preview URL" poll now matches
  `x.user.login === "github-actions[bot]" && x.user.type === "Bot"` alongside the marker.
  The preview URL + `<!-- d1:<uuid> -->` lookup and the SHA-bound
  `<!-- preview-deploy:none head:<sha> -->` verdict share that one `find`, so both are
  covered by the single constraint.
- **`.github/workflows/deploy.yml`** — both sticky-comment upserts (the `no-preview`
  verdict job and the per-app `deploy` matrix step) apply the same constraint. Without it,
  a forged sticky posted first is the comment `deploy.yml` *edits*, so the verdict `e2e`
  reads would live inside an attacker-authored comment they can keep rewriting. With it,
  `deploy.yml` ignores the forgery and creates its own comment.
- A marker-bearing comment from an untrusted author is warned about once and named in the
  timeout message, so a forgery attempt — and a future change in `deploy.yml`'s posting
  identity — is diagnosable instead of surfacing as an unexplained "no preview was posted"
  timeout.

## Why `github-actions[bot]` (verified, not assumed)

Both `deploy.yml` comment paths post through `actions/github-script@v7.0.1` with the
default `GITHUB_TOKEN`. Read back off the live artifacts via REST:

| comment | source path | `user.login` | `user.type` | `user.id` |
| --- | --- | --- | --- | --- |
| `### 🚀 Preview deployed` on #3757, #3737 | `deploy` matrix | `github-actions[bot]` | `Bot` | 41898282 |
| `### No preview deploy` on #3756 | `no-preview` job | `github-actions[bot]` | `Bot` | 41898282 |

The login is unforgeable: GitHub rejects `[` and `]` in usernames, so no user account can
hold `github-actions[bot]`. The `user.type === "Bot"` conjunct is belt-and-braces and makes
the intent explicit at the call site.

## Why the predicate is inlined three times rather than extracted to a shared module

`actions/github-script` can only `require()` a repo file from the checked-out tree, and on
a `pull_request` event that tree is the PR author's code. Sourcing the trust predicate from
there would let a PR rewrite the very check this fixes — and `no-preview` has no checkout
step at all. Inlining in the workflow YAML keeps the predicate on the trusted side of that
boundary. The full rationale is stated once, at the `ci.yml` read site; the `deploy.yml`
sites carry one-line pointers.

## Verification

- Forge simulation over the exact regexes: with a body-only `find`, an attacker comment
  ordered before the CI one yields `https://evil.workers.dev`, and a lone forged
  `:none` marker satisfies the skip. With the author constraint, the same input yields
  `https://real.workers.dev` and the forged skip does not match.
- All three `script:` blocks in the two workflows parse (wrapped and syntax-checked).
- `pnpm typecheck` green (33/33 tasks); `pnpm lint:worktree` clean skip (YAML-only diff).

Fixes #3740
