### PR TITLE
test(integration): an exhausted deploy warm probe names its own exhaustion (#3778)

### DIFF
--- a/apps/web/tests/integration/_edge-ready.unit.test.ts
+++ b/apps/web/tests/integration/_edge-ready.unit.test.ts
@@ -28,7 +28,7 @@ import {
 } from "./_edge-ready.ts";
 import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
 import {harness} from "./_harness.ts";
-import {awaitAuthRouteReady, awaitWorkerReady} from "./_integration.ts";
+import {awaitAuthRouteReady, awaitWorkerReady, WarmNotSettledError} from "./_integration.ts";
 
 // A tiny budget so the tests drive the readiness logic in milliseconds, not the real 60s.
 const BUDGET = {deadlineMs: 120, pollMs: 5} as const;
@@ -219,6 +219,27 @@ describe("awaitWorkerReady — typed readiness diagnostic (#3146)", () => {
 		await expect(
 			Effect.runPromise(awaitWorkerReady("https://stage.example.workers.dev", 40)),
 		).rejects.toThrow(/worker never served a healthy \/api\/health within the readiness window/);
+	});
+});
+
+// The DEPLOY-time WARM probes (`warmLiveDO` / `warmFateRead`) stay non-fatal, but an exhausted
+// budget must no longer be SILENT: `awaitEdgeReady` returns the last not-ready response rather than
+// throwing (pinned above), so a warm that merely awaited it emitted nothing at all and the failure
+// surfaced later as a bare `expected 503 to be 200` inside the first asserting test (#3778).
+describe("WarmNotSettledError — the exhausted-warm diagnostic (#3778)", () => {
+	it("names the probe, the budget, and the last response's shape in a greppable message", () => {
+		const e = new WarmNotSettledError(
+			"/fate/live warm",
+			new Response("", {status: 503, headers: {"content-type": "application/json"}}),
+			60_000,
+		);
+		expect(e).toBeInstanceOf(Error);
+		expect(e.name).toBe("WarmNotSettledError");
+		expect(e._tag).toBe("WarmNotSettled");
+		expect(e.message).toContain("/fate/live warm");
+		expect(e.message).toContain("60000ms");
+		expect(e.message).toContain("503");
+		expect(e.message).toContain("application/json");
 	});
 });
 

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -39,6 +39,7 @@ import {isTransientDeployError} from "./_deploy-transient.ts";
 import {
 	awaitEdgeReady,
 	DEPLOY_HEALTH_DEADLINE_MS,
+	EDGE_READY_DEADLINE_MS,
 	edgeFetch,
 	HOOK_TIMEOUT_MS,
 	PER_FILE_HEALTH_DEADLINE_MS,
@@ -105,6 +106,33 @@ class ProbeError extends Schema.TaggedErrorClass<ProbeError>()(
 		cause: Schema.Defect(),
 	},
 ) {}
+
+/**
+ * A warm probe's readiness budget lapsed without the probe ever going ready.
+ *
+ * `awaitEdgeReady` only THROWS when its deadline lapses while still on the placeholder-404; when
+ * it lapses on a not-ready RESPONSE it RETURNS that response (the #1060 no-early-stop guarantee).
+ * So a warm that merely awaited it could not tell "warmed" from "gave up", and an exhausted budget
+ * emitted NOTHING — no throw, no `catchCause` warning below, nothing. The first asserting test then
+ * failed a further budget later on a bare `expected 503 to be 200`, several layers from the cause,
+ * with the 503's body already released — so the run's own artifact could not say whether the warm
+ * had been exhausted (#3778). Thrown here so an exhausted warm rides the SAME non-fatal warning the
+ * thrown placeholder-404 already does, naming the budget and the last response's shape. Deliberately
+ * NON-fatal, unlike `awaitWorkerReady`'s `WorkerNotReadyError`: every dedicated stage runs these
+ * warms, including the many files that never touch `/fate/live`, so a warm names itself — it does
+ * not red a stage whose own assertions may well pass.
+ */
+export class WarmNotSettledError extends Error {
+	readonly _tag = "WarmNotSettled";
+	constructor(probe: string, res: Response, budgetMs: number) {
+		super(
+			`${probe} never went ready within its ${budgetMs}ms readiness budget — last response was ` +
+				`${res.status} (content-type: ${res.headers.get("content-type") ?? "none"}). The first ` +
+				`asserting test on this stage is likely to fail on that same status.`,
+		);
+		this.name = "WarmNotSettledError";
+	}
+}
 
 // The deploy gates' `catch`: keep the already-tagged `WorkerNotReadyError` unwrapped so `orDie`
 // dies with the SAME greppable diagnostic the retired `Effect.promise` produced (#3146); wrap any
@@ -255,9 +283,14 @@ export const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
 						headers: {accept: "text/event-stream", cookie},
 					}),
 				liveWarmReady,
-				{pollMs: WARM_POLL_MS},
+				// The budget is named at the call site (not left to the default) so the exhaustion
+				// diagnostic below cites the number actually spent, never a drifted copy.
+				{pollMs: WARM_POLL_MS, deadlineMs: EDGE_READY_DEADLINE_MS},
 			);
 			await res.body?.cancel().catch(() => {});
+			if (!liveWarmReady(res)) {
+				throw new WarmNotSettledError("/fate/live warm", res, EDGE_READY_DEADLINE_MS);
+			}
 		},
 		catch: (cause) => new ProbeError({cause}),
 	}).pipe(
@@ -292,7 +325,7 @@ export const warmFateRead = (url: string): Effect.Effect<void, never, never> =>
 		try: async () => {
 			// A 200 means the route + D1 read served; a cold PoP placeholder-404 (the thrown edge
 			// transient) / a non-200 that hasn't ripened rides the shared readiness budget → retry.
-			await awaitEdgeReady(
+			const res = await awaitEdgeReady(
 				() =>
 					edgeFetch(`${url}/fate`, {
 						method: "POST",
@@ -303,8 +336,11 @@ export const warmFateRead = (url: string): Effect.Effect<void, never, never> =>
 						}),
 					}),
 				fateReadReady,
-				{pollMs: WARM_POLL_MS},
+				{pollMs: WARM_POLL_MS, deadlineMs: EDGE_READY_DEADLINE_MS},
 			);
+			if (!fateReadReady(res)) {
+				throw new WarmNotSettledError("POST /fate warm", res, EDGE_READY_DEADLINE_MS);
+			}
 		},
 		catch: (cause) => new ProbeError({cause}),
 	}).pipe(


### PR DESCRIPTION
Fixes #3778.

**This is a collapsed investigation (ADR 0070).** #3778 is a `type:investigation` whose deliverable is a diagnosis; the diagnosis is carried in full below so `review-code` can verify this diff against the named cause. One bounded piece of it — the acceptance criterion that an exhausted `warmLiveDO` must stop surfacing as a bare status assertion — clears the collapse gate and lands here. The rest (the actual budget sizing, which needs a decision this run could not make) is routed as residue, not shipped as a guess.

---

## The diagnosis

### Which assertion tripped, and what it means (AC 1)

The failing run is CI run `29899582279` **attempt 1**, job `88857256503` (PR #3772, head `89dc27d5af3e43289e92e5ac9d302025006ce02b`). Its log gives the answer directly:

```
× tests/integration/fate-live-posts.test.ts > ... > subscribe → post.submit → prependNode frame arrives on the held SSE stream  75665ms
  AssertionError: expected 503 to be 200 // Object.is equality
  ❯ tests/integration/fate-live-posts.test.ts:42:26
```

Line 42 is `expect(connect.status).toBe(200)` — the **`h.openSse` connect**, *not* the `liveControl` subscribe. The report's two candidates are resolved: it is the connect.

The 75.7s duration is the mechanism. `h.openSse` is `awaitEdgeReady(() => req(...), sseReady)` on the default `EDGE_READY_DEADLINE_MS` (60s). `awaitEdgeReady` **returns the last response** when its deadline lapses on a not-ready *response* — the #1060 no-early-stop guarantee, pinned in `apps/web/tests/integration/_edge-ready.unit.test.ts` ("a not-ready RESPONSE (a 503 cold-start envelope) rides the budget and returns the last response on deadline"). So the assertion did not observe a single unlucky 503: it observed the **last of ~40 polls across a fully exhausted 60s budget**, plus the final `req`'s own retry window.

**Whether `warmLiveDO`'s budget had been exhausted: not recoverable from the run's artifact, by construction — and that is itself the finding.** The run logged **zero** `[integration] /fate/live warmup did not settle` lines. That absence proves nothing, because the warning only fires when the warm's promise *rejects*; when `awaitEdgeReady` lapses on a not-ready *response* it returns normally, `warmLiveDO` ignored the result, and `Effect.catchCause` never fired. An exhausted live warm emitted **nothing at all**. (The `catchCause` path does work when it is reached — e.g. run `29709833422` logs the warning for a warm whose *auth* step drew a placeholder-404 — so this is specifically the exhausted-response path being silent, not a broken logger.) On the balance of evidence the warm almost certainly did exhaust: `h.openSse` polls the identical URL and got non-200 for a full 60s starting moments later. But "almost certainly" is not the answer an acceptance criterion should get, which is why this PR makes it a fact next time.

### The outcome: a harness cold-start budget issue (AC 2)

Of the three outcomes #3778 named — harness cold-start budget, tolerated known cold-start, or a real defect in the live-view SSE path — the evidence says **harness cold-start budget**. The decisive corroboration is a **second instance of the same test case with a different failure face**:

- Run `29726308270` attempt 1, same case, **65.7s**, failed at `fate-live-posts.test.ts:53:15` (the `h.liveControl` call) with `CloudflarePlaceholder404Error: cloudflare placeholder 404 at /fate/live (edge not propagated)`.

A Cloudflare edge-placeholder 404 is **not a worker response at all** — `isCloudflarePlaceholder404` identifies the CF "nothing here yet" page served by a PoP that has not yet propagated a freshly-deployed `*.workers.dev` route. So the same case, on the same kind of freshly-deployed dedicated stage, exhausted the same 60s budget on a condition that provably never reached `LiveDO`. The 503 and the placeholder-404 are two faces of one condition: **on a fresh per-file stage, `/fate/live` is not serving for materially longer than the 60s the harness allots it.**

That this is a general fresh-stage property, not a `/fate/live` quirk, is confirmed on a third route: run `29721425694` attempt 1 killed `fate-live-owner-fence` and `fate-live-scoped` at their `beforeAll` with `cloudflare placeholder 404 at /api/auth/sign-up/email (edge not propagated)`. And the repo has already measured this once — `PER_FILE_HEALTH_DEADLINE_MS` was raised 100s → 180s (#3409) precisely because `/api/health` propagation exceeded 100s under merge_group batch load.

The asymmetry that follows is the root cause of the flake: `apps/web/tests/integration/_fate-live-warmup.ts` states that the DO-backed `/fate/live` path propagates **separately and later** than `/api/health` (#1058) — yet `awaitWorkerReady` gets 180s while `warmLiveDO` and the in-test polls each get 60s. The later-propagating route has the smallest budget.

**Not a defect in the live-view SSE path.** Nothing in the evidence implicates `LiveDO`, the cold-start retry seam, or the fan-out: one instance never reached the worker at all, and in both instances the *second* test case in the same file passed within seconds of the first giving up.

### Would a real client see this? (AC 3)

**No — not on the observed mechanism.** The observed unavailability is fresh-`*.workers.dev`-hostname edge propagation, proven by the placeholder-404 face, which production does not have: production serves from a long-propagated route and a redeploy reuses it. A real client hitting a genuinely idle-evicted `LiveDO` gets the worker seam's bounded retry (~1.5s worst case, `apps/web/worker/features/fate-live/cold-start-retry.ts`), and if that exhausts, the graceful 503 `LIVE_UNAVAILABLE` envelope — which ADR 0095's client half retries (`apps/web/src/fate/liveRetry.ts`). So the product-facing answer is that this is confined to a freshly-deployed test stage.

One honest caveat, since it is the question with product impact and is easy to drop: the 503 face's *body* is unrecoverable (the test asserts status only and the body is released), so we cannot prove that particular 503 was the worker's `LIVE_UNAVAILABLE` envelope rather than an edge 503. It does not change the conclusion — the placeholder-404 instance settles the mechanism — but it is the second reason this PR makes the last response's shape part of the diagnostic. Reading `liveRetry.ts` for this question also surfaced a real product risk that is **not** this issue's: the client budget is 5 attempts over ~7.75s and is terminal for the session, so any live outage longer than ~8s silently kills live in that tab. Filed as #3790.

### Tolerance (AC 5)

Not applicable: the conclusion is not "tolerate", so no tolerance is added to the test. The test is asserting something true — `/fate/live` really was not serving — and weakening it would hide a real signal. No retry, no widened test timeout, and no `skip` is added here.

---

## What this PR changes (AC 4)

`apps/web/tests/integration/_integration.ts` — both deploy-time warm probes now **post-check their own `ready` predicate** against the response `awaitEdgeReady` returns, and throw a typed `WarmNotSettledError` into the existing non-fatal path. `awaitWorkerReady` already does exactly this (it post-checks `healthReady` and throws `WorkerNotReadyError`); the warms were the two that did not.

The result: an exhausted warm now logs a named, greppable diagnostic through the *existing* `Effect.catchCause` warning, carrying the budget it spent and the last response's **status + content-type** — the shape the status-only assertion discards. Each call site names its budget explicitly rather than relying on the default, so the diagnostic cannot cite a number it did not spend.

It stays **non-fatal on purpose**, which is a deliberate answer to AC 4 rather than an omission: every dedicated stage runs these warms, including the many files that never touch `/fate/live`, so hard-failing the shared gate on a route most files do not use would *widen* the flake surface. A warm names itself; it does not red a stage whose own assertions may well pass.

`apps/web/tests/integration/_edge-ready.unit.test.ts` — pins the diagnostic's message shape, mirroring the existing `WorkerNotReadyError` pin in the same file.

## What this PR deliberately does not change

The budget sizing — the actual fix for the flake — is **not** here, because it fails the collapse gate: it needs a decision, not a bigger number. Raising `warmLiveDO` to match the health probe's 180s runs into a second finding from this investigation: the per-file `beforeAll` worst case is already `deploy` + 180s + 60s + 60s, which exceeds the 300s `HOOK_TIMEOUT_MS` it is capped by — so widening naively re-opens #3146's opaque "Hook timed out" guillotine. Both findings, and a sketch of the shared-deadline shape that would resolve them, are routed as **#3788** for triage.

The sequencing is deliberate: with this PR landed, the next occurrence prints the budget it spent and the status it ended on, so #3788 gets measured evidence instead of the inference this investigation had to settle for.

## Verification

- `pnpm typecheck` — green (33/33).
- `pnpm lint` — green.
- `apps/web/tests/integration/_edge-ready.unit.test.ts` — 28 passed, including the new pin.
- The contract this change keys on (`awaitEdgeReady` returns the last not-ready response rather than throwing) is not asserted from intuition — it is already unit-pinned in that same file, and the two CI instances above are the behavioral evidence.

Residue filed: #3788 (readiness budgets + the hook-ceiling overrun), #3790 (the terminal client live-retry budget).
