### PR TITLE
ci(lint): biome --reporter=github for inline PR annotations (#3872)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # `biome check` is lint + format in one pass (tabs/100-col/no-bracket-spacing).
-      - run: pnpm lint
+      # `--reporter=github` (CI-only) emits `::error file=…,line=…::` workflow commands so a
+      # lint/format failure renders as an inline annotation on the PR diff, not just buried log
+      # text a repair agent must dig through (#3872). The flag lives here rather than in the root
+      # `lint` script so local `pnpm lint` keeps the default human-readable reporter; this
+      # mirrors that script's primary-checkout branch (`biome check .`) with the reporter added.
+      - run: pnpm exec biome check --reporter=github .
 
       - run: pnpm typecheck
 


### PR DESCRIPTION
## What & why

The CI `check` job ran `pnpm lint` (plain `biome check .`), so a lint/format failure surfaced only as log text a repair agent or human had to dig through. Biome natively supports `--reporter=github`, which emits `::error file=…,line=…::` workflow commands GitHub renders as inline annotations on the PR diff.

## The change

One line in the lint step of the `check` job in `.github/workflows/ci.yml`: replace `pnpm lint` with a direct `pnpm exec biome check --reporter=github .`.

- The flag lives in the CI step, **not** the root `lint` script — local `pnpm lint` keeps the default human-readable reporter (unchanged).
- The CI invocation mirrors the root `lint` script's primary-checkout branch (`biome check .`) with the reporter added; CI always runs on the primary checkout, so the worktree-aware branch of that script never applied here anyway.

## Verification

- `--reporter=github` is present in `biome check --help` for the pinned biome (`@biomejs/biome` `^2.4.15` in the workspace catalog).
- `actionlint` passes clean on the edited `.github/workflows/ci.yml`.

## Acceptance criteria

- [x] A lint failure on a PR produces inline `::error` annotations on the diff, not only log text.
- [x] Local `pnpm lint` output is unchanged (default human-readable reporter).
- [x] Green runs are unaffected (same `biome check .` scope, only the reporter changes).

## §CP note

This touches `.github/workflows/ci.yml`, which is code-owner-gated (§CP / CI enforcement). The PR banks at the code-owner gate for approval — do not self-approve or merge.

Fixes #3872
