### PR TITLE
fix(crew-mcp): reach the release verb from the engine + document the two-key lane (#3796)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
@@ -89,6 +89,35 @@ describe("crew/channel-server — announce, discover, claim/collision-check (AC 
 		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
 	);
 
+	it.effect(
+		"a channel can release its own claim, freeing the resource for another (#3796 facet 2)",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				const tracker = CrewTracker.fromClient(client);
+				const [roleA, roleB] = [CREW_ROLES[0], CREW_ROLES[1]];
+
+				const a = yield* makeCrewChannel({role: roleA, address: "inbox://a"}).pipe(
+					Effect.provide(channelLayers(tracker, "inbox://a", alwaysUnreachable)),
+				);
+				const b = yield* makeCrewChannel({role: roleB, address: "inbox://b"}).pipe(
+					Effect.provide(channelLayers(tracker, "inbox://b", alwaysUnreachable)),
+				);
+
+				// A claims, so B collides while A holds it
+				assert.isTrue((yield* a.claim("issue-3059")).granted);
+				assert.isTrue((yield* b.claim("issue-3059")).collision, "B blocked while A holds it");
+
+				// A releases through the channel — the release verb is now reachable at the channel edge
+				yield* a.release("issue-3059");
+
+				// B can now claim the freed resource
+				const bAfter = yield* b.claim("issue-3059");
+				assert.isTrue(bAfter.granted, "the released resource is claimable by the next channel");
+				assert.strictEqual(bAfter.owner, "inbox://b");
+			}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
 	it.effect("an intake ping reaches the receiver's edge channel + returns its inbox-ack", () =>
 		Effect.gen(function* () {
 			const client = yield* RpcTest.makeClient(TrackerRegistry);

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.ts
@@ -73,6 +73,12 @@ export interface CrewChannel {
 	readonly discover: (role: CrewRole) => Effect.Effect<ReadonlyArray<RolePresence>>;
 	/** A claim/collision-check on a resource (e.g. an issue) — the typed granted/collision reply. */
 	readonly claim: (resource: string) => Effect.Effect<ClaimReply>;
+	/**
+	 * Free a resource claim this session holds — the claim's counterpart (ADR 0191 facet 3). Carried
+	 * here so the release verb reaches the engine toolset (#3796 facet 2): holder-guarded + idempotent
+	 * at the tracker, so releasing a claim you don't hold is a safe no-op.
+	 */
+	readonly release: (resource: string) => Effect.Effect<void>;
 }
 
 /**
@@ -109,6 +115,7 @@ export const makeCrewChannel = Effect.fn("crew.makeCrewChannel")(function* (
 		discover: (role: CrewRole) => tracker.lookup(role),
 		claim: (resource: string) =>
 			tracker.claim({resource, claimant: config.address, role: config.role}),
+		release: (resource: string) => tracker.release({resource, claimant: config.address}),
 	} satisfies CrewChannel;
 });
 

--- a/packages/pipeline-crew-mcp/src/crew/session.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.test.ts
@@ -443,6 +443,12 @@ describe("crew/session — the session-mode server advertises the channel edge (
 				const listed = yield* client["tools/list"]({});
 				const names = listed.tools.map((tool) => tool.name);
 				assert.include(names, "channel_send", "the model must be able to call channel_send");
+				assert.include(names, "channel_claim", "the model must be able to claim a lane");
+				assert.include(
+					names,
+					"channel_release",
+					"the model must be able to release a claim it holds (#3796 facet 2)",
+				);
 			}).pipe(Effect.scoped),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -41,6 +41,7 @@ import {
 	assertToolSchemas,
 	ChannelClaim,
 	ChannelDescribe,
+	ChannelRelease,
 	ChannelSend,
 	ChannelSink,
 	ChannelToolkit,
@@ -50,6 +51,8 @@ import {
 	claimToolHandlers,
 	KindsToolkit,
 	kindsToolHandlers,
+	ReleaseToolkit,
+	releaseToolHandlers,
 } from "../edge/index.ts";
 import {type Dialer, Inbox, type Tracker} from "../peer/index.ts";
 import {resolveRendezvous} from "../tracker/index.ts";
@@ -211,7 +214,7 @@ export const assembleCrewSession = <RIn, RSub = never>(
 			// Startup invariant (#3753): every tool this session will register must generate a spec-valid
 			// top-level `{"type":"object"}` inputSchema. A client rejects the WHOLE tools/list response on
 			// one bad schema, so the failure mode without this fence is a silently tool-less session.
-			yield* assertToolSchemas([ChannelToolkit, ClaimToolkit, KindsToolkit]);
+			yield* assertToolSchemas([ChannelToolkit, ClaimToolkit, ReleaseToolkit, KindsToolkit]);
 			const channel = yield* makeCrewChannel({role: config.role, address});
 			// Startup invariant (#3622): resolve the full discoverable channel contract BEFORE serving.
 			// A shared kind set that can't be fully resolved to a shape fails the build HERE (on the boot
@@ -229,6 +232,12 @@ export const assembleCrewSession = <RIn, RSub = never>(
 				Layer.provide(claimToolHandlers),
 				Layer.provide(Layer.succeed(ChannelClaim, {claim: channel.claim})),
 			);
+			// release: the channel_release toolkit (#3796 facet 2), the claim's counterpart — its
+			// ChannelRelease an INSTANT bind to the already-resolved channel's tracker release (Race 2).
+			const release = McpServer.toolkit(ReleaseToolkit).pipe(
+				Layer.provide(releaseToolHandlers),
+				Layer.provide(Layer.succeed(ChannelRelease, {release: channel.release})),
+			);
 			// discovery: the channel_kinds toolkit (#3622), its ChannelDescribe an INSTANT bind to the
 			// contract resolved just above — a static value, so it never re-derives the catalog nor awaits.
 			const kinds = McpServer.toolkit(KindsToolkit).pipe(
@@ -240,15 +249,17 @@ export const assembleCrewSession = <RIn, RSub = never>(
 				Layer.provide(ChannelSink.layerFromMcpServer),
 			);
 			// Provide the transport ONCE to the MERGED registrations — the single-instance memo (Race 1).
-			return Layer.mergeAll(outbound, claim, kinds, inbound).pipe(Layer.provide(transport));
+			return Layer.mergeAll(outbound, claim, release, kinds, inbound).pipe(
+				Layer.provide(transport),
+			);
 		}),
 	).pipe(Layer.provide(substrate));
 
 /**
  * The full runnable session layer: launch it (`Layer.launch`) to run one live crew session. The one
  * stdio `McpServer` is provided to the merged registrations exactly once (`assembleCrewSession`), so
- * the served server advertises the `channel_send` + `channel_claim` + `channel_kinds` tools + the
- * `claude/channel` capability; the heartbeat rides the same `substrate` the outbound binding announces on.
+ * the served server advertises the `channel_send` + `channel_claim` + `channel_release` + `channel_kinds`
+ * tools + the `claude/channel` capability; the heartbeat rides the same `substrate` the outbound binding announces on.
  */
 export const crewSessionLayer = (config: CrewSessionConfig) => {
 	// One per-session instance id, resolved once here and threaded to every address derivation, so an

--- a/packages/pipeline-crew-mcp/src/edge/claim-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/claim-tool.ts
@@ -17,6 +17,15 @@
  * error is `orDie`'d at the `CrewTracker` seam), so the tool carries no failure channel. The caller
  * reads `granted`/`collision`: granted ⇒ you own the lane, collision ⇒ another engine holds it and
  * `owner` names it — back off before opening a PR.
+ *
+ * Keyspace caveat — one lane has TWO keys (#3796 facet 1). A build lane is named by BOTH its issue
+ * number AND, later, the PR number that comes out of it, but the tracker keys claims on an opaque
+ * exact-match `resource`, so it cannot know `3686` (the issue) and `3713` (its PR) denote one lane —
+ * claiming one does NOT reserve the other, and two engines that claim different keys for the same
+ * lane both get `granted`. Until a canonical lane identity lands (the structural fix belongs to epic
+ * #3766's planning), the interim convention — stated on the tool below so an engine reads it at claim
+ * time — is: claim BOTH keys, the issue at dispatch and the PR the moment it opens. With both keys
+ * held by the first engine, the second claimant of EITHER key gets `collision: true`.
  */
 import {Context, Effect, Schema} from "effect";
 import {Tool, Toolkit} from "effect/unstable/ai";
@@ -41,9 +50,12 @@ export class ChannelClaim extends Context.Service<
 /** The one claim tool: `{resource}` in, the tracker's typed granted/collision reply out. */
 export const ClaimResource = Tool.make("channel_claim", {
 	description:
-		"Claim a resource (an issue id) against the tracker before opening a build lane; returns the " +
-		"typed reply. `granted: true` ⇒ you now hold the lane; `collision: true` ⇒ another engine " +
-		"already holds it (`owner` names the holder) — back off, do NOT open a duplicate lane.",
+		"Claim a resource (an issue or PR id) against the tracker before opening a build lane; returns " +
+		"the typed reply. `granted: true` ⇒ you now hold the lane; `collision: true` ⇒ another engine " +
+		"already holds it (`owner` names the holder) — back off, do NOT open a duplicate lane. One lane " +
+		"has TWO keys the tracker cannot link (the issue AND its PR number), so claim BOTH: the issue " +
+		"at dispatch, and the PR the moment it opens — else another engine can claim the other key for " +
+		"the same lane and also get granted. Release a key you no longer need with channel_release.",
 	parameters: Schema.Struct({resource: Schema.NonEmptyString}),
 	success: Messages.ClaimReply,
 });

--- a/packages/pipeline-crew-mcp/src/edge/index.ts
+++ b/packages/pipeline-crew-mcp/src/edge/index.ts
@@ -7,8 +7,9 @@
  *   - inbound  — `channelInboxLayer` is the peer's `Inbox`; each delivery `wake`s the
  *     session via the `ChannelSink` as a structured `<channel>` tag,
  *   - outbound — `channelServerLayer` serves the MCP server (capability + the `channel_send`
- *     relay tool + the `channel_claim` deconfliction tool), routing sends through the
- *     `ChannelSend` port and resource claims through the `ChannelClaim` port.
+ *     relay tool + the `channel_claim` / `channel_release` deconfliction tools), routing sends
+ *     through the `ChannelSend` port and resource claims/releases through the `ChannelClaim` /
+ *     `ChannelRelease` ports.
  */
 export {channelInboxLayer, formatChannelTag} from "./bridge.ts";
 export {ChannelSink} from "./channel-sink.ts";
@@ -32,6 +33,13 @@ export {
 	type ChannelNotificationPayload,
 	channelExperimentalCapability,
 } from "./mcp-channel.ts";
+export {
+	ChannelRelease,
+	ReleaseAck,
+	ReleaseResource,
+	ReleaseToolkit,
+	releaseToolHandlers,
+} from "./release-tool.ts";
 export {
 	ChannelSend,
 	ChannelToolkit,

--- a/packages/pipeline-crew-mcp/src/edge/release-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/release-tool.test.ts
@@ -1,0 +1,235 @@
+/**
+ * edge/release-tool — the channel_release deconfliction tool (#3796 facet 2). The release path
+ * existed at every layer below the edge (the `Release` RPC, the `releaseClaim` seam,
+ * `CrewTracker.release`), but no tool surfaced it, so an engine could not hand a claim back until its
+ * session presence aged out. This drives the tool against the REAL registry (`RpcTest` client of
+ * `TrackerRegistry` + `RegistryLive`) so the release genuinely frees the claim, and against a real
+ * in-memory `McpServer.layerHttp` per session (the harness `claim-tool.test.ts` uses).
+ *
+ * Harness shape (shared with claim-tool.test.ts): the in-process streamable-HTTP MCP client serves ONE
+ * `tools/call` per session, so a multi-step sequence is expressed as several single-call sessions over
+ * ONE shared registry. A claim's holder is its session ADDRESS (the claimant), so two sessions bound to
+ * the same address act as the same holder — that is how a later session releases the claim an earlier
+ * one took (release is holder-guarded, ADR 0191 facet 3).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Schema} from "effect";
+import {McpSchema, McpServer} from "effect/unstable/ai";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import {RpcSerialization, RpcTest} from "effect/unstable/rpc";
+import * as RpcClient from "effect/unstable/rpc/RpcClient";
+import {CrewTracker} from "../crew/tracker.ts";
+import {TrackerRegistry} from "../tracker/group.ts";
+import {TrackerHandlers} from "../tracker/handlers.ts";
+import {RegistryLive} from "../tracker/registry.ts";
+import {ChannelClaim, ClaimToolkit, claimToolHandlers} from "./claim-tool.ts";
+import {channelExperimentalCapability} from "./mcp-channel.ts";
+import {ChannelRelease, ReleaseToolkit, releaseToolHandlers} from "./release-tool.ts";
+
+class DisposeError extends Schema.TaggedErrorClass<DisposeError>()(
+	"@kampus/pipeline-crew-mcp/DisposeError",
+	{cause: Schema.Unknown},
+) {}
+
+const registryHandlers = TrackerHandlers.pipe(Layer.provide(RegistryLive));
+
+// A live crew session's claim + release ports, both bound to ONE peer address against the shared
+// registry (`CrewTracker.fromClient`). Release is holder-guarded (ADR 0191 facet 3) — the claimant IS
+// the address, so two sessions on the same address are the same holder.
+const sessionPorts = (
+	client: Parameters<typeof CrewTracker.fromClient>[0],
+	address: string,
+): Layer.Layer<ChannelClaim | ChannelRelease> =>
+	Layer.mergeAll(
+		Layer.effect(
+			ChannelClaim,
+			Effect.gen(function* () {
+				const tracker = yield* CrewTracker;
+				return {
+					claim: (resource: string) =>
+						tracker.claim({resource, claimant: address, role: "engineering-manager"}),
+				};
+			}),
+		),
+		Layer.effect(
+			ChannelRelease,
+			Effect.gen(function* () {
+				const tracker = yield* CrewTracker;
+				return {release: (resource: string) => tracker.release({resource, claimant: address})};
+			}),
+		),
+	).pipe(Layer.provide(CrewTracker.fromClient(client)));
+
+// An initialized MCP client serving BOTH channel_claim and channel_release, backed by `ports`.
+const makeSession = (ports: Layer.Layer<ChannelClaim | ChannelRelease>) =>
+	Effect.gen(function* () {
+		const serverLayer = Layer.mergeAll(
+			McpServer.toolkit(ClaimToolkit).pipe(Layer.provide(claimToolHandlers)),
+			McpServer.toolkit(ReleaseToolkit).pipe(Layer.provide(releaseToolHandlers)),
+		).pipe(
+			Layer.provide(ports),
+			Layer.provide(
+				McpServer.layerHttp({
+					name: "ChannelEdgeReleaseTestServer",
+					version: "0.0.0",
+					path: "/mcp",
+					experimental: channelExperimentalCapability,
+				}),
+			),
+		);
+		const {dispose, handler} = HttpRouter.toWebHandler(serverLayer, {disableLogger: true});
+		yield* Effect.addFinalizer(() =>
+			Effect.tryPromise({try: () => dispose(), catch: (cause) => new DisposeError({cause})}).pipe(
+				Effect.ignore,
+			),
+		);
+
+		let sessionId: string | null = null;
+		const customFetch: typeof fetch = async (input, init) => {
+			const request = input instanceof Request ? input : new Request(input, init);
+			if (sessionId) request.headers.set("Mcp-Session-Id", sessionId);
+			const response = await handler(request);
+			sessionId = response.headers.get("Mcp-Session-Id");
+			return response;
+		};
+
+		const clientLayer = RpcClient.layerProtocolHttp({url: "http://localhost/mcp"}).pipe(
+			Layer.provideMerge([FetchHttpClient.layer, RpcSerialization.layerJsonRpc()]),
+			Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch)),
+		);
+		const client = yield* RpcClient.make(McpSchema.ClientRpcs).pipe(Effect.provide(clientLayer));
+		yield* client.initialize({
+			protocolVersion: "9999-01-01",
+			capabilities: {},
+			clientInfo: {name: "TestClient", version: "0.0.0"},
+		});
+		return client;
+	});
+
+const claimReplyOf = (result: {structuredContent?: unknown}) =>
+	result.structuredContent as {
+		resource: string;
+		granted: boolean;
+		collision: boolean;
+		owner: string;
+	};
+
+const releaseAckOf = (result: {structuredContent?: unknown}) =>
+	result.structuredContent as {resource: string; released: boolean};
+
+describe("edge/release-tool — the channel_release counterpart (#3796 facet 2)", () => {
+	it.effect("advertises the channel_release tool", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const session = yield* makeSession(sessionPorts(client, "inbox://engineering-manager/a"));
+			const tools = yield* session["tools/list"]({});
+			assert.include(
+				tools.tools.map((t) => t.name),
+				"channel_release",
+			);
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect("releasing a held claim frees it — a second engine can then claim the resource", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const addrA = "inbox://engineering-manager/a";
+			const addrB = "inbox://engineering-manager/b";
+			const addrC = "inbox://engineering-manager/c";
+			const at = new Date().toISOString();
+			// A and C are live; the claim's liveness rides presence (ADR 0191 facet 2)
+			yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager", at});
+			yield* client.AnnouncePresence({peer: addrC, role: "engineering-manager", at});
+
+			// A claims #3686 (one call)
+			const claimA = yield* makeSession(sessionPorts(client, addrA));
+			assert.isTrue(
+				claimReplyOf(
+					yield* claimA["tools/call"]({name: "channel_claim", arguments: {resource: "3686"}}),
+				).granted,
+			);
+
+			// B probes #3686 while A holds it → collision (one call)
+			const probeB = yield* makeSession(sessionPorts(client, addrB));
+			assert.isTrue(
+				claimReplyOf(
+					yield* probeB["tools/call"]({name: "channel_claim", arguments: {resource: "3686"}}),
+				).collision,
+				"B is blocked while A holds the claim",
+			);
+
+			// A releases #3686 through the tool — a second A-address session is the same holder (one call)
+			const releaseA = yield* makeSession(sessionPorts(client, addrA));
+			const ack = releaseAckOf(
+				yield* releaseA["tools/call"]({name: "channel_release", arguments: {resource: "3686"}}),
+			);
+			assert.isTrue(ack.released);
+			assert.strictEqual(ack.resource, "3686");
+
+			// C claims #3686 → NOW granted, because A's release freed the claim (one call)
+			const claimC = yield* makeSession(sessionPorts(client, addrC));
+			const cReply = claimReplyOf(
+				yield* claimC["tools/call"]({name: "channel_claim", arguments: {resource: "3686"}}),
+			);
+			assert.isTrue(cReply.granted, "the released resource is claimable by the next engine");
+			assert.strictEqual(cReply.owner, addrC);
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect(
+		"release is holder-guarded: a non-holder's release does NOT free another engine's claim",
+		() =>
+			Effect.gen(function* () {
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				const addrA = "inbox://engineering-manager/a";
+				const addrB = "inbox://engineering-manager/b";
+				const addrC = "inbox://engineering-manager/c";
+				const at = new Date().toISOString();
+				yield* client.AnnouncePresence({peer: addrA, role: "engineering-manager", at});
+
+				// A holds #3686 (one call)
+				const claimA = yield* makeSession(sessionPorts(client, addrA));
+				assert.isTrue(
+					claimReplyOf(
+						yield* claimA["tools/call"]({name: "channel_claim", arguments: {resource: "3686"}}),
+					).granted,
+				);
+
+				// B (not the holder) tries to release A's claim — accepted-shaped ack, but a no-op (one call)
+				const releaseB = yield* makeSession(sessionPorts(client, addrB));
+				assert.isTrue(
+					releaseAckOf(
+						yield* releaseB["tools/call"]({name: "channel_release", arguments: {resource: "3686"}}),
+					).released,
+				);
+
+				// C probes #3686 → still collision: a non-holder release cannot steal-free the claim (one call)
+				const probeC = yield* makeSession(sessionPorts(client, addrC));
+				const cReply = claimReplyOf(
+					yield* probeC["tools/call"]({name: "channel_claim", arguments: {resource: "3686"}}),
+				);
+				assert.isTrue(cReply.collision, "a non-holder release cannot steal-free the claim");
+				assert.strictEqual(cReply.owner, addrA, "the resource stays with its real holder");
+			}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+
+	it.effect("releasing an unheld resource is an idempotent no-op", () =>
+		Effect.gen(function* () {
+			const client = yield* RpcTest.makeClient(TrackerRegistry);
+			const addrA = "inbox://engineering-manager/a";
+			yield* client.AnnouncePresence({
+				peer: addrA,
+				role: "engineering-manager",
+				at: new Date().toISOString(),
+			});
+			const a = yield* makeSession(sessionPorts(client, addrA));
+
+			// releasing a never-claimed resource — accepted, no error (one call)
+			const ack = releaseAckOf(
+				yield* a["tools/call"]({name: "channel_release", arguments: {resource: "9999"}}),
+			);
+			assert.isTrue(ack.released, "releasing an unheld resource is a safe no-op");
+		}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/edge/release-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/release-tool.ts
@@ -1,0 +1,70 @@
+/**
+ * edge/release-tool — the release half of the deconfliction edge: an MCP tool a session calls to
+ * free a resource claim it holds, the counterpart to `channel_claim` (`./claim-tool.ts`). Generic
+ * (crew-agnostic); see the boundary note in `../index.ts`.
+ *
+ * This is the edge-carry #3796 facet 2 was missing. The release path already existed at every layer
+ * BELOW the edge — the `ReleaseClaim` schema + the `Release` RPC (`../protocol/`), the `releaseClaim`
+ * seam (`../crew/catalog.ts`), and `CrewTracker.release` (`../crew/tracker.ts`, ADR 0191 facet 3) —
+ * but `CrewChannel` carried only `claim` and the session bound only that, so an engine that yielded,
+ * stood down, or claimed in error could not hand its claim back: it was held until the session's
+ * presence aged out, leaving a phantom claim that spuriously blocked the rightful owner. This tool
+ * surfaces the already-correct `Release` so a claim is releasable from the engine toolset.
+ *
+ * Release is holder-guarded and idempotent (ADR 0191 facet 3): the tracker frees ONLY a claim the
+ * caller holds, and freeing a claim you do not hold (or one already gone) is a no-op. So the wire
+ * `Release` is fire-and-forget with no reply — the tool has no failure channel, and its `released`
+ * ack means "the release was accepted", not "you were the holder" (the holder-guard is the tracker's,
+ * and a caller cannot learn another peer's holdership from its own release).
+ */
+import {Context, Effect, Schema} from "effect";
+import {Tool, Toolkit} from "effect/unstable/ai";
+
+/**
+ * The resource-release capability the tool wraps — the session's `CrewChannel.release` bound in the
+ * composition root (`../crew/channel-server.ts`), so the edge never constructs a tracker client (the
+ * crew composition does, #3059). `release(resource)` hits the tracker's `Release` RPC; releasing is
+ * holder-guarded + idempotent, so the capability has no error channel (a lost/absent claim no-ops).
+ */
+export class ChannelRelease extends Context.Service<
+	ChannelRelease,
+	{
+		readonly release: (resource: string) => Effect.Effect<void>;
+	}
+>()("@kampus/pipeline-crew-mcp/edge/ChannelRelease") {}
+
+/**
+ * The release acknowledgement — an edge-local ack, NOT a wire reply: the `Release` RPC is
+ * fire-and-forget (ADR 0191 facet 3), so `released` reports that the release was accepted (idempotent;
+ * it frees your claim iff you hold it), never that you were the holder.
+ */
+export const ReleaseAck = Schema.Struct({
+	resource: Schema.NonEmptyString,
+	released: Schema.Boolean,
+});
+
+/** The one release tool: `{resource}` in, the accepted-release ack out. */
+export const ReleaseResource = Tool.make("channel_release", {
+	description:
+		"Release a resource claim you hold (an issue or PR id), the counterpart to channel_claim; call " +
+		"it when you yield a lane, are told to stand down, or claimed in error, so the claim frees now " +
+		"instead of waiting for your session presence to age out. Holder-guarded and idempotent: it " +
+		"frees the claim ONLY if you hold it, and releasing one you do not hold (or already released) " +
+		"is a safe no-op.",
+	parameters: Schema.Struct({resource: Schema.NonEmptyString}),
+	success: ReleaseAck,
+});
+
+/** The release toolkit — registered on the session's one served `McpServer` alongside `channel_claim`. */
+export const ReleaseToolkit = Toolkit.make(ReleaseResource);
+
+/** The toolkit handler: route the release through the `ChannelRelease` port (the session's tracker release). */
+export const releaseToolHandlers = ReleaseToolkit.toLayer(
+	Effect.gen(function* () {
+		const releaser = yield* ChannelRelease;
+		return {
+			channel_release: ({resource}) =>
+				releaser.release(resource).pipe(Effect.as({resource, released: true})),
+		};
+	}),
+);

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
@@ -227,6 +227,85 @@ describe("registry-core — presence-derived claim liveness (ADR 0191 facet 2)",
 	});
 });
 
+// One build lane is named by TWO keys — its issue number AND the PR number that comes out of it —
+// but the tracker keys claims on an opaque exact-match `resource`, so it cannot know `3686` (issue)
+// and `3713` (its PR) denote one lane: claiming one does NOT reserve the other. That is the observed
+// #3796 facet 1 near-miss (one lane granted to two engines two seconds apart). The structural fix (a
+// canonical lane identity) belongs to epic #3766's planning; the interim convention — documented on
+// the channel_claim tool where engines read it — is that the first engine claims BOTH keys, and these
+// tests pin its two halves: unclaimed cross-key keys are independently grantable (the defect), and
+// once BOTH are held the second claimant of EITHER key collides (the mitigation).
+describe("registry-core — the two-key lane keyspace (#3796 facet 1)", () => {
+	it("the raw defect: an issue key and its PR key are independent claims — both grant to different holders", () => {
+		let state = withPresence(Core.empty(), "engine-a", "engineering-manager", T0);
+		state = withPresence(state, "engine-b", "engineering-manager", T0);
+		// engine A claims the PR key #3713
+		const aOnPr = Core.claimResource(state, {
+			resource: "3713",
+			holder: "engine-a",
+			claimantRole: "engineering-manager",
+			nowMillis: T0,
+		});
+		assert.strictEqual(aOnPr.outcome._tag, "Granted");
+		// engine B claims the ISSUE key #3686 for the SAME lane — granted, because the keys don't link
+		const bOnIssue = Core.claimResource(aOnPr.state, {
+			resource: "3686",
+			holder: "engine-b",
+			claimantRole: "engineering-manager",
+			nowMillis: T0 + secs(2),
+		});
+		assert.strictEqual(
+			bOnIssue.outcome._tag,
+			"Granted",
+			"the tracker cannot know 3686 and 3713 are one lane — the double-grant",
+		);
+	});
+
+	it("the interim mitigation: with the first engine holding BOTH keys, the second collides on EITHER", () => {
+		let state = withPresence(Core.empty(), "engine-a", "engineering-manager", T0);
+		state = withPresence(state, "engine-b", "engineering-manager", T0);
+		// engine A follows the convention — it claims BOTH the issue and the PR for its lane
+		state = Core.claimResource(state, {
+			resource: "3686",
+			holder: "engine-a",
+			claimantRole: "engineering-manager",
+			nowMillis: T0,
+		}).state;
+		state = Core.claimResource(state, {
+			resource: "3713",
+			holder: "engine-a",
+			claimantRole: "engineering-manager",
+			nowMillis: T0 + secs(1),
+		}).state;
+
+		// engine B claims the issue key — collision (A holds it)
+		const bIssue = Core.claimResource(state, {
+			resource: "3686",
+			holder: "engine-b",
+			claimantRole: "engineering-manager",
+			nowMillis: T0 + secs(2),
+		});
+		assert.deepStrictEqual(bIssue.outcome, {
+			_tag: "Collision",
+			holder: "engine-a",
+			sinceMillis: T0,
+		});
+
+		// engine B claims the PR key — collision too (A holds both halves of the lane)
+		const bPr = Core.claimResource(state, {
+			resource: "3713",
+			holder: "engine-b",
+			claimantRole: "engineering-manager",
+			nowMillis: T0 + secs(2),
+		});
+		assert.deepStrictEqual(bPr.outcome, {
+			_tag: "Collision",
+			holder: "engine-a",
+			sinceMillis: T0 + secs(1),
+		});
+	});
+});
+
 describe("registry-core — Release + reaping (ADR 0191 facets 2 + 3)", () => {
 	it("releaseClaim frees only the caller's own claim — steal-release is a no-op", () => {
 		let state = withPresence(Core.empty(), "peer-a", "builder", T0);


### PR DESCRIPTION
Fixes #3796

The crew resource claim could neither reliably **release** nor **exclude**. This lands the exclusive, in-scope halves and threads the design half to its epic.

## Facet 2 — the release verb is now reachable from the engine (AC2)
The release path already existed at every layer *below* the edge — `ReleaseClaim` schema, the `Release` RPC, the `releaseClaim` catalog seam, and `CrewTracker.release` (ADR 0191 facet 3) — but `CrewChannel` carried only `claim` and the session bound only that, so a yielded / stood-down / mistaken claim was held until the session's presence aged out, leaving a phantom claim that spuriously blocked the rightful owner. This is edge-carry work:

- `crew/channel-server.ts` — `CrewChannel` now carries `release`, wired to `CrewTracker.release`.
- `edge/release-tool.ts` (new) — the `ChannelRelease` port + the `channel_release` MCP tool, the claim's counterpart. Holder-guarded + idempotent: freeing a claim you don't hold (or one already gone) is a safe no-op, so the tool has no failure channel.
- `crew/session.ts` — `channel_release` is asserted schema-valid, bound as a zero-async `Layer.succeed(ChannelRelease, …)` (the Race-2 pattern), and merged into the single served instance alongside `channel_send` / `channel_claim` / `channel_kinds`.
- `edge/index.ts` — re-exports the new tool.

## Facet 1 — one lane, two keys: the interim convention, documented where engines read it (AC1 + AC3)
A build lane is named by BOTH its issue and its PR number, but the tracker keys claims on an opaque exact-match `resource` and cannot know `3686` (issue) and `3713` (its PR) denote one lane, so both granted to different engines. **The structural fix (a canonical lane identity) is a design decision that belongs to epic #3766's planning — this issue is the direct input evidence, not the place to pick the mechanism.** Until it lands, the interim convention is documented on the `channel_claim` tool (`edge/claim-tool.ts`), which is where an engine reads it at claim time: **claim BOTH keys — the issue at dispatch, the PR the moment it opens.** With both keys held by the first engine, the second claimant of either key gets `collision: true`.

## Tests
- `edge/release-tool.test.ts` (new) — advertises `channel_release`; releasing a held claim frees it for the next engine; release is holder-guarded (a non-holder cannot steal-free); releasing an unheld resource is an idempotent no-op. Driven against the real registry over the in-process MCP harness.
- `crew/channel-server.test.ts` — a channel can release its own claim, freeing the resource for another (facet 2 end-to-end at the channel layer).
- `crew/session.test.ts` — the served `tools/list` now advertises `channel_claim` + `channel_release`.
- `tracker/registry-core.test.ts` — the two-key lane: the raw double-grant defect (issue key and PR key grant independently to different holders), and the interim mitigation (with both keys held, the second claimant of *either* collides with `collision: true`).

Full `@kampus/pipeline-crew-mcp` suite: 315 passing. Typecheck + biome clean.

## Differentiation preserved (AC4)
This is `packages/pipeline-crew-mcp/` substrate work (not §CP; ADR 0187 places crew-mcp outside the control plane). It stays distinct from #3581 (substrates not *consulted*), #3751 (claim-token propagation), #3755 (lock absent / fallback), #3770 (`peer.send` pooling), and #3780 (pipeline-cli marker claims). The structural exclusion mechanism is epic #3766's.

## Note for the reviewer
The agent-corpus reinforcement of the claim-both-keys convention (`claude-plugins/pipeline-crew/agents/…`) is a §CP path and is intentionally out of scope here; the tool-surface doc is the non-§CP "where engines read it" surface. The permanent structural fix is epic #3766.