### PR TITLE
fix(lint): make pnpm format/lint worktree-aware and fail loud on zero files (#3777)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
 		"typecheck": "turbo run typecheck",
 		"test": "turbo run test",
 		"lint": "case \"$PWD\" in */.claude/worktrees/*) pnpm run lint:worktree ;; *) biome check . ;; esac",
-		"lint:worktree": "CHANGED=$({ git diff --name-only --diff-filter=ACMR origin/main; git ls-files --others --exclude-standard; } | grep -Ev '^node_modules/' | grep -E '\\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc|css|graphql)$' | sort -u || true); if [ -n \"$CHANGED\" ]; then biome check --files-ignore-unknown=true $CHANGED; else echo 'lint:worktree: no biome-handled changed files vs origin/main (clean skip)'; fi",
-		"format": "biome check --write .",
+		"lint:worktree": "node scripts/biome-worktree.mjs check",
+		"format": "case \"$PWD\" in */.claude/worktrees/*) pnpm run format:worktree ;; *) biome check --write . ;; esac",
+		"format:worktree": "node scripts/biome-worktree.mjs write",
 		"prepare": "if [ \"$(git rev-parse --git-dir 2>/dev/null)\" = \"$(git rev-parse --git-common-dir 2>/dev/null)\" ]; then lefthook install || true; else echo 'prepare: linked worktree — skipping lefthook install (git hooks are primary-checkout-managed)'; fi",
 		"postinstall": "node scripts/patch-effect-tsgo.mjs"
 	},

--- a/scripts/biome-worktree.mjs
+++ b/scripts/biome-worktree.mjs
@@ -1,0 +1,88 @@
+// Worktree-aware biome runner for the root `lint:worktree` / `format:worktree` scripts.
+//
+// Why this exists: `biome.jsonc` excludes `!**/.claude/worktrees` so the PRIMARY
+// checkout never descends into nested agent worktrees (#119). But an agent worktree
+// IS `.claude/worktrees/<id>/`, so a bare `biome check .` run from inside one
+// resolves its scan root to a path *under* that exclude and checks 0 files —
+// silently for `lint`, and loud-but-misleading (`Checked 0 files`, exit 1) for
+// `format` (#3777). The escape is to hand biome EXPLICIT changed-file paths, which
+// it matches relative to the biome root and so never trips the exclude — while the
+// primary-checkout protection (#119) stays intact because we only ever take this
+// path from inside a worktree.
+//
+// The load-bearing invariant (#3777): a check that examined zero files must never
+// present as success when the changed set could not be determined. We derive the
+// set from a diff against `origin/main`; if that baseline can't be resolved we FAIL
+// LOUD rather than skip green (the prior `|| true` swallowed exactly this). A
+// genuinely-empty changed set with a resolvable baseline is the one legitimate
+// zero-file pass.
+//
+// Runs from a pnpm script, so `node_modules/.bin` is already on PATH — Node
+// builtins + the local `biome` binary only.
+
+import {spawnSync} from "node:child_process";
+
+const mode = process.argv[2]; // "check" | "write"
+if (mode !== "check" && mode !== "write") {
+	console.error(`biome-worktree: expected mode "check" or "write", got ${JSON.stringify(mode)}`);
+	process.exit(2);
+}
+
+const BIOME_EXT = /\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc|css|graphql)$/;
+
+function git(args) {
+	return spawnSync("git", args, {encoding: "utf8"});
+}
+
+// The changed set is a diff against origin/main, so an unresolvable baseline means
+// we cannot know what changed — that is the fail-loud case, never a clean skip.
+const baseline = git(["rev-parse", "--verify", "--quiet", "origin/main"]);
+if (baseline.status !== 0) {
+	console.error(
+		"biome-worktree: cannot resolve `origin/main` — the changed-file baseline is unavailable, " +
+			"so this worktree's changes could NOT be checked. Refusing to exit success on an " +
+			"undetermined change set (#3777).",
+	);
+	console.error(
+		"  Fix: fetch the base ref into this worktree, e.g. `git fetch origin main:refs/remotes/origin/main`, then re-run.",
+	);
+	process.exit(1);
+}
+
+const tracked = git(["diff", "--name-only", "--diff-filter=ACMR", "origin/main"]);
+const untracked = git(["ls-files", "--others", "--exclude-standard"]);
+// A failing git invocation here is the same "cannot determine the set" hazard as an
+// unresolvable baseline — fail loud rather than proceed on a partial/empty list.
+if (tracked.status !== 0 || untracked.status !== 0) {
+	console.error(
+		"biome-worktree: `git diff`/`git ls-files` failed — could not compute the changed set. " +
+			"Refusing to exit success on an undetermined change set (#3777).",
+	);
+	console.error((tracked.stderr || "") + (untracked.stderr || ""));
+	process.exit(1);
+}
+
+const files = [...tracked.stdout.split("\n"), ...untracked.stdout.split("\n")]
+	.map((f) => f.trim())
+	.filter((f) => f && !f.startsWith("node_modules/") && BIOME_EXT.test(f))
+	.filter((f, i, a) => a.indexOf(f) === i);
+
+if (files.length === 0) {
+	// Baseline resolved and the diff succeeded: a truly empty biome-handled change
+	// set is the one legitimate zero-file pass.
+	console.log(
+		`biome-worktree (${mode}): no biome-handled changed files vs origin/main — nothing to do.`,
+	);
+	process.exit(0);
+}
+
+const args = ["check", "--files-ignore-unknown=true"];
+if (mode === "write") args.push("--write");
+args.push(...files);
+
+const biome = spawnSync("biome", args, {stdio: "inherit"});
+if (biome.error) {
+	console.error(`biome-worktree: failed to spawn biome — ${biome.error.message}`);
+	process.exit(1);
+}
+process.exit(biome.status ?? 1);


### PR DESCRIPTION
Closes #3777

## Problem

`biome check .` run from inside an agent worktree (`.claude/worktrees/<id>/`) resolves its scan root to a path *under* the `!**/.claude/worktrees` exclude — the exclude that exists to stop the **primary** checkout descending into nested worktree copies (#119). So biome checks **0 files**:

- `format` (`biome check --write .`) had **no** worktree branch at all → loud-but-misleading `Checked 0 files`, exit 1.
- `lint:worktree`'s empty-`CHANGED` branch echoed a friendly message and exited **0** — a pass-shaped result from a check that examined nothing (e.g. a missing/stale `origin/main`, whose failure the old `|| true` swallowed).

Root cause confirmed empirically from inside a worktree: `biome check .` → `Checked 0 files` (`- .` reported "ignored"), while `biome check apps` → 1021 files and an explicit file path → checked fine. Biome matches an **explicit** path relative to the biome root, so explicit paths escape the exclude; the bare `.` scan root does not.

## Fix

- `format` now mirrors `lint`'s `$PWD` dispatch: inside a worktree it routes to a new `format:worktree` script instead of the bare `biome check --write .`.
- Both `lint:worktree` and `format:worktree` delegate to a shared `scripts/biome-worktree.mjs` that hands biome the **explicit changed-file paths** (diff vs `origin/main` + untracked, filtered to biome-handled extensions) — which escape the exclude.
- The runner **fails loud** (exit 1, actionable message) when `origin/main` can't be resolved or the diff command fails, instead of exiting 0 on an undetermined change set. A genuinely empty change set with a resolvable baseline is the one legitimate zero-file pass.

## Acceptance criteria

- [x] `pnpm format` inside a worktree formats the worktree's own files (via a `format:worktree` mirroring the `lint` dispatch).
- [x] `lint:worktree`'s empty-`CHANGED` branch distinguishes "genuinely no changed files" (exit 0, clear message) from "could not resolve `origin/main`" (exit 1, loud).
- [x] Settled the open question: `lint`/`lint:worktree` does **not** check 0 files when there is a changed set and `origin/main` resolves — proven by an explicit-file invocation checking files correctly. Its only zero-file path was the empty-`CHANGED` branch, now fixed.
- [x] A check that examined zero files can never present as success when the change set is undetermined — enforced for both scripts by the shared runner.
- [x] The `!**/.claude/worktrees` exclude and both scripts' primary-checkout branches (`biome check .` / `biome check --write .`) are untouched, so the #119 protection is unchanged.

## Verification (from inside a worktree)

- `pnpm lint` → `Checked 8 files`, exit 0 (previously `Checked 0 files`/ignored).
- `pnpm format` → `Checked 8 files`, exit 0, no misleading "0 files ignored".
- Loud-fail path (no `origin/main`) → exit 1 with an actionable fetch hint.
- Genuinely-empty change set with resolvable baseline → exit 0 with a clear "nothing to do" message.
- Both changed files pass phoenix's biome config; `pnpm` scripts are valid JSON.

Not a §CP change: only the root `package.json` and a new `scripts/biome-worktree.mjs` — no CI workflow and no biome config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)