### PR TITLE
fix(crew): fan a role send across all live holders so EngineNudge reaches the owning seat at count>1 (#3770)

### DIFF
--- a/packages/pipeline-crew-mcp/src/crew/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/crew/tracker.ts
@@ -13,7 +13,7 @@
  *     that address back out (matching the `inbox://…` convention the tracker socket test uses).
  */
 import {NodeSocket} from "@effect/platform-node";
-import {Array as Arr, Context, Effect, type FileSystem, Layer, type Scope} from "effect";
+import {Context, Effect, type FileSystem, Layer, type Scope} from "effect";
 import {RpcClient, RpcSerialization} from "effect/unstable/rpc";
 import {type RolePresence, Tracker} from "../peer/index.ts";
 import type * as Schema from "../protocol/schema.ts";
@@ -164,9 +164,11 @@ export class CrewTracker extends Context.Service<
 
 /**
  * The generic `peer/Tracker` port, derived from `CrewTracker` — what `Peer.make` consumes. The
- * peer port resolves ONE live holder to dial (`peer.send` addresses a role, not an instance), so
- * it takes the head of `CrewTracker`'s live set: a bridge's single holder, or any one instance of
- * an engine pool. Fanning across the pool is the crew-facing `discover`'s job, not this port's.
+ * port passes `CrewTracker`'s full live set straight through: a bridge's single holder, or an
+ * engine pool's every seat. `peer.send` then FANS a message across that whole set (#3770), so a
+ * per-item advisory (`EngineNudge`) reaches the seat that owns the item — not just the head. This
+ * used to collapse the set to `Arr.head`, which could only ever dial the head seat, so a non-head
+ * owner never heard the nudge (the count>1 defect); the crew-facing `discover` exposes the same set.
  */
 export const peerTrackerLayer: Layer.Layer<Tracker, never, CrewTracker> = Layer.effect(
 	Tracker,
@@ -175,7 +177,7 @@ export const peerTrackerLayer: Layer.Layer<Tracker, never, CrewTracker> = Layer.
 		return {
 			announce: tracker.announce,
 			reserve: tracker.reserve,
-			lookup: (role) => tracker.lookup(role).pipe(Effect.map(Arr.head)),
+			lookup: tracker.lookup,
 		};
 	}),
 );

--- a/packages/pipeline-crew-mcp/src/peer/peer.test.ts
+++ b/packages/pipeline-crew-mcp/src/peer/peer.test.ts
@@ -11,7 +11,7 @@
  * open, gone once it closes (connection-is-lease, #3035).
  */
 import {assert, describe, it} from "@effect/vitest";
-import {Effect, Layer, Option, Ref} from "effect";
+import {Context, Effect, Layer, Ref, Result} from "effect";
 import * as Arr from "effect/Array";
 import {RpcTest} from "effect/unstable/rpc";
 import {type Connect, Dialer} from "./dialer.ts";
@@ -25,7 +25,8 @@ const CHANNEL_DEAF = "@kampus/pipeline-crew-mcp/ChannelDeafError";
 
 // A scoped in-memory tracker modelling the two presence phases (#3628): `reserve` holds a bare
 // (undiscoverable) slot, `announce` flips it attached; both free on scope close, and `lookup`
-// returns only attached entries — the same live-channel-half semantics as the real registry-core.
+// returns EVERY attached holder of a role (in announce order) — one for a bridge, N for an engine
+// pool — the same live-set semantics as the real registry-core (#3770).
 const FakeTracker = Layer.effect(
 	Tracker,
 	Effect.gen(function* () {
@@ -44,8 +45,8 @@ const FakeTracker = Layer.effect(
 			lookup: (role) =>
 				Ref.get(reg).pipe(
 					Effect.map((xs) =>
-						Arr.findFirst(xs, (x) => x.attached && x.presence.role === role).pipe(
-							Option.map((x) => x.presence),
+						Arr.filterMap(xs, (x) =>
+							x.attached && x.presence.role === role ? Result.succeed(x.presence) : Result.failVoid,
 						),
 					),
 				),
@@ -69,12 +70,12 @@ describe("peer/peer — announce + role lease", () => {
 						const peer = yield* Peer.make({self: "peer-a", role: "builder", address: "addr-a"});
 						yield* peer.announce;
 						const present = yield* tracker.lookup("builder");
-						assert.isTrue(Option.isSome(present));
+						assert.lengthOf(present, 1);
 					}),
 				);
 				// scope closed ⇒ connection dropped ⇒ lease freed
 				const after = yield* tracker.lookup("builder");
-				assert.isTrue(Option.isNone(after));
+				assert.lengthOf(after, 0);
 			}).pipe(Effect.provide([FakeTracker, Inbox.layer("peer-a"), alwaysUnreachable])),
 	);
 
@@ -89,7 +90,7 @@ describe("peer/peer — announce + role lease", () => {
 						// must not appear as a live peer — "up in tmux" must not read as "registered with a live inbox".
 						yield* Peer.make({self: "peer-a", role: "builder", address: "addr-a"});
 						const before = yield* tracker.lookup("builder");
-						assert.isTrue(Option.isNone(before), "unannounced ⇒ never a live peer");
+						assert.lengthOf(before, 0, "unannounced ⇒ never a live peer");
 					}),
 				);
 			}).pipe(Effect.provide([FakeTracker, Inbox.layer("peer-a"), alwaysUnreachable])),
@@ -159,5 +160,117 @@ describe("peer/peer — offline behavior (never a silent drop)", () => {
 					);
 				}),
 			).pipe(Effect.provide([FakeTracker, Inbox.layer("peer-a"), alwaysUnreachable])),
+	);
+});
+
+describe("peer/peer — fan a role send across an engine pool (count>1, #3770)", () => {
+	// A standalone in-memory inbox whose Deliver IS its own deliver, so the test can both DIAL it
+	// (via the connect) and READ what it received — the two halves the fan assertion needs.
+	const buildInbox = (id: string) =>
+		Layer.build(Inbox.layer(id)).pipe(Effect.map((ctx) => Context.get(ctx, Inbox)));
+
+	it.effect(
+		"an EngineNudge to a role with TWO live holders reaches BOTH seats — the head AND the non-head owner",
+		() =>
+			Effect.scoped(
+				Effect.gen(function* () {
+					const headSeat = yield* buildInbox("em-head");
+					const ownerSeat = yield* buildInbox("em-owner");
+					// route each announced address to its inbox; anything else is off the network
+					const connect: Connect = (address) =>
+						address === "addr-head"
+							? Effect.succeed({Deliver: headSeat.deliver})
+							: address === "addr-owner"
+								? Effect.succeed({Deliver: ownerSeat.deliver})
+								: Effect.fail(new PeerUnreachableError({target: address, reason: "no route"}));
+
+					yield* Effect.gen(function* () {
+						const tracker = yield* Tracker;
+						// two engine seats under ONE role — announce order makes em-head the head the old
+						// `Arr.head` resolver would have picked; em-owner is the seat it could never reach.
+						yield* tracker.announce({
+							role: "engineering-manager",
+							peer: "em-head",
+							address: "addr-head",
+						});
+						yield* tracker.announce({
+							role: "engineering-manager",
+							peer: "em-owner",
+							address: "addr-owner",
+						});
+						const cos = yield* Peer.make({
+							self: "cos",
+							role: "chief-of-staff",
+							address: "addr-cos",
+						});
+						yield* cos.send("engineering-manager", "EngineNudge", {target: {pr: 3838}});
+
+						const gotHead = yield* headSeat.received;
+						const gotOwner = yield* ownerSeat.received;
+						assert.lengthOf(gotHead, 1, "the head seat received the nudge");
+						assert.lengthOf(
+							gotOwner,
+							1,
+							"the NON-head seat received the nudge too — the count>1 fix (#3770)",
+						);
+						assert.strictEqual(gotHead[0]?.kind, "EngineNudge");
+						assert.strictEqual(gotOwner[0]?.kind, "EngineNudge");
+						// one logical message fanned to both seats, not two distinct sends
+						assert.strictEqual(
+							gotHead[0]?.messageId,
+							gotOwner[0]?.messageId,
+							"the same envelope reached both seats",
+						);
+					}).pipe(
+						Effect.provide([FakeTracker, Inbox.layer("cos"), Dialer.layerFromConnect(connect)]),
+					);
+				}),
+			),
+	);
+
+	it.effect(
+		"a fan tolerates a deaf seat in the pool — one holder deaf, another live still delivers (ack from the live seat)",
+		() =>
+			Effect.scoped(
+				Effect.gen(function* () {
+					const liveSeat = yield* buildInbox("em-live");
+					// addr-live answers; addr-deaf is announced but unreachable (a stale-socket seat)
+					const connect: Connect = (address) =>
+						address === "addr-live"
+							? Effect.succeed({Deliver: liveSeat.deliver})
+							: Effect.fail(new PeerUnreachableError({target: address, reason: "no route"}));
+
+					yield* Effect.gen(function* () {
+						const tracker = yield* Tracker;
+						yield* tracker.announce({
+							role: "engineering-manager",
+							peer: "em-deaf",
+							address: "addr-deaf",
+						});
+						yield* tracker.announce({
+							role: "engineering-manager",
+							peer: "em-live",
+							address: "addr-live",
+						});
+						const cos = yield* Peer.make({
+							self: "cos",
+							role: "chief-of-staff",
+							address: "addr-cos",
+						});
+						const ack = yield* cos.send("engineering-manager", "EngineNudge", {
+							target: {issue: 3641},
+						});
+						assert.strictEqual(
+							ack.by,
+							"em-live",
+							"delivered — the live seat acked despite a deaf pool-mate",
+						);
+						const gotLive = yield* liveSeat.received;
+						assert.lengthOf(gotLive, 1, "the live seat received the nudge");
+					}).pipe(
+						Effect.provide([FakeTracker, Inbox.layer("cos"), Dialer.layerFromConnect(connect)]),
+					);
+				}),
+			),
 	);
 });

--- a/packages/pipeline-crew-mcp/src/peer/peer.ts
+++ b/packages/pipeline-crew-mcp/src/peer/peer.ts
@@ -6,15 +6,17 @@
  * `make` reserves this peer's role slot as a BARE lease (holds the slot + backs the crew
  * cardinality claim + connection-is-lease, #3035) but does NOT make it discoverable. Becoming a
  * live peer is a separate `announce` step the caller runs once its inbox is attached and serving,
- * so presence reflects a live channel half, not mere construction (#3628). `send` looks the target role up via the
- * tracker (the tracker never relays) and dials that peer's inbox directly. A send to a role
- * with NO live peer surfaces as `PeerUnreachableError`; a send to a role that IS present but
- * whose inbox will not answer surfaces as a distinguishable `ChannelDeafError`, fast — never a
- * silent drop, never a hang.
+ * so presence reflects a live channel half, not mere construction (#3628). `send` looks the target
+ * role up via the tracker (the tracker never relays) and FANS the message to every live holder's
+ * inbox directly — one holder for a singleton bridge, every seat for an engine pool, so a per-item
+ * advisory reaches the seat that owns the item rather than only the head (#3770). A send to a role
+ * with NO live peer surfaces as `PeerUnreachableError`; a send whose holders are all present but
+ * deaf surfaces as a distinguishable `ChannelDeafError`, fast — never a silent drop, never a hang.
  */
 
 import {randomUUID} from "node:crypto";
-import {Duration, Effect, Option, type Scope} from "effect";
+import {Duration, Effect, Option, Result, type Scope} from "effect";
+import * as Arr from "effect/Array";
 import {Dialer} from "./dialer.ts";
 import {ChannelDeafError, PeerUnreachableError} from "./errors.ts";
 import {Inbox, type InboxAck, type InboxEnvelope} from "./inbox.ts";
@@ -50,9 +52,10 @@ export interface Peer {
 	 */
 	readonly announce: Effect.Effect<void, never, Scope.Scope>;
 	/**
-	 * Send a typed message to whichever live peer serves `targetRole`; resolves to its inbox-ack. A
-	 * role with no live peer fails with `PeerUnreachableError`; a role that is present but whose inbox
-	 * will not answer fails with a distinguishable `ChannelDeafError`, fast.
+	 * Send a typed message to `targetRole`, fanned to EVERY live holder of the role; resolves to a
+	 * delivery-receipt inbox-ack (delivered iff at least one holder acked). A role with no live peer
+	 * fails with `PeerUnreachableError`; a role whose holders are all present but deaf fails with a
+	 * distinguishable `ChannelDeafError`, fast.
 	 */
 	readonly send: (
 		targetRole: string,
@@ -74,16 +77,45 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 	// inbox socket server is bound and serving, so a channel-deaf session never becomes a live peer.
 	const announce = tracker.announce(presence);
 
+	// Dial ONE holder's inbox: the tracker returned a live lease, so a dial that won't complete is
+	// channel-deaf — presence reflected a stale socket file, not a live inbox (#3628). Fold BOTH a
+	// fast dial refusal (a dead/orphaned socket → PeerUnreachableError) and a genuine hang (the
+	// bounded timeout) into one distinguishable ChannelDeafError, so a caller tells "registered but
+	// deaf" from "nobody there". Reused per-holder by the fan below.
+	const dialHolder = (targetRole: string, address: string, envelope: InboxEnvelope) =>
+		dialer.send(address, envelope).pipe(
+			Effect.timeoutOrElse({
+				duration: DIAL_TIMEOUT,
+				orElse: () =>
+					Effect.fail(
+						new ChannelDeafError({
+							target: targetRole,
+							address,
+							reason: "the inbox did not answer within the dial timeout",
+						}),
+					),
+			}),
+			Effect.catchTag("@kampus/pipeline-crew-mcp/PeerUnreachableError", (cause) =>
+				Effect.fail(new ChannelDeafError({target: targetRole, address, reason: cause.reason})),
+			),
+		);
+
 	const send: Peer["send"] = (targetRole, kind, body) =>
 		Effect.gen(function* () {
-			const present = yield* tracker.lookup(targetRole);
-			if (Option.isNone(present)) {
+			const holders = yield* tracker.lookup(targetRole);
+			// No live holder of the role at all ⇒ nobody to dial (distinct from a present-but-deaf inbox).
+			if (!Arr.isReadonlyArrayNonEmpty(holders)) {
 				return yield* new PeerUnreachableError({
 					target: targetRole,
 					reason: `no live peer for role "${targetRole}"`,
 				});
 			}
-			const address = present.value.address;
+			// One logical message, FANNED to every live holder of the role — not routed to a single seat
+			// (#3770). A bridge has one holder, so this is an ordinary point-to-point send; an engine pool
+			// has N, so a per-item advisory (`EngineNudge`) reaches the seat that OWNS the item regardless
+			// of which seat that is. This replaces an `Arr.head` collapse that could only ever dial the
+			// head, so a non-head owner never heard the nudge. Fanning is safe because the nudge is
+			// advisory/non-routing: a seat that does not own the item ignores it (ADR 0189).
 			const envelope: InboxEnvelope = {
 				messageId: randomUUID(),
 				from: config.self,
@@ -91,26 +123,28 @@ export const make = Effect.fn("Peer.make")(function* (config: PeerConfig) {
 				body,
 				at: new Date().toISOString(),
 			};
-			// The tracker returned a live lease, so a dial that won't complete is channel-deaf — presence
-			// reflected a stale socket file, not a live inbox (#3628). Fold BOTH a fast dial refusal (a
-			// dead/orphaned socket → PeerUnreachableError) and a genuine hang (the bounded timeout) into one
-			// distinguishable ChannelDeafError, so the caller tells "registered but deaf" from "nobody there".
-			return yield* dialer.send(address, envelope).pipe(
-				Effect.timeoutOrElse({
-					duration: DIAL_TIMEOUT,
-					orElse: () =>
-						Effect.fail(
-							new ChannelDeafError({
-								target: targetRole,
-								address,
-								reason: "the inbox did not answer within the dial timeout",
-							}),
-						),
-				}),
-				Effect.catchTag("@kampus/pipeline-crew-mcp/PeerUnreachableError", (cause) =>
-					Effect.fail(new ChannelDeafError({target: targetRole, address, reason: cause.reason})),
-				),
+			// Deliver to the WHOLE pool before deciding the result — a fan must not fail-fast on one deaf
+			// seat and skip the rest, so each dial is reified into a Result and every holder is dialed.
+			const results = yield* Effect.forEach(
+				holders,
+				(holder) => Effect.result(dialHolder(targetRole, holder.address, envelope)),
+				{concurrency: "unbounded"},
 			);
+			// Delivered iff at least one live holder acked. The returned ack is a delivery RECEIPT for the
+			// fan (which holder answered first is immaterial — every reachable holder received the same
+			// envelope), NOT a routing choice like the old head-pick.
+			const ack = Arr.findFirst(results, Result.isSuccess);
+			if (Option.isSome(ack)) {
+				return ack.value.success;
+			}
+			// No holder acked ⇒ the entire live pool was deaf. Surface a ChannelDeafError — for a singleton
+			// bridge this is exactly the one holder's own deaf error, so behavior is identical to before the
+			// fan. `results` is non-empty (holders is) and here every entry is a failure, so one is present.
+			const deaf = Arr.findFirst(results, Result.isFailure);
+			return yield* Option.match(deaf, {
+				onSome: (failure) => Effect.fail(failure.failure),
+				onNone: () => Effect.die("unreachable: a non-empty fan with no ack must carry a failure"),
+			});
 		});
 
 	return {

--- a/packages/pipeline-crew-mcp/src/peer/tracker.ts
+++ b/packages/pipeline-crew-mcp/src/peer/tracker.ts
@@ -1,7 +1,7 @@
 /**
  * peer/tracker — the control-plane port a peer depends on: announce a role + inbox
- * address, and look a role up. Generic (crew-agnostic); see the boundary note in
- * `../index.ts`.
+ * address, and look a role up to its live holders. Generic (crew-agnostic); see the
+ * boundary note in `../index.ts`.
  *
  * This is the seam, not the registry: the tracker's internals (soft-state store, socket,
  * TTL) are a sibling module (#3055). peer/ codes against this abstract port so it stays
@@ -9,7 +9,7 @@
  * wired at the crew composition root (#3059). `announce` is scoped: the presence is held
  * for the peer's lifetime and released when its scope closes — connection-is-lease (#3035).
  */
-import {Context, type Effect, type Option, Schema, type Scope} from "effect";
+import {Context, type Effect, Schema, type Scope} from "effect";
 import {Messages} from "../protocol/index.ts";
 
 /** One presence record: the peer, the role it serves, and where its inbox is dialable. */
@@ -30,6 +30,13 @@ export class Tracker extends Context.Service<
 		 * claim, but is NOT discoverable via `lookup` until the peer attaches its inbox and announces.
 		 */
 		readonly reserve: (presence: RolePresence) => Effect.Effect<void, never, Scope.Scope>;
-		readonly lookup: (role: string) => Effect.Effect<Option.Option<RolePresence>>;
+		/**
+		 * Every live holder of `role` (`[]` ⇒ absent/expired) — the full set, not one chosen seat.
+		 * A bridge resolves to its single holder; an engine to its whole live pool, so `peer.send` can
+		 * fan a per-item advisory across the pool and reach the seat that owns the item rather than
+		 * only ever the head (#3770). Returning the pool here — instead of collapsing it to a head — is
+		 * what makes "silently drop every non-head holder" unrepresentable at the port.
+		 */
+		readonly lookup: (role: string) => Effect.Effect<ReadonlyArray<RolePresence>>;
 	}
 >()("@kampus/pipeline-crew-mcp/peer/Tracker") {}


### PR DESCRIPTION
When more than one engine seat serves the `engineering-manager` role, a chief-of-staff nudge about a specific PR/issue could only ever land on the first seat — never the seat that actually owns that work. That made the nudge undeliverable to the right seat with no way to reroute, wasting a spawned-and-killed coder lane and leaving a bridge believing it had an engine edge it did not have. This PR makes a role send fan to every live holder, so the owning seat always receives it.

## What changed

The send-resolution collapsed a role's live holders to `Arr.head` (`crew/tracker.ts`), so `peer.send` addressed a single seat. For a per-item advisory (`EngineNudge`, payload `{target: {pr|issue}}`) sent to the engine pool at `count>1`, that head was almost never the owner, and the pick was deterministic (4/4 landed on the wrong seat).

- **`peer/tracker.ts`** — the `Tracker` port's `lookup` now returns the full `ReadonlyArray<RolePresence>` live set instead of `Option<RolePresence>`, so the pool is visible at the port rather than silently dropped.
- **`crew/tracker.ts`** — `peerTrackerLayer` passes `CrewTracker`'s live set straight through (drops the `Arr.head` collapse); its docblock is reconciled with the fan.
- **`peer/peer.ts`** — `send` fans the same envelope to every live holder: one seat for a singleton bridge (byte-identical to before), every seat for an engine pool. Delivery succeeds iff at least one holder acks; an all-deaf pool still surfaces `ChannelDeafError`. The returned ack is a delivery receipt, not a routing choice.
- **`peer/peer.test.ts`** — a `count>1` fan reaches both the head and the non-head owner (same envelope), and a fan tolerates a deaf pool-mate.

Fanning is safe because the nudge is advisory and non-routing per ADR 0189: a seat that does not own the item ignores it. This is triage option 1 — no new tool surface; `channel_send` keeps its single-ack contract. Ships as an ordinary auto-ship lane (not §CP).

All acceptance criteria are met; AC5 (accept-and-document) is the alternative that was not taken.

Fixes #3770