### PR TITLE
fix(crew): make channel_kinds callable from every crew seat + self-healing schema reject (#3761)

### DIFF
--- a/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
+++ b/claude-plugins/pipeline-crew/CHANNEL-TOOL.md
@@ -1,11 +1,12 @@
-# The crew channel tool — its allowlist token, and the boot-window wait
+# The crew channel tools — their allowlist tokens, and the boot-window wait
 
-Every crew role coordinates over one MCP tool, `channel_send`, served by the crew channel
-MCP server (`@kampus/pipeline-crew-mcp`, wired per session via `--channels
-server:@kampus/pipeline-crew-mcp`). **This doc is the single source for two things a role
-needs to actually call it**: the exact allowlist token its `tools:` frontmatter must carry,
-and how to behave in the brief window right after boot before the channel has connected. The
-four crew defs cite this; they never re-derive it inline.
+Every crew role coordinates over the crew channel MCP server (`@kampus/pipeline-crew-mcp`, wired
+per session via `--channels server:@kampus/pipeline-crew-mcp`), which serves the send tool
+`channel_send`, the discovery tool `channel_kinds`, and — for the engine — the claim tool
+`channel_claim`. **This doc is the single source for two things a role needs to actually call
+them**: the exact allowlist token each `tools:` frontmatter must carry, and how to behave in the
+brief window right after boot before the channel has connected. The four crew defs cite this; they
+never re-derive it inline.
 
 ## The allowlist token — `mcp___kampus_pipeline-crew-mcp__channel_send`
 
@@ -31,6 +32,26 @@ name. For the server `@kampus/pipeline-crew-mcp` the `@` and `/` sanitize to `_`
 tool-name builder and confirmed against the live `/mcp` tool name — a wrong string
 silently fails closed and re-blocks cutover, so it is copied exactly, never approximated.
 
+## The discovery tool — `channel_kinds` (resolve a payload shape before sending)
+
+Every role that sends **also** carries the discovery tool, `channel_kinds` — the token derived the
+same way:
+
+```
+mcp___kampus_pipeline-crew-mcp__channel_kinds
+```
+
+`channel_kinds` takes **no arguments** and returns the whole channel contract: every message kind's
+payload as a JSON Schema, plus each role's sanctioned send/receive seams. A sender reads a kind's
+shape from it **before the first `channel_send` of that kind**, so it builds a valid `body` up front
+instead of discovering the shape from a send-time reject. That reject path is real and lossy:
+`channel_send` decode-checks `body` against the kind's schema (#3229), and a seat that booted with
+no inbound example to copy otherwise blind-guesses the shape and burns retries on rejected sends —
+the exact failure this tool exists to prevent (#3622/#3761). Because it is served on the same
+`McpServer` as `channel_send`, its allowlist token is required for the same reason: absent from a
+def's `tools:`, the tool is present-but-uncallable and the discovery step is impossible. Every
+sending seat lists it — the three bridges and the engine alike.
+
 ## The engine's second tool — `channel_claim` (resource deconfliction)
 
 The **engineering-manager** (the one engine role) additionally carries a second channel tool,
@@ -47,8 +68,8 @@ cross-engine lock. An engine calls `channel_claim {resource: "<issue>"}` **befor
 lane**: `granted` ⇒ it holds the lane, `collision` ⇒ another engine holds it (back off). Sending
 a `Claim`-shaped message via `channel_send` does **not** lock anything — it just delivers a
 message to an inbox — which is why the claim needs its own tool (#3509). Only the engine carries
-it; the bridges (chief-of-staff, cartographer, intake-desk) claim nothing and list `channel_send`
-alone.
+it; the bridges (chief-of-staff, cartographer, intake-desk) claim nothing, so they carry
+`channel_send` + `channel_kinds` but not `channel_claim`.
 
 ## The boot window — wait and re-check, never diagnose infra
 

--- a/claude-plugins/pipeline-crew/agents/crew-cartographer.md
+++ b/claude-plugins/pipeline-crew/agents/crew-cartographer.md
@@ -3,7 +3,7 @@ name: crew-cartographer
 description: 'Use this agent as the crew''s inbound-ideation bridge — the cartographer that turns the founder''s fog (a fuzzy, not-yet-decided destination) into charted work the pipeline can eventually consume. It runs the wayfinder skill: CHART mode opens/rewrites a wayfinder:map issue and lays out the open frontier as sub-issues; WORK mode advances one frontier ticket, records the answer, and graduates the fog. It never auto-resolves a founder decision — it surfaces the fork on the map and stops. Typical triggers include "chart a map for X", "start a wayfinder map", "work the wayfinder map #N", and "advance the map". Do NOT use it to implement, review, merge, or triage — it sits UPSTREAM of triage and produces a clarified plan, not a diff. See "When to invoke" for worked scenarios.'
 model: inherit
 color: green
-tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
+tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_kinds"]
 ---
 
 You are the **cartographer** — the crew's **inbound-ideation bridge**. You turn the founder's
@@ -92,6 +92,10 @@ session; the substrate resolves the target role's inbox for you:
   send; success returns an `InboxAck`, an unreachable peer a `PeerUnreachableError {target, reason}`.
   Inbound arrives to you as a `<channel from="inbox://<role>" kind="…">…</channel>` wake tag; an ack
   means delivered-to-inbox + wake enqueued, never seen-by-model.
+- **Resolve a kind's payload SHAPE with `channel_kinds` before its first send.** `channel_kinds`
+  (no args) returns every kind's payload as a JSON Schema; read the shape, then build a valid
+  `body` — don't blind-send and let a schema-mismatch reject teach you the shape one failed send at
+  a time ([`../CHANNEL-TOOL.md`](../CHANNEL-TOOL.md)).
 - **Your one live outbound edge is cartographer → intake-desk (`IntakePing`)** — when your charting
   produces work that has graduated out of the fog into concrete tickets, a ping nudges the intake
   desk that the needs-triage queue has grown. That is the whole of your channel graph.

--- a/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
+++ b/claude-plugins/pipeline-crew/agents/crew-chief-of-staff.md
@@ -3,7 +3,7 @@ name: crew-chief-of-staff
 description: 'Use this agent as the crew''s outbound-awareness bridge — the chief of staff that turns factory state into the founder''s understanding and owns human-facing comms to BOTH humans (the operator/founder and the control-plane approver). It gives situational-awareness reads off the board, carries out §CP banks the engine parked for a human approval (the human approves — never hand-merges — and the engine''s approval-aware shipper enqueues once that approval lands), and owns the single human-notification channel. Its charter is the live verifier: verify, never relay — a relayed claim is never truth, a subagent''s self-reported PASS is not truth until the artifact is read, and an enqueue is never a merge. It is a conversation PEER, not a switchboard, and it treats conversing as coordination, never as evidence. Typical triggers include "what''s the state of the board", "give me a situational-awareness read", "carry this banked §CP PR to the approver", and "ping me when X lands". Do NOT use it to spawn a coder/reviewer/shipper, to review a diff, or to merge a PR. See "When to invoke" for worked scenarios.'
 model: inherit
 color: magenta
-tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
+tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_kinds"]
 ---
 
 You are the **chief-of-staff** — the crew's **outbound-awareness bridge**. You turn the
@@ -77,6 +77,10 @@ session; the substrate resolves the target role's inbox for you:
   Success returns an `InboxAck`; an unreachable peer returns a `PeerUnreachableError {target,
   reason}`. Inbound arrives to you as a `<channel from="inbox://<role>" kind="…">…</channel>`
   wake tag.
+- **Resolve a kind's payload SHAPE with `channel_kinds` before its first send.** `channel_kinds`
+  (no args) returns every kind's payload as a JSON Schema; read the shape, then build a valid
+  `body` — don't blind-send and let a schema-mismatch reject teach you the shape one failed send at
+  a time ([`../CHANNEL-TOOL.md`](../CHANNEL-TOOL.md)).
 - **An ack means delivered-to-inbox + wake enqueued — never seen-by-model.** The peer will read
   it when it wakes; the ack is not a read receipt and never an answer.
 - **Your two live outbound edges:**

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -3,7 +3,7 @@ name: crew-engineering-manager
 description: 'Use this agent as an execution engine of the kampus pipeline crew — a fungible build session that drives triaged issues to merged PRs by conducting ephemeral kampus-pipeline subagents (coder → reviewer → shipper) under bounded concurrency. It is an ENGINE, not a bridge: it owns no human-facing seam, it pulls its work off the board, and it is cardinality N — a second engine boots cleanly and the two deconflict by resource claims against the tracker, not by a uniqueness lease. Typical triggers include "drive the backlog", "run the execution loop", "pick up the next lanes", and "what''s the state of the lanes". It holds WIP caps, claims a resource before opening a lane, verifies a merge actually LANDED (a merge-queue enqueue is never done), recovers stalled lanes, and BANKS control-plane PRs on the board until a control-plane human approves them, then spawns the approval-aware shipper to enqueue (it never hand-merges). It never implements, reviews, or merges by hand, and it never pings a human — it spawns the pipeline agents that build, banks §CP work on the board for the chief-of-staff to carry out to the approver, and spawns the approval-aware shipper once that approval lands at the PR''s current head. See "When to invoke" for worked scenarios.'
 model: inherit
 color: cyan
-tools: ["Task", "Bash", "Read", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_claim"]
+tools: ["Task", "Bash", "Read", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_claim", "mcp___kampus_pipeline-crew-mcp__channel_kinds"]
 ---
 
 You are an **engineering-manager** — an **execution engine** of the kampus pipeline crew. Under
@@ -62,6 +62,10 @@ session; the substrate resolves the target role's inbox for you:
   send; success returns an `InboxAck`, an unreachable peer a `PeerUnreachableError {target, reason}`.
   Inbound arrives to you as a `<channel from="inbox://<role>" kind="…">…</channel>` wake tag; an ack
   means delivered-to-inbox + wake enqueued, never seen-by-model.
+- **Resolve a kind's payload SHAPE with `channel_kinds` before its first send.** `channel_kinds`
+  (no args) returns every kind's payload as a JSON Schema; read the shape, then build a valid
+  `body` — don't blind-send and let a schema-mismatch reject teach you the shape one failed send at
+  a time ([`../CHANNEL-TOOL.md`](../CHANNEL-TOOL.md)).
 - **Your two live outbound edges:**
   - **engine → intake-desk (`IntakePing`)** — a nudge that the needs-triage queue is worth a pass
     (e.g. you filed a follow-up you want typed).
@@ -84,7 +88,8 @@ These hold on every run regardless of what the spawn prompt remembered to say.
 ### Cold-start — boot straight into the drain, zero external nudge
 
 On boot, once the channel is reachable, do two things before you wait for anything: send
-**`AnnouncePresence`** over the channel (you are live and pulling), then run **one initial board
+**`AnnouncePresence`** over the channel (you are live and pulling) — resolve its payload shape with
+`channel_kinds` first rather than blind-sending a guessed body — then run **one initial board
 sweep** — read the tracker for claimable triaged lanes and open as many as your WIP caps allow. A
 freshly-booted engine therefore begins draining under its own power; you do **not** wait to be
 pinged, relayed to, or told to start. That first sweep seeds the self-drain loop below, which carries

--- a/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
+++ b/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
@@ -3,7 +3,7 @@ name: crew-intake-desk
 description: 'Use this agent as the crew''s intake bridge — the desk that turns the world''s raw observations into typed, prioritized work AND talks back to whoever filed. It runs the report → triage loop over the target repo''s status:needs-triage queue and owns the planning/canon seam (spawning the planner over freshly-triaged epics and the canon/adr agents for canon/decision work, rather than running those skills inline). The talking-back — routing a human-filed issue it can''t act on to needs-info with specific questions instead of closing it — is what makes it a bridge, not a filter. Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", and "plan the triaged epics". Do NOT use it to implement, review, merge, or drive the build queue — that is the engine''s seam. See "When to invoke" for worked scenarios.'
 model: inherit
 color: yellow
-tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send"]
+tools: ["Read", "Bash", "Task", "mcp___kampus_pipeline-crew-mcp__channel_send", "mcp___kampus_pipeline-crew-mcp__channel_kinds"]
 ---
 
 You are the **intake-desk** — the crew's **intake bridge**. You turn the world's raw
@@ -80,6 +80,10 @@ session; the substrate resolves the target role's inbox for you:
   send; success returns an `InboxAck`, an unreachable peer a `PeerUnreachableError {target,
   reason}`. Inbound arrives to you as a `<channel from="inbox://<role>" kind="…">…</channel>` wake
   tag; an ack means delivered-to-inbox + wake enqueued, never seen-by-model.
+- **Resolve a kind's payload SHAPE with `channel_kinds` before its first send.** `channel_kinds`
+  (no args) returns every kind's payload as a JSON Schema; read the shape, then build a valid
+  `body` — don't blind-send and let a schema-mismatch reject teach you the shape one failed send at
+  a time ([`../CHANNEL-TOOL.md`](../CHANNEL-TOOL.md)).
 - **Your live inbound edges are the three `IntakePing`s** — from the cartographer, the engine, and
   the chief-of-staff. Each is a nudge that the needs-triage queue has grown and is worth a pass. A
   ping is a **latency optimization over the board**, never a work order: you triage the queue on

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.test.ts
@@ -245,4 +245,27 @@ describe("edge/send-tool — the channel edge server (ACs 1, 3)", () => {
 			assert.include(rendered, `body does not match the "IntakePing" schema`);
 		}),
 	);
+
+	// #3761: the schema-mismatch reject must be self-healing like the unknown-kind branch — it carries
+	// the expected payload SHAPE (rendered as a JSON Schema) and names `channel_kinds` as the up-front
+	// resolution path, so a seat with no inbound example recovers instead of blind-guessing the body.
+	it.effect("a schema-mismatch reject carries the expected shape + a channel_kinds pointer", () =>
+		Effect.gen(function* () {
+			const {client} = yield* makeInitializedClient;
+			const result = yield* client["tools/call"]({
+				name: "channel_send",
+				// a known kind, but the body is missing IntakePing's required `from`/`at`
+				arguments: {targetRole: "reviewer", kind: "IntakePing", body: {issue: 3057}},
+			});
+			assert.isTrue(result.isError);
+			const rendered = (result.content as ReadonlyArray<{text?: string}>)
+				.map((c) => c.text ?? "")
+				.join("\n");
+			// the expected shape is rendered as a JSON Schema document (IntakePing requires `from`)…
+			assert.include(rendered, "expected shape (JSON Schema)");
+			assert.include(rendered, "from");
+			// …and the discovery tool is named as the resolve-first path out of the reject.
+			assert.include(rendered, "channel_kinds");
+		}),
+	);
 });

--- a/packages/pipeline-crew-mcp/src/edge/send-tool.ts
+++ b/packages/pipeline-crew-mcp/src/edge/send-tool.ts
@@ -49,6 +49,26 @@ export class ChannelSend extends Context.Service<
 >()("@kampus/pipeline-crew-mcp/edge/ChannelSend") {}
 
 /**
+ * The self-healing hint appended to a schema-mismatch reject: the kind's expected payload rendered
+ * as a JSON Schema document, so the reject SHOWS the shape to match rather than leaving the sender to
+ * guess it one failed send at a time. This is the same one-step recovery the unknown-kind branch
+ * already gives by enumerating the catalog kinds — the schema branch lacked its equivalent, so a
+ * seat that booted with no inbound example to copy blind-guessed the body shape (#3761). The value is
+ * already resolved beside us: `toJsonSchemaDocument` renders the very shape `channel_kinds` serves.
+ * The render is the one fallible step (it throws on an unrepresentable schema — the same step
+ * `protocol/describe` guards), folded here to the `channel_kinds` pointer rather than a native throw.
+ */
+const expectedShapeHint = (kind: string, schema: Schema.Codec<unknown>): Effect.Effect<string> =>
+	Effect.try(
+		() =>
+			`expected shape (JSON Schema): ${JSON.stringify(Schema.toJsonSchemaDocument(schema))} — or call the \`channel_kinds\` tool to resolve every kind's shape before sending`,
+	).pipe(
+		Effect.orElseSucceed(
+			() => `call the \`channel_kinds\` tool to resolve the "${kind}" payload shape before sending`,
+		),
+	);
+
+/**
  * Decode `body` against the catalog schema for `kind` and RETURN the decoded struct — the single
  * boundary normalization for the send path. An unknown kind or a body that fails its kind's schema
  * short-circuits with an `InvalidMessageError`, so the send never reaches `ChannelSend.send` and the
@@ -80,12 +100,17 @@ const validateOutbound = (
 	// the tolerance is one decode step, not a hand-rolled `typeof body === "string"` JSON.parse.
 	const tolerant = Schema.Union([schema, Schema.fromJsonString(schema)]);
 	return Schema.decodeUnknownEffect(tolerant)(body).pipe(
-		Effect.mapError(
-			(error) =>
-				new InvalidMessageError({
-					kind,
-					reason: `body does not match the "${kind}" schema: ${error}`,
-				}),
+		Effect.catch((error) =>
+			expectedShapeHint(kind, schema).pipe(
+				Effect.flatMap((hint) =>
+					Effect.fail(
+						new InvalidMessageError({
+							kind,
+							reason: `body does not match the "${kind}" schema: ${error} — ${hint}`,
+						}),
+					),
+				),
+			),
 		),
 	);
 };

--- a/packages/pipeline-crew-mcp/src/standup/toolset-assert.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/toolset-assert.test.ts
@@ -217,4 +217,25 @@ describe("standup/toolset-assert — assertCrewSeatToolsets", () => {
 			Effect.provide(NodeServices.layer),
 		),
 	);
+
+	// #3761: the discovery tool `channel_kinds` must be CALLABLE from every sending seat, not just
+	// served — the def's `tools:` allowlist is the hard gate, so its token must be present (MCP tokens
+	// are exempt from the grantable check, so a listed token lands in `granted`). Reads the real defs:
+	// a seat that drops the token — the exact defect that left channel_kinds present-but-uncallable in
+	// every seat — reds here rather than at a live stand-up.
+	it.effect(
+		"every shipped crew seat can call channel_kinds (its token is in the granted set)",
+		() =>
+			Effect.gen(function* () {
+				for (const role of CREW_ROLES) {
+					const declared = yield* readSeatToolsetFromDef(REPO_ROOT, role);
+					const {granted} = resolveDeclaredToolset(declared);
+					assert.include(
+						granted,
+						"mcp___kampus_pipeline-crew-mcp__channel_kinds",
+						`crew-${role} must list the channel_kinds allowlist token so the discovery tool is callable`,
+					);
+				}
+			}).pipe(Effect.provide(NodeServices.layer)),
+	);
 });


### PR DESCRIPTION
Fixes #3761

## Root cause

`channel_kinds` (the #3622 discovery tool) is registered and served, but was **uncallable in every crew seat**: a seat boots as `claude --agent crew-<role>`, so the def `tools:` allowlist is the hard gate, and no def carried the `channel_kinds` token. Seats blind-sent and guessed payload shapes. The schema-mismatch reject compounded it — it returned the decode error but not the expected shape, unlike the unknown-kind branch in the same function, which enumerates the catalog and self-heals.

## Changes

- **Token → callable.** Added `mcp___kampus_pipeline-crew-mcp__channel_kinds` to the `tools:` frontmatter of every sending seat: `crew-chief-of-staff`, `crew-cartographer`, `crew-intake-desk`, `crew-engineering-manager`. (`crew-investigator` sends nothing and is unchanged.)
- **Doc.** `claude-plugins/pipeline-crew/CHANNEL-TOOL.md` now documents `channel_kinds` alongside `channel_send` / `channel_claim` — its exact token and what it is for — since that doc is the single source for allowlist tokens.
- **Instruction (ordered behind the token).** Each sending def instructs a `channel_kinds`-first schema resolve before the first send of a kind; the EM boot `AnnouncePresence` (the observed failure site) gets an explicit "resolve the shape first" pointer.
- **Self-healing reject.** `validateOutbound`'s schema-mismatch `InvalidMessageError` now carries the expected payload shape (rendered JSON Schema — the same value `channel_kinds` serves) plus a `channel_kinds` pointer, matching the unknown-kind branch's precedent. Modelled in the Effect `E`-channel (`Effect.try` + `orElseSucceed`), not a native throw (the repo's #2736 ban).

## Coverage

- `standup/toolset-assert.test.ts`: reads the real shipped defs and asserts `channel_kinds` is in every seat's granted (callable) set — a dropped token reds here rather than at a live stand-up.
- `edge/send-tool.test.ts`: a schema-mismatch reject carries the expected shape (rendered JSON Schema) and a `channel_kinds` pointer.

Full `@kampus/pipeline-crew-mcp` suite (323 tests) green; typecheck + biome clean.

## Acceptance criteria

- [x] `channel_kinds` allowlist token added to every crew def that sends on the channel.
- [x] `CHANNEL-TOOL.md` documents `channel_kinds` (token + purpose).
- [x] Crew defs instruct a `channel_kinds`-first schema resolve before the first send (behind the token).
- [x] The schema-mismatch `InvalidMessageError` carries the expected payload shape / `channel_kinds` pointer.
- [x] A seat with no inbound example can resolve a kind's payload shape without a failed send (the tool is now callable; the defs instruct using it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)