### PR TITLE
fix(integration): absorb cold-D1 signUp + session-readiness flake at the harness auth seam (#3799)

### DIFF
--- a/apps/web/tests/integration/_edge-ready.unit.test.ts
+++ b/apps/web/tests/integration/_edge-ready.unit.test.ts
@@ -381,6 +381,16 @@ describe("h.signUp — cold-edge readiness over the shared primitive (invariants
 			status: 422,
 			headers: {"content-type": "application/json"},
 		});
+	// better-auth's wrapper for a TRANSIENT user-creation D1 write failure — a 422 the harness
+	// now replays (distinct from the semantic `USER_ALREADY_EXISTS` above; #3799).
+	const failedToCreate422 = (): Response =>
+		new Response(
+			JSON.stringify({message: "Failed to create user", code: "FAILED_TO_CREATE_USER"}),
+			{
+				status: 422,
+				headers: {"content-type": "application/json"},
+			},
+		);
 	const badRequest400 = (): Response =>
 		new Response(JSON.stringify({code: "INVALID_EMAIL"}), {
 			status: 400,
@@ -418,9 +428,23 @@ describe("h.signUp — cold-edge readiness over the shared primitive (invariants
 		const session = await h.signUp("dup@test.local", "password-password", "dup");
 
 		expect(session.userId).toBe("u_existing");
-		// Exactly two calls: the 422 sign-up + the sign-in fallback — the 422 was NOT retried
-		// into the readiness budget (a real worker answer returns immediately under `() => true`).
-		expect(fetchMock).toHaveBeenCalledTimes(2);
+		// Three calls: the 422 sign-up + the sign-in fallback + the `get-session` readiness probe
+		// (#3799) — the 422 was NOT retried into the readiness budget (a real worker answer returns
+		// immediately under `() => true`); the third call is the post-fallback session gate.
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it("replays a transient 422 FAILED_TO_CREATE_USER, then resolves the created session (#3799)", async () => {
+		// Cold-D1 first-write throws once → better-auth 422 FAILED_TO_CREATE_USER; the replay creates
+		// the user, and the `get-session` gate confirms the session before it is handed back.
+		const fetchMock = stubFetch([failedToCreate422, () => authOk("u_created")]);
+		const h = buildHarness();
+
+		const session = await h.signUp("cold@test.local", "password-password", "cold");
+
+		expect(session.userId).toBe("u_created");
+		// sign-up (422 transient) + sign-up (retry → created) + get-session (readiness gate).
+		expect(fetchMock).toHaveBeenCalledTimes(3);
 	});
 
 	it("fails fast on a genuine 4xx — never retried into the readiness budget (invariant 2)", async () => {

--- a/apps/web/tests/integration/_harness-signup-disposition.unit.test.ts
+++ b/apps/web/tests/integration/_harness-signup-disposition.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Pins `signUpDisposition` of `_harness.ts`: the two 422 sign-up shapes must stay
+ * distinguishable so `signUp` replays only the TRANSIENT cold-D1 user-creation failure
+ * (`FAILED_TO_CREATE_USER`, #3799) while still routing the semantic duplicate
+ * (`USER_ALREADY_EXISTS`) to sign-in and surfacing every real client error (#3799).
+ */
+
+import {describe, expect, it} from "vitest";
+import {signUpDisposition} from "./_harness.ts";
+
+describe("signUpDisposition", () => {
+	it("routes a 422 USER_ALREADY_EXISTS to the sign-in fallback", () => {
+		expect(
+			signUpDisposition(422, JSON.stringify({message: "…", code: "USER_ALREADY_EXISTS"})),
+		).toBe("exists");
+	});
+
+	it("replays a 422 FAILED_TO_CREATE_USER as transient (the #3799 cold-D1 signature)", () => {
+		expect(
+			signUpDisposition(422, '{"message":"Failed to create user","code":"FAILED_TO_CREATE_USER"}'),
+		).toBe("transient");
+	});
+
+	it.each([
+		[422, JSON.stringify({code: "INVALID_EMAIL"}), "a different 422 validation code"],
+		[
+			400,
+			JSON.stringify({code: "FAILED_TO_CREATE_USER"}),
+			"the transient code on a non-422 status",
+		],
+		[401, "unauthorized", "a 401"],
+		[500, "boom", "a 5xx body handled by postIdempotent, not here"],
+	])("treats %s (%s) as terminal", (status, body) => {
+		expect(signUpDisposition(status as number, body as string)).toBe("terminal");
+	});
+});

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -331,6 +331,31 @@ export function frameData<T = unknown>(frame: string): T {
 }
 
 /**
+ * How to treat a NON-`ok` better-auth sign-up response (from its status + body text).
+ * The three dispositions make the two 422 shapes distinguishable at the one site that must
+ * tell them apart:
+ *
+ *   - `exists`    — 422 `USER_ALREADY_EXISTS`: the semantic duplicate a `NO_DESTROY` re-run
+ *                   (or a prior partial create) leaves behind → fall back to sign-in.
+ *   - `transient` — 422 `FAILED_TO_CREATE_USER`: better-auth's wrapper for a user-creation D1
+ *                   write that THREW. On a freshly-deployed stage's cold D1 the first
+ *                   user-creation write can fail this way (the same cold-first-write flake
+ *                   `postIdempotent` already replays for a 5xx, #32) — so a fresh sign-up
+ *                   replay resolves it, distinct from the semantic duplicate above (#3799).
+ *   - `terminal`  — any other response: a real client/validation error → surface at once.
+ *
+ * Pure over `(status, body)` so the two-422-code discrimination is unit-assertable, never
+ * buried in `signUp`'s control flow.
+ */
+export type SignUpDisposition = "exists" | "transient" | "terminal";
+export const signUpDisposition = (status: number, body: string): SignUpDisposition =>
+	status === 422 && body.includes("USER_ALREADY_EXISTS")
+		? "exists"
+		: status === 422 && body.includes("FAILED_TO_CREATE_USER")
+			? "transient"
+			: "terminal";
+
+/**
  * Build the HTTP harness over a deployed-worker URL accessor. The harness does NOT
  * deploy — `integrationStack()` (`_integration.ts`) owns the per-file `Test.make`
  * lifecycle and supplies `getUrl`, which resolves to this file's stage's worker URL
@@ -512,24 +537,70 @@ export function harness(
 		return {userId: data.user.id, cookie};
 	};
 
-	const signUp: Harness["signUp"] = async (email, password, name) => {
-		const res = await postAuthReady("/api/auth/sign-up/email", {email, password, name});
-		if (res.ok) return sessionFrom(res, "sign-up");
-		// Idempotent against the real remote D1 this file's stage deploys: a
-		// `NO_DESTROY` re-run reuses the same D1, so a seed user left by a prior run
-		// makes sign-up 422 USER_ALREADY_EXISTS. Fall back to sign-in so re-seeding a
-		// fixture is a no-op, not a hard fail.
-		const body = await res.text();
-		if (res.status === 422 && body.includes("USER_ALREADY_EXISTS")) {
-			const signIn = await postAuthReady("/api/auth/sign-in/email", {email, password});
-			if (!signIn.ok) {
-				throw new Error(
-					`sign-in (existing seed user) failed: ${signIn.status} ${await signIn.text()}`,
-				);
+	// A returned session cookie is only USABLE once its session row is consistently readable
+	// by the NEXT authenticated request. better-auth runs with no `cookieCache` (see
+	// `better-auth-live.ts`), so every session read hits D1 — and on a freshly-deployed
+	// stage's cold D1 the just-written session can lag the read replica the following
+	// vote/`definition.add` draws, surfacing as `UNAUTHORIZED` before the write propagates
+	// (#3799). Gate the returned session on `GET /api/auth/get-session` resolving its user, so
+	// `signUp` hands back a proven-live session, not a racing one. Fail-OPEN, like the warmups:
+	// a readiness probe must never RED a green stage, so an exhausted budget returns the session
+	// anyway (the caller's own idempotent op still retries) — this only front-loads the
+	// propagation wait off the first authenticated use.
+	const SESSION_READY_ATTEMPTS = 6;
+	const sessionReady = async (session: {
+		userId: string;
+		cookie: string;
+	}): Promise<{userId: string; cookie: string}> => {
+		for (let i = 0; i < SESSION_READY_ATTEMPTS; i++) {
+			const res = await req(
+				"/api/auth/get-session",
+				{headers: {cookie: session.cookie, origin: "http://localhost:3000"}},
+				{timeoutMs: REQUEST_TIMEOUT_MS},
+			);
+			if (res.ok) {
+				const data = (await res.json().catch(() => null)) as {user?: {id: string}} | null;
+				if (data?.user?.id) return session;
 			}
-			return sessionFrom(signIn, "sign-in");
+			await sleep(300 * (i + 1));
 		}
-		throw new Error(`sign-up failed: ${res.status} ${body}`);
+		return session;
+	};
+
+	// Replay a TRANSIENT cold-D1 user-creation failure (`FAILED_TO_CREATE_USER`, classified by
+	// `signUpDisposition`) — a fresh sign-up succeeds once the cold D1 accepts the write, and a
+	// partial create that DID commit converges on the next attempt's `USER_ALREADY_EXISTS`
+	// sign-in fallback. Bounded — a persistent failure still surfaces the last body.
+	const SIGNUP_CREATE_ATTEMPTS = 4;
+	const signUp: Harness["signUp"] = async (email, password, name) => {
+		let lastBody = "";
+		for (let i = 0; i < SIGNUP_CREATE_ATTEMPTS; i++) {
+			const res = await postAuthReady("/api/auth/sign-up/email", {email, password, name});
+			if (res.ok) return sessionReady(await sessionFrom(res, "sign-up"));
+			lastBody = await res.text();
+			switch (signUpDisposition(res.status, lastBody)) {
+				case "exists": {
+					// A `NO_DESTROY` re-run reuses the same D1, so a seed user left by a prior run
+					// makes sign-up 422 USER_ALREADY_EXISTS — sign in so re-seeding a fixture is a
+					// no-op, not a hard fail.
+					const signIn = await postAuthReady("/api/auth/sign-in/email", {email, password});
+					if (!signIn.ok) {
+						throw new Error(
+							`sign-in (existing seed user) failed: ${signIn.status} ${await signIn.text()}`,
+						);
+					}
+					return sessionReady(await sessionFrom(signIn, "sign-in"));
+				}
+				case "transient":
+					await sleep(400 * (i + 1));
+					continue;
+				case "terminal":
+					throw new Error(`sign-up failed: ${res.status} ${lastBody}`);
+			}
+		}
+		throw new Error(
+			`sign-up failed after ${SIGNUP_CREATE_ATTEMPTS} attempts (transient FAILED_TO_CREATE_USER): ${lastBody}`,
+		);
 	};
 
 	const signUpYazar: Harness["signUpYazar"] = async (email, password, name) => {


### PR DESCRIPTION
Fixes #3799

## What & why

The integration harness red-flagged `ci-required` in a merge-queue batch with two setup-stage signatures, on a base that passed the identical job on `main` minutes later:

- `signUp` `422 FAILED_TO_CREATE_USER` (`search-error-vs-empty`)
- `seedTerm` vote `UNAUTHORIZED` (`sozluk-keyset`)

**Determination — a genuine, fixable harness readiness race, not shared cross-run state.** Both failing files run on *dedicated, per-run-isolated* stages (`integrationStack`, keyed by `<slug>|<run-id>-<run-attempt>`), and seed identities are already per-process/per-file namespaced (`STAMP_SEED`, `nextSeedId`). So the reporter's "concurrent runs share auth/D1 state on a stage" hypothesis does **not** apply to these two — the per-run identity isolation the issue suggested is already present. The real cause is transient cold-D1 first-write flakiness at the harness's auth-provisioning seam, un-absorbed by the harness:

- better-auth wraps a **transient user-creation D1 write failure** as a `422 FAILED_TO_CREATE_USER` — a 4xx the existing 5xx-only retry (`postIdempotent`, #32) misses, so it surfaces as a hard setup fail.
- with no `cookieCache` (`apps/web/worker/features/pasaport/better-auth-live.ts`), every session read hits D1, so a just-written session can lag the read replica the immediately-following `definition.vote` / `definition.add` draws → `UNAUTHORIZED`.

## The fix — both at the single load-bearing seam, `signUp`

`apps/web/tests/integration/_harness.ts`:

- **`signUpDisposition`** — a pure, unit-pinned classifier that keeps the two `422` shapes distinct. `signUp` now **replays** a transient `FAILED_TO_CREATE_USER` (bounded, 4 attempts), still routes `USER_ALREADY_EXISTS` to the sign-in fallback, and surfaces every other 4xx at once. A partial create that *did* commit converges on the next attempt's `USER_ALREADY_EXISTS` sign-in.
- **`sessionReady`** — gate the returned cookie on `GET /api/auth/get-session` resolving its user (bounded, **fail-open** like the existing warmups — a readiness probe never reds a green stage), so `signUp` hands back a proven-live session instead of one racing D1 replication. This protects every author/voter/test session (authors' `definition.add` would hit the same `UNAUTHORIZED` window), not just the vote path.

This mirrors the harness's existing readiness philosophy (cold-edge placeholder-404 retry, cold-DO 503 retry, 5xx-on-cold-first-write retry #32, deploy-transient retry, D1-REST 429 retry) — two more transient cold-D1 shapes now absorbed at their source.

## Tests

- `apps/web/tests/integration/_harness-signup-disposition.unit.test.ts` — pins the two-`422`-code discrimination (`exists` / `transient` / `terminal`).
- `apps/web/tests/integration/_edge-ready.unit.test.ts` — extended the `h.signUp` coverage for the post-fallback session-readiness probe and the transient `FAILED_TO_CREATE_USER` replay.

`pnpm typecheck` clean; full unit suite green (2362 passed).

## Note

Root cause is distinct from the sibling classes: the 120s `beforeAll` timeout (#3146), the edge-propagation budget (#3788), and the merge-queue change-detect basis (#3797). No overlap with #3788's harness files.
