### PR TITLE
fix(sozluk): surface a Turkish field error for an unslugifiable "yeni tanım" term (#3789)

### DIFF
--- a/apps/web/src/components/sozluk/SozlukSubnavCta.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavCta.tsx
@@ -3,7 +3,7 @@ import {useNavigate} from "react-router";
 import {slugifyTerm} from "../../lib/slugifyTerm";
 import {Button} from "../ui/Button";
 import {Dialog} from "../ui/Dialog";
-import {Field, Form, Input, Label} from "../ui/Form";
+import {Field, FieldError, Form, Input, Label} from "../ui/Form";
 
 /**
  * sözlük's contextual create CTA — the `+ yeni tanım` promoted verb in its Subnav
@@ -22,13 +22,10 @@ export function SozlukSubnavCta() {
 	const navigate = useNavigate();
 	function onSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();
-		const term = String(new FormData(e.currentTarget).get("term") ?? "");
-		const slug = slugifyTerm(term);
-		// Dismiss ONLY once the submit has somewhere to go. `required` does not keep an
-		// unusable term out of here — base-ui's `Form` renders `noValidate` and gates on
-		// its own field validity, which a non-empty term of pure punctuation passes even
-		// though it slugifies to nothing. Closing before this guard swallowed the create
-		// silently: the dialog vanished, nothing navigated, nothing was said (#3746).
+		// `validateTerm` (below) blocks the base-ui submit while the term is unslugifiable,
+		// so a term that reaches here always yields a slug; the guard is the last-resort no-op
+		// that never navigates to an empty slug (#3746 dismiss, #3789 no-op).
+		const slug = slugifyTerm(String(new FormData(e.currentTarget).get("term") ?? ""));
 		if (!slug) return;
 		setOpen(false);
 		navigate(`/sozluk/${slug}`);
@@ -46,9 +43,10 @@ export function SozlukSubnavCta() {
 				<Dialog.Head title="Yeni tanım" description="oluşturmak istediğin terimi yaz." />
 				<Dialog.Body>
 					<Form onSubmit={onSubmit}>
-						<Field name="term">
+						<Field name="term" validate={validateTerm}>
 							<Label>Terim</Label>
 							<Input name="term" required autoFocus placeholder="terim…" />
+							<FieldError match="customError">{UNSLUGIFIABLE_TERM_MESSAGE}</FieldError>
 						</Field>
 						<Dialog.Foot>
 							<Dialog.Close render={<Button variant="tertiary">vazgeç</Button>} />
@@ -61,6 +59,20 @@ export function SozlukSubnavCta() {
 			</Dialog.Popup>
 		</Dialog.Root>
 	);
+}
+
+// A punctuation-only term (e.g. "!!!") is a non-empty value `required` accepts but that
+// `slugifyTerm` reduces to "" — the composer is slug-addressed, so it has nowhere to go.
+// Surfacing it as a field error (base-ui blocks the submit + flags `customError`) replaces the
+// silent no-op the bare `if (!slug) return` guard left behind (#3789). Empty is left to
+// `required`; only the non-empty-but-unslugifiable term errors here. Turkish copy, per the
+// user-facing sözlük surface (.glossary/LANGUAGE.md).
+const UNSLUGIFIABLE_TERM_MESSAGE = "Terim en az bir harf ya da rakam içermeli.";
+
+function validateTerm(value: unknown): string | null {
+	const term = String(value ?? "");
+	if (!term.trim()) return null;
+	return slugifyTerm(term) ? null : UNSLUGIFIABLE_TERM_MESSAGE;
 }
 
 function PlusGlyph() {

--- a/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
@@ -109,6 +109,24 @@ describe("SozlukSubnavLayout — sözlük product Subnav zone through SubnavShel
 		expect(screen.getByTestId("term-leaf").textContent).toContain("term:mevcut-terim");
 	});
 
+	/**
+	 * #3789: an unslugifiable term is no longer a silent no-op — it surfaces a Turkish field
+	 * error through the existing Field/FieldError affordance, so the user learns why `oluştur`
+	 * did nothing instead of only being able to `vazgeç`.
+	 */
+	it("surfaces a Turkish field error when the term slugifies to nothing — not a silent no-op", async () => {
+		renderZone("/sozluk/mevcut-terim");
+		fireEvent.click(screen.getByRole("button", {name: /yeni tanım/i}));
+		const field = await screen.findByLabelText("Terim");
+		fireEvent.change(field, {target: {value: "!!!"}});
+		const form = field.closest("form");
+		if (!form) throw new Error("the create field is not inside a form");
+		fireEvent.submit(form);
+		expect(await screen.findByText("Terim en az bir harf ya da rakam içermeli.")).toBeTruthy();
+		// still no navigation — the dialog stays put on the unusable term
+		expect(screen.getByTestId("term-leaf").textContent).toContain("term:mevcut-terim");
+	});
+
 	it("keeps the create dialog open when the typed term is lost before submit", async () => {
 		renderZone("/sozluk/mevcut-terim");
 		fireEvent.click(screen.getByRole("button", {name: /yeni tanım/i}));


### PR DESCRIPTION
Typing a term the slugifier can't represent (like `!!!`) into sözlük's "Yeni tanım" dialog used to do nothing when you pressed `oluştur` — no error, no hint, and the only way out was `vazgeç`. Now the dialog tells you why, in Turkish, through the same field-error affordance the rest of the app already uses. The submit is blocked and the field shows "Terim en az bir harf ya da rakam içermeli." until you type something that can become a slug.

## What changed

- `apps/web/src/components/sozluk/SozlukSubnavCta.tsx` — the "term" `Field` now runs a `validateTerm` check through base-ui's `Field.validate`. A non-empty term that `slugifyTerm` reduces to `""` flags `customError`, which base-ui uses to block the submit and drive the existing `<FieldError match="customError">`. The `if (!slug) return` guard stays as a last-resort no-navigate.
- Reuses the existing Field / Input / FieldError design-system surface (`components/ui/Form.tsx`) — no bespoke pattern. The error text uses the meaning-carrying `--danger` color (AA-compliant), not a decorative hint token. Empty input is still left to native `required`; only the non-empty-but-unslugifiable case errors here.
- `apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx` — a unit test for the `!!!`-class input next to the existing guard coverage, asserting the Turkish error surfaces and no navigation happens.

## Acceptance criteria

1. Unslugifiable term produces user-visible signal via the existing Field/validation affordance — done (`FieldError` on submit, driven by `Field.validate`).
2. Copy is Turkish — "Terim en az bir harf ya da rakam içermeli."
3. Unit coverage for the `!!!`-class input next to the existing guard tests — added.

The design manifest has no dedicated form-error recipe, but the `Field`/`FieldError` component family (used by `PanoCreateDialog`) is the prescribed field/validation surface — no gap to file.

Fixes #3789
