### PR TITLE
chore(pipeline-cli): repoint stale refs to the deleted ci-required/gh-phoenix/primary-index-tripwire packages (#3806)

### DIFF
--- a/packages/pipeline-cli/src/module-load-guard.ts
+++ b/packages/pipeline-cli/src/module-load-guard.ts
@@ -149,8 +149,9 @@ export interface SelfHealOptions {
  * Bounded, idempotent self-heal for the unlinked-workspace-dep condition (#2459).
  *
  * `main-sync` (and every pipeline-cli tool) runs from source as `node src/bin.ts …`, so a
- * `pipeline-cli` workspace-dep-graph change (PR #2447 switched `@kampus/ci-required` to a
- * `workspace:*` import) leaves the primary checkout's `node_modules` stale and the dynamic
+ * `pipeline-cli` workspace-dep-graph change (e.g. PR #2447, which switched the then-standalone
+ * `ci-required` package to a `workspace:*` import before it was inlined into pipeline-cli, #3802)
+ * leaves the primary checkout's `node_modules` stale and the dynamic
  * `import("./run.ts")` throws the unlinked-dep `ERR_MODULE_NOT_FOUND` `isUnlinkedDependencyError`
  * classifies. Rather than dead-ending at the legible remediation, we first try to heal the exact
  * condition: run one workspace install, then retry the load. The install runs **at most once** per

--- a/packages/pipeline-cli/src/module-load-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/module-load-guard.unit.test.ts
@@ -150,7 +150,7 @@ describe("loadWithSelfHeal", () => {
 	it("self-heals the unlinked-dep case: one install, then the retry succeeds", async () => {
 		const load = vi
 			.fn()
-			.mockRejectedValueOnce(unlinkedPkgErr("@kampus/ci-required"))
+			.mockRejectedValueOnce(unlinkedPkgErr("@kampus/example-workspace-dep"))
 			.mockResolvedValueOnce(undefined);
 		const install = vi.fn().mockResolvedValue(undefined);
 		const onHealAttempt = vi.fn();
@@ -158,11 +158,11 @@ describe("loadWithSelfHeal", () => {
 		// bounded: exactly one install, exactly one retry (two loads total) — never a loop
 		expect(install).toHaveBeenCalledTimes(1);
 		expect(load).toHaveBeenCalledTimes(2);
-		expect(onHealAttempt).toHaveBeenCalledWith("@kampus/ci-required");
+		expect(onHealAttempt).toHaveBeenCalledWith("@kampus/example-workspace-dep");
 	});
 
 	it("falls back to the #1798 remediation when the retry still can't link the dep", async () => {
-		const stillUnlinked = unlinkedPkgErr("@kampus/ci-required");
+		const stillUnlinked = unlinkedPkgErr("@kampus/example-workspace-dep");
 		const load = vi.fn().mockRejectedValue(stillUnlinked);
 		const install = vi.fn().mockResolvedValue(undefined);
 		// the second unlinked throw propagates so the bin prints remediation + exit(1)

--- a/packages/pipeline-cli/src/tools/ci-required/bin.ts
+++ b/packages/pipeline-cli/src/tools/ci-required/bin.ts
@@ -5,7 +5,7 @@
  * §1 "emit what you scanned"), exit 0 on PASS / 1 on FAIL.
  *
  * ZERO runtime dependencies on purpose: the `ci-required` gate job runs only
- * `actions/checkout` + `node packages/ci-required/src/bin.ts` — no `pnpm install`
+ * `actions/checkout` + `node packages/pipeline-cli/src/tools/ci-required/bin.ts` — no `pnpm install`
  * — so the always-on aggregator stays fast. Plain Node (no Effect import) for the
  * same reason: the Effect-CLI idiom would pull `@effect/platform-node` + `effect`
  * into the gate's install path.

--- a/packages/pipeline-cli/src/tools/ci-required/ci-required.ts
+++ b/packages/pipeline-cli/src/tools/ci-required/ci-required.ts
@@ -1,5 +1,5 @@
 /**
- * `@kampus/ci-required` core — the pure, IO-free verdict for the `ci-required`
+ * `ci-required` core — the pure, IO-free verdict for the `ci-required`
  * aggregator (issue #786, ADR 0092).
  *
  * `ci-required` is the single always-on status context the `main` ruleset

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
@@ -1,5 +1,5 @@
 /**
- * `@kampus/gh-phoenix` lint core — the pure, IO-free matchers that gate the skill
+ * `gh-phoenix` lint core — the pure, IO-free matchers that gate the skill
  * corpus. Two independent checks, both fail-closed on zero scope (ADR 0092):
  *
  *  1. GraphQL-path `gh` invocations (issue #743) — flags a reflexive `gh project`
@@ -97,7 +97,7 @@ const SELF_EXEMPT_SUFFIXES = [
 	"/skills/review-code/SKILL.md",
 	"/skills/ship-it/SKILL.md",
 	"/skills/gh-issue-intake-formats.md",
-	"/packages/gh-phoenix/README.md",
+	"/packages/pipeline-cli/src/tools/gh-phoenix/README.md",
 ] as const;
 
 const normalize = (path: string): string => `/${path.replace(/\\/g, "/").replace(/^\/+/, "")}`;

--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
@@ -1,5 +1,5 @@
 /**
- * `@kampus/gh-phoenix` router core — the pure, IO-free decision over a `gh`
+ * `gh-phoenix` router core — the pure, IO-free decision over a `gh`
  * argument vector. It is the shim that keeps a reflexive `gh pr edit` / `gh
  * project` from eating a Projects-classic GraphQL error on the kamp-us org
  * (issue #743): those verbs route to REST, classic-projects GraphQL fields are

--- a/packages/pipeline-cli/src/tools/main-sync/command.ts
+++ b/packages/pipeline-cli/src/tools/main-sync/command.ts
@@ -108,7 +108,7 @@ const treeHasTrackedModifications = (): boolean => {
 
 /**
  * The count of staged deletions under the instruction-trust prefixes — the #2778 signature (#2784),
- * classified with `@kampus/primary-index-tripwire`'s detection so main-sync's guaranteed refusal and
+ * classified with `primary-index-guard`'s tripwire detection so main-sync's guaranteed refusal and
  * the §CP `primary-index-guard` block share one definition. Indeterminate probe (command failed) ⇒ 0:
  * this count only ever TIGHTENS the guard (a positive count refuses), so a 0 fallback never
  * false-refuses; the incidental dirty checks still stand behind it.

--- a/packages/pipeline-cli/src/tools/primary-index-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/primary-index-guard/command.ts
@@ -1,7 +1,7 @@
 /**
  * The `primary-index-guard` tool — `pipeline-cli primary-index-guard pre-commit`.
  *
- * The BLOCKING §CP promotion of the read-only `@kampus/primary-index-tripwire` (PR #2783). Wired as
+ * The BLOCKING §CP promotion of the read-only `primary-index-tripwire` core (PR #2783). Wired as
  * git's own `pre-commit` hook (`lefthook.yml`), it fires as a commit carrying the #2778
  * mass-staged-deletion signature is CREATED on the PRIMARY checkout — the one caller-agnostic choke
  * point before a push can fast-forward that control-plane mass deletion onto `origin/main` (the

--- a/packages/pipeline-cli/src/tools/primary-index-guard/primary-index-guard.ts
+++ b/packages/pipeline-cli/src/tools/primary-index-guard/primary-index-guard.ts
@@ -1,6 +1,6 @@
 /**
  * `primary-index-guard` pure core — the BLOCKING §CP promotion of the read-only
- * `@kampus/primary-index-tripwire` (PR #2783). Decides whether a commit carrying the #2778
+ * `primary-index-tripwire` core (PR #2783). Decides whether a commit carrying the #2778
  * mass-staged-deletion signature (a mass control-plane staged deletion) against the PRIMARY
  * checkout is REFUSED. IO-free and total: a deterministic transform over already-gathered git
  * facts; the git boundary (staged-deletion probe, primary-checkout resolution) lives in

--- a/packages/pipeline-cli/src/tools/primary-index-guard/tripwire.ts
+++ b/packages/pipeline-cli/src/tools/primary-index-guard/tripwire.ts
@@ -1,5 +1,5 @@
 /**
- * `@kampus/primary-index-tripwire` pure core — decide whether a to-be-committed staged fileset
+ * `primary-index-guard` tripwire core — decide whether a to-be-committed staged fileset
  * carries the #2778 corruption signature (a mass staged-deletion of the instruction-trust set) and
  * build an attribution record naming WHO/WHERE is about to commit it.
  *

--- a/packages/pipeline-cli/src/tools/settings-env-guard/settings-env-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/settings-env-guard/settings-env-guard.unit.test.ts
@@ -12,7 +12,7 @@ import {type EnvEntry, findLiteralExpansions, judge, renderReport} from "./setti
 // ${...} token, so spelled-out fixtures would trip the rule on nearly every line.
 const brace = (name: string): string => `$\{${name}}`;
 const DATA_VALUE = `${brace("CLAUDE_PROJECT_DIR")}/.claude/.pipeline-cli-data`;
-const PATH_VALUE = `${brace("CLAUDE_PROJECT_DIR")}/packages/gh-phoenix/shim:/usr/bin:${brace("PATH")}`;
+const PATH_VALUE = `${brace("CLAUDE_PROJECT_DIR")}/packages/pipeline-cli/src/tools/gh-phoenix/shim:/usr/bin:${brace("PATH")}`;
 
 const entry = (key: string, value: string): EnvEntry => ({key, value});
 

--- a/packages/worker-relevance/src/bin.ts
+++ b/packages/worker-relevance/src/bin.ts
@@ -11,7 +11,7 @@
  * `integration_required`/`e2e_required` expressions can AND it in. Exits 0 always —
  * this is a classifier, not a gate; the workflow decides what to do with the verdict.
  *
- * ZERO runtime dependencies on purpose (the `@kampus/ci-required` idiom): the
+ * ZERO runtime dependencies on purpose (the `ci-required` idiom): the
  * `changes` job runs this with only checkout + setup-node + node — no `pnpm install`
  * — so the always-on changed-area detector stays fast. Plain Node (no Effect import)
  * for the same reason. The pure core (`classify` + `inputFromEnv` + the import


### PR DESCRIPTION
## What

Follow-up to #3805, which inlined the three former standalone packages `@kampus/ci-required`, `@kampus/gh-phoenix`, and `@kampus/primary-index-tripwire` into `packages/pipeline-cli/src/tools/` and deleted them — but left docblocks, a CI-invocation path, test fixtures, and cross-tool prose still naming them as standalone workspace members. This sweeps those stale references so nothing points at a deleted package. Pure doc-debt; no behavior change.

## Genuinely-stale references repointed (buckets 1/3/4/5)

- **Moved-file docblocks** — dropped the `@kampus/<pkg>` standalone-package framing so each reads as the pipeline-cli tool it now is:
  - `tools/gh-phoenix/lint.ts:2`, `tools/gh-phoenix/router.ts:2` → `gh-phoenix` lint/router core
  - `tools/ci-required/ci-required.ts:2` → `ci-required` core
  - `tools/primary-index-guard/{tripwire.ts:2, primary-index-guard.ts:3, command.ts:4}` → drop the `@kampus/primary-index-tripwire` package name (now the guard's tripwire/pure/tool cores)
- **CI-invocation path** — `tools/ci-required/bin.ts:8` repointed the present-tense CI path to `node packages/pipeline-cli/src/tools/ci-required/bin.ts`.
- **`module-load-guard`** — reworded the #2447 example to note `ci-required` was since inlined (`module-load-guard.ts`); swapped the self-heal test mock string to a neutral fixture `@kampus/example-workspace-dep` so the fixture never names a real package again (`module-load-guard.unit.test.ts`).
- **`settings-env-guard` fixture PATH** — repointed the shim segment to `packages/pipeline-cli/src/tools/gh-phoenix/shim` (`settings-env-guard.unit.test.ts:15`).
- **`gh-phoenix` lint self-exempt suffix** — repointed the dead `/packages/gh-phoenix/README.md` suffix to the tool-dir location (`tools/gh-phoenix/lint.ts`).
- **Cross-tool prose** — `worker-relevance/src/bin.ts` "the `ci-required` idiom"; `tools/main-sync/command.ts:111` "`primary-index-guard`'s tripwire detection".

Note: the formats-doc prose (`gh-issue-intake-formats.md`, the old bucket-1 line 1402–1403) was **already corrected in `main`** to describe the inline, so it needed no change here.

## Deliberately-retained forward-safe clauses (ADR 0100) — verifiably unchanged

None of these were touched by this PR (confirmed: not in the diff):

- `tools/control-plane-paths/control-plane-re.ts:42` — the `^packages/ci-required/` clause in `CONTROL_PLANE_RE`
- `gh-issue-intake-formats.md` — the mirrored `^packages/ci-required/` in the `CONTROL_PLANE_RE` copy
- `.github/CODEOWNERS:43` — `/packages/ci-required/  @kamp-us/control-plane`
- `tools/control-plane-paths/control-plane-paths.unit.test.ts:80` — the `packages/ci-required/src/bin.ts` assertion

These paths are retained on purpose (defense-in-depth against a re-created package at that path), per ADR 0100.

## Bucket 2 (ADRs 0100/0135/0187) — intentionally not amended

Per AC #2 and the `.decisions/` immutability convention, an ADR is not rewritten in place. Adding superseding/amendment notes to three ADRs for a purely cosmetic historical-package-name update is disproportionate: those ADRs correctly described the state at authoring time, the staleness is historical record (not live guidance), and the live guidance surfaces (the `CONTROL_PLANE_RE`, CODEOWNERS, and the formats doc) are already correct. Skipped with this rationale, which AC #2 sanctions.

## §CP

This PR **is control-plane** (touches `packages/pipeline-cli/**` and `packages/worker-relevance/**`) — it must be human-merged, not auto-shipped.

## Verification

- `pnpm install` — lockfile up to date, no changes.
- `pnpm typecheck` — 30/30 packages pass.
- Affected unit tests (`module-load-guard.unit.test.ts`, `settings-env-guard.unit.test.ts`) — 32/32 pass.

Fixes #3806
