### PR TITLE
chore(pipeline): strip phantom Grep/Glob from kampus-pipeline subagent defs (#3782)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/adr.md
+++ b/claude-plugins/kampus-pipeline/agents/adr.md
@@ -3,7 +3,7 @@ name: adr
 description: Use this agent when a meaningful technical decision, convention, or preference has been stated that future agents must respect and it needs recording as a `.decisions/NNNN-slug.md` file — it wraps the adr skill end to end over one decision. Typical triggers include "/adr", "record this decision", "save this as an ADR", and "ADR for X". Spawn it (with isolation:worktree) as the decision-recording stage of the pipeline; do NOT use it to author `.patterns/` docs (`canon`), maintain the `.glossary/` nouns (`glossary`), implement, review, or merge — it adds one ADR file, nothing more. See "When to invoke" in the agent body for worked scenarios.
 model: inherit
 color: blue
-tools: ["Read", "Edit", "Write", "Bash", "Grep", "Glob"]
+tools: ["Read", "Edit", "Write", "Bash"]
 ---
 
 You are the **adr** agent — the decision-recording stage of the kampus issue pipeline. You

--- a/claude-plugins/kampus-pipeline/agents/canon.md
+++ b/claude-plugins/kampus-pipeline/agents/canon.md
@@ -3,7 +3,7 @@ name: canon
 description: Use this agent when the repo's `.patterns/*.md` docs have drifted from the source and need re-grounding, or a pattern that clears the index bar has no doc yet — it wraps the canon skill end to end over one pattern surface. Typical triggers include "canon a pattern", "author a pattern doc for X", "refresh `.patterns/<x>` from source", "the patterns drifted from the code", and "bootstrap a pattern doc". Spawn it (with isolation:worktree) as the patterns-maintenance stage of the pipeline; do NOT use it to run an architecture audit, maintain the `.glossary/` nouns, record a `.decisions/` ADR, or touch application code — it edits `.patterns/` only. See "When to invoke" in the agent body for worked scenarios.
 model: inherit
 color: green
-tools: ["Read", "Edit", "Write", "Bash", "Grep", "Glob"]
+tools: ["Read", "Edit", "Write", "Bash"]
 ---
 
 You are the **canon** agent — the patterns-maintenance stage of the kampus issue pipeline.

--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -3,7 +3,7 @@ name: coder
 description: Use this agent when the pipeline needs the next triaged issue turned into a PR, or a FAIL'd PR repaired — it wraps the write-code skill end to end. Typical triggers include "work the next issue", "implement issue #N", "pick up an issue", and "repair PR #N" / "fix the FAIL on PR #N". Spawn it (with isolation:worktree) as the execution stage of the issue pipeline; do NOT use it to review, merge, or close a human-filed issue. See "When to invoke" in the agent body for worked scenarios.
 model: inherit
 color: green
-tools: ["Read", "Edit", "Write", "Bash", "Grep", "Glob"]
+tools: ["Read", "Edit", "Write", "Bash"]
 ---
 
 You are the **coder** — the execution stage of the kampus issue pipeline. You take the

--- a/claude-plugins/kampus-pipeline/agents/planner.md
+++ b/claude-plugins/kampus-pipeline/agents/planner.md
@@ -3,7 +3,7 @@ name: planner
 description: Use this agent when triage has emitted a genuinely-triaged `type:epic` that needs decomposing into a PRD-grade task ledger — it wraps the plan-epic skill end to end. Typical triggers include "plan the epic", "plan epic #N", "break down the epic #N", and "decompose epic #N into children". Spawn it (with isolation:worktree) as the planning stage of the issue pipeline, between triage and write-code; do NOT use it to classify, implement, review, or merge — and never to plan an epic that isn't already triaged. See "When to invoke" in the agent body for worked scenarios.
 model: inherit
 color: purple
-tools: ["Read", "Bash", "Grep", "Glob"]
+tools: ["Read", "Bash"]
 ---
 
 You are the **planner** — the epic-decomposition stage of the kampus issue pipeline. You

--- a/claude-plugins/kampus-pipeline/agents/reporter.md
+++ b/claude-plugins/kampus-pipeline/agents/reporter.md
@@ -3,7 +3,7 @@ name: reporter
 description: Use this agent the moment an observation worth tracking surfaces while doing other work — a bug, a refactor, a design question, an investigation, a missing test, a confusing convention — and you want it filed as a triageable GitHub issue without interrupting the main task. It wraps the report skill end to end. Typical triggers include "file an issue", "report this", "open a follow-up", "track this for later", and "/report". Spawn it to capture an observation into raw intake; do NOT use it to classify, prioritize, fix, or close — that is triage's and the coder's job.
 model: inherit
 color: cyan
-tools: ["Bash", "Read", "Grep", "Glob"]
+tools: ["Bash", "Read"]
 ---
 
 You are the **reporter** — the intake stage of the kampus issue pipeline. You take an

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -3,7 +3,7 @@ name: reviewer
 description: Use this agent when the pipeline needs a PR (or a planned epic) verified against its linked issue's acceptance criteria before it advances — it is the single routing review gate, wrapping the five review skills. Typical triggers include "review this PR", "verify PR #N", "gate PR #N before merge", and "review the plan for epic #N". Spawn it (with isolation:worktree) as the verification stage of the issue pipeline; it routes by artifact class and **fans across every class the diff spans** — code → review-code, docs → review-doc, skills/agents → review-skill (each present class gated in one pass), a UI-affecting PR → review-design (dispatched alongside), an epic plan → review-plan — landing one SHA-bound verdict per present class on the PR. It never edits a file, never merges, and never reviews its own work. See "When to invoke" in the agent body for worked scenarios.
 model: inherit
 color: purple
-tools: ["Read", "Grep", "Glob", "Bash"]
+tools: ["Read", "Bash"]
 ---
 
 You are the **reviewer** — the verification stage of the kampus issue pipeline. You take

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -3,7 +3,7 @@ name: shipper
 description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it (with isolation:worktree) once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". For control-plane PRs (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053): it enqueues a §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — the human owns the judgment (the approval), the pipeline owns the mechanics (the enqueue). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
 model: inherit
 color: blue
-tools: ["Read", "Bash", "Grep", "Glob"]
+tools: ["Read", "Bash"]
 ---
 
 You are the **shipper** — the terminal stage of the kampus issue pipeline and the one

--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -3,7 +3,7 @@ name: triager
 description: Use this agent when the pipeline needs the next raw issue turned into actionable, correctly-typed work — it wraps the triage skill end to end over one issue in the status:needs-triage queue. Typical triggers include "triage the queue", "triage issue #N", "process needs-triage", and "classify these issues". Spawn it as the intake-guardrail stage between report and write-code; do NOT use it to implement, review, merge, or plan an epic — it classifies and routes, nothing more. See "When to invoke" in the agent body for worked scenarios.
 model: inherit
 color: yellow
-tools: ["Read", "Bash", "Grep", "Glob"]
+tools: ["Read", "Bash"]
 ---
 
 You are the **triager** — the intake-guardrail stage of the kampus issue pipeline. You

--- a/claude-plugins/pipeline-crew/SPAWN-SCOPE.md
+++ b/claude-plugins/pipeline-crew/SPAWN-SCOPE.md
@@ -53,3 +53,13 @@ Two rules it enforces, both worth knowing when editing a def:
 - Do not name a tool in **both** `tools:` and `disallowedTools:` — the second deletes the first.
 - Do not declare `Grep` or `Glob`. They are not tools a top-level session is granted; `Bash` covers
   those reads.
+
+**Both rules bind the whole roster, not just the launched seats.** They are declaration rules for
+*every* def the crew ships — the crew seats here **and** the kampus-pipeline subagent defs under
+[`../kampus-pipeline/agents/`](../kampus-pipeline/agents/) (`coder`, `reviewer`, `shipper`,
+`planner`, `canon`, `adr`, `triager`, `reporter`). `toolset-assert.ts` only *enforces* them for the
+seats the launcher launches; **no launcher spawns the subagent defs**, so nothing mechanically
+catches a phantom `Grep`/`Glob` there — the rule itself is the guard. Every subagent def carried the
+same phantom `Grep`/`Glob` silent-drop as the seats did (#3782, the subagent half of #3764); when
+authoring or editing one, keep its `tools:` to what the CLI actually grants (`Read`, `Edit`,
+`Write`, `Bash`, and any `mcp___…` tool), never `Grep`/`Glob`.


### PR DESCRIPTION
Fixes #3782

## What & why

Every `claude-plugins/kampus-pipeline/agents/*.md` def declared `Grep` and `Glob` in its `tools:` allowlist, and the CLI grants **neither** at the top-level session — both are silently dropped, so the declaration reads like a grant but is a no-op. This is the **subagent half of #3764** (which fixed the crew seats): the same phantom-name silent-drop that kept #3764's load-bearing `Task` loss invisible for a whole session. `Bash` already covers those reads, so **no behavior change** is expected or wanted (`type:chore`).

## Changes

**AC1 — drop the phantom names from all eight defs.** `Grep`/`Glob` removed from `coder`, `reviewer`, `shipper`, `planner`, `canon`, `adr`, `triager`, `reporter`, leaving only the tools the CLI actually grants:

| def | before | after |
|---|---|---|
| `coder` / `adr` / `canon` | `["Read","Edit","Write","Bash","Grep","Glob"]` | `["Read","Edit","Write","Bash"]` |
| `planner` / `triager` / `shipper` | `[…,"Bash","Grep","Glob"]` | `["Read","Bash"]` |
| `reviewer` | `["Read","Grep","Glob","Bash"]` | `["Read","Bash"]` |
| `reporter` | `["Bash","Read","Grep","Glob"]` | `["Bash","Read"]` |

**AC2 — generalize the SPAWN-SCOPE.md rule.** The "do not declare `Grep` or `Glob`" rule now explicitly binds the **whole roster** — crew seats *and* the `kampus-pipeline` subagent defs — and notes that `toolset-assert.ts` only *enforces* it for the seats the launcher launches; **no launcher spawns the subagent defs**, so the rule itself is their only guard against reintroduction.

**AC3 — out of scope (routed, not graded).** A fail-closed toolset assert for the subagent defs is a design question (where would it live — no launcher spawns them?), left out per the issue and ADR 0079. Not filing a separate report: the AC2 doc rule is a sufficient guard for a `type:chore` cleanup, and the issue frames the assert as optional ("if the implementer thinks one is worth it").

## Verification

- `grep -rn "Grep\|Glob" claude-plugins/kampus-pipeline/agents/` → no matches.
- All eight `tools:` lines now name only CLI-grantable tools.

## Control-plane note

This touches `claude-plugins/kampus-pipeline/agents/**` and `claude-plugins/pipeline-crew/SPAWN-SCOPE.md` — pipeline control-plane. Scoped tightly to the agent-def frontmatter tool declarations and the one SPAWN-SCOPE declaration rule; no skill machinery, gate logic, or unrelated §CP paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
