### PR TITLE
fix(pipeline-cli): cross-check verdict `post` head against the target PR (#3801)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1297,15 +1297,28 @@ For a **non-blocking** PR (every other class), land an **explicit, recognizable 
 signal** so the next actor (human or authorized downstream step) knows it's verified and can
 merge. Two forms, either is valid — both must carry the per-criterion table as evidence.
 
-First, **resolve the head SHA you actually reviewed** and **write the verdict to a per-run
-temp file** (`VERDICT_FILE="$(mktemp /tmp/review-code-verdict.XXXXXX)"`) so multi-line markdown +
-backticks survive the shell — both forms below read it back via `cat`. Allocate it with
-`mktemp`, never a fixed or `${PR}`-keyed path — the per-run scratchpad namespace, §SP of
-[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). The PR number alone isn't
-unique (two reviews of the *same* PR running concurrently — the operator fans review-* out in
-parallel — collide on it, one run's unread verdict stalling the write or leaking into the
-other, #1465), and a clobbered temp reads back **successfully with the other run's content**,
-so there is no error to catch (#3718). The SHA goes into the marker's first
+First, **resolve the head SHA you actually reviewed**, then **compose the verdict body so no other
+run can clobber it before `verdict post` reads it.** Two collision-proof forms, in preference order:
+
+1. **Straight stdin (preferred — no scratch file at all).** Compose the body into a shell variable
+   (a heredoc preserves multi-line markdown + backticks) and pipe it directly into the tool:
+   `printf '%s' "$BODY" | $VERDICT post --pr "$PR" --gate code`. With no file on disk there is
+   nothing for a concurrent run to overwrite — the collision surface is gone by construction.
+2. **A §SP per-run scratch path**, when a file is genuinely needed (e.g. to hand the same body to
+   both `verdict validate` and the native `APPROVE`). Derive it from the per-run `$RUN_SCRATCH`
+   namespace keyed on `$CLAUDE_CODE_SESSION_ID` (§SP of
+   [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)), or allocate with `mktemp` —
+   **never a fixed name** (`verdict.md`) and **never a `${PR}`-keyed path.**
+
+Both the fixed-name and the `${PR}`-keyed path are unsafe: the PR number alone isn't unique (two
+reviews of the *same* PR run concurrently — the operator fans review-* out in parallel — and collide
+on it, #1465), and a clobbered file reads back **successfully with the other run's content**, so
+there is no error to catch (#3718). Worse, that clobber can publish a well-formed §CP verdict marker
+bound to the **wrong PR's SHA** (#3801). The post-time head cross-check in `verdict post` now refuses
+a body whose bound `@ <sha>` / `Reviewed-head:` SHA is not the target PR's current head, so a cross-PR
+clobber is caught at emission — but that guard is the backstop, not a licence to hand-compose into a
+shared name; keep the compose collision-free at the source (this is the #1465 `mktemp` mandate extended
+to the hand-compose step). The SHA goes into the marker's first
 line (`review-code: PASS @ <sha> — merge-ready`) — it is **load-bearing**: `ship-it` refuses
 any verdict not bound to the PR's current head (ADR
 [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md), issue #258). See the
@@ -1353,12 +1366,18 @@ else
   VERDICT="pnpm dlx @kampus/pipeline-cli@0.2.0 verdict"     # foreign install: the published CLI
 fi
 
-VERDICT_FILE="$(mktemp /tmp/review-code-verdict.XXXXXX)"
-# write your composed PASS verdict into "$VERDICT_FILE" (first line: review-code: PASS @ <HEAD_SHA> — merge-ready)
-BODY="$(cat "$VERDICT_FILE")"
-# Read-back assertion BEFORE the native APPROVE: the same gate `verdict post` enforces, so a
-# malformed `@ <sha>` (e.g. an mktemp scratch path, #2683) fails loud here, never in a review body.
-$VERDICT validate --gate code --body-file "$VERDICT_FILE" || {
+# Compose the PASS verdict straight into a shell variable (heredoc → multi-line markdown + backticks
+# survive) — NO scratch file, so no concurrent run can clobber it (#1465/#3718/#3801). First line:
+# review-code: PASS @ <HEAD_SHA> — merge-ready
+BODY="$(cat <<EOF
+review-code: PASS @ ${HEAD_SHA} — merge-ready
+… your per-criterion evidence table …
+EOF
+)"
+# Read-back assertion BEFORE the native APPROVE: the same gate `verdict post` enforces, piped on
+# stdin, so a malformed `@ <sha>` (e.g. an mktemp scratch path, #2683) fails loud here, never in a
+# review body.
+printf '%s' "$BODY" | $VERDICT validate --gate code || {
   echo "FATAL: composed review-code marker is malformed — refusing to post (fix the @ <sha> field; #2683)" >&2
   exit 1
 }
@@ -1368,10 +1387,11 @@ if gh api -X POST repos/$REPO/pulls/$PR/reviews \
     #  ship-it reads that commit_id for the same staleness test the marker's @ <sha> drives)
 else
   # APPROVE failed (e.g. 422 on your own PR) — upsert the structured pass comment instead, through
-  # the guarded tool: it PATCHes your newest own review-code marker (namespace-anchored, so it also
-  # upserts a prior advisory across a non-blocking↔blocking flip) else POSTs the first, and it
-  # fail-closes on a malformed/cross-namespace body so a broken marker never reaches GitHub.
-  $VERDICT post --pr "$PR" --gate code --body-file "$VERDICT_FILE"
+  # the guarded tool on stdin: it PATCHes your newest own review-code marker (namespace-anchored, so
+  # it also upserts a prior advisory across a non-blocking↔blocking flip) else POSTs the first, and
+  # it fail-closes on a malformed/cross-namespace body AND on a body bound to another PR's head
+  # (the #3801 post-time cross-check) so a broken/mis-bound marker never reaches GitHub.
+  printf '%s' "$BODY" | $VERDICT post --pr "$PR" --gate code
 fi
 ```
 
@@ -1548,13 +1568,19 @@ if [ -f packages/pipeline-cli/src/bin.ts ]; then
 else
   VERDICT="pnpm dlx @kampus/pipeline-cli@0.2.0 verdict"
 fi
-HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # resolve ONCE, before authoring the verdict file (mirror the PASS path)
-VERDICT_FILE="$(mktemp /tmp/review-code-verdict.XXXXXX)"   # per-run temp, not a fixed/PR-namespaced path (#1465)
-# … author "$VERDICT_FILE" now, embedding `review-code: FAIL @ $HEAD_SHA — not merge-ready` as its first line …
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # resolve ONCE, before composing (mirror the PASS path)
+# Compose straight into a shell variable and pipe on stdin — NO scratch file, so no fixed/PR-keyed
+# name a concurrent run can clobber (#1465/#3718/#3801). First line: review-code: FAIL @ $HEAD_SHA — not merge-ready
+BODY="$(cat <<EOF
+review-code: FAIL @ ${HEAD_SHA} — not merge-ready
+… your per-criterion evidence table …
+EOF
+)"
 # Upsert through the guarded tool (resolved above), exactly as the PASS path: it upserts the one
 # review-code marker (namespace-anchored, advisory included) and fail-closes on a malformed/
-# cross-namespace body, so the mktemp-path `@ <sha>` leak (#2683) can never reach GitHub.
-$VERDICT post --pr "$PR" --gate code --body-file "$VERDICT_FILE"
+# cross-namespace body (so the mktemp-path `@ <sha>` leak #2683 can't land) AND on a body bound to
+# another PR's head (the #3801 post-time cross-check).
+printf '%s' "$BODY" | $VERDICT post --pr "$PR" --gate code
 ```
 
 You *may* additionally request changes via a formal review

--- a/packages/pipeline-cli/src/tools/verdict/command.ts
+++ b/packages/pipeline-cli/src/tools/verdict/command.ts
@@ -128,6 +128,9 @@ const post = Command.make(
 		}
 		const result = yield* (yield* Github).post(pr, g, body).pipe(
 			Effect.catchTag("@kampus/verdict/VerdictInputError", (error) => fail(error.message)),
+			// The post-time head cross-check (#3801): a well-formed body bound to a DIFFERENT PR's head
+			// (a cross-PR scratchpad clobber, or a stale/rebased binding) is refused before it lands.
+			Effect.catchTag("@kampus/verdict/VerdictHeadMismatchError", (error) => fail(error.message)),
 			// The landed-comment self-verify (#3019): a body that passed the input gate but did not
 			// land as a clean in-namespace, leak-free marker fails the post — never a false success.
 			Effect.catchTag("@kampus/verdict/VerdictVerifyError", (error) => fail(error.message)),

--- a/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github-service.unit.test.ts
@@ -5,6 +5,7 @@ import {
 	Github,
 	GithubLive,
 	type RepoResolutionError,
+	VerdictHeadMismatchError,
 	VerdictInputError,
 	VerdictVerifyError,
 } from "./github.ts";
@@ -184,6 +185,8 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
 					comment({id: 1, login: "someone", body: "just chatter"}),
 				]),
+				[`GET ${P}/pulls/${PR}`]:
+					HEAD40 /* #3801 head cross-check reads live head; BODY binds HEAD40 */,
 				[`POST ${P}/issues/${PR}/comments`]: "999",
 				// the #3019 read-back: post re-fetches the landed comment and re-runs emissionDefect
 				[`GET ${P}/issues/comments/999`]: BODY,
@@ -201,6 +204,7 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
 					comment({id: 42, login: "usirin", body: `review-doc: FAIL @ ${OLD} — changes-requested`}),
 				]),
+				[`GET ${P}/pulls/${PR}`]: HEAD40 /* #3801: BODY binds HEAD40 */,
 				[`PATCH ${P}/issues/comments/42`]: "42",
 				[`GET ${P}/issues/comments/42`]: BODY,
 			}),
@@ -217,6 +221,7 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([
 					comment({id: 7, login: "cansirin", body: `review-doc: PASS @ ${OLD} — merge-ready`}),
 				]),
+				[`GET ${P}/pulls/${PR}`]: HEAD40 /* #3801: BODY binds HEAD40 */,
 				[`POST ${P}/issues/${PR}/comments`]: "1000",
 				[`GET ${P}/issues/comments/1000`]: BODY,
 			}),
@@ -275,6 +280,7 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 			provide(effect, {
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`GET ${P}/pulls/${PR}`]: "a".repeat(40) /* #3801: body binds a*40 */,
 				[`POST ${P}/issues/${PR}/comments`]: "777",
 				[`GET ${P}/issues/comments/777`]: `review-doc: PASS @ ${"a".repeat(40)}`,
 			}),
@@ -352,8 +358,83 @@ describe("Github.post — the ADR-0058 rule-2 upsert over a mock gh spawner", ()
 			provide(effect, {
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`GET ${P}/pulls/${PR}`]: HEAD40 /* #3801: advisory binds HEAD40 via Reviewed-head */,
 				[`POST ${P}/issues/${PR}/comments`]: "890",
 				[`GET ${P}/issues/comments/890`]: `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD40}`,
+			}),
+		),
+	);
+});
+
+// The #3801 post-time head cross-check: `post` refuses a well-formed body whose bound `@ <sha>` /
+// `Reviewed-head:` SHA is not the target PR's current head. This is the cross-PR verdict-integrity
+// hole — a body composed for PR B (bound to B's head) that gets POSTed to PR A. `emissionDefect`
+// passes it (it's well-formed), but A's live head is not B's SHA, so the head cross-check refuses it
+// before any write. No POST/PATCH fixture is supplied on the refusal cases: a write would 404.
+describe("Github.post — the post-time head cross-check (#3801, no cross-PR contamination)", () => {
+	// A's live head. FOREIGN is a DIFFERENT PR's head SHA — the value a clobbered shared-scratch body
+	// would carry. Both are full 40-hex (the emission shape), and they share no common prefix.
+	const A_HEAD = `${"c6192dee".repeat(5)}`; // 8*5 = 40 hex — PR #3787's real head shape
+	const FOREIGN = `${"80f6b847".repeat(5)}`; // 8*5 = 40 hex — the victim's clobbering PR head
+
+	it.effect("a PASS body bound to ANOTHER PR's head → VerdictHeadMismatchError, no write", () =>
+		Effect.gen(function* () {
+			const wrongPrBody = `review-code: PASS @ ${FOREIGN} — merge-ready`;
+			const error = yield* Effect.flip((yield* Github).post(PR, "code", wrongPrBody));
+			assert.isTrue(error instanceof VerdictHeadMismatchError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/pulls/${PR}`]: A_HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+			}),
+		),
+	);
+
+	it.effect(
+		"a §CP advisory whose `Reviewed-head:` names ANOTHER PR's head → VerdictHeadMismatchError",
+		() =>
+			Effect.gen(function* () {
+				// first line is a SHA-less advisory (passes emissionDefect), but the head anchor is foreign
+				const advisory = `review-code: advisory — see thread\n\nReviewed-head: @ ${FOREIGN}`;
+				const error = yield* Effect.flip((yield* Github).post(PR, "code", advisory));
+				assert.isTrue(error instanceof VerdictHeadMismatchError);
+			}).pipe((effect) =>
+				provide(effect, {
+					"GET user": "usirin",
+					[`GET ${P}/pulls/${PR}`]: A_HEAD,
+					[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				}),
+			),
+	);
+
+	it.effect("a PASS body bound to THIS PR's current head → POSTed (the check passes it)", () =>
+		Effect.gen(function* () {
+			const rightBody = `review-code: PASS @ ${A_HEAD} — merge-ready`;
+			const result = yield* (yield* Github).post(PR, "code", rightBody);
+			assert.deepStrictEqual(result, {_tag: "posted", commentId: 4242});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/pulls/${PR}`]: A_HEAD,
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`POST ${P}/issues/${PR}/comments`]: "4242",
+				[`GET ${P}/issues/comments/4242`]: `review-code: PASS @ ${A_HEAD} — merge-ready`,
+			}),
+		),
+	);
+
+	it.effect("a SHA-less advisory (binds no head) posts without any live-head lookup", () =>
+		Effect.gen(function* () {
+			// no `GET pulls` fixture — a bind-nothing advisory must not trigger the live-head read at all
+			const result = yield* (yield* Github).post(PR, "code", "review-code: advisory — see thread");
+			assert.deepStrictEqual(result, {_tag: "posted", commentId: 4343});
+		}).pipe((effect) =>
+			provide(effect, {
+				"GET user": "usirin",
+				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`POST ${P}/issues/${PR}/comments`]: "4343",
+				[`GET ${P}/issues/comments/4343`]: "review-code: advisory — see thread",
 			}),
 		),
 	);
@@ -374,6 +455,7 @@ describe("Github.post — the folded-in landed-comment self-verify (#3019)", () 
 			provide(effect, {
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`GET ${P}/pulls/${PR}`]: "a".repeat(40) /* #3801: CLEAN_INPUT binds a*40 */,
 				[`POST ${P}/issues/${PR}/comments`]: "555",
 				[`GET ${P}/issues/comments/555`]: `review-doc: PASS @ ${"a".repeat(40)}\n\nsee /private/tmp/review-verdict.E2CYtu`,
 			}),
@@ -390,6 +472,7 @@ describe("Github.post — the folded-in landed-comment self-verify (#3019)", () 
 				provide(effect, {
 					"GET user": "usirin",
 					[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+					[`GET ${P}/pulls/${PR}`]: "a".repeat(40) /* #3801: CLEAN_INPUT binds a*40 */,
 					[`POST ${P}/issues/${PR}/comments`]: "556",
 					[`GET ${P}/issues/comments/556`]: "@/tmp/review-doc-verdict.E2CYtu",
 				}),
@@ -406,6 +489,7 @@ describe("Github.post — the folded-in landed-comment self-verify (#3019)", () 
 				provide(effect, {
 					"GET user": "usirin",
 					[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+					[`GET ${P}/pulls/${PR}`]: "a".repeat(40) /* #3801: CLEAN_INPUT binds a*40 */,
 					[`POST ${P}/issues/${PR}/comments`]: "557",
 					[`GET ${P}/issues/comments/557`]: {
 						stdout: "",
@@ -424,6 +508,7 @@ describe("Github.post — the folded-in landed-comment self-verify (#3019)", () 
 			provide(effect, {
 				"GET user": "usirin",
 				[`GET ${P}/issues/${PR}/comments`]: JSON.stringify([]),
+				[`GET ${P}/pulls/${PR}`]: "a".repeat(40) /* #3801: CLEAN_INPUT binds a*40 */,
 				[`POST ${P}/issues/${PR}/comments`]: "558",
 				[`GET ${P}/issues/comments/558`]: CLEAN_INPUT,
 			}),

--- a/packages/pipeline-cli/src/tools/verdict/github.ts
+++ b/packages/pipeline-cli/src/tools/verdict/github.ts
@@ -40,7 +40,9 @@ import {
 	whoAmIArgs,
 } from "../tracker/gh-io.ts";
 import {
+	boundHeadShas,
 	emissionDefect,
+	headBindingDefect,
 	namespaceRe,
 	type Polarity,
 	resolveVerdict,
@@ -56,6 +58,21 @@ export {GhCommandError, GhParseError, RepoResolutionError} from "../tracker/gh-i
 /** A malformed request the caller must fix — e.g. a `post` body whose first line is the wrong gate's marker. */
 export class VerdictInputError extends Schema.TaggedErrorClass<VerdictInputError>()(
 	"@kampus/verdict/VerdictInputError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/**
+ * The verdict body binds a head SHA that is not the target PR's current head — the post-time
+ * cross-check (#3801). A body composed for PR B (bound to B's head) that is POSTed to PR A carries
+ * B's SHA, which does not match A's live head, so the post is refused rather than publishing a
+ * well-formed marker bound to the WRONG PR (the cross-PR scratchpad-clobber verdict-integrity hole).
+ * The caller re-reviews the current head and re-composes. Distinct from `VerdictInputError` (a
+ * malformed body) — the body is well-formed, its binding is just stale/foreign.
+ */
+export class VerdictHeadMismatchError extends Schema.TaggedErrorClass<VerdictHeadMismatchError>()(
+	"@kampus/verdict/VerdictHeadMismatchError",
 	{
 		message: Schema.String,
 	},
@@ -184,7 +201,11 @@ const read = Effect.fn("Github.read")(function* (
  * empty-SHA `@-` marker the read side refuses, #2646); and every SHA field it carries — the
  * first-line `@ <sha>` and the §CP advisory `Reviewed-head:` anchor — must be a clean full 40-hex,
  * not a partial/non-hex/path-glued value (rejects the `mktemp`-path leak of #2683). An advisory
- * SHA-less first line stays postable. Then scan our OWN prior marker in the namespace (newest by
+ * SHA-less first line stays postable. Then, when the body binds any head SHA, the post-time
+ * cross-check (#3801) fetches the target PR's live head and refuses if a bound SHA does not match it
+ * — closing the verdict-integrity hole where a body composed for another PR (bound to a different
+ * PR's SHA, e.g. via a clobbered shared scratch file) was postable and caught only on read-back.
+ * Then scan our OWN prior marker in the namespace (newest by
  * `(created_at, id)`) and PATCH it if present else POST a fresh one. The own-authored scope means
  * two reviewers never stomp each other's records. Finally, `verifyLanded` re-fetches the upserted
  * comment and re-runs `emissionDefect` on its LANDED body — the defense-in-depth self-verify (#3019)
@@ -199,6 +220,16 @@ const post = Effect.fn("Github.post")(function* (
 	const defect = emissionDefect(body, gate);
 	if (defect !== null) {
 		return yield* new VerdictInputError({message: `refusing to post: ${defect}`});
+	}
+	// Post-time head cross-check (#3801): only when the body actually binds a SHA — a SHA-less
+	// advisory binds nothing, so it needs no live-head lookup and stays postable. When it does bind,
+	// the marker's SHA must be THIS PR's current head, not another PR's (the cross-PR clobber).
+	if (boundHeadShas(body, gate).length > 0) {
+		const head = yield* currentHead(repo, pr);
+		const mismatch = headBindingDefect(body, gate, head);
+		if (mismatch !== null) {
+			return yield* new VerdictHeadMismatchError({message: `refusing to post: ${mismatch}`});
+		}
 	}
 	const me = (yield* runGh(whoAmIArgs)).trim();
 	const comments = yield* listComments(repo, pr);
@@ -255,6 +286,7 @@ export class Github extends Context.Service<
 			| GhCommandError
 			| GhParseError
 			| VerdictInputError
+			| VerdictHeadMismatchError
 			| VerdictVerifyError
 			| Schema.SchemaError
 		>;

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.ts
@@ -267,6 +267,65 @@ export const malformedEmittedSha = (body: string, gate: VerdictGate): string | n
 };
 
 /**
+ * The `Reviewed-head:` anchor SHA (ADR 0151) — the §CP advisory's explicit head binding. Read-side
+ * shape ({7,40} hex, `@`-optional) so the post-time cross-check can prefix-match an abbreviated
+ * anchor against the live head; the stricter full-40-hex EMISSION shape is enforced separately by
+ * `malformedEmittedSha`. Capture group 1 is the bound SHA.
+ */
+const reviewedHeadShaRe = /^\s*Reviewed-head:\s*@?\s*([0-9a-f]{7,40})/im;
+
+/**
+ * Every head SHA a verdict body binds itself to: the first-line `PASS|FAIL @ <sha>` marker and the
+ * §CP advisory's `Reviewed-head:` anchor. A SHA-less advisory binds nothing (empty array). These are
+ * the fields the post-time cross-check (`headBindingDefect`) matches against the PR's live head.
+ */
+export const boundHeadShas = (body: string, gate: VerdictGate): ReadonlyArray<string> => {
+	const shas: string[] = [];
+	const parsed = parseVerdict(body, gate);
+	if (parsed?.sha) shas.push(parsed.sha);
+	const anchor = reviewedHeadShaRe.exec(body);
+	if (anchor?.[1]) shas.push(anchor[1].toLowerCase());
+	return shas;
+};
+
+/**
+ * The post-time head cross-check (#3801) — the verdict-integrity hole this closes: a body composed
+ * for PR B (bound to B's head SHA) that gets POSTed to PR A must be refused, because A's live head is
+ * not B's. `emissionDefect` validates only marker *well-formedness*; the head-vs-target-PR binding
+ * (`isBoundToHead`, ADR 0058 rule 3) was evaluated ONLY at read time, so a well-formed marker bound
+ * to the WRONG PR's SHA was freely postable and caught only on read-back (and never at all if the
+ * clobbering body happened to carry the victim's own head). This asserts, at post time, that every
+ * SHA the body binds prefix-matches the target PR's current `head`. Returns the first mismatch as a
+ * human-readable defect, or null when the body binds no SHA (a SHA-less advisory) or every bound SHA
+ * matches the head. Fail-closed on an empty/unresolvable head: any bound SHA then mismatches (an
+ * empty head is never `isBoundToHead`), so a body that binds a SHA is refused rather than posted
+ * unverified — a SHA-less body still passes (nothing to verify).
+ *
+ * The two false-refusal cases the §CP guard-strengthening was weighed against (design note, per the
+ * issue's AC1 — recorded here at the enforcement site rather than left a silent predicate):
+ *
+ *  1. A legit re-post racing a just-pushed head. A reviewer binds to head X, then someone force-pushes
+ *     head Y before the `post` lands. This guard refuses the X-bound post. That refusal is CORRECT, not
+ *     a false positive: a rebase/force-push staleness-invalidates the prior review (ADR 0058), so a
+ *     verdict bound to X is genuinely un-attested for Y and must not be published against it — the same
+ *     "rebase → re-review → ship is atomic" invariant, enforced one step earlier (at emit, not just at
+ *     read). The reviewer re-resolves the head and re-reviews Y; nothing is lost.
+ *  2. A deliberately stale-bound FAIL. Is posting a FAIL bound to an old head ever valid? No consumer
+ *     honors it: `write-code`-repair reads `--expect FAIL` and acts ONLY on a `current`-head verdict, so
+ *     a `stale` FAIL never drives repair anyway (it resolves `stale`, not satisfied). Refusing to POST a
+ *     stale-bound FAIL removes nothing a reader would have used, and it keeps the namespace honest — a
+ *     marker's `@ <sha>` always names the head it actually attests.
+ */
+export const headBindingDefect = (body: string, gate: VerdictGate, head: string): string | null => {
+	for (const sha of boundHeadShas(body, gate)) {
+		if (!isBoundToHead(sha, head)) {
+			return `the verdict body binds head ${sha} but PR ${GATE_KEYWORD[gate]}'s current head is ${head || "<unresolved>"} — refusing to post a verdict bound to a DIFFERENT head (a cross-PR scratchpad clobber or a stale/rebased binding); re-review the current head and re-compose (ADR 0058 rule 3, #3801)`;
+		}
+	}
+	return null;
+};
+
+/**
  * The single fail-closed gate every verdict EMISSION passes before it can reach GitHub — the one
  * source `Github.post` and `verdict validate` both consume so a raw-`gh api` skill and the tool
  * enforce identical rules. Returns the first structural defect (as a human-readable reason), or

--- a/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/verdict/verdict-match.unit.test.ts
@@ -1,6 +1,8 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
+	boundHeadShas,
 	emissionDefect,
+	headBindingDefect,
 	isBoundToHead,
 	isNamespaceMarker,
 	isReviewed,
@@ -406,4 +408,74 @@ describe("emissionDefect — the one gate `post` and `validate` share (#2683/#27
 		assert.isNotNull(
 			emissionDefect(`review-code: PASS @ ${SHA40}\n\nsee /Users/foo/scratch/notes`, "code"),
 		));
+});
+
+// The #3801 post-time head cross-check core: which head SHAs a body binds, and whether they match a
+// given live head. This is the pure decision `Github.post` drives at the boundary — the cross-PR
+// contamination guard tested end-to-end over the mock spawner in github-service.unit.test.ts.
+describe("boundHeadShas — the head SHAs a verdict body binds itself to", () => {
+	const HEAD = "c6192dee".repeat(5); // 40 hex
+	const OTHER = "80f6b847".repeat(5); // 40 hex
+
+	it("collects the first-line PASS/FAIL marker's @ <sha>", () =>
+		assert.deepStrictEqual(boundHeadShas(`review-code: PASS @ ${HEAD} — merge-ready`, "code"), [
+			HEAD,
+		]));
+
+	it("collects the §CP advisory's Reviewed-head: anchor SHA", () =>
+		assert.deepStrictEqual(
+			boundHeadShas(`review-code: advisory — see thread\n\nReviewed-head: @ ${HEAD}`, "code"),
+			[HEAD],
+		));
+
+	it("collects BOTH the marker @ <sha> and the Reviewed-head: anchor", () =>
+		assert.deepStrictEqual(
+			boundHeadShas(
+				`review-code: PASS @ ${HEAD} — merge-ready\n\nReviewed-head: @ ${OTHER}`,
+				"code",
+			),
+			[HEAD, OTHER],
+		));
+
+	it("a SHA-less advisory binds nothing (empty array)", () =>
+		assert.deepStrictEqual(boundHeadShas("review-code: advisory — see thread", "code"), []));
+
+	it("another gate's marker is not read as this gate's binding", () =>
+		assert.deepStrictEqual(boundHeadShas(`review-doc: PASS @ ${HEAD}`, "code"), []));
+});
+
+describe("headBindingDefect — refuse a body bound to a head other than the target PR's (#3801)", () => {
+	const HEAD = "c6192dee".repeat(5); // the target PR's live head, 40 hex
+	const FOREIGN = "80f6b847".repeat(5); // a DIFFERENT PR's head — a clobbered cross-PR body
+
+	it("a marker bound to a FOREIGN head → defect (the cross-PR contamination case)", () =>
+		assert.isNotNull(
+			headBindingDefect(`review-code: PASS @ ${FOREIGN} — merge-ready`, "code", HEAD),
+		));
+
+	it("a Reviewed-head: anchor bound to a FOREIGN head → defect", () =>
+		assert.isNotNull(
+			headBindingDefect(
+				`review-code: advisory — see thread\n\nReviewed-head: @ ${FOREIGN}`,
+				"code",
+				HEAD,
+			),
+		));
+
+	it("a marker bound to the target PR's own head → null (postable)", () =>
+		assert.isNull(headBindingDefect(`review-code: PASS @ ${HEAD} — merge-ready`, "code", HEAD)));
+
+	it("a SHA-less advisory binds nothing → null (nothing to cross-check)", () =>
+		assert.isNull(headBindingDefect("review-code: advisory — see thread", "code", HEAD)));
+
+	it("an abbreviated bound SHA that prefixes the live head → null (ADR 0058 rule 3)", () =>
+		assert.isNull(
+			headBindingDefect(`review-code: PASS @ ${HEAD.slice(0, 12)} — merge-ready`, "code", HEAD),
+		));
+
+	it("fail-closed: an empty/unresolvable head refuses any body that binds a SHA", () =>
+		assert.isNotNull(headBindingDefect(`review-code: PASS @ ${HEAD} — merge-ready`, "code", "")));
+
+	it("fail-closed exemption: an empty head still passes a bind-nothing advisory", () =>
+		assert.isNull(headBindingDefect("review-code: advisory — see thread", "code", "")));
 });


### PR DESCRIPTION
Fixes #3801

## What this closes

The post-time half of the verdict-integrity hole: `pipeline-cli verdict post` could publish a **well-formed marker bound to the wrong PR's SHA**. The `emissionDefect` gate validates only marker *well-formedness*; the head-vs-PR binding (`isBoundToHead`, ADR 0058 rule 3) was evaluated **only at read time**. So a body composed for PR B (bound to B's head — e.g. via a clobbered shared scratch file, the #3718/#1465 collision class) and POSTed to PR A was freely postable, caught only on read-back — and never at all if the clobber happened to carry the victim's own head.

## Changes

- **Post-time cross-check (AC1).** New pure `headBindingDefect` / `boundHeadShas` in `verdict-match.ts`: every SHA a body binds — the first-line `PASS|FAIL @ <sha>` marker and the `Reviewed-head:` anchor (ADR 0151) — must prefix-match the target PR's current head. `Github.post` fetches the live head and refuses via a dedicated `VerdictHeadMismatchError` when a bound SHA isn't it. Fetches the head **only when the body binds a SHA** (a SHA-less advisory needs no lookup and stays postable). Fail-closed on an empty/unresolvable head.
  - **Design note (the false-refusal weighing AC1 mandates)** lives in the `headBindingDefect` docblock at the enforcement site: (1) a re-post racing a just-pushed head is *correctly* refused — the rebase staleness-invalidates the review (ADR 0058), same "rebase → re-review → ship is atomic" invariant enforced one step earlier; (2) a stale-bound FAIL has no consumer (`write-code`-repair acts only on a `current`-head verdict), so refusing it removes nothing and keeps the namespace honest.
- **Compose discipline made explicit (AC2).** `review-code` SKILL: hand-compose the verdict straight into a shell variable and pipe on stdin (no scratch file at all), or a §SP per-run path — **never a fixed name or `${PR}`-keyed path**. Extends the #1465 `mktemp` mandate to the hand-compose step.
- **Coverage (no cross-PR contamination).** Pure unit tests for `boundHeadShas` / `headBindingDefect` (foreign head → defect, own head → null, abbreviated prefix-match, empty-head fail-closed) + `Github.post` service tests proving a body bound to another PR's head is refused (`VerdictHeadMismatchError`, no write) and a current-head body posts. 93 verdict tests green; typecheck + biome clean.

## Relationship pinned (AC3)

#3735 remains the structural backstop (fail-closed lint on fixed-name scratch writes). This neither duplicates nor waits on it — the two compose as defense-in-depth: #3735 prevents the clobber at the source, this refuses a mis-bound marker at emission.

## §CP note

This is a gate-critical review-skill / verdict-tool change (§CP) — banked for control-plane approval; not to be self-approved or merged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)