### PR TITLE
fix(write-code): re-key isolation-expected detector off primary-checkout signal, not agent-type literal (#3406)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1843,8 +1843,16 @@ iso_preflight() {
   # NOT key on $WORKTREE_ROOT being set — so the #2440 no-op (isolation requested, $WORKTREE_ROOT
   # unset, which also disarms the $WORKTREE_ROOT-keyed worktree-guard) still trips this preflight;
   # it is then the sole surviving layer, exactly as in write-code (ADR 0172).
-  case "$CLAUDE_CODE_AGENT" in coder|*coder*|reviewer|*reviewer*|shipper|*shipper*) iso=1 ;; esac
+  # The THIRD clause is the env-independent corroboration — parity with the repo-side guard's
+  # `isIsolationExpected` (bash-pin.ts) and write-code's Step-4 detector (#3406): a NESTED/renamed
+  # spawn inherits the PARENT's agent-type string (e.g. `crew-engineering-manager`, ADR 0189), so the
+  # NAME match goes inert for it — but any agent-context run ($CLAUDE_CODE_AGENT non-empty) sitting on
+  # the PRIMARY checkout (gitdir == common) is a broken/absent worktree whatever its inherited name,
+  # and this clause arms regardless of the string. Do NOT hard-code an agent-type name to patch a
+  # rename — the corroboration removes the coupling rather than relocating it (#3406, #2462).
+  case "$CLAUDE_CODE_AGENT" in *coder*|*reviewer*|*shipper*) iso=1 ;; esac
   [ -n "$WORKTREE_ROOT" ] && iso=1
+  [ -n "$CLAUDE_CODE_AGENT" ] && [ "$gitdir" = "$common" ] && iso=1
   echo "$surface iso_preflight: git-dir=$gitdir common-dir=$common cwd=$(pwd) isolation-expected=$iso (agent=${CLAUDE_CODE_AGENT:-unset} worktree-root=${WORKTREE_ROOT:+set})"
   if [ "$gitdir" = "$common" ]; then
     if [ "$iso" = 1 ]; then

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -632,15 +632,29 @@ COMMON="$(cd "$COMMON" && pwd)"
 
 # Was worktree isolation EXPECTED for this run? The coder agent-type (agents/coder.md) asserts
 # isolation UNCONDITIONALLY, so any run under it expects the harness to have provisioned a linked
-# worktree + set $WORKTREE_ROOT. The signal is machine-checkable and harness-set — the agent-type
-# env var $CLAUDE_CODE_AGENT (stable across an agent's Bash calls, unlike a shell `export`),
-# corroborated by a set $WORKTREE_ROOT — NOT a per-run guess. A genuine standalone human run (a
-# direct `/write-code`) matches NEITHER. This is what lets the fail-closed branch below distinguish
-# "isolation expected but the harness no-op'd provisioning" (#2440) from a legitimate standalone
-# run, so it fires LOUD in the first case without regressing the second. See ADR 0172.
+# worktree + set $WORKTREE_ROOT. Three machine-checkable, harness-set signals arm it — NOT a per-run
+# guess — mirroring the repo-side guard's `isIsolationExpected` (bash-pin.ts) exactly (#3406):
+#   1. a direct isolation-asserting agent-type name ($CLAUDE_CODE_AGENT matching coder/reviewer/shipper);
+#   2. a set $WORKTREE_ROOT (the harness signalled a provisioned root);
+#   3. the ENV-INDEPENDENT corroboration — any agent-context run ($CLAUDE_CODE_AGENT non-empty) sitting
+#      on the PRIMARY checkout (git-dir == common-dir). A NESTED/renamed coder spawn inherits the
+#      PARENT's agent-type string (e.g. `crew-engineering-manager` / `junior-engineer`, ADR 0189), so the
+#      NAME match alone goes inert for it — but such a spawn on the primary checkout is a broken/absent
+#      worktree whatever its inherited name, and clause 3 catches it regardless of the string. Keying on
+#      the agent-type LITERAL alone was the #3406 defect: a renamed coder computed isolation-expected=0
+#      and silently self-provisioned. Do NOT hard-code any agent-type name (junior-engineer or otherwise)
+#      to "fix" it — that just relocates the coupling to the next rename; the corroboration removes it.
+# A genuine standalone human run (a direct `/write-code`, $CLAUDE_CODE_AGENT unset) matches NONE of the
+# three, so it never over-refuses and still reaches the Non-isolated fallback. This is what lets the
+# fail-closed branch below distinguish "isolation expected but the harness no-op'd provisioning" (#2440)
+# from a legitimate standalone run, firing LOUD in the first case without regressing the second. See
+# ADR 0172, #2462 (the guard's parallel re-keying), and #3406.
 ISOLATION_EXPECTED=0
-case "$CLAUDE_CODE_AGENT" in coder|*coder*) ISOLATION_EXPECTED=1 ;; esac   # ran AS the coder agent-type
+case "$CLAUDE_CODE_AGENT" in *coder*|*reviewer*|*shipper*) ISOLATION_EXPECTED=1 ;; esac   # direct isolation-asserting agent-type name
 [ -n "$WORKTREE_ROOT" ] && ISOLATION_EXPECTED=1                            # harness signalled a provisioned root
+# env-independent corroboration: a non-empty agent-type on the PRIMARY checkout (git-dir == common-dir) —
+# catches a nested/renamed coder whose inherited agent-type string doesn't name a role (#3406).
+[ -n "$CLAUDE_CODE_AGENT" ] && [ "$GITDIR" = "$COMMON" ] && ISOLATION_EXPECTED=1
 echo "write-code preflight: git-dir=$GITDIR common-dir=$COMMON cwd=$(pwd) isolation-expected=$ISOLATION_EXPECTED (agent=${CLAUDE_CODE_AGENT:-unset} worktree-root=${WORKTREE_ROOT:+set})"   # emit scanned scope (ADR 0092 §1)
 if [ "$GITDIR" = "$COMMON" ]; then
   if [ "$ISOLATION_EXPECTED" = 1 ]; then


### PR DESCRIPTION
Fixes #3406

## What was wrong

The write-code Step-4 `ISOLATION_EXPECTED` detector matched only the agent-type
literal `coder|*coder*`. A real coder spawn in this deployment reports the
**parent's** agent-type via `$CLAUDE_CODE_AGENT` (observed live this run:
`crew-engineering-manager`; the filer observed `junior-engineer`), which does not
match that pattern. So with `$WORKTREE_ROOT` unset the detector computed
`isolation-expected=0` and, on a lost/unprovisioned worktree landing on the
primary checkout, routed to the standalone **self-provision** fallback instead of
the fail-closed-**LOUD** branch ADR 0172 designed to surface a harness worktree
no-op (#2440). The layer-1 escalation-up-to-operator/EM never fired.

## The fix — parity with the repo-side guard, coupling removed not relocated

The repo-side worktree-guard (`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`,
`isIsolationExpected`) was already re-keyed by #2462 onto an env-string-independent
signal: `/coder|reviewer|shipper/.test(agentType) || (agentType.trim() !== "" && onPrimaryCheckout)`.
This brings the two SKILL-side detectors to the **same** parity:

- `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` — the Step-4 detector.
- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` — the shared
  `iso_preflight` helper (reviewer/shipper sibling), so the same string-coupling
  isn't carried there either.

Both now add the env-independent corroboration: a non-empty `$CLAUDE_CODE_AGENT`
sitting on the **primary checkout** (`git-dir == common-dir`) arms
`isolation-expected=1`, regardless of the agent-type name. No agent-type literal
(`junior-engineer` or otherwise) is hard-coded — ADR 0189 retires that name and
hard-coding would just relocate the coupling to the next rename.

## Acceptance criteria

- [x] The detector no longer depends solely on the agent-type string matching
  `coder|*coder*`: a coder spawn on the primary checkout with a non-empty
  `$CLAUDE_CODE_AGENT` (any name) and `$WORKTREE_ROOT` unset computes
  `isolation-expected=1` and takes the fail-closed-LOUD branch (parity with `bash-pin.ts`).
- [x] A genuine standalone `/write-code` (`$CLAUDE_CODE_AGENT` unset) still computes
  `isolation-expected=0` and reaches the non-isolated self-provision fallback — no over-refusal regression.
- [x] The shared `iso_preflight` helper in `gh-issue-intake-formats.md` is brought to the same parity.
- [x] No agent-type literal is hard-coded as the fix — the coupling is removed.

## Verification

Simulated the detector across the AC cases (renamed coder / `junior-engineer` /
`coder` / `reviewer` on primary → 1; standalone unset on primary → 0; renamed
coder in worktree with `$WORKTREE_ROOT` set → 1). All pass. This PR was itself
built under `$CLAUDE_CODE_AGENT=crew-engineering-manager` with `$WORKTREE_ROOT`
unset — the exact reproduction the old detector missed.

## §CP — human-merge-only

Edits two control-plane paths (`write-code/SKILL.md`, `gh-issue-intake-formats.md`)
under the live `CONTROL_PLANE_RE`. This is **§CP: human-merge-only**, owned by
`@kamp-us/control-plane` — not a mechanical auto-ship. Do not self-approve/merge.
