### PR TITLE
fix(fate-live): re-arm the exhausted live-reconnect budget instead of dying silently (#3790)

### DIFF
--- a/apps/web/src/fate/FateProvider.tsx
+++ b/apps/web/src/fate/FateProvider.tsx
@@ -63,6 +63,26 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 		return () => controller?.cancel();
 	}, [userId]);
 
+	// Re-arm the exhausted budget when the browser signals the live plane may be reachable
+	// again — a regained network (`online`) or a foregrounded tab (`visibilitychange`, the
+	// laptop sleep/wake case). Without this the budget is terminal for the session once its
+	// ~7.75s back-off span is spent, leaving the tab silently non-live until reload (#3790).
+	// `rearm` no-ops unless the budget is actually spent, so firing it on every visibility
+	// flip is cheap. Authenticated only — the pin never opens for an anon client.
+	useEffect(() => {
+		if (userId == null) return;
+		const rearm = () => controllerRef.current?.rearm(() => setRetryTick((tick) => tick + 1));
+		const onVisible = () => {
+			if (document.visibilityState === "visible") rearm();
+		};
+		window.addEventListener("online", rearm);
+		document.addEventListener("visibilitychange", onVisible);
+		return () => {
+			window.removeEventListener("online", rearm);
+			document.removeEventListener("visibilitychange", onVisible);
+		};
+	}, [userId]);
+
 	// Identity-change teardown (#2321): when the resolved identity changes — a switch A→B
 	// or a sign-out/account-deletion A→anon (all reduce to the same transition) — drop the
 	// PREVIOUS identity's persisted snapshot, so its private myVote/isSaved overlay never

--- a/apps/web/src/fate/liveRetry.ts
+++ b/apps/web/src/fate/liveRetry.ts
@@ -15,7 +15,14 @@
  * delivery shapes of the same server signal are covered.
  */
 
-/** Bounded retry budget — past this the pin stops re-attempting for the session. */
+/**
+ * Bounded retry budget for ONE connectivity window. Past this the pin stops the
+ * exponential back-off — but the exhausted budget is no longer terminal for the
+ * session: it re-arms on regained connectivity / a foregrounded tab (`rearm`, driven
+ * from `online`/`visibilitychange` in `FateProvider`), so an outage longer than the
+ * ~7.75s back-off span (a deploy window, a laptop sleep/wake) recovers without a reload
+ * (#3790). Sizing the budget itself is a separate question (out of scope, #3788).
+ */
 export const LIVE_RETRY_MAX_ATTEMPTS = 5;
 
 const LIVE_RETRY_BASE_MS = 250;
@@ -57,6 +64,15 @@ export interface LiveRetryController {
 	 * already pending, or once the budget is spent, is a no-op.
 	 */
 	readonly schedule: (fireRetry: () => void) => void;
+	/**
+	 * Re-arm a SPENT budget and reconnect immediately — the recovery path out of the
+	 * terminal-and-silent exhausted state (#3790). Driven from `online`/`visibilitychange`
+	 * (a regained network, or a foregrounded tab after sleep/wake): if the budget is spent,
+	 * restore it and fire the reconnect NOW; a fresh failure re-enters the normal back-off
+	 * from attempt 0. A no-op while attempts remain — the in-flight back-off already owns
+	 * recovery, and re-arming mid-window would reset its progress on every benign tab focus.
+	 */
+	readonly rearm: (fireRetry: () => void) => void;
 	/** Cancel a pending retry without firing it (unmount). */
 	readonly cancel: () => void;
 	/** Restore the full budget and drop any pending retry (new session identity). */
@@ -105,6 +121,14 @@ export function createLiveRetryController(
 				pending = null;
 				fireRetry();
 			}, delay);
+		},
+		rearm: (fireRetry) => {
+			// Only re-arm a spent budget; while attempts remain the pending back-off owns
+			// recovery. `drop()` is defensive — a spent budget holds no pending timer.
+			if (attempt < LIVE_RETRY_MAX_ATTEMPTS) return;
+			drop();
+			attempt = 0;
+			fireRetry();
 		},
 		cancel: drop,
 		reset: () => {

--- a/apps/web/src/fate/liveRetry.unit.test.ts
+++ b/apps/web/src/fate/liveRetry.unit.test.ts
@@ -149,6 +149,53 @@ describe("createLiveRetryController", () => {
 		expect(fire).not.toHaveBeenCalled();
 	});
 
+	it("rearm() restores a spent budget and reconnects immediately (regained connectivity/foreground)", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		// Spend the whole budget — the exhausted, once-terminal state (#3790).
+		for (let round = 0; round < LIVE_RETRY_MAX_ATTEMPTS; round++) {
+			controller.schedule(fire);
+			vi.advanceTimersByTime(nextLiveRetryDelayMs(round));
+		}
+		controller.schedule(fire); // spent → no-op
+		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS);
+		expect(vi.getTimerCount()).toBe(0);
+
+		// An `online`/`visibilitychange` re-arm: the reconnect fires NOW on a fresh budget.
+		controller.rearm(fire);
+		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS + 1);
+
+		// The fresh budget is full again — LIVE_RETRY_MAX_ATTEMPTS more back-off attempts.
+		for (let round = 0; round < LIVE_RETRY_MAX_ATTEMPTS; round++) {
+			controller.schedule(fire);
+			vi.advanceTimersByTime(nextLiveRetryDelayMs(round));
+		}
+		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS + 1 + LIVE_RETRY_MAX_ATTEMPTS);
+	});
+
+	it("rearm() is a no-op while attempts remain (in-flight back-off owns recovery)", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		controller.schedule(fire); // attempt 0 armed, a pending timer
+		expect(vi.getTimerCount()).toBe(1);
+		controller.rearm(fire); // budget not spent → no-op, does not disturb the back-off
+		expect(fire).not.toHaveBeenCalled();
+		expect(vi.getTimerCount()).toBe(1);
+		vi.advanceTimersByTime(nextLiveRetryDelayMs(0));
+		expect(fire).toHaveBeenCalledTimes(1);
+	});
+
+	it("rearm() on a fresh controller (nothing failed) is a no-op", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		controller.rearm(fire);
+		expect(fire).not.toHaveBeenCalled();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
 	it("cancel() drops a pending retry without firing it (unmount)", () => {
 		const controller = createLiveRetryController();
 		const fire = vi.fn();

--- a/ops/runbook-live-plane-degraded.md
+++ b/ops/runbook-live-plane-degraded.md
@@ -74,9 +74,13 @@ instance was cold or briefly unreachable and the bounded cold-start retry (~1.5s
 was exhausted, so the route returned the graceful 503
 ([`cold-start-retry.ts`](../apps/web/worker/features/fate-live/cold-start-retry.ts)). A
 *transient* burst around a deploy or an idle-eviction warm-up is **expected** and self-heals —
-the live pin re-opens on the next mount. Escalate only when 503s are **sustained** (not
-clearing as clients remount) or you see raw **500s** from `/fate/live` (an unhandled defect,
-outside the graceful path).
+the client's bounded reconnect budget (~7.75s of back-off) re-opens the stream on the next
+mount. An outage **longer** than that budget spends it, but no longer terminally: the client
+re-arms the budget and reconnects on regained connectivity (`online`) or a foregrounded tab
+(`visibilitychange` — the laptop sleep/wake case), so a spent-budget client recovers without a
+reload once the plane is reachable again ([`liveRetry.ts`](../apps/web/src/fate/liveRetry.ts),
+#3790). Escalate only when 503s are **sustained** (not clearing as clients remount/re-arm) or
+you see raw **500s** from `/fate/live` (an unhandled defect, outside the graceful path).
 
 **Stale views without 503s** is the fan-out channel — the stream is up but a publish never
 reached it. Rank the candidates:
@@ -129,9 +133,13 @@ runbook lie:
   the running worker, which recreates the isolate and its `LiveDO` bindings and clears any
   wedged warm state. This is the one blunt operational lever for a genuinely stuck transport
   channel (sustained 503s not clearing on remount).
-- **Let the live pin re-open.** By design the client re-opens the whole connect on the next
-  session mount, so a **client refresh** re-establishes a stream that hit a transient 503. For
-  a transient warm-up burst this is the *only* action needed — no operator lever at all.
+- **Let the live pin re-open / re-arm.** By design the client re-opens the whole connect on
+  the next session mount, so a **client refresh** re-establishes a stream that hit a transient
+  503. For an outage that outlasts the client's ~7.75s reconnect budget, the client re-arms and
+  reconnects on its own when connectivity returns (`online`) or the tab is foregrounded
+  (`visibilitychange`) — so a **redeploy does help spent-budget clients**: they re-arm as the
+  plane comes back, rather than staying dark until reload ([`liveRetry.ts`](../apps/web/src/fate/liveRetry.ts),
+  #3790). For a transient warm-up burst no operator lever is needed at all.
 
 **Levers that do not exist yet — state this plainly, do not improvise.** There is **no**
 per-`LiveDO`-instance restart, **no** live-plane feature flag or kill-switch, **no** fan-out


### PR DESCRIPTION
Closes #3790

## Problem

The SPA's live-reconnect budget was **terminal-and-silent**. `LIVE_RETRY_MAX_ATTEMPTS = 5`
gives ~7.75s of exponential back-off, after which `schedule()` is a bare no-op and only
`reset()` — called on a *new session identity* — restores the budget. There is no timer, no
`online`/`visibilitychange` re-arm. So any live-plane loss longer than ~8s (a deploy window, a
colo hiccup, an ordinary laptop sleep/wake) leaves that tab silently non-live until reload,
while reads and navigation keep working and the page looks healthy. This quietly re-creates the
exact #1418 outcome ADR 0095's retry narrowed but did not remove.

## Fix — recoverable-quietly (the stronger UX per the issue)

Make the exhausted state recover on its own, with no bespoke UI:

- **`apps/web/src/fate/liveRetry.ts`** — new `rearm(fireRetry)` on the controller. When the
  budget is spent, it restores the full budget and fires a reconnect **immediately**; a fresh
  failure then re-enters the normal back-off from attempt 0. It **no-ops while attempts remain**
  so an in-flight back-off owns its own recovery and a benign tab focus never resets mid-window.
- **`apps/web/src/fate/FateProvider.tsx`** — `online` and `visibilitychange` listeners
  (authenticated only — the pin never opens for an anon client) drive `rearm`. A regained
  network, or a foregrounded tab after sleep/wake, re-arms the spent budget and reconnects.
- **`apps/web/src/fate/liveRetry.unit.test.ts`** — regression coverage for the
  exhausted→re-armed transition at the controller level: re-arm restores a spent budget and
  reconnects immediately, re-arm is a no-op while attempts remain, re-arm on a fresh controller
  is a no-op.
- **`ops/runbook-live-plane-degraded.md`** — aligned with the shipped behavior: a spent-budget
  client now re-arms on connectivity/foreground, so its "let the live pin re-open" claim is true
  and a redeploy actually helps spent-budget clients rather than leaving them dark until reload.

## Scope

- Sizing the 5-attempt/back-off budget itself is **out of scope** (issue AC 4; that is #3788's
  neighborhood) — only the terminal behavior is changed here.
- No mutation is touched, so no fanout-guard classification is affected.

## Acceptance criteria

1. ✅ A live-plane loss >8s is no longer terminal-and-silent — the budget re-arms on
   `online`/`visibilitychange` and reconnects.
2. ✅ Runbook aligned with the shipped behavior.
3. ✅ Regression coverage for the exhausted→re-armed transition at the controller level (3 new
   controller tests; 18/18 pass).
4. ✅ Budget sizing left untouched.

## Verification

- `pnpm --filter @kampus/web exec vitest run --project unit src/fate/liveRetry.unit.test.ts` — 18/18 pass.
- `pnpm typecheck` — 30/30.
- `pnpm lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
