### PR TITLE
chore(pipeline-cli): worktree-reap — safe reaper for worktrees orphaned by dead crew sessions (#3754)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -71,6 +71,7 @@ import {verdictCommand} from "./tools/verdict/command.ts";
 import {wayfinderMapCommand} from "./tools/wayfinder-map/command.ts";
 import {workflowContractCommand} from "./tools/workflow-contract/command.ts";
 import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
+import {worktreeReapCommand} from "./tools/worktree-reap/command.ts";
 import {worktreeSweepCommand} from "./tools/worktree-sweep/command.ts";
 import {versionCommand} from "./version.ts";
 
@@ -132,6 +133,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	structuredOutputGuardCommand,
 	workflowContractCommand,
 	worktreeSweepCommand,
+	worktreeReapCommand,
 	codeownersCpCommand,
 	controlPlanePathsCommand,
 	cpCardinalityCommand,

--- a/packages/pipeline-cli/src/tools/worktree-reap/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/command.ts
@@ -1,0 +1,253 @@
+/**
+ * The `worktree-reap` tool — `pipeline-cli worktree-reap [--execute]`.
+ *
+ * A safe reaper for agent worktrees orphaned by DEAD crew sessions (issue #3754). Dead
+ * sessions leave their `isolation:worktree` trees (and checked-out branches) behind under
+ * `.claude/worktrees/`, where they accumulate and block their branches from being
+ * re-checked-out elsewhere. This verb identifies trees whose owning SESSION is provably
+ * dead, and reclaims only the ones that hold nothing recoverable.
+ *
+ * Eligibility is session-presence-based, never age-based (ADR 0191). The presence signal
+ * is the owning process the harness stamps into each agent worktree's git lock reason —
+ * `claude agent <id> (pid <N> start <date>)` (surfaced by `git worktree list --porcelain`
+ * as the `locked <reason>` line). That pid is the top-level crew session process; a worktree
+ * is orphan-eligible ONLY when its pid is provably not running (`process.kill(pid, 0)` →
+ * ESRCH). This is the deliberate contrast with the age-based `worktree-sweep` (mtime-idle,
+ * #2240): a genuinely idle-but-live session is spared here because its process still resolves.
+ *
+ * Safe by construction (enforcement lines):
+ *   1. The pure classifier (`worktree-reap.ts`) marks a worktree reapable ONLY when its
+ *      session is dead AND the tree is clean (no uncommitted changes) AND all its commits
+ *      have landed on `origin/main` (no unpushed work). A dirty / unpushed / live tree is
+ *      KEPT and named in the report, never destroyed. Every fact fails safe toward KEEP.
+ *   2. Reclaim is `git worktree unlock` (justified — the session is proven dead, so the
+ *      pid-lock is stale) followed by `git worktree remove` WITHOUT `--force`. Git itself
+ *      refuses a tree it judges unsafe (dirty/current) even after unlock, and that refusal
+ *      is caught and reported as KEPT, never escalated to `--force`. The unlock is scoped to
+ *      trees the classifier already proved dead+clean, so it never frees a live lane's lock.
+ *
+ * DRY-RUN by default: with no flag it prints what it WOULD reap / keep-dirty / spare and
+ * exits 0 without touching anything. The git IO uses `execFileSync` directly (mirrors
+ * `worktree-sweep`), so the tool's requirement stays at the Node platform ceiling the
+ * registry provides.
+ */
+import {execFileSync} from "node:child_process";
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {
+	computeWorktreeReapPlan,
+	isManagedAgentWorktree,
+	parseAgentLockOwner,
+	parseWorktreeList,
+	type ReapCandidate,
+} from "./worktree-reap.ts";
+
+interface GitResult {
+	readonly ok: boolean;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const runGit = (args: ReadonlyArray<string>): GitResult => {
+	// biome-ignore lint/plugin: best-effort git shell — a non-zero exit is fully absorbed into a {ok:false} GitResult the caller branches on, never the E channel; a total helper, not Effect-cosplay.
+	try {
+		const stdout = execFileSync("git", [...args], {encoding: "utf8"});
+		return {ok: true, stdout, stderr: ""};
+	} catch (cause) {
+		const e = cause as {stdout?: Buffer | string; stderr?: Buffer | string};
+		return {ok: false, stdout: String(e.stdout ?? ""), stderr: String(e.stderr ?? "")};
+	}
+};
+
+/**
+ * Is the owning session's process still running (ADR 0191 presence)? `process.kill(pid, 0)`
+ * sends no signal — it only probes existence: it returns cleanly when the pid resolves, throws
+ * `ESRCH` when it does not, and throws `EPERM` when the pid exists but is owned by another user.
+ * Only `ESRCH` proves the session dead; every other outcome (alive, EPERM, or an unexpected
+ * error) fails safe toward ALIVE → the worktree is SPARED. A reused pid therefore also reads
+ * alive — erring toward keeping a tree, never toward reaping a live one.
+ */
+const pidAlive = (pid: number): boolean => {
+	// biome-ignore lint/plugin: best-effort existence probe — `process.kill(pid, 0)` signals nothing and throws only to report absence (ESRCH); the throw is absorbed into a plain boolean the caller branches on, never the E channel. A total helper, not Effect-cosplay.
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (cause) {
+		return (cause as {code?: string}).code !== "ESRCH";
+	}
+};
+
+/** `git status --porcelain` non-empty ⇒ uncommitted. Indeterminate (command failed) ⇒ uncommitted (fail-safe KEEP). */
+const worktreeHasUncommitted = (path: string): boolean => {
+	const r = runGit(["-C", path, "status", "--porcelain"]);
+	if (!r.ok) return true;
+	return r.stdout.trim() !== "";
+};
+
+/**
+ * Is `head` reachable from `origin/main`? `git merge-base --is-ancestor` exits 0 when it is,
+ * 1 when not, and non-zero (128) when a ref can't be resolved — all non-zero cases collapse to
+ * "not reachable", which reads as unpushed (KEEP). So a missing `origin/main` fails safe.
+ */
+const reachableFromOriginMain = (head: string | null): boolean => {
+	if (head === null) return false;
+	return runGit(["merge-base", "--is-ancestor", head, "origin/main"]).ok;
+};
+
+/**
+ * Has `head`'s content already squash-merged into `origin/main`? A squash merge (ADR 0048)
+ * rewrites the branch's commits into one new commit, so the tip is NOT a commit-ancestor and
+ * `--is-ancestor` misses it (#1328). Detect it by patch-id equivalence: synthesize one dangling
+ * commit carrying the branch's cumulative diff against its merge-base with `origin/main`, then
+ * ask `git cherry` whether that change already exists upstream (`-` prefix ⇒ equivalent). Every
+ * git failure collapses to `false` (fail-safe: reads as unpushed → KEEP).
+ */
+const squashMergedToOriginMain = (head: string | null): boolean => {
+	if (head === null) return false;
+	const base = runGit(["merge-base", "origin/main", head]);
+	if (!base.ok) return false;
+	const tree = runGit(["rev-parse", `${head}^{tree}`]);
+	if (!tree.ok) return false;
+	const dangling = runGit(["commit-tree", tree.stdout.trim(), "-p", base.stdout.trim(), "-m", "_"]);
+	if (!dangling.ok) return false;
+	const cherry = runGit(["cherry", "origin/main", dangling.stdout.trim()]);
+	if (!cherry.ok) return false;
+	return cherry.stdout.trimStart().startsWith("-");
+};
+
+/**
+ * Does the tree hold unpushed commits — work not yet landed on `origin/main`? True unless its
+ * HEAD content is reachable (a non-squash merge / merged commit) OR squash-merged. This is the
+ * committed-work guard `git worktree remove` does NOT provide (the no-`--force` line only guards
+ * UNcommitted changes) — it is what spares the #3754 observed case: a tree checked out at an
+ * unpushed base. Fail-safe: an unresolvable ancestry reads unpushed → KEEP.
+ */
+const hasUnpushed = (head: string | null): boolean =>
+	!(reachableFromOriginMain(head) || squashMergedToOriginMain(head));
+
+const executeFlag = Flag.boolean("execute").pipe(
+	Flag.withDescription("actually reap the orphaned worktrees (default: dry-run, print only)"),
+);
+
+const reasonLine = (path: string, reason: string): string => `  ${reason.padEnd(14)} ${path}`;
+
+const worktreeReap = Command.make(
+	"worktree-reap",
+	{execute: executeFlag},
+	Effect.fn(function* ({execute}) {
+		const listed = runGit(["worktree", "list", "--porcelain"]);
+		if (!listed.ok) {
+			yield* Console.error(
+				`worktree-reap: \`git worktree list\` failed — ${listed.stderr.trim() || "is this a git repo?"}`,
+			);
+			return yield* Effect.sync(() => process.exit(1));
+		}
+
+		const parsed = parseWorktreeList(listed.stdout);
+		const candidates: ReadonlyArray<ReapCandidate> = parsed
+			.filter((p) => !p.bare)
+			.map((p) => {
+				// Only a managed agent worktree with a provable crew-agent owner is probed for facts —
+				// everything else short-circuits to a SPARE record (the classifier never consults the
+				// other fields for it), so no `git status` / ancestry / pid probe fires on the primary
+				// checkout or a foreign tree.
+				const owner = isManagedAgentWorktree(p.path) ? parseAgentLockOwner(p.lockReason) : null;
+				if (owner === null) {
+					return {
+						path: p.path,
+						branch: p.branch,
+						owner: null,
+						hasUncommitted: false,
+						hasUnpushed: false,
+					};
+				}
+				const alive = pidAlive(owner.pid);
+				// A LIVE session is spared regardless of tree state, so skip the costlier status/ancestry
+				// probes for it — only a dead-session tree needs its recoverable-work facts gathered.
+				if (alive) {
+					return {
+						path: p.path,
+						branch: p.branch,
+						owner: {pid: owner.pid, alive: true},
+						hasUncommitted: false,
+						hasUnpushed: false,
+					};
+				}
+				return {
+					path: p.path,
+					branch: p.branch,
+					owner: {pid: owner.pid, alive: false},
+					hasUncommitted: worktreeHasUncommitted(p.path),
+					hasUnpushed: hasUnpushed(p.head),
+				};
+			});
+
+		const plan = computeWorktreeReapPlan(candidates);
+
+		// ADR 0092 "emit what you scanned": the full plan is observable before any action.
+		yield* Console.log(
+			`worktree-reap: ${candidates.length} worktree(s) scanned — ${plan.toReap.length} orphaned-clean (reapable), ${plan.keptDirty.length} kept-dirty, ${plan.spared.length} spared${execute ? " (EXECUTE)" : " (dry-run)"}`,
+		);
+		if (plan.spared.length > 0) {
+			yield* Console.log("spared:");
+			for (const s of plan.spared) yield* Console.log(reasonLine(s.worktree.path, s.reason));
+		}
+		if (plan.keptDirty.length > 0) {
+			yield* Console.log("kept-dirty (holds recoverable work — never reaped):");
+			for (const k of plan.keptDirty) yield* Console.log(reasonLine(k.worktree.path, k.reason));
+		}
+		if (plan.toReap.length > 0) {
+			yield* Console.log("orphaned-clean (reapable):");
+			for (const r of plan.toReap)
+				yield* Console.log(reasonLine(r.worktree.path, `pid ${r.worktree.owner?.pid ?? "?"} dead`));
+		}
+
+		if (!execute) {
+			yield* Console.log("  (dry-run — pass --execute to reap; nothing touched)");
+			return;
+		}
+
+		let reaped = 0;
+		let refused = 0;
+		const freedBranches: Array<string> = [];
+		for (const r of plan.toReap) {
+			const path = r.worktree.path;
+			// The tree is locked with a stale pid-lock (its session is proven dead). Unlock it —
+			// scoped to this classified-dead+clean tree — so the non-forced remove can proceed. This
+			// unlock never touches a live lane: a live session was spared before ever reaching here.
+			const unlocked = runGit(["worktree", "unlock", path]);
+			if (!unlocked.ok) {
+				// An already-unlocked tree reports failure here; that is benign — proceed to remove.
+				const stderr = unlocked.stderr.trim();
+				if (stderr && !/not locked/i.test(stderr)) {
+					yield* Console.error(`  unlock warning ${path} — ${stderr}`);
+				}
+			}
+			// NEVER --force: git refuses a tree it judges unsafe, and we KEEP it (report, don't escalate).
+			const removed = runGit(["worktree", "remove", path]);
+			if (removed.ok) {
+				reaped += 1;
+				if (r.worktree.branch !== null) freedBranches.push(r.worktree.branch);
+				yield* Console.log(
+					`  reaped ${path}${r.worktree.branch !== null ? ` (freed branch ${r.worktree.branch})` : ""}`,
+				);
+			} else {
+				refused += 1;
+				yield* Console.error(
+					`  KEPT (git refused, never --force) ${path} — ${removed.stderr.trim()}`,
+				);
+			}
+		}
+		yield* Console.log(
+			`worktree-reap: reaped ${reaped}, kept ${plan.keptDirty.length + refused}, spared ${plan.spared.length}` +
+				(refused > 0 ? ` (${refused} reapable but refused by git → kept)` : "") +
+				(freedBranches.length > 0 ? ` — freed branches: ${freedBranches.join(", ")}` : ""),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Safe reaper for agent worktrees orphaned by DEAD crew sessions — session-presence-based (ADR 0191), clean+pushed only, never --force (#3754)",
+	),
+);
+
+export const worktreeReapCommand = worktreeReap;

--- a/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.ts
@@ -1,0 +1,249 @@
+/**
+ * `worktree-reap` pure core — classify each managed agent worktree into REAP /
+ * KEEP-DIRTY / SPARE with a reason, for the safe reaping of worktrees orphaned by
+ * DEAD crew sessions (issue #3754). IO-free and total: every decision is a
+ * deterministic transform over already-gathered facts. The git + process boundary
+ * (enumerate / status / ancestry / pid-liveness / unlock+remove) lives in
+ * `command.ts`; this module never runs a command and never removes anything.
+ *
+ * Eligibility is SESSION-PRESENCE-based, never age-based (issue #3754 AC; ADR 0191 —
+ * a resource claim's liveness rides its holder's presence). The presence signal is
+ * grounded in an observable git fact: the harness locks each agent worktree with a
+ * reason that embeds the owning session's process — `claude agent <id> (pid <N>
+ * start <date>)` (git worktree list --porcelain surfaces it as the `locked <reason>`
+ * line). That pid is the top-level crew SESSION process shared by all worktrees it
+ * provisioned; when it dies the session is gone and its worktrees are orphaned. A
+ * worktree is reap-eligible ONLY when that owning pid is provably not running — the
+ * presence-derived liveness ADR 0191 mandates, not an mtime idle window (the
+ * distinction from the age-based `worktree-sweep`, #2240).
+ *
+ * The safety property is the whole point (issue #3754 AC; MEMORY "Safe worktree
+ * prune"): a worktree is reaped ONLY when its owning session is DEAD *and* the tree
+ * holds nothing recoverable — no uncommitted changes AND no unpushed commits. A dirty
+ * or unpushed tree is KEPT (surfaced in the report as kept-dirty), never `--force`d.
+ * Every fact fails safe toward KEEP: an unprovable owner reads SPARE (never reaped), an
+ * indeterminate status reads uncommitted, an unresolvable ancestry reads unpushed, a
+ * pid that still resolves (incl. a reused pid) reads alive → spared. `git worktree
+ * remove` *without* `--force` is the second enforcement line in `command.ts`; this
+ * core only chooses WHETHER to attempt the remove, and never escalates to a forced one.
+ */
+
+/** The segment that marks a harness-managed agent worktree: `<main>/.claude/worktrees/<id>`. */
+const MANAGED_SEGMENT = "/.claude/worktrees/";
+
+/** True when the path is a managed agent worktree — never the primary checkout, never a foreign tree. */
+export const isManagedAgentWorktree = (path: string): boolean =>
+	path.replace(/\\/g, "/").includes(MANAGED_SEGMENT);
+
+/**
+ * The owning session parsed off a worktree's git lock reason. `pid` is the top-level
+ * crew session process the harness stamped into the lock (`claude agent <id> (pid <N>
+ * …)`); its liveness IS the session's presence (ADR 0191).
+ */
+export interface AgentLockOwner {
+	readonly pid: number;
+}
+
+/**
+ * Parse the owning session pid out of a worktree lock reason. Returns the owner ONLY
+ * for a harness-written crew-agent lock (`claude agent … (pid <N> …)`) — an operator's
+ * manual `git worktree lock` with a bespoke reason, an unlocked tree (`null` reason), or
+ * a reason with no parseable pid all yield `null`, so a worktree whose owner cannot be
+ * proven is never treated as orphaned (fail-safe SPARE). Keying on the `claude agent`
+ * prefix is deliberate: it refuses to read a pid out of a lock this reaper did not author,
+ * so a human-pinned worktree is left alone.
+ */
+export const parseAgentLockOwner = (lockReason: string | null): AgentLockOwner | null => {
+	if (lockReason === null) return null;
+	if (!/^claude agent\b/.test(lockReason.trim())) return null;
+	const m = lockReason.match(/\bpid\s+(\d+)\b/);
+	if (m === null || m[1] === undefined) return null;
+	const pid = Number.parseInt(m[1], 10);
+	return Number.isFinite(pid) && pid > 0 ? {pid} : null;
+};
+
+/**
+ * One worktree reduced to exactly the facts the decision needs. `owner` is the parsed
+ * session with its liveness already probed at the boundary (`null` when no crew-agent
+ * owner is provable). `hasUncommitted` (git status dirty) and `hasUnpushed` (commits not
+ * yet landed on `origin/main`) are gathered at the git boundary, both fail-safe toward
+ * KEEP: an indeterminate status reads uncommitted, an unresolvable ancestry reads unpushed.
+ */
+export interface ReapCandidate {
+	readonly path: string;
+	/** Short branch name, or `null` for a detached HEAD. Reported as the freed branch on a reap. */
+	readonly branch: string | null;
+	/**
+	 * The parsed owning session AND its probed liveness, or `null` when no crew-agent owner is
+	 * provable from the lock (unlocked, operator-locked, or unparseable). `alive` is the boundary's
+	 * `pid`-presence probe: it reads TRUE unless the pid is provably gone (a still-resolving or
+	 * reused pid fails safe toward alive → SPARE).
+	 */
+	readonly owner: (AgentLockOwner & {readonly alive: boolean}) | null;
+	readonly hasUncommitted: boolean;
+	readonly hasUnpushed: boolean;
+}
+
+/** Why a worktree is SPARED — never a candidate this run, or its session is still live. */
+export type SpareReason =
+	/** Not under `.claude/worktrees/` — the primary checkout or a foreign tree; never touched. */
+	| "not-managed"
+	/** No crew-agent owner is provable from the lock (unlocked, operator-locked, unparseable) — can't prove orphaned. */
+	| "owner-unknown"
+	/** The owning session's process is still running — a LIVE lane; spared (the ADR 0191 presence gate). */
+	| "live-session";
+
+/** Why an orphan is KEPT despite a dead session — it holds recoverable work; never destroyed. */
+export type KeepDirtyReason =
+	/** Uncommitted/untracked changes present — kept, never `--force` (unpushed work is sacred). */
+	| "uncommitted"
+	/** Committed work not yet landed on `origin/main` — kept, never destroyed (the #3754 observed case). */
+	| "unpushed";
+
+export type ReapDecision =
+	| {readonly kind: "spare"; readonly reason: SpareReason}
+	| {readonly kind: "keep-dirty"; readonly reason: KeepDirtyReason}
+	| {readonly kind: "reap"; readonly reason: "orphan-clean"};
+
+/**
+ * Classify a single worktree. The order of checks IS the safety policy:
+ *
+ *   1. Not a managed agent worktree → SPARE (`not-managed`). The primary checkout and any
+ *      foreign tree are never candidates, regardless of their other facts.
+ *   2. No provable crew-agent owner → SPARE (`owner-unknown`). Without a parseable owning
+ *      pid the session's liveness cannot be established, so orphanhood is unprovable — never
+ *      reap what we cannot prove dead.
+ *   3. Owning session ALIVE → SPARE (`live-session`). The ADR 0191 presence gate: a running
+ *      owner pid means a live lane; spared even when the tree is clean.
+ *   4. (Dead session) uncommitted → KEEP-DIRTY (`uncommitted`). Recoverable working-tree work.
+ *   5. (Dead session) unpushed → KEEP-DIRTY (`unpushed`). Committed work not on `origin/main`.
+ *   6. Otherwise → REAP (`orphan-clean`). Dead session, clean tree, all commits landed —
+ *      nothing recoverable to strand.
+ */
+export const classifyCandidate = (c: ReapCandidate): ReapDecision => {
+	if (!isManagedAgentWorktree(c.path)) {
+		return {kind: "spare", reason: "not-managed"};
+	}
+	if (c.owner === null) {
+		return {kind: "spare", reason: "owner-unknown"};
+	}
+	if (c.owner.alive) {
+		return {kind: "spare", reason: "live-session"};
+	}
+	if (c.hasUncommitted) {
+		return {kind: "keep-dirty", reason: "uncommitted"};
+	}
+	if (c.hasUnpushed) {
+		return {kind: "keep-dirty", reason: "unpushed"};
+	}
+	return {kind: "reap", reason: "orphan-clean"};
+};
+
+export interface PlannedReap {
+	readonly worktree: ReapCandidate;
+}
+
+export interface PlannedKeepDirty {
+	readonly worktree: ReapCandidate;
+	readonly reason: KeepDirtyReason;
+}
+
+export interface PlannedSpare {
+	readonly worktree: ReapCandidate;
+	readonly reason: SpareReason;
+}
+
+export interface WorktreeReapPlan {
+	readonly toReap: ReadonlyArray<PlannedReap>;
+	readonly keptDirty: ReadonlyArray<PlannedKeepDirty>;
+	readonly spared: ReadonlyArray<PlannedSpare>;
+}
+
+/** Fold the per-worktree decisions into the reap / kept-dirty / spared partition (the plan). */
+export const computeWorktreeReapPlan = (
+	candidates: ReadonlyArray<ReapCandidate>,
+): WorktreeReapPlan => {
+	const toReap: Array<PlannedReap> = [];
+	const keptDirty: Array<PlannedKeepDirty> = [];
+	const spared: Array<PlannedSpare> = [];
+	for (const worktree of candidates) {
+		const decision = classifyCandidate(worktree);
+		if (decision.kind === "reap") {
+			toReap.push({worktree});
+		} else if (decision.kind === "keep-dirty") {
+			keptDirty.push({worktree, reason: decision.reason});
+		} else {
+			spared.push({worktree, reason: decision.reason});
+		}
+	}
+	return {toReap, keptDirty, spared};
+};
+
+/** One parsed `git worktree list --porcelain` block, before the IO facts are gathered. */
+export interface ParsedWorktree {
+	readonly path: string;
+	readonly head: string | null;
+	/** Short branch name (`refs/heads/<x>` → `<x>`), or `null` for a detached/bare worktree. */
+	readonly branch: string | null;
+	readonly bare: boolean;
+	/**
+	 * The lock reason: `null` when the tree is NOT locked, `""` when locked with no reason,
+	 * or the reason string (`claude agent <id> (pid <N> …)` for a harness-provisioned tree).
+	 * The reason — not a mere locked boolean — is what carries the owning session's pid, so it
+	 * is preserved here rather than collapsed to a flag (the age-based sweep discards it).
+	 */
+	readonly lockReason: string | null;
+}
+
+/**
+ * Parse `git worktree list --porcelain` into one record per worktree. Blocks are
+ * separated by a blank line; each carries a `worktree <path>` line, then optional
+ * `HEAD <sha>`, `branch refs/heads/<name>` | `detached`, `bare`, `locked [<reason>]`
+ * lines. Pure — the IO that produced the text lives in `command.ts`.
+ */
+export const parseWorktreeList = (porcelain: string): ReadonlyArray<ParsedWorktree> => {
+	const out: Array<ParsedWorktree> = [];
+	let path: string | null = null;
+	let head: string | null = null;
+	let branch: string | null = null;
+	let bare = false;
+	let lockReason: string | null = null;
+
+	const flush = () => {
+		if (path !== null) {
+			out.push({path, head, branch, bare, lockReason});
+		}
+		path = null;
+		head = null;
+		branch = null;
+		bare = false;
+		lockReason = null;
+	};
+
+	for (const raw of porcelain.split("\n")) {
+		const line = raw.trimEnd();
+		if (line === "") {
+			flush();
+			continue;
+		}
+		if (line.startsWith("worktree ")) {
+			// A new block may start without a preceding blank line — flush the prior one.
+			flush();
+			path = line.slice("worktree ".length);
+		} else if (line.startsWith("HEAD ")) {
+			head = line.slice("HEAD ".length);
+		} else if (line.startsWith("branch ")) {
+			branch = line.slice("branch ".length).replace(/^refs\/heads\//, "");
+		} else if (line === "detached") {
+			branch = null;
+		} else if (line === "bare") {
+			bare = true;
+		} else if (line === "locked") {
+			lockReason = "";
+		} else if (line.startsWith("locked ")) {
+			lockReason = line.slice("locked ".length);
+		}
+	}
+	flush();
+	return out;
+};

--- a/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-reap/worktree-reap.unit.test.ts
@@ -1,0 +1,237 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	classifyCandidate,
+	computeWorktreeReapPlan,
+	isManagedAgentWorktree,
+	parseAgentLockOwner,
+	parseWorktreeList,
+	type ReapCandidate,
+} from "./worktree-reap.ts";
+
+const MAIN = "/Users/dev/phoenix";
+const wtPath = (id: string) => `${MAIN}/.claude/worktrees/${id}`;
+
+/** A dead-session, clean, all-pushed candidate — the reapable shape. Override per case. */
+const candidate = (over: Partial<ReapCandidate> = {}): ReapCandidate => ({
+	path: wtPath("agent-dead"),
+	branch: "umut/1234-thing",
+	owner: {pid: 4242, alive: false},
+	hasUncommitted: false,
+	hasUnpushed: false,
+	...over,
+});
+
+describe("isManagedAgentWorktree", () => {
+	it("matches a path under .claude/worktrees/", () => {
+		assert.isTrue(isManagedAgentWorktree(wtPath("agent-a")));
+	});
+
+	it("rejects the primary checkout and foreign trees", () => {
+		assert.isFalse(isManagedAgentWorktree(MAIN));
+		assert.isFalse(isManagedAgentWorktree("/Users/dev/wt-issue-99"));
+		assert.isFalse(isManagedAgentWorktree(""));
+	});
+
+	it("normalizes backslash separators (windows-shaped path)", () => {
+		assert.isTrue(isManagedAgentWorktree("C:\\Users\\dev\\phoenix\\.claude\\worktrees\\agent-a"));
+	});
+});
+
+describe("parseAgentLockOwner — the session-presence signal (pid off the harness lock reason)", () => {
+	it("extracts the owning pid from a harness crew-agent lock reason", () => {
+		const owner = parseAgentLockOwner(
+			"claude agent agent-aa838a5704e05b5b3 (pid 58975 start Fri Jul 24 06:51:03 2026)",
+		);
+		assert.deepStrictEqual(owner, {pid: 58975});
+	});
+
+	it("returns null for an unlocked tree (null reason) — owner unprovable", () => {
+		assert.isNull(parseAgentLockOwner(null));
+	});
+
+	it("returns null for a locked-with-no-reason tree (empty string)", () => {
+		assert.isNull(parseAgentLockOwner(""));
+	});
+
+	it("returns null for an operator's manual lock — never read a pid out of a foreign lock", () => {
+		// A human `git worktree lock --reason "pinned for debugging (pid 999)"` must NOT be parsed as
+		// a crew-agent owner, even though it contains a `pid` token: it lacks the `claude agent` prefix.
+		assert.isNull(parseAgentLockOwner("pinned for debugging (pid 999)"));
+		assert.isNull(parseAgentLockOwner("do not remove"));
+	});
+
+	it("returns null for a crew-agent lock with no parseable pid", () => {
+		assert.isNull(parseAgentLockOwner("claude agent agent-x (started, no pid recorded)"));
+	});
+
+	it("rejects a non-positive / zero pid", () => {
+		assert.isNull(parseAgentLockOwner("claude agent agent-x (pid 0 start now)"));
+	});
+});
+
+describe("classifyCandidate — the #3754 safety policy (dead+clean → reap; dead+dirty → kept; live → spared)", () => {
+	it("DEAD session + clean + all pushed → REAP (orphan reclaimed)", () => {
+		const d = classifyCandidate(candidate());
+		assert.strictEqual(d.kind, "reap");
+	});
+
+	it("LIVE session → SPARED even when the tree is clean (the ADR 0191 presence gate)", () => {
+		const d = classifyCandidate(candidate({owner: {pid: 4242, alive: true}}));
+		assert.deepStrictEqual(d, {kind: "spare", reason: "live-session"});
+	});
+
+	it("LIVE session with dirty work → still SPARED (liveness precedes the work checks)", () => {
+		const d = classifyCandidate(
+			candidate({owner: {pid: 4242, alive: true}, hasUncommitted: true, hasUnpushed: true}),
+		);
+		assert.deepStrictEqual(d, {kind: "spare", reason: "live-session"});
+	});
+
+	it("DEAD session + UNCOMMITTED work → KEEP-DIRTY, never reaped", () => {
+		const d = classifyCandidate(candidate({hasUncommitted: true}));
+		assert.deepStrictEqual(d, {kind: "keep-dirty", reason: "uncommitted"});
+	});
+
+	it("DEAD session + UNPUSHED commits → KEEP-DIRTY, never reaped (the #3754 observed case)", () => {
+		const d = classifyCandidate(candidate({hasUnpushed: true}));
+		assert.deepStrictEqual(d, {kind: "keep-dirty", reason: "unpushed"});
+	});
+
+	it("uncommitted is reported ahead of unpushed when both hold", () => {
+		const d = classifyCandidate(candidate({hasUncommitted: true, hasUnpushed: true}));
+		assert.deepStrictEqual(d, {kind: "keep-dirty", reason: "uncommitted"});
+	});
+
+	it("owner unprovable (null) → SPARED (owner-unknown), never reaped — can't prove orphaned", () => {
+		const d = classifyCandidate(candidate({owner: null}));
+		assert.deepStrictEqual(d, {kind: "spare", reason: "owner-unknown"});
+	});
+
+	it("owner unprovable wins even on a clean tree — no age fallback, no reap without a dead-session proof", () => {
+		const d = classifyCandidate(
+			candidate({owner: null, hasUncommitted: false, hasUnpushed: false}),
+		);
+		assert.strictEqual(d.kind, "spare");
+	});
+
+	it("non-managed path → SPARED (not-managed), never touched — even with a dead owner + clean tree", () => {
+		const d = classifyCandidate(
+			candidate({path: "/Users/dev/some/bespoke/wt", owner: {pid: 4242, alive: false}}),
+		);
+		assert.deepStrictEqual(d, {kind: "spare", reason: "not-managed"});
+	});
+});
+
+describe("computeWorktreeReapPlan — partitions into reap / kept-dirty / spared", () => {
+	it("routes each candidate to exactly one bucket", () => {
+		const reapable = candidate({path: wtPath("agent-reap")});
+		const dirty = candidate({path: wtPath("agent-dirty"), hasUncommitted: true});
+		const unpushed = candidate({path: wtPath("agent-unpushed"), hasUnpushed: true});
+		const live = candidate({path: wtPath("agent-live"), owner: {pid: 7, alive: true}});
+		const unknown = candidate({path: wtPath("agent-unknown"), owner: null});
+		const foreign = candidate({path: "/Users/dev/other-wt"});
+
+		const plan = computeWorktreeReapPlan([reapable, dirty, unpushed, live, unknown, foreign]);
+
+		assert.deepStrictEqual(
+			plan.toReap.map((r) => r.worktree.path),
+			[wtPath("agent-reap")],
+		);
+		assert.deepStrictEqual(
+			plan.keptDirty.map((k) => [k.worktree.path, k.reason]),
+			[
+				[wtPath("agent-dirty"), "uncommitted"],
+				[wtPath("agent-unpushed"), "unpushed"],
+			],
+		);
+		assert.deepStrictEqual(
+			plan.spared.map((s) => [s.worktree.path, s.reason]),
+			[
+				[wtPath("agent-live"), "live-session"],
+				[wtPath("agent-unknown"), "owner-unknown"],
+				["/Users/dev/other-wt", "not-managed"],
+			],
+		);
+	});
+
+	it("empty input → empty plan (fail-closed on zero scope: nothing reaped)", () => {
+		const plan = computeWorktreeReapPlan([]);
+		assert.deepStrictEqual(plan, {toReap: [], keptDirty: [], spared: []});
+	});
+});
+
+describe("parseWorktreeList — preserves the lock reason (the age-based sweep discards it)", () => {
+	it("captures path, HEAD, branch, and the crew-agent lock reason", () => {
+		const porcelain = [
+			"worktree /Users/dev/phoenix",
+			"HEAD 0420fedbc175d8f2bfd4ada19acec6f729e3d5bc",
+			"branch refs/heads/main",
+			"",
+			"worktree /Users/dev/phoenix/.claude/worktrees/agent-dead",
+			"HEAD d904a06b086a2bfdda5862b6fa0165271a6832dc",
+			"branch refs/heads/worktree-agent-dead",
+			"locked claude agent agent-dead (pid 58975 start Fri Jul 24 06:51:03 2026)",
+			"",
+		].join("\n");
+
+		const parsed = parseWorktreeList(porcelain);
+		assert.strictEqual(parsed.length, 2);
+		const [primary, agent] = parsed;
+		assert.deepStrictEqual(primary, {
+			path: "/Users/dev/phoenix",
+			head: "0420fedbc175d8f2bfd4ada19acec6f729e3d5bc",
+			branch: "main",
+			bare: false,
+			lockReason: null,
+		});
+		assert.strictEqual(
+			agent?.lockReason,
+			"claude agent agent-dead (pid 58975 start Fri Jul 24 06:51:03 2026)",
+		);
+	});
+
+	it("distinguishes unlocked (null), locked-no-reason (''), and detached", () => {
+		const porcelain = [
+			"worktree /wt/detached-locked",
+			"HEAD abc",
+			"detached",
+			"locked",
+			"",
+			"worktree /wt/plain",
+			"HEAD def",
+			"branch refs/heads/feature",
+			"",
+		].join("\n");
+
+		const parsed = parseWorktreeList(porcelain);
+		const [detachedLocked, plain] = parsed;
+		assert.strictEqual(detachedLocked?.branch, null);
+		assert.strictEqual(detachedLocked?.lockReason, "");
+		assert.strictEqual(plain?.lockReason, null);
+	});
+
+	it("end-to-end: a locked dead-session block parses into a reapable candidate shape", () => {
+		// The lock reason → owner pid path the command boundary walks, exercised purely.
+		const parsed = parseWorktreeList(
+			[
+				"worktree /Users/dev/phoenix/.claude/worktrees/agent-dead",
+				"HEAD d904a06b086a2bfdda5862b6fa0165271a6832dc",
+				"branch refs/heads/worktree-agent-dead",
+				"locked claude agent agent-dead (pid 4242 start Fri Jul 24 06:51:03 2026)",
+			].join("\n"),
+		);
+		const block = parsed[0];
+		if (block === undefined) throw new Error("expected one parsed worktree block");
+		const owner = parseAgentLockOwner(block.lockReason);
+		assert.deepStrictEqual(owner, {pid: 4242});
+		// With a dead pid gathered at the boundary, this is the reapable classification.
+		const d = classifyCandidate({
+			path: block.path,
+			branch: block.branch,
+			owner: owner === null ? null : {...owner, alive: false},
+			hasUncommitted: false,
+			hasUnpushed: false,
+		});
+		assert.strictEqual(d.kind, "reap");
+	});
+});


### PR DESCRIPTION
Fixes #3754

## What

Adds `pipeline-cli worktree-reap [--execute]` — a safe reaper for agent worktrees left behind by DEAD crew sessions. Dead `isolation:worktree` sessions leave their trees (and checked-out branches) under `.claude/worktrees/`, where they accumulate and block their branches from being re-checked-out elsewhere. This verb reclaims only trees it can PROVE are orphaned AND that hold nothing recoverable.

## Eligibility is session-presence-based, never age-based (ADR 0191)

The presence signal is grounded in an observable git fact: the harness locks each agent worktree with a reason that embeds the owning session process — `claude agent <id> (pid <N> start <date>)` — surfaced by `git worktree list --porcelain` as the `locked <reason>` line. That pid is the top-level crew **session** process shared by the worktrees it provisioned; a worktree is orphan-eligible ONLY when that pid is provably not running (`process.kill(pid, 0)` → `ESRCH`). A still-resolving (or reused) pid reads alive and is spared. This is the deliberate contrast with the mtime-idle `worktree-sweep` (#2240): a genuinely idle-but-live session is spared here because its process still resolves.

## Safety is load-bearing — never `--force`

- The pure classifier (`worktree-reap.ts`) marks a tree reapable ONLY when its session is **dead** AND the tree is **clean** (no uncommitted changes) AND **all commits landed** on `origin/main` (no unpushed work). A dirty OR unpushed tree is **kept-dirty and named in the report**, never destroyed — the #3754 observed instance was a tree checked out at an unpushed base, which this keeps.
- Reclaim **unlocks** the stale pid-lock (justified — the session is proven dead), then runs `git worktree remove` **WITHOUT `--force`**. Git's own refusal of an unsafe tree is caught and reported as KEPT, never escalated. Every fact fails safe toward KEEP; an unprovable owner is spared, never reaped.
- **Dry-run by default**: with no flag it prints the reap / kept-dirty / spared plan and touches nothing.

## Shape

Pure core + thin Effect bin (the `epic-ledger`/`leak-guard` idiom). Registered in `registry.ts` (single append).

## Tests

23 unit tests: eligibility (owner-pid parse off the lock reason; operator/foreign locks refused), `dead+clean → reaped`, `dead+uncommitted → kept`, `dead+unpushed → kept`, `live-session → spared`, `owner-unknown → spared` (no age fallback), `not-managed → spared`, the plan partition, and the `git worktree list --porcelain` lock-reason parse (unlocked vs locked-no-reason vs the crew-agent reason).

Smoke-tested against the live tree (190 worktrees): 0 false-positive reaps — every locked-with-live-pid tree spared, a gone-dir dead-session tree correctly kept-dirty (status probe fails → fail-safe uncommitted), and the rest spared as owner-unknown/not-managed.

Note (§CP): `packages/pipeline-cli/**` is a control-plane path — this is banked for control-plane approval, not auto-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)