### PR TITLE
fix(ci): pin the merge_group change-detect diff basis to the batch base_sha (#3797)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,12 @@ jobs:
       # (#3514/#690/#813; PR #3512, run 29659047210). Fix: gate the merge_group branch on the
       # SAME `backend` path filter the PR head uses, so the skip decision is consistent across
       # PR head and merge_group. `steps.filter.outputs.backend` IS computed on merge_group —
-      # `dorny/paths-filter` diffs the merge_group ref against the default branch (`main...ref`
-      # merge-base), i.e. the batch's cumulative diff — so a docs-only batch has
-      # `backend == false` in BOTH contexts. The worker-relevance AND is retained: a
+      # dorny diffs the batch's two-dot `base_sha..head` (the `mergebase` step above pins its
+      # `base` to `merge_group.base_sha`; #3797), i.e. the batch's cumulative diff on a STABLE
+      # basis — so a docs-only batch has `backend == false` deterministically in every batch,
+      # matching the PR head. (Before #3797 an empty `base` sent dorny to a merge-base search
+      # against a moving `main`, so the SAME docs-only PR #3747 flapped in-scope/out-of-scope
+      # across batches and a clean PR got ejected.) The worker-relevance AND is retained: a
       # lockfile-triggered-but-worker-irrelevant batch (`backend == true`, `worker_relevant ==
       # false`) still skips, mirroring the PR head. FAIL-SAFE TO RUNNING is preserved end to
       # end — `|| 'true'` defaults an absent/empty worker_relevant to running, the classify
@@ -149,28 +152,49 @@ jobs:
         with:
           fetch-depth: 0
 
-      # MERGE-BASE DIFF BASIS (issue #3722) — the second half of the change-detection
-      # contract, as load-bearing as the `token: ''` mode below. In git mode dorny diffs
-      # TWO-DOT from `pull_request.base.sha` to the checked-out ref (v3.0.2 `src/main.ts`:
-      # `git.getChanges(base || baseSha || defaultBranch, currentRef)`; `src/git.ts`
-      # `getChanges` runs `git diff --name-status <base>..<head>`). `base.sha` is the base
-      # BRANCH TIP at event time, while the checked-out `refs/pull/N/merge` is built on the
-      # tip as of when GitHub last regenerated it — so the moment main advances past a PR's
-      # merge ref, every file main changed in between is reported as changed HERE, in
-      # reverse. deploy.yml's filter reads the same globs off the same diff basis, so both
-      # must be anchored to the true common ancestor or they classify the same PR differently.
-      # That divergence wedged PR #3713: 22 phantom `e2e:` hits (apps/web/src, worker, …)
-      # from main's drift set `e2e_required=true` while deploy correctly skipped, so e2e
-      # polled 10 min for a preview comment that could never arrive and permanently redded a
-      # 4-file skills/pipeline-cli PR. Passing the true merge base as `base` makes the
-      # two-dot diff equal the PR's own three-dot diff. Fail-safe: on any failure the output
-      # is empty, dorny falls back to today's `base.sha` basis, and detection stays wide (it
-      # over-reports, never under-reports) — a doubt always RUNS a gate, never skips one.
+      # DIFF BASIS — the single source of "what change-detection diffs against" for BOTH
+      # cost-gated contexts (issue #3722 for `pull_request`, #3797 for `merge_group`), as
+      # load-bearing as the `token: ''` mode below. dorny's `base` input decides it, and an
+      # EXPLICIT COMMIT SHA is the only STABLE choice: dorny takes its deterministic two-dot
+      # `git diff <base>..<head>` path ONLY when `base` is a SHA (grounded in v3.0.2
+      # `src/main.ts` `getChangedFilesFromGit`: `isBaseSha` ⇒ `git.getChanges(baseSha, head)`;
+      # `src/git.ts` `getChanges` runs `git diff --name-status <base>..<head>`). A NON-SHA base
+      # — or an EMPTY one — instead routes to `getChangesSinceMergeBase`, a THREE-DOT merge-base
+      # search with depth-limited incremental fetching against a MOVING `main`, whose result
+      # drifts run to run. So this step emits a SHA per event:
+      #   - pull_request: the true merge base of `base.sha..HEAD`, so dorny's two-dot diff
+      #     equals the PR's own three-dot diff. `base.sha` is the base BRANCH TIP at event time
+      #     while the checked-out `refs/pull/N/merge` is built on an older tip, so diffing raw
+      #     `base.sha` reports every file main changed since, in reverse — the 22 phantom `e2e:`
+      #     hits that wedged PR #3713 (10-min preview poll on a deploy that correctly skipped).
+      #   - merge_group: the batch's own `base_sha`. An empty `base` here defaulted dorny to
+      #     `base = defaultBranch` ('main', a BRANCH NAME — not a SHA) ⇒ the unstable
+      #     merge-base-against-moving-main path, so the IDENTICAL docs-only PR #3747 got
+      #     "integration in scope" in one batch (flaked → ejected) and "out" in the next (#3797).
+      #     Pinning `base` to `merge_group.base_sha` makes dorny diff two-dot `base_sha..head_sha`
+      #     — the batch's cumulative diff on a stable basis, byte-for-byte the SAME basis the
+      #     worker-relevance classifier already uses (its `range=` below), so the two ANDed
+      #     integration signals read ONE basis and identical batch content yields an identical
+      #     scope decision every batch.
+      # deploy.yml's filter reads the same globs off this same `base:` input, so both stay
+      # anchored to one basis or they classify the same PR differently (`path-filter-guard`
+      # fails closed on that drift). Fail-safe: on any failure the output is empty, dorny falls
+      # back to its default-branch merge-base basis, and detection stays WIDE (it over-reports,
+      # never under-reports) — a doubt always RUNS a gate, never skips one.
       - id: mergebase
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        env:
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           set -uo pipefail
-          if sha=$(git merge-base "${{ github.event.pull_request.base.sha }}" HEAD 2>/dev/null); then
+          if [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+            if [ -n "$MERGE_GROUP_BASE_SHA" ]; then
+              echo "sha=$MERGE_GROUP_BASE_SHA" >> "$GITHUB_OUTPUT"
+              echo "::notice::change-detection diff basis = merge_group base_sha $MERGE_GROUP_BASE_SHA (stable two-dot batch diff base_sha..head)"
+            else
+              echo "::warning::merge_group base_sha empty — falling back to dorny's default-branch merge-base basis (detection stays wide, never narrower)"
+            fi
+          elif sha=$(git merge-base "${{ github.event.pull_request.base.sha }}" HEAD 2>/dev/null); then
             echo "sha=$sha" >> "$GITHUB_OUTPUT"
             echo "::notice::change-detection diff basis = merge base $sha (base.sha ${{ github.event.pull_request.base.sha }})"
           else
@@ -199,8 +223,9 @@ jobs:
         id: filter
         with:
           token: ''
-          # Empty on non-PR events, where dorny already merge-bases against the default
-          # branch itself — so `merge_group`/`push` behavior is untouched. `path-filter-guard`
+          # The explicit diff basis the `mergebase` step above pins: the PR merge base on
+          # `pull_request`, the batch `base_sha` on `merge_group` (#3797), and empty on `push`
+          # (dorny keeps its default-branch merge-base backstop there). `path-filter-guard`
           # fails closed if this `token`/`base` pairing ever drifts from deploy.yml's.
           base: ${{ steps.mergebase.outputs.sha }}
           filters: |


### PR DESCRIPTION
## What & why

Closes #3797.

On a `merge_group` ref the `changes` job (`detect changed areas`) left dorny/paths-filter's `base` input empty. Grounded in dorny v3.0.2 source (`src/main.ts` `getChangedFilesFromGit`, `src/git.ts` `getChanges`/`getChangesSinceMergeBase`):

- An **empty** `base` on a non-PR event makes dorny resolve `base = defaultBranch` — `main`, a **branch name, not a SHA**. That routes to `getChangesSinceMergeBase`: a **three-dot merge-base search with depth-limited incremental fetching against a moving `main`**. That basis drifts run to run.
- dorny takes its **deterministic two-dot `git diff <base>..<head>`** path (`git.getChanges`) **only when `base` is a commit SHA** (`isBaseSha`).

That drift is the bug: the identical docs-only PR #3747 got `backend == true` → **integration in scope** in batch 1 (flaked on an environmental teardown race → red `ci-required` → **ejected**) and `backend == false` → **out of scope** in batch 2 (merged clean). On the PR head itself integration was correctly skipped both times — only the batch-side decision flapped.

## The fix — one stable diff basis on the merge_group seam

Extend the existing `mergebase` step to also run on `merge_group` and emit `github.event.merge_group.base_sha`. Feeding dorny a **SHA** takes its two-dot `git diff base_sha..head` path — the batch's cumulative diff on a **stable** basis, **byte-for-byte the same basis the `worker-relevance` classifier already computes** (`range="$MERGE_GROUP_BASE_SHA..$MERGE_GROUP_HEAD_SHA"`). The two ANDed integration signals now read **one** basis, so identical batch content yields an identical scope decision in every batch, and a docs-only batch decides `backend == false` and skips integration deterministically.

## Acceptance criteria

1. **Root cause at the diff basis, not the flake** — the basis was dorny's implicit merge-base-against-moving-`main` search (empty `base` ⇒ non-SHA `defaultBranch`); pinned to the batch `base_sha` so identical PR content yields an identical scope decision every batch.
2. **#3747 regression case** — a docs-only ADR diff on a `merge_group` ref now diffs two-dot `base_sha..head` against the `backend` globs (which exclude `.decisions/**`/`*.md`), so `backend == false` → `integration_required == false` → integration skipped, deterministically.
3. **Composes with #3722/#3734's one-diff-basis rule** — reuses the SAME `mergebase` step + dorny `base:` input mechanism rather than adding a second basis convention; aligns dorny's basis with the worker-relevance classifier's basis on merge_group. The dorny `base:` **input string is unchanged**, so `path-filter-guard` (basis pairing vs deploy.yml) and `change-detect-guard` (`token: ''`) stay green.
4. **Out of scope (per triage):** the environmental integration flake the losing batch hit, and silent-ejection re-drive visibility — both route separately, not graded here.

The `dorny/paths-filter@v3.0.2` "`base` input parameter is ignored when action is triggered by pull request event" warning is a PR-event-only cosmetic warning (base is still first in `base || baseSha || defaultBranch`); on `merge_group` there is no such warning and `base` is fully honored — so this does not re-break #3722.

## Verification (local)

- `actionlint -color .github/workflows/ci.yml` — clean (actionlint 1.7.12, the CI-pinned version).
- `pipeline-cli change-detect-guard check` — pass (`token: ''` in force).
- `pipeline-cli path-filter-guard check` — pass (ci.yml/deploy.yml token/base basis identical, 12 glob entries).

## Note

Docs-only diff, so on this PR's own `pull_request` head the `backend`/`code`/`e2e` filters skip (correct); the merge_group path is exercised when this PR is batched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
