### PR TITLE
fix(integration): one shared readiness deadline bounds the per-file beforeAll under the hook ceiling (#3788)

### DIFF
--- a/apps/web/tests/integration/_edge-ready.ts
+++ b/apps/web/tests/integration/_edge-ready.ts
@@ -81,21 +81,29 @@ export const HOOK_TIMEOUT_MS = 300_000;
 // keeps its generous single budget (#3080). The per-file, hook-bound path uses the smaller budget below.
 export const DEPLOY_HEALTH_DEADLINE_MS = 120_000;
 
-// The per-file readiness budget for the hook-bound `integrationStack` deploy `beforeAll` (#3146).
-// Sized STRICTLY BELOW `HOOK_TIMEOUT_MS` with headroom for the deploy-before (~40-60s under
-// concurrent-stage batch load, more with the widened `deployTransientRetry`) + the trailing non-fatal
-// warms, so the poll GRACEFULLY bounded-returns a typed `WorkerNotReadyError`/re-thrown
-// `CloudflarePlaceholder404Error` diagnostic WELL before the vitest hook fires — a deterministic,
-// named failure instead of the opaque "Hook timed out" guillotine that evicted clean product PRs from
-// the merge queue: deploy(≤90) + readiness(180) = 270 < 300, so the typed throw wins the race.
-//
-// Raised 100s→180s for #3409: under merge_group BATCH load (~24 fresh `*.workers.dev` hostnames
-// propagating across the CF edge at once), `/api/health` edge propagation exceeded the prior 100s
-// budget, so `awaitEdgeReady` re-threw the edge-not-propagated `CloudflarePlaceholder404Error` and the
-// documented transient hard-failed the beforeAll instead of riding out as a WAIT — ejecting an
-// innocent co-batched PR (run 29561658100, fts-backfill). 180s gives the propagation transient enough
-// headroom while staying bounded: a worker that genuinely never serves still fails after the budget.
-export const PER_FILE_HEALTH_DEADLINE_MS = 180_000;
+// Headroom reserved between the per-file readiness chain's shared deadline and the vitest hook
+// guillotine at `HOOK_TIMEOUT_MS`, so the typed `WorkerNotReadyError`/`WarmNotSettledError` throw
+// always fires BEFORE the opaque "Hook timed out" (the #3146 invariant). Grounded in the poll
+// mechanics, not in propagation timing: `awaitEdgeReady` only checks the deadline BETWEEN polls, so
+// the last iteration can overshoot by one `WARM_POLL_MS` (~2s) plus a final fetch before the throw
+// propagates — 15s covers that with slack, and is not a number to "measure" against the edge.
+export const READINESS_HOOK_MARGIN_MS = 15_000;
+
+// The per-file readiness chain's ONE shared wall-clock deadline (epoch ms), anchored at the deploy
+// `beforeAll`'s start (`hookStartedAt`, captured before `deploy`) and derived from the hook ceiling.
+// `awaitWorkerReady` + `warmLiveDO` + `warmFateRead` all draw from this SINGLE deadline — each
+// consuming `deadline - now()` — so their budgets TOGETHER can never push the hook past
+// `HOOK_TIMEOUT_MS`. That makes the >300s worst case UNREPRESENTABLE by construction rather than
+// reasoned about in a sizing comment that had to keep summing every chain member (and silently
+// stopped: the retired per-probe budgets were health 180 + live 60 + fate 60 = 300 ON TOP of the
+// deploy — already over ceiling, the latent #3146 hole this closes). Two consequences fall out for
+// free: the later-propagating `/fate/live`/`POST /fate` warms are no longer capped at a fixed 60s
+// SMALLER than health's budget (#1058) — they use whatever health did not need, typically the bulk
+// of the window; and a probe reached after the window is already spent gets a floored-at-zero budget
+// and fails as its own named diagnostic, never the guillotine. Pure in its anchor + `Date.now()`,
+// so the bound is unit-pinned in `_edge-ready.unit.test.ts` (#3788).
+export const perFileReadinessDeadline = (hookStartedAt: number): number =>
+	hookStartedAt + HOOK_TIMEOUT_MS - READINESS_HOOK_MARGIN_MS;
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 

--- a/apps/web/tests/integration/_edge-ready.unit.test.ts
+++ b/apps/web/tests/integration/_edge-ready.unit.test.ts
@@ -22,8 +22,11 @@ import {
 	awaitEdgeReady,
 	CloudflarePlaceholder404Error,
 	edgeFetch,
+	HOOK_TIMEOUT_MS,
 	isCloudflarePlaceholder404,
 	isCloudflarePlaceholder404Error,
+	perFileReadinessDeadline,
+	READINESS_HOOK_MARGIN_MS,
 	WorkerNotReadyError,
 } from "./_edge-ready.ts";
 import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
@@ -193,9 +196,10 @@ describe("awaitAuthRouteReady — the bootstrap auth-route propagation gate (#24
 });
 
 // The DEPLOY-time worker-health gate turns a worker that never serves healthy JSON within its
-// readiness budget into a TYPED, greppable `WorkerNotReadyError` — and, sized below the hook ceiling
-// (`PER_FILE_HEALTH_DEADLINE_MS`), that throw fires before the vitest `beforeAll` guillotine so the
-// eviction cause is a named diagnostic, not the opaque "Hook timed out in 120000ms" (#3146).
+// readiness budget into a TYPED, greppable `WorkerNotReadyError` — and, given a budget bounded by the
+// shared readiness deadline that sits below the hook ceiling, that throw fires before the vitest
+// `beforeAll` guillotine so the eviction cause is a named diagnostic, not the opaque "Hook timed out
+// in 120000ms" (#3146).
 describe("awaitWorkerReady — typed readiness diagnostic (#3146)", () => {
 	afterEach(() => vi.unstubAllGlobals());
 
@@ -240,6 +244,41 @@ describe("WarmNotSettledError — the exhausted-warm diagnostic (#3778)", () => 
 		expect(e.message).toContain("60000ms");
 		expect(e.message).toContain("503");
 		expect(e.message).toContain("application/json");
+	});
+});
+
+// The per-file readiness chain (health + both warms) shares ONE wall-clock deadline anchored at the
+// hook's start and derived from the hook ceiling, so the three probes' budgets TOGETHER can never
+// push the `beforeAll` past `HOOK_TIMEOUT_MS` — the >300s worst case the retired fixed-per-probe
+// budgets (health 180 + live 60 + fate 60 = 300, atop deploy) summed into is unrepresentable by
+// construction (#3788). Pin the arithmetic that makes that bound hold.
+describe("perFileReadinessDeadline — the readiness chain is bounded by the hook ceiling (#3788)", () => {
+	const startedAt = 1_000_000;
+
+	it("keeps the whole readiness chain strictly below HOOK_TIMEOUT_MS from the hook start", () => {
+		const deadline = perFileReadinessDeadline(startedAt);
+		// Measured from the hook start, the chain can run at most until `deadline` — which is
+		// READINESS_HOOK_MARGIN_MS short of the ceiling, the headroom the typed throw needs to beat
+		// the vitest guillotine.
+		expect(deadline - startedAt).toBe(HOOK_TIMEOUT_MS - READINESS_HOOK_MARGIN_MS);
+		expect(deadline - startedAt).toBeLessThan(HOOK_TIMEOUT_MS);
+		expect(READINESS_HOOK_MARGIN_MS).toBeGreaterThan(0);
+	});
+
+	it("a probe reached after earlier probes spent part of the window gets only what remains (each consumes deadline - now)", () => {
+		const deadline = perFileReadinessDeadline(startedAt);
+		// health consumed 200s of the shared window; the live warm, reached now, sees only the remainder
+		// — strictly less than health got, and the sum can never exceed the window.
+		const nowAfterHealth = startedAt + 200_000;
+		const liveBudget = Math.max(0, deadline - nowAfterHealth);
+		expect(liveBudget).toBe(HOOK_TIMEOUT_MS - READINESS_HOOK_MARGIN_MS - 200_000);
+		expect(liveBudget).toBeLessThan(deadline - startedAt);
+	});
+
+	it("floors a probe's budget at 0 once the window is spent — an immediate typed throw, never a negative budget", () => {
+		const deadline = perFileReadinessDeadline(startedAt);
+		const nowAfterExhaustion = deadline + 5_000;
+		expect(Math.max(0, deadline - nowAfterExhaustion)).toBe(0);
 	});
 });
 

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -42,7 +42,7 @@ import {
 	EDGE_READY_DEADLINE_MS,
 	edgeFetch,
 	HOOK_TIMEOUT_MS,
-	PER_FILE_HEALTH_DEADLINE_MS,
+	perFileReadinessDeadline,
 	WorkerNotReadyError,
 } from "./_edge-ready.ts";
 import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
@@ -238,7 +238,10 @@ const stageFor = (metaUrl: string): string => {
  * GET-open `/fate/live` and retry while it 503s — so the cold-start cost is paid by
  * the gate, not by `fate-live.test.ts`'s first subscribe (#1018).
  */
-export const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
+export const warmLiveDO = (
+	url: string,
+	deadlineMs: number = EDGE_READY_DEADLINE_MS,
+): Effect.Effect<void, never, never> =>
 	Effect.tryPromise({
 		try: async () => {
 			const signUp = await fetch(`${url}/api/auth/sign-up/email`, {
@@ -283,13 +286,14 @@ export const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
 						headers: {accept: "text/event-stream", cookie},
 					}),
 				liveWarmReady,
-				// The budget is named at the call site (not left to the default) so the exhaustion
-				// diagnostic below cites the number actually spent, never a drifted copy.
-				{pollMs: WARM_POLL_MS, deadlineMs: EDGE_READY_DEADLINE_MS},
+				// The caller's budget (the per-file path passes what the shared readiness deadline has
+				// left; the shared-stage path takes the default) — threaded so the exhaustion diagnostic
+				// below cites the number actually spent, never a drifted copy.
+				{pollMs: WARM_POLL_MS, deadlineMs},
 			);
 			await res.body?.cancel().catch(() => {});
 			if (!liveWarmReady(res)) {
-				throw new WarmNotSettledError("/fate/live warm", res, EDGE_READY_DEADLINE_MS);
+				throw new WarmNotSettledError("/fate/live warm", res, deadlineMs);
 			}
 		},
 		catch: (cause) => new ProbeError({cause}),
@@ -320,7 +324,10 @@ export const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
  * The anonymous `health` query (`Stats.getLandingStats` reads D1) needs no auth; the wire
  * envelope (`{version, operations}`) mirrors the harness `fateBatch`.
  */
-export const warmFateRead = (url: string): Effect.Effect<void, never, never> =>
+export const warmFateRead = (
+	url: string,
+	deadlineMs: number = EDGE_READY_DEADLINE_MS,
+): Effect.Effect<void, never, never> =>
 	Effect.tryPromise({
 		try: async () => {
 			// A 200 means the route + D1 read served; a cold PoP placeholder-404 (the thrown edge
@@ -336,10 +343,10 @@ export const warmFateRead = (url: string): Effect.Effect<void, never, never> =>
 						}),
 					}),
 				fateReadReady,
-				{pollMs: WARM_POLL_MS, deadlineMs: EDGE_READY_DEADLINE_MS},
+				{pollMs: WARM_POLL_MS, deadlineMs},
 			);
 			if (!fateReadReady(res)) {
-				throw new WarmNotSettledError("POST /fate warm", res, EDGE_READY_DEADLINE_MS);
+				throw new WarmNotSettledError("POST /fate warm", res, deadlineMs);
 			}
 		},
 		catch: (cause) => new ProbeError({cause}),
@@ -384,12 +391,13 @@ export const deployTransientRetry = Effect.retry({
  * workers.dev route 404s (the CF edge placeholder) for a few seconds while it propagates, so it
  * rides the shared readiness budget (`awaitEdgeReady` + `edgeFetch`, ADR 0127): the thrown
  * placeholder-404 AND any non-ready response retry until healthy. A worker that never serves
- * healthy JSON within the bound (60 × 2s) DIES with a clear message rather than hanging —
- * `Effect.promise` turns the thrown exhaustion error into a defect, the same hard failure the
- * retired `Effect.die` produced. ONE copy for both deploy paths (the per-file `integrationStack`
- * and the shared-stage `_global-setup.ts`), each passing its OWN readiness budget: the shared path
- * takes the default `DEPLOY_HEALTH_DEADLINE_MS`, the hook-bound per-file path passes the smaller
- * `PER_FILE_HEALTH_DEADLINE_MS` so the typed throw beats the vitest hook ceiling (#3146; #3080).
+ * healthy JSON within `deadlineMs` DIES with a clear message rather than hanging — `Effect.promise`
+ * turns the thrown exhaustion error into a defect, the same hard failure the retired `Effect.die`
+ * produced. ONE copy for both deploy paths (the per-file `integrationStack` and the shared-stage
+ * `_global-setup.ts`), each passing its OWN readiness budget: the shared, non-hook-bound path takes
+ * the default `DEPLOY_HEALTH_DEADLINE_MS`, while the hook-bound per-file path passes what its shared
+ * readiness deadline has left (`perFileReadinessDeadline`), so the whole probe chain stays under the
+ * vitest hook ceiling and the typed throw beats it (#3146; #3080; #3788).
  */
 export const awaitWorkerReady = (
 	url: string,
@@ -477,37 +485,52 @@ export function integrationStack(metaUrl: string): Harness {
 	let d1Target: {accountId: string; databaseId: string} | undefined;
 
 	const stack = beforeAll(
-		deploy(Stack, {stage}).pipe(
-			deployTransientRetry,
-			Effect.tap((out: Input.Resolve<StackOutput>) =>
-				Effect.gen(function* () {
-					// The deploy publishes the worker URL with a trailing slash; the harness
-					// appends leading-slash paths, so strip it once here at the publish point
-					// to avoid `//api/...` (which workerd parses as a protocol-relative URL).
-					const resolved = out as {url: string; accountId: string; databaseId: string};
-					const url = resolved.url.replace(/\/+$/, "");
-					if (!url) return yield* Effect.die(new Error("deploy returned no worker url"));
-					workerUrl = url;
-					// The D1 uuid + account this stage deployed, read straight off the
-					// compiled Stack output (alchemy `Cloudflare.D1Database`) — the harness's
-					// setup-only D1 REST path reads the id the deploy knows, never a
-					// reconstructed physical name (#692).
-					if (!resolved.databaseId) {
-						return yield* Effect.die(new Error("deploy returned no D1 databaseId"));
-					}
-					d1Target = {accountId: resolved.accountId, databaseId: resolved.databaseId};
-					// Per-file, hook-bound readiness budget (`PER_FILE_HEALTH_DEADLINE_MS`), sized
-					// below the restored hook ceiling so a slow/stuck edge fails as a typed diagnostic
-					// BEFORE the vitest guillotine — never the opaque "Hook timed out" (#3146).
-					yield* awaitWorkerReady(url, PER_FILE_HEALTH_DEADLINE_MS);
-					yield* warmLiveDO(url);
-					yield* warmFateRead(url);
-				}),
-			),
-		),
+		// Capture the hook's start BEFORE `deploy` — `Effect.suspend` defers `Date.now()` to hook-run
+		// time (the accessor is built at module top level, run much later), so the shared readiness
+		// deadline derived from it below anchors on the real hook start, not module eval.
+		Effect.suspend(() => {
+			const hookStartedAt = Date.now();
+			return deploy(Stack, {stage}).pipe(
+				deployTransientRetry,
+				Effect.tap((out: Input.Resolve<StackOutput>) =>
+					Effect.gen(function* () {
+						// The deploy publishes the worker URL with a trailing slash; the harness
+						// appends leading-slash paths, so strip it once here at the publish point
+						// to avoid `//api/...` (which workerd parses as a protocol-relative URL).
+						const resolved = out as {url: string; accountId: string; databaseId: string};
+						const url = resolved.url.replace(/\/+$/, "");
+						if (!url) return yield* Effect.die(new Error("deploy returned no worker url"));
+						workerUrl = url;
+						// The D1 uuid + account this stage deployed, read straight off the
+						// compiled Stack output (alchemy `Cloudflare.D1Database`) — the harness's
+						// setup-only D1 REST path reads the id the deploy knows, never a
+						// reconstructed physical name (#692).
+						if (!resolved.databaseId) {
+							return yield* Effect.die(new Error("deploy returned no D1 databaseId"));
+						}
+						d1Target = {accountId: resolved.accountId, databaseId: resolved.databaseId};
+						// ONE shared wall-clock deadline for the whole readiness chain (health + both
+						// warms), anchored at the hook start and derived from the hook ceiling: each probe
+						// consumes `deadline - now()`, so together they can never push this beforeAll past
+						// HOOK_TIMEOUT_MS — the >300s worst case the retired fixed-per-probe budgets summed
+						// into is unrepresentable by construction. The later-propagating `/fate/live`/`POST
+						// /fate` warms now use whatever health did not need instead of a fixed 60s smaller
+						// than health's (#1058, #3788), and a probe reached after the window is spent gets a
+						// floored-at-0 budget → its own typed diagnostic, never the opaque "Hook timed out"
+						// (the #3146 invariant holds). See `perFileReadinessDeadline`.
+						const readinessDeadline = perFileReadinessDeadline(hookStartedAt);
+						const remaining = () => Math.max(0, readinessDeadline - Date.now());
+						yield* awaitWorkerReady(url, remaining());
+						yield* warmLiveDO(url, remaining());
+						yield* warmFateRead(url, remaining());
+					}),
+				),
+			);
+		}),
 		// Undo alchemy `Test.make`'s silent clamp of the deploy hook to its `DEFAULT_TIMEOUT` (120s):
-		// thread the already-configured `hookTimeout` so the hook honors 180s (see `HOOK_TIMEOUT_MS`).
-		// NOT a raised ceiling — a restored one; the readiness budget above stays well under it (#3146).
+		// thread the already-configured `hookTimeout` so the hook honors the full `HOOK_TIMEOUT_MS`
+		// (300s). NOT a raised ceiling — a restored one; the readiness chain above is bounded strictly
+		// under it by the shared deadline, so the typed throw always beats this guillotine (#3146; #3788).
 		{timeout: HOOK_TIMEOUT_MS},
 	);
 


### PR DESCRIPTION
Closes #3788

## What & why

The per-file integration deploy `beforeAll` gave `/api/health` 180s
(`PER_FILE_HEALTH_DEADLINE_MS`) but capped the two later probes — `warmLiveDO`
(`/fate/live`) and `warmFateRead` (`POST /fate`) — at a fixed 60s each. `/fate/live`
is documented to propagate *later* than `/api/health` (#1058), yet it got a third of
health's budget. Worse, the sizing comment reasoned only about `deploy + health`; it
omitted the two trailing 60s warms, so the real worst case — `health 180 + live 60 +
fate 60 = 300`, *on top of* the deploy — already exceeded `HOOK_TIMEOUT_MS` (300s), the
latent opaque "Hook timed out" guillotine #3146 was closed to prevent.

## The fix — one shared wall-clock deadline, bounded by construction

Instead of picking a bigger number per probe, the whole readiness chain now shares
**one** wall-clock deadline anchored at the hook's start and derived from the hook
ceiling (`perFileReadinessDeadline` = `hookStart + HOOK_TIMEOUT_MS - margin`). Health
and both warms each consume `deadline - now()`, so their budgets **together** can never
push the hook past `HOOK_TIMEOUT_MS`. The >300s worst case is now **unrepresentable by
construction** rather than reasoned about in a comment that had to keep summing every
chain member (and silently stopped summing).

Two properties fall out for free:
- The later-propagating `/fate/live` / `POST /fate` warms use **whatever health did not
  need** (typically the bulk of the window) instead of a fixed 60s smaller than health's.
- A probe reached after the window is already spent gets a **floored-at-0** budget → it
  fails as its own typed diagnostic (`WorkerNotReadyError` / `WarmNotSettledError`),
  never the opaque hook timeout. The #3146 named-diagnostic invariant holds.

### On the AC1 "grounding" requirement

AC1 asks the chosen sizing to be grounded in measured propagation rather than intuition.
The shared-deadline shape **sidesteps picking a per-probe number entirely** — every probe
draws from one ceiling-derived pool, so there is no intuited budget to ground. The only
constant introduced is the 15s hook-margin, and that is grounded in the poll mechanics
(`awaitEdgeReady` checks the deadline only *between* polls, so the last iteration can
overshoot by one `WARM_POLL_MS` ~2s + a final fetch before the typed throw propagates),
not in edge-propagation timing. This is the shape AC2 blesses as making the state
unrepresentable.

## Scope

- `apps/web/tests/integration/_edge-ready.ts` — retire `PER_FILE_HEALTH_DEADLINE_MS` +
  its no-longer-summing sizing comment; add `READINESS_HOOK_MARGIN_MS` and the pure
  `perFileReadinessDeadline(hookStartedAt)` helper.
- `apps/web/tests/integration/_integration.ts` — `integrationStack`'s hook captures its
  start (`Effect.suspend` → `Date.now()`), derives the shared deadline, and threads
  `deadline - now()` into `awaitWorkerReady` / `warmLiveDO` / `warmFateRead`. Both warms
  gain a `deadlineMs` param defaulting to the prior `EDGE_READY_DEADLINE_MS`.
- `_global-setup.ts` (the shared-stage caller, AC3) is left calling the warms with the
  default: it is **not** hook-bound, so it keeps its generous single budget unchanged — the
  defaulted param means the changed signatures don't regress it.
- `apps/web/tests/integration/_edge-ready.unit.test.ts` — unit-pin the bound: the chain
  stays `< HOOK_TIMEOUT_MS`, each probe consumes `deadline - now()`, and the budget floors
  at 0 (AC2's "provably ≤ ceiling").

## Verification

- `pnpm typecheck --filter=@kampus/web` (forced, fresh) — green.
- `biome check` on the three changed files — clean.
- `vitest --project unit tests/integration/_edge-ready.unit.test.ts` — 31 passed
  (28 prior + 3 new `perFileReadinessDeadline` bound tests).
