### PR TITLE
fix(pipeline-cli): read check-runs latest-per-context so a superseded run can't red a green head (#3762)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -17,6 +17,7 @@ import {campaignCommand} from "./tools/campaign/command.ts";
 import {catalogGuardCommand} from "./tools/catalog-guard/command.ts";
 import {changeDetectGuardCommand} from "./tools/change-detect-guard/command.ts";
 import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
+import {checksCommand} from "./tools/checks/command.ts";
 import {ciRequiredCommand} from "./tools/ci-required/command.ts";
 import {claimCommand} from "./tools/claim/command.ts";
 import {classProbeCommand} from "./tools/class-probe/command.ts";
@@ -187,4 +188,9 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	// 1–2): convert an open, CI-red, laneless PR into one idempotent triaged "heal red CI on
 	// PR #N" item so an engine adopts the lane, rather than free-scanning arbitrary red PRs.
 	orphanHealCommand,
+	// #3762 — the shared head-CI read: roll a SHA's check-runs up LATEST-PER-CONTEXT, so a
+	// superseded run can't red a green head (the false RED that opened a needless repair lane
+	// on PR #3733). The one tested reader every CI-state consumer cites instead of re-rolling
+	// the query, the single-source shape of `verdict read` (#3686).
+	checksCommand,
 ];

--- a/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
+++ b/packages/pipeline-cli/src/tools/adoption-lint/manifest.ts
@@ -178,6 +178,21 @@ export const DECISIONS: ReadonlyArray<OwnedDecision> = [
 		reason:
 			"re-derives the ADR-0115 earliest-authorized-claim resolution that `pipeline-cli claim is-mine` owns (resolve one owner by earliest authorized claim, default-deny), instead of citing the verb (#3687 / #3254)",
 	},
+	{
+		// `checks read` owns the head-CI rollup (#3762): read a SHA's check runs LATEST-PER-CONTEXT
+		// before evaluating conclusions. The fingerprint is the co-occurrence of both tells — the
+		// `/check-runs` endpoint path AND a read of a run's `conclusion` — so prose that merely
+		// mentions check-runs (doctor's comment) is not a false finding, while a file that actually
+		// rolls the endpoint up by hand is. A file that cites `pipeline-cli checks` is compliant.
+		verb: "checks read",
+		signature: [
+			/\/check-runs/, // the check-runs endpoint path
+			/conclusion/, // reads the runs' conclusions
+		],
+		citation: /pipeline-cli\s+checks\b/,
+		reason:
+			"re-derives the head-CI rollup that `pipeline-cli checks read` owns (latest-per-context, so a superseded run can't red a green head), instead of citing the verb (#3762 / #3254)",
+	},
 ];
 
 /**

--- a/packages/pipeline-cli/src/tools/checks/checks.ts
+++ b/packages/pipeline-cli/src/tools/checks/checks.ts
@@ -1,0 +1,129 @@
+/**
+ * The pure head-CI rollup core of `checks` — IO-free, total, unit-testable.
+ *
+ * The one decision every consumer that gates on CI state needs and repeatedly gets wrong:
+ * given a head SHA's check runs, is that head green, red, or still pending?
+ *
+ * `GET /repos/{owner}/{repo}/commits/{sha}/check-runs` returns EVERY run recorded for the
+ * SHA, including runs a later re-run superseded — its `filter=latest` default dedupes only
+ * WITHIN a check suite, and a re-run opens a NEW suite. Verified against the live API on
+ * `bb21a70f`: 123 runs over 41 distinct context names, with `ci-required` present three
+ * times — latest `success`, two earlier `failure`. So the naive `conclusion != "success"`
+ * filter reads a superseded failure as current and calls a green head red (#3762, which cost
+ * a needless repair lane on PR #3733). GitHub itself evaluates the most recent run per
+ * context, which is why `mergeable_state` disagreed with the naive read; `latestPerContext`
+ * re-encodes that, once, here.
+ */
+
+/** A single check run, as the check-runs REST endpoint surfaces it (only these fields decide). */
+export interface CheckRun {
+	/** The context name — GitHub's own unit of evaluation, and the dedupe key. */
+	readonly name: string;
+	/** The run's conclusion; `null` while it is still queued or in progress. */
+	readonly conclusion: string | null;
+	/** ISO-8601 start time — the recency key a re-run advances. */
+	readonly startedAt: string | null;
+	/** ISO-8601 completion time; `null` while unconcluded. Carried for a caller's red-since anchor. */
+	readonly completedAt: string | null;
+	/** Server-assigned, strictly-monotonic run id — the recency tiebreak. */
+	readonly id: number;
+}
+
+/** The legacy combined-status envelope, which covers commit statuses that aren't check runs. */
+export interface CombinedStatus {
+	/** `success` | `pending` | `failure`. */
+	readonly state: string;
+	/**
+	 * How many statuses that state summarizes. Load-bearing: the endpoint reports `pending`
+	 * for a commit with ZERO statuses (verified live — phoenix posts no commit statuses at
+	 * all, so its combined state is permanently `pending`), so the state is only a signal
+	 * when it actually summarizes something.
+	 */
+	readonly totalCount: number;
+}
+
+/** The rolled-up head-CI verdict. Three states, exhaustive: a head is red, still running, or green. */
+export type ChecksConclusion = "red" | "pending" | "green";
+
+export interface ChecksRollup {
+	readonly conclusion: ChecksConclusion;
+	/** The latest run per context, name-sorted — what the conclusion was actually computed over. */
+	readonly latest: ReadonlyArray<CheckRun>;
+	/** The latest-per-context runs that concluded red. Empty unless `conclusion` is `red`. */
+	readonly failing: ReadonlyArray<CheckRun>;
+	/** The latest-per-context runs that have not concluded yet. */
+	readonly running: ReadonlyArray<CheckRun>;
+}
+
+/**
+ * The conclusions that make a context red — GitHub's check-run vocabulary. Everything else
+ * (`success`, and the explicitly non-failing `neutral` / `skipped`, plus `stale` and any
+ * conclusion GitHub adds later) is non-failing: a red verdict needs positive evidence of a
+ * failure, never the absence of a success.
+ */
+export const RED_CONCLUSIONS: ReadonlySet<string> = new Set([
+	"failure",
+	"timed_out",
+	"cancelled",
+	"action_required",
+	"startup_failure",
+]);
+
+/** Is this run's conclusion a failure? A `null` (unconcluded) conclusion is never a failure. */
+export const isFailing = (run: CheckRun): boolean =>
+	run.conclusion !== null && RED_CONCLUSIONS.has(run.conclusion);
+
+/** Recency order: later `startedAt` wins; equal (or absent) start times fall back to the run id. */
+const moreRecent = (a: CheckRun, b: CheckRun): CheckRun => {
+	const at = a.startedAt ?? "";
+	const bt = b.startedAt ?? "";
+	if (at !== bt) return at > bt ? a : b;
+	return a.id >= b.id ? a : b;
+};
+
+/**
+ * Reduce a SHA's runs to the current run per context: group by `name`, keep the most recent.
+ * This is the whole defect fix — a superseded run is dropped before any conclusion is read,
+ * so an earlier red for a context that has since gone green cannot contribute a failure.
+ * Returned name-sorted so the output is deterministic regardless of REST page order.
+ */
+export const latestPerContext = (runs: ReadonlyArray<CheckRun>): ReadonlyArray<CheckRun> => {
+	const byName = new Map<string, CheckRun>();
+	for (const run of runs) {
+		const held = byName.get(run.name);
+		byName.set(run.name, held === undefined ? run : moreRecent(held, run));
+	}
+	return [...byName.values()].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+};
+
+export interface RollupInput {
+	readonly checkRuns: ReadonlyArray<CheckRun>;
+	readonly combinedStatus: CombinedStatus;
+}
+
+/**
+ * Roll a head's check runs + combined status into one verdict, latest-per-context.
+ *
+ * Red wins over pending wins over green: a failing current context is red even while other
+ * contexts still run, and an unconcluded context is pending rather than green. With no signal
+ * at all — no check runs and no statuses — the answer is `pending`, not `green`: nothing has
+ * reported yet, and a consumer that acts on red must not be handed a green it didn't earn.
+ */
+export const rollupChecks = (input: RollupInput): ChecksRollup => {
+	const latest = latestPerContext(input.checkRuns);
+	const failing = latest.filter(isFailing);
+	const running = latest.filter((run) => run.conclusion === null);
+	const status = input.combinedStatus;
+	const statusCounts = status.totalCount > 0;
+
+	const conclusion: ChecksConclusion =
+		failing.length > 0 || (statusCounts && status.state === "failure")
+			? "red"
+			: running.length > 0 || (statusCounts && status.state === "pending")
+				? "pending"
+				: latest.length === 0 && !statusCounts
+					? "pending"
+					: "green";
+
+	return {conclusion, latest, failing, running};
+};

--- a/packages/pipeline-cli/src/tools/checks/checks.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/checks/checks.unit.test.ts
@@ -1,0 +1,183 @@
+import {assert, describe, it} from "@effect/vitest";
+import {type CheckRun, isFailing, latestPerContext, rollupChecks} from "./checks.ts";
+
+let nextId = 1;
+const run = (over: Partial<CheckRun> & {readonly name: string}): CheckRun => ({
+	conclusion: "success",
+	startedAt: "2026-07-22T05:00:00Z",
+	completedAt: "2026-07-22T05:05:00Z",
+	id: nextId++,
+	...over,
+});
+
+const noStatuses = {state: "pending", totalCount: 0} as const;
+
+describe("latestPerContext — one current run per context name", () => {
+	it("keeps the most recent run and drops the superseded ones", () => {
+		const latest = latestPerContext([
+			run({name: "ci-required", conclusion: "failure", startedAt: "2026-07-22T05:50:04Z"}),
+			run({name: "ci-required", conclusion: "success", startedAt: "2026-07-22T06:21:26Z"}),
+			run({name: "ci-required", conclusion: "failure", startedAt: "2026-07-22T06:09:51Z"}),
+		]);
+		assert.deepStrictEqual(
+			latest.map((c) => [c.name, c.conclusion]),
+			[["ci-required", "success"]],
+		);
+	});
+
+	it("falls back to the run id when start times tie or are absent", () => {
+		const latest = latestPerContext([
+			run({name: "e2e", conclusion: "failure", startedAt: null, id: 10}),
+			run({name: "e2e", conclusion: "success", startedAt: null, id: 11}),
+		]);
+		assert.deepStrictEqual(latest[0]?.conclusion, "success");
+	});
+
+	it("is order-independent and name-sorted", () => {
+		const forward = latestPerContext([
+			run({name: "b", startedAt: "2026-07-22T01:00:00Z"}),
+			run({name: "a", conclusion: "failure", startedAt: "2026-07-22T01:00:00Z"}),
+			run({name: "a", startedAt: "2026-07-22T02:00:00Z"}),
+		]);
+		const reversed = latestPerContext([
+			run({name: "a", startedAt: "2026-07-22T02:00:00Z"}),
+			run({name: "a", conclusion: "failure", startedAt: "2026-07-22T01:00:00Z"}),
+			run({name: "b", startedAt: "2026-07-22T01:00:00Z"}),
+		]);
+		assert.deepStrictEqual(
+			forward.map((c) => [c.name, c.conclusion]),
+			[
+				["a", "success"],
+				["b", "success"],
+			],
+		);
+		assert.deepStrictEqual(
+			forward.map((c) => [c.name, c.conclusion]),
+			reversed.map((c) => [c.name, c.conclusion]),
+		);
+	});
+
+	it("keeps distinct contexts apart", () => {
+		const latest = latestPerContext([run({name: "lint"}), run({name: "typecheck"})]);
+		assert.deepStrictEqual(
+			latest.map((c) => c.name),
+			["lint", "typecheck"],
+		);
+	});
+});
+
+describe("isFailing — only an explicit failing conclusion is red", () => {
+	const table: ReadonlyArray<readonly [string | null, boolean]> = [
+		["failure", true],
+		["timed_out", true],
+		["cancelled", true],
+		["action_required", true],
+		["startup_failure", true],
+		["success", false],
+		["neutral", false],
+		["skipped", false],
+		["stale", false],
+		[null, false],
+	];
+	for (const [conclusion, expected] of table) {
+		it(`${conclusion ?? "null"} ⇒ ${expected ? "failing" : "not failing"}`, () => {
+			assert.strictEqual(isFailing(run({name: "x", conclusion})), expected);
+		});
+	}
+});
+
+describe("rollupChecks — the head verdict, computed latest-per-context", () => {
+	// The #3762 defect case, from PR #3733's real head: an earlier RED for a context whose
+	// latest run is green must resolve GREEN, not red.
+	it("a superseded red with a green latest is GREEN", () => {
+		const rollup = rollupChecks({
+			checkRuns: [
+				run({name: "ci-required", conclusion: "failure", startedAt: "2026-07-22T05:50:04Z"}),
+				run({name: "ci-required", conclusion: "failure", startedAt: "2026-07-22T06:09:51Z"}),
+				run({name: "ci-required", conclusion: "success", startedAt: "2026-07-22T06:21:26Z"}),
+				run({name: "e2e", conclusion: "failure", startedAt: "2026-07-22T05:58:40Z"}),
+				run({name: "e2e", conclusion: "skipped", startedAt: "2026-07-22T06:21:23Z"}),
+			],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(rollup.conclusion, "green");
+		assert.deepStrictEqual(rollup.failing, []);
+	});
+
+	it("a currently-failing context is RED and is reported by name", () => {
+		const rollup = rollupChecks({
+			checkRuns: [
+				run({name: "ci-required", conclusion: "success", startedAt: "2026-07-22T05:00:00Z"}),
+				run({name: "ci-required", conclusion: "failure", startedAt: "2026-07-22T06:00:00Z"}),
+			],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(rollup.conclusion, "red");
+		assert.deepStrictEqual(
+			rollup.failing.map((c) => c.name),
+			["ci-required"],
+		);
+	});
+
+	it("red wins over a still-running sibling context", () => {
+		const rollup = rollupChecks({
+			checkRuns: [
+				run({name: "lint", conclusion: "failure"}),
+				run({name: "e2e", conclusion: null, completedAt: null}),
+			],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(rollup.conclusion, "red");
+	});
+
+	it("an unconcluded context is PENDING, never green", () => {
+		const rollup = rollupChecks({
+			checkRuns: [run({name: "lint"}), run({name: "e2e", conclusion: null, completedAt: null})],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(rollup.conclusion, "pending");
+		assert.deepStrictEqual(
+			rollup.running.map((c) => c.name),
+			["e2e"],
+		);
+	});
+
+	it("neutral and skipped latest runs are green", () => {
+		const rollup = rollupChecks({
+			checkRuns: [run({name: "a", conclusion: "neutral"}), run({name: "b", conclusion: "skipped"})],
+			combinedStatus: noStatuses,
+		});
+		assert.strictEqual(rollup.conclusion, "green");
+	});
+
+	// The combined-status endpoint reports `pending` for a commit with zero statuses, which is
+	// exactly phoenix's shape — reading that state unguarded pins every head at pending forever.
+	it("a zero-status combined `pending` does not hold a green head at pending", () => {
+		const rollup = rollupChecks({
+			checkRuns: [run({name: "ci-required"})],
+			combinedStatus: {state: "pending", totalCount: 0},
+		});
+		assert.strictEqual(rollup.conclusion, "green");
+	});
+
+	it("a real failing commit status reds a head whose check runs are all green", () => {
+		const rollup = rollupChecks({
+			checkRuns: [run({name: "ci-required"})],
+			combinedStatus: {state: "failure", totalCount: 1},
+		});
+		assert.strictEqual(rollup.conclusion, "red");
+	});
+
+	it("a real pending commit status holds a head at pending", () => {
+		const rollup = rollupChecks({
+			checkRuns: [run({name: "ci-required"})],
+			combinedStatus: {state: "pending", totalCount: 2},
+		});
+		assert.strictEqual(rollup.conclusion, "pending");
+	});
+
+	it("no signal at all is PENDING, not an unearned green", () => {
+		const rollup = rollupChecks({checkRuns: [], combinedStatus: noStatuses});
+		assert.strictEqual(rollup.conclusion, "pending");
+	});
+});

--- a/packages/pipeline-cli/src/tools/checks/command.ts
+++ b/packages/pipeline-cli/src/tools/checks/command.ts
@@ -1,0 +1,109 @@
+/**
+ * The `checks` tool — `pipeline-cli checks read --pr N | --sha S [--expect green|red|pending]`.
+ *
+ *   node src/bin.ts checks read --pr 3733            # exit 0 = the head is green
+ *   node src/bin.ts checks read --pr 3733 --expect red   # exit 0 = the head is genuinely red
+ *
+ * The single tested head-CI read every consumer that gates on check-run state cites instead of
+ * hand-rolling the query (#3762, the same single-source move as `verdict read` in #3686). It
+ * exists because the naive `conclusion != "success"` filter over
+ * `commits/{sha}/check-runs` reads SUPERSEDED runs as current and calls a green head red —
+ * `checks.ts` documents the verified endpoint behavior that makes that so.
+ *
+ * The exit status is the answer, mirroring `verdict read`: 0 when the rollup equals `--expect`
+ * (default `green`), non-zero otherwise, with the reason on stderr and the full rollup as JSON
+ * on stdout for a caller that wants the failing context names. `GithubLive` is baked in with
+ * `Command.provide(...)` so the registered command's residual requirement is the Node platform
+ * union (the registry seam, epic #994).
+ */
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import type {ChecksConclusion} from "./checks.ts";
+import {Github, GithubLive} from "./github.ts";
+
+const FAIL_EXIT_CODE = 1;
+
+const CONCLUSIONS: ReadonlyArray<ChecksConclusion> = ["green", "red", "pending"];
+
+const prFlag = Flag.integer("pr").pipe(
+	Flag.optional,
+	Flag.withDescription("the pull request whose current head to read (resolves the head SHA)"),
+);
+
+const shaFlag = Flag.string("sha").pipe(
+	Flag.optional,
+	Flag.withDescription("the head SHA to read directly (alternative to --pr)"),
+);
+
+const expectFlag = Flag.string("expect").pipe(
+	Flag.optional,
+	Flag.withDescription(`the rollup an exit 0 means: ${CONCLUSIONS.join(" | ")} (default: green)`),
+);
+
+/** Print `reason` on stderr and exit non-zero — the "not satisfied / bad input" signal a caller branches on. */
+const fail = (reason: string): Effect.Effect<never> =>
+	Effect.sync(() => {
+		process.stderr.write(`checks: ${reason}\n`);
+		process.exit(FAIL_EXIT_CODE);
+	});
+
+const parseExpect = (raw: Option.Option<string>): Effect.Effect<ChecksConclusion, never> => {
+	const value = Option.getOrElse(raw, () => "green")
+		.trim()
+		.toLowerCase();
+	return (CONCLUSIONS as ReadonlyArray<string>).includes(value)
+		? Effect.succeed(value as ChecksConclusion)
+		: fail(`invalid --expect '${value}' — expected one of ${CONCLUSIONS.join(" | ")}`);
+};
+
+const read = Command.make(
+	"read",
+	{pr: prFlag, sha: shaFlag, expect: expectFlag},
+	Effect.fn(function* ({pr, sha, expect}) {
+		const expected = yield* parseExpect(expect);
+		const gh = yield* Github;
+		const pinned = Option.getOrUndefined(sha);
+		const prNumber = Option.getOrUndefined(pr);
+		if ((pinned === undefined) === (prNumber === undefined)) {
+			return yield* fail("pass exactly one of --pr <n> or --sha <sha>");
+		}
+		const head = pinned ?? (yield* gh.headSha(prNumber as number));
+		const rollup = yield* gh.read(head);
+		yield* Console.log(
+			JSON.stringify({
+				conclusion: rollup.conclusion,
+				sha: head,
+				contexts: rollup.latest.length,
+				failing: rollup.failing.map((c) => c.name),
+				running: rollup.running.map((c) => c.name),
+			}),
+		);
+		const detail =
+			rollup.conclusion === "red"
+				? ` (failing: ${rollup.failing.map((c) => c.name).join(", ")})`
+				: rollup.conclusion === "pending"
+					? ` (running: ${rollup.running.map((c) => c.name).join(", ") || "nothing has reported yet"})`
+					: "";
+		if (rollup.conclusion === expected) {
+			process.stderr.write(
+				`checks: ${head} is ${rollup.conclusion} over ${rollup.latest.length} contexts${detail}\n`,
+			);
+			return;
+		}
+		return yield* fail(
+			`${head} is ${rollup.conclusion} over ${rollup.latest.length} contexts${detail}, expected ${expected}`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Roll a head's check-runs up latest-per-context (exit 0 = the rollup matches --expect, default green)",
+	),
+);
+
+export const checksCommand = Command.make("checks").pipe(
+	Command.withSubcommands([read]),
+	Command.withDescription(
+		"Read a PR/commit head's CI state latest-per-context — the shared head-CI reader a stale superseded run can't red (#3762)",
+	),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/checks/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/checks/github-service.unit.test.ts
@@ -1,0 +1,149 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Github, GithubLive, type RepoResolutionError} from "./github.ts";
+
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+const enc = new TextEncoder();
+
+/** A `ChildProcessSpawner` answering `gh api` from a REST-path fixture map. */
+const mockSpawner = (
+	responses: Record<string, string>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const path = (args.find((a) => a.startsWith("repos/")) ?? "").replace(/\?.*$/, "");
+				const found = path in responses;
+				const stdout = found ? responses[path]! : "";
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(stdout)]),
+					stderr: Stream.fromIterable([
+						enc.encode(found ? "" : `gh: Not Found (HTTP 404) ${path}`),
+					]),
+					all: Stream.fromIterable([enc.encode(stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(found ? 0 : 1)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	responses: Record<string, string>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const SHA = "bb21a70f0000000000000000000000000000dead";
+const checkRunsPath = `repos/${PINNED_REPO}/commits/${SHA}/check-runs`;
+const statusPath = `repos/${PINNED_REPO}/commits/${SHA}/status`;
+const noStatuses = JSON.stringify({state: "pending", total_count: 0});
+
+const checkRun = (over: {
+	readonly name: string;
+	readonly conclusion: string | null;
+	readonly started_at: string;
+	readonly id: number;
+}) => ({completed_at: over.started_at, ...over});
+
+/** `gh api --paginate --slurp` hands back one envelope per page — the shape the shell decodes. */
+const pages = (...perPage: ReadonlyArray<ReadonlyArray<unknown>>) =>
+	JSON.stringify(perPage.map((check_runs) => ({total_count: 0, check_runs})));
+
+describe("Github.read — the fetched head rolls up latest-per-context", () => {
+	// The #3762 reproduction, through the real decode path: the endpoint hands back every run
+	// for the SHA, superseded ones included, and only the latest per context may decide.
+	it.effect("superseded reds do not red a head whose latest runs are green", () =>
+		Effect.gen(function* () {
+			const rollup = yield* provide(
+				Effect.flatMap(Github, (gh) => gh.read(SHA)),
+				{
+					// Split across two pages, with a context's superseding run on the SECOND page:
+					// a shell that dropped a page would resolve this head red.
+					[checkRunsPath]: pages(
+						[
+							checkRun({
+								name: "ci-required",
+								conclusion: "failure",
+								started_at: "2026-07-22T05:50:04Z",
+								id: 1,
+							}),
+							checkRun({
+								name: "e2e",
+								conclusion: "failure",
+								started_at: "2026-07-22T05:58:40Z",
+								id: 3,
+							}),
+						],
+						[
+							checkRun({
+								name: "ci-required",
+								conclusion: "success",
+								started_at: "2026-07-22T06:21:26Z",
+								id: 2,
+							}),
+							checkRun({
+								name: "e2e",
+								conclusion: "skipped",
+								started_at: "2026-07-22T06:21:23Z",
+								id: 4,
+							}),
+						],
+					),
+					[statusPath]: noStatuses,
+				},
+			);
+			assert.strictEqual(rollup.conclusion, "green");
+			assert.strictEqual(rollup.latest.length, 2);
+			assert.deepStrictEqual(rollup.failing, []);
+		}),
+	);
+
+	it.effect("a check run with no started_at still decodes and rolls up", () =>
+		Effect.gen(function* () {
+			const rollup = yield* provide(
+				Effect.flatMap(Github, (gh) => gh.read(SHA)),
+				{
+					[checkRunsPath]: pages([
+						{id: 1, name: "lint", conclusion: "failure", completed_at: null},
+						{id: 2, name: "lint", conclusion: "success", completed_at: null},
+					]),
+					[statusPath]: noStatuses,
+				},
+			);
+			assert.strictEqual(rollup.conclusion, "green");
+		}),
+	);
+});
+
+describe("Github.headSha — resolves the PR's current head", () => {
+	it.effect("reads .head.sha off the pulls endpoint", () =>
+		Effect.gen(function* () {
+			const sha = yield* provide(
+				Effect.flatMap(Github, (gh) => gh.headSha(3733)),
+				{[`repos/${PINNED_REPO}/pulls/3733`]: JSON.stringify({head: {sha: SHA}})},
+			);
+			assert.strictEqual(sha, SHA);
+		}),
+	);
+});

--- a/packages/pipeline-cli/src/tools/checks/github.ts
+++ b/packages/pipeline-cli/src/tools/checks/github.ts
@@ -1,0 +1,201 @@
+/**
+ * The GitHub boundary for `checks`: resolve a PR's head SHA and fetch that head's check runs
+ * + combined status over `gh api` REST, feeding the IO-free `checks.ts` rollup.
+ *
+ * Same service pattern as the `verdict` / `orphan-heal` children (epic #994): a
+ * `Context.Service` on `ChildProcessSpawner`, REST only (GraphQL is broken on the kamp-us
+ * org), every infra failure a typed error in the `E` channel, untrusted REST JSON
+ * Schema-decoded at the boundary.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {type ChecksRollup, rollupChecks} from "./checks.ts";
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/checks/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/checks/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/checks/RepoResolutionError",
+	{message: Schema.String},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const runGh = Effect.fn("Checks.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const json = Effect.fn("Checks.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/** Resolve the target repo (`owner/name`) per ADR 0062 §1: env override → `GITHUB_REPOSITORY` → `gh repo view`. */
+const resolveRepo = Effect.fn("Checks.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/checks/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+const RawCheckRun = Schema.Struct({
+	id: Schema.Number,
+	name: Schema.String,
+	conclusion: Schema.NullOr(Schema.String),
+	started_at: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	completed_at: Schema.NullOr(Schema.String),
+});
+/**
+ * The check-runs endpoint returns an OBJECT, so `--paginate` alone emits one JSON object per
+ * page — concatenated, unparseable as a whole. `--slurp` wraps the pages in an array instead;
+ * decoding that array and flattening is what makes a >100-run head readable at all. (Verified
+ * live: the #3762 head returns 123 runs over 2 pages, and the unslurped read throws.)
+ */
+const RawCheckRunPages = Schema.Array(Schema.Struct({check_runs: Schema.Array(RawCheckRun)}));
+const decodeCheckRunPages = Schema.decodeUnknownEffect(RawCheckRunPages);
+
+const RawCombinedStatus = Schema.Struct({state: Schema.String, total_count: Schema.Number});
+const decodeCombinedStatus = Schema.decodeUnknownEffect(RawCombinedStatus);
+
+const RawPr = Schema.Struct({head: Schema.Struct({sha: Schema.String})});
+const decodePr = Schema.decodeUnknownEffect(RawPr);
+
+const headSha = Effect.fn("Checks.headSha")(function* (repo: string, pr: number) {
+	const args = ["api", `repos/${repo}/pulls/${pr}`];
+	return (yield* decodePr(yield* json(args))).head.sha;
+});
+
+/**
+ * Read a head's rolled-up CI state. Paginating is load-bearing: a busy head easily exceeds one
+ * page (the #3762 reproduction head carried 123 runs), and a truncated page can hide the very
+ * run that supersedes a stale red.
+ */
+const read = Effect.fn("Checks.read")(function* (repo: string, sha: string) {
+	const checkArgs = [
+		"api",
+		"--paginate",
+		"--slurp",
+		`repos/${repo}/commits/${sha}/check-runs?per_page=100`,
+	];
+	const statusArgs = ["api", `repos/${repo}/commits/${sha}/status`];
+	const [pages, status] = yield* Effect.all(
+		[
+			decodeCheckRunPages(yield* json(checkArgs)),
+			decodeCombinedStatus(yield* json(statusArgs)),
+		] as const,
+		{concurrency: "unbounded"},
+	);
+	return rollupChecks({
+		checkRuns: pages
+			.flatMap((page) => page.check_runs)
+			.map((r) => ({
+				id: r.id,
+				name: r.name,
+				conclusion: r.conclusion,
+				startedAt: r.started_at ?? null,
+				completedAt: r.completed_at,
+			})),
+		combinedStatus: {state: status.state, totalCount: status.total_count},
+	});
+});
+
+type GhError = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;
+
+/**
+ * `Github` — the IO shell over `gh api` REST for the head-CI reads. Built by `GithubLive`,
+ * whose `R` is `ChildProcessSpawner`; repo resolution is cached and deferred to first use
+ * (ADR 0062 §1), so the layer build is side-effect-free.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly repoName: () => Effect.Effect<string, GhError>;
+		readonly headSha: (pr: number) => Effect.Effect<string, GhError>;
+		readonly read: (sha: string) => Effect.Effect<ChecksRollup, GhError>;
+	}
+>()("@kampus/checks/Github") {}
+
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				repoName: () => repo,
+				headSha: (pr) => repo.pipe(Effect.flatMap((r) => withSpawner(headSha(r, pr)))),
+				read: (sha) => repo.pipe(Effect.flatMap((r) => withSpawner(read(r, sha)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/orphan-heal/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/github-service.unit.test.ts
@@ -79,6 +79,98 @@ const laneOf = (body: string, responses: Record<string, Response>) =>
 		responses,
 	);
 
+const SHA = "bb21a70f0000000000000000000000000000dead";
+const checkRunsPath = `repos/${PINNED_REPO}/commits/${SHA}/check-runs`;
+const statusPath = `repos/${PINNED_REPO}/commits/${SHA}/status`;
+const noStatuses = JSON.stringify({state: "pending", total_count: 0});
+
+const checkRun = (over: {
+	readonly name: string;
+	readonly conclusion: string | null;
+	readonly started_at: string;
+	readonly id: number;
+}) => ({completed_at: over.started_at, ...over});
+
+/** `gh api --paginate --slurp` hands back one envelope per page — the shape the shell decodes. */
+const pages = (...perPage: ReadonlyArray<ReadonlyArray<unknown>>) =>
+	JSON.stringify(perPage.map((check_runs) => ({total_count: 0, check_runs})));
+
+const headCiOf = (responses: Record<string, Response>) =>
+	provide(
+		Effect.flatMap(Github, (gh) => gh.headCi(SHA)),
+		responses,
+	);
+
+describe("Github.headCi — the head read is latest-per-context (#3762)", () => {
+	// The live reproduction: PR #3733's head carried three `ci-required` runs — the latest
+	// green, two superseded reds — and the naive filter opened a repair lane on a green PR.
+	it.effect("a superseded red whose context has since gone green reads green", () =>
+		Effect.gen(function* () {
+			const ci = yield* headCiOf({
+				[checkRunsPath]: pages([
+					checkRun({
+						name: "ci-required",
+						conclusion: "failure",
+						started_at: "2026-07-22T05:50:04Z",
+						id: 1,
+					}),
+					checkRun({
+						name: "ci-required",
+						conclusion: "failure",
+						started_at: "2026-07-22T06:09:51Z",
+						id: 2,
+					}),
+					checkRun({
+						name: "ci-required",
+						conclusion: "success",
+						started_at: "2026-07-22T06:21:26Z",
+						id: 3,
+					}),
+				]),
+				[statusPath]: noStatuses,
+			});
+			assert.strictEqual(ci.conclusion, "green");
+		}),
+	);
+
+	it.effect("a context whose latest run failed is still red, with its name and red-since", () =>
+		Effect.gen(function* () {
+			const ci = yield* headCiOf({
+				[checkRunsPath]: pages([
+					checkRun({
+						name: "ci-required",
+						conclusion: "success",
+						started_at: "2026-07-22T05:50:04Z",
+						id: 1,
+					}),
+					checkRun({
+						name: "ci-required",
+						conclusion: "failure",
+						started_at: "2026-07-22T06:21:26Z",
+						id: 2,
+					}),
+				]),
+				[statusPath]: noStatuses,
+			});
+			assert.strictEqual(ci.conclusion, "red");
+			assert.strictEqual(ci.failingCheck, "ci-required");
+			assert.strictEqual(ci.redSince, "2026-07-22T06:21:26Z");
+		}),
+	);
+
+	it.effect("an unconcluded latest run is pending", () =>
+		Effect.gen(function* () {
+			const ci = yield* headCiOf({
+				[checkRunsPath]: pages([
+					checkRun({name: "e2e", conclusion: null, started_at: "2026-07-22T06:21:26Z", id: 1}),
+				]),
+				[statusPath]: noStatuses,
+			});
+			assert.strictEqual(ci.conclusion, "pending");
+		}),
+	);
+});
+
 describe("Github.inEngineLane — a read that could not execute is `unknown`, never `laneless` (#3701)", () => {
 	it.effect("a transient 5xx on the only closing ref defers instead of reading laneless", () =>
 		Effect.gen(function* () {

--- a/packages/pipeline-cli/src/tools/orphan-heal/github.ts
+++ b/packages/pipeline-cli/src/tools/orphan-heal/github.ts
@@ -13,6 +13,7 @@
 import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {rollupChecks} from "../checks/checks.ts";
 import {
 	type CiConclusion,
 	extractHealTargets,
@@ -115,15 +116,6 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 	});
 });
 
-// The failing check-run conclusions that make a head CI-red (GitHub's check-run vocabulary).
-const RED_CONCLUSIONS = new Set([
-	"failure",
-	"timed_out",
-	"cancelled",
-	"action_required",
-	"startup_failure",
-]);
-
 /** An open PR row from the pulls endpoint (draft flag + head sha + body carry the gate inputs). */
 const RawPr = Schema.Struct({
 	number: Schema.Number,
@@ -133,17 +125,23 @@ const RawPr = Schema.Struct({
 });
 const decodePrs = Schema.decodeUnknownEffect(Schema.Array(RawPr));
 
-/** A single head check-run (name + conclusion + when it completed — the red-since anchor). */
+/**
+ * A single head check-run. `id` + `started_at` are the recency keys the shared rollup dedupes
+ * on; `completed_at` is this tool's red-since anchor.
+ */
 const CheckRun = Schema.Struct({
+	id: Schema.Number,
 	name: Schema.String,
 	conclusion: Schema.NullOr(Schema.String),
+	started_at: Schema.optionalKey(Schema.NullOr(Schema.String)),
 	completed_at: Schema.NullOr(Schema.String),
 });
-const CheckRuns = Schema.Struct({check_runs: Schema.Array(CheckRun)});
-const decodeCheckRuns = Schema.decodeUnknownEffect(CheckRuns);
+/** One `--slurp`ed page per element — see the `--slurp` note on the fetch below. */
+const CheckRunPages = Schema.Array(Schema.Struct({check_runs: Schema.Array(CheckRun)}));
+const decodeCheckRunPages = Schema.decodeUnknownEffect(CheckRunPages);
 
 /** The legacy combined-status envelope — covers commit statuses that aren't check-runs. */
-const CombinedStatus = Schema.Struct({state: Schema.String});
+const CombinedStatus = Schema.Struct({state: Schema.String, total_count: Schema.Number});
 const decodeCombinedStatus = Schema.decodeUnknownEffect(CombinedStatus);
 
 const IssueLabels = Schema.Struct({labels: Schema.Array(Schema.Struct({name: Schema.String}))});
@@ -188,28 +186,47 @@ const listOpenPrs = Effect.fn("Github.listOpenPrs")(function* (repo: string) {
 	);
 });
 
+/**
+ * The head's rolled-up CI conclusion, plus this tool's red-since anchor.
+ *
+ * The red/pending/green decision is `pipeline-cli checks read`'s — `rollupChecks` reduces the
+ * SHA's runs LATEST-PER-CONTEXT before reading any conclusion, so a superseded red can't flag
+ * a green PR into a heal lane it doesn't need (#3762). This tool adds only what the shared
+ * rollup deliberately doesn't own: the grace-window anchor.
+ */
 const headCi = Effect.fn("Github.headCi")(function* (repo: string, sha: string) {
-	const checkArgs = ["api", "--paginate", `repos/${repo}/commits/${sha}/check-runs?per_page=100`];
-	const {check_runs} = yield* decodeCheckRuns(yield* json(checkArgs));
+	// `--slurp` because the check-runs endpoint returns an OBJECT: under bare `--paginate` a
+	// multi-page head emits one concatenated object per page and the parse throws (#3762).
+	const checkArgs = [
+		"api",
+		"--paginate",
+		"--slurp",
+		`repos/${repo}/commits/${sha}/check-runs?per_page=100`,
+	];
+	const pages = yield* decodeCheckRunPages(yield* json(checkArgs));
 	const statusArgs = ["api", `repos/${repo}/commits/${sha}/status`];
-	const {state} = yield* decodeCombinedStatus(yield* json(statusArgs));
+	const status = yield* decodeCombinedStatus(yield* json(statusArgs));
 
-	const failing = check_runs.filter(
-		(c) => c.conclusion !== null && RED_CONCLUSIONS.has(c.conclusion),
-	);
-	const isRed = failing.length > 0 || state === "failure";
-	if (!isRed) {
-		// pending ⇒ some check still running or the combined status is pending; else green.
-		const anyPending = state === "pending" || check_runs.some((c) => c.conclusion === null);
-		const conclusion: CiConclusion =
-			check_runs.length === 0 && state === "pending" ? "pending" : anyPending ? "pending" : "green";
-		return {conclusion} satisfies HeadCi;
+	const rollup = rollupChecks({
+		checkRuns: pages
+			.flatMap((page) => page.check_runs)
+			.map((c) => ({
+				id: c.id,
+				name: c.name,
+				conclusion: c.conclusion,
+				startedAt: c.started_at ?? null,
+				completedAt: c.completed_at,
+			})),
+		combinedStatus: {state: status.state, totalCount: status.total_count},
+	});
+	if (rollup.conclusion !== "red") {
+		return {conclusion: rollup.conclusion satisfies CiConclusion} satisfies HeadCi;
 	}
 
 	// red-since: the LATEST failing completion — conservative, so a just-failed head waits the
 	// full grace window rather than being flagged the instant CI finishes red.
-	const completions = failing
-		.map((c) => c.completed_at)
+	const completions = rollup.failing
+		.map((c) => c.completedAt)
 		.filter((t): t is string => typeof t === "string");
 	const redSince =
 		completions.length > 0
@@ -218,7 +235,7 @@ const headCi = Effect.fn("Github.headCi")(function* (repo: string, sha: string) 
 	return {
 		conclusion: "red",
 		redSince,
-		failingCheck: failing[0]?.name,
+		failingCheck: rollup.failing[0]?.name,
 	} satisfies HeadCi;
 });
 


### PR DESCRIPTION
Fixes #3762

## The defect, grounded against the live API

`GET /repos/{owner}/{repo}/commits/{sha}/check-runs` returns **every** run recorded for a
SHA, superseded ones included. Its `filter=latest` default only dedupes *within* a check
suite, and a re-run opens a **new** suite — so the default read still hands back duplicates
per context. Verified on the reported head `bb21a70f` rather than assumed:

```
total check runs: 123      distinct context names: 41
ci-required                        → success (06:21:26) · failure (06:09:51) · failure (05:50:04)
e2e (reads + authed + flows, …)    → skipped (06:21:23) · failure (05:58:40) · failure (05:39:02)
```

A naive `conclusion != "success"` filter therefore reads two superseded failures as current
and calls a fully green head red — the false RED that cost a repair lane on #3733. GitHub
evaluates the most recent run per context, which is why `mergeable_state` disagreed.

## Consumer survey — who is actually wrong today

The issue asked whether the trap is shared. It is narrower than the original report assumed:

| Consumer | Reads check-run state via | Verdict |
| --- | --- | --- |
| `packages/pipeline-cli/src/tools/orphan-heal/github.ts` (`headCi`) | raw `commits/{sha}/check-runs` | **AFFECTED** — no latest-per-context step |
| `ship-it` SKILL (Step 3 / merge-queue) | `gh pr checks` | not affected |
| `heal-ci` SKILL | `gh pr checks` | not affected |
| `write-code` SKILL | — | reads no check-run state at all |
| `doctor.sh` | `actions/workflows` count | not affected (check-runs appears only in a comment) |
| crew agent defs / `.claude/workflows/` | — | no check-run reads |

`gh pr checks` already rolls up latest-per-context: on the same head it returns **44 rows**
against the endpoint's **123 raw runs**, and reports `ci-required` as `SUCCESS` and the e2e
context as `SKIPPED`. So the two skills that gate on CI were reading correctly, and **no
skill needed editing** — which also keeps this PR clear of #3713, which is rewriting those
same three skills for `verdict read`.

The one shipped code consumer that is wrong is `orphan-heal`'s `headCi()`, exactly as triage
found. The other real recurrence vector is an **ad-hoc agent sweep** hand-rolling the query
in-session, which is what produced the live incident — that is what the new verb and the
`adoption-lint` entry exist for.

## What this adds

**`pipeline-cli checks read --pr N | --sha S [--expect green|red|pending]`** — one tested
head-CI reader, in the single-source shape of the `verdict read` adoption (#3686).

- `checks.ts` — the pure, IO-free core. `latestPerContext` groups by context name and keeps
  the most recent run (`started_at`, then run id) **before** any conclusion is evaluated;
  `rollupChecks` then decides red / pending / green over that reduced set.
- `neutral` and `skipped` are non-failing, per the issue's corrected shape. Red requires
  positive evidence of a failing conclusion, so a conclusion GitHub adds later is never a
  spurious red.
- The exit status is the answer, mirroring `verdict read`: 0 when the rollup equals
  `--expect` (default `green`), non-zero otherwise, with the rollup as JSON on stdout and
  the reason on stderr.
- `github.ts` — the thin `gh api` REST shell (REST only; repo resolved per ADR 0062 §1).

**`orphan-heal` adopts the core** rather than keeping a second copy. It keeps only what the
shared rollup deliberately doesn't own: the red-since grace anchor.

**`adoption-lint` gains one declared decision** (`checks read`), fingerprinted on the
co-occurrence of the `/check-runs` endpoint path and a read of `conclusion`, so a future
corpus file that hand-rolls the query reds instead of repeating the trap. The corpus lints
clean today.

## Two further defects the live run surfaced in the same read

Both were latent in `orphan-heal` and would have made the tool wrong in production; both are
fixed here because they sit inside the read this issue is about.

1. **`--paginate` on an object-returning endpoint.** The check-runs endpoint returns an
   object, so bare `--paginate` emits one concatenated JSON object *per page* — the parse
   throws on page 2. The first live invocation of the new verb died exactly this way on the
   123-run head. Fixed with `--slurp` + flatten. (Array endpoints *do* merge under
   `--paginate` — verified — so the other paginated reads were fine.)
2. **A zero-status combined status reads `pending`.** `commits/{sha}/status` reports
   `state: "pending"` for a commit with **no** statuses, which is exactly this repo's shape
   (`total_count: 0`). Reading that unguarded pinned every head at pending forever. The
   state now only counts when `total_count > 0`.

## Verification

- `pnpm --filter @kampus/pipeline-cli test` — 1688 tests, 121 files, green. New coverage:
  the defect case (an earlier RED for a context whose latest run is green resolves green),
  the id tiebreak, order-independence, the `neutral`/`skipped`/`stale`/`null` conclusion
  table, red-beats-pending, the two combined-status cases, and a two-page fixture whose
  superseding run lands on the second page.
- `pnpm --filter @kampus/pipeline-cli typecheck` — clean. Biome — clean.
- `adoption-lint check` over the full corpus — clean, every declared exemption still valid.
- `commands check` — 60 registered tools, all documented.
- Live, against the head that produced the false RED:

  ```
  $ node packages/pipeline-cli/src/bin.ts checks read --pr 3733
  {"conclusion":"green","sha":"bb21a70f…","contexts":43,"failing":[],"running":[]}
  checks: bb21a70f… is green over 43 contexts        (exit 0)
  ```

## Acceptance criteria

- [x] Check-run state is read latest-per-context, matching how GitHub evaluates a context.
- [x] `headCi()` adopts that reading and no longer classifies a green PR as red from a stale run.
- [x] The correct read lives in one tested place — a shared verb under `packages/pipeline-cli/src/tools/`.
- [x] Unit coverage for the defect case (earlier RED + latest green ⇒ green).
- [x] `neutral` and `skipped` treated as non-failing.
- [x] Remaining consumers surveyed: none other is wrong today; `adoption-lint` now points future
      corpus hand-rolls at the verb.

## Notes for review

- **§CP** — touches `packages/pipeline-cli/**`; needs a human control-plane approval.
- **Sibling-lane collisions.** `registry.ts` is touched with the minimum possible edit: one
  import line and one appended entry at the end of `registeredTools`, no reformatting of
  neighbours. #3774 and #3784 add no registry entry, so the merge should stay trivial. The
  `adoption-lint` manifest entry is likewise a single append at the end of `DECISIONS`.
- No skill files are touched, so there is no overlap with #3713.
