### PR TITLE
feat(pipeline-crew-mcp): attached-inbox liveness — presence reflects a live channel half (#3628)

### DIFF
--- a/packages/pipeline-crew-mcp/docs/explanation.md
+++ b/packages/pipeline-crew-mcp/docs/explanation.md
@@ -82,6 +82,18 @@ the shape it produces:
 The result is a claim that cannot age out mid-build and cannot outlive its holder — the two
 failures a wall-clock TTL forced you to choose between.
 
+## Presence has two phases: reserved vs attached
+
+Presence itself is split so that being *registered* means an inbox is actually serving, not merely
+that a process claimed a slot (#3628). A session **reserves** a bare lease at construction — enough
+to hold its role slot and back the cardinality claim's liveness clock above — but that bare lease is
+**not discoverable**: `lookup` (and so every `channel_send`) skips it. The session only **announces**
+an attached lease once its inbox socket is bound and serving, and only then does it appear as a live
+peer. The failure this designs out is the *channel-deaf* pane: a role that looks up in tmux but never
+attached its inbox half, so it used to register as live while every send to it dead-lettered. Under
+the two phases a channel-deaf session never becomes discoverable, and a send to a present-but-unserved
+inbox fails fast with a distinguishable `ChannelDeafError` rather than a generic timeout.
+
 ## The two-keyspace design
 
 `RegistryState` holds **two maps that never share** — presence leases keyed by `peer`, resource

--- a/packages/pipeline-crew-mcp/docs/reference.md
+++ b/packages/pipeline-crew-mcp/docs/reference.md
@@ -149,7 +149,7 @@ claims ride it.
 | Name | Definition |
 | --- | --- |
 | `DEFAULT_TTL_SECONDS` | `30` — the presence TTL applied on announce, until the first `heartbeat` sets a real one. |
-| `Lease` | `{ role: string; peer: string; ttlSeconds: number; lastSeenMillis: number }` — one presence lease. |
+| `Lease` | `{ role: string; peer: string; ttlSeconds: number; lastSeenMillis: number; attached: boolean }` — one presence lease. `attached` is the live-channel-half phase (#3628): a bare reservation (`false`) holds the role slot but is not discoverable; an announce (`true`) marks the inbox serving. |
 | `Claim` | `{ resource: string; holder: string; claimantRole: string; claimedAtMillis: number }` — one resource claim (no TTL of its own). |
 | `RegistryState` | `{ leases: ReadonlyMap<string, Lease>; claims: ReadonlyMap<string, Claim> }`. |
 | `PresenceRecord` | `{ peer: string; role: string; lastSeenMillis: number }` — a present peer as the core reports it. |
@@ -165,12 +165,13 @@ All are pure `(state, …) -> state` (or a read); the service (`../tracker/regis
 | Function | Signature | Behavior |
 | --- | --- | --- |
 | `empty` | `() => RegistryState` | A fresh registry, both keyspaces empty. |
-| `announce` | `(state, { role, peer, ttlSeconds, nowMillis }) => RegistryState` | Upsert `peer`'s lease keyed by `peer`, bumping `lastSeen` to now. Never rejects; two peers on one role coexist. |
+| `announce` | `(state, { role, peer, ttlSeconds, nowMillis }) => RegistryState` | Upsert `peer`'s lease keyed by `peer` as **attached** (serving/discoverable), bumping `lastSeen` to now. Never rejects; two peers on one role coexist. |
+| `reserve` | `(state, { role, peer, ttlSeconds, nowMillis }) => RegistryState` | Upsert `peer`'s lease as a **bare** (`attached: false`) reservation — holds the role slot and backs the cardinality claim's liveness, but is not returned by `lookup` until the peer announces attached (#3628). |
 | `claimResource` | `(state, { resource, holder, claimantRole, nowMillis }) => { state; outcome: ClaimOutcome }` | `Granted` when free, held by an aged-out holder, or re-claimed by `holder` itself (re-claim keeps `since`); `Collision` (state untouched) when a **different** holder with live presence holds it. |
 | `releaseClaim` | `(state, { resource, claimant }) => RegistryState` | Free the claim **only if** `claimant` is its holder; releasing a claim you do not hold, or a nonexistent one, is an idempotent no-op. |
 | `claimHolder` | `(state, resource, nowMillis) => string \| undefined` | The live holder of `resource`, or `undefined` when unclaimed or its holder's presence has aged out. |
 | `heartbeat` | `(state, { peer, ttlSeconds, nowMillis }) => RegistryState` | Refresh `peer`'s lease (bump `lastSeen`, adopt the TTL); never touches claims. A beat for a peer with no lease is a no-op. |
-| `lookup` | `(state, role, nowMillis) => ReadonlyArray<PresenceRecord>` | Every live lease serving `role`, or `[]`. Reads the presence keyspace only. |
+| `lookup` | `(state, role, nowMillis) => ReadonlyArray<PresenceRecord>` | Every live **attached** lease serving `role`, or `[]`. A bare reservation (inbox not yet serving) is deliberately invisible here (#3628). Reads the presence keyspace only. |
 | `release` | `(state, peer) => RegistryState` | Free `peer`'s lease and reap every claim it holds — a graceful connection close. |
 | `prune` | `(state, nowMillis) => RegistryState` | Drop every lease aged past its TTL, then reap every claim whose holder no longer has a live lease (leases pruned first). |
 
@@ -186,8 +187,9 @@ from this module (`typeof Schema.ClaimReply.Type`).
 | `claim` | `(input: { resource: string; claimant: string; role: string }) => Effect.Effect<ClaimReply>` |
 | `acquireClaim` | `(input: { resource: string; claimant: string; role: string }) => Effect.Effect<ClaimReply, never, Scope.Scope>` — claim for the enclosing scope; on close frees via `Release` iff it was `granted`. |
 | `release` | `(input: { resource: string; claimant: string }) => Effect.Effect<void>` |
-| `announce` | `(presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>` — soft presence held for the enclosing scope (connection-is-lease). |
-| `heartbeat` | `(input: { peer: string; ttlSeconds: number }) => Effect.Effect<void>` — presence-only refresh; never touches a claim. |
+| `announce` | `(presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>` — attached (serving/discoverable) presence held for the enclosing scope (connection-is-lease); run once the inbox attaches (#3628). |
+| `reserve` | `(presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>` — a bare role-slot reservation held for the enclosing scope; backs the cardinality claim but is not discoverable until `announce` (#3628). |
+| `heartbeat` | `(input: { peer: string; ttlSeconds: number }) => Effect.Effect<void>` — presence-only refresh; preserves the attached phase, never touches a claim. |
 | `lookup` | `(role: string) => Effect.Effect<ReadonlyArray<RolePresence>>` — every live holder (`[]` ⇒ absent/expired). |
 
 Layer constructors: `CrewTracker.fromClient(client)`, `crewTrackerSocketLayer(socketPath)`, and

--- a/packages/pipeline-crew-mcp/docs/tutorial.md
+++ b/packages/pipeline-crew-mcp/docs/tutorial.md
@@ -85,8 +85,8 @@ const program = Effect.gen(function* () {
 	const wakes = yield* Ref.make<ReadonlyArray<ChannelNotificationPayload>>([]);
 	const sink = Layer.succeed(ChannelSink, {wake: (p) => Ref.update(wakes, (xs) => [...xs, p])});
 
-	// Bring peer B up: build its channel (announces its presence to the tracker) and start its
-	// inbox socket server so a dial can reach it. Layer.build keeps both alive for the scope.
+	// Bring peer B up: build its channel (claims its role slot + reserves a bare presence) and start
+	// its inbox socket server so a dial can reach it. Layer.build keeps both alive for the scope.
 	const ctxB = yield* Layer.build(substrate(B));
 	const channelB = yield* Effect.provide(
 		makeCrewChannel({role: "engineering-manager", address: B}),
@@ -94,6 +94,9 @@ const program = Effect.gen(function* () {
 	);
 	yield* Layer.build(inboxServerSocketLayer(B).pipe(Layer.provide([sink, NodeFileSystem.layer])));
 	yield* Effect.sleep("400 millis"); // let B's inbox socket finish binding
+	// Only NOW that B's inbox is serving does it announce a discoverable presence — so a lookup returns
+	// B as a live peer, never a channel-deaf bare lease (#3628).
+	yield* channelB.announce;
 
 	// Bring peer A up on the same project tracker.
 	const ctxA = yield* Layer.build(substrate(A));
@@ -125,8 +128,10 @@ Effect.runPromise(program).then(
 Three things are worth pausing on, because they are the substrate's real seams:
 
 - **`makeCrewChannel`** is the composition root ([`../src/crew/channel-server.ts`](../src/crew/channel-server.ts)):
-  it claims the peer's role slot, announces presence, and hands you back a channel with `peer.send`
-  (outbound) and `claim` (deconfliction). It is exactly what a live `session` builds internally.
+  it claims the peer's role slot and reserves a bare presence lease, then hands you back a channel with
+  `peer.send` (outbound), `claim` (deconfliction), and `announce`. Presence becomes **discoverable**
+  only when you run `channel.announce` — which a live `session` does once its inbox socket is serving,
+  so presence reflects a live channel half, not a bare lease (#3628).
 - **`peer.send(role, kind, body)`** addresses a *role*. Under the hood it asks the tracker for a
   live holder, then dials that peer's inbox socket — the tracker is never in the message path.
 - **`channel.claim(resource)`** hits the tracker's claim RPC and returns a typed reply. Its

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.test.ts
@@ -67,6 +67,10 @@ describe("crew/channel-server — announce, discover, claim/collision-check (AC 
 			const b = yield* makeCrewChannel({role: roleB, address: "inbox://b"}).pipe(
 				Effect.provide(channelLayers(tracker, "inbox://b", alwaysUnreachable)),
 			);
+			// presence is announced explicitly now (the peer no longer announces on construction, #3628):
+			// each channel publishes its presence — standing in for "its inbox is attached and serving".
+			yield* a.announce;
+			yield* b.announce;
 
 			// discover each other across the flat topology (each a singleton set here)
 			const aFindsB = yield* a.discover(roleB);
@@ -256,6 +260,8 @@ describe("crew/channel-server — per-kind cardinality lease (AC 3)", () => {
 					Effect.provide(channelLayers(tracker, `inbox://${role}`, alwaysUnreachable)),
 				);
 				assert.strictEqual(channel.role, role);
+				// presence is published by the explicit announce now, not construction (#3628)
+				yield* channel.announce;
 			}
 			// every role is independently discoverable — five distinct leases coexist
 			for (const role of CREW_ROLES) {

--- a/packages/pipeline-crew-mcp/src/crew/channel-server.ts
+++ b/packages/pipeline-crew-mcp/src/crew/channel-server.ts
@@ -19,7 +19,7 @@
  */
 import {createHash} from "node:crypto";
 import {NodeSocket, NodeSocketServer} from "@effect/platform-node";
-import {Effect, type FileSystem, Layer} from "effect";
+import {Effect, type FileSystem, Layer, type Scope} from "effect";
 import {RpcClient, RpcSerialization, RpcServer} from "effect/unstable/rpc";
 import {type ChannelSink, channelInboxLayer} from "../edge/index.ts";
 import {
@@ -66,6 +66,12 @@ export interface CrewChannel {
 	/** The composed peer: its inbox (`received`) + its direct peer-to-peer `send`. */
 	readonly peer: Peer;
 	/**
+	 * Publish this channel's presence, held for the enclosing scope. Split out of `makeCrewChannel`
+	 * (the peer no longer announces on construction) so presence reflects a live channel half, not the
+	 * mere claim of a role slot (#3628): the session announces ONLY after its inbox socket server binds.
+	 */
+	readonly announce: Effect.Effect<void, never, Scope.Scope>;
+	/**
 	 * Role discovery: the live holders of `role` across the flat topology (`[]` ⇒ none). A bridge
 	 * resolves to its single holder; an engine to its whole live pool, so a caller can address one
 	 * chosen instance (dial its `address`) or fan across the set.
@@ -83,8 +89,10 @@ export interface CrewChannel {
 
 /**
  * Stand up a crew channel for one role: acquire its per-kind cardinality lease, then compose the
- * peer (which announces its presence for the connection lifetime). Requires the substrate seams —
- * `CrewTracker`, the peer `Tracker`/`Inbox`/`Dialer` ports — in context.
+ * peer. Constructing the channel does NOT announce presence — the caller runs `channel.announce`
+ * once its inbox is attached and serving (#3628), so a live lease is never published for a
+ * channel-deaf session. Requires the substrate seams — `CrewTracker`, the peer
+ * `Tracker`/`Inbox`/`Dialer` ports — in context.
  *
  * The lease is keyed by `cardinalityLeaseKey` (see above): a bridge collides on its shared role
  * key (a second live holder is REJECTED with `RoleUniquenessError`), an engine gets a per-instance
@@ -112,6 +120,7 @@ export const makeCrewChannel = Effect.fn("crew.makeCrewChannel")(function* (
 		role: config.role,
 		address: config.address,
 		peer,
+		announce: peer.announce,
 		discover: (role: CrewRole) => tracker.lookup(role),
 		claim: (resource: string) =>
 			tracker.claim({resource, claimant: config.address, role: config.role}),

--- a/packages/pipeline-crew-mcp/src/crew/heartbeat.ts
+++ b/packages/pipeline-crew-mcp/src/crew/heartbeat.ts
@@ -3,6 +3,11 @@
  * on an interval safely under `DEFAULT_TTL_SECONDS`, so a live session's presence + role lease
  * never ages out. Without it the substrate only functions for the first ~30s window (#3218).
  *
+ * The beat only ever REFRESHES an existing lease — it cannot manufacture presence (a beat for a peer
+ * with no lease is a registry-core no-op). Presence is created solely by the inbox-gated announce
+ * (`crew/session.ts`, #3628), so a channel-deaf session — one whose inbox never attached, so it never
+ * announced — holds no live presence no matter how its keepalive beats.
+ *
  * Presence-only by construction: each tick sends exactly one `Heartbeat {peer, ttlSeconds}` and
  * nothing else — it never refreshes or iterates a resource claim. A finished claim is freed by
  * `Release`; a crashed holder's claims are reaped when its presence ages out. Keeping the sender

--- a/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.assembly.test.ts
@@ -99,4 +99,53 @@ describe("crew/session — forked-stdio live-wake round-trip (session.ts:34 seam
 			}).pipe(Effect.scoped),
 		{timeout: 20000},
 	);
+
+	it.live(
+		"the live assembly publishes presence only AFTER its inbox socket binds — LookupRole returns the session (#3628 AC1/AC2)",
+		() =>
+			Effect.gen(function* () {
+				// A shared registry client, so the test can both back the session's substrate AND read
+				// LookupRole against the very registry the session announces on.
+				const client = yield* RpcTest.makeClient(TrackerRegistry);
+				const trackerLayer = CrewTracker.fromClient(client);
+				const address = `inbox://intake-desk-presence-${randomUUID().slice(0, 8)}`;
+				const substrate = Layer.mergeAll(
+					trackerLayer,
+					peerTrackerLayer.pipe(Layer.provide(trackerLayer)),
+					Inbox.layer(address),
+					Dialer.layerFromConnect((addr) =>
+						Effect.fail(
+							new PeerUnreachableError({target: addr, reason: "presence-test stub dialer"}),
+						),
+					),
+				);
+				const transport = McpServer.layerStdio({
+					name: "CrewPresenceTestServer",
+					version: "0.0.0",
+					experimental: channelExperimentalCapability,
+				}).pipe(Layer.provide(Stdio.layerTest({stdin: Stream.never})));
+				const serverLayer = assembleCrewSession(
+					{role: "intake-desk", projectRoot: "/x"},
+					address,
+					substrate,
+					transport,
+				).pipe(Layer.provide(NodeFileSystem.layer), Layer.orDie);
+
+				// Before boot: the role is not a live peer — construction/claim alone never publishes it.
+				const before = yield* client.LookupRole({role: "intake-desk"});
+				assert.lengthOf(before.peers, 0, "no presence before the inbox serves");
+
+				yield* Effect.forkScoped(Layer.launch(serverLayer));
+				yield* Effect.sleep("1500 millis"); // window for the socket bind + the gated announce
+
+				const after = yield* client.LookupRole({role: "intake-desk"});
+				assert.lengthOf(after.peers, 1, "presence is published once the inbox socket is serving");
+				assert.strictEqual(
+					after.peers[0]?.peer,
+					address,
+					"the announced peer is this session's inbox address",
+				);
+			}).pipe(Effect.scoped, Effect.provide(registryHandlers)),
+		{timeout: 20000},
+	);
 });

--- a/packages/pipeline-crew-mcp/src/crew/session.ts
+++ b/packages/pipeline-crew-mcp/src/crew/session.ts
@@ -19,9 +19,10 @@
  * registrations + provide the transport once; claim the peer FIRST so `ChannelSend` is an instant
  * binding when the toolkit registers) and `.patterns/mcp-server-effect.md` for the Effect idiom.
  *
- * The per-kind cardinality lease + presence announce ride the peer's scope (`makeCrewChannel`): a
- * second live session for a held BRIDGE role fails the build with `RoleUniquenessError`, an ENGINE
- * role admits N instances, and presence frees on teardown (connection-is-lease, #3035). A bridge's
+ * The per-kind cardinality lease rides the peer's scope (`makeCrewChannel`): a second live session
+ * for a held BRIDGE role fails the build with `RoleUniquenessError`, an ENGINE role admits N
+ * instances. Presence, by contrast, is announced only AFTER the inbox socket server binds (#3628), so
+ * it reflects a live channel half and frees on teardown (connection-is-lease, #3035). A bridge's
  * address is its role (`inbox://<role>`) — its singleton lease keeps discover→dial deterministic;
  * an engine's is per-instance (`inbox://<role>/<instance>`) so its pool never collapses. See
  * `inboxAddressFor` (ADR 0189).
@@ -248,8 +249,15 @@ export const assembleCrewSession = <RIn, RSub = never>(
 			const inbound = inboxServerSocketLayer(address).pipe(
 				Layer.provide(ChannelSink.layerFromMcpServer),
 			);
+			// presence reflects a live channel half (#3628): announce THIS session ONLY after its inbox
+			// socket server has bound and is serving. Sequencing the announce AFTER `inbound` (`inbound` is
+			// referenced twice but memoized, so the socket binds once — the Race-1 memo the whole assembly
+			// leans on) is what makes "announced but channel-deaf" unrepresentable: a session whose inbox
+			// never attaches never publishes presence, so LookupRole never returns a deaf peer. The claim
+			// (role slot) still happens early above — only the presence announce waits on the inbox.
+			const presence = Layer.effectDiscard(channel.announce).pipe(Layer.provide(inbound));
 			// Provide the transport ONCE to the MERGED registrations — the single-instance memo (Race 1).
-			return Layer.mergeAll(outbound, claim, release, kinds, inbound).pipe(
+			return Layer.mergeAll(outbound, claim, release, kinds, inbound, presence).pipe(
 				Layer.provide(transport),
 			);
 		}),
@@ -259,7 +267,8 @@ export const assembleCrewSession = <RIn, RSub = never>(
  * The full runnable session layer: launch it (`Layer.launch`) to run one live crew session. The one
  * stdio `McpServer` is provided to the merged registrations exactly once (`assembleCrewSession`), so
  * the served server advertises the `channel_send` + `channel_claim` + `channel_release` + `channel_kinds`
- * tools + the `claude/channel` capability; the heartbeat rides the same `substrate` the outbound binding announces on.
+ * tools + the `claude/channel` capability; the heartbeat rides the same `substrate` the inbox-gated
+ * presence announce publishes on, so its beats refresh the lease that announce created (#3628).
  */
 export const crewSessionLayer = (config: CrewSessionConfig) => {
 	// One per-session instance id, resolved once here and threaded to every address derivation, so an

--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -69,8 +69,17 @@ export class CrewTracker extends Context.Service<
 			readonly resource: string;
 			readonly claimant: string;
 		}) => Effect.Effect<void>;
-		/** Soft presence announce, held for the enclosing scope (connection-is-lease). */
+		/**
+		 * Soft presence announce as ATTACHED (the inbox is serving) — the discoverable phase (#3628),
+		 * held for the enclosing scope (connection-is-lease). Call this only once the inbox has attached.
+		 */
 		readonly announce: (presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>;
+		/**
+		 * Reserve this session's role slot as a BARE lease, held for the enclosing scope: it backs the
+		 * crew cardinality claim + connection-is-lease but is NOT discoverable via `lookup` until the
+		 * peer attaches its inbox and `announce`s (#3628). The construction-time half of the two phases.
+		 */
+		readonly reserve: (presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>;
 		/**
 		 * Refresh this session's presence + role lease before it ages out. Presence-only: the sender
 		 * sends one `Heartbeat {peer, ttlSeconds}` and never touches a resource claim (#3228). Driven
@@ -108,13 +117,33 @@ export class CrewTracker extends Context.Service<
 			announce: (presence) =>
 				Effect.acquireRelease(
 					// peer-id ≡ inbox-address: announce the dialable address so a lookup can dial it back.
+					// attached: true ⇒ the discoverable phase — the inbox is serving (#3628).
 					client
-						.AnnouncePresence({peer: presence.address, role: presence.role, at: now()})
+						.AnnouncePresence({
+							peer: presence.address,
+							role: presence.role,
+							attached: true,
+							at: now(),
+						})
 						.pipe(Effect.orDie),
 					// No wire release kind exists, so scope close is a client-side no-op. A live session
 					// keeps its lease via the heartbeat loop (crew/heartbeat.ts) refreshing it under
 					// DEFAULT_TTL_SECONDS; a dropped session's lease frees by TTL-aging once the beats
 					// stop — the tracker has no disconnect hook.
+					() => Effect.void,
+				),
+			reserve: (presence) =>
+				Effect.acquireRelease(
+					// attached: false ⇒ a bare role-slot reservation, not discoverable until the peer
+					// attaches its inbox and re-announces (#3628). Same scope/keepalive story as announce.
+					client
+						.AnnouncePresence({
+							peer: presence.address,
+							role: presence.role,
+							attached: false,
+							at: now(),
+						})
+						.pipe(Effect.orDie),
 					() => Effect.void,
 				),
 			heartbeat: ({peer, ttlSeconds}) =>
@@ -145,6 +174,7 @@ export const peerTrackerLayer: Layer.Layer<Tracker, never, CrewTracker> = Layer.
 		const tracker = yield* CrewTracker;
 		return {
 			announce: tracker.announce,
+			reserve: tracker.reserve,
 			lookup: (role) => tracker.lookup(role).pipe(Effect.map(Arr.head)),
 		};
 	}),

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -4,13 +4,14 @@
  * inbox-ack). Generic (crew-agnostic); see the boundary note in `../index.ts`.
  *
  * The tool wraps the `ChannelSend` port — the peer's `send` capability (`../peer`) — so the
- * edge never constructs a peer (the crew composition root does, #3059). A send to an
- * offline role surfaces as `PeerUnreachableError`, which the tool returns as an error result
- * to the caller — never a silent drop (#3035).
+ * edge never constructs a peer (the crew composition root does, #3059). A send to a role with
+ * no live peer surfaces as `PeerUnreachableError`; a send to a role that is present but whose
+ * inbox will not answer surfaces as `ChannelDeafError` (#3628) — both returned as an error result
+ * to the caller, never a silent drop (#3035).
  */
 import {Context, Effect, Schema} from "effect";
 import {Tool, Toolkit} from "effect/unstable/ai";
-import {InboxAck, PeerUnreachableError} from "../peer/index.ts";
+import {ChannelDeafError, InboxAck, PeerUnreachableError} from "../peer/index.ts";
 import {crewMessageKinds, payloadSchemaForKind} from "../protocol/index.ts";
 
 /**
@@ -43,7 +44,7 @@ export class ChannelSend extends Context.Service<
 			targetRole: string,
 			kind: string,
 			body: unknown,
-		) => Effect.Effect<InboxAck, PeerUnreachableError>;
+		) => Effect.Effect<InboxAck, PeerUnreachableError | ChannelDeafError>;
 	}
 >()("@kampus/pipeline-crew-mcp/edge/ChannelSend") {}
 
@@ -99,7 +100,7 @@ export const SendChannelMessage = Tool.make("channel_send", {
 		body: Schema.Unknown,
 	}),
 	success: InboxAck,
-	failure: Schema.Union([PeerUnreachableError, InvalidMessageError]),
+	failure: Schema.Union([PeerUnreachableError, ChannelDeafError, InvalidMessageError]),
 });
 
 export const ChannelToolkit = Toolkit.make(SendChannelMessage);

--- a/packages/pipeline-crew-mcp/src/peer/errors.ts
+++ b/packages/pipeline-crew-mcp/src/peer/errors.ts
@@ -16,3 +16,28 @@ export class PeerUnreachableError extends Schema.TaggedErrorClass<PeerUnreachabl
 		reason: Schema.String,
 	},
 ) {}
+
+/**
+ * A send whose target role IS present in the tracker but whose inbox is not actually serving —
+ * "channel-deaf". This is the failure the presence-reflects-a-live-channel-half fix makes legible
+ * (#3628): a peer used to be able to announce presence without its inbox socket ever attaching, so a
+ * dial found a live lease but a dead socket. Distinct from `PeerUnreachableError` (no live peer
+ * registered at all) so a caller can tell "nobody is there" apart from "someone is registered but
+ * their channel half never attached", and it fails FAST (a bounded dial) rather than hanging on a
+ * dead or orphaned socket.
+ */
+export class ChannelDeafError extends Schema.TaggedErrorClass<ChannelDeafError>()(
+	"@kampus/pipeline-crew-mcp/ChannelDeafError",
+	{
+		target: Schema.String,
+		address: Schema.String,
+		reason: Schema.String,
+	},
+) {
+	// McpServer renders a failed tool call as `Cause.pretty(cause)` (effect-smol McpServer.ts), which
+	// prints an error's `message`; a bare TaggedError's is empty. Fold the why into `message` so the
+	// channel-deaf reason reaches the tool output without reading source (the #3486 precedent).
+	override get message(): string {
+		return `channel-deaf: role "${this.target}" is registered at ${this.address} but its inbox is not serving — ${this.reason}`;
+	}
+}

--- a/packages/pipeline-crew-mcp/src/peer/index.ts
+++ b/packages/pipeline-crew-mcp/src/peer/index.ts
@@ -10,7 +10,7 @@
  */
 
 export {type Connect, Dialer, type InboxRpcClient} from "./dialer.ts";
-export {PeerUnreachableError} from "./errors.ts";
+export {ChannelDeafError, PeerUnreachableError} from "./errors.ts";
 export {
 	Deliver,
 	Inbox,

--- a/packages/pipeline-crew-mcp/src/peer/peer.test.ts
+++ b/packages/pipeline-crew-mcp/src/peer/peer.test.ts
@@ -1,8 +1,10 @@
 /**
- * Peer runtime behavior (ACs 1–3): a peer announces + holds its role lease for the
- * connection lifetime; sends a typed message directly to another peer's inbox (not via the
- * tracker) and gets an inbox-ack; and a send to an offline peer — absent role OR a dial
- * that fails — surfaces a typed `PeerUnreachableError`, never a silent drop.
+ * Peer runtime behavior: a peer publishes its presence via an explicit `announce` and holds its
+ * role lease for the connection lifetime; a constructed-but-unannounced peer (its inbox never
+ * attached) is NOT discoverable (#3628); it sends a typed message directly to another peer's inbox
+ * (not via the tracker) and gets an inbox-ack; a send to an ABSENT role surfaces a typed
+ * `PeerUnreachableError`; and a send to a PRESENT role whose inbox will not answer surfaces a
+ * distinguishable `ChannelDeafError` — never a silent drop.
  *
  * The tracker is a per-project registry (#3055); here it is an in-memory fake whose
  * `announce` is scoped, so lease-lifetime is observable: present while the peer's scope is
@@ -13,26 +15,40 @@ import {Effect, Layer, Option, Ref} from "effect";
 import * as Arr from "effect/Array";
 import {RpcTest} from "effect/unstable/rpc";
 import {type Connect, Dialer} from "./dialer.ts";
-import {PeerUnreachableError} from "./errors.ts";
+import {ChannelDeafError, PeerUnreachableError} from "./errors.ts";
 import {Inbox, inboxHandlers, PeerInbox} from "./inbox.ts";
 import * as Peer from "./peer.ts";
 import {type RolePresence, Tracker} from "./tracker.ts";
 
 const UNREACHABLE = "@kampus/pipeline-crew-mcp/PeerUnreachableError";
+const CHANNEL_DEAF = "@kampus/pipeline-crew-mcp/ChannelDeafError";
 
-// A scoped in-memory tracker: announce acquires presence and releases it on scope close.
+// A scoped in-memory tracker modelling the two presence phases (#3628): `reserve` holds a bare
+// (undiscoverable) slot, `announce` flips it attached; both free on scope close, and `lookup`
+// returns only attached entries — the same live-channel-half semantics as the real registry-core.
 const FakeTracker = Layer.effect(
 	Tracker,
 	Effect.gen(function* () {
-		const reg = yield* Ref.make<ReadonlyArray<RolePresence>>([]);
+		const reg = yield* Ref.make<ReadonlyArray<{presence: RolePresence; attached: boolean}>>([]);
+		const put = (presence: RolePresence, attached: boolean) =>
+			Effect.acquireRelease(
+				Ref.update(reg, (xs) => [
+					...xs.filter((x) => x.presence.peer !== presence.peer),
+					{presence, attached},
+				]),
+				() => Ref.update(reg, (xs) => xs.filter((x) => x.presence.peer !== presence.peer)),
+			);
 		return {
-			announce: (presence) =>
-				Effect.acquireRelease(
-					Ref.update(reg, (xs) => [...xs, presence]),
-					() => Ref.update(reg, (xs) => xs.filter((x) => x !== presence)),
-				),
+			reserve: (presence) => put(presence, false),
+			announce: (presence) => put(presence, true),
 			lookup: (role) =>
-				Ref.get(reg).pipe(Effect.map((xs) => Arr.findFirst(xs, (x) => x.role === role))),
+				Ref.get(reg).pipe(
+					Effect.map((xs) =>
+						Arr.findFirst(xs, (x) => x.attached && x.presence.role === role).pipe(
+							Option.map((x) => x.presence),
+						),
+					),
+				),
 		};
 	}),
 );
@@ -50,7 +66,8 @@ describe("peer/peer — announce + role lease", () => {
 				const tracker = yield* Tracker;
 				yield* Effect.scoped(
 					Effect.gen(function* () {
-						yield* Peer.make({self: "peer-a", role: "builder", address: "addr-a"});
+						const peer = yield* Peer.make({self: "peer-a", role: "builder", address: "addr-a"});
+						yield* peer.announce;
 						const present = yield* tracker.lookup("builder");
 						assert.isTrue(Option.isSome(present));
 					}),
@@ -58,6 +75,23 @@ describe("peer/peer — announce + role lease", () => {
 				// scope closed ⇒ connection dropped ⇒ lease freed
 				const after = yield* tracker.lookup("builder");
 				assert.isTrue(Option.isNone(after));
+			}).pipe(Effect.provide([FakeTracker, Inbox.layer("peer-a"), alwaysUnreachable])),
+	);
+
+	it.effect(
+		"a constructed-but-unannounced peer is NOT discoverable — presence reflects the announce, not construction (#3628)",
+		() =>
+			Effect.gen(function* () {
+				const tracker = yield* Tracker;
+				yield* Effect.scoped(
+					Effect.gen(function* () {
+						// The up-but-deaf case: a peer whose inbox never attached never runs `announce`, so it
+						// must not appear as a live peer — "up in tmux" must not read as "registered with a live inbox".
+						yield* Peer.make({self: "peer-a", role: "builder", address: "addr-a"});
+						const before = yield* tracker.lookup("builder");
+						assert.isTrue(Option.isNone(before), "unannounced ⇒ never a live peer");
+					}),
+				);
 			}).pipe(Effect.provide([FakeTracker, Inbox.layer("peer-a"), alwaysUnreachable])),
 	);
 });
@@ -102,16 +136,28 @@ describe("peer/peer — offline behavior (never a silent drop)", () => {
 		).pipe(Effect.provide([FakeTracker, Inbox.layer("peer-a"), alwaysUnreachable])),
 	);
 
-	it.effect("send to a present-but-unreachable peer fails with PeerUnreachableError", () =>
-		Effect.scoped(
-			Effect.gen(function* () {
-				const tracker = yield* Tracker;
-				yield* tracker.announce({role: "reviewer", peer: "peer-b", address: "addr-b"});
-				const a = yield* Peer.make({self: "peer-a", role: "builder", address: "addr-a"});
-				const err = yield* a.send("reviewer", "IntakePing", {}).pipe(Effect.flip);
-				assert.strictEqual(err._tag, UNREACHABLE);
-				assert.strictEqual(err.target, "addr-b");
-			}),
-		).pipe(Effect.provide([FakeTracker, Inbox.layer("peer-a"), alwaysUnreachable])),
+	it.effect(
+		"send to a present role whose inbox will not answer fails with a DISTINGUISHABLE ChannelDeafError, not PeerUnreachableError (#3628 AC3)",
+		() =>
+			Effect.scoped(
+				Effect.gen(function* () {
+					const tracker = yield* Tracker;
+					// reviewer/peer-b holds a live lease, but its inbox is deaf (the dial always fails): the
+					// exact "presence reflects a socket file, not a live channel half" case.
+					yield* tracker.announce({role: "reviewer", peer: "peer-b", address: "addr-b"});
+					const a = yield* Peer.make({self: "peer-a", role: "builder", address: "addr-a"});
+					const err = yield* a.send("reviewer", "IntakePing", {}).pipe(Effect.flip);
+					assert.strictEqual(err._tag, CHANNEL_DEAF, "channel-deaf, not a generic unreachable");
+					if (!(err instanceof ChannelDeafError)) {
+						return assert.fail(`expected ChannelDeafError, got ${err._tag}`);
+					}
+					assert.strictEqual(err.target, "reviewer", "the role that is registered but deaf");
+					assert.strictEqual(
+						err.address,
+						"addr-b",
+						"the dialed inbox address that would not answer",
+					);
+				}),
+			).pipe(Effect.provide([FakeTracker, Inbox.layer("peer-a"), alwaysUnreachable])),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/peer/peer.ts
+++ b/packages/pipeline-crew-mcp/src/peer/peer.ts
@@ -3,19 +3,30 @@
  * announces to the tracker and sends peer-to-peer. Generic (crew-agnostic); see the
  * boundary note in `../index.ts`.
  *
- * `make` is scoped: on start it announces its role + inbox address to the tracker and
- * holds the presence for its scope's lifetime — connection-is-lease (#3035); scope close
- * frees the role. `send` looks the target role up via the tracker (the tracker never
- * relays) and dials that peer's inbox directly. Both offline paths — no live peer for the
- * role, and a dial that fails — surface as `PeerUnreachableError`, never a silent drop.
+ * `make` reserves this peer's role slot as a BARE lease (holds the slot + backs the crew
+ * cardinality claim + connection-is-lease, #3035) but does NOT make it discoverable. Becoming a
+ * live peer is a separate `announce` step the caller runs once its inbox is attached and serving,
+ * so presence reflects a live channel half, not mere construction (#3628). `send` looks the target role up via the
+ * tracker (the tracker never relays) and dials that peer's inbox directly. A send to a role
+ * with NO live peer surfaces as `PeerUnreachableError`; a send to a role that IS present but
+ * whose inbox will not answer surfaces as a distinguishable `ChannelDeafError`, fast — never a
+ * silent drop, never a hang.
  */
 
 import {randomUUID} from "node:crypto";
-import {Effect, Option} from "effect";
+import {Duration, Effect, Option, type Scope} from "effect";
 import {Dialer} from "./dialer.ts";
-import {PeerUnreachableError} from "./errors.ts";
+import {ChannelDeafError, PeerUnreachableError} from "./errors.ts";
 import {Inbox, type InboxAck, type InboxEnvelope} from "./inbox.ts";
 import {Tracker} from "./tracker.ts";
+
+/**
+ * The bounded dial window: a present peer whose inbox does not answer within it fails fast as
+ * channel-deaf rather than hanging (#3628 AC3). It sits well above a healthy socket round-trip, so it
+ * only ever bounds a genuinely-stuck dial — a dead or orphaned unix socket refuses far sooner
+ * (`ECONNREFUSED`), which is already mapped to channel-deaf below.
+ */
+const DIAL_TIMEOUT = Duration.seconds(5);
 
 export interface PeerConfig {
 	/** This peer's opaque id. */
@@ -32,12 +43,22 @@ export interface Peer {
 	readonly address: string;
 	/** What this peer's inbox has received. */
 	readonly received: Effect.Effect<ReadonlyArray<InboxEnvelope>>;
-	/** Send a typed message to whichever live peer serves `targetRole`; resolves to its inbox-ack. */
+	/**
+	 * Flip this peer to a discoverable, ATTACHED presence, held for the enclosing scope. `make` already
+	 * reserved the bare role slot; the caller runs THIS only once its inbox is attached and serving, so
+	 * a session whose inbox never attaches never becomes discoverable via `LookupRole` (#3628).
+	 */
+	readonly announce: Effect.Effect<void, never, Scope.Scope>;
+	/**
+	 * Send a typed message to whichever live peer serves `targetRole`; resolves to its inbox-ack. A
+	 * role with no live peer fails with `PeerUnreachableError`; a role that is present but whose inbox
+	 * will not answer fails with a distinguishable `ChannelDeafError`, fast.
+	 */
 	readonly send: (
 		targetRole: string,
 		kind: string,
 		body: unknown,
-	) => Effect.Effect<InboxAck, PeerUnreachableError>;
+	) => Effect.Effect<InboxAck, PeerUnreachableError | ChannelDeafError>;
 }
 
 export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
@@ -45,8 +66,13 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 	const tracker = yield* Tracker;
 	const dialer = yield* Dialer;
 
-	// Announce holds the role lease for this scope's lifetime — connection-is-lease (#3035).
-	yield* tracker.announce({role: config.role, peer: config.self, address: config.address});
+	const presence = {role: config.role, peer: config.self, address: config.address};
+	// Reserve the bare role slot on construction — it holds the crew cardinality claim + the
+	// connection-is-lease slot for this scope, but is NOT discoverable until `announce` attaches it (#3628).
+	yield* tracker.reserve(presence);
+	// The attach flip: publish a discoverable, serving presence. Exposed for the caller to run once its
+	// inbox socket server is bound and serving, so a channel-deaf session never becomes a live peer.
+	const announce = tracker.announce(presence);
 
 	const send: Peer["send"] = (targetRole, kind, body) =>
 		Effect.gen(function* () {
@@ -57,6 +83,7 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 					reason: `no live peer for role "${targetRole}"`,
 				});
 			}
+			const address = present.value.address;
 			const envelope: InboxEnvelope = {
 				messageId: randomUUID(),
 				from: config.self,
@@ -64,7 +91,26 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 				body,
 				at: new Date().toISOString(),
 			};
-			return yield* dialer.send(present.value.address, envelope);
+			// The tracker returned a live lease, so a dial that won't complete is channel-deaf — presence
+			// reflected a stale socket file, not a live inbox (#3628). Fold BOTH a fast dial refusal (a
+			// dead/orphaned socket → PeerUnreachableError) and a genuine hang (the bounded timeout) into one
+			// distinguishable ChannelDeafError, so the caller tells "registered but deaf" from "nobody there".
+			return yield* dialer.send(address, envelope).pipe(
+				Effect.timeoutOrElse({
+					duration: DIAL_TIMEOUT,
+					orElse: () =>
+						Effect.fail(
+							new ChannelDeafError({
+								target: targetRole,
+								address,
+								reason: "the inbox did not answer within the dial timeout",
+							}),
+						),
+				}),
+				Effect.catchTag("@kampus/pipeline-crew-mcp/PeerUnreachableError", (cause) =>
+					Effect.fail(new ChannelDeafError({target: targetRole, address, reason: cause.reason})),
+				),
+			);
 		});
 
 	return {
@@ -72,6 +118,7 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 		role: config.role,
 		address: config.address,
 		received: inbox.received,
+		announce,
 		send,
 	};
 });

--- a/packages/pipeline-crew-mcp/src/peer/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/peer/tracker.ts
@@ -23,7 +23,13 @@ export type RolePresence = typeof RolePresence.Type;
 export class Tracker extends Context.Service<
 	Tracker,
 	{
+		/** Announce this peer as ATTACHED (its inbox is serving) — the discoverable phase (#3628). */
 		readonly announce: (presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>;
+		/**
+		 * Reserve this peer's role slot as a BARE lease — holds the slot + backs the crew cardinality
+		 * claim, but is NOT discoverable via `lookup` until the peer attaches its inbox and announces.
+		 */
+		readonly reserve: (presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>;
 		readonly lookup: (role: string) => Effect.Effect<Option.Option<RolePresence>>;
 	}
 >()("@kampus/pipeline-crew-mcp/peer/Tracker") {}

--- a/packages/pipeline-crew-mcp/src/protocol/schema.ts
+++ b/packages/pipeline-crew-mcp/src/protocol/schema.ts
@@ -127,10 +127,16 @@ export const PresenceEntry = Schema.Struct({
 	lastSeen: Timestamp,
 });
 
-/** A peer announcing that it serves a role (fire-and-forget). */
+/**
+ * A peer announcing its presence for a role (fire-and-forget). `attached` is the live-channel-half
+ * bit (#3628): `true` (or absent, the back-compatible default) publishes a discoverable, serving
+ * presence; `false` reserves a bare role slot that holds the crew cardinality claim but is NOT
+ * returned by a lookup until the peer's inbox attaches and it re-announces attached.
+ */
 export const PresenceAnnouncement = Schema.Struct({
 	peer: PeerId,
 	role: RoleId,
+	attached: Schema.optional(Schema.Boolean),
 	at: Timestamp,
 });
 

--- a/packages/pipeline-crew-mcp/src/tracker/handlers.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/handlers.ts
@@ -39,12 +39,19 @@ export const TrackerHandlers = TrackerRegistry.toLayer(
 					),
 			Release: (payload) =>
 				registry.releaseClaim({resource: payload.resource, claimant: payload.claimant}),
-			AnnouncePresence: (payload) =>
-				registry.announce({
+			// `attached` routes the two presence phases (#3628): attached (or absent, the
+			// back-compatible default) publishes a discoverable serving presence; `false` reserves a
+			// bare role slot that backs the cardinality claim but stays out of `LookupRole`.
+			AnnouncePresence: (payload) => {
+				const presence = {
 					role: payload.role,
 					peer: payload.peer,
 					ttlSeconds: DEFAULT_TTL_SECONDS,
-				}),
+				};
+				return (payload.attached ?? true)
+					? registry.announce(presence)
+					: registry.reserve(presence);
+			},
 			LookupRole: (payload) =>
 				registry.lookup(payload.role).pipe(
 					Effect.map((records) => ({

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.test.ts
@@ -36,6 +36,80 @@ describe("registry-core — announce / lookup", () => {
 	});
 });
 
+describe("registry-core — two presence phases: bare reservation vs attached (#3628)", () => {
+	it("a bare reservation holds a slot but is NOT discoverable; announcing attaches it", () => {
+		// reserve = the up-but-deaf case: a role slot held, but the inbox not yet serving.
+		const reserved = Core.reserve(Core.empty(), {
+			role: "intake-desk",
+			peer: "inbox://intake-desk",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		});
+		assert.deepStrictEqual(
+			Core.lookup(reserved, "intake-desk", T0),
+			[],
+			"a bare reservation is not a live peer — presence must reflect a live channel half",
+		);
+		// once the inbox attaches, the session announces and becomes discoverable
+		const attached = Core.announce(reserved, {
+			role: "intake-desk",
+			peer: "inbox://intake-desk",
+			ttlSeconds: 30,
+			nowMillis: T0 + secs(1),
+		});
+		assert.deepStrictEqual(Core.lookup(attached, "intake-desk", T0 + secs(1)), [
+			{peer: "inbox://intake-desk", role: "intake-desk", lastSeenMillis: T0 + secs(1)},
+		]);
+	});
+
+	it("a bare reservation still backs the cardinality claim's liveness (the slot holds pre-attach)", () => {
+		// The role-uniqueness lease must hold from construction, before the inbox attaches — so a
+		// reserved (not-yet-discoverable) holder still makes a competing claim COLLIDE.
+		let state = Core.reserve(Core.empty(), {
+			role: "chief-of-staff",
+			peer: "inbox://chief-of-staff-1",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		});
+		state = Core.claimResource(state, {
+			resource: "chief-of-staff",
+			holder: "inbox://chief-of-staff-1",
+			claimantRole: "chief-of-staff",
+			nowMillis: T0,
+		}).state;
+		const collided = Core.claimResource(state, {
+			resource: "chief-of-staff",
+			holder: "inbox://chief-of-staff-2",
+			claimantRole: "chief-of-staff",
+			nowMillis: T0 + secs(1),
+		});
+		assert.strictEqual(
+			collided.outcome._tag,
+			"Collision",
+			"a bare reservation keeps the role slot uniqueness-guarded before its inbox attaches",
+		);
+	});
+
+	it("a heartbeat preserves the attached phase — a beat never downgrades a serving peer", () => {
+		const attached = Core.announce(Core.empty(), {
+			role: "intake-desk",
+			peer: "inbox://intake-desk",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		});
+		const beat = Core.heartbeat(attached, {
+			peer: "inbox://intake-desk",
+			ttlSeconds: 30,
+			nowMillis: T0 + secs(20),
+		});
+		assert.lengthOf(
+			Core.lookup(beat, "intake-desk", T0 + secs(40)),
+			1,
+			"the beat kept it discoverable — attached survived the refresh",
+		);
+	});
+});
+
 describe("registry-core — heartbeat TTL aging", () => {
 	it("a peer that stops heart-beating ages out of lookups past its TTL", () => {
 		const state = Core.announce(Core.empty(), {
@@ -46,6 +120,18 @@ describe("registry-core — heartbeat TTL aging", () => {
 		});
 		assert.lengthOf(Core.lookup(state, "builder", T0 + secs(29)), 1, "still live before TTL");
 		assert.lengthOf(Core.lookup(state, "builder", T0 + secs(31)), 0, "aged out after TTL");
+	});
+
+	it("a heartbeat NEVER manufactures presence — a beat for a peer that never announced is a no-op (#3628 AC2)", () => {
+		// A channel-deaf session's keepalive must not conjure a live lease: presence is created only by
+		// `announce` (gated on the inbox attaching), so beating an unannounced peer leaves it undiscoverable.
+		const beaten = Core.heartbeat(Core.empty(), {
+			peer: "inbox://intake-desk",
+			ttlSeconds: 30,
+			nowMillis: T0,
+		});
+		assert.deepStrictEqual(beaten, Core.empty(), "the beat changed nothing — no lease to refresh");
+		assert.deepStrictEqual(Core.lookup(beaten, "intake-desk", T0), [], "still not a live peer");
 	});
 
 	it("a heartbeat refreshes the window, keeping the peer discoverable", () => {

--- a/packages/pipeline-crew-mcp/src/tracker/registry-core.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry-core.ts
@@ -10,6 +10,16 @@
  * lifecycles — keeping them in distinct typed maps makes "a `lookup` returns a claim holder"
  * unrepresentable rather than checked after the fact.
  *
+ * A lease is one of two phases — `reserve`d (bare) or `announce`d (attached) — so presence
+ * reflects a live channel half, not a socket file or a bare lease (#3628):
+ *   - A **bare** lease (`reserve`) holds the role slot and backs the crew cardinality claim
+ *     (its liveness clock, ADR 0191 facet 2) + connection-is-lease — but is NOT discoverable.
+ *   - An **attached** lease (`announce`) is a bare lease whose peer inbox is confirmed serving;
+ *     only attached leases are returned by `lookup`. A session that reserves its slot but never
+ *     attaches its inbox (channel-deaf) therefore never appears as a live peer.
+ * `holderHasLivePresence` (claim liveness) counts a live lease of EITHER phase — the slot holds
+ * from the reservation; `lookup` (discovery) counts only attached ones.
+ *
  * The three non-obvious model choices:
  *   - Presence is keyed by `peer` (the connection identity), NOT by role — so N distinct peers
  *     serving one role coexist as N distinct leases (a role's engine pool), and `lookup(role)`
@@ -30,12 +40,18 @@
 /** The default presence TTL applied on announce, until the first `heartbeat` sets a real one. */
 export const DEFAULT_TTL_SECONDS = 30;
 
-/** One presence lease: a peer, the role it serves, and its soft-state liveness window. */
+/**
+ * One presence lease: a peer, the role it serves, its soft-state liveness window, and whether its
+ * inbox is attached and serving. `attached` is the live-channel-half bit (#3628): a bare reservation
+ * holds the role slot (`attached: false`), an announce flips it on once the inbox serves. `lookup`
+ * returns only attached leases; the cardinality claim's liveness clock counts either phase.
+ */
 export interface Lease {
 	readonly role: string;
 	readonly peer: string;
 	readonly ttlSeconds: number;
 	readonly lastSeenMillis: number;
+	readonly attached: boolean;
 }
 
 /**
@@ -78,7 +94,11 @@ export const empty = (): RegistryState => ({leases: new Map(), claims: new Map()
 const isLive = (lease: Lease, nowMillis: number): boolean =>
 	nowMillis <= lease.lastSeenMillis + lease.ttlSeconds * 1000;
 
-/** True iff `holder` holds a live presence lease — the claim-liveness clock (ADR 0191 facet 2). */
+/**
+ * True iff `holder` holds a live presence lease of EITHER phase — the claim-liveness clock (ADR 0191
+ * facet 2). Attachment is deliberately not required: the cardinality claim's slot holds from the
+ * bare reservation on, so a role stays uniqueness-guarded before its inbox finishes attaching (#3628).
+ */
 const holderHasLivePresence = (
 	leases: ReadonlyMap<string, Lease>,
 	holder: string,
@@ -88,27 +108,42 @@ const holderHasLivePresence = (
 	return lease !== undefined && isLive(lease, nowMillis);
 };
 
-/**
- * Register `peer`'s presence for `role`: upsert its lease, bumping `lastSeen` to now. Keyed by
- * `peer`, so a re-announce refreshes the same lease and two distinct peers on one role coexist —
- * presence never rejects (role uniqueness is the crew cardinality claim's job, ADR 0189), it only
- * records who is live where.
- */
-export const announce = (
-	state: RegistryState,
-	input: {
-		readonly role: string;
-		readonly peer: string;
-		readonly ttlSeconds: number;
-		readonly nowMillis: number;
-	},
-): RegistryState => {
+type PresenceInput = {
+	readonly role: string;
+	readonly peer: string;
+	readonly ttlSeconds: number;
+	readonly nowMillis: number;
+};
+
+const putLease = (state: RegistryState, input: PresenceInput, attached: boolean): RegistryState => {
 	const {role, peer, ttlSeconds, nowMillis} = input;
-	const lease: Lease = {role, peer, ttlSeconds, lastSeenMillis: nowMillis};
+	const lease: Lease = {role, peer, ttlSeconds, lastSeenMillis: nowMillis, attached};
 	const leases = new Map(state.leases);
 	leases.set(peer, lease);
 	return {...state, leases};
 };
+
+/**
+ * Register `peer`'s presence for `role` as ATTACHED (its inbox is serving) — the discoverable phase:
+ * upsert the lease with `attached: true`, bumping `lastSeen` to now. Keyed by `peer`, so a
+ * re-announce refreshes the same lease and two distinct peers on one role coexist — presence never
+ * rejects (role uniqueness is the crew cardinality claim's job, ADR 0189), it only records who is
+ * live and serving. Callers announce ONLY once the inbox is attached, so a live channel half — not a
+ * bare lease — is what `lookup` surfaces (#3628).
+ */
+export const announce = (state: RegistryState, input: PresenceInput): RegistryState =>
+	putLease(state, input, true);
+
+/**
+ * Reserve `peer`'s role slot as a BARE lease (`attached: false`) — the not-yet-serving phase: it
+ * holds the slot and backs the crew cardinality claim's liveness clock (ADR 0191 facet 2) +
+ * connection-is-lease, but is NOT returned by `lookup`. This is the "presence reflects a socket file
+ * or a bare lease" case the fix makes non-discoverable (#3628): a session reserves on construction,
+ * then `announce`s only once its inbox attaches. A `reserve` over an already-attached lease would
+ * downgrade it, so the flow only ever goes reserve → announce, never back.
+ */
+export const reserve = (state: RegistryState, input: PresenceInput): RegistryState =>
+	putLease(state, input, false);
 
 /**
  * Claim `resource` on behalf of `holder`. Granted when the resource is free, held by a holder
@@ -180,9 +215,11 @@ export const claimHolder = (
 };
 
 /**
- * Refresh `peer`'s presence lease: bump `lastSeen` to now and adopt the heartbeat's TTL. Resource
+ * Refresh `peer`'s presence lease: bump `lastSeen` to now and adopt the heartbeat's TTL, PRESERVING
+ * its attached phase (a beat keeps a serving peer discoverable, never downgrades it). Resource
  * claims are never touched — they have no TTL to bump, and their liveness rides presence (ADR 0191
- * facet 4). A beat for a peer with no lease is a no-op (nothing to refresh).
+ * facet 4). A beat for a peer with no lease is a no-op (nothing to refresh) — so a beat can never
+ * manufacture presence for a session that never reserved/announced (#3628).
  */
 export const heartbeat = (
 	state: RegistryState,
@@ -197,11 +234,13 @@ export const heartbeat = (
 };
 
 /**
- * The present holders of `role` — every live lease whose peer serves `role`, or `[]` when none is
- * present. For a bridge the crew cardinality claim guarantees at most one live session, so the set
- * has one entry; for an engine the set carries every live instance in the pool (ADR 0189). An empty
- * array is the explicit not-present result (never a silent drop). Reads the presence keyspace only,
- * so it can never surface a resource-claim holder (ADR 0191).
+ * The present holders of `role` — every live, ATTACHED lease whose peer serves `role`, or `[]` when
+ * none is. Only attached leases surface: a bare reservation (a slot held but the inbox not yet
+ * serving) is deliberately invisible here, so a channel-deaf session is never returned as a live
+ * peer (#3628). For a bridge the crew cardinality claim guarantees at most one live session, so the
+ * set has one entry; for an engine the set carries every live instance in the pool (ADR 0189). An
+ * empty array is the explicit not-present result (never a silent drop). Reads the presence keyspace
+ * only, so it can never surface a resource-claim holder (ADR 0191).
  */
 export const lookup = (
 	state: RegistryState,
@@ -210,7 +249,7 @@ export const lookup = (
 ): ReadonlyArray<PresenceRecord> => {
 	const present: Array<PresenceRecord> = [];
 	for (const lease of state.leases.values()) {
-		if (lease.role === role && isLive(lease, nowMillis)) {
+		if (lease.role === role && lease.attached && isLive(lease, nowMillis)) {
 			present.push({peer: lease.peer, role: lease.role, lastSeenMillis: lease.lastSeenMillis});
 		}
 	}

--- a/packages/pipeline-crew-mcp/src/tracker/registry.ts
+++ b/packages/pipeline-crew-mcp/src/tracker/registry.ts
@@ -26,8 +26,10 @@ export interface ClaimInput {
 export class Registry extends Context.Service<
 	Registry,
 	{
-		/** Register `peer`'s presence for `role` — keyed by peer, so a role's engine pool coexists. */
+		/** Register `peer`'s presence for `role` as ATTACHED (serving) — the discoverable phase (#3628). */
 		readonly announce: (input: AnnounceInput) => Effect.Effect<void>;
+		/** Reserve `peer`'s role slot as a BARE lease — holds the slot + backs the claim, not discoverable. */
+		readonly reserve: (input: AnnounceInput) => Effect.Effect<void>;
 		/** Claim `resource` for `claimant`, returning granted or a collision with a live-presence holder. */
 		readonly claim: (input: ClaimInput) => Effect.Effect<Core.ClaimOutcome>;
 		/** Free `resource`'s claim iff `claimant` holds it — steal-release is a no-op (ADR 0191 facet 3). */
@@ -68,6 +70,12 @@ export const RegistryLive: Layer.Layer<Registry> = Layer.effect(Registry)(
 				Clock.currentTimeMillis.pipe(
 					Effect.flatMap((nowMillis) =>
 						Ref.update(ref, (state) => Core.announce(state, {...input, nowMillis})),
+					),
+				),
+			reserve: (input) =>
+				Clock.currentTimeMillis.pipe(
+					Effect.flatMap((nowMillis) =>
+						Ref.update(ref, (state) => Core.reserve(state, {...input, nowMillis})),
 					),
 				),
 			claim,


### PR DESCRIPTION
Crew presence used to go live the moment a process claimed a role slot, even if that session's inbox never actually attached. So a pane could look "online" while every message sent to it dead-lettered with a generic unreachable error. This teaches the substrate to only call a role live once its inbox is genuinely serving — and to fail a send to a not-yet-serving inbox fast, with a clear "channel-deaf" error instead of a silent timeout.

## What changed

Presence is now **two phases** (`packages/pipeline-crew-mcp/src/tracker/registry-core.ts`):

- **`reserve`** — a bare lease published at construction. It holds the role slot and backs the crew cardinality claim's liveness clock (ADR 0191 facet 2) + connection-is-lease, but is **not** discoverable.
- **`announce`** — flips the lease **attached** (serving). Only attached leases are returned by `lookup` / `LookupRole`.

A session `reserve`s when it's built (`peer.make`) and `announce`s only after its inbox socket server has bound — the announce layer is sequenced after `inbound` in `assembleCrewSession` (`src/crew/session.ts`). A channel-deaf session (inbox never attached) therefore never appears as a live peer.

A `channel_send` to a role that is present but whose inbox will not answer now fails with a distinguishable **`ChannelDeafError`** (`src/peer/errors.ts`), fast (a bounded dial), rather than a generic `PeerUnreachableError`/timeout. "No live peer at all" stays `PeerUnreachableError`.

The wire `PresenceAnnouncement` gains an optional `attached` flag (absent ⇒ the back-compatible attached default); the registry handler routes it to `announce` vs `reserve`.

## Acceptance criteria

- [x] A role whose session is up but whose channel half never attached is **not** returned as a live peer by `LookupRole` — driven at the pure level (`registry-core.test.ts`), the peer level (a constructed-but-unannounced peer, `peer.test.ts`), and the live assembly (`session.assembly.test.ts` LookupRole after boot).
- [x] Presence announce / heartbeat is gated on the inbox being attached and serving — announce is the only thing that publishes discoverable presence and it is sequenced after the inbox binds; a heartbeat can never manufacture presence (`registry-core.test.ts`).
- [x] A `channel_send` to a role with no live inbox fails fast with a distinguishable channel-deaf error (`ChannelDeafError`, `peer.test.ts` AC3), not a hang or generic timeout.
- [x] The existing attach round-trip still delivers end to end (`peer.test.ts`, `channel-server.test.ts`, `session.test.ts`, `session.assembly.test.ts` all green).

Out of scope (per the issue): the operator-facing report surface (#C5) and orphan-process reaping (#C4).

`pnpm typecheck` (30/30) and `pnpm lint:worktree` clean; 314 package tests pass.

Fixes #3628