### PR TITLE
fix(crew): stop the bridge seats self-denying Task, and fail loud on a declared-vs-actual toolset gap (#3764)

### DIFF
--- a/.github/workflows/crew-fanout-guard.yml
+++ b/.github/workflows/crew-fanout-guard.yml
@@ -1,14 +1,13 @@
 name: crew-fanout-guard
 
-# CI gate for #3606 (residual from #3597/#3605): invert the crew read-only-fanout
-# per-bridge spawn DENYLIST into an ENFORCED ALLOWLIST. claude-code's permission model
-# only *subtracts* denied agent-types — there is no "spawn only X" primitive — so a
-# FUTURE mutating agent-type added to the roster is silently spawnable by every bridge
-# until someone remembers to extend each denylist (the "a future reader silently reopens
-# the deleted edge" risk ADR 0196 warns of). This job asserts every crew bridge
-# (chief-of-staff / cartographer / intake-desk) denies every mutating roster agent-type
-# NOT on its sanctioned allowlist, and fails closed on an uncovered agent-type or zero
-# scope (ADR 0092) — so a new un-denied mutating agent reds the build. Roster-law
+# CI gate for #3606 (residual from #3597/#3605): assert every mutating roster agent-type
+# is EXPLICITLY CLASSIFIED — allowlisted or out-of-scope — for each crew bridge
+# (chief-of-staff / cartographer / intake-desk), failing closed on an unclassified pair or
+# zero scope (ADR 0092). Without it, a FUTURE mutating agent-type added to the roster is
+# silently in scope for every bridge (the "a future reader silently reopens the deleted
+# edge" risk ADR 0196 warns of). This is a completeness check on the POLICY, not
+# enforcement of it: the platform has no per-subagent deny, so the line is held by each
+# seat's charter prose (#3764, claude-plugins/pipeline-crew/SPAWN-SCOPE.md). Roster-law
 # boundary, ADR 0189/0196. The scan lives once in pipeline-cli's `crew-fanout-guard check`.
 on:
   pull_request:
@@ -23,7 +22,7 @@ concurrency:
 
 jobs:
   check:
-    name: every crew bridge denies non-allowlisted mutating agent-types
+    name: every crew bridge classifies every mutating agent-type
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -37,7 +36,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Exit 1 on an uncovered bridge×agent-type pair, a missing bridge def, a stale
-      # allowlist, or zero scope (report on stderr, fail-closed). See #3606.
+      # Exit 1 on an unclassified bridge×agent-type pair, a missing bridge def, a stale
+      # classification, or zero scope (report on stderr, fail-closed). See #3606.
       - name: Check crew bridge fanout scoping
         run: node packages/pipeline-cli/src/bin.ts crew-fanout-guard check

--- a/claude-plugins/pipeline-crew/REFERENCE.md
+++ b/claude-plugins/pipeline-crew/REFERENCE.md
@@ -23,7 +23,7 @@ carries the **same five frontmatter keys**; all are present in all four defs.
 | `description` | string (quoted) | The routing prose: what the agent is for, its typical triggers, and an explicit "Do NOT use it to…" negative. Single-quoted YAML; inner apostrophes are doubled (`''`). |
 | `model` | string | Always `inherit` — a spawned session runs on the tier of the session that launched it (the tier is set at launch via the config's `roles.<role>.tier`, not hardcoded in the def). |
 | `color` | string | The session's display color — one per role (see the roster below). |
-| `tools` | string[] | The hard allowlist of callable tools. A tool absent here is uncallable even if its MCP server is connected. Every def lists the channel tool by its full MCP token (below). |
+| `tools` | string[] | The hard allowlist of callable tools. A tool absent here is uncallable even if its MCP server is connected. Every def lists the channel tool by its full MCP token (below). A name the CLI cannot grant is dropped **silently**, so what may appear here is fenced — see [`SPAWN-SCOPE.md`](SPAWN-SCOPE.md). |
 
 ### The channel tool token — mandatory in every `tools:` allowlist
 
@@ -42,8 +42,8 @@ The **engineering-manager** (the one engine) carries a **second** channel token 
 `channel_send` — `mcp___kampus_pipeline-crew-mcp__channel_claim` — which claims a tracker
 resource before it opens a lane (cross-engine deconfliction, a real lock rather than a relayed
 message). Only the engine lists it; the three bridges list `channel_send` alone. So when
-reconstructing the engine def from the roster table below, note its `tools:` array is seven
-entries, not six. Why it needs its own tool: [`CHANNEL-TOOL.md`](CHANNEL-TOOL.md).
+reconstructing the engine def from the roster table below, note its `tools:` array is five
+entries, not four. Why it needs its own tool: [`CHANNEL-TOOL.md`](CHANNEL-TOOL.md).
 
 ### Per-def frontmatter values
 
@@ -51,10 +51,10 @@ The exact shipped values, matching each def head:
 
 | Def file | `name` | `color` | `tools` |
 |---|---|---|---|
-| [`agents/crew-cartographer.md`](agents/crew-cartographer.md) | `crew-cartographer` | `green` | `Read`, `Bash`, `Grep`, `Glob`, `Task`, `channel_send` |
-| [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md) | `crew-intake-desk` | `yellow` | `Read`, `Bash`, `Grep`, `Glob`, `Task`, `channel_send` |
-| [`agents/crew-engineering-manager.md`](agents/crew-engineering-manager.md) | `crew-engineering-manager` | `cyan` | `Task`, `Bash`, `Read`, `Grep`, `Glob`, `channel_send`, `channel_claim` |
-| [`agents/crew-chief-of-staff.md`](agents/crew-chief-of-staff.md) | `crew-chief-of-staff` | `magenta` | `Read`, `Bash`, `Grep`, `Glob`, `channel_send` |
+| [`agents/crew-cartographer.md`](agents/crew-cartographer.md) | `crew-cartographer` | `green` | `Read`, `Bash`, `Task`, `channel_send` |
+| [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md) | `crew-intake-desk` | `yellow` | `Read`, `Bash`, `Task`, `channel_send` |
+| [`agents/crew-engineering-manager.md`](agents/crew-engineering-manager.md) | `crew-engineering-manager` | `cyan` | `Task`, `Bash`, `Read`, `channel_send`, `channel_claim` |
+| [`agents/crew-chief-of-staff.md`](agents/crew-chief-of-staff.md) | `crew-chief-of-staff` | `magenta` | `Read`, `Bash`, `Task`, `channel_send` |
 
 `channel_send` above is the full `mcp___kampus_pipeline-crew-mcp__channel_send` token,
 abbreviated in this table for width; `channel_claim` on the engineering-manager row is

--- a/claude-plugins/pipeline-crew/SPAWN-SCOPE.md
+++ b/claude-plugins/pipeline-crew/SPAWN-SCOPE.md
@@ -1,0 +1,55 @@
+# Spawn scope — which agents a seat may spawn, and why it is a charter rule
+
+The roster law (ADR [0189](../../.decisions/0189-crew-roster-law-bridges-engines.md)) keeps the
+build drain on the **engine** and off the **bridges**: a bridge conducts its own seam and fans
+read-only investigations (ADR [0196](../../.decisions/0196-read-only-crew-fanout.md)), it never
+runs `coder → reviewer → shipper`. **This doc is the single source for how that line is held.**
+Each crew def states its own one-line spawn scope and cites this file; none of them re-derive the
+reasoning inline.
+
+## The line is a charter rule, not a permission mechanism (#3764)
+
+The defs used to carry `disallowedTools: ["Task(coder)", "Task(reviewer)", …]` and describe it as
+the permission engine hard-blocking those spawns. **That mechanism does not exist**, and the
+declaration was actively harmful. Established against the installed CLI by booting probe agent-defs
+and reading the `init` event's granted `tools`:
+
+- An agent-def `disallowedTools` entry is matched by its **base tool name**; the `(specifier)` is
+  **ignored**, and the **whole tool** is subtracted from that def's `tools:` allowlist. So
+  `disallowedTools: ["Task(coder)"]` never denied the `coder` subagent — it deleted `Task`.
+- A `permissions: { deny: [...] }` key in an agent def does not block the spawn either, under any
+  token spelling (`Task(x)`, `Task(<plugin>:x)`, `Agent(x)`, `Agent(<plugin>:x)`).
+
+The consequence was the live defect: all three bridge seats booted with **no `Task` at all**, so
+the intake-desk could not discharge its charter obligation to spawn the `planner` over a triaged
+epic, and no seat could reach the ADR 0196 read-only fanout. The restriction meant to scope a
+bridge's spawns had instead removed every spawn it was supposed to keep.
+
+So the scope is stated where a seat actually reads it — **its own charter prose** — and the
+platform grants `Task` at whole-tool granularity, which is the only granularity it offers. A seat
+that spawns outside its stated scope is violating its charter, the same way it would by
+implementing a ticket or merging a PR; nothing below the model enforces it.
+
+## What keeps the scope from silently going unstated
+
+`pipeline-cli crew-fanout-guard check` (CI) owns the per-bridge classification: every mutating
+agent-type in the roster must be on a bridge's sanctioned allowlist **or** its explicit
+out-of-scope list, both in
+[`packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts`](../../packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts).
+A newly-added agent-type on neither reds the build (ADR 0092). That is a completeness check on the
+*policy*, not an enforcement of it — it guarantees the line is always stated, never that it is
+obeyed.
+
+## What keeps a declared toolset from silently shrinking
+
+The CLI drops a tool name it cannot grant **with no warning**, which is why the `Task` loss ran a
+whole session unnoticed. The launcher now refuses a stand-up (or an on-demand `spawn-role`) whose
+seat def declares a toolset the CLI would not resolve intact —
+[`packages/pipeline-crew-mcp/src/standup/toolset-assert.ts`](../../packages/pipeline-crew-mcp/src/standup/toolset-assert.ts),
+which also carries the re-derivation command for the grantable tool set on a CLI version bump.
+
+Two rules it enforces, both worth knowing when editing a def:
+
+- Do not name a tool in **both** `tools:` and `disallowedTools:` — the second deletes the first.
+- Do not declare `Grep` or `Glob`. They are not tools a top-level session is granted; `Bash` covers
+  those reads.

--- a/claude-plugins/pipeline-crew/agents/crew-cartographer.md
+++ b/claude-plugins/pipeline-crew/agents/crew-cartographer.md
@@ -3,8 +3,7 @@ name: crew-cartographer
 description: 'Use this agent as the crew''s inbound-ideation bridge — the cartographer that turns the founder''s fog (a fuzzy, not-yet-decided destination) into charted work the pipeline can eventually consume. It runs the wayfinder skill: CHART mode opens/rewrites a wayfinder:map issue and lays out the open frontier as sub-issues; WORK mode advances one frontier ticket, records the answer, and graduates the fog. It never auto-resolves a founder decision — it surfaces the fork on the map and stops. Typical triggers include "chart a map for X", "start a wayfinder map", "work the wayfinder map #N", and "advance the map". Do NOT use it to implement, review, merge, or triage — it sits UPSTREAM of triage and produces a clarified plan, not a diff. See "When to invoke" for worked scenarios.'
 model: inherit
 color: green
-tools: ["Read", "Bash", "Grep", "Glob", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
-disallowedTools: ["Task(reviewer)", "Task(shipper)", "Task(crew-engineering-manager)", "Task(crew-chief-of-staff)", "Task(crew-intake-desk)", "Task(crew-cartographer)"]
+tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
 ---
 
 You are the **cartographer** — the crew's **inbound-ideation bridge**. You turn the founder's
@@ -74,17 +73,15 @@ not an execution edge.
 
 This is **additive** and does not touch your existing WORK-mode spawn of an investigation /
 deep-research subagent (or a spike/tracer coder for a Prototype ticket) — that legwork is
-unchanged. What it does **not** grant is any merge-pipeline spawn: your `disallowedTools`
-frontmatter denies `Task(reviewer)` and `Task(shipper)`, so the permission engine hard-blocks you
-from ever spawning the review/merge gate agents (the engine's seam) — and it **also** denies
-`Task(crew-engineering-manager)` (plus the peer bridges `Task(crew-chief-of-staff)` /
-`Task(crew-intake-desk)` and your own singleton seat `Task(crew-cartographer)`), so you cannot reach
-the reviewer/shipper *transitively* either — the engine whose charter is to spawn
-`coder → reviewer → shipper` is off-limits, closing the nested-spawn path rather than betting on
-unverified nested-`Task` platform behavior. Your Prototype-spike `coder`
-stays available — a throwaway tracer that answers a fog question is ideation legwork, not the
-coder→reviewer→shipper execution drain the roster law keeps off a bridge; denying reviewer/shipper
-(and the engine that would spawn them) is what holds that line without breaking the spike.
+unchanged. Your **whole** spawn scope is `coder`/`planner`/`canon`/`adr`/`triager`/`reporter` plus
+the read-only `crew-investigator`. You never spawn `reviewer` or `shipper` (the review/merge gate,
+the engine's seam), never the `crew-engineering-manager` that would spawn them for you, and never a
+peer bridge or a second copy of yourself. Your Prototype-spike `coder` stays in scope — a throwaway
+tracer that answers a fog question is ideation legwork, not the coder→reviewer→shipper execution
+drain the roster law keeps off a bridge; holding the line at reviewer/shipper (and the engine that
+would spawn them) is what keeps the spike without reopening the drain. Nothing below you enforces
+this — it is a charter rule you keep, for the reason and with the CI backstop in
+[`SPAWN-SCOPE.md`](../SPAWN-SCOPE.md).
 
 ## Addressing — your one live edge is cartographer → intake-desk
 
@@ -140,10 +137,9 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   (`isolation:worktree`) rather than running its skill in your context; the agents are
   `model: inherit`, so bring **this** session up on its configured tier and never pass an explicit
   model to a spawn. For an expensive read, fan it to the read-only `crew-investigator` (ADR 0196)
-  and take only its distilled finding; your `disallowedTools` frontmatter hard-denies
-  `Task(reviewer)` and `Task(shipper)` — and `Task(crew-engineering-manager)` (the execution
-  engine whose charter is to spawn them) — so you can never spawn a review/merge gate agent, directly
-  or transitively (the Prototype-spike `coder` stays available for ideation legwork).
+  and take only its distilled finding; you never spawn `reviewer`/`shipper` or the
+  `crew-engineering-manager` that would spawn them (the Prototype-spike `coder` stays in scope for
+  ideation legwork), per [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md).
 - **Address peers by role, never by locating a session; offline is log-and-continue.** The only
   addressing idiom is `channel_send {targetRole, kind, body}`; a `PeerUnreachableError` is logged and
   stepped over, never retried or escalated. The channel tool's callable allowlist token and the

--- a/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
+++ b/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
@@ -3,8 +3,7 @@ name: crew-chief-of-staff
 description: 'Use this agent as the crew''s outbound-awareness bridge — the chief of staff that turns factory state into the founder''s understanding and owns human-facing comms to BOTH humans (the operator/founder and the control-plane approver). It gives situational-awareness reads off the board, carries out §CP banks the engine parked for a human approval (the human approves — never hand-merges — and the engine''s approval-aware shipper enqueues once that approval lands), and owns the single human-notification channel. Its charter is the live verifier: verify, never relay — a relayed claim is never truth, a subagent''s self-reported PASS is not truth until the artifact is read, and an enqueue is never a merge. It is a conversation PEER, not a switchboard, and it treats conversing as coordination, never as evidence. Typical triggers include "what''s the state of the board", "give me a situational-awareness read", "carry this banked §CP PR to the approver", and "ping me when X lands". Do NOT use it to spawn a coder/reviewer/shipper, to review a diff, or to merge a PR. See "When to invoke" for worked scenarios.'
 model: inherit
 color: magenta
-tools: ["Read", "Bash", "Grep", "Glob", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
-disallowedTools: ["Task(coder)", "Task(reviewer)", "Task(shipper)", "Task(planner)", "Task(canon)", "Task(adr)", "Task(triager)", "Task(reporter)", "Task(crew-engineering-manager)", "Task(crew-cartographer)", "Task(crew-intake-desk)", "Task(crew-chief-of-staff)"]
+tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
 ---
 
 You are the **chief-of-staff** — the crew's **outbound-awareness bridge**. You turn the
@@ -170,21 +169,15 @@ in [#3543](https://github.com/kamp-us/phoenix/issues/3543)).
 **The fanout is read-only and scoped — it is NOT a new execution edge.** `crew-investigator` holds
 **no write tools** (no Edit/Write, no merge, no board-mutation, no `Task`), so a read you fan out
 can never mutate — it is a context-hygiene primitive, exactly aligned with your verify-and-carry
-charter, not the deleted "bridge runs the pipeline" edge. And your own grant is scoped to match:
-your `disallowedTools` frontmatter **denies spawning every other agent** — every `kampus-pipeline`
-agent (`Task(coder)`, `Task(reviewer)`, `Task(shipper)`, `Task(planner)`, `Task(canon)`, `Task(adr)`,
-`Task(triager)`, `Task(reporter)`) **and every other `pipeline-crew` agent that holds `Task` and could
-itself spawn one**: `Task(crew-engineering-manager)` — the execution engine whose charter is to spawn
-`coder → reviewer → shipper` — plus the peer bridges `Task(crew-cartographer)`, `Task(crew-intake-desk)`,
-and `Task(crew-chief-of-staff)` (a singleton bridge never re-spawns a bridge seat). `crew-investigator`
-holds no `Task` of its own, so it is the **only** agent you can spawn — and because the one engine and
-the coder-capable bridge are denied outright, no *transitive* spawn path to the pipeline survives
-either: the denial is roster-complete over every existing spawnable, not a bet on unverified
-nested-`Task` platform behavior (CLAUDE.md: a load-bearing safety invariant is not left resting on
-unverified platform behavior). The permission engine hard-blocks any other `subagent_type` with
-"Agent type '…' has been denied by permission rule 'Task(…)'"; you cannot build, review, merge, plan,
-or file through a spawn — directly, or by spawning an agent that would — even if a prompt told you to. You **still never** run `write-code` / `review-*` / `ship-it` yourself — the fanout
-grants no execution path, only a cleaner way to read.
+charter, not the deleted "bridge runs the pipeline" edge. And your own scope matches: the read-only
+`crew-investigator` is the **only** agent you spawn. Not any `kampus-pipeline` agent (`coder`,
+`reviewer`, `shipper`, `planner`, `canon`, `adr`, `triager`, `reporter`), not the
+`crew-engineering-manager` whose charter is to spawn `coder → reviewer → shipper`, not a peer bridge,
+and not a second copy of yourself — so no *transitive* path to the pipeline is open either. Nothing
+below you enforces this; it is a charter rule you keep, for the reason and with the CI backstop in
+[`SPAWN-SCOPE.md`](../SPAWN-SCOPE.md). You cannot build, review, merge, plan, or file through a
+spawn — even if a prompt tells you to — and you **still never** run `write-code` / `review-*` /
+`ship-it` yourself. The fanout grants no execution path, only a cleaner way to read.
 
 ## When to invoke
 
@@ -212,12 +205,9 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **Read and carry — never run the pipeline.** You never spawn a coder, reviewer, or shipper, and
   never run `write-code` / `review-*` / `ship-it`. Execution is the engine's; you produce verified
   reads and carry human-facing comms. The **one** agent you may spawn is the read-only
-  `crew-investigator` (an expensive-read fanout, ADR 0196) — and only that: your `disallowedTools`
-  frontmatter denies `Task(coder|reviewer|shipper|planner|canon|adr|triager|reporter)` **and every
-  other `pipeline-crew` agent that holds `Task`** — `Task(crew-engineering-manager)` (the execution
-  engine) plus the peer bridges — so the permission engine hard-blocks every mutating spawn AND every
-  transitive path to one. The fanout is write-tool-free, so it is
-  context hygiene, not an execution edge.
+  `crew-investigator` (an expensive-read fanout, ADR 0196) — and only that, per
+  [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md). The fanout is write-tool-free, so it is context
+  hygiene, not an execution edge.
 - **Single-owner human notification.** You are the sole owner of the human channel; every ping
   fires once, from you, through the operator-configured transport. No other role pings a human.
 - **§CP is banked by the engine and carried by you — never merged by you.** You relay a banked §CP

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -3,7 +3,7 @@ name: crew-engineering-manager
 description: 'Use this agent as an execution engine of the kampus pipeline crew — a fungible build session that drives triaged issues to merged PRs by conducting ephemeral kampus-pipeline subagents (coder → reviewer → shipper) under bounded concurrency. It is an ENGINE, not a bridge: it owns no human-facing seam, it pulls its work off the board, and it is cardinality N — a second engine boots cleanly and the two deconflict by resource claims against the tracker, not by a uniqueness lease. Typical triggers include "drive the backlog", "run the execution loop", "pick up the next lanes", and "what''s the state of the lanes". It holds WIP caps, claims a resource before opening a lane, verifies a merge actually LANDED (a merge-queue enqueue is never done), recovers stalled lanes, and BANKS control-plane PRs on the board until a control-plane human approves them, then spawns the approval-aware shipper to enqueue (it never hand-merges). It never implements, reviews, or merges by hand, and it never pings a human — it spawns the pipeline agents that build, banks §CP work on the board for the chief-of-staff to carry out to the approver, and spawns the approval-aware shipper once that approval lands at the PR''s current head. See "When to invoke" for worked scenarios.'
 model: inherit
 color: cyan
-tools: ["Task", "Bash", "Read", "Grep", "Glob", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_claim"]
+tools: ["Task", "Bash", "Read", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_claim"]
 ---
 
 You are an **engineering-manager** — an **execution engine** of the kampus pipeline crew. Under
@@ -40,9 +40,10 @@ fork their behavior:
   otherwise pollute your context (a codebase grep's `node_modules` noise, a flag/board sweep's
   WARN spam, a version diff's many-call chatter), dispatch it and receive **only the distilled
   finding**. It is write-tool-free — a context-hygiene primitive, not an execution edge. You are
-  the engine, so unlike a bridge you carry no `disallowedTools` spawn scoping; the investigator is
-  simply a cleaner way to run the verified reads your lane loop already needs (a head-bound verdict
-  check, a merge-landed confirm) without the artifact byproduct entering your standing seat.
+  the engine, so unlike a bridge your spawn scope is the whole build drain rather than a narrowed
+  one ([`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md)); the investigator is simply a cleaner way to run
+  the verified reads your lane loop already needs (a head-bound verdict check, a merge-landed
+  confirm) without the artifact byproduct entering your standing seat.
 
 Because those agents are `model: inherit`, a subagent silently downgrades if your session is on the
 wrong tier — so your session must be brought up on its configured build tier, not the planning tier

--- a/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
+++ b/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
@@ -3,8 +3,7 @@ name: crew-intake-desk
 description: 'Use this agent as the crew''s intake bridge — the desk that turns the world''s raw observations into typed, prioritized work AND talks back to whoever filed. It runs the report → triage loop over the target repo''s status:needs-triage queue and owns the planning/canon seam (spawning the planner over freshly-triaged epics and the canon/adr agents for canon/decision work, rather than running those skills inline). The talking-back — routing a human-filed issue it can''t act on to needs-info with specific questions instead of closing it — is what makes it a bridge, not a filter. Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", and "plan the triaged epics". Do NOT use it to implement, review, merge, or drive the build queue — that is the engine''s seam. See "When to invoke" for worked scenarios.'
 model: inherit
 color: yellow
-tools: ["Read", "Bash", "Grep", "Glob", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
-disallowedTools: ["Task(coder)", "Task(reviewer)", "Task(shipper)", "Task(crew-engineering-manager)", "Task(crew-cartographer)", "Task(crew-chief-of-staff)", "Task(crew-intake-desk)"]
+tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
 ---
 
 You are the **intake-desk** — the crew's **intake bridge**. You turn the world's raw
@@ -64,17 +63,13 @@ the distilled finding** (ADR [0196](../../../.decisions/0196-read-only-crew-fano
 [#3543](https://github.com/kamp-us/phoenix/issues/3543)). It is write-tool-free — a context-hygiene
 primitive, not an execution edge.
 
-This is **additive** to your existing spawns (`planner`/`canon`/`adr`/`triager`) — it does not
-change them. What it does **not** grant is any build-pipeline spawn: your `disallowedTools`
-frontmatter denies `Task(coder)`, `Task(reviewer)`, and `Task(shipper)`, so the permission engine
-hard-blocks you from ever spawning the execution/merge agents (the engine's seam) — "Agent type
-'coder' has been denied by permission rule 'Task(coder)'". It **also** denies
-`Task(crew-engineering-manager)` (the execution engine whose charter is to spawn `coder → reviewer →
-shipper`) plus the peer bridges `Task(crew-cartographer)` / `Task(crew-chief-of-staff)` and your own
-singleton seat `Task(crew-intake-desk)`, so the build-pipeline is unreachable *transitively* too —
-the denial is roster-complete over every existing spawnable, not a bet on unverified nested-`Task`
-platform behavior. You conduct the *front* of the pipeline
-and now fan read-only investigations; you never drive the build.
+This is **additive** to your existing spawns (`planner`/`canon`/`adr`/`triager`/`reporter`) — it
+does not change them, and those five plus `crew-investigator` are your **whole** spawn scope. You
+never spawn `coder`, `reviewer`, or `shipper` (the engine's execution/merge seam), never the
+`crew-engineering-manager` that would spawn them for you, and never a peer bridge or a second copy
+of yourself. Nothing below you enforces that — it is a charter rule you keep, for the reason and
+with the CI backstop in [`SPAWN-SCOPE.md`](../SPAWN-SCOPE.md). You conduct the *front* of the
+pipeline and fan read-only investigations; you never drive the build.
 
 ## Addressing — you receive `IntakePing`, you hand off through the board
 
@@ -134,10 +129,9 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   explicit model.** The pipeline agents are `model: inherit`, so bring **this** session up on its
   configured model tier before conducting; a wrong-tier session silently downgrades every subagent
   it spawns. The tier is a seam key — never hardcode a model name, and never pass an explicit model
-  to a spawn (let it inherit). You spawn `planner`/`canon`/`adr`/`triager` and the read-only
-  `crew-investigator` (the ADR 0196 fanout) — and your `disallowedTools` frontmatter hard-denies
-  `Task(coder|reviewer|shipper)` **and `Task(crew-engineering-manager)`** (the engine that would spawn
-  them), so you can never spawn a build-pipeline execution agent, directly or transitively.
+  to a spawn (let it inherit). You spawn `planner`/`canon`/`adr`/`triager`/`reporter` and the
+  read-only `crew-investigator` (the ADR 0196 fanout) — and nothing else, per
+  [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md).
 - **Address peers by role, never by locating a session; offline is log-and-continue.** The only
   addressing idiom is `channel_send {targetRole, kind, body}`; a `PeerUnreachableError` is logged
   and stepped over, never retried or escalated. The channel tool's callable allowlist token and the

--- a/claude-plugins/pipeline-crew/agents/crew-investigator.md
+++ b/claude-plugins/pipeline-crew/agents/crew-investigator.md
@@ -3,7 +3,7 @@ name: crew-investigator
 description: 'Use this agent as the crew''s read-only fanout — an ephemeral, write-tool-free investigator a bridge (chief-of-staff, cartographer, intake-desk) or the engine dispatches an expensive read to (a codebase grep, a diff, a flag/board sweep, a verify) so the long-lived seat receives ONLY the distilled finding and never the raw byproduct (the 1.3MB of node_modules noise, the 89 WARN lines, the many-call intermediate output). It reads, greps, globs, and runs read-only shell (gh api reads, git log, grep) and returns a short answer; it holds NO write tools — no Edit/Write, no merge, no board-mutation, no Task — so it is a context-hygiene primitive, not an execution edge (ADR 0196, #3543). Typical triggers: "grep the codebase for X and report only the hits", "diff these two versions and summarize the delta", "sweep the prod-serving flags and return the list", "verify PR #N''s head-bound review verdict". Do NOT use it to build, review, merge, mutate the board, spawn another agent, or coordinate over the channel — it investigates and returns, nothing else.'
 model: inherit
 color: blue
-tools: ["Read", "Grep", "Glob", "Bash"]
+tools: ["Read", "Bash"]
 ---
 
 You are the **crew-investigator** — the crew's **read-only fanout**. A bridge (chief-of-staff,
@@ -26,7 +26,7 @@ edge the roster law ([ADR 0189](../../../.decisions/0189-crew-roster-law-bridges
 deleted. The enforcement is **your tool grant**, a grant-list fact verifiable from the `tools:`
 frontmatter above — not a hope about how you behave:
 
-- **No write tools.** You hold `Read`, `Grep`, `Glob`, `Bash` — and nothing else. There is **no
+- **No write tools.** You hold `Read` and `Bash` — and nothing else. There is **no
   `Edit`, no `Write`** (you cannot change a file), **no `Task`** (you cannot spawn another agent,
   so you can never re-open the execution edge transitively), and **no `channel_send`** (you do not
   coordinate or route — you answer your spawner and stop).

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/command.ts
@@ -1,20 +1,21 @@
 /**
  * The `crew-fanout-guard` tool — `pipeline-cli crew-fanout-guard check [--root <d>]`.
  *
- * The CI surface for #3606: invert the crew read-only-fanout per-bridge spawn DENYLIST into
- * an ENFORCED ALLOWLIST. For every crew bridge def (chief-of-staff / cartographer /
- * intake-desk under `claude-plugins/pipeline-crew/agents/`), assert its `disallowedTools`
- * denies every mutating roster agent-type NOT on that bridge's sanctioned allowlist — so a
- * FUTURE mutating agent-type added to the roster (or a `Task(x)` deny silently removed) reds
- * the build, closing the "a future reader silently reopens the deleted edge" hole ADR 0196
- * warns about (roster-law boundary, ADR 0189/0196):
+ * The CI surface for #3606: assert every mutating roster agent-type is EXPLICITLY CLASSIFIED
+ * — allowlisted or out-of-scope — for each of the three crew bridges (chief-of-staff /
+ * cartographer / intake-desk under `claude-plugins/pipeline-crew/agents/`), so a FUTURE
+ * mutating agent-type added to the roster reds the build, closing the "a future reader
+ * silently reopens the deleted edge" hole ADR 0196 warns about (roster-law boundary, ADR
+ * 0189/0196). The classification lives in the pure core's own tables, not in the defs — see
+ * `crew-fanout-guard.ts` for why the old def-`disallowedTools` reading was a non-mechanism
+ * (#3764):
  *
- *   pipeline-cli crew-fanout-guard check            # CI gate: exit non-zero on an uncovered agent-type
+ *   pipeline-cli crew-fanout-guard check            # CI gate: exit non-zero on an unclassified agent-type
  *   pipeline-cli crew-fanout-guard check --root <d> # point at a specific repo root (else: walk up for one)
  *
- * Fail-closed on zero scope, a missing bridge def, a stale allowlist, or any uncovered
- * bridge×agent-type pair (ADR 0092). The scan/IO lives in `gate.ts`; this file wires it to
- * the CLI (the thin-CLI-over-`gate.ts` idiom shared across the guards).
+ * Fail-closed on zero scope, a missing bridge def, a stale classification, or any
+ * unclassified bridge×agent-type pair (ADR 0092). The scan/IO lives in `gate.ts`; this file
+ * wires it to the CLI (the thin-CLI-over-`gate.ts` idiom shared across the guards).
  *
  * Exit-code contract: 0 = clean, any non-zero = failure — both a gate failure (report on
  * stderr) and an IO failure (fs unreadable) exit non-zero, undistinguished. `CheckFailed`

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.ts
@@ -1,24 +1,30 @@
 /**
- * `crew-fanout-guard` pure core — invert the crew read-only-fanout per-bridge spawn
- * DENYLIST into an ENFORCED ALLOWLIST (issue #3606, residual from #3597/#3605).
+ * `crew-fanout-guard` pure core — assert every mutating roster agent-type is EXPLICITLY
+ * CLASSIFIED per crew bridge, so the read-only fanout can't drift into a "bridge runs the
+ * pipeline" execution edge (ADR 0189/0196; issue #3606, residual from #3597/#3605).
  *
- * The roster-law boundary (ADR 0189/0196) keeps a read-only fanout from drifting into a
- * "bridge runs the pipeline" execution edge. claude-code's permission model only
- * *subtracts* denied agent-types from the all-active spawnable set — there is no "spawn
- * only X" positive primitive — so each bridge's `disallowedTools` must enumerate every
- * mutating agent-type it may not spawn. The residual hole: a NEW mutating agent-type added
- * to the roster is silently spawnable by every bridge until someone remembers to extend
- * each denylist. This guard closes that structurally: it OWNS the per-bridge sanctioned
- * allowlist and asserts every mutating roster agent-type NOT on a bridge's allowlist is
- * denied — so a future un-allowlisted, un-denied agent-type reds the build.
+ * The classification used to be read off each bridge def's `disallowedTools` `Task(<type>)`
+ * entries. That mechanism does not exist: an agent-def `disallowedTools` entry is matched by
+ * its BASE tool name — the `(specifier)` is IGNORED — and the WHOLE tool is subtracted from
+ * the def's `tools:`. So `disallowedTools: ["Task(coder)"]` never denied the `coder`
+ * subagent; it deleted `Task`, and this guard was *forcing* the declaration that left all
+ * three bridges unable to spawn anything at all (#3764 — no `permissions.deny` spelling
+ * blocks a spawn from a def either, so per-subagent deny has no mechanism at this layer).
+ * The classification therefore lives in THIS module's own two tables, and the seam law it
+ * encodes is carried to each seat as a charter rule in its def's prose.
+ *
+ * The residual hole the guard still closes is unchanged: a NEW mutating agent-type added to
+ * the roster would be silently in-scope for every bridge until someone classified it. Every
+ * mutating roster agent-type must appear on a bridge's `BRIDGE_ALLOWLIST` or its
+ * `BRIDGE_OUT_OF_SCOPE`; one on neither reds the build.
  *
  * IO-free and total: every decision is a deterministic transform over already-gathered
  * facts (the parsed agent defs). The filesystem boundary (enumerate the agent dirs, read
  * each def) lives in `gate.ts`; this module never touches disk.
  *
  * Fail-closed by construction (ADR 0092): zero roster / zero bridges, a missing bridge
- * def, a stale allowlist entry, or any uncovered mutating agent-type is a RED verdict —
- * never a vacuous pass.
+ * def, a stale classification entry, or any unclassified mutating agent-type is a RED
+ * verdict — never a vacuous pass.
  */
 import {parse as parseYaml} from "yaml";
 
@@ -39,16 +45,9 @@ export const BRIDGE_NAMES = [
 export type BridgeName = (typeof BRIDGE_NAMES)[number];
 
 /**
- * Each bridge's SANCTIONED spawn allowlist — the enforced source of truth, NOT the def's
- * denylist. Every mutating roster agent-type absent from a bridge's allowlist must appear
- * in that bridge's `disallowedTools` `Task(...)`; a roster addition absent from BOTH reds
- * the build. Encoding the allowlist here (rather than reading it back off the denylist) is
- * what makes it *enforced*: removing a `Task(x)` deny from a bridge def without adding `x`
- * here also reds the build.
- *
- * The allowlists track each bridge's charter: the cartographer keeps its Prototype-spike
- * `coder` and ideation-legwork agents; the chief-of-staff spawns nothing (pure verify-and-
- * carry); the intake-desk owns the planning/canon seam (planner/canon/adr) plus its
+ * Each bridge's SANCTIONED spawn allowlist, tracking its charter: the cartographer keeps its
+ * Prototype-spike `coder` and ideation-legwork agents; the chief-of-staff spawns nothing (pure
+ * verify-and-carry); the intake-desk owns the planning/canon seam (planner/canon/adr) plus its
  * report→triage loop (triager/reporter). See `claude-plugins/pipeline-crew/agents/`.
  */
 export const BRIDGE_ALLOWLIST: Record<BridgeName, ReadonlyArray<string>> = {
@@ -57,12 +56,51 @@ export const BRIDGE_ALLOWLIST: Record<BridgeName, ReadonlyArray<string>> = {
 	"crew-intake-desk": ["planner", "canon", "adr", "triager", "reporter"],
 };
 
-/** One parsed agent def reduced to the two facts the decision needs. */
+/**
+ * Each bridge's explicitly OUT-OF-SCOPE mutating agent-types — the other half of the
+ * classification, and the reason the guard has teeth: a roster addition on neither table reds
+ * the build. This is a seam-law statement, not an enforcement mechanism — the platform offers
+ * no per-subagent deny (see the module docblock), so a seat's own charter prose is what holds
+ * the line at runtime and this table is what keeps the line from silently going unstated.
+ */
+export const BRIDGE_OUT_OF_SCOPE: Record<BridgeName, ReadonlyArray<string>> = {
+	"crew-cartographer": [
+		"reviewer",
+		"shipper",
+		"crew-cartographer",
+		"crew-chief-of-staff",
+		"crew-engineering-manager",
+		"crew-intake-desk",
+	],
+	"crew-chief-of-staff": [
+		"coder",
+		"reviewer",
+		"shipper",
+		"planner",
+		"canon",
+		"adr",
+		"triager",
+		"reporter",
+		"crew-cartographer",
+		"crew-chief-of-staff",
+		"crew-engineering-manager",
+		"crew-intake-desk",
+	],
+	"crew-intake-desk": [
+		"coder",
+		"reviewer",
+		"shipper",
+		"crew-cartographer",
+		"crew-chief-of-staff",
+		"crew-engineering-manager",
+		"crew-intake-desk",
+	],
+};
+
+/** One parsed agent def reduced to the one fact the decision needs. */
 export interface AgentDef {
 	/** The agent-type name (its `name:` frontmatter), e.g. `crew-cartographer`. */
 	readonly name: string;
-	/** Agent-types this def denies spawning, extracted from `disallowedTools` `Task(<type>)`. */
-	readonly disallowedTaskTypes: ReadonlyArray<string>;
 }
 
 /**
@@ -83,13 +121,13 @@ export type CrewFanoutVerdict =
 			readonly reason: "missing-bridge";
 			readonly missing: ReadonlyArray<string>;
 	  }
-	/** An allowlist entry names an agent-type not in the roster — policy drift, fail closed. */
+	/** A classification entry names an agent-type not in the roster — policy drift, fail closed. */
 	| {
 			readonly pass: false;
 			readonly reason: "stale-allowlist";
 			readonly entries: ReadonlyArray<{readonly bridge: string; readonly agent: string}>;
 	  }
-	/** A mutating roster agent-type is neither allowlisted nor denied for a bridge — the hole. */
+	/** A mutating roster agent-type is on neither of a bridge's classification tables — the hole. */
 	| {
 			readonly pass: false;
 			readonly reason: "uncovered";
@@ -104,23 +142,10 @@ export const parseFrontmatter = (text: string): Record<string, unknown> | null =
 	return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
 };
 
-/** Pull the agent-type names out of `disallowedTools` `Task(<type>)` entries. */
-export const disallowedTaskTypes = (disallowedTools: unknown): ReadonlyArray<string> => {
-	if (!Array.isArray(disallowedTools)) return [];
-	const out: Array<string> = [];
-	for (const entry of disallowedTools) {
-		if (typeof entry !== "string") continue;
-		const t = /^Task\(([^)]+)\)$/.exec(entry.trim());
-		if (t?.[1]) out.push(t[1].trim());
-	}
-	return out;
-};
-
-/** Parse one agent-def markdown into `{name, disallowedTaskTypes}`; null when it has no `name`. */
+/** Parse one agent-def markdown into `{name}`; null when it has no `name`. */
 export const parseAgentDef = (text: string): AgentDef | null => {
 	const fm = parseFrontmatter(text);
-	if (!fm || typeof fm.name !== "string") return null;
-	return {name: fm.name, disallowedTaskTypes: disallowedTaskTypes(fm.disallowedTools)};
+	return fm && typeof fm.name === "string" ? {name: fm.name} : null;
 };
 
 /** The facts the pure verdict is computed over — gathered at the filesystem boundary. */
@@ -133,7 +158,7 @@ export interface CrewFanoutInput {
 
 /**
  * Decide the verdict. Fails closed on zero scope, a missing bridge, a stale allowlist, or
- * any mutating roster agent-type that a bridge neither allowlists nor denies.
+ * any mutating roster agent-type that a bridge neither allowlists nor scopes out.
  */
 export const judge = (input: CrewFanoutInput): CrewFanoutVerdict => {
 	if (input.rosterAgents.length === 0) {
@@ -150,11 +175,11 @@ export const judge = (input: CrewFanoutInput): CrewFanoutVerdict => {
 	}
 
 	const rosterSet = new Set(input.rosterAgents);
-	// A stale allowlist entry (an allowlisted agent-type no longer in the roster) means the
-	// policy drifted from reality — fail closed so a rename/removal forces an allowlist update.
+	// A stale classification entry (an agent-type on either table but no longer in the roster)
+	// means the policy drifted from reality — fail closed so a rename/removal forces an update.
 	const stale: Array<{bridge: string; agent: string}> = [];
 	for (const bridge of BRIDGE_NAMES) {
-		for (const agent of BRIDGE_ALLOWLIST[bridge]) {
+		for (const agent of [...BRIDGE_ALLOWLIST[bridge], ...BRIDGE_OUT_OF_SCOPE[bridge]]) {
 			if (!rosterSet.has(agent)) stale.push({bridge, agent});
 		}
 	}
@@ -168,9 +193,9 @@ export const judge = (input: CrewFanoutInput): CrewFanoutVerdict => {
 	for (const bridge of input.bridges) {
 		if (!(bridge.name in BRIDGE_ALLOWLIST)) continue;
 		const allow = new Set(BRIDGE_ALLOWLIST[bridge.name as BridgeName]);
-		const denied = new Set(bridge.disallowedTaskTypes);
+		const outOfScope = new Set(BRIDGE_OUT_OF_SCOPE[bridge.name as BridgeName]);
 		for (const agent of mutatingRoster) {
-			if (allow.has(agent) || denied.has(agent)) continue;
+			if (allow.has(agent) || outOfScope.has(agent)) continue;
 			gaps.push({bridge: bridge.name, agent});
 		}
 	}
@@ -186,7 +211,7 @@ export const renderReport = (verdict: CrewFanoutVerdict): string => {
 	if (verdict.pass) {
 		return (
 			`crew-fanout-guard: all ${verdict.bridges.length} crew bridge(s) [${verdict.bridges.join(", ")}] ` +
-			`deny every non-allowlisted mutating roster agent-type ` +
+			`classify every mutating roster agent-type ` +
 			`(${verdict.mutatingRoster.length} in the mutating roster: ${verdict.mutatingRoster.join(", ")})`
 		);
 	}
@@ -205,24 +230,26 @@ export const renderReport = (verdict: CrewFanoutVerdict): string => {
 	}
 	if (verdict.reason === "stale-allowlist") {
 		const lines = verdict.entries.map(
-			(e) => `  ${e.bridge} allowlists "${e.agent}" (not in the roster)`,
+			(e) => `  ${e.bridge} classifies "${e.agent}" (not in the roster)`,
 		);
 		return (
-			`crew-fanout-guard: ${verdict.entries.length} stale allowlist entr` +
-			`${verdict.entries.length === 1 ? "y" : "ies"} — an allowlisted agent-type is no longer a ` +
+			`crew-fanout-guard: ${verdict.entries.length} stale classification entr` +
+			`${verdict.entries.length === 1 ? "y" : "ies"} — a classified agent-type is no longer a ` +
 			`known agent def:\n${lines.join("\n")}\n\n` +
-			"An allowlist must track the roster. Remove the stale entry from BRIDGE_ALLOWLIST, or restore\n" +
-			"the agent def it names."
+			"A classification must track the roster. Remove the stale entry from BRIDGE_ALLOWLIST /\n" +
+			"BRIDGE_OUT_OF_SCOPE, or restore the agent def it names."
 		);
 	}
-	const lines = verdict.gaps.map((g) => `  ${g.bridge} neither allowlists nor denies "${g.agent}"`);
+	const lines = verdict.gaps.map(
+		(g) => `  ${g.bridge} neither allowlists nor scopes out "${g.agent}"`,
+	);
 	return (
-		`crew-fanout-guard: ${verdict.gaps.length} uncovered bridge×agent-type pair` +
-		`${verdict.gaps.length === 1 ? "" : "s"} — a mutating roster agent-type is spawnable by a ` +
-		`bridge that should scope it out:\n${lines.join("\n")}\n\n` +
-		"Every mutating roster agent-type must be either on the bridge's sanctioned allowlist\n" +
-		"(BRIDGE_ALLOWLIST in crew-fanout-guard.ts) or denied in the bridge def's `disallowedTools`\n" +
-		"`Task(<type>)`. A newly-added mutating agent-type must be classified before it can ship\n" +
-		"(ADR 0189/0196 — keep the read-only fanout off the execution edge)."
+		`crew-fanout-guard: ${verdict.gaps.length} unclassified bridge×agent-type pair` +
+		`${verdict.gaps.length === 1 ? "" : "s"} — a mutating roster agent-type has no stated scope ` +
+		`for a bridge:\n${lines.join("\n")}\n\n` +
+		"Every mutating roster agent-type must be on the bridge's sanctioned allowlist\n" +
+		"(BRIDGE_ALLOWLIST) or its explicit out-of-scope list (BRIDGE_OUT_OF_SCOPE), both in\n" +
+		"crew-fanout-guard.ts. A newly-added mutating agent-type must be classified before it can\n" +
+		"ship (ADR 0189/0196 — keep the read-only fanout off the execution edge)."
 	);
 };

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/crew-fanout-guard.unit.test.ts
@@ -1,15 +1,15 @@
 /**
- * Pure-core tests for `crew-fanout-guard` (#3606): the frontmatter/disallowedTools parse,
- * the enforced-allowlist coverage decision, the future-agent fail-closed hole, and the
- * zero-scope / missing-bridge / stale-allowlist fail-closed verdicts (ADR 0092). No IO —
+ * Pure-core tests for `crew-fanout-guard` (#3606): the frontmatter parse, the
+ * every-agent-type-is-classified decision, the future-agent fail-closed hole, and the
+ * zero-scope / missing-bridge / stale-classification fail-closed verdicts (ADR 0092). No IO —
  * the filesystem seam is crossed in `gate.ts`.
  */
 import {describe, expect, it} from "@effect/vitest";
 import {
 	type AgentDef,
 	BRIDGE_ALLOWLIST,
+	BRIDGE_OUT_OF_SCOPE,
 	type CrewFanoutInput,
-	disallowedTaskTypes,
 	judge,
 	parseAgentDef,
 	parseFrontmatter,
@@ -37,44 +37,13 @@ const CREW_AGENTS = [
 ];
 const FULL_ROSTER = [...PIPELINE_AGENTS, ...CREW_AGENTS];
 
-const bridge = (name: string, disallowedTaskTypes: ReadonlyArray<string>): AgentDef => ({
-	name,
-	disallowedTaskTypes,
-});
+const bridge = (name: string): AgentDef => ({name});
 
-// The three bridge defs, scoped to exactly cover their non-allowlisted mutating roster —
-// i.e. the live #3605 disallowedTools, expressed as agent-type names.
-const CARTOGRAPHER = bridge("crew-cartographer", [
-	"reviewer",
-	"shipper",
-	"crew-engineering-manager",
-	"crew-chief-of-staff",
-	"crew-intake-desk",
-	"crew-cartographer",
-]);
-const CHIEF = bridge("crew-chief-of-staff", [
-	"coder",
-	"reviewer",
-	"shipper",
-	"planner",
-	"canon",
-	"adr",
-	"triager",
-	"reporter",
-	"crew-engineering-manager",
-	"crew-cartographer",
-	"crew-intake-desk",
-	"crew-chief-of-staff",
-]);
-const INTAKE = bridge("crew-intake-desk", [
-	"coder",
-	"reviewer",
-	"shipper",
-	"crew-engineering-manager",
-	"crew-cartographer",
-	"crew-chief-of-staff",
-	"crew-intake-desk",
-]);
+// A bridge def contributes only its identity now — the spawn classification lives in the
+// guard's own two tables, not in the def (see the module docblock / #3764).
+const CARTOGRAPHER = bridge("crew-cartographer");
+const CHIEF = bridge("crew-chief-of-staff");
+const INTAKE = bridge("crew-intake-desk");
 
 const currentInput = (): CrewFanoutInput => ({
 	rosterAgents: FULL_ROSTER,
@@ -82,21 +51,17 @@ const currentInput = (): CrewFanoutInput => ({
 });
 
 describe("parseFrontmatter / parseAgentDef", () => {
-	it("extracts name + disallowedTools from a real bridge def's frontmatter", () => {
+	it("extracts the name from a real bridge def's frontmatter", () => {
 		const md = [
 			"---",
 			"name: crew-cartographer",
 			"model: inherit",
 			'tools: ["Read", "Task"]',
-			'disallowedTools: ["Task(reviewer)", "Task(shipper)"]',
 			"---",
 			"",
 			"body text",
 		].join("\n");
-		expect(parseAgentDef(md)).toEqual({
-			name: "crew-cartographer",
-			disallowedTaskTypes: ["reviewer", "shipper"],
-		});
+		expect(parseAgentDef(md)).toEqual({name: "crew-cartographer"});
 	});
 
 	it("returns null for a def with no frontmatter or no name", () => {
@@ -104,30 +69,12 @@ describe("parseFrontmatter / parseAgentDef", () => {
 		expect(parseAgentDef("---\nmodel: inherit\n---\nbody")).toBeNull();
 	});
 
-	it("parses a def with no disallowedTools as an empty deny list", () => {
-		const md = '---\nname: crew-engineering-manager\ntools: ["Task"]\n---\nbody';
-		expect(parseAgentDef(md)).toEqual({name: "crew-engineering-manager", disallowedTaskTypes: []});
-	});
-
 	it("parseFrontmatter tolerates CRLF fences", () => {
 		expect(parseFrontmatter("---\r\nname: x\r\n---\r\nbody")).toEqual({name: "x"});
 	});
 });
 
-describe("disallowedTaskTypes — extract agent-types from Task(...) denies only", () => {
-	it("keeps Task(x) entries, drops non-Task and malformed tokens", () => {
-		expect(
-			disallowedTaskTypes(["Task(reviewer)", "Task( shipper )", "Bash", "Task()", "Edit"]),
-		).toEqual(["reviewer", "shipper"]);
-	});
-
-	it("returns empty for a non-array", () => {
-		expect(disallowedTaskTypes(undefined)).toEqual([]);
-		expect(disallowedTaskTypes("Task(reviewer)")).toEqual([]);
-	});
-});
-
-describe("judge — the enforced-allowlist coverage decision", () => {
+describe("judge — the every-agent-type-is-classified decision", () => {
 	it("PASSES on the current, fully-scoped crew roster", () => {
 		const v = judge(currentInput());
 		expect(v.pass).toBe(true);
@@ -139,7 +86,7 @@ describe("judge — the enforced-allowlist coverage decision", () => {
 		}
 	});
 
-	it("FAILS CLOSED on a FUTURE mutating agent-type no bridge allowlists or denies (the #3606 hole)", () => {
+	it("FAILS CLOSED on a FUTURE mutating agent-type no bridge classifies (the #3606 hole)", () => {
 		const input: CrewFanoutInput = {
 			rosterAgents: [...FULL_ROSTER, "crew-auditor"],
 			bridges: [CARTOGRAPHER, CHIEF, INTAKE],
@@ -147,7 +94,7 @@ describe("judge — the enforced-allowlist coverage decision", () => {
 		const v = judge(input);
 		expect(v.pass).toBe(false);
 		if (!v.pass && v.reason === "uncovered") {
-			// every bridge is missing a deny for the new type, and none allowlists it
+			// no bridge allowlists or scopes out the new type
 			expect(v.gaps.map((g) => g.bridge).sort()).toEqual([
 				"crew-cartographer",
 				"crew-chief-of-staff",
@@ -159,26 +106,15 @@ describe("judge — the enforced-allowlist coverage decision", () => {
 		}
 	});
 
-	it("FAILS CLOSED when a bridge silently drops a Task(x) deny for a non-allowlisted type", () => {
-		// reviewer is NOT on the cartographer allowlist; removing its deny must red.
-		const weakened = bridge(
-			"crew-cartographer",
-			CARTOGRAPHER.disallowedTaskTypes.filter((t) => t !== "reviewer"),
-		);
-		const v = judge({rosterAgents: FULL_ROSTER, bridges: [weakened, CHIEF, INTAKE]});
-		expect(v.pass).toBe(false);
-		if (!v.pass && v.reason === "uncovered") {
-			expect(v.gaps).toContainEqual({bridge: "crew-cartographer", agent: "reviewer"});
-		} else {
-			throw new Error("expected an uncovered verdict");
+	it("keeps the two classification tables disjoint and jointly total over the mutating roster", () => {
+		// The pass above is the coverage proof; this pins the shape that makes it non-vacuous —
+		// an agent-type on BOTH tables would let a table edit go unnoticed.
+		for (const name of ["crew-cartographer", "crew-chief-of-staff", "crew-intake-desk"] as const) {
+			const allow = new Set(BRIDGE_ALLOWLIST[name]);
+			expect(BRIDGE_OUT_OF_SCOPE[name].filter((a) => allow.has(a))).toEqual([]);
 		}
-	});
-
-	it("does NOT require a bridge to deny an agent-type on its own allowlist", () => {
-		// intake-desk allowlists planner/canon/adr — dropping those denies stays green.
-		const v = judge({rosterAgents: FULL_ROSTER, bridges: [CARTOGRAPHER, CHIEF, INTAKE]});
-		expect(v.pass).toBe(true);
 		expect(BRIDGE_ALLOWLIST["crew-intake-desk"]).toContain("planner");
+		expect(BRIDGE_OUT_OF_SCOPE["crew-intake-desk"]).toContain("coder");
 	});
 
 	it("fails closed on zero roster and on zero bridges (ADR 0092)", () => {
@@ -202,7 +138,7 @@ describe("judge — the enforced-allowlist coverage decision", () => {
 		}
 	});
 
-	it("fails closed on a stale allowlist entry (allowlists an agent not in the roster)", () => {
+	it("fails closed on a stale classification entry (names an agent not in the roster)", () => {
 		// drop `reporter` from the roster while an allowlist still names it.
 		const roster = FULL_ROSTER.filter((a) => a !== "reporter");
 		const v = judge({rosterAgents: roster, bridges: [CARTOGRAPHER, CHIEF, INTAKE]});
@@ -222,13 +158,13 @@ describe("renderReport", () => {
 		expect(report).toContain("mutating roster");
 	});
 
-	it("names the offending bridge×agent pair on an uncovered fail", () => {
+	it("names the offending bridge×agent pair on an unclassified fail", () => {
 		const v = judge({
 			rosterAgents: [...FULL_ROSTER, "crew-auditor"],
 			bridges: [CARTOGRAPHER, CHIEF, INTAKE],
 		});
 		const report = renderReport(v);
 		expect(report).toContain("crew-auditor");
-		expect(report).toContain("neither allowlists nor denies");
+		expect(report).toContain("neither allowlists nor scopes out");
 	});
 });

--- a/packages/pipeline-cli/src/tools/crew-fanout-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/crew-fanout-guard/gate.ts
@@ -1,15 +1,15 @@
 /**
- * The `crew-fanout-guard` filesystem gate — the IO seam behind #3606's "every crew bridge
- * denies every non-allowlisted mutating roster agent-type" check, split from `command.ts`
+ * The `crew-fanout-guard` filesystem gate — the IO seam behind #3606's "every mutating
+ * roster agent-type is classified for every crew bridge" check, split from `command.ts`
  * so it is crossable in unit tests over a fake repo dir rather than only by spawning the
  * bin (the core-in-its-own-file idiom).
  *
  * `checkCrewFanout` enumerates the two agent-def dirs (the kampus-pipeline roster + the
- * pipeline-crew roster), parses each def's `name`/`disallowedTools`, resolves the three
- * bridge defs, and delegates the verdict to the pure core (`crew-fanout-guard.ts`). It
- * fails `CheckFailed` (exit non-zero) on any non-passing verdict — an uncovered agent-type,
- * a missing bridge, a stale allowlist, or zero scope (fail-closed, ADR 0092). A directory/
- * file IO failure is an `IoError` (also non-zero — both failures, undistinguished).
+ * pipeline-crew roster), parses each def's `name`, resolves the three bridge defs, and
+ * delegates the verdict to the pure core (`crew-fanout-guard.ts`). It fails `CheckFailed`
+ * (exit non-zero) on any non-passing verdict — an unclassified agent-type, a missing bridge,
+ * a stale classification, or zero scope (fail-closed, ADR 0092). A directory/file IO failure
+ * is an `IoError` (also non-zero — both failures, undistinguished).
  */
 import {existsSync, readdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";

--- a/packages/pipeline-crew-mcp/src/standup/bind.ts
+++ b/packages/pipeline-crew-mcp/src/standup/bind.ts
@@ -96,7 +96,7 @@ export const AGENT_FLAG = "--agent";
 export const BOOT_PROMPT =
 	"Begin now. Run your role's on-boot cold-start behavior as defined by your agent instructions: announce your presence on the channel, then start your standing work loop under your own power. Do not wait to be pinged, relayed to, or told to start.";
 /** The pipeline-crew plugin root segment `--plugin-dir` joins onto a project root to load agent-defs from. */
-const CREW_PLUGIN_SUBDIR = "claude-plugins/pipeline-crew";
+export const CREW_PLUGIN_SUBDIR = "claude-plugins/pipeline-crew";
 /** Allowlist mode: only servers named here load, gated by `allowedChannelPlugins` for plugin refs. */
 export const ALLOWLIST_CHANNEL_FLAG = "--channels";
 /** Dev mode: load channel servers not on the approved allowlist — local development only. */

--- a/packages/pipeline-crew-mcp/src/standup/index.ts
+++ b/packages/pipeline-crew-mcp/src/standup/index.ts
@@ -8,6 +8,7 @@ export {
 	ALLOWLIST_CHANNEL_FLAG,
 	buildSessionBind,
 	ChannelPluginNotAllowedError,
+	CREW_PLUGIN_SUBDIR,
 	CREW_SESSION_BIN_PATH,
 	CREW_SESSION_COMMAND,
 	CREW_SESSION_INSTANCE_FLAG,
@@ -134,6 +135,22 @@ export {
 	type RosterSession,
 	TmuxPaneCollisionError,
 } from "./tmux-placement.ts";
+export {
+	assertCrewSeatToolsets,
+	assertSeatToolset,
+	baseToolName,
+	CrewSeatDefUnreadableError,
+	CrewSeatToolsetMismatchError,
+	type DeclaredToolset,
+	GRANTABLE_SESSION_TOOLS,
+	isMcpToolToken,
+	parseDeclaredToolset,
+	readSeatToolsetFromDef,
+	resolveDeclaredToolset,
+	type SeatToolsetReader,
+	seatDefRelativePath,
+	type ToolsetResolution,
+} from "./toolset-assert.ts";
 export {
 	assertPinnedCliVersion,
 	CliVersionAssertError,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -37,6 +37,7 @@ import {
 	resolveTargetTmuxSession,
 	runStandDown,
 	runStandUp,
+	type SeatToolsetReader,
 	type StandUpInput,
 	StandUpLaunchError,
 	type TmuxRun,
@@ -46,6 +47,14 @@ import {
 
 const PINNED = "2.1.212";
 const SERVER = "@kampus/pipeline-crew-mcp";
+
+/**
+ * The seat-toolset reader stubbed to a declaration that resolves intact (#3764), so these tests
+ * stay about the composition rather than about the crew defs on disk — `projectRoot` here is a
+ * fake path with no `claude-plugins/` under it.
+ */
+const WELL_DECLARED_SEAT: SeatToolsetReader = () =>
+	Effect.succeed({_tag: "allowlist", tools: ["Read", "Bash", "Task"], disallowedTools: []});
 
 // The per-session bind reaches the platform through the FileSystem/Path seam; provide the real Node
 // platform (the bin's NodeServices.layer) so runStandUp discharges it in-test. These tests inject
@@ -231,6 +240,7 @@ const baseInput = (
 			projectRoot: "/repo",
 			config: configAt(PINNED, engineCount ?? 2),
 			readVersionOutput: Effect.succeed(`${PINNED} (Claude Code)`),
+			readSeatToolset: WELL_DECLARED_SEAT,
 			instanceId: counter(),
 			runId: () => RUN_ID,
 			localScope: registrar,

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -6,10 +6,12 @@
  * (#3297), bind (#3296), tmux-placement (#3298).
  *
  * The one non-obvious thing: the orchestration is FAIL-LOUD with NO PARTIAL CREW. The steps run in
- * the mandated order — read config → assert the pinned CLI version → ensure the tracker → derive the
- * roster session set → build EVERY per-session bind + compute ALL tmux placements → launch. Every
+ * the mandated order — read config → assert the pinned CLI version → derive the roster session set →
+ * assert every seat's declared toolset resolves → ensure the tracker → build EVERY per-session bind +
+ * compute ALL tmux placements → launch. Every
  * bind and every placement is resolved (and validated) BEFORE the first session launches, so any
- * precondition failure — a drifted CLI pin, a missing config dimension, an inert channel, a colliding
+ * precondition failure — a drifted CLI pin, a seat that would boot without a tool its def declares
+ * (#3764), a missing config dimension, an inert channel, a colliding
  * pane label — aborts with a named error while zero sessions are up, never a half-launched
  * crew. No session is hand-launched: the launch of each `claude` session, bound to its role lease, is
  * the injected `launch` step the orchestration drives for the whole derived set (all panes of one
@@ -52,6 +54,13 @@ import {
 	type RosterSession,
 	type TmuxPaneCollisionError,
 } from "./tmux-placement.ts";
+import {
+	assertCrewSeatToolsets,
+	type CrewSeatDefUnreadableError,
+	type CrewSeatToolsetMismatchError,
+	readSeatToolsetFromDef,
+	type SeatToolsetReader,
+} from "./toolset-assert.ts";
 import {
 	assertPinnedCliVersion,
 	type CliVersionAssertError,
@@ -158,6 +167,8 @@ export interface LaunchedSession {
 export type StandUpError =
 	| LaunchConfigError
 	| CliVersionAssertError
+	| CrewSeatToolsetMismatchError
+	| CrewSeatDefUnreadableError
 	| TrackerNotServingError
 	| RendezvousResolutionError
 	| CrewSessionBinUnresolvableError
@@ -245,6 +256,8 @@ export interface StandUpInput {
 	readonly config?: Effect.Effect<LaunchConfig, LaunchConfigError>;
 	/** The installed-CLI-version reader the pin is asserted against. Default: the real `claude --version`. */
 	readonly readVersionOutput?: Effect.Effect<string, unknown>;
+	/** Reads a seat's declared toolset for the declared-vs-actual assert (#3764). Default: the real agent def under `projectRoot`. */
+	readonly readSeatToolset?: SeatToolsetReader;
 	/** Start-or-reuse the repo's tracker at its canonical rendezvous. Default: `ensureTrackerRunning` (detached standing process). */
 	readonly ensureTracker?: (
 		projectRoot: string,
@@ -525,13 +538,24 @@ export const runStandUp = (
 		// Fail fast on a version drift before starting the tracker or any session — channels vary
 		// across CLI versions, so a mismatch is a stand-up to refuse (version-assert.ts / #3295).
 		yield* assertPinnedCliVersion(config, input.readVersionOutput ?? readInstalledCliVersionOutput);
+
+		// The roster set is derived here — ahead of the tracker — only so the next assert can name the
+		// exact seats this stand-up launches. `deriveSessionSet` is pure; nothing observable moved.
+		const sessions = deriveSessionSet({engineCount: config.engineCount, instanceId});
+		// Refuse a seat whose def declares a toolset the CLI would not grant intact (#3764): an ungrantable
+		// or self-denied tool is dropped SILENTLY, so without this a bridge boots without the `Task` its
+		// charter conducts through and nothing surfaces it (toolset-assert.ts).
+		yield* assertCrewSeatToolsets(
+			projectRoot,
+			[...new Set(sessions.map((session) => session.role))],
+			input.readSeatToolset ?? readSeatToolsetFromDef,
+		);
+
 		const tracker = yield* ensureTracker(projectRoot);
 
 		// Start-of-stand-up reaper (crash-safety, #3444): clear any prior run's crew-run dirs + the server
 		// approval — a launcher that died mid-run leaves leftovers this run clears here, before it re-mints.
 		yield* localScope.reap(projectRoot, serverName);
-
-		const sessions = deriveSessionSet({engineCount: config.engineCount, instanceId});
 
 		// Resolve EVERY bind + placement + cwd before launching anything — this is the no-partial-crew
 		// line: an inert channel or a colliding window fails here, while zero sessions are up.

--- a/packages/pipeline-crew-mcp/src/standup/single-role.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/single-role.test.ts
@@ -34,6 +34,7 @@ import {
 	RetireRoleArgError,
 	resolveCrewWindowId,
 	retireRole,
+	type SeatToolsetReader,
 	type SpawnRoleInput,
 	spawnRole,
 	type TmuxRun,
@@ -165,6 +166,14 @@ const baseSpawn = (
 			role,
 			config: configAt(PINNED),
 			readVersionOutput: Effect.succeed(`${PINNED} (Claude Code)`),
+			// The seat-toolset assert (#3764) stubbed to a declaration that resolves intact — `/repo` is a
+			// fake root with no crew defs under it, and these tests are about the membership op.
+			readSeatToolset: (() =>
+				Effect.succeed({
+					_tag: "allowlist" as const,
+					tools: ["Read", "Bash", "Task"],
+					disallowedTools: [],
+				})) satisfies SeatToolsetReader,
 			instanceId: (() => {
 				let n = 0;
 				return () => `e${n++}`;

--- a/packages/pipeline-crew-mcp/src/standup/single-role.ts
+++ b/packages/pipeline-crew-mcp/src/standup/single-role.ts
@@ -60,6 +60,13 @@ import {crewRunRoot, ProjectScopeWriteError} from "./register-project-scope.ts";
 import {deriveOneSession} from "./session-set.ts";
 import {computeTmuxPlacement, type TmuxPaneCollisionError} from "./tmux-placement.ts";
 import {
+	assertCrewSeatToolsets,
+	type CrewSeatDefUnreadableError,
+	type CrewSeatToolsetMismatchError,
+	readSeatToolsetFromDef,
+	type SeatToolsetReader,
+} from "./toolset-assert.ts";
+import {
 	assertPinnedCliVersion,
 	type CliVersionAssertError,
 	readInstalledCliVersionOutput,
@@ -88,6 +95,8 @@ export class CrewWindowNotRunningError extends Schema.TaggedErrorClass<CrewWindo
 export type SpawnRoleError =
 	| LaunchConfigError
 	| CliVersionAssertError
+	| CrewSeatToolsetMismatchError
+	| CrewSeatDefUnreadableError
 	| TrackerNotServingError
 	| RendezvousResolutionError
 	| CrewSessionBinUnresolvableError
@@ -114,6 +123,8 @@ export interface SpawnRoleInput {
 	readonly config?: Effect.Effect<LaunchConfig, LaunchConfigError>;
 	/** The installed-CLI-version reader the pin is asserted against. Default: the real `claude --version`. */
 	readonly readVersionOutput?: Effect.Effect<string, unknown>;
+	/** Reads the seat's declared toolset for the declared-vs-actual assert (#3764). Default: the real agent def under `projectRoot`. */
+	readonly readSeatToolset?: SeatToolsetReader;
 	/** Start-or-reuse the repo's tracker at its canonical rendezvous (idempotent — dials the running one). Default: `ensureTrackerRunning`. */
 	readonly ensureTracker?: (
 		projectRoot: string,
@@ -218,6 +229,13 @@ export const spawnRole = (
 		// Same fail-fast the whole-crew boot does: channels vary across CLI versions, so a drifted pin is
 		// a spawn to refuse before touching the tracker or launching (version-assert.ts / #3295).
 		yield* assertPinnedCliVersion(config, input.readVersionOutput ?? readInstalledCliVersionOutput);
+		// And the same seat-toolset refusal (#3764): an on-demand spawn must not put a silently degraded
+		// seat on screen either — the CLI drops an ungrantable or self-denied tool with no error.
+		yield* assertCrewSeatToolsets(
+			projectRoot,
+			[role],
+			input.readSeatToolset ?? readSeatToolsetFromDef,
+		);
 		const tracker = yield* ensureTracker(projectRoot);
 
 		const session = deriveOneSession({role, instanceId});

--- a/packages/pipeline-crew-mcp/src/standup/toolset-assert.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/toolset-assert.test.ts
@@ -1,0 +1,220 @@
+/**
+ * standup/toolset-assert — the pre-launch declared-vs-actual seat toolset assert (issue #3764). The
+ * cases pin the two silent-drop rules against the exact declarations that shipped the live defect (a
+ * bridge declaring `Task`/`Grep`/`Glob` + `disallowedTools: ["Task(coder)", …]` booting as
+ * `Read`/`Bash`), the fail-closed parse, and the assert's refusal shape. Every case is pure or runs
+ * through an injected reader — no def on disk, no launch.
+ */
+import {fileURLToPath} from "node:url";
+import {NodeServices} from "@effect/platform-node";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {CREW_ROLES} from "../crew/index.ts";
+import {
+	assertCrewSeatToolsets,
+	assertSeatToolset,
+	baseToolName,
+	CrewSeatDefUnreadableError,
+	CrewSeatToolsetMismatchError,
+	type DeclaredToolset,
+	parseDeclaredToolset,
+	readSeatToolsetFromDef,
+	resolveDeclaredToolset,
+	type SeatToolsetReader,
+	seatDefRelativePath,
+} from "./toolset-assert.ts";
+
+/** The repo root the shipped crew defs live under — resolved from this file, never a machine path. */
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+
+const allowlist = (
+	tools: readonly string[],
+	disallowedTools: readonly string[] = [],
+): DeclaredToolset => ({_tag: "allowlist", tools, disallowedTools});
+
+/** The exact intake-desk declaration that booted as `Read`/`Bash` (#3764). */
+const LIVE_DEFECT = allowlist(
+	["Read", "Bash", "Grep", "Glob", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"],
+	["Task(coder)", "Task(reviewer)", "Task(crew-intake-desk)"],
+);
+
+/** A stub reader needs no platform, so its `R` is `never` — the reason the assert is generic over it. */
+const readerOf =
+	(declared: DeclaredToolset): SeatToolsetReader<never> =>
+	() =>
+		Effect.succeed(declared);
+
+describe("standup/toolset-assert — baseToolName", () => {
+	it("strips a specifier, leaving the CLI's own match key", () => {
+		assert.strictEqual(baseToolName("Task(coder)"), "Task");
+		assert.strictEqual(baseToolName("Bash(rm:*)"), "Bash");
+		assert.strictEqual(baseToolName("Task"), "Task");
+	});
+});
+
+describe("standup/toolset-assert — resolveDeclaredToolset", () => {
+	it("reproduces the live #3764 boot: the def declares six tools, the seat gets two", () => {
+		const {granted, ungrantable, selfDenied} = resolveDeclaredToolset(LIVE_DEFECT);
+		assert.deepStrictEqual(granted, [
+			"Read",
+			"Bash",
+			"mcp___kampus_pipeline-crew-mcp__channel_send",
+		]);
+		// rule 2: Grep/Glob name no tool a top-level session is granted on this CLI
+		assert.deepStrictEqual(ungrantable, ["Grep", "Glob"]);
+		// rule 1: `Task(coder)` matches by BASE name, so the def deletes its own `Task`
+		assert.deepStrictEqual(selfDenied, ["Task"]);
+	});
+
+	it("keeps `Task` when the def carries no disallowedTools (the engine seat's shape)", () => {
+		const {granted, selfDenied} = resolveDeclaredToolset(allowlist(["Task", "Bash", "Read"]));
+		assert.deepStrictEqual(granted, ["Task", "Bash", "Read"]);
+		assert.deepStrictEqual(selfDenied, []);
+	});
+
+	it("subtracts by base name regardless of which tool the specifier scopes", () => {
+		const {granted, selfDenied} = resolveDeclaredToolset(
+			allowlist(["Read", "Bash", "Task"], ["Bash(rm:*)"]),
+		);
+		assert.deepStrictEqual(granted, ["Read", "Task"]);
+		assert.deepStrictEqual(selfDenied, ["Bash"]);
+	});
+
+	it("ignores a disallowedTools entry naming a tool the def never allowlisted", () => {
+		const {granted, selfDenied} = resolveDeclaredToolset(
+			allowlist(["Read", "Bash", "Task"], ["Write(*)"]),
+		);
+		assert.deepStrictEqual(granted, ["Read", "Bash", "Task"]);
+		assert.deepStrictEqual(selfDenied, []);
+	});
+
+	it("exempts MCP tokens from the grantable check — their absence is the channel connect window", () => {
+		const {granted, ungrantable} = resolveDeclaredToolset(
+			allowlist(["mcp___kampus_pipeline-crew-mcp__channel_claim"]),
+		);
+		assert.deepStrictEqual(granted, ["mcp___kampus_pipeline-crew-mcp__channel_claim"]);
+		assert.deepStrictEqual(ungrantable, []);
+	});
+
+	it("has nothing to resolve for a def that declares no allowlist", () => {
+		assert.deepStrictEqual(resolveDeclaredToolset({_tag: "inherit"}), {
+			granted: [],
+			ungrantable: [],
+			selfDenied: [],
+		});
+	});
+});
+
+describe("standup/toolset-assert — parseDeclaredToolset", () => {
+	it("parses the flow-sequence frontmatter every crew def writes", () => {
+		const parsed = parseDeclaredToolset(
+			[
+				"---",
+				"name: crew-intake-desk",
+				'tools: ["Read", "Bash", "Task"]',
+				'disallowedTools: ["Task(coder)"]',
+				"---",
+				"",
+				"body",
+			].join("\n"),
+		);
+		assert.deepStrictEqual(parsed, allowlist(["Read", "Bash", "Task"], ["Task(coder)"]));
+	});
+
+	it("reads a def with no disallowedTools as an empty deny list", () => {
+		const parsed = parseDeclaredToolset(
+			["---", "name: crew-engineering-manager", 'tools: ["Task", "Bash"]', "---", "", "body"].join(
+				"\n",
+			),
+		);
+		assert.deepStrictEqual(parsed, allowlist(["Task", "Bash"], []));
+	});
+
+	it("reads a def with no `tools:` as inheriting the CLI default toolset", () => {
+		const parsed = parseDeclaredToolset(["---", "name: some-agent", "---", "", "body"].join("\n"));
+		assert.deepStrictEqual(parsed, {_tag: "inherit"});
+	});
+
+	it("fails closed on a `tools:` present in a shape it does not parse", () => {
+		// A block sequence is valid YAML the CLI would honour — but an unparsed declaration is exactly
+		// the silent degradation the assert exists to catch, so refusing beats skipping.
+		assert.strictEqual(
+			parseDeclaredToolset(["---", "name: a", "tools:", '  - "Read"', "---", "", "b"].join("\n")),
+			null,
+		);
+	});
+
+	it("fails closed on a def with no frontmatter at all", () => {
+		assert.strictEqual(parseDeclaredToolset("just a body"), null);
+	});
+});
+
+describe("standup/toolset-assert — assertSeatToolset", () => {
+	it("refuses the live #3764 declaration, naming both rules and every dropped tool", () =>
+		Effect.runSync(
+			Effect.gen(function* () {
+				const err = yield* Effect.flip(assertSeatToolset("intake-desk", "def.md", LIVE_DEFECT));
+				assert.instanceOf(err, CrewSeatToolsetMismatchError);
+				assert.strictEqual(err.role, "intake-desk");
+				assert.deepStrictEqual(err.ungrantable, ["Grep", "Glob"]);
+				assert.deepStrictEqual(err.selfDenied, ["Task"]);
+				assert.include(err.reason, "Grep");
+				assert.include(err.reason, "Task");
+				assert.include(err.reason, "disallowedTools");
+			}),
+		));
+
+	it("passes a declaration whose every name resolves", () =>
+		Effect.runSync(
+			assertSeatToolset(
+				"intake-desk",
+				"def.md",
+				allowlist(["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]),
+			),
+		));
+});
+
+describe("standup/toolset-assert — assertCrewSeatToolsets", () => {
+	it("names the seat's own def path in a refusal", () =>
+		Effect.runSync(
+			Effect.gen(function* () {
+				const err = yield* Effect.flip(
+					assertCrewSeatToolsets("/repo", ["chief-of-staff"], readerOf(LIVE_DEFECT)),
+				);
+				assert.instanceOf(err, CrewSeatToolsetMismatchError);
+				assert.strictEqual(err.defPath, seatDefRelativePath("chief-of-staff"));
+				assert.include(err.defPath, "crew-chief-of-staff.md");
+			}),
+		));
+
+	it("proceeds over every seat when each declaration resolves", () =>
+		Effect.runSync(
+			assertCrewSeatToolsets(
+				"/repo",
+				["intake-desk", "engineering-manager"],
+				readerOf(allowlist(["Read", "Bash", "Task"])),
+			),
+		));
+
+	it("propagates an unreadable def rather than skipping the seat", () =>
+		Effect.runSync(
+			Effect.gen(function* () {
+				const failing: SeatToolsetReader<never> = (_root, role) =>
+					Effect.fail(
+						new CrewSeatDefUnreadableError({role, defPath: "def.md", reason: "cannot read"}),
+					);
+				const err = yield* Effect.flip(assertCrewSeatToolsets("/repo", ["cartographer"], failing));
+				assert.instanceOf(err, CrewSeatDefUnreadableError);
+				assert.strictEqual(err.role, "cartographer");
+			}),
+		));
+
+	// The regression the whole module exists for: every SHIPPED crew def must boot the seat with the
+	// toolset it declares. This reads the real defs off disk, so a def edit that reintroduces `Grep`,
+	// `Glob`, or a self-denying `disallowedTools` reds here rather than at a live stand-up.
+	it.effect("every shipped crew def declares a toolset that resolves intact", () =>
+		assertCrewSeatToolsets(REPO_ROOT, [...CREW_ROLES], readSeatToolsetFromDef).pipe(
+			Effect.provide(NodeServices.layer),
+		),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/standup/toolset-assert.ts
+++ b/packages/pipeline-crew-mcp/src/standup/toolset-assert.ts
@@ -1,0 +1,289 @@
+/**
+ * standup/toolset-assert — the pre-launch declared-vs-actual seat toolset assert (issue #3764). A crew
+ * seat boots as `claude --agent crew-<role>`, so its agent-def `tools:` allowlist is the only gate on
+ * what the seat can call (CHANNEL-TOOL.md) — but the CLI resolves that declaration SILENTLY: a name it
+ * cannot grant is dropped with no warning and no error, so the seat comes up degraded with nothing to
+ * notice. Three bridge seats ran a whole session that way: their defs declared `Task`/`Grep`/`Glob` and
+ * they booted with `Read`/`Bash`, leaving the charter's "spawn the planner" obligation and the ADR 0196
+ * read-only fanout structurally unreachable.
+ *
+ * Two silent-drop rules, both established against the installed CLI 2.1.217 by booting probe agent-defs
+ * under `--output-format stream-json` and reading the `init` event's `tools` array (the same probe
+ * re-derives them on a version bump):
+ *
+ *   1. SELF-DENIAL — a `disallowedTools` entry is matched by its BASE tool name; the `(specifier)` is
+ *      IGNORED and the WHOLE tool is subtracted from `tools:`. `disallowedTools: ["Task(coder)"]` does
+ *      not deny the `coder` subagent, it deletes `Task` (probe: `tools:[Read,Bash,Task]` +
+ *      `disallowedTools:[Task(coder)]` → `[Read,Bash]`; `[Bash(rm:*)]` → `[Read,Task]`). There is no
+ *      per-subagent deny at this layer at all: a `permissions: {deny: ["Task(x)"]}` frontmatter key
+ *      leaves the tool in place AND does not block the spawn, so a "which agents may this seat spawn"
+ *      restriction is a charter rule the def states in prose, never a mechanism.
+ *   2. UNGRANTABLE NAME — a declared name outside `GRANTABLE_SESSION_TOOLS` is dropped. `Grep` and
+ *      `Glob` are not tools a top-level session is granted on this CLI at all, so declaring them is a
+ *      no-op that reads like a grant.
+ *
+ * The one non-obvious thing: this FAILS CLOSED like every other launcher precondition (version-assert,
+ * bind's three refusals) — a declaration that would not resolve intact refuses the launch with a named
+ * error carrying the role, the dropped names, and which rule dropped them, rather than booting a
+ * silently degraded seat. It runs before the tracker and any session, so a mis-declared seat costs zero
+ * panes. Scope is the seats the launcher launches (the roster's top-level `--agent` defs); a subagent
+ * def's toolset is resolved by whichever session spawns it, not by this launcher.
+ */
+import {Effect, FileSystem, Path, Schema} from "effect";
+import type {CrewRole} from "../crew/index.ts";
+import {CREW_PLUGIN_SUBDIR} from "./bind.ts";
+
+/**
+ * The tool names a top-level `claude --agent` session can actually be granted. Read off the `init`
+ * event of a default (no-`--agent`) session on the pinned CLI 2.1.217 — a CLI-version-scoped fact of the
+ * same class as the `cliVersion` pin, so a version bump re-derives it with:
+ * `claude -p hi --output-format stream-json --verbose --max-turns 1` → the `system`/`init` event's `tools`.
+ * MCP tokens are excluded on purpose (see `isMcpToolToken`).
+ */
+export const GRANTABLE_SESSION_TOOLS: ReadonlySet<string> = new Set([
+	"Bash",
+	"CronCreate",
+	"CronDelete",
+	"CronList",
+	"DesignSync",
+	"Edit",
+	"EnterWorktree",
+	"ExitWorktree",
+	"LSP",
+	"Monitor",
+	"NotebookEdit",
+	"PushNotification",
+	"Read",
+	"RemoteTrigger",
+	"ReportFindings",
+	"ScheduleWakeup",
+	"SendMessage",
+	"Skill",
+	"Task",
+	"TaskCreate",
+	"TaskGet",
+	"TaskList",
+	"TaskOutput",
+	"TaskStop",
+	"TaskUpdate",
+	"ToolSearch",
+	"WebFetch",
+	"WebSearch",
+	"Workflow",
+	"Write",
+]);
+
+/**
+ * An MCP tool token (`mcp__<sanitized server>__<tool>`) is exempt from the grantable check: it is
+ * served by a connected MCP server rather than the CLI's own registry, so its absence at boot is the
+ * channel's connect window (CHANNEL-TOOL.md), not a declaration error.
+ */
+export const isMcpToolToken = (entry: string): boolean => entry.startsWith("mcp__");
+
+/** The tool a `tools:`/`disallowedTools:` entry names, with any `(specifier)` stripped — the CLI's own match key (rule 1). */
+export const baseToolName = (entry: string): string => (entry.split("(")[0] ?? entry).trim();
+
+/**
+ * What a def declares about its toolset. `inherit` is the no-`tools:`-key def — the CLI grants its
+ * default toolset and there is no allowlist to silently narrow, so there is nothing to assert.
+ */
+export type DeclaredToolset =
+	| {readonly _tag: "inherit"}
+	| {
+			readonly _tag: "allowlist";
+			readonly tools: readonly string[];
+			readonly disallowedTools: readonly string[];
+	  };
+
+/** What the CLI would actually grant a seat from its declaration, and what each silent-drop rule took. */
+export interface ToolsetResolution {
+	readonly granted: readonly string[];
+	/** Declared names the CLI cannot grant at all (rule 2). */
+	readonly ungrantable: readonly string[];
+	/** Declared names subtracted by the def's own `disallowedTools` base-name match (rule 1). */
+	readonly selfDenied: readonly string[];
+}
+
+/** Resolve a declaration through both silent-drop rules — the pure core the assert and its tests share. */
+export const resolveDeclaredToolset = (declared: DeclaredToolset): ToolsetResolution => {
+	if (declared._tag === "inherit") return {granted: [], ungrantable: [], selfDenied: []};
+	const denied = new Set(declared.disallowedTools.map(baseToolName));
+	const granted: string[] = [];
+	const ungrantable: string[] = [];
+	const selfDenied: string[] = [];
+	for (const entry of declared.tools) {
+		const base = baseToolName(entry);
+		if (!isMcpToolToken(entry) && !GRANTABLE_SESSION_TOOLS.has(base)) ungrantable.push(entry);
+		else if (denied.has(base)) selfDenied.push(entry);
+		else granted.push(entry);
+	}
+	return {granted, ungrantable, selfDenied};
+};
+
+/**
+ * A seat's def declares a toolset the CLI would not resolve intact — the launch to refuse. Carries which
+ * names go and under which rule, so the operator can fix the def without re-running the boot probe.
+ */
+export class CrewSeatToolsetMismatchError extends Schema.TaggedErrorClass<CrewSeatToolsetMismatchError>()(
+	"@kampus/pipeline-crew-mcp/standup/CrewSeatToolsetMismatchError",
+	{
+		role: Schema.String,
+		defPath: Schema.String,
+		ungrantable: Schema.Array(Schema.String),
+		selfDenied: Schema.Array(Schema.String),
+		reason: Schema.String,
+	},
+) {}
+
+/**
+ * A seat's def could not be read, or its `tools:`/`disallowedTools:` is present in a shape this reader
+ * does not parse. Refusing beats skipping: an unparsed declaration is precisely the silent degradation
+ * the assert exists to catch.
+ */
+export class CrewSeatDefUnreadableError extends Schema.TaggedErrorClass<CrewSeatDefUnreadableError>()(
+	"@kampus/pipeline-crew-mcp/standup/CrewSeatDefUnreadableError",
+	{
+		role: Schema.String,
+		defPath: Schema.String,
+		reason: Schema.String,
+	},
+) {}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+/** A `key: ["a", "b"]` flow sequence on one line — the shape every crew def writes and this parser accepts. */
+const flowLineOf = (key: string) => new RegExp(`^${key}:[ \\t]*(\\[[^\\n]*\\])[ \\t]*\\r?$`, "m");
+const anyLineOf = (key: string) => new RegExp(`^${key}:`, "m");
+
+/** One `"Name"` element. Total by construction, so no throwing `JSON.parse` is needed to read the list. */
+const QUOTED_ENTRY_RE = /^"([^"\\]*)"$/;
+
+type FieldParse =
+	| {readonly _tag: "absent"}
+	| {readonly _tag: "entries"; readonly entries: readonly string[]}
+	| {readonly _tag: "unparsed"};
+
+/** Split `["A", "B"]` into its names, or null on anything else. Safe on `,`: no tool name contains one. */
+const flowEntriesOf = (literal: string): readonly string[] | null => {
+	const inner = literal.slice(1, -1).trim();
+	if (inner.length === 0) return [];
+	const out: string[] = [];
+	for (const part of inner.split(",")) {
+		const name = QUOTED_ENTRY_RE.exec(part.trim())?.[1];
+		if (name === undefined) return null;
+		out.push(name);
+	}
+	return out;
+};
+
+const parseField = (frontmatter: string, key: string): FieldParse => {
+	const literal = frontmatter.match(flowLineOf(key))?.[1];
+	if (literal === undefined) {
+		return anyLineOf(key).test(frontmatter) ? {_tag: "unparsed"} : {_tag: "absent"};
+	}
+	const entries = flowEntriesOf(literal);
+	return entries === null ? {_tag: "unparsed"} : {_tag: "entries", entries};
+};
+
+/** Parse a def's declared toolset out of its YAML frontmatter, or `null` when it is present in an unparsed shape. */
+export const parseDeclaredToolset = (source: string): DeclaredToolset | null => {
+	const frontmatter = source.match(FRONTMATTER_RE)?.[1];
+	if (frontmatter === undefined) return null;
+	const tools = parseField(frontmatter, "tools");
+	const disallowed = parseField(frontmatter, "disallowedTools");
+	if (tools._tag === "unparsed" || disallowed._tag === "unparsed") return null;
+	if (tools._tag === "absent") return {_tag: "inherit"};
+	return {
+		_tag: "allowlist",
+		tools: tools.entries,
+		disallowedTools: disallowed._tag === "entries" ? disallowed.entries : [],
+	};
+};
+
+/** The repo-relative def a seat boots from — the `--agent crew-<role>` target under bind's `--plugin-dir`. */
+export const seatDefRelativePath = (role: CrewRole): string =>
+	`${CREW_PLUGIN_SUBDIR}/agents/crew-${role}.md`;
+
+/**
+ * Reads one seat's declared toolset. Injected so the launch composition stays unit-testable with no
+ * real def on disk — hence `R`: the production reader carries the platform seam, a test stub carries
+ * `never`, and the assert's own context is whatever its reader needs rather than always the platform.
+ */
+export type SeatToolsetReader<R = FileSystem.FileSystem | Path.Path> = (
+	projectRoot: string,
+	role: CrewRole,
+) => Effect.Effect<DeclaredToolset, CrewSeatDefUnreadableError, R>;
+
+/** The production reader: parse the seat's agent def under the launched `--plugin-dir`. */
+export const readSeatToolsetFromDef: SeatToolsetReader = (projectRoot, role) =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const defPath = path.join(projectRoot, seatDefRelativePath(role));
+		const fs = yield* FileSystem.FileSystem;
+		const source = yield* fs.readFileString(defPath).pipe(
+			Effect.mapError(
+				(cause) =>
+					new CrewSeatDefUnreadableError({
+						role,
+						defPath,
+						reason: `cannot read: ${String(cause)}`,
+					}),
+			),
+		);
+		const declared = parseDeclaredToolset(source);
+		if (declared === null) {
+			return yield* new CrewSeatDefUnreadableError({
+				role,
+				defPath,
+				reason:
+					"no YAML frontmatter, or a `tools:`/`disallowedTools:` that is not a single-line flow sequence of double-quoted names — the assert refuses rather than skip an unparsed declaration",
+			});
+		}
+		return declared;
+	});
+
+/** Refuse when a seat's declaration would not resolve intact — the pure decision, separate from the read. */
+export const assertSeatToolset = (
+	role: CrewRole,
+	defPath: string,
+	declared: DeclaredToolset,
+): Effect.Effect<void, CrewSeatToolsetMismatchError> => {
+	const {ungrantable, selfDenied} = resolveDeclaredToolset(declared);
+	if (ungrantable.length === 0 && selfDenied.length === 0) return Effect.void;
+	const parts = [
+		ungrantable.length > 0
+			? `${JSON.stringify(ungrantable)} name no tool this CLI grants a top-level session, so they are silently dropped`
+			: undefined,
+		selfDenied.length > 0
+			? `${JSON.stringify(selfDenied)} are subtracted by this def's own \`disallowedTools\` (an entry matches by BASE tool name — the \`(specifier)\` is ignored and the WHOLE tool goes)`
+			: undefined,
+	].filter((part) => part !== undefined);
+	return Effect.fail(
+		new CrewSeatToolsetMismatchError({
+			role,
+			defPath,
+			ungrantable,
+			selfDenied,
+			reason: `the "${role}" seat would boot without tools its def declares: ${parts.join("; ")} — fix the def rather than boot a silently degraded seat`,
+		}),
+	);
+};
+
+/**
+ * Assert every named seat's declaration resolves intact, before the tracker or any session comes up.
+ * Serial (`concurrency: 1`) so the first mis-declared seat is the one named, deterministically.
+ */
+export const assertCrewSeatToolsets = <R = FileSystem.FileSystem | Path.Path>(
+	projectRoot: string,
+	roles: readonly CrewRole[],
+	read: SeatToolsetReader<R>,
+): Effect.Effect<void, CrewSeatToolsetMismatchError | CrewSeatDefUnreadableError, R> =>
+	Effect.forEach(
+		roles,
+		(role) =>
+			Effect.gen(function* () {
+				const declared = yield* read(projectRoot, role);
+				yield* assertSeatToolset(role, seatDefRelativePath(role), declared);
+			}),
+		{concurrency: 1, discard: true},
+	);


### PR DESCRIPTION
Fixes #3764

## The layer at fault (AC1)

**Neither of the two candidates the issue named.** The launcher passes a def's `tools:` through
correctly, and the platform **does** grant `Task` to a top-level `claude --agent` session. The
defect is in the **defs themselves**, and a CI guard was forcing it.

Established against the installed CLI 2.1.217 by booting probe agent-defs under
`--output-format stream-json` and reading the `init` event's granted `tools` — the same probe
re-derives everything below:

| probe def's declaration | tools the session actually booted with |
|---|---|
| `tools: [Read, Bash, Task]` | `[Read, Bash, Task]` |
| `tools: [Read, Bash, Task]` + `disallowedTools: [Task(coder)]` | `[Read, Bash]` |
| `tools: [Read, Bash, Task]` + `disallowedTools: [Bash(rm:*)]` | `[Read, Task]` |
| `tools: [Read, Bash, Task]` + `disallowedTools: [Write(*)]` | `[Read, Bash, Task]` |
| `tools: [Read, Bash, Grep, Glob]` | `[Read, Bash]` |

Two silent-drop rules fall out:

1. **Self-denial.** A `disallowedTools` entry is matched by its **base tool name** — the
   `(specifier)` is **ignored** — and the **whole tool** is subtracted from `tools:`. So
   `disallowedTools: ["Task(coder)"]` never denied the `coder` subagent; it **deleted `Task`**. An
   entry naming a tool the def doesn't allowlist is a no-op, which is why only the three bridges
   (which carry `Task(...)` denies) lost `Task` and the engine (which carries none) did not — the
   exact split the issue and its corroboration reported.
2. **Ungrantable name.** `Grep` and `Glob` are not tools a top-level session is granted on this CLI
   at all. A default session's `init` lists neither anywhere.

Both drops are silent: no warning, no error, no `denied by permission rule` message.

**There is no per-subagent deny mechanism at this layer.** A `permissions: { deny: [...] }` key in
an agent def leaves the tool in place **and does not block the spawn**, under every token spelling
tried (`Task(x)`, `Task(<plugin>:x)`, `Agent(x)`, `Agent(<plugin>:x)`) — verified by actually
spawning the denied subagent from a probe seat and watching it launch.

### The guard was causally upstream

`pipeline-cli crew-fanout-guard` (#3606) **required** every bridge def's `disallowedTools` to
enumerate `Task(<type>)` for each non-allowlisted mutating agent-type. Satisfying that guard
*guarantees* rule 1 fires. So the CI gate meant to narrow a bridge's spawn scope was what removed
every spawn the bridge had.

## What this changes

**The defs (AC2).** `Grep`/`Glob` dropped from all five crew defs; the inert-and-harmful
`disallowedTools` blocks removed from the three bridges. `crew-intake-desk` now boots with
`["Read","Bash","Task"]` — verified against the real CLI with the fixed def. That unblocks the
`planner` spawn (AC4) and the `crew-investigator` read-only fanout (AC3).

**The seam law is reconciled, not dropped (AC6).** The platform offers spawn scoping only at
whole-tool granularity, so "may spawn `planner` but not `coder`" cannot be a mechanism. It is now an
explicit **charter rule** in each seat's prose, with the *why* single-sourced in the new
`claude-plugins/pipeline-crew/SPAWN-SCOPE.md` rather than re-derived in three defs. `crew-fanout-guard`
keeps its teeth by moving the classification into its own two tables (`BRIDGE_ALLOWLIST` +
`BRIDGE_OUT_OF_SCOPE`): a roster addition on neither still reds the build, so the line can never
silently go unstated — it just no longer forces a declaration that breaks the seat. Stated plainly
in `SPAWN-SCOPE.md`: this is a completeness check on the policy, not enforcement of it.

**The launch fails loud (AC5).** New `packages/pipeline-crew-mcp/src/standup/toolset-assert.ts`
refuses a stand-up — and an on-demand `spawn-role` — whose seat def declares a toolset the CLI would
not resolve intact, naming the role, the dropped tools, and which rule dropped them. It runs before
the tracker and any pane, so a mis-declared seat costs zero panes, matching the pinned-CLI-version
assert's posture. The grantable-tool set is a CLI-version-scoped fact carried next to that pin, with
its re-derivation command in the module docblock.

## Verification

- `packages/pipeline-crew-mcp`: 308 tests pass, typecheck clean. The new suite reproduces the exact
  live declaration (declares six tools → seat gets two) and pins both rules.
- One test reads the **shipped** crew defs off disk, so a future edit reintroducing `Grep`/`Glob` or
  a self-denying `disallowedTools` reds in CI rather than at a live boot.
- `packages/pipeline-cli`: 1655 tests pass, typecheck clean; `crew-fanout-guard check` green against
  this tree.
- Live: `claude --agent crew-intake-desk` with the fixed def boots with `Task` present.

## Notes for review

- **Not the same root cause as #3761.** That one is an MCP server-side tool-schema problem; this is
  agent-def declaration resolution. They share only the symptom shape (a tool absent from a seat).
  No overlap in the fix.
- **Scoped to crew seats.** The `kampus-pipeline` subagent defs carry the same phantom `Grep`/`Glob`
  declaration; filed separately as #3782 rather than widened into this PR, since the launcher does
  not launch subagents and the assert has no jurisdiction there.
- **`packages/pipeline-cli` touch is confined** to `src/tools/crew-fanout-guard/`. No new registry
  entry, no adoption-lint manifest change — the two known collision points with the sibling lanes
  are untouched.
- This is a control-plane change (`claude-plugins/**` + the launcher), so it needs human
  control-plane approval before merge.
