### PR TITLE
feat(crew-mcp): crew channel doctor — one command to report registered/channel-deaf/orphaned + reap (#3630)

### DIFF
--- a/packages/pipeline-crew-mcp/src/bin.ts
+++ b/packages/pipeline-crew-mcp/src/bin.ts
@@ -9,6 +9,7 @@
  *   node src/bin.ts stand-down                        # tear down the crew's project-scope .mcp.json + server approval
  *   node src/bin.ts spawn-role <role>                 # add ONE member to the running crew (no whole-crew re-boot)
  *   node src/bin.ts retire-role <role> [--instance]   # retire ONE member (kill its pane + reclaim its artifacts)
+ *   node src/bin.ts doctor [--reap]                   # report crew channel health (registered/channel-deaf/orphaned) + reap
  *
  * The `spawn-role` / `retire-role` subcommands are the single-member membership ops (#3519): dynamic
  * add/remove/respawn of ONE crew member without the whole-crew re-boot `stand-up`/`stand-down` force.
@@ -51,7 +52,14 @@ import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Cause, Console, Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 
-import {CREW_ROLES, RoleUniquenessError, runCrewSession} from "./crew/index.ts";
+import {
+	CREW_ROLES,
+	collectLiveRegisteredForProject,
+	RoleUniquenessError,
+	renderCrewChannelHealth,
+	runCrewChannelDoctor,
+	runCrewSession,
+} from "./crew/index.ts";
 import {
 	CREW_WINDOW,
 	renderStandUpError,
@@ -263,6 +271,38 @@ const retireRoleCmd = Command.make(
 	),
 );
 
+const reapFlag = Flag.boolean("reap").pipe(
+	Flag.withDescription(
+		"also reap the orphaned crew server procs the report names (drives the #C4 reaper)",
+	),
+);
+
+const doctorCmd = Command.make(
+	"doctor",
+	{projectRoot: projectRootFlag, reap: reapFlag},
+	Effect.fn(function* ({projectRoot, reap}) {
+		yield* Console.error(
+			`pipeline-crew-mcp ${VERSION} — crew channel doctor over the canonical rendezvous (project ${projectRoot})`,
+		);
+		// Dial the rendezvous for the live-registered (attached) set, then classify every roster role's
+		// channel health and — with --reap — reap the orphans. The report goes to STDOUT (this is a plain
+		// operator report, not an MCP stdio server), the one startup line to STDERR.
+		const liveRegisteredAddresses = yield* collectLiveRegisteredForProject(projectRoot);
+		return yield* runCrewChannelDoctor({liveRegisteredAddresses, reap}).pipe(
+			Effect.flatMap((result) => Console.log(renderCrewChannelHealth(result))),
+			Effect.catch((error: unknown) =>
+				Console.error(`crew doctor failed: ${String(error)}`).pipe(
+					Effect.andThen(Effect.sync(() => process.exit(1))),
+				),
+			),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Report crew channel health (registered / channel-deaf / orphaned) over the rendezvous, and --reap the orphans",
+	),
+);
+
 const cli = Command.make(
 	"pipeline-crew-mcp",
 	{},
@@ -273,7 +313,15 @@ const cli = Command.make(
 	}),
 ).pipe(
 	Command.withDescription("The crew's channels-backed messaging substrate (epic #3045)"),
-	Command.withSubcommands([session, tracker, standUp, standDown, spawnRoleCmd, retireRoleCmd]),
+	Command.withSubcommands([
+		session,
+		tracker,
+		standUp,
+		standDown,
+		spawnRoleCmd,
+		retireRoleCmd,
+		doctorCmd,
+	]),
 );
 
 cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/pipeline-crew-mcp/src/crew/doctor.test.ts
+++ b/packages/pipeline-crew-mcp/src/crew/doctor.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The crew channel doctor (#3630): one command to SEE and FIX crew channel health. These drive the
+ * pure classifier + the reap composition entirely against fixtures — no real process, `ps`, tracker,
+ * or signal — proving:
+ *   - a role with an attached inbox is REGISTERED, a parented pane with no attached half is
+ *     CHANNEL-DEAF, a reparented (init-adopted) proc is ORPHANED, and a role with neither is ABSENT,
+ *   - the three are distinguished on ONE mixed registered/deaf/orphaned fixture (AC1/AC2/AC3),
+ *   - orphan identification is the reaper's (`isOrphanedCrewServer`), so the report matches what a reap
+ *     terminates, and `--reap` drives the reaper over exactly those orphans,
+ *   - a mixed engine pool (one instance attached, one deaf) reads reachable yet still surfaces the deaf
+ *     instance, and the render names each state + the fix pointers once.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	classifyCrewChannelHealth,
+	crewProcInboxAddress,
+	renderCrewChannelHealth,
+	roleOfInboxAddress,
+	runCrewChannelDoctor,
+} from "./doctor.ts";
+import {INIT_PID, type ProcessEntry, type ProcessReaper, type ProcessSnapshot} from "./reaper.ts";
+import type {CrewRole} from "./roles.ts";
+import {inboxAddressFor} from "./session.ts";
+
+const NODE = "/opt/node/bin/node";
+const BIN = "/Users/x/phoenix/packages/pipeline-crew-mcp/src/bin.ts";
+/** A bridge crew session server command — no `--instance` (bridges are singletons). */
+const bridgeCmd = (role: CrewRole) =>
+	`${NODE} ${BIN} session --role ${role} --project-root /Users/x/phoenix`;
+/** An engine crew session server command — carries a per-instance `--instance`. */
+const engineCmd = (instance: string) =>
+	`${NODE} ${BIN} session --role engineering-manager --project-root /Users/x/phoenix --instance ${instance}`;
+
+const LIVE_PANE_PPID = 5000;
+
+describe("roleOfInboxAddress — the inbox → role inverse", () => {
+	it("resolves a bridge address `inbox://<role>`", () => {
+		assert.strictEqual(roleOfInboxAddress("inbox://intake-desk"), "intake-desk");
+	});
+	it("resolves an engine address `inbox://<role>/<instance>`", () => {
+		assert.strictEqual(
+			roleOfInboxAddress("inbox://engineering-manager/eng-1"),
+			"engineering-manager",
+		);
+	});
+	it("rejects a non-inbox address and a non-crew role", () => {
+		assert.isUndefined(roleOfInboxAddress("tcp://intake-desk"));
+		assert.isUndefined(roleOfInboxAddress("inbox://deploy"));
+	});
+});
+
+describe("crewProcInboxAddress — a parsed proc's dialable address", () => {
+	it("a bridge folds no instance into its address", () => {
+		assert.strictEqual(
+			crewProcInboxAddress({role: "intake-desk", instance: undefined}),
+			"inbox://intake-desk",
+		);
+	});
+	it("an engine carries its per-instance discriminator", () => {
+		assert.strictEqual(
+			crewProcInboxAddress({role: "engineering-manager", instance: "eng-1"}),
+			"inbox://engineering-manager/eng-1",
+		);
+	});
+	it("an engine with no argv --instance can't be pinned down (never mistaken for registered)", () => {
+		assert.isUndefined(crewProcInboxAddress({role: "engineering-manager", instance: undefined}));
+	});
+});
+
+describe("classifyCrewChannelHealth — the mixed registered/deaf/orphaned fixture (AC1/AC2/AC3)", () => {
+	const selfPid = 4242;
+	// intake-desk: pane up AND attached ⇒ registered.
+	// chief-of-staff: pane up but NOT attached ⇒ channel-deaf (#C3).
+	// engineering-manager (eng-orphan): reparented to init, not registered ⇒ orphaned (#C4).
+	// cartographer: no pane, no registration ⇒ absent.
+	const processes: ReadonlyArray<ProcessEntry> = [
+		{pid: 100, ppid: LIVE_PANE_PPID, command: bridgeCmd("intake-desk")},
+		{pid: 200, ppid: LIVE_PANE_PPID, command: bridgeCmd("chief-of-staff")},
+		{pid: 300, ppid: INIT_PID, command: engineCmd("eng-orphan")},
+		{pid: 999, ppid: LIVE_PANE_PPID, command: "/usr/sbin/cupsd -l"}, // decoy, never matched
+	];
+	const liveRegisteredAddresses = new Set([inboxAddressFor("intake-desk", "")]);
+
+	const report = classifyCrewChannelHealth({processes, liveRegisteredAddresses, selfPid});
+	const rowFor = (role: CrewRole) => report.roles.find((r) => r.role === role);
+
+	it("a live attached inbox reads REGISTERED, distinct from deaf and absent", () => {
+		assert.strictEqual(rowFor("intake-desk")?.status, "registered");
+		assert.deepStrictEqual(rowFor("intake-desk")?.registered, ["inbox://intake-desk"]);
+	});
+
+	it("a pane up with no attached channel half reads CHANNEL-DEAF (#C3)", () => {
+		const row = rowFor("chief-of-staff");
+		assert.strictEqual(row?.status, "channel-deaf");
+		assert.deepStrictEqual(
+			row?.deaf.map((d) => d.pid),
+			[200],
+		);
+	});
+
+	it("a reparented, unregistered proc is ORPHANED (#C4), matching the reaper", () => {
+		assert.deepStrictEqual(
+			report.orphaned.map((o) => ({pid: o.pid, role: o.role, instance: o.instance})),
+			[{pid: 300, role: "engineering-manager", instance: "eng-orphan"}],
+		);
+	});
+
+	it("a role with neither a pane nor a registration reads ABSENT", () => {
+		assert.strictEqual(rowFor("cartographer")?.status, "absent");
+	});
+
+	it("scans the whole table (the decoy is counted, never matched)", () => {
+		assert.strictEqual(report.scanned, 4);
+	});
+});
+
+describe("classifyCrewChannelHealth — a mixed engine pool", () => {
+	const selfPid = 1;
+	it("reads registered on the attached instance yet still surfaces the deaf instance", () => {
+		const processes: ReadonlyArray<ProcessEntry> = [
+			{pid: 10, ppid: LIVE_PANE_PPID, command: engineCmd("eng-live")},
+			{pid: 11, ppid: LIVE_PANE_PPID, command: engineCmd("eng-deaf")},
+		];
+		const live = new Set([inboxAddressFor("engineering-manager", "eng-live")]);
+		const report = classifyCrewChannelHealth({processes, liveRegisteredAddresses: live, selfPid});
+		const row = report.roles.find((r) => r.role === "engineering-manager");
+		assert.strictEqual(row?.status, "registered");
+		assert.deepStrictEqual(
+			row?.deaf.map((d) => d.instance),
+			["eng-deaf"],
+		);
+	});
+});
+
+describe("runCrewChannelDoctor — the injected-seam composition", () => {
+	const selfPid = 4242;
+	const snapshotOf = (entries: ReadonlyArray<ProcessEntry>): ProcessSnapshot => ({
+		list: Effect.succeed(entries),
+	});
+
+	it.effect("does not reap without --reap, and reports the orphans it found", () =>
+		Effect.gen(function* () {
+			const killed: number[] = [];
+			const reaper: ProcessReaper = {
+				kill: (pid) =>
+					Effect.sync(() => {
+						killed.push(pid);
+						return "signalled";
+					}),
+			};
+			const result = yield* runCrewChannelDoctor({
+				liveRegisteredAddresses: new Set(),
+				snapshot: snapshotOf([{pid: 300, ppid: INIT_PID, command: bridgeCmd("intake-desk")}]),
+				reaper,
+				selfPid,
+			});
+			assert.deepStrictEqual(killed, [], "no kill without --reap");
+			assert.isUndefined(result.reaped);
+			assert.strictEqual(result.report.orphaned.length, 1);
+		}),
+	);
+
+	it.effect("with --reap, drives the reaper over exactly the orphaned procs", () =>
+		Effect.gen(function* () {
+			const killed: number[] = [];
+			const reaper: ProcessReaper = {
+				kill: (pid) =>
+					Effect.sync(() => {
+						killed.push(pid);
+						return "signalled";
+					}),
+			};
+			const result = yield* runCrewChannelDoctor({
+				liveRegisteredAddresses: new Set(),
+				snapshot: snapshotOf([
+					{pid: 300, ppid: INIT_PID, command: bridgeCmd("intake-desk")},
+					{pid: 301, ppid: 5000, command: bridgeCmd("chief-of-staff")}, // parented → deaf, never reaped
+				]),
+				reaper,
+				selfPid,
+				reap: true,
+			});
+			assert.deepStrictEqual(killed, [300], "only the orphan is reaped, not the deaf pane");
+			assert.strictEqual(result.reaped?.reaped.length, 1);
+		}),
+	);
+});
+
+describe("renderCrewChannelHealth — names each state + the fix pointers once", () => {
+	const selfPid = 4242;
+	it("renders registered/deaf/orphaned lines and the re-seat + reap hints", () => {
+		const report = classifyCrewChannelHealth({
+			processes: [
+				{pid: 100, ppid: 5000, command: bridgeCmd("intake-desk")},
+				{pid: 200, ppid: 5000, command: bridgeCmd("chief-of-staff")},
+				{pid: 300, ppid: INIT_PID, command: engineCmd("eng-orphan")},
+			],
+			liveRegisteredAddresses: new Set([inboxAddressFor("intake-desk", "")]),
+			selfPid,
+		});
+		const text = renderCrewChannelHealth({report, reaped: undefined});
+		assert.match(text, /intake-desk: ✓ registered/);
+		assert.match(text, /chief-of-staff: ⚠ channel-deaf/);
+		assert.match(text, /orphaned crew server procs \(1\)/);
+		assert.match(text, /retire-role .* spawn-role/, "the deaf-role fix pointer, stated once");
+		assert.match(text, /--reap/, "the reap hint when orphans exist and none reaped");
+		// The re-seat pointer appears exactly once (stated once, not per-row).
+		assert.strictEqual((text.match(/retire-role/g) ?? []).length, 1);
+	});
+});

--- a/packages/pipeline-crew-mcp/src/crew/doctor.ts
+++ b/packages/pipeline-crew-mcp/src/crew/doctor.ts
@@ -1,0 +1,291 @@
+/**
+ * crew/doctor — one command to SEE and FIX crew channel health in a single gesture (#3630).
+ *
+ * The reachability surface for the whole crew rewrite: it composes the three separately-built signals
+ * into one operator picture over the canonical rendezvous (#C2), classifying every roster role as
+ *   - REGISTERED — an attached channel half is live (`tracker` `lookup` returns it, #3628),
+ *   - CHANNEL-DEAF — its launch pane is up (a live, PARENTED `session --role` server proc) yet no
+ *     attached channel half is registered (#C3): "up in tmux but every send fails,"
+ *   - ABSENT — no live pane and no registration,
+ * and separately naming the ORPHANED crew server procs (reparented to init, #C4) the reaper reaps.
+ *
+ * It REUSES the merged parts, never reimplements them: `parseCrewSessionProc` + `isOrphanedCrewServer`
+ * (crew/reaper.ts, #3629) are the exact orphan discrimination `--reap` will act on, so the report is
+ * truthful about what a reap terminates; the live-registered set rides `CrewTracker.lookup`'s
+ * attached-inbox liveness (#3628). Channel-deaf is the one signal this module adds: a parented crew
+ * proc whose inbox address is not in the attached set — the reaper deliberately spares it (it is not an
+ * orphan), so it would otherwise go unseen. The fix it points at is re-seat via `retire-role` →
+ * `spawn-role` (#3576).
+ *
+ * The pure classifier (`classifyCrewChannelHealth`) takes a process snapshot + the live-registered set
+ * and returns the report — no IO, so the registered/deaf/orphaned discrimination is unit-tested against
+ * a mixed fixture with no real process, `ps`, tracker, or signal. Every side-effecting seam (the
+ * snapshot, the reaper, the tracker dial) is injected and defaults to production, the same idiom the
+ * reaper and the orchestration use.
+ */
+import {Effect} from "effect";
+import {resolveRendezvous} from "../tracker/index.ts";
+import {
+	type CrewSessionProc,
+	collectLiveRegisteredAddresses,
+	INIT_PID,
+	isOrphanedCrewServer,
+	type ProcessEntry,
+	type ProcessReaper,
+	type ProcessSnapshot,
+	type ProcessSnapshotError,
+	parseCrewSessionProc,
+	productionProcessSnapshot,
+	type ReapReport,
+	reapOrphanedCrewServers,
+} from "./reaper.ts";
+import {CREW_ROLES, type CrewRole, isCrewRole, kindOf} from "./roles.ts";
+import {inboxAddressFor} from "./session.ts";
+import {CrewTracker, crewTrackerSocketLayer} from "./tracker.ts";
+
+/** A role's channel health over the rendezvous: reachable, up-but-deaf, or not present. */
+export type ChannelHealthStatus = "registered" | "channel-deaf" | "absent";
+
+/** A parented crew server proc with no attached channel half — its pane is up but every send to it fails (#C3). */
+export interface DeafProc {
+	readonly pid: number;
+	readonly role: CrewRole;
+	readonly instance: string | undefined;
+}
+
+/** An orphaned (reparented-to-init) crew server proc the reaper would reap (#C4). */
+export interface OrphanedProc {
+	readonly pid: number;
+	readonly role: CrewRole;
+	readonly instance: string | undefined;
+}
+
+/** One role's health row: its status, its live attached inbox addresses, and any channel-deaf panes it has. */
+export interface RoleChannelHealth {
+	readonly role: CrewRole;
+	readonly status: ChannelHealthStatus;
+	readonly registered: ReadonlyArray<string>;
+	readonly deaf: ReadonlyArray<DeafProc>;
+}
+
+/** The whole crew's channel picture: per-role health, the reapable orphans, and the scan denominator. */
+export interface CrewChannelHealthReport {
+	readonly roles: ReadonlyArray<RoleChannelHealth>;
+	readonly orphaned: ReadonlyArray<OrphanedProc>;
+	/** How many processes the snapshot scanned — the discrimination denominator (observability). */
+	readonly scanned: number;
+}
+
+/** What the pure classifier reads: the process table, the live-registered (attached) address set, and self. */
+export interface CrewChannelHealthInput {
+	readonly processes: ReadonlyArray<ProcessEntry>;
+	readonly liveRegisteredAddresses: ReadonlySet<string>;
+	readonly selfPid: number;
+}
+
+/**
+ * The crew role an `inbox://<role>` or `inbox://<role>/<instance>` address serves, or `undefined` when
+ * it is not a dialable crew inbox — the read-side inverse of `inboxAddressFor`, used to bucket the
+ * registry's attached addresses by role without needing the proc that serves each.
+ */
+export const roleOfInboxAddress = (address: string): CrewRole | undefined => {
+	const match = address.match(/^inbox:\/\/([^/]+)(?:\/.*)?$/);
+	const role = match?.[1];
+	return role !== undefined && isCrewRole(role) ? role : undefined;
+};
+
+/**
+ * The dialable inbox address a parsed crew proc serves, or `undefined` when it can't be pinned down —
+ * an engine whose argv carries no `--instance` (a direct run that minted its id at runtime) can't be
+ * matched against the registry, so it resolves `undefined` and is never mistaken for registered. A
+ * bridge folds no instance into its address (`inbox://<role>`), so it always resolves.
+ */
+export const crewProcInboxAddress = (proc: CrewSessionProc): string | undefined => {
+	if (kindOf(proc.role) === "bridge") return inboxAddressFor(proc.role, "");
+	return proc.instance === undefined ? undefined : inboxAddressFor(proc.role, proc.instance);
+};
+
+/**
+ * Classify every roster role's channel health from a process snapshot + the live-registered set, and
+ * name the orphaned procs a reap would reap. Pure — the whole registered/deaf/orphaned discrimination
+ * with no IO. The three buckets are mutually exclusive per proc: an orphan (reparented, unregistered)
+ * is reaped; a parented proc is registered iff its inbox is in the attached set, else channel-deaf.
+ * A role is `registered` if any attached inbox serves it, else `channel-deaf` if a deaf pane is up for
+ * it, else `absent` — but every deaf pane is still surfaced in its role's `deaf` list so a mixed engine
+ * pool (one instance attached, another deaf) shows the deaf one even while the role reads reachable.
+ */
+export const classifyCrewChannelHealth = ({
+	processes,
+	liveRegisteredAddresses,
+	selfPid,
+}: CrewChannelHealthInput): CrewChannelHealthReport => {
+	const registeredByRole = new Map<CrewRole, Set<string>>();
+	const deafByRole = new Map<CrewRole, DeafProc[]>();
+	const orphaned: OrphanedProc[] = [];
+
+	// Seed registered straight off the registry: an attached lease is registered even if its serving
+	// proc isn't in this snapshot (a remote pane, or a `ps`-vs-lookup race).
+	for (const address of liveRegisteredAddresses) {
+		const role = roleOfInboxAddress(address);
+		if (role === undefined) continue;
+		const set = registeredByRole.get(role) ?? new Set<string>();
+		set.add(address);
+		registeredByRole.set(role, set);
+	}
+
+	for (const entry of processes) {
+		const proc = parseCrewSessionProc(entry.command);
+		if (proc === undefined) continue;
+		if (entry.pid === selfPid) continue;
+		if (isOrphanedCrewServer(entry, {selfPid, liveRegisteredAddresses})) {
+			orphaned.push({pid: entry.pid, role: proc.role, instance: proc.instance});
+			continue;
+		}
+		// A reparented proc the reaper spared is a still-serving engine instance — already registry-seeded.
+		if (entry.ppid === INIT_PID) continue;
+		// Parented ⇒ its launch pane is up. Registered iff its inbox is attached, else channel-deaf.
+		const address = crewProcInboxAddress(proc);
+		if (address !== undefined && liveRegisteredAddresses.has(address)) continue;
+		const list = deafByRole.get(proc.role) ?? [];
+		list.push({pid: entry.pid, role: proc.role, instance: proc.instance});
+		deafByRole.set(proc.role, list);
+	}
+
+	const roles = CREW_ROLES.map((role): RoleChannelHealth => {
+		const registered = [...(registeredByRole.get(role) ?? new Set<string>())].sort();
+		const deaf = deafByRole.get(role) ?? [];
+		const status: ChannelHealthStatus =
+			registered.length > 0 ? "registered" : deaf.length > 0 ? "channel-deaf" : "absent";
+		return {role, status, registered, deaf};
+	});
+
+	return {roles, orphaned, scanned: processes.length};
+};
+
+/** What one doctor run needs: the live-registered set, plus injectable seams defaulting to production. */
+export interface CrewChannelDoctorInput {
+	readonly liveRegisteredAddresses: ReadonlySet<string>;
+	readonly snapshot?: ProcessSnapshot;
+	readonly reaper?: ProcessReaper;
+	readonly selfPid?: number;
+	/** When true, drive the #C4 reaper over the orphans this run found (the fix half of the gesture). */
+	readonly reap?: boolean;
+}
+
+/** A doctor run's result: the health report, plus the reap report when `--reap` drove the reaper. */
+export interface CrewChannelDoctorResult {
+	readonly report: CrewChannelHealthReport;
+	readonly reaped: ReapReport | undefined;
+}
+
+/**
+ * Run the doctor over a known live-registered set: snapshot the process table, classify channel health,
+ * and — when `reap` is set — drive `reapOrphanedCrewServers` over the same set so the orphans it named
+ * are terminated (the reaper re-snapshots for the actual kill, so what it reaps matches what a re-run
+ * would find). The tracker dial is the caller's job (`collectLiveRegisteredForProject`), kept out so the
+ * classifier + reap composition stays transport-free and fully unit-testable.
+ */
+export const runCrewChannelDoctor = (
+	input: CrewChannelDoctorInput,
+): Effect.Effect<CrewChannelDoctorResult, ProcessSnapshotError> =>
+	Effect.gen(function* () {
+		const snapshot = input.snapshot ?? productionProcessSnapshot;
+		const selfPid = input.selfPid ?? process.pid;
+		const {liveRegisteredAddresses} = input;
+
+		const processes = yield* snapshot.list;
+		const report = classifyCrewChannelHealth({processes, liveRegisteredAddresses, selfPid});
+
+		const reaped = input.reap
+			? yield* reapOrphanedCrewServers({
+					liveRegisteredAddresses,
+					snapshot,
+					selfPid,
+					...(input.reaper !== undefined ? {reaper: input.reaper} : {}),
+				})
+			: undefined;
+
+		return {report, reaped};
+	});
+
+/**
+ * Dial the repo's canonical rendezvous tracker (#C2, ADR 0197) and collect the live-registered
+ * (attached) inbox set across the whole roster. Best-effort: an unreachable or absent tracker — no crew
+ * up — yields the empty set rather than failing the doctor, so the doctor still reports every up pane as
+ * channel-deaf/orphaned when the registry itself is gone (which is itself the diagnosis). Mirrors the
+ * orchestration's `productionReapOrphanProcesses` tracker dial.
+ */
+export const collectLiveRegisteredForProject = (
+	projectRoot: string,
+): Effect.Effect<ReadonlySet<string>> =>
+	resolveRendezvous(projectRoot).pipe(
+		Effect.flatMap((rendezvous) =>
+			Effect.gen(function* () {
+				const crewTracker = yield* CrewTracker;
+				return yield* collectLiveRegisteredAddresses((role) => crewTracker.lookup(role));
+			}).pipe(Effect.scoped, Effect.provide(crewTrackerSocketLayer(rendezvous.socketPath))),
+		),
+		Effect.orElseSucceed(() => new Set<string>()),
+	);
+
+/** A one-glyph status marker for the operator picture — reachable / up-but-deaf / not present. */
+const STATUS_GLYPH: Record<ChannelHealthStatus, string> = {
+	registered: "✓ registered",
+	"channel-deaf": "⚠ channel-deaf",
+	absent: "· absent",
+};
+
+/**
+ * Render the operator-facing channel-health report — one line per role, the orphan list, and the two
+ * fix pointers stated ONCE at the foot (re-seat a deaf pane via `retire-role` → `spawn-role`, #3576;
+ * `--reap` the orphans, #3629), never re-narrated per row.
+ */
+export const renderCrewChannelHealth = (result: CrewChannelDoctorResult): string => {
+	const {report, reaped} = result;
+	const lines: string[] = [];
+	lines.push("crew channel health — canonical rendezvous (#C2):");
+	for (const row of report.roles) {
+		const detail =
+			row.status === "registered"
+				? ` (${row.registered.join(", ")})`
+				: row.status === "channel-deaf"
+					? ` (pane(s) up: ${row.deaf.map((d) => `pid ${d.pid}`).join(", ")})`
+					: "";
+		lines.push(`  ${row.role}: ${STATUS_GLYPH[row.status]}${detail}`);
+		// A role can be reachable yet still carry a deaf instance (a mixed engine pool) — surface it.
+		if (row.status === "registered" && row.deaf.length > 0) {
+			lines.push(`    ⚠ also channel-deaf: ${row.deaf.map((d) => `pid ${d.pid}`).join(", ")}`);
+		}
+	}
+
+	if (report.orphaned.length === 0) {
+		lines.push("orphaned crew server procs: none");
+	} else {
+		lines.push(`orphaned crew server procs (${report.orphaned.length}):`);
+		for (const orphan of report.orphaned) {
+			lines.push(
+				`  pid ${orphan.pid} — ${orphan.role}${orphan.instance ? `/${orphan.instance}` : ""}`,
+			);
+		}
+	}
+
+	if (reaped !== undefined) {
+		lines.push(
+			reaped.reaped.length === 0
+				? "reaped: none (no orphans to reap)"
+				: `reaped ${reaped.reaped.length}: ${reaped.reaped
+						.map((r) => `pid ${r.pid} (${r.outcome})`)
+						.join(", ")}`,
+		);
+	} else if (report.orphaned.length > 0) {
+		lines.push("run again with --reap to terminate the orphaned procs (#3629).");
+	}
+
+	const hasDeaf = report.roles.some((row) => row.deaf.length > 0);
+	if (hasDeaf) {
+		lines.push("re-seat a channel-deaf role: retire-role <role> → spawn-role <role> (#3576).");
+	}
+
+	lines.push(`scanned ${report.scanned} processes.`);
+	return lines.join("\n");
+};

--- a/packages/pipeline-crew-mcp/src/crew/index.ts
+++ b/packages/pipeline-crew-mcp/src/crew/index.ts
@@ -29,6 +29,22 @@ export {
 	roleContracts,
 	type SeamContract,
 } from "./contract.ts";
+export {
+	type ChannelHealthStatus,
+	type CrewChannelDoctorInput,
+	type CrewChannelDoctorResult,
+	type CrewChannelHealthInput,
+	type CrewChannelHealthReport,
+	classifyCrewChannelHealth,
+	collectLiveRegisteredForProject,
+	crewProcInboxAddress,
+	type DeafProc,
+	type OrphanedProc,
+	type RoleChannelHealth,
+	renderCrewChannelHealth,
+	roleOfInboxAddress,
+	runCrewChannelDoctor,
+} from "./doctor.ts";
 export {RoleUniquenessError} from "./errors.ts";
 export {
 	type CrewSessionProc,


### PR DESCRIPTION
Gives the operator one command to see and fix crew channel health in a single gesture. Run `pipeline-crew-mcp doctor` and it reports, per crew role over the canonical rendezvous, which are **registered** with a live inbox, which panes are **up-but-channel-deaf** (running in tmux but every send fails), and which crew server procs are **orphaned** (crashed/re-run leftovers reparented to init) — and `--reap` terminates the orphans in the same pass. This is the reachability surface the crew rewrite was building toward: an operator seeing "intake-desk online but every send fails" gets one command that names it channel-deaf and points at the fix.

Fixes #3630

## What changed
- **`packages/pipeline-crew-mcp/src/crew/doctor.ts`** — the new module:
  - `classifyCrewChannelHealth` — the pure core: a process snapshot + the live-registered (attached) inbox set in, a per-role `registered | channel-deaf | absent` report + the orphan list out. No IO.
  - `runCrewChannelDoctor` — the injected-seam composition (snapshot / reaper / tracker-dial all injectable, defaulting to production); `--reap` drives `reapOrphanedCrewServers` over the orphans it found.
  - `collectLiveRegisteredForProject` — dials the repo's canonical rendezvous tracker (ADR 0197) for the attached set, best-effort (an absent tracker degrades to "everything up is deaf/orphaned", which is itself the diagnosis).
  - `renderCrewChannelHealth` — the operator-facing report, with the re-seat (`retire-role` → `spawn-role`, #3576) and `--reap` fix pointers stated once at the foot.
- **`packages/pipeline-crew-mcp/src/bin.ts`** — the `doctor [--reap]` subcommand, alongside `session`/`stand-up`/`spawn-role`/`retire-role`.
- **`packages/pipeline-crew-mcp/src/crew/index.ts`** — barrel exports.
- **`packages/pipeline-crew-mcp/src/crew/doctor.test.ts`** — 15 tests.

## Composes with the merged work, never reimplements it
- **#3628 (attached-inbox liveness).** "Registered" rides `CrewTracker.lookup`'s attached-lease semantics — a session that reserved its slot but never attached its inbox (channel-deaf) is not returned, so it never reads as registered.
- **#3629 (orphan reaper).** The orphan bucket IS the reaper's own `parseCrewSessionProc` + `isOrphanedCrewServer`, so the report is truthful about what `--reap` kills, and `--reap` calls `reapOrphanedCrewServers` directly. Channel-deaf is the one signal the doctor adds — a parented crew proc whose inbox isn't attached (the reaper deliberately spares it, so it would otherwise go unseen).

## Acceptance criteria
- [x] A subcommand reports per-role channel health over the rendezvous: registered-with-live-inbox vs up-but-channel-deaf vs orphaned.
- [x] A channel-deaf role (pane up, no attached channel half) is reported **deaf**, distinct from registered and from absent.
- [x] The command can reap orphaned procs (driving the #C4 reaper), and its identification is unit-tested against a mixed registered/deaf/orphaned fixture.

## Verification
- `pnpm typecheck` clean; `pnpm lint:worktree` clean.
- Package tests: 359 passed (16 in the doctor + bin surface).
- Live smoke run against the actual running crew: the dial + attached-inbox liveness resolved the real registered roles and the engine pool end to end, orphans none.

Not §CP: touches only `packages/pipeline-crew-mcp/**` (auto-ship on green, per the pipeline-cli-only §CP boundary). No `registry.ts` touched, so no conflict with the banked worktree-reap PR.