### PR TITLE
fix(ui): floor the Button primitive at the 36px tap target (#3791)

### DIFF
--- a/apps/web/src/admin/email-delivery/EmailDeliveryPanel.css
+++ b/apps/web/src/admin/email-delivery/EmailDeliveryPanel.css
@@ -42,12 +42,6 @@
 	resize: vertical;
 }
 
-/* Design law pillar 4: the 36px minimum hit area, from the --tap-min floor token. */
-.kp-email-delivery__btn {
-	min-height: var(--tap-min);
-	min-width: var(--tap-min);
-}
-
 .kp-email-delivery__table {
 	width: 100%;
 	border-collapse: collapse;

--- a/apps/web/src/admin/email-delivery/EmailDeliveryPanel.tsx
+++ b/apps/web/src/admin/email-delivery/EmailDeliveryPanel.tsx
@@ -151,7 +151,6 @@ function MarkForm({
 				size="sm"
 				type="submit"
 				disabled={busy}
-				className="kp-email-delivery__btn"
 				data-testid="email-delivery-mark-button"
 			>
 				{busy ? "işaretleniyor…" : "işaretle"}
@@ -240,7 +239,6 @@ function FailingRow({
 						size="sm"
 						onClick={onClear}
 						disabled={busy}
-						className="kp-email-delivery__btn"
 						data-testid={`email-delivery-clear-${data.id}`}
 					>
 						{busy ? "temizleniyor…" : "temizle"}

--- a/apps/web/src/admin/flags/FlagsPanel.css
+++ b/apps/web/src/admin/flags/FlagsPanel.css
@@ -67,12 +67,6 @@
 	gap: var(--s-1);
 }
 
-/* Design law pillar 4: the 36px minimum hit area, from the --tap-min floor token. */
-.kp-flags__btn {
-	min-height: var(--tap-min);
-	min-width: var(--tap-min);
-}
-
 .kp-flags__message {
 	color: var(--text-primary);
 	font: var(--t-body-sm);

--- a/apps/web/src/admin/flags/FlagsPanel.tsx
+++ b/apps/web/src/admin/flags/FlagsPanel.tsx
@@ -9,9 +9,10 @@
  * natively on the next read. The effect is per-browser only. Render decisions live DOM-free in
  * `flag-overrides.ts` (unit-tested); this is the thin shell. Lowercase-Turkish copy per the design law.
  *
- * a11y: a labelled region; each flag is a `role="group"`; the toggles are shared `Button`s (36px hit
- * area, focus ring, role tokens) with `aria-pressed` marking the active state; the outcome is text in
- * a `role="status"` live region, never color.
+ * a11y: a labelled region; each flag is a `role="group"`; the toggles are shared `Button`s — the
+ * 36px hit-area floor + focus ring come from the shared `.kp-btn` styles (`min-height`/`min-width:
+ * var(--tap-min)`, #3791), with `aria-pressed` marking the active state; the outcome is text in a
+ * `role="status"` live region, never color.
  */
 import {useState} from "react";
 import {Button} from "../../components/ui/Button";
@@ -79,7 +80,6 @@ export default function FlagsPanel() {
 									{TOGGLE_STATES.map((state) => (
 										<Button
 											key={state}
-											className="kp-flags__btn"
 											size="sm"
 											pressed={current === state}
 											onClick={() => toggle(flag.key, state)}

--- a/apps/web/src/admin/kullanicilar/KullanicilarPanel.css
+++ b/apps/web/src/admin/kullanicilar/KullanicilarPanel.css
@@ -37,12 +37,6 @@
 	font: var(--t-body-sm);
 }
 
-/* Design law pillar 4: the 36px minimum hit area, from the --tap-min floor token. */
-.kp-kullanicilar__btn {
-	min-height: var(--tap-min);
-	min-width: var(--tap-min);
-}
-
 .kp-kullanicilar__table {
 	width: 100%;
 	border-collapse: collapse;
@@ -82,17 +76,13 @@
 }
 
 /* Per-row role-assign affordance (#3523). Text-only status (design law pillar 4: state as
-   words, never color); the Button primitive carries the 36px hit-area + focus ring. */
+   words, never color); the Button primitive carries the 36px hit-area floor + focus ring
+   from the shared styles (Button.css `.kp-btn` min-height/min-width: var(--tap-min), #3791). */
 .kp-role {
 	display: flex;
 	flex-direction: column;
 	gap: var(--s-1);
 	align-items: flex-start;
-}
-
-.kp-role__btn {
-	min-height: var(--tap-min);
-	min-width: var(--tap-min);
 }
 
 .kp-role__message {

--- a/apps/web/src/admin/kullanicilar/KullanicilarPanel.tsx
+++ b/apps/web/src/admin/kullanicilar/KullanicilarPanel.tsx
@@ -85,7 +85,6 @@ function KullanicilarRoster() {
 					variant="secondary"
 					size="sm"
 					type="submit"
-					className="kp-kullanicilar__btn"
 					data-testid="kullanicilar-search-button"
 				>
 					ara

--- a/apps/web/src/admin/kullanicilar/RoleControls.tsx
+++ b/apps/web/src/admin/kullanicilar/RoleControls.tsx
@@ -15,7 +15,8 @@
  * re-joined server-side; a `RoleState` write does not update the `UserAdmin` entity in the
  * client store). Render decisions are DOM-free in `role-controls.ts` (unit-tested).
  *
- * a11y: the `Button` primitive (focus ring + 36px hit area from the shared styles); the
+ * a11y: the `Button` primitive carries the focus ring + the 36px hit-area floor from the
+ * shared styles (`.kp-btn` now floors `min-height`/`min-width` at `--tap-min`, #3791); the
  * outcome is a `role="status" aria-live="polite"` text region (state as words, never
  * color); copy is lowercase Turkish.
  */
@@ -70,7 +71,6 @@ export function RoleControls({userId, platformRole, onRoleChanged}: RoleControls
 			<Button
 				variant="secondary"
 				size="sm"
-				className="kp-role__btn"
 				onClick={onToggle}
 				disabled={busy}
 				data-testid={`role-toggle-${userId}`}

--- a/apps/web/src/components/ui/Button.css
+++ b/apps/web/src/components/ui/Button.css
@@ -6,6 +6,13 @@
 	align-items: center;
 	justify-content: center;
 	gap: 6px;
+	/* Tap-target floor (ADR 0162 pillar 4): the primitive owns the ≥36px hit area in
+	   both axes, so every consumer clears it without opting in — call sites no longer
+	   re-declare a per-instance --tap-min floor. min-height decouples the hit area from
+	   the glyph: the smaller --sm font shrinks the type, not the target, and the
+	   flex-centering above fills the box. This is the single floor. */
+	min-height: var(--tap-min);
+	min-width: var(--tap-min);
 	padding: 5px var(--s-3);
 	font: var(--t-body-sm);
 	font-weight: 500;


### PR DESCRIPTION
## What

Give the shared `Button` primitive a real tap-target floor. `.kp-btn` set no `min-height`/`min-width` and never referenced `--tap-min`, so it rendered ~30.8px (13×1.45 + 5+5 + 1+1) against the design law's 36px minimum (ADR 0162 pillar 4) — dragging every consumer under the floor.

## Approach — the primitive owns the floor (single source)

Acceptance criterion 1 offered two directions; I took the one the intent trail already assumed (three consumer comments claimed the primitive carried the 36px hit area):

- **`.kp-btn` floors itself** at `min-height`/`min-width: var(--tap-min)` in `apps/web/src/components/ui/Button.css`. Now no `Button` consumer renders below a 36px effective hit area.
- **`--sm` decouples glyph from hit area** (criterion 2): the base floor holds regardless of variant, so the smaller `--t-meta` glyph shrinks the type, not the target — flex-centering fills the box. No size-variant exception to the "never fall below" prohibition.
- **Consumer sweep + reconciliation** (criterion 3): the now-redundant per-call-site `--tap-min` floors on `Button` primitives are **removed** (single source, not left contradictory) along with their dead `className` hooks — `kp-kullanicilar__btn`, `kp-role__btn`, `kp-flags__btn`, `kp-email-delivery__btn`. Non-`Button` floors are correctly **kept**: the Topbar nav links (`<a>`), the segmented `ToggleGroup` toggles (Base UI Toggle), the `BildirimPopover` bell trigger (button-reset), and the input floors — none are `.kp-btn`, so the primitive change doesn't touch them. No visual breakage: Topbar renders no `Button` primitive and `--topbar-h` (38–56px) already exceeds 36px.
- **Three false comments corrected** (criterion 4): `RoleControls.tsx`, `KullanicilarPanel.css`, `FlagsPanel.tsx` — they claimed the primitive already carried the 36px hit area (false at filing); now true and attributed to `.kp-btn`'s floor.

## Out of scope (routed, not graded)

Promoting the `tap-target` a11y posture `warning → enforced` in a real-browser (Playwright) pass — worth its own filing so the floor stops being unmeasurable in the jsdom unit tier.

## Verification

- `pnpm typecheck` — 30/30 pass
- `pnpm lint` — clean (8 files)

Fixes #3791