### PR TITLE
feat(crew-mcp): reap orphaned crew server processes on crash-reclaim (#3629)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -31,6 +31,27 @@ export {
 } from "./contract.ts";
 export {RoleUniquenessError} from "./errors.ts";
 export {
+	type CrewSessionProc,
+	collectLiveRegisteredAddresses,
+	INIT_PID,
+	isOrphanedCrewServer,
+	type OrphanDiscriminationInput,
+	type ProcessEntry,
+	type ProcessReaper,
+	type ProcessSnapshot,
+	ProcessSnapshotError,
+	parseCrewSessionProc,
+	parseProcessTable,
+	productionProcessReaper,
+	productionProcessSnapshot,
+	REAP_SIGNAL,
+	type ReapOrphansInput,
+	type ReapOutcome,
+	type ReapReport,
+	type ReapSignalOutcome,
+	reapOrphanedCrewServers,
+} from "./reaper.ts";
+export {
 	type CardinalityOf,
 	CREW_DRIVE,
 	CREW_ROLES,

--- a/packages/pipeline-crew-mcp/src/crew/reaper.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/reaper.test.ts
@@ -1,0 +1,244 @@
+/**
+ * The orphan reaper (#3629): the process-table half of crash recovery. These drive orphan-vs-live
+ * discrimination entirely against fixtures — no real process, `ps`, or signal — proving:
+ *   - the command signature is tightly scoped (an unrelated process is never matched),
+ *   - a reparented (init-adopted) crew server is reaped while a live, parented, registered session
+ *     is never reaped,
+ *   - the one registry-resolvable spare (a still-serving engine instance) is honored, while a
+ *     day-old bridge orphan is reaped even when a live successor holds the same shared address,
+ *   - the sweep is idempotent and reports what it scanned + left live.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	collectLiveRegisteredAddresses,
+	INIT_PID,
+	isOrphanedCrewServer,
+	type ProcessEntry,
+	type ProcessReaper,
+	type ProcessSnapshot,
+	ProcessSnapshotError,
+	parseCrewSessionProc,
+	parseProcessTable,
+	type ReapSignalOutcome,
+	reapOrphanedCrewServers,
+} from "./reaper.ts";
+import {inboxAddressFor} from "./session.ts";
+
+const NODE = "/opt/node/bin/node";
+const BIN = "/Users/x/phoenix/packages/pipeline-crew-mcp/src/bin.ts";
+/** A bridge (intake-desk) crew session server command — no `--instance` (bridges are singletons). */
+const bridgeCmd = `${NODE} ${BIN} session --role intake-desk --project-root /Users/x/phoenix`;
+/** An engine (engineering-manager) crew session server command — carries a per-instance `--instance`. */
+const engineCmd = (instance: string) =>
+	`${NODE} ${BIN} session --role engineering-manager --project-root /Users/x/phoenix --instance ${instance}`;
+
+const empty: ReadonlySet<string> = new Set();
+
+describe("parseCrewSessionProc — tightly-scoped signature", () => {
+	it("parses a bridge session command: role, no instance", () => {
+		assert.deepStrictEqual(parseCrewSessionProc(bridgeCmd), {
+			role: "intake-desk",
+			instance: undefined,
+		});
+	});
+	it("parses an engine session command: role + instance", () => {
+		assert.deepStrictEqual(parseCrewSessionProc(engineCmd("eng-abc")), {
+			role: "engineering-manager",
+			instance: "eng-abc",
+		});
+	});
+	it("does not match a process missing the crew-mcp marker (a decoy `session --role`)", () => {
+		assert.isUndefined(
+			parseCrewSessionProc(`${NODE} /some/other/tool.js session --role intake-desk`),
+		);
+	});
+	it("does not match a crew-mcp process that is not the `session` subcommand", () => {
+		assert.isUndefined(parseCrewSessionProc(`${NODE} ${BIN} tracker --project-root /r`));
+	});
+	it("does not match a `--role` that is not a real crew role", () => {
+		assert.isUndefined(parseCrewSessionProc(`${NODE} ${BIN} session --role deploy`));
+	});
+	it("does not match an unrelated ansible-style `--role` process", () => {
+		assert.isUndefined(parseCrewSessionProc("ansible-playbook --role intake-desk site.yml"));
+	});
+});
+
+describe("isOrphanedCrewServer — orphan vs live discrimination", () => {
+	const selfPid = 4242;
+
+	it("reaps a reparented (init-adopted) bridge server", () => {
+		const entry: ProcessEntry = {pid: 900, ppid: INIT_PID, command: bridgeCmd};
+		assert.isTrue(isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses: empty}));
+	});
+
+	it("never reaps a live, parented crew session (ppid is its live launch pane)", () => {
+		const entry: ProcessEntry = {pid: 901, ppid: 5000, command: bridgeCmd};
+		const live = new Set([inboxAddressFor("intake-desk", "ignored")]);
+		assert.isFalse(isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses: live}));
+	});
+
+	it("never reaps the reaper's own process", () => {
+		const entry: ProcessEntry = {pid: selfPid, ppid: INIT_PID, command: bridgeCmd};
+		assert.isFalse(isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses: empty}));
+	});
+
+	it("never reaps an unrelated init-adopted process (tight scope)", () => {
+		const entry: ProcessEntry = {pid: 902, ppid: INIT_PID, command: "/usr/sbin/cupsd -l"};
+		assert.isFalse(isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses: empty}));
+	});
+
+	it("spares a reparented ENGINE whose exact per-instance address still holds a live lease", () => {
+		const entry: ProcessEntry = {pid: 903, ppid: INIT_PID, command: engineCmd("eng-live")};
+		const live = new Set([inboxAddressFor("engineering-manager", "eng-live")]);
+		assert.isFalse(isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses: live}));
+	});
+
+	it("reaps a reparented ENGINE whose address is NOT a live lease (its heartbeat lapsed)", () => {
+		const entry: ProcessEntry = {pid: 904, ppid: INIT_PID, command: engineCmd("eng-dead")};
+		const live = new Set([inboxAddressFor("engineering-manager", "eng-other")]);
+		assert.isTrue(isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses: live}));
+	});
+
+	it("reaps a day-old reparented BRIDGE orphan even when a live successor holds the shared address", () => {
+		// A bridge address (`inbox://intake-desk`) is shared across re-runs, so a live successor's lease
+		// cannot vouch for a reparented predecessor — the ppid signal reaps the zombie, which is the whole
+		// point of the fix (a re-run must not leave the old bridge server behind).
+		const entry: ProcessEntry = {pid: 905, ppid: INIT_PID, command: bridgeCmd};
+		const live = new Set([inboxAddressFor("intake-desk", "ignored")]);
+		assert.isTrue(isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses: live}));
+	});
+});
+
+/** A recording reaper: captures the pids it was asked to kill, resolving each to a scripted outcome. */
+const recordingReaper = (
+	killed: number[],
+	outcome: (pid: number) => ReapSignalOutcome = () => "signalled",
+): ProcessReaper => ({
+	kill: (pid) =>
+		Effect.sync(() => {
+			killed.push(pid);
+			return outcome(pid);
+		}),
+});
+
+const snapshotOf = (entries: ReadonlyArray<ProcessEntry>): ProcessSnapshot => ({
+	list: Effect.succeed(entries),
+});
+
+describe("reapOrphanedCrewServers — the sweep", () => {
+	it.effect("reaps exactly the orphans, leaving live + unrelated + self untouched", () =>
+		Effect.gen(function* () {
+			const selfPid = 100;
+			const entries: ProcessEntry[] = [
+				{pid: selfPid, ppid: INIT_PID, command: bridgeCmd}, // self — never reaped
+				{pid: 200, ppid: 5000, command: bridgeCmd}, // live parented bridge
+				{pid: 201, ppid: INIT_PID, command: bridgeCmd}, // orphan bridge → reap
+				{pid: 202, ppid: INIT_PID, command: engineCmd("eng-dead")}, // orphan engine → reap
+				{pid: 203, ppid: INIT_PID, command: engineCmd("eng-live")}, // orphan engine, still-live lease → spare
+				{pid: 204, ppid: INIT_PID, command: "/usr/sbin/cupsd"}, // unrelated init child
+			];
+			const killed: number[] = [];
+			const report = yield* reapOrphanedCrewServers({
+				liveRegisteredAddresses: new Set([
+					inboxAddressFor("engineering-manager", "eng-live"),
+					inboxAddressFor("intake-desk", "ignored"),
+				]),
+				snapshot: snapshotOf(entries),
+				reaper: recordingReaper(killed),
+				selfPid,
+			});
+			assert.deepStrictEqual(killed.sort(), [201, 202]);
+			assert.deepStrictEqual(report.reaped.map((r) => r.pid).sort(), [201, 202]);
+			assert.strictEqual(report.scanned, entries.length);
+			assert.deepStrictEqual(report.reaped.find((r) => r.pid === 201)?.role, "intake-desk");
+			assert.deepStrictEqual(report.reaped.find((r) => r.pid === 202)?.instance, "eng-dead");
+		}),
+	);
+
+	it.effect("is idempotent: a re-run finds the reaped procs gone and kills nothing", () =>
+		Effect.gen(function* () {
+			const killed: number[] = [];
+			const report = yield* reapOrphanedCrewServers({
+				liveRegisteredAddresses: empty,
+				// The reaped orphan is no longer in the table on the next pass.
+				snapshot: snapshotOf([{pid: 200, ppid: 5000, command: bridgeCmd}]),
+				reaper: recordingReaper(killed),
+				selfPid: 100,
+			});
+			assert.deepStrictEqual(killed, []);
+			assert.deepStrictEqual(report.reaped, []);
+		}),
+	);
+
+	it.effect("reports an already-gone orphan without failing (kill lost the race)", () =>
+		Effect.gen(function* () {
+			const killed: number[] = [];
+			const report = yield* reapOrphanedCrewServers({
+				liveRegisteredAddresses: empty,
+				snapshot: snapshotOf([{pid: 201, ppid: INIT_PID, command: bridgeCmd}]),
+				reaper: recordingReaper(killed, () => "already-gone"),
+				selfPid: 100,
+			});
+			assert.deepStrictEqual(killed, [201]);
+			assert.strictEqual(report.reaped[0]?.outcome, "already-gone");
+		}),
+	);
+
+	it.effect("surfaces a process-snapshot failure (never a silent zero-orphan pass)", () =>
+		Effect.gen(function* () {
+			const exit = yield* reapOrphanedCrewServers({
+				liveRegisteredAddresses: empty,
+				snapshot: {list: Effect.fail(new ProcessSnapshotError({reason: "ps -A failed: boom"}))},
+				reaper: recordingReaper([]),
+				selfPid: 100,
+			}).pipe(Effect.flip);
+			assert.instanceOf(exit, ProcessSnapshotError);
+		}),
+	);
+});
+
+describe("parseProcessTable — ps output parsing", () => {
+	it("parses `<pid> <ppid> <args…>` rows and skips unparseable lines", () => {
+		const out = [
+			"  201     1 /opt/node/bin/node /p/pipeline-crew-mcp/src/bin.ts session --role intake-desk",
+			"  200  5000 /opt/node/bin/node /p/pipeline-crew-mcp/src/bin.ts session --role chief-of-staff",
+			"garbage line with no leading pid",
+			"",
+		].join("\n");
+		assert.deepStrictEqual(parseProcessTable(out), [
+			{
+				pid: 201,
+				ppid: 1,
+				command: "/opt/node/bin/node /p/pipeline-crew-mcp/src/bin.ts session --role intake-desk",
+			},
+			{
+				pid: 200,
+				ppid: 5000,
+				command: "/opt/node/bin/node /p/pipeline-crew-mcp/src/bin.ts session --role chief-of-staff",
+			},
+		]);
+	});
+});
+
+describe("collectLiveRegisteredAddresses — union across the roster", () => {
+	it.effect("unions every present peer across all roles into one address set", () =>
+		Effect.gen(function* () {
+			const present: Record<string, ReadonlyArray<{readonly peer: string}>> = {
+				"intake-desk": [{peer: "inbox://intake-desk"}],
+				"engineering-manager": [
+					{peer: "inbox://engineering-manager/a"},
+					{peer: "inbox://engineering-manager/b"},
+				],
+			};
+			const addresses = yield* collectLiveRegisteredAddresses((role) =>
+				Effect.succeed(present[role] ?? []),
+			);
+			assert.deepStrictEqual([...addresses].sort(), [
+				"inbox://engineering-manager/a",
+				"inbox://engineering-manager/b",
+				"inbox://intake-desk",
+			]);
+		}),
+	);
+});

--- a/packages/pipeline-crew-mcp/src/crew/reaper.ts
+++ b/packages/pipeline-crew-mcp/src/crew/reaper.ts
@@ -170,7 +170,10 @@ export const productionProcessReaper: ProcessReaper = {
 				process.kill(pid, REAP_SIGNAL);
 				return "signalled";
 			},
-			catch: (cause) => cause,
+			// Type the error channel (the effect `unknownInEffectCatch` lint) — the value is unused, it
+			// is immediately folded to `already-gone` below, so any typed rendering serves; `String`
+			// matches the package's `Effect.try` catch idiom.
+			catch: (cause) => String(cause),
 		}).pipe(Effect.orElseSucceed((): ReapSignalOutcome => "already-gone")),
 };
 

--- a/packages/pipeline-crew-mcp/src/crew/reaper.ts
+++ b/packages/pipeline-crew-mcp/src/crew/reaper.ts
@@ -1,0 +1,254 @@
+/**
+ * crew/reaper — reap ORPHANED crew server processes: the process-table half of crash recovery.
+ *
+ * tracker/server.ts's `reclaimStaleSocket` cleans a crashed host's stale *socket file*; it does
+ * nothing about the crashed session's *process*. When a crew pane dies (crash, re-run, tmux kill),
+ * its `node … bin.ts session --role <role>` server child is reparented to init (PPID 1) and keeps
+ * running — the live diagnosis in epic #3624 found 4 day-old such orphans in the process table
+ * (failure mode 3). This module is the missing reap: it identifies crew session server procs that are
+ * no longer a live registered channel half and terminates them, so a crashed/re-run session leaves no
+ * zombie peer (#3629). It complements — never replaces — the socket-file reclaim.
+ *
+ * The orphan signal is REPARENTING TO INIT (`ppid === INIT_PID`): a live session's server is a child
+ * of its living launch pane, so `ppid === 1` is exactly "the pane that owned me is gone." That signal
+ * alone never touches a live registered session, which is parented. The canonical registry (ADR 0197)
+ * is consulted as the extra guard for the one case it can resolve: an ENGINE instance's per-instance
+ * address is unique, so a reparented engine whose exact address still holds a live presence lease is
+ * still serving and is spared (it reaps on a later pass once its lease ages out). A BRIDGE address is
+ * shared across re-runs, so it can't disambiguate a superseded orphan from its live successor — a
+ * reparented bridge server therefore reaps on the ppid signal alone, which is what actually clears the
+ * day-old bridge orphans the diagnosis found.
+ *
+ * Every side-effecting seam (the process snapshot, the kill, the live-registered address set) is
+ * injected and defaults to production, so orphan-vs-live discrimination is unit-tested against a
+ * fixture with no real process, `ps`, or signal — the injected-seam idiom the rest of the substrate uses.
+ */
+import {execFileSync} from "node:child_process";
+import {Effect, Schema} from "effect";
+import {CREW_ROLES, type CrewRole, isCrewRole, kindOf} from "./roles.ts";
+import {inboxAddressFor} from "./session.ts";
+
+/** The pid every orphaned (reparented) process is adopted by — init/launchd is PID 1 on macOS and Linux alike. */
+export const INIT_PID = 1;
+
+/** The package-path marker present in every crew session server command (`… /pipeline-crew-mcp/… /bin.ts …`). */
+const CREW_MCP_MARKER = "pipeline-crew-mcp";
+/** The bin subcommand that runs one live crew session — mirrors bind.ts's `CREW_SESSION_COMMAND`. */
+const CREW_SESSION_SUBCOMMAND = "session";
+
+/** One row of the process table: a pid, its parent pid, and the full command (argv) it runs. */
+export interface ProcessEntry {
+	readonly pid: number;
+	readonly ppid: number;
+	readonly command: string;
+}
+
+/** A crew session server proc's identity, parsed out of its `session --role <role> [--instance <id>]` argv. */
+export interface CrewSessionProc {
+	readonly role: CrewRole;
+	readonly instance: string | undefined;
+}
+
+/** Read a `--flag value` argument from a command string (bind.ts renders each as adjacent whitespace-separated tokens). */
+const flagValue = (command: string, flag: string): string | undefined => {
+	const match = command.match(new RegExp(`(?:^|\\s)${flag}[=\\s]+(\\S+)`));
+	return match?.[1];
+};
+
+/**
+ * Parse a process command into a crew session proc identity, or `undefined` when it is not one.
+ * Tightly scoped so an unrelated process is never matched: the command must carry the crew-mcp bin
+ * marker AND the `session` subcommand AND a `--role` naming an actual `CREW_ROLE`. A decoy `--role` on
+ * some other tool, a `session` of some other program, or a `--role <not-a-crew-role>` all resolve to
+ * `undefined` — the "without touching unrelated processes" scope guarantee.
+ */
+export const parseCrewSessionProc = (command: string): CrewSessionProc | undefined => {
+	if (!command.includes(CREW_MCP_MARKER)) return undefined;
+	if (!new RegExp(`(?:^|\\s)${CREW_SESSION_SUBCOMMAND}(?:\\s|$)`).test(command)) return undefined;
+	const role = flagValue(command, "--role");
+	if (role === undefined || !isCrewRole(role)) return undefined;
+	return {role, instance: flagValue(command, "--instance")};
+};
+
+/** The inputs orphan discrimination reads: this reaper's own pid (never reap self) and the live-registered address set. */
+export interface OrphanDiscriminationInput {
+	readonly selfPid: number;
+	readonly liveRegisteredAddresses: ReadonlySet<string>;
+}
+
+/**
+ * Is `entry` an orphaned crew server proc that should be reaped? True iff it is a crew session server
+ * (`parseCrewSessionProc`), it is not this process, it is reparented to init (`ppid === INIT_PID`), and
+ * it is not still a live registered engine instance. So a live registered session — parented, hence
+ * `ppid !== INIT_PID` — is never reaped, and neither is a reparented engine instance whose exact
+ * per-instance address still holds a live lease.
+ */
+export const isOrphanedCrewServer = (
+	entry: ProcessEntry,
+	{selfPid, liveRegisteredAddresses}: OrphanDiscriminationInput,
+): boolean => {
+	const proc = parseCrewSessionProc(entry.command);
+	if (proc === undefined) return false;
+	if (entry.pid === selfPid) return false;
+	if (entry.ppid !== INIT_PID) return false;
+	// The one registry-resolvable spare: a reparented ENGINE whose unique per-instance address still
+	// holds a live lease is actively serving — leave it, it reaps once the lease ages out. A bridge's
+	// shared address can't tell a superseded orphan from its live successor, so it reaps on ppid alone.
+	if (
+		proc.instance !== undefined &&
+		kindOf(proc.role) === "engine" &&
+		liveRegisteredAddresses.has(inboxAddressFor(proc.role, proc.instance))
+	) {
+		return false;
+	}
+	return true;
+};
+
+/** A process snapshot failed to read the OS process table — surfaced, never silently treated as "no orphans". */
+export class ProcessSnapshotError extends Schema.TaggedErrorClass<ProcessSnapshotError>()(
+	"@kampus/pipeline-crew-mcp/crew/ProcessSnapshotError",
+	{reason: Schema.String},
+) {}
+
+/** Enumerate the OS process table. Injected so the reaper is driven against a fixture with no real `ps`. */
+export interface ProcessSnapshot {
+	readonly list: Effect.Effect<ReadonlyArray<ProcessEntry>, ProcessSnapshotError>;
+}
+
+/** Whether a kill signal landed on a live process, or the process was already gone (idempotent re-reap). */
+export type ReapSignalOutcome = "signalled" | "already-gone";
+
+/** Terminate a process by pid. Injected so the reaper is driven with no real signal; production sends `REAP_SIGNAL`. */
+export interface ProcessReaper {
+	readonly kill: (pid: number) => Effect.Effect<ReapSignalOutcome>;
+}
+
+/**
+ * Read the process table via `ps -A -o pid=,ppid=,args=` — pid, ppid, and full argv per row, headers
+ * suppressed by the `=` suffixes. The `pid=,ppid=,args=` field set is portable across BSD (macOS) and
+ * GNU (Linux) `ps`.
+ */
+export const productionProcessSnapshot: ProcessSnapshot = {
+	list: Effect.try({
+		try: () =>
+			execFileSync("ps", ["-A", "-o", "pid=,ppid=,args="], {
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+			}),
+		catch: (cause) => new ProcessSnapshotError({reason: `ps -A failed: ${String(cause)}`}),
+	}).pipe(Effect.map(parseProcessTable)),
+};
+
+/** Parse `ps -o pid=,ppid=,args=` output: each non-empty line is `<pid> <ppid> <args…>`. Unparseable lines are skipped. */
+export function parseProcessTable(output: string): ReadonlyArray<ProcessEntry> {
+	const entries: ProcessEntry[] = [];
+	for (const line of output.split("\n")) {
+		const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.+)$/);
+		if (match === null) continue;
+		const [, pidStr, ppidStr, command] = match;
+		if (pidStr === undefined || ppidStr === undefined || command === undefined) continue;
+		const pid = Number(pidStr);
+		const ppid = Number(ppidStr);
+		if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+		entries.push({pid, ppid, command: command.trim()});
+	}
+	return entries;
+}
+
+/** The reap signal: `SIGTERM`, so a reaped orphan runs its scope teardown (unlinking its own inbox socket) rather than being hard-killed. */
+export const REAP_SIGNAL = "SIGTERM";
+
+/**
+ * Terminate via `process.kill(pid, SIGTERM)`. `ESRCH` (no such process) is the idempotent case — the
+ * orphan is already gone — reported as `already-gone`, never an error. A non-`ESRCH` fault (e.g. a
+ * permission `EPERM`) is folded to `already-gone` too, so one un-killable pid never aborts the sweep.
+ */
+export const productionProcessReaper: ProcessReaper = {
+	kill: (pid) =>
+		Effect.try({
+			try: (): ReapSignalOutcome => {
+				process.kill(pid, REAP_SIGNAL);
+				return "signalled";
+			},
+			catch: (cause) => cause,
+		}).pipe(Effect.orElseSucceed((): ReapSignalOutcome => "already-gone")),
+};
+
+/** The per-orphan result of a reap sweep: which crew server proc it was and whether the signal landed. */
+export interface ReapOutcome {
+	readonly pid: number;
+	readonly role: CrewRole;
+	readonly instance: string | undefined;
+	readonly outcome: ReapSignalOutcome;
+}
+
+/** The result of one reap sweep: what was reaped, how many procs were scanned, and the live halves left untouched. */
+export interface ReapReport {
+	readonly reaped: ReadonlyArray<ReapOutcome>;
+	/** How many processes the snapshot scanned — the discrimination denominator (observability). */
+	readonly scanned: number;
+	/** The live registered addresses left untouched — the operator picture the doctor (#3630) composes. */
+	readonly liveRegistered: ReadonlyArray<string>;
+}
+
+/** What one reap sweep needs: the live-registered address set, plus injectable seams defaulting to production. */
+export interface ReapOrphansInput {
+	readonly liveRegisteredAddresses: ReadonlySet<string>;
+	readonly snapshot?: ProcessSnapshot;
+	readonly reaper?: ProcessReaper;
+	readonly selfPid?: number;
+}
+
+/**
+ * Reap every orphaned crew server proc in the current process table (keyed off the canonical registry's
+ * live-registered set): snapshot the table, discriminate orphans (`isOrphanedCrewServer`), signal each,
+ * and report. Idempotent — a re-run finds the already-reaped procs gone from the next snapshot (or their
+ * kill resolves `already-gone`), so it is safe to run repeatedly and on every stand-up.
+ */
+export const reapOrphanedCrewServers = (
+	input: ReapOrphansInput,
+): Effect.Effect<ReapReport, ProcessSnapshotError> =>
+	Effect.gen(function* () {
+		const snapshot = input.snapshot ?? productionProcessSnapshot;
+		const reaper = input.reaper ?? productionProcessReaper;
+		const selfPid = input.selfPid ?? process.pid;
+		const {liveRegisteredAddresses} = input;
+
+		const entries = yield* snapshot.list;
+		const orphans = entries.flatMap((entry) => {
+			if (!isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses})) return [];
+			const proc = parseCrewSessionProc(entry.command);
+			return proc === undefined ? [] : [{entry, proc}];
+		});
+
+		const reaped: ReapOutcome[] = [];
+		for (const {entry, proc} of orphans) {
+			const outcome = yield* reaper.kill(entry.pid);
+			reaped.push({pid: entry.pid, role: proc.role, instance: proc.instance, outcome});
+		}
+
+		return {
+			reaped,
+			scanned: entries.length,
+			liveRegistered: [...liveRegisteredAddresses].sort(),
+		};
+	});
+
+/**
+ * Collect the inbox addresses currently holding a live presence lease, unioned across the whole roster —
+ * the "live registered channel half" set the reaper keys its engine-spare guard on. `lookup` is the
+ * registry's role → present-peers reader (tracker/registry.ts `Registry.lookup`, or a client of it),
+ * whose result reflects attached-inbox liveness (#3628); injected so this composes with either the
+ * in-process registry or a dialed tracker client, and is unit-testable against a fixture map.
+ */
+export const collectLiveRegisteredAddresses = (
+	lookup: (role: CrewRole) => Effect.Effect<ReadonlyArray<{readonly peer: string}>>,
+): Effect.Effect<ReadonlySet<string>> =>
+	Effect.gen(function* () {
+		const addresses = new Set<string>();
+		for (const role of CREW_ROLES) {
+			const present = yield* lookup(role);
+			for (const record of present) addresses.add(record.peer);
+		}
+		return addresses;
+	});

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.test.ts
@@ -212,6 +212,7 @@ const baseInput = (
 	resolveCalls: {n: number};
 	trackerCalls: () => number;
 	reaped: {readonly projectRoot: string; readonly serverName: string}[];
+	reapedProcesses: TrackerHandle[];
 	registered: CrewMcpEntry[][];
 	registeredCtx: {
 		readonly projectRoot: string;
@@ -224,6 +225,15 @@ const baseInput = (
 		recordingLauncher();
 	const {ensureTracker, calls} = recordingTracker();
 	const {registrar, reaped, registered, registeredCtx, cwdCalls} = recordingProjectScope(order);
+	// Recording process-reap seam: records the tracker it was handed and logs into the shared order so a
+	// test can prove the process-reap runs at the crash-reclaim seam (alongside the dir/socket reap) with
+	// no real tracker dial, `ps`, or signal. Also keeps every other test off the real process table.
+	const reapedProcesses: TrackerHandle[] = [];
+	const reapOrphanProcesses = (tracker: TrackerHandle) =>
+		Effect.sync(() => {
+			order.push("reap-processes");
+			reapedProcesses.push(tracker);
+		});
 	const {engineCount, ...rest} = overrides;
 	return {
 		launched: plans,
@@ -233,6 +243,7 @@ const baseInput = (
 		resolveCalls,
 		trackerCalls: calls,
 		reaped,
+		reapedProcesses,
 		registered,
 		registeredCtx,
 		cwdCalls,
@@ -247,6 +258,7 @@ const baseInput = (
 			ensureTracker,
 			resolveTargetSession,
 			launch,
+			reapOrphanProcesses,
 			...rest,
 		},
 	};
@@ -432,7 +444,16 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 		() =>
 			Effect.gen(function* () {
 				const N = 2;
-				const {input, launched, order, reaped, registered, registeredCtx, cwdCalls} = baseInput({
+				const {
+					input,
+					launched,
+					order,
+					reaped,
+					reapedProcesses,
+					registered,
+					registeredCtx,
+					cwdCalls,
+				} = baseInput({
 					engineCount: N,
 				});
 				yield* standUp(input);
@@ -441,11 +462,19 @@ describe("standup/orchestrate — the one stand-up command (issue #3299)", () =>
 				assert.strictEqual(reaped.length, 1);
 				assert.deepStrictEqual(reaped[0], {projectRoot: "/repo", serverName: SERVER});
 
-				// Ordering: reap runs before register, and register runs before any pane is launched.
+				// The process-table half of crash-reclaim swept once too (#3629), handed the ensured tracker so
+				// it can key its engine-spare guard off the live-registered set.
+				assert.strictEqual(reapedProcesses.length, 1);
+				assert.deepStrictEqual(reapedProcesses[0], trackerHandle);
+
+				// Ordering: both reclaim halves run before register, and register runs before any pane is
+				// launched; the process-reap runs at the same crash-reclaim seam (after the dir/socket reap).
 				const reapAt = order.indexOf("reap");
+				const reapProcAt = order.indexOf("reap-processes");
 				const registerAt = order.indexOf("register");
 				const firstLaunchAt = order.findIndex((e) => e.startsWith("launch:"));
-				assert.isBelow(reapAt, registerAt);
+				assert.isBelow(reapAt, reapProcAt);
+				assert.isBelow(reapProcAt, registerAt);
 				assert.isBelow(registerAt, firstLaunchAt);
 
 				// One register batch, carrying the run context the boot-gate seeds need.

--- a/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
+++ b/packages/pipeline-crew-mcp/src/standup/orchestrate.ts
@@ -24,7 +24,13 @@
 import {spawn} from "node:child_process";
 import {randomUUID} from "node:crypto";
 import {Effect, type FileSystem, type Path, Schema} from "effect";
-import {SESSION_SERVER_NAME} from "../crew/index.ts";
+import {
+	CrewTracker,
+	collectLiveRegisteredAddresses,
+	crewTrackerSocketLayer,
+	reapOrphanedCrewServers,
+	SESSION_SERVER_NAME,
+} from "../crew/index.ts";
 import type {RendezvousResolutionError} from "../tracker/index.ts";
 import {
 	buildSessionBind,
@@ -275,6 +281,11 @@ export interface StandUpInput {
 		targetSession: string,
 		intoWindow: string | undefined,
 	) => Effect.Effect<LaunchedSession, StandUpLaunchError>;
+	/** The process-table half of crash-reclaim (#3629): sweep orphaned crew server procs a prior run left
+	 * reparented to init, keyed off the live-registered set so a still-serving instance is spared. Runs
+	 * alongside `localScope.reap` (which reclaims crew-run dirs + the server approval). Default:
+	 * `productionReapOrphanProcesses` (dials the just-ensured tracker, then `ps`-sweeps + `SIGTERM`s). */
+	readonly reapOrphanProcesses?: (tracker: TrackerHandle) => Effect.Effect<void>;
 }
 
 /** What a completed stand-up returns: the tracker it ensured and every session it launched, in roster order. */
@@ -515,6 +526,23 @@ export const launchSessionInTmux = (
 	});
 
 /**
+ * Production process-reap (#3629): dial the just-ensured tracker for the live-registered address set,
+ * then sweep the process table for orphaned crew `session --role` servers a prior run left reparented
+ * to init and terminate them — the process-table complement to `localScope.reap`'s crew-run-dir/socket
+ * reclaim. Best-effort crash-hygiene: a `ps` snapshot or tracker-dial failure is swallowed, never
+ * aborting stand-up — these orphans are prior-run leftovers with distinct pids, not a precondition of
+ * the new crew (unlike the dir/approval reclaim, which clears about-to-collide state and stays loud).
+ */
+export const productionReapOrphanProcesses = (tracker: TrackerHandle): Effect.Effect<void> =>
+	Effect.gen(function* () {
+		const crewTracker = yield* CrewTracker;
+		const liveRegisteredAddresses = yield* collectLiveRegisteredAddresses((role) =>
+			crewTracker.lookup(role),
+		);
+		yield* reapOrphanedCrewServers({liveRegisteredAddresses});
+	}).pipe(Effect.scoped, Effect.provide(crewTrackerSocketLayer(tracker.socketPath)), Effect.ignore);
+
+/**
  * Stand up the whole crew from the operator config, in the mandated order and fail-loud with no
  * partial crew (issue #3299): read config → assert the pinned CLI version → ensure the tracker →
  * derive the roster session set → build every per-session bind + compute all tmux placements →
@@ -533,6 +561,7 @@ export const runStandUp = (
 		const ensureTracker = input.ensureTracker ?? ensureTrackerRunning;
 		const resolveTargetSession = input.resolveTargetSession ?? resolveTargetSessionDefault;
 		const launch = input.launch ?? launchSessionInTmux;
+		const reapOrphanProcesses = input.reapOrphanProcesses ?? productionReapOrphanProcesses;
 
 		const config = yield* input.config ?? readLaunchConfig();
 		// Fail fast on a version drift before starting the tracker or any session — channels vary
@@ -556,6 +585,11 @@ export const runStandUp = (
 		// Start-of-stand-up reaper (crash-safety, #3444): clear any prior run's crew-run dirs + the server
 		// approval — a launcher that died mid-run leaves leftovers this run clears here, before it re-mints.
 		yield* localScope.reap(projectRoot, serverName);
+		// The process-table half of the same crash-reclaim (#3629): a launcher/pane that died left its
+		// `session --role` server reparented to init and still running. Sweep those orphans now, keyed off
+		// the just-ensured tracker's live-registered set so a still-serving instance is spared. Best-effort
+		// (the seam swallows its own failures) so crash-hygiene never blocks the new crew from standing up.
+		yield* reapOrphanProcesses(tracker);
 
 		// Resolve EVERY bind + placement + cwd before launching anything — this is the no-partial-crew
 		// line: an inert channel or a colliding window fails here, while zero sessions are up.


### PR DESCRIPTION
Fixes #3629

## Summary
Crash-reclaim only cleaned the stale *socket file* (`tracker/server.ts`'s `reclaimStaleSocket`); it did nothing about the crashed session's *process*. When a crew pane dies (crash, re-run, tmux kill), its `node … bin.ts session --role <role>` server child is reparented to init (PPID 1) and keeps running — the live diagnosis in epic #3624 found 4 day-old such orphans in the process table (failure mode 3). This adds the missing reap.

## What changed
New `packages/pipeline-crew-mcp/src/crew/reaper.ts` (+ `reaper.test.ts`), exported from `crew/index.ts`:

- **Orphan signal — reparenting to init.** A live session's server is a child of its living launch pane, so `ppid === INIT_PID` is exactly "the pane that owned me is gone." That signal alone never touches a live, parented, registered session.
- **Keyed off the canonical registry (ADR 0197) for the one case it can resolve.** A reparented **engine** whose unique per-instance inbox address (`inbox://<role>/<instance>`) still holds a live presence lease is still serving, so it is **spared** (it reaps on a later pass once its lease ages out). A **bridge** address is shared across re-runs, so it can't disambiguate a superseded orphan from its live successor — a reparented bridge server reaps on the ppid signal alone, which is what actually clears the day-old bridge orphans the diagnosis found.
- **Tightly scoped signature.** `parseCrewSessionProc` matches only a command carrying the crew-mcp bin marker AND the `session` subcommand AND a `--role` naming a real `CREW_ROLE`; a decoy `--role` on another tool never matches.
- **Injected seams.** The process snapshot (`ps -A -o pid=,ppid=,args=`), the kill (`SIGTERM`, so the orphan runs its own scope teardown), and the live-registered address set are all injected and default to production, so discrimination is unit-tested against fixtures with no real process, `ps`, or signal.

The operator diagnostic/doctor surface (#C5 / #3630) that composes this reaper is out of scope here, per the epic task-split; `collectLiveRegisteredAddresses` is provided as the registry-consumption seam it (and production) wire the live set from.

## Acceptance criteria
- [x] Orphaned crew `session --role` server procs (reparented / not a live registered channel half) are identified and reaped; a live, registered session is never reaped — `isOrphanedCrewServer` gates on the ppid + engine-lease guard.
- [x] Reaping is idempotent and tightly scoped to crew-mcp session server procs — a test drives orphan-vs-live discrimination (including an unrelated init-adopted process and a decoy `--role`) without touching unrelated processes; re-running finds the reaped procs gone and kills nothing.
- [x] After a session crash/re-run, no day-old orphan crew server proc lingers — a reparented server (bridge or engine with a lapsed lease) is reaped even when a live successor holds the same shared bridge address.

## Testing
- `pnpm --filter @kampus/pipeline-crew-mcp typecheck` — clean.
- `pnpm exec biome check` on the touched files — clean.
- `vitest run src/crew` — 70 tests pass (19 new in `reaper.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)