### PR TITLE
fix(pipeline-cli): empty stdin fails closed, not as a gate-free answer (#3786)

### DIFF
--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.ts
@@ -133,6 +133,21 @@ export const classify = (
 	return CLASS_ORDER.filter((c) => present.has(c));
 };
 
+/**
+ * The fail-closed class set for a class-probe INVOCATION that read ZERO input (#3786).
+ * Deliberately distinct from `classify([])` — which is correctly empty ("an empty diff spans no
+ * class, nothing to gate") — because the bin cannot tell a legitimately empty diff from a
+ * dropped/undelivered stdin, and this probe is only ever piped a PR's changed-file list (`git
+ * diff --name-only` / `gh api pulls/$PR/files`), which is never legitimately empty. So a
+ * zero-length READ is a dropped stdin, not a gate-free PR, and must route through the same
+ * has-code path an unclassified file rides (§CLASS no-class fail-closed, #2765) rather than emit
+ * an empty required-gate set: an empty set makes ship-it Step 1's conjunction vacuously true
+ * (zero gates required → un-gated merge) and makes the reviewer fan dispatch nothing. The bin
+ * (`command.ts`) owns detecting zero-input at the IO boundary and warns loudly there; `classify`
+ * stays pure.
+ */
+export const NO_INPUT_FAILCLOSED_CLASSES: ReadonlyArray<ArtifactClass> = ["has-code"];
+
 /** The `review-*` namespaces a diff requires — one per present class, in canonical order. */
 export const requiredNamespaces = (
 	classes: ReadonlyArray<ArtifactClass>,

--- a/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/class-probe.unit.test.ts
@@ -8,6 +8,7 @@ import {
 	FAILCLOSED_UI_EXCLUDE_RE,
 	FAILCLOSED_UI_RE,
 	isUiAffecting,
+	NO_INPUT_FAILCLOSED_CLASSES,
 	parseClassProbes,
 	parseUiExclude,
 	parseUiProbe,
@@ -151,6 +152,24 @@ describe("classify — the no-class fail-open is closed: root tooling requires a
 	});
 
 	it("an empty diff is still un-gated — the fail-closed default fires only on a real file", () => {
+		expect(classify([], LIVE_PROBES)).toEqual([]);
+	});
+});
+
+describe("zero-input fail-closed — a dropped stdin can't yield an empty required-gate set (#3786)", () => {
+	// The #3786 fail-open: `classify([])` is correctly empty ("an empty diff spans no class"),
+	// but the BIN cannot tell a legitimately empty diff from a dropped/undelivered stdin, and the
+	// probe is only ever piped a PR's changed files. So a zero-length READ must route through the
+	// has-code fail-closed path (NO_INPUT_FAILCLOSED_CLASSES), never an empty set — an empty set
+	// makes ship-it Step 1's conjunction vacuously true (zero gates → un-gated merge). The bin owns
+	// the zero-input decision; the pure `classify([])` stays empty (asserted just below).
+	it("NO_INPUT_FAILCLOSED_CLASSES is has-code → review-code (a gate always runs)", () => {
+		expect(NO_INPUT_FAILCLOSED_CLASSES).toEqual(["has-code"]);
+		expect(requiredNamespaces(NO_INPUT_FAILCLOSED_CLASSES)).toEqual(["review-code"]);
+		expect(requiredNamespaces(NO_INPUT_FAILCLOSED_CLASSES).length).toBeGreaterThan(0);
+	});
+
+	it("keeps `classify([])` pure — empty diff still spans no class (the bin, not the core, fails closed)", () => {
 		expect(classify([], LIVE_PROBES)).toEqual([]);
 	});
 });

--- a/packages/pipeline-cli/src/tools/class-probe/command.test.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.test.ts
@@ -1,0 +1,56 @@
+import {spawnSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+// The stdin/exit contract of `pipeline-cli class-probe classify` over the shared bin. The #3786
+// exposure is an IO/stdin-delivery fact (an empty read must not read as a gate-free PR), so it is
+// exercised over the ACTUAL bin with real stdin wiring, not the pure core.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL("../../../../..", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const runSh = (cmd: string): RunResult => {
+	const r = spawnSync("sh", ["-c", cmd], {cwd: REPO_ROOT, encoding: "utf8"});
+	return {code: r.status ?? 0, stdout: r.stdout ?? "", stderr: r.stderr ?? ""};
+};
+
+const INNER = `node "${BIN}" class-probe classify --namespaces`;
+
+// The three empty-stdin shapes the #3786 report verified reproduce verbatim, each wired by real
+// shell redirection: an empty pipe (`printf ''`), `< /dev/null`, and a closed fd 0 (`<&-`).
+const EMPTY_SHAPES: ReadonlyArray<readonly [string, string]> = [
+	["printf '' (empty pipe)", `printf '' | ${INNER}`],
+	["< /dev/null", `${INNER} < /dev/null`],
+	["closed stdin <&-", `${INNER} <&-`],
+];
+
+describe("class-probe classify — empty stdin fails closed to review-code, never an empty set (#3786)", () => {
+	for (const [name, cmd] of EMPTY_SHAPES) {
+		it(`${name}: emits review-code (has-code), never an empty required-gate set`, () => {
+			const {code, stdout, stderr} = runSh(cmd);
+			// The load-bearing assertion: the required-namespace set is NON-EMPTY. An empty set would
+			// make ship-it Step 1's conjunction vacuously true (zero gates → un-gated merge).
+			expect(stdout.trim().split("\n").filter(Boolean)).toEqual(["review-code"]);
+			expect(code).toBe(0);
+			// And it is LOUD — a dropped stdin is visible at the point it happens, not silent.
+			expect(stderr).toContain("read 0 files");
+			expect(stderr).toContain("#3786");
+		});
+	}
+
+	it("piped real content is unaffected — a docs path still classifies review-doc (non-regression)", () => {
+		const {code, stdout} = runSh(`printf 'DEVELOPMENT.md\\n' | ${INNER}`);
+		expect(stdout.trim().split("\n").filter(Boolean)).toEqual(["review-doc"]);
+		expect(code).toBe(0);
+	});
+
+	it("the default (has-*) output also fails closed to has-code on empty stdin", () => {
+		const {stdout} = runSh(`printf '' | node "${BIN}" class-probe classify`);
+		expect(stdout.trim().split("\n").filter(Boolean)).toEqual(["has-code"]);
+	});
+});

--- a/packages/pipeline-cli/src/tools/class-probe/command.ts
+++ b/packages/pipeline-cli/src/tools/class-probe/command.ts
@@ -34,6 +34,7 @@ import {
 	classify,
 	DESIGN_NAMESPACE,
 	isUiAffecting,
+	NO_INPUT_FAILCLOSED_CLASSES,
 	parseClassProbes,
 	parseUiExclude,
 	parseUiProbe,
@@ -120,7 +121,14 @@ const classifyCmd = Command.make(
 		const uiRe = parseUiProbe(shipIt ?? "");
 		const uiExclude = parseUiExclude(shipIt ?? "");
 		const files = readFiles(filesFrom);
-		const classes = classify(files, probes);
+		// Fail closed on zero input (#3786): this probe is only ever piped a PR's changed-file
+		// list, which is never legitimately empty — an empty read is a dropped/undelivered stdin,
+		// indistinguishable at the pure core from a gate-free PR. Route it through the same has-code
+		// path an unclassified file rides (NO_INPUT_FAILCLOSED_CLASSES) so a dropped stdin can never
+		// yield an empty required-gate set; a distinct loud stderr line below makes the drop visible
+		// at the point it happens rather than silently reading as "this PR requires no gates".
+		const noInput = files.length === 0;
+		const classes = noInput ? NO_INPUT_FAILCLOSED_CLASSES : classify(files, probes);
 		const uiAffecting = isUiAffecting(files, uiRe, uiExclude);
 
 		if (formats === null) {
@@ -134,6 +142,13 @@ const classifyCmd = Command.make(
 			yield* Effect.sync(() =>
 				process.stderr.write(
 					`class-probe: could not read ${SHIP_IT_PATH} under ${rootDir} — using fail-closed UI_RE (require review-design).\n`,
+				),
+			);
+		}
+		if (noInput) {
+			yield* Effect.sync(() =>
+				process.stderr.write(
+					"class-probe: read 0 files (empty or undelivered stdin/--files-from) — failing closed to has-code (review-code). This probe is only ever piped a PR's changed files, which is never legitimately empty; an empty read is a dropped stdin, not a gate-free PR (#3786).\n",
 				),
 			);
 		}

--- a/packages/pipeline-cli/src/tools/guard-content-probe/command.test.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/command.test.ts
@@ -1,0 +1,61 @@
+import {spawnSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+// The stdin/exit contract of `pipeline-cli guard-content-probe classify` over the shared bin. Like
+// class-probe (#3786), the empty-stdin exposure is an IO-delivery fact, exercised over the ACTUAL
+// bin with real stdin wiring. The load-bearing invariant: every empty shape stays fail-closed to
+// `guard-touching` (exit 0) — only the reason EVIDENCE is sharpened.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL("../../../../..", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const runSh = (cmd: string): RunResult => {
+	const r = spawnSync("sh", ["-c", cmd], {cwd: REPO_ROOT, encoding: "utf8"});
+	return {code: r.status ?? 0, stdout: r.stdout ?? "", stderr: r.stderr ?? ""};
+};
+
+const INNER = `node "${BIN}" guard-content-probe classify --path .decisions/9999-x.md`;
+
+// The three empty-stdin shapes the #3786 report verified — an empty pipe (`printf ''`),
+// `< /dev/null`, and a closed fd 0 (`<&-`) — all deliver an empty read (zero bytes) to the verb.
+// Each must report reason `empty-input`, not the old misleading `unreadable-body` (AC3), while
+// staying fail-closed to guard-touching.
+const EMPTY_READ_SHAPES: ReadonlyArray<readonly [string, string]> = [
+	["printf '' (empty pipe)", `printf '' | ${INNER}`],
+	["< /dev/null", `${INNER} < /dev/null`],
+	["closed stdin <&-", `${INNER} <&-`],
+];
+
+describe("guard-content-probe classify — empty stdin stays §CP, evidence is honest (#3786)", () => {
+	for (const [name, cmd] of EMPTY_READ_SHAPES) {
+		it(`${name}: guard-touching (fail-closed, exit 0) with reason [empty-input]`, () => {
+			const {code, stdout, stderr} = runSh(cmd);
+			expect(stdout.trim()).toBe("guard-touching");
+			expect(code).toBe(0);
+			expect(stderr).toContain("[empty-input]");
+			// The old misleading evidence is gone — a blank body no longer reads as unreadable head.
+			expect(stderr).not.toContain("[unreadable-body]");
+		});
+	}
+
+	it("a guard-relaxing body still classifies guard-touching via a content hit (non-regression)", () => {
+		const body = "This decision relaxes the fail-closed enforcement guard.";
+		const {code, stdout, stderr} = runSh(`printf '%s\\n' "${body}" | ${INNER}`);
+		expect(stdout.trim()).toBe("guard-touching");
+		expect(code).toBe(0);
+		expect(stderr).toContain("[guard-vocabulary-match]");
+	});
+
+	it("an ordinary product ADR still classifies not-guard-touching, exit 1 (non-regression)", () => {
+		const body = "Term pages sort entries by score, newest first.";
+		const {code, stdout} = runSh(`printf '%s\\n' "${body}" | ${INNER}`);
+		expect(stdout.trim()).toBe("not-guard-touching");
+		expect(code).toBe(1);
+	});
+});

--- a/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.ts
@@ -46,7 +46,13 @@ export const parseGuardAdrRe = (formatsText: string): string =>
 
 /** Why the probe decided as it did — surfaced for the human reason line. */
 export type GuardProbeReason =
+	// A read that FAILED (null/undefined body — a delete/404/unreadable head).
 	| "unreadable-body"
+	// A read that SUCCEEDED but delivered no content (empty/whitespace-only body — an empty or
+	// undelivered stdin). Split from `unreadable-body` (#3786) so the evidence is honest: the
+	// verdict was always the right one (guard-touching, fail-closed) but the old `unreadable-body`
+	// reason mislabeled an empty-input read as if the head were unreadable.
+	| "empty-input"
 	| "guard-vocabulary-match"
 	| "uncompilable-regex"
 	| "no-match";
@@ -60,20 +66,28 @@ export interface GuardProbeResult {
 /**
  * Is an ADR's content guard-touching (§CP by content, ADR 0164)? Pure and total.
  *
- * Fail-closed order, transcribing ship-it Step 0 exactly:
- *   1. body null/empty ⇒ guard-touching (an ADR that couldn't be read at head is never
- *      proven guard-free — the `[ -z "$body" ] → BLOCKING` clause).
- *   2. `guardRe` won't compile ⇒ guard-touching (a broken boundary must never silently
+ * Fail-closed order, transcribing ship-it Step 0 exactly (the `[ -z "$body" ] → BLOCKING`
+ * clause covers both zero-input shapes below — an ADR body that couldn't be read at head is
+ * never proven guard-free):
+ *   1. body null/undefined ⇒ guard-touching, reason `unreadable-body` (a failed read — a
+ *      delete/404/unreadable head).
+ *   2. body empty/whitespace-only ⇒ guard-touching, reason `empty-input` (a read that succeeded
+ *      but delivered nothing — an empty/undelivered stdin; #3786 splits this off so the evidence
+ *      is honest rather than mislabeling it `unreadable-body`).
+ *   3. `guardRe` won't compile ⇒ guard-touching (a broken boundary must never silently
  *      match nothing).
- *   3. body matches `guardRe` (case-insensitive, like `grep -Ei`) ⇒ guard-touching.
- *   4. otherwise ⇒ not guard-touching.
+ *   4. body matches `guardRe` (case-insensitive, like `grep -Ei`) ⇒ guard-touching.
+ *   5. otherwise ⇒ not guard-touching.
  */
 export const probeGuardContent = (
 	body: string | null | undefined,
 	guardRe: string,
 ): GuardProbeResult => {
-	if (body === null || body === undefined || body.trim() === "") {
+	if (body === null || body === undefined) {
 		return {guardTouching: true, reason: "unreadable-body"};
+	}
+	if (body.trim() === "") {
+		return {guardTouching: true, reason: "empty-input"};
 	}
 	let re: RegExp;
 	try {

--- a/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/guard-content-probe/guard-content-probe.unit.test.ts
@@ -36,15 +36,35 @@ const GUARD_RE = parseGuardAdrRe(FORMATS_SLICE);
 
 describe("probeGuardContent — the ADR-0164 content-shape predicate (#3645)", () => {
 	describe("fail-closed: an unreadable ADR body is guard-touching", () => {
-		it("null body ⇒ guard-touching (delete/404/unreadable head)", () => {
+		it("null body ⇒ guard-touching, reason `unreadable-body` (a FAILED read: delete/404/unreadable head)", () => {
 			const r = probeGuardContent(null, GUARD_RE);
 			expect(r.guardTouching).toBe(true);
 			expect(r.reason).toBe("unreadable-body");
 		});
 
-		it("undefined and whitespace-only bodies ⇒ guard-touching", () => {
-			expect(probeGuardContent(undefined, GUARD_RE).guardTouching).toBe(true);
-			expect(probeGuardContent("   \n\t ", GUARD_RE).guardTouching).toBe(true);
+		it("undefined body ⇒ guard-touching, reason `unreadable-body`", () => {
+			const r = probeGuardContent(undefined, GUARD_RE);
+			expect(r.guardTouching).toBe(true);
+			expect(r.reason).toBe("unreadable-body");
+		});
+	});
+
+	describe("fail-closed: an empty/whitespace-only body reports `empty-input`, not a content hit (#3786)", () => {
+		// AC3: the blank-body verdict was always right (guard-touching, fail-closed) — the bug was
+		// the EVIDENCE. An empty/undelivered stdin read as `unreadable-body`, as if the head were
+		// unreadable. Split it off to `empty-input` (a read that succeeded but delivered nothing) so
+		// the reason is honest; the fail-closed verdict MUST NOT regress.
+		it("empty-string body ⇒ guard-touching, reason `empty-input`", () => {
+			const r = probeGuardContent("", GUARD_RE);
+			expect(r.guardTouching).toBe(true);
+			expect(r.reason).toBe("empty-input");
+		});
+
+		it("whitespace-only body ⇒ guard-touching, reason `empty-input` (not `unreadable-body`)", () => {
+			const r = probeGuardContent("   \n\t ", GUARD_RE);
+			expect(r.guardTouching).toBe(true);
+			expect(r.reason).toBe("empty-input");
+			expect(r.reason).not.toBe("unreadable-body");
 		});
 	});
 


### PR DESCRIPTION
Fixes #3786

## Problem

Two `pipeline-cli` classification verbs returned a confident, well-formed answer on empty/undelivered stdin instead of failing closed:

- **`class-probe classify`** emitted an **empty** required-gate set with exit 0 — indistinguishable from a legitimately gate-free PR. The root cause is `classify()`: `files.some(...)` is `false` on `[]`, so the no-class fail-closed branch (#2765) only fires for an *unclassified* file; zero files fell through to an empty set.
- **`guard-content-probe classify`** already fail-closed to `guard-touching` on a blank body (right verdict), but reported the reason as `[unreadable-body]` — as if the head were unreadable, when in fact stdin delivered an empty read.

## Fix

- **class-probe** — a zero-length read is now its **own condition**, handled at the IO boundary (`command.ts`): the bin routes it through the same has-code fail-closed path an unclassified file rides (`NO_INPUT_FAILCLOSED_CLASSES` → `review-code`), never an empty set, and writes a **loud stderr** line so a dropped stdin is visible at the point it happens. The pure `classify([])` stays `[]` (an empty diff genuinely spans no class); the zero-input decision belongs to the bin, which knows it is only ever piped a PR's changed files (never legitimately empty). Direction chosen per AC1/AC2 below: routing to `review-code` (not exit-code-only) is the robust fix because every consumer reads the verb's **stdout lines**.
- **guard-content-probe** — split the empty/whitespace read off to a new `empty-input` reason, distinct from `unreadable-body` (a failed null read from a delete/404/unreadable head). The fail-closed `guard-touching` verdict is unchanged.

## Acceptance criteria

1. **Zero files is its own condition, no empty answer with exit 0** — routed through the has-code fail-closed path (→ `review-code`) with a loud stderr warning. `classify([])` stays pure.
2. **Consumer audit (the gate-bypass is established, not just refuted):** every documented consumer invokes the verb **by pipe** and branches on its **stdout lines**:
   - `reviewer.md` (fan, ~150/236) — dispatches a gate for **exactly** each namespace `class-probe classify --namespaces` prints; an empty list → **zero gates dispatched**, and the coverage self-check then iterates an empty set and passes vacuously.
   - `ship-it` Step 0 (~378) — re-runs `class-probe classify` by pipe and gates the merge on the **conjunction** over the required-namespace set (Step 1). An **empty** set makes that conjunction **vacuously true → zero gates required → un-gated merge**. This is the terminal authority, so this is a genuine latent bypass, gated only on whether a harness drops stdin (the unidentified trigger from the report). Routing empty input to `review-code` closes it at the probe — ship-it can never compute an empty required set from a dropped stdin.
   - `review-code`/`review-doc` (~596/217) use `guard-content-probe`, which was already fail-closed; only its evidence was misleading.
3. **guard-content-probe** blank-body evidence fixed (`empty-input`), fail-closed verdict preserved.
4. **Regression tests** over the shared bin for both verbs across the three empty stdin shapes verified in the report — `printf ''`, `< /dev/null`, closed `<&-` — plus non-regression controls for piped real content.

## Tests

`vitest run` for both tool dirs: 60 passed. Added unit coverage (`NO_INPUT_FAILCLOSED_CLASSES` → review-code; `classify([])` stays pure; `empty-input` vs `unreadable-body`) and two new CLI integration suites (`command.test.ts`) that reproduce the three empty stdin shapes verbatim via real shell redirection over `bin.ts`. `tsgo` typecheck clean, biome clean.

## §CP note

Touches `packages/pipeline-cli/**` (the enforcement-guard machinery) → human control-plane merge. This is guard-**strengthening** (fail-open → fail-closed/loud), not weakening — no threat-model burden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
