### PR TITLE
chore(patterns): dedupe family-restated invariants to one owner + pointers (#3397)

### DIFF
--- a/.patterns/feature-flags-agent-workflow.md
+++ b/.patterns/feature-flags-agent-workflow.md
@@ -111,13 +111,13 @@ export const sozlukSearchDiscoveryFlag = (appId: Input<string>) =>
 	});
 ```
 
-Then yield it in `apps/web/alchemy.run.ts` with the resolved `appId`. The **default-=-safe-state
-invariant is load-bearing**: `defaultVariation: "off"` (IaC) and the safe read default (code, below)
-must agree, so a not-yet-flipped flag, a typo'd key, or a Flagship outage all degrade to the *old*
-path — never a half-shipped new one. Never invert this (a default-on flag defeats dark-ship — the
-feature is live the instant it merges). See
-[feature-flags-schema-lifecycle.md](./feature-flags-schema-lifecycle.md) for the full naming,
-type-discipline, and metadata rules.
+Then yield it in `apps/web/alchemy.run.ts` with the resolved `appId`. The
+**default-=-safe-state invariant** applies here: `defaultVariation: "off"` (IaC) and the safe read
+default (code, below) must agree, so the flag ships dark. Why that's load-bearing — how a
+not-yet-flipped flag, a typo'd key, or a Flagship outage all degrade to the *old* path, and why you
+never invert it — is owned by
+[feature-flags-schema-lifecycle.md](./feature-flags-schema-lifecycle.md#default-safe-invariant),
+alongside the full naming, type-discipline, and metadata rules.
 
 ### Step 2 — Gate the new code path behind the flag
 

--- a/.patterns/feature-flags-schema-lifecycle.md
+++ b/.patterns/feature-flags-schema-lifecycle.md
@@ -86,7 +86,7 @@ type to the flag's job:
 - **One flag, one decision.** A flag answers a single yes/no or single-variant question. If you're
   tempted to pack two unrelated toggles into one flag, that's two flags.
 
-## The default-=-safe-state invariant (load-bearing)
+## The default-=-safe-state invariant (load-bearing) {#default-safe-invariant}
 
 **Every flag's default is the off / old / safe path.** This is the contract that makes the whole
 system safe to operate, and it is enforced in two places that must agree:

--- a/.patterns/telemetry.md
+++ b/.patterns/telemetry.md
@@ -182,14 +182,13 @@ yield* telemetry.emit({
 ```
 
 > **The seam uses `ignoreCause` so callers don't have to.** The `ignore` vs `ignoreCause`
-> distinction still matters — it's just resolved **once, at the seam**, not at every call-site.
-> `Effect.ignore` discards only the **error (`E`) channel**, so a *defect* (a `die`, a thrown
-> bug in the emit path) would propagate and unwind the mutation; `Effect.ignoreCause` discards
-> the **whole `Cause`** — error **and** defect — so even a broken emit can never fail or slow the
-> mutation. `TelemetryLive` uses `Effect.ignoreCause` internally (see [The one invariant](#the-one-invariant-telemetry-can-never-fail-the-mutation-it-observes-s4)),
-> which makes `emit: Effect<void>` genuinely unfailable-and-undyable for **every** instrument by
-> construction — so a per-call-site wrap is redundant and instruments emit bare (#2085). Don't
-> re-add a call-site `ignoreCause`: it duplicates a guarantee the seam already gives.
+> distinction still matters — it's just resolved **once, at the seam**, not at every call-site (why
+> the whole-`Cause` discard, defects included, is the load-bearing choice is
+> [The one invariant](#the-one-invariant-telemetry-can-never-fail-the-mutation-it-observes-s4)).
+> Because `TelemetryLive` discharges it internally, `emit: Effect<void>` is genuinely
+> unfailable-and-undyable for **every** instrument by construction — so a per-call-site wrap is
+> redundant and instruments emit bare (#2085). Don't re-add a call-site `ignoreCause`: it
+> duplicates a guarantee the seam already gives.
 
 **5. Discharge the `Telemetry` layer requirement at `makeFateLayer`.** Emitting gives the
 feature's `*Live` a build-time `Telemetry` requirement. Discharge it with `Layer.provide` at the


### PR DESCRIPTION
Closes #3397

## Class G — Family-invariant dedupe

Where a shared invariant is re-stated across a doc family, state it **once** canonically and point the rest at it (founder-approved on #3375, Wave 3G). Out of scope: changing the invariants themselves.

The #3375 audit flagged four family-restated invariants. Two were re-verified as **already** canonical + pointer-based and needed no change; two carried a genuine remaining re-derivation, now collapsed.

### Consolidated

**1. `feature-flags` family — the default-=-safe-state invariant.**
- Canonical owner: `feature-flags-schema-lifecycle.md` §"The default-=-safe-state invariant (load-bearing)". Added an explicit `{#default-safe-invariant}` anchor so pointers are durable.
- `feature-flags-agent-workflow.md` (Step 1) previously **re-derived** the mechanics (a not-yet-flipped flag / typo'd key / Flagship outage all degrade to the old path; never invert it) and only linked to the naming/type/metadata rules. Collapsed the re-derivation to a precise pointer at the canonical anchor; kept the local instruction (the two defaults must agree, so the flag ships dark).
- `feature-flags.md` §"The one invariant" is the entry-doc summary and already defers "the full rationale" to schema-lifecycle — left as-is (correct summary-plus-pointer shape).

**2. `telemetry.md` — the `ignore` vs `ignoreCause` mechanics (S4).**
- Canonical owner: §"The one invariant: telemetry can never fail the mutation it observes (S4)" (lines ~48-56) fully derives why `ignoreCause` discards the whole `Cause` (defects included) whereas `ignore` only discards the typed `E`.
- The recipe blockquote ("The seam uses `ignoreCause` so callers don't have to") **re-derived** those same mechanics a second time while already linking back to the invariant section. Collapsed the duplicated mechanics to that pointer; kept the local conclusion (emit bare, don't re-add a call-site wrap, #2085).

### Already canonical — no change (re-verified)
- **one-request-per-screen**: owned by `fate-views-and-requests.md` §"Requests — one per screen"; `fate-page-queries.md` / `fate-client-setup.md` already point at it with anchors. The `fate-async-react.md` mentions are contextual premises (the no-waterfall argument), not re-derivations, and already carry a See-also pointer.
- **the fanned-mutation publish (invalidation) invariant**: owned by `fate-live-consistency.md` §"The invalidation invariant" `{#invalidation-invariant}`; `fate-live-publishing.md` / `fate-live-views.md` / `index.md` all point at it (Wave 3B split + existing cross-links).

Touching either of those would only risk **weakening** meaning, which the acceptance forbids.

## No invariant dropped or weakened (load-bearing constraint)
Every removed sentence's content lives verbatim-in-substance in the canonical section the new pointer targets. Only redundancy was removed; the agent-workflow pointer is now strictly better (it targets the invariant anchor, not just the naming rules).

## §CP verdict — per touched path
Re-checked with `pipeline-cli control-plane-paths`:
- `.patterns/feature-flags-agent-workflow.md` — **NON-§CP**
- `.patterns/feature-flags-schema-lifecycle.md` — **NON-§CP**
- `.patterns/telemetry.md` — **NON-§CP**

No `.claude/**`, `.github/**`, `skills/**`, `packages/pipeline-cli/`, `packages/ci-required/`, or `gh-issue-intake-formats.md` surface touched. `index.md` deliberately left untouched (Wave 3E / sibling-PR conflict avoidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)