### PR TITLE
fix(sozluk): hoist the yeni-tanım CTA dialog open-state above the unmounting boundary (#3840)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ import {EmailDeliveryNoticeMount} from "./components/membrane/EmailDeliveryNotic
 import {actorLabel} from "./components/moderation/actor-identity";
 import {PanoSubnavLayout} from "./components/pano/PanoSubnavLayout";
 import {EagerProfileContributionSkeleton} from "./components/profile/ProfileContributionSignal";
+import {SozlukCreateDialogProvider} from "./components/sozluk/SozlukCreateDialogState";
 import {SozlukSubnavLayout} from "./components/sozluk/SozlukSubnavLayout";
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
@@ -176,70 +177,80 @@ function Layout() {
 	return (
 		<TooltipProvider>
 			<ToastProvider>
-				<AppShell>
-					{/* boot-mode observer for the edge-resolved shell (ADR 0179) — geometry-inert */}
-					<EdgeShellBootMarker />
-					<Topbar
-						brandName="kamp.us"
-						reserveSignedInSlots={reserveSignedInSlots}
-						// akış is a mecmua SUB-destination living in the mecmua Subnav zone (#2603),
-						// so the topbar carries just the `mecmua` product noun — a cross-product
-						// destination, per placement law #2587.
-						nav={[
-							{to: "/sozluk", label: "sözlük"},
-							{to: "/pano", label: "pano"},
-							...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
-						]}
-						divanTo={chips?.divanTo}
-						{...(chips?.userProps ?? bootUserProps)}
-						karma={chips?.karma}
-						{...(chips?.bildirim ? {bildirim: chips.bildirim} : {})}
-						searchQuery={searchQuery}
-						onSearchSubmit={(query) => {
-							const target = searchTarget(query);
-							if (target) navigate(target);
-						}}
-						// No `onToggleTheme`: the three-way theme picker is the sole theme control
-						// (#2612), so no tema button renders.
-						themeChoice={themeChoice}
-						onThemeChange={setThemeChoice}
-						onLogout={onSignOut}
-						actions={
-							// giriş-yap rides the first-paint presence bit, not the settling session:
-							// `__BOOT__.user != null` (via signedInAtFirstPaint) suppresses the CTA for a
-							// signed-in user from the first frame, so it never flashes then swaps out
-							// (#2933, ADR 0185). Absent `__BOOT__` ⇒ this reduces to `isSignedIn`, today's split.
-							!signedInAtFirstPaint ? (
-								<button type="button" className="kp-topbar__btn" onClick={() => navigate("/auth")}>
-									giriş yap
-								</button>
-							) : null
-							// Signed in ⇒ no topbar action: pano's `+ gönderi` primary action lives in
-							// the pano Subnav CTA zone (placement law #2587), not the topbar.
-						}
-					/>
-					<Main>
-						{/* PUBLIC tier (ADR 0167): the anon-capable pano feed paints over the
+				{/* The sözlük create-dialog open-state lives here, above `FateProvider`'s
+				    `key={userId}` re-key and `LayoutContent`'s `needsBootstrap` Outlet swap, so
+				    an ancestor unmount can't silently destroy it — the #3840 hoist. The CTA reads
+				    it through context far below, the same bridge shape as `SetTopbarChipsContext`. */}
+				<SozlukCreateDialogProvider>
+					<AppShell>
+						{/* boot-mode observer for the edge-resolved shell (ADR 0179) — geometry-inert */}
+						<EdgeShellBootMarker />
+						<Topbar
+							brandName="kamp.us"
+							reserveSignedInSlots={reserveSignedInSlots}
+							// akış is a mecmua SUB-destination living in the mecmua Subnav zone (#2603),
+							// so the topbar carries just the `mecmua` product noun — a cross-product
+							// destination, per placement law #2587.
+							nav={[
+								{to: "/sozluk", label: "sözlük"},
+								{to: "/pano", label: "pano"},
+								...(mecmuaOn ? [{to: "/mecmua", label: "mecmua"}] : []),
+							]}
+							divanTo={chips?.divanTo}
+							{...(chips?.userProps ?? bootUserProps)}
+							karma={chips?.karma}
+							{...(chips?.bildirim ? {bildirim: chips.bildirim} : {})}
+							searchQuery={searchQuery}
+							onSearchSubmit={(query) => {
+								const target = searchTarget(query);
+								if (target) navigate(target);
+							}}
+							// No `onToggleTheme`: the three-way theme picker is the sole theme control
+							// (#2612), so no tema button renders.
+							themeChoice={themeChoice}
+							onThemeChange={setThemeChoice}
+							onLogout={onSignOut}
+							actions={
+								// giriş-yap rides the first-paint presence bit, not the settling session:
+								// `__BOOT__.user != null` (via signedInAtFirstPaint) suppresses the CTA for a
+								// signed-in user from the first frame, so it never flashes then swaps out
+								// (#2933, ADR 0185). Absent `__BOOT__` ⇒ this reduces to `isSignedIn`, today's split.
+								!signedInAtFirstPaint ? (
+									<button
+										type="button"
+										className="kp-topbar__btn"
+										onClick={() => navigate("/auth")}
+									>
+										giriş yap
+									</button>
+								) : null
+								// Signed in ⇒ no topbar action: pano's `+ gönderi` primary action lives in
+								// the pano Subnav CTA zone (placement law #2587), not the topbar.
+							}
+						/>
+						<Main>
+							{/* PUBLIC tier (ADR 0167): the anon-capable pano feed paints over the
 						    always-anonymous public client while `get-session` resolves, then
 						    hands off to the authed feed once the gate below commits. */}
-						{showEagerPanoFeed ? (
-							<PublicFateProvider>
-								<PanoFeed {...(eagerPanoHost ? {host: eagerPanoHost} : {})} />
-							</PublicFateProvider>
-						) : null}
-						{showEagerProfileSkeleton ? <EagerProfileContributionSkeleton /> : null}
-						{/* The routed content + fate-dependent chips live below the session
+							{showEagerPanoFeed ? (
+								<PublicFateProvider>
+									<PanoFeed {...(eagerPanoHost ? {host: eagerPanoHost} : {})} />
+								</PublicFateProvider>
+							) : null}
+							{showEagerProfileSkeleton ? <EagerProfileContributionSkeleton /> : null}
+							{/* The routed content + fate-dependent chips live below the session
 						    gate — FateProvider keeps its #438 remount guard (first & only key
 						    is the resolved identity), while the shell frame above already
 						    painted. */}
-						<FateProvider>
-							<SetTopbarChipsContext.Provider value={setChips}>
-								<LayoutContent />
-							</SetTopbarChipsContext.Provider>
-						</FateProvider>
-					</Main>
-					<Footer />
-				</AppShell>
+							<FateProvider>
+								<SetTopbarChipsContext.Provider value={setChips}>
+									<LayoutContent />
+								</SetTopbarChipsContext.Provider>
+							</FateProvider>
+						</Main>
+						<Footer />
+					</AppShell>
+				</SozlukCreateDialogProvider>
 			</ToastProvider>
 		</TooltipProvider>
 	);

--- a/apps/web/src/components/sozluk/SozlukCreateDialogState.tsx
+++ b/apps/web/src/components/sozluk/SozlukCreateDialogState.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+
+/**
+ * The `+ yeni tanım` create dialog's open-state, hoisted OUT of `SozlukSubnavCta`'s local
+ * `useState` so an ancestor unmount can no longer silently destroy it (#3840).
+ *
+ * #3600 pinned the closer: `open` lived in the CTA's local `useState`, so any unmount of an
+ * ancestor — `FateProvider`'s `key={userId}` re-key or `LayoutContent`'s `needsBootstrap`
+ * Outlet swap — reset it to `false`, reproducing the CI artifact (dialog gone, no backdrop,
+ * page un-`aria-hidden`, no error, still on `/sozluk`). Crucially NO `onOpenChange` reason
+ * fires on that path — the state is destroyed by React unmounting the CTA, not dismissed via
+ * `outside-press`/`escape` — which is how the closer is named: an absent dismiss reason ⇒
+ * ancestor unmount (base-ui 1.4.1's `outsidePress` only fires on a real backdrop-targeted
+ * pointer event, which the trigger-only open cannot produce).
+ *
+ * The fix owns the open-state in a provider mounted ABOVE that unmounting boundary (the
+ * `App.tsx` shell frame, above `FateProvider`) and lets the CTA read it through context — the
+ * same bridge shape `SetTopbarChipsContext` already uses to carry state across the session
+ * gate. A remount of the CTA subtree re-reads a surviving `open`, so the dialog re-appears
+ * instead of vanishing.
+ */
+type SozlukCreateDialogState = {
+	open: boolean;
+	setOpen: (open: boolean) => void;
+};
+
+const SozlukCreateDialogContext = React.createContext<SozlukCreateDialogState | null>(null);
+
+export function SozlukCreateDialogProvider({children}: {children: React.ReactNode}) {
+	const [open, setOpen] = React.useState(false);
+	const value = React.useMemo(() => ({open, setOpen}), [open]);
+	return (
+		<SozlukCreateDialogContext.Provider value={value}>
+			{children}
+		</SozlukCreateDialogContext.Provider>
+	);
+}
+
+/**
+ * Read the hoisted create-dialog open-state. Falls back to a component-local `useState` when
+ * rendered with no provider (isolated tests, an atölye exhibit) so the CTA stays
+ * self-contained; the fallback pair is inert whenever the provider is present, which in the
+ * real app it always is (mounted above the unmounting boundary in `App.tsx`).
+ */
+export function useSozlukCreateDialog(): SozlukCreateDialogState {
+	const hoisted = React.useContext(SozlukCreateDialogContext);
+	const [open, setOpen] = React.useState(false);
+	return hoisted ?? {open, setOpen};
+}

--- a/apps/web/src/components/sozluk/SozlukSubnavCta.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavCta.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * #3840 regression — the `+ yeni tanım` create dialog must survive an ancestor unmount.
+ *
+ * #3600 pinned the closer: with `open` in the CTA's local `useState`, an ancestor unmount
+ * (the shape of `FateProvider`'s `key={userId}` re-key or `LayoutContent`'s `needsBootstrap`
+ * Outlet swap) silently reset it to `false`, reproducing the CI artifact — dialog gone, no
+ * backdrop, no dismiss reason, still on `/sozluk`. NO `onOpenChange` reason fires on that path
+ * (React destroys the state, it is not dismissed), which is exactly how the closer is named:
+ * absent reason ⇒ ancestor unmount, not `outside-press`/`escape`.
+ *
+ * The harness below is that unmount: a `key`-flipping boundary between the hoist provider and
+ * the CTA forces a real unmount + remount of the CTA subtree. The two tests pin the artifact
+ * (without the hoist) and its fix (with it).
+ */
+import {act, fireEvent, render, screen} from "@testing-library/react";
+import * as React from "react";
+import {MemoryRouter} from "react-router";
+import {describe, expect, it} from "vitest";
+import {SozlukCreateDialogProvider} from "./SozlukCreateDialogState";
+import {SozlukSubnavCta} from "./SozlukSubnavCta";
+
+/**
+ * Renders the CTA under a `key`-flipping boundary. Calling the returned `remountSubtree`
+ * flips the key, which React resolves as an unmount + remount of everything below it — the
+ * ancestor-unmount #3600 pinned. `withHoist` wraps the boundary in the create-dialog provider
+ * (mounted ABOVE the boundary, as `App.tsx` mounts it above `FateProvider`); without it the
+ * CTA falls back to its own local state, reproducing the pre-fix fragility.
+ */
+function renderUnderUnmountingBoundary({withHoist}: {withHoist: boolean}) {
+	let flip: () => void = () => {};
+	function Harness() {
+		const [key, setKey] = React.useState(0);
+		flip = () => setKey((k) => k + 1);
+		const boundary = (
+			<div key={key}>
+				<SozlukSubnavCta />
+			</div>
+		);
+		return withHoist ? (
+			<SozlukCreateDialogProvider>{boundary}</SozlukCreateDialogProvider>
+		) : (
+			boundary
+		);
+	}
+	render(
+		<MemoryRouter initialEntries={["/sozluk"]}>
+			<Harness />
+		</MemoryRouter>,
+	);
+	// Flush the key flip inside `act` so the unmount + remount commits before the assertion —
+	// otherwise the state update is deferred and the DOM still shows the pre-flip dialog.
+	return {remountSubtree: () => act(() => flip())};
+}
+
+describe("SozlukSubnavCta — #3840 open-state survives an ancestor unmount", () => {
+	it("reproduces the #3600 artifact WITHOUT the hoist: an ancestor unmount vanishes the open dialog", () => {
+		const {remountSubtree} = renderUnderUnmountingBoundary({withHoist: false});
+		fireEvent.click(screen.getByRole("button", {name: /yeni tanım/i}));
+		expect(screen.getByLabelText("Terim")).toBeTruthy();
+
+		remountSubtree();
+
+		// The local `useState` was destroyed with the unmounted subtree — the dialog is gone,
+		// exactly the silent close #3600 pinned.
+		expect(screen.queryByLabelText("Terim")).toBeNull();
+	});
+
+	it("survives the same ancestor unmount WITH the hoist — the dialog stays open", () => {
+		const {remountSubtree} = renderUnderUnmountingBoundary({withHoist: true});
+		fireEvent.click(screen.getByRole("button", {name: /yeni tanım/i}));
+		expect(screen.getByLabelText("Terim")).toBeTruthy();
+
+		remountSubtree();
+
+		// `open` lives in the provider above the boundary, so the remounted CTA re-reads a
+		// surviving `true` — the dialog re-appears instead of vanishing.
+		expect(screen.getByLabelText("Terim")).toBeTruthy();
+	});
+});

--- a/apps/web/src/components/sozluk/SozlukSubnavCta.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavCta.tsx
@@ -1,9 +1,10 @@
-import * as React from "react";
+import type * as React from "react";
 import {useNavigate} from "react-router";
 import {slugifyTerm} from "../../lib/slugifyTerm";
 import {Button} from "../ui/Button";
 import {Dialog} from "../ui/Dialog";
 import {Field, FieldError, Form, Input, Label} from "../ui/Form";
+import {useSozlukCreateDialog} from "./SozlukCreateDialogState";
 
 /**
  * sözlük's contextual create CTA — the `+ yeni tanım` promoted verb in its Subnav
@@ -18,7 +19,10 @@ import {Field, FieldError, Form, Input, Label} from "../ui/Form";
  * branch — the exact target the old box reached, create dead-end handled there (#97).
  */
 export function SozlukSubnavCta() {
-	const [open, setOpen] = React.useState(false);
+	// `open` is hoisted above the FateProvider/needsBootstrap unmounting boundary (#3840) —
+	// see `SozlukCreateDialogState`. A component-local `useState` here is the exact fragility
+	// #3600 pinned: an ancestor unmount would silently reset it, vanishing the dialog.
+	const {open, setOpen} = useSozlukCreateDialog();
 	const navigate = useNavigate();
 	function onSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();

--- a/apps/web/tests/e2e/06-sozluk-home.spec.ts
+++ b/apps/web/tests/e2e/06-sozluk-home.spec.ts
@@ -84,31 +84,17 @@ test.describe("SozlukHome create-flow (+ yeni tanım → composer)", () => {
 
 		await page.getByRole("button", {name: /yeni tanım/i}).click();
 
-		// The dialog can be gone by the time a poll runs — the #3746 failure artifact caught
-		// the popup absent from the DOM entirely, on an idle `/sozluk`, not detached
-		// mid-interaction as #3583 assumed. That is why #3583's retry did not hold: a block
-		// that starts inside the open dialog and never reopens it cannot recover from a closed
-		// one, so every remaining poll burns its budget on a `Terim` that can never resolve.
-		// Reopening is what makes the retried unit self-sufficient. What closes the dialog is
-		// not yet pinned and is tracked on #3600; the app-side half of #3746 removed the one
-		// closer that was provable (a submit that slugified to nothing dismissed and navigated
-		// nowhere), which this spec cannot observe.
+		// The reopen-retry workaround is retired (#3840): #3600 pinned the silent closer as an
+		// ancestor unmount resetting the CTA's local `open` useState, and #3840 hoisted that
+		// state above the unmounting boundary — so the dialog no longer vanishes on an idle
+		// `/sozluk`, and the flow is a straight open → fill → submit → navigate.
 		const dialog = page.locator(".kp-dialog__popup");
 		await expect(dialog).toBeVisible();
-		await expect(async () => {
-			if (!(await dialog.isVisible())) {
-				await page.getByRole("button", {name: /yeni tanım/i}).click({timeout: 2_000});
-				await expect(dialog).toBeVisible({timeout: 2_000});
-			}
-			// The dialog collects the term name (the composer is slug-addressed). Bounded like
-			// the click below so one bad poll can't eat the whole `toPass` budget and starve
-			// the retry of a second attempt — the shape that turned #3583's loop into a
-			// single-shot.
-			await page.getByLabel("Terim").fill(term, {timeout: 2_000});
-			await page.getByRole("button", {name: /^oluştur$/i}).click({timeout: 2_000});
-			// The dialog slugifies + navigates to the fresh-slug composer route.
-			await expect(page).toHaveURL(new RegExp(`/sozluk/${slug}$`), {timeout: 2_000});
-		}).toPass({timeout: 9_000});
+		// The dialog collects the term name (the composer is slug-addressed).
+		await page.getByLabel("Terim").fill(term);
+		await page.getByRole("button", {name: /^oluştur$/i}).click();
+		// The dialog slugifies + navigates to the fresh-slug composer route.
+		await expect(page).toHaveURL(new RegExp(`/sozluk/${slug}$`));
 		// Signed-in fresh slug → NewTermComposer: term head + composer body.
 		await expect(page.locator(".kp-sozluk-term__head")).toBeVisible({timeout: 10_000});
 		await expect(page.locator('[data-testid="sozluk-composer-body"]')).toBeVisible();


### PR DESCRIPTION
Fixes #3840

## Problem

The sözlük `+ yeni tanım` create dialog closed silently mid-flow, dropping the user's uncontrolled input with no error and no toast. #3600 pinned the class: the dialog **closes** (`Dialog.Root` `open → false`, app-side) because `open` lived in `SozlukSubnavCta`'s local `useState` — so any ancestor unmount (`FateProvider`'s `key={userId}` re-key or `LayoutContent`'s `needsBootstrap` Outlet swap) reset it to `false`, reproducing the CI artifact (dialog gone, no backdrop, page un-`aria-hidden`, no error, still on `/sozluk`).

## Step 1 — naming the closer (the instrumentation step)

The discriminator #3600 prescribed is: a dismiss reason (`outside-press`/`escape`) ⇒ a dismiss guard; **no** reason fired ⇒ ancestor unmount ⇒ hoist. The named closer here is an **ancestor unmount, not a dismiss**, established two ways:

- **No `onOpenChange` reason fires on an ancestor unmount.** React destroys the CTA's `useState` on unmount — it is not a dismiss, so base-ui emits no `onOpenChange(false, …reason)`. The committed regression test drives exactly this path and shows the open dialog vanishing with no dismiss event.
- **`outside-press`/`escape` are ruled out by source, not intuition.** In the pinned `@base-ui/react@1.4.1`, `useDialogRoot`'s `outsidePress` returns `false` unless the pointer event's target is the dialog's own backdrop (`internalBackdropRef`/`backdropRef`). The e2e opens via a click on the trigger button only — it never produces a backdrop-targeted pointer event — so `outside-press` cannot fire, and there is no focus-out dismissal for a base-ui dialog.

(The full-browser `onOpenChange`-reason capture the AC contemplates needs a live preview + real sign-up, which this environment can't boot; the naming above is grounded in the base-ui source + the committed unmount reproduction instead.)

## Step 2 — the fix (hoist)

Own the dialog `open` state in a new `SozlukCreateDialogProvider`, mounted in `App.tsx`'s shell frame **above** `FateProvider`'s re-key and `LayoutContent`'s bootstrap swap — the same bridge shape `SetTopbarChipsContext` already uses to carry state across the session gate. `SozlukSubnavCta` reads it through `useSozlukCreateDialog()` instead of a local `useState`. A remount of the CTA subtree now re-reads a surviving `open`, so the dialog re-appears instead of being silently destroyed. The hook falls back to a component-local `useState` when rendered with no provider (isolated tests / an atölye exhibit), so the CTA stays self-contained.

## Tests

- **New client-tier regression** (`apps/web/src/components/sozluk/SozlukSubnavCta.test.tsx`): under a `key`-flipping boundary (the ancestor unmount #3600 pinned), the first case reproduces the artifact **without** the hoist (the open dialog vanishes) and the second proves it **survives** the same unmount **with** the hoist. The before/after pair is the discriminator, committed.
- **E2E workaround retired** (`apps/web/tests/e2e/06-sozluk-home.spec.ts`): the `:87-95` reopen-retry `toPass` block is replaced with the straight open → fill → submit → navigate flow, since the dialog no longer vanishes on an idle `/sozluk`.

## Acceptance criteria

- [x] The exact CI closer is named — ancestor unmount (no `onOpenChange` reason), `outside-press`/`escape` ruled out from base-ui source.
- [x] Open-state can no longer be silently destroyed by an ancestor unmount (hoisted above the unmounting boundary).
- [x] A committed regression test covers the closing mechanism (the client-tier before/after).
- [x] The #3600 CI artifact class stops reproducing and the e2e robustness workaround is retired.

## Verification

`pnpm fate:generate` + app/worker/node typecheck clean; biome check clean; the 17 sözlük client tests pass (including the new regression).
