### PR TITLE
feat(bildirim): coalesce mod pages per reporter/window in notifyReportFiled (#3641)

### DIFF
--- a/apps/web/worker/features/bildirim/Notification.testing.ts
+++ b/apps/web/worker/features/bildirim/Notification.testing.ts
@@ -17,6 +17,7 @@ const die =
 const failOnContact: NotificationShape = {
 	record: die("record"),
 	recordAggregate: die("recordAggregate"),
+	recordDigest: die("recordDigest"),
 	listForRecipient: die("listForRecipient"),
 	unreadCount: die("unreadCount"),
 	markRead: die("markRead"),

--- a/apps/web/worker/features/bildirim/Notification.ts
+++ b/apps/web/worker/features/bildirim/Notification.ts
@@ -12,8 +12,8 @@
  * die on infra errors (`orDieAccess`), so public signatures carry no error.
  */
 import {LivePublisher} from "@kampus/fate-effect";
-import {and, count, desc, eq, inArray, isNull, sql} from "drizzle-orm";
-import {Context, Effect, Layer} from "effect";
+import {and, count, desc, eq, gte, inArray, isNull, sql} from "drizzle-orm";
+import {Context, Duration, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {
@@ -47,6 +47,16 @@ export interface NotificationRecordInput {
 
 /** The aggregate-upsert input (#1695): one UNREAD row per `(recipient, kind, target)`. */
 export type NotificationAggregateInput = Omit<NotificationRecordInput, "count">;
+
+/**
+ * The windowed-digest input (#3641): the coalescing key is the ACTOR, not the target —
+ * one page per `(recipient, kind, actor)` per window, however many targets the actor
+ * acted on. `actorId` is therefore required and non-null; a system moment with no actor
+ * has no key to coalesce on, so it is unrepresentable here.
+ */
+export type NotificationDigestInput = Omit<NotificationRecordInput, "count" | "actorId"> & {
+	actorId: string;
+};
 
 export interface NotificationRow {
 	id: string;
@@ -138,6 +148,57 @@ export const insertUnlessUnreadStatement = (
 		);
 };
 
+/**
+ * The open-digest key's WHERE (#3641) — recipient-scoped and unread-only like the
+ * aggregate, but keyed on `actor_id` and floored at the window start. A page older
+ * than the window (or already read) matches nothing, so the next event mints a fresh
+ * page instead of bumping a stale one forever.
+ */
+const openDigestWhere = (input: NotificationDigestInput, since: Date) =>
+	and(
+		eq(schema.notification.recipientId, input.recipientId),
+		eq(schema.notification.kind, input.kind),
+		eq(schema.notification.actorId, input.actorId),
+		isNull(schema.notification.readAt),
+		gte(schema.notification.createdAt, since),
+	);
+
+/** Bump the recipient's open digest page for this actor/window (`count + 1`). */
+export const bumpOpenDigestStatement = (
+	db: DrizzleDb,
+	input: NotificationDigestInput,
+	since: Date,
+	now: Date,
+) =>
+	db
+		.update(schema.notification)
+		.set({count: sql`${schema.notification.count} + 1`, updatedAt: now})
+		.where(openDigestWhere(input, since));
+
+/**
+ * Mint the window's page ONLY if the actor has no open one — the guarded-insert half
+ * of {@link insertUnlessUnreadStatement}, keyed on the actor/window instead. The row
+ * carries the window's FIRST target, so the page still links a recipient straight to
+ * content; the later coalesced events live behind it (their count is the digest).
+ */
+export const insertUnlessOpenDigestStatement = (
+	db: DrizzleDb,
+	input: NotificationDigestInput & {id: string},
+	since: Date,
+	now: Date,
+) => {
+	const nowSeconds = Math.floor(now.getTime() / 1000);
+	const digestExists = db
+		.select({one: sql`1`})
+		.from(schema.notification)
+		.where(openDigestWhere(input, since));
+	return db
+		.insert(schema.notification)
+		.select(
+			sql`select ${input.id}, ${input.recipientId}, ${input.kind}, ${input.targetKind}, ${input.targetId}, ${input.actorId}, 1, NULL, ${nowSeconds}, ${nowSeconds} where not exists (${digestExists})`,
+		);
+};
+
 /** Flip EVERY unread notification of the recipient read. */
 export const markAllReadStatement = (db: DrizzleDb, recipientId: string, now: Date) =>
 	db
@@ -175,6 +236,20 @@ export class Notification extends Context.Service<
 		readonly recordAggregate: (
 			input: NotificationAggregateInput,
 		) => Effect.Effect<{aggregated: boolean}, never, LivePublisher>;
+
+		/**
+		 * Windowed digest-upsert (#3641): coalesce every event ONE actor causes inside
+		 * `window` into a single unread page per recipient — bump the open page's count,
+		 * or mint one carrying this event's target when the actor has none. Unlike
+		 * {@link recordAggregate} the target is NOT part of the key, so an actor spraying
+		 * N distinct targets still costs one row per recipient per window: this is the
+		 * fan-out BOUND, not a display roll-up. `digested: true` ⇔ an open page was
+		 * bumped. Same live-publish seam as {@link record}.
+		 */
+		readonly recordDigest: (
+			input: NotificationDigestInput,
+			window: Duration.Duration,
+		) => Effect.Effect<{digested: boolean}, never, LivePublisher>;
 
 		/**
 		 * The recipient's notifications, newest-first, forward keyset pagination
@@ -408,6 +483,25 @@ export const NotificationLive = Layer.effect(Notification)(
 				);
 				yield* publishChannel(input.recipientId);
 				return {aggregated: bumped.meta.changes > 0};
+			}),
+			// The actor/window-keyed twin of `recordAggregate` — same one-batch
+			// bump-then-guarded-insert, so two concurrent emits can't mint two pages.
+			recordDigest: Effect.fn("Notification.recordDigest")(function* (
+				input: NotificationDigestInput,
+				window: Duration.Duration,
+			) {
+				const id = crypto.randomUUID();
+				const now = new Date();
+				const since = new Date(now.getTime() - Duration.toMillis(window));
+				const [bumped] = yield* batch(
+					(db) =>
+						[
+							bumpOpenDigestStatement(db, input, since, now),
+							insertUnlessOpenDigestStatement(db, {...input, id}, since, now),
+						] as const,
+				);
+				yield* publishChannel(input.recipientId);
+				return {digested: bumped.meta.changes > 0};
 			}),
 			unreadCount: Effect.fn("Notification.unreadCount")(function* (recipientId: string) {
 				const rows = yield* run((db) => unreadCountQuery(db, recipientId));

--- a/apps/web/worker/features/bildirim/Notification.unit.test.ts
+++ b/apps/web/worker/features/bildirim/Notification.unit.test.ts
@@ -19,10 +19,12 @@
 import {assert, describe, it} from "@effect/vitest";
 import {LivePublisher} from "@kampus/fate-effect";
 import {drizzle} from "drizzle-orm/d1";
-import {Effect, Layer} from "effect";
+import {Duration, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, relations} from "../../db/Drizzle.ts";
 import {
+	bumpOpenDigestStatement,
 	bumpUnreadAggregateStatement,
+	insertUnlessOpenDigestStatement,
 	insertUnlessUnreadStatement,
 	markAllReadStatement,
 	markReadStatement,
@@ -278,6 +280,88 @@ describe("Notification.recordAggregate — bump-or-insert in one batch", () => {
 		}).pipe(
 			Effect.provide(
 				notificationLayer(aggregateAccess([{meta: {changes: 0}}, {meta: {changes: 1}}], [])).pipe(
+					Layer.merge(recordingPublisher().layer),
+				),
+			),
+		),
+	);
+});
+
+const digestInput = {
+	recipientId: "u-mod",
+	kind: "report-filed" as const,
+	targetKind: "post" as const,
+	targetId: "p1",
+	actorId: "u-reporter",
+};
+
+describe("recordDigest builders — actor-keyed, window-floored (the fan-out bound, #3641)", () => {
+	it("the bump keys on (recipient_id, kind, actor_id, unread, created_at >= window) — NOT the target", () => {
+		const {sql, params} = bumpOpenDigestStatement(
+			renderDb,
+			digestInput,
+			new Date(60_000),
+			new Date(120_000),
+		).toSQL();
+		assert.include(sql, '"recipient_id" = ?');
+		assert.include(sql, '"kind" = ?');
+		assert.include(sql, '"actor_id" = ?');
+		assert.include(sql, '"read_at" is null');
+		assert.include(sql, '"created_at" >= ?');
+		assert.include(sql, '"count" + 1');
+		// The target is deliberately absent from the key: one page bounds an actor's
+		// spray across MANY targets, which is exactly the amplification being cut.
+		assert.notInclude(sql, '"target_id"');
+		assert.include(params, "u-reporter");
+		// The window floor binds as the epoch SECONDS the column stores.
+		assert.include(params, 60);
+	});
+
+	it("the insert fires only when the actor has NO open page inside the window", () => {
+		const {sql, params} = insertUnlessOpenDigestStatement(
+			renderDb,
+			{...digestInput, id: "n-new"},
+			new Date(60_000),
+			new Date(120_000),
+		).toSQL();
+		assert.include(sql.toLowerCase(), "not exists");
+		assert.include(sql, '"actor_id" = ?');
+		assert.include(sql, '"created_at" >= ?');
+		// The minted row still carries THIS report's target, so the page links to content.
+		assert.include(params, "p1");
+		assert.include(params, "n-new");
+		assert.include(params, 60);
+	});
+});
+
+describe("Notification.recordDigest — bump-or-insert in one batch", () => {
+	const digestAccess = (batchResults: ReadonlyArray<unknown>): DrizzleAccess => ({
+		run: <A>(_fn: (db: never) => Promise<A>) => Effect.succeed([{count: 1}] as A),
+		batch: () => Effect.succeed(batchResults as never),
+	});
+
+	it.effect("an open page inside the window is bumped — digested, never a second row", () =>
+		Effect.gen(function* () {
+			const svc = yield* Notification;
+			const {digested} = yield* svc.recordDigest(digestInput, Duration.minutes(30));
+			assert.isTrue(digested);
+		}).pipe(
+			Effect.provide(
+				notificationLayer(digestAccess([{meta: {changes: 1}}, {meta: {changes: 0}}])).pipe(
+					Layer.merge(recordingPublisher().layer),
+				),
+			),
+		),
+	);
+
+	it.effect("no open page (first report, or the window elapsed) mints a fresh one", () =>
+		Effect.gen(function* () {
+			const svc = yield* Notification;
+			const {digested} = yield* svc.recordDigest(digestInput, Duration.minutes(30));
+			assert.isFalse(digested);
+		}).pipe(
+			Effect.provide(
+				notificationLayer(digestAccess([{meta: {changes: 0}}, {meta: {changes: 1}}])).pipe(
 					Layer.merge(recordingPublisher().layer),
 				),
 			),

--- a/apps/web/worker/features/bildirim/gate.ts
+++ b/apps/web/worker/features/bildirim/gate.ts
@@ -5,6 +5,14 @@
  * {@link Denied}, so nothing user-visible changes and nothing leaks even on a
  * direct wire call — the `funnel.summary` shape. One gate all sibling emitters'
  * surfaces reuse; no per-child flags.
+ *
+ * **Release sequencing (#3641, founder ruling on #2562).** `phoenix-bildirim` may not
+ * graduate — flip fully on, then retire (#3544) — unless `notifyReportFiled`'s
+ * per-reporter/window page coalescing (`REPORT_PAGE_WINDOW` in `mod-emitters.ts`) is
+ * live. That aggregation is the abuse control on the moderator pager: without it one
+ * karma-less account pages the whole team once per report per moderator, un-throttled.
+ * A karma floor was rejected as the gate (#2562/#3309); the per-actor rate limiter
+ * (#2561) is a companion, not a substitute.
  */
 import {Effect} from "effect";
 import {PHOENIX_BILDIRIM} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/bildirim/mod-emitters.ts
+++ b/apps/web/worker/features/bildirim/mod-emitters.ts
@@ -5,6 +5,8 @@
  *  - **report-filed** — a freshly-filed content report notifies EVERY moderator, so
  *    the two-person team learns of a new item in the queue without polling it. The
  *    target is the reported content, so the row links a moderator straight to it.
+ *    Pages are COALESCED per reporter per window ({@link REPORT_PAGE_WINDOW}) — the
+ *    abuse control that bounds how hard one account can page the team (#3641).
  *  - **caylak-pending** — a new çaylak entering the divan review queue notifies every
  *    moderator. Fired by the content-create path only on the çaylak's FIRST currently
  *    pending item (the 0→1 transition — see the divan-side gate), so it is the
@@ -17,8 +19,9 @@
  * is never paged about their own action (story 12). Fan-out is a simple per-recipient
  * loop for the two-person team — no subscription system (the brief).
  *
- * Each moment is discrete, so both use {@link Notification.record} (one row per
- * recipient) — NOT the vote path's aggregate-upsert.
+ * The çaylak moment is discrete, so it uses {@link Notification.record} (one row per
+ * recipient); the report page is windowed-coalesced (`recordDigest`) — neither is the
+ * vote path's per-target aggregate-upsert.
  *
  * The emits ride AFTER the committed report/create mutation and can never fail it: the
  * whole effect — flag read AND the moderator enumeration included — is swallowed-with-log
@@ -26,7 +29,7 @@
  * also absorbs the `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors.
  * Writes are gated on the spine's `phoenix-bildirim` flag (dark by default).
  */
-import {Effect} from "effect";
+import {Duration, Effect} from "effect";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {Divan} from "../divan/Divan.ts";
 import {allModerators} from "../kunye/moderate.ts";
@@ -52,10 +55,27 @@ const swallow = (label: string) =>
 	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
 
 /**
- * Notify every moderator that a content report was filed. The target is the reported
- * content (so the row links to it); the actor is the reporter, who is self-suppressed
- * if they are themselves a moderator. `targetKind` is a report {@link TargetKind}
+ * How long one reporter's mod pages coalesce (#3641, founder ruling on #2562). Every
+ * report the SAME reporter files inside this window bumps one open page per moderator
+ * instead of minting another row, so the pages a single account can aim at the team is
+ * bounded by elapsed time, not by how many targets it reports. Wide enough that a
+ * report spree is one page, short enough that a genuinely new burst hours later pages
+ * again. This aggregation is a release gate on `phoenix-bildirim` — see `gate.ts`.
+ */
+export const REPORT_PAGE_WINDOW = Duration.minutes(30);
+
+/**
+ * Notify every moderator that a content report was filed, coalesced per reporter per
+ * {@link REPORT_PAGE_WINDOW}: the window's first report mints the page (its target is
+ * the reported content, so the row links a moderator straight to it) and every later
+ * report by that reporter bumps its count — "N yeni içerik bildirildi", with the queue
+ * itself carrying the rest. The actor is the reporter, self-suppressed if they are
+ * themselves a moderator. `targetKind` is a report {@link TargetKind}
  * (`definition`/`post`/`comment`), a subset of the notification target taxonomy.
+ *
+ * Idempotency is unchanged and stays at the call site: `report.submit` emits only on a
+ * genuinely `created` report, so a re-report of the same target never reaches here —
+ * the window bounds DISTINCT reports, it is not a substitute for that guard.
  */
 export const notifyReportFiled = (input: {
 	reporterId: string;
@@ -68,13 +88,16 @@ export const notifyReportFiled = (input: {
 		if (recipients.length === 0) return;
 		const bildirim = yield* Notification;
 		for (const recipientId of recipients) {
-			yield* bildirim.record({
-				recipientId,
-				kind: REPORT_FILED_KIND,
-				targetKind: input.targetKind,
-				targetId: input.targetId,
-				actorId: input.reporterId,
-			});
+			yield* bildirim.recordDigest(
+				{
+					recipientId,
+					kind: REPORT_FILED_KIND,
+					targetKind: input.targetKind,
+					targetId: input.targetId,
+					actorId: input.reporterId,
+				},
+				REPORT_PAGE_WINDOW,
+			);
 		}
 	}).pipe(swallow(REPORT_FILED_KIND));
 

--- a/apps/web/worker/features/bildirim/mod-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/mod-emitters.unit.test.ts
@@ -11,7 +11,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {RelationStore} from "@kampus/authz";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
-import {Effect, Layer} from "effect";
+import {Duration, Effect, Layer} from "effect";
 import {Divan} from "../divan/Divan.ts";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
 import {Flags} from "../flagship/Flags.ts";
@@ -21,9 +21,14 @@ import {
 	notifyCaylakEntersDivan,
 	notifyReportFiled,
 	REPORT_FILED_KIND,
+	REPORT_PAGE_WINDOW,
 } from "./mod-emitters.ts";
 import {makeNotificationStub} from "./Notification.testing.ts";
-import type {NotificationRecordInput} from "./Notification.ts";
+import type {
+	Notification,
+	NotificationDigestInput,
+	NotificationRecordInput,
+} from "./Notification.ts";
 
 const runtimeContextStub: BaseRuntimeContext = {
 	Type: "mod-emitters-test",
@@ -104,39 +109,88 @@ describe("modRecipients — moderator resolution + actor self-suppression, pure"
 	});
 });
 
+// A `Notification` whose `recordDigest` captures the digest calls (input + window).
+const capturingDigest = () => {
+	const calls: Array<{input: NotificationDigestInput; window: Duration.Duration}> = [];
+	const layer = makeNotificationStub({
+		recordDigest: (input, window) =>
+			Effect.sync(() => {
+				calls.push({input, window});
+				return {digested: false};
+			}),
+	});
+	return {calls, layer};
+};
+
+/**
+ * An in-memory `Notification` whose `recordDigest` mirrors the SQL key (#3641): bump the
+ * recipient's page for `(kind, actor)` when one was minted inside the window, else mint a
+ * fresh one. The clock is scripted, so the window boundary is decidable with no engine
+ * (ADR 0082 T1/T2) — this is what makes "many reports → bounded pages" observable here.
+ */
+const digestingNotification = (clock: {now: Date}) => {
+	const pages: Array<{
+		recipientId: string;
+		kind: string;
+		actorId: string;
+		targetId: string;
+		count: number;
+		mintedAt: Date;
+	}> = [];
+	const layer = makeNotificationStub({
+		recordDigest: (input, window) =>
+			Effect.sync(() => {
+				const since = clock.now.getTime() - Duration.toMillis(window);
+				const open = pages.find(
+					(page) =>
+						page.recipientId === input.recipientId &&
+						page.kind === input.kind &&
+						page.actorId === input.actorId &&
+						page.mintedAt.getTime() >= since,
+				);
+				if (open) {
+					open.count += 1;
+					return {digested: true};
+				}
+				pages.push({
+					recipientId: input.recipientId,
+					kind: input.kind,
+					actorId: input.actorId,
+					targetId: input.targetId,
+					count: 1,
+					mintedAt: clock.now,
+				});
+				return {digested: false};
+			}),
+	});
+	return {pages, layer};
+};
+
 describe("notifyReportFiled — the report-filed mod page", () => {
 	it.effect(
-		"records one report-filed notification per moderator, targeting the reported content",
+		"pages every moderator through the reporter-keyed digest, targeting the reported content",
 		() =>
 			Effect.gen(function* () {
-				const calls: NotificationRecordInput[] = [];
+				const {calls, layer} = capturingDigest();
 				yield* notifyReportFiled({
 					reporterId: "u-reporter",
 					targetKind: "post",
 					targetId: "p1",
 				}).pipe(
 					Effect.provide(
-						Layer.mergeAll(
-							makeNotificationStub({
-								record: (input) => {
-									calls.push(input);
-									return Effect.succeed({id: "n1"});
-								},
-							}),
-							relationStoreOf(["u-mod-a", "u-mod-b"]),
-							requestContext(true),
-						),
+						Layer.mergeAll(layer, relationStoreOf(["u-mod-a", "u-mod-b"]), requestContext(true)),
 					),
 				);
 				assert.strictEqual(calls.length, 2);
-				assert.deepStrictEqual(calls[0], {
+				assert.deepStrictEqual(calls[0]?.input, {
 					recipientId: "u-mod-a",
 					kind: REPORT_FILED_KIND,
 					targetKind: "post",
 					targetId: "p1",
 					actorId: "u-reporter",
 				});
-				assert.deepStrictEqual(calls[1]?.recipientId, "u-mod-b");
+				assert.deepStrictEqual(calls[0]?.window, REPORT_PAGE_WINDOW);
+				assert.deepStrictEqual(calls[1]?.input.recipientId, "u-mod-b");
 			}),
 	);
 
@@ -144,27 +198,18 @@ describe("notifyReportFiled — the report-filed mod page", () => {
 		"a moderator who files a report is NOT paged about their own report (self-suppression)",
 		() =>
 			Effect.gen(function* () {
-				const calls: NotificationRecordInput[] = [];
+				const {calls, layer} = capturingDigest();
 				yield* notifyReportFiled({
 					reporterId: "u-mod-a",
 					targetKind: "comment",
 					targetId: "c1",
 				}).pipe(
 					Effect.provide(
-						Layer.mergeAll(
-							makeNotificationStub({
-								record: (input) => {
-									calls.push(input);
-									return Effect.succeed({id: "n1"});
-								},
-							}),
-							relationStoreOf(["u-mod-a", "u-mod-b"]),
-							requestContext(true),
-						),
+						Layer.mergeAll(layer, relationStoreOf(["u-mod-a", "u-mod-b"]), requestContext(true)),
 					),
 				);
 				assert.deepStrictEqual(
-					calls.map((c) => c.recipientId),
+					calls.map((c) => c.input.recipientId),
 					["u-mod-b"],
 				);
 			}),
@@ -215,6 +260,82 @@ describe("notifyReportFiled — the report-filed mod page", () => {
 				);
 				assert.strictEqual(exit._tag, "Success");
 			}),
+	);
+});
+
+describe("notifyReportFiled — per-reporter/window coalescing (the mod-pager fan-out bound)", () => {
+	const fileReport = (
+		reporterId: string,
+		targetId: string,
+		notifications: Layer.Layer<Notification>,
+	) =>
+		notifyReportFiled({reporterId, targetKind: "post", targetId}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					notifications,
+					relationStoreOf(["u-mod-a", "u-mod-b"]),
+					requestContext(true),
+				),
+			),
+		);
+
+	it.effect("a report spree by ONE reporter inside the window is ONE page per moderator", () =>
+		Effect.gen(function* () {
+			const clock = {now: new Date("2026-07-22T10:00:00Z")};
+			const {pages, layer} = digestingNotification(clock);
+			// Eight reports, a minute apart, across eight DISTINCT targets — the
+			// amplification shape: un-coalesced this is 16 rows on a two-person team.
+			for (let i = 0; i < 8; i++) {
+				clock.now = new Date(clock.now.getTime() + 60_000);
+				yield* fileReport("u-spammer", `p${i}`, layer);
+			}
+			assert.deepStrictEqual(
+				pages.map((page) => page.recipientId),
+				["u-mod-a", "u-mod-b"],
+			);
+			assert.deepStrictEqual(
+				pages.map((page) => page.count),
+				[8, 8],
+			);
+			// Each page still links to the window's FIRST reported target.
+			assert.deepStrictEqual(
+				pages.map((page) => page.targetId),
+				["p0", "p0"],
+			);
+		}),
+	);
+
+	it.effect("the window is per REPORTER — a second reporter opens their own page", () =>
+		Effect.gen(function* () {
+			const clock = {now: new Date("2026-07-22T10:00:00Z")};
+			const {pages, layer} = digestingNotification(clock);
+			yield* fileReport("u-reporter-a", "p1", layer);
+			yield* fileReport("u-reporter-b", "p2", layer);
+			assert.deepStrictEqual(
+				pages.map((page) => `${page.recipientId}/${page.actorId}`),
+				[
+					"u-mod-a/u-reporter-a",
+					"u-mod-b/u-reporter-a",
+					"u-mod-a/u-reporter-b",
+					"u-mod-b/u-reporter-b",
+				],
+			);
+		}),
+	);
+
+	it.effect("once the window elapses the next report mints a FRESH page (never silence)", () =>
+		Effect.gen(function* () {
+			const clock = {now: new Date("2026-07-22T10:00:00Z")};
+			const {pages, layer} = digestingNotification(clock);
+			yield* fileReport("u-reporter", "p1", layer);
+			clock.now = new Date(clock.now.getTime() + Duration.toMillis(REPORT_PAGE_WINDOW) + 60_000);
+			yield* fileReport("u-reporter", "p2", layer);
+			assert.strictEqual(pages.length, 4);
+			assert.deepStrictEqual(
+				pages.map((page) => page.count),
+				[1, 1, 1, 1],
+			);
+		}),
 	);
 });
 


### PR DESCRIPTION
Fixes #3641

## What

`notifyReportFiled` fanned one un-throttled `Notification.record` write per moderator per report, so a single karma-less account could page the whole two-person mod team once per report per moderator with no upper bound. This coalesces those mod pages **per reporter within a time window**: one page per reporter/window per moderator, not one per report per moderator.

## How

- **`Notification.recordDigest(input, window)`** (`apps/web/worker/features/bildirim/Notification.ts`) — the actor/window-keyed twin of `recordAggregate`. It bumps the recipient's open page for `(kind, actor)` when one was minted inside the window, otherwise mints one carrying this event's target. Same one-batch bump-then-guarded-insert (one D1 transaction, so two concurrent emits can't mint two pages) and the same `NotificationChannel` live-publish seam `record` already rides.
  - The **target is deliberately not part of the key** — an actor spraying N distinct targets is exactly the amplification being bounded, so this is a fan-out bound, not a display roll-up. `NotificationDigestInput` requires a non-null `actorId`, so an actor-less digest is unrepresentable.
  - The window floor is `created_at >= now - window`, so a page older than the window (or already read) is never bumped and the next report mints a fresh one — the pager never goes silent.
- **`notifyReportFiled`** (`mod-emitters.ts`) routes through it with a 30-minute `REPORT_PAGE_WINDOW`. Recipient resolution (`modRecipients`), acting-moderator self-suppression, and the fire-and-forget swallow posture (`catchCause`, ADR 0039) are untouched — the coalescing wraps the existing per-recipient loop.
- **Per-target idempotency preserved.** It lives at the call site (`report.submit` emits only on a genuinely `created` report), so a re-report of the same target still never reaches the emitter; the window bounds *distinct* reports and is not a substitute for that guard. Documented at the emitter so the two guards aren't confused for one.
- **Release-sequencing note** added to `gate.ts`: `phoenix-bildirim` may not graduate (flip fully on, then retire via #3544) unless this aggregation is live.

The client copy already renders the digest count (`report-filed` → "N yeni içerik bildirildi"), so no SPA change is needed.

## Acceptance criteria

- [x] Many reports by the same reporter in one window → at most one coalesced page per moderator for that reporter/window.
- [x] Per-target idempotency preserved (the `report.submit` `created` guard, unchanged).
- [x] Acting-moderator self-suppression and the swallow posture unchanged.
- [x] `gate.ts` records that this aggregation must be live before `phoenix-bildirim` graduates.
- [x] Tests cover the coalescing window (same reporter, many reports → bounded pages).

## Tests

- `Notification.unit.test.ts` — rendered-SQL assertions (ADR 0082 T1/T2, no engine): the bump keys on `(recipient_id, kind, actor_id, read_at IS NULL, created_at >= ?)` and **not** on `target_id`; the guarded insert fires only when the actor has no open page, and the minted row still carries this report's target. Plus the bump-vs-mint batch fold over the substituted `Drizzle` seam.
- `mod-emitters.unit.test.ts` — an in-memory `recordDigest` mirroring the SQL key with a scripted clock: eight reports by one reporter across eight distinct targets in-window → **two** pages (one per moderator, count 8, each linking to the first target) instead of sixteen rows; a second reporter opens their own page; once the window elapses the next report mints a fresh page.

Full unit project green (2348 tests), typecheck clean.

## Out of scope

The per-actor rate limiter (#2561), a karma floor (rejected in #2562/#3309), and `notifyCaylakPending` / `notifyCaylakEntersDivan` (already 0→1-gated).
