### PR TITLE
roadmap: complete Writing-Craft Import campaign (done)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | pipeline-cli @effect/platform migration | #32 | active |
 | Agentic design-system coverage | #33 | done |
 | Flag Retirement (ADR 0136) | #34 | active |
-| Writing-Craft Import | #30 | active |
+| Writing-Craft Import | #30 | done |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Flips `| Writing-Craft Import | #30 | active |` → `done`, paired with the milestone #30 close (0 open / 19 closed — fully drained, verified). This campaign pre-dates the campaign-approve trace mechanism (no wave label, no marker exists), so the `done` gate cannot verify by construction; completion was founder-ruled directly in session 2026-07-24 as a one-off exemption for this pre-trace campaign. roadmap-guard stays in sync: done row over a closed milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)