### PR TITLE
fix(ship-it): never park a `--auto` merge intent — clear it on every path that does not enqueue (#3723)

### DIFF
--- a/.decisions/0198-no-parked-merge-intent.md
+++ b/.decisions/0198-no-parked-merge-intent.md
@@ -1,0 +1,120 @@
+---
+id: 0198
+title: "ship-it never parks a merge intent — an armed `--auto` is a transient artifact of a completed gate pass, cleared at every path that does not enqueue (closes the §CP approve-then-enqueue ordering hole)"
+status: accepted
+date: 2026-07-22
+tags: [pipeline, ship-it, control-plane, merge-queue, security]
+---
+
+# 0198 — No parked merge intent: `--auto` never outlives the run that armed it
+
+**What this decides:** ship-it keeps the ADR-0135 §CP enqueue primitive (`gh pr merge --auto`)
+but adds a **lifecycle invariant** around it — an armed merge request may exist only between a
+fully-gated Step-4 enqueue and the queue accepting the PR. Every other path (run start, any
+STOP/refusal, a merge-queue ejection, an enqueue that did not take effect) **clears** it, verified
+by an `auto_merge` read-back.
+
+## Context
+
+ADR [0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md) split the §CP
+merge into *human judgment* (the control-plane approval) and *pipeline mechanics* (the enqueue).
+The mechanics half is not a formality: ship-it's enqueue step is exactly where the machine gates
+are asserted **at that instant** — current-head-bound verdicts in every required namespace (ADR
+[0058](0058-sha-bound-verdict-contract.md)), the SHA-bound run-evidence bundle (ADR
+[0054](0054-run-evidence-bundle.md)/0056), the landed-comment leak scan, and zero substantive
+unresolved review threads (ADR [0158](0158-unresolved-review-thread-is-a-merge-gate.md)).
+
+**The hole: a merge intent survives the run that armed it.** `gh pr merge --auto` is a *durable
+request*, not a one-shot action. When it does not take effect at the head it was made against —
+because a requirement is unmet, or the run was interrupted mid-ship — GitHub keeps it armed, and
+it fires the moment the last requirement lands. On a §CP PR that last requirement is the human
+approval. So a §CP PR carrying a stale arm **enqueues the instant a fresh approval lands, with no
+ship-it run in between**: the assertions above are skipped at the decisive instant.
+
+Observed live on PR #3700 (2026-07-20, issue
+[#3723](https://github.com/kamp-us/phoenix/issues/3723)): `added_to_merge_queue` fired **one second
+after** the approving review, from an arm left by an earlier attempt that was interrupted by a
+conflict-resolving rebase; the ship-it run that was supposed to gate the enqueue started afterward
+and found the PR already queued. The concrete bad case the arm permits: a §CP PR that is enqueued,
+ejected from the queue (the expected failure mode under concurrent merges — ADR
+[0132](0132-merge-queue-for-base-freshness.md)), rebased, re-reviewed and re-approved
+**re-enqueues on the re-approval alone** — even if the new head's run-evidence bundle is missing or
+failing, or a leak landed in a verdict comment.
+
+**Scope, stated precisely: this is an ordering/integrity defect, not an approval bypass.** The
+human approval is still required and branch protection still enforces it (ADR 0135 / ADR
+[0048](0048-ship-it-merge-actor.md)). What the stale arm defeats is the *sequencing* — the
+guarantee that the enqueue happens **inside** a run that has just asserted the machine gates.
+
+## Decision
+
+**An armed merge intent is a transient artifact of a completed gate pass, never a durable state.**
+The §CP enqueue primitive is unchanged (`gh pr merge --auto`, no method flag — the queue owns
+SQUASH, ADR 0132); what changes is that no ship-it path may leave one parked. Four sites, one rule:
+
+1. **Run start (`preflight`)** — clear any intent armed before this run's guards ran. An arm that
+   predates the assertions is backed by no gate pass at this head; this is what catches the
+   interrupted run (the #3700 mechanism), which by definition reaches no exit path of its own.
+2. **Every STOP/refusal (`refuse`)** — the §CP `awaiting control-plane approval` stop, an
+   unverified/stale verdict, a red or still-pending CI, a missing run-evidence bundle, a
+   substantive unresolved thread, a landed-comment leak, a dropped-trigger nudge. A run that
+   declines to enqueue must not leave behind the means to enqueue without it.
+3. **A merge-queue ejection (`ejected`)** — an ejected PR re-enters through a *fresh* ship-it gate
+   pass, never by a surviving intent firing on the re-approval.
+4. **After the bounded post-enqueue reconcile (`post-enqueue`)** — if the queue governs this PR but
+   it is not queued, the `--auto` did not take effect: what remains is a parked intent, not a queue
+   entry.
+
+**What is deliberately NOT touched: a live queue entry.** When the PR is in the merge queue,
+ship-it never dequeues it — that entry *is* an authorized in-flight merge from a completed gate
+pass, and the async merge is the queue's to finish (ADR 0132). Fighting the queue would be a
+different decision; this one only refuses to *park* intent.
+
+**The exemption that keeps `--auto` universal-safe.** On a PR the merge queue has never governed
+(the pre-queue regime ADR 0132's transition safety preserves, and any foreign repo with no queue —
+ADR [0062](0062-repo-as-config-plugin.md)), the armed request *is* the sanctioned enqueue
+mechanism, so `post-enqueue` keeps it. The exemption is scoped to that one site: at `preflight` the
+same arm is stale by construction, in either regime.
+
+**The decision is a tested function, and the clear is verified.** The branch lives in the pure core
+of `pipeline-cli merge-intent` (`packages/pipeline-cli/src/tools/merge-intent/`), the single source
+ship-it runs, so it cannot drift across shippers — the `cp-cardinality` (ADR
+[0175](0175-cp-self-approval-cardinality-check.md)) / `merge-queue-classify` precedent. The verb
+does not trust `gh pr merge --disable-auto`'s exit code, which is non-zero both when the disable
+failed and when nothing was armed: it **re-reads `auto_merge`** and reports success only on a live
+`null`, the same self-verify shape `verdict post` applies to a landed comment. An unprovable clear
+fails **loud** (exit 1) rather than reporting a clean stop.
+
+**Fail-closed direction.** An unreadable arm state resolves to *disarm*: a needless disarm costs
+one idempotent re-ship (every ship-it refusal is already re-dispatchable by construction), while a
+surviving parked intent costs an ungated enqueue.
+
+## Consequences
+
+- **The enqueue is once again strictly downstream of the gate assertions.** For a §CP PR the
+  approval can no longer, by itself, move the PR into the merge queue: with no armed intent, the
+  approval is inert until a ship-it run asserts the current-head machine gates and enqueues. The
+  ADR-0135 split (human judgment via the approval, mechanics via the enqueue) is restored in
+  ordering, not just in name.
+- **The eject → rebase → re-approve cycle re-enters through the gate.** The ejection clears the
+  intent, so the re-approval cannot re-enqueue on its own; a fresh ship-it run re-asserts the new
+  head's verdicts, run-evidence, leak scan and threads before the PR returns to the queue.
+- **A stop is now provably a stop.** ship-it's refusals were already durable and PR-visible
+  (#1928); they are now also *complete* — a refusal that cannot prove the intent is clear reports
+  `failed`, so "ship-it declined" no longer silently means "ship-it declined, and armed the merge."
+- **No new merge authority, no weakened guard.** ADR 0048's single-merge-authority is untouched
+  (ship-it still owns the enqueue), 0135's approval gate is untouched, 0058's SHA-binding is
+  untouched, and no existing refusal becomes an enqueue. The change only *removes* a path by which
+  an enqueue could happen without a run.
+- **Cost: one extra `gh` round trip per lifecycle site**, and a rare needless disarm on an
+  unreadable read — recovered by an idempotent re-ship.
+- **Banned:** leaving `--auto` armed on a PR a run declined to enqueue ("it can't merge without an
+  approval anyway" — true about *merging*, false about *gating*, the exact #3700 reasoning);
+  treating `gh pr merge --disable-auto`'s exit code as proof of the clear; dequeuing a PR that is
+  live in the merge queue; extending the pre-queue exemption beyond the `post-enqueue` site.
+- **Relationship.** Repairs the enqueue seam of [0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)
+  without changing its approve-then-enqueue model or its primitive. Preserves
+  [0048](0048-ship-it-merge-actor.md) (single merge authority) and
+  [0132](0132-merge-queue-for-base-freshness.md) (the queue owns the async merge; a live entry is
+  never disturbed). Extends [0058](0058-sha-bound-verdict-contract.md)'s "a moved head invalidates
+  what was bound to the old one" from verdicts and approvals to the **merge intent** itself.

--- a/.decisions/0198-no-parked-merge-intent.md
+++ b/.decisions/0198-no-parked-merge-intent.md
@@ -55,26 +55,33 @@ SQUASH, ADR 0132); what changes is that no ship-it path may leave one parked. Fo
 1. **Run start (`preflight`)** — clear any intent armed before this run's guards ran. An arm that
    predates the assertions is backed by no gate pass at this head; this is what catches the
    interrupted run (the #3700 mechanism), which by definition reaches no exit path of its own.
-2. **Every STOP/refusal (`refuse`)** — the §CP `awaiting control-plane approval` stop, an
-   unverified/stale verdict, a red or still-pending CI, a missing run-evidence bundle, a
-   substantive unresolved thread, a landed-comment leak, a dropped-trigger nudge. A run that
-   declines to enqueue must not leave behind the means to enqueue without it.
+2. **Every STOP/refusal (`refuse`)** — the §CP `awaiting control-plane approval` stop, a
+   current-head FAIL verdict, an unverified/stale verdict, a red or still-pending CI, a missing
+   run-evidence bundle, a substantive unresolved thread, a landed-comment leak, a dropped-trigger
+   nudge, and the Step-1 stops (draft, closed-unmerged, no linked issue). A run that declines to
+   enqueue must not leave behind the means to enqueue without it.
 3. **A merge-queue ejection (`ejected`)** — an ejected PR re-enters through a *fresh* ship-it gate
    pass, never by a surviving intent firing on the re-approval.
-4. **After the bounded post-enqueue reconcile (`post-enqueue`)** — if the queue governs this PR but
-   it is not queued, the `--auto` did not take effect: what remains is a parked intent, not a queue
-   entry.
+4. **After the bounded post-enqueue reconcile (`post-enqueue`)** — if a merge queue governs the
+   base branch but the PR is not queued, the `--auto` did not take effect: what remains is a
+   parked intent, not a queue entry.
 
 **What is deliberately NOT touched: a live queue entry.** When the PR is in the merge queue,
 ship-it never dequeues it — that entry *is* an authorized in-flight merge from a completed gate
 pass, and the async merge is the queue's to finish (ADR 0132). Fighting the queue would be a
 different decision; this one only refuses to *park* intent.
 
-**The exemption that keeps `--auto` universal-safe.** On a PR the merge queue has never governed
-(the pre-queue regime ADR 0132's transition safety preserves, and any foreign repo with no queue —
-ADR [0062](0062-repo-as-config-plugin.md)), the armed request *is* the sanctioned enqueue
-mechanism, so `post-enqueue` keeps it. The exemption is scoped to that one site: at `preflight` the
-same arm is stale by construction, in either regime.
+**The exemption that keeps `--auto` universal-safe, and the predicate it keys on.** Where **no
+merge queue governs the PR's base branch** — the pre-queue regime ADR 0132's transition safety
+preserves, and any foreign repo with no queue (ADR [0062](0062-repo-as-config-plugin.md)) — the
+armed request *is* the sanctioned enqueue mechanism, so `post-enqueue` keeps it. The predicate is
+deliberately a **property of the base branch, not of the PR**: it is read from the branch's active
+rulesets (a `merge_queue` rule on `GET /repos/{repo}/rules/branches/{branch}`). A per-PR proxy —
+"has the queue ever governed *this PR*?" — looks equivalent and is not: under a merge queue, a PR
+on its **first** enqueue attempt has no queue history either, so the proxy would exempt exactly the
+parked intent this ADR exists to clear (the state PR #3700 was in before its ungated enqueue). The
+exemption is additionally scoped to that one site: at `preflight` the same arm is stale by
+construction, in either regime.
 
 **The decision is a tested function, and the clear is verified.** The branch lives in the pure core
 of `pipeline-cli merge-intent` (`packages/pipeline-cli/src/tools/merge-intent/`), the single source
@@ -85,17 +92,22 @@ failed and when nothing was armed: it **re-reads `auto_merge`** and reports succ
 `null`, the same self-verify shape `verdict post` applies to a landed comment. An unprovable clear
 fails **loud** (exit 1) rather than reporting a clean stop.
 
-**Fail-closed direction.** An unreadable arm state resolves to *disarm*: a needless disarm costs
-one idempotent re-ship (every ship-it refusal is already re-dispatchable by construction), while a
+**Fail-closed direction — every read, in the direction of disarm.** An unreadable arm state
+resolves to *disarm*. An unreadable base-branch regime resolves to *queue-governed*, so a failed
+read can never reach the exemption's keep — the exemption is only ever taken on positive evidence
+that no queue governs the branch. The asymmetry is deliberate: a needless disarm costs one
+idempotent re-ship (every ship-it refusal is already re-dispatchable by construction), while a
 surviving parked intent costs an ungated enqueue.
 
 ## Consequences
 
-- **The enqueue is once again strictly downstream of the gate assertions.** For a §CP PR the
-  approval can no longer, by itself, move the PR into the merge queue: with no armed intent, the
-  approval is inert until a ship-it run asserts the current-head machine gates and enqueues. The
-  ADR-0135 split (human judgment via the approval, mechanics via the enqueue) is restored in
-  ordering, not just in name.
+- **The enqueue is once again strictly downstream of the gate assertions.** On a queue-governed
+  base branch — every PR in this repo — an approval can no longer, by itself, move a §CP PR into
+  the merge queue: no ship-it path leaves an arm behind, so the approval is inert until a run
+  asserts the current-head machine gates and enqueues. The ADR-0135 split (human judgment via the
+  approval, mechanics via the enqueue) is restored in ordering, not just in name. Where **no**
+  merge queue governs the base branch, the pre-queue exemption is in force by design and `--auto`
+  remains the enqueue mechanism — that regime is out of this ADR's scope, not an unstated residual.
 - **The eject → rebase → re-approve cycle re-enters through the gate.** The ejection clears the
   intent, so the re-approval cannot re-enqueue on its own; a fresh ship-it run re-asserts the new
   head's verdicts, run-evidence, leak scan and threads before the PR returns to the queue.
@@ -106,12 +118,15 @@ surviving parked intent costs an ungated enqueue.
   (ship-it still owns the enqueue), 0135's approval gate is untouched, 0058's SHA-binding is
   untouched, and no existing refusal becomes an enqueue. The change only *removes* a path by which
   an enqueue could happen without a run.
-- **Cost: one extra `gh` round trip per lifecycle site**, and a rare needless disarm on an
-  unreadable read — recovered by an idempotent re-ship.
+- **Cost: two extra `gh` round trips per lifecycle site** (the merge state plus the base-branch
+  regime probe), and a rare needless disarm on an unreadable read — recovered by an idempotent
+  re-ship.
 - **Banned:** leaving `--auto` armed on a PR a run declined to enqueue ("it can't merge without an
   approval anyway" — true about *merging*, false about *gating*, the exact #3700 reasoning);
   treating `gh pr merge --disable-auto`'s exit code as proof of the clear; dequeuing a PR that is
-  live in the merge queue; extending the pre-queue exemption beyond the `post-enqueue` site.
+  live in the merge queue; extending the pre-queue exemption beyond the `post-enqueue` site; and
+  re-keying that exemption onto a per-PR signal (queue history, arm age) instead of the base
+  branch's regime.
 - **Relationship.** Repairs the enqueue seam of [0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)
   without changing its approve-then-enqueue model or its primitive. Preserves
   [0048](0048-ship-it-merge-actor.md) (single merge authority) and

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-it
-description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132) — then a bounded post-enqueue reconcile watches a batch window to catch a merge-queue ejection (a dropped PR — still open, no longer queued, not merged), routing an ejected PR back to repair/re-queue instead of reporting a silent false success. When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). For a control-plane PR (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053) — it enqueues the §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — human judgment via the approval, pipeline mechanics via the enqueue. Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
+description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132) — then a bounded post-enqueue reconcile watches a batch window to catch a merge-queue ejection (a dropped PR — still open, no longer queued, not merged), routing an ejected PR back to repair/re-queue instead of reporting a silent false success. When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). For a control-plane PR (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053) — it enqueues the §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — human judgment via the approval, pipeline mechanics via the enqueue. Every path that does NOT enqueue clears the `--auto` merge intent (`pipeline-cli merge-intent disarm`, ADR 0198) so a later bare approval can never enqueue ahead of these gates. Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
 ---
 
 # ship-it
@@ -126,6 +126,65 @@ pointless.
    [0158](https://github.com/kamp-us/phoenix/blob/main/.decisions/0158-unresolved-review-thread-is-a-merge-gate.md)).
    A shipper that "resolves" a real objection just re-creates the throw-away one layer down —
    never blanket-resolve threads to clear the gate.
+6. **You never leave a merge intent armed.** `gh pr merge --auto` is a durable *request*: an arm
+   that outlives the run that made it enqueues the PR the moment the last requirement lands — on a
+   §CP PR, the instant a human approval arrives — with no ship-it run asserting guards 1–5 in
+   between. So an armed intent may exist **only** between a fully-gated Step-4 enqueue and the
+   queue accepting the PR; every other path clears it (see
+   [the no-parked-merge-intent invariant](#no-parked-merge-intent) below, ADR
+   [0198](https://github.com/kamp-us/phoenix/blob/main/.decisions/0198-no-parked-merge-intent.md)).
+
+<a id="no-parked-merge-intent"></a>
+## The no-parked-merge-intent invariant — `--auto` never outlives its run (guard 6)
+
+When `--auto` does not take effect at the head it was made against — a requirement unmet, or the
+run interrupted mid-ship — GitHub keeps the request **armed** and fires it later, unattended. On
+PR #3700 that armed leftover enqueued the PR **one second after** the approving review, before the
+ship-it run that was supposed to gate the enqueue had started; the run then found it `already
+queued to merge` and merely confirmed the guards after the fact ([#3723](https://github.com/kamp-us/phoenix/issues/3723)).
+The approval requirement held throughout — the defect is purely one of **ordering**: the
+assertions this skill makes *at* enqueue time can be skipped at the decisive instant. The bad case
+the arm permits is concrete: a §CP PR enqueued → ejected → rebased → re-approved **re-enqueues on
+the re-approval alone**, even with a missing run-evidence bundle at the new head.
+
+The enqueue primitive is unchanged (`gh pr merge --auto`, Step 4). What is added is a lifecycle
+rule with **four mandated sites** — run start, every stop/refusal, an ejection, and after the
+bounded reconcile:
+
+```bash
+# `merge-intent` owns the branch (ADR 0198): a live merge-queue entry is NEVER disturbed, the
+# pre-queue auto-merge regime is exempt at `post-enqueue` only, and an unreadable arm state
+# fail-closes to a clear. It verifies by re-reading `auto_merge` — never trust
+# `--disable-auto`'s exit code, which is non-zero both when the disable failed and when nothing
+# was armed. Exit 1 = the intent may STILL be armed: surface it, never report a clean stop over it.
+INTENT_UNCLEARED=0   # set by any failed disarm; the run's outcome line MUST carry it (see Reporting)
+disarm_intent() {   # $1 = preflight | refuse | post-enqueue | ejected
+  pipeline-cli merge-intent disarm --pr "$PR" --repo "$REPO" --site "$1" || {
+    echo "ship-it: FAILED to clear the merge intent on #$PR (site $1) — a later approval could enqueue it ungated (ADR 0198). Disable auto-merge by hand before this PR is approved again." >&2
+    return 1
+  }
+}
+
+# Site 1 — run start: the moment $PR and $REPO are resolved (Step 0's first lines) and BEFORE any
+# gate branches. An intent armed by an earlier or interrupted run is backed by no gate pass at this
+# head; this is the site that catches the INTERRUPTED run (#3700's mechanism), which by definition
+# reaches no exit path of its own. Abort the run if it cannot be cleared — a ship that cannot
+# establish the intent state cannot honor the invariant at any later site.
+disarm_intent preflight || exit 1
+```
+
+**Site 2 is every path that stops or refuses** — Step 0's `awaiting control-plane approval`, Step
+2/2b's `unverified …`, Step 3's gating red, the CI-settle refusals, Step 3z's dropped-trigger
+nudge, Step 3.5's run-evidence refusals, Step 3.6's substantive thread, Step 3.7's leak: each runs
+`disarm_intent refuse` **before it reports**. A run that declines to enqueue must not leave behind
+the means to enqueue without it. Sites 3 and 4 (`ejected`, `post-enqueue`) live in Step 5.5, where
+the terminal state is known.
+
+A failed disarm **never rewrites a stop path's own control flow** — each site records
+`INTENT_UNCLEARED=1` and continues to its existing disposition (so the durable PR-visible outcome
+of #1928 and the `heal-ci` routing are untouched) — but it **does** change what the run reports:
+an outcome line for a run with `INTENT_UNCLEARED=1` must name it, because "ship-it declined" and
+"ship-it declined and left the merge armed" are different facts.
 
 ## The merge-ready signals
 
@@ -373,7 +432,9 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
     enter the ADR 0132 queue too). §CP carries **one extra** gate — the team approval — layered on
     the same machine gates every PR clears.
   - **stop** (the cardinality branch's required current-head signal is absent, or the team is
-    empty) → **STOP.** Report `awaiting control-plane approval` and stop; do **not** enqueue. This
+    empty) → **STOP.** Run `disarm_intent refuse` (guard 6 — this is *the* stop the parked-intent
+    defect fires on: the approval this PR is waiting for would otherwise enqueue it the instant it
+    lands), then report `awaiting control-plane approval` and stop; do **not** enqueue. This
     **replaces** the old blanket refuse.
 
   This holds even if the rest of the diff is clean code/docs/skills — a mixed PR that touches the
@@ -872,6 +933,11 @@ verb exits non-zero on **both** `--expect PASS` and `--expect FAIL` — leaving 
 `<g>_FAIL=0`, which is exactly `unverified (verdict not bound to current head)` → refuse. There is
 no separate marker staleness test to run here, and none to keep in sync (#2102).
 
+Every `unverified …` here is a stop path, so it runs `disarm_intent refuse` before reporting
+(guard 6): the head that moved out from under the verdict is the same head an armed intent would
+enqueue behind your back — ADR 0058's staleness rule and ADR 0198's are one rule applied to two
+artifacts.
+
 Two signals `verdict read` does **not** resolve still need the test applied explicitly, so the
 helper stays: the **native review**'s `commit_id` (folded into the code namespace in Step 2) and the
 **§CP advisory**'s body `Reviewed-head` SHA (Step 2.§CP).
@@ -1074,7 +1140,8 @@ Classify in this order (`skipping`/`cancel` are non-blocking — neither a failu
 in-flight wait):
 
 1. **Any *gating* check red** (a `fail` whose name is not known-informational) → do **not**
-   merge. Route it to the self-heal lane: invoke [`/heal-ci`](../heal-ci/SKILL.md) with this
+   merge. Run `disarm_intent refuse` (guard 6), then route it to the self-heal lane: invoke
+   [`/heal-ci`](../heal-ci/SKILL.md) with this
    PR/run, then report the result (e.g. `routed to heal-ci`). `heal-ci` decides
    flake-vs-defect; you only refuse on a gating red and hand off — you still do not merge.
 2. **Else, any check pending** (no gating red, some unfinished) → **enter the bounded CI-settle
@@ -1145,6 +1212,7 @@ ci_settle_wait() {   # returns 0=settled-green→enqueue · 1=refused (budget-ex
       esac
     done < <(gh pr checks "$PR" --json name,state,bucket --jq '.[] | "\(.bucket)\t\(.name)"')
     if [ -n "$red" ]; then
+      disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: this wait ends without an enqueue — park nothing
       echo "gating check went red during settle-wait ($red) — routing to heal-ci"; return 2
     fi
     if [ -z "$pending" ]; then
@@ -1156,12 +1224,14 @@ ci_settle_wait() {   # returns 0=settled-green→enqueue · 1=refused (budget-ex
       # durable-comment/stop disposition as budget-exhaustion) so a re-dispatch re-runs Step 2b on the moved head.
       headnow="$(gh api repos/$REPO/pulls/$PR --jq '.head.sha')"
       if [ -n "$headnow" ] && [ "$headnow" != "$CURRENT_HEAD" ]; then
+        disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: a moved head invalidates the intent exactly as it does the verdict (ADR 0198/0058)
         gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — head moved during CI-settle (verified ${CURRENT_HEAD}, now ${headnow}) — **not enqueued**. The SHA-bound verdict and run-evidence (Step 2/2b) predate this head; re-dispatch ship-it to re-verify the moved head — idempotent, a re-ship on a re-verified head enqueues cleanly (#1928)." >/dev/null
         echo "refused — head moved during settle-wait (${CURRENT_HEAD} → ${headnow}); Step 2b must re-run — not enqueued"; return 1
       fi
       echo "gating checks settled green after ${waited}s — proceeding to Step 3.5 → enqueue"; return 0
     fi
     if [ "$waited" -ge "$SETTLE_BUDGET_SECS" ]; then
+      disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: the budget ran out without an enqueue — park nothing
       # Budget exhausted, still pending → the ONE required durable signal: an explicit PR-visible refusal.
       # A plain outcome note, NOT a review-* verdict marker — so it never blocks a later idempotent re-ship.
       gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: refused — CI still pending after ${SETTLE_BUDGET_SECS}s (gating checks unfinished:${pending}) — **not enqueued**. This head is not yet merge-ready; re-dispatch ship-it once CI settles — idempotent, a re-ship on the now-green head enqueues cleanly (#1928)." >/dev/null
@@ -1241,6 +1311,8 @@ loop:
 HEAD_PUSHED=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date')
 NUDGES=$(gh api "repos/$REPO/issues/$PR/events?per_page=100" \
   --jq "[.[] | select(.event==\"reopened\") | .created_at | select(. > \"$HEAD_PUSHED\")] | length")
+
+disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: BOTH exits below stop without enqueuing — park nothing (ADR 0198)
 
 if [ "${NUDGES:-0}" -ge 1 ]; then
   # Nudge exhausted → refuse and hand to a human, but leave a durable PR-visible signal (#1928):
@@ -1349,10 +1421,14 @@ schema, a stale commit, or any failed check refuses the merge with a *distinct* 
 string; never a silent pass:
 
 ```bash
+# Each of the four refusals below is a stop path, so each clears the merge intent before it
+# reports (guard 6 / ADR 0198) — one wrapper, not four hand-copied disarms.
+refuse_ship() { disarm_intent refuse || INTENT_UNCLEARED=1; echo "$1"; exit 0; }
+
 # 1. The bundle must exist. No head-SHA run, no run-evidence artifact, or no manifest in it
 #    → there is no proof this commit was run → refuse (ADR 0056: the artifact is the storage).
 if [ -z "$RUN_ID" ] || [ -z "$ART_ID" ] || [ ! -s "$MANIFEST" ]; then
-  echo "unverified (no run-evidence bundle)"; exit 0   # refuse — see Running it
+  refuse_ship "unverified (no run-evidence bundle)"   # refuse — see Running it
 fi
 
 # 2. schemaVersion the gate understands. Fail closed on an unrecognized MAJOR rather than
@@ -1362,18 +1438,18 @@ fi
 #    is only the human-readable echo for the refusal message.
 SCHEMA=$(jq -r '.schemaVersion // empty' "$MANIFEST")
 jq -e '.schemaVersion == 1' "$MANIFEST" >/dev/null \
-  || { echo "unverified (unsupported bundle schemaVersion: ${SCHEMA:-none})"; exit 0; }
+  || refuse_ship "unverified (unsupported bundle schemaVersion: ${SCHEMA:-none})"
 
 # 3. bundle.commit MUST equal the PR head SHA — evidence not for THIS commit is no evidence
 #    (ADR 0054 §1). A green run from an earlier push is stale → refuse.
 BUNDLE_COMMIT=$(jq -r '.commit // empty' "$MANIFEST")
-[ "$BUNDLE_COMMIT" = "$HEAD_SHA" ] || { echo "unverified (stale run-evidence bundle: commit $BUNDLE_COMMIT != head $HEAD_SHA)"; exit 0; }
+[ "$BUNDLE_COMMIT" = "$HEAD_SHA" ] || refuse_ship "unverified (stale run-evidence bundle: commit $BUNDLE_COMMIT != head $HEAD_SHA)"
 
 # 4. EVERY checks[] entry must be `pass`. Any `fail` (or an empty checks[]) → refuse.
 FAILED=$(jq -r '[.checks[]? | select(.status != "pass") | .name] | join(", ")' "$MANIFEST")
 NCHECKS=$(jq -r '.checks | length' "$MANIFEST")
 if [ "$NCHECKS" -eq 0 ] || [ -n "$FAILED" ]; then
-  echo "run-evidence checks failed (${FAILED:-no checks present})"; exit 0   # refuse
+  refuse_ship "run-evidence checks failed (${FAILED:-no checks present})"   # refuse
 fi
 ```
 
@@ -1485,7 +1561,8 @@ For **each** unresolved thread the query returns:
 
 - **Substantive** — a real objection: a requested change ("fix this", "handle this case", "this
   is wrong", "don't do X"), a bot finding that names a real defect (an unused import, a missing
-  guard), or anything you cannot confidently call trivial. → **REFUSE to enqueue.** Report
+  guard), or anything you cannot confidently call trivial. → **REFUSE to enqueue.** Run
+  `disarm_intent refuse` (guard 6), then report
   `unresolved substantive review thread (<path>:<line>, @<author>)` and stop — this is a FAIL-class
   refusal, routed back to `write-code` to address the thread on the branch. Do **not** resolve it.
 - **Genuine nit** — a trivial, already-satisfied, or obsolete note (a style preference already
@@ -1531,6 +1608,7 @@ matcher `redact-leaks` and `verdict post` already consume — one detector, not 
 ```bash
 # guard 4 — refuse the enqueue on ANY live leak in a landed comment (exit 2 = a leak; ADR 0092 fail-closed)
 pipeline-cli leak-guard scan-pr "$PR" || {
+  disarm_intent refuse || INTENT_UNCLEARED=1   # guard 6: a refusal parks nothing (ADR 0198)
   echo "ship-it: REFUSING to enqueue #$PR — a landed comment carries a machine-local path (issue #3019)." >&2
   echo "  Remediate, then re-run ship-it:" >&2
   echo "  1. redact each flagged comment body — pipeline-cli redact-leaks (the merged #3021 tool) preserves evidential shape;" >&2
@@ -1563,6 +1641,10 @@ base before it lands (ADR
 ```bash
 gh pr merge $PR --auto
 ```
+
+This is the **only** place a merge intent is ever armed (guard 6 / ADR 0198) — reaching it means
+every guard above cleared at *this* head, which is exactly what makes the arm legitimate. It stays
+armed only until the queue takes the PR; Step 5.5 clears it if the queue never does.
 
 Pass **no** merge-method flag: the merge queue owns the method (SQUASH, set in the ruleset),
 so a `--squash` here **conflicts** with the queue and silently no-ops the enqueue (exits 0 but
@@ -1684,6 +1766,20 @@ for i in $(seq 1 "$RECONCILE_TRIES"); do
 done
 # At the budget's end a still-`pending` PR (never a merge-queue event) is reported as a well-formed
 # pending, NOT ejected — the settle window is not an ejection (#1921).
+
+# Guard 6 (ADR 0198) — the reconcile's terminal read is the LAST place this run can leave an arm
+# behind, so it is also sites 3 and 4. `merged` and `queued` keep the intent (a live queue entry is
+# never disturbed); an `ejected` PR is cleared so a re-approval after its rebase cannot re-enqueue
+# it ahead of a fresh gate pass; and a PR the queue governs but never took is a PARKED intent, not
+# a queue entry — `merge-intent` distinguishes the two, so a pre-queue repo's legitimate armed
+# auto-merge is untouched.
+if [ "$MERGE_OUTCOME" = ejected ]; then
+  disarm_intent ejected || INTENT_UNCLEARED=1
+else
+  INTENT_ACTION=$(pipeline-cli merge-intent disarm --pr "$PR" --repo "$REPO" --site post-enqueue) || INTENT_UNCLEARED=1
+  [ "$INTENT_ACTION" = disarmed ] && \
+    echo "refused — the enqueue did not take effect at this head; the parked intent was cleared. Re-dispatch ship-it to re-assert the gates and enqueue (idempotent)."
+fi
 ```
 
 Then act on `MERGE_OUTCOME`, and only here — **never at Step 4's enqueue** — decide the run's
@@ -1698,7 +1794,11 @@ merge disposition:
   (ADR 0132: the actor does not block to the final merge). Report `enqueued: yes (→ auto-merges on
   green)` exactly as before — the reconcile confirmed it was **still in-flight, never ejected**,
   within the window. A `pending` PR at the budget's end is reported this way too — the settle window
-  is **never** an ejection (#1921).
+  is **never** an ejection (#1921). **One carve-out** (guard 6): a `pending` PR that the merge queue
+  has *already governed* never entered the queue this time, so what it carries is a parked intent,
+  not an in-flight enqueue — the guard-6 block above clears it and the run reports
+  `refused — the enqueue did not take effect at this head` instead. A PR the queue has **never**
+  governed keeps its arm (the pre-queue regime) and is reported as the well-formed pending above.
 - **`ejected`** — the queue **dropped** the PR (still open, no longer queued, not merged) — keyed on
   the authoritative `removed_from_merge_queue` timeline event, not on a momentary state. This is
   the silent stall this step exists to catch. Do **not** report shipped. **Route it back to
@@ -1714,7 +1814,10 @@ merge disposition:
   ```
 
   ship-it does **not** itself re-enqueue an ejected PR in the same run (a bare re-enqueue would
-  loop on the same unmerged batch conflict); the ejection is surfaced and handed to the repair /
+  loop on the same unmerged batch conflict) — **and, under guard 6, it leaves no arm that could
+  re-enqueue it either**: the ejected PR's intent is cleared above, so the eject → rebase →
+  re-review → re-approve cycle re-enters the queue only through a fresh ship-it gate pass, never on
+  the re-approval alone (ADR 0198). The ejection is surfaced and handed to the repair /
   re-queue lane (the `drive-issue.js` shipper stage consumes `ejected` and re-drives), the same
   fail → fix → re-request boundary write-code owns. The **success/watch distinction is now
   observable** — `QUEUED` never masks a stall, because the reconcile separated `merged` from
@@ -1972,6 +2075,12 @@ durable PR outcome comment), `no linked issue`, or a run-evidence refusal (Step 
 `unverified (no run-evidence bundle)`, `unverified (unsupported bundle schemaVersion: <v>)`,
 `unverified (stale run-evidence bundle: …)`, or `run-evidence checks failed (<names>)`. A
 refusal is a successful run — shipping the wrong PR is the only failure mode that matters.
+
+**A refusal carries one more fact: the merge intent is clear.** Every reason above is reported by a
+path that ran `disarm_intent refuse` (guard 6), so a refused PR cannot enqueue on the next approval
+without a fresh ship-it run. If a disarm ever failed (`INTENT_UNCLEARED=1`), append
+`merge intent: NOT cleared — auto-merge may still be armed, disable it by hand` to the ledger —
+never report a clean stop over an armed intent (ADR 0198).
 
 ## Conventions
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -152,12 +152,13 @@ rule with **four mandated sites** — run start, every stop/refusal, an ejection
 bounded reconcile:
 
 ```bash
-# `merge-intent` owns the branch (ADR 0198): a live merge-queue entry is NEVER disturbed, the
-# pre-queue auto-merge regime is exempt at `post-enqueue` only, and an unreadable arm state
-# fail-closes to a clear. It verifies by re-reading `auto_merge` — never trust
+# `merge-intent` owns the branch (ADR 0198): a live merge-queue entry is NEVER disturbed; the
+# pre-queue regime — read off the BASE BRANCH's ruleset, not this PR's queue history — is exempt at
+# `post-enqueue` only; and both reads fail closed toward a clear. It verifies by re-reading
+# `auto_merge` — never trust
 # `--disable-auto`'s exit code, which is non-zero both when the disable failed and when nothing
 # was armed. Exit 1 = the intent may STILL be armed: surface it, never report a clean stop over it.
-INTENT_UNCLEARED=0   # set by any failed disarm; the run's outcome line MUST carry it (see Reporting)
+INTENT_UNCLEARED=0   # set by any failed disarm; the run's outcome line MUST carry it (see Running it)
 disarm_intent() {   # $1 = preflight | refuse | post-enqueue | ejected
   pipeline-cli merge-intent disarm --pr "$PR" --repo "$REPO" --site "$1" || {
     echo "ship-it: FAILED to clear the merge intent on #$PR (site $1) — a later approval could enqueue it ungated (ADR 0198). Disable auto-merge by hand before this PR is approved again." >&2
@@ -165,20 +166,27 @@ disarm_intent() {   # $1 = preflight | refuse | post-enqueue | ejected
   }
 }
 
-# Site 1 — run start: the moment $PR and $REPO are resolved (Step 0's first lines) and BEFORE any
-# gate branches. An intent armed by an earlier or interrupted run is backed by no gate pass at this
-# head; this is the site that catches the INTERRUPTED run (#3700's mechanism), which by definition
-# reaches no exit path of its own. Abort the run if it cannot be cleared — a ship that cannot
-# establish the intent state cannot honor the invariant at any later site.
-disarm_intent preflight || exit 1
+# Site 1 — run start. This function is DEFINED here; the call itself is WIRED at Step 0, on the
+# line after `PR=` — the first point at which both $PR and $REPO exist (see "Step 0 — Classify the
+# diff"). Do not call it here: this block is preamble and runs before Step 0 resolves $PR.
 ```
 
-**Site 2 is every path that stops or refuses** — Step 0's `awaiting control-plane approval`, Step
+**Site 1 is Step 0's `disarm_intent preflight || exit 1`, and it is the one that catches the
+interrupted run** — #3700's actual mechanism, which by definition reaches no exit path of its own,
+so no `refuse` site can ever fire for it. An intent armed by an earlier or interrupted run is
+backed by no gate pass at this head. Abort the run if it cannot be cleared: a ship that cannot
+establish the intent state cannot honor the invariant at any later site.
+
+**Site 2 is every path that stops or refuses**, without exception — each runs `disarm_intent
+refuse` **before it reports**. A run that declines to enqueue must not leave behind the means to
+enqueue without it. The refusal strings enumerated in [Running it](#running-it) are that set; in
+step order they are Step 0's `awaiting control-plane approval`, Step 1's `draft` /
+`closed (unmerged)` / `no linked issue`, Step 2 guard 1's `latest verdict is FAIL (<gate>)`, Step
 2/2b's `unverified …`, Step 3's gating red, the CI-settle refusals, Step 3z's dropped-trigger
-nudge, Step 3.5's run-evidence refusals, Step 3.6's substantive thread, Step 3.7's leak: each runs
-`disarm_intent refuse` **before it reports**. A run that declines to enqueue must not leave behind
-the means to enqueue without it. Sites 3 and 4 (`ejected`, `post-enqueue`) live in Step 5.5, where
-the terminal state is known.
+nudge, Step 3.5's run-evidence refusals, Step 3.6's substantive thread, and Step 3.7's leak. Read
+the rule, not the list: a stop path this list forgot is still a Site-2 path, and Site 1 is the
+backstop that clears whatever any exit missed on the *next* run. Sites 3 and 4 (`ejected`,
+`post-enqueue`) live in Step 5.5, where the terminal state is known.
 
 A failed disarm **never rewrites a stop path's own control flow** — each site records
 `INTENT_UNCLEARED=1` and continues to its existing disposition (so the durable PR-visible outcome
@@ -264,6 +272,15 @@ PR=<pr number>
 # has NO surface in ship-it — it stages/commits nothing — so it is enforced upstream in the pre-bash
 # hook + write-code/review-code, not duplicated here.
 iso_preflight ship-it || exit 1   # ../gh-issue-intake-formats.md §RO-iso — define it there, cite here
+
+# Guard 6, SITE 1 (ADR 0198) — the first thing after $PR is known and BEFORE any gate branch, so a
+# `--auto` armed by an earlier or INTERRUPTED run (#3700's mechanism — the run that reaches no exit
+# path of its own, so no `refuse` site ever fires for it) cannot enqueue behind this run's back.
+# $REPO was resolved at the top of the skill; $PR one line up. `disarm_intent` is defined in
+# "The no-parked-merge-intent invariant" above. Abort on failure: a run that cannot establish the
+# intent state cannot honor the invariant at any later site.
+disarm_intent preflight || exit 1
+
 gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
 ```
 
@@ -432,9 +449,10 @@ echo "$FILES" | grep -Ev "$UI_EXCLUDE_RE" | grep -Eq "$UI_RE" && echo "has-ui"  
     enter the ADR 0132 queue too). §CP carries **one extra** gate — the team approval — layered on
     the same machine gates every PR clears.
   - **stop** (the cardinality branch's required current-head signal is absent, or the team is
-    empty) → **STOP.** Run `disarm_intent refuse` (guard 6 — this is *the* stop the parked-intent
-    defect fires on: the approval this PR is waiting for would otherwise enqueue it the instant it
-    lands), then report `awaiting control-plane approval` and stop; do **not** enqueue. This
+    empty) → **STOP.** Run `disarm_intent refuse || INTENT_UNCLEARED=1` (guard 6 — this is *the*
+    stop the parked-intent defect fires on: the approval this PR is waiting for would otherwise
+    enqueue it the instant it lands), then report `awaiting control-plane approval` and stop; do
+    **not** enqueue. This
     **replaces** the old blanket refuse.
 
   This holds even if the rest of the diff is clean code/docs/skills — a mixed PR that touches the
@@ -637,7 +655,8 @@ gh api repos/$REPO/pulls/$PR \
 ```
 
 If the PR is already `merged` → nothing to do, report it shipped and stop (idempotent).
-If it's `draft` or `state=closed` (unmerged) → stop, report why.
+If it's `draft` or `state=closed` (unmerged) → run `disarm_intent refuse || INTENT_UNCLEARED=1`
+(guard 6 — a Site-2 stop like any other), then stop and report why.
 
 Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `write-code`
 writes and `review-code` relies on) and pin it as a shell var Step 5 reads back:
@@ -694,7 +713,8 @@ no `claude-plugins/**` skills source).
 - **A real code or skills class is present** — a changed path under `apps/**`, `packages/**`,
   `infra/**`, or `claude-plugins/**` (skills source), i.e. the PR is **not**
   doc/vocab-surface-only — **with no issue reference at all** — neither a closing keyword **nor**
-  the explicit `Part of #N` partial-split marker above → stop and report `no linked issue`. In
+  the explicit `Part of #N` partial-split marker above → run `disarm_intent refuse ||
+  INTENT_UNCLEARED=1` (guard 6), then stop and report `no linked issue`. In
   this pipeline `write-code` always writes `Fixes #N` (or, for a deliberate partial split,
   `Part of #N`), so a code PR that names **no** issue at all is a broken seam, not a normal
   state — it has nothing to auto-close on merge and would leave dangling work. (Distinct from the
@@ -1029,7 +1049,9 @@ Then gate the merge on the classes present (Step 0):
      needs a current-head `review-design` PASS alongside those (e.g. a UI code PR needs
      `review-code` **and** `review-design`).
 2. If **any** required namespace's current-head verdict is **FAIL** → **do not merge.** The PR
-   has unaddressed failures as its *current* state, even if an older PASS exists. Report
+   has unaddressed failures as its *current* state, even if an older PASS exists. Run
+   `disarm_intent refuse || INTENT_UNCLEARED=1` (guard 6 — a FAIL'd PR that still carries an arm
+   would enqueue on the next approval with its failures unaddressed), report
    `latest verdict is FAIL (<which gate>)` and stop; the fix round-trip is `write-code`'s
    (code) / the doc author's job, not yours.
 3. If **every** required namespace's current-head verdict is PASS → guard 1 cleared, proceed to
@@ -1140,7 +1162,8 @@ Classify in this order (`skipping`/`cancel` are non-blocking — neither a failu
 in-flight wait):
 
 1. **Any *gating* check red** (a `fail` whose name is not known-informational) → do **not**
-   merge. Run `disarm_intent refuse` (guard 6), then route it to the self-heal lane: invoke
+   merge. Run `disarm_intent refuse || INTENT_UNCLEARED=1` (guard 6), then route it to the
+   self-heal lane: invoke
    [`/heal-ci`](../heal-ci/SKILL.md) with this
    PR/run, then report the result (e.g. `routed to heal-ci`). `heal-ci` decides
    flake-vs-defect; you only refuse on a gating red and hand off — you still do not merge.
@@ -1562,7 +1585,7 @@ For **each** unresolved thread the query returns:
 - **Substantive** — a real objection: a requested change ("fix this", "handle this case", "this
   is wrong", "don't do X"), a bot finding that names a real defect (an unused import, a missing
   guard), or anything you cannot confidently call trivial. → **REFUSE to enqueue.** Run
-  `disarm_intent refuse` (guard 6), then report
+  `disarm_intent refuse || INTENT_UNCLEARED=1` (guard 6), then report
   `unresolved substantive review thread (<path>:<line>, @<author>)` and stop — this is a FAIL-class
   refusal, routed back to `write-code` to address the thread on the branch. Do **not** resolve it.
 - **Genuine nit** — a trivial, already-satisfied, or obsolete note (a style preference already
@@ -1770,9 +1793,10 @@ done
 # Guard 6 (ADR 0198) — the reconcile's terminal read is the LAST place this run can leave an arm
 # behind, so it is also sites 3 and 4. `merged` and `queued` keep the intent (a live queue entry is
 # never disturbed); an `ejected` PR is cleared so a re-approval after its rebase cannot re-enqueue
-# it ahead of a fresh gate pass; and a PR the queue governs but never took is a PARKED intent, not
-# a queue entry — `merge-intent` distinguishes the two, so a pre-queue repo's legitimate armed
-# auto-merge is untouched.
+# it ahead of a fresh gate pass; and an arm that never became a queue entry on a QUEUE-GOVERNED
+# base branch is a PARKED intent — `merge-intent` reads the base branch's ruleset to tell the two
+# regimes apart, so a repo whose base branch has no merge queue keeps its legitimate armed
+# auto-merge while this repo's every unqueued arm is cleared.
 if [ "$MERGE_OUTCOME" = ejected ]; then
   disarm_intent ejected || INTENT_UNCLEARED=1
 else
@@ -1794,11 +1818,14 @@ merge disposition:
   (ADR 0132: the actor does not block to the final merge). Report `enqueued: yes (→ auto-merges on
   green)` exactly as before — the reconcile confirmed it was **still in-flight, never ejected**,
   within the window. A `pending` PR at the budget's end is reported this way too — the settle window
-  is **never** an ejection (#1921). **One carve-out** (guard 6): a `pending` PR that the merge queue
-  has *already governed* never entered the queue this time, so what it carries is a parked intent,
-  not an in-flight enqueue — the guard-6 block above clears it and the run reports
-  `refused — the enqueue did not take effect at this head` instead. A PR the queue has **never**
-  governed keeps its arm (the pre-queue regime) and is reported as the well-formed pending above.
+  is **never** an ejection (#1921). **One carve-out** (guard 6): on a base branch a **merge queue
+  governs** — every PR in this repo — a `pending` PR never entered the queue at all, so what it
+  carries is a parked intent, not an in-flight enqueue; the guard-6 block above clears it and the
+  run reports `refused — the enqueue did not take effect at this head` instead. Only where the base
+  branch has **no** merge queue does the arm stay (the pre-queue regime, where `--auto` *is* the
+  enqueue mechanism) and get reported as the well-formed pending above. The predicate is the
+  branch's regime, never this PR's own queue history: a first-attempt PR under a queue has no
+  history either, so keying on history would leave exactly the #3700 arm parked.
 - **`ejected`** — the queue **dropped** the PR (still open, no longer queued, not merged) — keyed on
   the authoritative `removed_from_merge_queue` timeline event, not on a momentary state. This is
   the silent stall this step exists to catch. Do **not** report shipped. **Route it back to

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -42,6 +42,7 @@ import {intakeComposeCommand} from "./tools/intake-compose/command.ts";
 import {intakeDedupCommand} from "./tools/intake-dedup/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {mainSyncCommand} from "./tools/main-sync/command.ts";
+import {mergeIntentCommand} from "./tools/merge-intent/command.ts";
 import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
 import {orphanHealCommand} from "./tools/orphan-heal/command.ts";
 import {patchGuardCommand} from "./tools/patch-guard/command.ts";
@@ -117,6 +118,10 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	spawnGuardCommand,
 	leakGuardCommand,
 	mergeQueueClassifyCommand,
+	// #3723 — ship-it's no-parked-merge-intent enforcement (ADR 0198): clears a `gh pr merge
+	// --auto` request left armed by a run that did NOT enqueue, so a later bare approval can't
+	// enqueue a §CP PR ahead of the gate assertions. Verified by an `auto_merge` read-back.
+	mergeIntentCommand,
 	pathFilterGuardCommand,
 	pointerGuardCommand,
 	ciRequiredCommand,

--- a/packages/pipeline-cli/src/tools/merge-intent/README.md
+++ b/packages/pipeline-cli/src/tools/merge-intent/README.md
@@ -27,11 +27,17 @@ of a completed gate pass, never a durable state.
 | the merge already landed | **keep** — nothing left to park |
 | the PR is in the merge queue | **keep** — a live entry is a gated in-flight merge; ship-it never dequeues what a completed gate pass enqueued (ADR 0132) |
 | nothing armed | **keep** |
-| `post-enqueue` on a PR the queue has never governed | **keep** — the pre-queue auto-merge regime, where the armed request *is* the sanctioned enqueue mechanism |
+| `post-enqueue` on a base branch **no merge queue governs** | **keep** — the pre-queue auto-merge regime, where the armed request *is* the sanctioned enqueue mechanism |
 | `preflight` / `refuse` / `ejected` / a parked `post-enqueue` | **disarm** |
 
-An unreadable arm state (`unknown`) resolves to **disarm**: a needless disarm costs one
-idempotent re-ship, a surviving parked intent costs an ungated enqueue.
+The exemption keys on the **base branch's regime** (a `merge_queue` rule on
+`GET /repos/{repo}/rules/branches/{branch}`), never on the PR's own queue history: under a merge
+queue a PR on its *first* enqueue attempt has no history either, so a per-PR proxy would exempt
+exactly the parked intent this tool exists to clear.
+
+Both reads fail **closed**: an unreadable arm state (`unknown`) resolves to *disarm*, and an
+unreadable regime resolves *queue-governed* so it can never reach the keep above. A needless
+disarm costs one idempotent re-ship; a surviving parked intent costs an ungated enqueue.
 
 ## Split of concerns
 

--- a/packages/pipeline-cli/src/tools/merge-intent/README.md
+++ b/packages/pipeline-cli/src/tools/merge-intent/README.md
@@ -1,0 +1,60 @@
+# merge-intent
+
+`pipeline-cli merge-intent disarm` — the enforcement half of **ship-it's
+no-parked-merge-intent invariant** (ADR
+[0198](https://github.com/kamp-us/phoenix/blob/main/.decisions/0198-no-parked-merge-intent.md),
+issue [#3723](https://github.com/kamp-us/phoenix/issues/3723)).
+
+## Why it exists
+
+ship-it enqueues with `gh pr merge --auto`. When that request does not take effect at the
+head it was made against, GitHub keeps it **armed** — and it fires the moment the missing
+requirement lands. On a control-plane PR that requirement is the human approval, so the
+enqueue happens **the instant a fresh approval arrives, with no ship-it run in between**:
+the assertions ship-it makes *at* enqueue time (current-head verdicts, the SHA-bound
+run-evidence bundle, the landed-comment leak scan, unresolved review threads) are skipped at
+the decisive instant. Observed on PR #3700, where `added_to_merge_queue` fired one second
+after the approving review.
+
+The approval requirement itself still holds (ADR 0135 / 0048) — the defect is strictly one
+of **ordering**. The fix is a lifecycle rule: an armed merge intent is a transient artifact
+of a completed gate pass, never a durable state.
+
+## The branch (ADR 0198, transcribed)
+
+| State / site | Action |
+| --- | --- |
+| the merge already landed | **keep** — nothing left to park |
+| the PR is in the merge queue | **keep** — a live entry is a gated in-flight merge; ship-it never dequeues what a completed gate pass enqueued (ADR 0132) |
+| nothing armed | **keep** |
+| `post-enqueue` on a PR the queue has never governed | **keep** — the pre-queue auto-merge regime, where the armed request *is* the sanctioned enqueue mechanism |
+| `preflight` / `refuse` / `ejected` / a parked `post-enqueue` | **disarm** |
+
+An unreadable arm state (`unknown`) resolves to **disarm**: a needless disarm costs one
+idempotent re-ship, a surviving parked intent costs an ungated enqueue.
+
+## Split of concerns
+
+The branch lives in the pure, unit-tested core (`merge-intent.ts`); the `gh` IO in the
+service (`github.ts`), which also owns the **read-back verify** — `gh pr merge
+--disable-auto` exits non-zero both when the disable failed and when nothing was armed, so
+its exit code cannot carry the guarantee, while re-reading `auto_merge` can. The
+merge-queue-membership resolution is imported from `merge-queue-classify`, not re-derived.
+
+## Usage
+
+```bash
+# every ship-it path that does NOT enqueue clears the intent before it reports
+pipeline-cli merge-intent disarm --pr "$PR" --site refuse || {
+  echo "ship-it: a merge intent may still be armed on #$PR — do not report a clean stop" >&2
+  exit 1
+}
+```
+
+Sites: `preflight` (run start), `refuse` (any STOP/refusal), `post-enqueue` (after the
+bounded reconcile), `ejected` (a merge-queue ejection).
+
+The outcome word (`kept` | `disarmed` | `failed`) goes to **stdout**, the deciding reason to
+**stderr**. Exit is **0 on `kept`/`disarmed`, 1 on `failed`** — an unresolvable repo, an
+unknown site, or a disarm the read-back cannot confirm all fail loud, because each leaves the
+invariant unproven.

--- a/packages/pipeline-cli/src/tools/merge-intent/command.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/command.ts
@@ -1,20 +1,17 @@
 /**
- * The `merge-intent` tool — `pipeline-cli merge-intent disarm [flags]` (issue #3723, ADR 0198).
+ * The `merge-intent` tool — the enforcement half of ship-it's no-parked-merge-intent invariant.
  *
  *   pipeline-cli merge-intent disarm --pr 3700 --site refuse
  *   pipeline-cli merge-intent disarm --pr 3700 --site ejected --repo owner/r
  *
- * The enforcement half of ship-it's no-parked-merge-intent invariant: at each lifecycle site
- * where a run could leave a `gh pr merge --auto` request armed, this verb reads the live merge
- * state, applies the pure `decideMergeIntent` branch, and — when the branch says so — clears the
- * request and **verifies the clear by re-reading `auto_merge`**.
+ * The interface a ship-it stop path codes against: the outcome word (`kept` / `disarmed` /
+ * `failed`) goes to **stdout**, the deciding reason to **stderr**, and the exit is **0 on
+ * `kept`/`disarmed`, 1 on `failed`** — so `pipeline-cli merge-intent disarm … || <surface it>`
+ * never reports a clean STOP over an intent this run could not prove clear. Every unproven
+ * outcome is `failed`: an unresolvable repo, an unknown site, a disarm the read-back cannot
+ * confirm.
  *
- * Prints the outcome word (`kept` / `disarmed` / `failed`) to **stdout** and the deciding reason
- * to **stderr**. Exit is **0 on `kept`/`disarmed`, 1 on `failed`** — so a ship-it stop path reads
- * `pipeline-cli merge-intent disarm … || <surface the failure>` and never reports a clean STOP
- * while an intent is still armed. Failing loud is the whole contract: an unresolvable repo, an
- * unknown site, or a disarm the read-back cannot confirm are all `failed`, because each leaves
- * the invariant unproven.
+ * See ADR 0198 (#3723).
  */
 import {Console, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
@@ -66,7 +63,7 @@ const disarmCmd = Command.make(
 
 		const decision = decideMergeIntent(site as IntentSite, state);
 		yield* say(
-			`#${pr} site=${site} armed=${state.armed} merged=${state.merged} queued=${state.queued} ever-queued=${state.everQueued} → ${decision.action}: ${decision.reason}`,
+			`#${pr} site=${site} armed=${state.armed} merged=${state.merged} queued=${state.queued} queue-governed=${state.queueGoverned} → ${decision.action}: ${decision.reason}`,
 		);
 		if (decision.action === "keep") {
 			return yield* Console.log("kept");

--- a/packages/pipeline-cli/src/tools/merge-intent/command.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/command.ts
@@ -1,0 +1,107 @@
+/**
+ * The `merge-intent` tool — `pipeline-cli merge-intent disarm [flags]` (issue #3723, ADR 0198).
+ *
+ *   pipeline-cli merge-intent disarm --pr 3700 --site refuse
+ *   pipeline-cli merge-intent disarm --pr 3700 --site ejected --repo owner/r
+ *
+ * The enforcement half of ship-it's no-parked-merge-intent invariant: at each lifecycle site
+ * where a run could leave a `gh pr merge --auto` request armed, this verb reads the live merge
+ * state, applies the pure `decideMergeIntent` branch, and — when the branch says so — clears the
+ * request and **verifies the clear by re-reading `auto_merge`**.
+ *
+ * Prints the outcome word (`kept` / `disarmed` / `failed`) to **stdout** and the deciding reason
+ * to **stderr**. Exit is **0 on `kept`/`disarmed`, 1 on `failed`** — so a ship-it stop path reads
+ * `pipeline-cli merge-intent disarm … || <surface the failure>` and never reports a clean STOP
+ * while an intent is still armed. Failing loud is the whole contract: an unresolvable repo, an
+ * unknown site, or a disarm the read-back cannot confirm are all `failed`, because each leaves
+ * the invariant unproven.
+ */
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {Github, GithubLive} from "./github.ts";
+import {decideMergeIntent, type IntentSite} from "./merge-intent.ts";
+
+const SITES: ReadonlyArray<IntentSite> = ["preflight", "refuse", "post-enqueue", "ejected"];
+
+const prFlag = Flag.integer("pr").pipe(
+	Flag.withDescription("the PR number whose merge intent is being resolved"),
+);
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription("owner/repo (default: CLAUDE_PIPELINE_REPO / gh repo view)"),
+);
+
+const siteFlag = Flag.string("site").pipe(
+	Flag.withDescription(`ship-it lifecycle site: ${SITES.join(" | ")}`),
+);
+
+const say = (line: string): Effect.Effect<void> =>
+	Effect.sync(() => process.stderr.write(`merge-intent: ${line}\n`));
+
+/** Print the loud failure word + reason and exit 1 — the invariant could not be proven. */
+const failed = (reason: string): Effect.Effect<void> =>
+	say(`FAILED — ${reason}`).pipe(
+		Effect.andThen(Console.log("failed")),
+		Effect.andThen(Effect.sync(() => process.exit(1))),
+	);
+
+const disarmCmd = Command.make(
+	"disarm",
+	{pr: prFlag, repo: repoFlag, site: siteFlag},
+	Effect.fn(function* ({pr, repo, site}) {
+		if (!SITES.includes(site as IntentSite)) {
+			return yield* failed(`unknown --site '${site}' (expected one of: ${SITES.join(", ")})`);
+		}
+		const repoOverride = Option.getOrUndefined(repo);
+		const github = yield* Github;
+		const state = yield* github
+			.state(pr, repoOverride)
+			.pipe(
+				Effect.catchTag("@kampus/merge-intent/RepoResolutionError", (e) =>
+					Effect.as(failed(e.message), null),
+				),
+			);
+		if (state === null) return;
+
+		const decision = decideMergeIntent(site as IntentSite, state);
+		yield* say(
+			`#${pr} site=${site} armed=${state.armed} merged=${state.merged} queued=${state.queued} ever-queued=${state.everQueued} → ${decision.action}: ${decision.reason}`,
+		);
+		if (decision.action === "keep") {
+			return yield* Console.log("kept");
+		}
+
+		const outcome = yield* github
+			.disarm(pr, repoOverride)
+			.pipe(
+				Effect.catchTag("@kampus/merge-intent/RepoResolutionError", (e) =>
+					Effect.as(failed(e.message), null),
+				),
+			);
+		if (outcome === null) return;
+		if (!outcome.cleared) {
+			// The disable did not take, or the read-back could not confirm it — either way the PR may
+			// still carry an intent that a later approval would fire, so this must not read as success.
+			return yield* failed(
+				`the merge intent on #${pr} is still armed (or unverifiable) after \`gh pr merge --disable-auto\` (exit ${outcome.exitCode}${outcome.stderr ? `: ${outcome.stderr}` : ""}) — disable it by hand before the PR is approved again`,
+			);
+		}
+		yield* say(
+			`#${pr} carries no armed auto-merge request (verified by read-back${outcome.exitCode === 0 ? "" : `; the disable itself exited ${outcome.exitCode}, tolerated`})`,
+		);
+		yield* Console.log("disarmed");
+	}),
+).pipe(
+	Command.withDescription(
+		"Clear a parked `--auto` merge intent at a ship-it lifecycle site, verified by read-back (ADR 0198, #3723)",
+	),
+);
+
+export const mergeIntentCommand = Command.make("merge-intent").pipe(
+	Command.withSubcommands([disarmCmd]),
+	Command.withDescription(
+		"ship-it's no-parked-merge-intent enforcement — no `--auto` survives a run that did not enqueue (ADR 0198, #3723)",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/merge-intent/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/github-service.unit.test.ts
@@ -1,0 +1,203 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Github, GithubLive, RepoResolutionError} from "./github.ts";
+import {decideMergeIntent} from "./merge-intent.ts";
+
+// The live `Github` layer resolves its target repo lazily (ADR 0062 §1): `--repo` →
+// `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`. Clear the ambient env so no
+// var leaks into the resolution branches these tests exercise.
+let savedRepo: string | undefined;
+let savedGh: string | undefined;
+beforeAll(() => {
+	savedRepo = process.env.CLAUDE_PIPELINE_REPO;
+	savedGh = process.env.GITHUB_REPOSITORY;
+	delete process.env.CLAUDE_PIPELINE_REPO;
+	delete process.env.GITHUB_REPOSITORY;
+});
+afterAll(() => {
+	if (savedRepo === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedRepo;
+	if (savedGh === undefined) delete process.env.GITHUB_REPOSITORY;
+	else process.env.GITHUB_REPOSITORY = savedGh;
+});
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+/**
+ * A `ChildProcessSpawner` answering the three calls the service makes: the `gh api …/pulls/<n>`
+ * read, the `gh api …/timeline` read, and the `gh pr merge --disable-auto` write. `pull` may be a
+ * list, consumed one per call, so a test can model the state BEFORE and AFTER the disable — the
+ * read-back verify's whole point. An unprovided call exits 1 (the read-failure path).
+ */
+const mockSpawner = (fixture: {
+	readonly pull?: Response | ReadonlyArray<Response>;
+	readonly timeline?: Response;
+	readonly disable?: Response;
+	readonly repoView?: Response;
+}): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> => {
+	const pulls = Array.isArray(fixture.pull)
+		? [...(fixture.pull as ReadonlyArray<Response>)]
+		: fixture.pull === undefined
+			? []
+			: [fixture.pull as Response];
+	return Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const isRepoView = args[0] === "repo" && args[1] === "view";
+				const isDisable = args.includes("--disable-auto");
+				const isTimeline = args.some((a) => a.includes("/timeline"));
+				const isPull = args.some((a) => a.includes("/pulls/"));
+				const pick = (): Response | undefined =>
+					isRepoView
+						? fixture.repoView
+						: isDisable
+							? fixture.disable
+							: isTimeline
+								? fixture.timeline
+								: isPull
+									? (pulls.shift() ?? pulls.at(-1))
+									: undefined;
+				const found = pick();
+				// `!== undefined`, not truthiness: an empty stdout is a legitimate canned success
+				// (`gh pr merge --disable-auto` prints nothing), not an unprovided call.
+				const canned =
+					found !== undefined ? normalize(found) : {stdout: "", exitCode: 1, stderr: "not found"};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+};
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	fixture: Parameters<typeof mockSpawner>[0],
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(fixture)))));
+
+/** The `--jq`-projected PR read the service issues. */
+const pull = (merged: boolean, armed: boolean): string => JSON.stringify({merged, armed});
+
+const timelineEvents = (...events: ReadonlyArray<string>): string =>
+	JSON.stringify(events.map((event, i) => ({event, created_at: `2026-01-01T00:0${i}:00Z`})));
+
+const REPO = "kamp-us/phoenix";
+
+describe("Github.state — the live merge state the ADR-0198 branch reads", () => {
+	it.effect("reports an armed, never-queued PR", () =>
+		Effect.gen(function* () {
+			const state = yield* (yield* Github).state(3700, REPO);
+			assert.deepStrictEqual(state, {
+				merged: false,
+				armed: true,
+				queued: false,
+				everQueued: false,
+			});
+		}).pipe((effect) => provide(effect, {pull: pull(false, true), timeline: "[]"})),
+	);
+
+	it.effect("reports a PR the queue governs but has dropped — the parked-intent shape", () =>
+		Effect.gen(function* () {
+			const state = yield* (yield* Github).state(3700, REPO);
+			assert.strictEqual(state.queued, false);
+			assert.strictEqual(state.everQueued, true);
+			assert.strictEqual(decideMergeIntent("post-enqueue", state).action, "disarm");
+		}).pipe((effect) =>
+			provide(effect, {
+				pull: pull(false, true),
+				timeline: timelineEvents("added_to_merge_queue", "removed_from_merge_queue"),
+			}),
+		),
+	);
+
+	it.effect("a queued PR is never disarmed at any site", () =>
+		Effect.gen(function* () {
+			const state = yield* (yield* Github).state(3700, REPO);
+			assert.strictEqual(state.queued, true);
+			assert.strictEqual(decideMergeIntent("preflight", state).action, "keep");
+		}).pipe((effect) =>
+			provide(effect, {pull: pull(false, true), timeline: timelineEvents("added_to_merge_queue")}),
+		),
+	);
+
+	it.effect("fail-closed: an unreadable PR read yields armed=unknown ⇒ disarm", () =>
+		Effect.gen(function* () {
+			const state = yield* (yield* Github).state(3700, REPO);
+			assert.strictEqual(state.armed, "unknown");
+			assert.strictEqual(decideMergeIntent("refuse", state).action, "disarm");
+		}).pipe((effect) => provide(effect, {timeline: "[]"})),
+	);
+
+	it.effect("no --repo override and an unresolvable repo fails RepoResolutionError", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip((yield* Github).state(3700));
+			assert.isTrue(error instanceof RepoResolutionError);
+		}).pipe((effect) => provide(effect, {pull: pull(false, true), timeline: "[]"})),
+	);
+});
+
+describe("Github.disarm — the read-back verify carries the guarantee, not the exit code", () => {
+	it.effect("confirms `cleared` when auto_merge reads null after the disable", () =>
+		Effect.gen(function* () {
+			const outcome = yield* (yield* Github).disarm(3700, REPO);
+			assert.strictEqual(outcome.cleared, true);
+			assert.strictEqual(outcome.exitCode, 0);
+		}).pipe((effect) => provide(effect, {pull: [pull(false, false)], disable: "", timeline: "[]"})),
+	);
+
+	it.effect("tolerates a non-zero disable when the read-back is clean (nothing was armed)", () =>
+		Effect.gen(function* () {
+			// `gh pr merge --disable-auto` errors when there is no auto-merge to disable; the
+			// invariant is still satisfied, so the exit code alone must not read as a failure.
+			const outcome = yield* (yield* Github).disarm(3700, REPO);
+			assert.strictEqual(outcome.cleared, true);
+			assert.strictEqual(outcome.exitCode, 1);
+			assert.match(outcome.stderr, /not in the auto-merge state/);
+		}).pipe((effect) =>
+			provide(effect, {
+				pull: [pull(false, false)],
+				disable: {stdout: "", exitCode: 1, stderr: "Pull request is not in the auto-merge state"},
+				timeline: "[]",
+			}),
+		),
+	);
+
+	it.effect("reports NOT cleared when the intent is still armed after the disable", () =>
+		Effect.gen(function* () {
+			const outcome = yield* (yield* Github).disarm(3700, REPO);
+			assert.strictEqual(outcome.cleared, false);
+		}).pipe((effect) => provide(effect, {pull: [pull(false, true)], disable: "", timeline: "[]"})),
+	);
+
+	it.effect("reports NOT cleared when the read-back itself is unreadable (unverifiable)", () =>
+		Effect.gen(function* () {
+			// armed reads `unknown` ⇒ the clear cannot be proven ⇒ the bin fails loud.
+			const outcome = yield* (yield* Github).disarm(3700, REPO);
+			assert.strictEqual(outcome.cleared, false);
+		}).pipe((effect) => provide(effect, {disable: "", timeline: "[]"})),
+	);
+});

--- a/packages/pipeline-cli/src/tools/merge-intent/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/github-service.unit.test.ts
@@ -34,14 +34,16 @@ const normalize = (response: Response): Canned =>
 	typeof response === "string" ? {stdout: response} : response;
 
 /**
- * A `ChildProcessSpawner` answering the three calls the service makes: the `gh api …/pulls/<n>`
- * read, the `gh api …/timeline` read, and the `gh pr merge --disable-auto` write. `pull` may be a
- * list, consumed one per call, so a test can model the state BEFORE and AFTER the disable — the
- * read-back verify's whole point. An unprovided call exits 1 (the read-failure path).
+ * A `ChildProcessSpawner` answering the four calls the service makes: the `gh api …/pulls/<n>`
+ * read, the `gh api …/timeline` read, the `gh api …/rules/branches/<b>` regime probe, and the
+ * `gh pr merge --disable-auto` write. `pull` may be a list, consumed one per call, so a test can
+ * model the state BEFORE and AFTER the disable — the read-back verify's whole point. An unprovided
+ * call exits 1 (the read-failure path).
  */
 const mockSpawner = (fixture: {
 	readonly pull?: Response | ReadonlyArray<Response>;
 	readonly timeline?: Response;
+	readonly rules?: Response;
 	readonly disable?: Response;
 	readonly repoView?: Response;
 }): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> => {
@@ -59,6 +61,7 @@ const mockSpawner = (fixture: {
 				const isRepoView = args[0] === "repo" && args[1] === "view";
 				const isDisable = args.includes("--disable-auto");
 				const isTimeline = args.some((a) => a.includes("/timeline"));
+				const isRules = args.some((a) => a.includes("/rules/branches/"));
 				const isPull = args.some((a) => a.includes("/pulls/"));
 				const pick = (): Response | undefined =>
 					isRepoView
@@ -67,9 +70,11 @@ const mockSpawner = (fixture: {
 							? fixture.disable
 							: isTimeline
 								? fixture.timeline
-								: isPull
-									? (pulls.shift() ?? pulls.at(-1))
-									: undefined;
+								: isRules
+									? fixture.rules
+									: isPull
+										? (pulls.shift() ?? pulls.at(-1))
+										: undefined;
 				const found = pick();
 				// `!== undefined`, not truthiness: an empty stdout is a legitimate canned success
 				// (`gh pr merge --disable-auto` prints nothing), not an unprovided call.
@@ -100,36 +105,88 @@ const provide = <A, E>(
 	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(fixture)))));
 
 /** The `--jq`-projected PR read the service issues. */
-const pull = (merged: boolean, armed: boolean): string => JSON.stringify({merged, armed});
+const pull = (merged: boolean, armed: boolean, base = "main"): string =>
+	JSON.stringify({merged, armed, base});
 
 const timelineEvents = (...events: ReadonlyArray<string>): string =>
 	JSON.stringify(events.map((event, i) => ({event, created_at: `2026-01-01T00:0${i}:00Z`})));
 
+/** `GET /repos/{repo}/rules/branches/{branch}` — the branch's rules across every active ruleset. */
+const branchRules = (...types: ReadonlyArray<string>): string =>
+	JSON.stringify(types.map((type) => ({type, ruleset_id: 1})));
+
 const REPO = "kamp-us/phoenix";
 
 describe("Github.state — the live merge state the ADR-0198 branch reads", () => {
-	it.effect("reports an armed, never-queued PR", () =>
+	it.effect("reports an armed PR on a queue-governed base branch", () =>
 		Effect.gen(function* () {
 			const state = yield* (yield* Github).state(3700, REPO);
 			assert.deepStrictEqual(state, {
 				merged: false,
 				armed: true,
 				queued: false,
-				everQueued: false,
+				queueGoverned: true,
 			});
-		}).pipe((effect) => provide(effect, {pull: pull(false, true), timeline: "[]"})),
+		}).pipe((effect) =>
+			provide(effect, {
+				pull: pull(false, true),
+				timeline: "[]",
+				rules: branchRules("pull_request", "merge_queue"),
+			}),
+		),
 	);
 
-	it.effect("reports a PR the queue governs but has dropped — the parked-intent shape", () =>
+	it.effect(
+		"the first-enqueue-attempt PR under a merge queue is a parked intent, not the pre-queue regime",
+		() =>
+			// The #3774 review's FAIL 1: keyed on the PR's own history this state reads "never queued"
+			// and would take the exemption — but the base branch carries a `merge_queue` rule, so the
+			// arm that never took is parked.
+			Effect.gen(function* () {
+				const state = yield* (yield* Github).state(3700, REPO);
+				assert.strictEqual(state.queued, false);
+				assert.strictEqual(state.queueGoverned, true);
+				assert.strictEqual(decideMergeIntent("post-enqueue", state).action, "disarm");
+			}).pipe((effect) =>
+				provide(effect, {
+					pull: pull(false, true),
+					timeline: "[]",
+					rules: branchRules("merge_queue"),
+				}),
+			),
+	);
+
+	it.effect("a base branch with no merge-queue rule keeps its legitimate armed auto-merge", () =>
+		Effect.gen(function* () {
+			const state = yield* (yield* Github).state(3700, REPO);
+			assert.strictEqual(state.queueGoverned, false);
+			assert.strictEqual(decideMergeIntent("post-enqueue", state).action, "keep");
+		}).pipe((effect) =>
+			provide(effect, {
+				pull: pull(false, true),
+				timeline: "[]",
+				rules: branchRules("pull_request", "non_fast_forward"),
+			}),
+		),
+	);
+
+	it.effect("a repo with no rulesets at all reads as the pre-queue regime", () =>
+		Effect.gen(function* () {
+			const state = yield* (yield* Github).state(3700, REPO);
+			assert.strictEqual(state.queueGoverned, false);
+		}).pipe((effect) => provide(effect, {pull: pull(false, true), timeline: "[]", rules: "[]"})),
+	);
+
+	it.effect("reports a PR the queue has dropped — the parked-intent shape", () =>
 		Effect.gen(function* () {
 			const state = yield* (yield* Github).state(3700, REPO);
 			assert.strictEqual(state.queued, false);
-			assert.strictEqual(state.everQueued, true);
 			assert.strictEqual(decideMergeIntent("post-enqueue", state).action, "disarm");
 		}).pipe((effect) =>
 			provide(effect, {
 				pull: pull(false, true),
 				timeline: timelineEvents("added_to_merge_queue", "removed_from_merge_queue"),
+				rules: branchRules("merge_queue"),
 			}),
 		),
 	);
@@ -140,7 +197,11 @@ describe("Github.state — the live merge state the ADR-0198 branch reads", () =
 			assert.strictEqual(state.queued, true);
 			assert.strictEqual(decideMergeIntent("preflight", state).action, "keep");
 		}).pipe((effect) =>
-			provide(effect, {pull: pull(false, true), timeline: timelineEvents("added_to_merge_queue")}),
+			provide(effect, {
+				pull: pull(false, true),
+				timeline: timelineEvents("added_to_merge_queue"),
+				rules: branchRules("merge_queue"),
+			}),
 		),
 	);
 
@@ -149,7 +210,30 @@ describe("Github.state — the live merge state the ADR-0198 branch reads", () =
 			const state = yield* (yield* Github).state(3700, REPO);
 			assert.strictEqual(state.armed, "unknown");
 			assert.strictEqual(decideMergeIntent("refuse", state).action, "disarm");
-		}).pipe((effect) => provide(effect, {timeline: "[]"})),
+		}).pipe((effect) => provide(effect, {timeline: "[]", rules: branchRules("merge_queue")})),
+	);
+
+	it.effect("fail-closed: an unreadable rules probe resolves queue-governed ⇒ no exemption", () =>
+		Effect.gen(function* () {
+			// The #3774 review's FAIL 2: the regime read must never fail OPEN, because `false` is the
+			// sole trigger of `post-enqueue`'s keep.
+			const state = yield* (yield* Github).state(3700, REPO);
+			assert.strictEqual(state.queueGoverned, true);
+			assert.strictEqual(decideMergeIntent("post-enqueue", state).action, "disarm");
+		}).pipe((effect) => provide(effect, {pull: pull(false, true), timeline: "[]"})),
+	);
+
+	it.effect("fail-closed: an unknown base branch resolves queue-governed without probing", () =>
+		Effect.gen(function* () {
+			const state = yield* (yield* Github).state(3700, REPO);
+			assert.strictEqual(state.queueGoverned, true);
+		}).pipe((effect) =>
+			provide(effect, {
+				pull: JSON.stringify({merged: false, armed: true, base: null}),
+				timeline: "[]",
+				rules: "[]",
+			}),
+		),
 	);
 
 	it.effect("no --repo override and an unresolvable repo fails RepoResolutionError", () =>

--- a/packages/pipeline-cli/src/tools/merge-intent/github.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/github.ts
@@ -140,12 +140,27 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 
 // REST-only arg builders — never GraphQL.
 
-/** The PR resource: `merged` and whether an auto-merge request is armed (`auto_merge != null`). */
+/**
+ * The PR resource: `merged`, whether an auto-merge request is armed (`auto_merge != null`), and the
+ * base branch — the branch whose queue regime rule 4's exemption is about.
+ */
 const prArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 	"api",
 	`repos/${repo}/pulls/${pr}`,
 	"--jq",
-	"{merged: (.merged == true), armed: (.auto_merge != null)}",
+	"{merged: (.merged == true), armed: (.auto_merge != null), base: .base.ref}",
+];
+
+/**
+ * The rules that apply to a branch, across every active ruleset. A `merge_queue` rule in the
+ * response is the authoritative "this branch is queue-governed" signal — the repo/branch-level
+ * property rule 4 keys on. (Classic branch protection carries no merge-queue field, and on a
+ * ruleset-governed repo `branches/<b>/protection` 404s, so this is the endpoint that answers it;
+ * verified live against `kamp-us/phoenix` `main`, which returns a `merge_queue` rule.)
+ */
+const branchRulesArgs = (repo: string, branch: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/rules/branches/${encodeURIComponent(branch)}`,
 ];
 
 /** The REST issue-timeline endpoint — the authoritative merge-queue-membership signal. */
@@ -168,8 +183,12 @@ const disableArgs = (repo: string, pr: number): ReadonlyArray<string> => [
 const RawPr = Schema.Struct({
 	merged: Schema.optionalKey(Schema.NullOr(Schema.Boolean)),
 	armed: Schema.optionalKey(Schema.NullOr(Schema.Boolean)),
+	base: Schema.optionalKey(Schema.NullOr(Schema.String)),
 });
 const decodePr = Schema.decodeUnknownEffect(RawPr);
+
+const RawRule = Schema.Struct({type: Schema.optionalKey(Schema.NullOr(Schema.String))});
+const decodeRules = Schema.decodeUnknownEffect(Schema.Array(RawRule));
 
 const RawTimelineEntry = Schema.Struct({
 	event: Schema.optionalKey(Schema.NullOr(Schema.String)),
@@ -177,34 +196,39 @@ const RawTimelineEntry = Schema.Struct({
 });
 const decodeTimeline = Schema.decodeUnknownEffect(Schema.Array(RawTimelineEntry));
 
-/** The `merged` + `armed` half of the state, recovered to the fail-closed unknown on any fault. */
+/**
+ * The `merged` + `armed` + base-branch half of the state, recovered to the fail-closed unknown on
+ * any fault (a `null` base then denies the regime probe its input — see `readQueueGoverned`).
+ */
 const readPr = Effect.fn("Github.readPr")(
 	function* (repo: string, pr: number) {
 		const args = prArgs(repo, pr);
 		const raw = yield* decodePr(yield* parseJson(args, yield* runGh(args)));
-		return {merged: raw.merged === true, armed: (raw.armed ?? false) as boolean | "unknown"};
+		return {
+			merged: raw.merged === true,
+			armed: (raw.armed ?? false) as boolean | "unknown",
+			base: raw.base ?? null,
+		};
 	},
 	(effect) =>
 		effect.pipe(
 			Effect.catchTags({
 				"@kampus/merge-intent/GhCommandError": () =>
-					Effect.succeed({merged: false, armed: "unknown" as const}),
+					Effect.succeed({merged: false, armed: "unknown" as const, base: null}),
 				"@kampus/merge-intent/GhParseError": () =>
-					Effect.succeed({merged: false, armed: "unknown" as const}),
-				SchemaError: () => Effect.succeed({merged: false, armed: "unknown" as const}),
+					Effect.succeed({merged: false, armed: "unknown" as const, base: null}),
+				SchemaError: () => Effect.succeed({merged: false, armed: "unknown" as const, base: null}),
 			}),
 		),
 );
 
 /**
- * The two merge-queue facts: is the PR queued *now* (last event wins — the resolution
- * `merge-queue-classify` owns, imported rather than re-derived), and has the queue *ever*
- * governed it (any `added_to_merge_queue`), which is what separates a parked intent from the
- * pre-queue auto-merge regime. An unreadable timeline recovers to "no queue history": the
- * decision then rests on `armed` alone, which already reads `null` — i.e. `keep` — for a PR
- * sitting in the queue, so a timeline fault cannot dequeue a live entry.
+ * Is the PR queued *now*? Last event wins — the resolution `merge-queue-classify` owns, imported
+ * rather than re-derived. An unreadable timeline recovers to "not queued": the decision then rests
+ * on `armed`, which already reads `null` — i.e. `keep` at rule 3 — for a PR sitting in the queue,
+ * so a timeline fault cannot dequeue a live entry.
  */
-const readQueue = Effect.fn("Github.readQueue")(
+const readQueued = Effect.fn("Github.readQueued")(
 	function* (repo: string, pr: number) {
 		const args = timelineArgs(repo, pr);
 		// `--paginate` concatenates JSON arrays; normalize `][` joins into one array before parsing.
@@ -216,27 +240,50 @@ const readQueue = Effect.fn("Github.readQueue")(
 			if (e.created_at != null) entry.created_at = e.created_at;
 			return entry;
 		});
-		return {
-			queued: lastMergeQueueEvent(projected) === "added_to_merge_queue",
-			everQueued: projected.some((e) => e.event === "added_to_merge_queue"),
-		};
+		return lastMergeQueueEvent(projected) === "added_to_merge_queue";
 	},
 	(effect) =>
 		effect.pipe(
 			Effect.catchTags({
-				"@kampus/merge-intent/GhCommandError": () =>
-					Effect.succeed({queued: false, everQueued: false}),
-				"@kampus/merge-intent/GhParseError": () =>
-					Effect.succeed({queued: false, everQueued: false}),
-				SchemaError: () => Effect.succeed({queued: false, everQueued: false}),
+				"@kampus/merge-intent/GhCommandError": () => Effect.succeed(false),
+				"@kampus/merge-intent/GhParseError": () => Effect.succeed(false),
+				SchemaError: () => Effect.succeed(false),
+			}),
+		),
+);
+
+/**
+ * Is the base branch governed by a merge queue? Every fault — an unknown base, a `gh` failure, an
+ * undecodable body — resolves **`true`**, because `false` is the sole trigger of rule 4's keep: a
+ * read this run could not make must never be the thing that lets an intent stay parked.
+ */
+const readQueueGoverned = Effect.fn("Github.readQueueGoverned")(
+	function* (repo: string, base: string | null) {
+		if (base === null || base.trim() === "") return true;
+		const args = branchRulesArgs(repo, base.trim());
+		const rules = yield* decodeRules(yield* parseJson(args, yield* runGh(args)));
+		return rules.some((r) => r.type === "merge_queue");
+	},
+	(effect) =>
+		effect.pipe(
+			Effect.catchTags({
+				"@kampus/merge-intent/GhCommandError": () => Effect.succeed(true),
+				"@kampus/merge-intent/GhParseError": () => Effect.succeed(true),
+				SchemaError: () => Effect.succeed(true),
 			}),
 		),
 );
 
 const readState = Effect.fn("Github.state")(function* (repo: string, pr: number) {
 	const pull = yield* readPr(repo, pr);
-	const queue = yield* readQueue(repo, pr);
-	return {...pull, ...queue} satisfies MergeIntentState;
+	const queued = yield* readQueued(repo, pr);
+	const queueGoverned = yield* readQueueGoverned(repo, pull.base);
+	return {
+		merged: pull.merged,
+		armed: pull.armed,
+		queued,
+		queueGoverned,
+	} satisfies MergeIntentState;
 });
 
 /** The verified outcome of a disarm attempt. */

--- a/packages/pipeline-cli/src/tools/merge-intent/github.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/github.ts
@@ -1,0 +1,307 @@
+/**
+ * The GitHub boundary for `merge-intent`: the live `Github` capability that reads the merge
+ * state ADR 0198's decision runs on, and performs the disarm **with a read-back verify**.
+ *
+ * Same service pattern as `merge-queue-classify/github.ts` / `verdict/github.ts`: a
+ * `Context.Service` on `ChildProcessSpawner` (`.patterns/effect-process-cli-shell.md`), `gh` REST
+ * (plus the `gh pr merge` porcelain the merge itself uses — never GraphQL queries, which the org's
+ * Projects-classic integration breaks), every infra failure a typed error in the `E` channel, and
+ * the untrusted `gh` JSON `Schema`-decoded at the boundary.
+ *
+ * The read-back verify is the point: `gh pr merge --disable-auto` exits non-zero both when the
+ * disable genuinely failed and when there was simply nothing armed, so its exit code cannot carry
+ * the guarantee. Re-reading `auto_merge` can — the claim this tool makes is "**the PR carries no
+ * armed auto-merge request**", asserted against live state after the attempt, the same
+ * self-verify shape `verdict post` applies to a landed comment (#3019).
+ */
+import {Config, Context, Effect, Layer, Option, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {lastMergeQueueEvent} from "../merge-queue-classify/merge-queue-classify.ts";
+import type {MergeIntentState} from "./merge-intent.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/merge-intent/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the reader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/merge-intent/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/merge-intent/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/** The raw result of a `gh` run — kept whole so a tolerated non-zero exit is still reportable. */
+interface GhResult {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode: number;
+}
+
+// See `merge-queue-classify/github.ts` `runGh`: spawn the handle directly (not
+// `ChildProcessSpawner.string`, which hides the exit code) and fold a spawn `PlatformError`
+// (e.g. `gh` off PATH) into the same shape at exit `-1`, so the `E` channel never carries a throw.
+const runGhRaw = Effect.fn("Github.runGhRaw")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		return {stdout, stderr, exitCode} satisfies GhResult;
+	},
+	Effect.scoped,
+	(effect) =>
+		Effect.catchTag(effect, "PlatformError", (cause) =>
+			Effect.succeed({stdout: "", stderr: cause.message, exitCode: -1} satisfies GhResult),
+		),
+);
+
+/** `runGhRaw` with a non-zero exit lowered into the typed `E` channel — the reads' shape. */
+const runGh = Effect.fn("Github.runGh")(function* (args: ReadonlyArray<string>) {
+	const result = yield* runGhRaw(args);
+	if (result.exitCode !== 0) {
+		return yield* new GhCommandError({args, exitCode: result.exitCode, stderr: result.stderr});
+	}
+	return result.stdout;
+});
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/** The env half of repo resolution (ADR 0062 §1), read via `Config` rather than `process.env`. */
+const repoFromEnv = Config.string("CLAUDE_PIPELINE_REPO").pipe(
+	Config.orElse(() => Config.string("GITHUB_REPOSITORY")),
+	Config.option,
+);
+
+/**
+ * Resolve the target repo (`owner/name`), per ADR 0062 §1: `CLAUDE_PIPELINE_REPO` →
+ * `GITHUB_REPOSITORY` → `gh repo view`. Never silently defaults — with no env and no resolvable
+ * current repo it fails `RepoResolutionError`, which the bin surfaces as a LOUD failure: a run
+ * that cannot address the PR cannot assert that no intent is armed on it.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = yield* repoFromEnv.pipe(Effect.orElseSucceed(() => Option.none<string>()));
+	if (Option.isSome(fromEnv) && REPO_RE.test(fromEnv.value.trim())) {
+		return fromEnv.value.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/merge-intent/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+// REST-only arg builders — never GraphQL.
+
+/** The PR resource: `merged` and whether an auto-merge request is armed (`auto_merge != null`). */
+const prArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/pulls/${pr}`,
+	"--jq",
+	"{merged: (.merged == true), armed: (.auto_merge != null)}",
+];
+
+/** The REST issue-timeline endpoint — the authoritative merge-queue-membership signal. */
+const timelineArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/${pr}/timeline?per_page=100`,
+	"--paginate",
+];
+
+/** `gh pr merge --disable-auto` — the porcelain that clears an armed merge request. */
+const disableArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"pr",
+	"merge",
+	String(pr),
+	"--repo",
+	repo,
+	"--disable-auto",
+];
+
+const RawPr = Schema.Struct({
+	merged: Schema.optionalKey(Schema.NullOr(Schema.Boolean)),
+	armed: Schema.optionalKey(Schema.NullOr(Schema.Boolean)),
+});
+const decodePr = Schema.decodeUnknownEffect(RawPr);
+
+const RawTimelineEntry = Schema.Struct({
+	event: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	created_at: Schema.optionalKey(Schema.NullOr(Schema.String)),
+});
+const decodeTimeline = Schema.decodeUnknownEffect(Schema.Array(RawTimelineEntry));
+
+/** The `merged` + `armed` half of the state, recovered to the fail-closed unknown on any fault. */
+const readPr = Effect.fn("Github.readPr")(
+	function* (repo: string, pr: number) {
+		const args = prArgs(repo, pr);
+		const raw = yield* decodePr(yield* parseJson(args, yield* runGh(args)));
+		return {merged: raw.merged === true, armed: (raw.armed ?? false) as boolean | "unknown"};
+	},
+	(effect) =>
+		effect.pipe(
+			Effect.catchTags({
+				"@kampus/merge-intent/GhCommandError": () =>
+					Effect.succeed({merged: false, armed: "unknown" as const}),
+				"@kampus/merge-intent/GhParseError": () =>
+					Effect.succeed({merged: false, armed: "unknown" as const}),
+				SchemaError: () => Effect.succeed({merged: false, armed: "unknown" as const}),
+			}),
+		),
+);
+
+/**
+ * The two merge-queue facts: is the PR queued *now* (last event wins — the resolution
+ * `merge-queue-classify` owns, imported rather than re-derived), and has the queue *ever*
+ * governed it (any `added_to_merge_queue`), which is what separates a parked intent from the
+ * pre-queue auto-merge regime. An unreadable timeline recovers to "no queue history": the
+ * decision then rests on `armed` alone, which already reads `null` — i.e. `keep` — for a PR
+ * sitting in the queue, so a timeline fault cannot dequeue a live entry.
+ */
+const readQueue = Effect.fn("Github.readQueue")(
+	function* (repo: string, pr: number) {
+		const args = timelineArgs(repo, pr);
+		// `--paginate` concatenates JSON arrays; normalize `][` joins into one array before parsing.
+		const merged = (yield* runGh(args)).replace(/\]\s*\[/g, ",");
+		const entries = yield* decodeTimeline(yield* parseJson(args, merged));
+		const projected = entries.map((e) => {
+			const entry: {event?: string; created_at?: string} = {};
+			if (e.event != null) entry.event = e.event;
+			if (e.created_at != null) entry.created_at = e.created_at;
+			return entry;
+		});
+		return {
+			queued: lastMergeQueueEvent(projected) === "added_to_merge_queue",
+			everQueued: projected.some((e) => e.event === "added_to_merge_queue"),
+		};
+	},
+	(effect) =>
+		effect.pipe(
+			Effect.catchTags({
+				"@kampus/merge-intent/GhCommandError": () =>
+					Effect.succeed({queued: false, everQueued: false}),
+				"@kampus/merge-intent/GhParseError": () =>
+					Effect.succeed({queued: false, everQueued: false}),
+				SchemaError: () => Effect.succeed({queued: false, everQueued: false}),
+			}),
+		),
+);
+
+const readState = Effect.fn("Github.state")(function* (repo: string, pr: number) {
+	const pull = yield* readPr(repo, pr);
+	const queue = yield* readQueue(repo, pr);
+	return {...pull, ...queue} satisfies MergeIntentState;
+});
+
+/** The verified outcome of a disarm attempt. */
+export interface DisarmOutcome {
+	/** Live `auto_merge == null` confirmed by the post-attempt read-back — the whole guarantee. */
+	readonly cleared: boolean;
+	/** The `gh pr merge --disable-auto` exit code; non-zero is tolerated when the read-back is clean. */
+	readonly exitCode: number;
+	/** `gh`'s stderr, carried so a genuine failure is legible in the run log. */
+	readonly stderr: string;
+}
+
+const disarmIntent = Effect.fn("Github.disarm")(function* (repo: string, pr: number) {
+	const attempt = yield* runGhRaw(disableArgs(repo, pr));
+	const after = yield* readPr(repo, pr);
+	return {
+		cleared: after.armed === false,
+		exitCode: attempt.exitCode,
+		stderr: attempt.stderr.trim(),
+	} satisfies DisarmOutcome;
+});
+
+/**
+ * `Github` — the IO shell over `gh` for the merge-intent lifecycle. `state(pr)` resolves the
+ * `MergeIntentState` the pure `decideMergeIntent` consumes; `disarm(pr)` clears the armed request
+ * and verifies the clear by re-reading `auto_merge`. A non-empty `repoOverride` (the `--repo`
+ * flag, ADR 0062 §1's highest precedence) wins over the resolved repo.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly state: (
+			pr: number,
+			repoOverride?: string,
+		) => Effect.Effect<MergeIntentState, RepoResolutionError>;
+		readonly disarm: (
+			pr: number,
+			repoOverride?: string,
+		) => Effect.Effect<DisarmOutcome, RepoResolutionError>;
+	}
+>()("@kampus/merge-intent/Github") {}
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once at construction
+ * and provided into each method body, so the public methods carry `R = never`. Repo resolution is
+ * deferred to first use (`Effect.cached`, ADR 0062 §1) and shared by both methods, so a `state` +
+ * `disarm` pair in one run resolves the repo once.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			const target = (repoOverride?: string) =>
+				repoOverride !== undefined && repoOverride.trim() !== ""
+					? Effect.succeed(repoOverride.trim())
+					: repo;
+			return {
+				state: (pr, repoOverride) =>
+					target(repoOverride).pipe(Effect.flatMap((r) => withSpawner(readState(r, pr)))),
+				disarm: (pr, repoOverride) =>
+					target(repoOverride).pipe(Effect.flatMap((r) => withSpawner(disarmIntent(r, pr)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/merge-intent/merge-intent.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/merge-intent.ts
@@ -1,20 +1,10 @@
 /**
- * `merge-intent` pure core — the decision behind ship-it's no-parked-merge-intent invariant
- * (ADR 0198, issue #3723).
+ * `merge-intent` pure core: may an armed `gh pr merge --auto` request survive at this point in
+ * ship-it's lifecycle? The branch lives here — a pure function of the PR's live merge state — so
+ * the answer cannot drift across shippers; the `gh` IO is in `github.ts` (the `cp-cardinality` /
+ * `merge-queue-classify` split).
  *
- * ship-it enqueues with `gh pr merge --auto`. When that request does not take effect at the
- * head it was made against, GitHub keeps it **armed**, and it fires the moment the missing
- * requirement lands — on a §CP PR, the instant a fresh control-plane approval arrives. That is
- * an enqueue with **no ship-it run in between**, so the assertions ship-it makes *at* enqueue
- * time (current-head verdicts, the run-evidence bundle, the leak scan, unresolved threads) are
- * skipped at the decisive instant (observed on PR #3700, where `added_to_merge_queue` fired one
- * second after the approving review).
- *
- * The fix is a lifecycle rule, not a new enqueue primitive: an armed merge intent is a
- * transient artifact of a completed gate pass, never a durable state. This core answers the one
- * question each lifecycle site asks — *may an armed intent survive here?* — as a pure function
- * of the PR's live merge state, so the answer cannot drift across shippers (the `cp-cardinality`
- * / `merge-queue-classify` split: the `gh` IO in the service, the branch in a tested core).
+ * See ADR 0198 (#3723) for why a surviving intent is a defect.
  */
 
 /**
@@ -36,8 +26,12 @@ export interface MergeIntentState {
 	readonly merged: boolean;
 	/** Currently in the merge queue (the last merge-queue timeline event is `added_to_merge_queue`). */
 	readonly queued: boolean;
-	/** The merge queue has governed this PR at least once (any `added_to_merge_queue` event). */
-	readonly everQueued: boolean;
+	/**
+	 * A merge queue governs the PR's **base branch** — a branch-level regime, never a per-PR fact
+	 * (rule 4 below has the why). `true` when the read failed, so an unread regime can't be the
+	 * thing that grants the exemption.
+	 */
+	readonly queueGoverned: boolean;
 }
 
 export type IntentAction = "disarm" | "keep";
@@ -56,7 +50,7 @@ const DISARM_REASON: Record<IntentSite, string> = {
 	refuse:
 		"this run refused to enqueue — an intent left armed would enqueue on the next bare approval, with no ship-it run asserting the machine gates in between",
 	"post-enqueue":
-		"the merge queue governs this PR but it is not queued — the enqueue did not take effect at this head, so what remains is a parked intent, not a queue entry",
+		"a merge queue governs this base branch but the PR is not queued — the enqueue did not take effect at this head, so what remains is a parked intent, not a queue entry",
 	ejected:
 		"the queue dropped the PR — it must re-enter through a fresh ship-it gate pass, never by a surviving intent firing on the re-approval",
 };
@@ -70,14 +64,17 @@ const DISARM_REASON: Record<IntentSite, string> = {
  *      authorized. ship-it never dequeues it: fighting the queue is a different decision, and
  *      the async merge is the queue's to finish (ADR 0132).
  *   3. `armed === false` — nothing armed, so nothing to clear.
- *   4. `post-enqueue` on a PR the queue has NEVER governed — the pre-queue auto-merge regime
- *      (ADR 0132 transition safety, and any foreign repo with no queue), where the armed
- *      request *is* the sanctioned enqueue mechanism. Only this site gets the exemption:
- *      at `preflight` the same arm is stale by construction, whatever the regime.
+ *   4. `post-enqueue` on a base branch **no merge queue governs** — the pre-queue auto-merge
+ *      regime (ADR 0132 transition safety, and any foreign repo with no queue), where the armed
+ *      request *is* the sanctioned enqueue mechanism. The predicate is the branch's regime, never
+ *      the PR's own queue history: under a queue, a first-attempt PR has no history either, so a
+ *      per-PR proxy would exempt exactly the parked intent this guard exists to clear. And only
+ *      this site gets the exemption — at `preflight` the same arm is stale in either regime.
  *   5. Otherwise — disarm.
  *
- * Fail-closed by construction: an unreadable `armed` (`"unknown"`) falls through to disarm. The
- * asymmetry is deliberate — a needless disarm costs one idempotent re-ship, a surviving parked
+ * Fail-closed by construction: an unreadable `armed` (`"unknown"`) falls through to disarm, and an
+ * unreadable regime resolves `queueGoverned: true` so a failed read can never reach rule 4's keep.
+ * The asymmetry is deliberate — a needless disarm costs one idempotent re-ship, a surviving parked
  * intent costs an ungated enqueue.
  */
 export const decideMergeIntent = (site: IntentSite, state: MergeIntentState): IntentDecision => {
@@ -93,10 +90,10 @@ export const decideMergeIntent = (site: IntentSite, state: MergeIntentState): In
 	if (state.armed === false) {
 		return at("keep", "no armed auto-merge request on the PR — nothing is parked");
 	}
-	if (site === "post-enqueue" && !state.everQueued) {
+	if (site === "post-enqueue" && !state.queueGoverned) {
 		return at(
 			"keep",
-			"no merge-queue event has ever governed this PR ⇒ the pre-queue auto-merge regime, where the armed request IS the sanctioned enqueue mechanism (ADR 0132 transition safety)",
+			"no merge queue governs the base branch ⇒ the pre-queue auto-merge regime, where the armed request IS the sanctioned enqueue mechanism (ADR 0132 transition safety)",
 		);
 	}
 	const unknown = state.armed === "unknown" ? " (arm state unreadable — treated as armed)" : "";

--- a/packages/pipeline-cli/src/tools/merge-intent/merge-intent.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/merge-intent.ts
@@ -1,0 +1,104 @@
+/**
+ * `merge-intent` pure core — the decision behind ship-it's no-parked-merge-intent invariant
+ * (ADR 0198, issue #3723).
+ *
+ * ship-it enqueues with `gh pr merge --auto`. When that request does not take effect at the
+ * head it was made against, GitHub keeps it **armed**, and it fires the moment the missing
+ * requirement lands — on a §CP PR, the instant a fresh control-plane approval arrives. That is
+ * an enqueue with **no ship-it run in between**, so the assertions ship-it makes *at* enqueue
+ * time (current-head verdicts, the run-evidence bundle, the leak scan, unresolved threads) are
+ * skipped at the decisive instant (observed on PR #3700, where `added_to_merge_queue` fired one
+ * second after the approving review).
+ *
+ * The fix is a lifecycle rule, not a new enqueue primitive: an armed merge intent is a
+ * transient artifact of a completed gate pass, never a durable state. This core answers the one
+ * question each lifecycle site asks — *may an armed intent survive here?* — as a pure function
+ * of the PR's live merge state, so the answer cannot drift across shippers (the `cp-cardinality`
+ * / `merge-queue-classify` split: the `gh` IO in the service, the branch in a tested core).
+ */
+
+/**
+ * Where in ship-it's lifecycle the question is asked. The site matters because only one of
+ * them — `post-enqueue` — can legitimately observe an armed request that is the *sanctioned*
+ * mechanism rather than a parked one.
+ */
+export type IntentSite = "preflight" | "refuse" | "post-enqueue" | "ejected";
+
+/** The live merge state the decision reads; resolved over `gh` REST by the service. */
+export interface MergeIntentState {
+	/**
+	 * Does the PR carry an armed auto-merge request (`auto_merge != null`)? `"unknown"` when the
+	 * read failed — treated as armed, because clearing an intent that was never there costs a
+	 * no-op while leaving one parked costs an ungated enqueue.
+	 */
+	readonly armed: boolean | "unknown";
+	/** The merge already landed — there is nothing left to park. */
+	readonly merged: boolean;
+	/** Currently in the merge queue (the last merge-queue timeline event is `added_to_merge_queue`). */
+	readonly queued: boolean;
+	/** The merge queue has governed this PR at least once (any `added_to_merge_queue` event). */
+	readonly everQueued: boolean;
+}
+
+export type IntentAction = "disarm" | "keep";
+
+export interface IntentDecision {
+	readonly action: IntentAction;
+	/** Human-readable justification naming the deciding signal — printed by the bin. */
+	readonly reason: string;
+}
+
+const at = (action: IntentAction, reason: string): IntentDecision => ({action, reason});
+
+const DISARM_REASON: Record<IntentSite, string> = {
+	preflight:
+		"an intent armed BEFORE this run's guards ran is backed by no gate pass at this head — clear it so only a completed Step-4 enqueue can arm one",
+	refuse:
+		"this run refused to enqueue — an intent left armed would enqueue on the next bare approval, with no ship-it run asserting the machine gates in between",
+	"post-enqueue":
+		"the merge queue governs this PR but it is not queued — the enqueue did not take effect at this head, so what remains is a parked intent, not a queue entry",
+	ejected:
+		"the queue dropped the PR — it must re-enter through a fresh ship-it gate pass, never by a surviving intent firing on the re-approval",
+};
+
+/**
+ * Decide whether an armed merge intent may survive at this lifecycle site (ADR 0198).
+ *
+ * Precedence:
+ *   1. `merged` — the merge landed; nothing to park.
+ *   2. `queued` — a live queue entry is a gated in-flight merge that a completed gate pass
+ *      authorized. ship-it never dequeues it: fighting the queue is a different decision, and
+ *      the async merge is the queue's to finish (ADR 0132).
+ *   3. `armed === false` — nothing armed, so nothing to clear.
+ *   4. `post-enqueue` on a PR the queue has NEVER governed — the pre-queue auto-merge regime
+ *      (ADR 0132 transition safety, and any foreign repo with no queue), where the armed
+ *      request *is* the sanctioned enqueue mechanism. Only this site gets the exemption:
+ *      at `preflight` the same arm is stale by construction, whatever the regime.
+ *   5. Otherwise — disarm.
+ *
+ * Fail-closed by construction: an unreadable `armed` (`"unknown"`) falls through to disarm. The
+ * asymmetry is deliberate — a needless disarm costs one idempotent re-ship, a surviving parked
+ * intent costs an ungated enqueue.
+ */
+export const decideMergeIntent = (site: IntentSite, state: MergeIntentState): IntentDecision => {
+	if (state.merged) {
+		return at("keep", "the merge already landed — there is no intent left to park");
+	}
+	if (state.queued) {
+		return at(
+			"keep",
+			"a live merge-queue entry is a gated in-flight merge, not a parked intent — ship-it never dequeues what a completed gate pass enqueued (ADR 0132)",
+		);
+	}
+	if (state.armed === false) {
+		return at("keep", "no armed auto-merge request on the PR — nothing is parked");
+	}
+	if (site === "post-enqueue" && !state.everQueued) {
+		return at(
+			"keep",
+			"no merge-queue event has ever governed this PR ⇒ the pre-queue auto-merge regime, where the armed request IS the sanctioned enqueue mechanism (ADR 0132 transition safety)",
+		);
+	}
+	const unknown = state.armed === "unknown" ? " (arm state unreadable — treated as armed)" : "";
+	return at("disarm", `${DISARM_REASON[site]}${unknown}`);
+};

--- a/packages/pipeline-cli/src/tools/merge-intent/merge-intent.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/merge-intent.unit.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, it} from "vitest";
+import {decideMergeIntent, type IntentSite, type MergeIntentState} from "./merge-intent.ts";
+
+/** An open, unqueued, armed PR — the shape every disarm case starts from. */
+const state = (over: Partial<MergeIntentState> = {}): MergeIntentState => ({
+	armed: true,
+	merged: false,
+	queued: false,
+	everQueued: false,
+	...over,
+});
+
+const SITES: ReadonlyArray<IntentSite> = ["preflight", "refuse", "post-enqueue", "ejected"];
+
+describe("decideMergeIntent — ship-it's no-parked-merge-intent invariant (ADR 0198, #3723)", () => {
+	describe("a live merge-queue entry is never disturbed", () => {
+		it.each(SITES)("keeps the intent at site %s when the PR is queued", (site) => {
+			const d = decideMergeIntent(site, state({queued: true, everQueued: true}));
+			expect(d.action).toBe("keep");
+			expect(d.reason).toMatch(/merge-queue entry/);
+		});
+
+		it.each(SITES)("keeps the intent at site %s when the merge already landed", (site) => {
+			const d = decideMergeIntent(site, state({merged: true, everQueued: true}));
+			expect(d.action).toBe("keep");
+		});
+	});
+
+	describe("nothing armed ⇒ nothing to clear", () => {
+		it.each(SITES)("keeps at site %s when the PR carries no armed request", (site) => {
+			expect(decideMergeIntent(site, state({armed: false})).action).toBe("keep");
+		});
+	});
+
+	describe("the refusing/stopping run leaves no armed intent (acceptance criterion 1)", () => {
+		it("disarms on a refuse — the §CP `awaiting control-plane approval` STOP", () => {
+			const d = decideMergeIntent("refuse", state({everQueued: true}));
+			expect(d.action).toBe("disarm");
+			expect(d.reason).toMatch(/next bare approval/);
+		});
+
+		it("disarms on a refuse even for a PR the queue never governed", () => {
+			// The pre-queue exemption is scoped to `post-enqueue`; a refusing run never parks.
+			expect(decideMergeIntent("refuse", state({everQueued: false})).action).toBe("disarm");
+		});
+	});
+
+	describe("an ejected PR re-enters through a fresh gate pass (acceptance criterion 2)", () => {
+		it("disarms on an ejection so the re-approval cannot re-enqueue on its own", () => {
+			const d = decideMergeIntent("ejected", state({everQueued: true, queued: false}));
+			expect(d.action).toBe("disarm");
+			expect(d.reason).toMatch(/fresh ship-it gate pass/);
+		});
+	});
+
+	describe("preflight clears a stale intent from an earlier or interrupted run", () => {
+		it("disarms an arm that predates this run's guards", () => {
+			const d = decideMergeIntent("preflight", state({everQueued: true}));
+			expect(d.action).toBe("disarm");
+			expect(d.reason).toMatch(/BEFORE this run's guards/);
+		});
+
+		it("disarms at preflight even with no merge-queue history — the arm is stale in either regime", () => {
+			expect(decideMergeIntent("preflight", state({everQueued: false})).action).toBe("disarm");
+		});
+	});
+
+	describe("post-enqueue distinguishes a parked intent from the pre-queue regime", () => {
+		it("disarms when the queue governs this PR but it is not queued (a parked intent)", () => {
+			const d = decideMergeIntent("post-enqueue", state({everQueued: true, queued: false}));
+			expect(d.action).toBe("disarm");
+			expect(d.reason).toMatch(/did not take effect/);
+		});
+
+		it("keeps when no merge-queue event has ever governed the PR (pre-queue auto-merge)", () => {
+			const d = decideMergeIntent("post-enqueue", state({everQueued: false}));
+			expect(d.action).toBe("keep");
+			expect(d.reason).toMatch(/pre-queue auto-merge regime/);
+		});
+	});
+
+	describe("fail-closed on an unreadable arm state", () => {
+		it.each([
+			"preflight",
+			"refuse",
+			"ejected",
+		] as const)("treats an unknown arm as armed at site %s", (site) => {
+			const d = decideMergeIntent(site, state({armed: "unknown"}));
+			expect(d.action).toBe("disarm");
+			expect(d.reason).toMatch(/unreadable/);
+		});
+
+		it("still keeps an unknown arm off a live queue entry", () => {
+			// Fail-closed never means dequeuing a merge the queue owns.
+			expect(decideMergeIntent("preflight", state({armed: "unknown", queued: true})).action).toBe(
+				"keep",
+			);
+		});
+	});
+});

--- a/packages/pipeline-cli/src/tools/merge-intent/merge-intent.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-intent/merge-intent.unit.test.ts
@@ -1,12 +1,12 @@
 import {describe, expect, it} from "vitest";
 import {decideMergeIntent, type IntentSite, type MergeIntentState} from "./merge-intent.ts";
 
-/** An open, unqueued, armed PR — the shape every disarm case starts from. */
+/** An open, unqueued, armed PR on a queue-governed base — the shape every disarm case starts from. */
 const state = (over: Partial<MergeIntentState> = {}): MergeIntentState => ({
 	armed: true,
 	merged: false,
 	queued: false,
-	everQueued: false,
+	queueGoverned: true,
 	...over,
 });
 
@@ -15,13 +15,13 @@ const SITES: ReadonlyArray<IntentSite> = ["preflight", "refuse", "post-enqueue",
 describe("decideMergeIntent — ship-it's no-parked-merge-intent invariant (ADR 0198, #3723)", () => {
 	describe("a live merge-queue entry is never disturbed", () => {
 		it.each(SITES)("keeps the intent at site %s when the PR is queued", (site) => {
-			const d = decideMergeIntent(site, state({queued: true, everQueued: true}));
+			const d = decideMergeIntent(site, state({queued: true}));
 			expect(d.action).toBe("keep");
 			expect(d.reason).toMatch(/merge-queue entry/);
 		});
 
 		it.each(SITES)("keeps the intent at site %s when the merge already landed", (site) => {
-			const d = decideMergeIntent(site, state({merged: true, everQueued: true}));
+			const d = decideMergeIntent(site, state({merged: true}));
 			expect(d.action).toBe("keep");
 		});
 	});
@@ -34,20 +34,20 @@ describe("decideMergeIntent — ship-it's no-parked-merge-intent invariant (ADR 
 
 	describe("the refusing/stopping run leaves no armed intent (acceptance criterion 1)", () => {
 		it("disarms on a refuse — the §CP `awaiting control-plane approval` STOP", () => {
-			const d = decideMergeIntent("refuse", state({everQueued: true}));
+			const d = decideMergeIntent("refuse", state());
 			expect(d.action).toBe("disarm");
 			expect(d.reason).toMatch(/next bare approval/);
 		});
 
-		it("disarms on a refuse even for a PR the queue never governed", () => {
+		it("disarms on a refuse even on a base branch with no merge queue", () => {
 			// The pre-queue exemption is scoped to `post-enqueue`; a refusing run never parks.
-			expect(decideMergeIntent("refuse", state({everQueued: false})).action).toBe("disarm");
+			expect(decideMergeIntent("refuse", state({queueGoverned: false})).action).toBe("disarm");
 		});
 	});
 
 	describe("an ejected PR re-enters through a fresh gate pass (acceptance criterion 2)", () => {
 		it("disarms on an ejection so the re-approval cannot re-enqueue on its own", () => {
-			const d = decideMergeIntent("ejected", state({everQueued: true, queued: false}));
+			const d = decideMergeIntent("ejected", state({queued: false}));
 			expect(d.action).toBe("disarm");
 			expect(d.reason).toMatch(/fresh ship-it gate pass/);
 		});
@@ -55,36 +55,38 @@ describe("decideMergeIntent — ship-it's no-parked-merge-intent invariant (ADR 
 
 	describe("preflight clears a stale intent from an earlier or interrupted run", () => {
 		it("disarms an arm that predates this run's guards", () => {
-			const d = decideMergeIntent("preflight", state({everQueued: true}));
+			const d = decideMergeIntent("preflight", state());
 			expect(d.action).toBe("disarm");
 			expect(d.reason).toMatch(/BEFORE this run's guards/);
 		});
 
-		it("disarms at preflight even with no merge-queue history — the arm is stale in either regime", () => {
-			expect(decideMergeIntent("preflight", state({everQueued: false})).action).toBe("disarm");
+		it("disarms at preflight on an unqueued base too — the arm is stale in either regime", () => {
+			expect(decideMergeIntent("preflight", state({queueGoverned: false})).action).toBe("disarm");
 		});
 	});
 
-	describe("post-enqueue distinguishes a parked intent from the pre-queue regime", () => {
-		it("disarms when the queue governs this PR but it is not queued (a parked intent)", () => {
-			const d = decideMergeIntent("post-enqueue", state({everQueued: true, queued: false}));
+	describe("post-enqueue keys the exemption on the BASE BRANCH regime, not the PR's history", () => {
+		it("disarms when a merge queue governs the base but the PR is not queued (parked intent)", () => {
+			const d = decideMergeIntent("post-enqueue", state({queueGoverned: true, queued: false}));
 			expect(d.action).toBe("disarm");
 			expect(d.reason).toMatch(/did not take effect/);
 		});
 
-		it("keeps when no merge-queue event has ever governed the PR (pre-queue auto-merge)", () => {
-			const d = decideMergeIntent("post-enqueue", state({everQueued: false}));
+		it("disarms a first-enqueue-attempt PR under a queue — the #3774 review's FAIL 1", () => {
+			// A per-PR "has this ever been queued?" proxy reads false here and would keep the arm;
+			// the branch regime says the queue governs this base, so the arm that never took is parked.
+			expect(decideMergeIntent("post-enqueue", state({queueGoverned: true})).action).toBe("disarm");
+		});
+
+		it("keeps when no merge queue governs the base branch (pre-queue auto-merge)", () => {
+			const d = decideMergeIntent("post-enqueue", state({queueGoverned: false}));
 			expect(d.action).toBe("keep");
 			expect(d.reason).toMatch(/pre-queue auto-merge regime/);
 		});
 	});
 
-	describe("fail-closed on an unreadable arm state", () => {
-		it.each([
-			"preflight",
-			"refuse",
-			"ejected",
-		] as const)("treats an unknown arm as armed at site %s", (site) => {
+	describe("fail-closed on an unreadable read", () => {
+		it.each(SITES)("treats an unknown arm as armed at site %s", (site) => {
 			const d = decideMergeIntent(site, state({armed: "unknown"}));
 			expect(d.action).toBe("disarm");
 			expect(d.reason).toMatch(/unreadable/);


### PR DESCRIPTION
Fixes #3723

## The defect (ordering, not an approval bypass)

A `gh pr merge --auto` left armed by an earlier or interrupted ship-it run is a **durable
request**: it survives a rebase + re-review and fires the instant a fresh control-plane approval
lands. GitHub then enqueues the §CP PR **before** the ship-it run that is supposed to assert the
machine gates has even started — on PR #3700, `added_to_merge_queue` fired one second after the
approving review, and the ship-it run that followed found it `already queued to merge`.

The approval requirement itself never lapses (ADR 0135 / 0048). What the parked arm defeats is the
*sequencing*: the current-head verdicts, the SHA-bound run-evidence bundle, the landed-comment leak
scan and the unresolved-thread check can all be skipped at the decisive instant. The concrete bad
case: a §CP PR enqueued → ejected → rebased → re-approved re-enqueues **on the re-approval alone**,
even with a missing or failing run-evidence bundle at the new head.

## The fix — a lifecycle invariant, not a new primitive

`gh pr merge --auto` stays the §CP enqueue primitive. What is added (ADR 0198) is: **an armed merge
intent may exist only between a fully-gated Step-4 enqueue and the queue accepting the PR.** Four
mandated sites clear it:

| Site | Why |
| --- | --- |
| `preflight` (run start) | catches the **interrupted** run — the #3700 mechanism, which by definition reaches no exit path of its own |
| `refuse` (every STOP/refusal) | a run that declines to enqueue must not leave behind the means to enqueue without it |
| `ejected` (merge-queue ejection) | the eject → rebase → re-approve cycle re-enters the queue only through a fresh gate pass |
| `post-enqueue` (after the bounded reconcile) | an `--auto` that never took effect is a parked intent, not a queue entry |

Two things are deliberately **not** touched: a **live merge-queue entry** is never dequeued (it is
an authorized in-flight merge; the async merge is the queue's to finish, ADR 0132), and a repo the
queue has never governed keeps its legitimate armed auto-merge (the pre-queue regime, exempt at
`post-enqueue` only).

## What's in the diff

- **`pipeline-cli merge-intent disarm`** (new tool): the branch in a pure, unit-tested core; the
  `gh` IO in a service that **verifies the clear by re-reading `auto_merge`** — `gh pr merge
  --disable-auto` exits non-zero both when the disable failed *and* when nothing was armed, so its
  exit code cannot carry the guarantee. Merge-queue membership is imported from
  `merge-queue-classify`, not re-derived. Fail-closed: an unreadable arm state disarms (a needless
  disarm costs one idempotent re-ship; a surviving parked intent costs an ungated enqueue), and an
  unprovable clear exits 1.
- **`ship-it/SKILL.md`**: guard 6 + the invariant section (the mechanism documented once, at the
  enqueue and the stop/refuse paths), the four sites wired in, and a refusal ledger that names an
  uncleared intent rather than reporting a clean stop. A failed disarm never rewrites a stop path's
  own control flow, so #1928's durable PR-visible outcomes and the `heal-ci` routing are untouched.
- **ADR 0198** — records the invariant, its fail-closed direction, and the two carve-outs.

## Acceptance criteria

- [x] After a §CP run STOPs or refuses, no `--auto` intent is left armed — every stop path runs
      `disarm_intent refuse` before reporting, and the clear is verified by read-back.
- [x] An ejected → rebased → re-approved §CP PR does not enqueue on the re-approval alone — the
      ejection clears the intent, so the enqueue happens only inside a run that re-asserted the
      current-head gates.
- [x] The mechanism is documented in `ship-it/SKILL.md` at the enqueue and stop/refuse paths,
      consistent with ADRs 0135/0048/0058, with ADR 0198 recorded.

## Verification

- `pipeline-cli` unit suite: 121 files / 1691 tests green (32 of them new, covering every branch of
  the core plus the service's read-back verify against a mock `gh` spawner).
- Repo `typecheck` + `biome check` clean; `commands check`, `pointer-guard check`, `adoption-lint
  check` (full corpus) and `gh-phoenix lint-skills` (full corpus) all pass.
- Live read-only smoke of the new verb against a merged PR: resolves state and correctly `kept`.

## Control plane

This PR is §CP (it touches the gate-critical `ship-it` skill, `packages/pipeline-cli/`, and a
guard-touching ADR). It needs a `@kamp-us/control-plane` approval at its current head before it can
enqueue.
