### PR TITLE
fix(sozluk): make the e2e retry reopen the dialog it asserts on + guard a silent create dismiss (#3746)

### DIFF
--- a/apps/web/src/components/sozluk/SozlukSubnavCta.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavCta.tsx
@@ -24,8 +24,14 @@ export function SozlukSubnavCta() {
 		e.preventDefault();
 		const term = String(new FormData(e.currentTarget).get("term") ?? "");
 		const slug = slugifyTerm(term);
+		// Dismiss ONLY once the submit has somewhere to go. `required` does not keep an
+		// unusable term out of here — base-ui's `Form` renders `noValidate` and gates on
+		// its own field validity, which a non-empty term of pure punctuation passes even
+		// though it slugifies to nothing. Closing before this guard swallowed the create
+		// silently: the dialog vanished, nothing navigated, nothing was said (#3746).
+		if (!slug) return;
 		setOpen(false);
-		if (slug) navigate(`/sozluk/${slug}`);
+		navigate(`/sozluk/${slug}`);
 	}
 	return (
 		<Dialog.Root open={open} onOpenChange={setOpen}>

--- a/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
@@ -91,6 +91,40 @@ describe("SozlukSubnavLayout — sözlük product Subnav zone through SubnavShel
 		expect(screen.getByTestId("term-leaf").textContent).toContain("term:yeni-terim");
 	});
 
+	/**
+	 * #3746: a submit the create flow cannot act on must not dismiss the dialog. `required`
+	 * is no defence — base-ui's `Form` renders `noValidate` and gates on its own field
+	 * validity, which a non-empty punctuation term passes on its way to slugifying into
+	 * nothing. That used to close the dialog while navigating nowhere.
+	 */
+	it("keeps the create dialog open when the term slugifies to nothing — never a silent dismiss", async () => {
+		renderZone("/sozluk/mevcut-terim");
+		fireEvent.click(screen.getByRole("button", {name: /yeni tanım/i}));
+		const field = await screen.findByLabelText("Terim");
+		fireEvent.change(field, {target: {value: "!!!"}});
+		const form = field.closest("form");
+		if (!form) throw new Error("the create field is not inside a form");
+		fireEvent.submit(form);
+		expect(screen.getByLabelText("Terim")).toBeTruthy();
+		expect(screen.getByTestId("term-leaf").textContent).toContain("term:mevcut-terim");
+	});
+
+	it("keeps the create dialog open when the typed term is lost before submit", async () => {
+		renderZone("/sozluk/mevcut-terim");
+		fireEvent.click(screen.getByRole("button", {name: /yeni tanım/i}));
+		const field = (await screen.findByLabelText("Terim")) as HTMLInputElement;
+		fireEvent.change(field, {target: {value: "gecerli terim"}});
+		// Drop the control's value with no change event, the way a remount of the
+		// uncontrolled input drops it (#3600). Which layer refuses the resulting empty
+		// submit is base-ui's business; that the dialog survives it is ours.
+		field.value = "";
+		const form = field.closest("form");
+		if (!form) throw new Error("the create field is not inside a form");
+		fireEvent.submit(form);
+		expect(screen.getByLabelText("Terim")).toBeTruthy();
+		expect(screen.getByTestId("term-leaf").textContent).toContain("term:mevcut-terim");
+	});
+
 	it("keeps the Subnav zone mounted across a within-sozluk navigation — no remount", () => {
 		const {container} = renderZone("/sozluk/mevcut-terim");
 		const before = container.querySelector(".kp-subnav");

--- a/apps/web/tests/e2e/06-sozluk-home.spec.ts
+++ b/apps/web/tests/e2e/06-sozluk-home.spec.ts
@@ -84,20 +84,27 @@ test.describe("SozlukHome create-flow (+ yeni tanım → composer)", () => {
 
 		await page.getByRole("button", {name: /yeni tanım/i}).click();
 
-		// The Base UI dialog portal re-renders shortly after open (a transition-status flip
-		// that detaches the popup subtree — the #3517 race), so a single fill→submit loses its
-		// target: the `oluştur` button detaches faster than Playwright's per-action auto-retry
-		// can outlast (#3585 only moved the failure here from the cancelled-animation
-		// AbortError), and a remount clears the uncontrolled `Terim` input. Retry the whole
-		// fill→submit→navigate as one unit until it sticks — each poll re-fills (idempotent)
-		// and re-clicks, and the block passes only once the submit's navigation actually lands,
-		// so a mid-interaction detach is absorbed instead of failing the test. The app-side
-		// portal re-render is tracked as a follow-up off #3583.
+		// The dialog can be gone by the time a poll runs — the #3746 failure artifact caught
+		// the popup absent from the DOM entirely, on an idle `/sozluk`, not detached
+		// mid-interaction as #3583 assumed. That is why #3583's retry did not hold: a block
+		// that starts inside the open dialog and never reopens it cannot recover from a closed
+		// one, so every remaining poll burns its budget on a `Terim` that can never resolve.
+		// Reopening is what makes the retried unit self-sufficient. What closes the dialog is
+		// not yet pinned and is tracked on #3600; the app-side half of #3746 removed the one
+		// closer that was provable (a submit that slugified to nothing dismissed and navigated
+		// nowhere), which this spec cannot observe.
 		const dialog = page.locator(".kp-dialog__popup");
 		await expect(dialog).toBeVisible();
 		await expect(async () => {
-			// The dialog collects the term name (the composer is slug-addressed).
-			await page.getByLabel("Terim").fill(term);
+			if (!(await dialog.isVisible())) {
+				await page.getByRole("button", {name: /yeni tanım/i}).click({timeout: 2_000});
+				await expect(dialog).toBeVisible({timeout: 2_000});
+			}
+			// The dialog collects the term name (the composer is slug-addressed). Bounded like
+			// the click below so one bad poll can't eat the whole `toPass` budget and starve
+			// the retry of a second attempt — the shape that turned #3583's loop into a
+			// single-shot.
+			await page.getByLabel("Terim").fill(term, {timeout: 2_000});
 			await page.getByRole("button", {name: /^oluştur$/i}).click({timeout: 2_000});
 			// The dialog slugifies + navigates to the fresh-slug composer route.
 			await expect(page).toHaveURL(new RegExp(`/sozluk/${slug}$`), {timeout: 2_000});


### PR DESCRIPTION
**Collapsed investigation (ADR 0070).** #3746 asked which of two things the residual flake was: a Base UI transition with no settled signal to await, or an app-side portal re-render the retry could not outlast. The answer is **neither** — the diagnosis is below, and the bounded fix it produced is collapsed into this PR.

## The diagnosis

### What the failure artifact actually shows

The one CI reproduction in the reported window is run `29713105838`, job `88260575705` — the `flows` lane, `06-sozluk-home.spec.ts:77`, failed then passed on retry. Its `error-context.md` page snapshot and `test-failed-1.png` show, at the moment of failure:

- **no dialog at all** — no `.kp-dialog__popup`, no backdrop, nothing portalled;
- the rest of the page fully rendered, un-`aria-hidden`, and idle: the `+ yeni tanım` trigger present, the alphabet, both term columns loaded, no error and no toast;
- still on `/sozluk`, not `/sozluk/<slug>`.

The reported error is `locator.fill: Timeout 5000ms exceeded — waiting for getByLabel('Terim')`, inside `Timeout 9000ms exceeded while waiting on the predicate`.

So the popup was **not** detached mid-interaction, and **not** hidden. It was **closed**, and the app then sat idle having done nothing. `await expect(dialog).toBeVisible()` on the line above had already passed, so it did open first.

### Why the #3583 mitigation could not hold

This is the root cause of the *mitigation's* failure, and it is independent of whatever closes the dialog.

The retried block begins **inside the already-open dialog** and never reopens it:

```ts
await expect(dialog).toBeVisible();
await expect(async () => {
  await page.getByLabel("Terim").fill(term);
  await page.getByRole("button", {name: /^oluştur$/i}).click({timeout: 2_000});
  await expect(page).toHaveURL(..., {timeout: 2_000});
}).toPass({timeout: 9_000});
```

Once the dialog is closed, `getByLabel('Terim')` can never resolve, so every remaining poll burns the 5s action timeout on a locator with no possible match. Two polls exhaust the 9s budget — which is exactly the 4s + 5s decomposition of the observed failure. The in-code comment's claim that "each poll re-fills (idempotent) and re-clicks" is false in the one state that matters: **the retried unit does not re-establish its own precondition.** No amount of extra waiting, a longer timeout, or a settled-signal primitive fixes that shape, which is why the mitigation "landed but did not close it".

### What is provably closing the dialog — and what is not

One closer is provable, and it is an app bug rather than a test one. `SozlukSubnavCta.onSubmit` dismissed the dialog *before* checking it had anywhere to go:

```ts
const slug = slugifyTerm(term);
setOpen(false);
if (slug) navigate(`/sozluk/${slug}`);
```

`required` does not keep an unusable term out of that handler. Grounded in the pinned `@base-ui/react@1.4.1` source:

- `field/root/useFieldValidation.js` — the field gate scores validity off the control's own `ValidityState`; a **non-empty** term of pure punctuation (`!!!`) is natively valid and passes.
- `form/Form.js` — `Form` renders with `noValidate: true` and substitutes its own gate, so native constraint validation never runs either.

`slugifyTerm("!!!")` is `""`. So the submit reached the handler, `setOpen(false)` ran, `navigate` did not — **the dialog vanished, nothing happened, and nothing was said.** That reproduces the exact CI signature deterministically: with the guard reverted, the new component test fails with `Unable to find a label with the text of: Terim`, the same locator the CI run timed out on. It is also a real product defect independent of CI — a user who types `!!!` or `...` loses the dialog with no feedback.

**What is not established:** the e2e's own term (`e2e create flow <base36>`) slugifies fine, so this closer is not the one that fired in that CI run. I checked and ruled out the obvious alternative — a lost input value reaching the handler as an empty submit — because Base UI's field gate *does* refuse an empty `required` control (pinned by the second test). What closes the dialog in CI is still open; it belongs to #3600's lane and is **not** fixed here.

### Correction to the stated mechanism on #3746 / #3600 (do not carry it forward)

Both issues, and the spec comment, rest on "the `Dialog.Popup` wrapper re-creates `<Portal><Backdrop/><Popup>` on every render, so a host re-render remounts the portalled subtree". **That is not how React reconciles.** `Popup` and `Backdrop` in `apps/web/src/components/ui/Dialog.tsx` are module-scope components, so re-rendering produces elements of the same type at the same position and React updates them in place — it never remounts. Re-creating JSX is not a remount; only a changed component identity, a changed `key`, or an ancestor unmount is. Whatever #3600 observed, that grounding does not support it.

### Same mechanism as #3600?

**Partly, and the distinction is load-bearing.** #3600 owns *why the popup subtree goes away*; this issue is about the failure that goes away being unrecoverable. They are the same symptom class (an open dialog stops existing) but different units of work, and #3600's stated cause is wrong per the correction above. This PR deliberately does not touch it.

## The change

- **`apps/web/src/components/sozluk/SozlukSubnavCta.tsx`** — guard on the slug before dismissing. A submit with nowhere to go now leaves the dialog open instead of silently swallowing the create.
- **`apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx`** — two component tests pinning the invariant: an unslugifiable term, and a value lost with no change event (the remount shape). The first fails without the guard, with the CI failure's own locator error.
- **`apps/web/tests/e2e/06-sozluk-home.spec.ts`** — the retried unit reopens the dialog when it is closed, so it is self-sufficient; the fill is bounded like the click so one bad poll cannot eat the whole budget and starve the retry of a second attempt. The old comment's mechanism did not survive the artifact and is replaced with what the artifact shows, pointing the unpinned closer at #3600.

The spec change is a repair of a proven structural defect in the retry, not a fresh wait/timeout — and the component tests, not the e2e, are what guard the app invariant, so a regression of the guard reds deterministically rather than being absorbed by the reopen.

## Acceptance criteria

- [x] Root cause named, grounded in Base UI source rather than intuition — neither of the two candidates the issue offered. The mitigation fails because its retried unit does not re-establish its own precondition; the one provable closer is an app-side unconditional dismiss, cited to `@base-ui/react@1.4.1` `form/Form.js` and `field/root/useFieldValidation.js`.
- [x] Decision on fix location, with the rejected alternative — fix **app-side** (the dismiss) plus a **structural** repair of the retry unit. Rejected: a test-side settled-signal wait on the Base UI transition, because the artifact shows a *closed* dialog on an idle page, not a transition still in flight — no settled signal exists to await, and awaiting one would not have made the retry recoverable.
- [x] The spec no longer flakes on the observed condition — the retry now recovers from a closed dialog whatever closed it, and the provable closer is removed at the source.
- [x] The diagnosis landed on a bounded, trivial change, so it is collapsed into this PR per ADR 0070 rather than split into residue.

Fixes #3746
