### PR TITLE
roadmap: record Pipeline Anywhere campaign (active)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | §CP Verdict Integrity | #38 | active |
 | Flag Graduation | #39 | active |
 | pipeline-cli Glue Consolidation | #40 | active |
+| Pipeline Anywhere | #35 | active |
 | pipeline-cli @effect/platform migration | #32 | active |
 | Agentic design-system coverage | #33 | done |
 | Flag Retirement (ADR 0136) | #34 | active |


### PR DESCRIPTION
Records the **Pipeline Anywhere** audit wave (`pipeline-anywhere`) as a bounded campaign — milestone #35, p1, platform-lane drained (ADR 0201 settled ground). Founder-approval trace verified: `pipeline-cli campaign verify-trace pipeline-anywhere` → PASS (marker comment on the tracking issue). Wave members: #3833 (publish-isolation CI guard, lead deliverable), #3653, #3366, #3761.

Fixes #3827

🤖 Generated with [Claude Code](https://claude.com/claude-code)