### PR TITLE
fix(worktree-guard): derive isolation identity from the harness sidecar, not the env (#3682)

### DIFF
--- a/.decisions/0198-worktree-isolation-identity-is-derived-not-inherited.md
+++ b/.decisions/0198-worktree-isolation-identity-is-derived-not-inherited.md
@@ -1,0 +1,75 @@
+---
+id: 0198
+title: Worktree-isolation identity is DERIVED from the harness sidecar and git plumbing, never inherited from the process env
+status: accepted
+date: 2026-07-22
+tags: [pipeline, pipeline-hardening, worktree, guards, isolation]
+---
+
+# 0198 — Worktree-isolation identity is derived, never inherited
+
+**What this decides:** the two facts every worktree-isolation consumer needs — *which worktree do I own* and *what agent-type am I* — are **derived** from the harness's per-subagent sidecar (corroborated by git plumbing), and the process env (`$WORKTREE_ROOT`, `$CLAUDE_CODE_AGENT`) is demoted to a last-resort fallback. Keying on the env is the defect, not a limitation to design around.
+
+## Context
+
+Investigation [#3682](https://github.com/kamp-us/phoenix/issues/3682) asked why concurrent `coder` lanes spawned with `isolation: worktree` bled edits into the shared primary checkout — and into each other's uncommitted work — despite a provisioning hook, a `PreToolUse` path guard, a `pre-bash` pin, and a fail-closed skill preflight all being in place.
+
+The answer is not a race, not intermittent provisioning, and not a missing guard. **The worktree was provisioned correctly and the guards were disarmed by their key.**
+
+### The evidence (observed live, in a correctly-provisioned coder worktree)
+
+| Signal | Value | Verdict |
+|---|---|---|
+| `pwd` / `git rev-parse --show-toplevel` | `<main>/.claude/worktrees/agent-<id>` | worktree exists |
+| `git rev-parse --absolute-git-dir` | `<main>/.git/worktrees/agent-<id>` | genuinely **linked** (≠ common dir) |
+| `$WORKTREE_ROOT` | **unset** | the leak |
+| `$CLAUDE_CODE_AGENT` | `crew-engineering-manager` | the **parent's** value, not `coder` |
+| sidecar `agent-<id>.meta.json` | `{"agentType":"coder","worktreePath":"<the worktree>", …}` | **both facts, correct** |
+
+Two independent, simultaneous misreports — in a lane where nothing was actually wrong.
+
+### Why `$WORKTREE_ROOT` is empty
+
+It is **read** by many guard modules and **written by nothing**: there is no `export WORKTREE_ROOT=` anywhere in `packages/` or `claude-plugins/`, and the `WorktreeCreate` hook cannot supply one — its only success channel is stdout-is-the-path (ADR [0178](0178-worktreecreate-hook-provisioning.md), contract grounded in a captured real payload per ADR [0180](0180-capture-real-runtime-artifact-before-coding.md)), and a hook is a subprocess whose `export` dies with it. The harness never promised the variable. The repo assumed it.
+
+The blast radius is total, because the empty root is not a degraded signal — it is an *inert* one. `resolvePath` returns `{kind:"allow"}` the moment the root is empty, so the `PreToolUse` `Read|Edit|Write` guard — the layer positioned **before every file write**, exactly where this class must be caught — allows every path, including a primary-checkout absolute path. Reproduced against the shipped binary, same code and same path, only the env differing:
+
+```
+$WORKTREE_ROOT unset  →  {"permissionDecision":"allow"}                    ← the edit lands in the SHARED tree
+$WORKTREE_ROOT set    →  {"permissionDecision":"allow", updatedInput:{…}}  ← rewritten into the worktree
+$WORKTREE_ROOT set    →  {"permissionDecision":"deny",  …corrected path}   ← for a path with no worktree copy
+```
+
+That is the complete edit-bleed mechanism, and it is **deterministic, not racy**. Every `isolation: worktree` subagent is permanently in the first state.
+
+### Why `$CLAUDE_CODE_AGENT` misreports
+
+It carries the **parent's** value through nested spawns, so a coder spawned under the crew is indistinguishable from its engineering-manager by that signal. `isIsolationExpected` already compensates with an env-independent second disjunct (`agentType !== "" && onPrimaryCheckout`), which is the right instinct — but it still *requires* a non-empty agent-type, so the env dependency was reduced, never removed.
+
+### The signal that was there all along
+
+The harness writes a per-subagent sidecar next to the transcript — `<transcript-dir>/<session>/subagents/agent-<agentId>.meta.json` — carrying that agent's **own** `worktreePath` and `agentType`. The repo already trusts it: `reap` reads exactly this sidecar for its `SubagentStop` owner gate (#2798). And the hook payload names it: the `PreToolUse` envelope is built from a shared base factory that supplies `session_id`, `transcript_path`, `cwd`, `agent_id`, and `agent_type` on **every** hook event (verified against the shipped binary, not assumed).
+
+So the authoritative identity was available on every hook call, in a file the codebase already knew how to read, while four guard modules keyed on a variable nothing sets.
+
+## Decision
+
+**Isolation identity is derived, in this precedence order, and the env is always last:**
+
+1. **The per-subagent sidecar** (`worktreePath`, `agentType`) — the agent's own, authoritative, survives the cwd reset and the env inheritance.
+2. **Git plumbing** — `git rev-parse --show-toplevel`, trusted **only** when `--absolute-git-dir ≠ --git-common-dir` proves a linked worktree. On the primary checkout the toplevel is the shared tree, which must never be reported as an isolated agent's root.
+3. **The process env** — `$WORKTREE_ROOT` / `$CLAUDE_CODE_AGENT`, last resort only.
+4. **Nothing** — resolve to `""`, never invent a target.
+
+This lands as `packages/pipeline-cli/src/tools/worktree-guard/isolation-identity.ts`: a pure, IO-free, unit-tested core (the caller does the sidecar read and the git probes). A probe that cannot run is **"unknown"** — never read as positive evidence in either direction.
+
+**Scope boundary, held deliberately.** This ADR decides the **detector**, not the **policy**. The resolved identity is wired into the record-only attribution path and **not** into any permission decision. Whether a guard should *refuse* on a proven-unsafe state is the open fail-open-vs-fail-closed fork in [#3743](https://github.com/kamp-us/phoenix/issues/3743) — which presupposes exactly this detector ("Detection is a separate concern: fixing it does not answer the fail-open-vs-closed question") and requires an adversarial threat-model of the shared-`.git/hooks` stall before any horn is implemented. That ruling is not taken here.
+
+## Consequences
+
+- **The forensic trail stops lying.** The `pre-bash` attribution log exists to attribute cross-lane contamination to a lane, and it recorded every isolated coder as its parent, rootless — blind in precisely the incidents it was built to explain. It now records the derived identity plus each field's provenance.
+- **A new binding rule for future work on these guards.** Any consumer needing "my worktree" or "my agent-type" calls `resolveIsolationIdentity`. Promoting the env back above the sidecar re-introduces this defect; the precedence order is the invariant, and the unit tests pin it.
+- **The guard-timing gap is characterized, and it is not a timing bug.** A raw `Edit`/`Write` is not a git op, so no `wt_preflight` or repo-side git guard fires on it — but the `PreToolUse` `Read|Edit|Write` hook already sits ahead of every file write. The correctly-positioned layer exists; it was disarmed, not mistimed. Re-keying it is what closes the window — but *arming* it changes what the guard refuses, so it is sequenced behind #3743.
+- **The agent-type misreport is fixable without the harness** — by not depending on the inherited variable. Both the payload's `agent_type` and the sidecar's `agentType` carry the agent's own value.
+- **This does not make concurrent lanes safe on its own.** Two other layers are independently down: worktree provisioning can silently no-op ([#3744](https://github.com/kamp-us/phoenix/issues/3744)), and the deployed guard binary is stale because the pinned `@kampus/pipeline-cli` version was never published, while the readiness check tests executability rather than version ([#3742](https://github.com/kamp-us/phoenix/issues/3742)) — so no source change here takes effect until that publish lands. Until all three are closed, **treat concurrent coder lanes as unsafe**: the write-code Step-4 preflight (ADR [0172](0172-write-code-fails-loud-when-expected-worktree-isolation-is-absent.md)) remains the surviving layer, and it is an agent-discipline check, not an enforced one.
+- **`$WORKTREE_ROOT` is not deleted.** It stays as a corroborator so an environment that *does* inject it keeps working — it simply stops being the key.

--- a/.decisions/0199-worktree-isolation-identity-is-derived-not-inherited.md
+++ b/.decisions/0199-worktree-isolation-identity-is-derived-not-inherited.md
@@ -1,12 +1,12 @@
 ---
-id: 0198
+id: 0199
 title: Worktree-isolation identity is DERIVED from the harness sidecar and git plumbing, never inherited from the process env
 status: accepted
 date: 2026-07-22
 tags: [pipeline, pipeline-hardening, worktree, guards, isolation]
 ---
 
-# 0198 — Worktree-isolation identity is derived, never inherited
+# 0199 — Worktree-isolation identity is derived, never inherited
 
 **What this decides:** the two facts every worktree-isolation consumer needs — *which worktree do I own* and *what agent-type am I* — are **derived** from the harness's per-subagent sidecar (corroborated by git plumbing), and the process env (`$WORKTREE_ROOT`, `$CLAUDE_CODE_AGENT`) is demoted to a last-resort fallback. Keying on the env is the defect, not a limitation to design around.
 

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -5,8 +5,8 @@
  * #741), moved into the pipeline-cli registry (epic #994, Phase 2 / #998). The four
  * hook subcommands each read the hook's stdin JSON envelope, run a pure core, and
  * emit the matching hook output; a fifth (`assert-clean`, #2666) is an operator/skill
- * invocation — not a hook — that fails closed on a dirty worktree. All read `$WORKTREE_ROOT` from the process
- * env (injected at spawn for an `isolation:worktree` subagent); an UNSET root makes
+ * invocation — not a hook — that fails closed on a dirty worktree. All read `$WORKTREE_ROOT` from
+ * the process env; an UNSET root makes
  * every subcommand a clean allow/skip no-op, so a non-worktree session is never
  * affected — with ONE exception (ADR 0172): `pre-bash` still refuses a head-moving git
  * op when isolation was EXPECTED (a direct coder/reviewer/shipper agent-type, or a nested
@@ -23,6 +23,13 @@
  *                                           stopping agent OWNS $WORKTREE_ROOT (the #2798 owner gate)
  *   Skill/operator invocation (not a hook):
  *     assert-clean [--path <d>]           — fail closed LOUD if the tree is dirty (#2666)
+ *
+ * `$WORKTREE_ROOT` is NOT injected by the harness and is written by nothing in this repo, so for a
+ * subagent it reads empty even inside a correctly-provisioned worktree — which is what disarms the
+ * root-keyed branches above (ADR 0198, #3682). `isolation-identity.ts` resolves the root and the
+ * agent-type from the harness's per-subagent sidecar instead; it is wired into the record-only
+ * attribution path here, and deliberately NOT into any permission decision — re-keying what the
+ * hooks REFUSE is gated on the open fail-open-vs-fail-closed ruling (#3743).
  *
  * The handlers are byte-identical to the former package's `bin.run.ts`. Its thin
  * `bin.ts` #777 stale-tree shim (a dynamic import gated on a dep-resolution probe)
@@ -51,6 +58,7 @@ import {Command, Flag} from "effect/unstable/cli";
 import {isIsolationExpected, pinBash} from "./bash-pin.ts";
 import {decideCleanTree} from "./clean-tree.ts";
 import {guardEnterWorktree} from "./enter-guard.ts";
+import {type AgentSidecar, resolveIsolationIdentity, sidecarPathFor} from "./isolation-identity.ts";
 import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
 import {decideReap} from "./reap.ts";
 
@@ -58,16 +66,24 @@ const GATE_FAIL_EXIT_CODE = 1;
 
 const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
 
-// Is this run sitting on the PRIMARY checkout? Env-independent signal (see ADR 0172 amendment,
-// #2462): `git rev-parse --absolute-git-dir` equals the (cwd-resolved) `--git-common-dir` on the
-// primary checkout, but differs in a linked worktree (whose per-tree git dir is
-// `.git/worktrees/<id>`) — the same signal write-code Step-4 uses. This corroborates the isolation
-// gate for a NESTED crew spawn whose inherited $CLAUDE_CODE_AGENT (engineering-manager) masks the
-// direct agent-type regex. Resolved against the hook's reported cwd; unknowable ⇒ false (degrade to
-// today's allow, never a spurious refusal).
-const onPrimaryCheckout = (cwd: string): boolean => {
+/**
+ * Which tree is this run sitting in? Env-independent signal (see ADR 0172 amendment, #2462):
+ * `git rev-parse --absolute-git-dir` equals the (cwd-resolved) `--git-common-dir` on the primary
+ * checkout, but differs in a linked worktree (whose per-tree git dir is `.git/worktrees/<id>`) —
+ * the same signal write-code Step-4 uses. This corroborates the isolation gate for a NESTED crew
+ * spawn whose inherited $CLAUDE_CODE_AGENT (engineering-manager) masks the direct agent-type regex.
+ *
+ * Tri-state on purpose: "unknown" (the probe could not run) is NOT "linked" and NOT "primary", so
+ * neither consumer below can read a failed probe as positive evidence in its own direction.
+ */
+type TreeKind =
+	| {readonly kind: "primary"}
+	| {readonly kind: "linked"; readonly toplevel: string}
+	| {readonly kind: "unknown"};
+
+const probeTree = (cwd: string): TreeKind => {
 	const base = cwd || process.cwd();
-	// biome-ignore lint/plugin: best-effort probe — an unknowable git dir degrades to false (not primary), never E (see file header).
+	// biome-ignore lint/plugin: best-effort probe — an unknowable git dir degrades to "unknown", never E (see file header).
 	try {
 		const opts = {cwd: base, encoding: "utf8" as const};
 		const gitDir = resolve(
@@ -78,9 +94,35 @@ const onPrimaryCheckout = (cwd: string): boolean => {
 			base,
 			execFileSync("git", ["rev-parse", "--git-common-dir"], opts).trim(),
 		);
-		return gitDir === commonDir;
+		if (gitDir === commonDir) return {kind: "primary"};
+		return {
+			kind: "linked",
+			toplevel: execFileSync("git", ["rev-parse", "--show-toplevel"], opts).trim(),
+		};
 	} catch {
-		return false;
+		return {kind: "unknown"};
+	}
+};
+
+// Unknowable ⇒ false (degrade to today's allow, never a spurious refusal).
+const onPrimaryCheckout = (cwd: string): boolean => probeTree(cwd).kind === "primary";
+
+/** The agent's OWN worktree + agent-type, from the harness sidecar named by the hook payload. */
+const readSidecar = (input: unknown): AgentSidecar | null => {
+	const path = sidecarPathFor({
+		transcriptPath: str(field(input, "transcript_path")),
+		agentId: str(field(input, "agent_id")),
+	});
+	if (path === null || !existsSync(path)) return null;
+	// biome-ignore lint/plugin: best-effort read — an unreadable/malformed sidecar degrades to null (fall down the evidence chain), never E (see file header).
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+		return {
+			worktreePath: str(field(parsed, "worktreePath")),
+			agentType: str(field(parsed, "agentType")),
+		};
+	} catch {
+		return null;
 	}
 };
 
@@ -90,17 +132,33 @@ const onPrimaryCheckout = (cwd: string): boolean => {
  * pre-commit tripwire sees only post-hoc index state). Best-effort and total: any failure is
  * swallowed so it can NEVER perturb the pin decision this hook actually emits. Writes through the
  * same out-of-repo log the read-only `primary-index-tripwire record` bin uses (no second surface).
+ *
+ * The recorded `agentType`/`worktreeRoot` come from {@link resolveIsolationIdentity}, not the raw
+ * env: this log exists to attribute cross-lane contamination to a lane, and the env misnames the
+ * lane in exactly the incidents it is meant to explain — an inherited `$CLAUDE_CODE_AGENT` and an
+ * unset `$WORKTREE_ROOT` recorded every isolated coder as its parent, rootless (ADR 0198, #3682).
+ * This is the record-only path on purpose; it emits no permission decision, so the resolved
+ * identity cannot change what any hook allows or refuses.
  */
-const recordBashStaging = (command: string, cwd: string): void => {
+const recordBashStaging = (command: string, cwd: string, input: unknown): void => {
 	// biome-ignore lint/plugin: best-effort attribution — any recording failure is swallowed so it can never perturb the pin decision, never E (see file header).
 	try {
+		const tree = probeTree(cwd);
+		const identity = resolveIsolationIdentity({
+			sidecar: readSidecar(input),
+			payloadAgentType: str(field(input, "agent_type")),
+			envWorktreeRoot: WORKTREE_ROOT,
+			envAgentType: process.env.CLAUDE_CODE_AGENT ?? "",
+			gitToplevel: tree.kind === "linked" ? tree.toplevel : "",
+			isLinkedWorktree: tree.kind === "linked",
+		});
 		const decision = decideBashStagingAttribution({
 			command,
 			cwd,
-			onPrimaryCheckout: onPrimaryCheckout(cwd),
-			agentType: process.env.CLAUDE_CODE_AGENT ?? "",
+			onPrimaryCheckout: tree.kind === "primary",
+			agentType: identity.agentType,
 			sessionId: process.env.CLAUDE_CODE_SESSION_ID ?? "",
-			worktreeRoot: WORKTREE_ROOT,
+			worktreeRoot: identity.worktreeRoot,
 			at: new Date().toISOString(),
 		});
 		if (decision.kind !== "record") return;
@@ -219,7 +277,7 @@ const preBash = Command.make(
 		const cwd = str(field(input, "cwd"));
 		// Run-time #2778 attribution (#2784): record a bulk-staging op before deciding the pin. Purely
 		// additive and best-effort — it never changes the pin decision emitted below.
-		recordBashStaging(command, cwd);
+		recordBashStaging(command, cwd, input);
 		const decision = pinBash({
 			worktreeRoot: WORKTREE_ROOT,
 			command,

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -26,7 +26,7 @@
  *
  * `$WORKTREE_ROOT` is NOT injected by the harness and is written by nothing in this repo, so for a
  * subagent it reads empty even inside a correctly-provisioned worktree — which is what disarms the
- * root-keyed branches above (ADR 0198, #3682). `isolation-identity.ts` resolves the root and the
+ * root-keyed branches above (ADR 0199, #3682). `isolation-identity.ts` resolves the root and the
  * agent-type from the harness's per-subagent sidecar instead; it is wired into the record-only
  * attribution path here, and deliberately NOT into any permission decision — re-keying what the
  * hooks REFUSE is gated on the open fail-open-vs-fail-closed ruling (#3743).
@@ -136,7 +136,7 @@ const readSidecar = (input: unknown): AgentSidecar | null => {
  * The recorded `agentType`/`worktreeRoot` come from {@link resolveIsolationIdentity}, not the raw
  * env: this log exists to attribute cross-lane contamination to a lane, and the env misnames the
  * lane in exactly the incidents it is meant to explain — an inherited `$CLAUDE_CODE_AGENT` and an
- * unset `$WORKTREE_ROOT` recorded every isolated coder as its parent, rootless (ADR 0198, #3682).
+ * unset `$WORKTREE_ROOT` recorded every isolated coder as its parent, rootless (ADR 0199, #3682).
  * This is the record-only path on purpose; it emits no permission decision, so the resolved
  * identity cannot change what any hook allows or refuses.
  */

--- a/packages/pipeline-cli/src/tools/worktree-guard/isolation-identity.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/isolation-identity.ts
@@ -8,7 +8,7 @@
  * correctly-provisioned worktree; `$CLAUDE_CODE_AGENT` is inherited, so a coder nested under the
  * crew reports its parent's `engineering-manager`. Both were observed misreporting *simultaneously*
  * in a live coder whose worktree was provisioned correctly — the guard layer was disarmed by the
- * key, not by a provisioning failure. See ADR 0198.
+ * key, not by a provisioning failure. See ADR 0199.
  *
  * The authoritative source is the per-subagent sidecar the harness writes next to the transcript
  * (`<transcript-dir>/<session>/subagents/agent-<agentId>.meta.json`), carrying the agent's OWN

--- a/packages/pipeline-cli/src/tools/worktree-guard/isolation-identity.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/isolation-identity.ts
@@ -1,0 +1,114 @@
+/**
+ * `worktree-guard` isolation-identity core — resolve WHO this hook invocation is and WHICH
+ * worktree it owns, without trusting the process env (#3682).
+ *
+ * The defect this exists to remove: every worktree-isolation consumer keyed on `$WORKTREE_ROOT`
+ * and `$CLAUDE_CODE_AGENT`, and **neither is reliable for a subagent**. `$WORKTREE_ROOT` is
+ * written by nothing in this repo and is not injected by the harness, so it reads empty inside a
+ * correctly-provisioned worktree; `$CLAUDE_CODE_AGENT` is inherited, so a coder nested under the
+ * crew reports its parent's `engineering-manager`. Both were observed misreporting *simultaneously*
+ * in a live coder whose worktree was provisioned correctly — the guard layer was disarmed by the
+ * key, not by a provisioning failure. See ADR 0198.
+ *
+ * The authoritative source is the per-subagent sidecar the harness writes next to the transcript
+ * (`<transcript-dir>/<session>/subagents/agent-<agentId>.meta.json`), carrying the agent's OWN
+ * `worktreePath` + `agentType`. `reap` already trusts this same sidecar for its owner gate (#2798);
+ * this core generalizes that one-off read into the shared identity resolution the other hooks need.
+ *
+ * Pure and IO-free by design: the caller reads the sidecar and runs the git probes, so every
+ * precedence rule below is unit-testable without a filesystem or a spawned agent.
+ */
+
+/** Where a resolved field came from — carried so an attribution record can be audited, not guessed. */
+export type IdentitySource = "sidecar" | "git-plumbing" | "payload" | "env" | "none";
+
+/** The fields this core consumes from the harness's per-subagent `agent-<id>.meta.json` sidecar. */
+export interface AgentSidecar {
+	readonly worktreePath: string;
+	readonly agentType: string;
+}
+
+export interface IsolationIdentity {
+	readonly worktreeRoot: string;
+	readonly worktreeRootSource: IdentitySource;
+	readonly agentType: string;
+	readonly agentTypeSource: IdentitySource;
+}
+
+const TRANSCRIPT_SUFFIX = ".jsonl";
+
+const trimmed = (v: string | undefined): string => (typeof v === "string" ? v.trim() : "");
+
+/**
+ * The sidecar path for `agentId`, derived from the hook payload's `transcript_path`.
+ *
+ * Shape grounded in the real on-disk artifact, not inferred: a transcript at
+ * `<dir>/<session>.jsonl` has its per-subagent sidecars under `<dir>/<session>/subagents/`.
+ * `null` when the inputs can't name one — an agent id carrying a path separator is rejected
+ * rather than escaped, so a malformed payload can never walk the read out of that directory.
+ */
+export const sidecarPathFor = (args: {
+	readonly transcriptPath: string;
+	readonly agentId: string;
+}): string | null => {
+	const transcriptPath = trimmed(args.transcriptPath);
+	const agentId = trimmed(args.agentId);
+	if (!transcriptPath.endsWith(TRANSCRIPT_SUFFIX) || agentId === "") return null;
+	if (agentId.includes("/") || agentId.includes("\\") || agentId.includes("..")) return null;
+	const base = transcriptPath.slice(0, -TRANSCRIPT_SUFFIX.length);
+	return `${base}/subagents/agent-${agentId}.meta.json`;
+};
+
+/**
+ * Resolve this run's worktree root + agent type from the strongest evidence available.
+ *
+ * Precedence is evidence quality, and **the env is last in both chains** — that ordering is the
+ * whole point of this core, so a future edit that promotes the env back above the sidecar is
+ * re-introducing #3682's defect. `git-plumbing` is trusted for the root only when the probe proved
+ * a LINKED worktree (git-dir ≠ common-dir); on the primary checkout the toplevel is the shared
+ * tree, which is precisely what must never be reported as an isolated agent's root.
+ *
+ * Every input is allowed to be absent: an unresolvable field returns `""` with source `"none"`,
+ * which is byte-identical to what the env-keyed consumers already see today. Resolution can
+ * therefore only ADD evidence, never remove a fallback a caller relies on.
+ */
+export const resolveIsolationIdentity = (args: {
+	readonly sidecar: AgentSidecar | null;
+	readonly payloadAgentType?: string;
+	readonly envWorktreeRoot?: string;
+	readonly envAgentType?: string;
+	/** `git rev-parse --show-toplevel`, or `""` when the probe could not run. */
+	readonly gitToplevel?: string;
+	/** `git rev-parse --absolute-git-dir` ≠ `--git-common-dir` — proof of a linked worktree. */
+	readonly isLinkedWorktree?: boolean;
+}): IsolationIdentity => {
+	const sidecarRoot = trimmed(args.sidecar?.worktreePath);
+	const sidecarAgent = trimmed(args.sidecar?.agentType);
+	const gitToplevel = trimmed(args.gitToplevel);
+	const envRoot = trimmed(args.envWorktreeRoot);
+	const payloadAgent = trimmed(args.payloadAgentType);
+	const envAgent = trimmed(args.envAgentType);
+
+	const root: {value: string; source: IdentitySource} = sidecarRoot
+		? {value: sidecarRoot, source: "sidecar"}
+		: args.isLinkedWorktree === true && gitToplevel
+			? {value: gitToplevel, source: "git-plumbing"}
+			: envRoot
+				? {value: envRoot, source: "env"}
+				: {value: "", source: "none"};
+
+	const agent: {value: string; source: IdentitySource} = sidecarAgent
+		? {value: sidecarAgent, source: "sidecar"}
+		: payloadAgent
+			? {value: payloadAgent, source: "payload"}
+			: envAgent
+				? {value: envAgent, source: "env"}
+				: {value: "", source: "none"};
+
+	return {
+		worktreeRoot: root.value,
+		worktreeRootSource: root.source,
+		agentType: agent.value,
+		agentTypeSource: agent.source,
+	};
+};

--- a/packages/pipeline-cli/src/tools/worktree-guard/isolation-identity.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/isolation-identity.unit.test.ts
@@ -1,0 +1,130 @@
+import {assert, describe, it} from "@effect/vitest";
+import {type AgentSidecar, resolveIsolationIdentity, sidecarPathFor} from "./isolation-identity.ts";
+
+const MAIN = "/Users/dev/code/phoenix";
+const WT = `${MAIN}/.claude/worktrees/agent-a7e57067b7e49bc32`;
+const TRANSCRIPT = "/Users/dev/.claude/projects/phoenix/f1052399-8e84-45a5-a5bf-bd63d3af99c9.jsonl";
+
+const sidecar = (over: Partial<AgentSidecar> = {}): AgentSidecar => ({
+	worktreePath: WT,
+	agentType: "coder",
+	...over,
+});
+
+describe("sidecarPathFor", () => {
+	it("derives the per-subagent sidecar from the payload transcript path", () => {
+		assert.strictEqual(
+			sidecarPathFor({transcriptPath: TRANSCRIPT, agentId: "a7e57067b7e49bc32"}),
+			"/Users/dev/.claude/projects/phoenix/f1052399-8e84-45a5-a5bf-bd63d3af99c9/subagents/agent-a7e57067b7e49bc32.meta.json",
+		);
+	});
+
+	it("returns null when the payload cannot name a sidecar", () => {
+		assert.isNull(sidecarPathFor({transcriptPath: "", agentId: "abc"}));
+		assert.isNull(sidecarPathFor({transcriptPath: TRANSCRIPT, agentId: ""}));
+		assert.isNull(sidecarPathFor({transcriptPath: "/no/suffix", agentId: "abc"}));
+	});
+
+	it("rejects a separator-bearing agent id rather than escaping it", () => {
+		assert.isNull(sidecarPathFor({transcriptPath: TRANSCRIPT, agentId: "../../etc/passwd"}));
+		assert.isNull(sidecarPathFor({transcriptPath: TRANSCRIPT, agentId: "a/b"}));
+		assert.isNull(sidecarPathFor({transcriptPath: TRANSCRIPT, agentId: "a\\b"}));
+	});
+});
+
+describe("resolveIsolationIdentity — the #3682 reproduction", () => {
+	it("recovers root AND agent type when BOTH env vars misreport (the live incident)", () => {
+		// The observed state inside a correctly-provisioned coder worktree: $WORKTREE_ROOT unset,
+		// $CLAUDE_CODE_AGENT carrying the parent crew's value.
+		const id = resolveIsolationIdentity({
+			sidecar: sidecar(),
+			envWorktreeRoot: "",
+			envAgentType: "crew-engineering-manager",
+		});
+		assert.strictEqual(id.worktreeRoot, WT);
+		assert.strictEqual(id.worktreeRootSource, "sidecar");
+		assert.strictEqual(id.agentType, "coder");
+		assert.strictEqual(id.agentTypeSource, "sidecar");
+	});
+
+	it("prefers the sidecar over a set-but-stale env root", () => {
+		const id = resolveIsolationIdentity({
+			sidecar: sidecar(),
+			envWorktreeRoot: `${MAIN}/.claude/worktrees/agent-someone-else`,
+		});
+		assert.strictEqual(id.worktreeRoot, WT);
+		assert.strictEqual(id.worktreeRootSource, "sidecar");
+	});
+});
+
+describe("resolveIsolationIdentity — falling back down the evidence chain", () => {
+	it("falls back to git plumbing when the sidecar is unreadable", () => {
+		const id = resolveIsolationIdentity({
+			sidecar: null,
+			gitToplevel: WT,
+			isLinkedWorktree: true,
+		});
+		assert.strictEqual(id.worktreeRoot, WT);
+		assert.strictEqual(id.worktreeRootSource, "git-plumbing");
+	});
+
+	it("never reports the PRIMARY checkout as a worktree root", () => {
+		// git-dir == common-dir ⇒ the toplevel is the shared tree. Reporting it as an isolated
+		// agent's root is the exact confusion that lets an edit land in the primary checkout.
+		const id = resolveIsolationIdentity({
+			sidecar: null,
+			gitToplevel: MAIN,
+			isLinkedWorktree: false,
+		});
+		assert.strictEqual(id.worktreeRoot, "");
+		assert.strictEqual(id.worktreeRootSource, "none");
+	});
+
+	it("uses the env root only as a last resort", () => {
+		const id = resolveIsolationIdentity({
+			sidecar: null,
+			isLinkedWorktree: false,
+			envWorktreeRoot: WT,
+		});
+		assert.strictEqual(id.worktreeRoot, WT);
+		assert.strictEqual(id.worktreeRootSource, "env");
+	});
+
+	it("prefers the payload agent type over the inherited env one", () => {
+		const id = resolveIsolationIdentity({
+			sidecar: null,
+			payloadAgentType: "coder",
+			envAgentType: "crew-engineering-manager",
+		});
+		assert.strictEqual(id.agentType, "coder");
+		assert.strictEqual(id.agentTypeSource, "payload");
+	});
+
+	it("degrades to today's env-only answer when nothing better exists", () => {
+		const id = resolveIsolationIdentity({
+			sidecar: null,
+			envWorktreeRoot: WT,
+			envAgentType: "coder",
+		});
+		assert.strictEqual(id.worktreeRootSource, "env");
+		assert.strictEqual(id.agentTypeSource, "env");
+	});
+
+	it("resolves to empty/none rather than inventing a target", () => {
+		const id = resolveIsolationIdentity({sidecar: null});
+		assert.strictEqual(id.worktreeRoot, "");
+		assert.strictEqual(id.worktreeRootSource, "none");
+		assert.strictEqual(id.agentType, "");
+		assert.strictEqual(id.agentTypeSource, "none");
+	});
+
+	it("treats whitespace-only inputs as absent", () => {
+		const id = resolveIsolationIdentity({
+			sidecar: sidecar({worktreePath: "   ", agentType: "  "}),
+			envWorktreeRoot: "  ",
+			envAgentType: " ",
+		});
+		assert.strictEqual(id.worktreeRootSource, "none");
+		assert.strictEqual(id.agentTypeSource, "none");
+	});
+});


### PR DESCRIPTION
Fixes #3682

**Investigation deliverable.** The diagnosis is the product; the code is the part of it that ships without a ruling. Not a collapsed-investigation quick fix — this is control-plane and takes the full path plus a human merge (ADRs 0053/0065).

## Root cause

Not a race, not intermittent provisioning, not a missing guard. **The worktree was provisioned correctly and the guards were disarmed by their key.**

Observed live, inside a correctly-provisioned `coder` worktree:

| Signal | Value | Verdict |
|---|---|---|
| `git rev-parse --show-toplevel` | `<main>/.claude/worktrees/agent-<id>` | worktree exists |
| `git rev-parse --absolute-git-dir` | `<main>/.git/worktrees/agent-<id>` | genuinely **linked** (≠ common dir) |
| `$WORKTREE_ROOT` | **unset** | the leak |
| `$CLAUDE_CODE_AGENT` | `crew-engineering-manager` | the **parent's** value, not `coder` |
| sidecar `agent-<id>.meta.json` | `{"agentType":"coder","worktreePath":"<the worktree>"}` | **both facts, correct** |

Two independent, simultaneous misreports in a lane where nothing was actually wrong.

`$WORKTREE_ROOT` is read by many guard modules and **written by nothing** — no `export WORKTREE_ROOT=` exists in `packages/` or `claude-plugins/`, and the `WorktreeCreate` hook cannot supply one (its only success channel is stdout-is-the-path, and a subprocess `export` dies with it). The harness never promised the variable; the repo assumed it.

The empty root is not a degraded signal, it is an **inert** one: `resolvePath` returns `allow` the instant the root is empty. Reproduced against the shipped binary — same code, same path, only the env differing:

```
$WORKTREE_ROOT unset  ->  {"permissionDecision":"allow"}                    <- edit lands in the SHARED tree
$WORKTREE_ROOT set    ->  {"permissionDecision":"allow", updatedInput:{..}} <- rewritten into the worktree
$WORKTREE_ROOT set    ->  {"permissionDecision":"deny", ..corrected path}   <- for a path with no worktree copy
```

Deterministic, not racy. Every `isolation: worktree` subagent is permanently in the first state.

## Acceptance criteria

**1. Root cause named — it is an in-repo keying defect, not a harness limitation to design around.** The reframe matters: the harness is not failing to provide `$WORKTREE_ROOT`, it never offered it. It *does* publish both facts — per hook call in the payload (`agent_id`, `agent_type`, `transcript_path`) and per agent on disk in the sidecar (`worktreePath`, `agentType`). The repo already reads that sidecar in `reap` for the #2798 owner gate. The authoritative identity was available on every hook call, in a file the codebase already knew how to read, while the guard modules keyed on a variable nothing sets.

**2. Guard-timing gap characterized — it is not a timing bug.** A raw `Edit`/`Write` is not a git op, so no `wt_preflight` or repo-side git guard fires on it. But the `PreToolUse` `Read|Edit|Write` hook (registered in `hooks.json`) already sits ahead of **every** file write — the exact "before any Edit/Write is possible" slot the issue asks for. The correctly-positioned layer exists; it was **disarmed, not mistimed**. No new guard is warranted, and adding one on top would have been the wrong move.

**3. Agent-type misreport explained, and fixable without the harness** — by not depending on the inherited variable. `$CLAUDE_CODE_AGENT` carries the parent's value through nested spawns. Both the payload's `agent_type` and the sidecar's `agentType` carry the agent's own. `isIsolationExpected` already had the right instinct (an env-independent second disjunct) but still requires a non-empty agent-type, so the dependency was reduced, never removed.

**4. Concrete recommendation, routed.** Detector fix here; the rest already has owners (below).

## What ships

- `isolation-identity.ts` — a pure, IO-free, unit-tested core resolving both facts by **evidence quality**: sidecar > git plumbing > env > nothing. The env is last in both chains; that ordering is the invariant and the tests pin it.
- A **tri-state** git probe (`primary` / `linked` / `unknown`) replacing a boolean that fail-safed to `false` — so a probe that could not run is never read as positive evidence in either direction. Git plumbing is trusted for the root only when git-dir ≠ common-dir proves a linked worktree; the primary checkout's toplevel must never be reported as an isolated agent's root.
- ADR 0199 recording the diagnosis and the binding rule.
- Corrects a false claim in the `command.ts` header (`$WORKTREE_ROOT` "injected at spawn").

## Scope held deliberately — this does NOT decide #3743

The resolved identity is wired into the **record-only attribution path**, which emits no permission decision. It cannot change what any hook allows or refuses.

Arming the enforcing hooks would change what the guard **refuses**, which is the open fail-open-vs-fail-closed fork in #3743 — a ruling that is not mine to make. #3743 explicitly presupposes this detector ("Detection is a separate concern: fixing it does not answer the fail-open-vs-closed question") and requires an adversarial threat-model of the shared-`.git/hooks` stall first. So this PR builds the prerequisite and **stops at that seam**.

Immediate value even so: the `pre-bash` attribution log exists to attribute cross-lane contamination to a lane, and it recorded every isolated coder as its parent, rootless — blind in precisely the incidents it was built to explain.

## Relationship to the sibling lanes (not duplicated, not fixed here)

- **#3744** — provisioning can silently no-op (the layer *before* any guard). Untouched.
- **#3743** — the fail-open-vs-closed ruling. Untouched, explicitly.
- **#3742** — the pinned `pipeline-cli` version was never published and the readiness check tests executability, not version, so a stale pre-ADR-0172 build runs. **Strict prerequisite: no source change here takes effect until that publish lands.**
- **#3594** — same family, the `Write`/`Edit` per-write enforcement question.

**Until all of these close, concurrent coder lanes remain unsafe.** The write-code Step-4 preflight (ADR 0172) is the surviving layer, and it is agent discipline, not enforcement.

## Verification

- `pnpm typecheck` — clean (33/33).
- `pnpm biome check` — clean.
- `pipeline-cli` worktree-guard suite — 97/97 pass (12 new).
- Pre-commit guards green (biome, leak-guard, primary-index-guard, primary-index-tripwire).
- Hook behavior reproduced end-to-end against the shipped binary in all three states above.

**Control-plane — needs human approval; I do not merge and do not approve.**

