### PR TITLE
docs(intake-formats): record the 2026-07-24 ruling that crew engine defs stay OUT of §CP (#3765)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1388,6 +1388,24 @@ closing the #375 drift class).
   [0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
   #2003; same ADR 0065 rationale that makes the gate-critical skills blocking). Agent defs are
   behavioral artifacts like skills → **`review-skill`-routed for the verdict**, **blocking for merge**.
+
+  **Deliberately OUT of §CP — the crew engine defs** (`claude-plugins/pipeline-crew/agents/**`, the
+  sibling `pipeline-crew` plugin, `crew-engineering-manager.md` et al.): scoped **only** to the
+  `kampus-pipeline` plugin above, the crew defs class **has-skills** (they ride a `review-skill` gate,
+  #2387) but are **NOT** §CP — they auto-ship on a `review-skill` PASS. This exclusion is a **live
+  founder ruling, re-affirmed 2026-07-24** (recorded on #3765), re-affirming #2342 ("extras don't
+  block") for the crew defs on a **stated containment basis, threat-modeled** for the one path that
+  matters: a weakened crew engine def cannot produce an **un-approved merge** through any path *other
+  than the shipper*, because the actual merge authority lives in the `ship-it` skill and `shipper.md`
+  — both §CP, both re-verifying the §CP approval **independently** of whatever a crew engine def
+  believes. The crew defs orchestrate (claim, spawn, bank, watch); they never gate a verdict nor
+  perform the merge. So the worst a weakened crew def can do is **fail to bank** — which surfaces as a
+  visible unshipped §CP PR a human notices — never drive a merge past the approval §CP requires. The
+  self-modification-of-guardrails risk that pulls `kampus-pipeline/agents/**` into §CP (ADR 0150) is
+  therefore contained short of the crew corpus. Do **not** add `pipeline-crew/agents/**` to
+  `CONTROL_PLANE_RE` on this ruling — it narrows nothing and widens nothing (#3765). Re-examine if a
+  crew def ever gains independent merge/gate authority, or per the #3766 direction of travel (moving
+  N-engine lane exclusion into the tracker/tool layer makes this exclusion even less load-bearing).
 - the **plugin hook surface** — `claude-plugins/kampus-pipeline/hooks/**` (the `install.sh`
   that drops the installed `pipeline-cli` and the `guard.sh` fail-open dispatch wrapper) plus
   `claude-plugins/kampus-pipeline/hooks.json` (the foreign-repo hook manifest). These are
@@ -1661,7 +1679,9 @@ manifest surface *declares* the plugin's skill/agent artifacts (and is the drift
 as the artifacts it manifests — no new class or gate is invented. This is **only** the review-class
 axis: `CONTROL_PLANE_RE` (§CP, who-merges) is a **separate** regex and is **untouched**, so a crew
 plugin's `agents/**` gains a `review-skill` gate yet still **auto-ships** on PASS (the founder #2342
-ruling — extras don't block — is preserved; the class fix and the §CP ruling compose).
+ruling — extras don't block — **re-affirmed 2026-07-24 on #3765** on the threat-modeled containment
+basis recorded in the §CP "Deliberately OUT — the crew engine defs" note above; the class fix and the
+§CP ruling compose).
 
 **Both consumers re-resolve these lines from `origin/main` at run time** (REST raw, `?ref=main`
 — the #981 idiom, generalized from `CONTROL_PLANE_RE`/`UI_RE` to the class probes), never trusting


### PR DESCRIPTION
Closes #3765

## What & why

Records the **founder ruling of 2026-07-24** (recorded on #3765 via chief-of-staff): `claude-plugins/pipeline-crew/agents/**` does **NOT** enter §CP. The ruling **re-affirms #2342** ("extras don't block") for the crew engine defs, with the containment argument as its stated basis. It **narrows nothing and widens nothing**.

Per issue #3765's actionable ACs, the intake-formats contract now states the *current* ruling and its reason at the §CP boundary, so the exclusion stays a **live decision** rather than drifting back into an unexamined default.

## Not a regex change (deliberately)

The ruling widens nothing, so `CONTROL_PLANE_RE` is **untouched** — verified byte-identical, no `pipeline-crew/**` clause added. This is a **documentation / boundary-passage edit only**, exactly as the filing asked ("a ruling over a regex change"). The `codeowners-cp check` drift gate passes (22 §CP paths covered), and `control-plane-re.ts` ↔ formats stay in sync.

## Changes (`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`)

1. **New "Deliberately OUT of §CP — the crew engine defs" note** in the §CP boundary list, placed adjacent to the `kampus-pipeline/agents/**` entry it contrasts with: the crew defs class **has-skills** (ride a `review-skill` gate, #2387) but are **NOT** §CP, and this is a live founder ruling re-affirmed 2026-07-24 on the recorded containment basis.
2. **Refreshed the `HAS_SKILLS_RE` passage's #2342 reference** to cite the 2026-07-24 re-affirmation, so it no longer reads as a stale one-time ruling.

## Threat model (AC discharged)

The ruling's basis is a threat model of the one path that matters: **can a weakened crew engine def produce an un-approved merge through any path *other than* the shipper?** No.

- **The merge authority is not in the crew corpus.** The actual merge is performed by the `ship-it` skill and `shipper.md` — **both §CP**, both of which **re-verify the §CP approval independently** of whatever a crew engine def believes. The crew defs orchestrate (claim, spawn, bank, watch); they never gate a verdict nor perform the merge.
- **Therefore the worst a weakened crew def can do is fail to *bank*** — which surfaces as a **visible unshipped §CP PR** a human notices — never drive a merge past the approval §CP requires.
- The self-modification-of-guardrails risk that pulls `kampus-pipeline/agents/**` into §CP (ADR 0150) is **contained short of the crew corpus** by that independent §CP re-verification at the merge boundary.

If a future crew def ever gained independent merge/gate authority, that containment would break and this is grounds to **reopen and widen** — not to silently widen the regex now. The note records that re-examination trigger, plus the #3766 direction of travel (moving N-engine lane exclusion into the tracker/tool layer makes this exclusion even less load-bearing).

## Control-plane status

This PR edits a gate-critical skill (`gh-issue-intake-formats.md`, which is itself in `CONTROL_PLANE_RE`) → it **IS §CP**. That is expected. It rides a `review-skill` gate and then the normal **bank-for-human-approval** merge path — do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
